### PR TITLE
Converge RuntimeEvent semantic source of truth

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -28,6 +28,7 @@
     "./bots": "./dist/bots/index.js",
     "./runtime-event-adapters": "./dist/runtime-event-adapters.js",
     "./runtime-event-read-model": "./dist/runtime-event-read-model.js",
+    "./agent-run-inspect": "./dist/agent-run-inspect.js",
     "./model-history": "./dist/model-history.js",
     "./invocation-context": "./dist/invocation-context.js",
     "./runtime-runner": "./dist/runtime-runner.js",

--- a/packages/runtime/src/__tests__/agent-run-inspect.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-inspect.test.ts
@@ -1,0 +1,202 @@
+import { describe, test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent } from '@maka/core';
+import { expect } from '../test-helpers.js';
+import { inspectAgentRunReadModel } from '../agent-run-inspect.js';
+
+const sessionId = 'session-1';
+const runId = 'run-1';
+const turnId = 'turn-1';
+const ts = 1_800_000_000_000;
+
+describe('inspectAgentRunReadModel', () => {
+  test('returns consistent diagnostics for a complete run', async () => {
+    const runStore = new MemoryAgentRunStore();
+    await runStore.createRun(makeHeader({ status: 'completed', completedAt: ts + 10, updatedAt: ts + 10 }));
+    await runStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_started', ts: ts + 1 }));
+    await runStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_completed', ts: ts + 10 }));
+    await runStore.appendRuntimeEvent(sessionId, runId, makeRuntimeEvent({
+      id: 'rt-user',
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: 'hello' },
+      ts: ts + 2,
+    }));
+    await runStore.appendRuntimeEvent(sessionId, runId, makeRuntimeEvent({
+      id: 'rt-assistant',
+      role: 'model',
+      author: 'agent',
+      content: { kind: 'text', text: 'hi' },
+      ts: ts + 3,
+    }));
+    await runStore.appendRuntimeEvent(sessionId, runId, makeRuntimeEvent({
+      id: 'rt-complete',
+      role: 'system',
+      author: 'system',
+      status: 'completed',
+      actions: { endInvocation: true },
+      ts: ts + 10,
+    }));
+
+    const inspected = await inspectAgentRunReadModel(runStore, { sessionId, runId });
+
+    expect(inspected.sourceHealth).toEqual({
+      runtimeLedger: 'present',
+      runtimeTerminalPresent: true,
+      operationalTerminalPresent: true,
+      statusConsistency: 'consistent',
+    });
+    expect(inspected.terminalRuntimeFact?.runStatus).toBe('completed');
+    expect(inspected.operationalTerminalEvent?.type).toBe('run_completed');
+    expect(inspected.runtimeEvents.map((event) => event.id)).toEqual(['rt-user', 'rt-assistant', 'rt-complete']);
+    expect(inspected.projection?.messages.map((message) => message.type)).toEqual(['user', 'assistant', 'turn_state']);
+    expect(inspected.diagnostics.some((diagnostic) => diagnostic.code === 'status_consistency_mismatch')).toBe(false);
+  });
+
+  test('reports missing and corrupt runtime-events without discarding operational facts', async () => {
+    const missingRuntimeStore = new MemoryAgentRunStore();
+    await missingRuntimeStore.createRun(makeHeader({ status: 'completed' }));
+    await missingRuntimeStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_completed' }));
+
+    const missing = await inspectAgentRunReadModel(missingRuntimeStore, { sessionId, runId });
+
+    expect(missing.events.map((event) => event.type)).toEqual(['run_completed']);
+    expect(missing.sourceHealth.runtimeLedger).toBe('missing');
+    expect(missing.sourceHealth.operationalTerminalPresent).toBe(true);
+    expect(missing.sourceHealth.runtimeTerminalPresent).toBe(false);
+    expect(missing.diagnostics.some((diagnostic) => diagnostic.code === 'missing_runtime_ledger')).toBe(true);
+
+    const corruptRuntimeStore = new MemoryAgentRunStore({ failRuntimeEventReads: true });
+    await corruptRuntimeStore.createRun(makeHeader({ status: 'completed' }));
+    await corruptRuntimeStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_completed' }));
+
+    const corrupt = await inspectAgentRunReadModel(corruptRuntimeStore, { sessionId, runId });
+
+    expect(corrupt.events.map((event) => event.type)).toEqual(['run_completed']);
+    expect(corrupt.sourceHealth.runtimeLedger).toBe('read_failed');
+    expect(corrupt.sourceHealth.operationalTerminalPresent).toBe(true);
+    expect(corrupt.diagnostics.some((diagnostic) => diagnostic.code === 'runtime_ledger_read_failed')).toBe(true);
+  });
+
+  test('diagnoses status disagreement between header operational and RuntimeEvent facts', async () => {
+    const runStore = new MemoryAgentRunStore();
+    await runStore.createRun(makeHeader({ status: 'failed', failureClass: 'tool_failed' }));
+    await runStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_failed' }));
+    await runStore.appendRuntimeEvent(sessionId, runId, makeRuntimeEvent({
+      id: 'rt-complete',
+      role: 'system',
+      author: 'system',
+      status: 'completed',
+      actions: { endInvocation: true },
+    }));
+
+    const inspected = await inspectAgentRunReadModel(runStore, { sessionId, runId });
+
+    expect(inspected.sourceHealth.statusConsistency).toBe('inconsistent');
+    expect(inspected.terminalRuntimeFact?.runStatus).toBe('completed');
+    expect(inspected.diagnostics.some((diagnostic) => diagnostic.code === 'status_consistency_mismatch')).toBe(true);
+  });
+});
+
+class MemoryAgentRunStore implements AgentRunStore {
+  private headers = new Map<string, AgentRunHeader>();
+  private events = new Map<string, AgentRunEvent[]>();
+  private runtimeEvents = new Map<string, RuntimeEvent[]>();
+
+  constructor(private readonly options: { failRuntimeEventReads?: boolean } = {}) {}
+
+  async createRun(header: AgentRunHeader): Promise<AgentRunHeader> {
+    this.headers.set(key(header.sessionId, header.runId), { ...header });
+    return { ...header };
+  }
+
+  async updateRun(sessionId: string, runId: string, patch: Partial<AgentRunHeader>): Promise<AgentRunHeader> {
+    const current = await this.readRun(sessionId, runId);
+    const next = { ...current, ...patch, sessionId, runId };
+    this.headers.set(key(sessionId, runId), next);
+    return { ...next };
+  }
+
+  async readRun(sessionId: string, runId: string): Promise<AgentRunHeader> {
+    const header = this.headers.get(key(sessionId, runId));
+    if (!header) throw new Error(`Unknown run ${runId}`);
+    return { ...header };
+  }
+
+  async listSessionRuns(sessionId: string): Promise<AgentRunHeader[]> {
+    return Array.from(this.headers.values())
+      .filter((header) => header.sessionId === sessionId)
+      .sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId))
+      .map((header) => ({ ...header }));
+  }
+
+  async appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void> {
+    const eventKey = key(sessionId, runId);
+    this.events.set(eventKey, [...(this.events.get(eventKey) ?? []), { ...event }]);
+  }
+
+  async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    return (this.events.get(key(sessionId, runId)) ?? []).map((event) => ({ ...event }));
+  }
+
+  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+    const eventKey = key(sessionId, runId);
+    this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), copyRuntimeEvent(event)]);
+  }
+
+  async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    if (this.options.failRuntimeEventReads) throw new Error('runtime ledger is corrupt');
+    return (this.runtimeEvents.get(key(sessionId, runId)) ?? []).map(copyRuntimeEvent);
+  }
+}
+
+function makeHeader(overrides: Partial<AgentRunHeader> = {}): AgentRunHeader {
+  return {
+    runId,
+    sessionId,
+    turnId,
+    status: 'running',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/cwd',
+    permissionMode: 'ask',
+    createdAt: ts,
+    updatedAt: ts,
+    ...overrides,
+  };
+}
+
+function makeRunEvent(overrides: Partial<AgentRunEvent> = {}): AgentRunEvent {
+  return {
+    type: 'run_started',
+    id: `op-${overrides.type ?? 'run_started'}`,
+    runId,
+    sessionId,
+    turnId,
+    ts,
+    ...overrides,
+  };
+}
+
+function makeRuntimeEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id: 'rt-1',
+    invocationId: 'inv-1',
+    runId,
+    sessionId,
+    turnId,
+    ts,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function copyRuntimeEvent(event: RuntimeEvent): RuntimeEvent {
+  return JSON.parse(JSON.stringify(event)) as RuntimeEvent;
+}
+
+function key(sessionId: string, runId: string): string {
+  return `${sessionId}:${runId}`;
+}

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -104,6 +104,207 @@ describe('AiSdkBackend model history', () => {
       { role: 'user', content: [{ type: 'text', text: 'current user' }] },
     ]);
   });
