### PR TITLE
Add archive-backed stale tool result pruning

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -141,7 +141,7 @@ import {
   setActiveProxy,
   testConnection,
 } from '@maka/runtime';
-import type { BotIncomingMessage, ToolArtifactRecorderInput } from '@maka/runtime';
+import type { BotIncomingMessage, ToolArtifactRecorderInput, ToolResultArchiveRecorderInput } from '@maka/runtime';
 import type { ContextBudgetPolicy } from '@maka/runtime';
 import { testProxyConnection } from '@maka/runtime/network/proxy-test';
 import { fetchWeChatQrcode, pollWeChatQrcodeStatus } from './wechat-scan-login.js';
@@ -684,6 +684,22 @@ async function persistToolArtifacts(cwd: string, event: ToolArtifactRecorderInpu
   }
 }
 
+async function persistArchivedToolResult(
+  event: ToolResultArchiveRecorderInput,
+): Promise<{ artifactId: string }> {
+  const artifact = await artifactStore.create({
+    sessionId: event.sessionId,
+    turnId: event.turnId,
+    name: `tool-result-${event.runtimeEventId}.json`,
+    kind: 'file',
+    content: event.serializedResult,
+    mimeType: 'application/json',
+    source: 'tool_result_archive',
+    summary: `Archived ${event.toolName} tool result for context budget replay`,
+  });
+  return { artifactId: artifact.id };
+}
+
 async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): Promise<string | null> {
   const candidate = isAbsolute(sourcePath) ? sourcePath : resolve(cwd, sourcePath);
   let root: string;
@@ -752,6 +768,7 @@ backends.register('ai-sdk', async (ctx) => {
           : event,
       ),
     recordToolArtifacts: (event) => persistToolArtifacts(ctx.header.cwd, event),
+    archiveToolResult: (event) => persistArchivedToolResult(event),
     recordRunTrace: ctx.recordRunTrace,
     newId: randomUUID,
     now: Date.now,
@@ -763,14 +780,37 @@ function buildContextBudgetPolicy(connection: LlmConnection): ContextBudgetPolic
   const maxHistoryEstimatedTokens =
     parseOptionalPositiveInt(process.env.MAKA_CONTEXT_HISTORY_BUDGET_TOKENS) ??
     defaultHistoryBudgetTokens(connection);
-  if (maxHistoryEstimatedTokens === undefined) return undefined;
   const maxHistoryTurns = parseOptionalPositiveInt(process.env.MAKA_CONTEXT_HISTORY_BUDGET_TURNS);
   const minRecentTurns = parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2);
+  const staleToolResultPrune = buildStaleToolResultPrunePolicy();
+  if (
+    maxHistoryEstimatedTokens === undefined &&
+    maxHistoryTurns === undefined &&
+    staleToolResultPrune === undefined
+  ) {
+    return undefined;
+  }
   return {
     name: 'desktop-default-history-budget',
-    maxHistoryEstimatedTokens,
     ...(maxHistoryTurns !== undefined ? { maxHistoryTurns } : {}),
+    ...(maxHistoryEstimatedTokens !== undefined ? { maxHistoryEstimatedTokens } : {}),
+    ...(staleToolResultPrune !== undefined ? { staleToolResultPrune } : {}),
     minRecentTurns,
+  };
+}
+
+function buildStaleToolResultPrunePolicy(): NonNullable<ContextBudgetPolicy['staleToolResultPrune']> | undefined {
+  if (process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResultEstimatedTokens: parsePositiveInt(
+      process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS,
+      2048,
+    ),
+    minRecentTurnsFull: parsePositiveInt(
+      process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS,
+      parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2),
+    ),
   };
 }
 

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -1,6 +1,6 @@
 export type ArtifactKind = 'file' | 'diff' | 'html' | 'image' | 'pdf';
 
-export type ArtifactSource = 'tool_result' | 'user_upload' | 'export' | 'snapshot' | 'fixture';
+export type ArtifactSource = 'tool_result' | 'tool_result_archive' | 'user_upload' | 'export' | 'snapshot' | 'fixture';
 
 export type ArtifactStatus = 'live' | 'deleted';
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -145,6 +145,19 @@ export type ToolResultContent =
   | { kind: 'file_diff'; paths: string[]; diff: string }
   | { kind: 'file_write'; path: string; bytes: number }
   | {
+      kind: 'archived_tool_result';
+      status: 'not_loaded' | 'missing' | 'corrupt';
+      runtimeEventId: string;
+      toolCallId: string;
+      toolName: string;
+      artifactId?: string;
+      bodySha256?: string;
+      originalEstimatedTokens: number;
+      originalBytes: number;
+      rewriteVersion: number;
+      reason: 'stale_tool_result_pruned_before_compact';
+    }
+  | {
       kind: 'terminal';
       cwd: string;
       cmd: string;

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -172,6 +172,9 @@ export interface ContextBudgetDiagnostic {
   prunedToolResultEstimatedTokensBefore?: number;
   prunedToolResultEstimatedTokensAfter?: number;
   archivePlaceholders?: number;
+  archiveWriteFailures?: number;
+  unarchivedToolResults?: number;
+  archivePlaceholderReasonCounts?: Record<string, number>;
 }
 
 export interface ToolInvocationRecord {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -186,6 +186,75 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('archives stale RuntimeEvent tool results before replay placeholder rewrite', async () => {
+    const model = completionModel();
+    const archiveRequests: Array<{ runtimeEventId: string; serializedResult: string; bodySha256: string }> = [];
+    const oldResult = { body: 'x'.repeat(500) };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'archive-test',
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archiveRequests.push({
+          runtimeEventId: event.runtimeEventId,
+          serializedResult: event.serializedResult,
+          bodySha256: event.bodySha256,
+        });
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'package.json' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: oldResult, isError: false },
+        }),
+      ],
+    }));
+
+    assert.equal(archiveRequests.length, 1);
+    assert.equal(archiveRequests[0]?.runtimeEventId, 'rt-result');
+    assert.equal(archiveRequests[0]?.serializedResult, JSON.stringify(oldResult));
+    assert.match(archiveRequests[0]?.bodySha256 ?? '', /^[a-f0-9]{64}$/);
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /"kind":"maka\.archived_tool_result"/);
+    assert.match(prompt, /"artifactId":"artifact-rt-result"/);
+    assert.match(prompt, /"runtimeEventId":"rt-result"/);
+    assert.equal(prompt.includes(oldResult.body), false);
+  });
+
   test('uses StoredMessage projection when RuntimeEvent tool results are unmatched', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
@@ -901,7 +970,7 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
     });
     assert.equal(optOut, undefined);
 
