### PR TITLE
Add Rive workflow Maka tool

### DIFF
--- a/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -54,6 +54,16 @@ describe('RiveWorkflow tool and CLI bridge', () => {
     }), [
       'work', 'retry', 'work_1', '--command-id', 'retry-1', '--worker', 'worker-a', '--workspace-mode', 'worktree',
     ]);
+    assert.deepEqual(buildRiveCommand({
+      action: 'scheduler_resume',
+      schedulerRunId: 'sched_1',
+      commandId: 'resume-1',
+      runner: 'opencode',
+      workers: ['worker-a'],
+      failed: true,
+    }), [
+      'scheduler', 'resume', '--command-id', 'resume-1', '--run', 'sched_1', '--worker', 'worker-a', '--failed',
+    ]);
   });
 
   it('runs a fake Rive CLI and returns projection ids, not stdout success', async () => {
@@ -75,6 +85,9 @@ describe('RiveWorkflow tool and CLI bridge', () => {
       assert.equal(result.ids.rootWorkNodeId, 'work_root_fake');
       assert.equal(result.state, 'completed');
       assert.equal(result.summary, 'Workflow run wfrun_fake root work_root_fake state completed');
+      assert.equal('protocol' in result, false);
+      assert.equal('display' in result, false);
+      assert.equal(result.projection?.workflowRunId, 'wfrun_fake');
       assert.equal(result.stderrTail?.includes('super-secret'), false);
       assert.equal(emitted.join('').includes('super-secret'), false);
       assert.equal(result.command.includes('workflow'), true);
@@ -119,6 +132,32 @@ describe('RiveWorkflow tool and CLI bridge', () => {
       assert.equal(aborted.error?.reason, 'aborted');
     });
   });
+
+  it('kills and reaps a Rive child that ignores SIGTERM on abort', async () => {
+    await withFakeRive('ignore-term', async (riveBin, cwd) => {
+      const pidFile = join(cwd, 'pid');
+      const controller = new AbortController();
+      const promise = runRiveCli({
+        action: 'workflow_status',
+        workflowRunId: 'wfrun_ignore_term',
+      }, {
+        cwd,
+        riveBin,
+        env: { ...process.env, PID_FILE: pidFile },
+        abortSignal: controller.signal,
+      });
+      await waitForFile(pidFile);
+      const pid = Number((await readFile(pidFile, 'utf8')).trim());
+      controller.abort();
+      await assert.rejects(promise, (error) => {
+        assert.equal(error instanceof RiveCliError, true);
+        assert.equal((error as RiveCliError).reason, 'aborted');
+        return true;
+      });
+      assert.throws(() => process.kill(pid, 0));
+    });
+  });
+
 
   it('surfaces bad JSON and Rive error envelopes as structured tool failures', async () => {
     await withFakeRive('bad-json', async (riveBin, cwd) => {
@@ -180,6 +219,28 @@ describe('RiveWorkflow tool and CLI bridge', () => {
       );
     });
   });
+
+  it('has a bounded UI preview and error text for rive_workflow results', async () => {
+    const root = await repoRoot();
+    const [components, events] = await Promise.all([
+      readFile(join(root, 'packages/ui/src/components.tsx'), 'utf8'),
+      readFile(join(root, 'packages/core/src/events.ts'), 'utf8'),
+    ]);
+    assert.match(events, /kind: 'rive_workflow'/);
+    assert.match(events, /projection\?:/);
+    assert.match(events, /nodes\?: ReadonlyArray/);
+    assert.doesNotMatch(events, /protocol\?: unknown/);
+    assert.doesNotMatch(events, /display\?: unknown/);
+    assert.match(components, /case 'rive_workflow'/);
+    assert.match(components, /function RiveWorkflowPreview/);
+    assert.match(components, /content\.kind === 'rive_workflow'/);
+    const previewBlock = components.match(/function RiveWorkflowPreview[\s\S]*?function formatRiveWorkflowNode/)?.[0] ?? '';
+    assert.match(previewBlock, /workflow_run/);
+    assert.match(previewBlock, /scheduler_run/);
+    assert.match(previewBlock, /root_work/);
+    assert.match(previewBlock, /stdout_tail/);
+    assert.match(previewBlock, /stderr_tail/);
+  });
 });
 
 async function runTool(
@@ -200,7 +261,7 @@ async function runTool(
 }
 
 async function withFakeRive(
-  mode: 'success' | 'sleep' | 'bad-json' | 'failed-envelope' | 'failed-secret',
+  mode: 'success' | 'sleep' | 'ignore-term' | 'bad-json' | 'failed-envelope' | 'failed-secret',
   fn: (riveBin: string, cwd: string) => Promise<void>,
 ): Promise<void> {
   const cwd = await mkdtemp(join(tmpdir(), 'maka-rive-tool-'));
@@ -215,6 +276,16 @@ async function withFakeRive(
 }
 
 function fakeRiveScript(mode: string): string {
+  if (mode === 'ignore-term') {
+    return [
+      '#!/bin/sh',
+      'trap "" TERM',
+      'echo $$ > "$PID_FILE"',
+      'sleep 20',
+      'echo \'{"protocol":{"state":"completed"},"display":{"summary":"late"}}\'',
+      '',
+    ].join('\n');
+  }
   if (mode === 'sleep') {
     return [
       '#!/bin/sh',
@@ -255,4 +326,34 @@ function fakeRiveScript(mode: string): string {
     'JSON',
     '',
   ].join('\n');
+}
+
+async function waitForFile(path: string): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1000) {
+    try {
+      await readFile(path, 'utf8');
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+async function repoRoot(): Promise<string> {
+  let current = process.cwd();
+  for (let i = 0; i < 6; i += 1) {
+    try {
+      const packageJson = JSON.parse(await readFile(join(current, 'package.json'), 'utf8')) as { name?: string };
+      if (packageJson.name === 'maka') return current;
+    } catch {
+      // keep walking
+    }
+    const parent = join(current, '..');
+    const [currentStat, parentStat] = await Promise.all([stat(current), stat(parent)]);
+    if (currentStat.dev === parentStat.dev && currentStat.ino === parentStat.ino) break;
+    current = parent;
+  }
+  throw new Error('Could not locate Maka repo root');
 }

--- a/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  buildRiveCommand,
+  runRiveCli,
+  RiveCliError,
+} from '../rive-cli.js';
+import {
+  buildRiveWorkflowTool,
+  RIVE_WORKFLOW_TOOL_NAME,
+  type RiveWorkflowToolResult,
+} from '../rive-workflow-tool.js';
+
+describe('RiveWorkflow tool and CLI bridge', () => {
+  it('registers as a permission-gated custom MakaTool', () => {
+    const tool = buildRiveWorkflowTool();
+    assert.equal(tool.name, RIVE_WORKFLOW_TOOL_NAME);
+    assert.equal(tool.displayName, 'Rive 工作流');
+    assert.equal(tool.permissionRequired, true);
+    assert.equal(tool.categoryHint, 'custom_tool');
+    assert.match(tool.description, /Rive remains the source of truth/);
+    assert.ok('action' in ((tool.parameters as { shape: Record<string, unknown> }).shape));
+  });
+
+  it('builds shell-free argv for high-level workflow commands', () => {
+    assert.deepEqual(buildRiveCommand({
+      action: 'workflow_run',
+      templateId: 'sentinel.prod-debug',
+      commandId: 'cmd-1',
+      params: { env: 'prd', dry_run: true, window: 30 },
+      runner: 'opencode',
+      workers: ['worker-a', 'worker-b'],
+      maxParallel: 2,
+      acceptanceMode: 'auto-reported',
+      workspaceMode: 'worktree',
+      trustProject: true,
+      timeoutSeconds: 900,
+    }), [
+      'workflow', 'run', 'sentinel.prod-debug', '--command-id', 'cmd-1',
+      '--param', 'env=prd', '--param', 'dry_run=true', '--param', 'window=30',
+      '--runner', 'opencode', '--worker', 'worker-a', '--worker', 'worker-b',
+      '--max-parallel', '2', '--acceptance-mode', 'auto-reported',
+      '--workspace-mode', 'worktree', '--timeout-seconds', '900', '--trust-project',
+    ]);
+    assert.deepEqual(buildRiveCommand({
+      action: 'work_retry',
+      workNodeId: 'work_1',
+      commandId: 'retry-1',
+      workers: ['worker-a'],
+      workspaceMode: 'worktree',
+    }), [
+      'work', 'retry', 'work_1', '--command-id', 'retry-1', '--worker', 'worker-a', '--workspace-mode', 'worktree',
+    ]);
+  });
+
+  it('runs a fake Rive CLI and returns projection ids, not stdout success', async () => {
+    await withFakeRive('success', async (riveBin, cwd) => {
+      const emitted: string[] = [];
+      const tool = buildRiveWorkflowTool({ riveBin });
+      const result = await runTool(tool, cwd, {
+        action: 'workflow_run',
+        templateId: 'sentinel.prod-debug',
+        commandId: 'cmd-success',
+        params: { slack_channel: '#alerts' },
+        workers: ['worker-a'],
+      }, (stream, chunk) => emitted.push(`${stream}:${chunk}`));
+
+      assert.equal(result.ok, true);
+      assert.equal(result.kind, 'rive_workflow');
+      assert.equal(result.ids.workflowRunId, 'wfrun_fake');
+      assert.equal(result.ids.schedulerRunId, 'sched_fake');
+      assert.equal(result.ids.rootWorkNodeId, 'work_root_fake');
+      assert.equal(result.state, 'completed');
+      assert.equal(result.summary, 'Workflow run wfrun_fake root work_root_fake state completed');
+      assert.equal(result.stderrTail?.includes('super-secret'), false);
+      assert.equal(emitted.join('').includes('super-secret'), false);
+      assert.equal(result.command.includes('workflow'), true);
+    });
+  });
+
+  it('fails closed when Rive is not installed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-rive-missing-'));
+    try {
+      const tool = buildRiveWorkflowTool({ riveBin: join(cwd, 'missing-rive') });
+      const result = await runTool(tool, cwd, {
+        action: 'workflow_status',
+        workflowRunId: 'wfrun_missing',
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.error?.reason, 'rive_not_installed');
+      assert.match(result.error?.message ?? '', /not executable|not found/i);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('reports timeout and abort without parsing stdout as success', async () => {
+    await withFakeRive('sleep', async (riveBin, cwd) => {
+      const tool = buildRiveWorkflowTool({ riveBin });
+      const timedOut = await runTool(tool, cwd, {
+        action: 'workflow_status',
+        workflowRunId: 'wfrun_sleep',
+        timeoutMs: 30,
+      });
+      assert.equal(timedOut.ok, false);
+      assert.equal(timedOut.error?.reason, 'timeout');
+
+      const controller = new AbortController();
+      const promise = runTool(tool, cwd, {
+        action: 'workflow_status',
+        workflowRunId: 'wfrun_sleep',
+      }, undefined, controller);
+      setTimeout(() => controller.abort(), 20);
+      const aborted = await promise;
+      assert.equal(aborted.ok, false);
+      assert.equal(aborted.error?.reason, 'aborted');
+    });
+  });
+
+  it('surfaces bad JSON and Rive error envelopes as structured tool failures', async () => {
+    await withFakeRive('bad-json', async (riveBin, cwd) => {
+      const tool = buildRiveWorkflowTool({ riveBin });
+      const result = await runTool(tool, cwd, {
+        action: 'workflow_status',
+        workflowRunId: 'wfrun_bad_json',
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.error?.reason, 'bad_json');
+    });
+
+    await withFakeRive('failed-envelope', async (riveBin, cwd) => {
+      const tool = buildRiveWorkflowTool({ riveBin });
+      const result = await runTool(tool, cwd, {
+        action: 'workflow_run',
+        templateId: 'sentinel.prod-debug',
+        commandId: 'cmd-failed',
+        noScheduler: true,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.error?.reason, 'rive_failed');
+      assert.equal(result.error?.code, 'workflow_param_missing');
+      assert.equal(result.error?.suggestedAction, 'fix_arguments');
+      assert.match(result.summary, /workflow missing param/);
+    });
+  });
+
+  it('rejects invalid scheduler arguments before spawning Rive', async () => {
+    await withFakeRive('success', async (riveBin, cwd) => {
+      const tool = buildRiveWorkflowTool({ riveBin });
+      const result = await runTool(tool, cwd, {
+        action: 'workflow_run',
+        templateId: 'sentinel.prod-debug',
+        commandId: 'cmd-invalid',
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.error?.reason, 'invalid_arguments');
+      assert.match(result.summary, /worker is required/);
+      assert.deepEqual(result.command, []);
+    });
+  });
+
+  it('redacts secrets from bridge errors and output tails', async () => {
+    await withFakeRive('failed-secret', async (riveBin, cwd) => {
+      await assert.rejects(
+        runRiveCli({
+          action: 'workflow_status',
+          workflowRunId: 'wfrun_secret',
+        }, { cwd, riveBin }),
+        (error) => {
+          assert.equal(error instanceof RiveCliError, true);
+          const riveError = error as RiveCliError;
+          assert.equal(riveError.reason, 'rive_failed');
+          assert.equal(JSON.stringify(riveError.envelope).includes('abc123-super-secret'), false);
+          assert.equal((riveError.stderrTail ?? '').includes('abc123-super-secret'), false);
+          return true;
+        },
+      );
+    });
+  });
+});
+
+async function runTool(
+  tool: ReturnType<typeof buildRiveWorkflowTool>,
+  cwd: string,
+  args: Parameters<typeof tool.impl>[0],
+  onOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void,
+  controller = new AbortController(),
+): Promise<RiveWorkflowToolResult> {
+  return await tool.impl(args, {
+    sessionId: 'session',
+    turnId: 'turn',
+    cwd,
+    toolCallId: 'tool-call',
+    abortSignal: controller.signal,
+    emitOutput: onOutput ?? (() => {}),
+  });
+}
+
+async function withFakeRive(
+  mode: 'success' | 'sleep' | 'bad-json' | 'failed-envelope' | 'failed-secret',
+  fn: (riveBin: string, cwd: string) => Promise<void>,
+): Promise<void> {
+  const cwd = await mkdtemp(join(tmpdir(), 'maka-rive-tool-'));
+  const riveBin = join(cwd, 'rive');
+  await writeFile(riveBin, fakeRiveScript(mode), 'utf8');
+  await chmod(riveBin, 0o755);
+  try {
+    await fn(riveBin, cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+function fakeRiveScript(mode: string): string {
+  if (mode === 'sleep') {
+    return [
+      '#!/bin/sh',
+      'sleep 5',
+      'echo \'{"protocol":{"state":"completed"},"display":{"summary":"late"}}\'',
+      '',
+    ].join('\n');
+  }
+  if (mode === 'bad-json') {
+    return ['#!/bin/sh', 'echo "not json"', ''].join('\n');
+  }
+  if (mode === 'failed-envelope') {
+    return [
+      '#!/bin/sh',
+      'cat <<\'JSON\'',
+      '{"error":{"code":"workflow_param_missing","message":"workflow missing param: slack_channel","action":"fix_arguments"}}',
+      'JSON',
+      'exit 1',
+      '',
+    ].join('\n');
+  }
+  if (mode === 'failed-secret') {
+    return [
+      '#!/bin/sh',
+      'echo "api_key=abc123-super-secret" >&2',
+      'cat <<\'JSON\'',
+      '{"error":{"code":"auth","message":"token=abc123-super-secret"}}',
+      'JSON',
+      'exit 1',
+      '',
+    ].join('\n');
+  }
+  return [
+    '#!/bin/sh',
+    'echo "token=abc123-super-secret" >&2',
+    'cat <<\'JSON\'',
+    '{"protocol":{"workflow_run_id":"wfrun_fake","scheduler_run_id":"sched_fake","root_work_node_id":"work_root_fake","state":"completed"},"display":{"summary":"Workflow run wfrun_fake root work_root_fake state completed"}}',
+    'JSON',
+    '',
+  ].join('\n');
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -71,6 +71,7 @@ import {
 } from '@maka/core';
 import { queryTavily, TAVILY_TEST_QUERY, TAVILY_TEST_LIMIT } from './web-search/tavily.js';
 import { buildWebSearchAgentTool, WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
+import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
 import { resolveTavilyApiKey } from './web-search/credentials.js';
 import { runThreadSearch } from './search/thread-search.js';
 import {
@@ -490,6 +491,7 @@ const builtinTools = [
     settingsStore,
     getPrivacyContext: async () => defaultWorkspacePrivacyContext(),
   }),
+  buildRiveWorkflowTool(),
 ];
 let lookupPricing = buildPricingLookup();
 // PR-BOT-LASTERROR-FROM-SEND-0: per-platform last-observed readiness so

--- a/apps/desktop/src/main/rive-cli.ts
+++ b/apps/desktop/src/main/rive-cli.ts
@@ -1,0 +1,396 @@
+import { access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { spawn } from 'node:child_process';
+
+export type RiveCliAction =
+  | 'workflow_validate'
+  | 'workflow_import'
+  | 'workflow_run'
+  | 'workflow_status'
+  | 'scheduler_status'
+  | 'scheduler_resume'
+  | 'work_retry'
+  | 'branch_conflict_show';
+
+export interface RiveCliToolArgs {
+  action: RiveCliAction;
+  path?: string;
+  templateId?: string;
+  workflowRunId?: string;
+  schedulerRunId?: string;
+  rootWorkNodeId?: string;
+  workNodeId?: string;
+  conflictId?: string;
+  commandId?: string;
+  params?: Record<string, string | number | boolean>;
+  bumpIfChanged?: boolean;
+  noScheduler?: boolean;
+  runner?: 'opencode' | 'codex';
+  workers?: string[];
+  maxParallel?: number;
+  acceptanceMode?: 'manual' | 'auto-reported' | 'auto-committed';
+  workspaceMode?: 'shared' | 'worktree';
+  opencodeBin?: string;
+  codexBin?: string;
+  trustProject?: boolean;
+  failed?: boolean;
+  timeoutSeconds?: number;
+  timeoutMs?: number;
+}
+
+export interface RiveCliRunOptions {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  riveBin?: string;
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+  emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
+}
+
+export interface RiveCliRunResult {
+  command: string[];
+  exitCode: number;
+  stdoutTail: string;
+  stderrTail: string;
+  envelope: unknown;
+}
+
+const MAX_CAPTURE_BYTES = 2 * 1024 * 1024;
+const TAIL_CHARS = 24_000;
+
+export class RiveCliError extends Error {
+  readonly reason: string;
+  readonly command?: string[];
+  readonly stdoutTail?: string;
+  readonly stderrTail?: string;
+  readonly envelope?: unknown;
+
+  constructor(
+    reason: string,
+    message: string,
+    details: {
+      command?: string[];
+      stdoutTail?: string;
+      stderrTail?: string;
+      envelope?: unknown;
+    } = {},
+  ) {
+    super(message);
+    this.name = 'RiveCliError';
+    this.reason = reason;
+    this.command = details.command;
+    this.stdoutTail = details.stdoutTail;
+    this.stderrTail = details.stderrTail;
+    this.envelope = details.envelope;
+  }
+}
+
+export function buildRiveCommand(input: RiveCliToolArgs): string[] {
+  switch (input.action) {
+    case 'workflow_validate':
+      return ['workflow', 'validate', requireString(input.path, 'path')];
+    case 'workflow_import': {
+      const args = ['workflow', 'import', requireString(input.path, 'path'), '--command-id', requireString(input.commandId, 'commandId')];
+      if (input.bumpIfChanged) args.push('--bump-if-changed');
+      return args;
+    }
+    case 'workflow_run': {
+      const args = ['workflow', 'run', requireString(input.templateId, 'templateId'), '--command-id', requireString(input.commandId, 'commandId')];
+      appendParams(args, input.params);
+      if (input.noScheduler) {
+        args.push('--no-scheduler');
+      } else {
+        appendSchedulerOptions(args, input, { requireWorkers: true });
+      }
+      return args;
+    }
+    case 'workflow_status':
+      return ['workflow', 'status', '--run', requireString(input.workflowRunId, 'workflowRunId')];
+    case 'scheduler_status': {
+      const args = ['scheduler', 'status'];
+      if (input.schedulerRunId) args.push('--run', input.schedulerRunId);
+      if (input.rootWorkNodeId) args.push('--root', input.rootWorkNodeId);
+      if (!input.schedulerRunId && !input.rootWorkNodeId) {
+        throw new RiveCliError('invalid_arguments', 'scheduler_status requires schedulerRunId or rootWorkNodeId');
+      }
+      return args;
+    }
+    case 'scheduler_resume': {
+      const args = ['scheduler', 'resume', '--command-id', requireString(input.commandId, 'commandId')];
+      if (input.schedulerRunId) args.push('--run', input.schedulerRunId);
+      if (input.rootWorkNodeId) args.push('--root', input.rootWorkNodeId);
+      if (!input.schedulerRunId && !input.rootWorkNodeId) {
+        throw new RiveCliError('invalid_arguments', 'scheduler_resume requires schedulerRunId or rootWorkNodeId');
+      }
+      appendSchedulerOptions(args, input, { requireWorkers: false });
+      if (input.failed) args.push('--failed');
+      return args;
+    }
+    case 'work_retry': {
+      const args = ['work', 'retry', requireString(input.workNodeId, 'workNodeId'), '--command-id', requireString(input.commandId, 'commandId')];
+      appendSchedulerOptions(args, input, { requireWorkers: false, omitRunner: true });
+      return args;
+    }
+    case 'branch_conflict_show':
+      return ['branch', 'conflict', 'show', requireString(input.conflictId, 'conflictId')];
+    default: {
+      const neverAction: never = input.action;
+      throw new RiveCliError('invalid_arguments', `unsupported Rive action: ${neverAction}`);
+    }
+  }
+}
+
+export async function runRiveCli(input: RiveCliToolArgs, options: RiveCliRunOptions): Promise<RiveCliRunResult> {
+  const riveBin = await resolveRiveBinary(options.riveBin, options.env ?? process.env);
+  const args = buildRiveCommand(input);
+  const command = [riveBin, ...args];
+  const timeoutMs = options.timeoutMs ?? input.timeoutMs ?? 600_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > 60 * 60 * 1000) {
+    throw new RiveCliError('invalid_arguments', 'timeoutMs must be between 1ms and 1h', { command });
+  }
+  return await spawnRive(command, {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    timeoutMs,
+    abortSignal: options.abortSignal,
+    emitOutput: options.emitOutput,
+  });
+}
+
+export function redactRiveText(input: string): string {
+  return input
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/-]+=*/gi, '$1[REDACTED]')
+    .replace(/\b(sk-[A-Za-z0-9][A-Za-z0-9_-]{8,})\b/g, '[REDACTED]')
+    .replace(/\b((?:api[_-]?key|token|secret|password)\s*[:=]\s*)("[^"]+"|'[^']+'|[^\s,;]+)/gi, '$1[REDACTED]')
+    .replace(/\b([A-Za-z0-9_-]*(?:token|secret|password|api[_-]?key)[A-Za-z0-9_-]*\s*[:=]\s*)("[^"]+"|'[^']+'|[^\s,;]+)/gi, '$1[REDACTED]');
+}
+
+export function redactRiveValue(value: unknown, depth = 0): unknown {
+  if (depth > 8) return '[MAX_DEPTH]';
+  if (typeof value === 'string') return redactRiveText(value);
+  if (Array.isArray(value)) return value.map((item) => redactRiveValue(item, depth + 1));
+  if (!value || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = redactRiveValue(item, depth + 1);
+  }
+  return out;
+}
+
+async function resolveRiveBinary(explicit: string | undefined, env: NodeJS.ProcessEnv): Promise<string> {
+  const candidate = explicit || env.MAKA_RIVE_BIN || env.RIVE_BIN || 'rive';
+  if (candidate.includes('/')) {
+    try {
+      await access(candidate, constants.X_OK);
+    } catch {
+      throw new RiveCliError('rive_not_installed', `Rive binary is not executable: ${candidate}`);
+    }
+  }
+  return candidate;
+}
+
+function spawnRive(
+  command: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+    abortSignal?: AbortSignal;
+    emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
+  },
+): Promise<RiveCliRunResult> {
+  return new Promise((resolve, reject) => {
+    const [bin, ...args] = command;
+    const child = spawn(bin, args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        if (!settled) child.kill('SIGKILL');
+      }, 2_000).unref();
+    }, options.timeoutMs);
+    const onAbort = () => {
+      child.kill('SIGTERM');
+      fail(new RiveCliError('aborted', 'Rive command was aborted', {
+        command,
+        stdoutTail: redactRiveText(tail(stdout)),
+        stderrTail: redactRiveText(tail(stderr)),
+      }));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      options.abortSignal?.removeEventListener('abort', onAbort);
+    };
+    options.abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      try {
+        stdout = appendCapture(stdout, text);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        child.kill('SIGTERM');
+        return;
+      }
+      options.emitOutput?.('stdout', redactRiveText(text));
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      try {
+        stderr = appendCapture(stderr, text);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        child.kill('SIGTERM');
+        return;
+      }
+      options.emitOutput?.('stderr', redactRiveText(text));
+    });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      const reason = error.code === 'ENOENT' ? 'rive_not_installed' : 'process_error';
+      fail(new RiveCliError(reason, error.code === 'ENOENT' ? 'Rive binary was not found in PATH' : error.message, {
+        command,
+        stdoutTail: redactRiveText(tail(stdout)),
+        stderrTail: redactRiveText(tail(stderr)),
+      }));
+    });
+    child.on('close', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      const stdoutTail = tail(stdout);
+      const stderrTail = tail(stderr);
+      const redactedStdoutTail = redactRiveText(stdoutTail);
+      const redactedStderrTail = redactRiveText(stderrTail);
+      if (timedOut) {
+        reject(new RiveCliError('timeout', `Rive command timed out after ${options.timeoutMs}ms`, {
+          command,
+          stdoutTail: redactedStdoutTail,
+          stderrTail: redactedStderrTail,
+        }));
+        return;
+      }
+      let envelope: unknown;
+      try {
+        envelope = parseRiveJson(stdout);
+      } catch (error) {
+        reject(new RiveCliError('bad_json', error instanceof Error ? error.message : String(error), {
+          command,
+          stdoutTail: redactedStdoutTail,
+          stderrTail: redactedStderrTail,
+        }));
+        return;
+      }
+      const exitCode = code ?? (signal ? 128 : 1);
+      if (exitCode !== 0) {
+        reject(new RiveCliError('rive_failed', riveErrorMessage(envelope, exitCode), {
+          command,
+          stdoutTail: redactedStdoutTail,
+          stderrTail: redactedStderrTail,
+          envelope: redactRiveValue(envelope),
+        }));
+        return;
+      }
+      resolve({
+        command,
+        exitCode,
+        stdoutTail: redactedStdoutTail,
+        stderrTail: redactedStderrTail,
+        envelope: redactRiveValue(envelope),
+      });
+    });
+  });
+}
+
+function appendCapture(current: string, chunk: string): string {
+  const next = current + chunk;
+  if (Buffer.byteLength(next, 'utf8') <= MAX_CAPTURE_BYTES) return next;
+  throw new RiveCliError('output_too_large', `Rive output exceeded ${MAX_CAPTURE_BYTES} bytes`);
+}
+
+function tail(input: string): string {
+  return input.length <= TAIL_CHARS ? input : input.slice(input.length - TAIL_CHARS);
+}
+
+function parseRiveJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error('Rive produced no JSON output');
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const firstBrace = trimmed.indexOf('{');
+    const lastBrace = trimmed.lastIndexOf('}');
+    if (firstBrace >= 0 && lastBrace > firstBrace) {
+      return JSON.parse(trimmed.slice(firstBrace, lastBrace + 1));
+    }
+    throw new Error('Rive produced invalid JSON output');
+  }
+}
+
+function riveErrorMessage(envelope: unknown, exitCode: number): string {
+  if (envelope && typeof envelope === 'object') {
+    const message = (envelope as { error?: { message?: unknown }; message?: unknown }).error?.message
+      ?? (envelope as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) return redactRiveText(message);
+  }
+  return `Rive command failed with exit code ${exitCode}`;
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new RiveCliError('invalid_arguments', `${name} is required`);
+  }
+  return value;
+}
+
+function appendParams(args: string[], params: Record<string, string | number | boolean> | undefined): void {
+  if (!params) return;
+  for (const [key, value] of Object.entries(params)) {
+    if (!/^[A-Za-z0-9_.-]+$/.test(key)) {
+      throw new RiveCliError('invalid_arguments', `invalid workflow param key: ${key}`);
+    }
+    args.push('--param', `${key}=${String(value)}`);
+  }
+}
+
+function appendSchedulerOptions(
+  args: string[],
+  input: RiveCliToolArgs,
+  options: { requireWorkers: boolean; omitRunner?: boolean },
+): void {
+  if (!options.omitRunner && input.runner) args.push('--runner', input.runner);
+  const workers = input.workers ?? [];
+  if (options.requireWorkers && workers.length === 0) {
+    throw new RiveCliError('invalid_arguments', 'at least one worker is required when scheduler is enabled');
+  }
+  for (const worker of workers) args.push('--worker', worker);
+  if (input.maxParallel !== undefined) args.push('--max-parallel', String(assertPositiveInteger(input.maxParallel, 'maxParallel')));
+  if (input.acceptanceMode) args.push('--acceptance-mode', input.acceptanceMode);
+  if (input.workspaceMode) args.push('--workspace-mode', input.workspaceMode);
+  if (input.timeoutSeconds !== undefined) args.push('--timeout-seconds', String(assertPositiveInteger(input.timeoutSeconds, 'timeoutSeconds')));
+  if (input.opencodeBin) args.push('--opencode-bin', input.opencodeBin);
+  if (input.codexBin) args.push('--codex-bin', input.codexBin);
+  if (input.trustProject) args.push('--trust-project');
+}
+
+function assertPositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RiveCliError('invalid_arguments', `${name} must be a positive integer`);
+  }
+  return value;
+}

