### PR TITLE
Fix active runtime read projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ npm run check:release
 | `OPENAI_API_KEY` | 首次启动时可用来 bootstrap OpenAI 连接。 |
 | `TAVILY_API_KEY` / `MAKA_TAVILY_API_KEY` | 联网搜索的 Tavily 凭据来源。 |
 | `MAKA_RIVE_BIN` / `RIVE_BIN` | 指定 Rive workflow 使用的 `rive` CLI。 |
-| `MAKA_RUNTIME_READ_SOURCE=legacy` | 调试 runtime read model 时强制回退旧 session-store 读取路径。 |
 | `MAKA_VISUAL_SMOKE_FIXTURE` | 启用确定性视觉 fixture，仅限 dev/test build。 |
 
 ## 项目结构

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -26,7 +26,7 @@ import {
   type SessionStore,
 } from '../session-manager.js';
 import type { RuntimeKernelLike } from '../runtime-kernel.js';
-import { RuntimeReadModel, RuntimeReadModelError } from '../runtime-read-model.js';
+import { RuntimeReadModel } from '../runtime-read-model.js';
 import type { AgentBackend } from '../ai-sdk-backend.js';
 import type { InvocationResult } from '../invocation-context.js';
 
@@ -419,11 +419,58 @@ describe('SessionManager permission mode updates', () => {
     await expectRejects(manager.getMessages(session.id), /RuntimeEvent ledger is missing/);
   });
 
