### PR TITLE
feat(browser): embedded browser automation (opencli CDP observe→act)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "screenshots:single": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/capture-screenshots.mjs --scenario",
     "smoke:real-window": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/desktop-real-window-smoke.mjs",
     "smoke:programmatic-window": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/ui run build && npm run build && node ../../scripts/desktop-real-window-smoke.mjs --programmatic-only",
+    "smoke:browser": "npm --workspace @maka/core run build && npm run build:main && electron scripts/browser-observe-act-smoke.mjs",
     "screenshots:diff": "node ../../scripts/diff-screenshots.mjs",
     "screenshots:diff:stable": "node ../../scripts/diff-screenshots.mjs --subset stable",
     "screenshots:baseline": "node ../../scripts/diff-screenshots.mjs --update-baseline",
@@ -27,6 +28,7 @@
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
+    "@jackwener/opencli": "1.8.4",
     "@maka/core": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0",
@@ -36,10 +38,12 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "vite": "^7.2.7"
+    "vite": "^7.2.7",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",
-    "@types/react-dom": "^19.2.3"
+    "@types/react-dom": "^19.2.3",
+    "@types/ws": "^8.18.1"
   }
 }

--- a/apps/desktop/scripts/browser-observe-act-smoke.mjs
+++ b/apps/desktop/scripts/browser-observe-act-smoke.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env electron
+/**
+ * P5 — real Electron observe→act smoke for the embedded browser.
+ *
+ * Run as an Electron main entry (`electron scripts/browser-observe-act-smoke.mjs`,
+ * or `npm --workspace @maka/desktop run smoke:browser`). It drives the
+ * *production* automation path end to end against a live Chromium:
+ *
+ *   BrowserViewController.attachAutomation()  → CdpBridge (sealed ws server)
+ *     → opencli CDPBridge.connect()           → real webContents.debugger
+ *       → snapshot / fillText / click / evaluate / extract
+ *
+ * This is the one seam the unit tests fake out (they stub the bridge + IPage):
+ * the real CDP round trip over a real DOM. A loopback HTTP server hosts a tiny
+ * form fixture, so the run is deterministic and needs no network.
+ *
+ * It then drives the visible-lease end to end through BrowserSession + the real
+ * host/manager/controller (the unit tests cover it only with a fake host): a
+ * background conversation's navigate/mutate is rejected and creates no view,
+ * while a shown conversation whose viewport has been reported can click/type.
+ *
+ * Exit 0 = every step passed; non-zero = a step failed or the run timed out.
+ */
+
+import { createServer } from 'node:http';
+import { app, BrowserWindow, session } from 'electron';
+import { CDPBridge } from '@jackwener/opencli/browser/cdp';
+import { htmlToMarkdown } from '@jackwener/opencli/utils';
+import { BrowserViewController } from '../dist/main/browser/controller.js';
+import { BrowserViewManager } from '../dist/main/browser/view-manager.js';
+import { createBrowserViewHost } from '../dist/main/browser/automation-host.js';
+import { provideBrowserViewHost } from '../dist/main/browser/browser-host.js';
+import {
+  withBrowserPage,
+  releaseBrowserSession,
+  revokeHiddenBrowserActions,
+  BrowserActionBlockedError,
+  BrowserActionRevokedError,
+} from '../dist/main/browser/session.js';
+
+const FIXTURE = `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Maka Smoke</title></head>
+  <body>
+    <h1>Maka observe-to-act smoke</h1>
+    <input id="q" type="text" aria-label="search query">
+    <button id="go" type="button">Go</button>
+    <div id="out"></div>
+    <script>
+      document.getElementById('go').addEventListener('click', () => {
+        document.getElementById('out').textContent = 'clicked:' + document.getElementById('q').value;
+      });
+    </script>
+  </body>
+</html>`;
+
+const RUN_TIMEOUT_MS = 60_000;
+const log = (m) => console.log(`[browser-smoke] ${m}`);
+
+/** First `[N]` ref on the snapshot line that mentions `needle`, or null. */
+function findRef(snapshot, needle) {
+  for (const line of String(snapshot).split('\n')) {
+    if (!line.toLowerCase().includes(needle.toLowerCase())) continue;
+    const m = /\[(\d+)\]/.exec(line);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+async function runSmoke() {
+  // Loopback fixture server, OS-assigned port — deterministic, no network.
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(FIXTURE);
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const fixtureUrl = `http://127.0.0.1:${server.address().port}/`;
+  log(`fixture served at ${fixtureUrl}`);
+
+  // The view must actually paint: opencli's native CDP click hit-tests a
+  // composited frame. A hidden window with a zero-bounds view never composites,
+  // so show the window (without stealing focus) and give the view real on-screen
+  // bounds, mirroring a displayed page.
+  const win = new BrowserWindow({ show: false, width: 1024, height: 768 });
+  win.showInactive();
+  const controller = new BrowserViewController(win, 'smoke', () => {});
+  controller.setViewport({ x: 0, y: 0, width: 1024, height: 768 });
+  const bridge = new CDPBridge();
+  // The visible-lease section (below) wires a real host over this manager;
+  // declared here so finally can tear it down.
+  let leaseManager = null;
+
+  const checks = [];
+  const check = (name, ok, detail = '') => {
+    checks.push({ name, ok });
+    log(`${ok ? 'PASS' : 'FAIL'} — ${name}${detail ? ` (${detail})` : ''}`);
+  };
+
+  try {
+    // The page-security backstop is installed once per shared partition session,
+    // not once per view: a second view must NOT add a second will-download listener.
+    const partition = session.fromPartition('persist:maka-browser');
+    const downloadListenersBefore = partition.listenerCount('will-download');
+    const controller2 = new BrowserViewController(win, 'smoke-backstop', () => {});
+    check(
+      'security backstop installs once per partition (no listener pileup)',
+      partition.listenerCount('will-download') === downloadListenersBefore,
+      `${downloadListenersBefore} -> ${partition.listenerCount('will-download')}`,
+    );
+    await controller2.dispose();
+
+    // Production attach: WebContents debugger → sealed loopback ws endpoint.
+    const endpoint = await controller.attachAutomation();
+    check('attachAutomation returns a loopback endpoint', /^ws:\/\/127\.0\.0\.1:\d+\//.test(endpoint.cdpEndpoint));
+
+    // Show the view before driving — the precondition the visible lease enforces
+    // in production, and what un-throttles the view so the native click below
+    // hit-tests a composited frame (throttling now tracks shown-ness, not attach).
+    controller.setViewport({ x: 0, y: 0, width: 1024, height: 768 });
+
+    // opencli connects as the CDP client (stealth auto-registers on connect).
+    const page = await bridge.connect({ cdpEndpoint: endpoint.cdpEndpoint });
+    check('opencli CDPBridge.connect resolves a page', typeof page?.snapshot === 'function');
+
+    // Navigate via the agent path (opencli goto, same call browser_navigate makes).
+    await page.goto(fixtureUrl, { waitUntil: 'load' });
+    const landed = (await page.getCurrentUrl?.()) ?? '';
+    check('goto lands on the fixture URL', landed.startsWith(fixtureUrl), landed);
+
+    // OBSERVE: snapshot the interactive elements and read their numbered refs.
+    const snapshot = await page.snapshot({ interactive: true });
+    const queryRef = findRef(snapshot, 'search query');
+    const submitRef = findRef(snapshot, 'Go');
+    check('snapshot lists the query field with a [ref]', Boolean(queryRef), `ref=${queryRef}`);
+    check('snapshot lists the Go button with a [ref]', Boolean(submitRef), `ref=${submitRef}`);
+    if (!queryRef || !submitRef) {
+      log(`--- snapshot dump ---\n${snapshot}\n--- end snapshot ---`);
+      throw new Error('snapshot did not expose the expected numbered refs');
+    }
+
+    // ACT by numbered ref: type into [queryRef], then click [submitRef].
+    const fill = await page.fillText(queryRef, 'hello');
+    check('fillText verifies the typed value by ref', fill.verified === true && fill.actual === 'hello', `actual=${JSON.stringify(fill.actual)}`);
+
+    const clicked = await page.click(submitRef);
+    check('click resolves a single match by ref', clicked.matches_n === 1, `matches_n=${clicked.matches_n}`);
+
+    // VERIFY the act landed in the real DOM.
+    const out = await page.evaluate('document.getElementById("out").textContent');
+    check('the click handler wrote clicked:hello', out === 'clicked:hello', `out=${JSON.stringify(out)}`);
+
+    // EXTRACT: real HTML → markdown (mirrors browser_extract).
+    const markdown = htmlToMarkdown(String(await page.evaluate('document.body.outerHTML')));
+    check('extract markdown reflects the page text', markdown.includes('clicked:hello'));
+
+    // ── Visible-lease, end to end through BrowserSession + the real host ──────
+    // Exercises the wiring the fake-host unit tests can't: controller
+    // .hasLiveViewport() ← setViewport, the host's canDrive, and the gate firing
+    // before resolveEndpoint. Free the direct-driven view first so this section
+    // owns the window (the native click needs the one composited frame).
+    await bridge.close().catch(() => {});
+    await controller.dispose().catch(() => {});
+    leaseManager = new BrowserViewManager({ create: (id) => new BrowserViewController(win, id, () => {}) });
+    let shownSession = null;
+    provideBrowserViewHost(createBrowserViewHost(leaseManager, () => shownSession));
+
+    // Background conversation (not the one on screen): EVERY kind — read,
+    // navigate, mutate — is rejected, and the gate runs before acquire, so no
+    // view or connection is created. observe is the P2-A case (a backgrounded
+    // conversation must not snapshot/extract a logged-in page the user can't
+    // see); mutate is the click-on-a-hidden-view case. Both get real-host
+    // coverage here, not just the fake-host unit tests.
+    shownSession = 'other-conversation';
+    let bgNavBlocked = false;
+    try {
+      await withBrowserPage('leaseS', 'navigate', async () => {}, { takeover: 'navigate' });
+    } catch (err) {
+      bgNavBlocked = err instanceof BrowserActionBlockedError;
+    }
+    check('visible-lease rejects a background-conversation navigate', bgNavBlocked);
+    let bgMutateBlocked = false;
+    try {
+      await withBrowserPage('leaseS', 'click', async () => {}, { takeover: 'mutate' });
+    } catch (err) {
+      bgMutateBlocked = err instanceof BrowserActionBlockedError;
+    }
+    check('visible-lease rejects a background-conversation mutate', bgMutateBlocked);
+    let bgObserveBlocked = false;
+    try {
+      await withBrowserPage('leaseS', 'snapshot', async () => {}, { takeover: 'observe' });
+    } catch (err) {
+      bgObserveBlocked = err instanceof BrowserActionBlockedError;
+    }
+    check('visible-lease rejects a background-conversation observe (no off-screen reads)', bgObserveBlocked);
+    check('a lease-rejected action creates no view or connection', leaseManager.liveCount() === 0);
+
+    // Shown conversation: navigate is allowed (it creates the panel) and loads.
+    shownSession = 'leaseS';
+    await withBrowserPage('leaseS', 'navigate', async (lease) => lease.goto(fixtureUrl, { waitUntil: 'load' }), {
+      takeover: 'navigate',
+    });
+
+    // Renderer reports the on-screen viewport → observe to read the numbered refs.
+    leaseManager.get('leaseS').setViewport({ x: 0, y: 0, width: 1024, height: 768 });
+    const leaseSnap = await withBrowserPage('leaseS', 'snapshot', (lease) => lease.snapshot({ interactive: true }), {
+      takeover: 'observe',
+    });
+    const leaseQuery = findRef(leaseSnap, 'search query');
+    const leaseSubmit = findRef(leaseSnap, 'Go');
+
+    // Permission-modal race (the P1 fix): the modal hides the native view
+    // (viewport cleared) while open, and the renderer restores the strip a moment
+    // AFTER the user approves. A mutate firing in that gap must WAIT for the
+    // restore and land, not reject. Clear the viewport, start a mutate, then
+    // restore the viewport mid-flight — the type must still complete.
+    leaseManager.get('leaseS').setViewport(null);
+    const racingType = withBrowserPage('leaseS', 'type', (lease) => lease.fillText(leaseQuery, 'leased'), {
+      takeover: 'mutate',
+    });
+    setTimeout(() => leaseManager.get('leaseS').setViewport({ x: 0, y: 0, width: 1024, height: 768 }), 30);
+    let raceLanded = true;
+    try {
+      await racingType;
+    } catch {
+      raceLanded = false;
+    }
+    check('visible-lease waits out a modal-close viewport restore so an approved mutate lands', raceLanded);
+
+    // With the viewport back, a click drives the real DOM.
+    await withBrowserPage('leaseS', 'click', (lease) => lease.click(leaseSubmit), { takeover: 'mutate' });
+    const leaseOut = await withBrowserPage(
+      'leaseS',
+      'read',
+      (lease) => lease.evaluate('document.getElementById("out").textContent'),
+      { takeover: 'observe' },
+    );
+    check('visible-lease allows + lands a click once shown with a viewport', leaseOut === 'clicked:leased');
+
+    // Throttling tracks shown-ness (the P2 fix): a shown view runs full-speed so
+    // native clicks composite, and HIDING it restores background throttling so a
+    // backgrounded conversation's cached page can't drain CPU.
+    const leaseView = leaseManager.get('leaseS');
+    check('a shown view runs un-throttled', leaseView.isBackgroundThrottled() === false);
+    leaseView.setViewport(null); // user switches away / panel hides
+    check('hiding a view restores background throttling (no hidden-page CPU drain)', leaseView.isBackgroundThrottled() === true);
+    leaseView.setViewport({ x: 0, y: 0, width: 1024, height: 768 }); // re-show for the revoke check
+
+    // Continuous lease (the P1 revoke fix): an action that started while the
+    // conversation was on screen must be SEVERED if the user switches away mid-
+    // run — not left reading the now-hidden page. Start a long read on the live
+    // cached connection, flip the shown conversation, and revoke; it must reject
+    // with the revoked error against the REAL bridge (the fake-host unit tests
+    // can't prove the live sever).
+    let revoked = false;
+    const longRead = withBrowserPage('leaseS', 'read', () => new Promise(() => {}), { takeover: 'observe' });
+    longRead.catch(() => {}); // asserted below; pre-handle so the reject is never unhandled
+    await new Promise((resolve) => setTimeout(resolve, 20)); // reuse the cached conn + enter run()
+    shownSession = 'other-conversation';
+    revokeHiddenBrowserActions('other-conversation');
+    try {
+      await longRead;
+    } catch (err) {
+      revoked = err instanceof BrowserActionRevokedError;
+    }
+    check('continuous lease revokes an in-flight read when the conversation goes off screen', revoked);
+  } finally {
+    // Teardown mirrors detach: close the client, stop the bridge, drop the view.
+    try {
+      await bridge.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      await controller.dispose();
+    } catch {
+      /* view already gone */
+    }
+    try {
+      await releaseBrowserSession('leaseS');
+      await leaseManager?.disposeAll();
+      provideBrowserViewHost(null);
+    } catch {
+      /* lease teardown is best-effort */
+    }
+    try {
+      if (!win.isDestroyed()) win.destroy();
+    } catch {
+      /* window already gone */
+    }
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  const passed = checks.filter((c) => c.ok).length;
+  log(`${passed}/${checks.length} checks passed`);
+  return passed === checks.length && checks.length > 0;
+}
+
+async function main() {
+  await app.whenReady();
+  let code = 1;
+  try {
+    const ok = await Promise.race([
+      runSmoke(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(`smoke timed out after ${RUN_TIMEOUT_MS}ms`)), RUN_TIMEOUT_MS),
+      ),
+    ]);
+    code = ok ? 0 : 1;
+    log(ok ? 'RESULT: PASS' : 'RESULT: FAIL');
+  } catch (err) {
+    log(`RESULT: FAIL — ${err instanceof Error ? err.message : String(err)}`);
+  }
+  app.exit(code);
+}
+
+main();

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -48,6 +48,8 @@ import type {
   DailyReviewSummary,
   WebSearchProvider,
   WebSearchResponse,
+  BrowserState,
+  BrowserViewRect,
 } from '@maka/core';
 import type {
   PricingConfig,
@@ -433,6 +435,19 @@ declare global {
           | { ok: true; target: 'file' | 'directory' }
           | { ok: false; reason: 'invalid_id' | 'missing' | 'blocked_path' | 'not_file' | 'not_directory' | 'open_failed' }
         >;
+      };
+      browser: {
+        setActiveSession(sessionId: string | null): void;
+        setViewport(input: { sessionId: string; rect: BrowserViewRect | null }): void;
+        navigate(sessionId: string, url: string): Promise<void>;
+        back(sessionId: string): Promise<void>;
+        forward(sessionId: string): Promise<void>;
+        reload(sessionId: string): Promise<void>;
+        stop(sessionId: string): Promise<void>;
+        close(sessionId: string): Promise<void>;
+        getState(sessionId: string): Promise<BrowserState | null>;
+        onState(handler: (payload: { sessionId: string; state: BrowserState }) => void): () => void;
+        onLive(handler: (payload: { sessionIds: string[] }) => void): () => void;
       };
     };
   }

--- a/apps/desktop/src/main/__tests__/automation-host.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-host.test.ts
@@ -1,0 +1,77 @@
+/**
+ * createBrowserViewHost.canDrive — the visible-lease gate, with the
+ * permission-modal viewport-restore wait. Driven through a fake manager +
+ * controller (no Electron), so it exercises the host's orchestration: observe
+ * is free, a backgrounded mutate is rejected without waiting, and a mutate on
+ * the shown conversation waits for the renderer to restore the strip before
+ * deciding. The controller's real poll lives in the Electron smoke.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createBrowserViewHost } from '../browser/automation-host.js';
+
+type FakeController = {
+  hasLiveViewport(): boolean;
+  waitForLiveViewport(timeoutMs: number, signal?: AbortSignal): Promise<boolean>;
+};
+
+function makeHost(shown: string | null, controller: FakeController | undefined) {
+  const manager = { get: () => controller } as never;
+  return createBrowserViewHost(manager, () => shown);
+}
+
+describe('createBrowserViewHost canDrive (visible lease + viewport-restore wait)', () => {
+  it('observe on a backgrounded conversation is rejected (no off-screen reads)', async () => {
+    const host = makeHost('other', { hasLiveViewport: () => false, waitForLiveViewport: async () => false });
+    assert.equal(await host.canDrive('s', 'observe'), false);
+  });
+
+  it('observe on the shown conversation is allowed without a viewport', async () => {
+    const host = makeHost('s', { hasLiveViewport: () => false, waitForLiveViewport: async () => false });
+    assert.equal(await host.canDrive('s', 'observe'), true);
+  });
+
+  it('navigate on the shown conversation is allowed without a viewport, no wait', async () => {
+    let waited = false;
+    const host = makeHost('s', {
+      hasLiveViewport: () => false,
+      waitForLiveViewport: async () => {
+        waited = true;
+        return true;
+      },
+    });
+    assert.equal(await host.canDrive('s', 'navigate'), true);
+    assert.equal(waited, false);
+  });
+
+  it('mutate on a backgrounded conversation is rejected immediately, without waiting', async () => {
+    let waited = false;
+    const host = makeHost('other', {
+      hasLiveViewport: () => false,
+      waitForLiveViewport: async () => {
+        waited = true;
+        return false;
+      },
+    });
+    assert.equal(await host.canDrive('s', 'mutate'), false);
+    assert.equal(waited, false); // !shown → no viewport wait, fast reject
+  });
+
+  it('mutate on the shown conversation waits for the restored viewport, then allows', async () => {
+    let live = false; // viewport absent (modal just closed) until the wait restores it
+    const host = makeHost('s', {
+      hasLiveViewport: () => live,
+      waitForLiveViewport: async () => {
+        live = true;
+        return true;
+      },
+    });
+    assert.equal(await host.canDrive('s', 'mutate'), true);
+  });
+
+  it('mutate on the shown conversation blocks when the viewport never returns', async () => {
+    const host = makeHost('s', { hasLiveViewport: () => false, waitForLiveViewport: async () => false });
+    assert.equal(await host.canDrive('s', 'mutate'), false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/browser-logic.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-logic.test.ts
@@ -1,0 +1,74 @@
+/** Pure embedded-browser logic (controller.ts's testable core). */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  browserActionAllowed,
+  deriveBrowserState,
+  parseNavigable,
+  safeExternalUrl,
+  viewportBounds,
+} from '../browser/logic.js';
+
+describe('browser logic', () => {
+  it('parseNavigable accepts only http(s) and normalizes', () => {
+    assert.equal(parseNavigable('https://example.com'), 'https://example.com/');
+    assert.equal(parseNavigable('http://a.test/x?y=1'), 'http://a.test/x?y=1');
+    assert.equal(parseNavigable('file:///etc/passwd'), null);
+    assert.equal(parseNavigable('javascript:alert(1)'), null);
+    assert.equal(parseNavigable('about:blank'), null);
+    assert.equal(parseNavigable('not a url'), null);
+  });
+
+  it('safeExternalUrl passes only mailto/tel', () => {
+    assert.equal(safeExternalUrl('mailto:a@b.com'), 'mailto:a@b.com');
+    assert.equal(safeExternalUrl('tel:+123'), 'tel:+123');
+    assert.equal(safeExternalUrl('file:///x'), null);
+    assert.equal(safeExternalUrl('https://x.com'), null);
+  });
+
+  it('viewportBounds rounds, clamps, and hides on empty', () => {
+    assert.deepEqual(viewportBounds({ x: 1.4, y: 2.6, width: 100.5, height: 50.4 }), {
+      x: 1,
+      y: 3,
+      width: 101,
+      height: 50,
+    });
+    assert.equal(viewportBounds(null), null);
+    assert.equal(viewportBounds({ x: 0, y: 0, width: 0, height: 100 }), null);
+    assert.equal(viewportBounds({ x: 0, y: 0, width: 100, height: -5 }), null);
+    // Negative origin clamps to 0 (matches the non-negative-rect contract).
+    assert.deepEqual(viewportBounds({ x: -3, y: -10.6, width: 80, height: 40 }), { x: 0, y: 0, width: 80, height: 40 });
+    // Non-finite / non-number fields (untyped IPC) hide rather than reach setBounds.
+    assert.equal(viewportBounds({ x: 0, y: 0, width: NaN, height: 100 }), null);
+    assert.equal(viewportBounds({ x: 0, y: 0, width: Infinity, height: 100 }), null);
+    assert.equal(viewportBounds({ x: NaN, y: 0, width: 100, height: 100 }), null);
+    assert.equal(viewportBounds({ x: 0, y: 0, width: '100' as unknown as number, height: 100 }), null);
+  });
+
+  it('browserActionAllowed enforces the visible lease', () => {
+    // observe reads the page — now gated like the rest: only the conversation on
+    // screen (reading a logged-in page off screen would leak its content). No
+    // viewport needed — reading doesn't require a composited frame.
+    assert.equal(browserActionAllowed('observe', { shown: true, hasViewport: false }), true);
+    assert.equal(browserActionAllowed('observe', { shown: false, hasViewport: false }), false);
+    assert.equal(browserActionAllowed('observe', { shown: false, hasViewport: true }), false);
+    // navigate creates/loads the panel — only the conversation on screen, no viewport needed yet.
+    assert.equal(browserActionAllowed('navigate', { shown: true, hasViewport: false }), true);
+    assert.equal(browserActionAllowed('navigate', { shown: false, hasViewport: true }), false);
+    // mutate acts on the page — on screen AND with real on-screen bounds (composited frame).
+    assert.equal(browserActionAllowed('mutate', { shown: true, hasViewport: true }), true);
+    assert.equal(browserActionAllowed('mutate', { shown: true, hasViewport: false }), false);
+    assert.equal(browserActionAllowed('mutate', { shown: false, hasViewport: true }), false);
+  });
+
+  it('deriveBrowserState computes hasPage and secure', () => {
+    const base = { title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null };
+    assert.equal(deriveBrowserState({ ...base, url: '' }).hasPage, false);
+    assert.equal(deriveBrowserState({ ...base, url: 'about:blank' }).hasPage, false);
+    const loaded = deriveBrowserState({ ...base, url: 'https://x.com/' });
+    assert.equal(loaded.hasPage, true);
+    assert.equal(loaded.secure, true);
+    assert.equal(deriveBrowserState({ ...base, url: 'http://x.com/' }).secure, false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/browser-session.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-session.test.ts
@@ -1,0 +1,343 @@
+/**
+ * BrowserSession lifecycle: lazy connect + cache, single-flight first acquire,
+ * connection-loss invalidation, takeover-reload, timeout/abort severing, and
+ * the delete-during-connect epoch race. Driven entirely through fakes (a fake
+ * view Host and a fake CDP bridge), so no Electron or live CDP endpoint.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import type { IPage } from '@jackwener/opencli/types';
+import {
+  type BridgeLike,
+  BrowserActionBlockedError,
+  BrowserActionCanceledError,
+  BrowserActionRevokedError,
+  BrowserToolTimeoutError,
+  releaseBrowserSession,
+  resetBrowserSessionsForTest,
+  revokeHiddenBrowserActions,
+  setBridgeFactoryForTest,
+  withBrowserPage,
+} from '../browser/session.js';
+import { type BrowserViewHost, provideBrowserViewHost } from '../browser/browser-host.js';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function makeFakePage(url: string | null = null): IPage {
+  return {
+    getCurrentUrl: async () => url,
+    evaluate: async () => '' as never,
+  } as unknown as IPage;
+}
+
+class FakeBridge implements BridgeLike {
+  closed = false;
+  reloads = 0;
+  constructor(private readonly page: IPage) {}
+  async connect(): Promise<IPage> {
+    return this.page;
+  }
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+  async send(method: string): Promise<unknown> {
+    if (method === 'Page.reload') this.reloads += 1;
+    return {};
+  }
+  async waitForEvent(): Promise<unknown> {
+    return {};
+  }
+}
+
+// Install a bridge factory that hands out one FakeBridge per connect(), each
+// wrapping the next page in `pages` (last page repeats). Returns the live list.
+function installBridges(pages: IPage[]): FakeBridge[] {
+  const created: FakeBridge[] = [];
+  setBridgeFactoryForTest(() => {
+    const page = pages[Math.min(created.length, pages.length - 1)] ?? makeFakePage();
+    const bridge = new FakeBridge(page);
+    created.push(bridge);
+    return bridge;
+  });
+  return created;
+}
+
+type HostSpy = {
+  host: BrowserViewHost;
+  resolved: string[];
+  released: string[];
+  disposed: string[];
+};
+
+function installHost(overrides: Partial<BrowserViewHost> = {}): HostSpy {
+  const spy: HostSpy = { resolved: [], released: [], disposed: [], host: null as never };
+  const host: BrowserViewHost = {
+    canDrive: () => true,
+    resolveEndpoint: async (id) => {
+      spy.resolved.push(id);
+      return { cdpEndpoint: `ws://127.0.0.1:1/${id}` };
+    },
+    releaseSession: async (id) => {
+      spy.released.push(id);
+    },
+    disposeSession: async (id) => {
+      spy.disposed.push(id);
+    },
+    ...overrides,
+  };
+  spy.host = host;
+  provideBrowserViewHost(host);
+  return spy;
+}
+
+afterEach(() => {
+  resetBrowserSessionsForTest();
+  setBridgeFactoryForTest(null);
+  provideBrowserViewHost(null);
+});
+
+describe('BrowserSession', () => {
+  it('connects once and reuses the cached connection across actions', async () => {
+    installHost();
+    const bridges = installBridges([makeFakePage()]);
+    const a = await withBrowserPage('s1', 'snapshot', async () => 'a');
+    const b = await withBrowserPage('s1', 'snapshot', async () => 'b');
+    assert.equal(a, 'a');
+    assert.equal(b, 'b');
+    assert.equal(bridges.length, 1);
+  });
+
+  it('shares one connect across two concurrent first actions (single-flight)', async () => {
+    const gate = deferred<void>();
+    let resolveCalls = 0;
+    installHost({
+      resolveEndpoint: async (id) => {
+        resolveCalls += 1;
+        await gate.promise;
+        return { cdpEndpoint: `ws://127.0.0.1:1/${id}` };
+      },
+    });
+    const bridges = installBridges([makeFakePage()]);
+    const p1 = withBrowserPage('s1', 'snapshot', async () => '1');
+    const p2 = withBrowserPage('s1', 'snapshot', async () => '2');
+    await tick();
+    gate.resolve();
+    const [r1, r2] = await Promise.all([p1, p2]);
+    assert.equal(r1, '1');
+    assert.equal(r2, '2');
+    assert.equal(bridges.length, 1); // one connect, not a race into two
+    assert.equal(resolveCalls, 1); // endpoint resolved once, shared by both callers
+  });
+
+  it('defers the takeover reload: observe never reloads, the first mutate hardens once', async () => {
+    installHost();
+    const bridges = installBridges([makeFakePage('https://example.com/feed')]);
+    // Pure observe must not disturb the page the user has open.
+    const observed = await withBrowserPage('s1', 'snapshot', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'observe',
+    });
+    assert.equal(observed, false);
+    assert.equal(bridges[0]?.reloads, 0);
+    // The first mutating action reloads once and flags it.
+    const firstMutate = await withBrowserPage('s1', 'click', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'mutate',
+    });
+    assert.equal(firstMutate, true);
+    assert.equal(bridges[0]?.reloads, 1);
+    // A later mutate does not reload again.
+    const laterMutate = await withBrowserPage('s1', 'click', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'mutate',
+    });
+    assert.equal(laterMutate, false);
+    assert.equal(bridges[0]?.reloads, 1);
+  });
+
+  it('a navigation clears the pending takeover without reloading (goto re-stealths)', async () => {
+    installHost();
+    const bridges = installBridges([makeFakePage('https://example.com/feed')]);
+    const nav = await withBrowserPage('s1', 'navigate', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'navigate',
+    });
+    assert.equal(nav, false);
+    assert.equal(bridges[0]?.reloads, 0);
+    // After navigating, even a mutate does not reload — the new document is already stealthed.
+    const afterNav = await withBrowserPage('s1', 'click', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'mutate',
+    });
+    assert.equal(afterNav, false);
+    assert.equal(bridges[0]?.reloads, 0);
+  });
+
+  it('never reloads a blank/non-web page, even before a mutate', async () => {
+    installHost();
+    const bridges = installBridges([makeFakePage(null)]);
+    const took = await withBrowserPage('s1', 'click', async (_p, info) => info.takeoverReloaded, {
+      takeover: 'mutate',
+    });
+    assert.equal(took, false);
+    assert.equal(bridges[0]?.reloads, 0);
+  });
+
+  it('invalidates and reconnects after a connection-loss error', async () => {
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage(), makeFakePage()]);
+    await assert.rejects(
+      withBrowserPage('s1', 'click', async () => {
+        throw new Error('CDP connection is not open');
+      }),
+      /browser page was closed/,
+    );
+    assert.equal(bridges[0]?.closed, true);
+    assert.deepEqual(spy.released, ['s1']);
+    // Next action re-resolves and reconnects on a fresh bridge.
+    const ok = await withBrowserPage('s1', 'click', async () => 'recovered');
+    assert.equal(ok, 'recovered');
+    assert.equal(bridges.length, 2);
+  });
+
+  it('times out, severs the connection, and surfaces a typed error', async () => {
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage()]);
+    await assert.rejects(
+      withBrowserPage('s1', 'wait', () => new Promise<never>(() => {}), { timeoutMs: 20 }),
+      BrowserToolTimeoutError,
+    );
+    assert.equal(bridges[0]?.closed, true);
+    assert.deepEqual(spy.released, ['s1']);
+  });
+
+  it('rejects immediately on an already-aborted signal without connecting', async () => {
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage()]);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    await assert.rejects(
+      withBrowserPage('s1', 'snapshot', async () => 'x', { abort: ctrl.signal }),
+      BrowserActionCanceledError,
+    );
+    assert.equal(bridges.length, 0);
+    assert.deepEqual(spy.resolved, []);
+  });
+
+  it('aborts a running action and severs the connection', async () => {
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage()]);
+    const ctrl = new AbortController();
+    const p = withBrowserPage('s1', 'wait', () => new Promise<never>(() => {}), { abort: ctrl.signal });
+    await tick();
+    ctrl.abort();
+    await assert.rejects(p, BrowserActionCanceledError);
+    assert.equal(bridges[0]?.closed, true);
+    assert.deepEqual(spy.released, ['s1']);
+  });
+
+  it('releaseBrowserSession disposes the view and closes the connection', async () => {
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage()]);
+    await withBrowserPage('s1', 'snapshot', async () => 'ok');
+    await releaseBrowserSession('s1');
+    assert.equal(bridges[0]?.closed, true);
+    assert.deepEqual(spy.disposed, ['s1']);
+  });
+
+  it('unwinds an acquire when the session is released mid-connect', async () => {
+    const gate = deferred<void>();
+    const spy = installHost({
+      resolveEndpoint: async (id) => {
+        await gate.promise;
+        return { cdpEndpoint: `ws://127.0.0.1:1/${id}` };
+      },
+    });
+    const bridges = installBridges([makeFakePage()]);
+    const p = withBrowserPage('s1', 'snapshot', async () => 'never');
+    await tick();
+    await releaseBrowserSession('s1'); // bumps the epoch while resolveEndpoint is pending
+    gate.resolve();
+    await assert.rejects(p, /deleted while the browser was connecting/);
+    assert.equal(bridges[0]?.closed, true);
+    // disposed twice: once by the release, once by the acquire unwinding itself.
+    assert.ok(spy.disposed.filter((id) => id === 's1').length >= 1);
+  });
+
+  it('visible-lease gate: blocks every vetoed kind — incl. observe — before connecting', async () => {
+    // Host vetoes everything (mirrors a conversation not on screen). The uniform
+    // lease gates reads too, so even observe is blocked before acquire.
+    const spy = installHost({ canDrive: () => false });
+    const bridges = installBridges([makeFakePage()]);
+    await assert.rejects(
+      withBrowserPage('s1', 'click', async () => 'x', { takeover: 'mutate' }),
+      BrowserActionBlockedError,
+    );
+    await assert.rejects(
+      withBrowserPage('s1', 'navigate', async () => 'x', { takeover: 'navigate' }),
+      BrowserActionBlockedError,
+    );
+    await assert.rejects(
+      withBrowserPage('s1', 'snapshot', async () => 'x', { takeover: 'observe' }),
+      BrowserActionBlockedError,
+    );
+    // Blocked before acquire: no endpoint resolved, no connection opened.
+    assert.deepEqual(spy.resolved, []);
+    assert.equal(bridges.length, 0);
+  });
+
+  it('revokes an in-flight action when the user switches away from its conversation', async () => {
+    // The visible lease is continuous, not just a preflight: an observe that
+    // started while visible must not keep reading the hidden page after a switch.
+    const spy = installHost();
+    const bridges = installBridges([makeFakePage()]);
+    const p = withBrowserPage('s1', 'snapshot', () => new Promise<never>(() => {}), { takeover: 'observe' });
+    await tick(); // connect + enter run()
+    revokeHiddenBrowserActions('other'); // window switched to another conversation
+    await assert.rejects(p, BrowserActionRevokedError);
+    // Severed and detached — no orphaned run() left driving the now-hidden page,
+    // and (crucially) the rejected action returns no page data to the tool.
+    assert.equal(bridges[0]?.closed, true);
+    assert.deepEqual(spy.released, ['s1']);
+  });
+
+  it('does not revoke an action for the conversation that is still shown', async () => {
+    installHost();
+    installBridges([makeFakePage()]);
+    const ctrl = new AbortController();
+    let settled = false;
+    const p = withBrowserPage('s1', 'snapshot', () => new Promise<never>(() => {}), {
+      takeover: 'observe',
+      abort: ctrl.signal,
+    });
+    void p.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await tick();
+    revokeHiddenBrowserActions('s1'); // s1 is the one now on screen → leave it running
+    await tick();
+    assert.equal(settled, false);
+    ctrl.abort(); // clean up the deliberately-dangling action
+    await assert.rejects(p, BrowserActionCanceledError);
+  });
+
+  it('fails clearly when no host is injected', async () => {
+    // no installHost(): host stays null
+    installBridges([makeFakePage()]);
+    await assert.rejects(
+      withBrowserPage('s1', 'snapshot', async () => 'x'),
+      /only available inside the desktop app/,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/browser-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-tools.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The six browser tools: ref normalization, takeover note, browser_wait
+ * argument validation, and each tool's output formatting driven end-to-end
+ * through a fake view Host + fake CDP page (no Electron, no live browser).
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import type { IPage } from '@jackwener/opencli/types';
+import type { MakaTool, MakaToolContext } from '@maka/runtime';
+import {
+  buildBrowserClickTool,
+  buildBrowserExtractTool,
+  buildBrowserNavigateTool,
+  buildBrowserSnapshotTool,
+  buildBrowserTools,
+  buildBrowserTypeTool,
+  buildBrowserWaitTool,
+  normalizeElementRef,
+  readHtmlJs,
+  takeoverNote,
+} from '../browser/browser-tools.js';
+import { type BridgeLike, resetBrowserSessionsForTest, setBridgeFactoryForTest } from '../browser/session.js';
+import { type BrowserViewHost, provideBrowserViewHost } from '../browser/browser-host.js';
+
+type FakePageConfig = {
+  url?: string;
+  title?: string;
+  click?: { matches_n: number; match_level: 'exact' | 'stable' | 'reidentified' };
+  fill?: { verified: boolean; actual: string; match_level: 'exact' | 'stable' | 'reidentified' };
+  snapshot?: unknown;
+  extractHtml?: string;
+  waitImpl?: (options: unknown) => Promise<void>;
+};
+
+function makeFakePage(cfg: FakePageConfig): IPage {
+  return {
+    getCurrentUrl: async () => cfg.url ?? null,
+    goto: async () => {},
+    evaluate: async (js: string) => {
+      if (js.includes('location.href')) return (cfg.url ?? '') as never;
+      if (js.includes('document.title')) return (cfg.title ?? '') as never;
+      if (js.includes('outerHTML')) {
+        return (cfg.extractHtml === undefined ? null : { html: cfg.extractHtml, truncated: false }) as never;
+      }
+      return '' as never;
+    },
+    snapshot: async () => cfg.snapshot ?? '[1] link "Home"',
+    click: async () => cfg.click ?? { matches_n: 1, match_level: 'exact' },
+    fillText: async () =>
+      cfg.fill
+        ? { filled: true, verified: cfg.fill.verified, expected: '', actual: cfg.fill.actual, length: 0, matches_n: 1, match_level: cfg.fill.match_level }
+        : { filled: true, verified: true, expected: '', actual: '', length: 0, matches_n: 1, match_level: 'exact' },
+    pressKey: async () => {},
+    wait: async (options: unknown) => {
+      if (cfg.waitImpl) return cfg.waitImpl(options);
+    },
+  } as unknown as IPage;
+}
+
+class FakeBridge implements BridgeLike {
+  constructor(private readonly page: IPage) {}
+  async connect(): Promise<IPage> {
+    return this.page;
+  }
+  async close(): Promise<void> {}
+  async send(): Promise<unknown> {
+    return {};
+  }
+  async waitForEvent(): Promise<unknown> {
+    return {};
+  }
+}
+
+function install(cfg: FakePageConfig): void {
+  const host: BrowserViewHost = {
+    canDrive: () => true,
+    resolveEndpoint: async (id) => ({ cdpEndpoint: `ws://127.0.0.1:1/${id}` }),
+    releaseSession: async () => {},
+    disposeSession: async () => {},
+  };
+  provideBrowserViewHost(host);
+  setBridgeFactoryForTest(() => new FakeBridge(makeFakePage(cfg)));
+}
+
+function ctx(): MakaToolContext {
+  return {
+    sessionId: 's1',
+    turnId: 't1',
+    cwd: '/tmp',
+    toolCallId: 'c1',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}
+
+function run<P>(tool: MakaTool<P, string>, args: P): Promise<string> {
+  return Promise.resolve(tool.impl(args, ctx())) as Promise<string>;
+}
+
+afterEach(() => {
+  resetBrowserSessionsForTest();
+  setBridgeFactoryForTest(null);
+  provideBrowserViewHost(null);
+});
+
+describe('browser tool helpers', () => {
+  it('normalizeElementRef unwraps a bracketed ref and passes selectors through', () => {
+    assert.equal(normalizeElementRef('[12]'), '12');
+    assert.equal(normalizeElementRef('  [3] '), '3');
+    assert.equal(normalizeElementRef('42'), '42');
+    assert.equal(normalizeElementRef('.btn.primary'), '.btn.primary');
+    assert.equal(normalizeElementRef('[data-id="x"]'), '[data-id="x"]');
+  });
+
+  it('takeoverNote appears only after a takeover reload', () => {
+    assert.equal(takeoverNote({ takeoverReloaded: false }), '');
+    assert.match(takeoverNote({ takeoverReloaded: true }), /reloaded once/);
+  });
+
+  it('buildBrowserTools returns the six tools, all in the browser permission category', () => {
+    const tools = buildBrowserTools();
+    assert.deepEqual(
+      tools.map((t) => t.name),
+      ['browser_navigate', 'browser_snapshot', 'browser_click', 'browser_type', 'browser_wait', 'browser_extract'],
+    );
+    // No explicit permissionRequired flag: the runtime defaults to "required"
+    // (it only skips the engine on an explicit `false`), so the browser category
+    // alone gates every tool.
+    assert.ok(tools.every((t) => t.categoryHint === 'browser'));
+  });
+});
+
+describe('browser tool execution', () => {
+  it('navigate reports the landed URL and title', async () => {
+    install({ url: 'https://example.com/welcome', title: 'Welcome' });
+    const out = await run(buildBrowserNavigateTool(), { url: 'https://example.com' });
+    assert.match(out, /Loaded https:\/\/example\.com\/welcome/);
+    assert.match(out, /Title: Welcome/);
+  });
+
+  it('navigate rejects a non-web URL before connecting', async () => {
+    install({});
+    await assert.rejects(run(buildBrowserNavigateTool(), { url: 'file:///etc/passwd' }), /Not a navigable URL/);
+  });
+
+  it('snapshot returns the element listing with the page URL', async () => {
+    install({ url: 'https://example.com/', snapshot: '[1] button "Search"' });
+    const out = await run(buildBrowserSnapshotTool(), {});
+    assert.match(out, /\[1\] button "Search"/);
+    assert.match(out, /example\.com/);
+  });
+
+  it('click reports the match count and warns on multiple matches', async () => {
+    install({ click: { matches_n: 3, match_level: 'stable' } });
+    const out = await run(buildBrowserClickTool(), { ref: '[5]' });
+    assert.match(out, /matched 3 elements, stable match/);
+    assert.match(out, /Multiple matches/);
+  });
+
+  it('type reports verification failure with the actual content', async () => {
+    install({ fill: { verified: false, actual: 'partial', match_level: 'exact' } });
+    const out = await run(buildBrowserTypeTool(), { ref: '[2]', text: 'hello', submit: true });
+    assert.match(out, /then pressed Enter/);
+    assert.match(out, /Not verified/);
+    assert.match(out, /"partial"/);
+  });
+
+  it('wait requires exactly one of text/selector/time', async () => {
+    install({});
+    await assert.rejects(run(buildBrowserWaitTool(), {}), /exactly one/);
+    await assert.rejects(run(buildBrowserWaitTool(), { text: 'a', time: 1 }), /exactly one/);
+    await assert.rejects(run(buildBrowserWaitTool(), { text: '   ' }), /non-empty/);
+  });
+
+  it('wait succeeds and names the condition', async () => {
+    install({ waitImpl: async () => {} });
+    const out = await run(buildBrowserWaitTool(), { text: 'Loaded' });
+    assert.match(out, /Done: text "Loaded"/);
+  });
+
+  it('extract converts page HTML to markdown', async () => {
+    install({ url: 'https://example.com/', extractHtml: "<h1>Hi</h1><p>See <a href='https://x.com'>x</a></p>" });
+    const out = await run(buildBrowserExtractTool(), {});
+    assert.match(out, /Hi/);
+    assert.match(out, /\[x\]\(https:\/\/x\.com\)/);
+  });
+
+  it('extract fails clearly when a selector matches nothing', async () => {
+    install({ url: 'https://example.com/' }); // extractHtml undefined => page returns null
+    await assert.rejects(run(buildBrowserExtractTool(), { selector: '#missing' }), /No element matches selector/);
+  });
+
+  it('extract page-side script swallows an invalid selector instead of throwing', () => {
+    // The fake IPage above ignores the selector, so the SyntaxError only fires
+    // in a real DOM. Drive the generated page script directly against a stub
+    // whose querySelector throws on a malformed selector (real browsers do):
+    // it must return null, which the impl maps to the friendly "No element
+    // matches selector" message rather than a raw DOMException.
+    const doc = {
+      body: { outerHTML: '<body>ok</body>' },
+      querySelector(sel: string) {
+        if (sel === '[12]') throw new Error("'[12]' is not a valid selector");
+        return null;
+      },
+    };
+    const exec = (selector: unknown): unknown =>
+      new Function('document', `return ${readHtmlJs(JSON.stringify(selector))};`)(doc);
+    assert.equal(exec('[12]'), null); // invalid selector → null, not a throw
+    assert.equal(exec('#missing'), null); // valid-but-absent → null (unchanged)
+    assert.deepEqual(exec(null), { html: '<body>ok</body>', truncated: false }); // no selector → body
+  });
+
+  it('a tool fails with a clear message when no host is injected', async () => {
+    // no install(): host stays null
+    await assert.rejects(run(buildBrowserSnapshotTool(), {}), /only available inside the desktop app/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
@@ -1,0 +1,105 @@
+/** BrowserViewManager bookkeeping: lazy create, reuse, live-change, dispose, leak invariant. */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { BrowserViewManager, type ManagedView } from '../browser/view-manager.js';
+import type { BrowserViewRect } from '../browser/logic.js';
+
+class StubView implements ManagedView {
+  disposed = false;
+  rect: BrowserViewRect | null = null;
+  constructor(
+    public readonly id: string,
+    private readonly url = '',
+  ) {}
+  setViewport(rect: BrowserViewRect | null): void {
+    this.rect = rect;
+  }
+  state(): { hasPage: boolean; url: string } {
+    return { hasPage: this.url !== '', url: this.url };
+  }
+  async dispose(): Promise<void> {
+    this.disposed = true;
+  }
+}
+
+function makeManager() {
+  const created: StubView[] = [];
+  const liveSets: string[][] = [];
+  const manager = new BrowserViewManager<StubView>({
+    create: (id) => {
+      const v = new StubView(id);
+      created.push(v);
+      return v;
+    },
+    onLiveChange: (ids) => liveSets.push(ids),
+  });
+  return { manager, created, liveSets };
+}
+
+describe('BrowserViewManager', () => {
+  it('creates a view once and reuses it', () => {
+    const { manager, created } = makeManager();
+    const a = manager.getOrCreate('s1');
+    const b = manager.getOrCreate('s1');
+    assert.equal(a, b);
+    assert.equal(created.length, 1);
+    assert.equal(manager.liveCount(), 1);
+  });
+
+  it('fires onLiveChange on create and dispose, not on reuse', async () => {
+    const { manager, liveSets } = makeManager();
+    manager.getOrCreate('s1');
+    manager.getOrCreate('s1'); // reuse — no fire
+    manager.getOrCreate('s2');
+    await manager.dispose('s1');
+    assert.deepEqual(liveSets, [['s1'], ['s1', 's2'], ['s2']]);
+  });
+
+  it('setViewport forwards to the view and no-ops when absent', () => {
+    const { manager } = makeManager();
+    manager.setViewport('missing', { x: 0, y: 0, width: 1, height: 1 }); // no throw
+    const v = manager.getOrCreate('s1');
+    manager.setViewport('s1', { x: 1, y: 2, width: 3, height: 4 });
+    assert.deepEqual(v.rect, { x: 1, y: 2, width: 3, height: 4 });
+  });
+
+  it('hideAllExcept hides every other view and leaves the kept one untouched', () => {
+    const { manager } = makeManager();
+    const a = manager.getOrCreate('s1');
+    const b = manager.getOrCreate('s2');
+    const c = manager.getOrCreate('s3');
+    // Seed a non-null rect so "untouched" is observable.
+    a.rect = { x: 1, y: 1, width: 1, height: 1 };
+    b.rect = { x: 2, y: 2, width: 2, height: 2 };
+    c.rect = { x: 3, y: 3, width: 3, height: 3 };
+    manager.hideAllExcept('s2');
+    assert.equal(a.rect, null); // hidden
+    assert.deepEqual(b.rect, { x: 2, y: 2, width: 2, height: 2 }); // kept
+    assert.equal(c.rect, null); // hidden
+    // null hides all.
+    manager.hideAllExcept(null);
+    assert.equal(b.rect, null);
+  });
+
+  it('dispose removes the view, disposes it, and lets the next create be fresh', async () => {
+    const { manager, created } = makeManager();
+    const first = manager.getOrCreate('s1');
+    await manager.dispose('s1');
+    assert.equal(first.disposed, true);
+    assert.equal(manager.liveCount(), 0);
+    const second = manager.getOrCreate('s1');
+    assert.notEqual(second, first);
+    assert.equal(created.length, 2);
+  });
+
+  it('disposeAll tears down every view (leak invariant)', async () => {
+    const { manager, created } = makeManager();
+    manager.getOrCreate('s1');
+    manager.getOrCreate('s2');
+    manager.getOrCreate('s3');
+    await manager.disposeAll();
+    assert.equal(manager.liveCount(), 0);
+    assert.ok(created.every((v) => v.disposed));
+  });
+});

--- a/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/cdp-bridge.test.ts
@@ -1,0 +1,324 @@
+/**
+ * CdpBridge security + relay contract. Ported from PawWork (bun:test → node:test).
+ * A stub `webContents.debugger` (EventEmitter) stands in for the real target, so
+ * these run CI-safe without Electron; the live attach is covered by the GUI smoke.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+import type { WebContents } from 'electron';
+import { type ClientOptions, WebSocket } from 'ws';
+import { CdpBridge, CdpBridgeError } from '../browser/cdp-bridge.js';
+
+// Stand-in for webContents.debugger: an EventEmitter that records sendCommand
+// calls and lets a test drive its result and emit CDP messages/detach.
+class MockDebugger extends EventEmitter {
+  attached = false;
+  calls: Array<{ method: string; params: unknown; sessionId?: string }> = [];
+  impl: (method: string, params: unknown, sessionId?: string) => Promise<unknown> = async () => ({});
+  isAttached() {
+    return this.attached;
+  }
+  attach(_version?: string) {
+    this.attached = true;
+  }
+  detach() {
+    this.attached = false;
+  }
+  sendCommand(method: string, params?: unknown, sessionId?: string) {
+    this.calls.push({ method, params, sessionId });
+    return this.impl(method, params, sessionId);
+  }
+}
+
+class MockWebContents extends EventEmitter {
+  destroyed = false;
+  debugger = new MockDebugger();
+  isDestroyed() {
+    return this.destroyed;
+  }
+}
+
+function makeWc() {
+  const wc = new MockWebContents();
+  return { wc, asWebContents: wc as unknown as WebContents };
+}
+
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()?.();
+});
+
+async function startBridge(wc: WebContents) {
+  const bridge = new CdpBridge(wc);
+  const endpoint = await bridge.start();
+  cleanups.push(() => bridge.stop());
+  return { bridge, cdpEndpoint: endpoint.cdpEndpoint };
+}
+
+function open(url: string, opts?: ClientOptions): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, opts);
+    let settled = false;
+    // Persistent error handler: a rejected upgrade (and teardown-time resets)
+    // emit 'error' — keep listening so none of them surface as unhandled.
+    ws.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+    ws.on('open', () => {
+      if (settled) return;
+      settled = true;
+      cleanups.push(() => ws.terminate());
+      resolve(ws);
+    });
+  });
+}
+
+function nextMessage(ws: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => ws.once('message', (data) => resolve(JSON.parse(String(data)))));
+}
+
+function withDifferentSecret(endpoint: string): string {
+  return endpoint.replace(/\/[^/]+$/, '/0000000000000000');
+}
+
+describe('CdpBridge', () => {
+  it('relays a CDP command to the debugger and returns its result', async () => {
+    const { wc, asWebContents } = makeWc();
+    wc.debugger.impl = async () => ({ result: { value: 42 } });
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    ws.send(JSON.stringify({ id: 7, method: 'Runtime.evaluate', params: { expression: '6*7' } }));
+    const msg = await nextMessage(ws);
+    assert.equal(msg.id, 7);
+    assert.deepEqual(msg.result, { result: { value: 42 } });
+    assert.equal(wc.debugger.calls[0]?.method, 'Runtime.evaluate');
+  });
+
+  it('forwards debugger events to the client', async () => {
+    const { wc, asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    const received = nextMessage(ws);
+    wc.debugger.emit('message', {}, 'Page.frameNavigated', { frame: { id: 'x' } }, '');
+    const msg = await received;
+    assert.equal(msg.method, 'Page.frameNavigated');
+    assert.deepEqual(msg.params, { frame: { id: 'x' } });
+  });
+
+  it('surfaces a debugger command error as a CDP error response', async () => {
+    const { wc, asWebContents } = makeWc();
+    wc.debugger.impl = async () => {
+      throw new Error('boom');
+    };
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    ws.send(JSON.stringify({ id: 1, method: 'Page.navigate', params: {} }));
+    const msg = (await nextMessage(ws)) as { id: number; error: { message: string } };
+    assert.equal(msg.id, 1);
+    assert.equal(msg.error.message, 'boom');
+  });
+
+  it('a query string after the secret path does not break authorization', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(`${cdpEndpoint}?v=1`);
+    assert.equal(ws.readyState, WebSocket.OPEN);
+  });
+
+  it('rejects a wrong secret at the upgrade', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    await assert.rejects(open(withDifferentSecret(cdpEndpoint)));
+  });
+
+  it('a rejected wrong-secret attempt does not consume the single slot', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    await assert.rejects(open(withDifferentSecret(cdpEndpoint)));
+    const ws = await open(cdpEndpoint);
+    assert.equal(ws.readyState, WebSocket.OPEN);
+  });
+
+  it('rejects a connection that carries a browser Origin', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    await assert.rejects(open(cdpEndpoint, { headers: { origin: 'https://evil.example' } }));
+  });
+
+  it('rejects a mismatched Host header (DNS-rebinding guard)', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    await assert.rejects(open(cdpEndpoint, { headers: { host: 'evil.example' } }));
+  });
+
+  it('allows only one connection at a time', async () => {
+    const { asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const first = await open(cdpEndpoint);
+    assert.equal(first.readyState, WebSocket.OPEN);
+    await assert.rejects(open(cdpEndpoint));
+  });
+
+  it('stop() detaches the debugger and closes the connection', async () => {
+    const { wc, asWebContents } = makeWc();
+    const bridge = new CdpBridge(asWebContents);
+    const { cdpEndpoint } = await bridge.start();
+    cleanups.push(() => bridge.stop());
+    const ws = await open(cdpEndpoint);
+    const closed = new Promise<void>((resolve) => ws.once('close', () => resolve()));
+    await bridge.stop();
+    await closed;
+    assert.equal(wc.debugger.attached, false);
+  });
+
+  it('teardown fails in-flight commands instead of leaving them to time out', async () => {
+    const { wc, asWebContents } = makeWc();
+    let release: (value: unknown) => void = () => {};
+    // A command the debugger never answers on its own.
+    wc.debugger.impl = () => new Promise((resolve) => (release = resolve));
+    const { bridge, cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    const errored = nextMessage(ws);
+    ws.send(JSON.stringify({ id: 99, method: 'Page.navigate', params: {} }));
+    await new Promise((resolve) => setTimeout(resolve, 20)); // let the command register as pending
+    await bridge.stop();
+    const msg = (await errored) as { id: number; error?: { message: string } };
+    assert.equal(msg.id, 99);
+    assert.equal(msg.error?.message, 'bridge closed');
+    release({}); // resolve the dangling promise so nothing leaks
+  });
+
+  it("teardown failure responses carry the command's sessionId", async () => {
+    const { wc, asWebContents } = makeWc();
+    let release: (value: unknown) => void = () => {};
+    wc.debugger.impl = () => new Promise((resolve) => (release = resolve));
+    const { bridge, cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    const errored = nextMessage(ws);
+    ws.send(JSON.stringify({ id: 5, method: 'Page.navigate', params: {}, sessionId: 'session-a' }));
+    await new Promise((resolve) => setTimeout(resolve, 20)); // let the command register as pending
+    await bridge.stop();
+    const msg = (await errored) as { id: number; sessionId?: string; error?: { message: string } };
+    assert.equal(msg.id, 5);
+    assert.equal(msg.sessionId, 'session-a');
+    assert.equal(msg.error?.message, 'bridge closed');
+    release({});
+  });
+
+  it('a reconnecting client reusing a command id never sees the previous client result', async () => {
+    const { wc, asWebContents } = makeWc();
+    const resolvers: Array<(value: unknown) => void> = [];
+    wc.debugger.impl = () => new Promise((resolve) => resolvers.push(resolve));
+    const { cdpEndpoint } = await startBridge(asWebContents);
+
+    const first = await open(cdpEndpoint);
+    first.send(JSON.stringify({ id: 1, method: 'Page.navigate', params: {} }));
+    await new Promise((resolve) => setTimeout(resolve, 20)); // let id 1 register as pending
+    first.terminate();
+
+    // The single slot frees only once the server has processed the close.
+    let second: WebSocket | null = null;
+    for (let attempt = 0; attempt < 50 && !second; attempt++) {
+      second = await open(cdpEndpoint).catch(() => null);
+      if (!second) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!second) throw new Error('could not reconnect after terminate');
+
+    const answered = nextMessage(second);
+    second.send(JSON.stringify({ id: 1, method: 'Runtime.evaluate', params: {} }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    resolvers[0]?.({ stale: true }); // the dead connection's command completes late
+    resolvers[1]?.({ fresh: true });
+    const msg = (await answered) as { id: number; result: Record<string, unknown> };
+    assert.equal(msg.id, 1);
+    assert.deepEqual(msg.result, { fresh: true });
+  });
+
+  it('an external debugger detach tears the bridge down', async () => {
+    const { wc, asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    const closed = new Promise<void>((resolve) => ws.once('close', () => resolve()));
+    // DevTools opening forcibly detaches the debugger.
+    wc.debugger.emit('detach', {}, 'Target.detachedFromTarget');
+    await closed;
+    assert.ok(ws.readyState >= WebSocket.CLOSING);
+  });
+
+  it('concurrent start() calls share one bridge instead of misreporting target-busy', async () => {
+    const { asWebContents } = makeWc();
+    const bridge = new CdpBridge(asWebContents);
+    cleanups.push(() => bridge.stop());
+    const [first, second] = await Promise.all([bridge.start(), bridge.start()]);
+    assert.equal(first.cdpEndpoint, second.cdpEndpoint);
+  });
+
+  it('stop() racing a start() in flight yields a typed error and a clean restart', async () => {
+    const { asWebContents } = makeWc();
+    const bridge = new CdpBridge(asWebContents);
+    const racing = bridge.start(); // still awaiting its ws listen
+    await bridge.stop();
+    await assert.rejects(racing, CdpBridgeError);
+    const endpoint = await bridge.start();
+    cleanups.push(() => bridge.stop());
+    const ws = await open(endpoint.cdpEndpoint);
+    assert.equal(ws.readyState, WebSocket.OPEN);
+  });
+
+  it('destroying the WebContents tears the bridge down', async () => {
+    const { wc, asWebContents } = makeWc();
+    const { cdpEndpoint } = await startBridge(asWebContents);
+    const ws = await open(cdpEndpoint);
+    const closed = new Promise<void>((resolve) => ws.once('close', () => resolve()));
+    // A directly destroyed WebContents is not guaranteed to emit a debugger
+    // 'detach' first — the 'destroyed' listener must tear the bridge down.
+    wc.destroyed = true;
+    wc.emit('destroyed');
+    await closed;
+    assert.ok(ws.readyState >= WebSocket.CLOSING);
+  });
+
+  it('drops an authorized upgrade that races stop() nulling the ws server', async () => {
+    const { asWebContents } = makeWc();
+    const { bridge, cdpEndpoint } = await startBridge(asWebContents);
+    const url = new URL(cdpEndpoint); // ws://127.0.0.1:<port>/<secret>
+    // Simulate the teardown window: wss is nulled but the http 'upgrade'
+    // listener is still live. An authorized upgrade must be destroyed, not
+    // left half-open (neither adopted nor destroyed).
+    const internals = bridge as unknown as {
+      wss: unknown;
+      socket: unknown;
+      onUpgrade: (req: IncomingMessage, socket: Duplex, head: Buffer) => void;
+    };
+    internals.wss = null;
+    let destroyed = false;
+    const socket = { destroy: () => (destroyed = true) } as unknown as Duplex;
+    const req = { url: url.pathname, headers: { host: `127.0.0.1:${url.port}` } } as unknown as IncomingMessage;
+    internals.onUpgrade(req, socket, Buffer.alloc(0));
+    assert.equal(destroyed, true);
+    assert.equal(internals.socket, null);
+  });
+
+  it('start() throws target-busy when the debugger is already attached', async () => {
+    const { wc, asWebContents } = makeWc();
+    wc.debugger.attached = true;
+    const bridge = new CdpBridge(asWebContents);
+    await assert.rejects(bridge.start(), CdpBridgeError);
+  });
+
+  it('start() throws target-destroyed for a gone WebContents', async () => {
+    const { wc, asWebContents } = makeWc();
+    wc.destroyed = true;
+    const bridge = new CdpBridge(asWebContents);
+    await assert.rejects(
+      bridge.start(),
+      (err: unknown) => err instanceof CdpBridgeError && err.code === 'target-destroyed',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/opencli-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/opencli-contract.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Contract test against the pinned @jackwener/opencli release: every IPage
+ * member the seven browser tools (and BrowserSession) call must exist on the
+ * page object CDPBridge.connect() returns, and the bridge-level API
+ * BrowserSession drives must exist on CDPBridge. A version bump that drops or
+ * renames one of these fails here instead of at runtime in a user's session.
+ *
+ * Ported from PawWork (bun:test → node:test) — the same opencli major.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { WebSocketServer } from 'ws';
+import { CDPBridge } from '@jackwener/opencli/browser/cdp';
+import { htmlToMarkdown } from '@jackwener/opencli/utils';
+
+const EXPECTED_OPENCLI_VERSION = '1.8.4';
+
+// page methods the tools map to + the ones BrowserSession itself uses.
+const REQUIRED_PAGE_METHODS = [
+  'goto',
+  'snapshot',
+  'click',
+  'fillText',
+  'pressKey',
+  'wait',
+  'evaluate',
+  'getCurrentUrl',
+] as const;
+
+function installedOpencliVersion(): string {
+  const require = createRequire(import.meta.url);
+  // dist/src/browser/cdp.js -> climb three dirs to the package root.
+  const cdpJs = require.resolve('@jackwener/opencli/browser/cdp');
+  const pkgRoot = join(dirname(cdpJs), '..', '..', '..');
+  return JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).version as string;
+}
+
+async function connectToFake(): Promise<{ page: Record<string, unknown>; close: () => Promise<void> }> {
+  const wss = new WebSocketServer({ port: 0, host: '127.0.0.1' });
+  // address() is null until the OS bind completes; reading it synchronously
+  // races the listen and throws.
+  await new Promise<void>((resolve) => wss.once('listening', () => resolve()));
+  const port = (wss.address() as { port: number }).port;
+  wss.on('connection', (ws) => {
+    ws.on('message', (data) => {
+      const cmd = JSON.parse(String(data)) as { id: number };
+      ws.send(JSON.stringify({ id: cmd.id, result: {} }));
+    });
+  });
+  // wss.close() stops accepting but leaves accepted sockets open — an
+  // un-terminated server socket keeps the node:test process alive after the
+  // suite finishes. Terminate the live connections, then close the server.
+  const shutdown = async (): Promise<void> => {
+    for (const client of wss.clients) client.terminate();
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  };
+  const bridge = new CDPBridge();
+  let page: Record<string, unknown>;
+  try {
+    page = (await bridge.connect({ cdpEndpoint: `ws://127.0.0.1:${port}/secret` })) as unknown as Record<
+      string,
+      unknown
+    >;
+  } catch (err) {
+    // The caller only gets `close` on success; release the listener here or a
+    // failed connect leaks the server into the rest of the test process.
+    await shutdown();
+    throw err;
+  }
+  return {
+    page,
+    close: async () => {
+      await bridge.close();
+      await shutdown();
+    },
+  };
+}
+
+describe('opencli contract', () => {
+  it('is pinned to the expected release', () => {
+    assert.equal(installedOpencliVersion(), EXPECTED_OPENCLI_VERSION);
+  });
+
+  it('CDPBridge exposes the bridge-level API BrowserSession uses', () => {
+    const bridge = new CDPBridge();
+    assert.equal(typeof bridge.connect, 'function');
+    assert.equal(typeof bridge.close, 'function');
+    assert.equal(typeof bridge.send, 'function');
+    assert.equal(typeof bridge.waitForEvent, 'function');
+  });
+
+  it('the connected page implements every method the browser tools call', async () => {
+    const { page, close } = await connectToFake();
+    try {
+      for (const method of REQUIRED_PAGE_METHODS) {
+        assert.equal(typeof page[method], 'function', `missing required page method: ${method}`);
+      }
+    } finally {
+      await close();
+    }
+  });
+
+  it('htmlToMarkdown converts extracted page HTML', () => {
+    const markdown = htmlToMarkdown("<h1>Title</h1><p>Body with <a href='https://example.com'>link</a>.</p>");
+    assert.ok(markdown.includes('Title'));
+    assert.ok(markdown.includes('[link](https://example.com)'));
+  });
+});

--- a/apps/desktop/src/main/browser/automation-host.ts
+++ b/apps/desktop/src/main/browser/automation-host.ts
@@ -1,0 +1,67 @@
+import type { BrowserViewHost } from './browser-host.js';
+import type { BrowserViewController } from './controller.js';
+import { browserActionAllowed } from './logic.js';
+import type { BrowserViewManager } from './view-manager.js';
+
+/**
+ * The desktop's implementation of the BrowserViewHost seam (browser-host.ts):
+ * with views owned by conversations, session → endpoint resolution is the
+ * identity mapping — ensure the conversation's view and attach the CDP bridge to
+ * it. An action always lands in its OWN session's view, but that view may be
+ * hidden (the user switched conversations), so canDrive enforces the visible
+ * lease: read/navigate/mutate only on the session currently on screen. The
+ * endpoint and its secret stay same-process values, never crossing renderer IPC
+ * or preload.
+ *
+ * `shownSessionId` reads main's live record of the conversation the window shows
+ * (browser:active-session). Call
+ * provideBrowserViewHost(createBrowserViewHost(manager, () => shownBrowserSessionId))
+ * once in main.ts.
+ */
+// Ceiling on how long a mutate waits for the renderer to restore the strip
+// viewport after a permission modal closes. The restore is normally sub-100ms;
+// this is the safety net before the action is declared genuinely undrivable.
+const VIEWPORT_RESTORE_WAIT_MS = 1000;
+
+export function createBrowserViewHost(
+  manager: BrowserViewManager<BrowserViewController>,
+  shownSessionId: () => string | null,
+): BrowserViewHost {
+  return {
+    canDrive(sessionId, kind, opts) {
+      const shown = sessionId === shownSessionId();
+      const controller = manager.get(sessionId);
+      if (browserActionAllowed(kind, { shown, hasViewport: controller?.hasLiveViewport() ?? false })) {
+        return true;
+      }
+      // The one recoverable miss: a mutate on the conversation that IS on screen
+      // but whose viewport is briefly gone because a permission modal just closed
+      // (it hid the native view) and the renderer has not re-reported the strip
+      // yet. Wait for that restore, then re-check, so the first approved
+      // click/type lands without a retry. A backgrounded conversation (!shown) is
+      // never drivable — reject it immediately, no wait.
+      if (kind === 'mutate' && shown && controller) {
+        return controller
+          .waitForLiveViewport(VIEWPORT_RESTORE_WAIT_MS, opts?.signal)
+          .then(() =>
+            browserActionAllowed('mutate', {
+              shown: sessionId === shownSessionId(),
+              hasViewport: controller.hasLiveViewport(),
+            }),
+          );
+      }
+      return false;
+    },
+    async resolveEndpoint(sessionId) {
+      return manager.getOrCreate(sessionId).attachAutomation();
+    },
+    async releaseSession(sessionId) {
+      await manager.get(sessionId)?.detachAutomation();
+    },
+    // The conversation was deleted or archived: its view dies with it (page,
+    // history, automation, the WebContentsView itself).
+    async disposeSession(sessionId) {
+      await manager.dispose(sessionId);
+    },
+  };
+}

--- a/apps/desktop/src/main/browser/browser-host.ts
+++ b/apps/desktop/src/main/browser/browser-host.ts
@@ -1,0 +1,66 @@
+/**
+ * Injection seam between the browser tools / BrowserSession (pure logic, no
+ * Electron) and the desktop view controller that owns each conversation's
+ * WebContentsView and its sealed CDP bridge. The controller calls
+ * provideBrowserViewHost() once it is ready (P3); until then the tools report
+ * the browser as unavailable.
+ *
+ * The endpoint and its secret are handed back as same-process values and never
+ * cross renderer IPC or preload (cdp-bridge.ts security rule 7). Unlike
+ * PawWork's cross-package IoC, the tools, session, and controller all live in
+ * this one package, so this is a plain module-level provider — no structural
+ * error normalization is needed (the controller throws CdpBridgeError directly).
+ */
+
+import type { BrowserActionKind } from './logic.js';
+
+export interface BrowserViewHost {
+  /**
+   * The visible-lease gate (see browserActionAllowed): may `sessionId` run a
+   * `kind` action right now? EVERY kind — read, navigate, mutate — requires the
+   * session to be the one the user is currently looking at (mutate also a real
+   * viewport), so the agent can never drive OR read a hidden view after a
+   * conversation switch. Checked before resolveEndpoint so a blocked action
+   * creates no view.
+   *
+   * Resolves async for one case: a mutate on the conversation that IS on screen
+   * but whose viewport is momentarily absent because a permission modal just
+   * closed (the modal hid the native view) and the renderer has not re-reported
+   * the strip yet. There it waits briefly for the restore so the first approved
+   * click/type lands without a retry. `signal` cancels that wait.
+   */
+  canDrive(sessionId: string, kind: BrowserActionKind, opts?: { signal?: AbortSignal }): boolean | Promise<boolean>;
+  /**
+   * Resolve (lazily starting) the CDP endpoint for `sessionId`'s OWN view. The
+   * view is the session's own, but it may be hidden — canDrive gates whether an
+   * action may reach it. Throws a `code`-carrying error on failure (CdpBridgeError:
+   * target-busy / target-destroyed / bridge-start-timeout).
+   */
+  resolveEndpoint(sessionId: string): Promise<{ cdpEndpoint: string }>;
+  /**
+   * Detach the CDP bridge attached on behalf of `sessionId` (connection lost,
+   * timed out, aborted); the view itself lives on. A no-op when nothing attached.
+   */
+  releaseSession(sessionId: string): Promise<void>;
+  /**
+   * The conversation is gone (deleted or archived): destroy its view outright —
+   * page, history, automation. A no-op for sessions that never had a view.
+   */
+  disposeSession(sessionId: string): Promise<void>;
+}
+
+let current: BrowserViewHost | null = null;
+
+/** Called once by the desktop main process after the view controller is ready (P3). */
+export function provideBrowserViewHost(host: BrowserViewHost | null): void {
+  current = host;
+}
+
+export function browserAutomationAvailable(): boolean {
+  return current !== null;
+}
+
+export function browserViewHost(): BrowserViewHost {
+  if (!current) throw new Error('Browser automation is only available inside the desktop app.');
+  return current;
+}

--- a/apps/desktop/src/main/browser/browser-tools.ts
+++ b/apps/desktop/src/main/browser/browser-tools.ts
@@ -1,0 +1,398 @@
+import { z } from 'zod';
+import { htmlToMarkdown } from '@jackwener/opencli/utils';
+import type { MakaTool } from '@maka/runtime';
+import {
+  type BrowserPageRun,
+  type TakeoverMode,
+  browserAutomationAvailable,
+  withBrowserPage,
+} from './session.js';
+import { parseNavigable } from './logic.js';
+
+/**
+ * Generic observe→act browser tools over opencli's numbered-ref model:
+ * browser_snapshot lists interactive elements as `[N]` refs, the act tools
+ * (click / type) take a ref and self-verify the match. All six drive the
+ * conversation's OWN embedded-browser view through BrowserSession.
+ *
+ * Permission: every tool is the dedicated `browser` category — Maka's mode
+ * gates it (block in `explore`, prompt in `ask` AND `execute`), so a browser
+ * action on the user's logged-in sessions is never silently auto-allowed; the
+ * visible view plus the user's "allow for this turn" is the safety net. A
+ * finer origin-keyed grant (remember "allow this site") is a later refinement.
+ */
+
+const BROWSER_TOOL_CATEGORY = 'browser' as const;
+
+// Above opencli's internal 30s CDP guard so a slow load surfaces the CDP
+// command timeout (which names the navigation) rather than our generic one.
+const NAVIGATE_TIMEOUT_MS = 35_000;
+const MAX_WAIT_SECONDS = 120;
+/** Per-call markdown budget; long pages page through `start`/`next_start_char`. */
+const EXTRACT_CHAR_LIMIT = 16_000;
+/**
+ * Page-side ceiling on the raw HTML read. Without it a huge DOM serializes
+ * fully over CDP and feeds htmlToMarkdown whole — a synchronous conversion no
+ * timeout can interrupt.
+ */
+const HTML_CHAR_LIMIT = 2_000_000;
+
+/**
+ * opencli's target resolver treats ONLY a bare number as a snapshot ref —
+ * "[12]" falls through to querySelectorAll and fails as an invalid CSS
+ * selector. browser_snapshot prints refs as "[12]" and teaches that spelling,
+ * so models echo it. Accept the bracketed form and hand opencli the number;
+ * anything else passes through as a CSS selector.
+ */
+export function normalizeElementRef(ref: string): string {
+  const match = /^\s*\[(\d+)\]\s*$/.exec(ref);
+  return match ? match[1] : ref;
+}
+
+/** One-line note appended to the action that hardened (reloaded) a taken-over page. */
+export function takeoverNote(info: { takeoverReloaded: boolean }): string {
+  return info.takeoverReloaded
+    ? '\n\nNote: attached to the page that was already open; it was reloaded once to apply automation hardening.'
+    : '';
+}
+
+/**
+ * Shared run path for the browser_* tools. Permission is decided by the engine
+ * BEFORE impl runs (via the tool's category), so this only guards availability
+ * and runs the action through BrowserSession with its tool-level timeout and
+ * the user's stop signal.
+ */
+async function runBrowserAction<T>(input: {
+  sessionId: string;
+  label: string;
+  abortSignal: AbortSignal;
+  timeoutMs?: number;
+  // How this action treats a page the user already had open (see TakeoverMode);
+  // omit for the pure-observe default, which never reloads.
+  takeover?: TakeoverMode;
+  run: BrowserPageRun<T>;
+}): Promise<T> {
+  if (!browserAutomationAvailable()) {
+    throw new Error('Browser automation is only available inside the desktop app.');
+  }
+  return withBrowserPage(input.sessionId, input.label, input.run, {
+    abort: input.abortSignal,
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    ...(input.takeover ? { takeover: input.takeover } : {}),
+  });
+}
+
+export function buildBrowserNavigateTool(): MakaTool<{ url: string }, string> {
+  return {
+    name: 'browser_navigate',
+    displayName: '浏览器导航',
+    description:
+      'Open a URL in the conversation\'s embedded browser. Pass a full http:// or https:// URL; other schemes are rejected. ' +
+      'Returns the URL actually landed on (after redirects) and the page title. Follow with browser_snapshot to see what is on the page.',
+    parameters: z.object({
+      url: z.string().min(1).max(4000).describe('Full http:// or https:// URL to open. Other schemes are rejected.'),
+    }),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async ({ url: rawUrl }, { sessionId, abortSignal }) => {
+      // Validate BEFORE goto: opencli's goto sends Page.navigate directly,
+      // bypassing the view's will-navigate guard, so the scheme check is here.
+      const url = parseNavigable(rawUrl);
+      if (!url) {
+        throw new Error(`Not a navigable URL: ${JSON.stringify(rawUrl)}. Pass a full http:// or https:// URL.`);
+      }
+      const result = await runBrowserAction({
+        sessionId,
+        label: 'navigate',
+        abortSignal,
+        timeoutMs: NAVIGATE_TIMEOUT_MS,
+        // goto re-commits the document with the stealth script, so this clears a
+        // pending takeover without an extra reload.
+        takeover: 'navigate',
+        run: async (page, info) => {
+          await page.goto(url, { waitUntil: 'load' });
+          // Read the document's real location: goto caches the REQUESTED url, so
+          // getCurrentUrl() would just echo it back and a redirect would never
+          // be visible.
+          const landed = await page.evaluate<string>('window.location.href').catch(() => url);
+          const title = await page.evaluate<string>('document.title').catch(() => '');
+          return { landed: typeof landed === 'string' && landed ? landed : url, title, info };
+        },
+      });
+      return (
+        [`Loaded ${result.landed}`, result.title ? `Title: ${result.title}` : undefined].filter(Boolean).join('\n') +
+        takeoverNote(result.info)
+      );
+    },
+  };
+}
+
+export function buildBrowserSnapshotTool(): MakaTool<Record<string, never>, string> {
+  return {
+    name: 'browser_snapshot',
+    displayName: '浏览器快照',
+    description:
+      'Observe the current page as a list of interactive elements (links, buttons, inputs), each tagged with a `[N]` ' +
+      'reference you pass to browser_click / browser_type. This is the primary way to see what is on the page before acting.',
+    parameters: z.object({}),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async (_args, { sessionId, abortSignal }) => {
+      const result = await runBrowserAction({
+        sessionId,
+        label: 'snapshot',
+        abortSignal,
+        run: async (page, info) => {
+          const snapshot = await page.snapshot({ interactive: true });
+          const url = (await page.getCurrentUrl?.()) ?? '';
+          return { snapshot, url, info };
+        },
+      });
+      const text =
+        typeof result.snapshot === 'string' ? result.snapshot : JSON.stringify(result.snapshot, null, 2);
+      return (result.url ? `${result.url}\n\n${text}` : text) + takeoverNote(result.info);
+    },
+  };
+}
+
+export function buildBrowserClickTool(): MakaTool<{ ref: string }, string> {
+  return {
+    name: 'browser_click',
+    displayName: '浏览器点击',
+    description:
+      'Click an element by its browser_snapshot reference (like "[12]") or a CSS selector. ' +
+      'Reports how many elements matched and the match confidence; re-snapshot if multiple matched.',
+    parameters: z.object({
+      ref: z.string().min(1).max(2000).describe('Element reference from browser_snapshot (like "[12]") or a CSS selector.'),
+    }),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async ({ ref }, { sessionId, abortSignal }) => {
+      const result = await runBrowserAction({
+        sessionId,
+        label: 'click',
+        abortSignal,
+        // A mutating action: harden a taken-over page (reload once) before clicking.
+        takeover: 'mutate',
+        run: async (page, info) => ({ outcome: await page.click(normalizeElementRef(ref)), info }),
+      });
+      const { matches_n, match_level } = result.outcome;
+      return (
+        `Clicked ${ref} (matched ${matches_n} element${matches_n === 1 ? '' : 's'}, ${match_level} match).` +
+        (matches_n > 1
+          ? ' Multiple matches — verify the right element reacted, or re-snapshot for a tighter ref.'
+          : '') +
+        takeoverNote(result.info)
+      );
+    },
+  };
+}
+
+export function buildBrowserTypeTool(): MakaTool<{ ref: string; text: string; submit?: boolean }, string> {
+  return {
+    name: 'browser_type',
+    displayName: '浏览器输入',
+    description:
+      'Fill text into a field by its browser_snapshot reference (like "[7]") or a CSS selector; replaces the field\'s current content. ' +
+      'Set submit=true to press Enter after (search boxes, single-field forms). Self-verifies the field now holds the requested text.',
+    parameters: z.object({
+      ref: z.string().min(1).max(2000).describe('Element reference from browser_snapshot (like "[7]") or a CSS selector.'),
+      text: z.string().max(100_000).describe("Text to fill in; replaces the field's current content."),
+      submit: z
+        .boolean()
+        .optional()
+        .describe('Press Enter after filling (for search boxes and single-field forms). Default false.'),
+    }),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async ({ ref, text, submit }, { sessionId, abortSignal }) => {
+      const result = await runBrowserAction({
+        sessionId,
+        label: 'type',
+        abortSignal,
+        // A mutating action: harden a taken-over page (reload once) before typing.
+        takeover: 'mutate',
+        run: async (page, info) => {
+          const outcome = await page.fillText(normalizeElementRef(ref), text);
+          if (submit) await page.pressKey('Enter');
+          return { outcome, info };
+        },
+      });
+      const { verified, actual, match_level } = result.outcome;
+      const lines = [
+        `Filled ${ref} (${match_level} match)${submit ? ', then pressed Enter' : ''}.`,
+        verified
+          ? 'Verified: the field contains the requested text.'
+          : `Not verified — the field now contains: ${JSON.stringify(actual)}`,
+      ];
+      return lines.join('\n') + takeoverNote(result.info);
+    },
+  };
+}
+
+export function buildBrowserWaitTool(): MakaTool<
+  { text?: string; selector?: string; time?: number; timeout?: number },
+  string
+> {
+  return {
+    name: 'browser_wait',
+    displayName: '浏览器等待',
+    description:
+      'Wait for the page to be ready: until `text` is visible, until a CSS `selector` matches, or a fixed `time` pause in seconds. ' +
+      'Provide exactly one of text / selector / time. Prefer text or selector over a blind pause.',
+    parameters: z.object({
+      text: z.string().optional().describe('Wait until this text is visible on the page.'),
+      selector: z.string().optional().describe('Wait until this CSS selector matches an element.'),
+      time: z
+        .number()
+        .optional()
+        .describe('Fixed pause in seconds (use only when nothing observable signals readiness).'),
+      timeout: z
+        .number()
+        .optional()
+        .describe('Wait limit in seconds for text/selector waits (defaults: text 30s, selector 10s).'),
+    }),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async ({ text, selector, time, timeout }, { sessionId, abortSignal }) => {
+      const conditions = [text, selector, time].filter((v) => v !== undefined);
+      if (conditions.length !== 1) {
+        throw new Error('Provide exactly one of `text`, `selector`, or `time`.');
+      }
+      // The checks below are truthy-based; a blank string would slip past the
+      // count above and turn into a meaningless bare-timeout wait.
+      for (const [key, value] of [
+        ['text', text],
+        ['selector', selector],
+      ] as const) {
+        if (value !== undefined && value.trim() === '') {
+          throw new Error(`\`${key}\` must be a non-empty string.`);
+        }
+      }
+      const requested = Math.min(time ?? timeout ?? (selector ? 10 : 30), MAX_WAIT_SECONDS);
+      if (requested <= 0) {
+        throw new Error('`time`/`timeout` must be a positive number of seconds.');
+      }
+      const condition = text
+        ? `text ${JSON.stringify(text)}`
+        : selector
+          ? `selector ${JSON.stringify(selector)}`
+          : `${requested}s pause`;
+      const info = await runBrowserAction({
+        sessionId,
+        label: 'wait',
+        abortSignal,
+        // The page-side wait owns the deadline; give the tool wrapper room past it.
+        timeoutMs: (requested + 5) * 1000,
+        run: async (page, pageInfo) => {
+          if (time !== undefined) {
+            await page.wait({ time: requested });
+            return pageInfo;
+          }
+          try {
+            await page.wait({
+              ...(text ? { text } : {}),
+              ...(selector ? { selector } : {}),
+              timeout: requested,
+            });
+          } catch (err) {
+            // The page-side waiter rejects with a raw in-page exception which
+            // neither says it was a timeout nor how to recover. Say both.
+            if (err instanceof Error && /Selector not found|Text not found/.test(err.message)) {
+              throw new Error(
+                `Waited ${requested}s but ${condition} never appeared. The page may be structured differently than expected — take a browser_snapshot to see what is actually there before retrying.`,
+              );
+            }
+            throw err;
+          }
+          return pageInfo;
+        },
+      });
+      return `Done: ${condition}.` + takeoverNote(info);
+    },
+  };
+}
+
+export function buildBrowserExtractTool(): MakaTool<{ selector?: string; start?: number }, string> {
+  return {
+    name: 'browser_extract',
+    displayName: '浏览器提取',
+    description:
+      'Read the page (or a CSS-selected region) as Markdown for analysis. Omit selector for the whole body. ' +
+      'Long pages page through `start` — the output names the next_start_char to continue from.',
+    parameters: z.object({
+      selector: z.string().optional().describe('CSS selector to extract from; omit for the whole page body.'),
+      start: z
+        .number()
+        .optional()
+        .describe("Character offset to continue from (use the previous call's next_start_char)."),
+    }),
+    categoryHint: BROWSER_TOOL_CATEGORY,
+    impl: async ({ selector, start: rawStart }, { sessionId, abortSignal }) => {
+      const start = Math.max(0, Math.floor(rawStart ?? 0));
+      const result = await runBrowserAction({
+        sessionId,
+        label: 'extract',
+        abortSignal,
+        run: async (page, info) => {
+          // The selector is JSON-serialized into the script (never string-
+          // concatenated), so it cannot inject.
+          const read = await page.evaluate<{ html: string; truncated: boolean } | null>(
+            readHtmlJs(JSON.stringify(selector ?? null)),
+          );
+          const url = (await page.getCurrentUrl?.()) ?? '';
+          return { read, url, info };
+        },
+      });
+      if (typeof result.read?.html !== 'string') {
+        throw new Error(
+          selector
+            ? `No element matches selector ${JSON.stringify(selector)}.`
+            : 'The page has no readable body yet — navigate somewhere first.',
+        );
+      }
+      const markdown = htmlToMarkdown(result.read.html);
+      const chunk = markdown.slice(start, start + EXTRACT_CHAR_LIMIT);
+      const nextStart = start + chunk.length;
+      const hasMore = nextStart < markdown.length;
+      return (
+        (result.url ? `${result.url}\n\n` : '') +
+        chunk +
+        (hasMore
+          ? `\n\n(Content continues — call browser_extract again with start=${nextStart}. next_start_char: ${nextStart})`
+          : '') +
+        (result.read.truncated
+          ? "\n\n(The page's HTML was larger than the extraction ceiling; trailing content was dropped before conversion. Use `selector` to target the part you need.)"
+          : '') +
+        takeoverNote(result.info)
+      );
+    },
+  };
+}
+
+// Runs inside the page. The selector arrives pre-serialized via JSON (never
+// string-concatenated into code), so selector content cannot inject script. A
+// malformed selector (e.g. a "[12]" ref a model echoed) makes querySelector
+// throw a SyntaxError; catch it and return null so the tool surfaces its
+// friendly "No element matches selector" message instead of a raw DOMException.
+export function readHtmlJs(selectorJson: string): string {
+  return `(() => {
+  const selector = ${selectorJson};
+  let el;
+  try {
+    el = selector ? document.querySelector(selector) : document.body;
+  } catch {
+    return null;
+  }
+  if (!el) return null;
+  const html = el.outerHTML;
+  return { html: html.slice(0, ${HTML_CHAR_LIMIT}), truncated: html.length > ${HTML_CHAR_LIMIT} };
+})()`;
+}
+
+/** The six generic observe→act browser tools, in observe-before-act order. */
+export function buildBrowserTools(): MakaTool[] {
+  return [
+    buildBrowserNavigateTool(),
+    buildBrowserSnapshotTool(),
+    buildBrowserClickTool(),
+    buildBrowserTypeTool(),
+    buildBrowserWaitTool(),
+    buildBrowserExtractTool(),
+  ] as MakaTool[];
+}

--- a/apps/desktop/src/main/browser/cdp-bridge.ts
+++ b/apps/desktop/src/main/browser/cdp-bridge.ts
@@ -1,0 +1,308 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { createServer, type IncomingMessage, type Server as HttpServer } from 'node:http';
+import type { Duplex } from 'node:stream';
+import type { WebContents } from 'electron';
+import { WebSocket, WebSocketServer } from 'ws';
+import { BRIDGE_START_TIMEOUT_MS, CDP_BRIDGE_SECRET_LENGTH } from './options.js';
+
+export type CdpBridgeErrorCode = 'target-busy' | 'target-destroyed' | 'bridge-start-timeout';
+
+/** Typed failure so callers branch on a code instead of matching message text. */
+export class CdpBridgeError extends Error {
+  constructor(
+    readonly code: CdpBridgeErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CdpBridgeError';
+  }
+}
+
+type IncomingCommand = { id?: number; method?: string; params?: unknown; sessionId?: string };
+
+export type AutomationEndpoint = { cdpEndpoint: string };
+
+/**
+ * Exposes one WebContents' CDP surface over a sealed local endpoint
+ * `ws://127.0.0.1:<random-port>/<secret>`, relaying ws CDP traffic to and from
+ * `webContents.debugger`. Security contract — each rule is covered by a test:
+ *
+ *  1. loopback only + OS-assigned random port (`listen(0, "127.0.0.1")`);
+ *  2. the per-bridge secret is matched at the HTTP upgrade with a constant-time
+ *     compare; a wrong secret is destroyed there and never consumes the single
+ *     connection slot (so it can't be used to starve the real client);
+ *  3. Host is pinned to the loopback authority and any browser `Origin` is
+ *     rejected, defeating DNS rebinding;
+ *  4. exactly one connection at a time;
+ *  5. the secret lives only in main-process memory — never logged, never
+ *     returned in errors;
+ *  6. only the single WebContents passed in is attached — never the main window,
+ *     never a global `--remote-debugging-port`.
+ *
+ * Rule 7 (endpoint/secret never leave main via renderer IPC / preload) is the
+ * caller's contract: `start()` hands the endpoint back as a same-process value.
+ */
+export class CdpBridge {
+  private http: HttpServer | null = null;
+  private wss: WebSocketServer | null = null;
+  private socket: WebSocket | null = null;
+  private port = 0;
+  private started = false;
+  private starting: Promise<AutomationEndpoint> | null = null;
+  // Set only while listen() is pending; stop() calls it so a teardown racing a
+  // start-in-flight fails the start immediately instead of letting it wait out
+  // its own timeout on a server that will never come up.
+  private abortListen: ((err: Error) => void) | null = null;
+  // A fresh secret per start() so a reused bridge (e.g. after DevTools stole the
+  // debugger) never re-serves an old path.
+  private secret = '';
+  private path = '';
+  // Outstanding client command ids, each keyed to the connection that issued
+  // it (and the CDP sessionId it was sent on): teardown can fail them
+  // immediately (instead of leaving the client to wait out its own ~30s CDP
+  // timeout) with a response the client can route, and a completion is only
+  // delivered to its own connection — a reconnecting client reusing the same
+  // ids must never receive a stale result from the previous connection.
+  private readonly pending = new Map<number, { ws: WebSocket; sessionId?: string }>();
+
+  constructor(private readonly wc: WebContents) {}
+
+  async start(): Promise<AutomationEndpoint> {
+    if (this.started) return { cdpEndpoint: this.endpointUrl() };
+    // Share an in-flight start: a second caller arriving mid-start would see
+    // its own bridge's freshly attached debugger and misreport target-busy.
+    if (!this.starting)
+      this.starting = this.doStart().finally(() => {
+        this.starting = null;
+      });
+    return this.starting;
+  }
+
+  private async doStart(): Promise<AutomationEndpoint> {
+    if (this.wc.isDestroyed()) throw new CdpBridgeError('target-destroyed', 'WebContents is gone');
+    // Rule 6: refuse if anything else already owns the debugger (DevTools or
+    // another client) instead of fighting over it.
+    if (this.wc.debugger.isAttached())
+      throw new CdpBridgeError('target-busy', 'debugger is already attached to this target');
+
+    this.secret = randomBytes(CDP_BRIDGE_SECRET_LENGTH).toString('hex');
+    this.path = `/${this.secret}`;
+    this.wc.debugger.attach('1.3');
+    this.wc.debugger.on('message', this.onDebuggerMessage);
+    this.wc.debugger.on('detach', this.onDebuggerDetach);
+    // A directly destroyed WebContents is not guaranteed to emit a debugger
+    // 'detach' first; without this the ws server (and its port) would leak.
+    this.wc.once('destroyed', this.onDebuggerDetach);
+
+    // The HTTP server exists only to host the ws upgrade; it never serves plain HTTP.
+    const http = createServer((_req, res) => {
+      res.writeHead(426);
+      res.end();
+    });
+    http.on('upgrade', this.onUpgrade);
+    this.http = http;
+    this.wss = new WebSocketServer({ noServer: true });
+
+    try {
+      await this.listen(http);
+    } catch (err) {
+      await this.stop();
+      throw err;
+    }
+    // stop() may have intervened after listen already succeeded (DevTools
+    // stealing the debugger mid-start, or the target going away); its cleanup
+    // nulled this.http, and address() on the closed server would be null.
+    // Surface a typed error instead of a TypeError so callers can branch.
+    if (this.http !== http) throw this.interruptedStartError();
+    this.port = (http.address() as { port: number }).port;
+    this.started = true;
+    return { cdpEndpoint: this.endpointUrl() };
+  }
+
+  async stop(): Promise<void> {
+    this.started = false;
+    this.abortListen?.(this.interruptedStartError());
+    // Fail every in-flight client command before closing, so a CDP client
+    // (opencli has no remote-close handler) fails fast instead of hanging until
+    // its own ~30s timeout.
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      for (const [id, entry] of this.pending) {
+        this.socket.send(
+          JSON.stringify({
+            id,
+            error: { code: -32000, message: 'bridge closed' },
+            ...(entry.sessionId ? { sessionId: entry.sessionId } : {}),
+          }),
+        );
+      }
+    }
+    this.pending.clear();
+    this.socket?.close();
+    this.socket = null;
+    this.wss?.close();
+    this.wss = null;
+    if (this.http) {
+      const http = this.http;
+      this.http = null;
+      // socket.close() above flushed the error frames; this then drops the TCP
+      // connection (possibly before the close handshake round-trips, so the
+      // client may observe close code 1005 rather than 1000 — fine for a CDP
+      // client) and frees anything half-open so close()'s callback always
+      // fires (it does not, by itself, terminate the upgraded ws).
+      http.closeAllConnections();
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+    }
+    if (!this.wc.isDestroyed()) {
+      this.wc.off('destroyed', this.onDebuggerDetach);
+      this.wc.debugger.off('message', this.onDebuggerMessage);
+      this.wc.debugger.off('detach', this.onDebuggerDetach);
+      if (this.wc.debugger.isAttached()) {
+        try {
+          this.wc.debugger.detach();
+        } catch {
+          /* already detached (e.g. DevTools took it) */
+        }
+      }
+    }
+  }
+
+  private endpointUrl(): string {
+    return `ws://127.0.0.1:${this.port}${this.path}`;
+  }
+
+  // Why a start was torn down from under its caller: the target is either
+  // gone (window/view destroyed) or taken (DevTools owns the debugger now).
+  private interruptedStartError(): CdpBridgeError {
+    return this.wc.isDestroyed()
+      ? new CdpBridgeError('target-destroyed', 'WebContents went away during start')
+      : new CdpBridgeError('target-busy', 'bridge was stopped during start');
+  }
+
+  private listen(http: HttpServer): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const settle = (complete: () => void) => {
+        clearTimeout(timer);
+        this.abortListen = null;
+        complete();
+      };
+      const timer = setTimeout(
+        () => settle(() => reject(new CdpBridgeError('bridge-start-timeout', 'ws bridge did not come up in time'))),
+        BRIDGE_START_TIMEOUT_MS,
+      );
+      this.abortListen = (err) => settle(() => reject(err));
+      http.once('error', (err) => settle(() => reject(err)));
+      http.listen(0, '127.0.0.1', () => settle(resolve));
+    });
+  }
+
+  private readonly onUpgrade = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+    // Rules 2/3: gate at the upgrade, BEFORE handing the socket to ws, so a
+    // rejected attempt never occupies the single connection slot.
+    if (!this.authorized(req)) {
+      socket.destroy();
+      return;
+    }
+    // Rule 4: one connection at a time.
+    if (this.socket) {
+      socket.destroy();
+      return;
+    }
+    // stop() nulls wss while this 'upgrade' listener is still attached to the
+    // http server; an upgrade arriving in that window must be dropped, not left
+    // a silent no-op that abandons the socket neither adopted nor destroyed.
+    const wss = this.wss;
+    if (!wss) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => this.adopt(ws));
+  };
+
+  private authorized(req: IncomingMessage): boolean {
+    // Rule 2: exact, constant-time secret match on the pathname (the path
+    // carries the secret; a query string is allowed and ignored so a CDP
+    // client appending parameters is not misrejected).
+    const provided = Buffer.from(this.pathname(req));
+    const expected = Buffer.from(this.path);
+    if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) return false;
+    // Rule 3: pin Host to the loopback authority; reject any browser Origin
+    // (a real CDP client is not a browser and sends none).
+    if (req.headers.host !== `127.0.0.1:${this.port}`) return false;
+    if (req.headers.origin !== undefined) return false;
+    return true;
+  }
+
+  private pathname(req: IncomingMessage): string {
+    try {
+      return new URL(req.url ?? '', 'ws://127.0.0.1').pathname;
+    } catch {
+      return '';
+    }
+  }
+
+  private adopt(ws: WebSocket) {
+    this.socket = ws;
+    // A protocol error from the client (malformed frame, invalid UTF-8) emits
+    // 'error' on the adopted socket; with no listener that is an uncaught
+    // exception that kills the whole main process. Drop the connection instead.
+    ws.on('error', () => ws.terminate());
+    ws.on('message', (data) => void this.onClientMessage(ws, data));
+    ws.on('close', () => {
+      if (this.socket === ws) this.socket = null;
+      // This connection's commands can no longer be answered; drop them so
+      // their late completions are discarded instead of being delivered to a
+      // future connection that happens to reuse the same ids.
+      for (const [id, entry] of this.pending) if (entry.ws === ws) this.pending.delete(id);
+    });
+  }
+
+  private async onClientMessage(ws: WebSocket, data: unknown) {
+    let cmd: IncomingCommand;
+    try {
+      cmd = JSON.parse(String(data)) as IncomingCommand;
+    } catch {
+      return;
+    }
+    if (typeof cmd.id !== 'number' || typeof cmd.method !== 'string') return;
+    const { id, sessionId } = cmd;
+    this.pending.set(id, { ws, sessionId });
+    try {
+      const result = await this.wc.debugger.sendCommand(cmd.method, cmd.params ?? {}, sessionId);
+      if (this.takePending(id, ws)) this.send({ id, result, ...(sessionId ? { sessionId } : {}) });
+    } catch (err) {
+      if (this.takePending(id, ws))
+        this.send({
+          id,
+          error: { code: -32000, message: err instanceof Error ? err.message : String(err) },
+          ...(sessionId ? { sessionId } : {}),
+        });
+    }
+  }
+
+  // True only while `id` is still pending AND still owned by `ws` — false after
+  // teardown already failed it (don't double-send) or after the issuing
+  // connection went away (don't leak a stale result to its successor).
+  private takePending(id: number, ws: WebSocket): boolean {
+    if (this.pending.get(id)?.ws !== ws) return false;
+    this.pending.delete(id);
+    return true;
+  }
+
+  // CDP events from the attached target are pushed straight to the client.
+  private readonly onDebuggerMessage = (_event: unknown, method: string, params: unknown, sessionId?: string) => {
+    this.send({ method, params, ...(sessionId ? { sessionId } : {}) });
+  };
+
+  // DevTools opening (or any external detach) forcibly detaches the debugger,
+  // and a destroyed WebContents takes the target away entirely; either way,
+  // tear the bridge down so the client sees a clean close instead of a hang.
+  private readonly onDebuggerDetach = () => {
+    void this.stop();
+  };
+
+  private send(payload: Record<string, unknown>) {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.send(JSON.stringify(payload));
+    }
+  }
+}

