### PR TITLE
Add Phase 6 archive retrieval

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, screen, shell } from 'electron';
 import { isExternalUrl } from './external-link-guard.js';
 import { readSavedBounds, writeSavedBounds, type SavedBounds } from './window-state.js';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { copyFile, mkdir, readFile, realpath } from 'node:fs/promises';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { release as osRelease, arch as osArch } from 'node:os';
@@ -141,7 +141,13 @@ import {
   setActiveProxy,
   testConnection,
 } from '@maka/runtime';
-import type { BotIncomingMessage, ToolArtifactRecorderInput, ToolResultArchiveRecorderInput } from '@maka/runtime';
+import type {
+  BotIncomingMessage,
+  ToolArtifactRecorderInput,
+  ToolResultArchiveReaderInput,
+  ToolResultArchiveReadResult,
+  ToolResultArchiveRecorderInput,
+} from '@maka/runtime';
 import type { ContextBudgetPolicy } from '@maka/runtime';
 import { testProxyConnection } from '@maka/runtime/network/proxy-test';
 import { fetchWeChatQrcode, pollWeChatQrcodeStatus } from './wechat-scan-login.js';
@@ -700,6 +706,24 @@ async function persistArchivedToolResult(
   return { artifactId: artifact.id };
 }
 
+async function readArchivedToolResult(
+  event: ToolResultArchiveReaderInput,
+): Promise<ToolResultArchiveReadResult> {
+  const record = await artifactStore.get(event.artifactId);
+  if (!record) return { ok: false, reason: 'not_found' };
+  if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+  if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+  if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
+  if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+
+  const read = await artifactStore.readText(event.artifactId, {
+    maxBytes: event.maxBytes ?? event.originalBytes,
+  });
+  if (!read.ok) return read;
+  if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+  return { ok: true, serializedResult: read.text };
+}
+
 async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): Promise<string | null> {
   const candidate = isAbsolute(sourcePath) ? sourcePath : resolve(cwd, sourcePath);
   let root: string;
@@ -769,6 +793,7 @@ backends.register('ai-sdk', async (ctx) => {
       ),
     recordToolArtifacts: (event) => persistToolArtifacts(ctx.header.cwd, event),
     archiveToolResult: (event) => persistArchivedToolResult(event),
+    readToolResultArchive: (event) => readArchivedToolResult(event),
     recordRunTrace: ctx.recordRunTrace,
     newId: randomUUID,
     now: Date.now,
@@ -783,10 +808,16 @@ function buildContextBudgetPolicy(connection: LlmConnection): ContextBudgetPolic
   const maxHistoryTurns = parseOptionalPositiveInt(process.env.MAKA_CONTEXT_HISTORY_BUDGET_TURNS);
   const minRecentTurns = parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2);
   const staleToolResultPrune = buildStaleToolResultPrunePolicy();
+  const archiveRetrieval = buildArchiveRetrievalPolicy();
+  const historySearch = buildHistorySearchPolicy();
+  const historyRewrite = buildHistoryRewriteGatePolicy();
   if (
     maxHistoryEstimatedTokens === undefined &&
     maxHistoryTurns === undefined &&
-    staleToolResultPrune === undefined
+    staleToolResultPrune === undefined &&
+    archiveRetrieval === undefined &&
+    historySearch === undefined &&
+    historyRewrite === undefined
   ) {
     return undefined;
   }
@@ -795,6 +826,9 @@ function buildContextBudgetPolicy(connection: LlmConnection): ContextBudgetPolic
     ...(maxHistoryTurns !== undefined ? { maxHistoryTurns } : {}),
     ...(maxHistoryEstimatedTokens !== undefined ? { maxHistoryEstimatedTokens } : {}),
     ...(staleToolResultPrune !== undefined ? { staleToolResultPrune } : {}),
+    ...(archiveRetrieval !== undefined ? { archiveRetrieval } : {}),
+    ...(historySearch !== undefined ? { historySearch } : {}),
+    ...(historyRewrite !== undefined ? { historyRewrite } : {}),
     minRecentTurns,
   };
 }
@@ -814,6 +848,37 @@ function buildStaleToolResultPrunePolicy(): NonNullable<ContextBudgetPolicy['sta
   };
 }
 
