### PR TITLE
Add DeepSeek synthesis cache high-water

### DIFF
--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -187,6 +187,29 @@ export interface ContextBudgetDiagnostic {
   historyAroundRetrievedEvents?: number;
   historyAroundEstimatedTokens?: number;
   historyAroundSkippedEvents?: number;
+  synthesisCacheEnabled?: boolean;
+  synthesisCacheMode?: 'off' | 'lookup' | 'insert' | 'fallback_archive_retrieval';
+  synthesisCacheBlocksAvailable?: number;
+  synthesisCacheBlocksSelected?: number;
+  synthesisCacheBlockIds?: string[];
+  synthesisCacheEstimatedTokens?: number;
+  synthesisCacheSkipped?: number;
+  synthesisCacheSkippedReasonCounts?: Record<string, number>;
+  synthesisCacheInvalidated?: number;
+  synthesisCacheInvalidationReasonCounts?: Record<string, number>;
+  highWaterName?: string;
+  highWaterSeq?: number;
+  highWaterReason?:
+    | 'archive_prune'
+    | 'history_search_gated_retrieval'
+    | 'synthesis_cache_write'
+    | 'synthesis_cache_select'
+    | 'manual_reset'
+    | 'system_change'
+    | 'tools_change'
+    | 'log_rewrite';
+  highWaterRequestShapeHashBefore?: string;
+  highWaterRequestShapeHashAfter?: string;
   historyRewriteVersion?: string;
   historyRewriteResetReason?: string;
   historyRewriteGate?: string;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   applyRuntimeEventContextBudget,
+  type SynthesisCacheBlock,
 } from '../context-budget.js';
 import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
 