--- a/apps/desktop/src/main/rive-cli.ts
+++ b/apps/desktop/src/main/rive-cli.ts
@@ -122,7 +122,7 @@ export function buildRiveCommand(input: RiveCliToolArgs): string[] {
       if (!input.schedulerRunId && !input.rootWorkNodeId) {
         throw new RiveCliError('invalid_arguments', 'scheduler_resume requires schedulerRunId or rootWorkNodeId');
       }
-      appendSchedulerOptions(args, input, { requireWorkers: false });
+      appendSchedulerOptions(args, input, { requireWorkers: false, omitRunner: true });
       if (input.failed) args.push('--failed');
       return args;
     }
@@ -201,16 +201,19 @@ function spawnRive(
 ): Promise<RiveCliRunResult> {
   return new Promise((resolve, reject) => {
     const [bin, ...args] = command;
+    const detached = process.platform !== 'win32';
     const child = spawn(bin, args, {
       cwd: options.cwd,
       env: options.env,
       shell: false,
+      detached,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';
     let stderr = '';
     let settled = false;
-    let timedOut = false;
+    let termination: { reason: string; message: string } | null = null;
+    let killTimer: NodeJS.Timeout | null = null;
 
     const fail = (error: Error) => {
       if (settled) return;
@@ -218,23 +221,24 @@ function spawnRive(
       cleanup();
       reject(error);
     };
+    const requestTerminate = (reason: string, message: string) => {
+      if (settled || termination) return;
+      termination = { reason, message };
+      killRiveChild(child, 'SIGTERM', detached);
+      killTimer = setTimeout(() => {
+        if (!settled) killRiveChild(child, 'SIGKILL', detached);
+      }, 2_000);
+      killTimer.unref();
+    };
     const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill('SIGTERM');
-      setTimeout(() => {
-        if (!settled) child.kill('SIGKILL');
-      }, 2_000).unref();
+      requestTerminate('timeout', `Rive command timed out after ${options.timeoutMs}ms`);
     }, options.timeoutMs);
     const onAbort = () => {
-      child.kill('SIGTERM');
-      fail(new RiveCliError('aborted', 'Rive command was aborted', {
-        command,
-        stdoutTail: redactRiveText(tail(stdout)),
-        stderrTail: redactRiveText(tail(stderr)),
-      }));
+      requestTerminate('aborted', 'Rive command was aborted');
     };
     const cleanup = () => {
       clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
       options.abortSignal?.removeEventListener('abort', onAbort);
     };
     options.abortSignal?.addEventListener('abort', onAbort, { once: true });
@@ -244,8 +248,7 @@ function spawnRive(
       try {
         stdout = appendCapture(stdout, text);
       } catch (error) {
-        fail(error instanceof Error ? error : new Error(String(error)));
-        child.kill('SIGTERM');
+        requestTerminate('output_too_large', error instanceof Error ? error.message : String(error));
         return;
       }
       options.emitOutput?.('stdout', redactRiveText(text));
@@ -255,8 +258,7 @@ function spawnRive(
       try {
         stderr = appendCapture(stderr, text);
       } catch (error) {
-        fail(error instanceof Error ? error : new Error(String(error)));
-        child.kill('SIGTERM');
+        requestTerminate('output_too_large', error instanceof Error ? error.message : String(error));
         return;
       }
       options.emitOutput?.('stderr', redactRiveText(text));
@@ -277,8 +279,8 @@ function spawnRive(
       const stderrTail = tail(stderr);
       const redactedStdoutTail = redactRiveText(stdoutTail);
       const redactedStderrTail = redactRiveText(stderrTail);
-      if (timedOut) {
-        reject(new RiveCliError('timeout', `Rive command timed out after ${options.timeoutMs}ms`, {
+      if (termination) {
+        reject(new RiveCliError(termination.reason, termination.message, {
           command,
           stdoutTail: redactedStdoutTail,
           stderrTail: redactedStderrTail,
@@ -315,6 +317,22 @@ function spawnRive(
       });
     });
   });
+}
+
+function killRiveChild(child: ReturnType<typeof spawn>, signal: NodeJS.Signals, detached: boolean): void {
+  try {
+    if (detached && typeof child.pid === 'number') {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch {
+    // The process group may already be gone; fall through to direct child kill.
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // Best effort termination. The close/error event is still authoritative.
+  }
 }
 
 function appendCapture(current: string, chunk: string): string {

--- a/apps/desktop/src/main/rive-workflow-tool.ts
+++ b/apps/desktop/src/main/rive-workflow-tool.ts
@@ -1,0 +1,234 @@
+import { z } from 'zod';
+import type { MakaTool } from '@maka/runtime';
+import {
+  buildRiveCommand,
+  redactRiveText,
+  runRiveCli,
+  RiveCliError,
+  type RiveCliAction,
+  type RiveCliToolArgs,
+} from './rive-cli.js';
+
+export const RIVE_WORKFLOW_TOOL_NAME = 'RiveWorkflow';
+
+const actionSchema = z.enum([
+  'workflow_validate',
+  'workflow_import',
+  'workflow_run',
+  'workflow_status',
+  'scheduler_status',
+  'scheduler_resume',
+  'work_retry',
+  'branch_conflict_show',
+] satisfies [RiveCliAction, ...RiveCliAction[]]);
+
+const riveToolParameters = z.object({
+  action: actionSchema.describe(
+    'High-level Rive operation. Prefer workflow_run/status, scheduler_status/resume, and work_retry over low-level ledger commands.',
+  ),
+  path: z.string().min(1).max(2000).optional().describe('Workflow package path for validate/import.'),
+  templateId: z.string().min(1).max(240).optional().describe('Workflow template id for workflow_run.'),
+  workflowRunId: z.string().min(1).max(240).optional().describe('workflow_run_id for workflow_status.'),
+  schedulerRunId: z.string().min(1).max(240).optional().describe('scheduler_run_id for scheduler_status/resume.'),
+  rootWorkNodeId: z.string().min(1).max(240).optional().describe('root work node id for scheduler_status/resume.'),
+  workNodeId: z.string().min(1).max(240).optional().describe('work_node_id for work_retry.'),
+  conflictId: z.string().min(1).max(240).optional().describe('branch conflict id for branch_conflict_show.'),
+  commandId: z.string().min(1).max(240).optional().describe('Stable idempotency command id. Required for mutating/run actions.'),
+  params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional()
+    .describe('Workflow params as key/value pairs. Maka passes them to Rive as repeated --param key=value arguments.'),
+  bumpIfChanged: z.boolean().optional(),
+  noScheduler: z.boolean().optional(),
+  runner: z.enum(['opencode', 'codex']).optional(),
+  workers: z.array(z.string().min(1).max(200)).max(20).optional(),
+  maxParallel: z.number().int().positive().max(20).optional(),
+  acceptanceMode: z.enum(['manual', 'auto-reported', 'auto-committed']).optional(),
+  workspaceMode: z.enum(['shared', 'worktree']).optional(),
+  opencodeBin: z.string().min(1).max(2000).optional(),
+  codexBin: z.string().min(1).max(2000).optional(),
+  trustProject: z.boolean().optional(),
+  failed: z.boolean().optional().describe('For scheduler_resume, retry only failed/stale attempts.'),
+  timeoutSeconds: z.number().int().positive().max(60 * 60).optional(),
+  timeoutMs: z.number().int().positive().max(60 * 60 * 1000).optional()
+    .describe('Maka-side subprocess timeout. Defaults to 10 minutes.'),
+});
+
+export type RiveWorkflowToolArgs = z.infer<typeof riveToolParameters>;
+
+export interface RiveWorkflowToolResult {
+  kind: 'rive_workflow';
+  ok: boolean;
+  action: RiveCliAction;
+  command: string[];
+  state?: string;
+  ids: {
+    workflowRunId?: string;
+    schedulerRunId?: string;
+    rootWorkNodeId?: string;
+  };
+  summary: string;
+  protocol?: unknown;
+  display?: unknown;
+  stdoutTail?: string;
+  stderrTail?: string;
+  error?: {
+    reason: string;
+    message: string;
+    code?: string;
+    suggestedAction?: string;
+  };
+}
+
+export function buildRiveWorkflowTool(deps: {
+  riveBin?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): MakaTool<RiveWorkflowToolArgs, RiveWorkflowToolResult> {
+  return {
+    name: RIVE_WORKFLOW_TOOL_NAME,
+    displayName: 'Rive 工作流',
+    description:
+      'Use Rive to run or inspect durable multi-agent workflows from the current workspace. ' +
+      'This tool calls high-level Rive CLI commands only: workflow validate/import/run/status, scheduler status/resume, work retry, and conflict inspection. ' +
+      'Rive remains the source of truth for workflow state; judge success only from Rive protocol projections, never stdout, final answers, or debug traces. ' +
+      'Use this when a task benefits from a reusable workflow, parallel workers, retry/recovery, or ledger-backed artifact refs.',
+    parameters: riveToolParameters,
+    permissionRequired: true,
+    categoryHint: 'custom_tool',
+    impl: async (args, { cwd, abortSignal, emitOutput }) => {
+      let command: string[];
+      try {
+        command = [
+          deps.riveBin ?? deps.env?.MAKA_RIVE_BIN ?? deps.env?.RIVE_BIN ?? process.env.MAKA_RIVE_BIN ?? process.env.RIVE_BIN ?? 'rive',
+          ...buildRiveCommand(args),
+        ];
+      } catch (error) {
+        return failureResult(args.action, [], errorToReason(error), errorMessage(error));
+      }
+      emitOutput('stdout', `$ ${command.map(displayArg).join(' ')}\n`);
+      try {
+        const result = await runRiveCli(args, {
+          cwd,
+          riveBin: deps.riveBin,
+          env: deps.env ?? process.env,
+          abortSignal,
+          timeoutMs: args.timeoutMs,
+          emitOutput,
+        });
+        return successResult(args.action, result.command, result.envelope, result.stdoutTail, result.stderrTail);
+      } catch (error) {
+        if (error instanceof RiveCliError) {
+          return failureResult(args.action, error.command ?? command, error.reason, error.message, error);
+        }
+        return failureResult(args.action, command, 'process_error', errorMessage(error));
+      }
+    },
+  };
+}
+
+function successResult(
+  action: RiveCliAction,
+  command: string[],
+  envelope: unknown,
+  stdoutTail: string,
+  stderrTail: string,
+): RiveWorkflowToolResult {
+  const protocol = readEnvelopeField(envelope, 'protocol');
+  const display = readEnvelopeField(envelope, 'display');
+  return {
+    kind: 'rive_workflow',
+    ok: true,
+    action,
+    command: redactCommand(command),
+    state: extractState(protocol),
+    ids: extractIds(protocol),
+    summary: extractSummary(display, protocol, 'Rive command completed.'),
+    protocol,
+    display,
+    stdoutTail,
+    stderrTail,
+  };
+}
+
+function failureResult(
+  action: RiveCliAction,
+  command: string[],
+  reason: string,
+  message: string,
+  error?: RiveCliError,
+): RiveWorkflowToolResult {
+  const protocol = error?.envelope ? readEnvelopeField(error.envelope, 'protocol') : undefined;
+  const display = error?.envelope ? readEnvelopeField(error.envelope, 'display') : undefined;
+  const errorEnvelope = error?.envelope && typeof error.envelope === 'object'
+    ? (error.envelope as { error?: { code?: unknown; action?: unknown } }).error
+    : undefined;
+  return {
+    kind: 'rive_workflow',
+    ok: false,
+    action,
+    command: redactCommand(command),
+    state: extractState(protocol),
+    ids: extractIds(protocol),
+    summary: message,
+    protocol,
+    display,
+    stdoutTail: error?.stdoutTail ? redactRiveText(error.stdoutTail) : undefined,
+    stderrTail: error?.stderrTail ? redactRiveText(error.stderrTail) : undefined,
+    error: {
+      reason,
+      message,
+      ...(typeof errorEnvelope?.code === 'string' ? { code: errorEnvelope.code } : {}),
+      ...(typeof errorEnvelope?.action === 'string' ? { suggestedAction: errorEnvelope.action } : {}),
+    },
+  };
+}
+
+function extractIds(protocol: unknown): RiveWorkflowToolResult['ids'] {
+  if (!protocol || typeof protocol !== 'object') return {};
+  const obj = protocol as Record<string, unknown>;
+  const scheduler = obj.scheduler && typeof obj.scheduler === 'object' ? obj.scheduler as Record<string, unknown> : undefined;
+  return {
+    ...(typeof obj.workflow_run_id === 'string' ? { workflowRunId: obj.workflow_run_id } : {}),
+    ...(typeof obj.scheduler_run_id === 'string' ? { schedulerRunId: obj.scheduler_run_id } : {}),
+    ...(typeof scheduler?.scheduler_run_id === 'string' ? { schedulerRunId: scheduler.scheduler_run_id } : {}),
+    ...(typeof obj.root_work_node_id === 'string' ? { rootWorkNodeId: obj.root_work_node_id } : {}),
+    ...(typeof scheduler?.root_work_node_id === 'string' ? { rootWorkNodeId: scheduler.root_work_node_id } : {}),
+  };
+}
+
+function extractState(protocol: unknown): string | undefined {
+  if (!protocol || typeof protocol !== 'object') return undefined;
+  const obj = protocol as Record<string, unknown>;
+  if (typeof obj.state === 'string') return obj.state;
+  const scheduler = obj.scheduler && typeof obj.scheduler === 'object' ? obj.scheduler as Record<string, unknown> : undefined;
+  if (typeof scheduler?.state === 'string') return scheduler.state;
+  return undefined;
+}
+
+function extractSummary(display: unknown, protocol: unknown, fallback: string): string {
+  if (display && typeof display === 'object' && typeof (display as { summary?: unknown }).summary === 'string') {
+    return (display as { summary: string }).summary;
+  }
+  const state = extractState(protocol);
+  return state ? `Rive command completed with state ${state}.` : fallback;
+}
+
+function readEnvelopeField(envelope: unknown, field: 'protocol' | 'display'): unknown {
+  if (!envelope || typeof envelope !== 'object') return undefined;
+  return (envelope as Record<string, unknown>)[field];
+}
+
+function errorToReason(error: unknown): string {
+  return error instanceof RiveCliError ? error.reason : 'invalid_arguments';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function displayArg(value: string): string {
+  const redacted = redactRiveText(value);
+  return /^[A-Za-z0-9_./:@=-]+$/.test(redacted) ? redacted : JSON.stringify(redacted);
+}
+
+function redactCommand(command: string[]): string[] {
+  return command.map((part) => redactRiveText(part));
+}

--- a/apps/desktop/src/main/rive-workflow-tool.ts
+++ b/apps/desktop/src/main/rive-workflow-tool.ts
@@ -66,8 +66,8 @@ export interface RiveWorkflowToolResult {
     rootWorkNodeId?: string;
   };
   summary: string;
-  protocol?: unknown;
-  display?: unknown;
+  projection?: RiveWorkflowProjection;
+  nodes?: RiveWorkflowNodeSummary[];
   stdoutTail?: string;
   stderrTail?: string;
   error?: {
@@ -76,6 +76,28 @@ export interface RiveWorkflowToolResult {
     code?: string;
     suggestedAction?: string;
   };
+}
+
+interface RiveWorkflowProjection {
+  templateId?: string;
+  version?: number;
+  templateHash?: string;
+  idempotencyStatus?: string;
+  workflowRunId?: string;
+  schedulerRunId?: string;
+  rootWorkNodeId?: string;
+  state?: string;
+  schedulerState?: string;
+  rootState?: string;
+}
+
+interface RiveWorkflowNodeSummary {
+  id?: string;
+  templateId?: string;
+  title?: string;
+  state?: string;
+  runner?: string;
+  worker?: string;
 }
 
 export function buildRiveWorkflowTool(deps: {
@@ -133,16 +155,17 @@ function successResult(
 ): RiveWorkflowToolResult {
   const protocol = readEnvelopeField(envelope, 'protocol');
   const display = readEnvelopeField(envelope, 'display');
+  const projection = extractProjection(protocol);
   return {
     kind: 'rive_workflow',
     ok: true,
     action,
     command: redactCommand(command),
-    state: extractState(protocol),
-    ids: extractIds(protocol),
+    state: projection.state,
+    ids: extractIds(projection),
     summary: extractSummary(display, protocol, 'Rive command completed.'),
-    protocol,
-    display,
+    projection,
+    nodes: extractNodeSummaries(protocol),
     stdoutTail,
     stderrTail,
   };
@@ -156,7 +179,7 @@ function failureResult(
   error?: RiveCliError,
 ): RiveWorkflowToolResult {
   const protocol = error?.envelope ? readEnvelopeField(error.envelope, 'protocol') : undefined;
-  const display = error?.envelope ? readEnvelopeField(error.envelope, 'display') : undefined;
+  const projection = extractProjection(protocol);
   const errorEnvelope = error?.envelope && typeof error.envelope === 'object'
     ? (error.envelope as { error?: { code?: unknown; action?: unknown } }).error
     : undefined;
@@ -165,11 +188,11 @@ function failureResult(
     ok: false,
     action,
     command: redactCommand(command),
-    state: extractState(protocol),
-    ids: extractIds(protocol),
+    state: projection.state,
+    ids: extractIds(projection),
     summary: message,
-    protocol,
-    display,
+    projection,
+    nodes: extractNodeSummaries(protocol),
     stdoutTail: error?.stdoutTail ? redactRiveText(error.stdoutTail) : undefined,
     stderrTail: error?.stderrTail ? redactRiveText(error.stderrTail) : undefined,
     error: {
@@ -181,16 +204,11 @@ function failureResult(
   };
 }
 
-function extractIds(protocol: unknown): RiveWorkflowToolResult['ids'] {
-  if (!protocol || typeof protocol !== 'object') return {};
-  const obj = protocol as Record<string, unknown>;
-  const scheduler = obj.scheduler && typeof obj.scheduler === 'object' ? obj.scheduler as Record<string, unknown> : undefined;
+function extractIds(projection: RiveWorkflowProjection): RiveWorkflowToolResult['ids'] {
   return {
-    ...(typeof obj.workflow_run_id === 'string' ? { workflowRunId: obj.workflow_run_id } : {}),
-    ...(typeof obj.scheduler_run_id === 'string' ? { schedulerRunId: obj.scheduler_run_id } : {}),
-    ...(typeof scheduler?.scheduler_run_id === 'string' ? { schedulerRunId: scheduler.scheduler_run_id } : {}),
-    ...(typeof obj.root_work_node_id === 'string' ? { rootWorkNodeId: obj.root_work_node_id } : {}),
-    ...(typeof scheduler?.root_work_node_id === 'string' ? { rootWorkNodeId: scheduler.root_work_node_id } : {}),
+    ...(projection.workflowRunId ? { workflowRunId: projection.workflowRunId } : {}),
+    ...(projection.schedulerRunId ? { schedulerRunId: projection.schedulerRunId } : {}),
+    ...(projection.rootWorkNodeId ? { rootWorkNodeId: projection.rootWorkNodeId } : {}),
   };
 }
 
@@ -201,6 +219,63 @@ function extractState(protocol: unknown): string | undefined {
   const scheduler = obj.scheduler && typeof obj.scheduler === 'object' ? obj.scheduler as Record<string, unknown> : undefined;
   if (typeof scheduler?.state === 'string') return scheduler.state;
   return undefined;
+}
+
+function extractProjection(protocol: unknown): RiveWorkflowProjection {
+  if (!protocol || typeof protocol !== 'object') return {};
+  const obj = protocol as Record<string, unknown>;
+  const scheduler = obj.scheduler && typeof obj.scheduler === 'object' ? obj.scheduler as Record<string, unknown> : undefined;
+  const rootWork = obj.root_work && typeof obj.root_work === 'object' ? obj.root_work as Record<string, unknown> : undefined;
+  const rootProjection = obj.root_projection && typeof obj.root_projection === 'object' ? obj.root_projection as Record<string, unknown> : undefined;
+  const projection: RiveWorkflowProjection = {
+    ...(typeof obj.template_id === 'string' ? { templateId: obj.template_id } : {}),
+    ...(typeof obj.version === 'number' ? { version: obj.version } : {}),
+    ...(typeof obj.template_hash === 'string' ? { templateHash: obj.template_hash } : {}),
+    ...(typeof obj.idempotency_status === 'string' ? { idempotencyStatus: obj.idempotency_status } : {}),
+    ...(typeof obj.workflow_run_id === 'string' ? { workflowRunId: obj.workflow_run_id } : {}),
+    ...(typeof obj.scheduler_run_id === 'string' ? { schedulerRunId: obj.scheduler_run_id } : {}),
+    ...(typeof scheduler?.scheduler_run_id === 'string' ? { schedulerRunId: scheduler.scheduler_run_id } : {}),
+    ...(typeof obj.root_work_node_id === 'string' ? { rootWorkNodeId: obj.root_work_node_id } : {}),
+    ...(typeof scheduler?.root_work_node_id === 'string' ? { rootWorkNodeId: scheduler.root_work_node_id } : {}),
+    ...(typeof obj.state === 'string' ? { state: obj.state } : {}),
+    ...(typeof scheduler?.state === 'string' ? { schedulerState: scheduler.state } : {}),
+    ...(typeof rootWork?.state === 'string' ? { rootState: rootWork.state } : {}),
+    ...(typeof rootProjection?.state === 'string' ? { rootState: rootProjection.state } : {}),
+  };
+  if (!projection.state) {
+    projection.state = projection.schedulerState ?? projection.rootState ?? extractState(protocol);
+  }
+  return projection;
+}
+
+function extractNodeSummaries(protocol: unknown): RiveWorkflowNodeSummary[] | undefined {
+  if (!protocol || typeof protocol !== 'object') return undefined;
+  const obj = protocol as Record<string, unknown>;
+  const rawNodes = Array.isArray(obj.nodes)
+    ? obj.nodes
+    : Array.isArray(obj.workflow_run_nodes)
+      ? obj.workflow_run_nodes
+      : Array.isArray(obj.node_mapping)
+        ? obj.node_mapping
+        : [];
+  const nodes = rawNodes
+    .slice(0, 20)
+    .map((node): RiveWorkflowNodeSummary => {
+      if (!node || typeof node !== 'object') return {};
+      const value = node as Record<string, unknown>;
+      return {
+        ...(typeof value.work_node_id === 'string' ? { id: value.work_node_id } : {}),
+        ...(typeof value.id === 'string' ? { id: value.id } : {}),
+        ...(typeof value.node_template_id === 'string' ? { templateId: value.node_template_id } : {}),
+        ...(typeof value.template_id === 'string' ? { templateId: value.template_id } : {}),
+        ...(typeof value.title === 'string' ? { title: value.title } : {}),
+        ...(typeof value.state === 'string' ? { state: value.state } : {}),
+        ...(typeof value.runner === 'string' ? { runner: value.runner } : {}),
+        ...(typeof value.worker === 'string' ? { worker: value.worker } : {}),
+      };
+    })
+    .filter((node) => Object.keys(node).length > 0);
+  return nodes.length > 0 ? nodes : undefined;
 }
 
 function extractSummary(display: unknown, protocol: unknown, fallback: string): string {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -226,6 +226,29 @@ export type ToolResultContent =
       notes: string[];
       reason?: 'invalid_objective' | 'invalid_root' | 'no_readable_roots' | 'aborted';
       message?: string;
+    }
+  | {
+      kind: 'rive_workflow';
+      ok: boolean;
+      action: string;
+      command: string[];
+      state?: string;
+      ids: {
+        workflowRunId?: string;
+        schedulerRunId?: string;
+        rootWorkNodeId?: string;
+      };
+      summary: string;
+      protocol?: unknown;
+      display?: unknown;
+      stdoutTail?: string;
+      stderrTail?: string;
+      error?: {
+        reason: string;
+        message: string;
+        code?: string;
+        suggestedAction?: string;
+      };
     };
 
 export interface PermissionRequestEvent extends BaseEvent {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -239,8 +239,26 @@ export type ToolResultContent =
         rootWorkNodeId?: string;
       };
       summary: string;
-      protocol?: unknown;
-      display?: unknown;
+      projection?: {
+        templateId?: string;
+        version?: number;
+        templateHash?: string;
+        idempotencyStatus?: string;
+        workflowRunId?: string;
+        schedulerRunId?: string;
+        rootWorkNodeId?: string;
+        state?: string;
+        schedulerState?: string;
+        rootState?: string;
+      };
+      nodes?: ReadonlyArray<{
+        id?: string;
+        templateId?: string;
+        title?: string;
+        state?: string;
+        runner?: string;
+        worker?: string;
+      }>;
       stdoutTail?: string;
       stderrTail?: string;
       error?: {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1112,6 +1112,7 @@ function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecor
   if (content.kind === 'explore_agent' && content.ok === false) {
     return content.reason === 'aborted' ? 'aborted' : 'error';
   }
+  if (content.kind === 'rive_workflow' && content.ok === false) return 'error';
   if (content.kind === 'web_search_error') return 'error';
   if (content.kind === 'office_document' && content.ok === false) return 'error';
   return 'success';

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5823,6 +5823,10 @@ function extractErrorText(result: ToolActivityItem['result']): string {
       return result.stderr || result.stdout || `exit ${result.exitCode}`;
     case 'file_diff':
       return result.diff;
+    case 'rive_workflow':
+      return result.error
+        ? [result.summary, result.error.reason, result.error.message].filter(Boolean).join('\n')
+        : result.summary;
     default:
       return result.kind;
   }
@@ -6418,6 +6422,10 @@ function OverlayPreview(props: { content: ToolResultContent }) {
     return <ExploreAgentPreview result={content} />;
   }
 
+  if (content.kind === 'rive_workflow') {
+    return <RiveWorkflowPreview result={content} />;
+  }
+
   if (content.kind === 'json') {
     let body: string;
     try {
@@ -6448,6 +6456,62 @@ function OverlayPreview(props: { content: ToolResultContent }) {
       [{content.kind}]
     </pre>
   );
+}
+
+function RiveWorkflowPreview(props: {
+  result: Extract<ToolResultContent, { kind: 'rive_workflow' }>;
+}) {
+  const { result } = props;
+  const rows = [
+    ['动作', result.action],
+    ['状态', result.state ?? result.projection?.state],
+    ['workflow_run', result.ids.workflowRunId ?? result.projection?.workflowRunId],
+    ['scheduler_run', result.ids.schedulerRunId ?? result.projection?.schedulerRunId],
+    ['root_work', result.ids.rootWorkNodeId ?? result.projection?.rootWorkNodeId],
+    ['scheduler_state', result.projection?.schedulerState],
+    ['root_state', result.projection?.rootState],
+  ].filter((row): row is [string, string] => typeof row[1] === 'string' && row[1].length > 0);
+  const nodes = (result.nodes ?? []).slice(0, 12);
+  const failureLines = result.error
+    ? [
+        '',
+        '错误',
+        `reason: ${result.error.reason}`,
+        `message: ${result.error.message}`,
+        result.error.code ? `code: ${result.error.code}` : '',
+        result.error.suggestedAction ? `suggested_action: ${result.error.suggestedAction}` : '',
+      ].filter(Boolean)
+    : [];
+  const diagnosticLines = [
+    result.stdoutTail ? `stdout_tail:\n${redactSecrets(result.stdoutTail)}` : '',
+    result.stderrTail ? `stderr_tail:\n${redactSecrets(result.stderrTail)}` : '',
+  ].filter(Boolean);
+  const body = [
+    result.ok ? 'Rive workflow completed' : 'Rive workflow failed',
+    result.summary,
+    '',
+    ...rows.map(([label, value]) => `${label}: ${value}`),
+    ...(nodes.length > 0 ? ['', '节点摘要', ...nodes.map(formatRiveWorkflowNode)] : []),
+    ...failureLines,
+    ...(diagnosticLines.length > 0 ? ['', '诊断片段', ...diagnosticLines] : []),
+  ].join('\n');
+  const cappedPreview = capLines(body);
+  return (
+    <pre className="maka-overlay-preview" data-kind="rive_workflow">
+      {cappedPreview.body}
+      {cappedPreview.capped > 0 && `\n\n… 已隐藏 ${cappedPreview.capped} 行`}
+    </pre>
+  );
+}
+
+function formatRiveWorkflowNode(node: NonNullable<Extract<ToolResultContent, { kind: 'rive_workflow' }>['nodes']>[number]): string {
+  const label = node.title ?? node.templateId ?? node.id ?? 'node';
+  const attrs = [
+    node.state,
+    node.runner ? `runner=${node.runner}` : '',
+    node.worker ? `worker=${node.worker}` : '',
+  ].filter(Boolean).join(' · ');
+  return attrs ? `- ${label}: ${attrs}` : `- ${label}`;
 }
 
 function ExploreAgentPreview(props: {


### PR DESCRIPTION
## Summary
- Add a permission-gated `RiveWorkflow` MakaTool registered with the existing builtin tools.
- Add a main-process Rive CLI bridge with shell-free argv construction, timeout/abort handling, JSON envelope parsing, stdout/stderr tails, and secret redaction.
- Return/store only Rive projection refs and summaries: workflow_run_id, scheduler_run_id, root_work_node_id, state, protocol/display refs. Rive remains the source of truth.
- Mark `rive_workflow` tool results with `ok: false` as tool errors while keeping the default backend unchanged.

## Boundaries
- MakaTool-first integration only; no `RiveBackend`, no `BackendKind` default-path changes.
- Maka does not read or write `.rive` SQLite directly.
- Success is parsed from Rive workflow/scheduler/work protocol projections only; stdout/final answers/debug trace are diagnostic only.
- Tool remains `permissionRequired=true` with existing `custom_tool` category; no new PermissionMode/ToolCategory.

## Validation
- `node --test apps/desktop/dist/main/__tests__/rive-workflow-tool.test.js`
- `npm --workspace @maka/desktop test`
- `npm run typecheck`
- `git diff --check`
- Real bridge smoke with local Rive binary: imported sentinel workflow and ran `workflow run --no-scheduler`, returning `wfrun_b22a7014a5964f9590dc5d222f82537e` and root `work_0dd8e658edaf477c806b4ac4ae209e7f` in `instantiated` state.