-  test('active RuntimeEvent ledger produces an explicit read-model error', async () => {
+  test('getMessages includes in-flight projection cache rows for an active RuntimeEvent run', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const manager = makeManagerForReadCutover(store, runStore);
     const session = await manager.createSession(makeInput());
+    const completed = await seedRuntimeReadTurn({
+      store,
+      runStore,
+      sessionId: session.id,
+      turnId: 'turn-1',
+      runId: 'run-1',
+      userText: 'completed question',
+      assistantText: 'completed answer',
+      legacyIdPrefix: 'legacy',
+    });
+    const activeMessages: StoredMessage[] = [
+      { type: 'user', id: 'active-user', turnId: 'turn-2', ts: 201, text: 'active question' },
+      { type: 'assistant', id: 'active-assistant', turnId: 'turn-2', ts: 202, text: 'partial active answer', modelId: 'fake-model' },
+      { type: 'turn_state', id: 'active-state', turnId: 'turn-2', ts: 203, status: 'running', partialOutputRetained: true },
+    ];
+    await store.appendMessages(session.id, activeMessages);
+    await runStore.createRun(makeRunHeader({
+      sessionId: session.id,
+      runId: 'run-2',
+      turnId: 'turn-2',
+      status: 'running',
+      createdAt: 200,
+      updatedAt: 203,
+    }));
+
+    const messages = await manager.getMessages(session.id);
+    expect(messages).toEqual([...completed.projectedMessages, ...activeMessages]);
+    expect(await manager.listTurns(session.id)).toEqual([
+      { turnId: 'turn-1', status: 'completed', partialOutputRetained: true },
+      { turnId: 'turn-2', status: 'running', partialOutputRetained: true },
+    ]);
+
+    const view = await new RuntimeReadModel({
+      runStore,
+      runtimeEventStore: runStore,
+      projectionCache: store,
+    }).getSessionView(session.id);
+    expect(view.diagnostics.some((diagnostic) =>
+      diagnostic.code === 'incomplete_event' &&
+      diagnostic.message.includes('in-flight projection cache')
+    )).toBe(true);
+  });
+
+  test('active RuntimeEvent ledger without a projection cache produces an explicit read-model error', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const session = await store.create(makeInput());
     await runStore.createRun(makeRunHeader({
       sessionId: session.id,
       runId: 'run-1',
@@ -431,15 +478,10 @@ describe('SessionManager permission mode updates', () => {
       status: 'running',
     }));
 
-    try {
-      await manager.getMessages(session.id);
-    } catch (error) {
-      expect(error instanceof RuntimeReadModelError).toBe(true);
-      if (!(error instanceof RuntimeReadModelError)) throw error;
-      expect(error.diagnostics.map((diagnostic) => diagnostic.code)).toContain('incomplete_event');
-      return;
-    }
-    throw new Error('Expected active ledger read to fail');
+    await expectRejects(
+      new RuntimeReadModel({ runStore, runtimeEventStore: runStore }).getSessionView(session.id),
+      /RuntimeEvent ledger is incomplete for an active run/,
+    );
   });
 
   test('getMessages rejects when runtime ledger read fails', async () => {
@@ -1220,6 +1262,35 @@ describe('SessionManager permission mode updates', () => {
     expect(events.map((event) => event.type)).toContain('run_cancelled');
   });
 
+  test('stopSession keeps aborted state even if the backend emits a late error', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const gate = makeGate();
+    backends.register('fake', (ctx) => new LateErrorBackend(ctx, gate));
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(12_720) });
+    const session = await manager.createSession(makeInput());
+
+    const iterator = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
+    await iterator.next();
+    await manager.stopSession(session.id, { source: 'stop_button' });
+
+    gate.release();
+    await iterator.next();
+    await iterator.next();
+
+    expect((await store.readHeader(session.id)).status).toBe('aborted');
+    const [turn] = await store.listTurns(session.id);
+    expect(turn?.status).toBe('aborted');
+    expect(turn?.abortSource).toBe('renderer.stop_button');
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.status).toBe('cancelled');
+    expect(run?.failureClass).toBeUndefined();
+    const events = (await runStore.readEvents(session.id, run!.runId)).map((event) => event.type);
+    expect(events).toContain('run_cancelled');
+    expect(events.includes('run_failed')).toBe(false);
+  });
+
   test('durable run ledger records lifecycle trace events and redacts obvious secrets', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -1870,6 +1941,29 @@ class TestBackend implements AgentBackend {
   async stop(): Promise<void> {}
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
 
+  async dispose(): Promise<void> {
+    if (this.ctx.store instanceof MemorySessionStore) {
+      this.ctx.store.disposeCount += 1;
+    }
+  }
+}
+
+class LateErrorBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: BackendFactoryContext, private readonly gate: Gate) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    yield { type: 'text_delta', id: `${input.turnId}-delta`, turnId: input.turnId, ts: 1, messageId: `${input.turnId}-m`, text: 'ok' };
+    await this.gate.promise;
+    yield { type: 'error', id: `${input.turnId}-error`, turnId: input.turnId, ts: 2, recoverable: false, reason: 'late_error', message: 'late backend error' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
   async dispose(): Promise<void> {
     if (this.ctx.store instanceof MemorySessionStore) {
       this.ctx.store.disposeCount += 1;

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -196,6 +196,10 @@ export class AgentRun {
       }
     }
     if (ev.type === 'error') {
+      if (this.stopped) {
+        this.finalStatus = { status: 'aborted' };
+        return;
+      }
       this.turnFailed = true;
       this.finalStatus = transition ?? { status: 'blocked', blockedReason: 'unknown' };
       await this.input.hooks.appendTurnState(this.sessionId, this.turnId, 'failed', this.lineage, {
@@ -216,6 +220,10 @@ export class AgentRun {
   }
 
   async recordFailure(error: unknown): Promise<void> {
+    if (this.stopped) {
+      this.finalStatus = { status: 'aborted' };
+      return;
+    }
     this.finalStatus = { status: 'blocked', blockedReason: 'unknown' };
     await this.input.hooks.appendTurnState(this.sessionId, this.turnId, 'failed', this.lineage, {
       errorClass: error instanceof Error ? error.name : 'unknown',

--- a/packages/runtime/src/runtime-read-model.ts
+++ b/packages/runtime/src/runtime-read-model.ts
@@ -60,6 +60,7 @@ export class RuntimeReadModel {
 
   async getSessionView(sessionId: string): Promise<RuntimeReadModelSessionView> {
     const diagnostics: RuntimeEventReadModelDiagnostic[] = [];
+    const inFlightTurnIds = new Set<string>();
     let runs: AgentRunHeader[];
     try {
       runs = await this.deps.runStore.listSessionRuns(sessionId);
@@ -80,13 +81,23 @@ export class RuntimeReadModel {
     for (let runIndex = 0; runIndex < runs.length; runIndex += 1) {
       const run = runs[runIndex]!;
       if (!isTerminalRunStatus(run.status)) {
-        throw new RuntimeReadModelError('RuntimeEvent ledger is incomplete for an active run', [
-          readModelDiagnostic('incomplete_event', 'active run has no stable RuntimeEvent read projection', {
-            runId: run.runId,
-            turnId: run.turnId,
-            status: run.status,
-          }),
-        ]);
+        const diagnostic = readModelDiagnostic('incomplete_event', 'active run is using the in-flight projection cache', {
+          runId: run.runId,
+          turnId: run.turnId,
+          status: run.status,
+        });
+        diagnostics.push(diagnostic);
+        inFlightTurnIds.add(run.turnId);
+        if (!this.deps.projectionCache) {
+          throw new RuntimeReadModelError('RuntimeEvent ledger is incomplete for an active run', [
+            readModelDiagnostic('incomplete_event', 'active run has no stable RuntimeEvent read projection', {
+              runId: run.runId,
+              turnId: run.turnId,
+              status: run.status,
+            }),
+          ]);
+        }
+        continue;
       }
 
       let runEvents: RuntimeEvent[];
@@ -139,6 +150,7 @@ export class RuntimeReadModel {
       events: ordered.map((item) => item.event),
       diagnostics,
       terminalFacts,
+      inFlightTurnIds,
     });
   }
 
@@ -147,6 +159,7 @@ export class RuntimeReadModel {
     events: RuntimeEvent[];
     diagnostics: RuntimeEventReadModelDiagnostic[];
     terminalFacts?: RuntimeEventTerminalFact[];
+    inFlightTurnIds?: ReadonlySet<string>;
   }): Promise<RuntimeReadModelSessionView> {
     const projected = projectRuntimeEventsToStoredMessages(input.events, { runHeaders: input.runs });
     const diagnostics = [...input.diagnostics, ...projected.diagnostics];
@@ -154,13 +167,32 @@ export class RuntimeReadModel {
       throw new RuntimeReadModelError('RuntimeEvent read projection is incomplete', diagnostics);
     }
 
-    const cacheDiagnostics = await this.compareProjectionCache(input.runs[0]?.sessionId, projected.messages);
-    diagnostics.push(...cacheDiagnostics);
+    const sessionId = input.runs[0]?.sessionId;
+    let cachedMessages: StoredMessage[] | undefined;
+    if (sessionId && this.deps.projectionCache) {
+      try {
+        cachedMessages = await this.deps.projectionCache.readMessages(sessionId);
+      } catch (error) {
+        const diagnostic = readModelDiagnostic('unsupported_event', 'SessionProjectionCache.readMessages failed', {
+          error: errorMessage(error),
+        });
+        diagnostics.push(diagnostic);
+        if (input.inFlightTurnIds && input.inFlightTurnIds.size > 0) {
+          throw new RuntimeReadModelError('RuntimeEvent active projection cache read failed', diagnostics);
+        }
+      }
+    }
+
+    const messages = input.inFlightTurnIds && input.inFlightTurnIds.size > 0
+      ? mergeInFlightProjectionCache(projected.messages, cachedMessages ?? [], input.inFlightTurnIds)
+      : projected.messages;
+
+    diagnostics.push(...this.compareProjectionCache(messages, cachedMessages));
 
     return {
       source: 'runtime_events',
-      messages: projected.messages,
-      turns: deriveTurnRecords(projected.messages),
+      messages,
+      turns: deriveTurnRecords(messages),
       events: input.events,
       runs: input.runs,
       diagnostics,
@@ -169,21 +201,35 @@ export class RuntimeReadModel {
     };
   }
 
-  private async compareProjectionCache(
-    sessionId: string | undefined,
+  private compareProjectionCache(
     messages: readonly StoredMessage[],
-  ): Promise<RuntimeEventReadModelDiagnostic[]> {
-    if (!sessionId || !this.deps.projectionCache) return [];
-    let cached: StoredMessage[];
-    try {
-      cached = await this.deps.projectionCache.readMessages(sessionId);
-    } catch (error) {
-      return [readModelDiagnostic('unsupported_event', 'SessionProjectionCache.readMessages failed', {
-        error: errorMessage(error),
-      })];
-    }
+    cached: readonly StoredMessage[] | undefined,
+  ): RuntimeEventReadModelDiagnostic[] {
+    if (!cached) return [];
     return compareRuntimeReadModelMessages(messages, cached).diagnostics;
   }
+}
+
+function mergeInFlightProjectionCache(
+  runtimeMessages: readonly StoredMessage[],
+  cachedMessages: readonly StoredMessage[],
+  inFlightTurnIds: ReadonlySet<string>,
+): StoredMessage[] {
+  const merged = runtimeMessages.map((message, index) => ({ message, index }));
+  const seenIds = new Set(runtimeMessages.map((message) => message.id));
+  for (const cached of cachedMessages) {
+    const turnId = messageTurnId(cached);
+    if (!turnId || !inFlightTurnIds.has(turnId) || seenIds.has(cached.id)) continue;
+    seenIds.add(cached.id);
+    merged.push({ message: cached, index: merged.length });
+  }
+  return merged
+    .sort((a, b) => a.message.ts - b.message.ts || a.index - b.index)
+    .map((entry) => entry.message);
+}
+
+function messageTurnId(message: StoredMessage): string | undefined {
+  return 'turnId' in message && typeof message.turnId === 'string' ? message.turnId : undefined;
 }
 
 function hasHardProjectionDiagnostic(diagnostics: readonly RuntimeEventReadModelDiagnostic[]): boolean {


### PR DESCRIPTION
## Summary
- allow public RuntimeReadModel reads during active runs by merging completed RuntimeEvent projection with the active turn's projection-cache rows
- preserve aborted state when a stopped run emits a late error or throws after stop
- remove stale MAKA_RUNTIME_READ_SOURCE=legacy README entry

## Tests
- npm run typecheck --workspace packages/runtime
- npm run build --workspace packages/runtime
- node --test packages/runtime/dist/__tests__/session-manager.test.js
- npm run test --workspace packages/runtime
- git diff --check