### PR TITLE
Add request-shape prefix diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
@@ -47,11 +47,12 @@ describe('session environment prompt', () => {
     assert.doesNotMatch(prompt, /Git branch: .*\nmalicious/);
   });
 
-  it('is injected into the main system prompt path before tool-specific context', async () => {
+  it('is injected as a current-turn tail instead of durable system prefix', async () => {
     const source = await readFile(join(process.cwd(), 'src/main/main.ts'), 'utf8');
 
-    assert.match(source, /buildSessionEnvironmentPromptFragment\(\{/);
+    assert.match(source, /turnTailPrompt:\s*\(\{ cwd \}\) => buildTurnTailPrompt\(cwd\)/);
+    assert.match(source, /async function buildTurnTailPrompt\(cwd\?: string\)/);
     assert.match(source, /projectGit:\s*await resolveProjectGitInfo\(cwd\)/);
-    assert.match(source, /personalization\.text,\n\s*environment,\n\s*deepResearch/);
+    assert.doesNotMatch(source, /personalization\.text,\n\s*environment,\n\s*deepResearch/);
   });
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -736,6 +736,7 @@ backends.register('ai-sdk', async (ctx) => {
     tools: builtinTools,
     providerOptions: buildProviderOptions(connection, model),
     systemPrompt: ({ cwd }) => buildSystemPrompt(ctx.header, cwd),
+    turnTailPrompt: ({ cwd }) => buildTurnTailPrompt(cwd),
     recordLlmCall: (event) => recordLlmCall({ repo: telemetryRepo, lookupPricing }, event),
     recordToolInvocation: (event) =>
       recordToolInvocation(
@@ -3287,12 +3288,6 @@ async function handleQuickChatStart(rawInput: unknown): Promise<QuickChatResult>
 async function buildSystemPrompt(header: Pick<SessionHeader, 'labels'>, cwd?: string): Promise<string | undefined> {
   const settings = await settingsStore.get();
   const personalization = buildPersonalizationPromptFragment(settings.personalization);
-  const environment = cwd
-    ? buildSessionEnvironmentPromptFragment({
-        cwd,
-        projectGit: await resolveProjectGitInfo(cwd),
-      })
-    : undefined;
   const skills = await buildSkillsPromptFragment(workspaceRoot);
   const workspaceInstructions = settings.workspaceInstructions.enabled && cwd
     ? await buildWorkspaceInstructionsPromptFragment(cwd)
@@ -3312,7 +3307,6 @@ async function buildSystemPrompt(header: Pick<SessionHeader, 'labels'>, cwd?: st
   const memoryFragment = await buildLocalMemoryPromptFragment();
   const fragments = [
     personalization.text,
-    environment,
     deepResearch,
     botPlatformHint,
     skills,
@@ -3320,6 +3314,14 @@ async function buildSystemPrompt(header: Pick<SessionHeader, 'labels'>, cwd?: st
     memoryFragment,
   ].filter((fragment): fragment is string => Boolean(fragment));
   return fragments.length > 0 ? fragments.join('\n\n') : undefined;
+}
+
+async function buildTurnTailPrompt(cwd?: string): Promise<string | undefined> {
+  if (!cwd) return undefined;
+  return buildSessionEnvironmentPromptFragment({
+    cwd,
+    projectGit: await resolveProjectGitInfo(cwd),
+  });
 }
 
 async function buildLocalMemoryPromptFragment(): Promise<string | undefined> {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -10,6 +10,7 @@
  */
 
 import type { PermissionRequest, PermissionResponse, ToolCategory } from './permission.js';
+import type { PrefixChangeReason } from './usage-stats/types.js';
 
 export const TOOL_OUTPUT_STREAMS = ['stdout', 'stderr'] as const;
 export const TOOL_OUTPUT_DELTA_MAX_CHARS = 8192;
@@ -332,6 +333,8 @@ export interface TokenUsageEvent extends BaseEvent {
   cacheCreation?: number;
   costUsd?: number;
   contextRemaining?: number;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
 }
 
 export interface ErrorEvent extends BaseEvent {

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -16,6 +16,7 @@
 
 import type { AttachmentRef } from './events.js';
 import type { PermissionRequest, PermissionResponse } from './permission.js';
+import type { PrefixChangeReason } from './usage-stats/types.js';
 
 // ============================================================================
 // Role / Author / Status
@@ -177,6 +178,8 @@ export interface RuntimeEventTokenUsage {
   cacheCreation?: number;
   costUsd?: number;
   contextRemaining?: number;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
 }
 
 /**

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -11,6 +11,7 @@
 
 import type { AttachmentRef, ToolResultContent } from './events.js';
 import type { PermissionMode } from './permission.js';
+import type { PrefixChangeReason } from './usage-stats/types.js';
 
 export const SESSION_STATUSES = [
   'active',
@@ -240,6 +241,8 @@ export interface TokenUsageMessage {
   /** Backward-compatible alias for cacheWriteInput. */
   cacheCreation?: number;
   costUsd?: number;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
 }
 
 export interface TurnStateMessage {

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -70,6 +70,8 @@ export interface UsageLogRow {
   errorClass?: string;
   sessionId?: string;
   turnId?: string;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
 }
 
 export interface PricingConfig {
@@ -113,7 +115,19 @@ export interface LlmCallRecord {
   status: 'success' | 'error' | 'aborted';
   errorClass?: string;
   startedAt: number;
+  prefixHash?: string;
+  prefixChangeReason?: PrefixChangeReason;
 }
+
+export type PrefixChangeReason =
+  | 'first_turn'
+  | 'system_prompt_changed'
+  | 'tool_schema_changed'
+  | 'provider_options_changed'
+  | 'model_or_provider_changed'
+  | 'history_projection_changed'
+  | 'stable'
+  | 'unknown';
 
 export interface ToolInvocationRecord {
   sessionId?: string;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -7,6 +7,7 @@ import type { SessionEvent } from '@maka/core/events';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { ToolResultMessage } from '@maka/core/session';
 import type { LlmCallRecord } from '@maka/core/usage-stats/types';
+import { z } from 'zod';
 import {
   AiSdkBackend,
   INVALID_TOOL_NAME,
@@ -19,6 +20,10 @@ import {
   type RunTraceEvent,
 } from '../ai-sdk-backend.js';
 import { PermissionEngine } from '../permission-engine.js';
+import {
+  canonicalizeToolSet,
+  computeRequestShapeDiagnostic,
+} from '../request-shape.js';
 
 describe('AiSdkBackend model history', () => {
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
@@ -641,6 +646,157 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(llmRecords[0]?.reasoningTokens, 2);
     assert.equal(llmRecords[0]?.totalTokens, 17);
     assert.equal(llmRecords[0]?.rawFinishReason, 'stop');
+  });
+});
+
+describe('AiSdkBackend request-shape diagnostics', () => {
+  test('identical request shape keeps the same hash and reports stable after first turn', () => {
+    const tools = canonicalizeToolSet([
+      testTool('Read', z.object({ path: z.string() })),
+      testTool('Bash', z.object({ command: z.string() })),
+    ], testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() })));
+    const first = computeRequestShapeDiagnostic({
+      connection: connection(),
+      modelId: 'mock-model-id',
+      systemPrompt: 'durable system',
+      providerOptions: { temperature: 0, nested: { b: 2, a: 1 } },
+      providerTools: tools.providerTools,
+      activeTools: tools.activeTools,
+      priorMessages: [{ role: 'user', content: 'hello' }],
+    }, undefined);
+    const second = computeRequestShapeDiagnostic({
+      connection: connection(),
+      modelId: 'mock-model-id',
+      systemPrompt: 'durable system',
+      providerOptions: { nested: { a: 1, b: 2 }, temperature: 0 },
+      providerTools: tools.providerTools,
+      activeTools: tools.activeTools,
+      priorMessages: [{ role: 'user', content: 'hello' }],
+    }, first);
+
+    assert.equal(first.prefixChangeReason, 'first_turn');
+    assert.equal(second.prefixChangeReason, 'stable');
+    assert.equal(second.prefixHash, first.prefixHash);
+  });
+
+  test('classifies targeted request-shape changes', () => {
+    const tools = canonicalizeToolSet([
+      testTool('Read', z.object({ path: z.string() })),
+    ], testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() })));
+    const baseInput = {
+      connection: connection(),
+      modelId: 'mock-model-id',
+      systemPrompt: 'durable system',
+      providerOptions: { temperature: 0 },
+      providerTools: tools.providerTools,
+      activeTools: tools.activeTools,
+      priorMessages: [{ role: 'user' as const, content: 'hello' }],
+    };
+    const base = computeRequestShapeDiagnostic(baseInput, undefined);
+
+    assert.equal(computeRequestShapeDiagnostic({
+      ...baseInput,
+      systemPrompt: 'changed system',
+    }, base).prefixChangeReason, 'system_prompt_changed');
+    assert.equal(computeRequestShapeDiagnostic({
+      ...baseInput,
+      providerTools: canonicalizeToolSet([
+        testTool('Read', z.object({ path: z.string(), offset: z.number().optional() })),
+      ], testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() }))).providerTools,
+    }, base).prefixChangeReason, 'tool_schema_changed');
+    assert.equal(computeRequestShapeDiagnostic({
+      ...baseInput,
+      providerOptions: { temperature: 1 },
+    }, base).prefixChangeReason, 'provider_options_changed');
+    assert.equal(computeRequestShapeDiagnostic({
+      ...baseInput,
+      modelId: 'other-model',
+    }, base).prefixChangeReason, 'model_or_provider_changed');
+    assert.equal(computeRequestShapeDiagnostic({
+      ...baseInput,
+      priorMessages: [{ role: 'assistant' as const, content: 'hello' }],
+    }, base).prefixChangeReason, 'history_projection_changed');
+  });
+
+  test('tool canonicalization is independent of registration order and places invalid last', () => {
+    const invalid = testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() }));
+    const first = canonicalizeToolSet([
+      testTool('Write', z.object({ path: z.string(), content: z.string() })),
+      testTool('Read', z.object({ path: z.string() })),
+    ], invalid);
+    const second = canonicalizeToolSet([
+      testTool('Read', z.object({ path: z.string() })),
+      testTool('Write', z.object({ content: z.string(), path: z.string() })),
+    ], invalid);
+
+    assert.deepEqual(first.activeTools, ['Read', 'Write']);
+    assert.deepEqual(first.providerTools.map((tool) => tool.name), ['Read', 'Write', INVALID_TOOL_NAME]);
+    assert.deepEqual(second.providerTools.map((tool) => tool.name), ['Read', 'Write', INVALID_TOOL_NAME]);
+    assert.equal(
+      computeRequestShapeDiagnostic({
+        connection: connection(),
+        modelId: 'mock-model-id',
+        providerTools: first.providerTools,
+        activeTools: first.activeTools,
+        priorMessages: [],
+      }, undefined).componentHashes.toolSchemaHash,
+      computeRequestShapeDiagnostic({
+        connection: connection(),
+        modelId: 'mock-model-id',
+        providerTools: second.providerTools,
+        activeTools: second.activeTools,
+        priorMessages: [],
+      }, undefined).componentHashes.toolSchemaHash,
+    );
+  });
+
+  test('volatile turn-tail facts do not churn the durable prefix hash', async () => {
+    const events: SessionEvent[] = [];
+    const llmRecords: LlmCallRecord[] = [];
+    const models: MockLanguageModelV3[] = [];
+    let date = '2026-05-29';
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => {
+        const model = completionModel();
+        models.push(model);
+        return model;
+      },
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      systemPrompt: 'durable system prompt',
+      turnTailPrompt: () => `Maka session environment:\n<env>\n  Today's date: ${date}\n</env>`,
+      recordLlmCall: (record) => {
+        llmRecords.push(record);
+      },
+    });
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+    date = '2026-05-30';
+    for await (const event of backend.send({ turnId: 'turn-2', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    const usageEvents = events.filter((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usageEvents[0]?.prefixChangeReason, 'first_turn');
+    assert.equal(usageEvents[1]?.prefixChangeReason, 'stable');
+    assert.equal(usageEvents[1]?.prefixHash, usageEvents[0]?.prefixHash);
+    assert.equal(llmRecords[1]?.prefixChangeReason, 'stable');
+    assert.match(JSON.stringify(compactPrompt(models[0]!)), /2026-05-29/);
+    assert.match(JSON.stringify(compactPrompt(models[1]!)), /2026-05-30/);
+    assert.equal(JSON.stringify(modelCallSettings(models[0]!)).includes('2026-05-29'), false);
+    assert.equal(JSON.stringify(modelCallSettings(models[1]!)).includes('2026-05-30'), false);
   });
 });
 
@@ -1685,6 +1841,23 @@ function compactPrompt(model: MockLanguageModelV3): unknown {
     role: message.role,
     content: message.content,
   }));