+function buildArchiveRetrievalPolicy(): NonNullable<ContextBudgetPolicy['archiveRetrieval']> | undefined {
+  if (process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResults: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS, 3),
+    maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_TOKENS, 8192),
+    maxBytes: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES, 1024 * 1024),
+    order: 'newest_first',
+  };
+}
+
+function buildHistorySearchPolicy(): NonNullable<ContextBudgetPolicy['historySearch']> | undefined {
+  if (process.env.MAKA_CONTEXT_HISTORY_SEARCH !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResults: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_MAX_RESULTS, 5),
+    around: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_AROUND, 1),
+    maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_MAX_TOKENS, 4096),
+  };
+}
+
+function buildHistoryRewriteGatePolicy(): NonNullable<ContextBudgetPolicy['historyRewrite']> | undefined {
+  if (process.env.MAKA_CONTEXT_HISTORY_REWRITE !== 'on') return undefined;
+  return {
+    enabled: true,
+    name: process.env.MAKA_CONTEXT_HISTORY_REWRITE_NAME ?? 'desktop-history-rewrite',
+    historyRewriteVersion: process.env.MAKA_CONTEXT_HISTORY_REWRITE_VERSION ?? 'phase6-v1',
+    resetReason: process.env.MAKA_CONTEXT_HISTORY_REWRITE_RESET_REASON ?? 'operator_enabled_history_rewrite_gate',
+  };
+}
+
 function defaultHistoryBudgetTokens(connection: LlmConnection): number | undefined {
   if (connection.providerType === 'deepseek') return undefined;
   return 32_000;
@@ -828,6 +893,10 @@ function parseOptionalPositiveInt(value: string | undefined): number | undefined
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
 }
 
 function buildSubscriptionModelFetch(

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -175,6 +175,19 @@ export interface ContextBudgetDiagnostic {
   archiveWriteFailures?: number;
   unarchivedToolResults?: number;
   archivePlaceholderReasonCounts?: Record<string, number>;
+  retrievedArchiveToolResults?: number;
+  retrievedArchiveEstimatedTokens?: number;
+  archiveRetrievalSkipped?: number;
+  archiveRetrievalFailures?: number;
+  archiveRetrievalSkippedReasonCounts?: Record<string, number>;
+  archiveRetrievalFailureReasonCounts?: Record<string, number>;
+  historySearchMatches?: number;
+  historyAroundRetrievedEvents?: number;
+  historyAroundEstimatedTokens?: number;
+  historyAroundSkippedEvents?: number;
+  historyRewriteVersion?: string;
+  historyRewriteResetReason?: string;
+  historyRewriteGate?: string;
 }
 
 export interface ToolInvocationRecord {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
 import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
 import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
@@ -253,6 +254,158 @@ describe('AiSdkBackend model history', () => {
     assert.match(prompt, /"artifactId":"artifact-rt-result"/);
     assert.match(prompt, /"runtimeEventId":"rt-result"/);
     assert.equal(prompt.includes(oldResult.body), false);
+  });
+
+  test('history search does not re-add stale full tool results after archive pruning', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const oldResult = { body: 'SECRET_PAYLOAD_SHOULD_NOT_RETURN'.repeat(20) };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'archive-search-test',
+        maxHistoryTurns: 1,
+        minRecentTurns: 0,
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        historySearch: {
+          enabled: true,
+          maxResults: 1,
+          around: 1,
+          maxEstimatedTokens: 4096,
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => ({ artifactId: `artifact-${event.runtimeEventId}` }),
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'Find SECRET_PAYLOAD_SHOULD_NOT_RETURN',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call',
+          turnId: 'turn-old',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'secret.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result',
+          turnId: 'turn-old',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: oldResult, isError: false },
+        }),
+        runtimeEvent({
+          id: 'rt-new',
+          turnId: 'turn-new',
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'newer retained context' },
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.equal(prompt.includes(oldResult.body), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.archivePlaceholders, 1);
+    assert.equal(usage?.contextBudget?.historySearchMatches, 0);
+  });
+
+  test('hydrates archived RuntimeEvent tool results for model replay when retrieval is enabled', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    let archivedBody = '';
+    const oldResult = { body: 'retrieved archived payload' };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'archive-retrieval-test',
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        archiveRetrieval: {
+          enabled: true,
+          maxResults: 1,
+          maxEstimatedTokens: 1024,
+          maxBytes: 1024,
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archivedBody = event.serializedResult;
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => ({
+        ok: true,
+        serializedResult: event.bodySha256 === sha256(archivedBody) ? archivedBody : 'tampered',
+      }),
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'package.json' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: oldResult, isError: false },
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /retrieved archived payload/);
+    assert.equal(prompt.includes('maka.archived_tool_result'), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
+    assert.equal(usage?.contextBudget?.archiveRetrievalFailures, 0);
   });
 
   test('uses StoredMessage projection when RuntimeEvent tool results are unmatched', async () => {
@@ -2169,6 +2322,10 @@ function modelCallSettings(model: MockLanguageModelV3): unknown {
   if (!call) return {};
   const { prompt: _prompt, ...rest } = call;
   return rest;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
 }
 
 function testTool(name: string, parameters: unknown): MakaTool {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
+import type { ModelMessage } from 'ai';
 import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
 import type { LanguageModelV3StreamPart } from '@ai-sdk/provider';
 import type { LlmConnection, SessionHeader } from '@maka/core';
@@ -336,7 +338,7 @@ describe('AiSdkBackend model history', () => {
     const model = completionModel();
     const events: SessionEvent[] = [];
     let archivedBody = '';
-    const oldResult = { body: 'retrieved archived payload' };
+    const oldResult = { body: 'retrieved 中文 archived payload 🙂'.repeat(3) };
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
@@ -368,10 +370,15 @@ describe('AiSdkBackend model history', () => {
         archivedBody = event.serializedResult;
         return { artifactId: `artifact-${event.runtimeEventId}` };
       },
-      readToolResultArchive: async (event) => ({
-        ok: true,
-        serializedResult: event.bodySha256 === sha256(archivedBody) ? archivedBody : 'tampered',
-      }),
+      readToolResultArchive: async (event) => {
+        if (event.originalBytes !== utf8Bytes(archivedBody)) {
+          return { ok: false, reason: 'size_mismatch' };
+        }
+        return {
+          ok: true,
+          serializedResult: event.bodySha256 === sha256(archivedBody) ? archivedBody : 'tampered',
+        };
+      },
     });
 
     for await (const event of backend.send({
@@ -399,7 +406,7 @@ describe('AiSdkBackend model history', () => {
     }
 
     const prompt = JSON.stringify(compactPrompt(model));
-    assert.match(prompt, /retrieved archived payload/);
+    assert.match(prompt, /retrieved 中文 archived payload/);
     assert.equal(prompt.includes('maka.archived_tool_result'), false);
     const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
       event.type === 'token_usage'
@@ -973,6 +980,58 @@ describe('AiSdkBackend request-shape diagnostics', () => {
     assert.notEqual(historyChanged.requestShapeHash, base.requestShapeHash);
   });
 
+  test('tool-result output hydration changes request shape without changing durable prefix', () => {
+    const tools = canonicalizeToolSet([
+      testTool('Read', z.object({ path: z.string() })),
+    ], testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() })));
+    const toolCallMessage: ModelMessage = {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        input: { path: 'archive.txt' },
+      }],
+    };
+    const placeholderToolResult: ModelMessage = {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        output: { type: 'text', value: '[archived placeholder]' },
+      }],
+    };
+    const hydratedToolResult: ModelMessage = {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        output: { type: 'text', value: 'hydrated archive payload '.repeat(20) },
+      }],
+    };
+    const baseInput = {
+      connection: connection(),
+      modelId: 'mock-model-id',
+      systemPrompt: 'durable system',
+      providerOptions: { temperature: 0 },
+      providerTools: tools.providerTools,
+      activeTools: tools.activeTools,
+      priorMessages: [toolCallMessage, placeholderToolResult],
+    };
+    const placeholder = computeRequestShapeDiagnostic(baseInput, undefined);
+    const hydrated = computeRequestShapeDiagnostic({
+      ...baseInput,
+      priorMessages: [toolCallMessage, hydratedToolResult],
+    }, placeholder);
+
+    assert.equal(hydrated.prefixChangeReason, 'stable');
+    assert.equal(hydrated.prefixHash, placeholder.prefixHash);
+    assert.equal(hydrated.requestShapeChangeReason, 'history_projection_changed');
+    assert.notEqual(hydrated.requestShapeHash, placeholder.requestShapeHash);
+  });
+
   test('tool canonicalization is independent of registration order and places invalid last', () => {
     const invalid = testTool(INVALID_TOOL_NAME, z.object({ tool: z.string().optional() }));
     const first = canonicalizeToolSet([
@@ -1156,7 +1215,7 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
           artifactId: 'artifact-old-result',
           bodySha256: 'sha256-old-result',
           originalEstimatedTokens: JSON.stringify(oldResult).length,
-          originalBytes: JSON.stringify(oldResult).length,
+          originalBytes: utf8Bytes(JSON.stringify(oldResult)),
           rewriteVersion: 1,
           reason: 'stale_tool_result_pruned_before_compact',
         }],
@@ -2326,6 +2385,10 @@ function modelCallSettings(model: MockLanguageModelV3): unknown {
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
+}
+
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
 }
 
 function testTool(name: string, parameters: unknown): MakaTool {

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -1,0 +1,326 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+  applyRuntimeEventContextBudget,
+  deserializeToolResultArchive,
+  retrieveArchivedToolResultsForReplay,
+  retrieveRuntimeEventHistoryAround,
+  serializeToolResultForArchive,
+} from '../context-budget.js';
+
+describe('context-budget archive retrieval', () => {
+  test('deserializes JSON, undefined, and fallback strings', () => {
+    assert.deepEqual(deserializeToolResultArchive('{"kind":"text","text":"ok"}'), { kind: 'text', text: 'ok' });
+    assert.equal(deserializeToolResultArchive('undefined'), undefined);
+    assert.equal(deserializeToolResultArchive('plain fallback'), 'plain fallback');
+  });
+
+  test('hydrates archived placeholders for replay only after hash validation', async () => {
+    const originalResult = { kind: 'text', text: 'old archived payload' };
+    const serialized = serializeToolResultForArchive(originalResult);
+    const events = [
+      toolCall('call-old', 'turn-old', 'tool-old'),
+      toolResult('result-old', 'turn-old', 'tool-old', originalResult),
+      toolCall('call-new', 'turn-new', 'tool-new'),
+      toolResult('result-new', 'turn-new', 'tool-new', { kind: 'text', text: 'new full payload' }),
+    ];
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 1,
+        archiveRefs: [{
+          runtimeEventId: 'result-old',
+          toolCallId: 'tool-old',
+          toolName: 'Read',
+          artifactId: 'artifact-old',
+          bodySha256: sha256(serialized),
+          originalEstimatedTokens: serialized.length,
+          originalBytes: serialized.length,
+          rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+          reason: 'stale_tool_result_pruned_before_compact',
+        }],
+      },
+      archiveRetrieval: { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      minRecentTurns: 2,
+      charsPerToken: 1,
+    });
+
+    assert.ok(budgeted);
+    const retrieval = await retrieveArchivedToolResultsForReplay(
+      budgeted.events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async () => ({ ok: true, serializedResult: serialized }),
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    const originalBudgeted = budgeted.events.find((event) => event.id === 'result-old');
+    assert.equal(
+      originalBudgeted?.content?.kind === 'function_response'
+        ? (originalBudgeted.content.result as { kind?: string }).kind
+        : undefined,
+      ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    );
+    const hydrated = retrieval.events.find((event) => event.id === 'result-old');
+    assert.deepEqual(
+      hydrated?.content?.kind === 'function_response' ? hydrated.content.result : undefined,
+      originalResult,
+    );
+    assert.equal(retrieval.diagnosticPatch.retrievedArchiveToolResults, 1);
+    assert.equal(retrieval.diagnosticPatch.retrievedArchiveEstimatedTokens, serialized.length);
+  });
+
+  test('keeps placeholders and records corrupt/missing archive diagnostics', async () => {
+    const serialized = serializeToolResultForArchive({ kind: 'text', text: 'body' });
+    const events = [toolCall('call-1', 'turn-1', 'tool-1'), archivedResult('result-1', 'turn-1', 'tool-1', {
+      artifactId: 'artifact-1',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: serialized.length,
+    })];
+
+    const corrupt = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async () => ({ ok: true, serializedResult: 'tampered' }),
+      { sessionId: 'session-1' },
+    );
+    assert.equal(corrupt.diagnosticPatch.archiveRetrievalFailures, 1);
+    assert.deepEqual(corrupt.diagnosticPatch.archiveRetrievalFailureReasonCounts, { corrupt: 1 });
+    assert.equal(
+      corrupt.events[1]?.content?.kind === 'function_response'
+        ? (corrupt.events[1].content.result as { kind?: string }).kind
+        : undefined,
+      ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    );
+
+    const missing = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async () => ({ ok: false, reason: 'not_found' }),
+      { sessionId: 'session-1' },
+    );
+    assert.deepEqual(missing.diagnosticPatch.archiveRetrievalFailureReasonCounts, { not_found: 1 });
+  });
+
+  test('fails open when retrieval is disabled or no reader is available', async () => {
+    const serialized = serializeToolResultForArchive({ kind: 'text', text: 'body' });
+    const events = [archivedResult('result-1', 'turn-1', 'tool-1', {
+      artifactId: 'artifact-1',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: serialized.length,
+    })];
+
+    const disabled = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: false, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async () => ({ ok: true, serializedResult: serialized }),
+      { sessionId: 'session-1' },
+    );
+    assert.notEqual(disabled.events, events);
+    assert.deepEqual(disabled.events, events);
+    assert.deepEqual(disabled.diagnosticPatch, {});
+
+    const noReader = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      undefined,
+      { sessionId: 'session-1' },
+    );
+    assert.deepEqual(noReader.events, events);
+    assert.deepEqual(noReader.diagnosticPatch, {});
+  });
+
+  test('skips oversized candidates before reading archives', async () => {
+    const small = serializeToolResultForArchive({ kind: 'text', text: 'small' });
+    const big = serializeToolResultForArchive({ kind: 'text', text: 'big' });
+    const events = [
+      archivedResult('result-big', 'turn-1', 'tool-big', {
+        artifactId: 'artifact-big',
+        bodySha256: sha256(big),
+        originalEstimatedTokens: 500,
+        originalBytes: 5000,
+      }),
+      archivedResult('result-small', 'turn-2', 'tool-small', {
+        artifactId: 'artifact-small',
+        bodySha256: sha256(small),
+        originalEstimatedTokens: small.length,
+        originalBytes: small.length,
+      }),
+    ];
+    const readIds: string[] = [];
+
+    const result = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: true, maxResults: 2, maxEstimatedTokens: 100, maxBytes: 100 },
+      async (input) => {
+        readIds.push(input.runtimeEventId);
+        return { ok: true, serializedResult: small };
+      },
+      { sessionId: 'session-1' },
+    );
+
+    assert.deepEqual(readIds, ['result-small']);
+    assert.equal(result.diagnosticPatch.retrievedArchiveToolResults, 1);
+    assert.equal(result.diagnosticPatch.archiveRetrievalSkipped, 1);
+    assert.deepEqual(result.diagnosticPatch.archiveRetrievalSkippedReasonCounts, { max_bytes: 1 });
+  });
+
+  test('selects newest placeholders first and obeys max result bounds', async () => {
+    const first = serializeToolResultForArchive({ kind: 'text', text: 'first' });
+    const second = serializeToolResultForArchive({ kind: 'text', text: 'second' });
+    const events = [
+      toolCall('call-1', 'turn-1', 'tool-1'),
+      archivedResult('result-1', 'turn-1', 'tool-1', {
+        artifactId: 'artifact-1',
+        bodySha256: sha256(first),
+        originalEstimatedTokens: first.length,
+        originalBytes: first.length,
+      }),
+      toolCall('call-2', 'turn-2', 'tool-2'),
+      archivedResult('result-2', 'turn-2', 'tool-2', {
+        artifactId: 'artifact-2',
+        bodySha256: sha256(second),
+        originalEstimatedTokens: second.length,
+        originalBytes: second.length,
+      }),
+    ];
+    const seen: string[] = [];
+
+    const retrieved = await retrieveArchivedToolResultsForReplay(
+      events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async (input) => {
+        seen.push(input.runtimeEventId);
+        return { ok: true, serializedResult: input.runtimeEventId === 'result-2' ? second : first };
+      },
+      { sessionId: 'session-1' },
+    );
+
+    assert.deepEqual(seen, ['result-2']);
+    assert.equal(retrieved.diagnosticPatch.retrievedArchiveToolResults, 1);
+    assert.deepEqual(
+      retrieved.events[3]?.content?.kind === 'function_response'
+        ? retrieved.events[3].content.result
+        : undefined,
+      { kind: 'text', text: 'second' },
+    );
+  });
+});
+
+describe('context-budget search and rewrite diagnostics', () => {
+  test('retrieves bounded around-context for deterministic RuntimeEvent search hits', () => {
+    const events = [
+      textEvent('before', 'turn-1', 'setup context'),
+      textEvent('target', 'turn-2', 'needle project archive detail'),
+      textEvent('after', 'turn-3', 'follow-up context'),
+      textEvent('far', 'turn-4', 'unrelated'),
+    ];
+
+    const result = retrieveRuntimeEventHistoryAround(
+      events,
+      'please find needle',
+      { enabled: true, maxResults: 1, around: 1, maxEstimatedTokens: 1000 },
+      { charsPerToken: 1 },
+    );
+
+    assert.deepEqual(result.events.map((event) => event.id), ['before', 'target', 'after']);
+    assert.equal(result.diagnosticPatch.historySearchMatches, 1);
+    assert.equal(result.diagnosticPatch.historyAroundRetrievedEvents, 3);
+  });
+
+  test('records named history rewrite gate version and reset reason', () => {
+    const budgeted = applyRuntimeEventContextBudget(
+      [textEvent('event-1', 'turn-1', 'hello')],
+      {
+        historyRewrite: {
+          enabled: true,
+          name: 'phase6-high-water',
+          historyRewriteVersion: 'phase6-v1',
+          resetReason: 'explicit_test_reset',
+        },
+      },
+    );
+
+    assert.ok(budgeted);
+    assert.equal(budgeted.diagnostic.historyRewriteGate, 'phase6-high-water');
+    assert.equal(budgeted.diagnostic.historyRewriteVersion, 'phase6-v1');
+    assert.equal(budgeted.diagnostic.historyRewriteResetReason, 'explicit_test_reset');
+  });
+});
+
+function textEvent(id: string, turnId: string, text: string): RuntimeEvent {
+  return baseEvent({
+    id,
+    turnId,
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', text },
+  });
+}
+
+function toolCall(id: string, turnId: string, toolCallId: string): RuntimeEvent {
+  return baseEvent({
+    id,
+    turnId,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'function_call', id: toolCallId, name: 'Read', args: { path: `${toolCallId}.txt` } },
+  });
+}
+
+function toolResult(id: string, turnId: string, toolCallId: string, result: unknown): RuntimeEvent {
+  return baseEvent({
+    id,
+    turnId,
+    role: 'tool',
+    author: 'tool',
+    content: { kind: 'function_response', id: toolCallId, name: 'Read', result },
+  });
+}
+
+function archivedResult(
+  id: string,
+  turnId: string,
+  toolCallId: string,
+  archive: {
+    artifactId: string;
+    bodySha256: string;
+    originalEstimatedTokens: number;
+    originalBytes: number;
+  },
+): RuntimeEvent {
+  return toolResult(id, turnId, toolCallId, {
+    kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+    runtimeEventId: id,
+    toolCallId,
+    toolName: 'Read',
+    reason: 'stale_tool_result_pruned_before_compact',
+    ...archive,
+  });
+}
+
+function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id: 'event',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    invocationId: 'invocation-1',
+    ts: 1_800_000_000_000,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
@@ -40,7 +41,7 @@ describe('context-budget archive retrieval', () => {
           artifactId: 'artifact-old',
           bodySha256: sha256(serialized),
           originalEstimatedTokens: serialized.length,
-          originalBytes: serialized.length,
+          originalBytes: utf8Bytes(serialized),
           rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
           reason: 'stale_tool_result_pruned_before_compact',
         }],