--- a/apps/desktop/src/main/browser/controller.ts
+++ b/apps/desktop/src/main/browser/controller.ts
@@ -1,0 +1,276 @@
+import { type BrowserWindow, type Session, shell, WebContentsView } from 'electron';
+import { CdpBridge, type AutomationEndpoint } from './cdp-bridge.js';
+import { browserViewWebPreferences } from './options.js';
+import {
+  type BrowserState,
+  type BrowserViewRect,
+  deriveBrowserState,
+  parseNavigable,
+  safeExternalUrl,
+  viewportBounds,
+} from './logic.js';
+
+// The security backstop is PARTITION-level: every conversation's view shares
+// `persist:maka-browser`, so the handlers + will-download guard belong to that
+// one session, not to each view. Install once per session — `will-download` is
+// an ADDITIVE listener, so re-adding it per view would pile up listeners (Node
+// MaxListeners warning) and never detach on dispose.
+const backstopInstalledFor = new WeakSet<Session>();
+
+// Poll interval for waitForLiveViewport — roughly one animation frame, the
+// cadence at which the renderer re-reports the strip rect after a modal closes.
+const VIEWPORT_RESTORE_POLL_MS = 16;
+
+/**
+ * Owns ONE embedded browser per conversation: a native WebContentsView attached
+ * to the single app window, floating above the renderer DOM. The renderer
+ * reserves a strip and mirrors its on-screen rect via setViewport; the view
+ * starts hidden + zero-bounds so an ordinary chat reserves nothing. Page,
+ * history, and the CDP automation live and die with the conversation.
+ *
+ * The window is shared, but each conversation gets its own controller/view, so
+ * switching conversations never shows another conversation's page (the view
+ * manager hides the ones not in front).
+ */
+export class BrowserViewController {
+  private readonly view: WebContentsView;
+  private destroyed = false;
+  private favicon: string | null = null;
+  /** True while the view holds real on-screen bounds (last setViewport painted it). */
+  private shownWithBounds = false;
+  private automation: CdpBridge | null = null;
+
+  constructor(
+    private readonly window: BrowserWindow,
+    private readonly sessionId: string,
+    private readonly onState: (sessionId: string, state: BrowserState) => void,
+  ) {
+    this.view = new WebContentsView({ webPreferences: browserViewWebPreferences() });
+    this.window.contentView.addChildView(this.view);
+    this.view.setVisible(false);
+    this.applySecurityBackstop();
+    this.wireEvents();
+  }
+
+  private get wc() {
+    return this.view.webContents;
+  }
+
+  private wireEvents(): void {
+    const wc = this.wc;
+    wc.on('did-start-loading', () => this.emitState());
+    wc.on('did-stop-loading', () => this.emitState());
+    wc.on('did-navigate', () => {
+      this.favicon = null;
+      this.emitState();
+    });
+    wc.on('did-navigate-in-page', () => this.emitState());
+    wc.on('page-title-updated', () => this.emitState());
+    wc.on('page-favicon-updated', (_event, favicons: string[]) => {
+      this.favicon = favicons[0] ?? null;
+      this.emitState();
+    });
+    wc.on('did-fail-load', () => this.emitState());
+
+    // Single-view browser: keep http(s) "open in new window" links in-place and
+    // hand any other scheme to the system browser. Never spawn a child window.
+    wc.setWindowOpenHandler(({ url }) => {
+      const navigable = parseNavigable(url);
+      if (navigable) void this.loadInternal(navigable);
+      else this.openExternal(url);
+      return { action: 'deny' };
+    });
+
+    // Block link navigations to non-web schemes (file://, etc.); route real
+    // external schemes to the system browser instead of failing silently.
+    wc.on('will-navigate', (event, url) => {
+      if (parseNavigable(url)) return;
+      event.preventDefault();
+      this.openExternal(url);
+    });
+  }
+
+  /**
+   * Fail-closed backstop for what the PAGE could do on its own: deny popups,
+   * device/privacy permissions (camera, mic, geolocation, …), and downloads
+   * (no browser_download tool yet). Same-tab http(s) navigation flows freely so
+   * logins and in-site links work; the agent re-gates effects per page.
+   */
+  private applySecurityBackstop(): void {
+    const { session } = this.wc;
+    // Once per shared partition session, not once per view (see backstopInstalledFor).
+    if (backstopInstalledFor.has(session)) return;
+    backstopInstalledFor.add(session);
+    session.setPermissionRequestHandler((_wc, _permission, callback) => callback(false));
+    session.setPermissionCheckHandler(() => false);
+    session.on('will-download', (event) => event.preventDefault());
+  }
+
+  private openExternal(url: string): void {
+    const safe = safeExternalUrl(url);
+    if (safe) void shell.openExternal(safe).catch(() => {});
+  }
+
+  private async loadInternal(url: string): Promise<void> {
+    // loadURL rejects on aborted/failed loads (e.g. a superseding navigation);
+    // the did-fail-load handler already surfaces errors, so swallow here.
+    try {
+      await this.wc.loadURL(url);
+    } catch {
+      /* surfaced via did-fail-load */
+    }
+  }
+
+  state(): BrowserState {
+    if (this.destroyed || this.wc.isDestroyed()) {
+      return deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null });
+    }
+    const wc = this.wc;
+    return deriveBrowserState({
+      url: wc.getURL(),
+      title: wc.getTitle(),
+      canGoBack: wc.navigationHistory.canGoBack(),
+      canGoForward: wc.navigationHistory.canGoForward(),
+      loading: wc.isLoading(),
+      favicon: this.favicon,
+    });
+  }
+
+  private emitState(): void {
+    if (this.destroyed) return;
+    this.onState(this.sessionId, this.state());
+  }
+
+  async navigate(input: string): Promise<void> {
+    const url = parseNavigable(input);
+    if (!url) return;
+    await this.loadInternal(url);
+  }
+
+  goBack(): void {
+    if (this.wc.navigationHistory.canGoBack()) this.wc.navigationHistory.goBack();
+  }
+
+  goForward(): void {
+    if (this.wc.navigationHistory.canGoForward()) this.wc.navigationHistory.goForward();
+  }
+
+  reload(): void {
+    this.wc.reload();
+  }
+
+  stop(): void {
+    this.wc.stop();
+  }
+
+  /** Position + show the view over `rect`, or hide it when the rect is empty/null. */
+  setViewport(rect: BrowserViewRect | null): void {
+    if (this.destroyed) return;
+    const bounds = viewportBounds(rect);
+    const show = Boolean(bounds);
+    // Background throttling tracks shown-ness, toggled only on the transition.
+    // A HIDDEN conversation's cached page must throttle so a backgrounded one
+    // can't burn CPU/battery (the visible lease forbids driving it anyway). A
+    // SHOWN view keeps full speed: a native CDP click hit-tests a composited
+    // frame, which the OS drops on a throttled view whenever the app isn't
+    // focused — so "shown but app unfocused" still has to stay un-throttled to
+    // let the approved click land. (hideAllExcept fires setViewport(null) on
+    // every switch away, so this is where a conversation going off screen
+    // restores its throttle.)
+    if (show !== this.shownWithBounds && !this.wc.isDestroyed()) {
+      this.wc.setBackgroundThrottling(!show);
+    }
+    if (!bounds) {
+      this.shownWithBounds = false;
+      this.view.setVisible(false);
+      return;
+    }
+    this.shownWithBounds = true;
+    this.view.setBounds(bounds);
+    this.view.setVisible(true);
+  }
+
+  /** Visible-lease input: the view is on screen with non-empty bounds (see canDrive). */
+  hasLiveViewport(): boolean {
+    return !this.destroyed && this.shownWithBounds;
+  }
+
+  /** True when this view's renderer is background-throttled (hidden). Read-only. */
+  isBackgroundThrottled(): boolean {
+    return !this.wc.isDestroyed() && this.wc.getBackgroundThrottling();
+  }
+
+  /**
+   * Resolve true once the view is composited on screen again (hasLiveViewport),
+   * or false if it has not within `timeoutMs`. The mutate lease awaits this so
+   * the FIRST click/type after a browser permission grant lands: the permission
+   * modal hides the native view (the renderer sends setViewport(null) while it
+   * is open) and only re-reports the strip a frame or two after the modal
+   * closes — without this wait the lease would reject the just-approved action
+   * before that restore arrives. Polls rather than subscribing: the restore is a
+   * single sub-100ms event, so a short poll is simpler than waiter bookkeeping.
+   */
+  async waitForLiveViewport(timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (!this.hasLiveViewport()) {
+      if (this.destroyed || signal?.aborted || Date.now() >= deadline) return false;
+      await new Promise((resolve) => setTimeout(resolve, VIEWPORT_RESTORE_POLL_MS));
+    }
+    return true;
+  }
+
+  /**
+   * Bring up (or reuse) the CDP automation bridge over this view's WebContents
+   * and return its sealed, main-process-only endpoint.
+   */
+  async attachAutomation(): Promise<AutomationEndpoint> {
+    // A view that has never loaded a document has no renderer process, and
+    // debugger commands stall forever instead of failing — the client's
+    // connect-time Page.enable would eat its whole 30s CDP timeout. Commit
+    // about:blank first so the CDP session always has a live target (the UI
+    // treats about: as "no page", and the probe maps it to no URL).
+    if (!this.wc.getURL() && !this.wc.isDestroyed()) {
+      try {
+        await this.wc.loadURL('about:blank');
+      } catch {
+        /* a racing real navigation provides a document too */
+      }
+    }
+    if (!this.automation) this.automation = new CdpBridge(this.wc);
+    // Background throttling is governed by setViewport (shown ⇒ un-throttled),
+    // not here: the visible lease only drives a view while its conversation is
+    // on screen, so by the time automation runs the view is already shown and
+    // un-throttled, and a later switch away re-throttles it via setViewport(null).
+    return this.automation.start();
+  }
+
+  async detachAutomation(): Promise<void> {
+    await this.automation?.stop();
+    this.automation = null;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    // Final empty-state push: the renderer panel outlives the view, so without
+    // this it would keep showing stale hasPage/url for a page that is gone.
+    this.onState(
+      this.sessionId,
+      deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null }),
+    );
+    // Tear down the ws bridge; the debugger detaches with the wc.close() below.
+    // Each step guarded so a half-gone window (during quit) can't strand the rest.
+    await this.automation?.stop().catch(() => {});
+    this.automation = null;
+    try {
+      if (!this.window.isDestroyed()) this.window.contentView.removeChildView(this.view);
+    } catch {
+      /* window already torn down */
+    }
+    try {
+      if (!this.wc.isDestroyed()) this.wc.close();
+    } catch {
+      /* webContents already destroyed */
+    }
+  }
+}

