### PR TITLE
[codex] fix runtime ledger refresh race

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -294,6 +294,34 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents[2]?.status).toBe('completed');
   });
 
+  test('completed turns are readable when the complete event reaches the renderer', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const runtimeEventStore = new MemoryRuntimeEventStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TextCompleteBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_625),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    const iterator = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.type).toBe('text_delta');
+    expect((await iterator.next()).value?.type).toBe('text_complete');
+    expect((await iterator.next()).value?.type).toBe('complete');
+
+    const messages = await manager.getMessages(session.id);
+    expect(messages.map((message) => message.type)).toEqual(['user', 'assistant', 'turn_state']);
+
+    await iterator.next();
+  });
+
   test('runtime event ledger write failure does not fail sendMessage', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -1946,6 +1974,46 @@ class TestBackend implements AgentBackend {
       this.ctx.store.disposeCount += 1;
     }
   }
+}
+
+class TextCompleteBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(ctx: BackendFactoryContext) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const messageId = `${input.turnId}-m`;
+    yield {
+      type: 'text_delta',
+      id: `${input.turnId}-delta`,
+      turnId: input.turnId,
+      ts: 7_000,
+      messageId,
+      text: 'ok',
+    };
+    yield {
+      type: 'text_complete',
+      id: `${input.turnId}-text-complete`,
+      turnId: input.turnId,
+      ts: 7_001,
+      messageId,
+      text: 'ok',
+    };
+    yield {
+      type: 'complete',
+      id: `${input.turnId}-complete`,
+      turnId: input.turnId,
+      ts: 7_002,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
 }
 
 class LateErrorBackend implements AgentBackend {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -91,8 +91,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const aiSdkFlow = new AiSdkFlow({
       backend: begin.backend,
       drainAfterTerminal: true,
-      onSessionEvent: async (sessionEvent) => {
+      onSessionEvent: async (sessionEvent, runtimeEvent) => {
         await run.recordSessionEvent(sessionEvent);
+        await run.recordRuntimeEvents([runtimeEvent]);
         await sessionEvents.push(sessionEvent);
       },
       onError: async (error) => {
@@ -110,6 +111,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const runner = new RuntimeRunner({
       flow: aiSdkFlow,
       providers: { newId: this.deps.newId, now: this.deps.now },
+      onInitialRuntimeEvent: (event) => run.recordRuntimeEvents([event]),
       stopOnTerminal: false,
     });
     const runnerResult = runner.run({
@@ -124,7 +126,6 @@ export class RuntimeKernel implements RuntimeKernelLike {
       lineage: run.lineage,
       abortSignal: abortController.signal,
     }).then(async (result) => {
-      await run.recordRuntimeEvents(result.events);
       await this.deps.runtimeInvocationObserver?.(result);
       return result;
     }, (error) => {

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -101,6 +101,12 @@ export interface RuntimeRunnerDeps {
   /** Injectable id/time providers. Defaults to crypto.randomUUID / Date.now. */
   providers?: InvocationProviders;
   /**
+   * Called after the initial user RuntimeEvent is built and before the flow is
+   * dispatched. RuntimeRunner still does not own storage; orchestration layers
+   * can use this to keep durable ledgers ahead of renderer-visible events.
+   */
+  onInitialRuntimeEvent?: (event: RuntimeEvent) => Promise<void> | void;
+  /**
    * Whether to stop collecting at the first terminal RuntimeEvent. Defaults
    * to true for standalone runner callers; production bridges can set false
    * to keep draining cleanup/trailing events from wrapped streams.
@@ -116,12 +122,14 @@ export class RuntimeRunner {
   private readonly flow: AgentFlowLike;
   private readonly gate: RuntimeGate | undefined;
   private readonly providers: InvocationProviders;
+  private readonly onInitialRuntimeEvent: RuntimeRunnerDeps['onInitialRuntimeEvent'];
   private readonly stopOnTerminal: boolean;
 
   constructor(deps: RuntimeRunnerDeps) {
     this.flow = deps.flow;
     this.gate = deps.gate;
     this.providers = deps.providers ?? createDefaultInvocationProviders();
+    this.onInitialRuntimeEvent = deps.onInitialRuntimeEvent;
     this.stopOnTerminal = deps.stopOnTerminal ?? true;
   }
 
@@ -195,7 +203,9 @@ export class RuntimeRunner {
     const events: RuntimeEvent[] = [];
 
     // 4. Emit the initial user RuntimeEvent before any flow event.
-    events.push(buildUserEvent(ctx, request));
+    const userEvent = buildUserEvent(ctx, request);
+    await this.onInitialRuntimeEvent?.(userEvent);
+    events.push(userEvent);
     const flowInput = buildFlowInput(request);
 
     // 5. Dispatch to the flow and collect canonical events. By default the


### PR DESCRIPTION
## What changed

This fixes a race where the renderer could auto-refresh a chat after receiving the terminal session event, before the matching RuntimeEvent ledger entries were durable.

The runtime now records the initial user RuntimeEvent before dispatching the flow, and records each streamed RuntimeEvent before exposing the corresponding SessionEvent to the renderer.

## Why

After an AI response completed, the desktop app automatically refreshed the conversation. In a narrow timing window, the read model saw a terminal session state but could not yet find the terminal RuntimeEvent ledger fact, which surfaced as the toast:

`刷新对话失败 对话内容暂时无法刷新，请稍后重试。`

## User impact

Completed turns should be readable immediately when the renderer receives the completion event, so the chat can refresh without showing a false refresh-failure toast.

## Tests

- Added a runtime regression test for reading messages immediately after the `complete` event reaches the renderer.
- `npm run typecheck --workspaces --if-present`
- `npm --workspace @maka/runtime run test`
- `npm run build`
- `git diff --check`

## Notes

This does not change UI copy, layout, model behavior, or historical ledger recovery.