-    const budgeted = applyRuntimeEventContextBudget(events, {
+    const missingArchive = applyRuntimeEventContextBudget(events, {
       staleToolResultPrune: {
         enabled: true,
         maxResultEstimatedTokens: 1,
@@ -910,21 +979,68 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
       minRecentTurns: 1,
       charsPerToken: 1,
     });
+    assert.ok(missingArchive);
+    assert.equal(missingArchive.diagnostic.prunedToolResults, undefined);
+    assert.equal(missingArchive.diagnostic.archiveWriteFailures, 1);
+    const missingArchiveOldResponse = missingArchive.events.find((event) => event.id === 'old-result');
+    assert.equal(missingArchiveOldResponse?.content?.kind, 'function_response');
+    assert.deepEqual(
+      missingArchiveOldResponse?.content?.kind === 'function_response'
+        ? missingArchiveOldResponse.content.result
+        : undefined,
+      oldResult,
+    );
+
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 1,
+        archiveRefs: [{
+          runtimeEventId: 'old-result',
+          toolCallId: 'tool-old',
+          toolName: 'Read',
+          artifactId: 'artifact-old-result',
+          bodySha256: 'sha256-old-result',
+          originalEstimatedTokens: JSON.stringify(oldResult).length,
+          originalBytes: JSON.stringify(oldResult).length,
+          rewriteVersion: 1,
+          reason: 'stale_tool_result_pruned_before_compact',
+        }],
+      },
+      minRecentTurns: 1,
+      charsPerToken: 1,
+    });
 
     assert.ok(budgeted);
     assert.equal(budgeted.diagnostic.prunedToolResults, 1);
     assert.equal(budgeted.diagnostic.archivePlaceholders, 1);
+    assert.equal(budgeted.diagnostic.archiveWriteFailures, undefined);
+    assert.deepEqual(budgeted.diagnostic.archivePlaceholderReasonCounts, {
+      stale_tool_result_pruned_before_compact: 1,
+    });
     const oldResponse = budgeted.events.find((event) => event.id === 'old-result');
     assert.equal(oldResponse?.content?.kind, 'function_response');
     const oldResponseContent = oldResponse?.content;
     assert.equal(oldResponseContent?.kind, 'function_response');
     const placeholder = oldResponseContent?.kind === 'function_response'
-      ? oldResponseContent.result as { kind?: string; runtimeEventId?: string; toolCallId?: string; toolName?: string }
+      ? oldResponseContent.result as {
+        kind?: string;
+        rewriteVersion?: number;
+        artifactId?: string;
+        runtimeEventId?: string;
+        toolCallId?: string;
+        toolName?: string;
+        bodySha256?: string;
+      }
       : undefined;
     assert.equal(placeholder?.kind, ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND);
+    assert.equal(placeholder?.rewriteVersion, 1);
+    assert.equal(placeholder?.artifactId, 'artifact-old-result');
     assert.equal(placeholder?.runtimeEventId, 'old-result');
     assert.equal(placeholder?.toolCallId, 'tool-old');
     assert.equal(placeholder?.toolName, 'Read');
+    assert.equal(placeholder?.bodySha256, 'sha256-old-result');
 
     const newResponse = budgeted.events.find((event) => event.id === 'new-result');
     assert.equal(newResponse?.content?.kind, 'function_response');

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -283,6 +283,49 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics.map((diag) => diag.code)).toEqual(['context_remaining_unsupported']);
   });
 