@@ -528,6 +529,231 @@ describe('AiSdkBackend model history', () => {
     assert.equal(usage?.contextBudget?.archiveRetrievalEligibleTurns, 1);
     assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
     assert.equal(usage?.contextBudget?.historySearchMatches, 1);
+  });
+
+  test('uses selected synthesis block instead of hydrating covered archived payload', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const archivedBodies = new Map<string, string>();
+    const readRuntimeEventIds: string[] = [];
+    const oldResult = { body: 'RAW_SYNTHESIS_ARCHIVE_PAYLOAD'.repeat(20) };
+    const serialized = JSON.stringify(oldResult);
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'rt-result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-rt-result-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'synthesis-cache-test',
+        maxHistoryTurns: 1,
+        minRecentTurns: 0,
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        archiveRetrieval: {
+          enabled: true,
+          mode: 'history_search_gated',
+          maxResults: 1,
+          maxEstimatedTokens: 4096,
+          maxBytes: 4096,
+        },
+        historySearch: {
+          enabled: true,
+          maxResults: 1,
+          around: 1,
+          maxEstimatedTokens: 4096,
+        },
+        synthesisCache: {
+          enabled: true,
+          blocks: [block],
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archivedBodies.set(event.runtimeEventId, event.serializedResult);
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => {
+        readRuntimeEventIds.push(event.runtimeEventId);
+        const body = archivedBodies.get(event.runtimeEventId);
+        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+      },
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'Recover key-alpha',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call-alpha',
+          turnId: 'turn-alpha',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-alpha', name: 'Read', args: { path: 'key-alpha.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-alpha',
+          turnId: 'turn-alpha',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-alpha', name: 'Read', result: oldResult, isError: false },
+        }),
+        runtimeTextEvent({
+          id: 'rt-new',
+          turnId: 'turn-new',
+          role: 'user',
+          author: 'user',
+          text: 'newer retained context',
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    assert.deepEqual(readRuntimeEventIds, []);
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /maka_synthesis_cache_block/);
+    assert.match(prompt, /SYNTHESIS_SENTINEL_KEY_ALPHA/);
+    assert.equal(prompt.includes('RAW_SYNTHESIS_ARCHIVE_PAYLOAD'), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.synthesisCacheBlocksSelected, 1);
+    assert.deepEqual(usage?.contextBudget?.synthesisCacheBlockIds, ['synth-key-alpha']);
+    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, undefined);
+  });
+
+  test('falls back to gated archive retrieval when synthesis request asks for evidence', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const archivedBodies = new Map<string, string>();
+    const readRuntimeEventIds: string[] = [];
+    const oldResult = { body: 'RAW_SYNTHESIS_ARCHIVE_PAYLOAD'.repeat(20) };
+    const serialized = JSON.stringify(oldResult);
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'rt-result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-rt-result-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'synthesis-cache-raw-test',
+        maxHistoryTurns: 1,
+        minRecentTurns: 0,
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        archiveRetrieval: {
+          enabled: true,
+          mode: 'history_search_gated',
+          maxResults: 1,
+          maxEstimatedTokens: 4096,
+          maxBytes: 4096,
+        },
+        historySearch: {
+          enabled: true,
+          maxResults: 1,
+          around: 1,
+          maxEstimatedTokens: 4096,
+        },
+        synthesisCache: {
+          enabled: true,
+          blocks: [block],
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archivedBodies.set(event.runtimeEventId, event.serializedResult);
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => {
+        readRuntimeEventIds.push(event.runtimeEventId);
+        const body = archivedBodies.get(event.runtimeEventId);
+        return body ? { ok: true, serializedResult: body } : { ok: false, reason: 'not_found' };
+      },
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'Show raw evidence for key-alpha',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call-alpha',
+          turnId: 'turn-alpha',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-alpha', name: 'Read', args: { path: 'key-alpha.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-alpha',
+          turnId: 'turn-alpha',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-alpha', name: 'Read', result: oldResult, isError: false },
+        }),
+        runtimeTextEvent({
+          id: 'rt-new',
+          turnId: 'turn-new',
+          role: 'user',
+          author: 'user',
+          text: 'newer retained context',
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    assert.deepEqual(readRuntimeEventIds, ['rt-result-alpha']);
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /RAW_SYNTHESIS_ARCHIVE_PAYLOAD/);
+    assert.equal(prompt.includes('maka_synthesis_cache_block'), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.synthesisCacheBlocksSelected, 0);
+    assert.deepEqual(usage?.contextBudget?.synthesisCacheSkippedReasonCounts, {
+      raw_evidence_requested: 1,
+    });
+    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
   });
 
   test('uses StoredMessage projection when RuntimeEvent tool results are unmatched', async () => {
@@ -2481,6 +2707,52 @@ function runtimeEvent(input: {
     ...(input.content ? { content: input.content } : {}),
     ...(input.status ? { status: input.status } : {}),
     ...(input.actions ? { actions: input.actions } : {}),
+  };
+}
+
+function synthesisBlock(input: {
+  queryKey: string;
+  turnId: string;
+  runtimeEventId: string;
+  toolCallId: string;
+  artifactId: string;
+  bodySha256: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+}): SynthesisCacheBlock {
+  return {
+    kind: 'maka.synthesis_cache_block',
+    version: 1,
+    blockId: `synth-${input.queryKey}`,
+    sessionId: 'session-1',
+    createdAt: 2,
+    highWaterName: `after-gated-${input.queryKey}`,
+    highWaterSeq: 1,
+    coverage: {
+      queryKeys: [input.queryKey],
+      turnIds: [input.turnId],
+      runtimeEventIds: [input.runtimeEventId],
+      toolNames: ['Read'],
+      toolCallIds: [input.toolCallId],
+      artifactIds: [input.artifactId],
+      bodySha256: [input.bodySha256],
+    },
+    summary: 'SYNTHESIS_SENTINEL_KEY_ALPHA',
+    limitations: ['Does not include raw tool output.'],
+    sourceRefs: [{
+      kind: 'archived_tool_result',
+      sessionId: 'session-1',
+      turnId: input.turnId,
+      runtimeEventId: input.runtimeEventId,
+      toolCallId: input.toolCallId,
+      toolName: 'Read',
+      artifactId: input.artifactId,
+      bodySha256: input.bodySha256,
+      originalEstimatedTokens: input.originalEstimatedTokens,
+      originalBytes: input.originalBytes,
+      placeholderReason: 'stale_tool_result_pruned_before_compact',
+    }],
+    createdFrom: 'gated_archive_retrieval',
   };
 }
 

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -8,9 +8,12 @@ import {
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   deserializeToolResultArchive,
+  renderSynthesisCacheBlock,
   retrieveArchivedToolResultsForReplay,
   retrieveRuntimeEventHistoryAround,
+  selectSynthesisCacheForReplay,
   serializeToolResultForArchive,
+  type SynthesisCacheBlock,
 } from '../context-budget.js';
 
 describe('context-budget archive retrieval', () => {
@@ -327,6 +330,208 @@ describe('context-budget archive retrieval', () => {
   });
 });
 
+describe('context-budget synthesis cache', () => {
+  test('selects a source-bearing synthesis block and injects it for replay only', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      toolCall('call-alpha', 'turn-alpha', 'tool-alpha'),
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+      textEvent('recent', 'turn-recent', 'newer retained context'),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    assert.equal(result.selectedBlocks.length, 1);
+    assert.equal(result.diagnosticPatch.synthesisCacheMode, 'lookup');
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheBlockIds, ['synth-key-alpha']);
+    assert.equal(result.diagnosticPatch.highWaterName, 'after-gated-key-alpha');
+    assert.equal(events.some((event) => event.id === 'result-alpha'), true);
+    assert.equal(result.events.some((event) => event.id === 'result-alpha'), false);
+    assert.equal(result.events.some((event) => event.id === 'recent'), true);
+    const synthetic = result.events.find((event) => event.id === 'synthesis-cache:synth-key-alpha');
+    assert.equal(synthetic?.role, 'model');
+    assert.match(
+      synthetic?.content?.kind === 'text' ? synthetic.content.text : '',
+      /<maka_synthesis_cache_block/,
+    );
+    assert.match(renderSynthesisCacheBlock(block), /artifact-alpha/);
+  });
+
+  test('does not select synthesis when raw evidence is requested', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Show raw archive evidence for key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1' },
+    );
+
+    assert.equal(result.selectedBlocks.length, 0);
+    assert.equal(result.diagnosticPatch.synthesisCacheMode, 'fallback_archive_retrieval');
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheSkippedReasonCounts, {
+      raw_evidence_requested: 1,
+    });
+    assert.deepEqual(result.events, events);
+  });
+
+  test('does not select synthesis for a longer uncovered key that shares a prefix', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha-noise-01',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1' },
+    );
+
+    assert.equal(result.selectedBlocks.length, 0);
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheSkippedReasonCounts, {
+      coverage_miss: 1,
+    });
+  });
+
+  test('invalidates synthesis when source placeholder hashes do not match', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: 'sha256:mismatch',
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1' },
+    );
+
+    assert.equal(result.selectedBlocks.length, 0);
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheInvalidationReasonCounts, {
+      source_hash_mismatch: 1,
+    });
+  });
+
+  test('invalidates synthesis when a newer matching tool result exists', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+      {
+        ...archivedResult('result-newer', 'turn-newer', 'tool-newer', {
+          artifactId: 'artifact-newer',
+          bodySha256: sha256(serialized),
+          originalEstimatedTokens: serialized.length,
+          originalBytes: utf8Bytes(serialized),
+        }),
+        ts: 1_800_000_000_010,
+        content: {
+          kind: 'function_response' as const,
+          id: 'tool-newer',
+          name: 'Read',
+          result: { text: 'new key-alpha payload' },
+          isError: false,
+        },
+      },
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1' },
+    );
+
+    assert.equal(result.selectedBlocks.length, 0);
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheInvalidationReasonCounts, {
+      new_relevant_tool_result: 1,
+    });
+  });
+});
+
 describe('context-budget search and rewrite diagnostics', () => {
   test('retrieves bounded around-context for deterministic RuntimeEvent search hits', () => {
     const events = [
@@ -418,6 +623,52 @@ function archivedResult(
     reason: 'stale_tool_result_pruned_before_compact',
     ...archive,
   });
+}
+
+function synthesisBlock(input: {
+  queryKey: string;
+  turnId: string;
+  runtimeEventId: string;
+  toolCallId: string;
+  artifactId: string;
+  bodySha256: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+}): SynthesisCacheBlock {
+  return {
+    kind: 'maka.synthesis_cache_block',
+    version: 1,
+    blockId: `synth-${input.queryKey}`,
+    sessionId: 'session-1',
+    createdAt: 1_800_000_000_001,
+    highWaterName: `after-gated-${input.queryKey}`,
+    highWaterSeq: 1,
+    coverage: {
+      queryKeys: [input.queryKey],
+      turnIds: [input.turnId],
+      runtimeEventIds: [input.runtimeEventId],
+      toolNames: ['Read'],
+      toolCallIds: [input.toolCallId],
+      artifactIds: [input.artifactId],
+      bodySha256: [input.bodySha256],
+    },
+    summary: `The stable answer for ${input.queryKey} is SYNTH_SENTINEL.`,
+    limitations: ['Does not include raw tool output.'],
+    sourceRefs: [{
+      kind: 'archived_tool_result',
+      sessionId: 'session-1',
+      turnId: input.turnId,
+      runtimeEventId: input.runtimeEventId,
+      toolCallId: input.toolCallId,
+      toolName: 'Read',
+      artifactId: input.artifactId,
+      bodySha256: input.bodySha256,
+      originalEstimatedTokens: input.originalEstimatedTokens,
+      originalBytes: input.originalBytes,
+      placeholderReason: 'stale_tool_result_pruned_before_compact',
+    }],
+    createdFrom: 'gated_archive_retrieval',
+  };
 }
 
 function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -108,6 +108,7 @@ import {
   estimateRuntimeEventsTokens,
   retrieveArchivedToolResultsForReplay,
   retrieveRuntimeEventHistoryAround,
+  selectSynthesisCacheForReplay,
   type ContextBudgetPolicy,
   type StaleToolResultArchiveCandidate,
   type ToolResultArchiveReader,
@@ -418,6 +419,10 @@ export class AiSdkBackend implements AgentBackend {
           activeTools,
           priorMessages: priorReplay.messages,
         }, this.priorRequestShape);
+        if (priorReplay.contextBudget?.highWaterReason) {
+          priorReplay.contextBudget.highWaterRequestShapeHashBefore = this.priorRequestShape?.requestShapeHash;
+          priorReplay.contextBudget.highWaterRequestShapeHashAfter = requestShape.requestShapeHash;
+        }
         requestShapeForTelemetry = requestShape;
         this.priorRequestShape = requestShape;
         trace.modelStreamStarted(activeTools, {
@@ -762,22 +767,41 @@ export class AiSdkBackend implements AgentBackend {
       );
     }
 
-    const retrieval = await retrieveArchivedToolResultsForReplay(
+    const synthesis = selectSynthesisCacheForReplay(
       runtimeContext,
-      contextBudget?.archiveRetrieval,
-      this.input.readToolResultArchive,
+      input.text,
+      contextBudget?.synthesisCache,
       {
         sessionId: this.sessionId,
         charsPerToken: contextBudget?.charsPerToken,
-        allowedTurnIds: archiveRetrievalAllowedTurnIds,
       },
     );
-    runtimeContext = retrieval.events;
-    if (contextBudget?.archiveRetrieval?.enabled === true) {
+    runtimeContext = synthesis.events;
+    if (contextBudget?.synthesisCache?.enabled === true) {
       contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
         contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
-        retrieval.diagnosticPatch,
+        synthesis.diagnosticPatch,
       );
+    }
+
+    if (synthesis.selectedBlocks.length === 0) {
+      const retrieval = await retrieveArchivedToolResultsForReplay(
+        runtimeContext,
+        contextBudget?.archiveRetrieval,
+        this.input.readToolResultArchive,
+        {
+          sessionId: this.sessionId,
+          charsPerToken: contextBudget?.charsPerToken,
+          allowedTurnIds: archiveRetrievalAllowedTurnIds,
+        },
+      );
+      runtimeContext = retrieval.events;
+      if (contextBudget?.archiveRetrieval?.enabled === true) {
+        contextBudgetDiagnostic = mergeContextBudgetDiagnostic(
+          contextBudgetDiagnostic ?? buildContextBudgetDiagnosticShell(priorRuntimeContext, runtimeContext, contextBudget),
+          retrieval.diagnosticPatch,
+        );
+      }
     }
 
     const plan = buildRuntimeEventModelReplayPlan(
@@ -1132,6 +1156,14 @@ function mergeContextBudgetDiagnostic(
     archiveRetrievalSkippedReasonCounts: mergeCountRecords(
       base.archiveRetrievalSkippedReasonCounts,
       patch.archiveRetrievalSkippedReasonCounts,
+    ),
+    synthesisCacheSkippedReasonCounts: mergeCountRecords(
+      base.synthesisCacheSkippedReasonCounts,
+      patch.synthesisCacheSkippedReasonCounts,
+    ),
+    synthesisCacheInvalidationReasonCounts: mergeCountRecords(
+      base.synthesisCacheInvalidationReasonCounts,
+      patch.synthesisCacheInvalidationReasonCounts,
     ),
   };
 }

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -26,6 +26,8 @@ export interface ContextBudgetPolicy {
   archiveRetrieval?: ArchiveRetrievalPolicy;
   /** Optional deterministic prior-history search used to re-add bounded around-context. Defaults off. */
   historySearch?: RuntimeEventHistorySearchPolicy;
+  /** Optional replay-only source-bearing synthesis cache over older RuntimeEvent history. Defaults off. */
+  synthesisCache?: SynthesisCachePolicy;
   /** Named rewrite/compaction gate for diagnostics and explicit cache-shape resets. */
   historyRewrite?: HistoryRewriteGatePolicy;
 }
@@ -64,6 +66,107 @@ export interface RuntimeEventHistorySearchPolicy {
   maxResults?: number;
   around?: number;
   maxEstimatedTokens?: number;
+}
+
+export interface SynthesisCachePolicy {
+  enabled: boolean;
+  /** Source-bearing blocks available for the current replay projection. */
+  blocks?: readonly SynthesisCacheBlock[];
+  /** Defaults to `lookup`; creation/persistence is owned by the harness or caller. */
+  mode?: 'lookup';
+  /** Defaults to 1 to keep replay bounded and deterministic. */
+  maxBlocks?: number;
+  /**
+   * When true (default), a newer matching tool result invalidates older synthesis
+   * for the same tool/query key.
+   */
+  invalidateOnNewToolResult?: boolean;
+}
+
+export interface SynthesisCacheBlock {
+  kind: 'maka.synthesis_cache_block';
+  version: 1;
+  blockId: string;
+  sessionId: string;
+  createdAt: number;
+  highWaterName: string;
+  highWaterSeq: number;
+  sourceRef?: {
+    sourceRef?: string;
+    repoRoot?: string;
+    gitCommit?: string;
+    harnessRunId?: string;
+  };
+  coverage: SynthesisCacheCoverage;
+  summary: string;
+  limitations: string[];
+  sourceRefs: readonly SynthesisSourceRef[];
+  createdFrom:
+    | 'gated_archive_retrieval'
+    | 'eager_archive_retrieval'
+    | 'full_context'
+    | 'live_tool_result'
+    | 'host_deterministic';
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+}
+
+export interface SynthesisCacheCoverage {
+  queryKeys: string[];
+  turnIds: string[];
+  runtimeEventIds: string[];
+  toolNames: string[];
+  toolCallIds: string[];
+  artifactIds: string[];
+  bodySha256: string[];
+}
+
+export type SynthesisSourceRef =
+  | {
+      kind: 'archived_tool_result';
+      sessionId: string;
+      turnId: string;
+      runtimeEventId: string;
+      toolCallId: string;
+      toolName: string;
+      artifactId: string;
+      bodySha256: string;
+      originalEstimatedTokens: number;
+      originalBytes: number;
+      placeholderReason: ArchivedToolResultReason;
+    }
+  | {
+      kind: 'runtime_event';
+      sessionId: string;
+      turnId: string;
+      runtimeEventId: string;
+      role: 'user' | 'model' | 'tool' | 'system';
+      contentKind: string;
+    }
+  | {
+      kind: 'history_search_hit';
+      sessionId: string;
+      turnId: string;
+      runtimeEventId: string;
+      score: number;
+      matchedTerms: string[];
+    }
+  | {
+      kind: 'live_tool_result';
+      sessionId: string;
+      turnId: string;
+      runtimeEventId: string;
+      toolCallId: string;
+      toolName: string;
+      argsSha256: string;
+      resultSha256: string;
+      artifactId?: string;
+    };
+
+export interface SynthesisCacheReplayResult {
+  events: RuntimeEvent[];
+  selectedBlocks: SynthesisCacheBlock[];
+  diagnosticPatch: Partial<ContextBudgetDiagnostic>;
 }
 
 export interface HistoryRewriteGatePolicy {
@@ -183,6 +286,7 @@ export function applyRuntimeEventContextBudget(
   const pruneEnabled = prunePolicy?.enabled === true;
   const archiveRetrievalEnabled = policy?.archiveRetrieval?.enabled === true;
   const historySearchEnabled = policy?.historySearch?.enabled === true;
+  const synthesisCacheEnabled = policy?.synthesisCache?.enabled === true;
   const historyRewriteEnabled = policy?.historyRewrite?.enabled === true;
   const enabled = Boolean(
     policy?.maxHistoryEstimatedTokens ||
@@ -190,6 +294,7 @@ export function applyRuntimeEventContextBudget(
     pruneEnabled ||
     archiveRetrievalEnabled ||
     historySearchEnabled ||
+    synthesisCacheEnabled ||
     historyRewriteEnabled
   );
   if (!enabled) return undefined;
@@ -439,6 +544,123 @@ export function retrieveRuntimeEventHistoryAround(
       ...(skipped > 0 ? { historyAroundSkippedEvents: skipped } : {}),
     },
   };
+}
+
+export function selectSynthesisCacheForReplay(
+  events: readonly RuntimeEvent[],
+  query: string,
+  policy: SynthesisCachePolicy | undefined,
+  options: { sessionId: string; charsPerToken?: number } = { sessionId: '' },
+): SynthesisCacheReplayResult {
+  if (policy?.enabled !== true) {
+    return { events: [...events], selectedBlocks: [], diagnosticPatch: {} };
+  }
+
+  const charsPerToken = options.charsPerToken ?? 4;
+  const blocks = policy.blocks ?? [];
+  const maxBlocks = finitePositive(policy.maxBlocks) ?? 1;
+  const selectedBlocks: SynthesisCacheBlock[] = [];
+  const skippedReasonCounts: Record<string, number> = {};
+  const invalidationReasonCounts: Record<string, number> = {};
+  const rawEvidenceReason = rawEvidenceRequestReason(query);
+  const sourceIndex = buildSynthesisSourceIndex(events);
+
+  for (const block of blocks) {
+    if (selectedBlocks.length >= maxBlocks) break;
+    const validationReason = validateSynthesisCacheBlock(block, sourceIndex, options.sessionId);
+    if (validationReason) {
+      increment(invalidationReasonCounts, validationReason);
+      continue;
+    }
+    if (!synthesisBlockCoversQuery(block, query)) {
+      increment(skippedReasonCounts, 'coverage_miss');
+      continue;
+    }
+    if (rawEvidenceReason) {
+      increment(skippedReasonCounts, rawEvidenceReason);
+      continue;
+    }
+    const newerReason = policy.invalidateOnNewToolResult === false
+      ? undefined
+      : newerRelevantToolResultReason(block, events, query);
+    if (newerReason) {
+      increment(invalidationReasonCounts, newerReason);
+      continue;
+    }
+    selectedBlocks.push(block);
+  }
+
+  const selectedTokenEstimate = selectedBlocks.reduce(
+    (total, block) => total + estimateTokens(renderSynthesisCacheBlock(block).length, charsPerToken),
+    0,
+  );
+  const skipped = Object.values(skippedReasonCounts).reduce((total, count) => total + count, 0);
+  const invalidated = Object.values(invalidationReasonCounts).reduce((total, count) => total + count, 0);
+  const diagnosticPatch: Partial<ContextBudgetDiagnostic> = {
+    synthesisCacheEnabled: true,
+    synthesisCacheMode: selectedBlocks.length > 0 ? 'lookup' : 'fallback_archive_retrieval',
+    synthesisCacheBlocksAvailable: blocks.length,
+    synthesisCacheBlocksSelected: selectedBlocks.length,
+    ...(selectedBlocks.length > 0
+      ? {
+          synthesisCacheBlockIds: selectedBlocks.map((block) => block.blockId),
+          synthesisCacheEstimatedTokens: selectedTokenEstimate,
+          highWaterName: selectedBlocks[0]!.highWaterName,
+          highWaterSeq: selectedBlocks[0]!.highWaterSeq,
+          highWaterReason: 'synthesis_cache_select',
+        }
+      : {}),
+    ...(skipped > 0
+      ? {
+          synthesisCacheSkipped: skipped,
+          synthesisCacheSkippedReasonCounts: skippedReasonCounts,
+        }
+      : {}),
+    ...(invalidated > 0
+      ? {
+          synthesisCacheInvalidated: invalidated,
+          synthesisCacheInvalidationReasonCounts: invalidationReasonCounts,
+        }
+      : {}),
+  };
+
+  if (selectedBlocks.length === 0) {
+    return { events: [...events], selectedBlocks, diagnosticPatch };
+  }
+
+  const coveredTurns = new Set<string>();
+  const coveredEventIds = new Set<string>();
+  for (const block of selectedBlocks) {
+    for (const turnId of block.coverage.turnIds) coveredTurns.add(turnId);
+    for (const eventId of block.coverage.runtimeEventIds) coveredEventIds.add(eventId);
+    for (const ref of block.sourceRefs) {
+      if ('turnId' in ref) coveredTurns.add(ref.turnId);
+      if ('runtimeEventId' in ref) coveredEventIds.add(ref.runtimeEventId);
+    }
+  }
+  const retained = events.filter((event) =>
+    !coveredEventIds.has(event.id) && !coveredTurns.has(turnKey(event))
+  );
+  return {
+    events: [
+      ...retained,
+      ...selectedBlocks.map((block) => synthesisBlockRuntimeEvent(block, options.sessionId)),
+    ],
+    selectedBlocks,
+    diagnosticPatch,
+  };
+}
+
+export function renderSynthesisCacheBlock(block: SynthesisCacheBlock): string {
+  const sourceText = block.sourceRefs.map((ref) => renderSynthesisSourceRef(ref)).join('; ');
+  return [
+    `<maka_synthesis_cache_block id="${escapeAttribute(block.blockId)}" high_water="${escapeAttribute(block.highWaterName)}" seq="${block.highWaterSeq}">`,
+    `summary: ${block.summary}`,
+    `coverage: queryKeys=[${block.coverage.queryKeys.join(', ')}], turnIds=[${block.coverage.turnIds.join(', ')}], runtimeEventIds=[${block.coverage.runtimeEventIds.join(', ')}], artifactIds=[${block.coverage.artifactIds.join(', ')}]`,
+    `limitations: ${block.limitations.join('; ')}`,
+    `sources: ${sourceText}`,
+    '</maka_synthesis_cache_block>',
+  ].join('\n');
 }
 
 export function buildPromptSegmentEstimates(input: PromptSegmentInput): PromptSegmentEstimate[] {
@@ -858,6 +1080,190 @@ function runtimeEventSearchText(event: RuntimeEvent): string {
     case 'error':
       return `${content.message} ${content.reason ?? ''} ${content.code ?? ''}`;
   }
+}
+
+function buildSynthesisSourceIndex(events: readonly RuntimeEvent[]): Map<string, RuntimeEvent> {
+  return new Map(events.map((event) => [event.id, event]));
+}
+
+function validateSynthesisCacheBlock(
+  block: SynthesisCacheBlock,
+  sourceIndex: ReadonlyMap<string, RuntimeEvent>,
+  sessionId: string,
+): string | undefined {
+  if (
+    block.kind !== 'maka.synthesis_cache_block' ||
+    block.version !== 1 ||
+    !nonEmpty(block.blockId) ||
+    !nonEmpty(block.sessionId) ||
+    (sessionId.length > 0 && block.sessionId !== sessionId) ||
+    !Number.isFinite(block.createdAt) ||
+    !nonEmpty(block.highWaterName) ||
+    !Number.isFinite(block.highWaterSeq) ||
+    !nonEmpty(block.summary) ||
+    !Array.isArray(block.limitations) ||
+    block.sourceRefs.length === 0
+  ) {
+    return 'unsupported_policy';
+  }
+  if (
+    block.coverage.queryKeys.length === 0 ||
+    block.coverage.turnIds.length === 0 ||
+    block.coverage.runtimeEventIds.length === 0 ||
+    block.coverage.artifactIds.length === 0 ||
+    block.coverage.bodySha256.length === 0 ||
+    !allNonEmpty(block.coverage.queryKeys) ||
+    !allNonEmpty(block.coverage.turnIds) ||
+    !allNonEmpty(block.coverage.runtimeEventIds) ||
+    !allNonEmpty(block.coverage.toolNames) ||
+    !allNonEmpty(block.coverage.toolCallIds) ||
+    !allNonEmpty(block.coverage.artifactIds) ||
+    !allNonEmpty(block.coverage.bodySha256)
+  ) {
+    return 'unsupported_policy';
+  }
+
+  for (const ref of block.sourceRefs) {
+    const event = sourceIndex.get(ref.runtimeEventId);
+    if (!event) return ref.kind === 'archived_tool_result' ? 'archive_missing' : 'coverage_miss';
+    if (ref.sessionId !== block.sessionId || (sessionId.length > 0 && ref.sessionId !== sessionId)) {
+      return 'source_hash_mismatch';
+    }
+    if (event.turnId !== ref.turnId) return 'source_hash_mismatch';
+    if (ref.kind === 'archived_tool_result') {
+      if (
+        !nonEmpty(ref.artifactId) ||
+        !nonEmpty(ref.bodySha256) ||
+        !nonEmpty(ref.toolCallId) ||
+        !nonEmpty(ref.toolName) ||
+        ref.originalEstimatedTokens <= 0 ||
+        ref.originalBytes <= 0 ||
+        ref.placeholderReason !== 'stale_tool_result_pruned_before_compact'
+      ) {
+        return 'unsupported_policy';
+      }
+      if (event.content?.kind !== 'function_response') return 'source_hash_mismatch';
+      if (!isArchivedToolResultPlaceholder(event.content.result)) return 'source_hash_mismatch';
+      const placeholder = event.content.result;
+      if (
+        placeholder.artifactId !== ref.artifactId ||
+        placeholder.bodySha256 !== ref.bodySha256 ||
+        placeholder.toolCallId !== ref.toolCallId ||
+        placeholder.toolName !== ref.toolName ||
+        placeholder.originalEstimatedTokens !== ref.originalEstimatedTokens ||
+        placeholder.originalBytes !== ref.originalBytes ||
+        placeholder.reason !== ref.placeholderReason
+      ) {
+        return 'source_hash_mismatch';
+      }
+    }
+  }
+  return undefined;
+}
+
+function synthesisBlockCoversQuery(block: SynthesisCacheBlock, query: string): boolean {
+  return block.coverage.queryKeys.some((key) => queryContainsCoveredKey(query, key));
+}
+
+function queryContainsCoveredKey(query: string, key: string): boolean {
+  const normalizedQuery = query.toLowerCase();
+  const normalizedKey = key.toLowerCase().trim();
+  if (normalizedKey.length === 0) return false;
+  let index = normalizedQuery.indexOf(normalizedKey);
+  while (index >= 0) {
+    const before = index === 0 ? '' : normalizedQuery[index - 1]!;
+    const after = normalizedQuery[index + normalizedKey.length] ?? '';
+    if (!isQueryKeyContinuation(before) && !isQueryKeyContinuation(after)) {
+      return true;
+    }
+    index = normalizedQuery.indexOf(normalizedKey, index + normalizedKey.length);
+  }
+  return false;
+}
+
+function isQueryKeyContinuation(char: string): boolean {
+  return /^[a-z0-9_-]$/.test(char);
+}
+
+function rawEvidenceRequestReason(query: string): 'raw_evidence_requested' | 'exact_output_requested' | undefined {
+  const normalized = query.toLowerCase();
+  if (/\b(exact|verbatim|original wording|word-for-word|full output)\b/.test(normalized)) {
+    return 'exact_output_requested';
+  }
+  if (/\b(raw|evidence|proof|show how|debug|source|archive|tool output|original tool)\b/.test(normalized)) {
+    return 'raw_evidence_requested';
+  }
+  return undefined;
+}
+
+function newerRelevantToolResultReason(
+  block: SynthesisCacheBlock,
+  events: readonly RuntimeEvent[],
+  query: string,
+): 'new_relevant_tool_result' | undefined {
+  const sourceEventIds = new Set(block.coverage.runtimeEventIds);
+  const toolNames = new Set(block.coverage.toolNames);
+  const sourceTimes = events
+    .filter((event) => sourceEventIds.has(event.id))
+    .map((event) => event.ts);
+  const newestSourceTs = sourceTimes.length > 0 ? Math.max(...sourceTimes) : block.createdAt;
+  const keys = block.coverage.queryKeys.map((key) => key.toLowerCase());
+  const queryText = query.toLowerCase();
+  for (const event of events) {
+    if (event.ts <= newestSourceTs || event.content?.kind !== 'function_response') continue;
+    if (sourceEventIds.has(event.id) || !toolNames.has(event.content.name)) continue;
+    const eventText = runtimeEventSearchText(event).toLowerCase();
+    if (keys.some((key) => eventText.includes(key) || queryText.includes(key))) {
+      return 'new_relevant_tool_result';
+    }
+  }
+  return undefined;
+}
+
+function synthesisBlockRuntimeEvent(block: SynthesisCacheBlock, sessionId: string): RuntimeEvent {
+  return {
+    id: `synthesis-cache:${block.blockId}`,
+    sessionId,
+    runId: `synthesis-cache:${block.blockId}`,
+    turnId: `synthesis-cache:${block.highWaterSeq}`,
+    invocationId: `synthesis-cache:${block.blockId}`,
+    ts: block.createdAt,
+    partial: false,
+    role: 'model',
+    author: 'system',
+    content: {
+      kind: 'text',
+      text: renderSynthesisCacheBlock(block),
+    },
+    refs: {
+      artifactId: block.coverage.artifactIds[0],
+    },
+  };
+}
+
+function renderSynthesisSourceRef(ref: SynthesisSourceRef): string {
+  switch (ref.kind) {
+    case 'archived_tool_result':
+      return `archived_tool_result(runtimeEventId=${ref.runtimeEventId}, turnId=${ref.turnId}, artifactId=${ref.artifactId}, bodySha256=${ref.bodySha256}, toolName=${ref.toolName})`;
+    case 'runtime_event':
+      return `runtime_event(runtimeEventId=${ref.runtimeEventId}, turnId=${ref.turnId}, role=${ref.role}, contentKind=${ref.contentKind})`;
+    case 'history_search_hit':
+      return `history_search_hit(runtimeEventId=${ref.runtimeEventId}, turnId=${ref.turnId}, score=${ref.score}, matchedTerms=${ref.matchedTerms.join('|')})`;
+    case 'live_tool_result':
+      return `live_tool_result(runtimeEventId=${ref.runtimeEventId}, turnId=${ref.turnId}, toolName=${ref.toolName}, resultSha256=${ref.resultSha256})`;
+  }
+}
+
+function escapeAttribute(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function allNonEmpty(values: readonly unknown[]): boolean {
+  return values.every(nonEmpty);
 }
 
 function tokenizeSearchQuery(query: string): string[] {

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -56,6 +56,19 @@ if (process.env.MAKA_COST_BASELINE_PHASE7_TOOL_MATRIX === 'on') {
   process.exit(exitCode);
 }
 
+if (process.env.MAKA_COST_BASELINE_PHASE8_SYNTHESIS_MATRIX === 'on') {
+  const exitCode = await runPhase8SynthesisMatrix({
+    apiKey,
+    model,
+    repoRoot,
+    outputRoot,
+    runId,
+    seed,
+    cwd,
+  });
+  process.exit(exitCode);
+}
+
 const sessionStore = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
@@ -615,6 +628,356 @@ async function runPhase7ToolScenario(input) {
   };
 }
 
+async function runPhase8SynthesisMatrix(input) {
+  const matrixOutputRoot = join(input.outputRoot, input.runId, 'phase8-synthesis-matrix');
+  await mkdir(matrixOutputRoot, { recursive: true });
+  const sentinel = process.env.MAKA_COST_BASELINE_PHASE7_SENTINEL
+    ?? `PHASE7_SENTINEL_${sha256(`${input.seed}:phase7`).slice(0, 16)}`;
+  const lookupKey = process.env.MAKA_COST_BASELINE_PHASE7_LOOKUP_KEY ?? 'phase7-live-key';
+  const resultLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_PHASE7_RESULT_LINES, 220);
+  const noisyArchiveCount = parsePositiveInt(process.env.MAKA_COST_BASELINE_PHASE7_NOISY_ARCHIVES, 8);
+  const cases = [];
+  for (const matrixCase of [
+    { name: 'single_archive_recovery', noiseArchiveCount: 0 },
+    { name: 'multi_archive_selectivity', noiseArchiveCount: noisyArchiveCount },
+  ]) {
+    const scenarios = [];
+    for (const mode of ['full', 'gated', 'synthesis_gated']) {
+      scenarios.push(await runPhase8SynthesisScenario({
+        ...input,
+        matrixOutputRoot: join(matrixOutputRoot, matrixCase.name),
+        matrixCase: matrixCase.name,
+        mode,
+        sentinel,
+        lookupKey,
+        resultLines,
+        noiseArchiveCount: matrixCase.noiseArchiveCount,
+      }));
+    }
+    cases.push({
+      name: matrixCase.name,
+      noiseArchiveCount: matrixCase.noiseArchiveCount,
+      archiveCount: matrixCase.noiseArchiveCount + 1,
+      scenarios,
+    });
+  }
+  const invariantFailures = validatePhase8SynthesisMatrix(cases, sentinel);
+  const scenarios = cases[0]?.scenarios ?? [];
+  const report = {
+    sourceRef: process.env.MAKA_COST_BASELINE_SOURCE_REF ?? 'local-build',
+    scenario: {
+      name: 'phase8_synthesis_cache_high_water_matrix',
+      cases: cases.map((matrixCase) => matrixCase.name),
+      modes: scenarios.map((scenario) => scenario.mode),
+    },
+    passed: invariantFailures.length === 0,
+    invariantFailures,
+    repoRoot: input.repoRoot,
+    outputRoot: matrixOutputRoot,
+    model: input.model,
+    seed: input.seed,
+    lookupKey,
+    sentinelSha256: sha256(sentinel),
+    resultLines,
+    noisyArchiveCount,
+    cases,
+    scenarios,
+  };
+  const jsonPath = resolve(
+    process.env.MAKA_COST_BASELINE_PHASE8_MATRIX_JSON
+      ?? join(matrixOutputRoot, 'phase8-synthesis-live-matrix.json'),
+  );
+  await mkdir(resolve(jsonPath, '..'), { recursive: true });
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  console.log(JSON.stringify({
+    jsonPath,
+    model: input.model,
+    scenario: report.scenario.name,
+    cases: cases.map((matrixCase) => ({
+      name: matrixCase.name,
+      modes: matrixCase.scenarios.map((scenario) => ({
+        mode: scenario.mode,
+        recoveryArchivedToolResultsRead: scenario.recoveryArchivedToolResultsRead,
+        repeatedAnswerExactlySentinel: scenario.repeatedAnswerExactlySentinel,
+        repeatedArchivedToolResultsRead: scenario.repeatedArchivedToolResultsRead,
+        rawEvidenceArchivedToolResultsRead: scenario.rawEvidenceArchivedToolResultsRead,
+        noiseCoverageArchivedToolResultsRead: scenario.noiseCoverageArchivedToolResultsRead,
+        selectedSynthesisBlockIds: scenario.repeatedContextBudget?.synthesisCacheBlockIds ?? [],
+        noiseSynthesisSelected: scenario.noiseCoverageContextBudget?.synthesisCacheBlocksSelected ?? 0,
+        recoveryUsage: scenario.recoveryUsage,
+        repeatedUsage: scenario.repeatedUsage,
+        scenarioUsageTotals: scenario.scenarioUsageTotals,
+      })),
+    })),
+    invariantFailures,
+  }, null, 2));
+  if (invariantFailures.length > 0) {
+    console.error([
+      'Phase 8 synthesis matrix invariant failures:',
+      ...invariantFailures.map((failure) => `- ${failure}`),
+    ].join('\n'));
+    return 1;
+  }
+  return 0;
+}
+
+async function runPhase8SynthesisScenario(input) {
+  const workspaceRoot = join(input.matrixOutputRoot, input.mode, 'workspace');
+  await mkdir(workspaceRoot, { recursive: true });
+  const sessionStore = createSessionStore(workspaceRoot);
+  const runStore = createAgentRunStore(workspaceRoot);
+  const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+  const artifactStore = createArtifactStore(workspaceRoot);
+  const permissionEngine = new PermissionEngine(createDefaultPermissionEngineDeps());
+  const backends = new BackendRegistry();
+  const llmRecords = [];
+  const runTraceEvents = [];
+  const archiveReads = [];
+  const archiveRefsByRuntimeEventId = new Map();
+  const synthesisBlocks = [];
+  let activeTurnId;
+  const tools = [buildPhase7LookupTool(input)];
+  const connection = {
+    slug: `deepseek-live-phase8-${input.mode}`,
+    name: `DeepSeek live Phase 8 ${input.mode}`,
+    providerType: 'deepseek',
+    baseUrl: 'https://api.deepseek.com',
+    defaultModel: input.model,
+    enabled: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  const contextBudget = buildPhase8ContextBudgetPolicy(input.mode, synthesisBlocks);
+  const systemPrompt = [
+    'You are a Maka Phase 8 live harness assistant.',
+    `Lookup key: ${input.lookupKey}`,
+    'When asked to store the Phase 8 lookup, call Phase7Lookup exactly once with the lookup key.',
+    'After the tool result is available, answer exactly STORED.',
+    'Do not include the sentinel value in the storage acknowledgement.',
+    'When later asked to recover the sentinel, answer only the sentinel value found in prior tool results or a source-bearing synthesis cache block.',
+    'Do not call Phase7Lookup during sentinel recovery; recovery must use prior context only.',
+  ].join('\n');
+
+  backends.register('ai-sdk', async (ctx) =>
+    new AiSdkBackend({
+      sessionId: ctx.sessionId,
+      header: { ...ctx.header, model: input.model },
+      appendMessage: (message) => ctx.store.appendMessage(ctx.sessionId, message),
+      connection,
+      apiKey: input.apiKey,
+      modelId: input.model,
+      permissionEngine,
+      modelFactory: getAIModel,
+      tools,
+      providerOptions: buildProviderOptions(connection, input.model),
+      contextBudget,
+      systemPrompt,
+      turnTailPrompt: phase7TurnTailPrompt(input.cwd),
+      recordLlmCall: (record) => llmRecords.push(record),
+      recordRunTrace: (event) => runTraceEvents.push(event),
+      archiveToolResult: async (event) => {
+        const cached = archiveRefsByRuntimeEventId.get(event.runtimeEventId);
+        if (
+          cached &&
+          cached.bodySha256 === event.bodySha256 &&
+          cached.originalBytes === event.originalBytes &&
+          cached.originalEstimatedTokens === event.originalEstimatedTokens
+        ) {
+          return { artifactId: cached.artifactId };
+        }
+        const artifact = await artifactStore.create({
+          sessionId: event.sessionId,
+          turnId: event.turnId,
+          name: `phase8-tool-result-${event.runtimeEventId}.json`,
+          kind: 'file',
+          content: event.serializedResult,
+          mimeType: 'application/json',
+          source: 'tool_result_archive',
+          summary: `Archived ${event.toolName} Phase 8 tool result for ${input.mode}`,
+        });
+        archiveRefsByRuntimeEventId.set(event.runtimeEventId, {
+          sessionId: event.sessionId,
+          turnId: event.turnId,
+          runtimeEventId: event.runtimeEventId,
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          artifactId: artifact.id,
+          bodySha256: event.bodySha256,
+          originalEstimatedTokens: event.originalEstimatedTokens,
+          originalBytes: event.originalBytes,
+          placeholderReason: event.reason,
+        });
+        return { artifactId: artifact.id };
+      },
+      readToolResultArchive: async (event) => {
+        archiveReads.push({
+          requestTurnId: activeTurnId,
+          runtimeEventId: event.runtimeEventId,
+          turnId: event.turnId,
+          artifactId: event.artifactId,
+        });
+        const record = await artifactStore.get(event.artifactId);
+        if (!record) return { ok: false, reason: 'not_found' };
+        if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+        if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+        if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
+        if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+        const read = await artifactStore.readText(event.artifactId, {
+          maxBytes: event.maxBytes ?? event.originalBytes,
+        });
+        if (!read.ok) return read;
+        if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+        return { ok: true, serializedResult: read.text };
+      },
+      newId: randomUUID,
+      now: Date.now,
+      maxSteps: 4,
+      streamConnectTimeoutMs: 30_000,
+      streamIdleTimeoutMs: 120_000,
+    }),
+  );
+
+  const manager = new SessionManager({
+    store: sessionStore,
+    runStore,
+    runtimeEventStore,
+    backends,
+    newId: randomUUID,
+    now: Date.now,
+  });
+  const session = await manager.createSession({
+    cwd: input.cwd,
+    backend: 'ai-sdk',
+    llmConnectionSlug: connection.slug,
+    model: input.model,
+    permissionMode: 'explore',
+    name: `DeepSeek Phase 8 ${input.mode}`,
+  });
+
+  const storeSpecs = buildPhase7StoreSpecs(input);
+  const storeTurns = [];
+  for (const storeSpec of storeSpecs) {
+    storeTurns.push({
+      ...storeSpec,
+      ...(await sendPhase7ScenarioTurn(
+        manager,
+        session.id,
+        storeSpec.turnId,
+        [
+          `Store the Phase 8 lookup for key ${storeSpec.key}.`,
+          'Call Phase7Lookup, then acknowledge with exactly STORED.',
+          'Do not repeat any sentinel value.',
+        ].join('\n'),
+        (turnId) => { activeTurnId = turnId; },
+      )),
+    });
+  }
+  await sendPhase7ScenarioTurn(
+    manager,
+    session.id,
+    'phase8-filler',
+    'Answer exactly OK. This turn exists so the old tool result becomes stale for pruning.',
+    (turnId) => { activeTurnId = turnId; },
+  );
+  if (input.mode === 'synthesis_gated') {
+    const targetTurnId = storeSpecs.find((spec) => spec.target)?.turnId;
+    const source = [...archiveRefsByRuntimeEventId.values()].find((ref) => ref.turnId === targetTurnId);
+    if (source) {
+      synthesisBlocks.push(buildPhase8SynthesisBlock({
+        sessionId: session.id,
+        lookupKey: input.lookupKey,
+        sentinel: input.sentinel,
+        source,
+        sourceRef: process.env.MAKA_COST_BASELINE_SOURCE_REF ?? 'local-build',
+        repoRoot: input.repoRoot,
+        createdFrom: 'host_deterministic',
+      }));
+    }
+  }
+
+  const coveredTurn = await sendPhase7ScenarioTurn(
+    manager,
+    session.id,
+    'phase8-covered-recovery',
+    `Recover the sentinel for lookup key ${input.lookupKey} from prior Phase 8 context. Do not call tools. Answer only the sentinel.`,
+    (turnId) => { activeTurnId = turnId; },
+  );
+  const noiseKey = `${input.lookupKey}-noise-01`;
+  const noiseCoverageTurn = input.mode === 'synthesis_gated' && input.noiseArchiveCount > 0
+    ? await sendPhase7ScenarioTurn(
+        manager,
+        session.id,
+        'phase8-noise-coverage-miss',
+        `Recover the noise sentinel for lookup key ${noiseKey} from prior Phase 8 context. Do not call tools. Answer only the sentinel.`,
+        (turnId) => { activeTurnId = turnId; },
+      )
+    : undefined;
+  const rawEvidenceTurn = input.mode === 'synthesis_gated'
+    ? await sendPhase7ScenarioTurn(
+        manager,
+        session.id,
+        'phase8-raw-evidence',
+        `Show the raw tool output evidence for lookup key ${input.lookupKey}. Do not call tools.`,
+        (turnId) => { activeTurnId = turnId; },
+      )
+    : undefined;
+  activeTurnId = undefined;
+
+  const coveredUsageEvent = coveredTurn.events.find((event) => event.type === 'token_usage');
+  const noiseCoverageUsageEvent = noiseCoverageTurn?.events.find((event) => event.type === 'token_usage');
+  const rawEvidenceUsageEvent = rawEvidenceTurn?.events.find((event) => event.type === 'token_usage');
+  const pricingId = `${connection.providerType}:${input.model}`;
+  const coveredRecordOffset = rawEvidenceTurn ? (noiseCoverageTurn ? -3 : -2) : (noiseCoverageTurn ? -2 : -1);
+  const noiseRecordOffset = rawEvidenceTurn ? -2 : -1;
+  return {
+    matrixCase: input.matrixCase,
+    mode: input.mode,
+    contextBudget,
+    sessionId: session.id,
+    synthesisBlocksCreated: synthesisBlocks,
+    storeTurns: storeTurns.map((turn) => ({
+      turnId: turn.turnId,
+      key: turn.key,
+      target: turn.target,
+      assistantText: turn.assistantText,
+    })),
+    recoveryAnswer: coveredTurn.assistantText,
+    recoveryArchivedToolResultsRead: archiveReads.filter((read) => read.requestTurnId === 'phase8-covered-recovery').length,
+    recoveryContextBudget: coveredUsageEvent?.contextBudget,
+    repeatedAnswer: coveredTurn.assistantText,
+    repeatedRecoveredSentinel: coveredTurn.assistantText.includes(input.sentinel),
+    repeatedAnswerExactlySentinel: coveredTurn.assistantText.trim() === input.sentinel,
+    archiveReads,
+    repeatedArchivedToolResultsRead: archiveReads.filter((read) => read.requestTurnId === 'phase8-covered-recovery').length,
+    noiseCoverageAnswer: noiseCoverageTurn?.assistantText,
+    noiseCoverageArchivedToolResultsRead: archiveReads.filter((read) => read.requestTurnId === 'phase8-noise-coverage-miss').length,
+    noiseCoverageContextBudget: noiseCoverageUsageEvent?.contextBudget,
+    rawEvidenceArchivedToolResultsRead: archiveReads.filter((read) => read.requestTurnId === 'phase8-raw-evidence').length,
+    repeatedContextBudget: coveredUsageEvent?.contextBudget,
+    rawEvidenceContextBudget: rawEvidenceUsageEvent?.contextBudget,
+    recoveryUsage: usageSummary(coveredUsageEvent, llmRecords.at(coveredRecordOffset), pricingId),
+    repeatedUsage: usageSummary(coveredUsageEvent, llmRecords.at(coveredRecordOffset), pricingId),
+    noiseCoverageUsage: noiseCoverageTurn
+      ? usageSummary(noiseCoverageUsageEvent, llmRecords.at(noiseRecordOffset), pricingId)
+      : undefined,
+    rawEvidenceUsage: rawEvidenceTurn ? usageSummary(rawEvidenceUsageEvent, llmRecords.at(-1), pricingId) : undefined,
+    scenarioUsageTotals: usageTotals(llmRecords, pricingId),
+    requestShapeTrace: runTraceEvents
+      .filter((event) =>
+        event.data?.requestShapeHash ||
+        event.data?.requestShapeChangeReason ||
+        event.data?.contextBudget
+      )
+      .map((event) => ({
+        phase: event.phase,
+        type: event.type,
+        requestShapeHash: event.data?.requestShapeHash,
+        requestShapeChangeReason: event.data?.requestShapeChangeReason,
+        contextBudget: event.data?.contextBudget,
+      })),
+  };
+}
+
 function buildPhase7LookupTool(input) {
   return {
     name: 'Phase7Lookup',
@@ -697,6 +1060,66 @@ function buildPhase7ContextBudgetPolicy(mode) {
   return {
     ...base,
     archiveRetrieval,
+  };
+}
+
+function buildPhase8ContextBudgetPolicy(mode, synthesisBlocks) {
+  if (mode === 'full') return undefined;
+  const gated = buildPhase7ContextBudgetPolicy('gated');
+  if (mode !== 'synthesis_gated') return gated;
+  return {
+    ...gated,
+    name: 'phase8-synthesis-gated',
+    synthesisCache: {
+      enabled: true,
+      blocks: synthesisBlocks,
+      maxBlocks: 1,
+    },
+  };
+}
+
+function buildPhase8SynthesisBlock(input) {
+  return {
+    kind: 'maka.synthesis_cache_block',
+    version: 1,
+    blockId: `phase8-synth-${sha256(`${input.sessionId}:${input.lookupKey}`).slice(0, 16)}`,
+    sessionId: input.sessionId,
+    createdAt: Date.now(),
+    highWaterName: `phase8-after-gated-${input.lookupKey}`,
+    highWaterSeq: 1,
+    sourceRef: {
+      sourceRef: input.sourceRef,
+      repoRoot: input.repoRoot,
+      harnessRunId: process.env.MAKA_COST_BASELINE_RUN_ID,
+    },
+    coverage: {
+      queryKeys: [input.lookupKey],
+      turnIds: [input.source.turnId],
+      runtimeEventIds: [input.source.runtimeEventId],
+      toolNames: [input.source.toolName],
+      toolCallIds: [input.source.toolCallId],
+      artifactIds: [input.source.artifactId],
+      bodySha256: [input.source.bodySha256],
+    },
+    summary: `For lookup key ${input.lookupKey}, the recoverable sentinel is ${input.sentinel}.`,
+    limitations: [
+      'Does not include raw tool output.',
+      'Does not cover noise lookup keys or changed archive bodies.',
+    ],
+    sourceRefs: [{
+      kind: 'archived_tool_result',
+      sessionId: input.sessionId,
+      turnId: input.source.turnId,
+      runtimeEventId: input.source.runtimeEventId,
+      toolCallId: input.source.toolCallId,
+      toolName: input.source.toolName,
+      artifactId: input.source.artifactId,
+      bodySha256: input.source.bodySha256,
+      originalEstimatedTokens: input.source.originalEstimatedTokens,
+      originalBytes: input.source.originalBytes,
+      placeholderReason: input.source.placeholderReason,
+    }],
+    createdFrom: input.createdFrom ?? 'gated_archive_retrieval',
   };
 }
 
@@ -859,6 +1282,88 @@ function validatePhase7ToolMatrix(cases, sentinel) {
       }
       if ((eager?.finalContextBudget?.retrievedArchiveEstimatedTokens ?? 0) <= (gated?.finalContextBudget?.retrievedArchiveEstimatedTokens ?? 0)) {
         failures.push(`${matrixCase.name}: eager scenario did not report higher retrieved archive token volume than gated`);
+      }
+    }
+  }
+  return failures;
+}
+
+function validatePhase8SynthesisMatrix(cases, sentinel) {
+  const failures = [];
+  for (const matrixCase of cases) {
+    const byMode = new Map(matrixCase.scenarios.map((scenario) => [scenario.mode, scenario]));
+    for (const mode of ['full', 'gated', 'synthesis_gated']) {
+      const scenario = byMode.get(mode);
+      if (!scenario) {
+        failures.push(`${matrixCase.name}: missing ${mode} scenario`);
+        continue;
+      }
+      if (!scenario.repeatedRecoveredSentinel || !scenario.repeatedAnswerExactlySentinel) {
+        failures.push(`${matrixCase.name}: ${mode} repeated turn did not recover exactly ${sentinel}`);
+      }
+      if ((scenario.repeatedUsage?.cacheMissInput ?? 0) < 0) {
+        failures.push(`${matrixCase.name}: ${mode} repeated cacheMissInput was not measurable`);
+      }
+      if (typeof scenario.repeatedUsage?.estimatedCostUsd !== 'number') {
+        failures.push(`${matrixCase.name}: ${mode} repeated estimatedCostUsd was not measurable`);
+      }
+    }
+    const gated = byMode.get('gated');
+    const synthesis = byMode.get('synthesis_gated');
+    if (gated && (gated.recoveryArchivedToolResultsRead ?? 0) < 1) {
+      failures.push(`${matrixCase.name}: gated covered turn did not read the target archive`);
+    }
+    if (gated && (gated.recoveryContextBudget?.retrievedArchiveToolResults ?? 0) < 1) {
+      failures.push(`${matrixCase.name}: gated covered turn did not report archive retrieval`);
+    }
+    if (gated && (gated.repeatedArchivedToolResultsRead ?? 0) < 1) {
+      failures.push(`${matrixCase.name}: gated comparison turn did not read the target archive`);
+    }
+    if (synthesis) {
+      if ((synthesis.synthesisBlocksCreated?.length ?? 0) !== 1) {
+        failures.push(`${matrixCase.name}: synthesis_gated did not create one synthesis block`);
+      }
+      if ((synthesis.repeatedArchivedToolResultsRead ?? 0) !== 0) {
+        failures.push(`${matrixCase.name}: synthesis_gated repeated turn read archives`);
+      }
+      if ((synthesis.repeatedContextBudget?.synthesisCacheBlocksSelected ?? 0) !== 1) {
+        failures.push(`${matrixCase.name}: synthesis_gated repeated turn did not select synthesis`);
+      }
+      if (
+        gated &&
+        typeof gated.repeatedUsage?.input === 'number' &&
+        typeof synthesis.repeatedUsage?.input === 'number' &&
+        synthesis.repeatedUsage.input >= gated.repeatedUsage.input
+      ) {
+        failures.push(`${matrixCase.name}: synthesis_gated comparison input was not below gated`);
+      }
+      if (
+        gated &&
+        typeof gated.repeatedUsage?.estimatedCostUsd === 'number' &&
+        typeof synthesis.repeatedUsage?.estimatedCostUsd === 'number' &&
+        synthesis.repeatedUsage.estimatedCostUsd >= gated.repeatedUsage.estimatedCostUsd
+      ) {
+        failures.push(`${matrixCase.name}: synthesis_gated comparison cost was not below gated`);
+      }
+      if ((synthesis.rawEvidenceArchivedToolResultsRead ?? 0) < 1) {
+        failures.push(`${matrixCase.name}: synthesis_gated raw evidence turn did not fall back to archive retrieval`);
+      }
+      if ((synthesis.rawEvidenceContextBudget?.retrievedArchiveToolResults ?? 0) < 1) {
+        failures.push(`${matrixCase.name}: synthesis_gated raw evidence turn did not report archive retrieval`);
+      }
+      if (matrixCase.name === 'multi_archive_selectivity') {
+        if ((synthesis.repeatedContextBudget?.synthesisCacheBlocksSelected ?? 0) !== 1) {
+          failures.push(`${matrixCase.name}: synthesis_gated selected more or fewer than one block`);
+        }
+        if ((synthesis.repeatedContextBudget?.archiveRetrievalSkipped ?? 0) > 0) {
+          failures.push(`${matrixCase.name}: synthesis_gated repeated turn should skip archive retrieval entirely`);
+        }
+        if ((synthesis.noiseCoverageContextBudget?.synthesisCacheBlocksSelected ?? 0) !== 0) {
+          failures.push(`${matrixCase.name}: synthesis_gated noise query selected target synthesis`);
+        }
+        if ((synthesis.noiseCoverageContextBudget?.synthesisCacheSkippedReasonCounts?.coverage_miss ?? 0) < 1) {
+          failures.push(`${matrixCase.name}: synthesis_gated noise query did not report coverage miss`);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds an opt-in DeepSeek synthesis cache high-water layer over RuntimeEvent replay.

The implementation is intentionally narrow:

- `ContextBudgetPolicy.synthesisCache` is disabled by default.
- Synthesis blocks are caller-supplied, source-bearing, and validated against archived RuntimeEvent placeholders.
- Selected blocks are injected as replay-only synthetic RuntimeEvents; persisted RuntimeEvents and archive placeholders are not mutated.
- Raw/evidence/exact-output requests, coverage misses, source mismatches, and invalidations fall back to the existing gated archive retrieval path.
- Context-budget diagnostics now report synthesis mode, selected block ids, skip/invalidation reason counts, and named high-water fields beside provider cache/cost telemetry.

## Live Matrix

Paid DeepSeek Phase 8 matrix passed with no invariant failures:

`/tmp/rive-maka-synthesis-cache-20260616/output/phase8-synthesis-live-matrix.json`

Key results:

- `single_archive_recovery`: gated read 1 archive, 5,302 input, cost $0.00039954; synthesis selected 1 block, read 0 archives, 832 input, cost $0.00016544; raw-evidence fallback read 1 archive.
- `multi_archive_selectivity`: gated read 1 archive and skipped 8 by `history_search_gate`, 7,565 input, cost $0.00057535; synthesis selected 1 block, read 0 archives, 3,102 input, cost $0.00036874; raw-evidence fallback read 1 archive.
- Noise-key probe selected 0 synthesis blocks and reported `coverage_miss`, so `phase7-live-key` no longer covers `phase7-live-key-noise-01`.

## Verification

- `npm run build --workspace packages/core`
- `npm run build --workspace packages/runtime`
- `node --test packages/runtime/dist/__tests__/context-budget.test.js` (15 tests)
- `node --test packages/runtime/dist/__tests__/ai-sdk-backend.test.js` (44 tests)
- `node --check scripts/deepseek-live-cost-baseline.mjs`
- `git diff --check`
