### PR TITLE
Add cache-aware request shape diagnostics

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -11,6 +11,7 @@
 
 import type { PermissionRequest, PermissionResponse, ToolCategory } from './permission.js';
 import type {
+  CacheMissInputSource,
   ContextBudgetDiagnostic,
   PrefixChangeReason,
   PromptSegmentEstimate,
@@ -328,6 +329,7 @@ export interface TokenUsageEvent extends BaseEvent {
   cacheHitInput?: number;
   cacheMissInput?: number;
   cacheWriteInput?: number;
+  cacheMissInputSource?: CacheMissInputSource;
   reasoning?: number;
   total?: number;
   rawFinishReason?: string;
@@ -339,6 +341,8 @@ export interface TokenUsageEvent extends BaseEvent {
   contextRemaining?: number;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
   promptSegments?: PromptSegmentEstimate[];
   contextBudget?: ContextBudgetDiagnostic;
 }

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -17,6 +17,7 @@
 import type { AttachmentRef } from './events.js';
 import type { PermissionRequest, PermissionResponse } from './permission.js';
 import type {
+  CacheMissInputSource,
   ContextBudgetDiagnostic,
   PrefixChangeReason,
   PromptSegmentEstimate,
@@ -173,6 +174,7 @@ export interface RuntimeEventTokenUsage {
   cacheHitInput?: number;
   cacheMissInput?: number;
   cacheWriteInput?: number;
+  cacheMissInputSource?: CacheMissInputSource;
   reasoning?: number;
   total?: number;
   rawFinishReason?: string;
@@ -184,6 +186,8 @@ export interface RuntimeEventTokenUsage {
   contextRemaining?: number;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
   promptSegments?: PromptSegmentEstimate[];
   contextBudget?: ContextBudgetDiagnostic;
 }

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -12,6 +12,7 @@
 import type { AttachmentRef, ToolResultContent } from './events.js';
 import type { PermissionMode } from './permission.js';
 import type {
+  CacheMissInputSource,
   ContextBudgetDiagnostic,
   PrefixChangeReason,
   PromptSegmentEstimate,
@@ -237,6 +238,7 @@ export interface TokenUsageMessage {
   cacheHitInput?: number;
   cacheMissInput?: number;
   cacheWriteInput?: number;
+  cacheMissInputSource?: CacheMissInputSource;
   reasoning?: number;
   total?: number;
   rawFinishReason?: string;
@@ -247,6 +249,8 @@ export interface TokenUsageMessage {
   costUsd?: number;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
   promptSegments?: PromptSegmentEstimate[];
   contextBudget?: ContextBudgetDiagnostic;
 }

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -43,6 +43,7 @@ export interface UsageBucket {
   cacheMissTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  cacheMissInputSource?: CacheMissInputSource;
   reasoningTokens: number;
   totalTokens: number;
   costUsd: number;
@@ -72,6 +73,8 @@ export interface UsageLogRow {
   turnId?: string;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
   promptSegments?: PromptSegmentEstimate[];
   contextBudget?: ContextBudgetDiagnostic;
 }
@@ -119,6 +122,9 @@ export interface LlmCallRecord {
   startedAt: number;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
+  requestShapeHash?: string;
+  requestShapeChangeReason?: PrefixChangeReason;
+  cacheMissInputSource?: CacheMissInputSource;
   promptSegments?: PromptSegmentEstimate[];
   contextBudget?: ContextBudgetDiagnostic;
 }
@@ -132,6 +138,8 @@ export type PrefixChangeReason =
   | 'history_projection_changed'
   | 'stable'
   | 'unknown';
+
+export type CacheMissInputSource = 'explicit' | 'derived';
 
 export type PromptSegmentKind =
   | 'system_prompt'
@@ -160,6 +168,10 @@ export interface ContextBudgetDiagnostic {
   droppedTurns: number;
   keptEvents: number;
   droppedEvents: number;
+  prunedToolResults?: number;
+  prunedToolResultEstimatedTokensBefore?: number;
+  prunedToolResultEstimatedTokensAfter?: number;
+  archivePlaceholders?: number;
 }
 
 export interface ToolInvocationRecord {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -24,7 +24,11 @@ import {
   canonicalizeToolSet,
   computeRequestShapeDiagnostic,
 } from '../request-shape.js';
-import { applyRuntimeEventContextBudget } from '../context-budget.js';
+import {
+  ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  applyRuntimeEventContextBudget,
+} from '../context-budget.js';
+import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
 
 describe('AiSdkBackend model history', () => {
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
@@ -532,6 +536,7 @@ describe('AiSdkBackend usage telemetry', () => {
       outputTokens: 20,
       cacheHitInputTokens: 30,
       cacheMissInputTokens: 60,
+      cacheMissInputSource: 'derived',
       cachedInputTokens: 30,
       cacheWriteInputTokens: 10,
       reasoningTokens: 5,
@@ -605,12 +610,17 @@ describe('AiSdkBackend usage telemetry', () => {
       output?: number;
       cacheHitInput?: number;
       cacheMissInput?: number;
+      cacheMissInputSource?: string;
       cacheWriteInput?: number;
       cacheRead?: number;
       cacheCreation?: number;
       reasoning?: number;
       total?: number;
       rawFinishReason?: string;
+      prefixHash?: string;
+      prefixChangeReason?: string;
+      requestShapeHash?: string;
+      requestShapeChangeReason?: string;
     } | undefined;
     const usageEvent = events.find((event) => event.type === 'token_usage') as
       | Extract<SessionEvent, { type: 'token_usage' }>
@@ -622,31 +632,46 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(usageMessage?.output, 7);
     assert.equal(usageMessage?.cacheHitInput, 3);
     assert.equal(usageMessage?.cacheMissInput, 5);
+    assert.equal(usageMessage?.cacheMissInputSource, 'explicit');
     assert.equal(usageMessage?.cacheWriteInput, 2);
     assert.equal(usageMessage?.cacheRead, 3);
     assert.equal(usageMessage?.cacheCreation, 2);
     assert.equal(usageMessage?.reasoning, 2);
     assert.equal(usageMessage?.total, 17);
     assert.equal(usageMessage?.rawFinishReason, 'stop');
+    assert.equal(usageMessage?.prefixChangeReason, 'first_turn');
+    assert.equal(usageMessage?.requestShapeChangeReason, 'first_turn');
+    assert.ok(usageMessage?.prefixHash);
+    assert.ok(usageMessage?.requestShapeHash);
     assert.equal(usageEvent?.input, 10);
     assert.equal(usageEvent?.output, 7);
     assert.equal(usageEvent?.cacheHitInput, 3);
     assert.equal(usageEvent?.cacheMissInput, 5);
+    assert.equal(usageEvent?.cacheMissInputSource, 'explicit');
     assert.equal(usageEvent?.cacheWriteInput, 2);
     assert.equal(usageEvent?.cacheRead, 3);
     assert.equal(usageEvent?.cacheCreation, 2);
     assert.equal(usageEvent?.reasoning, 2);
     assert.equal(usageEvent?.total, 17);
     assert.equal(usageEvent?.rawFinishReason, 'stop');
+    assert.equal(usageEvent?.prefixChangeReason, 'first_turn');
+    assert.equal(usageEvent?.requestShapeChangeReason, 'first_turn');
+    assert.ok(usageEvent?.prefixHash);
+    assert.ok(usageEvent?.requestShapeHash);
     assert.equal(llmRecords[0]?.inputTokens, 10);
     assert.equal(llmRecords[0]?.outputTokens, 7);
     assert.equal(llmRecords[0]?.cacheHitInputTokens, 3);
     assert.equal(llmRecords[0]?.cacheMissInputTokens, 5);
+    assert.equal(llmRecords[0]?.cacheMissInputSource, 'explicit');
     assert.equal(llmRecords[0]?.cachedInputTokens, 3);
     assert.equal(llmRecords[0]?.cacheWriteInputTokens, 2);
     assert.equal(llmRecords[0]?.reasoningTokens, 2);
     assert.equal(llmRecords[0]?.totalTokens, 17);
     assert.equal(llmRecords[0]?.rawFinishReason, 'stop');
+    assert.equal(llmRecords[0]?.prefixChangeReason, 'first_turn');
+    assert.equal(llmRecords[0]?.requestShapeChangeReason, 'first_turn');
+    assert.ok(llmRecords[0]?.prefixHash);
+    assert.ok(llmRecords[0]?.requestShapeHash);
   });
 });
 
@@ -676,8 +701,11 @@ describe('AiSdkBackend request-shape diagnostics', () => {
     }, first);
 
     assert.equal(first.prefixChangeReason, 'first_turn');
+    assert.equal(first.requestShapeChangeReason, 'first_turn');
     assert.equal(second.prefixChangeReason, 'stable');
+    assert.equal(second.requestShapeChangeReason, 'stable');
     assert.equal(second.prefixHash, first.prefixHash);
+    assert.equal(second.requestShapeHash, first.requestShapeHash);
   });
 
   test('classifies targeted request-shape changes', () => {
@@ -713,10 +741,14 @@ describe('AiSdkBackend request-shape diagnostics', () => {
       ...baseInput,
       modelId: 'other-model',
     }, base).prefixChangeReason, 'model_or_provider_changed');
-    assert.equal(computeRequestShapeDiagnostic({
+    const historyChanged = computeRequestShapeDiagnostic({
       ...baseInput,
       priorMessages: [{ role: 'assistant' as const, content: 'hello' }],
-    }, base).prefixChangeReason, 'history_projection_changed');
+    }, base);
+    assert.equal(historyChanged.prefixChangeReason, 'stable');
+    assert.equal(historyChanged.prefixHash, base.prefixHash);
+    assert.equal(historyChanged.requestShapeChangeReason, 'history_projection_changed');
+    assert.notEqual(historyChanged.requestShapeHash, base.requestShapeHash);
   });
 
   test('tool canonicalization is independent of registration order and places invalid last', () => {
@@ -793,7 +825,11 @@ describe('AiSdkBackend request-shape diagnostics', () => {
     assert.equal(usageEvents[0]?.prefixChangeReason, 'first_turn');
     assert.equal(usageEvents[1]?.prefixChangeReason, 'stable');
     assert.equal(usageEvents[1]?.prefixHash, usageEvents[0]?.prefixHash);
+    assert.equal(usageEvents[0]?.requestShapeChangeReason, 'first_turn');
+    assert.equal(usageEvents[1]?.requestShapeChangeReason, 'stable');
+    assert.equal(usageEvents[1]?.requestShapeHash, usageEvents[0]?.requestShapeHash);
     assert.equal(llmRecords[1]?.prefixChangeReason, 'stable');
+    assert.equal(llmRecords[1]?.requestShapeChangeReason, 'stable');
     assert.match(JSON.stringify(compactPrompt(models[0]!)), /2026-05-29/);
     assert.match(JSON.stringify(compactPrompt(models[1]!)), /2026-05-30/);
     assert.equal(JSON.stringify(modelCallSettings(models[0]!)).includes('2026-05-29'), false);
@@ -822,6 +858,94 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
     assert.equal(budgeted.diagnostic.droppedTurns, 1);
     assert.equal(budgeted.diagnostic.keptTurns, 1);
     assert.equal(budgeted.diagnostic.droppedEvents, 2);
+  });
+
+  test('stale tool-result pruning replaces old payloads before budgeting and preserves replay pairing', () => {
+    const oldResult = { body: 'x'.repeat(500) };
+    const newResult = { body: 'y'.repeat(500) };
+    const events = [
+      runtimeEvent({
+        id: 'old-call',
+        turnId: 'old',
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-old', name: 'Read', args: { path: 'old.txt' } },
+      }),
+      runtimeEvent({
+        id: 'old-result',
+        turnId: 'old',
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'tool-old', name: 'Read', result: oldResult },
+      }),
+      runtimeEvent({
+        id: 'new-call',
+        turnId: 'new',
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'tool-new', name: 'Read', args: { path: 'new.txt' } },
+      }),
+      runtimeEvent({
+        id: 'new-result',
+        turnId: 'new',
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'tool-new', name: 'Read', result: newResult },
+      }),
+    ];
+
+    const optOut = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: { enabled: false, maxResultEstimatedTokens: 1 },
+      minRecentTurns: 1,
+      charsPerToken: 1,
+    });
+    assert.equal(optOut, undefined);
+
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 1,
+      },
+      minRecentTurns: 1,
+      charsPerToken: 1,
+    });
+
+    assert.ok(budgeted);
+    assert.equal(budgeted.diagnostic.prunedToolResults, 1);
+    assert.equal(budgeted.diagnostic.archivePlaceholders, 1);
+    const oldResponse = budgeted.events.find((event) => event.id === 'old-result');
+    assert.equal(oldResponse?.content?.kind, 'function_response');
+    const oldResponseContent = oldResponse?.content;
+    assert.equal(oldResponseContent?.kind, 'function_response');
+    const placeholder = oldResponseContent?.kind === 'function_response'
+      ? oldResponseContent.result as { kind?: string; runtimeEventId?: string; toolCallId?: string; toolName?: string }
+      : undefined;
+    assert.equal(placeholder?.kind, ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND);
+    assert.equal(placeholder?.runtimeEventId, 'old-result');
+    assert.equal(placeholder?.toolCallId, 'tool-old');
+    assert.equal(placeholder?.toolName, 'Read');
+
+    const newResponse = budgeted.events.find((event) => event.id === 'new-result');
+    assert.equal(newResponse?.content?.kind, 'function_response');
+    assert.deepEqual(
+      newResponse?.content?.kind === 'function_response' ? newResponse.content.result : undefined,
+      newResult,
+    );
+
+    const replayPlan = buildRuntimeEventModelReplayPlan(budgeted.events);
+    assert.deepEqual(
+      replayPlan.diagnostics.filter((diagnostic) =>
+        diagnostic.code === 'unmatched_tool_result' || diagnostic.code === 'tool_id_mismatch'
+      ),
+      [],
+    );
+    const oldReplayResult = replayPlan.items.find((item) =>
+      item.kind === 'tool_result' && item.toolCallId === 'tool-old'
+    );
+    assert.equal(oldReplayResult?.kind, 'tool_result');
+    assert.equal(oldReplayResult?.eventId, 'old-result');
+    assert.equal(oldReplayResult?.kind === 'tool_result' ? oldReplayResult.toolName : undefined, 'Read');
   });
 
   test('usage events include prompt segments and context budget diagnostics', async () => {

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -105,6 +105,7 @@ describe('ModelAdapter stream and error normalization', () => {
         outputTokens: 5,
         cacheHitInputTokens: 7,
         cacheMissInputTokens: 10,
+        cacheMissInputSource: 'derived',
         cachedInputTokens: 7,
         cacheWriteInputTokens: 3,
         reasoningTokens: 2,
@@ -135,6 +136,7 @@ describe('ModelAdapter stream and error normalization', () => {
         outputTokens: 20,
         cacheHitInputTokens: 40,
         cacheMissInputTokens: 60,
+        cacheMissInputSource: 'explicit',
         cachedInputTokens: 40,
         cacheWriteInputTokens: 0,
         reasoningTokens: 8,
@@ -185,6 +187,7 @@ describe('ModelAdapter stream and error normalization', () => {
         outputTokens: 20,
         cacheHitInputTokens: 70,
         cacheMissInputTokens: 30,
+        cacheMissInputSource: 'explicit',
         cachedInputTokens: 70,
         cacheWriteInputTokens: 0,
         reasoningTokens: 9,
@@ -224,6 +227,7 @@ describe('ModelAdapter stream and error normalization', () => {
         outputTokens: 2,
         cacheHitInputTokens: 1408,
         cacheMissInputTokens: 52,
+        cacheMissInputSource: 'explicit',
         cachedInputTokens: 1408,
         cacheWriteInputTokens: 0,
         reasoningTokens: 0,
@@ -252,6 +256,15 @@ describe('ModelAdapter stream and error normalization', () => {
         cacheWriteInputTokens: 20,
       })?.cacheMissInputTokens,
       50,
+    );
+    assert.equal(
+      normalizeAiSdkUsage({
+        inputTokens: 100,
+        outputTokens: 10,
+        cachedInputTokens: 30,
+        cacheWriteInputTokens: 20,
+      })?.cacheMissInputSource,
+      'derived',
     );
 
     assert.equal(

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -394,6 +394,8 @@ export class AiSdkBackend implements AgentBackend {
         trace.modelStreamStarted(activeTools, {
           prefixHash: requestShape.prefixHash,
           prefixChangeReason: requestShape.prefixChangeReason,
+          requestShapeHash: requestShape.requestShapeHash,
+          requestShapeChangeReason: requestShape.requestShapeChangeReason,
           promptSegments,
           ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
         });
@@ -487,6 +489,8 @@ export class AiSdkBackend implements AgentBackend {
               ...tokenUsage,
               prefixHash: requestShape.prefixHash,
               prefixChangeReason: requestShape.prefixChangeReason,
+              requestShapeHash: requestShape.requestShapeHash,
+              requestShapeChangeReason: requestShape.requestShapeChangeReason,
             });
             const tu: TokenUsageMessage = {
               type: 'token_usage',
@@ -497,6 +501,7 @@ export class AiSdkBackend implements AgentBackend {
               output: tokenUsage.outputTokens,
               cacheHitInput: tokenUsage.cacheHitInputTokens,
               cacheMissInput: tokenUsage.cacheMissInputTokens,
+              cacheMissInputSource: tokenUsage.cacheMissInputSource,
               cacheWriteInput: tokenUsage.cacheWriteInputTokens,
               reasoning: tokenUsage.reasoningTokens,
               total: tokenUsage.totalTokens,
@@ -505,6 +510,8 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
               prefixHash: requestShape.prefixHash,
               prefixChangeReason: requestShape.prefixChangeReason,
+              requestShapeHash: requestShape.requestShapeHash,
+              requestShapeChangeReason: requestShape.requestShapeChangeReason,
               promptSegments,
               ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
             };
@@ -518,6 +525,7 @@ export class AiSdkBackend implements AgentBackend {
               output: tokenUsage.outputTokens,
               cacheHitInput: tokenUsage.cacheHitInputTokens,
               cacheMissInput: tokenUsage.cacheMissInputTokens,
+              cacheMissInputSource: tokenUsage.cacheMissInputSource,
               cacheWriteInput: tokenUsage.cacheWriteInputTokens,
               reasoning: tokenUsage.reasoningTokens,
               total: tokenUsage.totalTokens,
@@ -526,6 +534,8 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
               prefixHash: requestShape.prefixHash,
               prefixChangeReason: requestShape.prefixChangeReason,
+              requestShapeHash: requestShape.requestShapeHash,
+              requestShapeChangeReason: requestShape.requestShapeChangeReason,
               promptSegments,
               ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
             } satisfies TokenUsageEvent);
@@ -588,6 +598,9 @@ export class AiSdkBackend implements AgentBackend {
           outputTokens: tokenUsage?.outputTokens ?? 0,
           cacheHitInputTokens: tokenUsage?.cacheHitInputTokens ?? 0,
           cacheMissInputTokens: tokenUsage?.cacheMissInputTokens ?? 0,
+          ...(tokenUsage?.cacheMissInputSource !== undefined
+            ? { cacheMissInputSource: tokenUsage.cacheMissInputSource }
+            : {}),
           cachedInputTokens: tokenUsage?.cachedInputTokens ?? 0,
           cacheWriteInputTokens: tokenUsage?.cacheWriteInputTokens ?? 0,
           reasoningTokens: tokenUsage?.reasoningTokens ?? 0,
@@ -601,6 +614,8 @@ export class AiSdkBackend implements AgentBackend {
           ...(requestShapeForTelemetry !== undefined ? {
             prefixHash: requestShapeForTelemetry.prefixHash,
             prefixChangeReason: requestShapeForTelemetry.prefixChangeReason,
+            requestShapeHash: requestShapeForTelemetry.requestShapeHash,
+            requestShapeChangeReason: requestShapeForTelemetry.requestShapeChangeReason,
           } : {}),
           ...(promptSegmentsForTelemetry.length > 0 ? { promptSegments: promptSegmentsForTelemetry } : {}),
           ...(contextBudgetForTelemetry !== undefined ? { contextBudget: contextBudgetForTelemetry } : {}),

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -305,6 +305,9 @@ export function mapSessionEventToRuntimeEvent(
             output: event.output,
             ...(event.cacheHitInput !== undefined ? { cacheHitInput: event.cacheHitInput } : {}),
             ...(event.cacheMissInput !== undefined ? { cacheMissInput: event.cacheMissInput } : {}),
+            ...(event.cacheMissInputSource !== undefined
+              ? { cacheMissInputSource: event.cacheMissInputSource }
+              : {}),
             ...(event.cacheWriteInput !== undefined ? { cacheWriteInput: event.cacheWriteInput } : {}),
             ...(event.reasoning !== undefined ? { reasoning: event.reasoning } : {}),
             ...(event.total !== undefined ? { total: event.total } : {}),
@@ -318,6 +321,10 @@ export function mapSessionEventToRuntimeEvent(
             ...(event.prefixHash !== undefined ? { prefixHash: event.prefixHash } : {}),
             ...(event.prefixChangeReason !== undefined
               ? { prefixChangeReason: event.prefixChangeReason }
+              : {}),
+            ...(event.requestShapeHash !== undefined ? { requestShapeHash: event.requestShapeHash } : {}),
+            ...(event.requestShapeChangeReason !== undefined
+              ? { requestShapeChangeReason: event.requestShapeChangeReason }
               : {}),
             ...(event.promptSegments !== undefined ? { promptSegments: event.promptSegments } : {}),
             ...(event.contextBudget !== undefined ? { contextBudget: event.contextBudget } : {}),

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -18,6 +18,29 @@ export interface ContextBudgetPolicy {
   minRecentTurns?: number;
   /** Estimate conversion. Defaults to 4 chars/token, intentionally conservative for mixed text. */
   charsPerToken?: number;
+  /** Optional replay-only pruning for stale oversized tool results before whole-turn compaction. */
+  staleToolResultPrune?: StaleToolResultPrunePolicy;
+}
+
+export interface StaleToolResultPrunePolicy {
+  enabled: boolean;
+  /** Tool result payloads above this estimate are replaced with archive placeholders. Defaults to 2048. */
+  maxResultEstimatedTokens?: number;
+  /** Keep this many newest turns' tool results full. Defaults to ContextBudgetPolicy.minRecentTurns, then 1. */
+  minRecentTurnsFull?: number;
+}
+
+export const ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND = 'maka.archived_tool_result';
+const DEFAULT_MAX_TOOL_RESULT_ESTIMATED_TOKENS = 2048;
+
+export interface ArchivedToolResultPlaceholder {
+  kind: typeof ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND;
+  runtimeEventId: string;
+  toolCallId: string;
+  toolName: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  reason: 'stale_tool_result_pruned_before_compact';
 }
 
 export interface BudgetedRuntimeContext {
@@ -40,14 +63,19 @@ export function applyRuntimeEventContextBudget(
   events: readonly RuntimeEvent[],
   policy: ContextBudgetPolicy | undefined,
 ): BudgetedRuntimeContext | undefined {
-  const enabled = Boolean(policy?.maxHistoryEstimatedTokens || policy?.maxHistoryTurns);
+  const prunePolicy = policy?.staleToolResultPrune;
+  const pruneEnabled = prunePolicy?.enabled === true;
+  const enabled = Boolean(policy?.maxHistoryEstimatedTokens || policy?.maxHistoryTurns || pruneEnabled);
   if (!enabled) return undefined;
+  if (!policy) return undefined;
   const charsPerToken = policy?.charsPerToken ?? 4;
   const maxTokens = finitePositive(policy?.maxHistoryEstimatedTokens);
   const maxTurns = finitePositive(policy?.maxHistoryTurns);
   const minRecentTurns = Math.max(0, Math.floor(policy?.minRecentTurns ?? 1));
-  const turnGroups = groupEventsByTurn(events, charsPerToken);
   const estimatedTokensBefore = estimateRuntimeEventsTokens(events, charsPerToken);
+  const pruned = pruneStaleToolResultsBeforeCompact(events, policy, charsPerToken);
+  const budgetEvents = pruned.events;
+  const turnGroups = groupEventsByTurn(budgetEvents, charsPerToken);
 
   const keptTurnIds = new Set<string>();
   let keptTokens = 0;
@@ -65,7 +93,7 @@ export function applyRuntimeEventContextBudget(
     keptTokens += group.estimatedTokens;
   }
 
-  const keptEvents = events.filter((event) => keptTurnIds.has(event.turnId));
+  const keptEvents = budgetEvents.filter((event) => keptTurnIds.has(turnKey(event)));
   const diagnostic: ContextBudgetDiagnostic = {
     enabled: true,
     ...(policy?.name ? { policyName: policy.name } : {}),
@@ -76,7 +104,15 @@ export function applyRuntimeEventContextBudget(
     keptTurns: keptTurnIds.size,
     droppedTurns: Math.max(0, turnGroups.length - keptTurnIds.size),
     keptEvents: keptEvents.length,
-    droppedEvents: Math.max(0, events.length - keptEvents.length),
+    droppedEvents: Math.max(0, budgetEvents.length - keptEvents.length),
+    ...(pruned.prunedToolResults > 0
+      ? {
+          prunedToolResults: pruned.prunedToolResults,
+          prunedToolResultEstimatedTokensBefore: pruned.estimatedTokensBefore,
+          prunedToolResultEstimatedTokensAfter: pruned.estimatedTokensAfter,
+          archivePlaceholders: pruned.prunedToolResults,
+        }
+      : {}),
   };
   return { events: keptEvents, diagnostic };
 }
@@ -123,7 +159,7 @@ function groupEventsByTurn(events: readonly RuntimeEvent[], charsPerToken: numbe
   const order: string[] = [];
   const byTurn = new Map<string, RuntimeEvent[]>();
   for (const event of events) {
-    const key = event.turnId || '<unknown-turn>';
+    const key = turnKey(event);
     const group = byTurn.get(key);
     if (group) group.push(event);
     else {
@@ -135,6 +171,94 @@ function groupEventsByTurn(events: readonly RuntimeEvent[], charsPerToken: numbe
     turnId,
     estimatedTokens: estimateRuntimeEventsTokens(byTurn.get(turnId) ?? [], charsPerToken),
   }));
+}
+
+function pruneStaleToolResultsBeforeCompact(
+  events: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy,
+  charsPerToken: number,
+): {
+  events: RuntimeEvent[];
+  prunedToolResults: number;
+  estimatedTokensBefore: number;
+  estimatedTokensAfter: number;
+} {
+  const prunePolicy = policy.staleToolResultPrune;
+  if (prunePolicy?.enabled !== true) {
+    return { events: [...events], prunedToolResults: 0, estimatedTokensBefore: 0, estimatedTokensAfter: 0 };
+  }
+
+  const maxResultEstimatedTokens =
+    finitePositive(prunePolicy.maxResultEstimatedTokens)
+    ?? DEFAULT_MAX_TOOL_RESULT_ESTIMATED_TOKENS;
+  const minRecentTurnsFull = Math.max(
+    0,
+    Math.floor(prunePolicy.minRecentTurnsFull ?? policy.minRecentTurns ?? 1),
+  );
+  const protectedTurnIds = recentTurnIds(events, minRecentTurnsFull);
+
+  let prunedToolResults = 0;
+  let estimatedTokensBefore = 0;
+  let estimatedTokensAfter = 0;
+  const prunedEvents = events.map((event) => {
+    const content = event.content;
+    if (
+      event.partial ||
+      content?.kind !== 'function_response' ||
+      protectedTurnIds.has(turnKey(event))
+    ) {
+      return event;
+    }
+
+    const resultBytes = stableJsonLength(content.result);
+    const resultEstimatedTokens = estimateTokens(resultBytes, charsPerToken);
+    if (resultEstimatedTokens <= maxResultEstimatedTokens) return event;
+
+    const placeholder: ArchivedToolResultPlaceholder = {
+      kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+      runtimeEventId: event.id,
+      toolCallId: content.id,
+      toolName: content.name,
+      originalEstimatedTokens: resultEstimatedTokens,
+      originalBytes: resultBytes,
+      reason: 'stale_tool_result_pruned_before_compact',
+    };
+    const placeholderEstimatedTokens = estimateTokens(stableJsonLength(placeholder), charsPerToken);
+    prunedToolResults += 1;
+    estimatedTokensBefore += resultEstimatedTokens;
+    estimatedTokensAfter += placeholderEstimatedTokens;
+    return {
+      ...event,
+      content: {
+        ...content,
+        result: placeholder,
+      },
+    };
+  });
+
+  return {
+    events: prunedEvents,
+    prunedToolResults,
+    estimatedTokensBefore,
+    estimatedTokensAfter,
+  };
+}
+
+function recentTurnIds(events: readonly RuntimeEvent[], count: number): Set<string> {
+  if (count <= 0) return new Set();
+  const order: string[] = [];
+  const seen = new Set<string>();
+  for (const event of events) {
+    const key = turnKey(event);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    order.push(key);
+  }
+  return new Set(order.slice(Math.max(0, order.length - count)));
+}
+
+function turnKey(event: RuntimeEvent): string {
+  return event.turnId || '<unknown-turn>';
 }
 
 function estimateRuntimeEventChars(event: RuntimeEvent): number {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -70,6 +70,7 @@ export type { StreamWatchdogInput, StreamWatchdogPhase, StreamWatchdogTimeout } 
 export { getAIModel, buildProviderOptions } from './model-factory.js';
 export type { ModelFactoryInput as GetAIModelInput } from './model-factory.js';
 export {
+  ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   applyRuntimeEventContextBudget,
   buildPromptSegmentEstimates,
   estimateModelMessagesChars,
@@ -79,6 +80,8 @@ export {
 export type {
   BudgetedRuntimeContext,
   ContextBudgetPolicy,
+  StaleToolResultPrunePolicy,
+  ArchivedToolResultPlaceholder,
   PromptSegmentInput,
 } from './context-budget.js';
 export { testConnection } from './test-connection.js';

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -7,6 +7,7 @@ import type {
 } from '@maka/core/events';
 import { PROVIDER_DEFAULTS, type LlmConnection } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
+import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import type { ModelMessage } from 'ai';
 
 import type { AsyncEventQueue } from './async-queue.js';
@@ -287,6 +288,7 @@ export interface NormalizedAiSdkUsage {
   outputTokens: number;
   cacheHitInputTokens: number;
   cacheMissInputTokens: number;
+  cacheMissInputSource: CacheMissInputSource;
   cacheWriteInputTokens: number;
   reasoningTokens: number;
   totalTokens: number;
@@ -341,6 +343,8 @@ export function normalizeAiSdkUsage(
   const cacheMissInputTokens =
     explicitCacheMissInputTokens
     ?? Math.max(0, inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+  const cacheMissInputSource: CacheMissInputSource =
+    explicitCacheMissInputTokens !== undefined ? 'explicit' : 'derived';
   const reasoningTokens =
     finiteToken(usage.reasoningTokens)
     ?? finiteTokenFromBreakdown(usage.outputTokens, 'reasoning')
@@ -361,6 +365,7 @@ export function normalizeAiSdkUsage(
     outputTokens,
     cacheHitInputTokens,
     cacheMissInputTokens,
+    cacheMissInputSource,
     cacheWriteInputTokens,
     reasoningTokens,
     totalTokens,

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -29,9 +29,15 @@ export interface RequestShapeComponents {
   historyProjectionHash: string;
 }
 
+export type DurablePrefixComponents = Omit<RequestShapeComponents, 'historyProjectionHash'>;
+
 export interface RequestShapeDiagnostic {
+  /** Durable provider prefix shape, excluding prior-history projection. */
   prefixHash: string;
   prefixChangeReason: PrefixChangeReason;
+  /** Full request shape, including prior-history projection. */
+  requestShapeHash: string;
+  requestShapeChangeReason: PrefixChangeReason;
   componentHashes: RequestShapeComponents;
 }
 
@@ -67,10 +73,17 @@ export function computeRequestShapeDiagnostic(
     }),
     historyProjectionHash: stableHash(input.priorMessages.map(messageShapeForHash)),
   };
-  const prefixHash = stableHash(componentHashes);
+  const durablePrefixComponents = durableComponents(componentHashes);
+  const prefixHash = stableHash(durablePrefixComponents);
+  const requestShapeHash = stableHash(componentHashes);
   return {
     prefixHash,
-    prefixChangeReason: classifyPrefixChange(componentHashes, prior?.componentHashes),
+    prefixChangeReason: classifyDurablePrefixChange(
+      durablePrefixComponents,
+      prior ? durableComponents(prior.componentHashes) : undefined,
+    ),
+    requestShapeHash,
+    requestShapeChangeReason: classifyRequestShapeChange(componentHashes, prior?.componentHashes),
     componentHashes,
   };
 }
@@ -93,7 +106,19 @@ export function stableStringify(value: unknown): string {
   return JSON.stringify(canonicalize(value));
 }
 
-function classifyPrefixChange(
+function classifyDurablePrefixChange(
+  current: DurablePrefixComponents,
+  prior: DurablePrefixComponents | undefined,
+): PrefixChangeReason {
+  if (!prior) return 'first_turn';
+  if (current.modelProviderHash !== prior.modelProviderHash) return 'model_or_provider_changed';
+  if (current.systemPromptHash !== prior.systemPromptHash) return 'system_prompt_changed';
+  if (current.toolSchemaHash !== prior.toolSchemaHash) return 'tool_schema_changed';
+  if (current.providerOptionsHash !== prior.providerOptionsHash) return 'provider_options_changed';
+  return 'stable';
+}
+
+function classifyRequestShapeChange(
   current: RequestShapeComponents,
   prior: RequestShapeComponents | undefined,
 ): PrefixChangeReason {
@@ -104,6 +129,15 @@ function classifyPrefixChange(
   if (current.providerOptionsHash !== prior.providerOptionsHash) return 'provider_options_changed';
   if (current.historyProjectionHash !== prior.historyProjectionHash) return 'history_projection_changed';
   return 'stable';
+}
+
+function durableComponents(components: RequestShapeComponents): DurablePrefixComponents {
+  return {
+    modelProviderHash: components.modelProviderHash,
+    systemPromptHash: components.systemPromptHash,
+    providerOptionsHash: components.providerOptionsHash,
+    toolSchemaHash: components.toolSchemaHash,
+  };
 }
 
 function toolShapeForDiagnostics(tool: MakaTool): unknown {

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -1,5 +1,6 @@
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type {
+  CacheMissInputSource,
   ContextBudgetDiagnostic,
   PrefixChangeReason,
   PromptSegmentEstimate,
@@ -100,6 +101,8 @@ export class RunTrace {
     prefix?: {
       prefixHash: string;
       prefixChangeReason: PrefixChangeReason;
+      requestShapeHash?: string;
+      requestShapeChangeReason?: PrefixChangeReason;
       promptSegments?: PromptSegmentEstimate[];
       contextBudget?: ContextBudgetDiagnostic;
     },
@@ -128,6 +131,7 @@ export class RunTrace {
     outputTokens: number;
     cacheHitInputTokens: number;
     cacheMissInputTokens: number;
+    cacheMissInputSource?: CacheMissInputSource;
     cachedInputTokens: number;
     cacheWriteInputTokens: number;
     reasoningTokens: number;
@@ -135,12 +139,15 @@ export class RunTrace {
     rawFinishReason?: string;
     prefixHash?: string;
     prefixChangeReason?: PrefixChangeReason;
+    requestShapeHash?: string;
+    requestShapeChangeReason?: PrefixChangeReason;
   }): void {
     this.emit('usage', 'usage_recorded', 'Token usage recorded', {
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       cacheHitInputTokens: usage.cacheHitInputTokens,
       cacheMissInputTokens: usage.cacheMissInputTokens,
+      ...(usage.cacheMissInputSource !== undefined ? { cacheMissInputSource: usage.cacheMissInputSource } : {}),
       cachedInputTokens: usage.cachedInputTokens,
       cacheWriteInputTokens: usage.cacheWriteInputTokens,
       reasoningTokens: usage.reasoningTokens,
@@ -148,6 +155,10 @@ export class RunTrace {
       ...(usage.rawFinishReason !== undefined ? { rawFinishReason: usage.rawFinishReason } : {}),
       ...(usage.prefixHash !== undefined ? { prefixHash: usage.prefixHash } : {}),
       ...(usage.prefixChangeReason !== undefined ? { prefixChangeReason: usage.prefixChangeReason } : {}),
+      ...(usage.requestShapeHash !== undefined ? { requestShapeHash: usage.requestShapeHash } : {}),
+      ...(usage.requestShapeChangeReason !== undefined
+        ? { requestShapeChangeReason: usage.requestShapeChangeReason }
+        : {}),
     });
   }
 

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -482,6 +482,7 @@ function projectTokenUsage(
     output: usage.output,
     ...(usage.cacheHitInput !== undefined ? { cacheHitInput: usage.cacheHitInput } : {}),
     ...(usage.cacheMissInput !== undefined ? { cacheMissInput: usage.cacheMissInput } : {}),
+    ...(usage.cacheMissInputSource !== undefined ? { cacheMissInputSource: usage.cacheMissInputSource } : {}),
     ...(usage.cacheWriteInput !== undefined ? { cacheWriteInput: usage.cacheWriteInput } : {}),
     ...(usage.reasoning !== undefined ? { reasoning: usage.reasoning } : {}),
     ...(usage.total !== undefined ? { total: usage.total } : {}),
@@ -491,6 +492,10 @@ function projectTokenUsage(
     ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
     ...(usage.prefixHash !== undefined ? { prefixHash: usage.prefixHash } : {}),
     ...(usage.prefixChangeReason !== undefined ? { prefixChangeReason: usage.prefixChangeReason } : {}),
+    ...(usage.requestShapeHash !== undefined ? { requestShapeHash: usage.requestShapeHash } : {}),
+    ...(usage.requestShapeChangeReason !== undefined
+      ? { requestShapeChangeReason: usage.requestShapeChangeReason }
+      : {}),
     ...(usage.promptSegments !== undefined ? { promptSegments: usage.promptSegments } : {}),
     ...(usage.contextBudget !== undefined ? { contextBudget: usage.contextBudget } : {}),
   });
@@ -808,6 +813,7 @@ function semanticMessage(message: StoredMessage): unknown {
         output: message.output,
         cacheHitInput: message.cacheHitInput,
         cacheMissInput: message.cacheMissInput,
+        cacheMissInputSource: message.cacheMissInputSource,
         cacheWriteInput: message.cacheWriteInput,
         reasoning: message.reasoning,
         total: message.total,
@@ -817,6 +823,8 @@ function semanticMessage(message: StoredMessage): unknown {
         costUsd: message.costUsd,
         prefixHash: message.prefixHash,
         prefixChangeReason: message.prefixChangeReason,
+        requestShapeHash: message.requestShapeHash,
+        requestShapeChangeReason: message.requestShapeChangeReason,
         promptSegments: message.promptSegments,
         contextBudget: message.contextBudget,
       };

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -14,9 +14,11 @@ export function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): voi
     try {
       const cacheHitInputTokens = record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0;
       const cacheWriteInputTokens = record.cacheWriteInputTokens ?? 0;
+      const derivedCacheMissInputTokens = record.cacheMissInputTokens === undefined;
       const cacheMissInputTokens =
         record.cacheMissInputTokens
         ?? Math.max(0, record.inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+      const cacheMissInputSource = record.cacheMissInputSource ?? (derivedCacheMissInputTokens ? 'derived' : undefined);
       const cachedInputTokens = cacheHitInputTokens;
       const reasoningTokens = record.reasoningTokens ?? 0;
       const totalTokens = record.totalTokens ?? record.inputTokens + record.outputTokens + reasoningTokens;
@@ -36,6 +38,7 @@ export function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): voi
         id: `usage_${record.turnId ?? randomUUID()}`,
         cacheHitInputTokens,
         cacheMissInputTokens,
+        ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),
         cachedInputTokens,
         cacheWriteInputTokens,
         reasoningTokens,

--- a/packages/storage/src/telemetry-repo.ts
+++ b/packages/storage/src/telemetry-repo.ts
@@ -147,6 +147,7 @@ class FileTelemetryRepo implements TelemetryRepo {
         cacheMissTokens: row.cacheMissInputTokens,
         cacheReadTokens: row.cacheHitInputTokens,
         cacheWriteTokens: row.cacheWriteInputTokens,
+        ...(row.cacheMissInputSource ? { cacheMissInputSource: row.cacheMissInputSource } : {}),
         reasoningTokens: row.reasoningTokens,
         totalTokens: row.totalTokens,
         costUsd: row.costUsd,
@@ -157,6 +158,8 @@ class FileTelemetryRepo implements TelemetryRepo {
         ...(row.turnId ? { turnId: row.turnId } : {}),
         ...(row.prefixHash ? { prefixHash: row.prefixHash } : {}),
         ...(row.prefixChangeReason ? { prefixChangeReason: row.prefixChangeReason } : {}),
+        ...(row.requestShapeHash ? { requestShapeHash: row.requestShapeHash } : {}),
+        ...(row.requestShapeChangeReason ? { requestShapeChangeReason: row.requestShapeChangeReason } : {}),
         ...(row.promptSegments ? { promptSegments: row.promptSegments } : {}),
         ...(row.contextBudget ? { contextBudget: row.contextBudget } : {}),
       } satisfies UsageLogRow));

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -168,9 +168,16 @@ for (let i = 1; i <= turnCount; i += 1) {
     stopReason: completeEvent?.stopReason,
     prefixChangeReason: usageEvent?.prefixChangeReason,
     prefixHash: usageEvent?.prefixHash,
+    requestShapeChangeReason: usageEvent?.requestShapeChangeReason,
+    requestShapeHash: usageEvent?.requestShapeHash,
     input: usageEvent?.input ?? llmRecord?.inputTokens,
     cacheHitInput: usageEvent?.cacheHitInput ?? llmRecord?.cacheHitInputTokens,
     cacheMissInput: usageEvent?.cacheMissInput ?? llmRecord?.cacheMissInputTokens,
+    cacheMissInputSource: usageEvent?.cacheMissInputSource ?? llmRecord?.cacheMissInputSource,
+    cacheMissShapeSource: classifyCacheMissShape(
+      usageEvent?.prefixChangeReason,
+      usageEvent?.requestShapeChangeReason,
+    ),
     output: usageEvent?.output ?? llmRecord?.outputTokens,
     total: usageEvent?.total,
     estimatedCostUsd: cost?.totalCost,
@@ -205,12 +212,19 @@ const report = {
   totals,
   turns,
   runTracePrefixEvents: runTraceEvents
-    .filter((event) => event.data?.prefixHash || event.data?.prefixChangeReason)
+    .filter((event) =>
+      event.data?.prefixHash ||
+      event.data?.prefixChangeReason ||
+      event.data?.requestShapeHash ||
+      event.data?.requestShapeChangeReason
+    )
     .map((event) => ({
       phase: event.phase,
       type: event.type,
       prefixHash: event.data?.prefixHash,
       prefixChangeReason: event.data?.prefixChangeReason,
+      requestShapeHash: event.data?.requestShapeHash,
+      requestShapeChangeReason: event.data?.requestShapeChangeReason,
       promptSegments: event.data?.promptSegments,
       contextBudget: event.data?.contextBudget,
     })),
@@ -229,13 +243,32 @@ function buildContextBudgetPolicy() {
   const maxHistoryEstimatedTokens = parseOptionalPositiveInt(
     process.env.MAKA_CONTEXT_HISTORY_BUDGET_TOKENS,
   );
-  if (maxHistoryEstimatedTokens === undefined) return undefined;
   const maxHistoryTurns = parseOptionalPositiveInt(process.env.MAKA_CONTEXT_HISTORY_BUDGET_TURNS);
+  const staleToolResultPrune = buildStaleToolResultPrunePolicy();
+  if (maxHistoryEstimatedTokens === undefined && maxHistoryTurns === undefined && !staleToolResultPrune) {
+    return undefined;
+  }
   return {
     name: process.env.MAKA_CONTEXT_BUDGET_NAME ?? 'cost-baseline-history-budget',
-    maxHistoryEstimatedTokens,
     minRecentTurns: parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2),
+    ...(maxHistoryEstimatedTokens !== undefined ? { maxHistoryEstimatedTokens } : {}),
+    ...(staleToolResultPrune ? { staleToolResultPrune } : {}),
     ...(maxHistoryTurns !== undefined ? { maxHistoryTurns } : {}),
+  };
+}
+
+function buildStaleToolResultPrunePolicy() {
+  if (process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResultEstimatedTokens: parsePositiveInt(
+      process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS,
+      2048,
+    ),
+    minRecentTurnsFull: parsePositiveInt(
+      process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS,
+      parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2),
+    ),
   };
 }
 
@@ -247,6 +280,14 @@ function parseOptionalPositiveInt(value) {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function classifyCacheMissShape(prefixChangeReason, requestShapeChangeReason) {
+  if (!prefixChangeReason && !requestShapeChangeReason) return undefined;
+  if (prefixChangeReason === 'first_turn') return 'first_turn';
+  if (prefixChangeReason && prefixChangeReason !== 'stable') return 'explicit_durable_prefix_change';
+  if (requestShapeChangeReason && requestShapeChangeReason !== 'stable') return 'derived_request_shape_change';
+  return 'stable_shape';
 }
 
 function renderMarkdown(report, jsonPath) {
@@ -271,8 +312,8 @@ function renderMarkdown(report, jsonPath) {
     '',
     '## Turns',
     '',
-    '| turn | input | hit | miss | output | reason | prior history est | budget after |',
-    '| ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: |',
+    '| turn | input | hit | miss | output | prefix reason | request reason | miss source | prior history est | budget after |',
+    '| ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: |',
   ];
   for (const turn of report.turns) {
     const prior = turn.promptSegments?.find((segment) => segment.kind === 'prior_history');
@@ -283,6 +324,8 @@ function renderMarkdown(report, jsonPath) {
       turn.cacheMissInput ?? 0,
       turn.output ?? 0,
       turn.prefixChangeReason ?? '',
+      turn.requestShapeChangeReason ?? '',
+      turn.cacheMissShapeSource ?? turn.cacheMissInputSource ?? '',
       prior?.estimatedTokens ?? 0,
       turn.contextBudget?.estimatedTokensAfter ?? 0,
     ].join(' | ') + ' |');


### PR DESCRIPTION
## Summary

- Split `prefixHash` / `prefixChangeReason` into durable-prefix diagnostics and add `requestShapeHash` / `requestShapeChangeReason` for full request/history shape.
- Add `cacheMissInputSource` so telemetry can distinguish provider-explicit cache miss counts from locally derived counts.
- Add opt-in stale tool-result prune-before-compact for RuntimeEvent replay context, using archive placeholders that preserve tool call/result pairing and point back to the canonical RuntimeEvent id.
- Extend the DeepSeek live baseline report with durable-prefix, request-shape, and cache-miss source fields.

Refs #19.

## Rive gate

- Workflow: `maka.deepseek-cache-aware-context-phase4@1`
- Run: `wfrun_0f5c0ffb0f7f4118b32f8b039b93d932`
- Scheduler: `sched_bcb15b2b764a48ecbe9f137ecdb0cdbf`
- Resume scheduler: `sched_1e7e934da7094c4ab772a22cb2b5e5a3`
- Root: `work_7a2ee18aff4649a4a9625828125f7533` accepted/done

## Verification

- `npm run typecheck --workspace packages/core`
- `npm run typecheck --workspace packages/runtime`
- `npm run typecheck --workspace packages/storage`
- `npm run test --workspace packages/runtime` (465/465)
- `npm run test --workspace packages/storage` (81/81)
- `npm run test --workspace packages/core` (614/614)
- `npm run build --workspaces --if-present`
- `git diff --check`