--- a/apps/desktop/src/main/browser/logic.ts
+++ b/apps/desktop/src/main/browser/logic.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure embedded-browser logic — no electron import, so every rule here is pinned
+ * by plain unit tests. The electron-bound view lives in controller.ts.
+ */
+
+import type { BrowserState, BrowserViewRect } from '@maka/core';
+
+export type { BrowserState, BrowserViewRect };
+
+/**
+ * Validate an address before loading it into the embedded view. Only http/https
+ * are navigable: file://, javascript:, and other schemes are rejected so a typed
+ * address or an in-page link can never reach the local filesystem or privileged
+ * surfaces. Returns the parsed (normalized) URL string, or null if not allowed.
+ */
+export function parseNavigable(input: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+  if (url.protocol === 'http:' || url.protocol === 'https:') return url.toString();
+  return null;
+}
+
+// Page-provided non-web links are handed to the OS only for this tight set of
+// schemes. Everything else (file:, javascript:, custom app protocols) is dropped
+// so a hostile page can't launch local files or arbitrary registered handlers.
+const EXTERNAL_SCHEMES = new Set(['mailto:', 'tel:']);
+
+/**
+ * The page-provided URL to hand to the system handler, or null to drop it. Only
+ * a small allow-list of safe schemes escapes; navigable http/https links are
+ * handled in-place by parseNavigable and never reach here.
+ */
+export function safeExternalUrl(url: string): string | null {
+  const scheme = url.slice(0, url.indexOf(':') + 1).toLowerCase();
+  return EXTERNAL_SCHEMES.has(scheme) ? url : null;
+}
+
+/**
+ * Clamp a renderer-reported rect to integer, non-negative bounds (setBounds
+ * rejects negatives). Returns null when there is no room to show the view (a
+ * collapsed/empty strip — modal open, panel unmounted, mid-collapse) so the
+ * caller hides it rather than painting a sliver.
+ */
+export function viewportBounds(rect: BrowserViewRect | null): BrowserViewRect | null {
+  if (!rect) return null;
+  // The rect crosses an untyped IPC boundary; a NaN/Infinity/non-number would
+  // otherwise flow into setBounds and crash or wedge the native view. Reject the
+  // whole rect (hide) unless every field is a finite number.
+  if (![rect.x, rect.y, rect.width, rect.height].every((n) => Number.isFinite(n))) return null;
+  const width = Math.max(0, Math.round(rect.width));
+  const height = Math.max(0, Math.round(rect.height));
+  if (width <= 0 || height <= 0) return null;
+  // Clamp x/y non-negative too: a strip momentarily scrolled/laid out above the
+  // content area can report a negative origin, and the comment's contract is a
+  // fully non-negative rect.
+  return { x: Math.max(0, Math.round(rect.x)), y: Math.max(0, Math.round(rect.y)), width, height };
+}
+
+/** What a browser action does to the page, for the visible-lease gate below. */
+export type BrowserActionKind = 'observe' | 'mutate' | 'navigate';
+
+/**
+ * The visible-lease policy. The agent runs in a conversation's runtime, which may
+ * NOT be the conversation on screen; without this gate it could drive a hidden,
+ * zero-bounds view after the user switches away. EVERY action — including a
+ * read (observe) — must happen in the conversation the user is looking at:
+ * observing a logged-in page off screen would let a backgrounded conversation
+ * exfiltrate its content the user can't see. `mutate` (click/type) additionally
+ * needs real on-screen bounds, because opencli's native CDP click hit-tests a
+ * composited frame a hidden view lacks; observe/navigate need only that the
+ * session is shown (reading and goto don't require a painted frame).
+ */
+export function browserActionAllowed(
+  kind: BrowserActionKind,
+  view: { shown: boolean; hasViewport: boolean },
+): boolean {
+  if (!view.shown) return false;
+  return kind === 'mutate' ? view.hasViewport : true;
+}
+
+export interface BrowserStateSnapshot {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  loading: boolean;
+  favicon: string | null;
+}
+
+/**
+ * Derive the renderer-facing state from a raw webContents snapshot. `hasPage` is
+ * false until a real page is loaded (empty or about: URL), which keeps the DOM
+ * empty state visible and the native overlay hidden; `secure` reflects https.
+ */
+export function deriveBrowserState(snapshot: BrowserStateSnapshot): BrowserState {
+  return {
+    url: snapshot.url,
+    title: snapshot.title,
+    canGoBack: snapshot.canGoBack,
+    canGoForward: snapshot.canGoForward,
+    loading: snapshot.loading,
+    favicon: snapshot.favicon,
+    secure: /^https:\/\//i.test(snapshot.url),
+    hasPage: snapshot.url !== '' && !snapshot.url.startsWith('about:'),
+  };
+}