+  test('archived tool-result placeholders project to diagnostic tool-result rows', () => {
+    const events = baseEvents();
+    const toolResult = events.find((event) => event.id === 'evt-tool-result');
+    if (toolResult?.content?.kind !== 'function_response') throw new Error('fixture missing tool result');
+    toolResult.content.result = {
+      kind: 'maka.archived_tool_result',
+      rewriteVersion: 1,
+      artifactId: 'artifact-tool-result',
+      runtimeEventId: 'evt-tool-result',
+      toolCallId: 'tool-1',
+      toolName: 'Read',
+      bodySha256: 'a'.repeat(64),
+      originalEstimatedTokens: 200,
+      originalBytes: 800,
+      reason: 'stale_tool_result_pruned_before_compact',
+    };
+
+    const out = projectRuntimeEventsToStoredMessages(events, { runHeaders: [header] });
+    const projected = out.messages.find((message) => message.type === 'tool_result');
+
+    expect(projected).toMatchObject({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      content: {
+        kind: 'archived_tool_result',
+        status: 'not_loaded',
+        artifactId: 'artifact-tool-result',
+        bodySha256: 'a'.repeat(64),
+        runtimeEventId: 'evt-tool-result',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        originalEstimatedTokens: 200,
+        originalBytes: 800,
+        rewriteVersion: 1,
+        reason: 'stale_tool_result_pruned_before_compact',
+      },
+    });
+    expect(out.diagnostics.map((diag) => diag.code)).toEqual([
+      'archived_tool_result_placeholder',
+      'context_remaining_unsupported',
+    ]);
+  });
+
   test('projected rows materialize to the same runtime view model as equivalent legacy rows', () => {
     const out = projectRuntimeEventsToStoredMessages(baseEvents(), { runHeaders: [header] });
     const projected = materializeSession(out.messages);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -40,6 +40,7 @@ import type {
   TextCompleteEvent,
   TokenUsageEvent,
 } from '@maka/core/events';
+import { createHash } from 'node:crypto';
 import type {
   StoredMessage,
   AssistantMessage,
@@ -55,6 +56,7 @@ import type {
   PermissionDecision,
 } from '@maka/core/backend-types';
 import type { LlmConnection } from '@maka/core/llm-connections';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
 import type {
   ContextBudgetDiagnostic,
@@ -99,9 +101,13 @@ import {
   type RequestShapeDiagnostic,
 } from './request-shape.js';
 import {
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   buildPromptSegmentEstimates,
+  collectStaleToolResultArchiveCandidates,
   type ContextBudgetPolicy,
+  type StaleToolResultArchiveCandidate,
+  type ToolResultArchiveRef,
 } from './context-budget.js';
 
 export {
@@ -147,6 +153,13 @@ export const INVALID_TOOL_NAME = 'invalid';
 export type AppendMessageFn = (m: StoredMessage) => Promise<void>;
 export type LlmTelemetryRecorder = (record: LlmCallRecord) => void;
 export type ToolTelemetryRecorder = (record: ToolInvocationRecord) => void;
+export interface ToolResultArchiveRecorderInput extends StaleToolResultArchiveCandidate {
+  sessionId: string;
+  bodySha256: string;
+}
+export type ToolResultArchiveRecorder = (
+  input: ToolResultArchiveRecorderInput,
+) => Promise<{ artifactId: string } | void> | { artifactId: string } | void;
 
 export interface AiSdkBackendInput {
   // ── Session context ────────────────────────────────────────────────────
@@ -199,6 +212,12 @@ export interface AiSdkBackendInput {
    * file-backed persistence.
    */
   recordToolArtifacts?: ToolArtifactRecorder;
+  /**
+   * Optional archive writer for replay-only stale tool-result pruning. The
+   * runtime rewrites only candidates whose original body has been durably
+   * archived by this callback.
+   */
+  archiveToolResult?: ToolResultArchiveRecorder;
 }
 
 export interface SystemPromptContext {
@@ -337,7 +356,7 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     // --- Build messages from RuntimeEvent history and its compatibility projection. ---
-    const priorReplay = this.buildPriorMessages(input);
+    const priorReplay = await this.buildPriorMessages(input);
 
     // --- Background pump: streamText → fullStream → normalize → queue ---
     const pumpDone: Promise<void> = (async () => {
@@ -690,25 +709,24 @@ export class AiSdkBackend implements AgentBackend {
    *  V0.1: text-only round-tripping. Tool calls / results within projected
    *  history are deliberately NOT replayed unless RuntimeEvent native replay
    *  is available for the provider. */
-  private buildPriorMessages(input: BackendSendInput): {
+  private async buildPriorMessages(input: BackendSendInput): Promise<{
     messages: ModelMessage[];
     gate: RuntimeEventReplayFallbackGate | 'stored_message_projection';
     diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
     runtimeEventCount?: number;
     contextBudget?: ContextBudgetDiagnostic;
-  } {
+  }> {
     const projectedMessages = this.materializePriorMessages(
       input.context.filter((message) => message.turnId !== input.turnId),
     );
     if (!input.runtimeContext) {
       return { messages: projectedMessages, gate: 'stored_message_projection', diagnostics: [] };
     }
-    const budgeted = applyRuntimeEventContextBudget(
-      input.runtimeContext.filter((event) => event.turnId !== input.turnId),
-      this.input.contextBudget,
-    );
+    const priorRuntimeContext = input.runtimeContext.filter((event) => event.turnId !== input.turnId);
+    const contextBudget = await this.prepareContextBudgetPolicy(priorRuntimeContext);
+    const budgeted = applyRuntimeEventContextBudget(priorRuntimeContext, contextBudget);
     const runtimeContext = budgeted?.events
-      ?? input.runtimeContext.filter((event) => event.turnId !== input.turnId);
+      ?? priorRuntimeContext;
 
     const plan = buildRuntimeEventModelReplayPlan(
       runtimeContext,
@@ -759,6 +777,45 @@ export class AiSdkBackend implements AgentBackend {
       diagnostics: plan.diagnostics,
       runtimeEventCount: runtimeContext.length,
       ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+    };
+  }
+
+  private async prepareContextBudgetPolicy(
+    runtimeContext: readonly RuntimeEvent[],
+  ): Promise<ContextBudgetPolicy | undefined> {
+    const policy = this.input.contextBudget;
+    if (policy?.staleToolResultPrune?.enabled !== true) return policy;
+    const candidates = collectStaleToolResultArchiveCandidates(runtimeContext, policy);
+    if (candidates.length === 0) return policy;
+
+    const archiveRefs: ToolResultArchiveRef[] = [];
+    for (const candidate of candidates) {
+      const bodySha256 = sha256(candidate.serializedResult);
+      const archived = await Promise.resolve(this.input.archiveToolResult?.({
+        ...candidate,
+        sessionId: this.sessionId,
+        bodySha256,
+      })).catch(() => undefined);
+      if (!archived?.artifactId) continue;
+      archiveRefs.push({
+        runtimeEventId: candidate.runtimeEventId,
+        toolCallId: candidate.toolCallId,
+        toolName: candidate.toolName,
+        artifactId: archived.artifactId,
+        bodySha256,
+        originalEstimatedTokens: candidate.originalEstimatedTokens,
+        originalBytes: candidate.originalBytes,
+        rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+        reason: candidate.reason,
+      });
+    }
+
+    return {
+      ...policy,
+      staleToolResultPrune: {
+        ...policy.staleToolResultPrune,
+        archiveRefs,
+      },
     };
   }
 
@@ -920,6 +977,10 @@ function toolResultOutput(value: unknown, isError: boolean): AiSdkToolResultOutp
   return typeof value === 'string'
     ? { type: 'text', value }
     : { type: 'json', value: jsonValue(value) };
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
 }
 
 function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolean {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -28,19 +28,54 @@ export interface StaleToolResultPrunePolicy {
   maxResultEstimatedTokens?: number;
   /** Keep this many newest turns' tool results full. Defaults to ContextBudgetPolicy.minRecentTurns, then 1. */
   minRecentTurnsFull?: number;
+  /**
+   * Archive refs keyed by RuntimeEvent id. Rewrites only happen when a
+   * matching ref exists, so archive-write failure keeps original content.
+   */
+  archiveRefs?: readonly ToolResultArchiveRef[] | Readonly<Record<string, ToolResultArchiveRef>>;
 }
 
 export const ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND = 'maka.archived_tool_result';
+export const ARCHIVED_TOOL_RESULT_REWRITE_VERSION = 1;
 const DEFAULT_MAX_TOOL_RESULT_ESTIMATED_TOKENS = 2048;
+export type ArchivedToolResultReason = 'stale_tool_result_pruned_before_compact';
 
 export interface ArchivedToolResultPlaceholder {
   kind: typeof ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND;
+  rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
+  artifactId: string;
   runtimeEventId: string;
   toolCallId: string;
   toolName: string;
+  bodySha256: string;
   originalEstimatedTokens: number;
   originalBytes: number;
-  reason: 'stale_tool_result_pruned_before_compact';
+  reason: ArchivedToolResultReason;
+}
+
+export interface StaleToolResultArchiveCandidate {
+  runtimeEventId: string;
+  turnId: string;
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  serializedResult: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
+  reason: ArchivedToolResultReason;
+}
+
+export interface ToolResultArchiveRef {
+  runtimeEventId: string;
+  toolCallId: string;
+  toolName: string;
+  artifactId: string;
+  bodySha256: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
+  reason: ArchivedToolResultReason;
 }
 
 export interface BudgetedRuntimeContext {
@@ -111,6 +146,15 @@ export function applyRuntimeEventContextBudget(
           prunedToolResultEstimatedTokensBefore: pruned.estimatedTokensBefore,
           prunedToolResultEstimatedTokensAfter: pruned.estimatedTokensAfter,
           archivePlaceholders: pruned.prunedToolResults,
+          archivePlaceholderReasonCounts: {
+            stale_tool_result_pruned_before_compact: pruned.prunedToolResults,
+          },
+        }
+      : {}),
+    ...(pruned.archiveWriteFailures > 0
+      ? {
+          archiveWriteFailures: pruned.archiveWriteFailures,
+          unarchivedToolResults: pruned.archiveWriteFailures,
         }
       : {}),
   };
@@ -180,12 +224,19 @@ function pruneStaleToolResultsBeforeCompact(
 ): {
   events: RuntimeEvent[];
   prunedToolResults: number;
+  archiveWriteFailures: number;
   estimatedTokensBefore: number;
   estimatedTokensAfter: number;
 } {
   const prunePolicy = policy.staleToolResultPrune;
   if (prunePolicy?.enabled !== true) {
-    return { events: [...events], prunedToolResults: 0, estimatedTokensBefore: 0, estimatedTokensAfter: 0 };
+    return {
+      events: [...events],
+      prunedToolResults: 0,
+      archiveWriteFailures: 0,
+      estimatedTokensBefore: 0,
+      estimatedTokensAfter: 0,
+    };
   }
 
   const maxResultEstimatedTokens =
@@ -196,8 +247,10 @@ function pruneStaleToolResultsBeforeCompact(
     Math.floor(prunePolicy.minRecentTurnsFull ?? policy.minRecentTurns ?? 1),
   );
   const protectedTurnIds = recentTurnIds(events, minRecentTurnsFull);
+  const archiveRefs = normalizeArchiveRefs(prunePolicy.archiveRefs);
 
   let prunedToolResults = 0;
+  let archiveWriteFailures = 0;
   let estimatedTokensBefore = 0;
   let estimatedTokensAfter = 0;
   const prunedEvents = events.map((event) => {
@@ -210,15 +263,33 @@ function pruneStaleToolResultsBeforeCompact(
       return event;
     }
 
-    const resultBytes = stableJsonLength(content.result);
+    if (isArchivedToolResultPlaceholder(content.result)) return event;
+
+    const serializedResult = serializeToolResultForArchive(content.result);
+    const resultBytes = serializedResult.length;
     const resultEstimatedTokens = estimateTokens(resultBytes, charsPerToken);
     if (resultEstimatedTokens <= maxResultEstimatedTokens) return event;
 
-    const placeholder: ArchivedToolResultPlaceholder = {
-      kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    const archiveRef = archiveRefs.get(event.id);
+    if (!archiveRef || !archiveRefMatches(archiveRef, {
       runtimeEventId: event.id,
       toolCallId: content.id,
       toolName: content.name,
+      originalBytes: resultBytes,
+      originalEstimatedTokens: resultEstimatedTokens,
+    })) {
+      archiveWriteFailures += 1;
+      return event;
+    }
+
+    const placeholder: ArchivedToolResultPlaceholder = {
+      kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+      rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+      artifactId: archiveRef.artifactId,
+      runtimeEventId: event.id,
+      toolCallId: content.id,
+      toolName: content.name,
+      bodySha256: archiveRef.bodySha256,
       originalEstimatedTokens: resultEstimatedTokens,
       originalBytes: resultBytes,
       reason: 'stale_tool_result_pruned_before_compact',
@@ -239,9 +310,127 @@ function pruneStaleToolResultsBeforeCompact(
   return {
     events: prunedEvents,
     prunedToolResults,
+    archiveWriteFailures,
     estimatedTokensBefore,
     estimatedTokensAfter,
   };
+}
+
+export function collectStaleToolResultArchiveCandidates(
+  events: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): StaleToolResultArchiveCandidate[] {
+  const prunePolicy = policy?.staleToolResultPrune;
+  if (prunePolicy?.enabled !== true) return [];
+  const charsPerToken = policy?.charsPerToken ?? 4;
+  const maxResultEstimatedTokens =
+    finitePositive(prunePolicy.maxResultEstimatedTokens)
+    ?? DEFAULT_MAX_TOOL_RESULT_ESTIMATED_TOKENS;
+  const minRecentTurnsFull = Math.max(
+    0,
+    Math.floor(prunePolicy.minRecentTurnsFull ?? policy?.minRecentTurns ?? 1),
+  );
+  const protectedTurnIds = recentTurnIds(events, minRecentTurnsFull);
+  const candidates: StaleToolResultArchiveCandidate[] = [];
+  for (const event of events) {
+    const content = event.content;
+    if (
+      event.partial ||
+      content?.kind !== 'function_response' ||
+      protectedTurnIds.has(turnKey(event)) ||
+      isArchivedToolResultPlaceholder(content.result)
+    ) {
+      continue;
+    }
+    const serializedResult = serializeToolResultForArchive(content.result);
+    const originalBytes = serializedResult.length;
+    const originalEstimatedTokens = estimateTokens(originalBytes, charsPerToken);
+    if (originalEstimatedTokens <= maxResultEstimatedTokens) continue;
+    candidates.push({
+      runtimeEventId: event.id,
+      turnId: event.turnId,
+      toolCallId: content.id,
+      toolName: content.name,
+      result: content.result,
+      serializedResult,
+      originalEstimatedTokens,
+      originalBytes,
+      rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+      reason: 'stale_tool_result_pruned_before_compact',
+    });
+  }
+  return candidates;
+}
+
+export function serializeToolResultForArchive(result: unknown): string {
+  if (result === undefined) return 'undefined';
+  try {
+    return JSON.stringify(result) ?? 'null';
+  } catch {
+    return String(result);
+  }
+}
+
+export function isArchivedToolResultPlaceholder(value: unknown): value is ArchivedToolResultPlaceholder {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ArchivedToolResultPlaceholder>;
+  return candidate.kind === ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND
+    && candidate.rewriteVersion === ARCHIVED_TOOL_RESULT_REWRITE_VERSION
+    && typeof candidate.artifactId === 'string'
+    && candidate.artifactId.length > 0
+    && typeof candidate.runtimeEventId === 'string'
+    && candidate.runtimeEventId.length > 0
+    && typeof candidate.toolCallId === 'string'
+    && candidate.toolCallId.length > 0
+    && typeof candidate.toolName === 'string'
+    && candidate.toolName.length > 0
+    && typeof candidate.bodySha256 === 'string'
+    && candidate.bodySha256.length > 0
+    && typeof candidate.originalEstimatedTokens === 'number'
+    && Number.isFinite(candidate.originalEstimatedTokens)
+    && candidate.originalEstimatedTokens > 0
+    && typeof candidate.originalBytes === 'number'
+    && Number.isFinite(candidate.originalBytes)
+    && candidate.originalBytes > 0
+    && candidate.reason === 'stale_tool_result_pruned_before_compact';
+}
+
+function normalizeArchiveRefs(
+  refs: StaleToolResultPrunePolicy['archiveRefs'],
+): Map<string, ToolResultArchiveRef> {
+  const map = new Map<string, ToolResultArchiveRef>();
+  if (!refs) return map;
+  if (Array.isArray(refs)) {
+    for (const ref of refs) map.set(ref.runtimeEventId, ref);
+    return map;
+  }
+  for (const [runtimeEventId, ref] of Object.entries(refs)) {
+    map.set(runtimeEventId, ref);
+  }
+  return map;
+}
+
+function archiveRefMatches(
+  ref: ToolResultArchiveRef,
+  candidate: {
+    runtimeEventId: string;
+    toolCallId: string;
+    toolName: string;
+    originalEstimatedTokens: number;
+    originalBytes: number;
+  },
+): boolean {
+  return ref.runtimeEventId === candidate.runtimeEventId
+    && ref.toolCallId === candidate.toolCallId
+    && ref.toolName === candidate.toolName
+    && ref.rewriteVersion === ARCHIVED_TOOL_RESULT_REWRITE_VERSION
+    && ref.reason === 'stale_tool_result_pruned_before_compact'
+    && typeof ref.artifactId === 'string'
+    && ref.artifactId.length > 0
+    && typeof ref.bodySha256 === 'string'
+    && ref.bodySha256.length > 0
+    && ref.originalEstimatedTokens === candidate.originalEstimatedTokens
+    && ref.originalBytes === candidate.originalBytes;
 }
 
 function recentTurnIds(events: readonly RuntimeEvent[], count: number): Set<string> {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,6 +35,8 @@ export type {
   ModelFactoryInput,
   RunTraceEvent,
   RunTraceRecorder,
+  ToolResultArchiveRecorder,
+  ToolResultArchiveRecorderInput,
 } from './ai-sdk-backend.js';
 export { PiAgentBackend, normalizePiAgentFrame } from './pi-agent-backend.js';
 export type {
@@ -71,16 +73,23 @@ export { getAIModel, buildProviderOptions } from './model-factory.js';
 export type { ModelFactoryInput as GetAIModelInput } from './model-factory.js';
 export {
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   buildPromptSegmentEstimates,
+  collectStaleToolResultArchiveCandidates,
   estimateModelMessagesChars,
   estimateRuntimeEventsTokens,
   estimateTokens,
+  isArchivedToolResultPlaceholder,
+  serializeToolResultForArchive,
 } from './context-budget.js';
 export type {
+  ArchivedToolResultReason,
   BudgetedRuntimeContext,
   ContextBudgetPolicy,
   StaleToolResultPrunePolicy,
+  StaleToolResultArchiveCandidate,
+  ToolResultArchiveRef,
   ArchivedToolResultPlaceholder,
   PromptSegmentInput,
 } from './context-budget.js';

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -11,11 +11,13 @@ import {
   isTerminalRuntimeEvent,
   isTerminalRuntimeEventStatus,
 } from '@maka/core';
+import { isArchivedToolResultPlaceholder } from './context-budget.js';
 
 export type RuntimeEventReadModelDiagnosticCode =
   | 'partial_skipped'
   | 'unsupported_event'
   | 'incomplete_event'
+  | 'archived_tool_result_placeholder'
   | 'generated_id'
   | 'context_remaining_unsupported'
   | 'tool_use_id_mismatch'
@@ -414,11 +416,39 @@ function projectFunctionResponse(
       refToolCallId: event.refs?.toolCallId,
     });
   }
-  if (!isToolResultContent(event.content.result)) {
+  const archivedPlaceholder = isArchivedToolResultPlaceholder(event.content.result)
+    ? event.content.result
+    : undefined;
+  if (!archivedPlaceholder && !isToolResultContent(event.content.result)) {
     diagnostic(state, event, 'incomplete_event', 'function_response result is not a legacy ToolResultContent');
     return false;
   }
+  if (archivedPlaceholder) {
+    diagnostic(state, event, 'archived_tool_result_placeholder', 'function_response result is archived and not loaded in read model', {
+      artifactId: archivedPlaceholder.artifactId,
+      runtimeEventId: archivedPlaceholder.runtimeEventId,
+      toolCallId: archivedPlaceholder.toolCallId,
+      toolName: archivedPlaceholder.toolName,
+      reason: archivedPlaceholder.reason,
+      rewriteVersion: archivedPlaceholder.rewriteVersion,
+    });
+  }
   if (event.content.name) state.toolNameByUseId.set(toolUseId, event.content.name);
+  const resultContent: ToolResultContent = archivedPlaceholder
+    ? {
+        kind: 'archived_tool_result',
+        status: 'not_loaded',
+        runtimeEventId: archivedPlaceholder.runtimeEventId,
+        toolCallId: archivedPlaceholder.toolCallId,
+        toolName: archivedPlaceholder.toolName,
+        artifactId: archivedPlaceholder.artifactId,
+        bodySha256: archivedPlaceholder.bodySha256,
+        originalEstimatedTokens: archivedPlaceholder.originalEstimatedTokens,
+        originalBytes: archivedPlaceholder.originalBytes,
+        rewriteVersion: archivedPlaceholder.rewriteVersion,
+        reason: archivedPlaceholder.reason,
+      }
+    : event.content.result as ToolResultContent;
   messages.push({
     type: 'tool_result',
     id: stableMessageId(event, state, 'tool_result'),
@@ -426,7 +456,7 @@ function projectFunctionResponse(
     ts: event.ts,
     toolUseId,
     isError: event.content.isError === true,
-    content: event.content.result,
+    content: resultContent,
     ...(numberStateDelta(event, 'durationMs') !== undefined
       ? { durationMs: numberStateDelta(event, 'durationMs') }
       : {}),
@@ -673,6 +703,7 @@ function isToolResultContent(value: unknown): value is ToolResultContent {
     || kind === 'file_write'
     || kind === 'terminal'
     || kind === 'image'
+    || kind === 'archived_tool_result'
     || kind === 'summary'
     || kind === 'web_search'
     || kind === 'web_search_error'

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -67,6 +67,32 @@ describe('FileArtifactStore', () => {
     });
   });
 
+  test('persists archived tool-result artifacts by id', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const first = createArtifactStore(workspaceRoot);
+      await first.create({
+        id: 'archive-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'tool-result-evt-1.json',
+        kind: 'file',
+        content: '{"kind":"json","value":{"ok":true}}',
+        mimeType: 'application/json',
+        source: 'tool_result_archive',
+        now: 100,
+      });
+
+      const second = createArtifactStore(workspaceRoot);
+      const record = await second.get('archive-1');
+      assert.equal(record?.source, 'tool_result_archive');
+      assert.equal(record?.sizeBytes, 35);
+      assert.deepEqual(await second.readText('archive-1'), {
+        ok: true,
+        text: '{"kind":"json","value":{"ok":true}}',
+      });
+    });
+  });
+
   test('soft delete hides rows and blocks reads without purging file bytes', async () => {
     await withStore(async (store) => {
       await store.create({

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -17,6 +17,7 @@ import {
 } from '../packages/runtime/dist/index.js';
 import {
   createAgentRunStore,
+  createArtifactStore,
   createRuntimeEventStore,
   createSessionStore,
 } from '../packages/storage/dist/index.js';
@@ -44,6 +45,7 @@ const payloadLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_PAYLOAD_LIN
 const sessionStore = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+const artifactStore = createArtifactStore(workspaceRoot);
 const permissionEngine = new PermissionEngine(createDefaultPermissionEngineDeps());
 const backends = new BackendRegistry();
 const llmRecords = [];
@@ -100,6 +102,19 @@ backends.register('ai-sdk', async (ctx) =>
     turnTailPrompt,
     recordLlmCall: (record) => llmRecords.push(record),
     recordRunTrace: (event) => runTraceEvents.push(event),
+    archiveToolResult: async (event) => {
+      const artifact = await artifactStore.create({
+        sessionId: event.sessionId,
+        turnId: event.turnId,
+        name: `tool-result-${event.runtimeEventId}.json`,
+        kind: 'file',
+        content: event.serializedResult,
+        mimeType: 'application/json',
+        source: 'tool_result_archive',
+        summary: `Archived ${event.toolName} tool result for DeepSeek cost baseline replay`,
+      });
+      return { artifactId: artifact.id };
+    },
     newId: randomUUID,
     now: Date.now,
     maxSteps: 1,
@@ -147,6 +162,9 @@ for (let i = 1; i <= turnCount; i += 1) {
   const completeEvent = events.find((event) => event.type === 'complete');
   const errorEvent = events.find((event) => event.type === 'error');
   const llmRecord = llmRecords.at(-1);
+  const cacheMissInputSource = usageEvent?.cacheMissInputSource ?? llmRecord?.cacheMissInputSource;
+  const cacheMissInput = usageEvent?.cacheMissInput ?? llmRecord?.cacheMissInputTokens;
+  const contextBudgetDiagnostic = usageEvent?.contextBudget ?? llmRecord?.contextBudget;
   const cost = llmRecord
     ? computeCost(
         {
@@ -172,8 +190,11 @@ for (let i = 1; i <= turnCount; i += 1) {
     requestShapeHash: usageEvent?.requestShapeHash,
     input: usageEvent?.input ?? llmRecord?.inputTokens,
     cacheHitInput: usageEvent?.cacheHitInput ?? llmRecord?.cacheHitInputTokens,
-    cacheMissInput: usageEvent?.cacheMissInput ?? llmRecord?.cacheMissInputTokens,
-    cacheMissInputSource: usageEvent?.cacheMissInputSource ?? llmRecord?.cacheMissInputSource,
+    cacheMissInput,
+    cacheMissInputSource,
+    providerExplicitCacheMissInput: cacheMissInputSource === 'explicit' ? cacheMissInput : null,
+    locallyDerivedCacheMissInput: cacheMissInputSource === 'derived' ? cacheMissInput : null,
+    cacheWriteInput: usageEvent?.cacheWriteInput ?? llmRecord?.cacheWriteInputTokens,
     cacheMissShapeSource: classifyCacheMissShape(
       usageEvent?.prefixChangeReason,
       usageEvent?.requestShapeChangeReason,
@@ -182,7 +203,10 @@ for (let i = 1; i <= turnCount; i += 1) {
     total: usageEvent?.total,
     estimatedCostUsd: cost?.totalCost,
     promptSegments: usageEvent?.promptSegments ?? llmRecord?.promptSegments,
-    contextBudget: usageEvent?.contextBudget ?? llmRecord?.contextBudget,
+    contextBudget: contextBudgetDiagnostic,
+    archivePlaceholders: contextBudgetDiagnostic?.archivePlaceholders ?? 0,
+    archiveWriteFailures: contextBudgetDiagnostic?.archiveWriteFailures ?? 0,
+    archivePlaceholderReasonCounts: contextBudgetDiagnostic?.archivePlaceholderReasonCounts,
     errorReason: errorEvent?.reason,
   });
 }
@@ -191,13 +215,36 @@ const totals = turns.reduce((acc, turn) => {
   acc.input += turn.input ?? 0;
   acc.cacheHitInput += turn.cacheHitInput ?? 0;
   acc.cacheMissInput += turn.cacheMissInput ?? 0;
+  acc.cacheWriteInput += turn.cacheWriteInput ?? 0;
   acc.output += turn.output ?? 0;
   acc.estimatedCostUsd += turn.estimatedCostUsd ?? 0;
+  if (turn.cacheMissInputSource === 'explicit') acc.explicitCacheMissTurns += 1;
+  else if (turn.cacheMissInputSource === 'derived') acc.derivedCacheMissTurns += 1;
+  else acc.unknownCacheMissTurns += 1;
+  acc.archivePlaceholders += turn.archivePlaceholders ?? 0;
+  acc.archiveWriteFailures += turn.archiveWriteFailures ?? 0;
+  for (const [reason, count] of Object.entries(turn.archivePlaceholderReasonCounts ?? {})) {
+    acc.archivePlaceholderReasonCounts[reason] = (acc.archivePlaceholderReasonCounts[reason] ?? 0) + count;
+  }
   return acc;
-}, { input: 0, cacheHitInput: 0, cacheMissInput: 0, output: 0, estimatedCostUsd: 0 });
+}, {
+  input: 0,
+  cacheHitInput: 0,
+  cacheMissInput: 0,
+  cacheWriteInput: 0,
+  output: 0,
+  estimatedCostUsd: 0,
+  explicitCacheMissTurns: 0,
+  derivedCacheMissTurns: 0,
+  unknownCacheMissTurns: 0,
+  archivePlaceholders: 0,
+  archiveWriteFailures: 0,
+  archivePlaceholderReasonCounts: {},
+});
 
 const report = {
   sourceRef: process.env.MAKA_COST_BASELINE_SOURCE_REF ?? 'local-build',
+  scenario: buildScenario(contextBudget),
   repoRoot,
   workspaceRoot,
   model,
@@ -237,6 +284,42 @@ const markdownPath = join(outputDir, 'deepseek-live-cost-baseline.md');
 await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
 await writeFile(markdownPath, renderMarkdown(report, jsonPath), 'utf8');
 console.log(JSON.stringify({ jsonPath, markdownPath, totals, turnCount, toolMode, contextBudget }, null, 2));
+
+function buildScenario(policy) {
+  const explicitName = process.env.MAKA_COST_BASELINE_SCENARIO;
+  if (explicitName) {
+    return {
+      name: explicitName,
+      contextBudgetMode: contextBudgetMode(policy),
+      archivePruneEnabled: policy?.staleToolResultPrune?.enabled === true,
+      historyTokenCap: policy?.maxHistoryEstimatedTokens ?? null,
+      historyTurnCap: policy?.maxHistoryTurns ?? null,
+    };
+  }
+  return {
+    name: scenarioNameForPolicy(policy),
+    contextBudgetMode: contextBudgetMode(policy),
+    archivePruneEnabled: policy?.staleToolResultPrune?.enabled === true,
+    historyTokenCap: policy?.maxHistoryEstimatedTokens ?? null,
+    historyTurnCap: policy?.maxHistoryTurns ?? null,
+  };
+}
+
+function scenarioNameForPolicy(policy) {
+  if (!policy) return 'budget_off';
+  if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
+    return 'archive_prune_on';
+  }
+  return 'emergency-history-cap';
+}
+
+function contextBudgetMode(policy) {
+  if (!policy) return 'off';
+  if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
+    return 'archive_prune_only';
+  }
+  return 'emergency_cap';
+}
 
 function buildContextBudgetPolicy() {
   if (process.env.MAKA_CONTEXT_BUDGET === 'off') return undefined;
@@ -296,6 +379,7 @@ function renderMarkdown(report, jsonPath) {
     '',
     `JSON: \`${jsonPath}\``,
     `Model: \`${report.model}\``,
+    `Scenario: \`${report.scenario.name}\` (${report.scenario.contextBudgetMode})`,
     `Turns: ${report.turnCount}`,
     `Tools: ${report.toolMode} (${report.toolCount})`,
     `Stable policy lines: ${report.stablePolicyLines}`,
@@ -307,13 +391,18 @@ function renderMarkdown(report, jsonPath) {
     `- input: ${report.totals.input}`,
     `- cacheHitInput: ${report.totals.cacheHitInput}`,
     `- cacheMissInput: ${report.totals.cacheMissInput}`,
+    `- cacheWriteInput: ${report.totals.cacheWriteInput}`,
     `- output: ${report.totals.output}`,
     `- estimatedCostUsd: ${report.totals.estimatedCostUsd}`,
+    `- cacheMissSourceTurns: explicit=${report.totals.explicitCacheMissTurns}, derived=${report.totals.derivedCacheMissTurns}, unknown=${report.totals.unknownCacheMissTurns}`,
+    `- archivePlaceholders: ${report.totals.archivePlaceholders}`,
+    `- archiveWriteFailures: ${report.totals.archiveWriteFailures}`,
+    `- archivePlaceholderReasonCounts: ${JSON.stringify(report.totals.archivePlaceholderReasonCounts)}`,
     '',
     '## Turns',
     '',
-    '| turn | input | hit | miss | output | prefix reason | request reason | miss source | prior history est | budget after |',
-    '| ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: |',
+    '| turn | input | hit | miss | write | output | prefix reason | request reason | miss source | archive | archive fail | prior history est | budget after |',
+    '| ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |',
   ];
   for (const turn of report.turns) {
     const prior = turn.promptSegments?.find((segment) => segment.kind === 'prior_history');
@@ -322,10 +411,13 @@ function renderMarkdown(report, jsonPath) {
       turn.input ?? 0,
       turn.cacheHitInput ?? 0,
       turn.cacheMissInput ?? 0,
+      turn.cacheWriteInput ?? 0,
       turn.output ?? 0,
       turn.prefixChangeReason ?? '',
       turn.requestShapeChangeReason ?? '',
       turn.cacheMissShapeSource ?? turn.cacheMissInputSource ?? '',
+      turn.archivePlaceholders ?? 0,
+      turn.archiveWriteFailures ?? 0,
       prior?.estimatedTokens ?? 0,
       turn.contextBudget?.estimatedTokensAfter ?? 0,
     ].join(' | ') + ' |');


### PR DESCRIPTION
## Summary
- add archive-backed replay-only stale tool-result pruning so oversized old RuntimeEvent tool results are only replaced after the original payload is persisted as a `tool_result_archive` artifact
- keep the RuntimeEvent ledger unchanged, fail open when archive writes are unavailable, and project archive placeholders as readable diagnostic tool-result rows
- extend DeepSeek live baseline reporting with explicit/derived cache-miss source counts, cache-write tokens, archive placeholder counts, and scenario labels

## Rive DAG
- workflow: `maka.deepseek-archive-backed-prune-phase5@1`
- run: `wfrun_6a791ad57e4d4156b08a36ac4ae70dcc`
- scheduler: `sched_8a156ccc2fd64e6ea043ef3dab8a2322`
- final resume scheduler: `sched_8524748e925d4587937d7451d2d4d36e`
- root: `work_ac7ee51ba1c344be86e728284a2f1550`

## Verification
- `npm run typecheck`
- `npm run build --workspaces --if-present`
- `npm run test --workspace packages/core` (614/614)
- `npm run test --workspace packages/runtime` (467/467)
- `npm run test --workspace packages/storage` (82/82)
- `npm run test --workspace apps/desktop` (1399/1399)
- `node --check scripts/deepseek-live-cost-baseline.mjs`
- `git diff --check`
