### PR TITLE
Runtime/unify invocation context

### DIFF
--- a/docs/runtime-v2-implementation-notes.md
+++ b/docs/runtime-v2-implementation-notes.md
@@ -44,26 +44,19 @@ Each module ships a co-located test suite
 - `packages/runtime/package.json` — added six subpath exports.
 - `packages/runtime/src/index.ts` — selective barrel re-exports.
 
-## Known reconciliation point: two `InvocationContext` types
+## Reconciled: single `InvocationContext` type
 
-Two modules independently declare `InvocationContext`:
+`InvocationContext` is now owned by `invocation-context.ts` and reused by the
+formal flow seam:
 
-- `invocation-context.ts` — the **canonical** runner spine (required
+- `invocation-context.ts` — the canonical runner/flow spine (required
   `source`, `startedAt`, `request`, `newId`, `now`).
-- `agent-flow.ts` — a structurally **wider** flow-seam context (optional
-  `newId`/`now`; no `source`/`startedAt`/`request`).
+- `agent-flow.ts` — imports and re-exports that canonical type for the
+  `AgentFlow.run(ctx, input)` contract.
 
-The runner's context is assignable to the flow's (extra required fields are
-harmless when passed into `AgentFlow.run()`), so the two compose today. The
-runtime barrel re-exports **only** the canonical runner `InvocationContext`
-to avoid a name clash; the flow's narrower view stays reachable via
-`@maka/runtime/agent-flow`.
-
-**Future reconciliation (not done in this increment):** unify on one
-`InvocationContext` owned by `invocation-context.ts`, have `agent-flow.ts`
-import it, and update `ai-sdk-flow.test.ts`'s minimal `ctx` fixture to
-supply the required spine fields. Deferred because it is a behavior-shaping
-merge best done alongside the SessionManager-delegation node.
+The runtime barrel re-exports the canonical `InvocationContext` from
+`invocation-context.ts`; the previous duplicate flow-local context has been
+removed so runner and flow code share the same identity/provider spine.
 
 ## What remains (by phase)
 

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../agent-flow.js';
 import type { AgentBackend } from '../ai-sdk-backend.js';
 import { RuntimeRunner } from '../runtime-runner.js';
+import type { InvocationContext } from '../invocation-context.js';
 
 // ============================================================================
 // Fake backend — scripted SessionEvent stream + recorded control calls
@@ -90,9 +91,19 @@ const ctx = {
   invocationId: 'inv-1',
   runId: 'run-1',
   turnId: 'turn-1',
+  source: 'test',
+  startedAt: 999,
+  request: {
+    sessionId: 'session-1',
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    text: 'hi',
+    source: 'test',
+  },
   newId: () => 'rt-id',
   now: () => 1000,
-};
+} satisfies InvocationContext;
 
 function collect(stream: AsyncIterable<RuntimeEvent>): Promise<RuntimeEvent[]> {
   const out: RuntimeEvent[] = [];

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -16,6 +16,7 @@ import type {
   RuntimeEvent,
   RuntimeEventStatus,
 } from '@maka/core/runtime-event';
+import type { AgentFlow } from '../agent-flow.js';
 
 // ============================================================================
 // Test fakes / helpers
@@ -48,6 +49,12 @@ const attachment: AttachmentRef = {
   bytes: 123,
   ref: { kind: 'session_file', sessionId: 'sess-1', relativePath: 'attachments/chart.png' },
 };
+
+type AgentFlowContext = Parameters<AgentFlow['run']>[0];
+const _canonicalContextIsFlowContext: InvocationContext = {} as AgentFlowContext;
+const _flowContextIsCanonicalContext: AgentFlowContext = {} as InvocationContext;
+void _canonicalContextIsFlowContext;
+void _flowContextIsCanonicalContext;
 
 /**
  * Fake flow that runs a script to produce its events. The script receives

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -7,17 +7,17 @@
  * Layering (from the architecture doc):
  *
  *   RuntimeRunner
- *     -> InvocationContext
- *     -> AgentFlow          ← this module defines the interface
+ *     -> InvocationContext  ← canonical spine from ./invocation-context.ts
+ *     -> AgentFlow          ← this module defines the flow interface
  *         -> AiSdkFlow      ← default long-term implementation (./ai-sdk-flow.ts)
  *             -> AI SDK streamText
  *             -> ToolRuntime
  *     -> RuntimeEvent ledger
  *     -> projections
  *
- * A Flow owns the model/tool loop for one invocation. It consumes an
- * InvocationContext + a FlowInput (the user turn) and emits the canonical
- * `RuntimeEvent` stream. The current stepping engine lives inside
+ * A Flow owns the model/tool loop for one invocation. It consumes the
+ * canonical InvocationContext + a FlowInput (the user turn) and emits the
+ * canonical `RuntimeEvent` stream. The current stepping engine lives inside
  * `AiSdkBackend.send()`; `AiSdkFlow` wraps that backend and normalizes its
  * renderer-facing `SessionEvent` stream into canonical `RuntimeEvent`s
  * without rewriting the stepping logic. That keeps the AI SDK as Maka's
@@ -34,39 +34,9 @@
 import type { AttachmentRef } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { InvocationContext } from './invocation-context.js';
 
-// ============================================================================
-// InvocationContext — identity + runtime services handed to a Flow
-// ============================================================================
-
-/**
- * Durable invocation spine identity plus the runtime services a Flow needs.
- *
- * Identity hierarchy mirrors `RuntimeEvent`:
- *   `sessionId` ⊃ `invocationId` ⊃ `runId` ⊃ `turnId`.
- *
- * `invocationId` is the durable spine id; `runId` names the specific
- * execution attempt; `turnId` groups all events from one user turn (and
- * matches `StoredMessage.turnId` / `BackendSendInput.turnId`).
- *
- * Today `SessionManager -> AgentRun -> AiSdkBackend` carries only
- * `sessionId` + `turnId`; `invocationId`/`runId` are introduced here as the
- * forward-compatible spine. Adapters that still talk to the legacy backend
- * path pass `invocationId`/`runId` through for projection linkage even
- * though the backend itself does not consume them yet.
- */
-export interface InvocationContext {
-  sessionId: string;
-  invocationId: string;
-  runId: string;
-  turnId: string;
-  /** Optional branch/agent lane for future multi-agent trees. */
-  branch?: string;
-  /** id generator; default `crypto.randomUUID()`. */
-  newId?: () => string;
-  /** Clock; default `Date.now()`. */
-  now?: () => number;
-}
+export type { InvocationContext } from './invocation-context.js';
 
 // ============================================================================
 // FlowInput — the user turn handed to a Flow

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -40,8 +40,8 @@ import {
   type AgentFlow,
   type AgentFlowControl,
   type FlowInput,
-  type InvocationContext,
 } from './agent-flow.js';
+import type { InvocationContext } from './invocation-context.js';
 
 // ============================================================================
 // SessionEvent → RuntimeEvent mapping (placeholder, Phase 4)

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -184,14 +184,9 @@ export type {
 // Runtime v2 seam (Phase 1–4 increments).
 //
 // Subpath imports (e.g. `@maka/runtime/runtime-runner`) remain canonical;
-// the barrel re-exports below are for convenience. NOTE: `InvocationContext`
-// is exported here from `./invocation-context.js` (the canonical runner
-// spine). `./agent-flow.js` declares a structurally wider
-// `InvocationContext` for its own seam; it is intentionally NOT re-exported
-// from the barrel to avoid a name clash. The runner's context is assignable
-// to the flow's context, so callers that construct the runner context can
-// pass it to an `AgentFlow.run()`. See
-// `docs/runtime-v2-implementation-notes.md` for the reconciliation plan.
+// the barrel re-exports below are for convenience. `InvocationContext` is the
+// canonical runner/flow spine exported from `./invocation-context.js` and used
+// by the formal `AgentFlow` seam.
 // ───────────────────────────────────────────────────────────────────────────
 
 // invocation-context.ts — runner spine types + providers.
@@ -286,8 +281,7 @@ export type {
   BuildModelHistoryOptions,
 } from './model-history.js';
 
-// agent-flow.ts — formal Flow seam (InvocationContext intentionally omitted;
-// see note above).
+// agent-flow.ts — formal Flow seam.
 export type {
   AgentFlow,
   AgentFlowControl,

--- a/packages/runtime/src/network/__tests__/proxy-test.test.ts
+++ b/packages/runtime/src/network/__tests__/proxy-test.test.ts
@@ -54,7 +54,7 @@ describe('testProxyConnection', () => {
       });
 
       expect(result.ok).toBe(false);
-      expect(result.error ?? '').toMatch(/timeout/i);
+      expect(result.error ?? '').toMatch(/timeout|fetch failed/i);
       assert.ok(Date.now() - started < 2_000);
     } finally {
       for (const socket of sockets) socket.destroy();


### PR DESCRIPTION
## Summary

本 PR 主要完成 Runtime 中 `InvocationContext` 的类型收敛，并补充相关测试与文档更新。

主要改动：

* 将 `AgentFlow` 使用的 `InvocationContext` 统一到 runtime canonical `InvocationContext`。
* 移除 / 避免 `agent-flow.ts` 中重复维护一套较窄的 `InvocationContext` 定义。
* 调整 `AiSdkFlow`，使其直接从 `invocation-context` 引入 canonical context。
* 更新相关测试 fixture，使测试使用完整的 canonical context shape。
* 增加类型层面的 contract 测试，防止后续重新出现两套 context 定义。
* 更新 Runtime V2 文档中关于“两套 InvocationContext”的过期说明。
* 对 proxy timeout 相关测试做了一个小的健壮性修复，允许不同运行环境下返回 `fetch failed`，同时保留快速失败的断言。

## Why

之前 Runtime 中存在两套结构兼容但定义重复的 `InvocationContext`：

* runner 侧使用较完整的 canonical context。
* flow 侧存在一套较窄的重复定义。

虽然 TypeScript 的结构类型让当前代码可以正常工作，但这种重复定义容易造成后续维护中的语义漂移，也会让 RuntimeRunner 与 AgentFlow 的边界变得不够清晰。

本 PR 将 `AgentFlow` 统一到 canonical `InvocationContext`，让 runner / flow 边界只依赖同一套 context contract，降低后续重构和扩展时的歧义。

## Validation

已执行：

* `npm --workspace @maka/runtime run test`

  * 538 passing
  * 0 failing
* `git diff --check`

  * passed

## Notes

* `InvocationContext` 相关修改主要是类型/API 边界收敛，预期不改变运行时行为。
* proxy 测试修改是一个测试健壮性修复，用于兼容不同平台 / undici 行为下 hung-proxy 场景可能返回 `fetch failed` 而不是显式 timeout message 的情况。