--- a/apps/desktop/src/main/browser/options.ts
+++ b/apps/desktop/src/main/browser/options.ts
@@ -1,0 +1,38 @@
+/**
+ * Embedded-browser tuning constants. Ported from PawWork's browser/options.ts.
+ */
+
+import type { WebPreferences } from 'electron';
+
+/**
+ * Single app-owned persistent partition: one browsing session shared by every
+ * conversation, surviving restarts. `persist:` keeps cookies/storage on disk so
+ * a login done in one conversation is available to all. Each conversation still
+ * has its OWN view/page/nav state.
+ */
+export const BROWSER_PARTITION = 'persist:maka-browser';
+
+/**
+ * WebPreferences for an embedded-browser WebContentsView. It loads arbitrary
+ * external sites the agent drives, so it is locked down and deliberately
+ * distinct from the app renderer: NO preload — the page must never receive the
+ * app's IPC bridge — plus sandbox, context isolation, no Node, web security on.
+ */
+export function browserViewWebPreferences(): WebPreferences {
+  return {
+    partition: BROWSER_PARTITION,
+    sandbox: true,
+    contextIsolation: true,
+    nodeIntegration: false,
+    webSecurity: true,
+  };
+}
+
+/**
+ * CDP automation bridge tuning. The secret is a high-entropy token carried in
+ * the ws path and kept in main-process memory only; the start timeout bounds how
+ * long we wait for the bridge's ws server to come up (debugger attach itself is
+ * synchronous) before surfacing a typed error instead of hanging.
+ */
+export const CDP_BRIDGE_SECRET_LENGTH = 32;
+export const BRIDGE_START_TIMEOUT_MS = 5_000;