+}
+
+function modelCallSettings(model: MockLanguageModelV3): unknown {
+  const call = model.doStreamCalls[0] as unknown as Record<string, unknown> | undefined;
+  if (!call) return {};
+  const { prompt: _prompt, ...rest } = call;
+  return rest;
+}
+
+function testTool(name: string, parameters: unknown): MakaTool {
+  return {
+    name,
+    description: `${name} description`,
+    parameters,
+    permissionRequired: false,
+    impl: async () => ({ ok: true }),
+  };
 }
 
 async function drain(iterable: AsyncIterable<unknown>): Promise<void> {

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -118,8 +118,8 @@ describe('RunTrace extraction contract', () => {
     assert.match(backend, /private currentRunTrace: RunTrace \| null = null;/);
     assert.match(backend, /trace\.turnStarted\(\)/);
     assert.match(backend, /trace\.modelResolved\(\)/);
-    assert.match(backend, /trace\.modelStreamStarted\(activeTools\)/);
-    assert.match(backend, /trace\.usageRecorded\(tokenUsage\)/);
+    assert.match(backend, /trace\.modelStreamStarted\(activeTools, \{/);
+    assert.match(backend, /trace\.usageRecorded\(\{\n\s+\.\.\.tokenUsage,/);
     assert.match(backend, /this\.currentRunTrace\?\.abortRequested\(_reason\)/);
     assert.match(barrel, /RunTraceEvent/);
     assert.match(barrel, /RunTraceRecorder/);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -89,6 +89,11 @@ import {
   type RuntimeEventModelReplayPlan,
   type RuntimeEventReplayFallbackGate,
 } from './model-history.js';
+import {
+  canonicalizeToolSet,
+  computeRequestShapeDiagnostic,
+  type RequestShapeDiagnostic,
+} from './request-shape.js';
 
 export {
   DEFAULT_PERMISSION_TIMEOUT_MS,
@@ -168,6 +173,8 @@ export interface AiSdkBackendInput {
   permissionTimeoutMs?: number;
   /** Optional system prompt (skills + workspace AGENTS.md merged upstream). */
   systemPrompt?: string | ((context: SystemPromptContext) => string | undefined | Promise<string | undefined>);
+  /** Optional provider-visible current-turn tail kept out of the durable system prefix. */
+  turnTailPrompt?: string | ((context: SystemPromptContext) => string | undefined | Promise<string | undefined>);
   /** Provider-native options passed through to ai-sdk. */
   providerOptions?: Record<string, unknown>;
   /** Optional fire-and-forget telemetry hooks. Tool implementations remain unaware. */
@@ -213,6 +220,7 @@ export class AiSdkBackend implements AgentBackend {
   /** Paused while the backend is waiting on a user permission decision. */
   private currentWatchdog: StreamWatchdog | null = null;
   private currentRunTrace: RunTrace | null = null;
+  private priorRequestShape: RequestShapeDiagnostic | undefined;
 
   constructor(input: AiSdkBackendInput) {
     this.input = input;
@@ -269,6 +277,7 @@ export class AiSdkBackend implements AgentBackend {
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
     let rawFinishReason: string | undefined;
+    let requestShapeForTelemetry: RequestShapeDiagnostic | undefined;
     const trace = new RunTrace({
       sessionId: this.sessionId,
       turnId,
@@ -304,9 +313,9 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     // --- Build ai-sdk tools dict with permission-wrapped execute ---
+    const canonicalTools = canonicalizeToolSet(this.input.tools, buildInvalidMakaTool());
     const aiSdkTools: Record<string, unknown> = {};
-    const allTools = [...this.input.tools, buildInvalidMakaTool()];
-    for (const t of allTools) {
+    for (const t of canonicalTools.providerTools) {
       aiSdkTools[t.name] = {
         description: t.description,
         inputSchema: t.parameters,
@@ -316,11 +325,6 @@ export class AiSdkBackend implements AgentBackend {
 
     // --- Build messages from RuntimeEvent history and its compatibility projection. ---
     const priorReplay = this.buildPriorMessages(input);
-    const messages = priorReplay.messages;
-    messages.push({
-      role: 'user',
-      content: this.buildUserContent(input.text, input.attachments),
-    });
 
     // --- Background pump: streamText → fullStream → normalize → queue ---
     const pumpDone: Promise<void> = (async () => {
@@ -341,8 +345,31 @@ export class AiSdkBackend implements AgentBackend {
         });
         this.currentWatchdog = watchdog;
         watchdog.start();
-        const activeTools = this.input.tools.map((tool) => tool.name);
-        trace.modelStreamStarted(activeTools);
+        const activeTools = canonicalTools.activeTools;
+        const systemPrompt = await this.resolveSystemPrompt();
+        const turnTailPrompt = await this.resolveTurnTailPrompt();
+        const messages = [
+          ...priorReplay.messages,
+          {
+            role: 'user' as const,
+            content: this.buildUserContent(input.text, input.attachments, turnTailPrompt),
+          },
+        ];
+        const requestShape = computeRequestShapeDiagnostic({
+          connection: this.input.connection,
+          modelId: this.input.modelId,
+          systemPrompt,
+          providerOptions: this.input.providerOptions,
+          providerTools: canonicalTools.providerTools,
+          activeTools,
+          priorMessages: priorReplay.messages,
+        }, this.priorRequestShape);
+        requestShapeForTelemetry = requestShape;
+        this.priorRequestShape = requestShape;
+        trace.modelStreamStarted(activeTools, {
+          prefixHash: requestShape.prefixHash,
+          prefixChangeReason: requestShape.prefixChangeReason,
+        });
 
         const result = await this.modelAdapter.startStream({
           model,
@@ -354,11 +381,11 @@ export class AiSdkBackend implements AgentBackend {
           ) => {
             return repairMakaToolCall({
               toolCall,
-              availableToolNames: this.input.tools.map((tool) => tool.name),
+              availableToolNames: activeTools,
               error,
             });
           },
-          system: await this.resolveSystemPrompt(),
+          system: systemPrompt,
           abortSignal: this.abortController!.signal,
         });
 
@@ -429,7 +456,11 @@ export class AiSdkBackend implements AgentBackend {
         try {
           tokenUsage = normalizeAiSdkUsage(await result.usage, { rawFinishReason });
           if (tokenUsage) {
-            trace.usageRecorded(tokenUsage);
+            trace.usageRecorded({
+              ...tokenUsage,
+              prefixHash: requestShape.prefixHash,
+              prefixChangeReason: requestShape.prefixChangeReason,
+            });
             const tu: TokenUsageMessage = {
               type: 'token_usage',
               id: this.newId(),
@@ -445,6 +476,8 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
               ...(tokenUsage.cachedInputTokens > 0 ? { cacheRead: tokenUsage.cachedInputTokens } : {}),
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
+              prefixHash: requestShape.prefixHash,
+              prefixChangeReason: requestShape.prefixChangeReason,
             };
             await this.input.appendMessage(tu).catch(() => {});
             queue.push({
@@ -462,6 +495,8 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
               ...(tokenUsage.cachedInputTokens > 0 ? { cacheRead: tokenUsage.cachedInputTokens } : {}),
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
+              prefixHash: requestShape.prefixHash,
+              prefixChangeReason: requestShape.prefixChangeReason,
             } satisfies TokenUsageEvent);
           }
         } catch {
@@ -532,6 +567,10 @@ export class AiSdkBackend implements AgentBackend {
           status: streamStatus,
           ...(streamErrorClass ? { errorClass: streamErrorClass } : {}),
           startedAt,
+          ...(requestShapeForTelemetry !== undefined ? {
+            prefixHash: requestShapeForTelemetry.prefixHash,
+            prefixChangeReason: requestShapeForTelemetry.prefixChangeReason,
+          } : {}),
         });
         queue.close();
       }
@@ -720,8 +759,10 @@ export class AiSdkBackend implements AgentBackend {
   }
 
   /** Build the user content payload for the current turn (text + attachment refs). */
-  private buildUserContent(text: string, attachments?: AttachmentRef[]): string {
-    return formatTextWithAttachmentRefs(text, attachments);
+  private buildUserContent(text: string, attachments?: AttachmentRef[], turnTailPrompt?: string): string {
+    const content = formatTextWithAttachmentRefs(text, attachments);
+    if (!turnTailPrompt) return content;
+    return `${content}\n\n${turnTailPrompt}`;
   }
 
   private async resolveSystemPrompt(): Promise<string | undefined> {
@@ -733,6 +774,17 @@ export class AiSdkBackend implements AgentBackend {
       });
     }
     return this.input.systemPrompt;
+  }
+
+  private async resolveTurnTailPrompt(): Promise<string | undefined> {
+    if (typeof this.input.turnTailPrompt === 'function') {
+      return await this.input.turnTailPrompt({
+        sessionId: this.sessionId,
+        cwd: this.input.header.cwd,
+        workspaceRoot: this.input.header.workspaceRoot,
+      });
+    }
+    return this.input.turnTailPrompt;
   }
 
   private async *drain(queue: AsyncEventQueue<SessionEvent>): AsyncIterable<SessionEvent> {

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -315,6 +315,10 @@ export function mapSessionEventToRuntimeEvent(
             ...(event.contextRemaining !== undefined
               ? { contextRemaining: event.contextRemaining }
               : {}),
+            ...(event.prefixHash !== undefined ? { prefixHash: event.prefixHash } : {}),
+            ...(event.prefixChangeReason !== undefined
+              ? { prefixChangeReason: event.prefixChangeReason }
+              : {}),
           },
         },
       };

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -1,0 +1,197 @@
+import { createHash } from 'node:crypto';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import type { PrefixChangeReason } from '@maka/core/usage-stats/types';
+import type { ModelMessage } from 'ai';
+import { toJSONSchema } from 'zod';
+
+import type { MakaTool } from './tool-runtime.js';
+
+export interface CanonicalToolSet {
+  providerTools: MakaTool[];
+  activeTools: string[];
+}
+
+export interface RequestShapeInput {
+  connection: LlmConnection;
+  modelId: string;
+  systemPrompt?: string;
+  providerOptions?: Record<string, unknown>;
+  providerTools: readonly MakaTool[];
+  activeTools: readonly string[];
+  priorMessages: readonly ModelMessage[];
+}
+
+export interface RequestShapeComponents {
+  modelProviderHash: string;
+  systemPromptHash: string;
+  providerOptionsHash: string;
+  toolSchemaHash: string;
+  historyProjectionHash: string;
+}
+
+export interface RequestShapeDiagnostic {
+  prefixHash: string;
+  prefixChangeReason: PrefixChangeReason;
+  componentHashes: RequestShapeComponents;
+}
+
+export function canonicalizeToolSet(
+  tools: readonly MakaTool[],
+  invalidTool: MakaTool,
+): CanonicalToolSet {
+  const visibleTools = tools
+    .filter((tool) => tool.name !== invalidTool.name)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    providerTools: [...visibleTools, invalidTool],
+    activeTools: visibleTools.map((tool) => tool.name),
+  };
+}
+
+export function computeRequestShapeDiagnostic(
+  input: RequestShapeInput,
+  prior: RequestShapeDiagnostic | undefined,
+): RequestShapeDiagnostic {
+  const componentHashes: RequestShapeComponents = {
+    modelProviderHash: stableHash({
+      providerId: input.connection.providerType,
+      connectionSlug: input.connection.slug,
+      modelId: input.modelId,
+    }),
+    systemPromptHash: stableHash(input.systemPrompt ?? ''),
+    providerOptionsHash: stableHash(input.providerOptions ?? {}),
+    toolSchemaHash: stableHash({
+      activeTools: [...input.activeTools],
+      providerTools: input.providerTools.map(toolShapeForHash),
+    }),
+    historyProjectionHash: stableHash(input.priorMessages.map(messageShapeForHash)),
+  };
+  const prefixHash = stableHash(componentHashes);
+  return {
+    prefixHash,
+    prefixChangeReason: classifyPrefixChange(componentHashes, prior?.componentHashes),
+    componentHashes,
+  };
+}
+
+export function stableHash(value: unknown): string {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function classifyPrefixChange(
+  current: RequestShapeComponents,
+  prior: RequestShapeComponents | undefined,
+): PrefixChangeReason {
+  if (!prior) return 'first_turn';
+  if (current.modelProviderHash !== prior.modelProviderHash) return 'model_or_provider_changed';
+  if (current.systemPromptHash !== prior.systemPromptHash) return 'system_prompt_changed';
+  if (current.toolSchemaHash !== prior.toolSchemaHash) return 'tool_schema_changed';
+  if (current.providerOptionsHash !== prior.providerOptionsHash) return 'provider_options_changed';
+  if (current.historyProjectionHash !== prior.historyProjectionHash) return 'history_projection_changed';
+  return 'stable';
+}
+
+function toolShapeForHash(tool: MakaTool): unknown {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: schemaShapeForHash(tool.parameters),
+  };
+}
+
+function schemaShapeForHash(schema: unknown): unknown {
+  if (isObjectLike(schema)) {
+    try {
+      return stripJsonSchemaRuntimeFields(toJSONSchema(schema as never, {
+        io: 'input',
+        target: 'draft-07',
+        unrepresentable: 'any',
+        cycles: 'ref',
+        reused: 'inline',
+      }));
+    } catch {
+      // Fall through to structural canonicalization for plain JSON-schema-like objects.
+    }
+  }
+  return schema;
+}
+
+function stripJsonSchemaRuntimeFields(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripJsonSchemaRuntimeFields);
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === '~standard' || key === '$schema') continue;
+    out[key] = stripJsonSchemaRuntimeFields(entry);
+  }
+  return out;
+}
+
+function messageShapeForHash(message: ModelMessage): unknown {
+  const raw = message as unknown as { role?: unknown; content?: unknown };
+  return {
+    role: typeof raw.role === 'string' ? raw.role : 'unknown',
+    content: contentShapeForHash(raw.content),
+  };
+}
+
+function contentShapeForHash(content: unknown): unknown {
+  if (typeof content === 'string') {
+    return { type: 'text', chars: content.length };
+  }
+  if (Array.isArray(content)) {
+    return content.map((part) => {
+      if (!isObjectLike(part)) return { type: typeof part };
+      const type = typeof part.type === 'string' ? part.type : 'unknown';
+      return {
+        type,
+        ...(typeof part.toolName === 'string' ? { toolName: part.toolName } : {}),
+        ...(typeof part.toolCallId === 'string' ? { toolCallId: part.toolCallId } : {}),
+        ...(typeof part.text === 'string' ? { chars: part.text.length } : {}),
+      };
+    });
+  }
+  return { type: typeof content };
+}
+
+function canonicalize(value: unknown, parentKey?: string): unknown {
+  if (value === null) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'undefined' || typeof value === 'function' || typeof value === 'symbol') {
+    return `[${typeof value}]`;
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalize(item));
+    return shouldSortArray(parentKey)
+      ? items.slice().sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)))
+      : items;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (!isObjectLike(value)) return String(value);
+
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    out[key] = canonicalize(value[key], key);
+  }
+  return out;
+}
+
+function shouldSortArray(parentKey: string | undefined): boolean {
+  return parentKey === 'required' || parentKey === 'enum';
+}
+
+function isObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!isObjectLike(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -1,4 +1,5 @@
 import { generalizedErrorMessage } from '@maka/core/redaction';
+import type { PrefixChangeReason } from '@maka/core/usage-stats/types';
 
 export type RunTracePhase = 'turn' | 'model' | 'tool' | 'permission' | 'abort' | 'usage';
 
@@ -90,9 +91,13 @@ export class RunTrace {
     });
   }
 
-  modelStreamStarted(activeTools: readonly string[]): void {
+  modelStreamStarted(
+    activeTools: readonly string[],
+    prefix?: { prefixHash: string; prefixChangeReason: PrefixChangeReason },
+  ): void {
     this.emit('model', 'model_stream_started', 'Model stream started', {
       activeTools: [...activeTools],
+      ...(prefix !== undefined ? prefix : {}),
     });
   }
 
@@ -119,6 +124,8 @@ export class RunTrace {
     reasoningTokens: number;
     totalTokens: number;
     rawFinishReason?: string;
+    prefixHash?: string;
+    prefixChangeReason?: PrefixChangeReason;
   }): void {
     this.emit('usage', 'usage_recorded', 'Token usage recorded', {
       inputTokens: usage.inputTokens,
@@ -130,6 +137,8 @@ export class RunTrace {
       reasoningTokens: usage.reasoningTokens,
       totalTokens: usage.totalTokens,
       ...(usage.rawFinishReason !== undefined ? { rawFinishReason: usage.rawFinishReason } : {}),
+      ...(usage.prefixHash !== undefined ? { prefixHash: usage.prefixHash } : {}),
+      ...(usage.prefixChangeReason !== undefined ? { prefixChangeReason: usage.prefixChangeReason } : {}),
     });
   }
 

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -489,6 +489,8 @@ function projectTokenUsage(
     ...(usage.cacheRead !== undefined ? { cacheRead: usage.cacheRead } : {}),
     ...(usage.cacheCreation !== undefined ? { cacheCreation: usage.cacheCreation } : {}),
     ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
+    ...(usage.prefixHash !== undefined ? { prefixHash: usage.prefixHash } : {}),
+    ...(usage.prefixChangeReason !== undefined ? { prefixChangeReason: usage.prefixChangeReason } : {}),
   });
   return true;
 }
@@ -811,6 +813,8 @@ function semanticMessage(message: StoredMessage): unknown {
         cacheRead: message.cacheRead,
         cacheCreation: message.cacheCreation,
         costUsd: message.costUsd,
+        prefixHash: message.prefixHash,
+        prefixChangeReason: message.prefixChangeReason,
       };
     case 'turn_state':
       return {

--- a/packages/storage/src/telemetry-repo.ts
+++ b/packages/storage/src/telemetry-repo.ts
@@ -155,6 +155,8 @@ class FileTelemetryRepo implements TelemetryRepo {
         ...(row.errorClass ? { errorClass: row.errorClass } : {}),
         ...(row.sessionId ? { sessionId: row.sessionId } : {}),
         ...(row.turnId ? { turnId: row.turnId } : {}),
+        ...(row.prefixHash ? { prefixHash: row.prefixHash } : {}),
+        ...(row.prefixChangeReason ? { prefixChangeReason: row.prefixChangeReason } : {}),
       } satisfies UsageLogRow));
     return { rows: rows.slice(offset, offset + limit), total: rows.length };
   }


### PR DESCRIPTION
Refs #19.

## Summary
- Add request-shape prefix diagnostics on the existing `RuntimeRunner -> AiSdkFlow -> AiSdkBackend -> ModelAdapter` path, with per-session `prefixHash` and `prefixChangeReason` propagation through token usage, RuntimeEvents, run trace, and LLM telemetry.
- Canonicalize AI SDK tool assembly by sorting provider-visible tool names, placing the internal `invalid` repair tool last, and using the same deterministic order for `activeTools` and repair candidates.
- Move volatile desktop session environment facts (cwd/git/date/platform) out of the durable system prompt and into a current-turn tail, while preserving durable personalization, skills, workspace instructions, memory, bot, and deep-research system prompt fragments.

## Rive Review
- Workflow: `maka.deepseek-cost-runtime-phase2@1`
- Run: `wfrun_e81d5db134fb48e796cdf09678072186`
- Review artifact: `/tmp/rive-maka-phase2-request-shape-20260616/output/02-review-report.md`
- Review found one required fix: update the Runtime source-contract test for the new diagnostic-bearing `RunTrace` call shapes. Fixed in this PR before commit.

## Validation
- `npm run typecheck`
- `npm --workspace @maka/runtime test` (462/462)
- `npm --workspace @maka/core test` (614/614)
- `npm --workspace @maka/storage test` (81/81)
- `npm --workspace @maka/desktop test` (1399/1399)
- `npm run build`
- `git diff --check`
- Live DeepSeek product-path smoke with local key: two `deepseek-chat` turns returned `OK`; first turn reported `prefixChangeReason=first_turn`, second reported `stable`, both shared the same `prefixHash`. DeepSeek returned normalized miss counters for both turns (`input=2306`, `cacheMissInput=2306`, `cacheHitInput=0`, `output=1`), so this smoke verified the local diagnostic path and provider usage-field normalization but did not observe a cache-hit token in this run.
