### PR TITLE
Extract Runtime Kernel read model boundary

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -149,7 +149,7 @@ import {
   PROVIDER_DEFAULTS,
   type LlmConnection,
 } from '@maka/core/llm-connections';
-import { createAgentRunStore, createArtifactStore, createConnectionStore, createPlanReminderStore, createSessionStore, createSettingsStore, createTelemetryRepo, resolveArtifactPath } from '@maka/storage';
+import { createAgentRunStore, createArtifactStore, createConnectionStore, createPlanReminderStore, createRuntimeEventStore, createSessionStore, createSettingsStore, createTelemetryRepo, resolveArtifactPath } from '@maka/storage';
 import {
   ensureSessionCanSendOrRebind,
   errorCode,
@@ -222,6 +222,7 @@ const visualSmokeFixture = resolveVisualSmokeFixture(
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', visualSmokeFixture?.workspaceName ?? 'default');
 const store = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
+const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
 const connectionStore = createConnectionStore(workspaceRoot);
 const settingsStore = createSettingsStore(workspaceRoot);
 const telemetryRepo = createTelemetryRepo(workspaceRoot);
@@ -946,6 +947,7 @@ backends.register('fake', (ctx) =>
 const runtime = new SessionManager({
   store,
   runStore,
+  runtimeEventStore,
   backends,
   newId: randomUUID,
   now: Date.now,

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -1,5 +1,4 @@
 import type { PermissionMode } from './permission.js';
-import type { RuntimeEvent } from './runtime-event.js';
 import type { BackendKind } from './session.js';
 
 export const AGENT_RUN_STATUSES = [
@@ -83,6 +82,4 @@ export interface AgentRunStore {
   listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
   appendEvent(sessionId: string, runId: string, event: AgentRunEvent): Promise<void>;
   readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
-  appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void>;
-  readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
 }

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -20,13 +20,16 @@ export interface BackendSendInput {
   text: string;
   attachments?: AttachmentRef[];
   /**
-   * Prior messages from JSONL. Adapter materializes these into the SDK's
-   * expected conversation shape.
+   * Prior conversation projected from the RuntimeEvent ledger into the
+   * existing StoredMessage public shape. Adapters materialize this into the
+   * SDK's expected conversation shape when native RuntimeEvent replay is not
+   * available.
    */
   context: StoredMessage[];
   /**
    * Optional prior RuntimeEvent ledger for model-history projection. Backends
-   * prefer this only when supplied and usable; `context` remains the fallback.
+   * prefer this when supplied and usable; `context` is the RuntimeEvent-derived
+   * compatibility projection.
    */
   runtimeContext?: RuntimeEvent[];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,11 @@ export {
   createRuntimeEventId,
 } from './runtime-event.js';
 
+// runtime-event-store.ts
+export type {
+  RuntimeEventStore,
+} from './runtime-event-store.js';
+
 // session.ts
 export type {
   SessionHeader,

--- a/packages/core/src/runtime-event-store.ts
+++ b/packages/core/src/runtime-event-store.ts
@@ -1,0 +1,7 @@
+import type { RuntimeEvent } from './runtime-event.js';
+
+export interface RuntimeEventStore {
+  appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void>;
+  readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
+}

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -4,8 +4,9 @@
  * This is the single internal runtime fact model. It is NOT a UI event
  * (see ./events.ts `SessionEvent`) and NOT a trace row (RunTrace) or
  * telemetry record. StoredMessage JSONL, renderer SessionEvent,
- * AgentRunStore, RunTrace, and TelemetryRepo are all projections that
- * should be written from — or explicitly linked to — these events.
+ * AgentRunStore operational rows, RunTrace, and TelemetryRepo are all
+ * projections that should be written from -- or explicitly linked to -- these
+ * events.
  *
  * Source: docs/runtime-v2-architecture-evolution.md §Canonical RuntimeEvent
  *

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -28,6 +28,7 @@
     "./bots": "./dist/bots/index.js",
     "./runtime-event-adapters": "./dist/runtime-event-adapters.js",
     "./runtime-event-read-model": "./dist/runtime-event-read-model.js",
+    "./runtime-kernel": "./dist/runtime-kernel.js",
     "./agent-run-inspect": "./dist/agent-run-inspect.js",
     "./model-history": "./dist/model-history.js",
     "./invocation-context": "./dist/invocation-context.js",

--- a/packages/runtime/src/__tests__/agent-run-inspect.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-inspect.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from 'node:test';
-import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent } from '@maka/core';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 import { expect } from '../test-helpers.js';
 import { inspectAgentRunReadModel } from '../agent-run-inspect.js';
 
@@ -37,7 +37,7 @@ describe('inspectAgentRunReadModel', () => {
       ts: ts + 10,
     }));
 
-    const inspected = await inspectAgentRunReadModel(runStore, { sessionId, runId });
+    const inspected = await inspectAgentRunReadModel(runStore, runStore, { sessionId, runId });
 
     expect(inspected.sourceHealth).toEqual({
       runtimeLedger: 'present',
@@ -57,7 +57,7 @@ describe('inspectAgentRunReadModel', () => {
     await missingRuntimeStore.createRun(makeHeader({ status: 'completed' }));
     await missingRuntimeStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_completed' }));
 
-    const missing = await inspectAgentRunReadModel(missingRuntimeStore, { sessionId, runId });
+    const missing = await inspectAgentRunReadModel(missingRuntimeStore, missingRuntimeStore, { sessionId, runId });
 
     expect(missing.events.map((event) => event.type)).toEqual(['run_completed']);
     expect(missing.sourceHealth.runtimeLedger).toBe('missing');
@@ -69,7 +69,7 @@ describe('inspectAgentRunReadModel', () => {
     await corruptRuntimeStore.createRun(makeHeader({ status: 'completed' }));
     await corruptRuntimeStore.appendEvent(sessionId, runId, makeRunEvent({ type: 'run_completed' }));
 
-    const corrupt = await inspectAgentRunReadModel(corruptRuntimeStore, { sessionId, runId });
+    const corrupt = await inspectAgentRunReadModel(corruptRuntimeStore, corruptRuntimeStore, { sessionId, runId });
 
     expect(corrupt.events.map((event) => event.type)).toEqual(['run_completed']);
     expect(corrupt.sourceHealth.runtimeLedger).toBe('read_failed');
@@ -89,7 +89,7 @@ describe('inspectAgentRunReadModel', () => {
       actions: { endInvocation: true },
     }));
 
-    const inspected = await inspectAgentRunReadModel(runStore, { sessionId, runId });
+    const inspected = await inspectAgentRunReadModel(runStore, runStore, { sessionId, runId });
 
     expect(inspected.sourceHealth.statusConsistency).toBe('inconsistent');
     expect(inspected.terminalRuntimeFact?.runStatus).toBe('completed');
@@ -97,7 +97,7 @@ describe('inspectAgentRunReadModel', () => {
   });
 });
 
-class MemoryAgentRunStore implements AgentRunStore {
+class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   private headers = new Map<string, AgentRunHeader>();
   private events = new Map<string, AgentRunEvent[]>();
   private runtimeEvents = new Map<string, RuntimeEvent[]>();
@@ -146,6 +146,22 @@ class MemoryAgentRunStore implements AgentRunStore {
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     if (this.options.failRuntimeEventReads) throw new Error('runtime ledger is corrupt');
     return (this.runtimeEvents.get(key(sessionId, runId)) ?? []).map(copyRuntimeEvent);
+  }
+
+  async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
+    const ordered: Array<{ event: RuntimeEvent; runId: string; eventIndex: number }> = [];
+    for (const [eventKey, events] of this.runtimeEvents.entries()) {
+      const [eventSessionId, runId] = eventKey.split(':');
+      if (eventSessionId !== sessionId || !runId) continue;
+      events.forEach((event, eventIndex) => ordered.push({ event: copyRuntimeEvent(event), runId, eventIndex }));
+    }
+    ordered.sort((a, b) =>
+      a.event.ts - b.event.ts ||
+      a.runId.localeCompare(b.runId) ||
+      a.eventIndex - b.eventIndex ||
+      a.event.id.localeCompare(b.event.id)
+    );
+    return ordered.map((item) => item.event);
   }
 }
 

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -41,8 +41,8 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
         runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
@@ -58,7 +58,7 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
-  test('falls back to StoredMessage context when RuntimeEvent projection is empty', async () => {
+  test('uses StoredMessage projection when RuntimeEvent replay is empty', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
@@ -78,8 +78,8 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
         {
@@ -99,8 +99,8 @@ describe('AiSdkBackend model history', () => {
     }));
 
     assert.deepEqual(compactPrompt(model), [
-      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
       { role: 'user', content: [{ type: 'text', text: 'current user' }] },
     ]);
   });
@@ -125,12 +125,12 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
-        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'legacy user' }),
-        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'legacy assistant' }),
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'projection user' }),
+        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'projection assistant' }),
         runtimeEvent({
           id: 'rt-call',
           turnId: 'turn-prev',
@@ -149,8 +149,8 @@ describe('AiSdkBackend model history', () => {
     }));
 
     assert.deepEqual(compactPrompt(model), [
-      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
       {
         role: 'assistant',
         content: [{
@@ -176,7 +176,7 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
-  test('falls back to legacy context when RuntimeEvent tool results are unmatched', async () => {
+  test('uses StoredMessage projection when RuntimeEvent tool results are unmatched', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
@@ -196,8 +196,8 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
         runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
@@ -212,13 +212,13 @@ describe('AiSdkBackend model history', () => {
     }));
 
     assert.deepEqual(compactPrompt(model), [
-      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
       { role: 'user', content: [{ type: 'text', text: 'current user' }] },
     ]);
   });
 
-  test('falls back to legacy context when RuntimeEvent replay has unsupported content', async () => {
+  test('uses StoredMessage projection when RuntimeEvent replay has unsupported content', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
@@ -238,8 +238,8 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
         runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'runtime user' }),
@@ -254,13 +254,13 @@ describe('AiSdkBackend model history', () => {
     }));
 
     assert.deepEqual(compactPrompt(model), [
-      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
       { role: 'user', content: [{ type: 'text', text: 'current user' }] },
     ]);
   });
 
-  test('falls back to legacy context instead of leaking unsupported thinking text', async () => {
+  test('uses StoredMessage projection instead of leaking unsupported thinking text', async () => {
     const model = completionModel();
     const openAiConnection = { ...connection(), providerType: 'openai' as const };
     const backend = new AiSdkBackend({
@@ -281,11 +281,11 @@ describe('AiSdkBackend model history', () => {
       turnId: 'turn-current',
       text: 'current user',
       context: [
-        { type: 'user', id: 'legacy-u', turnId: 'turn-prev', ts: 1, text: 'legacy user' },
-        { type: 'assistant', id: 'legacy-a', turnId: 'turn-prev', ts: 2, text: 'legacy assistant', modelId: 'm' },
+        { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'projection user' },
+        { type: 'assistant', id: 'projection-a', turnId: 'turn-prev', ts: 2, text: 'projection assistant', modelId: 'm' },
       ],
       runtimeContext: [
-        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'legacy user' }),
+        runtimeTextEvent({ id: 'rt-u', turnId: 'turn-prev', role: 'user', author: 'user', text: 'projection user' }),
         runtimeEvent({
           id: 'rt-thinking',
           turnId: 'turn-prev',
@@ -293,14 +293,14 @@ describe('AiSdkBackend model history', () => {
           author: 'agent',
           content: { kind: 'thinking', text: 'private chain of thought', signature: 'sig-1' },
         }),
-        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'legacy assistant' }),
+        runtimeTextEvent({ id: 'rt-a', turnId: 'turn-prev', role: 'model', author: 'agent', text: 'projection assistant' }),
       ],
     }));
 
     const promptJson = JSON.stringify(compactPrompt(model));
     assert.deepEqual(compactPrompt(model), [
-      { role: 'user', content: [{ type: 'text', text: 'legacy user' }] },
-      { role: 'assistant', content: [{ type: 'text', text: 'legacy assistant' }] },
+      { role: 'user', content: [{ type: 'text', text: 'projection user' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'projection assistant' }] },
       { role: 'user', content: [{ type: 'text', text: 'current user' }] },
     ]);
     assert.equal(promptJson.includes('private chain of thought'), false);

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -538,7 +538,7 @@ describe('compareRuntimeReadModelMessages', () => {
 });
 
 describe('SessionManager read behavior', () => {
-  test('getMessages still returns legacy stored messages from the SessionStore', async () => {
+  test('getMessages requires RuntimeReadModel stores instead of reading SessionStore messages directly', async () => {
     const messages: StoredMessage[] = equivalentLegacyMessages();
     const store = new ReadOnlyStore(messages);
     const manager = new SessionManager({
@@ -548,10 +548,8 @@ describe('SessionManager read behavior', () => {
       now: () => ts,
     });
 
-    const out = await manager.getMessages(sessionId);
-
-    expect(out).toEqual(messages);
-    expect(store.readMessagesCalls).toBe(1);
+    await expectRejects(manager.getMessages(sessionId), /RuntimeReadModel requires AgentRunStore and RuntimeEventStore/);
+    expect(store.readMessagesCalls).toBe(0);
   });
 });
 
@@ -598,6 +596,16 @@ class ReadOnlyStore implements SessionStore {
   async setFlagged(_sessionId: string, _isFlagged: boolean): Promise<void> {}
   async rename(_sessionId: string, _name: string): Promise<void> {}
   async remove(_sessionId: string): Promise<void> {}
+}
+
+async function expectRejects(promise: Promise<unknown>, pattern: RegExp): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error instanceof Error ? error.message : String(error)).toMatch(pattern);
+    return;
+  }
+  throw new Error(`Expected promise to reject with ${pattern}`);
 }
 
 function makeHeader(id: string): SessionHeader {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -8,6 +8,7 @@ import type {
   AgentRunHeader,
   AgentRunStore,
   RuntimeEvent,
+  RuntimeEventStore,
   SessionEvent,
   SessionHeader,
   SessionListFilter,
@@ -24,6 +25,8 @@ import {
   type BackendFactoryContext,
   type SessionStore,
 } from '../session-manager.js';
+import type { RuntimeKernelLike } from '../runtime-kernel.js';
+import { RuntimeReadModel, RuntimeReadModelError } from '../runtime-read-model.js';
 import type { AgentBackend } from '../ai-sdk-backend.js';
 import type { InvocationResult } from '../invocation-context.js';
 
@@ -86,7 +89,7 @@ describe('SessionManager permission mode updates', () => {
     const secondGate = makeGate();
     const gates = [firstGate, secondGate];
     backends.register('fake', (ctx) => new TestBackend(ctx, gates.shift()));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(4_000) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(4_000) });
     const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
 
     const first = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'first' })[Symbol.asyncIterator]();
@@ -210,15 +213,42 @@ describe('SessionManager permission mode updates', () => {
     expect(built).toEqual(['Before']);
   });
 
-  test('sendMessage is driven through RuntimeRunner while preserving the SessionEvent stream', async () => {
+  test('sendMessage delegates through RuntimeKernel while preserving the SessionEvent stream', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    const runtimeKernel = new DelegatingRuntimeKernel([
+      { type: 'text_delta', id: 'delegated-delta', turnId: 'turn-1', ts: 1, messageId: 'm-1', text: 'hello' },
+      { type: 'complete', id: 'delegated-complete', turnId: 'turn-1', ts: 2, stopReason: 'end_turn' },
+    ]);
+    const manager = new SessionManager({
+      store,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_250),
+      runtimeKernel,
+    });
+    const session = await manager.createSession(makeInput());
+
+    const sessionEvents = await collectSessionEvents(
+      manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }),
+    );
+
+    expect(runtimeKernel.starts).toEqual([{ sessionId: session.id, input: { turnId: 'turn-1', text: 'hello' } }]);
+    expect(sessionEvents.map((event) => event.id)).toEqual(['delegated-delta', 'delegated-complete']);
+    expect(sessionEvents.map((event) => event.type)).toEqual(['text_delta', 'complete']);
+  });
+
+  test('RuntimeKernel drives RuntimeRunner while preserving the SessionEvent stream', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
+    const runtimeEventStore = new MemoryRuntimeEventStore();
     const backends = new BackendRegistry();
     const observed: InvocationResult[] = [];
     backends.register('fake', (ctx) => new TestBackend(ctx));
     const manager = new SessionManager({
       store,
       runStore,
+      runtimeEventStore,
       backends,
       newId: nextId(),
       now: nextNow(6_500),
@@ -253,7 +283,7 @@ describe('SessionManager permission mode updates', () => {
     expect(result.events[1]?.content).toEqual({ kind: 'text', text: 'ok' });
     expect(result.events[2]?.status).toBe('completed');
 
-    const runtimeEvents = await runStore.readRuntimeEvents(session.id, run.runId);
+    const runtimeEvents = await runtimeEventStore.readRuntimeEvents(session.id, run.runId);
     expect(runtimeEvents.map((event) => event.id)).toEqual(['id-7', 'turn-1-delta', 'turn-1-complete']);
     expect(runtimeEvents.map((event) => event.runId)).toEqual([run.runId, run.runId, run.runId]);
     expect(runtimeEvents.map((event) => event.sessionId)).toEqual([session.id, session.id, session.id]);
@@ -266,12 +296,14 @@ describe('SessionManager permission mode updates', () => {
 
   test('runtime event ledger write failure does not fail sendMessage', async () => {
     const store = new MemorySessionStore();
-    const runStore = new MemoryAgentRunStore({ failRuntimeEventAppends: true });
+    const runStore = new MemoryAgentRunStore();
+    const runtimeEventStore = new MemoryRuntimeEventStore({ failRuntimeEventAppends: true });
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
     const manager = new SessionManager({
       store,
       runStore,
+      runtimeEventStore,
       backends,
       newId: nextId(),
       now: nextNow(6_750),
@@ -287,7 +319,7 @@ describe('SessionManager permission mode updates', () => {
     expect(sessionEvents.map((event) => event.id)).toEqual(['turn-1-delta', 'turn-1-complete']);
     const [run] = await runStore.listSessionRuns(session.id);
     if (!run) throw new Error('AgentRunStore run was not created');
-    expect(await runStore.readRuntimeEvents(session.id, run.runId)).toEqual([]);
+    expect(await runtimeEventStore.readRuntimeEvents(session.id, run.runId)).toEqual([]);
   });
 
   test('getMessages prefers RuntimeEvent-projected messages when legacy rows are present', async () => {
@@ -312,7 +344,31 @@ describe('SessionManager permission mode updates', () => {
     expect(JSON.stringify(messages.map((message) => message.id)) === JSON.stringify(seeded.legacyMessages.map((message) => message.id))).toBe(false);
   });
 
-  test('getMessages falls back to legacy when projection is missing a legacy semantic row', async () => {
+  test('RuntimeReadModel projects messages turns replay and terminal facts without SessionStore messages', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const session = await store.create(makeInput());
+    const seeded = await seedRuntimeReadTurn({
+      store,
+      runStore,
+      sessionId: session.id,
+      turnId: 'turn-1',
+      runId: 'run-1',
+      userText: 'runtime question',
+      assistantText: 'runtime answer',
+      legacyIdPrefix: 'cache',
+    });
+    store.failReadMessagesFor.add(session.id);
+
+    const view = await new RuntimeReadModel({ runStore, runtimeEventStore: runStore }).getSessionView(session.id);
+
+    expect(view.messages).toEqual(seeded.projectedMessages);
+    expect(view.turns).toEqual([{ turnId: 'turn-1', status: 'completed', partialOutputRetained: true }]);
+    expect(view.terminalFacts.map((fact) => fact.runStatus)).toEqual(['completed']);
+    expect(view.replayPlan.textMessages.map((message) => message.content)).toEqual(['runtime question', 'runtime answer']);
+  });
+
+  test('projection/cache mismatch does not override RuntimeEvent read output', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const manager = makeManagerForReadCutover(store, runStore);
@@ -336,10 +392,13 @@ describe('SessionManager permission mode updates', () => {
       runtimeEvent({ id: 'rt-complete', sessionId: session.id, runId: 'run-1', turnId: 'turn-1', ts: 103, role: 'system', author: 'system', status: 'completed', actions: { endInvocation: true } }),
     ]);
 
-    expect(await manager.getMessages(session.id)).toEqual(legacyMessages);
+    expect(await manager.getMessages(session.id)).toEqual([
+      { type: 'user', id: 'rt-user', turnId: 'turn-1', ts: 101, text: 'question' },
+      { type: 'turn_state', id: 'rt-complete', turnId: 'turn-1', ts: 103, status: 'completed', partialOutputRetained: false },
+    ]);
   });
 
-  test('getMessages falls back to legacy when a terminal run has no runtime ledger', async () => {
+  test('getMessages rejects when a terminal run has no runtime ledger', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const manager = makeManagerForReadCutover(store, runStore);
@@ -357,10 +416,33 @@ describe('SessionManager permission mode updates', () => {
       completedAt: 102,
     }));
 
-    expect(await manager.getMessages(session.id)).toEqual(legacyMessages);
+    await expectRejects(manager.getMessages(session.id), /RuntimeEvent ledger is missing/);
   });
 
-  test('getMessages falls back to legacy when runtime ledger read fails', async () => {
+  test('active RuntimeEvent ledger produces an explicit read-model error', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const manager = makeManagerForReadCutover(store, runStore);
+    const session = await manager.createSession(makeInput());
+    await runStore.createRun(makeRunHeader({
+      sessionId: session.id,
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'running',
+    }));
+
+    try {
+      await manager.getMessages(session.id);
+    } catch (error) {
+      expect(error instanceof RuntimeReadModelError).toBe(true);
+      if (!(error instanceof RuntimeReadModelError)) throw error;
+      expect(error.diagnostics.map((diagnostic) => diagnostic.code)).toContain('incomplete_event');
+      return;
+    }
+    throw new Error('Expected active ledger read to fail');
+  });
+
+  test('getMessages rejects when runtime ledger read fails', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failRuntimeEventReads: true });
     const manager = makeManagerForReadCutover(store, runStore);
@@ -376,10 +458,10 @@ describe('SessionManager permission mode updates', () => {
       legacyIdPrefix: 'legacy',
     });
 
-    expect(await manager.getMessages(session.id)).toEqual(seeded.legacyMessages);
+    await expectRejects(manager.getMessages(session.id), /RuntimeEvent ledger read failed/);
   });
 
-  test('MAKA_RUNTIME_READ_SOURCE=legacy forces legacy reads even when RuntimeEvents are complete', async () => {
+  test('MAKA_RUNTIME_READ_SOURCE does not force legacy reads when RuntimeEvents are complete', async () => {
     const previous = process.env.MAKA_RUNTIME_READ_SOURCE;
     process.env.MAKA_RUNTIME_READ_SOURCE = 'legacy';
     try {
@@ -398,7 +480,7 @@ describe('SessionManager permission mode updates', () => {
         legacyIdPrefix: 'legacy',
       });
 
-      expect(await manager.getMessages(session.id)).toEqual(seeded.legacyMessages);
+      expect(await manager.getMessages(session.id)).toEqual(seeded.projectedMessages);
     } finally {
       if (previous === undefined) delete process.env.MAKA_RUNTIME_READ_SOURCE;
       else process.env.MAKA_RUNTIME_READ_SOURCE = previous;
@@ -433,7 +515,7 @@ describe('SessionManager permission mode updates', () => {
     ]);
   });
 
-  test('mixed legacy-only system notes force legacy fallback instead of disappearing', async () => {
+  test('mixed projection-cache-only system notes do not override RuntimeEvent projection', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const manager = makeManagerForReadCutover(store, runStore);
@@ -459,7 +541,7 @@ describe('SessionManager permission mode updates', () => {
 
     const messages = await manager.getMessages(session.id);
 
-    expect(messages).toEqual([...seeded.legacyMessages, legacyNote]);
+    expect(messages).toEqual(seeded.projectedMessages);
   });
 
   test('getMessages orders RuntimeEvent-primary reads by session event chronology across runs', async () => {
@@ -574,7 +656,7 @@ describe('SessionManager permission mode updates', () => {
     backends.register('fake', (ctx) => new EventBackend(ctx, [
       { type: 'complete', stopReason: 'end_turn' },
     ]));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(6_760) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(6_760) });
     const session = await manager.createSession(makeInput());
     await seedRuntimeRun(runStore, makeRunHeader({
       sessionId: session.id,
@@ -604,7 +686,7 @@ describe('SessionManager permission mode updates', () => {
     backends.register('fake', (ctx) => new EventBackend(ctx, [
       { type: 'complete', stopReason: 'end_turn' },
     ]));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(6_770) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(6_770) });
     const session = await manager.createSession(makeInput());
     await seedRuntimeReadTurn({
       store,
@@ -651,6 +733,50 @@ describe('SessionManager permission mode updates', () => {
     expect(childMessages[1]).toMatchObject({ type: 'assistant', turnId: 'source', text: 'runtime branch answer' });
     expect(childMessages[2]).toMatchObject({ type: 'system_note', kind: 'session_start' });
     expect(childMessages.some((message) => message.type === 'turn_state')).toBe(false);
+
+    const runtimeMessages = await manager.getMessages(child.id);
+    expect(runtimeMessages[0]).toMatchObject({ type: 'user', turnId: 'source', text: 'runtime branch context' });
+    expect(runtimeMessages[1]).toMatchObject({ type: 'assistant', turnId: 'source', text: 'runtime branch answer' });
+  });
+
+  test('branch child next turn receives cloned RuntimeEvent context', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const backendInstances: TestBackend[] = [];
+    backends.register('fake', (ctx) => {
+      const backend = new TestBackend(ctx);
+      backendInstances.push(backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore, runtimeEventStore: runStore, backends,
+      newId: nextId(),
+      now: nextNow(6_870),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ name: 'Parent' }));
+
+    await drain(manager.sendMessage(session.id, { turnId: 'source', text: 'branch seed' }));
+    const child = await manager.branchFromTurn(session.id, { sourceTurnId: 'source', name: 'Child' });
+    await store.appendMessage(child.id, {
+      type: 'assistant',
+      id: 'child-cache-only',
+      turnId: 'cache-only',
+      ts: 6_999,
+      text: 'cache-only child context',
+      modelId: 'fake-model',
+    });
+
+    await drain(manager.sendMessage(child.id, { turnId: 'child-next', text: 'child follow-up' }));
+
+    const childInput = backendInstances[1]?.sendInputs[0];
+    if (!childInput) throw new Error('child backend input was not recorded');
+    expect(childInput.context.some((message) => message.type === 'user' && message.turnId === 'source' && message.text === 'branch seed')).toBe(true);
+    expect(childInput.context.some((message) => message.type === 'assistant' && message.id === 'child-cache-only')).toBe(false);
+    expect(childInput.runtimeContext?.map((event) => event.turnId)).toEqual(['source', 'source', 'source']);
+    expect(childInput.runtimeContext?.[0]?.sessionId).toBe(child.id);
   });
 
   test('multi-run RuntimeEvent projection preserves retry regenerate and branch lineage on turns', async () => {
@@ -725,7 +851,7 @@ describe('SessionManager permission mode updates', () => {
     });
   });
 
-  test('getMessages keeps legacy SessionStore behavior when no runStore is provided', async () => {
+  test('getMessages fails fast when RuntimeReadModel stores are not provided', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
@@ -736,10 +862,10 @@ describe('SessionManager permission mode updates', () => {
     ];
     await store.appendMessages(session.id, legacyMessages);
 
-    expect(await manager.getMessages(session.id)).toEqual(legacyMessages);
+    await expectRejects(manager.getMessages(session.id), /RuntimeReadModel requires AgentRunStore and RuntimeEventStore/);
   });
 
-  test('next turn receives complete prior RuntimeEvent context alongside legacy context', async () => {
+  test('next turn receives complete prior RuntimeEvent context and projection context', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -751,8 +877,7 @@ describe('SessionManager permission mode updates', () => {
     });
     const manager = new SessionManager({
       store,
-      runStore,
-      backends,
+      runStore, runtimeEventStore: runStore, backends,
       newId: nextId(),
       now: nextNow(6_800),
       runtimeSource: 'test',
@@ -765,13 +890,13 @@ describe('SessionManager permission mode updates', () => {
     const secondInput = backendInstances[0]?.sendInputs[1];
     if (!secondInput) throw new Error('second backend input was not recorded');
     expect(secondInput.context.some((message) => message.type === 'user' && message.turnId === 'turn-1')).toBe(true);
-    expect(secondInput.context.some((message) => message.type === 'user' && message.turnId === 'turn-2')).toBe(true);
+    expect(secondInput.context.some((message) => message.type === 'user' && message.turnId === 'turn-2')).toBe(false);
     expect(secondInput.runtimeContext?.map((event) => event.turnId)).toEqual(['turn-1', 'turn-1', 'turn-1']);
     expect(secondInput.runtimeContext?.map((event) => event.role)).toEqual(['user', 'model', 'system']);
     expect(secondInput.runtimeContext?.[0]?.content).toEqual({ kind: 'text', text: 'first' });
   });
 
-  test('next turn falls back to legacy when RuntimeEvents do not cover legacy model-visible context', async () => {
+  test('next turn still receives RuntimeEvent context when projection cache has extra rows', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -783,8 +908,7 @@ describe('SessionManager permission mode updates', () => {
     });
     const manager = new SessionManager({
       store,
-      runStore,
-      backends,
+      runStore, runtimeEventStore: runStore, backends,
       newId: nextId(),
       now: nextNow(6_850),
       runtimeSource: 'test',
@@ -797,18 +921,18 @@ describe('SessionManager permission mode updates', () => {
       id: 'legacy-extra-assistant',
       turnId: 'legacy-extra',
       ts: 6_899,
-      text: 'legacy-only context',
+      text: 'cache-only context',
       modelId: 'fake-model',
     });
     await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'second' }));
 
     const secondInput = backendInstances[0]?.sendInputs[1];
     if (!secondInput) throw new Error('second backend input was not recorded');
-    expect(secondInput.runtimeContext).toBeUndefined();
-    expect(secondInput.context.some((message) => message.type === 'assistant' && message.id === 'legacy-extra-assistant')).toBe(true);
+    expect(secondInput.runtimeContext?.map((event) => event.turnId)).toEqual(['turn-1', 'turn-1', 'turn-1']);
+    expect(secondInput.context.some((message) => message.type === 'assistant' && message.id === 'legacy-extra-assistant')).toBe(false);
   });
 
-  test('next turn remains legacy-only when prior RuntimeEvent ledger is unusable', async () => {
+  test('next turn fails when prior RuntimeEvent ledger is unusable', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failRuntimeEventAppends: true });
     const backends = new BackendRegistry();
@@ -820,8 +944,7 @@ describe('SessionManager permission mode updates', () => {
     });
     const manager = new SessionManager({
       store,
-      runStore,
-      backends,
+      runStore, runtimeEventStore: runStore, backends,
       newId: nextId(),
       now: nextNow(6_900),
       runtimeSource: 'test',
@@ -829,25 +952,23 @@ describe('SessionManager permission mode updates', () => {
     const session = await manager.createSession(makeInput());
 
     await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'first' }));
-    await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'second' }));
-
-    const secondInput = backendInstances[0]?.sendInputs[1];
-    if (!secondInput) throw new Error('second backend input was not recorded');
-    expect(secondInput.runtimeContext).toBeUndefined();
-    expect(secondInput.context.some((message) => message.type === 'user' && message.turnId === 'turn-1')).toBe(true);
-    expect(secondInput.context.some((message) => message.type === 'user' && message.turnId === 'turn-2')).toBe(true);
+    await expectRejects(
+      drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'second' })),
+      /RuntimeEvent ledger is missing/,
+    );
+    expect(backendInstances[0]?.sendInputs.length).toBe(1);
   });
 
-  test('sendMessage production source uses AiSdkFlow instead of an inline mapper flow', async () => {
-    const source = await readFile(new URL('../../src/session-manager.ts', import.meta.url), 'utf8');
-    const sendMessageSource = source.slice(
-      source.indexOf('async *sendMessage'),
+  test('RuntimeKernel production source uses AiSdkFlow instead of an inline mapper flow', async () => {
+    const source = await readFile(new URL('../../src/runtime-kernel.ts', import.meta.url), 'utf8');
+    const startTurnSource = source.slice(
+      source.indexOf('async *startTurn'),
       source.indexOf('async stopSession'),
     );
 
-    expect(sendMessageSource.includes('new AiSdkFlow')).toBe(true);
-    expect(sendMessageSource.includes('mapSessionEventToRuntimeEvent')).toBe(false);
-    expect(sendMessageSource.includes('createSessionEventMapMemory')).toBe(false);
+    expect(startTurnSource.includes('new AiSdkFlow')).toBe(true);
+    expect(startTurnSource.includes('mapSessionEventToRuntimeEvent')).toBe(false);
+    expect(startTurnSource.includes('createSessionEventMapMemory')).toBe(false);
   });
 
   test('rejects backend configuration updates while a turn is actively streaming', async () => {
@@ -885,7 +1006,7 @@ describe('SessionManager permission mode updates', () => {
     backends.register('fake', () => {
       throw new Error('backend init failed');
     });
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(7_500) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(7_500) });
     const session = await manager.createSession(makeInput());
 
     await expectRejects(
@@ -937,7 +1058,7 @@ describe('SessionManager permission mode updates', () => {
       { type: 'permission_request', requestId: 'pr-1', toolUseId: 'tool-1', toolName: 'Bash', category: 'shell_safe', reason: 'custom', args: {} },
       { type: 'complete', stopReason: 'permission_handoff' },
     ]));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(9_000) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(9_000) });
     const session = await manager.createSession(makeInput());
 
     await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
@@ -1078,7 +1199,7 @@ describe('SessionManager permission mode updates', () => {
     const backends = new BackendRegistry();
     const gate = makeGate();
     backends.register('fake', (ctx) => new TestBackend(ctx, gate));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_700) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_700) });
     const session = await manager.createSession(makeInput());
 
     const iterator = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
@@ -1104,7 +1225,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TraceBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_750) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_750) });
     const session = await manager.createSession(makeInput());
 
     await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
@@ -1185,7 +1306,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_810) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_810) });
     const session = await manager.createSession(makeInput({ status: 'running' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await seedRun(runStore, makeRunHeader({
@@ -1217,7 +1338,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_815) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_815) });
     const session = await manager.createSession(makeInput({ status: 'running' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await seedRun(runStore, makeRunHeader({
@@ -1267,7 +1388,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_817) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_817) });
     const failed = await manager.createSession(makeInput({ status: 'running' }));
     const aborted = await manager.createSession(makeInput({ status: 'running' }));
     const cancelled = await manager.createSession(makeInput({ status: 'running' }));
@@ -1337,7 +1458,7 @@ describe('SessionManager permission mode updates', () => {
     expect((await runStore.readEvents(cancelled.id, 'cancelled-run')).map((event) => event.type)).toContain('run_cancelled');
   });
 
-  test('startup recovery falls back when RuntimeEvents are unreadable or terminal facts are incomplete', async () => {
+  test('startup recovery refuses cache-completed recovery without a RuntimeEvent terminal fact', async () => {
     const unreadableStore = new MemorySessionStore();
     const unreadableRunStore = new MemoryAgentRunStore({ failRuntimeEventReads: true });
     const incompleteStore = new MemorySessionStore();
@@ -1346,15 +1467,13 @@ describe('SessionManager permission mode updates', () => {
     backends.register('fake', (ctx) => new TestBackend(ctx));
     const unreadableManager = new SessionManager({
       store: unreadableStore,
-      runStore: unreadableRunStore,
-      backends,
+      runStore: unreadableRunStore, runtimeEventStore: unreadableRunStore, backends,
       newId: nextId(),
       now: nextNow(12_818),
     });
     const incompleteManager = new SessionManager({
       store: incompleteStore,
-      runStore: incompleteRunStore,
-      backends,
+      runStore: incompleteRunStore, runtimeEventStore: incompleteRunStore, backends,
       newId: nextId(),
       now: nextNow(12_819),
     });
@@ -1411,11 +1530,12 @@ describe('SessionManager permission mode updates', () => {
     await unreadableManager.recoverInterruptedSessions();
     await incompleteManager.recoverInterruptedSessions();
 
-    expect((await unreadableRunStore.readRun(unreadable.id, 'run-1')).status).toBe('completed');
-    expect((await unreadableStore.listTurns(unreadable.id))[0]?.status).toBe('completed');
-    expect((await incompleteRunStore.readRun(incomplete.id, 'run-1')).status).toBe('completed');
-    expect((await incompleteStore.listTurns(incomplete.id))[0]?.status).toBe('completed');
-    expect((await incompleteRunStore.readEvents(incomplete.id, 'run-1')).find((event) => event.type === 'run_completed')?.data?.recoveryReason).toBe('stale_completed_run');
+    expect((await unreadableRunStore.readRun(unreadable.id, 'run-1')).status).toBe('failed');
+    expect((await unreadableStore.listTurns(unreadable.id))[0]?.status).toBe('failed');
+    expect((await incompleteRunStore.readRun(incomplete.id, 'run-1')).status).toBe('failed');
+    expect((await incompleteStore.listTurns(incomplete.id))[0]?.status).toBe('failed');
+    expect((await unreadableRunStore.readEvents(unreadable.id, 'run-1')).find((event) => event.type === 'run_failed')?.data?.recoveryReason).toBe('model_stream_completed_without_runtime_terminal');
+    expect((await incompleteRunStore.readEvents(incomplete.id, 'run-1')).find((event) => event.type === 'run_failed')?.data?.recoveryReason).toBe('model_stream_completed_without_runtime_terminal');
   });
 
   test('startup recovery fails stale tool tails while preserving partial output retention', async () => {
@@ -1423,7 +1543,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_820) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_820) });
     const session = await manager.createSession(makeInput({ status: 'running' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await store.appendMessage(session.id, {
@@ -1459,7 +1579,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_830) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_830) });
     const session = await manager.createSession(makeInput({ status: 'waiting_for_user' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await seedRun(runStore, makeRunHeader({
@@ -1487,7 +1607,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_840) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_840) });
     const session = await manager.createSession(makeInput({ status: 'running' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await seedRun(runStore, makeRunHeader({
@@ -1514,7 +1634,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_850) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_850) });
     const session = await manager.createSession(makeInput({ status: 'running' }));
     await seedRunningTurn(store, session.id, 'turn-1');
     await seedRun(runStore, makeRunHeader({
@@ -1550,7 +1670,7 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(12_860) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_860) });
     const completed = await manager.createSession(makeInput({ status: 'active' }));
     const failed = await manager.createSession(makeInput({ status: 'active' }));
     const cancelled = await manager.createSession(makeInput({ status: 'active' }));
@@ -1613,19 +1733,28 @@ describe('SessionManager permission mode updates', () => {
 
   test('retry creates a new sibling turn and does not rewrite the aborted source turn', async () => {
     const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     const events: PartialEvent[] = [
-      { type: 'abort', reason: 'user_stop' },
+      { type: 'complete', stopReason: 'end_turn' },
     ];
     backends.register('fake', (ctx) => new EventBackend(ctx, events));
-    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(13_000) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(13_000) });
     const session = await manager.createSession(makeInput());
-    await drain(manager.sendMessage(session.id, { turnId: 'source', text: 'try this' }));
+    await seedRuntimeRun(runStore, makeRunHeader({
+      sessionId: session.id,
+      runId: 'source-run',
+      turnId: 'source',
+      status: 'cancelled',
+      completedAt: 102,
+    }), [
+      runtimeEvent({ id: 'source-user', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 101, role: 'user', author: 'user', content: { kind: 'text', text: 'try this' } }),
+      runtimeEvent({ id: 'source-abort', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 102, role: 'system', author: 'system', status: 'aborted', actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } } }),
+    ]);
 
-    events.splice(0, events.length, { type: 'complete', stopReason: 'end_turn' });
     await drain(manager.retryTurn(session.id, { sourceTurnId: 'source', turnId: 'retry-1' }));
 
-    const turns = await store.listTurns(session.id);
+    const turns = await manager.listTurns(session.id);
     expect(turns.find((turn) => turn.turnId === 'source')?.status).toBe('aborted');
     const retry = turns.find((turn) => turn.turnId === 'retry-1');
     expect(retry?.status).toBe('completed');
@@ -1637,11 +1766,12 @@ describe('SessionManager permission mode updates', () => {
 
   test('regenerate creates a new sibling turn from a completed source turn', async () => {
     const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new EventBackend(ctx, [
       { type: 'complete', stopReason: 'end_turn' },
     ]));
-    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(14_000) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(14_000) });
     const session = await manager.createSession(makeInput());
     await drain(manager.sendMessage(session.id, { turnId: 'source', text: 'answer this' }));
 
@@ -1656,11 +1786,12 @@ describe('SessionManager permission mode updates', () => {
 
   test('branchFromTurn creates a new session with parent lineage and copied message boundary', async () => {
     const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new EventBackend(ctx, [
       { type: 'complete', stopReason: 'end_turn' },
     ]));
-    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(15_000) });
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(15_000) });
     const session = await manager.createSession(makeInput({ name: 'Parent' }));
     await drain(manager.sendMessage(session.id, { turnId: 'source', text: 'context' }));
     await drain(manager.sendMessage(session.id, { turnId: 'after', text: 'do not copy' }));
@@ -1675,6 +1806,50 @@ describe('SessionManager permission mode updates', () => {
     expect(childMessages.some((message) => message.type === 'turn_state')).toBe(false);
   });
 });
+
+class DelegatingRuntimeKernel implements RuntimeKernelLike {
+  readonly starts: Array<{ sessionId: string; input: Parameters<RuntimeKernelLike['startTurn']>[1] }> = [];
+  readonly stopped: string[] = [];
+  readonly permissionResponses: string[] = [];
+  activeRuns = false;
+  disposed: string[] = [];
+  cachedHeaders: SessionHeader[] = [];
+
+  constructor(private readonly events: readonly SessionEvent[] = []) {}
+
+  async *startTurn(
+    sessionId: string,
+    input: Parameters<RuntimeKernelLike['startTurn']>[1],
+  ): AsyncIterable<SessionEvent> {
+    this.starts.push({ sessionId, input });
+    for (const event of this.events) {
+      yield event;
+    }
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    this.stopped.push(sessionId);
+  }
+
+  async respondToPermission(
+    sessionId: string,
+    _response: Parameters<RuntimeKernelLike['respondToPermission']>[1],
+  ): Promise<void> {
+    this.permissionResponses.push(sessionId);
+  }
+
+  hasActiveRuns(): boolean {
+    return this.activeRuns;
+  }
+
+  updateCachedHeader(_sessionId: string, header: SessionHeader): void {
+    this.cachedHeaders.push(header);
+  }
+
+  async disposeBackend(sessionId: string): Promise<void> {
+    this.disposed.push(sessionId);
+  }
+}
 
 class TestBackend implements AgentBackend {
   readonly kind = 'fake' as const;
@@ -1900,7 +2075,7 @@ class MemorySessionStore implements SessionStore {
   }
 }
 
-class MemoryAgentRunStore implements AgentRunStore {
+class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   private headers = new Map<string, AgentRunHeader>();
   private events = new Map<string, AgentRunEvent[]>();
   private runtimeEvents = new Map<string, RuntimeEvent[]>();
@@ -1950,6 +2125,55 @@ class MemoryAgentRunStore implements AgentRunStore {
   async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     if (this.options.failRuntimeEventReads) throw new Error('runtime event read failed');
     return (this.runtimeEvents.get(key(sessionId, runId)) ?? []).map(copyRuntimeEvent);
+  }
+
+  async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
+    const ordered: Array<{ event: RuntimeEvent; runId: string; eventIndex: number }> = [];
+    for (const [eventKey, events] of this.runtimeEvents.entries()) {
+      const [eventSessionId, runId] = eventKey.split(':');
+      if (eventSessionId !== sessionId || !runId) continue;
+      events.forEach((event, eventIndex) => ordered.push({ event: copyRuntimeEvent(event), runId, eventIndex }));
+    }
+    ordered.sort((a, b) =>
+      a.event.ts - b.event.ts ||
+      a.runId.localeCompare(b.runId) ||
+      a.eventIndex - b.eventIndex ||
+      a.event.id.localeCompare(b.event.id)
+    );
+    return ordered.map((item) => item.event);
+  }
+}
+
+class MemoryRuntimeEventStore implements RuntimeEventStore {
+  private runtimeEvents = new Map<string, RuntimeEvent[]>();
+
+  constructor(private readonly options: { failRuntimeEventAppends?: boolean; failRuntimeEventReads?: boolean } = {}) {}
+
+  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+    if (this.options.failRuntimeEventAppends) throw new Error('runtime event append failed');
+    const eventKey = key(sessionId, runId);
+    this.runtimeEvents.set(eventKey, [...(this.runtimeEvents.get(eventKey) ?? []), copyRuntimeEvent(event)]);
+  }
+
+  async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    if (this.options.failRuntimeEventReads) throw new Error('runtime event read failed');
+    return (this.runtimeEvents.get(key(sessionId, runId)) ?? []).map(copyRuntimeEvent);
+  }
+
+  async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
+    const ordered: Array<{ event: RuntimeEvent; runId: string; eventIndex: number }> = [];
+    for (const [eventKey, events] of this.runtimeEvents.entries()) {
+      const [eventSessionId, runId] = eventKey.split(':');
+      if (eventSessionId !== sessionId || !runId) continue;
+      events.forEach((event, eventIndex) => ordered.push({ event: copyRuntimeEvent(event), runId, eventIndex }));
+    }
+    ordered.sort((a, b) =>
+      a.event.ts - b.event.ts ||
+      a.runId.localeCompare(b.runId) ||
+      a.eventIndex - b.eventIndex ||
+      a.event.id.localeCompare(b.event.id)
+    );
+    return ordered.map((item) => item.event);
   }
 }
 
@@ -2008,15 +2232,15 @@ function makeRunEvent(overrides: Partial<AgentRunEvent> = {}): AgentRunEvent {
   };
 }
 
-function makeManagerForReadCutover(store: MemorySessionStore, runStore: AgentRunStore): SessionManager {
+function makeManagerForReadCutover(store: MemorySessionStore, runStore: AgentRunStore & RuntimeEventStore): SessionManager {
   const backends = new BackendRegistry();
   backends.register('fake', (ctx) => new TestBackend(ctx));
-  return new SessionManager({ store, runStore, backends, newId: nextId(), now: nextNow(6_755) });
+  return new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(6_755) });
 }
 
 async function seedRuntimeReadTurn(input: {
   store: MemorySessionStore;
-  runStore: AgentRunStore;
+  runStore: AgentRunStore & RuntimeEventStore;
   sessionId: string;
   turnId: string;
   runId: string;
@@ -2085,7 +2309,7 @@ async function seedRuntimeReadTurn(input: {
 
 async function seedRuntimeReadTurnWithHeader(input: {
   store: MemorySessionStore;
-  runStore: AgentRunStore;
+  runStore: AgentRunStore & RuntimeEventStore;
   sessionId: string;
   turnId: string;
   runId: string;
@@ -2172,7 +2396,7 @@ async function seedRun(
 }
 
 async function seedRuntimeRun(
-  runStore: AgentRunStore,
+  runStore: AgentRunStore & RuntimeEventStore,
   header: AgentRunHeader,
   events: RuntimeEvent[],
 ): Promise<void> {

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -95,7 +95,8 @@ export interface FlowInput {
   context: StoredMessage[];
   /**
    * Optional prior RuntimeEvent ledger for model-history projection. Flows
-   * forward this to backends that can prefer it over legacy context.
+   * forward this to backends that can prefer it over the StoredMessage-shaped
+   * compatibility projection.
    */
   runtimeContext?: RuntimeEvent[];
   /** Abort signal propagated to the underlying engine. */

--- a/packages/runtime/src/agent-run-inspect.ts
+++ b/packages/runtime/src/agent-run-inspect.ts
@@ -1,4 +1,4 @@
-import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, StoredMessage } from '@maka/core';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore, StoredMessage } from '@maka/core';
 import {
   classifyRuntimeEventTerminalFact,
   projectRuntimeEventsToStoredMessages,
@@ -61,12 +61,13 @@ export interface InspectAgentRunOptions {
 
 export async function inspectAgentRunReadModel(
   runStore: AgentRunStore,
+  runtimeEventStore: RuntimeEventStore,
   options: InspectAgentRunOptions,
 ): Promise<AgentRunInspectModel> {
   const header = options.header ?? await runStore.readRun(options.sessionId, options.runId);
   const diagnostics: AgentRunInspectDiagnostic[] = [];
   const events = await readOperationalEvents(runStore, header, diagnostics);
-  const runtimeRead = await readRuntimeEvents(runStore, header, diagnostics);
+  const runtimeRead = await readRuntimeEvents(runtimeEventStore, header, diagnostics);
   const runtimeEvents = runtimeRead.events;
 
   const operationalTerminalEvent = latestOperationalTerminalEvent(events);
@@ -141,12 +142,13 @@ export async function inspectAgentRunReadModel(
 
 export async function inspectSessionRunReadModels(
   runStore: AgentRunStore,
+  runtimeEventStore: RuntimeEventStore,
   sessionId: string,
 ): Promise<AgentRunInspectModel[]> {
   const headers = await runStore.listSessionRuns(sessionId);
   const models: AgentRunInspectModel[] = [];
   for (const header of headers) {
-    models.push(await inspectAgentRunReadModel(runStore, { sessionId, runId: header.runId, header }));
+    models.push(await inspectAgentRunReadModel(runStore, runtimeEventStore, { sessionId, runId: header.runId, header }));
   }
   return models;
 }
@@ -181,12 +183,12 @@ async function readOperationalEvents(
 }
 
 async function readRuntimeEvents(
-  runStore: AgentRunStore,
+  runtimeEventStore: RuntimeEventStore,
   header: AgentRunHeader,
   diagnostics: AgentRunInspectDiagnostic[],
 ): Promise<{ state: AgentRunInspectSourceHealth['runtimeLedger']; events: RuntimeEvent[] }> {
   try {
-    const events = await runStore.readRuntimeEvents(header.sessionId, header.runId);
+    const events = await runtimeEventStore.readRuntimeEvents(header.sessionId, header.runId);
     if (events.length === 0) {
       diagnostics.push(inspectDiagnostic(
         header,
@@ -200,7 +202,7 @@ async function readRuntimeEvents(
     diagnostics.push(inspectDiagnostic(
       header,
       'runtime_ledger_read_failed',
-      'AgentRunStore.readRuntimeEvents failed',
+      'RuntimeEventStore.readRuntimeEvents failed',
       errorMessage(error),
     ));
     return { state: 'read_failed', events: [] };

--- a/packages/runtime/src/agent-run-recovery.ts
+++ b/packages/runtime/src/agent-run-recovery.ts
@@ -1,5 +1,4 @@
 import type { AgentRunEvent, AgentRunHeader } from '@maka/core';
-import type { StoredMessage } from '@maka/core/session';
 import type { UserMessageInput } from '@maka/core/runtime-inputs';
 
 export interface AgentRunRecoveryDecision {
@@ -18,32 +17,15 @@ export interface AgentRunRecoveryDecision {
 export function classifyAgentRunRecovery(
   header: AgentRunHeader,
   events: readonly AgentRunEvent[],
-  sessionMessages: readonly StoredMessage[],
 ): AgentRunRecoveryDecision | undefined {
   if (isTerminalRunStatus(header.status)) return undefined;
 
   const lastEvent = lastNonCorruptEvent(events);
   const hasCorruptEvent = events.some((event) => event.type === 'event_corrupt');
   const lastEventType = lastEvent?.type;
-  const lastTurnState = latestTurnState(sessionMessages, header.turnId);
-  const hasAssistantOutput = sessionMessages.some((message) =>
-    message.type === 'assistant' && message.turnId === header.turnId && message.text.trim().length > 0,
-  );
-  const hasToolOutput = sessionMessages.some((message) =>
-    message.type === 'tool_result' && message.turnId === header.turnId,
-  );
 
   if (lastEventType === 'model_stream_completed' && !hasTerminalRunEvent(events)) {
-    if (hasAssistantOutput || lastTurnState?.status === 'completed') {
-      return {
-        runId: header.runId,
-        turnId: header.turnId,
-        status: 'completed',
-        diagnostic: diagnostic('stale_completed_run', lastEventType, hasCorruptEvent),
-        lineage: headerLineage(header),
-      };
-    }
-    return failedDecision(header, 'app_restarted', diagnostic('model_stream_completed_without_projection', lastEventType, hasCorruptEvent));
+    return failedDecision(header, 'app_restarted', diagnostic('model_stream_completed_without_runtime_terminal', lastEventType, hasCorruptEvent));
   }
 
   if (
@@ -58,7 +40,7 @@ export function classifyAgentRunRecovery(
     return failedDecision(
       header,
       'app_restarted',
-      diagnostic('tool_interrupted', lastEventType, hasCorruptEvent, { partialOutputRetained: hasToolOutput }),
+      diagnostic('tool_interrupted', lastEventType, hasCorruptEvent),
     );
   }
 
@@ -110,17 +92,6 @@ function lastNonCorruptEvent(events: readonly AgentRunEvent[]): AgentRunEvent | 
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
     if (event && event.type !== 'event_corrupt') return event;
-  }
-  return undefined;
-}
-
-function latestTurnState(
-  messages: readonly StoredMessage[],
-  turnId: string,
-): Extract<StoredMessage, { type: 'turn_state' }> | undefined {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message?.type === 'turn_state' && message.turnId === turnId) return message;
   }
   return undefined;
 }

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1,4 +1,5 @@
-import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent } from '@maka/core';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { isTerminalRuntimeEvent } from '@maka/core';
 import { redactSecrets } from '@maka/core/redaction';
 import type {
   SessionBlockedReason,
@@ -15,10 +16,8 @@ import type { BackendSendInput } from '@maka/core/backend-types';
 import type { AgentBackend } from './ai-sdk-backend.js';
 import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
-import {
-  buildRuntimeEventModelReplayPlan,
-  type TextModelMessage,
-} from './model-history.js';
+import { buildRuntimeEventModelReplayPlan } from './model-history.js';
+import { projectRuntimeEventsToStoredMessages } from './runtime-event-read-model.js';
 
 export interface AgentRunActiveSession {
   sessionId: string;
@@ -54,6 +53,7 @@ export interface AgentRunInput {
   userInput: UserMessageInput;
   store: SessionStore;
   runStore?: AgentRunStore;
+  runtimeEventStore?: RuntimeEventStore;
   newId: () => string;
   now: () => number;
   hooks: AgentRunHooks;
@@ -62,6 +62,11 @@ export interface AgentRunInput {
 export interface AgentRunBeginResult {
   backend: AgentBackend;
   backendInput: BackendSendInput;
+}
+
+interface PriorRuntimeContext {
+  events: RuntimeEvent[];
+  runs: AgentRunHeader[];
 }
 
 export class AgentRun {
@@ -75,7 +80,9 @@ export class AgentRun {
   private stopped = false;
   private abortSource: string | undefined;
   private traceQueue: Promise<void> = Promise.resolve();
+  private runtimeEventQueue: Promise<void> = Promise.resolve();
   private runStoreAvailable = true;
+  private runtimeEventStoreAvailable = true;
   private failureClass: string | undefined;
   private failureMessage: string | undefined;
   private lastTs = 0;
@@ -151,8 +158,10 @@ export class AgentRun {
 
     await this.input.hooks.updateStatus(this.sessionId, 'running', undefined, this.lastTs);
 
-    const legacyContext = await this.input.store.readMessages(this.sessionId);
-    const runtimeContext = await this.buildRuntimeContextIfComplete(legacyContext);
+    const priorRuntimeContext = await this.buildPriorRuntimeContext();
+    const projectionContext = priorRuntimeContext
+      ? projectRuntimeEventsToStoredMessages(priorRuntimeContext.events, { runHeaders: priorRuntimeContext.runs }).messages
+      : [];
 
     return {
       backend: this.active.backend,
@@ -160,8 +169,8 @@ export class AgentRun {
         turnId: this.turnId,
         text: this.input.userInput.text,
         ...(this.input.userInput.attachments ? { attachments: this.input.userInput.attachments } : {}),
-        context: legacyContext,
-        ...(runtimeContext !== undefined ? { runtimeContext } : {}),
+        context: projectionContext,
+        ...(priorRuntimeContext ? { runtimeContext: priorRuntimeContext.events } : {}),
       },
     };
   }
@@ -198,10 +207,10 @@ export class AgentRun {
   }
 
   async recordRuntimeEvents(events: readonly RuntimeEvent[]): Promise<void> {
-    if (!this.input.runStore || !this.runStoreAvailable || events.length === 0) return;
+    if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable || events.length === 0) return;
     for (const event of events) {
-      await this.enqueueRunStore('append runtime event', async () => {
-        await this.input.runStore?.appendRuntimeEvent(this.sessionId, this.runId, event);
+      await this.enqueueRuntimeEventStore('append runtime event', async () => {
+        await this.input.runtimeEventStore?.appendRuntimeEvent(this.sessionId, this.runId, event);
       });
     }
   }
@@ -284,34 +293,44 @@ export class AgentRun {
     }
   }
 
-  private async buildRuntimeContextIfComplete(
-    legacyContext: readonly StoredMessage[],
-  ): Promise<RuntimeEvent[] | undefined> {
-    if (!this.input.runStore || !this.runStoreAvailable) return undefined;
-    try {
-      const runtimeContext: RuntimeEvent[] = [];
-      const runs = await this.input.runStore.listSessionRuns(this.sessionId);
-      for (const run of runs) {
-        if (run.runId === this.runId || run.turnId === this.turnId) continue;
-        const events = await this.input.runStore.readRuntimeEvents(this.sessionId, run.runId);
-        runtimeContext.push(
-          ...events.filter((event) => event.runId !== this.runId && event.turnId !== this.turnId),
-        );
+  private async buildPriorRuntimeContext(): Promise<PriorRuntimeContext | undefined> {
+    if (
+      !this.input.runStore ||
+      !this.input.runtimeEventStore ||
+      !this.runStoreAvailable ||
+      !this.runtimeEventStoreAvailable
+    ) return undefined;
+    const runs = await this.input.runStore.listSessionRuns(this.sessionId);
+    const priorRuns = runs.filter((run) => run.runId !== this.runId && run.turnId !== this.turnId);
+    if (priorRuns.length === 0) return undefined;
+
+    const ordered: Array<{ event: RuntimeEvent; runIndex: number; eventIndex: number }> = [];
+    for (let runIndex = 0; runIndex < priorRuns.length; runIndex += 1) {
+      const run = priorRuns[runIndex]!;
+      if (!isTerminalRunStatus(run.status)) {
+        continue;
       }
-      if (runtimeContext.length === 0) return undefined;
-
-      const runtimeReplayPlan = buildRuntimeEventModelReplayPlan(runtimeContext);
-      const runtimeMessages = runtimeReplayPlan.textMessages;
-      if (runtimeMessages.length === 0) return undefined;
-
-      const legacyPriorMessages = materializeLegacyTextMessages(
-        legacyContext.filter((message) => message.turnId !== this.turnId),
-      );
-      if (!runtimeMessagesCoverLegacy(runtimeMessages, legacyPriorMessages)) return undefined;
-      return runtimeContext;
-    } catch {
-      return undefined;
+      const events = await this.input.runtimeEventStore.readRuntimeEvents(this.sessionId, run.runId);
+      if (events.length === 0) {
+        throw new Error(`Cannot build model context: RuntimeEvent ledger is missing for prior run ${run.runId}`);
+      }
+      if (!events.some(isTerminalRuntimeEvent)) {
+        throw new Error(`Cannot build model context: RuntimeEvent ledger has no terminal fact for prior run ${run.runId}`);
+      }
+      for (let eventIndex = 0; eventIndex < events.length; eventIndex += 1) {
+        const event = events[eventIndex]!;
+        if (event.runId === this.runId || event.turnId === this.turnId) continue;
+        ordered.push({ event, runIndex, eventIndex });
+      }
     }
+
+    ordered.sort((a, b) => a.runIndex - b.runIndex || a.eventIndex - b.eventIndex);
+    const events = ordered.map((item) => item.event);
+    if (events.length === 0) return undefined;
+
+    const runtimeReplayPlan = buildRuntimeEventModelReplayPlan(events);
+    if (runtimeReplayPlan.items.length === 0) return undefined;
+    return { events, runs: priorRuns };
   }
 
   private async markRunStarted(ts: number): Promise<void> {
@@ -465,6 +484,16 @@ export class AgentRun {
     return next;
   }
 
+  private enqueueRuntimeEventStore(label: string, operation: () => Promise<void>): Promise<void> {
+    if (!this.input.runtimeEventStore || !this.runtimeEventStoreAvailable) return Promise.resolve();
+    const next = this.runtimeEventQueue.then(operation, operation).catch(async (error) => {
+      this.runtimeEventStoreAvailable = false;
+      await this.enqueueTraceWriteFailure(error, label);
+    });
+    this.runtimeEventQueue = next.catch(() => {});
+    return next;
+  }
+
   private async enqueueTraceWriteFailure(error: unknown, label = 'agent run store write'): Promise<void> {
     const message = errorMessage(error);
     try {
@@ -498,34 +527,6 @@ function traceToRunEvent(event: RunTraceEvent, runId: string): AgentRunEvent {
     message: redactTraceString(event.message),
     data: sanitizeTraceData(event.data),
   };
-}
-
-function materializeLegacyTextMessages(stored: readonly StoredMessage[]): TextModelMessage[] {
-  const out: TextModelMessage[] = [];
-  for (const message of stored) {
-    if (message.type === 'user') {
-      out.push({ role: 'user', content: message.text });
-    } else if (message.type === 'assistant') {
-      out.push({ role: 'assistant', content: message.text });
-    }
-  }
-  return out;
-}
-
-function runtimeMessagesCoverLegacy(
-  runtimeMessages: readonly TextModelMessage[],
-  legacyMessages: readonly TextModelMessage[],
-): boolean {
-  if (runtimeMessages.length !== legacyMessages.length) return false;
-  return legacyMessages.every((legacyMessage, index) => {
-    const runtimeMessage = runtimeMessages[index];
-    if (!runtimeMessage || runtimeMessage.role !== legacyMessage.role) return false;
-    if (runtimeMessage.content === legacyMessage.content) return true;
-    return (
-      runtimeMessage.role === 'user' &&
-      runtimeMessage.content.startsWith(`${legacyMessage.content}\n\n[attachment: `)
-    );
-  });
 }
 
 function sanitizeTraceData(data: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
@@ -569,6 +570,10 @@ function statusPatch(
     blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
     statusUpdatedAt: ts,
   };
+}
+
+function isTerminalRunStatus(status: AgentRunHeader['status']): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
 }
 
 function statusFromEvent(event: SessionEvent): { status: SessionStatus; blockedReason?: SessionBlockedReason } | undefined {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -312,7 +312,7 @@ export class AiSdkBackend implements AgentBackend {
       };
     }
 
-    // --- Build messages from context, preferring durable RuntimeEvents when usable. ---
+    // --- Build messages from RuntimeEvent history and its compatibility projection. ---
     const priorReplay = this.buildPriorMessages(input);
     const messages = priorReplay.messages;
     messages.push({
@@ -577,32 +577,32 @@ export class AiSdkBackend implements AgentBackend {
     return this.modelAdapter.makeErrorEvent(turnId, err);
   }
 
-  /** Materialize stored messages into ai-sdk's message format.
-   *  V0.1: text-only round-tripping. Tool calls / results within stored
-   *  history are deliberately NOT replayed — ai-sdk's streamText starts
-   *  fresh each turn and the tool state isn't part of the prompt. */
+  /** Materialize RuntimeEvent-derived projections into ai-sdk's message format.
+   *  V0.1: text-only round-tripping. Tool calls / results within projected
+   *  history are deliberately NOT replayed unless RuntimeEvent native replay
+   *  is available for the provider. */
   private buildPriorMessages(input: BackendSendInput): {
     messages: ModelMessage[];
-    gate: RuntimeEventReplayFallbackGate | 'legacy_stored_messages';
+    gate: RuntimeEventReplayFallbackGate | 'stored_message_projection';
     diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
   } {
-    const legacyMessages = this.materializePriorMessages(
+    const projectedMessages = this.materializePriorMessages(
       input.context.filter((message) => message.turnId !== input.turnId),
     );
     if (!input.runtimeContext) {
-      return { messages: legacyMessages, gate: 'legacy_stored_messages', diagnostics: [] };
+      return { messages: projectedMessages, gate: 'stored_message_projection', diagnostics: [] };
     }
 
     const plan = buildRuntimeEventModelReplayPlan(
       input.runtimeContext.filter((event) => event.turnId !== input.turnId),
     );
     if (plan.items.length === 0) {
-      return { messages: legacyMessages, gate: 'legacy_stored_messages', diagnostics: plan.diagnostics };
+      return { messages: projectedMessages, gate: 'stored_message_projection', diagnostics: plan.diagnostics };
     }
 
     if (hasBlockingReplayDiagnostics(plan)) {
       return {
-        messages: legacyMessages,
+        messages: projectedMessages,
         gate: 'runtime_replay_unsupported_semantics',
         diagnostics: plan.diagnostics,
       };
@@ -618,7 +618,7 @@ export class AiSdkBackend implements AgentBackend {
 
     if (!this.canReplayProviderNative(plan)) {
       return {
-        messages: legacyMessages,
+        messages: projectedMessages,
         gate: 'runtime_replay_unsupported_semantics',
         diagnostics: plan.diagnostics,
       };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -191,6 +191,20 @@ export type {
   RuntimeEventTerminalFact,
   RuntimeEventTerminalFactResult,
 } from './runtime-event-read-model.js';
+export {
+  RuntimeReadModel,
+  RuntimeReadModelError,
+} from './runtime-read-model.js';
+export type {
+  RuntimeReadModelDeps,
+  RuntimeReadModelProjectionCache,
+  RuntimeReadModelSessionView,
+} from './runtime-read-model.js';
+export { RuntimeKernel } from './runtime-kernel.js';
+export type {
+  RuntimeKernelDeps,
+  RuntimeKernelLike,
+} from './runtime-kernel.js';
 
 // agent-run-inspect.ts — internal AgentRun/RuntimeEvent source-health view.
 export {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -1,0 +1,403 @@
+import type { AgentRunStore, RuntimeEventStore } from '@maka/core';
+import type { SessionEvent } from '@maka/core/events';
+import type {
+  SessionBlockedReason,
+  SessionHeader,
+  SessionStatus,
+  StoredMessage,
+  SystemNoteMessage,
+  TurnRecord,
+} from '@maka/core/session';
+import type { UserMessageInput } from '@maka/core/runtime-inputs';
+import type { PermissionResponse } from '@maka/core/permission';
+import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
+import { AiSdkFlow } from './ai-sdk-flow.js';
+import type { AgentBackend } from './ai-sdk-backend.js';
+import type { InvocationResult, InvocationSource } from './invocation-context.js';
+import { RuntimeRunner } from './runtime-runner.js';
+import type { BackendRegistry, SessionStore, StopSessionInput } from './session-manager.js';
+
+export interface RuntimeKernelLike {
+  startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
+  stopSession(sessionId: string, input?: StopSessionInput): Promise<void>;
+  respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
+  hasActiveRuns(sessionId: string): boolean;
+  updateCachedHeader(sessionId: string, header: SessionHeader): void;
+  disposeBackend(sessionId: string): Promise<void>;
+}
+
+export interface RuntimeKernelDeps {
+  store: SessionStore;
+  runStore?: AgentRunStore;
+  runtimeEventStore?: RuntimeEventStore;
+  backends: BackendRegistry;
+  newId: () => string;
+  now: () => number;
+  runtimeSource?: InvocationSource;
+  runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
+}
+
+interface ActiveSession extends AgentRunActiveSession {
+  sessionId: string;
+  backend: AgentBackend;
+  cachedHeader: SessionHeader;
+  activeRuns: Map<string, AgentRun>;
+  turnToRunId: Map<string, string>;
+}
+
+export class RuntimeKernel implements RuntimeKernelLike {
+  private readonly active = new Map<string, ActiveSession>();
+
+  constructor(private readonly deps: RuntimeKernelDeps) {}
+
+  async *startTurn(
+    sessionId: string,
+    input: UserMessageInput,
+  ): AsyncIterable<SessionEvent> {
+    const header = await this.deps.store.readHeader(sessionId);
+    const run = new AgentRun({
+      sessionId,
+      header,
+      userInput: input,
+      store: this.deps.store,
+      runStore: this.deps.runStore,
+      runtimeEventStore: this.deps.runtimeEventStore,
+      newId: this.deps.newId,
+      now: this.deps.now,
+      hooks: {
+        ensureActive: (targetSessionId, nextHeader) => this.ensureActive(targetSessionId, nextHeader),
+        registerRun: (active, activeRun) => this.registerRun(active, activeRun),
+        unregisterRun: (active, activeRun) => this.unregisterRun(active, activeRun),
+        updateHeader: (targetSessionId, patch) => this.updateHeader(targetSessionId, patch),
+        updateStatus: (targetSessionId, status, blockedReason, ts) =>
+          this.updateStatus(targetSessionId, status, blockedReason, ts),
+        appendTurnState: (targetSessionId, turnId, status, lineage, options) =>
+          this.appendTurnState(targetSessionId, turnId, status, lineage, options),
+      },
+    });
+
+    const sessionEvents = new AsyncEventQueue<SessionEvent>();
+    const abortController = new AbortController();
+    let flowDone = false;
+    let begin: AgentRunBeginResult;
+    try {
+      begin = await run.begin();
+    } catch (error) {
+      await run.recordFailure(error);
+      await run.finalize();
+      throw error;
+    }
+
+    const aiSdkFlow = new AiSdkFlow({
+      backend: begin.backend,
+      drainAfterTerminal: true,
+      onSessionEvent: async (sessionEvent) => {
+        await run.recordSessionEvent(sessionEvent);
+        await sessionEvents.push(sessionEvent);
+      },
+      onError: async (error) => {
+        if (!isAsyncEventQueueClosed(error)) {
+          await run.recordFailure(error);
+          sessionEvents.fail(error);
+        }
+      },
+      onFinally: async () => {
+        flowDone = true;
+        await run.finalize();
+        sessionEvents.close();
+      },
+    });
+    const runner = new RuntimeRunner({
+      flow: aiSdkFlow,
+      providers: { newId: this.deps.newId, now: this.deps.now },
+      stopOnTerminal: false,
+    });
+    const runnerResult = runner.run({
+      sessionId,
+      runId: run.runId,
+      turnId: run.turnId,
+      text: input.text,
+      ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
+      context: begin.backendInput.context,
+      ...(begin.backendInput.runtimeContext !== undefined ? { runtimeContext: begin.backendInput.runtimeContext } : {}),
+      source: this.deps.runtimeSource ?? 'desktop',
+      lineage: run.lineage,
+      abortSignal: abortController.signal,
+    }).then(async (result) => {
+      await run.recordRuntimeEvents(result.events);
+      await this.deps.runtimeInvocationObserver?.(result);
+      return result;
+    }, (error) => {
+      sessionEvents.fail(error);
+      throw error;
+    });
+
+    try {
+      for await (const event of sessionEvents) {
+        yield event;
+      }
+      await runnerResult;
+    } finally {
+      if (!flowDone) {
+        abortController.abort();
+        sessionEvents.close();
+      }
+      await runnerResult.catch(() => undefined);
+    }
+  }
+
+  async stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
+    const active = this.active.get(sessionId);
+    if (!active) return;
+    const abortSource = normalizeStopSessionSource(input.source);
+    await active.backend.stop('user_stop');
+    const activeRuns = [...active.activeRuns.values()];
+    for (const run of activeRuns) {
+      run.stop(input.source);
+    }
+    await this.updateStatus(sessionId, 'aborted');
+    for (const run of activeRuns) {
+      await this.appendTurnState(
+        sessionId,
+        run.turnId,
+        'aborted',
+        run.lineage,
+        { ts: this.deps.now(), abortSource },
+      ).catch(() => {});
+    }
+    await this.deps.store.appendMessage(sessionId, {
+      type: 'system_note',
+      id: this.deps.newId(),
+      ts: this.deps.now(),
+      kind: 'abort',
+      ...(abortSource ? { data: { source: abortSource } } : {}),
+    } satisfies SystemNoteMessage);
+  }
+
+  async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {
+    const active = this.active.get(sessionId);
+    if (!active) return;
+    await active.backend.respondToPermission(response);
+  }
+
+  hasActiveRuns(sessionId: string): boolean {
+    return (this.active.get(sessionId)?.activeRuns.size ?? 0) > 0;
+  }
+
+  updateCachedHeader(sessionId: string, header: SessionHeader): void {
+    const active = this.active.get(sessionId);
+    if (active) active.cachedHeader = header;
+  }
+
+  async disposeBackend(sessionId: string): Promise<void> {
+    const active = this.active.get(sessionId);
+    if (!active) return;
+    this.active.delete(sessionId);
+    try {
+      await active.backend.dispose();
+    } catch {
+      // best-effort
+    }
+  }
+
+  private async ensureActive(
+    sessionId: string,
+    header: SessionHeader,
+  ): Promise<ActiveSession> {
+    const existing = this.active.get(sessionId);
+    if (existing) {
+      existing.cachedHeader = header;
+      return existing;
+    }
+    const backend = await this.deps.backends.build(header.backend, {
+      sessionId,
+      workspaceRoot: header.workspaceRoot,
+      header,
+      store: this.deps.store,
+      recordRunTrace: (event) => {
+        const active = this.active.get(sessionId);
+        const runId = active?.turnToRunId.get(event.turnId);
+        const run = runId ? active?.activeRuns.get(runId) : undefined;
+        run?.recordRunTrace(event);
+      },
+    });
+    const entry: ActiveSession = {
+      sessionId,
+      backend,
+      cachedHeader: header,
+      activeRuns: new Map(),
+      turnToRunId: new Map(),
+    };
+    this.active.set(sessionId, entry);
+    return entry;
+  }
+
+  private registerRun(active: AgentRunActiveSession, run: AgentRun): void {
+    active.activeRuns.set(run.runId, run);
+    active.turnToRunId.set(run.turnId, run.runId);
+  }
+
+  private unregisterRun(active: AgentRunActiveSession, run: AgentRun): void {
+    active.activeRuns.delete(run.runId);
+    if (active.turnToRunId.get(run.turnId) === run.runId) {
+      active.turnToRunId.delete(run.turnId);
+    }
+  }
+
+  private async updateStatus(
+    sessionId: string,
+    status: SessionStatus,
+    blockedReason?: SessionBlockedReason,
+    ts = this.deps.now(),
+  ): Promise<void> {
+    await this.updateHeader(sessionId, statusPatch(status, ts, blockedReason));
+  }
+
+  private async updateHeader(
+    sessionId: string,
+    patch: Partial<SessionHeader>,
+  ): Promise<SessionHeader> {
+    const next = await this.deps.store.updateHeader(sessionId, patch);
+    this.updateCachedHeader(sessionId, next);
+    return next;
+  }
+
+  private async appendTurnState(
+    sessionId: string,
+    turnId: string,
+    status: TurnRecord['status'],
+    lineage: AgentRunLineage = {},
+    options: { ts?: number; errorClass?: string; abortSource?: string } = {},
+  ): Promise<void> {
+    const ts = options.ts ?? this.deps.now();
+    await this.deps.store.appendMessage(sessionId, {
+      type: 'turn_state',
+      id: this.deps.newId(),
+      turnId,
+      ts,
+      status,
+      ...(lineage.parentTurnId ? { parentTurnId: lineage.parentTurnId } : {}),
+      ...(lineage.retriedFromTurnId ? { retriedFromTurnId: lineage.retriedFromTurnId } : {}),
+      ...(lineage.regeneratedFromTurnId ? { regeneratedFromTurnId: lineage.regeneratedFromTurnId } : {}),
+      ...(lineage.branchOfTurnId ? { branchOfTurnId: lineage.branchOfTurnId } : {}),
+      ...(lineage.parentSessionId ? { parentSessionId: lineage.parentSessionId } : {}),
+      ...(status === 'aborted' ? { abortedAt: ts } : {}),
+      ...(status === 'aborted' && options.abortSource ? { abortSource: options.abortSource } : {}),
+      ...(status === 'failed' ? { errorClass: options.errorClass ?? 'unknown' } : {}),
+      partialOutputRetained: await this.turnHasRetainedOutput(sessionId, turnId),
+    });
+  }
+
+  private async turnHasRetainedOutput(sessionId: string, turnId: string): Promise<boolean> {
+    const messages = await this.deps.store.readMessages(sessionId).catch(() => []);
+    return messages.some((message) =>
+      (message.type === 'assistant' && message.turnId === turnId && message.text.trim().length > 0) ||
+      (message.type === 'tool_result' && message.turnId === turnId),
+    );
+  }
+}
+
+function statusPatch(
+  status: SessionStatus,
+  ts: number,
+  blockedReason?: SessionBlockedReason,
+): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
+  return {
+    status,
+    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
+    statusUpdatedAt: ts,
+  };
+}
+
+function normalizeStopSessionSource(source: StopSessionInput['source'] | undefined): string | undefined {
+  switch (source) {
+    case 'stop_button': return 'renderer.stop_button';
+    case undefined: return undefined;
+  }
+}
+
+class AsyncEventQueueClosed extends Error {
+  constructor() {
+    super('Async event queue closed');
+    this.name = 'AsyncEventQueueClosed';
+  }
+}
+
+function isAsyncEventQueueClosed(error: unknown): boolean {
+  return error instanceof AsyncEventQueueClosed;
+}
+
+interface AsyncEventQueueEntry<T> {
+  value: T;
+  delivered: () => void;
+  rejected: (error: unknown) => void;
+}
+
+class AsyncEventQueue<T> implements AsyncIterable<T> {
+  private readonly values: Array<AsyncEventQueueEntry<T>> = [];
+  private readonly waiters: Array<{
+    resolve: (entry: AsyncEventQueueEntry<T> | undefined) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private closed = false;
+  private failure: unknown;
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this.consume()[Symbol.asyncIterator]();
+  }
+
+  push(value: T): Promise<void> {
+    if (this.failure) return Promise.reject(this.failure);
+    if (this.closed) return Promise.reject(new AsyncEventQueueClosed());
+    return new Promise<void>((resolve, reject) => {
+      const entry = { value, delivered: resolve, rejected: reject };
+      const waiter = this.waiters.shift();
+      if (waiter) {
+        waiter.resolve(entry);
+        return;
+      }
+      this.values.push(entry);
+    });
+  }
+
+  fail(error: unknown): void {
+    if (this.failure) return;
+    this.failure = error;
+    for (const value of this.values.splice(0)) value.rejected(error);
+    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const closed = new AsyncEventQueueClosed();
+    for (const value of this.values.splice(0)) value.rejected(closed);
+    for (const waiter of this.waiters.splice(0)) waiter.resolve(undefined);
+  }
+
+  private async *consume(): AsyncIterable<T> {
+    while (true) {
+      const entry = await this.nextEntry();
+      if (!entry) return;
+      try {
+        yield entry.value;
+      } finally {
+        entry.delivered();
+      }
+    }
+  }
+
+  private nextEntry(): Promise<AsyncEventQueueEntry<T> | undefined> {
+    if (this.values.length > 0) {
+      const next = this.values.shift()!;
+      return Promise.resolve(next);
+    }
+    if (this.failure) return Promise.reject(this.failure);
+    if (this.closed) return Promise.resolve(undefined);
+    return new Promise<AsyncEventQueueEntry<T> | undefined>((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+}
+
+export type { AgentRunLineage };

--- a/packages/runtime/src/runtime-read-model.ts
+++ b/packages/runtime/src/runtime-read-model.ts
@@ -1,0 +1,215 @@
+import type {
+  AgentRunHeader,
+  AgentRunStore,
+  RuntimeEvent,
+  RuntimeEventStore,
+  StoredMessage,
+  TurnRecord,
+} from '@maka/core';
+import { deriveTurnRecords, isTerminalRuntimeEvent } from '@maka/core';
+import {
+  classifyRuntimeEventTerminalFact,
+  compareRuntimeReadModelMessages,
+  projectRuntimeEventsToStoredMessages,
+  type RuntimeEventReadModelDiagnostic,
+  type RuntimeEventTerminalFact,
+} from './runtime-event-read-model.js';
+import { buildRuntimeEventModelReplayPlan, type RuntimeEventModelReplayPlan } from './model-history.js';
+
+export interface RuntimeReadModelProjectionCache {
+  readMessages(sessionId: string): Promise<StoredMessage[]>;
+}
+
+export interface RuntimeReadModelDeps {
+  runStore: AgentRunStore;
+  runtimeEventStore: RuntimeEventStore;
+  projectionCache?: RuntimeReadModelProjectionCache;
+}
+
+export interface RuntimeReadModelSessionView {
+  source: 'runtime_events';
+  messages: StoredMessage[];
+  turns: TurnRecord[];
+  events: RuntimeEvent[];
+  runs: AgentRunHeader[];
+  diagnostics: RuntimeEventReadModelDiagnostic[];
+  terminalFacts: RuntimeEventTerminalFact[];
+  replayPlan: RuntimeEventModelReplayPlan;
+}
+
+export class RuntimeReadModelError extends Error {
+  readonly diagnostics: RuntimeEventReadModelDiagnostic[];
+
+  constructor(message: string, diagnostics: RuntimeEventReadModelDiagnostic[]) {
+    super(message);
+    this.name = 'RuntimeReadModelError';
+    this.diagnostics = diagnostics;
+  }
+}
+
+export class RuntimeReadModel {
+  constructor(private readonly deps: RuntimeReadModelDeps) {}
+
+  async getSessionMessages(sessionId: string): Promise<StoredMessage[]> {
+    return (await this.getSessionView(sessionId)).messages;
+  }
+
+  async getSessionTurns(sessionId: string): Promise<TurnRecord[]> {
+    return (await this.getSessionView(sessionId)).turns;
+  }
+
+  async getSessionView(sessionId: string): Promise<RuntimeReadModelSessionView> {
+    const diagnostics: RuntimeEventReadModelDiagnostic[] = [];
+    let runs: AgentRunHeader[];
+    try {
+      runs = await this.deps.runStore.listSessionRuns(sessionId);
+    } catch (error) {
+      throw new RuntimeReadModelError('RuntimeReadModel could not list AgentRun headers', [
+        readModelDiagnostic('unsupported_event', 'AgentRunStore.listSessionRuns failed', {
+          error: errorMessage(error),
+        }),
+      ]);
+    }
+
+    if (runs.length === 0) {
+      return this.buildView({ runs, events: [], diagnostics });
+    }
+
+    const ordered: Array<{ event: RuntimeEvent; runIndex: number; eventIndex: number }> = [];
+    const terminalFacts: RuntimeEventTerminalFact[] = [];
+    for (let runIndex = 0; runIndex < runs.length; runIndex += 1) {
+      const run = runs[runIndex]!;
+      if (!isTerminalRunStatus(run.status)) {
+        throw new RuntimeReadModelError('RuntimeEvent ledger is incomplete for an active run', [
+          readModelDiagnostic('incomplete_event', 'active run has no stable RuntimeEvent read projection', {
+            runId: run.runId,
+            turnId: run.turnId,
+            status: run.status,
+          }),
+        ]);
+      }
+
+      let runEvents: RuntimeEvent[];
+      try {
+        runEvents = await this.deps.runtimeEventStore.readRuntimeEvents(sessionId, run.runId);
+      } catch (error) {
+        throw new RuntimeReadModelError('RuntimeEvent ledger read failed', [
+          readModelDiagnostic('unsupported_event', 'RuntimeEventStore.readRuntimeEvents failed', {
+            runId: run.runId,
+            error: errorMessage(error),
+          }),
+        ]);
+      }
+
+      if (runEvents.length === 0) {
+        throw new RuntimeReadModelError('RuntimeEvent ledger is missing for a terminal run', [
+          readModelDiagnostic('incomplete_event', 'terminal run has no readable RuntimeEvent ledger', {
+            runId: run.runId,
+            turnId: run.turnId,
+          }),
+        ]);
+      }
+      if (!runEvents.some(isTerminalRuntimeEvent)) {
+        throw new RuntimeReadModelError('RuntimeEvent ledger has no terminal fact for a terminal run', [
+          readModelDiagnostic('incomplete_event', 'terminal run has no terminal RuntimeEvent', {
+            runId: run.runId,
+            turnId: run.turnId,
+          }),
+        ]);
+      }
+
+      const terminalFact = classifyRuntimeEventTerminalFact(run, runEvents);
+      diagnostics.push(...terminalFact.diagnostics);
+      if (terminalFact.fact) terminalFacts.push(terminalFact.fact);
+
+      for (let eventIndex = 0; eventIndex < runEvents.length; eventIndex += 1) {
+        ordered.push({ event: runEvents[eventIndex]!, runIndex, eventIndex });
+      }
+    }
+
+    ordered.sort((a, b) =>
+      a.event.ts - b.event.ts ||
+      a.runIndex - b.runIndex ||
+      a.eventIndex - b.eventIndex ||
+      a.event.id.localeCompare(b.event.id)
+    );
+
+    return this.buildView({
+      runs,
+      events: ordered.map((item) => item.event),
+      diagnostics,
+      terminalFacts,
+    });
+  }
+
+  private async buildView(input: {
+    runs: AgentRunHeader[];
+    events: RuntimeEvent[];
+    diagnostics: RuntimeEventReadModelDiagnostic[];
+    terminalFacts?: RuntimeEventTerminalFact[];
+  }): Promise<RuntimeReadModelSessionView> {
+    const projected = projectRuntimeEventsToStoredMessages(input.events, { runHeaders: input.runs });
+    const diagnostics = [...input.diagnostics, ...projected.diagnostics];
+    if (hasHardProjectionDiagnostic(projected.diagnostics)) {
+      throw new RuntimeReadModelError('RuntimeEvent read projection is incomplete', diagnostics);
+    }
+
+    const cacheDiagnostics = await this.compareProjectionCache(input.runs[0]?.sessionId, projected.messages);
+    diagnostics.push(...cacheDiagnostics);
+
+    return {
+      source: 'runtime_events',
+      messages: projected.messages,
+      turns: deriveTurnRecords(projected.messages),
+      events: input.events,
+      runs: input.runs,
+      diagnostics,
+      terminalFacts: input.terminalFacts ?? [],
+      replayPlan: buildRuntimeEventModelReplayPlan(input.events),
+    };
+  }
+
+  private async compareProjectionCache(
+    sessionId: string | undefined,
+    messages: readonly StoredMessage[],
+  ): Promise<RuntimeEventReadModelDiagnostic[]> {
+    if (!sessionId || !this.deps.projectionCache) return [];
+    let cached: StoredMessage[];
+    try {
+      cached = await this.deps.projectionCache.readMessages(sessionId);
+    } catch (error) {
+      return [readModelDiagnostic('unsupported_event', 'SessionProjectionCache.readMessages failed', {
+        error: errorMessage(error),
+      })];
+    }
+    return compareRuntimeReadModelMessages(messages, cached).diagnostics;
+  }
+}
+
+function hasHardProjectionDiagnostic(diagnostics: readonly RuntimeEventReadModelDiagnostic[]): boolean {
+  return diagnostics.some((diagnostic) =>
+    diagnostic.code === 'incomplete_event' ||
+    diagnostic.code === 'unsupported_event' ||
+    diagnostic.code === 'tool_use_id_mismatch'
+  );
+}
+
+function readModelDiagnostic(
+  code: RuntimeEventReadModelDiagnostic['code'],
+  message: string,
+  detail?: unknown,
+): RuntimeEventReadModelDiagnostic {
+  return {
+    code,
+    message,
+    ...(detail !== undefined ? { detail } : {}),
+  };
+}
+
+function isTerminalRunStatus(status: AgentRunHeader['status']): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -18,8 +18,9 @@
  *      status.
  *
  * Out-of-scope (deliberately): direct SessionStore writes, projection
- * driving, and AgentRunStore ledger writes. Those remain owned by AgentRun
- * while SessionManager delegates invocation execution through this shell.
+ * driving, operational AgentRunStore writes, and RuntimeEventStore ledger
+ * writes. Those remain owned by the runtime orchestration around AgentRun while
+ * SessionManager delegates invocation execution through this shell.
  */
 
 import {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -45,26 +45,23 @@ import type {
 } from '@maka/core/runtime-inputs';
 import type { PermissionResponse } from '@maka/core/permission';
 import type { PermissionMode } from '@maka/core/permission';
-import { DEEP_RESEARCH_SESSION_LABEL, deriveTurnRecords, isDeepResearchSession, isTerminalRuntimeEvent } from '@maka/core';
-import type { AgentRunHeader, AgentRunStore, RuntimeEvent } from '@maka/core';
+import { DEEP_RESEARCH_SESSION_LABEL, isDeepResearchSession } from '@maka/core';
+import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 import {
-  compareRuntimeReadModelMessages,
-  projectRuntimeEventsToStoredMessages,
-  type RuntimeEventReadModelDiagnostic,
   type RuntimeEventTerminalFact,
 } from './runtime-event-read-model.js';
+import { RuntimeReadModel, type RuntimeReadModelSessionView } from './runtime-read-model.js';
 import { inspectAgentRunReadModel, type AgentRunInspectModel } from './agent-run-inspect.js';
 
 import type { AgentBackend } from './ai-sdk-backend.js';
 import type { RunTraceRecorder } from './run-trace.js';
-import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
+import type { AgentRunLineage } from './agent-run.js';
 import { classifyAgentRunRecovery, type AgentRunRecoveryDecision } from './agent-run-recovery.js';
-import { AiSdkFlow } from './ai-sdk-flow.js';
 import type {
   InvocationResult,
   InvocationSource,
 } from './invocation-context.js';
-import { RuntimeRunner } from './runtime-runner.js';
+import { RuntimeKernel, type RuntimeKernelLike } from './runtime-kernel.js';
 
 export interface StopSessionInput {
   source?: 'stop_button';
@@ -74,10 +71,8 @@ export interface StopSessionInput {
 // SessionStore contract (matches the storage package surface)
 // ============================================================================
 
-// SessionStore remains the compatibility ledger and projection cache for UI,
-// branch/retry, and legacy recovery. RuntimeEvent-complete runs should make new
-// semantic decisions from the AgentRun/RuntimeEvent read model first, then fall
-// back to these StoredMessage rows only when compatibility requires it.
+// StoredMessage rows remain a projection/cache surface for existing public
+// shapes. RuntimeEventStore is the semantic conversation ledger.
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
@@ -133,35 +128,21 @@ export class BackendRegistry {
 export interface SessionManagerDeps {
   store: SessionStore;
   runStore?: AgentRunStore;
+  runtimeEventStore?: RuntimeEventStore;
   backends: BackendRegistry;
   newId: () => string;
   now: () => number;
   runtimeSource?: InvocationSource;
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
-}
-
-interface ActiveSession extends AgentRunActiveSession {
-  sessionId: string;
-  backend: AgentBackend;
-  /** Tracks the latest header we've read (used to short-circuit some reads). */
-  cachedHeader: SessionHeader;
-  activeRuns: Map<string, AgentRun>;
-  turnToRunId: Map<string, string>;
-}
-
-type SessionReadSource = 'runtime_events' | 'legacy_session_store';
-
-interface SessionReadView {
-  source: SessionReadSource;
-  messages: StoredMessage[];
-  turns: TurnRecord[];
-  diagnostics: RuntimeEventReadModelDiagnostic[];
+  runtimeKernel?: RuntimeKernelLike;
 }
 
 export class SessionManager {
-  private readonly active = new Map<string, ActiveSession>();
+  private readonly runtimeKernel: RuntimeKernelLike;
 
-  constructor(private readonly deps: SessionManagerDeps) {}
+  constructor(private readonly deps: SessionManagerDeps) {
+    this.runtimeKernel = deps.runtimeKernel ?? new RuntimeKernel(deps);
+  }
 
   // --------------------------------------------------------------------------
   // Session lifecycle
@@ -177,11 +158,11 @@ export class SessionManager {
   }
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {
-    return (await this.readSessionView(sessionId)).messages;
+    return (await this.readModel().getSessionView(sessionId)).messages;
   }
 
   async listTurns(sessionId: string): Promise<TurnRecord[]> {
-    return (await this.readSessionView(sessionId)).turns;
+    return (await this.readModel().getSessionView(sessionId)).turns;
   }
 
   async recoverInterruptedSessions(): Promise<string[]> {
@@ -189,7 +170,7 @@ export class SessionManager {
       .filter((session) => session.status !== 'archived');
     const recovered: string[] = [];
     for (const session of interrupted) {
-      if (this.active.has(session.id)) continue;
+      if (this.runtimeKernel.hasActiveRuns(session.id)) continue;
       let messages: StoredMessage[] = [];
       let messagesReadable = true;
       try {
@@ -199,7 +180,7 @@ export class SessionManager {
       }
 
       if (this.deps.runStore) {
-        const runRecovery = await this.recoverAgentRunsFromLedger(session.id, messages).catch(() => undefined);
+        const runRecovery = await this.recoverAgentRunsFromLedger(session.id).catch(() => undefined);
         if (runRecovery?.hasLedger) {
           if (runRecovery.recovered) {
             await this.updateStatus(session.id, 'active').catch(() => {});
@@ -239,29 +220,26 @@ export class SessionManager {
     sessionId: string,
     patch: Partial<SessionHeader>,
   ): Promise<SessionSummary> {
-    const active = this.active.get(sessionId);
     const backendConfigChanged = changesBackendConfig(patch);
-    if (active && backendConfigChanged && active.activeRuns.size > 0) {
+    if (backendConfigChanged && this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('Cannot change backend configuration while a turn is running');
     }
 
     const next = await this.deps.store.updateHeader(sessionId, patch);
-    if (active) {
-      active.cachedHeader = next;
-      if (backendConfigChanged) {
-        // AgentBackend instances snapshot backend/model config at construction
-        // time. If a stale session is rebound to a real default connection, the
-        // next turn must build a fresh backend instead of reusing FakeBackend or
-        // an AiSdkBackend pointed at a deleted connection.
-        await this.disposeBackend(sessionId);
-      }
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+    if (backendConfigChanged) {
+      // AgentBackend instances snapshot backend/model config at construction
+      // time. If a stale session is rebound to a real default connection, the
+      // next turn must build a fresh backend instead of reusing FakeBackend or
+      // an AiSdkBackend pointed at a deleted connection.
+      await this.runtimeKernel.disposeBackend(sessionId);
     }
     return headerToSummary(next);
   }
 
   async archive(sessionId: string): Promise<void> {
     await this.deps.store.archive(sessionId);
-    await this.disposeBackend(sessionId);
+    await this.runtimeKernel.disposeBackend(sessionId);
   }
 
   async unarchive(sessionId: string): Promise<void> {
@@ -274,21 +252,20 @@ export class SessionManager {
     blockedReason?: SessionBlockedReason,
   ): Promise<SessionSummary> {
     const next = await this.deps.store.updateHeader(sessionId, statusPatch(status, this.deps.now(), blockedReason));
-    const active = this.active.get(sessionId);
-    if (active) active.cachedHeader = next;
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
     return headerToSummary(next);
   }
 
   async setFlagged(sessionId: string, isFlagged: boolean): Promise<void> {
     await this.deps.store.setFlagged(sessionId, isFlagged);
-    const active = this.active.get(sessionId);
-    if (active) active.cachedHeader = { ...active.cachedHeader, isFlagged };
+    const header = await this.deps.store.readHeader(sessionId).catch(() => undefined);
+    if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
   }
 
   async renameSession(sessionId: string, name: string): Promise<void> {
     await this.deps.store.rename(sessionId, name);
-    const active = this.active.get(sessionId);
-    if (active) active.cachedHeader = { ...active.cachedHeader, name };
+    const header = await this.deps.store.readHeader(sessionId).catch(() => undefined);
+    if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
   }
 
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {
@@ -296,8 +273,7 @@ export class SessionManager {
     const leavingDeepResearch = isDeepResearchSession(previous.labels) && mode !== 'explore';
     if (previous.permissionMode === mode && !leavingDeepResearch) return headerToSummary(previous);
 
-    const active = this.active.get(sessionId);
-    if (active && active.activeRuns.size > 0) {
+    if (this.runtimeKernel.hasActiveRuns(sessionId)) {
       throw new Error('当前对话正在运行，等结束后再切换权限模式。');
     }
     if (previous.status === 'waiting_for_user') {
@@ -318,17 +294,15 @@ export class SessionManager {
       data: { from: previous.permissionMode, to: mode },
     } satisfies SystemNoteMessage);
 
-    if (active) {
-      active.cachedHeader = next;
-      // AiSdkBackend snapshots the header at construction time. Rebuild the
-      // backend before the next turn so PermissionEngine receives the new mode.
-      await this.disposeBackend(sessionId);
-    }
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
+    // AiSdkBackend snapshots the header at construction time. Rebuild the
+    // backend before the next turn so PermissionEngine receives the new mode.
+    await this.runtimeKernel.disposeBackend(sessionId);
     return headerToSummary(next);
   }
 
   async remove(sessionId: string): Promise<void> {
-    await this.disposeBackend(sessionId);
+    await this.runtimeKernel.disposeBackend(sessionId);
     await this.deps.store.remove(sessionId);
   }
 
@@ -341,134 +315,18 @@ export class SessionManager {
    * (desktop main) is expected to forward the events to the renderer over
    * the IPC bridge.
    *
-   * Runtime v2 bridge:
-   *   1. Create one AgentRun, which remains the persistence/ledger owner.
-   *   2. Begin it to resolve the production backend and model context.
-   *   3. Run AiSdkFlow through RuntimeRunner for canonical RuntimeEvents.
-   *   4. Forward the original SessionEvents to callers unchanged.
-   *   5. Drain the backend stream fully so stop/abort cleanup semantics stay intact.
+   * Runtime v2 bridge: SessionManager remains the public facade; RuntimeKernel
+   * owns AgentRun/AiSdkFlow/RuntimeRunner orchestration and ledger recording.
    */
   async *sendMessage(
     sessionId: string,
     input: UserMessageInput,
   ): AsyncIterable<SessionEvent> {
-    const header = await this.deps.store.readHeader(sessionId);
-    const run = new AgentRun({
-      sessionId,
-      header,
-      userInput: input,
-      store: this.deps.store,
-      runStore: this.deps.runStore,
-      newId: this.deps.newId,
-      now: this.deps.now,
-      hooks: {
-        ensureActive: (targetSessionId, nextHeader) => this.ensureActive(targetSessionId, nextHeader),
-        registerRun: (active, activeRun) => this.registerRun(active, activeRun),
-        unregisterRun: (active, activeRun) => this.unregisterRun(active, activeRun),
-        updateHeader: (targetSessionId, patch) => this.updateHeader(targetSessionId, patch),
-        updateStatus: (targetSessionId, status, blockedReason, ts) =>
-          this.updateStatus(targetSessionId, status, blockedReason, ts),
-        appendTurnState: (targetSessionId, turnId, status, lineage, options) =>
-          this.appendTurnState(targetSessionId, turnId, status, lineage, options),
-      },
-    });
-
-    const sessionEvents = new AsyncEventQueue<SessionEvent>();
-    const abortController = new AbortController();
-    let flowDone = false;
-    let begin: AgentRunBeginResult;
-    try {
-      begin = await run.begin();
-    } catch (error) {
-      await run.recordFailure(error);
-      await run.finalize();
-      throw error;
-    }
-    const aiSdkFlow = new AiSdkFlow({
-      backend: begin.backend,
-      drainAfterTerminal: true,
-      onSessionEvent: async (sessionEvent) => {
-        await run.recordSessionEvent(sessionEvent);
-        await sessionEvents.push(sessionEvent);
-      },
-      onError: async (error) => {
-        if (!isAsyncEventQueueClosed(error)) {
-          await run.recordFailure(error);
-          sessionEvents.fail(error);
-        }
-      },
-      onFinally: async () => {
-        flowDone = true;
-        await run.finalize();
-        sessionEvents.close();
-      },
-    });
-    const runner = new RuntimeRunner({
-      flow: aiSdkFlow,
-      providers: { newId: this.deps.newId, now: this.deps.now },
-      stopOnTerminal: false,
-    });
-    const runnerResult = runner.run({
-      sessionId,
-      runId: run.runId,
-      turnId: run.turnId,
-      text: input.text,
-      ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
-      context: begin.backendInput.context,
-      ...(begin.backendInput.runtimeContext !== undefined ? { runtimeContext: begin.backendInput.runtimeContext } : {}),
-      source: this.deps.runtimeSource ?? 'desktop',
-      lineage: run.lineage,
-      abortSignal: abortController.signal,
-    }).then(async (result) => {
-      await run.recordRuntimeEvents(result.events);
-      await this.deps.runtimeInvocationObserver?.(result);
-      return result;
-    }, (error) => {
-      sessionEvents.fail(error);
-      throw error;
-    });
-
-    try {
-      for await (const event of sessionEvents) {
-        yield event;
-      }
-      await runnerResult;
-    } finally {
-      if (!flowDone) {
-        abortController.abort();
-        sessionEvents.close();
-      }
-      await runnerResult.catch(() => undefined);
-    }
+    yield* this.runtimeKernel.startTurn(sessionId, input);
   }
 
   async stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
-    const active = this.active.get(sessionId);
-    if (!active) return;
-    const abortSource = normalizeStopSessionSource(input.source);
-    await active.backend.stop('user_stop');
-    const activeRuns = [...active.activeRuns.values()];
-    for (const run of activeRuns) {
-      run.stop(input.source);
-    }
-    await this.updateStatus(sessionId, 'aborted');
-    for (const run of activeRuns) {
-      await this.appendTurnState(
-        sessionId,
-        run.turnId,
-        'aborted',
-        run.lineage,
-        { ts: this.deps.now(), abortSource },
-      ).catch(() => {});
-    }
-    // Append the abort SystemNote synchronously (matches §9 Step 6 step 4).
-    await this.deps.store.appendMessage(sessionId, {
-      type: 'system_note',
-      id: this.deps.newId(),
-      ts: this.deps.now(),
-      kind: 'abort',
-      ...(abortSource ? { data: { source: abortSource } } : {}),
-    } satisfies SystemNoteMessage);
+    await this.runtimeKernel.stopSession(sessionId, input);
   }
 
   async *retryTurn(
@@ -506,7 +364,8 @@ export class SessionManager {
     input: BranchFromTurnInput,
   ): Promise<SessionSummary> {
     const header = await this.deps.store.readHeader(sessionId);
-    const { messages } = await this.readSessionView(sessionId);
+    const sourceView = await this.readModel().getSessionView(sessionId);
+    const { messages } = sourceView;
     const copied = copyMessagesThroughTurnBoundary(messages, input.sourceTurnId);
     if (copied.length === 0) throw new Error(`Cannot branch from unknown turn ${input.sourceTurnId}`);
     const next = await this.deps.store.create({
@@ -521,6 +380,7 @@ export class SessionManager {
       branchOfTurnId: input.sourceTurnId,
       status: 'active',
     });
+    await this.cloneBranchRuntimeLedger(next.id, sourceView, copied);
     await this.deps.store.appendMessages(next.id, copied);
     await this.deps.store.appendMessage(next.id, {
       type: 'system_note',
@@ -536,69 +396,12 @@ export class SessionManager {
     sessionId: string,
     response: PermissionResponse,
   ): Promise<void> {
-    const active = this.active.get(sessionId);
-    if (!active) return;
-    await active.backend.respondToPermission(response);
+    await this.runtimeKernel.respondToPermission(sessionId, response);
   }
 
   // --------------------------------------------------------------------------
   // Internal helpers
   // --------------------------------------------------------------------------
-
-  private async ensureActive(
-    sessionId: string,
-    header: SessionHeader,
-  ): Promise<ActiveSession> {
-    const existing = this.active.get(sessionId);
-    if (existing) {
-      existing.cachedHeader = header;
-      return existing;
-    }
-    const backend = await this.deps.backends.build(header.backend, {
-      sessionId,
-      workspaceRoot: header.workspaceRoot,
-      header,
-      store: this.deps.store,
-      recordRunTrace: (event) => {
-        const active = this.active.get(sessionId);
-        const runId = active?.turnToRunId.get(event.turnId);
-        const run = runId ? active?.activeRuns.get(runId) : undefined;
-        run?.recordRunTrace(event);
-      },
-    });
-    const entry: ActiveSession = {
-      sessionId,
-      backend,
-      cachedHeader: header,
-      activeRuns: new Map(),
-      turnToRunId: new Map(),
-    };
-    this.active.set(sessionId, entry);
-    return entry;
-  }
-
-  private registerRun(active: AgentRunActiveSession, run: AgentRun): void {
-    active.activeRuns.set(run.runId, run);
-    active.turnToRunId.set(run.turnId, run.runId);
-  }
-
-  private unregisterRun(active: AgentRunActiveSession, run: AgentRun): void {
-    active.activeRuns.delete(run.runId);
-    if (active.turnToRunId.get(run.turnId) === run.runId) {
-      active.turnToRunId.delete(run.turnId);
-    }
-  }
-
-  private async disposeBackend(sessionId: string): Promise<void> {
-    const active = this.active.get(sessionId);
-    if (!active) return;
-    this.active.delete(sessionId);
-    try {
-      await active.backend.dispose();
-    } catch {
-      // best-effort
-    }
-  }
 
   private async updateStatus(
     sessionId: string,
@@ -614,8 +417,7 @@ export class SessionManager {
     patch: Partial<SessionHeader>,
   ): Promise<SessionHeader> {
     const next = await this.deps.store.updateHeader(sessionId, patch);
-    const active = this.active.get(sessionId);
-    if (active) active.cachedHeader = next;
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
     return next;
   }
 
@@ -659,7 +461,7 @@ export class SessionManager {
     allowed: readonly TurnRecord['status'][],
     action: string,
   ): Promise<TurnRecord> {
-    const turn = (await this.readSessionView(sessionId)).turns.find((candidate) => candidate.turnId === turnId);
+    const turn = (await this.readModel().getSessionView(sessionId)).turns.find((candidate) => candidate.turnId === turnId);
     if (!turn) throw new Error(`Cannot ${action}: unknown turn ${turnId}`);
     if (!allowed.includes(turn.status)) {
       throw new Error(`Cannot ${action}: turn ${turnId} is ${turn.status}`);
@@ -668,131 +470,82 @@ export class SessionManager {
   }
 
   private async requireUserMessageForTurn(sessionId: string, turnId: string): Promise<UserMessage> {
-    const user = (await this.readSessionView(sessionId)).messages
+    const user = (await this.readModel().getSessionView(sessionId)).messages
       .find((message): message is UserMessage => message.type === 'user' && message.turnId === turnId);
     if (!user) throw new Error(`Turn ${turnId} has no user message`);
     return user;
   }
 
-  private async readSessionView(sessionId: string): Promise<SessionReadView> {
-    const legacy = await this.readLegacyMessages(sessionId);
-    const fallback = (diagnostics: RuntimeEventReadModelDiagnostic[] = []): SessionReadView => {
-      if (!legacy.readable) throw legacy.error;
-      return {
-        source: 'legacy_session_store',
-        messages: legacy.messages,
-        turns: deriveTurnRecords(legacy.messages),
-        diagnostics,
-      };
-    };
-
-    if (runtimeReadSourceForcedLegacy()) {
-      return fallback([readDiagnostic('unsupported_event', 'RuntimeEvent read projection disabled by MAKA_RUNTIME_READ_SOURCE')]);
+  private readModel(): RuntimeReadModel {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('RuntimeReadModel requires AgentRunStore and RuntimeEventStore');
     }
-    if (!this.deps.runStore) {
-      return fallback();
-    }
-
-    let runs: AgentRunHeader[];
-    try {
-      runs = await this.deps.runStore.listSessionRuns(sessionId);
-    } catch {
-      return fallback([readDiagnostic('unsupported_event', 'AgentRunStore.listSessionRuns failed')]);
-    }
-    if (runs.length === 0) {
-      return fallback();
-    }
-
-    const events: RuntimeEvent[] = [];
-    const ordered: Array<{ event: RuntimeEvent; runIndex: number; eventIndex: number }> = [];
-    for (let runIndex = 0; runIndex < runs.length; runIndex += 1) {
-      const run = runs[runIndex]!;
-      if (!isTerminalRunStatus(run.status)) {
-        return fallback([readDiagnostic('incomplete_event', 'RuntimeEvent read projection is not used for active runs', run)]);
-      }
-
-      let runEvents: RuntimeEvent[];
-      try {
-        runEvents = await this.deps.runStore.readRuntimeEvents(sessionId, run.runId);
-      } catch (error) {
-        return fallback([
-          readDiagnostic('unsupported_event', 'AgentRunStore.readRuntimeEvents failed', {
-            runId: run.runId,
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        ]);
-      }
-
-      if (runEvents.length === 0) {
-        return fallback([readDiagnostic('incomplete_event', 'terminal run has no readable RuntimeEvent ledger', { runId: run.runId })]);
-      }
-      if (!runEvents.some(isTerminalRuntimeEvent)) {
-        return fallback([readDiagnostic('incomplete_event', 'terminal run has no terminal RuntimeEvent', { runId: run.runId })]);
-      }
-
-      for (let eventIndex = 0; eventIndex < runEvents.length; eventIndex += 1) {
-        ordered.push({ event: runEvents[eventIndex]!, runIndex, eventIndex });
-      }
-    }
-
-    // RuntimeEvent-primary reads use session chronology across terminal runs,
-    // with stable run/ledger/id tie-breakers. This matches legacy message
-    // reads better than concatenating each run ledger in creation order when
-    // overlapping runs complete out of order.
-    ordered.sort((a, b) =>
-      a.event.ts - b.event.ts ||
-      a.runIndex - b.runIndex ||
-      a.eventIndex - b.eventIndex ||
-      a.event.id.localeCompare(b.event.id)
-    );
-    for (const item of ordered) events.push(item.event);
-
-    const projected = projectRuntimeEventsToStoredMessages(events, { runHeaders: runs });
-    if (hasHardProjectionDiagnostic(projected.diagnostics)) {
-      return fallback(projected.diagnostics);
-    }
-
-    const diagnostics = [...projected.diagnostics];
-    if (legacy.readable) {
-      const compatibility = compareRuntimeReadModelMessages(projected.messages, legacy.messages);
-      diagnostics.push(...compatibility.diagnostics);
-      if (hasHardCompatibilityDiagnostic(compatibility.diagnostics)) {
-        return fallback(diagnostics);
-      }
-    }
-
-    return {
-      source: 'runtime_events',
-      messages: projected.messages,
-      turns: deriveTurnRecords(projected.messages),
-      diagnostics,
-    };
+    return new RuntimeReadModel({
+      runStore: this.deps.runStore,
+      runtimeEventStore: this.deps.runtimeEventStore,
+      projectionCache: this.deps.store,
+    });
   }
 
-  private async readLegacyMessages(sessionId: string): Promise<
-    | { readable: true; messages: StoredMessage[] }
-    | { readable: false; error: unknown }
-  > {
-    try {
-      return { readable: true, messages: await this.deps.store.readMessages(sessionId) };
-    } catch (error) {
-      return { readable: false, error };
+  private async cloneBranchRuntimeLedger(
+    childSessionId: string,
+    sourceView: RuntimeReadModelSessionView,
+    copiedMessages: readonly StoredMessage[],
+  ): Promise<void> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) return;
+    const copiedTurnIds = new Set<string>();
+    for (const message of copiedMessages) {
+      if ('turnId' in message && typeof message.turnId === 'string') copiedTurnIds.add(message.turnId);
+    }
+    if (copiedTurnIds.size === 0) return;
+
+    for (const sourceRun of sourceView.runs) {
+      if (!copiedTurnIds.has(sourceRun.turnId)) continue;
+      const sourceEvents = sourceView.events.filter((event) =>
+        event.runId === sourceRun.runId &&
+        copiedTurnIds.has(event.turnId)
+      );
+      if (sourceEvents.length === 0) continue;
+
+      const runId = this.deps.newId();
+      const invocationIds = new Map<string, string>();
+      await this.deps.runStore.createRun({
+        ...sourceRun,
+        sessionId: childSessionId,
+        runId,
+      });
+
+      for (const event of sourceEvents) {
+        await this.deps.runtimeEventStore.appendRuntimeEvent(
+          childSessionId,
+          runId,
+          cloneRuntimeEventForBranch(event, {
+            sessionId: childSessionId,
+            runId,
+            eventId: this.deps.newId(),
+            invocationId: remapInvocationId(invocationIds, event.invocationId, this.deps.newId),
+          }),
+        );
+      }
     }
   }
 
   private async recoverAgentRunsFromLedger(
     sessionId: string,
-    messages: readonly StoredMessage[],
   ): Promise<{ hasLedger: boolean; recovered: boolean }> {
-    if (!this.deps.runStore) return { hasLedger: false, recovered: false };
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) return { hasLedger: false, recovered: false };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     if (runs.length === 0) return { hasLedger: false, recovered: false };
 
     let recovered = false;
     for (const run of runs) {
-      const inspected = await inspectAgentRunReadModel(this.deps.runStore, { sessionId, runId: run.runId, header: run });
+      const inspected = await inspectAgentRunReadModel(
+        this.deps.runStore,
+        this.deps.runtimeEventStore,
+        { sessionId, runId: run.runId, header: run },
+      );
       const runtimeDecision = this.classifyRuntimeEventRecovery(inspected);
-      const decision = runtimeDecision ?? classifyAgentRunRecovery(run, inspected.events, messages);
+      const decision = runtimeDecision ?? classifyAgentRunRecovery(run, inspected.events);
       if (!decision) continue;
       await this.applyAgentRunRecovery(sessionId, decision, inspected.events);
       recovered = true;
@@ -995,40 +748,29 @@ function turnStateLineage(
   };
 }
 
-function statusFromEvent(event: SessionEvent): { status: SessionStatus; blockedReason?: SessionBlockedReason } | undefined {
-  switch (event.type) {
-    case 'permission_request':
-      return { status: 'waiting_for_user', blockedReason: 'permission_required' };
-    case 'permission_decision_ack':
-      return event.decision === 'allow' ? { status: 'running' } : { status: 'aborted' };
-    case 'error':
-      return { status: 'blocked', blockedReason: blockedReasonFromErrorReason(event.reason) };
-    case 'abort':
-      return { status: 'aborted' };
-    case 'complete':
-      if (event.stopReason === 'permission_handoff') return { status: 'waiting_for_user', blockedReason: 'permission_required' };
-      if (event.stopReason === 'user_stop') return { status: 'aborted' };
-      if (event.stopReason === 'error') return { status: 'blocked', blockedReason: 'unknown' };
-      return { status: 'active' };
-    default:
-      return undefined;
-  }
+function cloneRuntimeEventForBranch(
+  event: RuntimeEvent,
+  ids: { sessionId: string; runId: string; eventId: string; invocationId: string },
+): RuntimeEvent {
+  return {
+    ...event,
+    id: ids.eventId,
+    invocationId: ids.invocationId,
+    sessionId: ids.sessionId,
+    runId: ids.runId,
+  };
 }
 
-function turnStatusFromEvent(event: SessionEvent): { status: TurnRecord['status']; errorClass?: string } | undefined {
-  switch (event.type) {
-    case 'abort':
-      return { status: 'aborted' };
-    case 'error':
-      return { status: 'failed', errorClass: event.reason ?? event.code ?? 'unknown' };
-    case 'complete':
-      if (event.stopReason === 'user_stop') return { status: 'aborted' };
-      if (event.stopReason === 'error') return { status: 'failed', errorClass: 'unknown' };
-      if (event.stopReason === 'permission_handoff') return { status: 'running' };
-      return { status: 'completed' };
-    default:
-      return undefined;
-  }
+function remapInvocationId(
+  mapping: Map<string, string>,
+  sourceInvocationId: string,
+  newId: () => string,
+): string {
+  const existing = mapping.get(sourceInvocationId);
+  if (existing) return existing;
+  const next = newId();
+  mapping.set(sourceInvocationId, next);
+  return next;
 }
 
 function copyMessagesThroughTurnBoundary(messages: readonly StoredMessage[], turnId: string): StoredMessage[] {
@@ -1098,137 +840,6 @@ function runtimeTerminalFactToRecoveryDecision(
       ...(header.parentSessionId ? { parentSessionId: header.parentSessionId } : {}),
     },
   };
-}
-
-function hasHardProjectionDiagnostic(diagnostics: readonly RuntimeEventReadModelDiagnostic[]): boolean {
-  return diagnostics.some((diagnostic) =>
-    diagnostic.code === 'incomplete_event' ||
-    diagnostic.code === 'unsupported_event' ||
-    diagnostic.code === 'tool_use_id_mismatch'
-  );
-}
-
-function hasHardCompatibilityDiagnostic(diagnostics: readonly RuntimeEventReadModelDiagnostic[]): boolean {
-  // A projected view missing a legacy semantic row means RuntimeEvents cannot
-  // yet render the public session faithfully. Extra projected rows are allowed:
-  // for compatible runtime-ledger sessions they represent RuntimeEvents being
-  // fresher than stale legacy rows, while diagnostics keep that mismatch visible.
-  return diagnostics.some((diagnostic) => diagnostic.code === 'missing_legacy_message');
-}
-
-function readDiagnostic(
-  code: RuntimeEventReadModelDiagnostic['code'],
-  message: string,
-  detail?: unknown,
-): RuntimeEventReadModelDiagnostic {
-  return {
-    code,
-    message,
-    ...(detail !== undefined ? { detail } : {}),
-  };
-}
-
-function runtimeReadSourceForcedLegacy(): boolean {
-  return process.env.MAKA_RUNTIME_READ_SOURCE === 'legacy';
-}
-
-function blockedReasonFromErrorReason(reason: string | undefined): SessionBlockedReason {
-  if (!reason) return 'unknown';
-  if (reason === 'permission_required') return 'permission_required';
-  if (reason === 'tool_failed') return 'tool_failed';
-  if (reason === 'auth' || reason.includes('api_key') || reason.includes('connection')) return 'NO_REAL_CONNECTION';
-  return 'unknown';
-}
-
-function normalizeStopSessionSource(source: StopSessionInput['source'] | undefined): string | undefined {
-  switch (source) {
-    case 'stop_button': return 'renderer.stop_button';
-    case undefined: return undefined;
-  }
-}
-
-class AsyncEventQueueClosed extends Error {
-  constructor() {
-    super('Async event queue closed');
-    this.name = 'AsyncEventQueueClosed';
-  }
-}
-
-function isAsyncEventQueueClosed(error: unknown): boolean {
-  return error instanceof AsyncEventQueueClosed;
-}
-
-interface AsyncEventQueueEntry<T> {
-  value: T;
-  delivered: () => void;
-  rejected: (error: unknown) => void;
-}
-
-class AsyncEventQueue<T> implements AsyncIterable<T> {
-  private readonly values: Array<AsyncEventQueueEntry<T>> = [];
-  private readonly waiters: Array<{
-    resolve: (entry: AsyncEventQueueEntry<T> | undefined) => void;
-    reject: (error: unknown) => void;
-  }> = [];
-  private closed = false;
-  private failure: unknown;
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return this.consume()[Symbol.asyncIterator]();
-  }
-
-  push(value: T): Promise<void> {
-    if (this.failure) return Promise.reject(this.failure);
-    if (this.closed) return Promise.reject(new AsyncEventQueueClosed());
-    return new Promise<void>((resolve, reject) => {
-      const entry = { value, delivered: resolve, rejected: reject };
-      const waiter = this.waiters.shift();
-      if (waiter) {
-        waiter.resolve(entry);
-        return;
-      }
-      this.values.push(entry);
-    });
-  }
-
-  fail(error: unknown): void {
-    if (this.failure) return;
-    this.failure = error;
-    for (const value of this.values.splice(0)) value.rejected(error);
-    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
-  }
-
-  close(): void {
-    if (this.closed) return;
-    this.closed = true;
-    const closed = new AsyncEventQueueClosed();
-    for (const value of this.values.splice(0)) value.rejected(closed);
-    for (const waiter of this.waiters.splice(0)) waiter.resolve(undefined);
-  }
-
-  private async *consume(): AsyncIterable<T> {
-    while (true) {
-      const entry = await this.nextEntry();
-      if (!entry) return;
-      try {
-        yield entry.value;
-      } finally {
-        entry.delivered();
-      }
-    }
-  }
-
-  private nextEntry(): Promise<AsyncEventQueueEntry<T> | undefined> {
-    if (this.values.length > 0) {
-      const next = this.values.shift()!;
-      return Promise.resolve(next);
-    }
-    if (this.failure) return Promise.reject(this.failure);
-    if (this.closed) return Promise.resolve(undefined);
-    return new Promise<AsyncEventQueueEntry<T> | undefined>((resolve, reject) => {
-      this.waiters.push({ resolve, reject });
-    });
-  }
 }
 
 // Re-export the suppressed-unused types so this file is the canonical home

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { createAgentRunStore } from '../agent-run-store.js';
+import { createAgentRunStore, createRuntimeEventStore } from '../agent-run-store.js';
 import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
 
 describe('AgentRunStore', () => {
@@ -87,16 +87,16 @@ describe('AgentRunStore', () => {
   });
 
   it('appends and reads runtime events from a separate per-run ledger', async () => {
-    await withStore(async (store, root) => {
-      await store.createRun(makeHeader());
-      await store.appendEvent('session-1', 'run-1', makeEvent({ id: 'operational-event' }));
-      await store.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-1', role: 'user' }));
-      await store.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-2', role: 'model' }));
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      await runStore.appendEvent('session-1', 'run-1', makeEvent({ id: 'operational-event' }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-1', role: 'user' }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-2', role: 'model' }));
 
-      const runtimeEvents = await store.readRuntimeEvents('session-1', 'run-1');
+      const runtimeEvents = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
       assert.deepEqual(runtimeEvents.map((event) => event.id), ['runtime-1', 'runtime-2']);
       assert.deepEqual(runtimeEvents.map((event) => event.role), ['user', 'model']);
-      assert.deepEqual((await store.readEvents('session-1', 'run-1')).map((event) => event.id), ['operational-event']);
+      assert.deepEqual((await runStore.readEvents('session-1', 'run-1')).map((event) => event.id), ['operational-event']);
 
       const runtimeEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
       const operationalEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'events.jsonl');
@@ -106,16 +106,16 @@ describe('AgentRunStore', () => {
   });
 
   it('returns an empty runtime event list when the runtime ledger is missing', async () => {
-    await withStore(async (store) => {
-      await store.createRun(makeHeader());
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
 
-      assert.deepEqual(await store.readRuntimeEvents('session-1', 'run-1'), []);
+      assert.deepEqual(await runtimeEventStore.readRuntimeEvents('session-1', 'run-1'), []);
     });
   });
 
   it('rejects durable corrupt runtime event lines instead of shortening the canonical ledger', async () => {
-    await withStore(async (store, root) => {
-      await store.createRun(makeHeader());
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
       const runtimeEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
       await writeFile(
         runtimeEventsPath,
@@ -126,15 +126,15 @@ describe('AgentRunStore', () => {
       );
 
       await assert.rejects(
-        () => store.readRuntimeEvents('session-1', 'run-1'),
+        () => runtimeEventStore.readRuntimeEvents('session-1', 'run-1'),
         /Invalid RuntimeEvent JSONL line 2 for run run-1/,
       );
     });
   });
 
   it('ignores an unterminated partial runtime event tail', async () => {
-    await withStore(async (store, root) => {
-      await store.createRun(makeHeader());
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
       const runtimeEventsPath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
       await writeFile(
         runtimeEventsPath,
@@ -142,8 +142,21 @@ describe('AgentRunStore', () => {
           '\n{"id":"partial"',
       );
 
-      const events = await store.readRuntimeEvents('session-1', 'run-1');
+      const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
       assert.deepEqual(events.map((event) => event.id), ['runtime-1']);
+    });
+  });
+
+  it('reads session runtime events through RuntimeEventStore in stable chronology', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader({ runId: 'run-2', turnId: 'turn-2' }));
+      await runStore.createRun(makeHeader({ runId: 'run-1', turnId: 'turn-1' }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-2', makeRuntimeEvent({ id: 'runtime-2', runId: 'run-2', turnId: 'turn-2', ts: 20 }));
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', makeRuntimeEvent({ id: 'runtime-1', runId: 'run-1', turnId: 'turn-1', ts: 10 }));
+
+      const events = await runtimeEventStore.readSessionRuntimeEvents('session-1');
+
+      assert.deepEqual(events.map((event) => event.id), ['runtime-1', 'runtime-2']);
     });
   });
 });
@@ -152,6 +165,21 @@ async function withStore(fn: (store: ReturnType<typeof createAgentRunStore>, roo
   const root = await mkdtemp(join(tmpdir(), 'maka-agent-run-store-'));
   try {
     await fn(createAgentRunStore(root), root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function withStores(
+  fn: (
+    runStore: ReturnType<typeof createAgentRunStore>,
+    runtimeEventStore: ReturnType<typeof createRuntimeEventStore>,
+    root: string,
+  ) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-agent-run-store-'));
+  try {
+    await fn(createAgentRunStore(root), createRuntimeEventStore(root), root);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,12 +1,16 @@
 import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent } from '@maka/core';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
 export function createAgentRunStore(workspaceRoot: string): AgentRunStore {
   return new FileAgentRunStore(workspaceRoot);
+}
+
+export function createRuntimeEventStore(workspaceRoot: string): RuntimeEventStore {
+  return new FileRuntimeEventStore(workspaceRoot);
 }
 
 class FileAgentRunStore implements AgentRunStore {
@@ -111,44 +115,6 @@ class FileAgentRunStore implements AgentRunStore {
     return events;
   }
 
-  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
-    assertSafeId(sessionId, 'Invalid session id');
-    assertSafeId(runId, 'Invalid run id');
-    await this.withQueue(sessionId, runId, async () => {
-      await mkdir(this.runDir(sessionId, runId), { recursive: true });
-      await appendFile(this.runtimeEventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
-    });
-  }
-
-  async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
-    assertSafeId(sessionId, 'Invalid session id');
-    assertSafeId(runId, 'Invalid run id');
-    let text: string;
-    try {
-      text = await readFile(this.runtimeEventsPath(sessionId, runId), 'utf8');
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
-      throw error;
-    }
-    const rawLines = text.split('\n');
-    const endsWithNewline = text.endsWith('\n');
-    const lines = rawLines
-      .map((line, index) => ({ line, lineNumber: index + 1 }))
-      .filter((entry) => entry.line.trim().length > 0);
-    const lastLineNumber = lines.at(-1)?.lineNumber;
-    const events: RuntimeEvent[] = [];
-    for (const entry of lines) {
-      try {
-        events.push(JSON.parse(entry.line) as RuntimeEvent);
-      } catch (error) {
-        if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
-        const message = error instanceof Error ? error.message : 'Invalid JSON';
-        throw new Error(`Invalid RuntimeEvent JSONL line ${entry.lineNumber} for run ${runId}: ${message}`);
-      }
-    }
-    return events;
-  }
-
   private async readRunUnlocked(sessionId: string, runId: string): Promise<AgentRunHeader> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
@@ -173,6 +139,82 @@ class FileAgentRunStore implements AgentRunStore {
     return join(this.runDir(sessionId, runId), 'events.jsonl');
   }
 
+  private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    const key = `${sessionId}:${runId}`;
+    const previous = this.writeQueues.get(key) ?? Promise.resolve();
+    const next = previous.then(operation, operation);
+    this.writeQueues.set(
+      key,
+      next.catch(() => {
+        // Keep the chain alive after failures.
+      }),
+    );
+    return next;
+  }
+}
+
+class FileRuntimeEventStore implements RuntimeEventStore {
+  private readonly sessionsRoot: string;
+  private readonly writeQueues = new Map<string, Promise<void>>();
+
+  constructor(workspaceRoot: string) {
+    this.sessionsRoot = join(workspaceRoot, 'sessions');
+  }
+
+  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.withQueue(sessionId, runId, async () => {
+      await mkdir(this.runDir(sessionId, runId), { recursive: true });
+      await appendFile(this.runtimeEventsPath(sessionId, runId), JSON.stringify(event, sanitizeJson) + '\n', 'utf8');
+    });
+  }
+
+  async readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    return readRuntimeEventJsonl(this.runtimeEventsPath(sessionId, runId), runId);
+  }
+
+  async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    const runsRoot = this.runsRoot(sessionId);
+    let entries;
+    try {
+      entries = await readdir(runsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    const ordered: Array<{ event: RuntimeEvent; runId: string; eventIndex: number }> = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !isSafeId(entry.name)) continue;
+      const events = await this.readRuntimeEvents(sessionId, entry.name);
+      for (let eventIndex = 0; eventIndex < events.length; eventIndex += 1) {
+        ordered.push({ event: events[eventIndex]!, runId: entry.name, eventIndex });
+      }
+    }
+    ordered.sort((a, b) =>
+      a.event.ts - b.event.ts ||
+      a.runId.localeCompare(b.runId) ||
+      a.eventIndex - b.eventIndex ||
+      a.event.id.localeCompare(b.event.id)
+    );
+    return ordered.map((item) => item.event);
+  }
+
+  private runsRoot(sessionId: string): string {
+    assertSafeId(sessionId, 'Invalid session id');
+    return join(this.sessionsRoot, sessionId, 'runs');
+  }
+
+  private runDir(sessionId: string, runId: string): string {
+    assertSafeId(runId, 'Invalid run id');
+    return join(this.runsRoot(sessionId), runId);
+  }
+
   private runtimeEventsPath(sessionId: string, runId: string): string {
     return join(this.runDir(sessionId, runId), 'runtime-events.jsonl');
   }
@@ -191,6 +233,33 @@ class FileAgentRunStore implements AgentRunStore {
     );
     return next;
   }
+}
+
+async function readRuntimeEventJsonl(path: string, runId: string): Promise<RuntimeEvent[]> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const rawLines = text.split('\n');
+  const endsWithNewline = text.endsWith('\n');
+  const lines = rawLines
+    .map((line, index) => ({ line, lineNumber: index + 1 }))
+    .filter((entry) => entry.line.trim().length > 0);
+  const lastLineNumber = lines.at(-1)?.lineNumber;
+  const events: RuntimeEvent[] = [];
+  for (const entry of lines) {
+    try {
+      events.push(JSON.parse(entry.line) as RuntimeEvent);
+    } catch (error) {
+      if (!endsWithNewline && entry.lineNumber === lastLineNumber) continue;
+      const message = error instanceof Error ? error.message : 'Invalid JSON';
+      throw new Error(`Invalid RuntimeEvent JSONL line ${entry.lineNumber} for run ${runId}: ${message}`);
+    }
+  }
+  return events;
 }
 
 async function writeAtomic(path: string, content: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Introduce `RuntimeEventStore`, `RuntimeReadModel`, and `RuntimeKernel` as first-class runtime boundaries.
- Make RuntimeEvent the semantic read/model-history source for messages, turns, retry/regenerate/branch, recovery, and next-turn context.
- Demote AgentRunStore to run headers and operational lifecycle events; remove the legacy SessionStore semantic read fallback / env rollback path.
- Preserve public SessionEvent/UI/gateway contracts while making cache-only StoredMessage rows unable to drive semantic reads.
- Clone parent RuntimeEvents into branch child sessions so branch reads and model context remain RuntimeEvent-backed.

## Verification
- `npm run typecheck --workspace packages/runtime`
- `npm run build --workspace packages/runtime`
- `node --test packages/runtime/dist/__tests__/session-manager.test.js`
- `git diff --check`

A full workspace `npm run test --workspaces --if-present` passed before rebasing this same commit onto the now-merged PR #14 base; the rebase was clean and the focused runtime checks above passed after rebase.