--- a/apps/desktop/src/main/browser/session.ts
+++ b/apps/desktop/src/main/browser/session.ts
@@ -1,0 +1,406 @@
+import { CDPBridge } from '@jackwener/opencli/browser/cdp';
+import type { IPage } from '@jackwener/opencli/types';
+import { browserAutomationAvailable, browserViewHost } from './browser-host.js';
+import { type BrowserActionKind, parseNavigable } from './logic.js';
+
+/**
+ * Owner of the live CDP connection into a conversation's embedded browser.
+ *
+ * One connection per CONVERSATION: views (and their sealed ws bridges) belong
+ * to a session, so session → endpoint is the identity mapping. Maka sessions
+ * are FLAT (no parent chain), so the session id IS the conversation id — no
+ * root-session walk, unlike PawWork. The connection is torn down when the
+ * session is deleted or archived (releaseBrowserSession).
+ *
+ * opencli's CDPBridge.connect() registers its stealth script via
+ * Page.addScriptToEvaluateOnNewDocument, which only affects FUTURE documents.
+ * Connecting before the view's first navigation covers the agent-first flow;
+ * when the agent takes over a page the user already opened, that page predates
+ * the script. It is reloaded once to harden it — but ONLY before the first
+ * mutating action (click/type), never before a pure observe (snapshot / extract
+ * / wait), so the agent merely looking at a page the user has open
+ * cannot wipe their unsaved input. A navigation re-commits with the script, so
+ * it just clears the pending takeover without a reload. (Reload is the only
+ * contract-clean path — the stealth source itself is not a public export.)
+ */
+
+/** Shorter than opencli's internal 30s CDP guard so tools fail first, with a browser-flavored message. */
+export const BROWSER_TOOL_TIMEOUT_MS = 25_000;
+
+/** Best-effort wait for the takeover reload to settle; navigation events keep flowing afterwards either way. */
+const TAKEOVER_RELOAD_TIMEOUT_MS = 10_000;
+
+export class BrowserToolTimeoutError extends Error {
+  constructor(label: string, ms: number) {
+    super(
+      `Browser ${label} timed out after ${Math.round(ms / 1000)}s. The page may still be loading; try browser_wait or a simpler action.`,
+    );
+    this.name = 'BrowserToolTimeoutError';
+  }
+}
+
+export class BrowserActionCanceledError extends Error {
+  constructor(label: string) {
+    super(`Browser ${label} was canceled.`);
+    this.name = 'BrowserActionCanceledError';
+  }
+}
+
+export class BrowserActionBlockedError extends Error {
+  constructor(label: string) {
+    super(
+      `Browser ${label} blocked: the agent can only read, navigate, or act on the embedded browser while ` +
+        `this conversation is the one on screen. Ask the user to switch back to this conversation (and keep ` +
+        `its browser panel open) to continue.`,
+    );
+    this.name = 'BrowserActionBlockedError';
+  }
+}
+
+export class BrowserActionRevokedError extends Error {
+  constructor(label: string) {
+    super(
+      `Browser ${label} stopped: the user switched away from this conversation mid-action, so the agent can no ` +
+        `longer read or drive a page they can't see. Ask the user to switch back to this conversation to continue.`,
+    );
+    this.name = 'BrowserActionRevokedError';
+  }
+}
+
+/**
+ * The slice of opencli's CDPBridge that BrowserSession drives. Prod uses the
+ * real bridge; tests inject a fake so the connection lifecycle (loss,
+ * takeover-reload, abort-sever) is deterministic without a live CDP endpoint.
+ */
+export interface BridgeLike {
+  connect(opts: { cdpEndpoint: string }): Promise<IPage>;
+  close(): Promise<void>;
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  waitForEvent(event: string, timeoutMs?: number): Promise<unknown>;
+}
+
+let createBridge: () => BridgeLike = () => new CDPBridge();
+
+/** Test seam: swap the bridge factory; pass null to restore the real one. */
+export function setBridgeFactoryForTest(factory: (() => BridgeLike) | null): void {
+  createBridge = factory ?? (() => new CDPBridge());
+}
+
+type Connection = {
+  /** Owning session — 1:1 with its conversation's view and endpoint. */
+  session: string;
+  bridge: BridgeLike;
+  page: IPage;
+  closed: boolean;
+  /**
+   * connect() attached to an already-committed page that predates the stealth
+   * script and still owes one hardening reload. Resolved lazily by
+   * withBrowserPage: the first mutating action reloads (observe never does), and
+   * a navigation clears it without a reload (goto re-commits with the script).
+   */
+  pendingTakeover: boolean;
+};
+
+/**
+ * How an action resolves a pending takeover (see Connection.pendingTakeover).
+ * Shares the visible-lease kind (logic.ts): the action's effect on the page is
+ * the same axis that gates whether it may reach a hidden view.
+ */
+export type TakeoverMode = BrowserActionKind;
+
+const bySession = new Map<string, Connection>();
+// In-flight first acquires: the underlying ws bridge accepts a single client,
+// so two concurrent first calls for one conversation must share one attempt
+// instead of racing into a second connection (which the bridge would reject).
+const pendingAcquires = new Map<string, Promise<Connection>>();
+// Release generation per conversation. A delete/archive cannot reliably see an
+// in-flight acquire, so instead of the release waiting on the acquire, the
+// acquire notices the bump after connecting and unwinds itself — otherwise its
+// resolveEndpoint would resurrect the just-disposed view and the connection
+// would outlive the conversation with nothing left to ever clean it up.
+const releaseEpochs = new Map<string, number>();
+// In-flight actions per conversation, so the visible lease can REVOKE — not just
+// preflight. canDrive gates the START on screen; this severs an action that was
+// still running when the user switched away (browser:active-session), so a
+// wait / navigate / extract / mutate can never keep reading or driving a now-
+// hidden, logged-in page. Keyed by session because only the shown conversation
+// may have one in flight, but a Set tolerates overlap defensively.
+const inFlightBySession = new Map<string, Set<AbortController>>();
+
+function trackInFlight(sessionId: string): AbortController {
+  const ctrl = new AbortController();
+  const set = inFlightBySession.get(sessionId) ?? new Set<AbortController>();
+  set.add(ctrl);
+  inFlightBySession.set(sessionId, set);
+  return ctrl;
+}
+
+function untrackInFlight(sessionId: string, ctrl: AbortController): void {
+  const set = inFlightBySession.get(sessionId);
+  if (!set) return;
+  set.delete(ctrl);
+  if (set.size === 0) inFlightBySession.delete(sessionId);
+}
+
+/**
+ * The window switched to `shownSessionId` (or to nothing): abort any browser
+ * action still running for a DIFFERENT conversation. The visible lease is
+ * continuous, not a one-time preflight — an action that started while visible
+ * must not keep reading or driving a page the user can no longer see. Severs the
+ * connection like a timeout/abort; the page itself survives for when the user
+ * switches back. Called from main's browser:active-session handler.
+ */
+export function revokeHiddenBrowserActions(shownSessionId: string | null): void {
+  for (const [sessionId, set] of inFlightBySession) {
+    if (sessionId === shownSessionId) continue;
+    for (const ctrl of set) ctrl.abort();
+  }
+}
+
+// Every way the underlying connection reports being gone: opencli's send()
+// pre-check ("CDP connection is not open"), its close() ("CDP connection
+// closed"), and the main-process bridge failing in-flight commands on teardown
+// ("bridge closed").
+const CONNECTION_LOST = /CDP connection is not open|CDP connection closed|bridge closed/i;
+
+function isConnectionLoss(err: unknown): boolean {
+  return err instanceof Error && CONNECTION_LOST.test(err.message);
+}
+
+async function currentPageUrl(page: IPage): Promise<string | null> {
+  if (page.getCurrentUrl) return page.getCurrentUrl();
+  try {
+    const url = await page.evaluate<string>('window.location.href');
+    return typeof url === 'string' ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+async function connect(session: string, endpoint: string): Promise<Connection> {
+  const bridge = createBridge();
+  const page = await bridge.connect({ cdpEndpoint: endpoint });
+  // An already-committed navigable page predates the stealth script, so it owes
+  // a hardening reload. Don't reload now: connect() can't tell whether the agent
+  // is about to observe or mutate, and observing must never disturb a page the
+  // user may have unsaved input on. withBrowserPage resolves the takeover.
+  const url = await currentPageUrl(page);
+  const pendingTakeover = Boolean(url && parseNavigable(url));
+  return { session, bridge, page, closed: false, pendingTakeover };
+}
+
+// Reload the taken-over page once so its current document gets the stealth
+// script (addScriptToEvaluateOnNewDocument only affects future documents).
+async function applyTakeoverReload(conn: Connection): Promise<void> {
+  const loaded = conn.bridge.waitForEvent('Page.loadEventFired', TAKEOVER_RELOAD_TIMEOUT_MS).catch(() => undefined);
+  await conn.bridge.send('Page.reload', {});
+  await loaded;
+}
+
+function invalidate(conn: Connection): void {
+  if (conn.closed) return;
+  conn.closed = true;
+  bySession.delete(conn.session);
+  void conn.bridge.close().catch(() => {});
+  // Tell the main process to drop its attachment now: with the bySession
+  // mapping gone, a later session delete/archive can no longer do it, and the
+  // host would keep a stale bridge alive forever. Best-effort — a re-acquire
+  // re-attaches regardless.
+  if (browserAutomationAvailable()) {
+    void browserViewHost()
+      .releaseSession(conn.session)
+      .catch(() => {});
+  }
+}
+
+async function acquire(sessionId: string): Promise<Connection> {
+  const cached = bySession.get(sessionId);
+  if (cached && !cached.closed) return cached;
+
+  // Single-flight per conversation: a failed attempt clears itself so the next
+  // call retries fresh; concurrent callers share the same outcome either way.
+  const inflight = pendingAcquires.get(sessionId);
+  if (inflight) return inflight;
+  const promise = (async () => {
+    const epoch = releaseEpochs.get(sessionId);
+    const endpoint = await browserViewHost().resolveEndpoint(sessionId);
+    let conn: Connection;
+    try {
+      conn = await connect(sessionId, endpoint.cdpEndpoint);
+    } catch (err) {
+      // resolveEndpoint already attached the host's bridge, but nothing on this
+      // side maps the session yet — a later release would no-op and leak the
+      // attachment. Undo it now.
+      await browserViewHost()
+        .releaseSession(sessionId)
+        .catch(() => {});
+      throw err;
+    }
+    if (releaseEpochs.get(sessionId) !== epoch) {
+      // The conversation was deleted or archived while we were connecting —
+      // resolveEndpoint resurrected its view after the release disposed it.
+      // Unwind completely: close the socket, dispose the recreated view.
+      conn.closed = true;
+      await conn.bridge.close().catch(() => {});
+      await browserViewHost()
+        .disposeSession(sessionId)
+        .catch(() => {});
+      throw new Error('The conversation was deleted while the browser was connecting.');
+    }
+    bySession.set(sessionId, conn);
+    return conn;
+  })().finally(() => pendingAcquires.delete(sessionId));
+  pendingAcquires.set(sessionId, promise);
+  return promise;
+}
+
+export type BrowserPageRun<T> = (page: IPage, info: { takeoverReloaded: boolean }) => Promise<T>;
+
+/**
+ * Run one tool action against the session's embedded-browser page: lazy connect
+ * + cache, a tool-level timeout that beats opencli's internal 30s guard, and
+ * cache invalidation on connection loss so the next call re-resolves and
+ * reconnects instead of failing forever.
+ */
+export async function withBrowserPage<T>(
+  sessionId: string,
+  label: string,
+  run: BrowserPageRun<T>,
+  opts?: { timeoutMs?: number; abort?: AbortSignal; takeover?: TakeoverMode },
+): Promise<T> {
+  if (opts?.abort?.aborted) throw new BrowserActionCanceledError(label);
+  const kind: TakeoverMode = opts?.takeover ?? 'observe';
+  // Visible-lease gate (browserActionAllowed): EVERY action — read, navigate, or
+  // mutate — must target the conversation on screen, so the agent can never drive
+  // (or even read) a view the user can't see. Runs BEFORE acquire, so a vetoed
+  // background action creates no view and opens no connection. For a mutate whose
+  // viewport is briefly absent (a permission modal just closed), canDrive waits
+  // out the renderer's strip restore so the first approved click/type lands;
+  // abort during that wait surfaces as a cancel, not a block. The lease is also
+  // CONTINUOUS: revokeHiddenBrowserActions severs this action mid-run if the user
+  // switches away before it finishes (see trackInFlight below).
+  const drivable = await browserViewHost().canDrive(sessionId, kind, { signal: opts?.abort });
+  if (opts?.abort?.aborted) throw new BrowserActionCanceledError(label);
+  if (!drivable) throw new BrowserActionBlockedError(label);
+  const ms = opts?.timeoutMs ?? BROWSER_TOOL_TIMEOUT_MS;
+  let conn: Connection | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  let onRevoke: (() => void) | undefined;
+  // Track this action so a switch away from the conversation can revoke it (the
+  // visible lease is continuous, not just the preflight canDrive above).
+  // Registered AFTER canDrive resolved true, with no await between, so the
+  // active-session IPC can't slip a revoke into the gap.
+  const revoke = trackInFlight(sessionId);
+  // Abort, timeout, and revoke don't just stop the wait — they sever the
+  // connection. CDP has no command-level cancel, so an orphaned run() would
+  // otherwise keep driving the page after the user hit stop, switched away, or
+  // after the tool already reported failure. Closing the socket fails its
+  // in-flight and subsequent commands locally; the next action re-probes and
+  // reconnects.
+  //
+  // The race covers acquire() too — the first action's endpoint resolution and
+  // CDP connect answer to the same budget and the same stop button. The abort
+  // listener registers BEFORE acquire on purpose: a signal that fires mid-
+  // acquire would never fire a listener added after it ("abort" does not re-fire
+  // on already-aborted signals), and the canceled action would run anyway.
+  // Severing is conditional because there is no connection until acquire
+  // returns; an abandoned in-flight acquire settles in the background and only
+  // fills the cache for the next action.
+  const interrupted = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      if (conn) invalidate(conn);
+      reject(new BrowserToolTimeoutError(label, ms));
+    }, ms);
+    onAbort = () => {
+      if (conn) invalidate(conn);
+      reject(new BrowserActionCanceledError(label));
+    };
+    opts?.abort?.addEventListener('abort', onAbort, { once: true });
+    onRevoke = () => {
+      if (conn) invalidate(conn);
+      reject(new BrowserActionRevokedError(label));
+    };
+    revoke.signal.addEventListener('abort', onRevoke, { once: true });
+  });
+  try {
+    const acquiring = acquire(sessionId);
+    // The race abandons this promise when interrupted wins; its eventual
+    // rejection must not surface as an unhandled error.
+    acquiring.catch(() => {});
+    conn = await Promise.race([acquiring, interrupted]);
+    // Resolve a pending takeover by the action's kind: a mutating action hardens
+    // the page first (reload), a navigation just clears it (goto re-commits with
+    // the script), and a pure observe leaves it pending so a later mutate still
+    // hardens — observing never reloads the page the user has open.
+    let takeoverReloaded = false;
+    if (conn.pendingTakeover) {
+      if (kind === 'mutate') {
+        await Promise.race([applyTakeoverReload(conn), interrupted]);
+        conn.pendingTakeover = false;
+        takeoverReloaded = true;
+      } else if (kind === 'navigate') {
+        conn.pendingTakeover = false;
+      }
+    }
+    return await Promise.race([run(conn.page, { takeoverReloaded }), interrupted]);
+  } catch (err) {
+    if (conn && isConnectionLoss(err)) {
+      invalidate(conn);
+      // The connection dying mid-action means the page was closed out from under
+      // the tool — the user closed the browser tab, or the conversation was torn
+      // down. The raw "CDP connection is not open" says neither what happened nor
+      // what to do; say both. No automatic retry: a close is the user's call.
+      throw new Error(
+        `The browser page was closed while ${label} was running. The next browser action starts over from a fresh blank page.`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    if (onAbort) opts?.abort?.removeEventListener('abort', onAbort);
+    untrackInFlight(sessionId, revoke);
+  }
+}
+
+/**
+ * The session was deleted or archived: drop its browser connection and have the
+ * desktop destroy its view outright. A session that never attached, or a
+ * non-existent id, no-ops at every step.
+ */
+export async function releaseBrowserSession(sessionId: string): Promise<void> {
+  // Bump first: an acquire still in flight for this conversation unwinds itself
+  // when it sees the new epoch (see acquire) — it cannot be awaited here because
+  // it may not have registered in pendingAcquires yet, and a hung endpoint
+  // resolution must not block the session's deletion.
+  releaseEpochs.set(sessionId, (releaseEpochs.get(sessionId) ?? 0) + 1);
+  const conn = bySession.get(sessionId);
+  if (conn) {
+    bySession.delete(sessionId);
+    conn.closed = true;
+    await conn.bridge.close().catch(() => {});
+  }
+  // Dispose unconditionally, not just when a connection exists: a conversation
+  // the user browsed by hand has a live view but never had a CDP connection, and
+  // its view must still die with the session. disposeSession implies the bridge
+  // detach that releaseSession would have done.
+  if (browserAutomationAvailable()) {
+    await browserViewHost()
+      .disposeSession(sessionId)
+      .catch(() => {});
+  }
+}
+
+export { browserAutomationAvailable };
+
+/** Test seam: reset module state between tests. */
+export function resetBrowserSessionsForTest(): void {
+  for (const conn of bySession.values()) {
+    conn.closed = true;
+    void conn.bridge.close().catch(() => {});
+  }
+  bySession.clear();
+  pendingAcquires.clear();
+  releaseEpochs.clear();
+  inFlightBySession.clear();
+}

--- a/apps/desktop/src/main/browser/view-manager.ts
+++ b/apps/desktop/src/main/browser/view-manager.ts
@@ -1,0 +1,96 @@
+import type { BrowserViewRect } from './logic.js';
+
+/**
+ * Per-conversation lifecycle for embedded-browser views. One view per
+ * conversation, lazily created on first use (navigate or automation) and torn
+ * down when the conversation is deleted/archived or the app quits.
+ *
+ * Deliberately electron-free: it maps sessionId → controller and delegates the
+ * real view create/destroy to an injected factory (the electron-backed
+ * BrowserViewController lives in controller.ts, wired only in main.ts). That
+ * keeps the bookkeeping — including the leak invariant — unit-testable with a
+ * stub controller.
+ */
+
+/** The slice of a controller the manager itself drives; tests pass a stub. */
+export interface ManagedView {
+  setViewport(rect: BrowserViewRect | null): void;
+  state(): { hasPage: boolean; url: string };
+  dispose(): Promise<void>;
+}
+
+export interface BrowserViewManagerDeps<C extends ManagedView> {
+  /** Create a real view for `sessionId`. Called at most once per id. */
+  create: (sessionId: string) => C;
+  /**
+   * Notified with the live session-id set whenever a view is created or
+   * disposed, so the renderer can show/hide its browser panel. Never fired on
+   * reuse — only on a real create/destroy.
+   */
+  onLiveChange?: (liveSessionIds: string[]) => void;
+}
+
+export class BrowserViewManager<C extends ManagedView> {
+  private readonly views = new Map<string, C>();
+
+  constructor(private readonly deps: BrowserViewManagerDeps<C>) {}
+
+  /** Lazily create (or reuse) the view for `sessionId`. */
+  getOrCreate(sessionId: string): C {
+    let view = this.views.get(sessionId);
+    if (!view) {
+      view = this.deps.create(sessionId);
+      this.views.set(sessionId, view);
+      this.notifyLiveChange();
+    }
+    return view;
+  }
+
+  get(sessionId: string): C | undefined {
+    return this.views.get(sessionId);
+  }
+
+  /** Position the session's view over `rect`, or hide it (null). No-op if absent. */
+  setViewport(sessionId: string, rect: BrowserViewRect | null): void {
+    this.views.get(sessionId)?.setViewport(rect);
+  }
+
+  /**
+   * Hide every view except `keepSessionId`'s (pass null to hide all). Main calls
+   * this on every active-conversation switch so it OWNS which embedded view is
+   * visible: a stale view can never float over the newly-shown conversation
+   * because of renderer effect ordering or a reload. The kept view is left
+   * untouched — its panel's per-frame rect mirror re-positions it.
+   */
+  hideAllExcept(keepSessionId: string | null): void {
+    for (const [id, view] of this.views) {
+      if (id !== keepSessionId) view.setViewport(null);
+    }
+  }
+
+  /** Tear down one session's view. No-op if it was never created. */
+  async dispose(sessionId: string): Promise<void> {
+    const view = this.views.get(sessionId);
+    if (!view) return;
+    // Drop from the map first so a concurrent getOrCreate makes a fresh view
+    // rather than handing back the one being destroyed.
+    this.views.delete(sessionId);
+    this.notifyLiveChange();
+    await view.dispose();
+  }
+
+  /** Tear down every view (app quit). */
+  async disposeAll(): Promise<void> {
+    const ids = [...this.views.keys()];
+    await Promise.all(ids.map((id) => this.dispose(id)));
+  }
+
+  /** Live view count — asserts the leak invariant in tests. */
+  liveCount(): number {
+    return this.views.size;
+  }
+
+  private notifyLiveChange(): void {
+    this.deps.onLiveChange?.([...this.views.keys()]);
+  }
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -207,6 +207,13 @@ import {
 } from './text-file-import.js';
 import { buildExploreAgentTool } from './explore-agent-tool.js';
 import { buildOfficeDocumentEditTool, buildOfficeDocumentTool } from './office-document-tool.js';
+import { buildBrowserTools } from './browser/browser-tools.js';
+import { BrowserViewManager } from './browser/view-manager.js';
+import { BrowserViewController } from './browser/controller.js';
+import { createBrowserViewHost } from './browser/automation-host.js';
+import { provideBrowserViewHost } from './browser/browser-host.js';
+import { releaseBrowserSession, revokeHiddenBrowserActions } from './browser/session.js';
+import type { BrowserViewRect } from './browser/logic.js';
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 
@@ -549,6 +556,10 @@ const builtinTools = [
     getPrivacyContext: async () => defaultWorkspacePrivacyContext(),
   }),
   buildRiveWorkflowTool(),
+  // Embedded-browser observe→act tools. They drive the conversation's own
+  // WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
+  // outside the app (no host) they report the browser as unavailable.
+  ...buildBrowserTools(),
 ];
 let lookupPricing = buildPricingLookup();
 // PR-BOT-LASTERROR-FROM-SEND-0: per-platform last-observed readiness so
