### PR TITLE
Add RuntimeEvent read model projection

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,6 +27,7 @@
     "./telemetry": "./dist/telemetry/index.js",
     "./bots": "./dist/bots/index.js",
     "./runtime-event-adapters": "./dist/runtime-event-adapters.js",
+    "./runtime-event-read-model": "./dist/runtime-event-read-model.js",
     "./model-history": "./dist/model-history.js",
     "./invocation-context": "./dist/invocation-context.js",
     "./runtime-runner": "./dist/runtime-runner.js",

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -1,0 +1,545 @@
+import { describe, test } from 'node:test';
+import type {
+  AgentRunHeader,
+  CreateSessionInput,
+  RuntimeEvent,
+  SessionHeader,
+  SessionListFilter,
+  SessionSummary,
+  StoredMessage,
+  TurnRecord,
+} from '@maka/core';
+import { deriveTurnRecords } from '@maka/core';
+import { expect } from '../test-helpers.js';
+import {
+  compareRuntimeReadModelMessages,
+  projectRuntimeEventsToStoredMessages,
+} from '../runtime-event-read-model.js';
+import { materializeSession } from '../materializer.js';
+import {
+  BackendRegistry,
+  SessionManager,
+  type SessionStore,
+} from '../session-manager.js';
+
+const ts = 1_800_000_000_000;
+const sessionId = 'sess-1';
+const runId = 'run-1';
+const turnId = 'turn-1';
+const invocationId = 'inv-1';
+let eventSeq = 0;
+
+const header: AgentRunHeader = {
+  runId,
+  sessionId,
+  turnId,
+  status: 'completed',
+  backendKind: 'ai-sdk',
+  llmConnectionSlug: 'anthropic',
+  modelId: 'claude-sonnet-4-5',
+  cwd: '/tmp/work',
+  permissionMode: 'ask',
+  createdAt: ts,
+  updatedAt: ts + 20,
+  completedAt: ts + 20,
+  parentTurnId: 'parent-turn',
+};
+
+function ev(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  eventSeq += 1;
+  return {
+    id: `event-${eventSeq}`,
+    invocationId,
+    runId,
+    sessionId,
+    turnId,
+    ts,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function baseEvents(): RuntimeEvent[] {
+  return [
+    ev({
+      id: 'evt-user',
+      ts: ts + 1,
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: 'read the file' },
+      refs: { storedMessageId: 'legacy-user' },
+    }),
+    ev({
+      id: 'evt-tool-call',
+      ts: ts + 2,
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'tool-1',
+        name: 'Read',
+        args: { path: '/tmp/a.txt' },
+      },
+      actions: { stateDelta: { displayName: 'Read file', intent: 'inspect' } },
+      refs: { toolCallId: 'tool-1' },
+    }),
+    ev({
+      id: 'evt-permission-request',
+      ts: ts + 3,
+      role: 'system',
+      author: 'system',
+      actions: {
+        permissionRequest: {
+          requestId: 'req-1',
+          toolUseId: 'tool-1',
+          toolName: 'Read',
+          category: 'read',
+          reason: 'custom',
+          args: { path: '/tmp/a.txt' },
+          hint: 'needs read access',
+        },
+      },
+      refs: { toolCallId: 'tool-1' },
+    }),
+    ev({
+      id: 'evt-permission-decision',
+      ts: ts + 4,
+      role: 'system',
+      author: 'user',
+      actions: {
+        permissionDecision: {
+          requestId: 'req-1',
+          decision: 'allow',
+          rememberForTurn: true,
+        },
+      },
+      refs: { toolCallId: 'tool-1' },
+    }),
+    ev({
+      id: 'evt-tool-result',
+      ts: ts + 5,
+      role: 'tool',
+      author: 'tool',
+      content: {
+        kind: 'function_response',
+        id: 'tool-1',
+        name: 'Read',
+        result: { kind: 'text', text: 'file contents' },
+      },
+      actions: { stateDelta: { durationMs: 42 } },
+      refs: { toolCallId: 'tool-1', storedMessageId: 'legacy-result' },
+    }),
+    ev({
+      id: 'evt-assistant',
+      ts: ts + 6,
+      role: 'model',
+      author: 'agent',
+      content: { kind: 'text', text: 'The file says: file contents' },
+      refs: { storedMessageId: 'legacy-assistant' },
+    }),
+    ev({
+      id: 'evt-token',
+      ts: ts + 7,
+      role: 'system',
+      author: 'system',
+      actions: {
+        tokenUsage: {
+          input: 100,
+          output: 25,
+          cacheRead: 10,
+          costUsd: 0.002,
+          contextRemaining: 9000,
+        },
+      },
+    }),
+    ev({
+      id: 'evt-complete',
+      ts: ts + 8,
+      role: 'system',
+      author: 'system',
+      status: 'completed',
+      actions: { endInvocation: true },
+    }),
+  ];
+}
+
+function equivalentLegacyMessages(): StoredMessage[] {
+  return [
+    {
+      type: 'user',
+      id: 'legacy-user',
+      turnId,
+      ts: ts + 1,
+      text: 'read the file',
+    },
+    {
+      type: 'tool_call',
+      id: 'tool-1',
+      turnId,
+      ts: ts + 2,
+      toolName: 'Read',
+      displayName: 'Read file',
+      intent: 'inspect',
+      args: { path: '/tmp/a.txt' },
+    },
+    {
+      type: 'permission_decision',
+      id: 'req-1',
+      turnId,
+      ts: ts + 4,
+      toolUseId: 'tool-1',
+      toolName: 'Read',
+      decision: 'allow',
+      rememberForTurn: true,
+      hint: 'needs read access',
+    },
+    {
+      type: 'tool_result',
+      id: 'legacy-result',
+      turnId,
+      ts: ts + 5,
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'text', text: 'file contents' },
+      durationMs: 42,
+    },
+    {
+      type: 'assistant',
+      id: 'legacy-assistant',
+      turnId,
+      ts: ts + 6,
+      text: 'The file says: file contents',
+      modelId: 'claude-sonnet-4-5',
+    },
+    {
+      type: 'token_usage',
+      id: 'evt-token',
+      turnId,
+      ts: ts + 7,
+      input: 100,
+      output: 25,
+      cacheRead: 10,
+      costUsd: 0.002,
+    },
+    {
+      type: 'turn_state',
+      id: 'evt-complete',
+      turnId,
+      ts: ts + 8,
+      status: 'completed',
+      parentTurnId: 'parent-turn',
+      partialOutputRetained: true,
+    },
+  ];
+}
+
+describe('projectRuntimeEventsToStoredMessages', () => {
+  test('full RuntimeEvent turn projects legacy-compatible rows', () => {
+    const out = projectRuntimeEventsToStoredMessages(baseEvents(), { runHeaders: [header] });
+
+    expect(out.messages.map((message) => message.type)).toEqual([
+      'user',
+      'tool_call',
+      'permission_decision',
+      'tool_result',
+      'assistant',
+      'token_usage',
+      'turn_state',
+    ]);
+    expect(out.messages[1]).toMatchObject({
+      type: 'tool_call',
+      id: 'tool-1',
+      toolName: 'Read',
+      displayName: 'Read file',
+      intent: 'inspect',
+    });
+    expect(out.messages[2]).toMatchObject({
+      type: 'permission_decision',
+      id: 'req-1',
+      toolUseId: 'tool-1',
+      toolName: 'Read',
+      decision: 'allow',
+      hint: 'needs read access',
+    });
+    expect(out.messages[3]).toMatchObject({
+      type: 'tool_result',
+      id: 'legacy-result',
+      toolUseId: 'tool-1',
+      durationMs: 42,
+    });
+    expect(out.messages[4]).toMatchObject({
+      type: 'assistant',
+      modelId: 'claude-sonnet-4-5',
+      text: 'The file says: file contents',
+    });
+    expect(out.messages[6]).toMatchObject({
+      type: 'turn_state',
+      status: 'completed',
+      parentTurnId: 'parent-turn',
+      partialOutputRetained: true,
+    });
+    expect(out.diagnostics.map((diag) => diag.code)).toEqual(['context_remaining_unsupported']);
+  });
+
+  test('projected rows materialize to the same runtime view model as equivalent legacy rows', () => {
+    const out = projectRuntimeEventsToStoredMessages(baseEvents(), { runHeaders: [header] });
+    const projected = materializeSession(out.messages);
+    const legacy = materializeSession(equivalentLegacyMessages());
+
+    expect(projected).toEqual(legacy);
+  });
+
+  test('partial RuntimeEvents are excluded', () => {
+    const out = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-partial',
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'streaming' },
+      }),
+      ev({
+        id: 'evt-final',
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'final' },
+      }),
+    ], { runHeaders: [header] });
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({ type: 'assistant', text: 'final' });
+    expect(out.diagnostics.map((diag) => diag.code)).toEqual(['partial_skipped']);
+  });
+
+  test('unsupported and incomplete events are diagnostic-only', () => {
+    const out = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-thinking',
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'private reasoning' },
+      }),
+      ev({
+        id: 'evt-permission-orphan',
+        actions: {
+          permissionDecision: {
+            requestId: 'missing-request',
+            decision: 'deny',
+          },
+        },
+      }),
+      ev({
+        id: 'evt-invalid-result',
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'tool-x',
+          name: 'Read',
+          result: 'plain string is not ToolResultContent',
+        },
+      }),
+    ], { runHeaders: [header] });
+
+    expect(out.messages).toEqual([]);
+    expect(out.diagnostics.map((diag) => diag.code)).toEqual([
+      'unsupported_event',
+      'unsupported_event',
+      'incomplete_event',
+      'unsupported_event',
+      'incomplete_event',
+      'unsupported_event',
+    ]);
+  });
+
+  test('failed terminal RuntimeEvent maps to failed turn state when run header carries failure class', () => {
+    const out = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-failed',
+        ts: ts + 9,
+        status: 'failed',
+        actions: { endInvocation: true },
+      }),
+    ], {
+      runHeaders: [{ ...header, status: 'failed', failureClass: 'tool_failed' }],
+    });
+
+    expect(out.messages).toEqual([{
+      type: 'turn_state',
+      id: 'evt-failed',
+      turnId,
+      ts: ts + 9,
+      status: 'failed',
+      parentTurnId: 'parent-turn',
+      errorClass: 'tool_failed',
+      partialOutputRetained: false,
+    }]);
+    expect(out.diagnostics).toEqual([]);
+  });
+});
+
+describe('compareRuntimeReadModelMessages', () => {
+  test('accepts semantically equivalent projected and legacy messages despite id differences', () => {
+    const projected = projectRuntimeEventsToStoredMessages(baseEvents(), { runHeaders: [header] });
+    const legacyWithDifferentIds = equivalentLegacyMessages().map((message) => {
+      if (message.type === 'tool_call' || message.type === 'permission_decision') return message;
+      return { ...message, id: `different-${message.id}` } as StoredMessage;
+    });
+    const result = compareRuntimeReadModelMessages(projected.messages, legacyWithDifferentIds);
+
+    expect(result.compatible).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('treats nested JSON with different property order as compatible', () => {
+    const projected = projectRuntimeEventsToStoredMessages([
+      ev({
+        id: 'evt-tool-call-json',
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'tool-json',
+          name: 'JsonTool',
+          args: { beta: 2, alpha: { z: 3, a: 1 } },
+        },
+      }),
+      ev({
+        id: 'evt-tool-result-json',
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'tool-json',
+          name: 'JsonTool',
+          result: { kind: 'json', value: { outer: { y: 2, x: 1 }, list: [{ b: 2, a: 1 }] } },
+        },
+      }),
+    ], { runHeaders: [header] });
+    const legacy: StoredMessage[] = [
+      {
+        type: 'tool_call',
+        id: 'tool-json',
+        turnId,
+        ts,
+        toolName: 'JsonTool',
+        args: { alpha: { a: 1, z: 3 }, beta: 2 },
+      },
+      {
+        type: 'tool_result',
+        id: 'different-result-id',
+        turnId,
+        ts,
+        toolUseId: 'tool-json',
+        isError: false,
+        content: { kind: 'json', value: { list: [{ a: 1, b: 2 }], outer: { x: 1, y: 2 } } },
+      },
+    ];
+
+    const result = compareRuntimeReadModelMessages(projected.messages, legacy);
+
+    expect(result.compatible).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('rejects missing tool result and assistant text cases', () => {
+    const projected = projectRuntimeEventsToStoredMessages(baseEvents(), { runHeaders: [header] });
+    const missing = projected.messages.filter((message) =>
+      message.type !== 'tool_result' && message.type !== 'assistant'
+    );
+    const result = compareRuntimeReadModelMessages(missing, equivalentLegacyMessages());
+
+    expect(result.compatible).toBe(false);
+    expect(result.diagnostics.map((diag) => diag.code)).toEqual([
+      'missing_legacy_message',
+      'missing_legacy_message',
+    ]);
+  });
+});
+
+describe('SessionManager read behavior', () => {
+  test('getMessages still returns legacy stored messages from the SessionStore', async () => {
+    const messages: StoredMessage[] = equivalentLegacyMessages();
+    const store = new ReadOnlyStore(messages);
+    const manager = new SessionManager({
+      store,
+      backends: new BackendRegistry(),
+      newId: () => 'id',
+      now: () => ts,
+    });
+
+    const out = await manager.getMessages(sessionId);
+
+    expect(out).toEqual(messages);
+    expect(store.readMessagesCalls).toBe(1);
+  });
+});
+
+class ReadOnlyStore implements SessionStore {
+  readMessagesCalls = 0;
+
+  constructor(private readonly messages: StoredMessage[]) {}
+
+  async create(_input: CreateSessionInput): Promise<SessionHeader> {
+    throw new Error('not implemented');
+  }
+
+  async list(_filter?: SessionListFilter): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async readHeader(id: string): Promise<SessionHeader> {
+    return makeHeader(id);
+  }
+
+  async readMessages(_sessionId: string): Promise<StoredMessage[]> {
+    this.readMessagesCalls += 1;
+    return [...this.messages];
+  }
+
+  async listTurns(_sessionId: string): Promise<TurnRecord[]> {
+    return deriveTurnRecords(this.messages);
+  }
+
+  async appendMessage(_sessionId: string, _m: StoredMessage): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async appendMessages(_sessionId: string, _ms: StoredMessage[]): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async updateHeader(id: string, patch: Partial<SessionHeader>): Promise<SessionHeader> {
+    return { ...makeHeader(id), ...patch };
+  }
+
+  async archive(_sessionId: string): Promise<void> {}
+  async unarchive(_sessionId: string): Promise<void> {}
+  async setFlagged(_sessionId: string, _isFlagged: boolean): Promise<void> {}
+  async rename(_sessionId: string, _name: string): Promise<void> {}
+  async remove(_sessionId: string): Promise<void> {}
+}
+
+function makeHeader(id: string): SessionHeader {
+  return {
+    id,
+    workspaceRoot: '/tmp/work',
+    cwd: '/tmp/work',
+    createdAt: ts,
+    lastUsedAt: ts,
+    name: 'Session',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    hasUnread: false,
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    connectionLocked: false,
+    model: 'fake-model',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -176,6 +176,19 @@ export type {
   RuntimeEventToDraftOptions,
 } from './runtime-event-adapters.js';
 
+// runtime-event-read-model.ts — side-by-side RuntimeEvent read projection.
+export {
+  projectRuntimeEventsToStoredMessages,
+  compareRuntimeReadModelMessages,
+} from './runtime-event-read-model.js';
+export type {
+  ProjectRuntimeEventsToStoredMessagesOptions,
+  RuntimeEventReadModelDiagnostic,
+  RuntimeEventReadModelDiagnosticCode,
+  RuntimeEventReadModelProjection,
+  RuntimeReadModelCompatibilityResult,
+} from './runtime-event-read-model.js';
+
 // model-history.ts — policy-driven model-history projection.
 export { buildModelHistoryFromRuntimeEvents } from './model-history.js';
 export type {

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -1,0 +1,574 @@
+import type {
+  AgentRunHeader,
+  RuntimeEvent,
+  RuntimeEventStatus,
+  StoredMessage,
+  ToolResultContent,
+  TurnStatus,
+} from '@maka/core';
+import {
+  isPartialRuntimeEvent,
+  isTerminalRuntimeEvent,
+} from '@maka/core';
+
+export type RuntimeEventReadModelDiagnosticCode =
+  | 'partial_skipped'
+  | 'unsupported_event'
+  | 'incomplete_event'
+  | 'generated_id'
+  | 'context_remaining_unsupported'
+  | 'tool_use_id_mismatch'
+  | 'missing_legacy_message'
+  | 'unexpected_projected_message';
+
+export interface RuntimeEventReadModelDiagnostic {
+  code: RuntimeEventReadModelDiagnosticCode;
+  eventId?: string;
+  runId?: string;
+  turnId?: string;
+  message: string;
+  detail?: unknown;
+}
+
+export interface RuntimeEventReadModelProjection {
+  messages: StoredMessage[];
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+}
+
+export interface ProjectRuntimeEventsToStoredMessagesOptions {
+  runHeaders: readonly AgentRunHeader[] | Readonly<Record<string, AgentRunHeader>>;
+}
+
+export interface RuntimeReadModelCompatibilityResult {
+  compatible: boolean;
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+}
+
+interface ProjectionState {
+  headers: Map<string, AgentRunHeader>;
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+  toolNameByUseId: Map<string, string>;
+  permissionRequestById: Map<string, {
+    requestId: string;
+    toolUseId: string;
+    toolName: string;
+    hint?: string;
+  }>;
+}
+
+export function projectRuntimeEventsToStoredMessages(
+  events: readonly RuntimeEvent[],
+  options: ProjectRuntimeEventsToStoredMessagesOptions,
+): RuntimeEventReadModelProjection {
+  const state: ProjectionState = {
+    headers: normalizeHeaders(options.runHeaders),
+    diagnostics: [],
+    toolNameByUseId: new Map(),
+    permissionRequestById: new Map(),
+  };
+  const messages: StoredMessage[] = [];
+
+  for (const event of events) {
+    if (isPartialRuntimeEvent(event)) {
+      diagnostic(state, event, 'partial_skipped', 'partial RuntimeEvent skipped');
+      continue;
+    }
+
+    let projected = false;
+    const content = event.content;
+    if (content) {
+      switch (content.kind) {
+        case 'text':
+          projected = projectText(event, state, messages) || projected;
+          break;
+        case 'function_call':
+          projected = projectFunctionCall(event, state, messages) || projected;
+          break;
+        case 'function_response':
+          projected = projectFunctionResponse(event, state, messages) || projected;
+          break;
+        case 'thinking':
+          diagnostic(state, event, 'unsupported_event', 'thinking content has no legacy read-model row');
+          break;
+        case 'error':
+          if (!isTerminalRuntimeEvent(event)) {
+            diagnostic(state, event, 'unsupported_event', 'non-terminal error content has no safe legacy read-model row');
+          }
+          break;
+      }
+    }
+
+    if (event.actions?.permissionRequest) {
+      const request = event.actions.permissionRequest;
+      state.permissionRequestById.set(request.requestId, {
+        requestId: request.requestId,
+        toolUseId: request.toolUseId,
+        toolName: request.toolName,
+        ...(request.hint !== undefined ? { hint: request.hint } : {}),
+      });
+      state.toolNameByUseId.set(request.toolUseId, request.toolName);
+      projected = true;
+    }
+
+    if (event.actions?.permissionDecision) {
+      projected = projectPermissionDecision(event, state, messages) || projected;
+    }
+
+    if (event.actions?.tokenUsage) {
+      projected = projectTokenUsage(event, state, messages) || projected;
+    }
+
+    if (isTerminalRuntimeEvent(event)) {
+      projected = projectTerminalTurnState(event, state, messages) || projected;
+    }
+
+    if (event.actions?.tokenUsage?.contextRemaining !== undefined) {
+      diagnostic(state, event, 'context_remaining_unsupported', 'token usage contextRemaining is diagnostic-only in StoredMessage');
+    }
+
+    if (!projected) {
+      diagnostic(state, event, 'unsupported_event', 'RuntimeEvent shape is not supported by the legacy read-model projection');
+    }
+  }
+
+  return { messages, diagnostics: state.diagnostics };
+}
+
+export function compareRuntimeReadModelMessages(
+  projected: readonly StoredMessage[],
+  legacy: readonly StoredMessage[],
+): RuntimeReadModelCompatibilityResult {
+  const diagnostics: RuntimeEventReadModelDiagnostic[] = [];
+  const projectedCounts = countSemanticMessages(projected);
+  const legacyCounts = countSemanticMessages(legacy);
+
+  for (const [key, count] of legacyCounts) {
+    const projectedCount = projectedCounts.get(key) ?? 0;
+    if (projectedCount < count) {
+      diagnostics.push({
+        code: 'missing_legacy_message',
+        message: 'projected RuntimeEvent read model is missing a legacy semantic message',
+        detail: JSON.parse(key) as unknown,
+      });
+    }
+  }
+
+  for (const [key, count] of projectedCounts) {
+    const legacyCount = legacyCounts.get(key) ?? 0;
+    if (legacyCount < count) {
+      diagnostics.push({
+        code: 'unexpected_projected_message',
+        message: 'projected RuntimeEvent read model has no matching legacy semantic message',
+        detail: JSON.parse(key) as unknown,
+      });
+    }
+  }
+
+  return { compatible: diagnostics.length === 0, diagnostics };
+}
+
+function projectText(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  if (event.content?.kind !== 'text') return false;
+  if (event.role === 'user') {
+    messages.push({
+      type: 'user',
+      id: stableMessageId(event, state, 'user'),
+      turnId: event.turnId,
+      ts: event.ts,
+      text: event.content.text,
+      ...(event.content.attachments !== undefined && event.content.attachments.length > 0
+        ? { attachments: event.content.attachments }
+        : {}),
+    });
+    return true;
+  }
+
+  if (event.role === 'model') {
+    const header = state.headers.get(event.runId);
+    if (!header?.modelId) {
+      diagnostic(state, event, 'incomplete_event', 'model text RuntimeEvent requires AgentRunHeader.modelId');
+      return false;
+    }
+    messages.push({
+      type: 'assistant',
+      id: stableMessageId(event, state, 'assistant'),
+      turnId: event.turnId,
+      ts: event.ts,
+      text: event.content.text,
+      modelId: header.modelId,
+    });
+    return true;
+  }
+
+  diagnostic(state, event, 'unsupported_event', `text content with role ${event.role} is not projected`);
+  return false;
+}
+
+function projectFunctionCall(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  if (event.content?.kind !== 'function_call') return false;
+  const toolUseId = toolUseIdFor(event);
+  if (!toolUseId) {
+    diagnostic(state, event, 'incomplete_event', 'function_call RuntimeEvent requires content.id or refs.toolCallId');
+    return false;
+  }
+  if (event.content.id !== toolUseId) {
+    diagnostic(state, event, 'tool_use_id_mismatch', 'function_call content.id differs from refs.toolCallId', {
+      contentId: event.content.id,
+      refToolCallId: event.refs?.toolCallId,
+    });
+  }
+  state.toolNameByUseId.set(toolUseId, event.content.name);
+  messages.push({
+    type: 'tool_call',
+    id: toolUseId,
+    turnId: event.turnId,
+    ts: event.ts,
+    toolName: event.content.name,
+    ...(stringStateDelta(event, 'displayName') !== undefined
+      ? { displayName: stringStateDelta(event, 'displayName') }
+      : {}),
+    ...(stringStateDelta(event, 'intent') !== undefined
+      ? { intent: stringStateDelta(event, 'intent') }
+      : {}),
+    args: event.content.args,
+  });
+  return true;
+}
+
+function projectFunctionResponse(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  if (event.content?.kind !== 'function_response') return false;
+  const toolUseId = toolUseIdFor(event);
+  if (!toolUseId) {
+    diagnostic(state, event, 'incomplete_event', 'function_response RuntimeEvent requires content.id or refs.toolCallId');
+    return false;
+  }
+  if (event.content.id !== toolUseId) {
+    diagnostic(state, event, 'tool_use_id_mismatch', 'function_response content.id differs from refs.toolCallId', {
+      contentId: event.content.id,
+      refToolCallId: event.refs?.toolCallId,
+    });
+  }
+  if (!isToolResultContent(event.content.result)) {
+    diagnostic(state, event, 'incomplete_event', 'function_response result is not a legacy ToolResultContent');
+    return false;
+  }
+  if (event.content.name) state.toolNameByUseId.set(toolUseId, event.content.name);
+  messages.push({
+    type: 'tool_result',
+    id: stableMessageId(event, state, 'tool_result'),
+    turnId: event.turnId,
+    ts: event.ts,
+    toolUseId,
+    isError: event.content.isError === true,
+    content: event.content.result,
+    ...(numberStateDelta(event, 'durationMs') !== undefined
+      ? { durationMs: numberStateDelta(event, 'durationMs') }
+      : {}),
+  });
+  return true;
+}
+
+function projectPermissionDecision(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  const decision = event.actions?.permissionDecision;
+  if (!decision) return false;
+  const request = state.permissionRequestById.get(decision.requestId);
+  const toolUseId = event.refs?.toolCallId ?? request?.toolUseId;
+  if (!toolUseId) {
+    diagnostic(state, event, 'incomplete_event', 'permission decision requires refs.toolCallId or a paired permission request');
+    return false;
+  }
+  const toolName = request?.toolName ?? state.toolNameByUseId.get(toolUseId);
+  if (!toolName) {
+    diagnostic(state, event, 'incomplete_event', 'permission decision requires a paired permission request or tool call for toolName');
+    return false;
+  }
+  messages.push({
+    type: 'permission_decision',
+    id: decision.requestId,
+    turnId: event.turnId,
+    ts: event.ts,
+    toolUseId,
+    toolName,
+    decision: decision.decision,
+    ...(decision.rememberForTurn !== undefined ? { rememberForTurn: decision.rememberForTurn } : {}),
+    ...(request?.hint !== undefined ? { hint: request.hint } : {}),
+  });
+  return true;
+}
+
+function projectTokenUsage(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  const usage = event.actions?.tokenUsage;
+  if (!usage) return false;
+  messages.push({
+    type: 'token_usage',
+    id: stableMessageId(event, state, 'token_usage'),
+    turnId: event.turnId,
+    ts: event.ts,
+    input: usage.input,
+    output: usage.output,
+    ...(usage.cacheRead !== undefined ? { cacheRead: usage.cacheRead } : {}),
+    ...(usage.cacheCreation !== undefined ? { cacheCreation: usage.cacheCreation } : {}),
+    ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
+  });
+  return true;
+}
+
+function projectTerminalTurnState(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  messages: StoredMessage[],
+): boolean {
+  const header = state.headers.get(event.runId);
+  if (!header) {
+    diagnostic(state, event, 'incomplete_event', 'terminal RuntimeEvent requires an AgentRunHeader');
+    return false;
+  }
+  const status = turnStatusFor(event.status, header.status);
+  if (!status) {
+    diagnostic(state, event, 'incomplete_event', 'terminal RuntimeEvent status cannot be mapped to a legacy TurnStatus');
+    return false;
+  }
+  const partialOutputRetained = messages.some((message) =>
+    message.turnId === event.turnId &&
+    ((message.type === 'assistant' && message.text.trim().length > 0) || message.type === 'tool_result')
+  );
+  messages.push({
+    type: 'turn_state',
+    id: stableMessageId(event, state, 'turn_state'),
+    turnId: event.turnId,
+    ts: event.ts,
+    status,
+    ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
+    ...(header.retriedFromTurnId ? { retriedFromTurnId: header.retriedFromTurnId } : {}),
+    ...(header.regeneratedFromTurnId ? { regeneratedFromTurnId: header.regeneratedFromTurnId } : {}),
+    ...(header.branchOfTurnId ? { branchOfTurnId: header.branchOfTurnId } : {}),
+    ...(header.parentSessionId ? { parentSessionId: header.parentSessionId } : {}),
+    ...(status === 'aborted' ? { abortedAt: event.ts } : {}),
+    ...(status === 'failed' ? { errorClass: header.failureClass ?? 'unknown' } : {}),
+    partialOutputRetained,
+  });
+  if (status === 'failed' && !header.failureClass) {
+    diagnostic(state, event, 'incomplete_event', 'failed terminal event did not carry an exact AgentRunHeader.failureClass');
+  }
+  if (status === 'aborted') {
+    diagnostic(state, event, 'incomplete_event', 'abortSource is not present in RuntimeEvent or AgentRunHeader metadata');
+  }
+  return true;
+}
+
+function stableMessageId(
+  event: RuntimeEvent,
+  state: ProjectionState,
+  kind: StoredMessage['type'],
+  contentId?: string,
+): string {
+  const stable = event.refs?.storedMessageId
+    ?? event.refs?.providerEventId
+    ?? contentId
+    ?? event.id;
+  if (stable) return stable;
+  const generated = `rtproj:${event.id}:${kind}`;
+  diagnostic(state, event, 'generated_id', 'projection used a deterministic generated id', { id: generated });
+  return generated;
+}
+
+function toolUseIdFor(event: RuntimeEvent): string | undefined {
+  if (event.content?.kind !== 'function_call' && event.content?.kind !== 'function_response') {
+    return event.refs?.toolCallId;
+  }
+  return event.content.id || event.refs?.toolCallId;
+}
+
+function normalizeHeaders(
+  headers: readonly AgentRunHeader[] | Readonly<Record<string, AgentRunHeader>>,
+): Map<string, AgentRunHeader> {
+  if (Array.isArray(headers)) {
+    return new Map(headers.map((header) => [header.runId, header]));
+  }
+  return new Map(Object.values(headers).map((header) => [header.runId, header]));
+}
+
+function turnStatusFor(
+  eventStatus: RuntimeEventStatus | undefined,
+  runStatus: AgentRunHeader['status'],
+): TurnStatus | undefined {
+  if (eventStatus === 'completed') return 'completed';
+  if (eventStatus === 'failed') return 'failed';
+  if (eventStatus === 'aborted' || eventStatus === 'cancelled') return 'aborted';
+  if (runStatus === 'completed') return 'completed';
+  if (runStatus === 'failed') return 'failed';
+  if (runStatus === 'cancelled') return 'aborted';
+  return undefined;
+}
+
+function stringStateDelta(event: RuntimeEvent, key: string): string | undefined {
+  const value = event.actions?.stateDelta?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberStateDelta(event: RuntimeEvent, key: string): number | undefined {
+  const value = event.actions?.stateDelta?.[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function isToolResultContent(value: unknown): value is ToolResultContent {
+  if (!value || typeof value !== 'object') return false;
+  const kind = (value as { kind?: unknown }).kind;
+  return kind === 'text'
+    || kind === 'json'
+    || kind === 'file_diff'
+    || kind === 'file_write'
+    || kind === 'terminal'
+    || kind === 'image'
+    || kind === 'summary'
+    || kind === 'web_search'
+    || kind === 'web_search_error'
+    || kind === 'office_document'
+    || kind === 'explore_agent'
+    || kind === 'rive_workflow';
+}
+
+function diagnostic(
+  state: ProjectionState,
+  event: RuntimeEvent,
+  code: RuntimeEventReadModelDiagnosticCode,
+  message: string,
+  detail?: unknown,
+): void {
+  state.diagnostics.push({
+    code,
+    eventId: event.id,
+    runId: event.runId,
+    turnId: event.turnId,
+    message,
+    ...(detail !== undefined ? { detail } : {}),
+  });
+}
+
+function countSemanticMessages(messages: readonly StoredMessage[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    const key = stableSemanticKey(semanticMessage(message));
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function stableSemanticKey(value: unknown): string {
+  return JSON.stringify(sortSemanticValue(value));
+}
+
+function sortSemanticValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortSemanticValue);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, sortSemanticValue((value as Record<string, unknown>)[key])]),
+  );
+}
+
+function semanticMessage(message: StoredMessage): unknown {
+  switch (message.type) {
+    case 'user':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        text: message.text,
+        attachments: message.attachments ?? [],
+      };
+    case 'assistant':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        text: message.text,
+        modelId: message.modelId,
+        thinking: message.thinking,
+      };
+    case 'tool_call':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        toolUseId: message.id,
+        toolName: message.toolName,
+        displayName: message.displayName,
+        intent: message.intent,
+        args: message.args,
+      };
+    case 'tool_result':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        toolUseId: message.toolUseId,
+        isError: message.isError,
+        content: message.content,
+        durationMs: message.durationMs,
+      };
+    case 'permission_decision':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        toolUseId: message.toolUseId,
+        toolName: message.toolName,
+        decision: message.decision,
+        rememberForTurn: message.rememberForTurn,
+        hint: message.hint,
+      };
+    case 'token_usage':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        input: message.input,
+        output: message.output,
+        cacheRead: message.cacheRead,
+        cacheCreation: message.cacheCreation,
+        costUsd: message.costUsd,
+      };
+    case 'turn_state':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        status: message.status,
+        parentTurnId: message.parentTurnId,
+        retriedFromTurnId: message.retriedFromTurnId,
+        regeneratedFromTurnId: message.regeneratedFromTurnId,
+        branchOfTurnId: message.branchOfTurnId,
+        parentSessionId: message.parentSessionId,
+        abortedAt: message.abortedAt,
+        abortSource: message.abortSource,
+        errorClass: message.errorClass,
+        partialOutputRetained: message.partialOutputRetained,
+      };
+    case 'system_note':
+      return {
+        type: message.type,
+        turnId: message.turnId,
+        kind: message.kind,
+        data: message.data,
+      };
+  }
+}


### PR DESCRIPTION
## Summary
- add a side-by-side RuntimeEvent to StoredMessage read-model projection helper
- add semantic compatibility comparison between projected and legacy StoredMessage rows
- cover user/model text, tool calls/results, permission decisions, token usage, terminal turn state, partial skipping, and legacy read-path preservation

## Verification
- npm run build --workspace packages/core
- npm run typecheck --workspace packages/runtime
- npm run test --workspace packages/runtime -- --runInBand
- git diff --check