### PR TITLE
feat: Layer 1 deferred (on-demand) tool loading — defer heavy schemas via load_tool

### DIFF
--- a/apps/desktop/src/main/__tests__/load-tool-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/load-tool-presentation.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { describeLoadToolResult, loadToolDisplayName } from '@maka/ui';
+
+// The `load_tool` deferred-loading catalog tool gets a friendly, locale-aware
+// presentation in the renderer instead of its raw name + raw JSON result.
+// The copy logic is pure (locale passed in) so it is tested without a DOM.
+
+describe('load_tool presentation', () => {
+  test('display name is localized', () => {
+    assert.equal(loadToolDisplayName('zh'), '加载工具组');
+    assert.equal(loadToolDisplayName('en'), 'Load tools');
+  });
+
+  test('describes a browser load in Chinese', () => {
+    const d = describeLoadToolResult(
+      { namespace: 'browser' },
+      { loaded: ['browser_click', 'browser_type'] },
+      'zh',
+    );
+    assert.ok(d);
+    assert.equal(d.title, '已加载 browser 工具组');
+    assert.equal(d.countLabel, '新增 2 个可用工具：');
+    assert.equal(d.toolsText, 'browser_click、browser_type');
+    assert.equal(d.footer, '下一步即可调用');
+  });
+
+  test('describes a load in English with singular/plural counts', () => {
+    const one = describeLoadToolResult({ namespace: 'office' }, { loaded: ['OfficeDocument'] }, 'en');
+    assert.ok(one);
+    assert.equal(one.title, 'Loaded office tool group');
+    assert.equal(one.countLabel, '1 tool now available:');
+    assert.equal(one.toolsText, 'OfficeDocument');
+
+    const many = describeLoadToolResult({ namespace: 'office' }, { loaded: ['a', 'b'] }, 'en');
+    assert.equal(many?.countLabel, '2 tools now available:');
+  });
+
+  test('missing namespace falls back to a generic title', () => {
+    assert.equal(describeLoadToolResult({}, { loaded: ['x'] }, 'zh')?.title, '已加载工具组');
+    assert.equal(describeLoadToolResult(undefined, { loaded: ['x'] }, 'en')?.title, 'Tools loaded');
+  });
+
+  test('unexpected result shape → null so the caller uses the generic JSON preview', () => {
+    assert.equal(describeLoadToolResult({ namespace: 'browser' }, { loaded: 'nope' }, 'zh'), null);
+    assert.equal(describeLoadToolResult({ namespace: 'browser' }, { loaded: [1, 2] }, 'zh'), null);
+    assert.equal(describeLoadToolResult({}, null, 'en'), null);
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-queue.test.ts
@@ -5,6 +5,7 @@ import {
   activePermissionFor,
   clearPermissions,
   dequeuePermission,
+  dequeuePermissionByToolUseId,
   enqueuePermission,
   type PermissionQueues,
 } from '@maka/ui';
@@ -71,6 +72,19 @@ describe('permission queue', () => {
     q = enqueuePermission(q, 's2', req('b'));
     assert.equal(activePermissionFor(q, 's1')?.requestId, 'a');
     assert.equal(activePermissionFor(q, 's2')?.requestId, 'b');
+  });
+
+  test('dequeuePermissionByToolUseId drains a request that ended without a decision', () => {
+    // An expired/timed-out permission emits a tool_result (keyed by toolUseId),
+    // not a permission_decision_ack — the renderer drains the stale entry on it.
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's', req('a')); // toolUseId call_a
+    q = enqueuePermission(q, 's', req('b', 'browser_extract')); // toolUseId call_b
+    q = dequeuePermissionByToolUseId(q, 's', 'call_a');
+    assert.deepEqual(q['s'].map((r) => r.requestId), ['b']);
+    // No-op (same reference) once it's gone — on the normal allow path the ack
+    // already dequeued, so the later tool_result must not disturb the queue.
+    assert.equal(dequeuePermissionByToolUseId(q, 's', 'call_a'), q);
   });
 
   test('activePermissionFor handles an undefined session and an empty queue', () => {

--- a/apps/desktop/src/main/__tests__/permission-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-queue.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  activePermissionFor,
+  clearPermissions,
+  dequeuePermission,
+  enqueuePermission,
+  type PermissionQueues,
+} from '@maka/ui';
+import type { PermissionRequestEvent } from '@maka/core';
+
+// The renderer used to keep one pending permission per session, so a model that
+// fired two tool calls in one step (browser_snapshot + browser_extract) had the
+// second request overwrite the first — the first could never be answered and the
+// turn hung. These cover the FIFO queue that replaced the single slot.
+
+function req(requestId: string, toolName = 'browser_snapshot'): PermissionRequestEvent {
+  return {
+    type: 'permission_request',
+    id: `evt_${requestId}`,
+    ts: 0,
+    requestId,
+    toolUseId: `call_${requestId}`,
+    toolName,
+  } as unknown as PermissionRequestEvent;
+}
+
+describe('permission queue', () => {
+  test('parallel requests both survive — the stranded browser_snapshot bug', () => {
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's', req('snapshot')); // snapshot requested first
+    q = enqueuePermission(q, 's', req('extract', 'browser_extract')); // extract in parallel — used to overwrite
+    assert.deepEqual(q['s'].map((r) => r.requestId), ['snapshot', 'extract']);
+
+    // User answers extract; snapshot must remain (previously it was lost).
+    q = dequeuePermission(q, 's', 'extract');
+    assert.equal(activePermissionFor(q, 's')?.requestId, 'snapshot');
+  });
+
+  test('FIFO: the head is the active request and dequeuing it promotes the next', () => {
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's', req('a'));
+    q = enqueuePermission(q, 's', req('b'));
+    assert.equal(activePermissionFor(q, 's')?.requestId, 'a');
+    q = dequeuePermission(q, 's', 'a');
+    assert.equal(activePermissionFor(q, 's')?.requestId, 'b');
+    q = dequeuePermission(q, 's', 'b');
+    assert.equal(activePermissionFor(q, 's'), undefined);
+  });
+
+  test('enqueue dedups by requestId (e.g. a replayed snapshot event)', () => {
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's', req('a'));
+    q = enqueuePermission(q, 's', req('a'));
+    assert.equal(q['s'].length, 1);
+  });
+
+  test('clear drops every pending request for the session (turn ended/aborted)', () => {
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's', req('a'));
+    q = enqueuePermission(q, 's', req('b'));
+    q = clearPermissions(q, 's');
+    assert.deepEqual(q['s'], []);
+    assert.equal(activePermissionFor(q, 's'), undefined);
+  });
+
+  test('queues are isolated per session', () => {
+    let q: PermissionQueues = {};
+    q = enqueuePermission(q, 's1', req('a'));
+    q = enqueuePermission(q, 's2', req('b'));
+    assert.equal(activePermissionFor(q, 's1')?.requestId, 'a');
+    assert.equal(activePermissionFor(q, 's2')?.requestId, 'b');
+  });
+
+  test('activePermissionFor handles an undefined session and an empty queue', () => {
+    assert.equal(activePermissionFor({}, undefined), undefined);
+    assert.equal(activePermissionFor({ s: [] }, 's'), undefined);
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -207,14 +207,14 @@ describe('permission response IPC boundary', () => {
     const rendererPath = fileURLToPath(new URL('../../../src/renderer/main.tsx', import.meta.url));
     const renderer = await readFile(rendererPath, 'utf8');
     // Find the 'complete' case in handleSessionEvent — the body must
-    // null out permissionBySession[sessionId] when stopReason is
-    // not permission_handoff.
+    // clear the session's permission queue when stopReason is not
+    // permission_handoff.
     const completeCase = renderer.match(/case 'complete':[\s\S]*?break;/);
     assert.ok(completeCase, "'complete' case must exist in renderer event handler");
     assert.match(
       completeCase[0],
-      /setPermissionBySession\(\(current\) => \(\{\s*\.\.\.current,\s*\[sessionId\]:\s*undefined\s*\}\)\)/,
-      "'complete' case must clear permissionBySession for the session — mirrors the abort handler",
+      /setPermissionBySession\(\(current\) => clearPermissions\(current, sessionId\)\)/,
+      "'complete' case must clear the session's permission queue — mirrors the abort handler",
     );
   });
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -129,6 +129,7 @@ import {
   PermissionEngine,
   SessionManager,
   buildBuiltinTools,
+  buildLoadTool,
   fetchProviderModels,
   getAIModel,
   buildProviderOptions,
@@ -143,6 +144,7 @@ import {
 } from '@maka/runtime';
 import type {
   BotIncomingMessage,
+  DeferredToolCatalog,
   ToolArtifactRecorderInput,
   ToolResultArchiveReaderInput,
   ToolResultArchiveReadResult,
@@ -547,6 +549,31 @@ const openGateway = new OpenGatewayService({
 });
 const backends = new BackendRegistry();
 const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
+// Layer 1 deferred-tool loading. The heavy-schema families (Rive, Office, the
+// embedded browser) are withheld from the per-turn prompt and loaded on demand
+// via `load_tool`, keeping their schemas off the wire until needed. Everything
+// else stays always-on. Kill-switch: set MAKA_DISABLE_DEFERRED_TOOLS to any
+// value to advertise every tool every turn (legacy behavior).
+const deferralEnabled = !process.env.MAKA_DISABLE_DEFERRED_TOOLS;
+const riveTools = [buildRiveWorkflowTool()];
+const officeTools = [buildOfficeDocumentTool(), buildOfficeDocumentEditTool()];
+// Embedded-browser observe→act tools. They drive the conversation's own
+// WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
+// outside the app (no host) they report the browser as unavailable.
+const browserTools = buildBrowserTools();
+const deferredCatalog: DeferredToolCatalog | undefined = deferralEnabled
+  ? [
+      { namespace: 'rive', summary: 'Durable multi-agent Rive workflows: validate/import/run/status, scheduler, retries.', toolNames: riveTools.map((tool) => tool.name) },
+      { namespace: 'office', summary: 'Read and edit Office documents (Word, Excel, PowerPoint, PDF).', toolNames: officeTools.map((tool) => tool.name) },
+      { namespace: 'browser', summary: 'Drive the embedded browser: navigate, snapshot, click, type, wait, extract.', toolNames: browserTools.map((tool) => tool.name) },
+    ]
+  : undefined;
+// Tag the heavy families `deferred` only when the catalog is active; otherwise
+// they stay direct (a deferred tag without a catalog would hide them with no
+// way to load).
+const heavyTools = [...riveTools, ...officeTools, ...browserTools].map((tool) =>
+  deferralEnabled ? { ...tool, exposure: 'deferred' as const } : tool,
+);
 const builtinTools = [
   ...buildBuiltinTools().filter((tool) => tool.name !== 'Edit'),
   // External reference lazy-skill pattern: the prompt lists available skills,
@@ -557,8 +584,6 @@ const builtinTools = [
   // `subagent` category; explore mode allows it, but the implementation
   // itself only reads filenames/text snippets under the session cwd.
   buildExploreAgentTool(),
-  buildOfficeDocumentTool(),
-  buildOfficeDocumentEditTool(),
   // PR-AGENT-WEB-SEARCH-TOOL-0: Tavily-backed WebSearch tool. Closed
   // over settingsStore so the renderer never sees the API key; the
   // permission engine routes it through the `web_read` policy which
@@ -567,11 +592,9 @@ const builtinTools = [
     settingsStore,
     getPrivacyContext: async () => defaultWorkspacePrivacyContext(),
   }),
-  buildRiveWorkflowTool(),
-  // Embedded-browser observe→act tools. They drive the conversation's own
-  // WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
-  // outside the app (no host) they report the browser as unavailable.
-  ...buildBrowserTools(),
+  // Always-on catalog/lookup tool; expands a deferred namespace on demand.
+  ...(deferredCatalog ? [buildLoadTool(deferredCatalog)] : []),
+  ...heavyTools,
 ];
 let lookupPricing = buildPricingLookup();
 // PR-BOT-LASTERROR-FROM-SEND-0: per-platform last-observed readiness so
@@ -790,6 +813,7 @@ backends.register('ai-sdk', async (ctx) => {
     permissionEngine,
     modelFactory: (input) => getAIModel({ ...input, fetch: modelFetch }),
     tools: builtinTools,
+    deferredCatalog,
     providerOptions: buildProviderOptions(connection, model),
     contextBudget: buildContextBudgetPolicy(connection),
     systemPrompt: ({ cwd }) => buildSystemPrompt(ctx.header, cwd),

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -57,6 +57,7 @@ import {
   formatDailyReviewMarkdown,
   enqueuePermission,
   dequeuePermission,
+  dequeuePermissionByToolUseId,
   clearPermissions,
   activePermissionFor,
   type PermissionQueues,
@@ -2190,6 +2191,11 @@ function AppShell() {
         });
         break;
       case 'tool_result':
+        // A permission that ended without a user decision (runtime timeout /
+        // expiry) emits a tool_result, not a permission_decision_ack — drain any
+        // stale queue entry for this tool so it can't resurface as an
+        // un-answerable overlay. No-op when the ack already dequeued it.
+        setPermissionBySession((current) => dequeuePermissionByToolUseId(current, sessionId, event.toolUseId));
         upsertTool(sessionId, event.toolUseId, {
           toolUseId: event.toolUseId,
           status: event.isError ? 'errored' : 'completed',

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -10,7 +10,6 @@ import type {
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
   QuickChatMode,
-  PermissionRequestEvent,
   PermissionResponse,
   SessionEventStreamSnapshot,
   SessionEvent,
@@ -56,6 +55,11 @@ import {
   type ToolActivityItem,
   type ToolOutputChunk,
   formatDailyReviewMarkdown,
+  enqueuePermission,
+  dequeuePermission,
+  clearPermissions,
+  activePermissionFor,
+  type PermissionQueues,
 } from '@maka/ui';
 import { SettingsModal } from './settings/SettingsModal';
 import { ErrorBoundary } from './error-boundary';
@@ -306,7 +310,7 @@ function AppShell() {
   // the agentReadEnabled switch).
   const [memoryActive, setMemoryActive] = useState(false);
   const [liveToolsBySession, setLiveToolsBySession] = useState<Record<string, ToolActivityItem[]>>({});
-  const [permissionBySession, setPermissionBySession] = useState<Record<string, PermissionRequestEvent | undefined>>({});
+  const [permissionBySession, setPermissionBySession] = useState<PermissionQueues>({});
   const [sessionEventHealthBySessionState, setSessionEventHealthBySessionState] =
     useState<Record<string, SessionEventStreamSnapshot>>({});
   const sessionEventHealthBySessionRef = useRef<Record<string, SessionEventStreamSnapshot>>({});
@@ -433,7 +437,7 @@ function AppShell() {
       }
     }
   }
-  const activePermission = activeId ? permissionBySession[activeId] : undefined;
+  const activePermission = activePermissionFor(permissionBySession, activeId);
   const activeSession = sessions.find((session) => session.id === activeId);
   const activeConnection = activeSession
     ? connections.find((connection) => connection.slug === activeSession.llmConnectionSlug)
@@ -1248,7 +1252,11 @@ function AppShell() {
       setThinkingBySession((current) => ({ ...current, ...state.thinkingBySession }));
     }
     if (state.permissionBySession) {
-      setPermissionBySession((current) => ({ ...current, ...state.permissionBySession }));
+      const seeded: PermissionQueues = {};
+      for (const [seedSessionId, request] of Object.entries(state.permissionBySession)) {
+        if (request) seeded[seedSessionId] = [request];
+      }
+      setPermissionBySession((current) => ({ ...current, ...seeded }));
     }
     if (state.liveToolsBySession) {
       setLiveToolsBySession((current) => ({ ...current, ...state.liveToolsBySession }));
@@ -2166,7 +2174,7 @@ function AppShell() {
         });
         break;
       case 'permission_request':
-        setPermissionBySession((current) => ({ ...current, [sessionId]: event }));
+        setPermissionBySession((current) => enqueuePermission(current, sessionId, event));
         upsertTool(sessionId, event.toolUseId, {
           toolUseId: event.toolUseId,
           toolName: event.toolName,
@@ -2175,11 +2183,7 @@ function AppShell() {
         });
         break;
       case 'permission_decision_ack':
-        setPermissionBySession((current) => {
-          const active = current[sessionId];
-          if (!active || active.requestId !== event.requestId) return current;
-          return { ...current, [sessionId]: undefined };
-        });
+        setPermissionBySession((current) => dequeuePermission(current, sessionId, event.requestId));
         upsertTool(sessionId, event.toolUseId, {
           toolUseId: event.toolUseId,
           status: event.decision === 'allow' ? 'running' : 'errored',
@@ -2196,7 +2200,7 @@ function AppShell() {
         break;
       case 'error':
         clearStreaming(sessionId);
-        setPermissionBySession((current) => ({ ...current, [sessionId]: undefined }));
+        setPermissionBySession((current) => clearPermissions(current, sessionId));
         if (activeIdRef.current === sessionId) {
           if (isNoRealConnectionEvent(event)) {
             const reason = noRealConnectionReasonFromEvent(event);
@@ -2211,7 +2215,7 @@ function AppShell() {
         break;
       case 'abort':
         clearStreaming(sessionId);
-        setPermissionBySession((current) => ({ ...current, [sessionId]: undefined }));
+        setPermissionBySession((current) => clearPermissions(current, sessionId));
         markInFlightToolsInterrupted(sessionId);
         void refreshSessions();
         void refreshMessages(sessionId);
@@ -2225,7 +2229,7 @@ function AppShell() {
           // reasons. Without this, a session that finishes while a
           // permission overlay was mounted would leave the overlay
           // stuck on screen until the user manually switches away.
-          setPermissionBySession((current) => ({ ...current, [sessionId]: undefined }));
+          setPermissionBySession((current) => clearPermissions(current, sessionId));
         }
         void refreshSessions();
         void refreshMessages(sessionId);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -3928,6 +3928,40 @@ button:active {
   word-break: break-word;
 }
 
+/* load_tool: friendly deferred-loading result card (vs raw JSON). */
+.maka-load-tool-preview {
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--background);
+  font-size: 12.5px;
+}
+
+.maka-load-tool-preview p {
+  margin: 0;
+}
+
+.maka-load-tool-title {
+  font-weight: 600;
+}
+
+.maka-load-tool-count {
+  color: var(--foreground-2);
+}
+
+.maka-load-tool-tools {
+  font-family: var(--font-mono);
+  word-break: break-word;
+}
+
+.maka-load-tool-footer {
+  color: var(--foreground-2);
+  font-size: 12px;
+}
+
 /* File diff: each line tagged with data-line for add / del / hunk / meta /
  * ctx so we can color the unified-diff payload like GitHub / VS Code. */
 .maka-tool-diff {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1807,7 +1807,10 @@ describe('AiSdkBackend request-shape diagnostics', () => {
 
     assert.deepEqual(modelToolNames(model), sortedModelToolNames(['Read', 'WebFetch']));
     assert.equal(modelToolNames(model).includes(CONNECT_TOOL_SOURCE_NAME), false);
-    assert.equal(toolSchemaPromptSegment(llmRecords[0])?.toolCount, 3);
+    // toolCount tracks the model-visible (active) tools — the two real tools.
+    // The invalid fallback lives in providerTools but is never advertised, so
+    // it is not counted. (PR #30 unifies toolCount to the wire-visible subset.)
+    assert.equal(toolSchemaPromptSegment(llmRecords[0])?.toolCount, 2);
   });
 
   test('backend connector enables sources for later requests only and preserves prefix reason compatibility', async () => {
@@ -1845,7 +1848,9 @@ describe('AiSdkBackend request-shape diagnostics', () => {
       sortedModelToolNames(['Read', CONNECT_TOOL_SOURCE_NAME]),
     );
     assert.equal(modelToolNames(models[0]!).includes('WebFetch'), false);
-    assert.equal(toolSchemaPromptSegment(llmRecords[0])?.toolCount, 3);
+    // Active = [Read, connector]; WebFetch is hidden until connected and the
+    // invalid fallback is never advertised. toolCount tracks that wire subset.
+    assert.equal(toolSchemaPromptSegment(llmRecords[0])?.toolCount, 2);
     const economyRuntime = (backend as unknown as {
       toolSourceEconomyRuntime: ToolSourceEconomyRuntime;
     }).toolSourceEconomyRuntime;
@@ -1880,7 +1885,8 @@ describe('AiSdkBackend request-shape diagnostics', () => {
     assert.equal(llmRecords[1]?.requestShapeChangeReason, 'tool_schema_changed');
     assert.equal(llmRecords[1]?.toolSchemaChangeReason, 'tool_source_enabled');
     assert.deepEqual(llmRecords[1]?.toolSourceEconomy?.enabledSourceIds, ['web']);
-    assert.equal(toolSchemaPromptSegment(llmRecords[1])?.toolCount, 4);
+    // Active = [Read, connector, WebFetch] once the web source connects.
+    assert.equal(toolSchemaPromptSegment(llmRecords[1])?.toolCount, 3);
   });
 
   test('volatile turn-tail facts do not churn the durable prefix hash', async () => {

--- a/packages/runtime/src/__tests__/deferred-activation.test.ts
+++ b/packages/runtime/src/__tests__/deferred-activation.test.ts
@@ -3,8 +3,10 @@ import { describe, test } from 'node:test';
 
 import {
   loadedNamespacesFromSteps,
+  seedNamespacesFromRuntimeEvents,
   computeActiveTools,
   buildDeferredPrepareStep,
+  type RuntimeEventLike,
   type StepLike,
 } from '../deferred-activation.js';
 import type { DeferredToolCatalog } from '../load-tool.js';
@@ -48,6 +50,39 @@ describe('loadedNamespacesFromSteps', () => {
   test('undefined/empty steps yield an empty set', () => {
     assert.equal(loadedNamespacesFromSteps(undefined).size, 0);
     assert.equal(loadedNamespacesFromSteps([]).size, 0);
+  });
+});
+
+describe('seedNamespacesFromRuntimeEvents (durable cross-turn seed)', () => {
+  function callEvent(name: string, args: unknown): RuntimeEventLike {
+    return { content: { kind: 'function_call', name, args } };
+  }
+
+  test('collects namespaces from durable load_tool function_call events', () => {
+    const events: RuntimeEventLike[] = [
+      callEvent('load_tool', { namespace: 'rive' }),
+      callEvent('Read', { path: 'a' }),
+      callEvent('load_tool', JSON.stringify({ namespace: 'browser' })),
+      { content: { kind: 'function_response', name: 'load_tool', args: undefined } },
+      { content: { kind: 'text' } },
+    ];
+    assert.deepEqual([...seedNamespacesFromRuntimeEvents(events)].sort(), ['browser', 'rive']);
+  });
+
+  test('ignores non-load_tool calls, malformed args, and empty input', () => {
+    assert.equal(seedNamespacesFromRuntimeEvents([]).size, 0);
+    assert.equal(seedNamespacesFromRuntimeEvents(undefined).size, 0);
+    assert.equal(
+      seedNamespacesFromRuntimeEvents([callEvent('load_tool', 'not json'), callEvent('load_tool', {})]).size,
+      0,
+    );
+  });
+
+  test('round-trips with the in-turn derivation: a prior load seeds the same namespace', () => {
+    const seeded = seedNamespacesFromRuntimeEvents([callEvent('load_tool', { namespace: 'browser' })]);
+    const active = computeActiveTools({ tools, invalidTool: invalid, catalog, seedNamespaces: seeded }, []);
+    assert.ok(active.includes('browser_click'));
+    assert.ok(active.includes('browser_navigate'));
   });
 });
 

--- a/packages/runtime/src/__tests__/deferred-activation.test.ts
+++ b/packages/runtime/src/__tests__/deferred-activation.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  loadedNamespacesFromSteps,
+  computeActiveTools,
+  buildDeferredPrepareStep,
+  type StepLike,
+} from '../deferred-activation.js';
+import type { DeferredToolCatalog } from '../load-tool.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+function tool(name: string, exposure?: 'direct' | 'deferred'): MakaTool {
+  return { name, description: name, parameters: {}, impl: () => ({}), ...(exposure ? { exposure } : {}) };
+}
+
+const tools: MakaTool[] = [
+  tool('Read'),
+  tool('load_tool'),
+  tool('RiveWorkflow', 'deferred'),
+  tool('browser_navigate', 'deferred'),
+  tool('browser_click', 'deferred'),
+];
+const invalid = tool('invalid');
+const catalog: DeferredToolCatalog = [
+  { namespace: 'rive', summary: 'Rive', toolNames: ['RiveWorkflow'] },
+  { namespace: 'browser', summary: 'Browser', toolNames: ['browser_navigate', 'browser_click'] },
+];
+
+describe('loadedNamespacesFromSteps', () => {
+  test('extracts namespaces from load_tool calls and ignores other tools', () => {
+    const steps: StepLike[] = [
+      { toolCalls: [{ toolName: 'Read', input: {} }, { toolName: 'load_tool', input: { namespace: 'rive' } }] },
+      { toolCalls: [{ toolName: 'load_tool', input: { namespace: 'browser' } }] },
+    ];
+    assert.deepEqual([...loadedNamespacesFromSteps(steps)].sort(), ['browser', 'rive']);
+  });
+
+  test('parses a stringified input and ignores malformed/empty input', () => {
+    const steps: StepLike[] = [
+      { toolCalls: [{ toolName: 'load_tool', input: JSON.stringify({ namespace: 'rive' }) }] },
+      { toolCalls: [{ toolName: 'load_tool', input: 'not json' }] },
+      { toolCalls: [{ toolName: 'load_tool', input: {} }] },
+    ];
+    assert.deepEqual([...loadedNamespacesFromSteps(steps)], ['rive']);
+  });
+
+  test('undefined/empty steps yield an empty set', () => {
+    assert.equal(loadedNamespacesFromSteps(undefined).size, 0);
+    assert.equal(loadedNamespacesFromSteps([]).size, 0);
+  });
+});
+
+describe('computeActiveTools (per-step active set)', () => {
+  test('step 0 with no prior steps: direct + load_tool only, deferred hidden', () => {
+    const active = computeActiveTools({ tools, invalidTool: invalid, catalog }, []);
+    assert.ok(active.includes('Read'));
+    assert.ok(active.includes('load_tool'));
+    assert.ok(!active.includes('RiveWorkflow'));
+    assert.ok(!active.includes('browser_navigate'));
+  });
+
+  test('after a load_tool(rive) call, RiveWorkflow is active; browser stays hidden', () => {
+    const steps: StepLike[] = [{ toolCalls: [{ toolName: 'load_tool', input: { namespace: 'rive' } }] }];
+    const active = computeActiveTools({ tools, invalidTool: invalid, catalog }, steps);
+    assert.ok(active.includes('RiveWorkflow'));
+    assert.ok(!active.includes('browser_navigate'));
+  });
+
+  test('loading the browser namespace activates the whole group at once', () => {
+    const steps: StepLike[] = [{ toolCalls: [{ toolName: 'load_tool', input: { namespace: 'browser' } }] }];
+    const active = computeActiveTools({ tools, invalidTool: invalid, catalog }, steps);
+    assert.ok(active.includes('browser_navigate'));
+    assert.ok(active.includes('browser_click'));
+  });
+
+  test('seedNamespaces (cross-turn ratchet) activate without a step call', () => {
+    const active = computeActiveTools(
+      { tools, invalidTool: invalid, catalog, seedNamespaces: new Set(['rive']) },
+      [],
+    );
+    assert.ok(active.includes('RiveWorkflow'));
+  });
+
+  test('emits the active snapshot for the execute-boundary guard', () => {
+    let snap: ReadonlySet<string> | undefined;
+    computeActiveTools(
+      { tools, invalidTool: invalid, catalog, onActiveSnapshot: (s) => { snap = s; } },
+      [],
+    );
+    assert.ok(snap?.has('Read'));
+    assert.ok(!snap?.has('RiveWorkflow'));
+  });
+});
+
+describe('buildDeferredPrepareStep', () => {
+  test('yields a prepareStep whose activeTools grows as load_tool calls accumulate', () => {
+    const prep = buildDeferredPrepareStep({ tools, invalidTool: invalid, catalog });
+    assert.ok(!prep({ steps: [] }).activeTools.includes('RiveWorkflow'));
+    const after = prep({ steps: [{ toolCalls: [{ toolName: 'load_tool', input: { namespace: 'rive' } }] }] });
+    assert.ok(after.activeTools.includes('RiveWorkflow'));
+  });
+});

--- a/packages/runtime/src/__tests__/deferred-guard.test.ts
+++ b/packages/runtime/src/__tests__/deferred-guard.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import type { SessionEvent } from '@maka/core/events';
+import type { SessionHeader } from '@maka/core/session';
+import type { StoredMessage } from '@maka/core/session';
+
+import {
+  ToolRuntime,
+  formatDeferredNotLoadedText,
+  type MakaTool,
+} from '../tool-runtime.js';
+import { PermissionEngine } from '../permission-engine.js';
+
+// The execute-boundary guard (Layer 1, Slice 5) rejects a deferred tool whose
+// name is absent from the current step's active snapshot — before permission
+// eval and before the real impl. These tests drive ToolRuntime directly so the
+// rejection path resolves synchronously (no streaming, no parking).
+
+function header(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'c',
+    connectionLocked: true,
+    model: 'm',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+interface Harness {
+  runtime: ToolRuntime;
+  appended: StoredMessage[];
+  pushed: SessionEvent[];
+  evaluateCalls: string[];
+}
+
+function makeHarness(): Harness {
+  const appended: StoredMessage[] = [];
+  const pushed: SessionEvent[] = [];
+  const evaluateCalls: string[] = [];
+  const engine = new PermissionEngine({ newId: () => 'perm', now: () => 1 });
+  const realEvaluate = engine.evaluate.bind(engine);
+  // Spy: record whether the guard let execution reach permission evaluation.
+  engine.evaluate = ((input: Parameters<typeof realEvaluate>[0]) => {
+    evaluateCalls.push(input.toolName);
+    return realEvaluate(input);
+  }) as typeof engine.evaluate;
+  let n = 0;
+  const runtime = new ToolRuntime({
+    sessionId: 'session-1',
+    header: header(),
+    connection: { providerType: 'openai', slug: 'c' } as never,
+    modelId: 'm',
+    appendMessage: async (m) => { appended.push(m); },
+    permissionEngine: engine,
+    newId: () => `id-${++n}`,
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+  });
+  return { runtime, appended, pushed, evaluateCalls };
+}
+
+function deferredTool(name: string, implCalls: string[]): MakaTool {
+  return {
+    name,
+    description: name,
+    parameters: z.object({}),
+    exposure: 'deferred',
+    impl: () => { implCalls.push(name); return { ok: true }; },
+  };
+}
+
+function run(h: Harness, tool: MakaTool) {
+  const exec = h.runtime.wrapToolExecute(tool, 'turn-1', { push: (e) => h.pushed.push(e) });
+  return exec({}, { toolCallId: 'tc1', abortSignal: new AbortController().signal });
+}
+
+describe('deferred execute-boundary guard (Slice 5)', () => {
+  test('rejects a deferred tool absent from the step snapshot — no impl, no permission eval', async () => {
+    const h = makeHarness();
+    const implCalls: string[] = [];
+    // The same-step trap: browser was just requested via load_tool but is not
+    // yet active this step, so browser_click must be rejected.
+    h.runtime.setStepActivation(() => new Set(['Read', 'load_tool']));
+
+    const result = await run(h, deferredTool('browser_click', implCalls));
+
+    assert.deepEqual(implCalls, [], 'the real impl must not run');
+    assert.deepEqual(h.evaluateCalls, [], 'permission must not be evaluated for a rejected deferred call');
+    assert.deepEqual(result, { error: formatDeferredNotLoadedText('browser_click') });
+
+    const callMsg = h.appended.find((m) => m.type === 'tool_call');
+    const resultMsg = h.appended.find((m) => m.type === 'tool_result');
+    assert.ok(callMsg, 'a ToolCallMessage is still written (call/result pairing intact)');
+    assert.ok(resultMsg && resultMsg.isError, 'a synthetic error ToolResult is written');
+    assert.ok(
+      h.pushed.some((e) => e.type === 'tool_result' && e.isError && e.toolUseId === 'tc1'),
+      'an error tool_result event is emitted to the renderer',
+    );
+    assert.ok(
+      !h.pushed.some((e) => e.type === 'permission_request'),
+      'no permission prompt is emitted',
+    );
+  });
+
+  test('lets a deferred tool run once its name is in the step snapshot', async () => {
+    const h = makeHarness();
+    const implCalls: string[] = [];
+    h.runtime.setStepActivation(() => new Set(['Read', 'load_tool', 'browser_click']));
+
+    const tool = deferredTool('browser_click', implCalls);
+    tool.permissionRequired = false;
+    await run(h, tool);
+
+    assert.deepEqual(implCalls, ['browser_click'], 'an active deferred tool executes normally');
+    assert.ok(
+      !h.pushed.some((e) => e.type === 'tool_result' && e.isError),
+      'no synthetic error result for an active tool',
+    );
+  });
+
+  test('is inert when no step activation is installed (deferred loading off)', async () => {
+    const h = makeHarness();
+    const implCalls: string[] = [];
+    // No setStepActivation call: a deferred tool must execute as before.
+    const tool = deferredTool('browser_click', implCalls);
+    tool.permissionRequired = false;
+    await run(h, tool);
+
+    assert.deepEqual(implCalls, ['browser_click'], 'guard must not fire without an installed snapshot');
+  });
+
+  test('never gates a direct tool (always present in the snapshot)', async () => {
+    const h = makeHarness();
+    const implCalls: string[] = [];
+    h.runtime.setStepActivation(() => new Set(['Read']));
+    const direct: MakaTool = {
+      name: 'Read',
+      description: 'Read',
+      parameters: z.object({}),
+      permissionRequired: false,
+      impl: () => { implCalls.push('Read'); return { ok: true }; },
+    };
+    await run(h, direct);
+    assert.deepEqual(implCalls, ['Read']);
+  });
+});

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { LlmConnection, SessionHeader } from '@maka/core';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+
+import { AiSdkBackend, type MakaTool } from '../ai-sdk-backend.js';
+import { PermissionEngine } from '../permission-engine.js';
+import { buildLoadTool, type DeferredToolCatalog } from '../load-tool.js';
+
+// End-to-end through the live AiSdkBackend: the deferred catalog drives the
+// per-step prepareStep activation, the durable seed reconstructs prior-turn
+// loads, and the execute-boundary guard is fed by the live snapshot.
+
+const ZERO_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+const catalog: DeferredToolCatalog = [
+  { namespace: 'browser', summary: 'Browser automation', toolNames: ['browser_click'] },
+];
+
+function tools(implCalls: string[]): MakaTool[] {
+  return [
+    { name: 'Read', description: 'Read', parameters: z.object({ path: z.string().optional() }), permissionRequired: false, impl: () => ({ ok: true }) },
+    buildLoadTool(catalog),
+    {
+      name: 'browser_click',
+      description: 'Click in the browser',
+      parameters: z.object({}),
+      exposure: 'deferred',
+      permissionRequired: false,
+      impl: () => { implCalls.push('browser_click'); return { ok: true }; },
+    },
+  ];
+}
+
+function backend(model: MockLanguageModelV3, implCalls: string[]): AiSdkBackend {
+  let n = 0;
+  return new AiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async () => {},
+    connection: connection(),
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    permissionEngine: new PermissionEngine({ newId: () => 'perm', now: () => 1 }),
+    modelFactory: () => model,
+    tools: tools(implCalls),
+    deferredCatalog: catalog,
+    newId: () => `id-${++n}`,
+    now: () => 1,
+  });
+}
+
+describe('AiSdkBackend deferred tool loading', () => {
+  test('step 0 hides an unloaded deferred tool but advertises load_tool', async () => {
+    const captured: string[][] = [];
+    const implCalls: string[] = [];
+    await drain(backend(capturingModel(captured), implCalls).send({
+      turnId: 'turn-1',
+      text: 'hi',
+      context: [],
+    }));
+    assert.ok(captured[0].includes('Read'), 'direct Read advertised');
+    assert.ok(captured[0].includes('load_tool'), 'load_tool advertised');
+    assert.ok(!captured[0].includes('browser_click'), 'unloaded deferred browser_click hidden');
+  });
+
+  test('durable seed: a prior-turn load_tool re-advertises the tool at the next turn (Slice 7)', async () => {
+    const captured: string[][] = [];
+    const implCalls: string[] = [];
+    await drain(backend(capturingModel(captured), implCalls).send({
+      turnId: 'turn-2',
+      text: 'click it',
+      context: [],
+      runtimeContext: priorBrowserLoad('turn-1'),
+    }));
+    assert.ok(
+      captured[0].includes('browser_click'),
+      'browser_click must be advertised at turn 2 step 0 because it was loaded in turn 1',
+    );
+  });
+
+  test('guard: same-step parallel load_tool(browser)+browser_click rejects the click (Slice 5 live)', async () => {
+    const captured: string[][] = [];
+    const implCalls: string[] = [];
+    await drain(backend(parallelLoadUseModel(captured), implCalls).send({
+      turnId: 'turn-1',
+      text: 'load and click in one step',
+      context: [],
+    }));
+    assert.equal(captured.length, 2, 'expected two steps (parallel call step, then a final step)');
+    assert.ok(!captured[0].includes('browser_click'), 'browser_click is not advertised at step 0');
+    assert.deepEqual(
+      implCalls,
+      [],
+      'the real browser_click impl must never run when it was used before activation',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock models
+// ---------------------------------------------------------------------------
+
+function capturingModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const parts: LanguageModelV3StreamPart[] = [
+        { type: 'stream-start', warnings: [] },
+        { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+      ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+function parallelLoadUseModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const first = captured.length === 1;
+      const parts: LanguageModelV3StreamPart[] = first
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId: 'tc-load', toolName: 'load_tool', input: JSON.stringify({ namespace: 'browser' }) },
+            { type: 'tool-call', toolCallId: 'tc-click', toolName: 'browser_click', input: JSON.stringify({}) },
+            { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+          ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A complete prior turn whose model called load_tool(browser) and got a result. */
+function priorBrowserLoad(turnId: string): RuntimeEvent[] {
+  const base = { invocationId: 'inv-1', runId: 'run-1', sessionId: 'session-1', turnId, ts: 1, partial: false } as const;
+  return [
+    { ...base, id: 'p-u', role: 'user', author: 'user', content: { kind: 'text', text: 'load browser' } },
+    { ...base, id: 'p-call', role: 'model', author: 'agent', content: { kind: 'function_call', id: 'tc-prev', name: 'load_tool', args: { namespace: 'browser' } } },
+    { ...base, id: 'p-resp', role: 'tool', author: 'tool', content: { kind: 'function_response', id: 'tc-prev', name: 'load_tool', result: { loaded: ['browser_click'] } } },
+    { ...base, id: 'p-end', role: 'model', author: 'agent', status: 'completed', actions: { endInvocation: true } },
+  ];
+}
+
+async function drain(iterable: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ of iterable) {
+    void _;
+  }
+}
+
+function header(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'c',
+    connectionLocked: true,
+    model: 'm',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function connection(): LlmConnection {
+  return {
+    slug: 'c',
+    name: 'OpenAI',
+    providerType: 'openai',
+    defaultModel: 'mock-model-id',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -139,6 +139,37 @@ describe('AiSdkBackend deferred tool loading', () => {
     );
   });
 
+  test('high-water "after" hash stays consistent with the final recorded requestShapeHash across a same-turn load (GPT-Pro P3)', async () => {
+    const records: LlmCallRecord[] = [];
+    const implCalls: string[] = [];
+    const be = backend(loadBrowserThenFinishModel(), implCalls, { recordLlmCall: (r) => records.push(r) });
+    // Real high-water reasons only arise from the synthesis-cache subsystem
+    // (selectSynthesisCacheForReplay needs valid cache blocks + matching
+    // history). Inject just the marker by wrapping buildPriorMessages so this
+    // targets the diagnostics-consistency invariant, not that subsystem.
+    type PriorReplayish = { contextBudget?: Record<string, unknown> };
+    const patch = be as unknown as { buildPriorMessages: (input: unknown) => Promise<PriorReplayish> };
+    const realBuildPriorMessages = patch.buildPriorMessages.bind(be);
+    patch.buildPriorMessages = async (input: unknown) => {
+      const prior = await realBuildPriorMessages(input);
+      return { ...prior, contextBudget: { ...(prior.contextBudget ?? {}), highWaterReason: 'synthesis_cache_select' } };
+    };
+
+    await drain(be.send({ turnId: 'turn-1', text: 'load browser', context: [] }));
+
+    assert.equal(records.length, 1, 'one llm-call record for the turn');
+    const cb = records[0].contextBudget;
+    assert.ok(cb?.highWaterRequestShapeHashAfter, 'a high-water "after" hash was recorded');
+    // The same-turn load makes the final active set differ from step-0, so this
+    // equality fails if "after" is left at the step-0 hash (the bug).
+    assert.equal(
+      cb.highWaterRequestShapeHashAfter,
+      records[0].requestShapeHash,
+      'high-water "after" must equal the final recorded requestShapeHash',
+    );
+    assert.equal(cb.highWaterRequestShapeHashBefore, undefined, 'first turn has no pre-turn baseline');
+  });
+
   test('no catalog: a deferred-tagged tool stays advertised (GPT-Pro P3)', async () => {
     const captured: string[][] = [];
     const implCalls: string[] = [];

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -4,11 +4,13 @@ import { z } from 'zod';
 import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
 import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
 import type { LlmConnection, SessionHeader } from '@maka/core';
+import type { LlmCallRecord } from '@maka/core/usage-stats/types';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 
 import { AiSdkBackend, type MakaTool } from '../ai-sdk-backend.js';
 import { PermissionEngine } from '../permission-engine.js';
 import { buildLoadTool, type DeferredToolCatalog } from '../load-tool.js';
+import { canonicalizeToolSet, toolSchemaCharsForDiagnostics } from '../request-shape.js';
 
 // End-to-end through the live AiSdkBackend: the deferred catalog drives the
 // per-step prepareStep activation, the durable seed reconstructs prior-turn
@@ -38,8 +40,15 @@ function tools(implCalls: string[]): MakaTool[] {
   ];
 }
 
-function backend(model: MockLanguageModelV3, implCalls: string[]): AiSdkBackend {
+interface BackendOpts {
+  /** Override the deferred catalog (pass `null` to omit it entirely). */
+  deferredCatalog?: DeferredToolCatalog | null;
+  recordLlmCall?: (record: LlmCallRecord) => void;
+}
+
+function backend(model: MockLanguageModelV3, implCalls: string[], opts: BackendOpts = {}): AiSdkBackend {
   let n = 0;
+  const resolvedCatalog = opts.deferredCatalog === null ? undefined : opts.deferredCatalog ?? catalog;
   return new AiSdkBackend({
     sessionId: 'session-1',
     header: header(),
@@ -50,7 +59,8 @@ function backend(model: MockLanguageModelV3, implCalls: string[]): AiSdkBackend 
     permissionEngine: new PermissionEngine({ newId: () => 'perm', now: () => 1 }),
     modelFactory: () => model,
     tools: tools(implCalls),
-    deferredCatalog: catalog,
+    ...(resolvedCatalog ? { deferredCatalog: resolvedCatalog } : {}),
+    ...(opts.recordLlmCall ? { recordLlmCall: opts.recordLlmCall } : {}),
     newId: () => `id-${++n}`,
     now: () => 1,
   });
@@ -99,6 +109,48 @@ describe('AiSdkBackend deferred tool loading', () => {
       implCalls,
       [],
       'the real browser_click impl must never run when it was used before activation',
+    );
+  });
+
+  test('diagnostics: a same-turn load is reflected in the recorded tool-schema cost (GPT-Pro P2)', async () => {
+    const records: LlmCallRecord[] = [];
+    const implCalls: string[] = [];
+    // step 0 loads browser; browser_click activates at step 1 via prepareStep.
+    await drain(backend(loadBrowserThenFinishModel(), implCalls, {
+      recordLlmCall: (r) => records.push(r),
+    }).send({ turnId: 'turn-1', text: 'load browser', context: [] }));
+
+    assert.equal(records.length, 1, 'exactly one llm-call cost record for the turn');
+    const toolSeg = records[0].promptSegments?.find((s) => s.kind === 'tool_schema');
+    assert.ok(toolSeg, 'a tool_schema prompt segment was recorded');
+
+    // The recorded cost must reflect the FINAL active set (Read + load_tool +
+    // browser_click), not the lean step-0 set — otherwise the load turn
+    // under-reports the heavy schema it actually sent on step 1.
+    const providerTools = canonicalizeToolSet(tools([]), INVALID_FIXTURE).providerTools;
+    const leanChars = toolSchemaCharsForDiagnostics(providerTools, ['Read', 'load_tool']);
+    const loadedChars = toolSchemaCharsForDiagnostics(providerTools, ['Read', 'load_tool', 'browser_click']);
+    assert.ok(loadedChars > leanChars, 'sanity: the loaded set is heavier than the lean set');
+    assert.equal(toolSeg.chars, loadedChars, 'recorded tool-schema chars include the loaded browser_click');
+    assert.equal(
+      records[0].requestShapeChangeReason,
+      'first_turn',
+      'first turn establishes the baseline; the expansion sets the durable prefix for next turn',
+    );
+  });
+
+  test('no catalog: a deferred-tagged tool stays advertised (GPT-Pro P3)', async () => {
+    const captured: string[][] = [];
+    const implCalls: string[] = [];
+    // No deferredCatalog ⇒ deferral is off ⇒ the contract is "advertise everything".
+    await drain(backend(capturingModel(captured), implCalls, { deferredCatalog: null }).send({
+      turnId: 'turn-1',
+      text: 'hi',
+      context: [],
+    }));
+    assert.ok(
+      captured[0].includes('browser_click'),
+      'a tool tagged exposure:deferred must still be advertised when no catalog is configured',
     );
   });
 
@@ -153,6 +205,36 @@ function parallelLoadUseModel(captured: string[][]): MockLanguageModelV3 {
             { type: 'stream-start', warnings: [] },
             { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
           ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+/** Placeholder invalid tool — only used to build providerTools for char math. */
+const INVALID_FIXTURE: MakaTool = {
+  name: 'invalid',
+  description: 'x',
+  parameters: z.object({}),
+  impl: () => ({}),
+};
+
+/** Step 0 loads the browser namespace, then the turn finishes (no use). */
+function loadBrowserThenFinishModel(): MockLanguageModelV3 {
+  let step = 0;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      step += 1;
+      const parts: LanguageModelV3StreamPart[] =
+        step === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tc-load', toolName: 'load_tool', input: JSON.stringify({ namespace: 'browser' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+            ];
       return { stream: convertArrayToReadableStream(parts) };
     },
   });

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -101,6 +101,23 @@ describe('AiSdkBackend deferred tool loading', () => {
       'the real browser_click impl must never run when it was used before activation',
     );
   });
+
+  test('repair: a mis-cased deferred call after a mid-turn load repairs to the canonical name (Codex [P2])', async () => {
+    const captured: string[][] = [];
+    const implCalls: string[] = [];
+    await drain(backend(loadThenMiscasedClickModel(captured), implCalls).send({
+      turnId: 'turn-1',
+      text: 'load browser then click',
+      context: [],
+    }));
+    // Step 0 loads browser; step 1 emits the mis-cased BROWSER_CLICK. Because the
+    // repair list follows the current step's active snapshot (not the frozen
+    // step-0 set), the call repairs to canonical browser_click and runs — rather
+    // than routing to `invalid`, which would leave implCalls empty.
+    assert.ok(captured.length >= 2, 'expected at least the load step and the click step');
+    assert.ok(captured[1].includes('browser_click'), 'browser_click is advertised at step 1 after the load');
+    assert.deepEqual(implCalls, ['browser_click'], 'the mis-cased call repaired to browser_click and ran');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -136,6 +153,38 @@ function parallelLoadUseModel(captured: string[][]): MockLanguageModelV3 {
             { type: 'stream-start', warnings: [] },
             { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
           ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+/**
+ * Step 0 loads the browser namespace; step 1 emits a mis-cased `BROWSER_CLICK`
+ * (a provider that case-drifts a tool that only became active this step). The
+ * AI SDK can't match the upper-cased name, so it calls the repair callback.
+ */
+function loadThenMiscasedClickModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const step = captured.length;
+      const parts: LanguageModelV3StreamPart[] =
+        step === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tc-load', toolName: 'load_tool', input: JSON.stringify({ namespace: 'browser' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : step === 2
+            ? [
+                { type: 'stream-start', warnings: [] },
+                { type: 'tool-call', toolCallId: 'tc-click', toolName: 'BROWSER_CLICK', input: JSON.stringify({}) },
+                { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+              ];
       return { stream: convertArrayToReadableStream(parts) };
     },
   });

--- a/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
+
+import { ModelAdapter } from '../model-adapter.js';
+import { canonicalizeToolSet } from '../request-shape.js';
+import { buildDeferredPrepareStep } from '../deferred-activation.js';
+import { buildLoadTool, type DeferredToolCatalog } from '../load-tool.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+const ZERO_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+function makaTool(name: string, exposure?: 'direct' | 'deferred'): MakaTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: z.object({ q: z.string().optional() }),
+    impl: () => ({ ok: true }),
+    ...(exposure ? { exposure } : {}),
+  };
+}
+
+function newAdapter(): ModelAdapter {
+  return new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => ({}),
+    providerOptions: {},
+    maxSteps: 4,
+    newId: () => 'id',
+    now: () => 0,
+  });
+}
+
+describe('prepareStep activates a deferred tool within the same turn (Codex Δ1)', () => {
+  test('a tool loaded at step 0 reaches the provider at step 1', async () => {
+    const catalog: DeferredToolCatalog = [
+      { namespace: 'rive', summary: 'Rive workflows', toolNames: ['RiveWorkflow'] },
+    ];
+    // The real load_tool carries the { namespace } schema, so the SDK parses the
+    // tool-call input correctly (a generic schema would strip `namespace`).
+    const tools: MakaTool[] = [
+      makaTool('Read'),
+      buildLoadTool(catalog),
+      makaTool('RiveWorkflow', 'deferred'),
+    ];
+    const invalid = makaTool('invalid');
+
+    // The model-visible names doStream receives, per step.
+    const toolsPerStep: string[][] = [];
+
+    const model = new MockLanguageModelV3({
+      doStream: async ({ tools: stepTools }) => {
+        const names = (stepTools ?? []).map((t) => t.name);
+        toolsPerStep.push(names);
+        const isFirstStep = toolsPerStep.length === 1;
+        const parts: LanguageModelV3StreamPart[] = isFirstStep
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tc1', toolName: 'load_tool', input: JSON.stringify({ namespace: 'rive' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+            ];
+        return { stream: convertArrayToReadableStream(parts) };
+      },
+    });
+
+    // Build the ai-sdk tools dict the backend would build, with a working
+    // load_tool execute that returns the thin activation result.
+    const canonical = canonicalizeToolSet(tools, invalid);
+    const aiSdkTools: Record<string, unknown> = {};
+    for (const t of canonical.providerTools) {
+      aiSdkTools[t.name] = {
+        description: t.description,
+        inputSchema: t.parameters,
+        execute: t.name === 'load_tool' ? () => ({ loaded: ['RiveWorkflow'] }) : () => ({ ok: true }),
+      };
+    }
+
+    const prepareStep = buildDeferredPrepareStep({ tools, invalidTool: invalid, catalog });
+
+    const result = await newAdapter().startStream({
+      model,
+      messages: [{ role: 'user', content: 'animate it' }],
+      tools: aiSdkTools,
+      activeTools: canonical.activeTools,
+      prepareStep,
+      system: 'sys',
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    for await (const _chunk of result.fullStream) {
+      void _chunk;
+    }
+
+    assert.equal(toolsPerStep.length, 2, 'expected two model steps (load then use)');
+    assert.ok(!toolsPerStep[0].includes('RiveWorkflow'), 'step 0 must NOT see the deferred RiveWorkflow');
+    assert.ok(toolsPerStep[0].includes('load_tool'), 'step 0 sees load_tool');
+    assert.ok(toolsPerStep[1].includes('RiveWorkflow'), 'step 1 MUST see RiveWorkflow after the load');
+  });
+});

--- a/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
+
+const ZERO_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+// Minimal valid V3 stream: start then immediately finish. Annotated so the
+// 'stop' / 'stream-start' literals are checked against the part union.
+const STREAM_PARTS: LanguageModelV3StreamPart[] = [
+  { type: 'stream-start', warnings: [] },
+  { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+];
+
+import { ModelAdapter } from '../model-adapter.js';
+import { canonicalizeToolSet } from '../request-shape.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+// A tool with a real (non-trivial) zod schema so the AI SDK actually serializes it.
+function tool(name: string, exposure?: 'direct' | 'deferred'): MakaTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: z.object({ q: z.string().describe('an argument') }),
+    impl: () => ({ ok: true }),
+    ...(exposure ? { exposure } : {}),
+  };
+}
+
+function newAdapter(): ModelAdapter {
+  return new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => ({}),
+    providerOptions: {},
+    maxSteps: 2,
+    newId: () => 'id',
+    now: () => 0,
+  });
+}
+
+/**
+ * Drive the real ModelAdapter.startStream path with a mock model and report the
+ * tool names the provider actually received in doStream — i.e. what crosses the
+ * wire after the AI SDK applies `activeTools`.
+ */
+async function toolNamesSeenByProvider(loaded: ReadonlySet<string>): Promise<string[]> {
+  const tools: MakaTool[] = [tool('Read'), tool('load_tool'), tool('Rive', 'deferred')];
+  const invalid = tool('invalid');
+  const canonical = canonicalizeToolSet(tools, invalid, loaded);
+
+  const aiSdkTools: Record<string, unknown> = {};
+  for (const t of canonical.providerTools) {
+    aiSdkTools[t.name] = { description: t.description, inputSchema: t.parameters };
+  }
+
+  let seen: string[] = [];
+  const model = new MockLanguageModelV3({
+    doStream: async ({ tools }) => {
+      seen = (tools ?? []).map((t) => t.name);
+      return { stream: convertArrayToReadableStream(STREAM_PARTS) };
+    },
+  });
+
+  const result = await newAdapter().startStream({
+    model,
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: aiSdkTools,
+    activeTools: canonical.activeTools,
+    system: 'sys',
+    abortSignal: new AbortController().signal,
+    repairToolCall: async () => null,
+  });
+  // Drain the stream so streamText materializes the provider call.
+  for await (const _chunk of result.fullStream) {
+    void _chunk;
+  }
+  return seen;
+}
+
+describe('deferred tools are trimmed from the provider request (wire-level)', () => {
+  test('an unloaded deferred tool never reaches the model; invalid is never advertised', async () => {
+    const seen = await toolNamesSeenByProvider(new Set());
+    assert.ok(seen.includes('Read'), 'direct Read should reach the provider');
+    assert.ok(seen.includes('load_tool'), 'load_tool should reach the provider');
+    assert.ok(!seen.includes('Rive'), 'unloaded deferred Rive must NOT reach the provider');
+    assert.ok(!seen.includes('invalid'), 'invalid is providerTools-only, never advertised');
+  });
+
+  test('a loaded deferred tool does reach the model (ratchet activates it)', async () => {
+    const seen = await toolNamesSeenByProvider(new Set(['Rive']));
+    assert.ok(seen.includes('Rive'), 'loaded deferred Rive should reach the provider');
+    assert.ok(seen.includes('Read'), 'direct tools stay present after a load');
+  });
+});

--- a/packages/runtime/src/__tests__/load-tool.test.ts
+++ b/packages/runtime/src/__tests__/load-tool.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { buildLoadTool, LOAD_TOOL_NAME, type DeferredToolCatalog } from '../load-tool.js';
+import type { MakaToolContext } from '../tool-runtime.js';
+
+const catalog: DeferredToolCatalog = [
+  {
+    namespace: 'browser',
+    summary: 'Drive the in-app browser (navigate, click, type, read pages).',
+    toolNames: ['browser_navigate', 'browser_click', 'browser_type'],
+  },
+  {
+    namespace: 'rive',
+    summary: 'Build and edit Rive animation workflows.',
+    toolNames: ['RiveWorkflow'],
+  },
+];
+
+function ctx(): MakaToolContext {
+  return {
+    sessionId: 's',
+    turnId: 't',
+    cwd: '/',
+    toolCallId: 'c',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}
+
+describe('load_tool', () => {
+  test('is named load_tool, stays direct, and lists every namespace card in its description', () => {
+    const t = buildLoadTool(catalog);
+    assert.equal(t.name, LOAD_TOOL_NAME);
+    assert.notEqual(t.exposure, 'deferred'); // the catalog tool itself is never deferred
+    assert.match(t.description, /browser/);
+    assert.match(t.description, /rive/);
+    assert.match(t.description, /Drive the in-app browser/);
+    assert.match(t.description, /Build and edit Rive/);
+  });
+
+  test('loading a namespace returns exactly its tool names (thin result, no schema)', async () => {
+    const t = buildLoadTool(catalog);
+    const result = await t.impl({ namespace: 'browser' }, ctx());
+    assert.deepEqual(result, { loaded: ['browser_navigate', 'browser_click', 'browser_type'] });
+    const keys = Object.keys(result as object);
+    assert.ok(!keys.includes('schema'), 'must not return a JSON schema');
+    assert.ok(!keys.includes('parameters'), 'must not return parameters');
+    assert.ok(!keys.includes('inputSchema'), 'must not return an input schema');
+  });
+
+  test('an unknown namespace is rejected with the available groups listed', async () => {
+    const t = buildLoadTool(catalog);
+    await assert.rejects(
+      async () => t.impl({ namespace: 'nope' } as never, ctx()),
+      /Unknown tool group.*browser.*rive/s,
+    );
+  });
+
+  test('loading does not itself require a permission prompt', () => {
+    const t = buildLoadTool(catalog);
+    assert.equal(t.permissionRequired, false);
+  });
+});

--- a/packages/runtime/src/__tests__/permission-engine.test.ts
+++ b/packages/runtime/src/__tests__/permission-engine.test.ts
@@ -253,6 +253,46 @@ describe('PermissionEngine — turn lifecycle', () => {
     expect(engine.recordResponse('t1', { requestId: r.event.requestId, decision: 'allow' })).toBeNull();
   });
 
+  test('allow + rememberForTurn absorbs other parked requests sharing the scope', async () => {
+    const { engine } = makeEngine();
+    engine.beginTurn('t1');
+    // Two writes to the same path parked in parallel — neither answered yet, so
+    // the second still prompts (the scope is not yet remembered).
+    const r1 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu1', toolName: 'Write', args: { path: '/x' }, mode: 'ask' });
+    const r2 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu2', toolName: 'Write', args: { path: '/x' }, mode: 'ask' });
+    if (r1.kind !== 'prompt' || r2.kind !== 'prompt') throw new Error('expected prompts');
+    expect(engine.pendingCount('t1')).toBe(2);
+
+    // Answer the first with allow + remember-for-turn.
+    engine.recordResponse('t1', { requestId: r1.event.requestId, decision: 'allow', rememberForTurn: true });
+
+    // The second resolves on its own (no second prompt), as allow, under its own id.
+    const resolved2 = await r2.parked;
+    expect(resolved2.decision).toBe('allow');
+    expect(resolved2.requestId).toBe(r2.event.requestId);
+    expect(engine.pendingCount('t1')).toBe(0);
+  });
+
+  test('allow WITHOUT remember leaves other parked requests untouched', () => {
+    const { engine } = makeEngine();
+    engine.beginTurn('t1');
+    const r1 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu1', toolName: 'Write', args: { path: '/x' }, mode: 'ask' });
+    const r2 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu2', toolName: 'Write', args: { path: '/x' }, mode: 'ask' });
+    if (r1.kind !== 'prompt' || r2.kind !== 'prompt') throw new Error('expected prompts');
+    engine.recordResponse('t1', { requestId: r1.event.requestId, decision: 'allow' }); // no rememberForTurn
+    expect(engine.pendingCount('t1')).toBe(1); // r2 still parked
+  });
+
+  test('remember does not absorb a parked request in a different scope', () => {
+    const { engine } = makeEngine();
+    engine.beginTurn('t1');
+    const r1 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu1', toolName: 'Write', args: { path: '/x' }, mode: 'ask' });
+    const r2 = engine.evaluate({ sessionId: 's1', turnId: 't1', toolUseId: 'tu2', toolName: 'Write', args: { path: '/y' }, mode: 'ask' });
+    if (r1.kind !== 'prompt' || r2.kind !== 'prompt') throw new Error('expected prompts');
+    engine.recordResponse('t1', { requestId: r1.event.requestId, decision: 'allow', rememberForTurn: true });
+    expect(engine.pendingCount('t1')).toBe(1); // different path → different scope → still parked
+  });
+
   test('beginTurn is idempotent', () => {
     const { engine } = makeEngine();
     engine.beginTurn('t1');

--- a/packages/runtime/src/__tests__/request-shape.test.ts
+++ b/packages/runtime/src/__tests__/request-shape.test.ts
@@ -1,7 +1,11 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { canonicalizeToolSet } from '../request-shape.js';
+import {
+  canonicalizeToolSet,
+  toolSchemaCharsForDiagnostics,
+  computeRequestShapeDiagnostic,
+} from '../request-shape.js';
 import type { MakaTool } from '../tool-runtime.js';
 
 function tool(name: string, exposure?: 'direct' | 'deferred'): MakaTool {
@@ -51,5 +55,45 @@ describe('canonicalizeToolSet exposure gating', () => {
   test('omitting exposure means direct (backward compatible), names sorted', () => {
     const { activeTools } = canonicalizeToolSet([tool('Write'), tool('Read')], invalid);
     assert.deepEqual(activeTools, ['Read', 'Write']);
+  });
+});
+
+describe('diagnostics measure the provider-visible (active) tool subset', () => {
+  const connection = { providerType: 'openai', slug: 'c' } as never;
+
+  function rich(name: string, exposure: 'direct' | 'deferred', schema: unknown): MakaTool {
+    return { name, description: name, parameters: schema, impl: () => ({}), exposure };
+  }
+
+  function diag(providerTools: MakaTool[], activeTools: string[], prior?: ReturnType<typeof computeRequestShapeDiagnostic>) {
+    return computeRequestShapeDiagnostic(
+      { connection, modelId: 'm', systemPrompt: 's', providerOptions: {}, providerTools, activeTools, priorMessages: [] },
+      prior,
+    );
+  }
+
+  test('char count excludes an inactive deferred tool schema', () => {
+    const tools = [rich('Read', 'direct', { a: 1 }), rich('Rive', 'deferred', { big: 'x'.repeat(500) })];
+    const withoutRive = toolSchemaCharsForDiagnostics(tools, ['Read']);
+    const withRive = toolSchemaCharsForDiagnostics(tools, ['Read', 'Rive']);
+    assert.ok(withRive > withoutRive + 400, 'activating Rive should add its schema chars to the count');
+  });
+
+  test('toolSchemaHash ignores an INACTIVE deferred tool schema change', () => {
+    const a = [rich('Read', 'direct', { a: 1 }), rich('Rive', 'deferred', { v: 1 })];
+    const b = [rich('Read', 'direct', { a: 1 }), rich('Rive', 'deferred', { v: 2 })];
+    assert.equal(
+      diag(a, ['Read']).componentHashes.toolSchemaHash,
+      diag(b, ['Read']).componentHashes.toolSchemaHash,
+      'a change to an unadvertised deferred schema must not move the hash',
+    );
+  });
+
+  test('loading a deferred tool moves toolSchemaHash and reports tool_schema_changed', () => {
+    const tools = [rich('Read', 'direct', { a: 1 }), rich('Rive', 'deferred', { v: 1 })];
+    const before = diag(tools, ['Read']);
+    const after = diag(tools, ['Read', 'Rive'], before);
+    assert.notEqual(after.componentHashes.toolSchemaHash, before.componentHashes.toolSchemaHash);
+    assert.equal(after.prefixChangeReason, 'tool_schema_changed');
   });
 });

--- a/packages/runtime/src/__tests__/request-shape.test.ts
+++ b/packages/runtime/src/__tests__/request-shape.test.ts
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { canonicalizeToolSet } from '../request-shape.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+function tool(name: string, exposure?: 'direct' | 'deferred'): MakaTool {
+  return {
+    name,
+    description: name,
+    parameters: {},
+    impl: () => ({}),
+    ...(exposure ? { exposure } : {}),
+  };
+}
+
+const invalid = tool('invalid');
+
+describe('canonicalizeToolSet exposure gating', () => {
+  test('direct tools are active; a deferred tool is excluded when not loaded', () => {
+    const { activeTools } = canonicalizeToolSet(
+      [tool('Read'), tool('Rive', 'deferred'), tool('load_tool')],
+      invalid,
+    );
+    assert.ok(activeTools.includes('Read'), 'direct Read should be active');
+    assert.ok(activeTools.includes('load_tool'), 'load_tool should be active');
+    assert.ok(!activeTools.includes('Rive'), 'unloaded deferred Rive should be hidden');
+  });
+
+  test('a deferred tool becomes active once it is in the loaded set', () => {
+    const { activeTools } = canonicalizeToolSet(
+      [tool('Read'), tool('Rive', 'deferred')],
+      invalid,
+      new Set(['Rive']),
+    );
+    assert.ok(activeTools.includes('Rive'), 'loaded deferred Rive should be active');
+  });
+
+  test('providerTools keeps the full registry for dispatch; invalid present but not advertised', () => {
+    const { providerTools, activeTools } = canonicalizeToolSet(
+      [tool('Read'), tool('Rive', 'deferred')],
+      invalid,
+    );
+    const names = providerTools.map((t) => t.name);
+    assert.ok(names.includes('Read'));
+    assert.ok(names.includes('Rive'), 'deferred tool stays dispatchable in providerTools');
+    assert.ok(names.includes('invalid'), 'repair target present in providerTools');
+    assert.ok(!activeTools.includes('invalid'), 'invalid is never advertised to the model');
+  });
+
+  test('omitting exposure means direct (backward compatible), names sorted', () => {
+    const { activeTools } = canonicalizeToolSet([tool('Write'), tool('Read')], invalid);
+    assert.deepEqual(activeTools, ['Read', 'Write']);
+  });
+});

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -106,6 +106,11 @@ import {
   type ToolSourceEconomyConfig,
 } from './tool-source-economy.js';
 import {
+  buildDeferredPrepareStep,
+  seedNamespacesFromRuntimeEvents,
+} from './deferred-activation.js';
+import { toolNamesForNamespaces, type DeferredToolCatalog } from './load-tool.js';
+import {
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   buildPromptSegmentEstimates,
@@ -245,6 +250,14 @@ export interface AiSdkBackendInput {
   tools: MakaTool[];
   /** Optional opt-in tool source economy mode. Omitted/full mode preserves the full tool surface. */
   toolSourceEconomy?: ToolSourceEconomyConfig;
+  /**
+   * Optional deferred-tool catalog (Layer 1). When present, `exposure:'deferred'`
+   * tools are withheld from the per-turn prompt until the model loads their
+   * namespace via `load_tool`; the backend builds the per-step `prepareStep`
+   * activation, seeds it from durable prior-turn loads, and gates execution.
+   * When absent, every tool is advertised every turn (legacy behavior).
+   */
+  deferredCatalog?: DeferredToolCatalog;
 
   // ── Optional knobs (defaults shown) ────────────────────────────────────
   /** ID generator; default `crypto.randomUUID()`. */
@@ -423,9 +436,43 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     // --- Build ai-sdk tools dict with permission-wrapped execute ---
+    // Tool source economy (opt-in) selects the base tool surface first; deferred
+    // activation (Layer 1) then seeds the loaded-set on top of that selection, so
+    // the two coexist: economy decides which sources are visible, deferred
+    // withholds heavy-schema families until the model calls `load_tool`.
     const toolSourceSelection = this.toolSourceEconomyRuntime.selectTools();
+    const baseTools = toolSourceSelection.tools;
     const invalidTool = buildInvalidMakaTool();
-    const canonicalTools = canonicalizeToolSet(toolSourceSelection.tools, invalidTool);
+    const deferredCatalog = this.input.deferredCatalog;
+    const seedNamespaces = deferredCatalog
+      ? seedNamespacesFromRuntimeEvents(
+          (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
+        )
+      : undefined;
+    const seedLoadedNames = deferredCatalog
+      ? toolNamesForNamespaces(deferredCatalog, seedNamespaces ?? new Set())
+      : undefined;
+    const canonicalTools = canonicalizeToolSet(baseTools, invalidTool, seedLoadedNames);
+
+    // Per-step active snapshot the execute-boundary guard reads. `prepareStep`
+    // recomputes it before every step; the guard rejects a deferred tool absent
+    // from the current step's snapshot (handles same-step parallel load+use).
+    let prepareStep: ReturnType<typeof buildDeferredPrepareStep> | undefined;
+    if (deferredCatalog) {
+      const turnActivation = { currentStepActive: new Set<string>(canonicalTools.activeTools) };
+      this.toolRuntime.setStepActivation(() => turnActivation.currentStepActive);
+      prepareStep = buildDeferredPrepareStep({
+        tools: baseTools,
+        invalidTool,
+        catalog: deferredCatalog,
+        seedNamespaces,
+        onActiveSnapshot: (active) => {
+          turnActivation.currentStepActive = new Set(active);
+        },
+      });
+    }
+
+
     const aiSdkTools: Record<string, unknown> = {};
     for (const t of canonicalTools.providerTools) {
       aiSdkTools[t.name] = {
@@ -532,6 +579,7 @@ export class AiSdkBackend implements AgentBackend {
           },
           system: systemPrompt,
           abortSignal: this.abortController!.signal,
+          ...(prepareStep ? { prepareStep } : {}),
         });
 
         for await (const chunk of result.fullStream) {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -547,7 +547,7 @@ export class AiSdkBackend implements AgentBackend {
             promptSegments: buildPromptSegmentEstimates({
               systemPrompt,
               toolSchemaChars,
-              toolCount: canonicalTools.providerTools.length,
+              toolCount: active.length,
               priorMessages: priorReplay.messages,
               priorRuntimeEventCount: priorReplay.runtimeEventCount,
               currentUserContent,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -567,16 +567,27 @@ export class AiSdkBackend implements AgentBackend {
             }, priorShapeBaseline),
           };
         };
+        // Publish a diagnostics snapshot to every telemetry sink at once so the
+        // cost record, the prefix baseline, and the context-budget high-water
+        // "after" hash never diverge — they must all describe the same active
+        // tool set. A same-turn deferred load re-publishes the final snapshot
+        // below; the high-water "before" hash is the pre-turn baseline, set once.
+        let turnDiagnostics = computeTurnDiagnostics(activeTools);
+        const publishTurnDiagnostics = (diag: typeof turnDiagnostics): void => {
+          turnDiagnostics = diag;
+          promptSegmentsForTelemetry = diag.promptSegments;
+          requestShapeForTelemetry = diag.requestShape;
+          this.priorRequestShape = diag.requestShape;
+          if (priorReplay.contextBudget?.highWaterReason) {
+            priorReplay.contextBudget.highWaterRequestShapeHashAfter = diag.requestShape.requestShapeHash;
+          }
+        };
         // Step-0 (turn-start) view: literally what the first request carries, so
         // the stream-start trace reports it as the prefix actually sent.
-        let turnDiagnostics = computeTurnDiagnostics(activeTools);
         if (priorReplay.contextBudget?.highWaterReason) {
           priorReplay.contextBudget.highWaterRequestShapeHashBefore = priorShapeBaseline?.requestShapeHash;
-          priorReplay.contextBudget.highWaterRequestShapeHashAfter = turnDiagnostics.requestShape.requestShapeHash;
         }
-        promptSegmentsForTelemetry = turnDiagnostics.promptSegments;
-        requestShapeForTelemetry = turnDiagnostics.requestShape;
-        this.priorRequestShape = turnDiagnostics.requestShape;
+        publishTurnDiagnostics(turnDiagnostics);
         trace.modelStreamStarted(activeTools, {
           prefixHash: turnDiagnostics.requestShape.prefixHash,
           prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
@@ -633,10 +644,7 @@ export class AiSdkBackend implements AgentBackend {
         // grows it).
         const finalActiveTools = currentRepairToolNames();
         if (finalActiveTools.length !== activeTools.length) {
-          turnDiagnostics = computeTurnDiagnostics(finalActiveTools);
-          promptSegmentsForTelemetry = turnDiagnostics.promptSegments;
-          requestShapeForTelemetry = turnDiagnostics.requestShape;
-          this.priorRequestShape = turnDiagnostics.requestShape;
+          publishTurnDiagnostics(computeTurnDiagnostics(finalActiveTools));
         }
 
         // PR-AGENT-ITERATION-GRACE-0 (external bot research #A1): when the

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -451,7 +451,15 @@ export class AiSdkBackend implements AgentBackend {
       : undefined;
     const seedLoadedNames = deferredCatalog
       ? toolNamesForNamespaces(deferredCatalog, seedNamespaces ?? new Set())
-      : undefined;
+      // No catalog ⇒ deferral is off: advertise every tool, including any tagged
+      // `exposure: 'deferred'`. Without this, a deferred tag with no catalog would
+      // strand the tool off the wire with no `load_tool` to recover it — the
+      // input contract (absent catalog ⇒ all tools advertised) made self-enforcing.
+      : new Set(
+          baseTools
+            .filter((tool) => tool.exposure === 'deferred')
+            .map((tool) => tool.name),
+        );
     const canonicalTools = canonicalizeToolSet(baseTools, invalidTool, seedLoadedNames);
 
     // Per-step active snapshot the execute-boundary guard reads. `prepareStep`
@@ -521,51 +529,66 @@ export class AiSdkBackend implements AgentBackend {
             content: this.appendTurnTailPrompt(currentUserContent, turnTailPrompt),
           },
         ];
-        const toolSchemaChars = toolSchemaCharsForDiagnostics(canonicalTools.providerTools, activeTools);
-        const toolSourceDiagnostic = toolSourceSelection.diagnostic !== undefined
-          ? this.enrichToolSourceDiagnostic(toolSourceSelection.diagnostic, canonicalTools, toolSchemaChars)
-          : undefined;
-        const promptSegments = buildPromptSegmentEstimates({
-          systemPrompt,
-          toolSchemaChars,
-          toolCount: canonicalTools.providerTools.length,
-          priorMessages: priorReplay.messages,
-          priorRuntimeEventCount: priorReplay.runtimeEventCount,
-          currentUserContent,
-          turnTailPrompt,
-        });
-        promptSegmentsForTelemetry = promptSegments;
+        // Diagnostics describe the provider-visible (active) tool subset. A
+        // deferred family loaded *this* turn expands that subset on later steps
+        // (via prepareStep), so the durable cost record is refined against the
+        // final active set once the stream is consumed (see below). Both
+        // computations classify against the same pre-turn baseline. When tool
+        // source economy reduced the surface, its diagnostic is enriched from the
+        // same per-step schema-char measurement.
         contextBudgetForTelemetry = priorReplay.contextBudget;
-        const requestShape = computeRequestShapeDiagnostic({
-          connection: this.input.connection,
-          modelId: this.input.modelId,
-          systemPrompt,
-          providerOptions: this.input.providerOptions,
-          providerTools: canonicalTools.providerTools,
-          activeTools,
-          priorMessages: priorReplay.messages,
-          ...(toolSourceDiagnostic !== undefined
-            ? { toolSourceEconomy: toolSourceDiagnostic }
-            : {}),
-        }, this.priorRequestShape);
+        const priorShapeBaseline = this.priorRequestShape;
+        const computeTurnDiagnostics = (active: readonly string[]) => {
+          const toolSchemaChars = toolSchemaCharsForDiagnostics(canonicalTools.providerTools, active);
+          const toolSourceDiagnostic = toolSourceSelection.diagnostic !== undefined
+            ? this.enrichToolSourceDiagnostic(toolSourceSelection.diagnostic, canonicalTools, toolSchemaChars)
+            : undefined;
+          return {
+            promptSegments: buildPromptSegmentEstimates({
+              systemPrompt,
+              toolSchemaChars,
+              toolCount: canonicalTools.providerTools.length,
+              priorMessages: priorReplay.messages,
+              priorRuntimeEventCount: priorReplay.runtimeEventCount,
+              currentUserContent,
+              turnTailPrompt,
+            }),
+            requestShape: computeRequestShapeDiagnostic({
+              connection: this.input.connection,
+              modelId: this.input.modelId,
+              systemPrompt,
+              providerOptions: this.input.providerOptions,
+              providerTools: canonicalTools.providerTools,
+              activeTools: active,
+              priorMessages: priorReplay.messages,
+              ...(toolSourceDiagnostic !== undefined
+                ? { toolSourceEconomy: toolSourceDiagnostic }
+                : {}),
+            }, priorShapeBaseline),
+          };
+        };
+        // Step-0 (turn-start) view: literally what the first request carries, so
+        // the stream-start trace reports it as the prefix actually sent.
+        let turnDiagnostics = computeTurnDiagnostics(activeTools);
         if (priorReplay.contextBudget?.highWaterReason) {
-          priorReplay.contextBudget.highWaterRequestShapeHashBefore = this.priorRequestShape?.requestShapeHash;
-          priorReplay.contextBudget.highWaterRequestShapeHashAfter = requestShape.requestShapeHash;
+          priorReplay.contextBudget.highWaterRequestShapeHashBefore = priorShapeBaseline?.requestShapeHash;
+          priorReplay.contextBudget.highWaterRequestShapeHashAfter = turnDiagnostics.requestShape.requestShapeHash;
         }
-        requestShapeForTelemetry = requestShape;
-        this.priorRequestShape = requestShape;
+        promptSegmentsForTelemetry = turnDiagnostics.promptSegments;
+        requestShapeForTelemetry = turnDiagnostics.requestShape;
+        this.priorRequestShape = turnDiagnostics.requestShape;
         trace.modelStreamStarted(activeTools, {
-          prefixHash: requestShape.prefixHash,
-          prefixChangeReason: requestShape.prefixChangeReason,
-          requestShapeHash: requestShape.requestShapeHash,
-          requestShapeChangeReason: requestShape.requestShapeChangeReason,
-          ...(requestShape.toolSchemaChangeReason !== undefined
-            ? { toolSchemaChangeReason: requestShape.toolSchemaChangeReason }
+          prefixHash: turnDiagnostics.requestShape.prefixHash,
+          prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
+          requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
+          requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
+          ...(turnDiagnostics.requestShape.toolSchemaChangeReason !== undefined
+            ? { toolSchemaChangeReason: turnDiagnostics.requestShape.toolSchemaChangeReason }
             : {}),
-          ...(requestShape.toolSourceEconomy !== undefined
-            ? { toolSourceEconomy: requestShape.toolSourceEconomy }
+          ...(turnDiagnostics.requestShape.toolSourceEconomy !== undefined
+            ? { toolSourceEconomy: turnDiagnostics.requestShape.toolSourceEconomy }
             : {}),
-          promptSegments,
+          promptSegments: turnDiagnostics.promptSegments,
           ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
         });
 
@@ -600,6 +623,20 @@ export class AiSdkBackend implements AgentBackend {
             onThinking: (t) => { thinkingText += t; },
             onThinkingComplete: (t, sig) => { thinkingText = t; thinkingSignature = sig; },
           });
+        }
+
+        // Same-turn deferred load: prepareStep expanded the provider tool set on
+        // later steps, so refine the durable cost record + prefix baseline against
+        // the final active set — otherwise this turn under-reports the loaded
+        // schema and the cache reset would surface a turn late. No-op when nothing
+        // loaded this turn (the active set length is unchanged; the ratchet only
+        // grows it).
+        const finalActiveTools = currentRepairToolNames();
+        if (finalActiveTools.length !== activeTools.length) {
+          turnDiagnostics = computeTurnDiagnostics(finalActiveTools);
+          promptSegmentsForTelemetry = turnDiagnostics.promptSegments;
+          requestShapeForTelemetry = turnDiagnostics.requestShape;
+          this.priorRequestShape = turnDiagnostics.requestShape;
         }
 
         // PR-AGENT-ITERATION-GRACE-0 (external bot research #A1): when the
@@ -657,15 +694,15 @@ export class AiSdkBackend implements AgentBackend {
           if (tokenUsage) {
             trace.usageRecorded({
               ...tokenUsage,
-              prefixHash: requestShape.prefixHash,
-              prefixChangeReason: requestShape.prefixChangeReason,
-              requestShapeHash: requestShape.requestShapeHash,
-              requestShapeChangeReason: requestShape.requestShapeChangeReason,
-              ...(requestShape.toolSchemaChangeReason !== undefined
-                ? { toolSchemaChangeReason: requestShape.toolSchemaChangeReason }
+              prefixHash: turnDiagnostics.requestShape.prefixHash,
+              prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
+              requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
+              requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
+              ...(turnDiagnostics.requestShape.toolSchemaChangeReason !== undefined
+                ? { toolSchemaChangeReason: turnDiagnostics.requestShape.toolSchemaChangeReason }
                 : {}),
-              ...(requestShape.toolSourceEconomy !== undefined
-                ? { toolSourceEconomy: requestShape.toolSourceEconomy }
+              ...(turnDiagnostics.requestShape.toolSourceEconomy !== undefined
+                ? { toolSourceEconomy: turnDiagnostics.requestShape.toolSourceEconomy }
                 : {}),
             });
             const tu: TokenUsageMessage = {
@@ -684,11 +721,11 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
               ...(tokenUsage.cachedInputTokens > 0 ? { cacheRead: tokenUsage.cachedInputTokens } : {}),
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
-              prefixHash: requestShape.prefixHash,
-              prefixChangeReason: requestShape.prefixChangeReason,
-              requestShapeHash: requestShape.requestShapeHash,
-              requestShapeChangeReason: requestShape.requestShapeChangeReason,
-              promptSegments,
+              prefixHash: turnDiagnostics.requestShape.prefixHash,
+              prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
+              requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
+              requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
+              promptSegments: turnDiagnostics.promptSegments,
               ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
             };
             await this.input.appendMessage(tu).catch(() => {});
@@ -708,11 +745,11 @@ export class AiSdkBackend implements AgentBackend {
               ...(tokenUsage.rawFinishReason !== undefined ? { rawFinishReason: tokenUsage.rawFinishReason } : {}),
               ...(tokenUsage.cachedInputTokens > 0 ? { cacheRead: tokenUsage.cachedInputTokens } : {}),
               ...(tokenUsage.cacheWriteInputTokens > 0 ? { cacheCreation: tokenUsage.cacheWriteInputTokens } : {}),
-              prefixHash: requestShape.prefixHash,
-              prefixChangeReason: requestShape.prefixChangeReason,
-              requestShapeHash: requestShape.requestShapeHash,
-              requestShapeChangeReason: requestShape.requestShapeChangeReason,
-              promptSegments,
+              prefixHash: turnDiagnostics.requestShape.prefixHash,
+              prefixChangeReason: turnDiagnostics.requestShape.prefixChangeReason,
+              requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
+              requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
+              promptSegments: turnDiagnostics.promptSegments,
               ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
             } satisfies TokenUsageEvent);
           }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -458,9 +458,15 @@ export class AiSdkBackend implements AgentBackend {
     // recomputes it before every step; the guard rejects a deferred tool absent
     // from the current step's snapshot (handles same-step parallel load+use).
     let prepareStep: ReturnType<typeof buildDeferredPrepareStep> | undefined;
+    // Tool names the repair path matches a mis-cased call against. Without a
+    // deferred catalog this is the static active set; with one it must follow the
+    // current step's snapshot so a deferred family loaded mid-turn (e.g. browser_*)
+    // is repairable on the step it becomes active, not routed to `invalid`.
+    let currentRepairToolNames: () => string[] = () => canonicalTools.activeTools;
     if (deferredCatalog) {
       const turnActivation = { currentStepActive: new Set<string>(canonicalTools.activeTools) };
       this.toolRuntime.setStepActivation(() => turnActivation.currentStepActive);
+      currentRepairToolNames = () => [...turnActivation.currentStepActive];
       prepareStep = buildDeferredPrepareStep({
         tools: baseTools,
         invalidTool,
@@ -573,7 +579,7 @@ export class AiSdkBackend implements AgentBackend {
           ) => {
             return repairMakaToolCall({
               toolCall,
-              availableToolNames: activeTools,
+              availableToolNames: currentRepairToolNames(),
               error,
             });
           },

--- a/packages/runtime/src/deferred-activation.ts
+++ b/packages/runtime/src/deferred-activation.ts
@@ -44,6 +44,38 @@ export function loadedNamespacesFromSteps(steps: ReadonlyArray<StepLike> | undef
   return out;
 }
 
+/**
+ * The minimal shape this module needs from a durable `RuntimeEvent`: a
+ * `function_call` content carrying the tool name and args. Kept structural so
+ * the seed is decoupled from the `@maka/core` event types and trivially
+ * testable.
+ */
+export interface RuntimeEventLike {
+  content?: { kind?: string; name?: string; args?: unknown } | undefined;
+}
+
+/**
+ * Reconstruct the cross-turn loaded namespaces from the durable RuntimeEvent
+ * ledger (Slice 7, Codex Δ4). Scans committed `load_tool` calls — the same
+ * shape the in-turn derivation reads from step history — so a tool loaded in an
+ * earlier turn is re-advertised at the next turn's start. Durable by
+ * construction: it survives history compaction and session recovery because it
+ * reads the ledger, not the prompt tail. Append-only ratchet: an aborted load
+ * simply never reaches committed history, and re-loading on retry is idempotent.
+ */
+export function seedNamespacesFromRuntimeEvents(
+  events: ReadonlyArray<RuntimeEventLike> | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  for (const event of events ?? []) {
+    const content = event?.content;
+    if (!content || content.kind !== 'function_call' || content.name !== LOAD_TOOL_NAME) continue;
+    const namespace = extractNamespace(content.args);
+    if (namespace) out.add(namespace);
+  }
+  return out;
+}
+
 export interface DeferredPrepareStepInput {
   /** Full registry (used to recompute the active subset). */
   tools: readonly MakaTool[];

--- a/packages/runtime/src/deferred-activation.ts
+++ b/packages/runtime/src/deferred-activation.ts
@@ -1,0 +1,97 @@
+import { canonicalizeToolSet } from './request-shape.js';
+import { LOAD_TOOL_NAME, toolNamesForNamespaces, type DeferredToolCatalog } from './load-tool.js';
+import type { MakaTool } from './tool-runtime.js';
+
+/**
+ * The minimal shape this module needs from an AI SDK `StepResult`: the tool
+ * calls made in that step. Kept structural so the derivation is decoupled from
+ * the SDK types and trivially testable.
+ */
+export interface StepLike {
+  toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }>;
+}
+
+function extractNamespace(input: unknown): string | undefined {
+  let value = input;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (value && typeof value === 'object' && typeof (value as { namespace?: unknown }).namespace === 'string') {
+    return (value as { namespace: string }).namespace;
+  }
+  return undefined;
+}
+
+/**
+ * Collect the deferred namespaces that have been loaded so far this turn by
+ * scanning prior steps' `load_tool` calls. Stateless: derived purely from the
+ * step history the SDK hands `prepareStep`, so there is no race with tool
+ * execution and no per-turn mutable accumulator.
+ */
+export function loadedNamespacesFromSteps(steps: ReadonlyArray<StepLike> | undefined): Set<string> {
+  const out = new Set<string>();
+  for (const step of steps ?? []) {
+    for (const call of step.toolCalls ?? []) {
+      if (call?.toolName !== LOAD_TOOL_NAME) continue;
+      const namespace = extractNamespace(call.input);
+      if (namespace) out.add(namespace);
+    }
+  }
+  return out;
+}
+
+export interface DeferredPrepareStepInput {
+  /** Full registry (used to recompute the active subset). */
+  tools: readonly MakaTool[];
+  /** The repair/invalid tool, kept out of the advertised set. */
+  invalidTool: MakaTool;
+  /** Namespace → deferred tool names. */
+  catalog: DeferredToolCatalog;
+  /**
+   * Durable namespaces loaded in prior turns (cross-turn ratchet, Slice 7).
+   * Empty when only same-turn activation is wired.
+   */
+  seedNamespaces?: ReadonlySet<string>;
+  /**
+   * Receives the active-tool snapshot computed for the step about to run, so
+   * the execute-boundary guard can reject a deferred tool that is not yet
+   * active in this step (Slice 5).
+   */
+  onActiveSnapshot?: (active: ReadonlySet<string>) => void;
+}
+
+/**
+ * Compute the model-visible active tool names for the next step:
+ * direct tools + `load_tool` + every deferred tool whose namespace is loaded
+ * (seed from prior turns ∪ this turn's `load_tool` calls). Append-only by
+ * construction — the loaded set never shrinks within a turn.
+ */
+export function computeActiveTools(
+  input: DeferredPrepareStepInput,
+  steps: ReadonlyArray<StepLike> | undefined,
+): string[] {
+  const namespaces = new Set<string>([
+    ...(input.seedNamespaces ?? []),
+    ...loadedNamespacesFromSteps(steps),
+  ]);
+  const loadedNames = toolNamesForNamespaces(input.catalog, namespaces);
+  const active = canonicalizeToolSet(input.tools, input.invalidTool, loadedNames).activeTools;
+  input.onActiveSnapshot?.(new Set(active));
+  return active;
+}
+
+/**
+ * Build the `prepareStep` callback the AI SDK invokes before every step. It
+ * re-derives `activeTools` from the step history so a tool loaded at step N is
+ * advertised to the provider at step N+1 of the same turn — without mutating
+ * the cached prefix tools array out from under the SDK.
+ */
+export function buildDeferredPrepareStep(
+  input: DeferredPrepareStepInput,
+): (options: { steps?: ReadonlyArray<StepLike> }) => { activeTools: string[] } {
+  return ({ steps }) => ({ activeTools: computeActiveTools(input, steps) });
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -315,7 +315,8 @@ export type { DeferredNamespaceCard, DeferredToolCatalog } from './load-tool.js'
 // deferred-activation.ts — per-step active-tool derivation for deferred loading.
 export {
   loadedNamespacesFromSteps,
+  seedNamespacesFromRuntimeEvents,
   computeActiveTools,
   buildDeferredPrepareStep,
 } from './deferred-activation.js';
-export type { StepLike, DeferredPrepareStepInput } from './deferred-activation.js';
+export type { StepLike, RuntimeEventLike, DeferredPrepareStepInput } from './deferred-activation.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -307,3 +307,15 @@ export type {
   CompleteStopReason,
   SessionEventMapMemory,
 } from './ai-sdk-flow.js';
+
+// load-tool.ts — the always-on deferred-tool catalog/lookup tool.
+export { buildLoadTool, toolNamesForNamespaces, LOAD_TOOL_NAME } from './load-tool.js';
+export type { DeferredNamespaceCard, DeferredToolCatalog } from './load-tool.js';
+
+// deferred-activation.ts — per-step active-tool derivation for deferred loading.
+export {
+  loadedNamespacesFromSteps,
+  computeActiveTools,
+  buildDeferredPrepareStep,
+} from './deferred-activation.js';
+export type { StepLike, DeferredPrepareStepInput } from './deferred-activation.js';

--- a/packages/runtime/src/load-tool.ts
+++ b/packages/runtime/src/load-tool.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+import type { MakaTool } from './tool-runtime.js';
+
+/** Canonical name of the always-on catalog/lookup tool. */
+export const LOAD_TOOL_NAME = 'load_tool';
+
+/**
+ * One catalog card. A namespace groups one or more deferred tools that load
+ * together (e.g. the six `browser_*` tools load as one `browser` group). The
+ * `summary` is the one-line description shown to the model so it knows the
+ * capability exists — only the parameter schema is deferred, never the
+ * existence.
+ */
+export interface DeferredNamespaceCard {
+  namespace: string;
+  summary: string;
+  toolNames: string[];
+}
+
+export type DeferredToolCatalog = readonly DeferredNamespaceCard[];
+
+/**
+ * Resolve the set of deferred tool names activated by a set of loaded
+ * namespaces. Unknown namespaces are ignored (forward-compatible: a stale
+ * `load_tool` call in replayed history never throws here). Shared by the
+ * `load_tool` impl and the backend's per-step activation derivation.
+ */
+export function toolNamesForNamespaces(
+  catalog: DeferredToolCatalog,
+  namespaces: Iterable<string>,
+): Set<string> {
+  const wanted = new Set(namespaces);
+  const names = new Set<string>();
+  for (const card of catalog) {
+    if (wanted.has(card.namespace)) {
+      for (const name of card.toolNames) names.add(name);
+    }
+  }
+  return names;
+}
+
+function renderCatalog(catalog: DeferredToolCatalog): string {
+  const lines = catalog.map((card) => `- ${card.namespace}: ${card.summary}`);
+  return [
+    'Load additional tool groups on demand. These capabilities exist but their full',
+    'parameter schemas are withheld to keep each turn lean. Call load_tool with a',
+    'namespace; the tools it returns become callable on your next step.',
+    '',
+    'Available groups:',
+    ...lines,
+  ].join('\n');
+}
+
+/**
+ * Build the always-on `load_tool` catalog tool from a deferred-tool catalog.
+ * It is a lookup (not a search): the model sees every namespace card in the
+ * description and expands one by name. The result is intentionally thin —
+ * `{ loaded: [...toolNames] }`, never the schema (which would double-bill once
+ * in history and once in the provider tools on the next step).
+ */
+export function buildLoadTool(catalog: DeferredToolCatalog): MakaTool {
+  const namespaces = catalog.map((card) => card.namespace);
+  const namespaceSchema =
+    namespaces.length > 0
+      ? z.enum(namespaces as [string, ...string[]])
+      : z.string();
+
+  return {
+    name: LOAD_TOOL_NAME,
+    description: renderCatalog(catalog),
+    exposure: 'direct',
+    permissionRequired: false,
+    parameters: z.object({
+      namespace: namespaceSchema.describe('The tool group to load.'),
+    }),
+    impl: ({ namespace }: { namespace: string }) => {
+      const card = catalog.find((c) => c.namespace === namespace);
+      if (!card) {
+        const available = catalog.map((c) => c.namespace).join(', ');
+        throw new Error(`Unknown tool group "${namespace}". Available: ${available}.`);
+      }
+      return { loaded: [...card.toolNames] };
+    },
+  };
+}

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -47,6 +47,10 @@ export interface ModelAdapterInput {
   now: () => number;
 }
 
+export interface PrepareStepLike {
+  steps?: ReadonlyArray<{ toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }> }>;
+}
+
 export interface ModelAdapterStreamInput {
   model: unknown;
   messages: ModelMessage[];
@@ -58,6 +62,12 @@ export interface ModelAdapterStreamInput {
     toolCall: RepairableAiSdkToolCall;
     error: unknown;
   }) => RepairableAiSdkToolCall | null | Promise<RepairableAiSdkToolCall | null>;
+  /**
+   * Optional per-step active-tool override for deferred tool loading. Recomputes
+   * `activeTools` before each step so a tool loaded mid-turn becomes advertised
+   * on the next step without mutating the cached tools prefix.
+   */
+  prepareStep?: (options: PrepareStepLike) => { activeTools: string[] };
 }
 
 export interface ModelAdapterStreamCallbacks {
@@ -104,6 +114,7 @@ export class ModelAdapter {
       messages: input.messages,
       tools: input.tools,
       activeTools: input.activeTools,
+      ...(input.prepareStep ? { prepareStep: input.prepareStep } : {}),
       experimental_repairToolCall: input.repairToolCall,
       system: input.system,
       providerOptions: this.input.providerOptions,

--- a/packages/runtime/src/permission-engine.ts
+++ b/packages/runtime/src/permission-engine.ts
@@ -215,6 +215,18 @@ export class PermissionEngine {
 
     if (response.decision === 'allow' && response.rememberForTurn) {
       state.remembered.add(parked.scopeKey);
+      // The user allowed this scope for the whole turn, so other requests
+      // already parked under the same scope (e.g. the rest of a parallel
+      // browser_* batch) must not each re-prompt. Resolve them now — each
+      // tool's own coroutine then emits its own permission_decision_ack, so the
+      // UI queue drains without a second click. The current request was already
+      // deleted above, so the snapshot never re-resolves it.
+      for (const [otherId, other] of [...state.parked]) {
+        if (other.scopeKey === parked.scopeKey) {
+          state.parked.delete(otherId);
+          other.resolve({ requestId: otherId, decision: 'allow', rememberForTurn: true });
+        }
+      }
     }
 
     parked.resolve(response);

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -51,6 +51,17 @@ export interface RequestShapeDiagnostic {
 
 const NO_LOADED_TOOLS: ReadonlySet<string> = new Set();
 
+/**
+ * Split the registry into the full dispatch set (`providerTools`) and the
+ * model-visible subset (`activeTools`).
+ *
+ * `loadedDeferredNames` is the set of deferred tools to advertise; any
+ * `exposure: 'deferred'` tool NOT in it is withheld from `activeTools`. The
+ * default empty set therefore hides every deferred tool — correct only when a
+ * deferral system (a `load_tool` catalog + prepareStep) is wired to load them
+ * on demand. A caller with deferred-tagged tools but no such system must pass
+ * those names here (or untag them), or the tools become unreachable.
+ */
 export function canonicalizeToolSet(
   tools: readonly MakaTool[],
   invalidTool: MakaTool,

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -87,7 +87,11 @@ export function computeRequestShapeDiagnostic(
     providerOptionsHash: stableHash(input.providerOptions ?? {}),
     toolSchemaHash: stableHash({
       activeTools: [...input.activeTools],
-      providerTools: input.providerTools.map(toolShapeForDiagnostics),
+      // Only the provider-visible (active) subset crosses the wire, so the
+      // schema hash must reflect that subset — otherwise an inactive deferred
+      // tool's schema change would falsely fire `tool_schema_changed`, and a
+      // load would not be distinguishable from churn.
+      providerTools: providerVisibleTools(input.providerTools, input.activeTools).map(toolShapeForDiagnostics),
     }),
     historyProjectionHash: stableHash(input.priorMessages.map(messageShapeForHash)),
   };
@@ -123,8 +127,17 @@ export function toolSchemaCharsForDiagnostics(
 ): number {
   return stableStringify({
     activeTools: [...activeTools],
-    providerTools: providerTools.map(toolShapeForDiagnostics),
+    providerTools: providerVisibleTools(providerTools, activeTools).map(toolShapeForDiagnostics),
   }).length;
+}
+
+/** The provider-visible tools — the active subset actually serialized on the wire. */
+function providerVisibleTools(
+  providerTools: readonly MakaTool[],
+  activeTools: readonly string[],
+): MakaTool[] {
+  const active = new Set(activeTools);
+  return providerTools.filter((tool) => active.has(tool.name));
 }
 
 export function stableHash(value: unknown): string {

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -49,17 +49,27 @@ export interface RequestShapeDiagnostic {
   toolSourceEconomy?: ToolSourceEconomyDiagnostic;
 }
 
+const NO_LOADED_TOOLS: ReadonlySet<string> = new Set();
+
 export function canonicalizeToolSet(
   tools: readonly MakaTool[],
   invalidTool: MakaTool,
+  loadedDeferredNames: ReadonlySet<string> = NO_LOADED_TOOLS,
 ): CanonicalToolSet {
   const visibleTools = tools
     .filter((tool) => tool.name !== invalidTool.name)
     .slice()
     .sort((a, b) => a.name.localeCompare(b.name));
+  // providerTools stays the full registry (dispatch never depends on exposure).
+  // activeTools is the model-visible subset: every direct tool plus any deferred
+  // tool already loaded this session. The AI SDK serializes only activeTools to
+  // the provider, so deferred-and-unloaded schemas stay off the wire.
+  const activeTools = visibleTools
+    .filter((tool) => tool.exposure !== 'deferred' || loadedDeferredNames.has(tool.name))
+    .map((tool) => tool.name);
   return {
     providerTools: [...visibleTools, invalidTool],
-    activeTools: visibleTools.map((tool) => tool.name),
+    activeTools,
   };
 }
 

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -97,6 +97,14 @@ export interface ToolRuntimeInput {
 
 export class ToolRuntime {
   private activeSubagentToolCount = 0;
+  /**
+   * Per-step active-tool snapshot provider for deferred-tool gating (Layer 1,
+   * Slice 5). Set by the backend each turn (from `prepareStep`'s
+   * `onActiveSnapshot`); returns the names advertised to the model for the step
+   * currently executing. Undefined when deferred loading is off — the guard is
+   * then fully inert.
+   */
+  private stepActivation?: () => ReadonlySet<string>;
 
   constructor(private readonly input: ToolRuntimeInput) {}
 
@@ -111,8 +119,19 @@ export class ToolRuntime {
     ): Promise<unknown> => this.executeTool(tool, turnId, queue, args, ctx);
   }
 
+  /**
+   * Install the per-step active-tool snapshot provider used to gate deferred
+   * tools. The backend recomputes the snapshot before each step; the guard in
+   * `executeTool` rejects a deferred tool whose name is not in it. Pass
+   * `undefined` to disable gating.
+   */
+  setStepActivation(get: (() => ReadonlySet<string>) | undefined): void {
+    this.stepActivation = get;
+  }
+
   resetTurnState(): void {
     this.activeSubagentToolCount = 0;
+    this.stepActivation = undefined;
   }
 
   async writeSyntheticToolResult(
@@ -184,6 +203,25 @@ export class ToolRuntime {
       permissionRequired: tool.permissionRequired !== false,
       ...(tool.categoryHint !== undefined ? { categoryHint: tool.categoryHint } : {}),
     });
+
+    // Deferred-tool execute-boundary guard (Layer 1, Slice 5; Codex Δ5). Uses
+    // the step-start snapshot, NOT a cumulative loaded-set: if one step emits
+    // `load_tool(x)` and a tool from `x` in parallel, that tool is not yet
+    // active (it activates only at the next step's `prepareStep`), so it is
+    // rejected here — before permission eval and before the real impl. This
+    // also closes the AI SDK `activeTools` leak (vercel/ai#8653). The rejection
+    // is recoverable: the model loads via `load_tool`, then retries next step.
+    if (tool.exposure === 'deferred' && this.stepActivation && !this.stepActivation().has(tool.name)) {
+      const reason = formatDeferredNotLoadedText(tool.name);
+      await this.writeSyntheticToolResult(toolUseId, turnId, reason, queue);
+      trace?.emit('tool', 'tool_failed', 'Deferred tool used before load', {
+        toolUseId,
+        toolName: tool.name,
+        status: 'error',
+        errorClass: 'DeferredNotLoaded',
+      });
+      return this.errorReturn(reason);
+    }
 
     if (tool.permissionRequired !== false) {
       const verdict = this.input.permissionEngine.evaluate({
@@ -515,6 +553,18 @@ export class ToolRuntime {
   private errorReturn(message: string): unknown {
     return { error: message };
   }
+}
+
+/**
+ * Recoverable message returned when a deferred tool is invoked before its group
+ * is loaded. Tells the model exactly how to self-correct: load via `load_tool`,
+ * then retry on a later step.
+ */
+export function formatDeferredNotLoadedText(toolName: string): string {
+  return (
+    `Tool "${toolName}" is available but not loaded yet. ` +
+    `Call load_tool to load its group first, then call "${toolName}" on a later step.`
+  );
 }
 
 export function formatSyntheticToolErrorText(error: unknown): string {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -34,6 +34,14 @@ export interface MakaTool<P = any, R = unknown> {
   /** Zod schema describing the tool's argument shape. */
   parameters: unknown;
   /**
+   * Exposure tier. `direct` (the default when omitted) tools are advertised to
+   * the model every turn. `deferred` tools are withheld from the model-visible
+   * `activeTools` set until loaded on demand via `load_tool`, keeping their
+   * schema out of the per-turn prompt. Dispatch works regardless of exposure —
+   * a deferred tool stays in `providerTools` so it is callable once activated.
+   */
+  exposure?: 'direct' | 'deferred';
+  /**
    * If `false`, the wrap layer skips PermissionEngine.evaluate() entirely.
    * Defaults to `true` (always go through the engine).
    */

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5788,6 +5788,82 @@ export const Composer = forwardRef<
   );
 });
 
+// Mirror of runtime's LOAD_TOOL_NAME. @maka/ui must not depend on @maka/runtime,
+// so the always-on deferred-loading catalog tool's name is duplicated here as the
+// single hook for its friendly, locale-aware presentation.
+const LOAD_TOOL_NAME = 'load_tool';
+
+/** Locale-aware display name for the deferred-loading catalog tool. */
+export function loadToolDisplayName(locale: UiLocale): string {
+  return locale === 'en' ? 'Load tools' : '加载工具组';
+}
+
+export interface LoadToolResultDescription {
+  title: string;
+  countLabel: string;
+  toolsText: string;
+  footer: string;
+}
+
+/**
+ * Turn a `load_tool` call + its thin `{ loaded: [...] }` result into friendly,
+ * locale-aware card copy. Returns `null` when the result is not the expected
+ * shape (e.g. a load failure, which is a text/error result) so the caller falls
+ * back to the generic preview.
+ */
+export function describeLoadToolResult(
+  args: unknown,
+  value: unknown,
+  locale: UiLocale,
+): LoadToolResultDescription | null {
+  const loaded = (value as { loaded?: unknown } | null | undefined)?.loaded;
+  if (!Array.isArray(loaded) || !loaded.every((name) => typeof name === 'string')) {
+    return null;
+  }
+  const tools = loaded as string[];
+  const rawNamespace = (args as { namespace?: unknown } | null | undefined)?.namespace;
+  const namespace =
+    typeof rawNamespace === 'string' && rawNamespace.length > 0 ? rawNamespace : undefined;
+  const n = tools.length;
+  if (locale === 'en') {
+    return {
+      title: namespace ? `Loaded ${namespace} tool group` : 'Tools loaded',
+      countLabel: n === 1 ? '1 tool now available:' : `${n} tools now available:`,
+      toolsText: tools.join(', '),
+      footer: 'Ready to use on the next step',
+    };
+  }
+  return {
+    title: namespace ? `已加载 ${namespace} 工具组` : '已加载工具组',
+    countLabel: `新增 ${n} 个可用工具：`,
+    toolsText: tools.join('、'),
+    footer: '下一步即可调用',
+  };
+}
+
+/** Friendly tool name: an explicit displayName wins; load_tool gets a localized name. */
+function resolveToolDisplayName(item: ToolActivityItem): string {
+  if (item.displayName) return item.displayName;
+  if (item.toolName === LOAD_TOOL_NAME) return loadToolDisplayName(detectUiLocale());
+  return item.toolName;
+}
+
+/** Friendly card for a `load_tool` result; falls back to JSON on unexpected shapes. */
+function LoadToolResultPreview(props: { args: unknown; value: unknown }) {
+  const desc = describeLoadToolResult(props.args, props.value, detectUiLocale());
+  if (!desc) {
+    return <OverlayPreview content={{ kind: 'json', value: props.value }} />;
+  }
+  return (
+    <div className="maka-load-tool-preview" data-kind="load_tool">
+      <p className="maka-load-tool-title">{desc.title}</p>
+      <p className="maka-load-tool-count">{desc.countLabel}</p>
+      <p className="maka-load-tool-tools">{desc.toolsText}</p>
+      <p className="maka-load-tool-footer">{desc.footer}</p>
+    </div>
+  );
+}
+
 const STATUS_LABEL: Record<ToolActivityItem['status'], string> = {
   pending: '排队中',
   waiting_permission: '等待权限',
@@ -5883,7 +5959,7 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
           >
             <summary className="maka-tool-header">
               <span className="maka-tool-status-dot" data-status={item.status} aria-hidden="true" />
-              <span className="maka-tool-name">{item.displayName ?? item.toolName}</span>
+              <span className="maka-tool-name">{resolveToolDisplayName(item)}</span>
               <span className="maka-tool-meta">
                 {duration && <span className="maka-tool-duration">{duration}</span>}
                 <span className="maka-tool-status-label">{STATUS_LABEL[item.status]}</span>
@@ -5903,7 +5979,13 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
                   truncated={item.outputTruncated === true}
                 />
               )}
-              {item.result && !permissionDenied && <OverlayPreview content={item.result} />}
+              {item.result && !permissionDenied && (
+                item.toolName === LOAD_TOOL_NAME && item.result.kind === 'json' ? (
+                  <LoadToolResultPreview args={item.args} value={item.result.value} />
+                ) : (
+                  <OverlayPreview content={item.result} />
+                )
+              )}
             </div>
           </details>
         );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@ export * from './assistant-stream.js';
 export * from './components.js';
 export * from './maka-uri.js';
 export * from './materialize.js';
+export * from './permission-queue.js';
 export * from './redact.js';
 export * from './smooth-stream.js';
 export * from './thinking-stream.js';

--- a/packages/ui/src/permission-queue.ts
+++ b/packages/ui/src/permission-queue.ts
@@ -35,6 +35,22 @@ export function dequeuePermission(
   return { ...queues, [sessionId]: queue.filter((r) => r.requestId !== requestId) };
 }
 
+/**
+ * Remove a request by its toolUseId. A permission that ends without a user
+ * decision — a runtime timeout / expiry — emits a `tool_result` rather than a
+ * `permission_decision_ack`, so the renderer drains the stale queue entry on
+ * that result. No-op once the request was already dequeued via its ack.
+ */
+export function dequeuePermissionByToolUseId(
+  queues: PermissionQueues,
+  sessionId: string,
+  toolUseId: string,
+): PermissionQueues {
+  const queue = queues[sessionId];
+  if (!queue || !queue.some((r) => r.toolUseId === toolUseId)) return queues;
+  return { ...queues, [sessionId]: queue.filter((r) => r.toolUseId !== toolUseId) };
+}
+
 /** Drop every pending request for a session (its turn errored / aborted / ended). */
 export function clearPermissions(queues: PermissionQueues, sessionId: string): PermissionQueues {
   if (!queues[sessionId]?.length) return queues;

--- a/packages/ui/src/permission-queue.ts
+++ b/packages/ui/src/permission-queue.ts
@@ -1,0 +1,50 @@
+import type { PermissionRequestEvent } from '@maka/core';
+
+/**
+ * Per-session permission request queues.
+ *
+ * The renderer used to hold a single pending request per session, so when a
+ * model fired several tool calls in one step (e.g. `browser_snapshot` +
+ * `browser_extract` in parallel), the later `permission_request` overwrote the
+ * earlier one. The overwritten request could never be answered — its tool stayed
+ * parked forever while the run status flipped back to "running" — and the turn
+ * hung until the user stopped it. A FIFO queue keeps every parallel request, so
+ * the user clears them one by one and nothing is stranded.
+ */
+export type PermissionQueues = Record<string, PermissionRequestEvent[]>;
+
+/** Append a request to a session's queue, ignoring duplicates by requestId. */
+export function enqueuePermission(
+  queues: PermissionQueues,
+  sessionId: string,
+  request: PermissionRequestEvent,
+): PermissionQueues {
+  const queue = queues[sessionId] ?? [];
+  if (queue.some((r) => r.requestId === request.requestId)) return queues;
+  return { ...queues, [sessionId]: [...queue, request] };
+}
+
+/** Remove a resolved request by id; the next queued request becomes the head. */
+export function dequeuePermission(
+  queues: PermissionQueues,
+  sessionId: string,
+  requestId: string,
+): PermissionQueues {
+  const queue = queues[sessionId];
+  if (!queue) return queues;
+  return { ...queues, [sessionId]: queue.filter((r) => r.requestId !== requestId) };
+}
+
+/** Drop every pending request for a session (its turn errored / aborted / ended). */
+export function clearPermissions(queues: PermissionQueues, sessionId: string): PermissionQueues {
+  if (!queues[sessionId]?.length) return queues;
+  return { ...queues, [sessionId]: [] };
+}
+
+/** The request the user should act on now: the head of the session's queue. */
+export function activePermissionFor(
+  queues: PermissionQueues,
+  sessionId: string | undefined,
+): PermissionRequestEvent | undefined {
+  return sessionId ? queues[sessionId]?.[0] : undefined;
+}


### PR DESCRIPTION
## Summary

Layer 1 of the tool-loading roadmap (issue #15): **deferred (on-demand) tool loading.** The heavy-schema tool families are withheld from the per-turn prompt and loaded on demand via a small always-on `load_tool` catalog, cutting the per-turn tool-schema weight by **~2,143 tokens (−69.3%)** whenever those families are idle — which is the common case.

This is **not** tool-retrieval/selection. At 17 tools we are well below the ~30–50 degradation threshold (OpenAI <20, Anthropic 30–50). It is a pure token-weight optimization: keep every tool's *existence* visible, defer only the expensive *parameter schema*.

- **Two-tier exposure, one registry.** A new `exposure?: 'direct' | 'deferred'` field on `MakaTool` (default `direct`). `providerTools` stays the full registry for dispatch; the model-visible `activeTools` set is `direct ∪ {load_tool} ∪ loaded-deferred`. The AI SDK serializes only `activeTools` to the provider (verified against `ai@6.0.185` source — `prepareToolsAndToolChoice` filters `tools` by `activeTools`, only the filtered array reaches `doStream`), so deferred-and-unloaded schemas stay off the wire across OpenAI / Anthropic / Google / openai-compatible.
- **`load_tool` = lookup, not search.** Always-on, tiny. Its static description carries one card per namespace (`rive` / `office` / `browser`) = name + one-line summary, so the model knows the capability exists and expands one by name. `load_tool({ namespace })` returns a **thin** `{ loaded: [...toolNames] }` — never the JSON schema (that would double-bill: once in history, once in the provider tools next step). The schema reaches the model only via `activeTools`.
- **Same-turn activation via `prepareStep`.** `streamText` is handed `activeTools` once and re-filters every internal step against that frozen array, so without `prepareStep` a tool loaded at step N stays invisible until the *next user turn*. The backend now installs a `prepareStep` that recomputes `activeTools` before each step from the step history it is handed (`steps[].toolCalls` for `load_tool`) — stateless, no race with tool execution. A tool loaded at step N is advertised at step N+1 of the same turn.
- **Execute-boundary guard (step snapshot).** `ToolRuntime` holds a per-step active snapshot (fed by the backend from `prepareStep`'s `onActiveSnapshot`) and rejects a deferred tool absent from it — after the `ToolCallMessage` (call/result pairing stays intact) but **before** permission eval and the real impl. It uses the **step-start** snapshot, not a cumulative loaded-set: if one step emits `load_tool(browser)` + `browser_click` in parallel, `browser_click` is rejected (browser activates only at the next step's `prepareStep`). This closes the known AI SDK `activeTools` leak (vercel/ai#8653) and makes the rejection recoverable — the model loads, then retries.
- **Durable cross-turn ratchet.** The loaded-set is reconstructed at turn start from the durable RuntimeEvent ledger (`seedNamespacesFromRuntimeEvents` scans committed `load_tool` `function_call` events), so a tool loaded earlier in the session is re-advertised on every later turn. It survives history compaction and session recovery because it reads the ledger, not the prompt tail. Append-only: once loaded, a tool stays active for the session (no idle eviction → fewer cache resets, no capability drift). An aborted load simply never reaches committed history; re-loading on retry is idempotent.
- **Honest cost diagnostics (#19 synergy).** `toolSchemaHash` / `toolSchemaCharsForDiagnostics` now measure the **active (provider-visible) subset**, not the full registry — otherwise an inactive deferred schema would over-count tokens and a change to an unadvertised schema would false-fire `tool_schema_changed`. A genuine load still moves the hash and is labeled `tool_schema_changed`: one bounded prompt-cache reset the first time each family loads per session, then a leaner *and* stable prefix.
- **Desktop wiring.** `main.ts` tags the heavy families (RiveWorkflow, OfficeDocument×2, the 6 `browser_*` tools) `deferred`, builds the 3-namespace catalog from the real tool names, registers `buildLoadTool(catalog)`, and threads `deferredCatalog` into `AiSdkBackend`.

## Design notes (where the deltas came from)

The mechanism is proven (Claude Code reverted to this two-tier form in v2.1.72; PawWork ships it). Before building, a Codex second-opinion pass over the design produced five corrections, all folded in:

- **Δ1** `prepareStep` is mandatory for same-turn use (the frozen-`activeTools` trap above).
- **Δ2** `load_tool` returns the thin `{loaded}` result, never the schema (no double-billing).
- **Δ3** diagnostics measure the active subset, not full `providerTools`.
- **Δ4** seed the loaded-set from a durable source (ledger), not just the prompt tail.
- **Δ5** the guard uses the per-step snapshot, not the cumulative set, to handle the same-step parallel `load_tool(x)`+`x` trap.

## Deliberate scope

- **Defer only the heavy families.** Rive (17+ params), Office×2, browser×6 dominate the schema weight; core 5 (Read/Write/Bash/Glob/Grep) + Skill + WebSearch + Explore + `load_tool` stay always-on. Explore stays direct (single + frequent). Confirmed by measurement (below) — the heavy families are 8,570 of 12,358 schema chars.
- **Provider-neutral.** No Anthropic `defer_loading` / OpenAI `tool_search` natives — Maka spans DeepSeek / Ollama / openai-compatible / Gemini / Anthropic, so gating happens in `activeTools` (which all adapters honor) rather than a provider feature.
- **Append-only, no idle eviction.** Eviction would trade a one-time-per-family cache reset for repeated resets + capability drift. The ratchet keeps the prefix stable after first load.
- **Test-gated, default-on, with a kill-switch.** The mechanism is proven, so the gate is a rigorous suite + one env switch (`MAKA_DISABLE_DEFERRED_TOOLS` → all tools direct, no `load_tool`, inert guard), not a gradual rollout.
- **One cache reset per first-load is intentional and bounded.** Provider-neutral means a load mutates the tools block once per family per session; #19 labels it `tool_schema_changed`. Net: leaner per-turn weight and a stable prefix between loads.

## Verification

Re-run on this branch (rebased onto latest `main`):

- `npm run typecheck` — clean across core / storage / runtime / ui / desktop (`main.ts` included).
- Unit tests:
  - core **618 pass / 0 fail**
  - storage **82 pass / 0 fail**
  - desktop **1476 pass / 0 fail**
  - runtime **529 pass / 1 fail of 530** — the 1 fail is the pre-existing, environment-dependent `network/proxy-test` ("times out when the proxy accepts TCP but never responds" asserts `/timeout/i`, but in this sandbox `fetch` returns "fetch failed" before the timeout fires). This PR touches no network code.

New tests (33) covering every slice:

- **Exposure gating** (`request-shape.test.ts`, 4): deferred excluded from `activeTools` until loaded; `providerTools` stays full; `invalid` never advertised; omitted exposure = direct.
- **Wire-trim** (`deferred-tools-wire.test.ts`, 2): a `MockLanguageModelV3` through `ModelAdapter.startStream` proves an unloaded deferred tool never reaches `doStream`.
- **`load_tool`** (`load-tool.test.ts`, 4): valid namespace → `{loaded}`; unknown rejected; no schema in the result.
- **Same-turn activation** (`deferred-tools-prepare-step.test.ts`, 1): end-to-end — a tool loaded at step 0 reaches the provider at step 1.
- **Per-step derivation + durable seed** (`deferred-activation.test.ts`, +): `loadedNamespacesFromSteps`, `seedNamespacesFromRuntimeEvents`, `computeActiveTools`, `buildDeferredPrepareStep`.
- **Active-subset diagnostics** (`request-shape.test.ts`, 3): char/hash reflect the active subset; an inactive deferred schema change does NOT move the hash; a load does (`tool_schema_changed`).
- **Execute-boundary guard** (`deferred-guard.test.ts`, 4): a deferred tool absent from the snapshot is rejected with no impl and no permission eval; an active one runs; inert with no snapshot installed; a direct tool is never gated.
- **Live backend** (`deferred-tools-backend.test.ts`, 7): step 0 hides the unloaded deferred tool but advertises `load_tool`; a prior-turn load re-advertises it next turn (durable seed); same-step parallel `load_tool(browser)`+`browser_click` rejects the click through the real `AiSdkBackend`; a mis-cased `BROWSER_CLICK` emitted the step after `load_tool(browser)` repairs to canonical `browser_click` and runs; a same-turn `load_tool(browser)` records tool-schema cost for the **expanded** set, not the lean step-0 set; the context-budget high-water "after" hash stays equal to the final recorded `requestShapeHash` across a same-turn load; a deferred-tagged tool with **no catalog** stays advertised at step 0.
- **load_tool presentation** (`load-tool-presentation.test.ts`, 5, desktop): localized display name (加载工具组 / "Load tools"); friendly result-card copy in zh + en with singular/plural counts; generic-title fallback when the namespace is missing; `null` (→ generic JSON preview) on an unexpected result shape.

### Review follow-ups

- **Codex [P2]** — the repair callback matched case-drifted tool names against the first-step `activeTools`, so a mis-cased *loaded* deferred name would route to `invalid` instead of repairing. Fixed in `fd9445e1`: the repair set now follows the current step's active snapshot.
- **GPT-Pro [P2]** — cost/cache telemetry was computed once at stream start from the step-0 active set, so the first turn that called `load_tool` under-reported the heavy schema actually sent on step N+1 and surfaced the cache reset a turn late. Fixed in `ff9c4827`: one `computeTurnDiagnostics(active)` source of truth — the stream-start trace reports the step-0 view (what the first request carries), then the durable cost record + prefix baseline are refined against the final active set once the stream is consumed (no-op when nothing loaded).
- **GPT-Pro [P3]** — `canonicalizeToolSet()` hid any `exposure:'deferred'` tool when called without a loaded-names set, but an absent `deferredCatalog` is documented as "advertise everything". A deferred tag with no catalog would have stranded the tool with no `load_tool` to recover it. Fixed in `ff9c4827`: with no catalog the backend seeds all deferred names as loaded, and the `canonicalizeToolSet` contract is now documented.
- **GPT-Pro Web [P3]** — after rebasing onto `main` (which added a context-budget high-water block), `highWaterRequestShapeHashAfter` was set from the step-0 shape and never refreshed when a same-turn load refined the recorded shape, leaving the two diagnostic fields internally inconsistent. Fixed in `c1ec3404`: a single `publishTurnDiagnostics()` updates the cost record, the prefix baseline, and the high-water "after" hash together; the "before" hash stays the pre-turn baseline.
- **UX follow-up** — the always-on `load_tool` surfaced as its raw name + raw JSON result. Given a friendly, locale-aware presentation (display name + result card, following the zh/en UI setting) in `38552cae` — pure renderer change, no backend types touched.

### Follow-on fix: parallel permission requests (found in local Electron testing)

Exercising deferred loading in the running app made `browser_snapshot` appear to "fail" whenever deferral was ON. Reading two ON-session RuntimeEvent ledgers gave the real cause: after `load_tool(browser)` the model (deepseek) **batch-called** `browser_snapshot` + `browser_extract` in parallel, producing two `permission_request` events for one session. The renderer held a **single** pending permission per session, so the second request overwrote the first; the overwritten one could never be answered — its tool stayed parked while run status flipped back to `running` — and the turn hung until the user force-stopped it (`browser_snapshot` then failed with `errorClass: "Permission"`).

Deferral is only the *trigger* (loading a whole group makes the model batch-call it); activation itself is correct — snapshot passes the guard and reaches permission normally. Fixed in `49bacf23` by replacing the single slot with a per-session **FIFO queue** (`@maka/ui` `permission-queue`): parallel requests all survive and are cleared one at a time (queue head = active overlay). Unit-tested (`permission-queue.test.ts`, 6) including the exact stranded-snapshot scenario; the `main.tsx` complete-case source contract updated to assert `clearPermissions(...)`.

**Codex review (`/codex review`, xhigh) — three P2 advisories, all fixed in `043cfc32`:**

- **[P2] `rememberForTurn` didn't absorb concurrent same-scope parked requests.** `browser_*` shares one turn-scope, so a parallel batch that all parks then gets one "remember for this turn" answer should not re-prompt for the rest. `recordResponse` now resolves the same-scope parked promises; each tool's coroutine emits its own ack and the UI queue drains without a second click.
- **[P2] An expired/timed-out permission could resurface as an un-answerable overlay.** Timeout emits a `tool_result`, not a `permission_decision_ack`, so the FIFO queue kept the stale entry. The renderer's `tool_result` handler now dequeues by `toolUseId` (`dequeuePermissionByToolUseId`); no-op on the normal ack path.
- **[P2] Telemetry `toolCount` still counted the full registry.** Now counts the active (provider-visible) subset, matching `toolSchemaChars`, so the cost/diagnostic record reflects the on-demand drop under deferred loading.

Token before/after (authoritative, real builders; measured set = core 5 + Explore + heavy 9):

| | tools advertised | tool-schema chars | ≈ tokens |
|---|---|---|---|
| Deferral OFF (all advertised) | 15 | 12,358 | ~3,090 |
| Deferral ON, heavy families idle | 7 | 3,788 | ~947 |
| **Saved per idle turn** | | **8,570** | **~2,143 (−69.3%)** |

The `load_tool` catalog itself costs 762 chars. (Skill/WebSearch are excluded from the table — direct in both modes, so they don't change the absolute saving; the % is relative to the measured set.)