@@ -987,6 +998,30 @@ const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 const planReminderTimers = new Map<string, NodeJS.Timeout>();
 const PLAN_REMINDER_DEFAULT_SNOOZE_MS = 10 * 60 * 1000;
 
+// Embedded browser: one WebContentsView per conversation, lazily created on
+// first use. The factory reads the live mainWindow at create time, so views
+// created after a window re-open attach to the current window.
+let browserViews: BrowserViewManager<BrowserViewController> | undefined;
+// The session the renderer currently shows; browser:* renderer channels are
+// validated against it so a stale/miswired panel can't steer another
+// conversation's view (the agent path uses the runtime's trusted sessionId).
+let shownBrowserSessionId: string | null = null;
+
+function getBrowserViews(): BrowserViewManager<BrowserViewController> {
+  if (!browserViews) {
+    browserViews = new BrowserViewManager<BrowserViewController>({
+      create: (sessionId) => {
+        if (!mainWindow) throw new Error('Embedded browser used before the window is ready.');
+        return new BrowserViewController(mainWindow, sessionId, (sid, state) => {
+          mainWindow?.webContents.send('browser:state', { sessionId: sid, state });
+        });
+      },
+      onLiveChange: (sessionIds) => mainWindow?.webContents.send('browser:live', { sessionIds }),
+    });
+  }
+  return browserViews;
+}
+
 /**
  * Guard against saved x/y referencing a display that no longer exists
  * (laptop docked → undocked, external monitor unplugged). Walks the
@@ -1165,6 +1200,9 @@ async function createWindow(): Promise<void> {
   mainWindow.on('unmaximize', scheduleSave);
   mainWindow.on('close', () => {
     if (saveTimer) clearTimeout(saveTimer);
+    // The window owns the embedded-browser views (children of its contentView);
+    // tear them down so their WebContents close with it instead of leaking.
+    void browserViews?.disposeAll();
     if (!mainWindow) return;
     const final: SavedBounds = mainWindow.isMaximized()
       ? { ...mainWindow.getNormalBounds(), isMaximized: true }
@@ -2326,6 +2364,9 @@ function registerIpc(): void {
   });
   ipcMain.handle('sessions:archive', async (_event, sessionId: string) => {
     await runtime.archive(sessionId);
+    // An archived conversation is no longer shown: drop its browser connection
+    // and view so it does not keep a live Chromium page in the background.
+    await releaseBrowserSession(sessionId);
     emitSessionsChanged('archived', sessionId);
   });
   ipcMain.handle('sessions:unarchive', async (_event, sessionId: string) => {
@@ -2376,7 +2417,77 @@ function registerIpc(): void {
   });
   ipcMain.handle('sessions:remove', async (_event, sessionId: string) => {
     await runtime.remove(sessionId);
+    // Drop the conversation's browser connection and destroy its view (no-op
+    // if it never opened one). releaseBrowserSession disposes the view via the
+    // host, covering both agent-driven and hand-opened views.
+    await releaseBrowserSession(sessionId);
     emitSessionsChanged('deleted', sessionId);
+  });
+
+  // ── Embedded browser (P3) ──────────────────────────────────────────────────
+  // Provide the host the browser tools / BrowserSession resolve through. The
+  // endpoint + secret it returns stay same-process and never cross these
+  // renderer channels.
+  // The getter reads the live shownBrowserSessionId so the host's visible-lease
+  // gate (canDrive) reflects the conversation the window currently shows.
+  provideBrowserViewHost(createBrowserViewHost(getBrowserViews(), () => shownBrowserSessionId));
+
+  // Never trust the renderer's target: it must be the session the calling
+  // window currently shows (reported via browser:active-session). The agent
+  // automation path does NOT use these channels — it uses the runtime's
+  // sessionId — so this only guards the human's manual navigation.
+  ipcMain.on('browser:active-session', (_event, sessionId: unknown) => {
+    shownBrowserSessionId = typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : null;
+    // Main owns visibility: proactively hide every other conversation's view so a
+    // stale one can never float over the newly-shown conversation, regardless of
+    // renderer effect ordering or a reload. The shown view is re-positioned by
+    // its panel's rect mirror.
+    getBrowserViews().hideAllExcept(shownBrowserSessionId);
+    // The visible lease is continuous: revoke any browser action still running
+    // for a conversation that just went off screen, so it can't keep reading or
+    // driving a hidden, logged-in page. canDrive only gates the START.
+    revokeHiddenBrowserActions(shownBrowserSessionId);
+  });
+  const browserTargetOk = (target: unknown): target is string =>
+    typeof target === 'string' && target.length > 0 && target === shownBrowserSessionId;
+
+  // The renderer mirrors its browser panel strip's on-screen rect here so the
+  // native view tracks it; a null rect (modal open / panel unmounted) hides it.
+  ipcMain.on('browser:setViewport', (_event, input: { sessionId?: unknown; rect?: BrowserViewRect | null }) => {
+    if (!browserTargetOk(input?.sessionId)) return;
+    getBrowserViews().setViewport(input.sessionId, input.rect ?? null);
+  });
+  // Create on first navigate so conversations that never open the browser pay nothing.
+  ipcMain.handle('browser:navigate', async (_event, target: unknown, url: unknown) => {
+    if (!browserTargetOk(target)) return;
+    await getBrowserViews().getOrCreate(target).navigate(String(url ?? ''));
+  });
+  ipcMain.handle('browser:back', (_event, target: unknown) => {
+    if (browserTargetOk(target)) getBrowserViews().get(target)?.goBack();
+  });
+  ipcMain.handle('browser:forward', (_event, target: unknown) => {
+    if (browserTargetOk(target)) getBrowserViews().get(target)?.goForward();
+  });
+  ipcMain.handle('browser:reload', (_event, target: unknown) => {
+    if (browserTargetOk(target)) getBrowserViews().get(target)?.reload();
+  });
+  ipcMain.handle('browser:stop', (_event, target: unknown) => {
+    if (browserTargetOk(target)) getBrowserViews().get(target)?.stop();
+  });
+  // Read-only state query, intentionally NOT gated by browserTargetOk: the panel
+  // issues it from its mount effect, which runs BEFORE the parent's
+  // setActiveSession updates shownBrowserSessionId. Gating it dropped the seed
+  // during a conversation switch, leaving the switched-to panel stuck on its
+  // empty state with the native view hidden. Reading a session's own view state
+  // is not a trust boundary — only mutation (navigate/back/...) and view
+  // positioning (setViewport) are, and those stay guarded.
+  ipcMain.handle('browser:get-state', (_event, target: unknown) =>
+    typeof target === 'string' && target.length > 0 ? (getBrowserViews().get(target)?.state() ?? null) : null,
+  );
+  // The tab's × promises "Close": destroy the conversation's page outright via
+  // the same dispose chain as session delete.
+  ipcMain.handle('browser:close-page', async (_event, target: unknown) => {
+    if (browserTargetOk(target)) await releaseBrowserSession(target);
   });
 
   ipcMain.handle('connections:list', async () => {
@@ -3616,6 +3727,7 @@ app.on('before-quit', () => {
   for (const id of Array.from(planReminderTimers.keys())) clearPlanReminderTimer(id);
   void botRegistry.stopAll();
   void openGateway.stop();
+  void browserViews?.disposeAll();
 });
 
 app.on('activate', () => {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -49,6 +49,8 @@ import type {
   DailyReviewSummary,
   WebSearchProvider,
   WebSearchResponse,
+  BrowserState,
+  BrowserViewRect,
 } from '@maka/core';
 import type {
   PricingConfig,
@@ -740,6 +742,51 @@ contextBridge.exposeInMainWorld('maka', {
       | { ok: false; reason: 'invalid_id' | 'missing' | 'blocked_path' | 'not_file' | 'not_directory' | 'open_failed' }
     > {
       return ipcRenderer.invoke('skills:open', id, target);
+    },
+  },
+  // Embedded browser (P3). The native WebContentsView floats above the DOM; the
+  // renderer panel only mirrors its strip's rect and drives navigation. No
+  // automation endpoint/secret is ever exposed here — that stays main-internal.
+  browser: {
+    /** Tell main which conversation this window shows, so it can validate targets. */
+    setActiveSession(sessionId: string | null): void {
+      ipcRenderer.send('browser:active-session', sessionId);
+    },
+    /** Mirror the panel strip's on-screen rect (null hides the native view). */
+    setViewport(input: { sessionId: string; rect: BrowserViewRect | null }): void {
+      ipcRenderer.send('browser:setViewport', input);
+    },
+    navigate(sessionId: string, url: string): Promise<void> {
+      return ipcRenderer.invoke('browser:navigate', sessionId, url);
+    },
+    back(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('browser:back', sessionId);
+    },
+    forward(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('browser:forward', sessionId);
+    },
+    reload(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('browser:reload', sessionId);
+    },
+    stop(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('browser:stop', sessionId);
+    },
+    close(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('browser:close-page', sessionId);
+    },
+    getState(sessionId: string): Promise<BrowserState | null> {
+      return ipcRenderer.invoke('browser:get-state', sessionId);
+    },
+    onState(handler: (payload: { sessionId: string; state: BrowserState }) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { sessionId: string; state: BrowserState }) =>
+        handler(payload);
+      ipcRenderer.on('browser:state', listener);
+      return () => ipcRenderer.off('browser:state', listener);
+    },
+    onLive(handler: (payload: { sessionIds: string[] }) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { sessionIds: string[] }) => handler(payload);
+      ipcRenderer.on('browser:live', listener);
+      return () => ipcRenderer.off('browser:live', listener);
     },
   },
 });

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -1,0 +1,175 @@
+/**
+ * BrowserPanel (P3) — the renderer half of the embedded browser's right-side
+ * panel.
+ *
+ * The browser itself is a native Electron WebContentsView that floats ABOVE the
+ * renderer DOM (not a React child), so this component does not render the page.
+ * It draws the chrome (address bar + nav controls) and reserves a strip, then
+ * mirrors that strip's on-screen rect to main, which positions the native view
+ * to match. When the strip is hidden (a modal is open), the panel unmounts, or
+ * no page is loaded yet, it hands main a null rect so the native layer hides and
+ * either a centered dialog or the DOM empty state shows through.
+ *
+ * It mounts only for sessions with a live view (see browser:live), so an
+ * ordinary chat reserves no space.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, RotateCw, X } from 'lucide-react';
+import type { BrowserState } from '@maka/core';
+
+const EMPTY_STATE: BrowserState = {
+  url: '',
+  title: '',
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  favicon: null,
+  secure: false,
+  hasPage: false,
+};
+
+export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
+  const { sessionId, hidden } = props;
+  const stripRef = useRef<HTMLDivElement>(null);
+  const [state, setState] = useState<BrowserState>(EMPTY_STATE);
+  // The address input is editable; it only snaps to the live URL when the user
+  // is not mid-edit (tracked by focus) so typing is never clobbered by a
+  // did-navigate state push.
+  const [address, setAddress] = useState('');
+  const editingRef = useRef(false);
+
+  // Subscribe to this session's state pushes + seed the initial state.
+  useEffect(() => {
+    let alive = true;
+    const apply = (next: BrowserState) => {
+      if (!alive) return;
+      setState(next);
+      if (!editingRef.current) setAddress(next.url);
+    };
+    void window.maka.browser.getState(sessionId).then((s) => apply(s ?? EMPTY_STATE));
+    const off = window.maka.browser.onState((payload) => {
+      if (payload.sessionId === sessionId) apply(payload.state);
+    });
+    return () => {
+      alive = false;
+      off();
+    };
+  }, [sessionId]);
+
+  // Mirror the strip's on-screen rect to main every animation frame while it is
+  // showable. Position shifts on window resize and sidebar drags even when the
+  // size is unchanged, which a ResizeObserver would miss; a getBoundingClientRect
+  // per frame is negligible and the IPC only fires when the rect changes.
+  const showView = !hidden && state.hasPage;
+  useEffect(() => {
+    if (!showView) {
+      window.maka.browser.setViewport({ sessionId, rect: null });
+      return;
+    }
+    const el = stripRef.current;
+    if (!el) return;
+    let raf = 0;
+    let last = '';
+    const tick = () => {
+      const r = el.getBoundingClientRect();
+      const rect = {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      };
+      const key = `${rect.x},${rect.y},${rect.width},${rect.height}`;
+      if (key !== last) {
+        last = key;
+        window.maka.browser.setViewport({ sessionId, rect });
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.maka.browser.setViewport({ sessionId, rect: null });
+    };
+  }, [sessionId, showView]);
+
+  const go = useCallback(() => {
+    const url = address.trim();
+    if (!url) return;
+    // Bare hostnames get https://; anything already schemed passes through and
+    // main rejects non-web schemes.
+    const full = /^[a-z]+:\/\//i.test(url) ? url : `https://${url}`;
+    void window.maka.browser.navigate(sessionId, full);
+  }, [address, sessionId]);
+
+  return (
+    <div className="maka-browser-panel" aria-label="嵌入式浏览器">
+      <div className="maka-browser-toolbar">
+        <button
+          type="button"
+          className="maka-browser-navbtn"
+          title="后退"
+          disabled={!state.canGoBack}
+          onClick={() => void window.maka.browser.back(sessionId)}
+        >
+          <ChevronLeft size={16} aria-hidden />
+        </button>
+        <button
+          type="button"
+          className="maka-browser-navbtn"
+          title="前进"
+          disabled={!state.canGoForward}
+          onClick={() => void window.maka.browser.forward(sessionId)}
+        >
+          <ChevronRight size={16} aria-hidden />
+        </button>
+        <button
+          type="button"
+          className="maka-browser-navbtn"
+          title={state.loading ? '停止' : '刷新'}
+          onClick={() =>
+            state.loading ? void window.maka.browser.stop(sessionId) : void window.maka.browser.reload(sessionId)
+          }
+        >
+          {state.loading ? <X size={16} aria-hidden /> : <RotateCw size={16} aria-hidden />}
+        </button>
+        <input
+          className="maka-browser-address"
+          type="text"
+          spellCheck={false}
+          placeholder="输入网址并回车"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          onFocus={() => {
+            editingRef.current = true;
+          }}
+          onBlur={() => {
+            editingRef.current = false;
+            setAddress(state.url);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.currentTarget.blur();
+              go();
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="maka-browser-navbtn"
+          title="关闭页面"
+          onClick={() => void window.maka.browser.close(sessionId)}
+        >
+          <X size={16} aria-hidden />
+        </button>
+      </div>
+      <div className="maka-browser-strip" ref={stripRef}>
+        {!state.hasPage && (
+          <div className="maka-browser-empty">
+            <p>嵌入式浏览器</p>
+            <p className="maka-browser-empty-hint">输入网址打开页面，或让助手帮你导航并操作。</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -70,6 +70,7 @@ import {
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import { ProviderLogo } from './settings/ProvidersPanel';
 import { ArtifactPane } from './artifact-pane';
+import { BrowserPanel } from './browser-panel';
 import { deriveChatHeaderAlert } from './chat-header-alert';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveSessionStatusGroups } from './session-status-grouping';
@@ -252,6 +253,9 @@ function AppShell() {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const sessionsRef = useRef<SessionSummary[]>([]);
   const [activeId, setActiveIdState] = useState<string | undefined>();
+  // P3: session ids with a live embedded-browser view. The right-side
+  // BrowserPanel mounts only for these, so ordinary chats reserve no space.
+  const [liveBrowserSessionIds, setLiveBrowserSessionIds] = useState<string[]>([]);
   const [navSelection, setNavSelection] = useState<NavSelection>(() => readNavSelection());
   const navSelectionRef = useRef<NavSelection>(navSelection);
   const [messages, setMessages] = useState<StoredMessage[]>([]);
@@ -891,6 +895,17 @@ function AppShell() {
 
   useEffect(() => {
     activeIdRef.current = activeId;
+  }, [activeId]);
+
+  // P3 embedded browser: track which sessions have a live view (panel mounts
+  // only for those) and tell main which session this window shows (so it can
+  // validate browser:* IPC targets).
+  useEffect(() => {
+    const off = window.maka.browser.onLive((payload) => setLiveBrowserSessionIds(payload.sessionIds));
+    return off;
+  }, []);
+  useEffect(() => {
+    window.maka.browser.setActiveSession(activeId ?? null);
   }, [activeId]);
 
   useEffect(() => {
@@ -2842,6 +2857,9 @@ function AppShell() {
                 onImportFolderOutline={importFolderOutlineIntoComposer}
               />
             </div>
+            {activeId && liveBrowserSessionIds.includes(activeId) && (
+              <BrowserPanel sessionId={activeId} hidden={hasModalOpen} />
+            )}
             <ArtifactPane sessionId={activeId} />
           </div>
           </MakaUriContext.Provider>

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1811,6 +1811,7 @@
   .maka-reason-text[data-reason="git_destructive"]  { color: var(--destructive-text); font-weight: 500; }
   .maka-reason-text[data-reason="privileged"]       { color: var(--destructive-text); font-weight: 500; }
   .maka-reason-text[data-reason="network"]          { color: var(--info-text); }
+  .maka-reason-text[data-reason="browser"]          { color: var(--info-text); }
   .maka-reason-text[data-reason="custom"]           { color: var(--foreground-70); }
 
   /* ---- Code blocks (used in args preview inside permission dialog) --- */

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2813,6 +2813,8 @@ button:active {
   -webkit-app-region: no-drag;
   margin-right: 6px;
   margin-bottom: 9px;
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 .maka-chat-header-memory-pill:hover {
@@ -2839,6 +2841,7 @@ button:active {
   margin-right: 6px;
   margin-bottom: 9px;
   white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 .maka-chat-header-mode-pill svg {
@@ -2924,6 +2927,7 @@ button:active {
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
+  flex: 0 0 auto;
   -webkit-app-region: no-drag;
   cursor: pointer;
   transition: transform 0.12s var(--ease-out-strong);
@@ -2967,6 +2971,10 @@ button:active {
   line-height: 1.4;
   margin-right: 6px;
   -webkit-app-region: no-drag;
+  /* Short status label (运行中 etc.): keep on one line and never let the
+     tight header (browser panel open) collapse it into vertical text. */
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 .maka-chat-header-status[data-tone="accent"] {
   background: oklch(from var(--accent) l c h / 0.14);
@@ -3009,6 +3017,10 @@ button:active {
   background: var(--foreground-5);
   border: 1px solid var(--border);
   -webkit-app-region: no-drag;
+  /* Keep the pill at its intrinsic width when the header is tight (e.g. the
+     browser panel narrows the chat column). The flexible tab title absorbs the
+     squeeze and truncates; the mode labels never collapse into vertical text. */
+  flex: 0 0 auto;
 }
 
 .maka-mode-switcher[data-disabled] {
@@ -3027,6 +3039,7 @@ button:active {
   padding: 3px 11px;
   font-size: 12px;
   font-weight: 500;
+  white-space: nowrap;
   transition: background 140ms ease, color 140ms ease;
 }
 
@@ -8511,6 +8524,91 @@ button:active {
 .maka-detail-with-artifacts > .mainColumn {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+/* P3 BrowserPanel — a right-side split: a chrome toolbar (address bar + nav)
+   over a strip the native WebContentsView floats above. The strip itself is
+   empty by design (the native layer paints there); only the empty state shows
+   when no page is loaded. */
+.maka-browser-panel {
+  flex: 0 0 auto;
+  width: 520px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--background);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.maka-browser-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.maka-browser-navbtn {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.maka-browser-navbtn:hover:not(:disabled) {
+  background: var(--surface-hover, rgba(127, 127, 127, 0.12));
+}
+
+.maka-browser-navbtn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.maka-browser-address {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: var(--surface, var(--background));
+  color: var(--text);
+  font-size: 12px;
+}
+
+.maka-browser-strip {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.maka-browser-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  text-align: center;
+  padding: 24px;
+  color: var(--text-muted, #888);
+}
+
+.maka-browser-empty-hint {
+  font-size: 12px;
+  max-width: 280px;
 }
 
 .maka-artifact-pane {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
+        "@jackwener/opencli": "1.8.4",
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0",
@@ -34,11 +35,13 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "vite": "^7.2.7"
+        "vite": "^7.2.7",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
-        "@types/react-dom": "^19.2.3"
+        "@types/react-dom": "^19.2.3",
+        "@types/ws": "^8.18.1"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -412,6 +415,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@electron/get": {
@@ -869,6 +882,29 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@jackwener/opencli": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@jackwener/opencli/-/opencli-1.8.4.tgz",
+      "integrity": "sha512-T/1uwMtNVOqFu2fp3HBW5dKlt84uaTg6gaiFuRq9JLLr/z/NcSsOwdB1e4VqKVAcA1d9Zsp8QmH+xMLWxwqypA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mozilla/readability": "^0.6.0",
+        "cli-table3": "^0.6.5",
+        "commander": "^14.0.3",
+        "js-yaml": "^4.1.0",
+        "turndown": "^7.2.2",
+        "turndown-plugin-gfm": "^1.0.2",
+        "undici": "^6.25.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "opencli": "dist/src/main.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -933,6 +969,21 @@
     "node_modules/@maka/ui": {
       "resolved": "packages/ui",
       "link": true
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -1463,6 +1514,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -1549,6 +1610,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -1728,6 +1795,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -1777,6 +1859,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/convert-source-map": {
@@ -2532,6 +2623,28 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -4258,6 +4371,25 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -4567,6 +4699,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/packages/core/src/__tests__/permission.test.ts
+++ b/packages/core/src/__tests__/permission.test.ts
@@ -274,6 +274,33 @@ describe('preToolUse — turnRemembered', () => {
   });
 });
 
+describe('preToolUse — browser permission contract', () => {
+  test('a browser prompt carries the browser-specific reason (not custom)', () => {
+    const r = evaluate('browser_click', { ref: '[12]' }, 'ask', [], 'browser');
+    expect(r.needsPrompt).toBe(true);
+    expect(r.category).toBe('browser');
+    expect(r.partialRequest?.reason).toBe('browser');
+  });
+
+  test('browser scope is one turn-wide key, shared across every browser_* tool + args', () => {
+    // The whole observe→act loop collapses to a single scope key — unlike
+    // file_write above, which scopes per path.
+    expect(permissionScopeKey('browser_click', { ref: '[12]' }, 'browser')).toBe('browser');
+    expect(permissionScopeKey('browser_type', { ref: '[3]', text: 'hi' }, 'browser')).toBe('browser');
+    expect(permissionScopeKey('browser_navigate', { url: 'https://x.com' }, 'browser')).toBe('browser');
+  });
+
+  test('"allow for this turn" on one browser action carries the rest of the loop', () => {
+    const remembered = [permissionScopeKey('browser_navigate', { url: 'https://x.com' }, 'browser')];
+    // A different browser tool, different args → allowed without re-prompting.
+    const click = evaluate('browser_click', { ref: '[99]' }, 'execute', remembered, 'browser');
+    expect(click.proceed).toBe(true);
+    expect(click.needsPrompt).toBe(false);
+    const type = evaluate('browser_type', { ref: '[2]', text: 'x' }, 'ask', remembered, 'browser');
+    expect(type.proceed).toBe(true);
+  });
+});
+
 describe('PERMISSION_POLICY matrix invariants', () => {
   const categories: ToolCategory[] = [
     'read',
@@ -285,6 +312,7 @@ describe('PERMISSION_POLICY matrix invariants', () => {
     'git_destructive',
     'network_send',
     'privileged',
+    'browser',
     'custom_tool',
     'subagent',
   ];
@@ -308,6 +336,13 @@ describe('PERMISSION_POLICY matrix invariants', () => {
 
   test('execute mode never blocks privileged — always prompts', () => {
     expect(PERMISSION_POLICY.execute.privileged).toBe('prompt');
+  });
+
+  test('browser is prompt-on-effect: blocked in explore, prompts in ask AND execute (never auto-allowed)', () => {
+    expect(PERMISSION_POLICY.explore.browser).toBe('block');
+    expect(PERMISSION_POLICY.ask.browser).toBe('prompt');
+    // The key contrast with network_send: not silently allowed in execute.
+    expect(PERMISSION_POLICY.execute.browser).toBe('prompt');
   });
 
   test('explore mode allows local reads + safe shell (web_read prompts post PR-AGENT-WEB-SEARCH-TOOL-0)', () => {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared embedded-browser types crossing the main ↔ preload ↔ renderer
+ * boundary (window.maka.browser). The main-process logic that derives these
+ * lives in apps/desktop/src/main/browser/logic.ts.
+ */
+
+/** Renderer-facing snapshot of one conversation's embedded browser. */
+export interface BrowserState {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  loading: boolean;
+  favicon: string | null;
+  /** https origin. */
+  secure: boolean;
+  /** A real page is loaded (not blank / about:) — gates the DOM empty state. */
+  hasPage: boolean;
+}
+
+/** Where the embedded view sits, in renderer CSS px (1:1 with the window's content DIP). */
+export interface BrowserViewRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -282,6 +282,7 @@ export interface PermissionRequestEvent extends BaseEvent {
     | 'network'
     | 'git_destructive'
     | 'privileged'
+    | 'browser'
     | 'custom';
   args: unknown;
   hint?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,6 +115,9 @@ export type {
 } from './agent-run.js';
 export { AGENT_RUN_STATUSES } from './agent-run.js';
 
+// browser.ts
+export type { BrowserState, BrowserViewRect } from './browser.js';
+
 // session-event-health.ts
 export type {
   SessionEventStreamSnapshot,

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -32,6 +32,7 @@ export type ToolCategory =
   | 'git_destructive' //   git reset --hard, push --force, branch -D, ...
   | 'network_send' //      POST / PUT / DELETE
   | 'privileged' //        sudo, chmod, chown, kill, systemctl
+  | 'browser' //           embedded-browser observe→act on the user's logged-in sessions
   | 'custom_tool' //       our own session-scoped tools without a stricter category hint
   | 'subagent'; //         read-only delegated exploration tools
 
@@ -45,6 +46,7 @@ export const TOOL_CATEGORIES: readonly ToolCategory[] = [
   'git_destructive',
   'network_send',
   'privileged',
+  'browser',
   'custom_tool',
   'subagent',
 ];
@@ -74,6 +76,9 @@ export const PERMISSION_POLICY: Record<PermissionMode, Record<ToolCategory, Poli
     git_destructive: 'block',
     network_send: 'block',
     privileged: 'block',
+    // Driving the user's logged-in browser is an out-of-process effect; explore
+    // mode is read-only-local, so block it like other network/write effects.
+    browser: 'block',
     custom_tool: 'prompt',
     subagent: 'allow',
   },
@@ -87,6 +92,7 @@ export const PERMISSION_POLICY: Record<PermissionMode, Record<ToolCategory, Poli
     git_destructive: 'prompt',
     network_send: 'prompt',
     privileged: 'prompt',
+    browser: 'prompt',
     custom_tool: 'allow',
     subagent: 'prompt',
   },
@@ -103,6 +109,11 @@ export const PERMISSION_POLICY: Record<PermissionMode, Record<ToolCategory, Poli
     fs_destructive: 'prompt',
     git_destructive: 'prompt',
     privileged: 'prompt',
+    // Browser act/observe drives the user's logged-in sessions — effectively
+    // irreversible (it can post, send, buy). Prompt even in execute so the
+    // visible view stays a confirmed safety net, not a default-allow. The
+    // user's "allow for this turn" then carries the observe→act loop.
+    browser: 'prompt',
   },
 };
 
@@ -297,6 +308,13 @@ export function preToolUse(input: PreToolUseInput): PreToolUseResult {
 }
 
 export function permissionScopeKey(toolName: string, args: unknown, category: ToolCategory): string {
+  // Browser actions share ONE turn-scope across every browser_* tool and its
+  // args: "allow for this turn" on the first prompt then carries the whole
+  // observe→act loop (snapshot → click → type → navigate …), as the policy
+  // comment promises. The visible-conversation lease — not per-call prompts —
+  // is the safety net for which page is driven. Other categories stay scoped
+  // to the specific tool + args below.
+  if (category === 'browser') return 'browser';
   switch (toolName) {
     case 'Write':
     case 'Edit':
@@ -356,6 +374,8 @@ function categoryToReason(c: ToolCategory): PermissionRequest['reason'] {
       return 'git_destructive';
     case 'privileged':
       return 'privileged';
+    case 'browser':
+      return 'browser';
     default:
       return 'custom';
   }
@@ -377,6 +397,7 @@ export interface PermissionRequest {
     | 'network'
     | 'git_destructive'
     | 'privileged'
+    | 'browser'
     | 'custom';
   args: unknown;
   hint?: string;

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -20,6 +20,7 @@ import {
   FolderOpen,
   GitBranch,
   GitMerge,
+  Globe,
   HelpCircle,
   Hourglass,
   Loader2,
@@ -6086,6 +6087,7 @@ const REASON_PRESETS: Record<ReasonKind, ReasonPreset> = {
   git_destructive: { label: '不可恢复的 Git 操作', Icon: GitMerge, tone: 'destructive' },
   network: { label: '对外网络请求', Icon: Wifi, tone: 'info' },
   privileged: { label: '特权操作 (sudo / su)', Icon: ShieldAlert, tone: 'destructive' },
+  browser: { label: '读取和操作你登录的浏览器会话 · 请确认', Icon: Globe, tone: 'caution' },
   custom: { label: '自定义请求', Icon: HelpCircle, tone: 'info' },
 };
 
@@ -6206,6 +6208,11 @@ export function PermissionDialog(props: {
             />
             本轮对话内记住选择（同类型工具不再询问，关闭/切换对话后失效）
           </label>
+          {props.request.reason === 'browser' && rememberForTurn && (
+            <p className="maka-permission-hint" role="note">
+              勾选后，本轮接下来的浏览、读取页面、导航、点击、输入都不再逐次询问。你会全程看到它操作的页面，随时可以停止；本轮结束后授权失效。
+            </p>
+          )}
           {isDestructive && (
             <p className="maka-permission-danger-note" role="note">
               这类操作不可恢复，确认前请再读一遍上面的参数。
@@ -6235,6 +6242,33 @@ export function PermissionDialog(props: {
 }
 
 /**
+ * One-line summary for a browser_* action. Names the concrete action (open /
+ * read / click / type) so the prompt reads as a real browser step, not an opaque
+ * tool call — reinforcing that a browser grant spans reads AND acts. The typed
+ * text and full args stay in the raw `<details>` block below.
+ */
+function renderBrowserSummary(toolName: string, args: Record<string, unknown>): ReactNode {
+  const ref = typeof args.ref === 'string' ? args.ref : '';
+  const url = typeof args.url === 'string' ? args.url : '';
+  const selector = typeof args.selector === 'string' ? args.selector : '';
+  const line =
+    toolName === 'browser_navigate'
+      ? `即将在浏览器中打开 ${url || '一个网址'}`
+      : toolName === 'browser_click'
+        ? `即将在当前页面点击元素 ${ref}`.trim()
+        : toolName === 'browser_type'
+          ? `即将在当前页面输入文本${ref ? ` 到元素 ${ref}` : ''}`
+          : toolName === 'browser_snapshot'
+            ? '即将读取当前页面的可交互元素列表'
+            : toolName === 'browser_extract'
+              ? `即将读取当前页面内容${selector ? `（${selector}）` : ''}`
+              : toolName === 'browser_wait'
+                ? '即将等待当前页面满足某个条件'
+                : '即将操作当前浏览器页面';
+  return <p className="maka-permission-line">{line}</p>;
+}
+
+/**
  * Per-tool human-readable summary of what the request will do, used at the
  * top of the permission dialog body. Falls back to undefined if we can't
  * recognize the tool — the raw args `<details>` block is always available.
@@ -6242,6 +6276,13 @@ export function PermissionDialog(props: {
 function renderPermissionSummary(request: PermissionRequestEvent): ReactNode | undefined {
   const args = (request.args ?? {}) as Record<string, unknown>;
   switch (request.toolName) {
+    case 'browser_navigate':
+    case 'browser_snapshot':
+    case 'browser_click':
+    case 'browser_type':
+    case 'browser_wait':
+    case 'browser_extract':
+      return renderBrowserSummary(request.toolName, args);
     case 'Bash': {
       const command = typeof args.command === 'string' ? args.command : undefined;
       if (!command) return undefined;


### PR DESCRIPTION
## Summary

Embedded browser automation for the desktop agent — ported from PawWork's opencli CDP + numbered-ref observe→act approach. The agent drives a real, per-conversation Chromium view through 6 generic tools, and the page renders live in a right-side panel.

- **Sealed CDP bridge** (`cdp-bridge.ts`): wraps `webContents.debugger` behind a loopback WebSocket (`ws://127.0.0.1:<random-port>/<secret>`, secret kept in main-process memory only). opencli's `CDPBridge` client connects to it; its stealth script auto-registers on connect and applies to future documents.
- **6 generic observe→act tools** (registered unconditionally, no flag): `browser_navigate / snapshot / click / type / wait / extract`. Loop: numbered `[ref]` snapshot (observe) → act by ref (click/type).
- **Per-conversation views**: each conversation owns a `WebContentsView` child of the main window — lazily created, stacked, all hidden except the shown one. Views are in-memory (ephemeral across app restart, by design); a shared persistent partition (`persist:maka-browser`) keeps cookies/login on disk so a login in one conversation is available to all and survives restart.
- **Dedicated `browser` permission category** — prompt-on-effect: blocked in explore, prompts in ask *and* execute (browser effects are treated as irreversible, not auto-allowed like read tools). Takeover-reload is deferred to first effect: observe never reloads, the first mutate reloads once to apply stealth to an already-open page, navigate clears without reloading.
- **Visible-conversation lease**: the agent touches the browser only for the conversation currently on screen. EVERY action — `snapshot` / `extract` / `wait` (read), `navigate`, `click` / `type` (act) — is rejected when the calling conversation is backgrounded, so a background conversation can't even read a logged-in page the user can't see; a mutate additionally requires a real, non-empty on-screen viewport (opencli's native CDP click hit-tests a composited frame a hidden view lacks). The check runs before the view/connection is acquired, so a vetoed background action creates neither. The lease is **continuous, not just a preflight**: an action already running when the user switches away is revoked and its connection severed, so a long `wait`/`navigate`/`extract`/delayed mutate can never keep reading or driving a now-hidden page. Because the permission modal hides the native view while it is open, a mutate on the on-screen conversation whose viewport is momentarily absent (the modal just closed) waits briefly for the renderer to restore the strip rather than rejecting — so the first approved click/type lands without a retry. The user always sees the page the agent is acting on — the visible view plus the per-turn permission prompt is the safety net, now enforced rather than assumed.
- **Renderer panel** (`browser-panel.tsx`): address bar + nav controls (lucide icons, matching the app's icon set). The panel reserves a strip and mirrors its on-screen rect to main each animation frame, so the native view tracks the strip on resize / sidebar drags. The page is a native view floating above the DOM, not a React child.

## Deliberate scope

- Browser views are **ephemeral across app restart** (login persists, the live page does not) — the simplest split; the agent re-opens on demand. Persisting the live URL across restarts was intentionally skipped.
- **Multi-session parallel browsing is out of scope for now (YAGNI), tracked as a follow-up.** The browser is single-window: one view is drawn at a time, and the visible-lease rejects mutations on an off-screen conversation. The blocker is the presentation layer, not state management — the runtime already runs sessions concurrently (`SessionManager` keys active sessions by id) and each conversation already owns its own view + CDP connection + history. A hidden embedded `WebContentsView` simply can't be driven for clicks: tested directly, a non-displayed view still does snapshot / type / navigate, but a native click silently no-ops because it never composites a frame to hit-test — true even with PawWork's exact 1280×720 default bound, parented or not. PawWork (where this was ported from) gets parallelism by being multi-window (each conversation's view displayed in its own visible window), not by hidden rendering. A follow-up would pick a presentation change — multi-window (à la PawWork), single-window split-pane, or offscreen rendering — and the current lease is just the single-window special case of "a view must be displayed somewhere to be driven", which generalizes when that lands.
- **No "open browser from UI" button** yet — the only cold entry is the agent (a `navigate` creates the conversation's panel). The address bar handles manual navigation once a page is open, but it lives inside the panel, which mounts only for a live view — so it is not itself a cold-start entry. A small open-browser affordance is deferred to a follow-up PR.
- **No `browser_screenshot`** yet — the app feeds no images to the model at all (attachments are stringified into the prompt), so a screenshot tool would only ever return a byte count the model can't use. Deferred to the phase-2 multimodal PR, which adds image-to-model support and rebuilds the tool against it.
- **Cut after review.** Two independent reviewers (Codex + a fresh-eye pass, Occam's-razor focus) drove a cleanup commit that removed the dead tool/host surface: the screenshot stub, speculative `snapshot` knobs, a duplicated URL validator, an unwired probe abstraction, and a few zero-caller exports (−157 lines, no capability lost).
- **Hardened after a second review round.** Added the visible-conversation lease above — the safety gap the review flagged (the agent could otherwise act on a hidden, backgrounded view). Plus two small fixes: `viewportBounds` now rejects non-finite rects from the untyped IPC boundary before they reach `setBounds`, and the shared-partition security backstop (`will-download` + permission handlers) installs once per session instead of once per view (no listener pile-up across conversations).
- **Tightened after a third review round.** The browser permission is now a single explicit contract: `browser` gets its own prompt reason (the dialog names the logged-in session it drives, not a generic “custom” request) and one turn-wide permission scope, so “allow for this turn” actually carries the whole observe→act loop instead of re-prompting on every ref. Plus: `browser_extract` recovers from an invalid CSS selector (a `[12]` ref a model echoes) as a clean “no match” instead of a raw DOMException, and `@jackwener/opencli` is pinned to exact `1.8.4` to match the contract test’s “pinned release” assertion.
- **Tightened after a fourth review round.** Two safety gaps closed by one model — *the agent touches the browser only for the conversation you're watching, and only after you approve it for the turn*: (1) the first approved click/type after a permission grant no longer loses the race against the renderer's viewport restore (the modal hides the native view; the mutate now waits briefly for the strip to come back rather than rejecting); (2) the visible lease now gates reads too, so a backgrounded conversation can't `snapshot`/`extract` a logged-in page off screen; and (3) the prompt is honest that one browser grant covers the whole turn's reads, navigation, clicks, and typing (rather than splitting into two prompts — the live visible view is the act-phase safety net).
- **Tightened after a fifth review round.** The whole-turn browser note no longer overstates: it renders only when "本轮记住" is checked (the runtime persists the grant only on `allow && rememberForTurn` — locked by the `rememberForTurn=false does NOT add to set` test), and it drops the inaccurate "switching conversations revokes the grant" line. `endTurn` fires on run completion/abort (closing a conversation aborts its turn), never on a plain switch — a switch just parks the action behind the visible lease and resumes it on return without re-asking. The note now states the grant expires when the turn ends.
- **Tightened after a sixth review round.** The visible lease is now CONTINUOUS, not a one-time preflight: `canDrive()` only gated the start, so a `browser_wait` / `navigate` / `extract` / delayed mutate that began while shown kept running after the user switched away. `withBrowserPage` registers each in-flight action; main's `browser:active-session` handler calls `revokeHiddenBrowserActions(shown)` on every switch, severing any action whose conversation just went off screen (same connection-sever path as a timeout/abort) and rejecting with a new `BrowserActionRevokedError` — so no tool result can carry hidden-page data. And background throttling is now scoped to shown-ness instead of held off for the whole cached connection's life: a hidden conversation's page throttles normally (no off-screen CPU drain), while a shown view stays full-speed so native CDP clicks composite (deleting the override outright was tried and rejected — the smoke proves it's load-bearing for clicks on any view the OS backgrounds, e.g. the app being unfocused). Covered by two new session unit tests + three new smoke checks (live-bridge revoke, both throttle transitions); smoke now 19/19.
- Chat-header badges were hardened so the narrower chat column (browser panel open) no longer collapses short status pills (e.g. 运行中) into vertical text; only the tab title and model label absorb the squeeze.

## Verification

Freshly re-run on this branch:

- `npm run typecheck` — clean across core / storage / runtime / ui / desktop.
- Unit tests:
  - core **618 pass / 0 fail**
  - storage **76 pass / 0 fail**
  - desktop **1469 pass / 0 fail**
  - runtime **396 pass / 1 fail** — pre-existing & environment-dependent, not from this PR (which touches **no** runtime/network code). The failing test `network/proxy-test` "times out when the proxy accepts TCP but never responds" asserts the error text matches `/timeout/i`, but in this sandbox `fetch` to the target returns "fetch failed" before the 100 ms timeout fires — a machine-dependence the test's own comment calls out.

Validated on this branch (CDP path unchanged by the later UI commits):

- `npm run smoke:browser` — **19/19**: real Electron observe→act E2E (sealed ws bridge ↔ `webContents.debugger` ↔ opencli ↔ live DOM): goto → numbered snapshot → fill-by-ref → click-by-ref → DOM-effect verify → markdown extract, plus a check that the partition security backstop installs once across views, plus the visible-lease driven through the real host/manager/`BrowserSession` end to end (background-conversation read/navigate/mutate all rejected with no view or connection created; a mutate on the shown conversation waits out a modal-close viewport restore and lands; click/type land once the conversation is shown with a viewport). New this round: an in-flight read is **revoked against the live bridge** when its conversation goes off screen, and a shown view runs un-throttled while **hiding it restores background throttling**.
- Manual GUI smoke on real sites: panel render, address bar + nav, agent observe→act, permission prompts (explore/ask/execute), per-conversation view isolation, shared login partition, stealth probe, archive/quit teardown.