@@ -74,13 +75,66 @@ describe('context-budget archive retrieval', () => {
     assert.equal(retrieval.diagnosticPatch.retrievedArchiveEstimatedTokens, serialized.length);
   });
 
+  test('uses UTF-8 byte length for non-ASCII archive size validation', async () => {
+    const originalResult = { kind: 'text', text: '旧归档 payload 🙂'.repeat(3) };
+    const serialized = serializeToolResultForArchive(originalResult);
+    assert.ok(utf8Bytes(serialized) > serialized.length);
+    const events = [
+      toolCall('call-old', 'turn-old', 'tool-old'),
+      toolResult('result-old', 'turn-old', 'tool-old', originalResult),
+      toolCall('call-new', 'turn-new', 'tool-new'),
+      toolResult('result-new', 'turn-new', 'tool-new', { kind: 'text', text: 'new full payload' }),
+    ];
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 1,
+        archiveRefs: [{
+          runtimeEventId: 'result-old',
+          toolCallId: 'tool-old',
+          toolName: 'Read',
+          artifactId: 'artifact-old',
+          bodySha256: sha256(serialized),
+          originalEstimatedTokens: serialized.length,
+          originalBytes: utf8Bytes(serialized),
+          rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+          reason: 'stale_tool_result_pruned_before_compact',
+        }],
+      },
+      archiveRetrieval: { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      minRecentTurns: 1,
+      charsPerToken: 1,
+    });
+
+    assert.ok(budgeted);
+    assert.equal(budgeted.diagnostic.prunedToolResults, 1);
+    const retrieval = await retrieveArchivedToolResultsForReplay(
+      budgeted.events,
+      { enabled: true, maxResults: 1, maxEstimatedTokens: 1024, maxBytes: 1024 },
+      async (input) =>
+        input.originalBytes === utf8Bytes(serialized)
+          ? { ok: true, serializedResult: serialized }
+          : { ok: false, reason: 'size_mismatch' },
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    const hydrated = retrieval.events.find((event) => event.id === 'result-old');
+    assert.deepEqual(
+      hydrated?.content?.kind === 'function_response' ? hydrated.content.result : undefined,
+      originalResult,
+    );
+    assert.equal(retrieval.diagnosticPatch.retrievedArchiveToolResults, 1);
+    assert.equal(retrieval.diagnosticPatch.archiveRetrievalFailures, 0);
+  });
+
   test('keeps placeholders and records corrupt/missing archive diagnostics', async () => {
     const serialized = serializeToolResultForArchive({ kind: 'text', text: 'body' });
     const events = [toolCall('call-1', 'turn-1', 'tool-1'), archivedResult('result-1', 'turn-1', 'tool-1', {
       artifactId: 'artifact-1',
       bodySha256: sha256(serialized),
       originalEstimatedTokens: serialized.length,
-      originalBytes: serialized.length,
+      originalBytes: utf8Bytes(serialized),
     })];
 
     const corrupt = await retrieveArchivedToolResultsForReplay(
@@ -113,7 +167,7 @@ describe('context-budget archive retrieval', () => {
       artifactId: 'artifact-1',
       bodySha256: sha256(serialized),
       originalEstimatedTokens: serialized.length,
-      originalBytes: serialized.length,
+      originalBytes: utf8Bytes(serialized),
     })];
 
     const disabled = await retrieveArchivedToolResultsForReplay(
@@ -150,7 +204,7 @@ describe('context-budget archive retrieval', () => {
         artifactId: 'artifact-small',
         bodySha256: sha256(small),
         originalEstimatedTokens: small.length,
-        originalBytes: small.length,
+        originalBytes: utf8Bytes(small),
       }),
     ];
     const readIds: string[] = [];
@@ -180,14 +234,14 @@ describe('context-budget archive retrieval', () => {
         artifactId: 'artifact-1',
         bodySha256: sha256(first),
         originalEstimatedTokens: first.length,
-        originalBytes: first.length,
+        originalBytes: utf8Bytes(first),
       }),
       toolCall('call-2', 'turn-2', 'tool-2'),
       archivedResult('result-2', 'turn-2', 'tool-2', {
         artifactId: 'artifact-2',
         bodySha256: sha256(second),
         originalEstimatedTokens: second.length,
-        originalBytes: second.length,
+        originalBytes: utf8Bytes(second),
       }),
     ];
     const seen: string[] = [];
@@ -323,4 +377,8 @@ function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
+}
+
+function utf8Bytes(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
 }

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -14,6 +14,7 @@ import { expect } from '../test-helpers.js';
 import {
   compareRuntimeReadModelMessages,
   projectRuntimeEventsToStoredMessages,
+  projectRuntimeEventsToStoredMessagesWithArchiveStatuses,
 } from '../runtime-event-read-model.js';
 import { materializeSession } from '../materializer.js';
 import {
@@ -324,6 +325,45 @@ describe('projectRuntimeEventsToStoredMessages', () => {
       'archived_tool_result_placeholder',
       'context_remaining_unsupported',
     ]);
+  });
+
+  test('archive status wrapper can project missing and corrupt rows without changing sync defaults', () => {
+    const events = baseEvents();
+    const toolResult = events.find((event) => event.id === 'evt-tool-result');
+    if (toolResult?.content?.kind !== 'function_response') throw new Error('fixture missing tool result');
+    toolResult.content.result = {
+      kind: 'maka.archived_tool_result',
+      rewriteVersion: 1,
+      artifactId: 'artifact-tool-result',
+      runtimeEventId: 'evt-tool-result',
+      toolCallId: 'tool-1',
+      toolName: 'Read',
+      bodySha256: 'a'.repeat(64),
+      originalEstimatedTokens: 200,
+      originalBytes: 800,
+      reason: 'stale_tool_result_pruned_before_compact',
+    };
+
+    const defaultOut = projectRuntimeEventsToStoredMessages(events, { runHeaders: [header] });
+    const defaultProjected = defaultOut.messages.find((message) => message.type === 'tool_result');
+    expect(defaultProjected).toMatchObject({ type: 'tool_result' });
+    expect(archivedStatus(defaultProjected)).toBe('not_loaded');
+
+    const missingOut = projectRuntimeEventsToStoredMessagesWithArchiveStatuses(events, {
+      runHeaders: [header],
+      archiveStatuses: { 'evt-tool-result': 'missing' },
+    });
+    const missingProjected = missingOut.messages.find((message) => message.type === 'tool_result');
+    expect(missingProjected).toMatchObject({ type: 'tool_result' });
+    expect(archivedStatus(missingProjected)).toBe('missing');
+
+    const corruptOut = projectRuntimeEventsToStoredMessagesWithArchiveStatuses(events, {
+      runHeaders: [header],
+      archiveStatuses: [{ runtimeEventId: 'evt-tool-result', status: 'corrupt' }],
+    });
+    const corruptProjected = corruptOut.messages.find((message) => message.type === 'tool_result');
+    expect(corruptProjected).toMatchObject({ type: 'tool_result' });
+    expect(archivedStatus(corruptProjected)).toBe('corrupt');
   });
 
   test('projected rows materialize to the same runtime view model as equivalent legacy rows', () => {
@@ -649,6 +689,11 @@ async function expectRejects(promise: Promise<unknown>, pattern: RegExp): Promis
     return;
   }
   throw new Error(`Expected promise to reject with ${pattern}`);
+}
+
+function archivedStatus(message: StoredMessage | undefined): string | undefined {
+  if (message?.type !== 'tool_result') return undefined;
+  return message.content.kind === 'archived_tool_result' ? message.content.status : undefined;
 }
 
 function makeHeader(id: string): SessionHeader {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -105,8 +105,12 @@ import {
   applyRuntimeEventContextBudget,
   buildPromptSegmentEstimates,
   collectStaleToolResultArchiveCandidates,
+  estimateRuntimeEventsTokens,
+  retrieveArchivedToolResultsForReplay,
+  retrieveRuntimeEventHistoryAround,
   type ContextBudgetPolicy,
   type StaleToolResultArchiveCandidate,
+  type ToolResultArchiveReader,
   type ToolResultArchiveRef,
 } from './context-budget.js';
 
@@ -218,6 +222,12 @@ export interface AiSdkBackendInput {
    * archived by this callback.
    */
   archiveToolResult?: ToolResultArchiveRecorder;
+  /**
+   * Optional archive reader for replay-only stale tool-result retrieval. The
+   * runtime never mutates persisted RuntimeEvents; successful reads hydrate
+   * the current model request only.
+   */
+  readToolResultArchive?: ToolResultArchiveReader;
 }
 
 export interface SystemPromptContext {
@@ -725,8 +735,46 @@ export class AiSdkBackend implements AgentBackend {
     const priorRuntimeContext = input.runtimeContext.filter((event) => event.turnId !== input.turnId);
     const contextBudget = await this.prepareContextBudgetPolicy(priorRuntimeContext);
     const budgeted = applyRuntimeEventContextBudget(priorRuntimeContext, contextBudget);
-    const runtimeContext = budgeted?.events
+    let runtimeContext = budgeted?.events
       ?? priorRuntimeContext;
+    let contextBudgetDiagnostic = budgeted?.diagnostic;
+
+    const historySearchSource = buildHistorySearchSource(priorRuntimeContext, contextBudget);
+    const historyAround = retrieveRuntimeEventHistoryAround(
+      historySearchSource,
+      input.text,
+      contextBudget?.historySearch,
+      { charsPerToken: contextBudget?.charsPerToken },
+    );
+    if (historyAround.events.length > 0) {
+      runtimeContext = mergeRuntimeEventsInOriginalOrder(priorRuntimeContext, runtimeContext, historyAround.events);
+      contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+        contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+        historyAround.diagnosticPatch,
+      );
+    } else if (contextBudget?.historySearch?.enabled === true) {
+      contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+        contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+        historyAround.diagnosticPatch,
+      );
+    }
+
+    const retrieval = await retrieveArchivedToolResultsForReplay(
+      runtimeContext,
+      contextBudget?.archiveRetrieval,
+      this.input.readToolResultArchive,
+      {
+        sessionId: this.sessionId,
+        charsPerToken: contextBudget?.charsPerToken,
+      },
+    );
+    runtimeContext = retrieval.events;
+    if (contextBudget?.archiveRetrieval?.enabled === true) {
+      contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+        contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+        retrieval.diagnosticPatch,
+      );
+    }
 
     const plan = buildRuntimeEventModelReplayPlan(
       runtimeContext,
@@ -737,7 +785,7 @@ export class AiSdkBackend implements AgentBackend {
         gate: 'stored_message_projection',
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
-        ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+        ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
       };
     }
 