+
+  test('preserves RuntimeEvent tool calls and results as structured AI SDK parts', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
+        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'legacy user' }),
+        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'legacy assistant' }),
+        runtimeEvent({
+          id: 'rt-call',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'package.json' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: 'contents', isError: false },
+        }),
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      {
+        role: 'assistant',
+        content: [{
+          type: 'tool-call',
+          toolCallId: 'tool-1',
+          toolName: 'Read',
+          input: { path: 'package.json' },
+          providerExecuted: undefined,
+          providerOptions: undefined,
+        }],
+      },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'tool-1',
+          toolName: 'Read',
+          output: { type: 'text', value: 'contents' },
+          providerOptions: undefined,
+        }],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
+  test('falls back to legacy context when RuntimeEvent tool results are unmatched', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
+        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
+        runtimeEvent({
+          id: 'rt-unmatched-result',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'missing-call', name: 'Read', result: 'contents', isError: false },
+        }),
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
+  test('falls back to legacy context when RuntimeEvent replay has unsupported content', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
+        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
+        runtimeEvent({
+          id: 'rt-error',
+          turnId: 'turn-prev',
+          role: 'system',
+          author: 'system',
+          content: { kind: 'error', reason: 'tool_failed', message: 'Tool failed' },
+        }),
+      ],
+    }));
+
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+  });
+
+  test('falls back to legacy context instead of leaking unsupported thinking text', async () => {
+    const model = completionModel();
+    const openAiConnection = { ...connection(), providerType: 'openai' as const };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: openAiConnection,
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [
+        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
+        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+      ],
+      runtimeContext: [
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'legacy user' }),
+        runtimeEvent({
+          id: 'rt-thinking',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'thinking', text: 'private chain of thought', signature: 'sig-1' },
+        }),
+        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'legacy assistant' }),
+      ],
+    }));
+
+    const promptJson = JSON.stringify(compactPrompt(model));
+    assert.deepEqual(compactPrompt(model), [
+      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'current user' }] },
+    ]);
+    assert.equal(promptJson.includes('private chain of thought'), false);
+  });
 });
 
 describe('AiSdkBackend error surfaces', () => {
@@ -1423,6 +1624,31 @@ function runtimeTextEvent(input: {
     role: input.role,
     author: input.author,
     content: { kind: 'text', text: input.text },
+  };
+}
+
+function runtimeEvent(input: {
+  id: string;
+  turnId: string;
+  role: RuntimeEvent['role'];
+  author: RuntimeEvent['author'];
+  content?: RuntimeEvent['content'];
+  status?: RuntimeEvent['status'];
+  actions?: RuntimeEvent['actions'];
+}): RuntimeEvent {
+  return {
+    id: input.id,
+    invocationId: 'inv-1',
+    runId: 'run-prev',
+    sessionId: 'session-1',
+    turnId: input.turnId,
+    ts: 1,
+    partial: false,
+    role: input.role,
+    author: input.author,
+    ...(input.content ? { content: input.content } : {}),
+    ...(input.status ? { status: input.status } : {}),
+    ...(input.actions ? { actions: input.actions } : {}),
   };
 }
 

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -35,6 +35,7 @@ import {
 } from '../runtime-event-adapters.js';
 import {
   buildModelHistoryFromRuntimeEvents,
+  buildRuntimeEventModelReplayPlan,
   buildTextModelMessagesFromRuntimeEvents,
   type ModelHistoryEntry,
 } from '../model-history.js';
@@ -833,6 +834,105 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
       },
       { role: 'assistant', content: 'final answer' },
     ]);
+  });
+
+  test('runtime replay plan preserves structured tool calls and results', () => {
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'read package' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'package.json' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'tool-1',
+          name: 'Read',
+          result: { ok: true, text: 'contents' },
+          isError: false,
+        },
+      }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    expect(plan.hasProviderNativeSemantics).toBe(true);
+    expect(plan.semanticKinds).toEqual(['text', 'tool_call', 'tool_result']);
+    expect(plan.items).toEqual([
+      { kind: 'text', role: 'user', content: 'read package', eventId: events[0]?.id, ts: events[0]?.ts },
+      {
+        kind: 'tool_call',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        input: { path: 'package.json' },
+        eventId: events[1]?.id,
+        ts: events[1]?.ts,
+      },
+      {
+        kind: 'tool_result',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        output: { ok: true, text: 'contents' },
+        isError: false,
+        eventId: events[2]?.id,
+        ts: events[2]?.ts,
+      },
+    ]);
+  });
+
+  test('runtime replay plan carries thinking separately and text replay never leaks it', () => {
+    const events: RuntimeEvent[] = [
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'private reasoning', signature: 'sig-1' },
+      }),
+      ev({ role: 'model', author: 'agent', content: { kind: 'text', text: 'public answer' } }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    expect(plan.items.map((item) => item.kind)).toEqual(['thinking', 'text']);
+    expect(plan.textMessages).toEqual([{ role: 'assistant', content: 'public answer' }]);
+    expect(buildTextModelMessagesFromRuntimeEvents(events)).toEqual([
+      { role: 'assistant', content: 'public answer' },
+    ]);
+  });
+
+  test('runtime replay plan diagnoses unsigned thinking without flattening it into text', () => {
+    const events: RuntimeEvent[] = [
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'thinking', text: 'private reasoning' },
+      }),
+      ev({ role: 'model', author: 'agent', content: { kind: 'text', text: 'answer' } }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    expect(plan.diagnostics.map((diagnostic) => diagnostic.code)).toContain('unsigned_thinking');
+    expect(plan.textMessages).toEqual([{ role: 'assistant', content: 'answer' }]);
+  });
+
+  test('terminal RuntimeEvents are diagnostic-only for replay semantics', () => {
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'q' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        status: 'completed',
+        actions: { endInvocation: true },
+      }),
+    ];
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+
+    expect(plan.items).toHaveLength(1);
+    expect(plan.diagnostics.map((diagnostic) => diagnostic.code)).toContain('terminal_fact_diagnostic_only');
   });
 });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -771,6 +771,43 @@ describe('SessionManager permission mode updates', () => {
     expect(secondInput.runtimeContext?.[0]?.content).toEqual({ kind: 'text', text: 'first' });
   });
 
+  test('next turn falls back to legacy when RuntimeEvents do not cover legacy model-visible context', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const backendInstances: TestBackend[] = [];
+    backends.register('fake', (ctx) => {
+      const backend = new TestBackend(ctx);
+      backendInstances.push(backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_850),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'first' }));
+    await store.appendMessage(session.id, {
+      type: 'assistant',
+      id: 'legacy-extra-assistant',
+      turnId: 'legacy-extra',
+      ts: 6_899,
+      text: 'legacy-only context',
+      modelId: 'fake-model',
+    });
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'second' }));
+
+    const secondInput = backendInstances[0]?.sendInputs[1];
+    if (!secondInput) throw new Error('second backend input was not recorded');
+    expect(secondInput.runtimeContext).toBeUndefined();
+    expect(secondInput.context.some((message) => message.type === 'assistant' && message.id === 'legacy-extra-assistant')).toBe(true);
+  });
+
   test('next turn remains legacy-only when prior RuntimeEvent ledger is unusable', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failRuntimeEventAppends: true });
