### PR TITLE
Add demand-gated archive retrieval live matrix

### DIFF
--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -175,6 +175,8 @@ export interface ContextBudgetDiagnostic {
   archiveWriteFailures?: number;
   unarchivedToolResults?: number;
   archivePlaceholderReasonCounts?: Record<string, number>;
+  archiveRetrievalMode?: 'eager' | 'history_search_gated';
+  archiveRetrievalEligibleTurns?: number;
   retrievedArchiveToolResults?: number;
   retrievedArchiveEstimatedTokens?: number;
   archiveRetrievalSkipped?: number;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -415,6 +415,121 @@ describe('AiSdkBackend model history', () => {
     assert.equal(usage?.contextBudget?.archiveRetrievalFailures, 0);
   });
 
+  test('gates archive hydration to RuntimeEvent turns selected by history search', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const archivedBodies = new Map<string, string>();
+    const readRuntimeEventIds: string[] = [];
+    const selectedResult = { body: 'PHASE7_SELECTED_SENTINEL'.repeat(20) };
+    const unselectedResult = { body: 'PHASE7_UNSELECTED_SENTINEL'.repeat(20) };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'archive-retrieval-gated-test',
+        maxHistoryTurns: 1,
+        minRecentTurns: 0,
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        archiveRetrieval: {
+          enabled: true,
+          mode: 'history_search_gated',
+          maxResults: 2,
+          maxEstimatedTokens: 4096,
+          maxBytes: 4096,
+        },
+        historySearch: {
+          enabled: true,
+          maxResults: 1,
+          around: 1,
+          maxEstimatedTokens: 4096,
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archivedBodies.set(event.runtimeEventId, event.serializedResult);
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => {
+        readRuntimeEventIds.push(event.runtimeEventId);
+        const body = archivedBodies.get(event.runtimeEventId);
+        assert.ok(body);
+        return event.bodySha256 === sha256(body)
+          ? { ok: true, serializedResult: body }
+          : { ok: false, reason: 'corrupt' };
+      },
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'Find needle-a and recover its archived result',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call-a',
+          turnId: 'turn-a',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-a', name: 'Read', args: { path: 'needle-a.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-a',
+          turnId: 'turn-a',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-a', name: 'Read', result: selectedResult, isError: false },
+        }),
+        runtimeEvent({
+          id: 'rt-call-b',
+          turnId: 'turn-b',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-b', name: 'Read', args: { path: 'needle-b.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-b',
+          turnId: 'turn-b',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-b', name: 'Read', result: unselectedResult, isError: false },
+        }),
+        runtimeTextEvent({
+          id: 'rt-new',
+          turnId: 'turn-new',
+          role: 'user',
+          author: 'user',
+          text: 'newer retained context',
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    assert.deepEqual(readRuntimeEventIds, ['rt-result-a']);
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /PHASE7_SELECTED_SENTINEL/);
+    assert.equal(prompt.includes('PHASE7_UNSELECTED_SENTINEL'), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
+    assert.equal(usage?.contextBudget?.archiveRetrievalEligibleTurns, 1);
+    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
+    assert.equal(usage?.contextBudget?.historySearchMatches, 1);
+  });
+
   test('uses StoredMessage projection when RuntimeEvent tool results are unmatched', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -265,6 +265,66 @@ describe('context-budget archive retrieval', () => {
       { kind: 'text', text: 'second' },
     );
   });
+
+  test('gates archive reads to history-selected turns when requested', async () => {
+    const selected = serializeToolResultForArchive({ kind: 'text', text: 'selected' });
+    const unselected = serializeToolResultForArchive({ kind: 'text', text: 'unselected' });
+    const events = [
+      archivedResult('result-selected', 'turn-selected', 'tool-selected', {
+        artifactId: 'artifact-selected',
+        bodySha256: sha256(selected),
+        originalEstimatedTokens: selected.length,
+        originalBytes: utf8Bytes(selected),
+      }),
+      archivedResult('result-unselected', 'turn-unselected', 'tool-unselected', {
+        artifactId: 'artifact-unselected',
+        bodySha256: sha256(unselected),
+        originalEstimatedTokens: unselected.length,
+        originalBytes: utf8Bytes(unselected),
+      }),
+    ];
+    const reads: string[] = [];
+
+    const retrieved = await retrieveArchivedToolResultsForReplay(
+      events,
+      {
+        enabled: true,
+        mode: 'history_search_gated',
+        maxResults: 2,
+        maxEstimatedTokens: 1024,
+        maxBytes: 1024,
+      },
+      async (input) => {
+        reads.push(input.runtimeEventId);
+        return {
+          ok: true,
+          serializedResult: input.runtimeEventId === 'result-selected' ? selected : unselected,
+        };
+      },
+      { sessionId: 'session-1', allowedTurnIds: new Set(['turn-selected']) },
+    );
+
+    assert.deepEqual(reads, ['result-selected']);
+    assert.equal(retrieved.diagnosticPatch.archiveRetrievalMode, 'history_search_gated');
+    assert.equal(retrieved.diagnosticPatch.archiveRetrievalEligibleTurns, 1);
+    assert.equal(retrieved.diagnosticPatch.retrievedArchiveToolResults, 1);
+    assert.equal(retrieved.diagnosticPatch.archiveRetrievalSkipped, 1);
+    assert.deepEqual(retrieved.diagnosticPatch.archiveRetrievalSkippedReasonCounts, {
+      history_search_gate: 1,
+    });
+    assert.deepEqual(
+      retrieved.events[0]?.content?.kind === 'function_response'
+        ? retrieved.events[0].content.result
+        : undefined,
+      { kind: 'text', text: 'selected' },
+    );
+    assert.equal(
+      retrieved.events[1]?.content?.kind === 'function_response'
+        ? (retrieved.events[1].content.result as { kind?: string }).kind
+        : undefined,
+      ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    );
+  });
 });
 
 describe('context-budget search and rewrite diagnostics', () => {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -746,6 +746,9 @@ export class AiSdkBackend implements AgentBackend {
       contextBudget?.historySearch,
       { charsPerToken: contextBudget?.charsPerToken },
     );
+    const archiveRetrievalAllowedTurnIds = contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
+      ? new Set(historyAround.events.map((event) => runtimeEventTurnKey(event)))
+      : undefined;
     if (historyAround.events.length > 0) {
       runtimeContext = mergeRuntimeEventsInOriginalOrder(priorRuntimeContext, runtimeContext, historyAround.events);
       contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
@@ -766,6 +769,7 @@ export class AiSdkBackend implements AgentBackend {
       {
         sessionId: this.sessionId,
         charsPerToken: contextBudget?.charsPerToken,
+        allowedTurnIds: archiveRetrievalAllowedTurnIds,
       },
     );
     runtimeContext = retrieval.events;
@@ -1070,8 +1074,8 @@ function buildContextBudgetDiagnosticShell(
   policy: ContextBudgetPolicy | undefined,
 ): ContextBudgetDiagnostic {
   const charsPerToken = policy?.charsPerToken ?? 4;
-  const turnCountBefore = new Set(before.map((event) => event.turnId || '<unknown-turn>')).size;
-  const turnCountAfter = new Set(after.map((event) => event.turnId || '<unknown-turn>')).size;
+  const turnCountBefore = new Set(before.map((event) => runtimeEventTurnKey(event))).size;
+  const turnCountAfter = new Set(after.map((event) => runtimeEventTurnKey(event))).size;
   return {
     enabled: true,
     ...(policy?.name ? { policyName: policy.name } : {}),
@@ -1093,6 +1097,10 @@ function buildContextBudgetDiagnosticShell(
         }
       : {}),
   };
+}
+
+function runtimeEventTurnKey(event: RuntimeEvent): string {
+  return event.turnId || '<unknown-turn>';
 }
 
 function buildHistorySearchSource(

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -45,11 +45,18 @@ export interface StaleToolResultPrunePolicy {
 
 export interface ArchiveRetrievalPolicy {
   enabled: boolean;
+  /**
+   * Defaults to `eager` for Phase 6 compatibility. `history_search_gated`
+   * only hydrates placeholders whose turn was selected by history search.
+   */
+  mode?: ArchiveRetrievalMode;
   maxResults?: number;
   maxEstimatedTokens?: number;
   maxBytes?: number;
   order?: 'newest_first';
 }
+
+export type ArchiveRetrievalMode = 'eager' | 'history_search_gated';
 
 export interface RuntimeEventHistorySearchPolicy {
   enabled: boolean;
@@ -256,13 +263,19 @@ export async function retrieveArchivedToolResultsForReplay(
   events: readonly RuntimeEvent[],
   policy: ArchiveRetrievalPolicy | undefined,
   reader: ToolResultArchiveReader | undefined,
-  options: { sessionId: string; charsPerToken?: number },
+  options: {
+    sessionId: string;
+    charsPerToken?: number;
+    allowedTurnIds?: ReadonlySet<string> | readonly string[];
+  },
 ): Promise<ArchiveRetrievalResult> {
   if (policy?.enabled !== true || !reader) {
     return { events: [...events], diagnosticPatch: {} };
   }
 
   const charsPerToken = options.charsPerToken ?? 4;
+  const mode = policy.mode ?? 'eager';
+  const allowedTurnIds = normalizeAllowedTurnIds(options.allowedTurnIds);
   const maxResults = finitePositive(policy.maxResults) ?? 3;
   const maxEstimatedTokens = finitePositive(policy.maxEstimatedTokens) ?? 8_192;
   const maxBytes = finitePositive(policy.maxBytes) ?? 1024 * 1024;
@@ -278,6 +291,11 @@ export async function retrieveArchivedToolResultsForReplay(
 
   for (const candidate of candidates) {
     if (retrieved >= maxResults) break;
+    if (mode === 'history_search_gated' && !allowedTurnIds.has(turnKey(candidate.event))) {
+      skipped += 1;
+      increment(skippedReasonCounts, 'history_search_gate');
+      continue;
+    }
     if (candidate.placeholder.originalBytes > maxBytes) {
       skipped += 1;
       increment(skippedReasonCounts, 'max_bytes');
@@ -331,6 +349,10 @@ export async function retrieveArchivedToolResultsForReplay(
   return {
     events: hydratedEvents,
     diagnosticPatch: {
+      archiveRetrievalMode: mode,
+      ...(mode === 'history_search_gated'
+        ? { archiveRetrievalEligibleTurns: allowedTurnIds.size }
+        : {}),
       retrievedArchiveToolResults: retrieved,
       retrievedArchiveEstimatedTokens: retrievedTokens,
       archiveRetrievalSkipped: skipped,
@@ -779,6 +801,14 @@ function collectArchiveRetrievalCandidates(
     candidates.push({ event, placeholder: event.content.result });
   }
   return order === 'newest_first' ? candidates.reverse() : candidates;
+}
+
+function normalizeAllowedTurnIds(
+  turnIds: ReadonlySet<string> | readonly string[] | undefined,
+): ReadonlySet<string> {
+  if (!turnIds) return new Set();
+  if (turnIds instanceof Set) return turnIds;
+  return new Set(turnIds);
 }
 
 function scoreRuntimeEventSearchHit(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -91,6 +91,7 @@ export type {
   ArchivedToolResultReason,
   BudgetedRuntimeContext,
   ContextBudgetPolicy,
+  ArchiveRetrievalMode,
   ArchiveRetrievalPolicy,
   ArchiveRetrievalResult,
   HistoryRewriteGatePolicy,

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
+import { z } from 'zod';
 import {
   AiSdkBackend,
   BackendRegistry,
@@ -41,6 +42,19 @@ const cwd = resolve(process.env.MAKA_COST_BASELINE_CWD ?? repoRoot);
 const contextBudget = buildContextBudgetPolicy();
 const stablePolicyLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_STABLE_POLICY_LINES, 140);
 const payloadLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_PAYLOAD_LINES, 70);
+
+if (process.env.MAKA_COST_BASELINE_PHASE7_TOOL_MATRIX === 'on') {
+  const exitCode = await runPhase7ToolMatrix({
+    apiKey,
+    model,
+    repoRoot,
+    outputRoot,
+    runId,
+    seed,
+    cwd,
+  });
+  process.exit(exitCode);
+}
 
 const sessionStore = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
@@ -316,6 +330,392 @@ await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
 await writeFile(markdownPath, renderMarkdown(report, jsonPath), 'utf8');
 console.log(JSON.stringify({ jsonPath, markdownPath, totals, turnCount, toolMode, contextBudget }, null, 2));
 
+async function runPhase7ToolMatrix(input) {
+  const matrixOutputRoot = join(input.outputRoot, input.runId, 'phase7-tool-matrix');
+  await mkdir(matrixOutputRoot, { recursive: true });
+  const sentinel = process.env.MAKA_COST_BASELINE_PHASE7_SENTINEL
+    ?? `PHASE7_SENTINEL_${sha256(`${input.seed}:phase7`).slice(0, 16)}`;
+  const lookupKey = process.env.MAKA_COST_BASELINE_PHASE7_LOOKUP_KEY ?? 'phase7-live-key';
+  const resultLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_PHASE7_RESULT_LINES, 220);
+  const scenarios = [];
+  for (const mode of ['full', 'prune', 'eager', 'gated']) {
+    scenarios.push(await runPhase7ToolScenario({
+      ...input,
+      matrixOutputRoot,
+      mode,
+      sentinel,
+      lookupKey,
+      resultLines,
+    }));
+  }
+  const invariantFailures = validatePhase7ToolMatrix(scenarios, sentinel);
+
+  const report = {
+    sourceRef: process.env.MAKA_COST_BASELINE_SOURCE_REF ?? 'local-build',
+    scenario: {
+      name: 'phase7_tool_archive_retrieval_matrix',
+      modes: scenarios.map((scenario) => scenario.mode),
+    },
+    passed: invariantFailures.length === 0,
+    invariantFailures,
+    repoRoot: input.repoRoot,
+    outputRoot: matrixOutputRoot,
+    model: input.model,
+    seed: input.seed,
+    lookupKey,
+    sentinelSha256: sha256(sentinel),
+    resultLines,
+    scenarios,
+  };
+  const jsonPath = resolve(
+    process.env.MAKA_COST_BASELINE_PHASE7_MATRIX_JSON
+      ?? join(matrixOutputRoot, 'phase7-tool-live-matrix.json'),
+  );
+  await mkdir(resolve(jsonPath, '..'), { recursive: true });
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(JSON.stringify({
+    jsonPath,
+    model: input.model,
+    scenario: report.scenario.name,
+    modes: scenarios.map((scenario) => ({
+      mode: scenario.mode,
+      recoveredSentinel: scenario.recoveredSentinel,
+      archivedToolResultsRead: scenario.archivedToolResultsRead,
+      toolCalls: scenario.toolCalls,
+    })),
+    invariantFailures,
+  }, null, 2));
+  if (invariantFailures.length > 0) {
+    console.error([
+      'Phase 7 tool matrix invariant failures:',
+      ...invariantFailures.map((failure) => `- ${failure}`),
+    ].join('\n'));
+    return 1;
+  }
+  return 0;
+}
+
+async function runPhase7ToolScenario(input) {
+  const workspaceRoot = join(input.matrixOutputRoot, input.mode, 'workspace');
+  await mkdir(workspaceRoot, { recursive: true });
+  const sessionStore = createSessionStore(workspaceRoot);
+  const runStore = createAgentRunStore(workspaceRoot);
+  const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+  const artifactStore = createArtifactStore(workspaceRoot);
+  const permissionEngine = new PermissionEngine(createDefaultPermissionEngineDeps());
+  const backends = new BackendRegistry();
+  const llmRecords = [];
+  const runTraceEvents = [];
+  const archiveReads = [];
+  const tools = [buildPhase7LookupTool(input)];
+  const connection = {
+    slug: `deepseek-live-phase7-${input.mode}`,
+    name: `DeepSeek live Phase 7 ${input.mode}`,
+    providerType: 'deepseek',
+    baseUrl: 'https://api.deepseek.com',
+    defaultModel: input.model,
+    enabled: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  const contextBudget = buildPhase7ContextBudgetPolicy(input.mode);
+  const systemPrompt = [
+    'You are a Maka Phase 7 live harness assistant.',
+    `Lookup key: ${input.lookupKey}`,
+    'When asked to store the Phase 7 lookup, call Phase7Lookup exactly once with the lookup key.',
+    'After the tool result is available, answer exactly STORED.',
+    'Do not include the sentinel value in the storage acknowledgement.',
+    'When later asked to recover the sentinel, answer only the sentinel value found in prior tool results.',
+    'Do not call Phase7Lookup during sentinel recovery; recovery must use prior context only.',
+  ].join('\n');
+
+  backends.register('ai-sdk', async (ctx) =>
+    new AiSdkBackend({
+      sessionId: ctx.sessionId,
+      header: { ...ctx.header, model: input.model },
+      appendMessage: (message) => ctx.store.appendMessage(ctx.sessionId, message),
+      connection,
+      apiKey: input.apiKey,
+      modelId: input.model,
+      permissionEngine,
+      modelFactory: getAIModel,
+      tools,
+      providerOptions: buildProviderOptions(connection, input.model),
+      contextBudget,
+      systemPrompt,
+      turnTailPrompt: phase7TurnTailPrompt(input.cwd),
+      recordLlmCall: (record) => llmRecords.push(record),
+      recordRunTrace: (event) => runTraceEvents.push(event),
+      archiveToolResult: async (event) => {
+        const artifact = await artifactStore.create({
+          sessionId: event.sessionId,
+          turnId: event.turnId,
+          name: `phase7-tool-result-${event.runtimeEventId}.json`,
+          kind: 'file',
+          content: event.serializedResult,
+          mimeType: 'application/json',
+          source: 'tool_result_archive',
+          summary: `Archived ${event.toolName} Phase 7 tool result for ${input.mode}`,
+        });
+        return { artifactId: artifact.id };
+      },
+      readToolResultArchive: async (event) => {
+        archiveReads.push({
+          runtimeEventId: event.runtimeEventId,
+          turnId: event.turnId,
+          artifactId: event.artifactId,
+        });
+        const record = await artifactStore.get(event.artifactId);
+        if (!record) return { ok: false, reason: 'not_found' };
+        if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+        if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+        if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
+        if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+        const read = await artifactStore.readText(event.artifactId, {
+          maxBytes: event.maxBytes ?? event.originalBytes,
+        });
+        if (!read.ok) return read;
+        if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+        return { ok: true, serializedResult: read.text };
+      },
+      newId: randomUUID,
+      now: Date.now,
+      maxSteps: 4,
+      streamConnectTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 120_000,
+    }),
+  );
+
+  const manager = new SessionManager({
+    store: sessionStore,
+    runStore,
+    runtimeEventStore,
+    backends,
+    newId: randomUUID,
+    now: Date.now,
+  });
+  const session = await manager.createSession({
+    cwd: input.cwd,
+    backend: 'ai-sdk',
+    llmConnectionSlug: connection.slug,
+    model: input.model,
+    permissionMode: 'explore',
+    name: `DeepSeek Phase 7 ${input.mode}`,
+  });
+
+  const storeTurn = await sendPhase7Turn(
+    manager,
+    session.id,
+    'phase7-store',
+    [
+      `Store the Phase 7 lookup for key ${input.lookupKey}.`,
+      'Call Phase7Lookup, then acknowledge with exactly STORED.',
+      'Do not repeat the sentinel.',
+    ].join('\n'),
+  );
+  const fillerTurn = await sendPhase7Turn(
+    manager,
+    session.id,
+    'phase7-filler',
+    'Answer exactly OK. This turn exists so the old tool result becomes stale for pruning.',
+  );
+  const recoverTurn = await sendPhase7Turn(
+    manager,
+    session.id,
+    'phase7-recover',
+    `Recover the sentinel for lookup key ${input.lookupKey} from the archived Phase 7 tool result. Do not call tools. Answer only the sentinel.`,
+  );
+  const finalUsage = recoverTurn.events.find((event) => event.type === 'token_usage');
+  const storageAnswerIncludedSentinel = storeTurn.assistantText.includes(input.sentinel);
+  return {
+    mode: input.mode,
+    contextBudget,
+    sessionId: session.id,
+    toolCalls: [...storeTurn.events, ...fillerTurn.events, ...recoverTurn.events]
+      .filter((event) => event.type === 'tool_start')
+      .map((event) => ({ turnId: event.turnId, toolName: event.toolName })),
+    storageAnswerIncludedSentinel,
+    finalAnswer: recoverTurn.assistantText,
+    recoveredSentinel: recoverTurn.assistantText.includes(input.sentinel),
+    archivedToolResultsRead: archiveReads.length,
+    archiveReads,
+    finalContextBudget: finalUsage?.contextBudget,
+    finalUsage: usageSummary(finalUsage, llmRecords.at(-1)),
+    requestShapeTrace: runTraceEvents
+      .filter((event) =>
+        event.data?.requestShapeHash ||
+        event.data?.requestShapeChangeReason ||
+        event.data?.contextBudget
+      )
+      .map((event) => ({
+        phase: event.phase,
+        type: event.type,
+        requestShapeHash: event.data?.requestShapeHash,
+        requestShapeChangeReason: event.data?.requestShapeChangeReason,
+        contextBudget: event.data?.contextBudget,
+      })),
+  };
+}
+
+function buildPhase7LookupTool(input) {
+  return {
+    name: 'Phase7Lookup',
+    description: 'Deterministic Phase 7 harness tool. Use only when asked to store the Phase 7 lookup key.',
+    parameters: z.object({
+      key: z.string().describe('The lookup key requested by the user.'),
+    }),
+    permissionRequired: false,
+    impl: ({ key }) => ({
+      key,
+      sentinel: input.sentinel,
+      rows: Array.from({ length: input.resultLines }, (_, index) => ({
+        index,
+        text: `phase7 archived payload row ${String(index + 1).padStart(3, '0')} for ${key}`,
+      })),
+    }),
+  };
+}
+
+function buildPhase7ContextBudgetPolicy(mode) {
+  if (mode === 'full') return undefined;
+  const base = {
+    name: `phase7-${mode}`,
+    minRecentTurns: 1,
+    charsPerToken: 4,
+    staleToolResultPrune: {
+      enabled: true,
+      maxResultEstimatedTokens: parsePositiveInt(
+        process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS,
+        128,
+      ),
+      minRecentTurnsFull: 0,
+    },
+  };
+  if (mode === 'prune') return base;
+  const archiveRetrieval = {
+    enabled: true,
+    mode: mode === 'gated' ? 'history_search_gated' : 'eager',
+    maxResults: 4,
+    maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_TOKENS, 16_384),
+    maxBytes: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES, 2 * 1024 * 1024),
+    order: 'newest_first',
+  };
+  if (mode === 'gated') {
+    return {
+      ...base,
+      archiveRetrieval,
+      historySearch: {
+        enabled: true,
+        maxResults: 1,
+        around: 1,
+        maxEstimatedTokens: 4096,
+      },
+    };
+  }
+  return {
+    ...base,
+    archiveRetrieval,
+  };
+}
+
+function phase7TurnTailPrompt(cwd) {
+  return [
+    '<current-session-environment>',
+    `cwd: ${cwd}`,
+    `calendar_date: ${process.env.MAKA_COST_BASELINE_DATE ?? new Date().toISOString().slice(0, 10)}`,
+    '</current-session-environment>',
+  ].join('\n');
+}
+
+async function sendPhase7Turn(manager, sessionId, turnId, text) {
+  const events = [];
+  for await (const event of manager.sendMessage(sessionId, { turnId, text })) {
+    events.push(event);
+  }
+  return {
+    events,
+    assistantText: events
+      .filter((event) => event.type === 'text_complete')
+      .map((event) => event.text)
+      .join('\n'),
+  };
+}
+
+function usageSummary(usageEvent, llmRecord) {
+  return {
+    input: usageEvent?.input ?? llmRecord?.inputTokens,
+    output: usageEvent?.output ?? llmRecord?.outputTokens,
+    cacheHitInput: usageEvent?.cacheHitInput ?? llmRecord?.cacheHitInputTokens,
+    cacheMissInput: usageEvent?.cacheMissInput ?? llmRecord?.cacheMissInputTokens,
+    cacheWriteInput: usageEvent?.cacheWriteInput ?? llmRecord?.cacheWriteInputTokens,
+    requestShapeChangeReason: usageEvent?.requestShapeChangeReason ?? llmRecord?.requestShapeChangeReason,
+    contextBudget: usageEvent?.contextBudget ?? llmRecord?.contextBudget,
+  };
+}
+
+function validatePhase7ToolMatrix(scenarios, sentinel) {
+  const failures = [];
+  const byMode = new Map(scenarios.map((scenario) => [scenario.mode, scenario]));
+  for (const mode of ['full', 'prune', 'eager', 'gated']) {
+    const scenario = byMode.get(mode);
+    if (!scenario) {
+      failures.push(`missing ${mode} scenario`);
+      continue;
+    }
+    if (scenario.storageAnswerIncludedSentinel) {
+      failures.push(`${mode} scenario repeated sentinel in storage acknowledgement`);
+    }
+    if (scenario.toolCalls.length !== 1) {
+      failures.push(`${mode} scenario expected exactly one tool call, saw ${scenario.toolCalls.length}`);
+    } else {
+      const [call] = scenario.toolCalls;
+      if (call.turnId !== 'phase7-store' || call.toolName !== 'Phase7Lookup') {
+        failures.push(`${mode} scenario unexpected tool call ${call.toolName} on ${call.turnId}`);
+      }
+    }
+  }
+
+  const full = byMode.get('full');
+  const prune = byMode.get('prune');
+  const eager = byMode.get('eager');
+  const gated = byMode.get('gated');
+  if (full && !full.recoveredSentinel) failures.push('full scenario did not recover sentinel');
+  if (full?.recoveredSentinel && full.finalAnswer.trim() !== sentinel) {
+    failures.push('full scenario final answer was not exactly the sentinel');
+  }
+  if (prune?.recoveredSentinel) failures.push('prune scenario recovered sentinel without archive retrieval');
+  if (prune && prune.archivedToolResultsRead !== 0) failures.push('prune scenario unexpectedly read archives');
+  if (eager && !eager.recoveredSentinel) failures.push('eager scenario did not recover sentinel');
+  if (eager?.recoveredSentinel && eager.finalAnswer.trim() !== sentinel) {
+    failures.push('eager scenario final answer was not exactly the sentinel');
+  }
+  if (eager && eager.archivedToolResultsRead < 1) failures.push('eager scenario did not read any archive');
+  if (eager?.finalContextBudget?.archiveRetrievalMode !== 'eager') {
+    failures.push('eager scenario did not report eager retrieval mode');
+  }
+  if ((eager?.finalContextBudget?.retrievedArchiveToolResults ?? 0) < 1) {
+    failures.push('eager scenario final turn did not retrieve an archive');
+  }
+  if (gated && !gated.recoveredSentinel) failures.push('gated scenario did not recover sentinel');
+  if (gated?.recoveredSentinel && gated.finalAnswer.trim() !== sentinel) {
+    failures.push('gated scenario final answer was not exactly the sentinel');
+  }
+  if (gated && gated.archivedToolResultsRead < 1) failures.push('gated scenario did not read any archive');
+  if (gated?.finalContextBudget?.archiveRetrievalMode !== 'history_search_gated') {
+    failures.push('gated scenario did not report history_search_gated retrieval mode');
+  }
+  if ((gated?.finalContextBudget?.retrievedArchiveToolResults ?? 0) < 1) {
+    failures.push('gated scenario final turn did not retrieve an archive');
+  }
+  if ((gated?.finalContextBudget?.archiveRetrievalEligibleTurns ?? 0) < 1) {
+    failures.push('gated scenario did not report any archive retrieval eligible turns');
+  }
+  if ((gated?.finalContextBudget?.historySearchMatches ?? 0) < 1) {
+    failures.push('gated scenario did not report a history search match');
+  }
+  return failures;
+}
+
 function buildScenario(policy) {
   const explicitName = process.env.MAKA_COST_BASELINE_SCENARIO;
   if (explicitName) {
@@ -341,22 +741,31 @@ function buildScenario(policy) {
 function scenarioNameForPolicy(policy) {
   if (!policy) return 'budget_off';
   if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
-    return policy.archiveRetrieval?.enabled === true
-      ? 'archive_prune_on_retrieval_on'
-      : 'archive_prune_on_retrieval_off';
+    if (policy.archiveRetrieval?.enabled === true) {
+      return policy.archiveRetrieval.mode === 'history_search_gated'
+        ? 'archive_prune_on_retrieval_history_search_gated'
+        : 'archive_prune_on_retrieval_on';
+    }
+    return 'archive_prune_on_retrieval_off';
   }
   if (policy.historyRewrite?.enabled === true) return 'named_history_rewrite';
-  return policy.archiveRetrieval?.enabled === true
-    ? 'emergency_history_cap_archive_retrieval_on'
-    : 'emergency_history_cap';
+  if (policy.archiveRetrieval?.enabled === true) {
+    return policy.archiveRetrieval.mode === 'history_search_gated'
+      ? 'emergency_history_cap_archive_retrieval_history_search_gated'
+      : 'emergency_history_cap_archive_retrieval_on';
+  }
+  return 'emergency_history_cap';
 }
 
 function contextBudgetMode(policy) {
   if (!policy) return 'off';
   if (policy.staleToolResultPrune?.enabled === true && !policy.maxHistoryEstimatedTokens && !policy.maxHistoryTurns) {
-    return policy.archiveRetrieval?.enabled === true
-      ? 'archive_prune_plus_retrieval'
-      : 'archive_prune_only';
+    if (policy.archiveRetrieval?.enabled === true) {
+      return policy.archiveRetrieval.mode === 'history_search_gated'
+        ? 'archive_prune_plus_history_search_gated_retrieval'
+        : 'archive_prune_plus_retrieval';
+    }
+    return 'archive_prune_only';
   }
   return 'emergency_cap';
 }
@@ -410,8 +819,10 @@ function buildStaleToolResultPrunePolicy() {
 
 function buildArchiveRetrievalPolicy() {
   if (process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL !== 'on') return undefined;
+  const mode = parseArchiveRetrievalMode(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MODE);
   return {
     enabled: true,
+    ...(mode ? { mode } : {}),
     maxResults: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS, 3),
     maxEstimatedTokens: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_TOKENS, 8192),
     maxBytes: parsePositiveInt(process.env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES, 1024 * 1024),
@@ -447,6 +858,12 @@ function parseOptionalPositiveInt(value) {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseArchiveRetrievalMode(value) {
+  if (!value || value === 'eager') return undefined;
+  if (value === 'history_search_gated') return value;
+  throw new Error(`Unsupported MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MODE: ${value}`);
 }
 
 function classifyCacheMissShape(prefixChangeReason, requestShapeChangeReason) {


### PR DESCRIPTION
## Summary

- Add `archiveRetrieval.mode`, defaulting to existing eager hydration while enabling opt-in `history_search_gated` retrieval.
- Gate archive reads by RuntimeEvent turns selected by history search before invoking the archive reader, with diagnostics for mode and eligible turns.
- Extend the DeepSeek live baseline with a Phase 7 tool-using matrix that compares full, prune-only, eager retrieval, and history-search-gated retrieval.
- Make the Phase 7 live matrix fail non-zero when invariants are violated: tool-call shape, sentinel hiding, prune failure, eager/gated recovery, and gated history-search eligibility.

## Verification

- Rive workflow `wfrun_b782e68b93544676ba38a1f68a307800` completed: design, implementation, independent review.
- `npm run typecheck`
- `npm run build --workspaces --if-present`
- `node --test packages/runtime/dist/__tests__/context-budget.test.js`
- `node --test packages/runtime/dist/__tests__/ai-sdk-backend.test.js`
- `node --check scripts/deepseek-live-cost-baseline.mjs`
- `git diff --check`
- Paid DeepSeek strict Phase 7 matrix: `/tmp/rive-maka-phase7-live-matrix-20260616/output/phase7-live-matrix-strict2.json`, `passed=true`, `invariantFailures=[]`.

Part of #19.