@@ -747,7 +795,7 @@ export class AiSdkBackend implements AgentBackend {
         gate: 'runtime_replay_unsupported_semantics',
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
-        ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+        ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
       };
     }
 
@@ -757,7 +805,7 @@ export class AiSdkBackend implements AgentBackend {
         gate: 'runtime_replay_text_only',
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
-        ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+        ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
       };
     }
 
@@ -767,7 +815,7 @@ export class AiSdkBackend implements AgentBackend {
         gate: 'runtime_replay_unsupported_semantics',
         diagnostics: plan.diagnostics,
         runtimeEventCount: runtimeContext.length,
-        ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+        ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
       };
     }
 
@@ -776,7 +824,7 @@ export class AiSdkBackend implements AgentBackend {
       gate: 'runtime_replay_provider_native',
       diagnostics: plan.diagnostics,
       runtimeEventCount: runtimeContext.length,
-      ...(budgeted ? { contextBudget: budgeted.diagnostic } : {}),
+      ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
     };
   }
 
@@ -991,6 +1039,105 @@ function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolea
     diagnostic.code === 'unmatched_tool_result' ||
     diagnostic.code === 'tool_id_mismatch'
   );
+}
+
+function mergeRuntimeEventsInOriginalOrder(
+  original: readonly RuntimeEvent[],
+  current: readonly RuntimeEvent[],
+  extra: readonly RuntimeEvent[],
+): RuntimeEvent[] {
+  const wantedIds = new Set<string>();
+  const byId = new Map<string, RuntimeEvent>();
+  for (const event of current) {
+    wantedIds.add(event.id);
+    byId.set(event.id, event);
+  }
+  for (const event of extra) {
+    wantedIds.add(event.id);
+    if (!byId.has(event.id)) byId.set(event.id, event);
+  }
+  const out: RuntimeEvent[] = [];
+  for (const event of original) {
+    if (!wantedIds.has(event.id)) continue;
+    out.push(byId.get(event.id) ?? event);
+  }
+  return out;
+}
+
+function buildContextBudgetDiagnosticShell(
+  before: readonly RuntimeEvent[],
+  after: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): ContextBudgetDiagnostic {
+  const charsPerToken = policy?.charsPerToken ?? 4;
+  const turnCountBefore = new Set(before.map((event) => event.turnId || '<unknown-turn>')).size;
+  const turnCountAfter = new Set(after.map((event) => event.turnId || '<unknown-turn>')).size;
+  return {
+    enabled: true,
+    ...(policy?.name ? { policyName: policy.name } : {}),
+    ...(policy?.maxHistoryEstimatedTokens !== undefined
+      ? { maxHistoryEstimatedTokens: policy.maxHistoryEstimatedTokens }
+      : {}),
+    ...(policy?.maxHistoryTurns !== undefined ? { maxHistoryTurns: policy.maxHistoryTurns } : {}),
+    estimatedTokensBefore: estimateRuntimeEventsTokens(before, charsPerToken),
+    estimatedTokensAfter: estimateRuntimeEventsTokens(after, charsPerToken),
+    keptTurns: turnCountAfter,
+    droppedTurns: Math.max(0, turnCountBefore - turnCountAfter),
+    keptEvents: after.length,
+    droppedEvents: Math.max(0, before.length - after.length),
+    ...(policy?.historyRewrite?.enabled === true
+      ? {
+          historyRewriteVersion: policy.historyRewrite.historyRewriteVersion,
+          historyRewriteResetReason: policy.historyRewrite.resetReason,
+          historyRewriteGate: policy.historyRewrite.name ?? 'history-rewrite',
+        }
+      : {}),
+  };
+}
+
+function buildHistorySearchSource(
+  events: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): readonly RuntimeEvent[] {
+  if (policy?.staleToolResultPrune?.enabled !== true) return events;
+  return applyRuntimeEventContextBudget(events, {
+    ...policy,
+    maxHistoryEstimatedTokens: undefined,
+    maxHistoryTurns: undefined,
+    archiveRetrieval: undefined,
+    historySearch: undefined,
+    historyRewrite: undefined,
+  })?.events ?? events;
+}
+
+function mergeContextBudgetDiagnostic(
+  base: ContextBudgetDiagnostic,
+  patch: Partial<ContextBudgetDiagnostic>,
+): ContextBudgetDiagnostic {
+  return {
+    ...base,
+    ...patch,
+    archiveRetrievalFailureReasonCounts: mergeCountRecords(
+      base.archiveRetrievalFailureReasonCounts,
+      patch.archiveRetrievalFailureReasonCounts,
+    ),
+    archiveRetrievalSkippedReasonCounts: mergeCountRecords(
+      base.archiveRetrievalSkippedReasonCounts,
+      patch.archiveRetrievalSkippedReasonCounts,
+    ),
+  };
+}
+
+function mergeCountRecords(
+  left: Record<string, number> | undefined,
+  right: Record<string, number> | undefined,
+): Record<string, number> | undefined {
+  if (!left && !right) return undefined;
+  const out: Record<string, number> = { ...(left ?? {}) };
+  for (const [key, value] of Object.entries(right ?? {})) {
+    out[key] = (out[key] ?? 0) + value;
+  }
+  return out;
 }
 
 function jsonValue(value: unknown): JSONValue {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { ModelMessage } from 'ai';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type {
@@ -20,6 +21,12 @@ export interface ContextBudgetPolicy {
   charsPerToken?: number;
   /** Optional replay-only pruning for stale oversized tool results before whole-turn compaction. */
   staleToolResultPrune?: StaleToolResultPrunePolicy;
+  /** Optional replay-only archive hydration after pruning. Defaults off. */
+  archiveRetrieval?: ArchiveRetrievalPolicy;
+  /** Optional deterministic prior-history search used to re-add bounded around-context. Defaults off. */
+  historySearch?: RuntimeEventHistorySearchPolicy;
+  /** Named rewrite/compaction gate for diagnostics and explicit cache-shape resets. */
+  historyRewrite?: HistoryRewriteGatePolicy;
 }
 
 export interface StaleToolResultPrunePolicy {
@@ -33,6 +40,29 @@ export interface StaleToolResultPrunePolicy {
    * matching ref exists, so archive-write failure keeps original content.
    */
   archiveRefs?: readonly ToolResultArchiveRef[] | Readonly<Record<string, ToolResultArchiveRef>>;
+}
+
+export interface ArchiveRetrievalPolicy {
+  enabled: boolean;
+  maxResults?: number;
+  maxEstimatedTokens?: number;
+  maxBytes?: number;
+  order?: 'newest_first';
+}
+
+export interface RuntimeEventHistorySearchPolicy {
+  enabled: boolean;
+  query?: string;
+  maxResults?: number;
+  around?: number;
+  maxEstimatedTokens?: number;
+}
+
+export interface HistoryRewriteGatePolicy {
+  enabled: boolean;
+  name?: string;
+  historyRewriteVersion: string;
+  resetReason: string;
 }
 
 export const ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND = 'maka.archived_tool_result';
@@ -78,6 +108,49 @@ export interface ToolResultArchiveRef {
   reason: ArchivedToolResultReason;
 }
 
+export type ToolResultArchiveReadFailureReason =
+  | 'not_found'
+  | 'deleted'
+  | 'too_large'
+  | 'not_allowed'
+  | 'read_failed'
+  | 'source_mismatch'
+  | 'session_mismatch'
+  | 'size_mismatch'
+  | 'corrupt';
+
+export interface ToolResultArchiveReaderInput extends ArchivedToolResultPlaceholder {
+  sessionId: string;
+  maxBytes?: number;
+}
+
+export type ToolResultArchiveReadResult =
+  | { ok: true; serializedResult: string }
+  | { ok: false; reason: ToolResultArchiveReadFailureReason };
+
+export type ToolResultArchiveReader = (
+  input: ToolResultArchiveReaderInput,
+) => Promise<ToolResultArchiveReadResult> | ToolResultArchiveReadResult;
+
+export interface ArchiveRetrievalResult {
+  events: RuntimeEvent[];
+  diagnosticPatch: Partial<ContextBudgetDiagnostic>;
+}
+
+export interface RuntimeEventHistorySearchHit {
+  eventId: string;
+  turnId: string;
+  ts: number;
+  score: number;
+  matchedTerms: string[];
+}
+
+export interface RuntimeEventHistoryAroundResult {
+  events: RuntimeEvent[];
+  hits: RuntimeEventHistorySearchHit[];
+  diagnosticPatch: Partial<ContextBudgetDiagnostic>;
+}
+
 export interface BudgetedRuntimeContext {
   events: RuntimeEvent[];
   diagnostic: ContextBudgetDiagnostic;
@@ -100,7 +173,17 @@ export function applyRuntimeEventContextBudget(
 ): BudgetedRuntimeContext | undefined {
   const prunePolicy = policy?.staleToolResultPrune;
   const pruneEnabled = prunePolicy?.enabled === true;
-  const enabled = Boolean(policy?.maxHistoryEstimatedTokens || policy?.maxHistoryTurns || pruneEnabled);
+  const archiveRetrievalEnabled = policy?.archiveRetrieval?.enabled === true;
+  const historySearchEnabled = policy?.historySearch?.enabled === true;
+  const historyRewriteEnabled = policy?.historyRewrite?.enabled === true;
+  const enabled = Boolean(
+    policy?.maxHistoryEstimatedTokens ||
+    policy?.maxHistoryTurns ||
+    pruneEnabled ||
+    archiveRetrievalEnabled ||
+    historySearchEnabled ||
+    historyRewriteEnabled
+  );
   if (!enabled) return undefined;
   if (!policy) return undefined;
   const charsPerToken = policy?.charsPerToken ?? 4;
@@ -140,6 +223,13 @@ export function applyRuntimeEventContextBudget(
     droppedTurns: Math.max(0, turnGroups.length - keptTurnIds.size),
     keptEvents: keptEvents.length,
     droppedEvents: Math.max(0, budgetEvents.length - keptEvents.length),
+    ...(policy.historyRewrite?.enabled === true
+      ? {
+          historyRewriteVersion: policy.historyRewrite.historyRewriteVersion,
+          historyRewriteResetReason: policy.historyRewrite.resetReason,
+          historyRewriteGate: policy.historyRewrite.name ?? 'history-rewrite',
+        }
+      : {}),
     ...(pruned.prunedToolResults > 0
       ? {
           prunedToolResults: pruned.prunedToolResults,
@@ -159,6 +249,173 @@ export function applyRuntimeEventContextBudget(
       : {}),
   };
   return { events: keptEvents, diagnostic };
+}
+
+export async function retrieveArchivedToolResultsForReplay(
+  events: readonly RuntimeEvent[],
+  policy: ArchiveRetrievalPolicy | undefined,
+  reader: ToolResultArchiveReader | undefined,
+  options: { sessionId: string; charsPerToken?: number },
+): Promise<ArchiveRetrievalResult> {
+  if (policy?.enabled !== true || !reader) {
+    return { events: [...events], diagnosticPatch: {} };
+  }
+
+  const charsPerToken = options.charsPerToken ?? 4;
+  const maxResults = finitePositive(policy.maxResults) ?? 3;
+  const maxEstimatedTokens = finitePositive(policy.maxEstimatedTokens) ?? 8_192;
+  const maxBytes = finitePositive(policy.maxBytes) ?? 1024 * 1024;
+  const candidates = collectArchiveRetrievalCandidates(events, policy.order ?? 'newest_first');
+
+  let retrieved = 0;
+  let retrievedTokens = 0;
+  let skipped = 0;
+  let failures = 0;
+  const skippedReasonCounts: Record<string, number> = {};
+  const failureReasonCounts: Record<string, number> = {};
+  const replacements = new Map<string, unknown>();
+
+  for (const candidate of candidates) {
+    if (retrieved >= maxResults) break;
+    if (candidate.placeholder.originalBytes > maxBytes) {
+      skipped += 1;
+      increment(skippedReasonCounts, 'max_bytes');
+      continue;
+    }
+    if (candidate.placeholder.originalEstimatedTokens > maxEstimatedTokens) {
+      skipped += 1;
+      increment(skippedReasonCounts, 'max_candidate_tokens');
+      continue;
+    }
+    if (retrievedTokens + candidate.placeholder.originalEstimatedTokens > maxEstimatedTokens) {
+      skipped += 1;
+      increment(skippedReasonCounts, 'max_total_tokens');
+      continue;
+    }
+
+    const readResult = await Promise.resolve(reader({
+      ...candidate.placeholder,
+      sessionId: options.sessionId,
+      maxBytes,
+    })).catch((): ToolResultArchiveReadResult => ({ ok: false, reason: 'read_failed' }));
+    if (!readResult.ok) {
+      failures += 1;
+      increment(failureReasonCounts, readResult.reason);
+      continue;
+    }
+    const actualHash = sha256(readResult.serializedResult);
+    if (actualHash !== candidate.placeholder.bodySha256) {
+      failures += 1;
+      increment(failureReasonCounts, 'corrupt');
+      continue;
+    }
+
+    replacements.set(candidate.event.id, deserializeToolResultArchive(readResult.serializedResult));
+    retrieved += 1;
+    retrievedTokens += candidate.placeholder.originalEstimatedTokens;
+  }
+
+  const hydratedEvents = events.map((event) => {
+    const replacement = replacements.get(event.id);
+    if (!replacements.has(event.id) || event.content?.kind !== 'function_response') return event;
+    return {
+      ...event,
+      content: {
+        ...event.content,
+        result: replacement,
+      },
+    };
+  });
+
+  return {
+    events: hydratedEvents,
+    diagnosticPatch: {
+      retrievedArchiveToolResults: retrieved,
+      retrievedArchiveEstimatedTokens: retrievedTokens,
+      archiveRetrievalSkipped: skipped,
+      archiveRetrievalFailures: failures,
+      ...(Object.keys(skippedReasonCounts).length > 0
+        ? { archiveRetrievalSkippedReasonCounts: skippedReasonCounts }
+        : {}),
+      ...(Object.keys(failureReasonCounts).length > 0
+        ? { archiveRetrievalFailureReasonCounts: failureReasonCounts }
+        : {}),
+    },
+  };
+}
+
+export function deserializeToolResultArchive(serialized: string): unknown {
+  if (serialized === 'undefined') return undefined;
+  try {
+    return JSON.parse(serialized) as unknown;
+  } catch {
+    return serialized;
+  }
+}
+
+export function searchRuntimeEventHistory(
+  events: readonly RuntimeEvent[],
+  query: string,
+  policy: RuntimeEventHistorySearchPolicy | undefined,
+): RuntimeEventHistorySearchHit[] {
+  if (policy?.enabled !== true) return [];
+  const terms = tokenizeSearchQuery(query);
+  if (terms.length === 0) return [];
+  const maxResults = finitePositive(policy.maxResults) ?? 5;
+  return events
+    .map((event) => scoreRuntimeEventSearchHit(event, terms))
+    .filter((hit): hit is RuntimeEventHistorySearchHit => hit !== undefined)
+    .sort((a, b) => b.score - a.score || b.ts - a.ts || b.eventId.localeCompare(a.eventId))
+    .slice(0, maxResults);
+}
+
+export function retrieveRuntimeEventHistoryAround(
+  events: readonly RuntimeEvent[],
+  query: string,
+  policy: RuntimeEventHistorySearchPolicy | undefined,
+  options: { charsPerToken?: number } = {},
+): RuntimeEventHistoryAroundResult {
+  if (policy?.enabled !== true) {
+    return { events: [], hits: [], diagnosticPatch: {} };
+  }
+  const charsPerToken = options.charsPerToken ?? 4;
+  const around = Math.max(0, Math.floor(policy.around ?? 1));
+  const maxEstimatedTokens = finitePositive(policy.maxEstimatedTokens) ?? 4_096;
+  const hits = searchRuntimeEventHistory(events, policy.query ?? query, policy);
+  const selectedIndexes = new Set<number>();
+  const indexesByEventId = new Map(events.map((event, index) => [event.id, index]));
+  for (const hit of hits) {
+    const index = indexesByEventId.get(hit.eventId);
+    if (index === undefined) continue;
+    for (let cursor = Math.max(0, index - around); cursor <= Math.min(events.length - 1, index + around); cursor += 1) {
+      selectedIndexes.add(cursor);
+    }
+  }
+
+  const selectedEvents: RuntimeEvent[] = [];
+  let selectedTokens = 0;
+  let skipped = 0;
+  for (const index of [...selectedIndexes].sort((a, b) => a - b)) {
+    const event = events[index]!;
+    const estimate = estimateRuntimeEventsTokens([event], charsPerToken);
+    if (selectedTokens + estimate > maxEstimatedTokens) {
+      skipped += 1;
+      continue;
+    }
+    selectedEvents.push(event);
+    selectedTokens += estimate;
+  }
+
+  return {
+    events: selectedEvents,
+    hits,
+    diagnosticPatch: {
+      historySearchMatches: hits.length,
+      historyAroundRetrievedEvents: selectedEvents.length,
+      historyAroundEstimatedTokens: selectedTokens,
+      ...(skipped > 0 ? { historyAroundSkippedEvents: skipped } : {}),
+    },
+  };
 }
 
 export function buildPromptSegmentEstimates(input: PromptSegmentInput): PromptSegmentEstimate[] {
@@ -505,6 +762,98 @@ function stableJsonLength(value: unknown): number {
   } catch {
     return String(value).length;
   }
+}
+
+function collectArchiveRetrievalCandidates(
+  events: readonly RuntimeEvent[],
+  order: NonNullable<ArchiveRetrievalPolicy['order']>,
+): Array<{
+  event: RuntimeEvent;
+  placeholder: ArchivedToolResultPlaceholder;
+}> {
+  const candidates: Array<{ event: RuntimeEvent; placeholder: ArchivedToolResultPlaceholder }> = [];
+  for (const event of events) {
+    if (event.content?.kind !== 'function_response') continue;
+    if (!isArchivedToolResultPlaceholder(event.content.result)) continue;
+    candidates.push({ event, placeholder: event.content.result });
+  }
+  return order === 'newest_first' ? candidates.reverse() : candidates;
+}
+
+function scoreRuntimeEventSearchHit(
+  event: RuntimeEvent,
+  terms: readonly string[],
+): RuntimeEventHistorySearchHit | undefined {
+  const haystack = runtimeEventSearchText(event).toLowerCase();
+  if (!haystack) return undefined;
+  let score = 0;
+  const matchedTerms: string[] = [];
+  for (const term of terms) {
+    if (!haystack.includes(term)) continue;
+    matchedTerms.push(term);
+    score += term.length;
+  }
+  if (score <= 0) return undefined;
+  return {
+    eventId: event.id,
+    turnId: turnKey(event),
+    ts: event.ts,
+    score,
+    matchedTerms,
+  };
+}
+
+function runtimeEventSearchText(event: RuntimeEvent): string {
+  const content = event.content;
+  if (!content) return '';
+  switch (content.kind) {
+    case 'text':
+    case 'thinking':
+      return content.text;
+    case 'function_call':
+      return `${content.name} ${stableStringify(content.args)}`;
+    case 'function_response':
+      if (isArchivedToolResultPlaceholder(content.result)) {
+        return [
+          content.name,
+          content.result.toolName,
+          content.result.toolCallId,
+          content.result.artifactId,
+          content.result.bodySha256,
+          content.result.reason,
+        ].join(' ');
+      }
+      return `${content.name} ${stableStringify(content.result)}`;
+    case 'error':
+      return `${content.message} ${content.reason ?? ''} ${content.code ?? ''}`;
+  }
+}
+
+function tokenizeSearchQuery(query: string): string[] {
+  return [...new Set(
+    query
+      .toLowerCase()
+      .split(/[^a-z0-9_./:-]+/i)
+      .map((term) => term.trim())
+      .filter((term) => term.length >= 2),
+  )].slice(0, 16);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return '';
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+function increment(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
 }
 
 function finitePositive(value: number | undefined): number | undefined {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import type { ModelMessage } from 'ai';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
@@ -523,8 +524,8 @@ function pruneStaleToolResultsBeforeCompact(
     if (isArchivedToolResultPlaceholder(content.result)) return event;
 
     const serializedResult = serializeToolResultForArchive(content.result);
-    const resultBytes = serializedResult.length;
-    const resultEstimatedTokens = estimateTokens(resultBytes, charsPerToken);
+    const resultBytes = utf8ByteLength(serializedResult);
+    const resultEstimatedTokens = estimateTokens(serializedResult.length, charsPerToken);
     if (resultEstimatedTokens <= maxResultEstimatedTokens) return event;
 
     const archiveRef = archiveRefs.get(event.id);
@@ -600,8 +601,8 @@ export function collectStaleToolResultArchiveCandidates(
       continue;
     }
     const serializedResult = serializeToolResultForArchive(content.result);
-    const originalBytes = serializedResult.length;
-    const originalEstimatedTokens = estimateTokens(originalBytes, charsPerToken);
+    const originalBytes = utf8ByteLength(serializedResult);
+    const originalEstimatedTokens = estimateTokens(serializedResult.length, charsPerToken);
     if (originalEstimatedTokens <= maxResultEstimatedTokens) continue;
     candidates.push({
       runtimeEventId: event.id,
@@ -854,6 +855,10 @@ function increment(counts: Record<string, number>, key: string): void {
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
+}
+
+function utf8ByteLength(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
 }
 
 function finitePositive(value: number | undefined): number | undefined {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -81,14 +81,28 @@ export {
   estimateRuntimeEventsTokens,
   estimateTokens,
   isArchivedToolResultPlaceholder,
+  deserializeToolResultArchive,
+  retrieveArchivedToolResultsForReplay,
+  retrieveRuntimeEventHistoryAround,
+  searchRuntimeEventHistory,
   serializeToolResultForArchive,
 } from './context-budget.js';
 export type {
   ArchivedToolResultReason,
   BudgetedRuntimeContext,
   ContextBudgetPolicy,
+  ArchiveRetrievalPolicy,
+  ArchiveRetrievalResult,
+  HistoryRewriteGatePolicy,
+  RuntimeEventHistoryAroundResult,
+  RuntimeEventHistorySearchHit,
+  RuntimeEventHistorySearchPolicy,
   StaleToolResultPrunePolicy,
   StaleToolResultArchiveCandidate,
+  ToolResultArchiveReader,
+  ToolResultArchiveReaderInput,
+  ToolResultArchiveReadFailureReason,
+  ToolResultArchiveReadResult,
   ToolResultArchiveRef,
   ArchivedToolResultPlaceholder,
   PromptSegmentInput,
@@ -203,10 +217,13 @@ export type {
 // runtime-event-read-model.ts — side-by-side RuntimeEvent read projection.
 export {
   projectRuntimeEventsToStoredMessages,
+  projectRuntimeEventsToStoredMessagesWithArchiveStatuses,
+  applyArchivedToolResultReadModelStatuses,
   compareRuntimeReadModelMessages,
   classifyRuntimeEventTerminalFact,
 } from './runtime-event-read-model.js';
 export type {
+  ArchivedToolResultReadModelStatus,
   ProjectRuntimeEventsToStoredMessagesOptions,
   RuntimeEventReadModelDiagnostic,
   RuntimeEventReadModelDiagnosticCode,

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { PrefixChangeReason } from '@maka/core/usage-stats/types';
@@ -197,10 +198,21 @@ function contentShapeForHash(content: unknown): unknown {
         ...(typeof part.toolName === 'string' ? { toolName: part.toolName } : {}),
         ...(typeof part.toolCallId === 'string' ? { toolCallId: part.toolCallId } : {}),
         ...(typeof part.text === 'string' ? { chars: part.text.length } : {}),
+        ...('output' in part ? { output: payloadShapeForHash(part.output) } : {}),
       };
     });
   }
   return { type: typeof content };
+}
+
+function payloadShapeForHash(value: unknown): unknown {
+  const serialized = stableStringify(value);
+  return {
+    type: value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value,
+    chars: serialized.length,
+    bytes: Buffer.byteLength(serialized, 'utf8'),
+    hash: stableHash(value),
+  };
 }
 
 function canonicalize(value: unknown, parentKey?: string): unknown {

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -42,6 +42,11 @@ export interface ProjectRuntimeEventsToStoredMessagesOptions {
   runHeaders: readonly AgentRunHeader[] | Readonly<Record<string, AgentRunHeader>>;
 }
 
+export interface ArchivedToolResultReadModelStatus {
+  runtimeEventId: string;
+  status: Extract<ToolResultContent, { kind: 'archived_tool_result' }>['status'];
+}
+
 export interface RuntimeReadModelCompatibilityResult {
   compatible: boolean;
   diagnostics: RuntimeEventReadModelDiagnostic[];
@@ -163,6 +168,51 @@ export function projectRuntimeEventsToStoredMessages(
   }
 
   return { messages, diagnostics: state.diagnostics };
+}
+
+export function projectRuntimeEventsToStoredMessagesWithArchiveStatuses(
+  events: readonly RuntimeEvent[],
+  options: ProjectRuntimeEventsToStoredMessagesOptions & {
+    archiveStatuses: readonly ArchivedToolResultReadModelStatus[] | Readonly<Record<string, ArchivedToolResultReadModelStatus['status']>>;
+  },
+): RuntimeEventReadModelProjection {
+  return projectRuntimeEventsToStoredMessages(
+    applyArchivedToolResultReadModelStatuses(events, options.archiveStatuses),
+    options,
+  );
+}
+
+export function applyArchivedToolResultReadModelStatuses(
+  events: readonly RuntimeEvent[],
+  archiveStatuses: readonly ArchivedToolResultReadModelStatus[] | Readonly<Record<string, ArchivedToolResultReadModelStatus['status']>>,
+): RuntimeEvent[] {
+  const statuses = normalizeArchiveStatuses(archiveStatuses);
+  if (statuses.size === 0) return [...events];
+  return events.map((event) => {
+    const status = statuses.get(event.id);
+    if (!status || event.content?.kind !== 'function_response') return event;
+    if (!isArchivedToolResultPlaceholder(event.content.result)) return event;
+    const placeholder = event.content.result;
+    return {
+      ...event,
+      content: {
+        ...event.content,
+        result: {
+          kind: 'archived_tool_result',
+          status,
+          runtimeEventId: placeholder.runtimeEventId,
+          toolCallId: placeholder.toolCallId,
+          toolName: placeholder.toolName,
+          artifactId: placeholder.artifactId,
+          bodySha256: placeholder.bodySha256,
+          originalEstimatedTokens: placeholder.originalEstimatedTokens,
+          originalBytes: placeholder.originalBytes,
+          rewriteVersion: placeholder.rewriteVersion,
+          reason: placeholder.reason,
+        } satisfies ToolResultContent,
+      },
+    };
+  });
 }
 
 export function compareRuntimeReadModelMessages(
@@ -346,6 +396,22 @@ function projectText(
 
   diagnostic(state, event, 'unsupported_event', `text content with role ${event.role} is not projected`);
   return false;
+}
+
+function normalizeArchiveStatuses(
+  archiveStatuses: readonly ArchivedToolResultReadModelStatus[] | Readonly<Record<string, ArchivedToolResultReadModelStatus['status']>>,
+): Map<string, ArchivedToolResultReadModelStatus['status']> {
+  const map = new Map<string, ArchivedToolResultReadModelStatus['status']>();
+  if (Array.isArray(archiveStatuses)) {
+    for (const item of archiveStatuses) {
+      map.set(item.runtimeEventId, item.status);
+    }
+    return map;
+  }
+  for (const [runtimeEventId, status] of Object.entries(archiveStatuses)) {
+    map.set(runtimeEventId, status);
+  }
+  return map;
 }
 
 function projectThinking(

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -2,7 +2,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   AiSdkBackend,
   BackendRegistry,
@@ -115,6 +115,20 @@ backends.register('ai-sdk', async (ctx) =>
       });
       return { artifactId: artifact.id };
     },
+    readToolResultArchive: async (event) => {
+      const record = await artifactStore.get(event.artifactId);
+      if (!record) return { ok: false, reason: 'not_found' };
+      if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+      if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+      if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
+      if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+      const read = await artifactStore.readText(event.artifactId, {
+        maxBytes: event.maxBytes ?? event.originalBytes,
+      });
+      if (!read.ok) return read;
+      if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+      return { ok: true, serializedResult: read.text };
+    },
     newId: randomUUID,
     now: Date.now,
     maxSteps: 1,
@@ -207,6 +221,11 @@ for (let i = 1; i <= turnCount; i += 1) {
     archivePlaceholders: contextBudgetDiagnostic?.archivePlaceholders ?? 0,
     archiveWriteFailures: contextBudgetDiagnostic?.archiveWriteFailures ?? 0,
     archivePlaceholderReasonCounts: contextBudgetDiagnostic?.archivePlaceholderReasonCounts,
+    retrievedArchiveToolResults: contextBudgetDiagnostic?.retrievedArchiveToolResults ?? 0,
+    retrievedArchiveEstimatedTokens: contextBudgetDiagnostic?.retrievedArchiveEstimatedTokens ?? 0,
+    archiveRetrievalSkipped: contextBudgetDiagnostic?.archiveRetrievalSkipped ?? 0,
+    archiveRetrievalFailures: contextBudgetDiagnostic?.archiveRetrievalFailures ?? 0,
+    archiveRetrievalFailureReasonCounts: contextBudgetDiagnostic?.archiveRetrievalFailureReasonCounts,
     errorReason: errorEvent?.reason,
   });
 }
@@ -223,8 +242,15 @@ const totals = turns.reduce((acc, turn) => {
   else acc.unknownCacheMissTurns += 1;
   acc.archivePlaceholders += turn.archivePlaceholders ?? 0;
   acc.archiveWriteFailures += turn.archiveWriteFailures ?? 0;
+  acc.retrievedArchiveToolResults += turn.retrievedArchiveToolResults ?? 0;
+  acc.retrievedArchiveEstimatedTokens += turn.retrievedArchiveEstimatedTokens ?? 0;
+  acc.archiveRetrievalSkipped += turn.archiveRetrievalSkipped ?? 0;
+  acc.archiveRetrievalFailures += turn.archiveRetrievalFailures ?? 0;
   for (const [reason, count] of Object.entries(turn.archivePlaceholderReasonCounts ?? {})) {
     acc.archivePlaceholderReasonCounts[reason] = (acc.archivePlaceholderReasonCounts[reason] ?? 0) + count;
+  }
+  for (const [reason, count] of Object.entries(turn.archiveRetrievalFailureReasonCounts ?? {})) {
+    acc.archiveRetrievalFailureReasonCounts[reason] = (acc.archiveRetrievalFailureReasonCounts[reason] ?? 0) + count;
   }
   return acc;
 }, {
@@ -240,6 +266,11 @@ const totals = turns.reduce((acc, turn) => {
   archivePlaceholders: 0,
   archiveWriteFailures: 0,
   archivePlaceholderReasonCounts: {},
+  retrievedArchiveToolResults: 0,
+  retrievedArchiveEstimatedTokens: 0,
+  archiveRetrievalSkipped: 0,
+  archiveRetrievalFailures: 0,
+  archiveRetrievalFailureReasonCounts: {},
 });
 
 const report = {
@@ -294,6 +325,7 @@ function buildScenario(policy) {
       archivePruneEnabled: policy?.staleToolResultPrune?.enabled === true,
       historyTokenCap: policy?.maxHistoryEstimatedTokens ?? null,
       historyTurnCap: policy?.maxHistoryTurns ?? null,
+      archiveRetrievalEnabled: policy?.archiveRetrieval?.enabled === true,
     };
   }
   return {
@@ -302,21 +334,29 @@ function buildScenario(policy) {
     archivePruneEnabled: policy?.staleToolResultPrune?.enabled === true,
     historyTokenCap: policy?.maxHistoryEstimatedTokens ?? null,
     historyTurnCap: policy?.maxHistoryTurns ?? null,
+    archiveRetrievalEnabled: policy?.archiveRetrieval?.enabled === true,
   };
 }
 
 function scenarioNameForPolicy(policy) {
   if (!policy) return 'budget_off';
   if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
-    return 'archive_prune_on';
+    return policy.archiveRetrieval?.enabled === true
+      ? 'archive_prune_on_retrieval_on'
+      : 'archive_prune_on_retrieval_off';
   }
-  return 'emergency-history-cap';
+  if (policy.historyRewrite?.enabled === true) return 'named_history_rewrite';
+  return policy.archiveRetrieval?.enabled === true
+    ? 'emergency_history_cap_archive_retrieval_on'
+    : 'emergency_history_cap';
 }
 
 function contextBudgetMode(policy) {
   if (!policy) return 'off';
   if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
-    return 'archive_prune_only';
+    return policy.archiveRetrieval?.enabled === true
+      ? 'archive_prune_plus_retrieval'
+      : 'archive_prune_only';
   }
   return 'emergency_cap';
 }
@@ -328,7 +368,17 @@ function buildContextBudgetPolicy() {
   );
   const maxHistoryTurns = parseOptionalPositiveInt(process.env.MAKA_CONTEXT_HISTORY_BUDGET_TURNS);
   const staleToolResultPrune = buildStaleToolResultPrunePolicy();
-  if (maxHistoryEstimatedTokens === undefined && maxHistoryTurns === undefined && !staleToolResultPrune) {
+  const archiveRetrieval = buildArchiveRetrievalPolicy();
+  const historySearch = buildHistorySearchPolicy();
+  const historyRewrite = buildHistoryRewriteGatePolicy();
+  if (
+    maxHistoryEstimatedTokens === undefined &&
+    maxHistoryTurns === undefined &&
+    !staleToolResultPrune &&
+    !archiveRetrieval &&
+    !historySearch &&
+    !historyRewrite
+  ) {
     return undefined;
   }
   return {
@@ -336,6 +386,9 @@ function buildContextBudgetPolicy() {
     minRecentTurns: parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2),
     ...(maxHistoryEstimatedTokens !== undefined ? { maxHistoryEstimatedTokens } : {}),
     ...(staleToolResultPrune ? { staleToolResultPrune } : {}),
+    ...(archiveRetrieval ? { archiveRetrieval } : {}),
+    ...(historySearch ? { historySearch } : {}),
+    ...(historyRewrite ? { historyRewrite } : {}),
     ...(maxHistoryTurns !== undefined ? { maxHistoryTurns } : {}),
   };
 }
@@ -355,6 +408,37 @@ function buildStaleToolResultPrunePolicy() {
   };
 }
 
+function buildArchiveRetrievalPolicy() {
+  if (process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResults: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS, 3),
+    maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_TOKENS, 8192),
+    maxBytes: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES, 1024 * 1024),
+    order: 'newest_first',
+  };
+}
+
+function buildHistorySearchPolicy() {
+  if (process.env.MAKA_CONTEXT_HISTORY_SEARCH !== 'on') return undefined;
+  return {
+    enabled: true,
+    maxResults: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_MAX_RESULTS, 5),
+    around: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_AROUND, 1),
+    maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_HISTORY_SEARCH_MAX_TOKENS, 4096),
+  };
+}
+
+function buildHistoryRewriteGatePolicy() {
+  if (process.env.MAKA_CONTEXT_HISTORY_REWRITE !== 'on') return undefined;
+  return {
+    enabled: true,
+    name: process.env.MAKA_CONTEXT_HISTORY_REWRITE_NAME ?? 'baseline-history-rewrite',
+    historyRewriteVersion: process.env.MAKA_CONTEXT_HISTORY_REWRITE_VERSION ?? 'phase6-v1',
+    resetReason: process.env.MAKA_CONTEXT_HISTORY_REWRITE_RESET_REASON ?? 'operator_enabled_history_rewrite_gate',
+  };
+}
+
 function parsePositiveInt(value, fallback) {
   return parseOptionalPositiveInt(value) ?? fallback;
 }
@@ -371,6 +455,10 @@ function classifyCacheMissShape(prefixChangeReason, requestShapeChangeReason) {
   if (prefixChangeReason && prefixChangeReason !== 'stable') return 'explicit_durable_prefix_change';
   if (requestShapeChangeReason && requestShapeChangeReason !== 'stable') return 'derived_request_shape_change';
   return 'stable_shape';
+}
+
+function sha256(text) {
+  return createHash('sha256').update(text).digest('hex');
 }
 
 function renderMarkdown(report, jsonPath) {
@@ -398,11 +486,16 @@ function renderMarkdown(report, jsonPath) {
     `- archivePlaceholders: ${report.totals.archivePlaceholders}`,
     `- archiveWriteFailures: ${report.totals.archiveWriteFailures}`,
     `- archivePlaceholderReasonCounts: ${JSON.stringify(report.totals.archivePlaceholderReasonCounts)}`,
+    `- retrievedArchiveToolResults: ${report.totals.retrievedArchiveToolResults}`,
+    `- retrievedArchiveEstimatedTokens: ${report.totals.retrievedArchiveEstimatedTokens}`,
+    `- archiveRetrievalSkipped: ${report.totals.archiveRetrievalSkipped}`,
+    `- archiveRetrievalFailures: ${report.totals.archiveRetrievalFailures}`,
+    `- archiveRetrievalFailureReasonCounts: ${JSON.stringify(report.totals.archiveRetrievalFailureReasonCounts)}`,
     '',
     '## Turns',
     '',
-    '| turn | input | hit | miss | write | output | prefix reason | request reason | miss source | archive | archive fail | prior history est | budget after |',
-    '| ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |',
+    '| turn | input | hit | miss | write | output | prefix reason | request reason | miss source | archive | retrieved | retrieval fail | prior history est | budget after |',
+    '| ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |',
   ];
   for (const turn of report.turns) {
     const prior = turn.promptSegments?.find((segment) => segment.kind === 'prior_history');
@@ -417,7 +510,8 @@ function renderMarkdown(report, jsonPath) {
       turn.requestShapeChangeReason ?? '',
       turn.cacheMissShapeSource ?? turn.cacheMissInputSource ?? '',
       turn.archivePlaceholders ?? 0,
-      turn.archiveWriteFailures ?? 0,
+      turn.retrievedArchiveToolResults ?? 0,
+      turn.archiveRetrievalFailures ?? 0,
       prior?.estimatedTokens ?? 0,
       turn.contextBudget?.estimatedTokensAfter ?? 0,
     ].join(' | ') + ' |');


### PR DESCRIPTION
Refs #19.

## Summary

- Close the Phase 5 archive read loop with opt-in archive hydration for RuntimeEvent replay: bounded reads, SHA-256 validation, missing/corrupt/size diagnostics, and desktop/baseline harness wiring through `ArtifactStore`.
- Add deterministic lightweight RuntimeEvent history search with bounded around-context retrieval, plus named history rewrite diagnostics for explicit cache-shape resets.
- Preserve immutable persisted RuntimeEvent ledgers: pruning, archive placeholder rewrite, search retrieval, and archive hydration operate on the replay view only.
- Post-review patch fixes UTF-8 archive byte accounting and makes hydrated tool-result output visible in request-shape history diagnostics while keeping durable prefix hashes stable.

## Rive

- Workflow: `maka.deepseek-archive-retrieval-phase6@1`
- Run: `wfrun_8ea4ead63c8240e0ad8190c0c5b86634`
- Final scheduler: `sched_308618c75a3d426293ceb0a398bec6d0`
- Root: `work_f18542cef7064daa97067881cacfbb6d`
- Artifacts: `/tmp/rive-maka-phase6-archive-retrieval-20260616/output/`
- Independent review returned `PATCH_REQUIRED`; the follow-up commit `e28c5786` fixes both blockers before this PR was opened.

## Verification

- `npm run test --workspace packages/runtime -- context-budget` passed: 480 tests.
- `npm run test --workspace packages/runtime -- ai-sdk-backend` passed: 480 tests.
- `node --check scripts/deepseek-live-cost-baseline.mjs` passed.
- `npm run typecheck` passed.
- `npm run build --workspaces --if-present` passed.
- `npm run test --workspace packages/core` passed: 614 tests.
- `npm run test --workspace packages/runtime` passed: 480 tests.
- `npm run test --workspace packages/storage` passed: 82 tests.
- `npm run test --workspace apps/desktop` passed: 1399 tests.
- `git diff --check` passed.

## Paid DeepSeek smoke matrix

A small bounded two-turn matrix ran with the local `DEEPSEEK_API_KEY`:

- `budget_off`
- `archive_prune_on_retrieval_off`
- `archive_prune_on_retrieval_on`

All three tiny no-tool runs reported input `942`, cache-miss input `942`, cache-hit input `0`, output `2`, estimated cost `$0.00025654`, and explicit cache-miss turns `2`. Archive placeholders/retrieval counts were `0` in this smoke because the live path did not invoke tools; unit and integration coverage exercise archive creation, recovery, corrupt/missing/size diagnostics, and replay behavior.

## Caveats

- Retrieval remains opt-in.
- The live smoke validates scenario/report serialization, not a cost win. A larger paid matrix with tool-using prompts is still needed before claiming DeepSeek savings or quality parity.
- History search is intentionally lightweight substring scoring, not semantic/BM25 retrieval.