@@ -1173,6 +1210,212 @@ describe('SessionManager permission mode updates', () => {
     expect(run?.failureClass).toBe('app_restarted');
     const events = await runStore.readEvents(session.id, 'run-1');
     expect(events.map((event) => event.type)).toContain('run_failed');
+  });
+
+  test('startup recovery uses a completed RuntimeEvent terminal fact before incomplete AgentRun events', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_815) });
+    const session = await manager.createSession(makeInput({ status: 'running' }));
+    await seedRunningTurn(store, session.id, 'turn-1');
+    await seedRun(runStore, makeRunHeader({
+      sessionId: session.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'running',
+    }), [
+      makeRunEvent({ sessionId: session.id, runId: 'run-1', turnId: 'turn-1', type: 'run_started', ts: 11 }),
+      makeRunEvent({ sessionId: session.id, runId: 'run-1', turnId: 'turn-1', type: 'model_stream_started', ts: 12 }),
+    ]);
+    await runStore.appendRuntimeEvent(session.id, 'run-1', runtimeEvent({
+      id: 'rt-completed',
+      sessionId: session.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      ts: 13,
+      role: 'system',
+      author: 'system',
+      status: 'completed',
+      actions: { endInvocation: true },
+    }));
+
+    const recovered = await manager.recoverInterruptedSessions();
+
+    expect(recovered).toEqual([session.id]);
+    expect((await store.readHeader(session.id)).status).toBe('active');
+    const [turn] = await store.listTurns(session.id);
+    expect(turn?.status).toBe('completed');
+    const storedTurnStates = (await store.readMessages(session.id)).filter((message) =>
+      message.type === 'turn_state' && message.turnId === 'turn-1'
+    );
+    expect(storedTurnStates.map((message) => message.type === 'turn_state' ? message.status : '')).toEqual([
+      'running',
+      'completed',
+    ]);
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.status).toBe('completed');
+    const events = await runStore.readEvents(session.id, 'run-1');
+    expect(events.map((event) => event.type)).toEqual(['run_started', 'model_stream_started', 'run_completed']);
+    const recoveredEvent = events.find((event) => event.type === 'run_completed');
+    expect(recoveredEvent?.data?.recoveryReason).toBe('runtime_event_terminal_fact');
+  });
+
+  test('startup recovery maps failed aborted and cancelled RuntimeEvent terminal facts consistently', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_817) });
+    const failed = await manager.createSession(makeInput({ status: 'running' }));
+    const aborted = await manager.createSession(makeInput({ status: 'running' }));
+    const cancelled = await manager.createSession(makeInput({ status: 'running' }));
+
+    await seedRunningTurn(store, failed.id, 'failed-turn');
+    await seedRunningTurn(store, aborted.id, 'aborted-turn');
+    await seedRunningTurn(store, cancelled.id, 'cancelled-turn');
+    await seedRun(runStore, makeRunHeader({ sessionId: failed.id, runId: 'failed-run', turnId: 'failed-turn', status: 'running' }), [
+      makeRunEvent({ sessionId: failed.id, runId: 'failed-run', turnId: 'failed-turn', type: 'run_started', ts: 11 }),
+    ]);
+    await seedRun(runStore, makeRunHeader({ sessionId: aborted.id, runId: 'aborted-run', turnId: 'aborted-turn', status: 'running' }), [
+      makeRunEvent({ sessionId: aborted.id, runId: 'aborted-run', turnId: 'aborted-turn', type: 'run_started', ts: 21 }),
+    ]);
+    await seedRun(runStore, makeRunHeader({ sessionId: cancelled.id, runId: 'cancelled-run', turnId: 'cancelled-turn', status: 'running' }), [
+      makeRunEvent({ sessionId: cancelled.id, runId: 'cancelled-run', turnId: 'cancelled-turn', type: 'run_started', ts: 31 }),
+    ]);
+    await runStore.appendRuntimeEvent(failed.id, 'failed-run', runtimeEvent({
+      id: 'rt-failed',
+      sessionId: failed.id,
+      runId: 'failed-run',
+      turnId: 'failed-turn',
+      ts: 12,
+      role: 'system',
+      author: 'system',
+      status: 'failed',
+      content: { kind: 'error', reason: 'tool_failed', message: 'Tool failed' },
+      actions: { endInvocation: true },
+    }));
+    await runStore.appendRuntimeEvent(aborted.id, 'aborted-run', runtimeEvent({
+      id: 'rt-aborted',
+      sessionId: aborted.id,
+      runId: 'aborted-run',
+      turnId: 'aborted-turn',
+      ts: 22,
+      role: 'system',
+      author: 'system',
+      status: 'aborted',
+      actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } },
+    }));
+    await runStore.appendRuntimeEvent(cancelled.id, 'cancelled-run', runtimeEvent({
+      id: 'rt-cancelled',
+      sessionId: cancelled.id,
+      runId: 'cancelled-run',
+      turnId: 'cancelled-turn',
+      ts: 32,
+      role: 'system',
+      author: 'system',
+      status: 'cancelled',
+      actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } },
+    }));
+
+    const recovered = await manager.recoverInterruptedSessions();
+
+    expect(recovered).toEqual([failed.id, aborted.id, cancelled.id]);
+    expect((await runStore.readRun(failed.id, 'failed-run')).status).toBe('failed');
+    expect((await runStore.readRun(failed.id, 'failed-run')).failureClass).toBe('tool_failed');
+    expect((await store.listTurns(failed.id))[0]?.status).toBe('failed');
+    expect((await store.listTurns(failed.id))[0]?.errorClass).toBe('tool_failed');
+    expect((await runStore.readRun(aborted.id, 'aborted-run')).status).toBe('cancelled');
+    expect((await store.listTurns(aborted.id))[0]?.status).toBe('aborted');
+    expect((await store.listTurns(aborted.id))[0]?.abortSource).toBe('renderer.stop_button');
+    expect((await runStore.readRun(cancelled.id, 'cancelled-run')).status).toBe('cancelled');
+    expect((await store.listTurns(cancelled.id))[0]?.status).toBe('aborted');
+    expect((await store.listTurns(cancelled.id))[0]?.abortSource).toBe('renderer.stop_button');
+    expect((await runStore.readEvents(failed.id, 'failed-run')).map((event) => event.type)).toContain('run_failed');
+    expect((await runStore.readEvents(aborted.id, 'aborted-run')).map((event) => event.type)).toContain('run_cancelled');
+    expect((await runStore.readEvents(cancelled.id, 'cancelled-run')).map((event) => event.type)).toContain('run_cancelled');
+  });
+
+  test('startup recovery falls back when RuntimeEvents are unreadable or terminal facts are incomplete', async () => {
+    const unreadableStore = new MemorySessionStore();
+    const unreadableRunStore = new MemoryAgentRunStore({ failRuntimeEventReads: true });
+    const incompleteStore = new MemorySessionStore();
+    const incompleteRunStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const unreadableManager = new SessionManager({
+      store: unreadableStore,
+      runStore: unreadableRunStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_818),
+    });
+    const incompleteManager = new SessionManager({
+      store: incompleteStore,
+      runStore: incompleteRunStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(12_819),
+    });
+    const unreadable = await unreadableManager.createSession(makeInput({ status: 'running' }));
+    const incomplete = await incompleteManager.createSession(makeInput({ status: 'running' }));
+
+    await seedRunningTurn(unreadableStore, unreadable.id, 'turn-1');
+    await unreadableStore.appendMessage(unreadable.id, {
+      type: 'assistant',
+      id: 'assistant-1',
+      turnId: 'turn-1',
+      ts: 13,
+      text: 'done',
+      modelId: 'fake-model',
+    });
+    await seedRun(unreadableRunStore, makeRunHeader({
+      sessionId: unreadable.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'running',
+    }), [
+      makeRunEvent({ sessionId: unreadable.id, runId: 'run-1', turnId: 'turn-1', type: 'model_stream_completed', ts: 12 }),
+    ]);
+
+    await seedRunningTurn(incompleteStore, incomplete.id, 'turn-1');
+    await incompleteStore.appendMessage(incomplete.id, {
+      type: 'assistant',
+      id: 'assistant-1',
+      turnId: 'turn-1',
+      ts: 13,
+      text: 'done',
+      modelId: 'fake-model',
+    });
+    await seedRun(incompleteRunStore, makeRunHeader({
+      sessionId: incomplete.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'running',
+    }), [
+      makeRunEvent({ sessionId: incomplete.id, runId: 'run-1', turnId: 'turn-1', type: 'model_stream_completed', ts: 12 }),
+    ]);
+    await incompleteRunStore.appendRuntimeEvent(incomplete.id, 'run-1', runtimeEvent({
+      id: 'rt-incomplete-failed',
+      sessionId: incomplete.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      ts: 14,
+      role: 'system',
+      author: 'system',
+      status: 'failed',
+      actions: { endInvocation: true },
+    }));
+
+    await unreadableManager.recoverInterruptedSessions();
+    await incompleteManager.recoverInterruptedSessions();
+
+    expect((await unreadableRunStore.readRun(unreadable.id, 'run-1')).status).toBe('completed');
+    expect((await unreadableStore.listTurns(unreadable.id))[0]?.status).toBe('completed');
+    expect((await incompleteRunStore.readRun(incomplete.id, 'run-1')).status).toBe('completed');
+    expect((await incompleteStore.listTurns(incomplete.id))[0]?.status).toBe('completed');
+    expect((await incompleteRunStore.readEvents(incomplete.id, 'run-1')).find((event) => event.type === 'run_completed')?.data?.recoveryReason).toBe('stale_completed_run');
   });
 
   test('startup recovery fails stale tool tails while preserving partial output retention', async () => {

--- a/packages/runtime/src/agent-run-inspect.ts
+++ b/packages/runtime/src/agent-run-inspect.ts
@@ -1,0 +1,278 @@
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, StoredMessage } from '@maka/core';
+import {
+  classifyRuntimeEventTerminalFact,
+  projectRuntimeEventsToStoredMessages,
+  type RuntimeEventReadModelDiagnostic,
+  type RuntimeEventTerminalFact,
+} from './runtime-event-read-model.js';
+import {
+  buildRuntimeEventModelReplayPlan,
+  type RuntimeEventModelReplayPlan,
+} from './model-history.js';
+
+export type AgentRunInspectDiagnosticCode =
+  | 'operational_ledger_read_failed'
+  | 'operational_event_corrupt'
+  | 'operational_terminal_missing'
+  | 'missing_runtime_ledger'
+  | 'runtime_ledger_read_failed'
+  | 'runtime_terminal_missing'
+  | 'status_consistency_mismatch'
+  | RuntimeEventReadModelDiagnostic['code'];
+
+export interface AgentRunInspectDiagnostic {
+  code: AgentRunInspectDiagnosticCode;
+  runId: string;
+  turnId: string;
+  message: string;
+  eventId?: string;
+  detail?: unknown;
+}
+
+export interface AgentRunInspectSourceHealth {
+  runtimeLedger: 'present' | 'missing' | 'read_failed';
+  runtimeTerminalPresent: boolean;
+  operationalTerminalPresent: boolean;
+  statusConsistency: 'consistent' | 'inconsistent' | 'incomplete';
+}
+
+export interface AgentRunInspectProjectionSummary {
+  messages: StoredMessage[];
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+}
+
+export interface AgentRunInspectModel {
+  header: AgentRunHeader;
+  events: AgentRunEvent[];
+  runtimeEvents: RuntimeEvent[];
+  terminalRuntimeFact?: RuntimeEventTerminalFact;
+  operationalTerminalEvent?: AgentRunEvent;
+  modelReplay?: RuntimeEventModelReplayPlan;
+  projection?: AgentRunInspectProjectionSummary;
+  sourceHealth: AgentRunInspectSourceHealth;
+  diagnostics: AgentRunInspectDiagnostic[];
+}
+
+export interface InspectAgentRunOptions {
+  sessionId: string;
+  runId: string;
+  header?: AgentRunHeader;
+}
+
+export async function inspectAgentRunReadModel(
+  runStore: AgentRunStore,
+  options: InspectAgentRunOptions,
+): Promise<AgentRunInspectModel> {
+  const header = options.header ?? await runStore.readRun(options.sessionId, options.runId);
+  const diagnostics: AgentRunInspectDiagnostic[] = [];
+  const events = await readOperationalEvents(runStore, header, diagnostics);
+  const runtimeRead = await readRuntimeEvents(runStore, header, diagnostics);
+  const runtimeEvents = runtimeRead.events;
+
+  const operationalTerminalEvent = latestOperationalTerminalEvent(events);
+  if (!operationalTerminalEvent) {
+    diagnostics.push(inspectDiagnostic(
+      header,
+      'operational_terminal_missing',
+      'operational AgentRunEvent ledger has no terminal run event',
+    ));
+  }
+
+  let terminalRuntimeFact: RuntimeEventTerminalFact | undefined;
+  if (runtimeRead.state === 'present') {
+    const terminalFactResult = classifyRuntimeEventTerminalFact(header, runtimeEvents);
+    terminalRuntimeFact = terminalFactResult.fact;
+    diagnostics.push(...terminalFactResult.diagnostics.map((diagnostic) =>
+      fromRuntimeReadModelDiagnostic(header, diagnostic)
+    ));
+    if (!terminalRuntimeFact) {
+      diagnostics.push(inspectDiagnostic(
+        header,
+        'runtime_terminal_missing',
+        'runtime ledger has no complete terminal RuntimeEvent fact',
+      ));
+    }
+  }
+
+  const projection = runtimeEvents.length > 0
+    ? projectRuntimeEventsToStoredMessages(runtimeEvents, { runHeaders: [header] })
+    : undefined;
+  if (projection) {
+    diagnostics.push(...projection.diagnostics.map((diagnostic) =>
+      fromRuntimeReadModelDiagnostic(header, diagnostic)
+    ));
+  }
+
+  const modelReplay = runtimeEvents.length > 0
+    ? buildRuntimeEventModelReplayPlan(runtimeEvents)
+    : undefined;
+
+  const statusConsistency = computeStatusConsistency(header, operationalTerminalEvent, terminalRuntimeFact);
+  if (statusConsistency === 'inconsistent') {
+    diagnostics.push(inspectDiagnostic(
+      header,
+      'status_consistency_mismatch',
+      'AgentRunHeader, operational terminal event, and RuntimeEvent terminal fact disagree',
+      {
+        headerStatus: header.status,
+        operationalStatus: operationalTerminalEvent ? operationalStatusFor(operationalTerminalEvent) : undefined,
+        runtimeStatus: terminalRuntimeFact?.runStatus,
+      },
+    ));
+  }
+
+  return {
+    header,
+    events,
+    runtimeEvents,
+    ...(terminalRuntimeFact ? { terminalRuntimeFact } : {}),
+    ...(operationalTerminalEvent ? { operationalTerminalEvent } : {}),
+    ...(modelReplay ? { modelReplay } : {}),
+    ...(projection ? { projection } : {}),
+    sourceHealth: {
+      runtimeLedger: runtimeRead.state,
+      runtimeTerminalPresent: terminalRuntimeFact !== undefined,
+      operationalTerminalPresent: operationalTerminalEvent !== undefined,
+      statusConsistency,
+    },
+    diagnostics,
+  };
+}
+
+export async function inspectSessionRunReadModels(
+  runStore: AgentRunStore,
+  sessionId: string,
+): Promise<AgentRunInspectModel[]> {
+  const headers = await runStore.listSessionRuns(sessionId);
+  const models: AgentRunInspectModel[] = [];
+  for (const header of headers) {
+    models.push(await inspectAgentRunReadModel(runStore, { sessionId, runId: header.runId, header }));
+  }
+  return models;
+}
+
+async function readOperationalEvents(
+  runStore: AgentRunStore,
+  header: AgentRunHeader,
+  diagnostics: AgentRunInspectDiagnostic[],
+): Promise<AgentRunEvent[]> {
+  try {
+    const events = await runStore.readEvents(header.sessionId, header.runId);
+    for (const event of events) {
+      if (event.type !== 'event_corrupt') continue;
+      diagnostics.push(inspectDiagnostic(
+        header,
+        'operational_event_corrupt',
+        'operational AgentRunEvent ledger contains a corrupt row',
+        event.data,
+        event.id,
+      ));
+    }
+    return events;
+  } catch (error) {
+    diagnostics.push(inspectDiagnostic(
+      header,
+      'operational_ledger_read_failed',
+      'AgentRunStore.readEvents failed',
+      errorMessage(error),
+    ));
+    return [];
+  }
+}
+
+async function readRuntimeEvents(
+  runStore: AgentRunStore,
+  header: AgentRunHeader,
+  diagnostics: AgentRunInspectDiagnostic[],
+): Promise<{ state: AgentRunInspectSourceHealth['runtimeLedger']; events: RuntimeEvent[] }> {
+  try {
+    const events = await runStore.readRuntimeEvents(header.sessionId, header.runId);
+    if (events.length === 0) {
+      diagnostics.push(inspectDiagnostic(
+        header,
+        'missing_runtime_ledger',
+        'runtime-events ledger is missing or empty for this run',
+      ));
+      return { state: 'missing', events };
+    }
+    return { state: 'present', events };
+  } catch (error) {
+    diagnostics.push(inspectDiagnostic(
+      header,
+      'runtime_ledger_read_failed',
+      'AgentRunStore.readRuntimeEvents failed',
+      errorMessage(error),
+    ));
+    return { state: 'read_failed', events: [] };
+  }
+}
+
+function computeStatusConsistency(
+  header: AgentRunHeader,
+  operationalTerminalEvent: AgentRunEvent | undefined,
+  terminalRuntimeFact: RuntimeEventTerminalFact | undefined,
+): AgentRunInspectSourceHealth['statusConsistency'] {
+  const statuses = [
+    isTerminalRunStatus(header.status) ? header.status : undefined,
+    operationalTerminalEvent ? operationalStatusFor(operationalTerminalEvent) : undefined,
+    terminalRuntimeFact?.runStatus,
+  ].filter((status): status is 'completed' | 'failed' | 'cancelled' => status !== undefined);
+
+  if (statuses.length < 2) return 'incomplete';
+  return statuses.every((status) => status === statuses[0]) ? 'consistent' : 'inconsistent';
+}
+
+function latestOperationalTerminalEvent(events: readonly AgentRunEvent[]): AgentRunEvent | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+    if (operationalStatusFor(event)) return event;
+  }
+  return undefined;
+}
+
+function operationalStatusFor(event: AgentRunEvent): 'completed' | 'failed' | 'cancelled' | undefined {
+  if (event.type === 'run_completed') return 'completed';
+  if (event.type === 'run_failed') return 'failed';
+  if (event.type === 'run_cancelled') return 'cancelled';
+  return undefined;
+}
+
+function isTerminalRunStatus(status: AgentRunHeader['status']): status is 'completed' | 'failed' | 'cancelled' {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function fromRuntimeReadModelDiagnostic(
+  header: AgentRunHeader,
+  diagnostic: RuntimeEventReadModelDiagnostic,
+): AgentRunInspectDiagnostic {
+  return {
+    code: diagnostic.code,
+    runId: diagnostic.runId ?? header.runId,
+    turnId: diagnostic.turnId ?? header.turnId,
+    message: diagnostic.message,
+    ...(diagnostic.eventId ? { eventId: diagnostic.eventId } : {}),
+    ...(diagnostic.detail !== undefined ? { detail: diagnostic.detail } : {}),
+  };
+}
+
+function inspectDiagnostic(
+  header: AgentRunHeader,
+  code: AgentRunInspectDiagnosticCode,
+  message: string,
+  detail?: unknown,
+  eventId?: string,
+): AgentRunInspectDiagnostic {
+  return {
+    code,
+    runId: header.runId,
+    turnId: header.turnId,
+    message,
+    ...(eventId ? { eventId } : {}),
+    ...(detail !== undefined ? { detail } : {}),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/agent-run-recovery.ts
+++ b/packages/runtime/src/agent-run-recovery.ts
@@ -5,8 +5,9 @@ import type { UserMessageInput } from '@maka/core/runtime-inputs';
 export interface AgentRunRecoveryDecision {
   runId: string;
   turnId: string;
-  status: 'failed' | 'completed';
+  status: 'failed' | 'completed' | 'cancelled';
   failureClass?: string;
+  abortSource?: string;
   diagnostic?: Record<string, unknown>;
   lineage: Partial<Pick<
     UserMessageInput,

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -16,7 +16,7 @@ import type { AgentBackend } from './ai-sdk-backend.js';
 import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
 import {
-  buildTextModelMessagesFromRuntimeEvents,
+  buildRuntimeEventModelReplayPlan,
   type TextModelMessage,
 } from './model-history.js';
 
@@ -300,7 +300,8 @@ export class AgentRun {
       }
       if (runtimeContext.length === 0) return undefined;
 
-      const runtimeMessages = buildTextModelMessagesFromRuntimeEvents(runtimeContext);
+      const runtimeReplayPlan = buildRuntimeEventModelReplayPlan(runtimeContext);
+      const runtimeMessages = runtimeReplayPlan.textMessages;
       if (runtimeMessages.length === 0) return undefined;
 
       const legacyPriorMessages = materializeLegacyTextMessages(

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -57,6 +57,7 @@ import type {
 } from '@maka/core/backend-types';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import type { JSONValue, ModelMessage } from 'ai';
 import { z } from 'zod';
 
 import { PermissionEngine } from './permission-engine.js';
@@ -81,8 +82,11 @@ import {
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import {
-  buildTextModelMessagesFromRuntimeEvents,
+  buildRuntimeEventModelReplayPlan,
   formatTextWithAttachmentRefs,
+  type RuntimeEventModelReplayItem,
+  type RuntimeEventModelReplayPlan,
+  type RuntimeEventReplayFallbackGate,
 } from './model-history.js';
 
 export {
@@ -95,6 +99,12 @@ export type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export { normalizeAiSdkUsage } from './model-adapter.js';
 export type { ModelFactory, ModelFactoryInput, RepairableAiSdkToolCall } from './model-adapter.js';
 export type { RunTraceEvent, RunTraceRecorder } from './run-trace.js';
+
+type AiSdkToolResultOutput =
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: JSONValue }
+  | { type: 'error-text'; value: string }
+  | { type: 'error-json'; value: JSONValue };
 
 // ============================================================================
 // AgentBackend interface
@@ -303,16 +313,8 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     // --- Build messages from context, preferring durable RuntimeEvents when usable. ---
-    const runtimeMessages = input.runtimeContext
-      ? buildTextModelMessagesFromRuntimeEvents(
-        input.runtimeContext.filter((event) => event.turnId !== input.turnId),
-      )
-      : [];
-    const messages = runtimeMessages.length > 0
-      ? runtimeMessages
-      : this.materializePriorMessages(
-        input.context.filter((message) => message.turnId !== input.turnId),
-      );
+    const priorReplay = this.buildPriorMessages(input);
+    const messages = priorReplay.messages;
     messages.push({
       role: 'user',
       content: this.buildUserContent(input.text, input.attachments),
@@ -579,11 +581,114 @@ export class AiSdkBackend implements AgentBackend {
    *  V0.1: text-only round-tripping. Tool calls / results within stored
    *  history are deliberately NOT replayed — ai-sdk's streamText starts
    *  fresh each turn and the tool state isn't part of the prompt. */
-  private materializePriorMessages(stored: readonly StoredMessage[]): Array<{
-    role: 'user' | 'assistant' | 'system';
-    content: string;
-  }> {
-    const out: Array<{ role: 'user' | 'assistant' | 'system'; content: string }> = [];
+  private buildPriorMessages(input: BackendSendInput): {
+    messages: ModelMessage[];
+    gate: RuntimeEventReplayFallbackGate | 'legacy_stored_messages';
+    diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
+  } {
+    const legacyMessages = this.materializePriorMessages(
+      input.context.filter((message) => message.turnId !== input.turnId),
+    );
+    if (!input.runtimeContext) {
+      return { messages: legacyMessages, gate: 'legacy_stored_messages', diagnostics: [] };
+    }
+
+    const plan = buildRuntimeEventModelReplayPlan(
+      input.runtimeContext.filter((event) => event.turnId !== input.turnId),
+    );
+    if (plan.items.length === 0) {
+      return { messages: legacyMessages, gate: 'legacy_stored_messages', diagnostics: plan.diagnostics };
+    }
+
+    if (hasBlockingReplayDiagnostics(plan)) {
+      return {
+        messages: legacyMessages,
+        gate: 'runtime_replay_unsupported_semantics',
+        diagnostics: plan.diagnostics,
+      };
+    }
+
+    if (!plan.hasProviderNativeSemantics) {
+      return {
+        messages: plan.textMessages,
+        gate: 'runtime_replay_text_only',
+        diagnostics: plan.diagnostics,
+      };
+    }
+
+    if (!this.canReplayProviderNative(plan)) {
+      return {
+        messages: legacyMessages,
+        gate: 'runtime_replay_unsupported_semantics',
+        diagnostics: plan.diagnostics,
+      };
+    }
+
+    return {
+      messages: this.materializeRuntimeReplayPlan(plan),
+      gate: 'runtime_replay_provider_native',
+      diagnostics: plan.diagnostics,
+    };
+  }
+
+  private canReplayProviderNative(plan: RuntimeEventModelReplayPlan): boolean {
+    const support = this.modelAdapter.runtimeEventReplaySupport();
+    for (const item of plan.items) {
+      if (item.kind === 'tool_call' && !support.toolCalls) return false;
+      if (item.kind === 'tool_result' && !support.toolResults) return false;
+      if (item.kind === 'thinking' && (!support.signedThinking || !item.signature)) return false;
+    }
+    return true;
+  }
+
+  private materializeRuntimeReplayPlan(plan: RuntimeEventModelReplayPlan): ModelMessage[] {
+    const out: ModelMessage[] = [];
+    for (const item of plan.items) {
+      out.push(this.materializeRuntimeReplayItem(item));
+    }
+    return out;
+  }
+
+  private materializeRuntimeReplayItem(item: RuntimeEventModelReplayItem): ModelMessage {
+    switch (item.kind) {
+      case 'text':
+        return { role: item.role, content: item.content };
+      case 'thinking':
+        return {
+          role: 'assistant',
+          content: [{
+            type: 'reasoning',
+            text: item.text,
+            providerOptions: {
+              anthropic: { signature: item.signature },
+            },
+          }],
+        };
+      case 'tool_call':
+        return {
+          role: 'assistant',
+          content: [{
+            type: 'tool-call',
+            toolCallId: item.toolCallId,
+            toolName: item.toolName,
+            input: item.input,
+          }],
+        };
+      case 'tool_result':
+        return {
+          role: 'tool',
+          content: [{
+            type: 'tool-result',
+            toolCallId: item.toolCallId,
+            toolName: item.toolName,
+            output: toolResultOutput(item.output, item.isError),
+          }],
+        };
+    }
+  }
+
+  private materializePriorMessages(stored: readonly StoredMessage[]): ModelMessage[] {
+    const out: ModelMessage[] = [];
     for (const m of stored) {
       if (m.type === 'user') out.push({ role: 'user', content: m.text });
       else if (m.type === 'assistant') out.push({ role: 'assistant', content: m.text });
@@ -661,4 +766,39 @@ function buildInvalidMakaTool(): MakaTool<{ tool?: string; error?: string }, nev
       throw new Error(`模型请求了不可用或格式错误的工具${requested}：${error || 'tool call could not be parsed'}`);
     },
   };
+}
+
+function toolResultOutput(value: unknown, isError: boolean): AiSdkToolResultOutput {
+  if (isError) {
+    return typeof value === 'string'
+      ? { type: 'error-text', value }
+      : { type: 'error-json', value: jsonValue(value) };
+  }
+  return typeof value === 'string'
+    ? { type: 'text', value }
+    : { type: 'json', value: jsonValue(value) };
+}
+
+function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolean {
+  return plan.diagnostics.some((diagnostic) =>
+    diagnostic.code === 'unsupported_role' ||
+    diagnostic.code === 'unsupported_content' ||
+    diagnostic.code === 'unsigned_thinking' ||
+    diagnostic.code === 'unmatched_tool_result' ||
+    diagnostic.code === 'tool_id_mismatch'
+  );
+}
+
+function jsonValue(value: unknown): JSONValue {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'number'
+    || typeof value === 'boolean'
+    || Array.isArray(value)
+    || typeof value === 'object'
+  ) {
+    return value as JSONValue;
+  }
+  return String(value);
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -180,6 +180,7 @@ export type {
 export {
   projectRuntimeEventsToStoredMessages,
   compareRuntimeReadModelMessages,
+  classifyRuntimeEventTerminalFact,
 } from './runtime-event-read-model.js';
 export type {
   ProjectRuntimeEventsToStoredMessagesOptions,
@@ -187,7 +188,23 @@ export type {
   RuntimeEventReadModelDiagnosticCode,
   RuntimeEventReadModelProjection,
   RuntimeReadModelCompatibilityResult,
+  RuntimeEventTerminalFact,
+  RuntimeEventTerminalFactResult,
 } from './runtime-event-read-model.js';
+
+// agent-run-inspect.ts — internal AgentRun/RuntimeEvent source-health view.
+export {
+  inspectAgentRunReadModel,
+  inspectSessionRunReadModels,
+} from './agent-run-inspect.js';
+export type {
+  AgentRunInspectDiagnostic,
+  AgentRunInspectDiagnosticCode,
+  AgentRunInspectModel,
+  AgentRunInspectProjectionSummary,
+  AgentRunInspectSourceHealth,
+  InspectAgentRunOptions,
+} from './agent-run-inspect.js';
 
 // model-history.ts — policy-driven model-history projection.
 export { buildModelHistoryFromRuntimeEvents } from './model-history.js';

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -7,6 +7,7 @@ import type {
 } from '@maka/core/events';
 import { PROVIDER_DEFAULTS, type LlmConnection } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
+import type { ModelMessage } from 'ai';
 
 import type { AsyncEventQueue } from './async-queue.js';
 import { classifyError, errorReasonFromClass } from './tool-runtime.js';
@@ -47,7 +48,7 @@ export interface ModelAdapterInput {
 
 export interface ModelAdapterStreamInput {
   model: unknown;
-  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  messages: ModelMessage[];
   tools: Record<string, unknown>;
   activeTools: string[];
   system?: string;
@@ -67,6 +68,15 @@ export interface ModelAdapterStreamCallbacks {
 
 export class ModelAdapter {
   constructor(private readonly input: ModelAdapterInput) {}
+
+  runtimeEventReplaySupport(): ModelAdapterRuntimeEventReplaySupport {
+    const protocol = PROVIDER_DEFAULTS[this.input.connection.providerType].protocol;
+    return {
+      toolCalls: true,
+      toolResults: true,
+      signedThinking: protocol === 'anthropic',
+    };
+  }
 
   resolveModel(): unknown {
     if (PROVIDER_DEFAULTS[this.input.connection.providerType].authKind !== 'none' && !this.input.apiKey) {
@@ -183,6 +193,12 @@ export class ModelAdapter {
       default:               return 'end_turn';
     }
   }
+}
+
+export interface ModelAdapterRuntimeEventReplaySupport {
+  toolCalls: boolean;
+  toolResults: boolean;
+  signedThinking: boolean;
 }
 
 export interface AiSdkStreamChunk {

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -35,6 +35,7 @@
 
 import {
   isPartialRuntimeEvent,
+  isTerminalRuntimeEvent,
   runtimeEventHasModelVisibleContent,
   type RuntimeEvent,
   type RuntimeEventTextContent,
@@ -62,6 +63,76 @@ export interface ModelHistoryEntry {
 export interface TextModelMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
+}
+
+export type RuntimeEventReplayFallbackGate =
+  | 'runtime_replay_text_only'
+  | 'runtime_replay_provider_native'
+  | 'runtime_replay_unsupported_semantics';
+
+export type RuntimeEventReplayDiagnosticCode =
+  | 'partial_skipped'
+  | 'unsupported_role'
+  | 'unsupported_content'
+  | 'system_runtime_fact_diagnostic_only'
+  | 'terminal_fact_diagnostic_only'
+  | 'unsigned_thinking'
+  | 'unmatched_tool_result'
+  | 'tool_id_mismatch';
+
+export interface RuntimeEventReplayDiagnostic {
+  code: RuntimeEventReplayDiagnosticCode;
+  message: string;
+  eventId?: string;
+  turnId?: string;
+  detail?: Record<string, unknown>;
+}
+
+export type RuntimeEventReplaySemanticKind =
+  | 'text'
+  | 'thinking'
+  | 'tool_call'
+  | 'tool_result';
+
+export type RuntimeEventModelReplayItem =
+  | {
+      kind: 'text';
+      role: 'user' | 'assistant' | 'system';
+      content: string;
+      eventId: string;
+      ts: number;
+    }
+  | {
+      kind: 'thinking';
+      text: string;
+      signature?: string;
+      eventId: string;
+      ts: number;
+    }
+  | {
+      kind: 'tool_call';
+      toolCallId: string;
+      toolName: string;
+      input: unknown;
+      eventId: string;
+      ts: number;
+    }
+  | {
+      kind: 'tool_result';
+      toolCallId: string;
+      toolName: string;
+      output: unknown;
+      isError: boolean;
+      eventId: string;
+      ts: number;
+    };
+
+export interface RuntimeEventModelReplayPlan {
+  items: RuntimeEventModelReplayItem[];
+  textMessages: TextModelMessage[];
+  semanticKinds: RuntimeEventReplaySemanticKind[];
+  diagnostics: RuntimeEventReplayDiagnostic[];
+  hasProviderNativeSemantics: boolean;
 }
 
 // ============================================================================
@@ -152,6 +223,181 @@ export interface RuntimeEventTextMessageOptions {
   includeSystemEvents?: boolean;
 }
 
+export interface BuildRuntimeEventModelReplayPlanOptions {
+  includeSystemEvents?: boolean;
+}
+
+export function buildRuntimeEventModelReplayPlan(
+  events: readonly RuntimeEvent[],
+  options: BuildRuntimeEventModelReplayPlanOptions = {},
+): RuntimeEventModelReplayPlan {
+  const includeSystemEvents = options.includeSystemEvents ?? false;
+  const items: RuntimeEventModelReplayItem[] = [];
+  const diagnostics: RuntimeEventReplayDiagnostic[] = [];
+  const callsById = new Map<string, { name: string; eventId: string }>();
+  const semanticKinds = new Set<RuntimeEventReplaySemanticKind>();
+
+  for (const event of events) {
+    if (isPartialRuntimeEvent(event)) {
+      diagnostics.push(diagnostic(event, 'partial_skipped', 'partial RuntimeEvent skipped for model replay'));
+      continue;
+    }
+
+    if (isTerminalRuntimeEvent(event)) {
+      diagnostics.push(diagnostic(
+        event,
+        'terminal_fact_diagnostic_only',
+        'terminal RuntimeEvent status is diagnostic-only for model replay',
+        { status: event.status },
+      ));
+    }
+
+    if (!event.content) {
+      if (event.actions && !isTerminalRuntimeEvent(event)) {
+        diagnostics.push(diagnostic(
+          event,
+          'system_runtime_fact_diagnostic_only',
+          'RuntimeEvent actions are diagnostic-only for model replay',
+          { actionKeys: Object.keys(event.actions) },
+        ));
+      }
+      continue;
+    }
+
+    if (!runtimeEventHasModelVisibleContent(event)) {
+      diagnostics.push(diagnostic(
+        event,
+        'unsupported_content',
+        'RuntimeEvent content kind is not model-replayable',
+        { kind: event.content.kind },
+      ));
+      continue;
+    }
+
+    if (event.role === 'system' && !includeSystemEvents) {
+      diagnostics.push(diagnostic(
+        event,
+        'system_runtime_fact_diagnostic_only',
+        'system RuntimeEvent content is diagnostic-only unless system replay is enabled',
+      ));
+      continue;
+    }
+
+    switch (event.content.kind) {
+      case 'text': {
+        const role = modelTextRole(event.role);
+        if (!role) {
+          diagnostics.push(diagnostic(event, 'unsupported_role', 'text RuntimeEvent role is not model-replayable', {
+            role: event.role,
+          }));
+          continue;
+        }
+        semanticKinds.add('text');
+        items.push({
+          kind: 'text',
+          role,
+          content: formatTextWithAttachmentRefs(event.content),
+          eventId: event.id,
+          ts: event.ts,
+        });
+        break;
+      }
+      case 'thinking': {
+        if (event.role !== 'model') {
+          diagnostics.push(diagnostic(event, 'unsupported_role', 'thinking RuntimeEvent must use model role', {
+            role: event.role,
+          }));
+          continue;
+        }
+        if (!event.content.signature) {
+          diagnostics.push(diagnostic(event, 'unsigned_thinking', 'thinking RuntimeEvent has no replay signature'));
+        }
+        semanticKinds.add('thinking');
+        items.push({
+          kind: 'thinking',
+          text: event.content.text,
+          ...(event.content.signature ? { signature: event.content.signature } : {}),
+          eventId: event.id,
+          ts: event.ts,
+        });
+        break;
+      }
+      case 'function_call': {
+        if (event.role !== 'model') {
+          diagnostics.push(diagnostic(event, 'unsupported_role', 'function_call RuntimeEvent must use model role', {
+            role: event.role,
+          }));
+          continue;
+        }
+        semanticKinds.add('tool_call');
+        callsById.set(event.content.id, { name: event.content.name, eventId: event.id });
+        items.push({
+          kind: 'tool_call',
+          toolCallId: event.content.id,
+          toolName: event.content.name,
+          input: event.content.args,
+          eventId: event.id,
+          ts: event.ts,
+        });
+        break;
+      }
+      case 'function_response': {
+        if (event.role !== 'tool') {
+          diagnostics.push(diagnostic(event, 'unsupported_role', 'function_response RuntimeEvent must use tool role', {
+            role: event.role,
+          }));
+          continue;
+        }
+        const call = callsById.get(event.content.id);
+        if (!call) {
+          diagnostics.push(diagnostic(event, 'unmatched_tool_result', 'function_response has no prior matching function_call', {
+            toolCallId: event.content.id,
+          }));
+        } else if (call.name !== event.content.name) {
+          diagnostics.push(diagnostic(event, 'tool_id_mismatch', 'function_response name differs from matching function_call', {
+            toolCallId: event.content.id,
+            callName: call.name,
+            resultName: event.content.name,
+            callEventId: call.eventId,
+          }));
+        }
+        semanticKinds.add('tool_result');
+        items.push({
+          kind: 'tool_result',
+          toolCallId: event.content.id,
+          toolName: event.content.name,
+          output: event.content.result,
+          isError: event.content.isError === true,
+          eventId: event.id,
+          ts: event.ts,
+        });
+        break;
+      }
+      default:
+        diagnostics.push(diagnostic(
+          event,
+          'unsupported_content',
+          'RuntimeEvent content kind is not model-replayable',
+          { kind: (event.content as RuntimeEventContent).kind },
+        ));
+        break;
+    }
+  }
+
+  const textMessages = items
+    .filter((item): item is Extract<RuntimeEventModelReplayItem, { kind: 'text' }> => item.kind === 'text')
+    .map((item) => ({ role: item.role, content: item.content }));
+  return {
+    items,
+    textMessages,
+    semanticKinds: [...semanticKinds],
+    diagnostics,
+    hasProviderNativeSemantics: semanticKinds.has('thinking')
+      || semanticKinds.has('tool_call')
+      || semanticKinds.has('tool_result'),
+  };
+}
+
 /**
  * Convert projected RuntimeEvent history into the current AI SDK text-only
  * message shape. Tool/function and thinking entries are intentionally skipped.
@@ -184,6 +430,34 @@ export function buildTextModelMessagesFromRuntimeEvents(
     });
   }
   return out;
+}
+
+function modelTextRole(role: RuntimeEventRole): TextModelMessage['role'] | undefined {
+  switch (role) {
+    case 'user':
+      return 'user';
+    case 'model':
+      return 'assistant';
+    case 'system':
+      return 'system';
+    default:
+      return undefined;
+  }
+}
+
+function diagnostic(
+  event: RuntimeEvent,
+  code: RuntimeEventReplayDiagnosticCode,
+  message: string,
+  detail?: Record<string, unknown>,
+): RuntimeEventReplayDiagnostic {
+  return {
+    code,
+    message,
+    eventId: event.id,
+    turnId: event.turnId,
+    ...(detail ? { detail } : {}),
+  };
 }
 
 export function formatTextWithAttachmentRefs(

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -9,6 +9,7 @@ import type {
 import {
   isPartialRuntimeEvent,
   isTerminalRuntimeEvent,
+  isTerminalRuntimeEventStatus,
 } from '@maka/core';
 
 export type RuntimeEventReadModelDiagnosticCode =
@@ -41,6 +42,22 @@ export interface ProjectRuntimeEventsToStoredMessagesOptions {
 
 export interface RuntimeReadModelCompatibilityResult {
   compatible: boolean;
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+}
+
+export interface RuntimeEventTerminalFact {
+  runId: string;
+  turnId: string;
+  runStatus: 'completed' | 'failed' | 'cancelled';
+  turnStatus: 'completed' | 'failed' | 'aborted';
+  terminalEvent: RuntimeEvent;
+  failureClass?: string;
+  abortSource?: string;
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+}
+
+export interface RuntimeEventTerminalFactResult {
+  fact?: RuntimeEventTerminalFact;
   diagnostics: RuntimeEventReadModelDiagnostic[];
 }
 
@@ -177,6 +194,114 @@ export function compareRuntimeReadModelMessages(
   }
 
   return { compatible: diagnostics.length === 0, diagnostics };
+}
+
+export function classifyRuntimeEventTerminalFact(
+  header: AgentRunHeader,
+  events: readonly RuntimeEvent[],
+): RuntimeEventTerminalFactResult {
+  const diagnostics: RuntimeEventReadModelDiagnostic[] = [];
+  if (events.length === 0) {
+    diagnostics.push(readModelDiagnostic(
+      'incomplete_event',
+      'runtime ledger has no readable RuntimeEvents',
+      { runId: header.runId, turnId: header.turnId },
+    ));
+    return { diagnostics };
+  }
+
+  const terminalSignals = events.filter((event) =>
+    !isPartialRuntimeEvent(event) &&
+    event.sessionId === header.sessionId &&
+    event.runId === header.runId &&
+    event.turnId === header.turnId &&
+    isTerminalRuntimeEvent(event)
+  );
+
+  if (terminalSignals.length === 0) {
+    diagnostics.push(readModelDiagnostic(
+      'incomplete_event',
+      'runtime ledger has no matching terminal RuntimeEvent',
+      { runId: header.runId, turnId: header.turnId },
+    ));
+    return { diagnostics };
+  }
+  if (terminalSignals.length > 1) {
+    diagnostics.push(readModelDiagnostic(
+      'incomplete_event',
+      'runtime ledger has multiple matching terminal RuntimeEvents',
+      {
+        runId: header.runId,
+        turnId: header.turnId,
+        eventIds: terminalSignals.map((event) => event.id),
+      },
+    ));
+    return { diagnostics };
+  }
+
+  const terminalEvent = terminalSignals[0]!;
+  if (!isTerminalRuntimeEventStatus(terminalEvent.status)) {
+    diagnostics.push(readModelDiagnostic(
+      'incomplete_event',
+      'terminal RuntimeEvent requires a terminal status for recovery',
+      terminalEvent,
+    ));
+    return { diagnostics };
+  }
+
+  if (terminalEvent.status === 'completed') {
+    const fact: RuntimeEventTerminalFact = {
+      runId: header.runId,
+      turnId: header.turnId,
+      runStatus: 'completed',
+      turnStatus: 'completed',
+      terminalEvent,
+      diagnostics,
+    };
+    return { fact, diagnostics };
+  }
+
+  if (terminalEvent.status === 'failed') {
+    const failureClass = failureClassFromRuntimeEvent(terminalEvent, header);
+    if (!failureClass) {
+      diagnostics.push(readModelDiagnostic(
+        'incomplete_event',
+        'failed terminal RuntimeEvent requires a stable failure class',
+        terminalEvent,
+      ));
+      return { diagnostics };
+    }
+    const fact: RuntimeEventTerminalFact = {
+      runId: header.runId,
+      turnId: header.turnId,
+      runStatus: 'failed',
+      turnStatus: 'failed',
+      terminalEvent,
+      failureClass,
+      diagnostics,
+    };
+    return { fact, diagnostics };
+  }
+
+  const abortSource = abortSourceFromRuntime(terminalEvent, header);
+  if (!abortSource) {
+    diagnostics.push(readModelDiagnostic(
+      'incomplete_event',
+      'aborted terminal RuntimeEvent requires an abort source',
+      terminalEvent,
+    ));
+    return { diagnostics };
+  }
+  const fact: RuntimeEventTerminalFact = {
+    runId: header.runId,
+    turnId: header.turnId,
+    runStatus: 'cancelled',
+    turnStatus: 'aborted',
+    terminalEvent,
+    abortSource,
+    diagnostics,
+  };
+  return { fact, diagnostics };
 }
 
 function projectText(
@@ -449,10 +574,24 @@ function abortSourceFromRuntime(event: RuntimeEvent, header: AgentRunHeader): st
     ?? stringRecordValue(header as unknown as Record<string, unknown>, 'abortSource');
 }
 
+function failureClassFromRuntimeEvent(event: RuntimeEvent, header: AgentRunHeader): string | undefined {
+  if (header.failureClass) return header.failureClass;
+  return stringStateDelta(event, 'failureClass')
+    ?? stringStateDelta(event, 'errorClass')
+    ?? stringStateDelta(event, 'reason')
+    ?? stringStateDelta(event, 'code')
+    ?? (event.content?.kind === 'error' ? nonEmptyString(event.content.reason) : undefined)
+    ?? (event.content?.kind === 'error' ? nonEmptyString(event.content.code) : undefined);
+}
+
 function stringRecordValue(value: unknown, key: string): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const result = (value as Record<string, unknown>)[key];
   return typeof result === 'string' && result.length > 0 ? result : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function stableMessageId(
@@ -542,6 +681,40 @@ function diagnostic(
     message,
     ...(detail !== undefined ? { detail } : {}),
   });
+}
+
+function readModelDiagnostic(
+  code: RuntimeEventReadModelDiagnosticCode,
+  message: string,
+  detail: RuntimeEvent | { runId: string; turnId: string; [key: string]: unknown },
+): RuntimeEventReadModelDiagnostic {
+  if (isRuntimeEventDiagnosticDetail(detail)) {
+    return {
+      code,
+      eventId: detail.id,
+      runId: detail.runId,
+      turnId: detail.turnId,
+      message,
+    };
+  }
+  return {
+    code,
+    runId: detail.runId,
+    turnId: detail.turnId,
+    message,
+    detail,
+  };
+}
+
+function isRuntimeEventDiagnosticDetail(
+  detail: RuntimeEvent | { runId: string; turnId: string; [key: string]: unknown },
+): detail is RuntimeEvent {
+  return (
+    typeof (detail as RuntimeEvent).id === 'string' &&
+    typeof (detail as RuntimeEvent).sessionId === 'string' &&
+    typeof detail.runId === 'string' &&
+    typeof detail.turnId === 'string'
+  );
 }
 
 function countSemanticMessages(messages: readonly StoredMessage[]): Map<string, number> {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -51,7 +51,9 @@ import {
   compareRuntimeReadModelMessages,
   projectRuntimeEventsToStoredMessages,
   type RuntimeEventReadModelDiagnostic,
+  type RuntimeEventTerminalFact,
 } from './runtime-event-read-model.js';
+import { inspectAgentRunReadModel, type AgentRunInspectModel } from './agent-run-inspect.js';
 
 import type { AgentBackend } from './ai-sdk-backend.js';
 import type { RunTraceRecorder } from './run-trace.js';
@@ -72,6 +74,10 @@ export interface StopSessionInput {
 // SessionStore contract (matches the storage package surface)
 // ============================================================================
 
+// SessionStore remains the compatibility ledger and projection cache for UI,
+// branch/retry, and legacy recovery. RuntimeEvent-complete runs should make new
+// semantic decisions from the AgentRun/RuntimeEvent read model first, then fall
+// back to these StoredMessage rows only when compatibility requires it.
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
@@ -784,18 +790,27 @@ export class SessionManager {
 
     let recovered = false;
     for (const run of runs) {
-      const events = await this.deps.runStore.readEvents(sessionId, run.runId);
-      const decision = classifyAgentRunRecovery(run, events, messages);
+      const inspected = await inspectAgentRunReadModel(this.deps.runStore, { sessionId, runId: run.runId, header: run });
+      const runtimeDecision = this.classifyRuntimeEventRecovery(inspected);
+      const decision = runtimeDecision ?? classifyAgentRunRecovery(run, inspected.events, messages);
       if (!decision) continue;
-      await this.applyAgentRunRecovery(sessionId, decision);
+      await this.applyAgentRunRecovery(sessionId, decision, inspected.events);
       recovered = true;
     }
     return { hasLedger: true, recovered };
   }
 
+  private classifyRuntimeEventRecovery(
+    inspected: AgentRunInspectModel,
+  ): AgentRunRecoveryDecision | undefined {
+    if (isTerminalRunStatus(inspected.header.status) || !inspected.terminalRuntimeFact) return undefined;
+    return runtimeTerminalFactToRecoveryDecision(inspected.header, inspected.terminalRuntimeFact);
+  }
+
   private async applyAgentRunRecovery(
     sessionId: string,
     decision: AgentRunRecoveryDecision,
+    existingEvents: readonly { type: string }[] = [],
   ): Promise<void> {
     const ts = this.deps.now();
     if (decision.status === 'completed') {
@@ -804,16 +819,42 @@ export class SessionManager {
         completedAt: ts,
         updatedAt: ts,
       });
-      await this.deps.runStore?.appendEvent(sessionId, decision.runId, {
-        type: 'run_completed',
-        id: this.deps.newId(),
-        runId: decision.runId,
-        sessionId,
-        turnId: decision.turnId,
-        ts,
-        data: { recovered: true, ...decision.diagnostic },
+      if (!hasTerminalAgentRunEvent(existingEvents)) {
+        await this.deps.runStore?.appendEvent(sessionId, decision.runId, {
+          type: 'run_completed',
+          id: this.deps.newId(),
+          runId: decision.runId,
+          sessionId,
+          turnId: decision.turnId,
+          ts,
+          data: { recovered: true, ...decision.diagnostic },
+        });
+      }
+      await this.appendTerminalTurnStateIfNeeded(sessionId, decision, 'completed', { ts }).catch(() => {});
+      return;
+    }
+
+    if (decision.status === 'cancelled') {
+      await this.deps.runStore?.updateRun(sessionId, decision.runId, {
+        status: 'cancelled',
+        completedAt: ts,
+        updatedAt: ts,
       });
-      await this.appendTurnState(sessionId, decision.turnId, 'completed', decision.lineage, { ts }).catch(() => {});
+      if (!hasTerminalAgentRunEvent(existingEvents)) {
+        await this.deps.runStore?.appendEvent(sessionId, decision.runId, {
+          type: 'run_cancelled',
+          id: this.deps.newId(),
+          runId: decision.runId,
+          sessionId,
+          turnId: decision.turnId,
+          ts,
+          data: { recovered: true, ...decision.diagnostic },
+        });
+      }
+      await this.appendTerminalTurnStateIfNeeded(sessionId, decision, 'aborted', {
+        ts,
+        abortSource: decision.abortSource,
+      }).catch(() => {});
       return;
     }
 
@@ -824,19 +865,33 @@ export class SessionManager {
       updatedAt: ts,
       failureClass,
     });
-    await this.deps.runStore?.appendEvent(sessionId, decision.runId, {
-      type: 'run_failed',
-      id: this.deps.newId(),
-      runId: decision.runId,
-      sessionId,
-      turnId: decision.turnId,
-      ts,
-      data: { recovered: true, failureClass, ...decision.diagnostic },
-    });
-    await this.appendTurnState(sessionId, decision.turnId, 'failed', decision.lineage, {
+    if (!hasTerminalAgentRunEvent(existingEvents)) {
+      await this.deps.runStore?.appendEvent(sessionId, decision.runId, {
+        type: 'run_failed',
+        id: this.deps.newId(),
+        runId: decision.runId,
+        sessionId,
+        turnId: decision.turnId,
+        ts,
+        data: { recovered: true, failureClass, ...decision.diagnostic },
+      });
+    }
+    await this.appendTerminalTurnStateIfNeeded(sessionId, decision, 'failed', {
       ts,
       errorClass: failureClass,
     }).catch(() => {});
+  }
+
+  private async appendTerminalTurnStateIfNeeded(
+    sessionId: string,
+    decision: AgentRunRecoveryDecision,
+    status: TurnRecord['status'],
+    options: { ts: number; errorClass?: string; abortSource?: string },
+  ): Promise<void> {
+    const messages = await this.deps.store.readMessages(sessionId).catch(() => []);
+    const latest = latestTurnState(messages, decision.turnId);
+    if (latest && isTerminalTurnStatus(latest.status) && latest.status === status) return;
+    await this.appendTurnState(sessionId, decision.turnId, status, decision.lineage, options);
   }
 }
 
@@ -995,6 +1050,54 @@ function copyMessagesThroughTurnBoundary(messages: readonly StoredMessage[], tur
 
 function isTerminalRunStatus(status: AgentRunHeader['status']): boolean {
   return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function isTerminalTurnStatus(status: TurnRecord['status']): boolean {
+  return status === 'completed' || status === 'failed' || status === 'aborted';
+}
+
+function hasTerminalAgentRunEvent(events: readonly { type: string }[]): boolean {
+  return events.some((event) =>
+    event.type === 'run_completed' ||
+    event.type === 'run_failed' ||
+    event.type === 'run_cancelled'
+  );
+}
+
+function latestTurnState(
+  messages: readonly StoredMessage[],
+  turnId: string,
+): Extract<StoredMessage, { type: 'turn_state' }> | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.type === 'turn_state' && message.turnId === turnId) return message;
+  }
+  return undefined;
+}
+
+function runtimeTerminalFactToRecoveryDecision(
+  header: AgentRunHeader,
+  fact: RuntimeEventTerminalFact,
+): AgentRunRecoveryDecision {
+  return {
+    runId: fact.runId,
+    turnId: fact.turnId,
+    status: fact.runStatus,
+    ...(fact.failureClass ? { failureClass: fact.failureClass } : {}),
+    ...(fact.abortSource ? { abortSource: fact.abortSource } : {}),
+    diagnostic: {
+      recoveryReason: 'runtime_event_terminal_fact',
+      runtimeEventId: fact.terminalEvent.id,
+      runtimeEventStatus: fact.terminalEvent.status,
+    },
+    lineage: {
+      ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
+      ...(header.retriedFromTurnId ? { retriedFromTurnId: header.retriedFromTurnId } : {}),
+      ...(header.regeneratedFromTurnId ? { regeneratedFromTurnId: header.regeneratedFromTurnId } : {}),
+      ...(header.branchOfTurnId ? { branchOfTurnId: header.branchOfTurnId } : {}),
+      ...(header.parentSessionId ? { parentSessionId: header.parentSessionId } : {}),
+    },
+  };
 }
 
 function hasHardProjectionDiagnostic(diagnostics: readonly RuntimeEventReadModelDiagnostic[]): boolean {


### PR DESCRIPTION
## Summary
- add a RuntimeEvent model replay plan and explicit AI SDK replay gates for text-only, provider-native, and unsupported semantic fallback
- prefer complete RuntimeEvent terminal facts during startup recovery before operational AgentRunEvent / legacy SessionStore fallback
- add an internal AgentRun inspect read model joining headers, operational events, RuntimeEvents, terminal facts, replay plan, projection summary, and diagnostics

## Rive
- workflow: `wfrun_2fff27cd5edb4986991410f03f32c116`
- scheduler: `sched_54fd8a06184444d980337bf0996f9295`
- root: `work_9ce3439d6c1241328bff8309b62df7bb`
- template: `maka.runtimeevent-semantic-source-convergence-20260615`

## Verification
- `npm run build --workspace packages/core`
- `npm run typecheck --workspace packages/runtime`
- `npm run build --workspace packages/runtime`
- `node --test packages/runtime/dist/__tests__/runtime-event-adapters.test.js packages/runtime/dist/__tests__/ai-sdk-backend.test.js packages/runtime/dist/__tests__/session-manager.test.js packages/runtime/dist/__tests__/agent-run-inspect.test.js`
- `npm run test --workspace packages/runtime -- --runInBand`
- `npm run test --workspace packages/storage -- --runInBand`
- `npm run typecheck`
- `npm run test --workspaces --if-present`
- `git diff --check`
- `git diff --cached --check`
