### PR TITLE
Add isolated headless benchmark foundation

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -27,20 +27,56 @@ maka-headless eval examples/demo.spec.json --out /tmp/maka-headless-demo
 
 `eval` is **untrusted by construction**: the config under test is something you
 are *measuring*, possibly weak or adversarial, so it must not reach the host.
-Without OS-level isolation the only safe enforcement is to **fail closed**:
+Without OS-level isolation the only safe enforcement is to **fail closed by
+default**:
 
-- Only the inert **`fake`** backend runs. Any model-backed backend (`ai-sdk`,
-  `pi-agent`) is **refused** before a run starts — it would execute
-  shell / network / file tools on your machine, and the throwaway workspace is
-  a copy, not a sandbox.
-- Real-model eval lands once the **isolated executor** ships (a follow-up:
-  per-run container, env allowlist so tools never inherit your secrets,
-  network policy). Until then `eval` on a real backend exits non-zero with a
-  clear refusal.
+- The CLI still wires only the inert **`fake`** backend. A model-backed backend
+  in a JSON spec exits non-zero unless the caller uses the programmatic API to
+  provide backend wiring.
+- Programmatic real-model eval must pass `realBackendIsolation` to
+  `runExperiment` plus a `registerBackends` factory. The isolation record is an
+  explicit assertion that tool execution is already outside the host credential
+  process (for example Harbor / Terminal-Bench or a Docker workspace executor).
+- If the caller wants Maka's standard tool surface, use
+  `buildIsolatedHeadlessTools(executor)`: it replaces `Bash` with a command
+  executor supplied by the isolation boundary, while keeping path-confined pure
+  file tools in the throwaway workspace.
 
 (An *operational* mode — intentionally running a trusted agent that *may* touch
 the host — can slot into this same entry later. That is a different, explicit
 trust posture, never the eval default.)
+
+Programmatic sketch:
+
+```ts
+import {
+  buildIsolatedHeadlessTools,
+  runExperiment,
+  type IsolatedToolExecutor,
+} from '@maka/headless';
+
+const executor: IsolatedToolExecutor = {
+  async exec(input) {
+    // Route to Harbor/Docker/etc. Do not inherit host env/secrets.
+    return { exitCode: 0, stdout: '', stderr: '' };
+  },
+};
+
+await runExperiment(config, task, {
+  storageRoot: '/tmp/maka-headless-runs',
+  realBackendIsolation: {
+    kind: 'external',
+    label: 'Harbor task container',
+    toolExecutor: executor,
+  },
+  registerBackends(registry, context) {
+    registry.register('ai-sdk', (ctx) => createAiSdkBackend({
+      ...ctx,
+      tools: buildIsolatedHeadlessTools(context.toolExecutor!),
+    }));
+  },
+});
+```
 
 ## Spec
 
@@ -85,8 +121,7 @@ and exits 0.
 
 ## Scope
 
-MVP. Deliberately later, as pure additions: the isolated executor (and with it
-real-model eval), parallel matrix execution, LLM/rule evaluators (today:
-exit-code of a command), SWE-bench pack ingestion, and a richer report than the
-markdown grid. Promote the contracts into `@maka/core` once a second consumer
-exists.
+MVP. Deliberately later, as pure additions: first-class Docker/Harbor backend
+registrars, parallel matrix execution, LLM/rule evaluators (today: exit-code of
+a command), SWE-bench pack ingestion, and a richer report than the markdown
+grid. Promote the contracts into `@maka/core` once a second consumer exists.

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -7,6 +7,7 @@ import { BackendRegistry, FakeBackend, type AgentBackend, type SessionStore } fr
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { Config, Task } from '../contracts.js';
+import type { HeadlessBackendContext } from '../isolation.js';
 import { runExperiment } from '../runner.js';
 
 const registerFakeBackend = (registry: BackendRegistry): void => {
@@ -83,6 +84,41 @@ const registerFailingBackend = (registry: BackendRegistry): void => {
     new FailingBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
   );
 };
+
+class IsolatedRealBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+  constructor(private readonly ctx: { sessionId: string; header: SessionHeader; store: SessionStore }) {
+    this.sessionId = ctx.sessionId;
+  }
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const turnId = input.turnId;
+    const ts = Date.now();
+    const messageId = 'isolated-real-msg';
+    await writeFile(join(this.ctx.header.cwd, 'solved.txt'), 'ok\n', 'utf8');
+    await this.ctx.store.appendMessage(this.sessionId, {
+      type: 'assistant',
+      id: messageId,
+      turnId,
+      ts,
+      text: 'solved inside explicit isolation',
+      modelId: this.ctx.header.model,
+    });
+    yield { type: 'text_complete', id: 'isolated-real-tc', turnId, ts, messageId, text: 'solved inside explicit isolation' };
+    yield { type: 'complete', id: 'isolated-real-c', turnId, ts, stopReason: 'end_turn' };
+  }
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerIsolatedRealBackend = (seen: HeadlessBackendContext[]): NonNullable<Parameters<typeof runExperiment>[2]['registerBackends']> =>
+  (registry, context) => {
+    seen.push(context);
+    registry.register('ai-sdk', (ctx) =>
+      new IsolatedRealBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+    );
+  };
 
 // A fixture whose grading script exits non-zero against the buggy source —
 // the only way `node check.mjs` passes is if the grading script is replaced.
@@ -246,6 +282,37 @@ describe('fail-closed (a model-backed backend does not run without isolation)', 
       );
     });
   });
+
+  test('runs a model-backed backend only when the caller supplies explicit isolation', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const realConfig: Config = {
+        id: 'real-cfg',
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-chat',
+      };
+      const task: Task = {
+        id: 'real-task',
+        instruction: 'create solved.txt',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f solved.txt', protectedPaths: [] },
+      };
+      const contexts: HeadlessBackendContext[] = [];
+
+      const result = await runExperiment(realConfig, task, {
+        storageRoot,
+        registerBackends: registerIsolatedRealBackend(contexts),
+        realBackendIsolation: { kind: 'external', label: 'unit-test isolated backend' },
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.passed, true);
+      assert.equal(contexts.length, 1);
+      assert.equal(contexts[0]?.realBackendIsolation?.label, 'unit-test isolated backend');
+      assert.equal(contexts[0]?.config.id, 'real-cfg');
+      assert.equal(contexts[0]?.task.id, 'real-task');
+    });
+  });
 });
 
 describe('failed runs surface as an error (not a silent ⚠️ + exit 0)', () => {
@@ -268,6 +335,7 @@ describe('failed runs surface as an error (not a silent ⚠️ + exit 0)', () =>
 
       assert.equal(result.status, 'failed');
       assert.ok(result.error, 'a failed run must carry an error so the CLI exit code and the table agree');
+      assert.equal(result.errorClass, 'backend_failed');
       assert.equal(result.passed, false);
     });
   });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { buildIsolatedBashTool, buildIsolatedHeadlessTools } from '../tools.js';
+
+describe('isolated headless tools', () => {
+  test('Bash delegates execution to the isolated executor', async () => {
+    const calls: unknown[] = [];
+    const emitted: Array<{ stream: string; chunk: string }> = [];
+    const bash = buildIsolatedBashTool({
+      async exec(input) {
+        calls.push(input);
+        return { exitCode: 7, stdout: 'out\n', stderr: 'err\n' };
+      },
+    });
+
+    const result = await bash.impl(
+      { command: 'npm test', timeout_ms: 12_000 },
+      {
+        sessionId: 's',
+        turnId: 't',
+        cwd: '/workspace',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: (stream, chunk) => emitted.push({ stream, chunk }),
+      },
+    );
+
+    assert.deepEqual(calls, [{ command: 'npm test', cwd: '/workspace', timeoutMs: 12_000 }]);
+    assert.deepEqual(emitted, [
+      { stream: 'stdout', chunk: 'out\n' },
+      { stream: 'stderr', chunk: 'err\n' },
+    ]);
+    assert.deepEqual(result, {
+      kind: 'terminal',
+      cwd: '/workspace',
+      cmd: 'npm test',
+      exitCode: 7,
+      stdout: 'out\n',
+      stderr: 'err\n',
+    });
+  });
+
+  test('standard isolated tool surface replaces only Bash', () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const names = tools.map((tool) => tool.name);
+    assert.equal(names[0], 'Bash');
+    assert.ok(names.includes('Read'));
+    assert.ok(names.includes('Write'));
+    assert.equal(names.filter((name) => name === 'Bash').length, 1);
+  });
+});

--- a/packages/headless/src/backends.ts
+++ b/packages/headless/src/backends.ts
@@ -2,12 +2,9 @@ import { type BackendRegistry, FakeBackend } from '@maka/runtime';
 
 /**
  * Backend wiring for headless eval. The engine stays backend-agnostic
- * (runExperiment takes `registerBackends`); today only the inert stub is
- * wired, because eval fails closed on anything that runs real tools.
- *
- * The real ('ai-sdk') backend — model + builtin tools + credential plumbing —
- * returns alongside the isolated executor (follow-up PR), since it can only
- * run safely inside one.
+ * (runExperiment takes `registerBackends`); the default remains only the inert
+ * stub. Real backend callers must provide their own factory and an explicit
+ * `realBackendIsolation` boundary to runExperiment.
  */
 
 /** Register the deterministic stub backend ('fake') — no model, no tools. */

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -9,15 +9,15 @@ import { readResults, toComparisonTable, writeResults } from './results.js';
  * Reject a spec we cannot run safely or score trustworthily, BEFORE any run
  * starts — eval is a hard boundary, not a per-cell failure:
  *  - a model-backed backend would execute the config under test on the host
- *    with no isolation; only the inert "fake" backend runs until the container
- *    executor lands (follow-up PR);
+ *    with no isolation; the CLI wires only "fake", while real backends use the
+ *    programmatic API with explicit realBackendIsolation;
  *  - a task with no declared grading boundary cannot be scored honestly.
  */
 function validateEvalSpec(spec: ExperimentSpec): void {
   for (const config of spec.configs) {
     if (backendNeedsIsolation(config.backend)) {
       throw new Error(
-        `config "${config.id}": backend "${config.backend}" requires an isolated executor, not available in this build — only "fake" runs (real-model eval lands with the container executor)`,
+        `config "${config.id}": backend "${config.backend}" requires an isolated executor and programmatic backend wiring — the CLI only wires "fake" by default`,
       );
     }
   }

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -88,4 +88,6 @@ export interface ResultRecord {
   finishedAt: number;
   /** Present when the run threw before producing a result (matrix-level failure). */
   error?: string;
+  /** Stable failure class from the runtime invocation when status is failed. */
+  errorClass?: string;
 }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -6,3 +6,11 @@ export type { Config, Task, TaskVerification, ResultRecord } from './contracts.j
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export { readResults, writeResults, toComparisonTable } from './results.js';
+export type {
+  HeadlessBackendContext,
+  IsolatedCommandInput,
+  IsolatedCommandResult,
+  IsolatedToolExecutor,
+  RealBackendIsolation,
+} from './isolation.js';
+export { buildIsolatedBashTool, buildIsolatedHeadlessTools } from './tools.js';

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,0 +1,72 @@
+import type { Config, Task } from './contracts.js';
+
+export interface IsolatedCommandInput {
+  command: string;
+  cwd: string;
+  timeoutMs?: number;
+}
+
+export interface IsolatedCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Executes agent-visible shell commands outside the host credential process.
+ *
+ * Implementations can be a Harbor/Terminal-Bench environment, a Docker
+ * container, or another executor that gives the model a task workspace without
+ * inheriting host env/files. The headless runner does not infer that safety:
+ * callers must pass an explicit RealBackendIsolation record before any
+ * model-backed backend is allowed.
+ */
+export interface IsolatedToolExecutor {
+  exec(input: IsolatedCommandInput): Promise<IsolatedCommandResult>;
+}
+
+export interface ExternalRealBackendIsolation {
+  kind: 'external';
+  /**
+   * Human-readable evidence for audit logs/errors, e.g. "Harbor task
+   * container" or "Docker workspace executor". It must be non-empty so a real
+   * backend cannot be enabled by an accidental truthy object.
+   */
+  label: string;
+  /**
+   * Optional command executor for callers that want to reuse the built-in
+   * headless Bash tool. A caller may omit this when its registered backend is
+   * already isolated internally.
+   */
+  toolExecutor?: IsolatedToolExecutor;
+}
+
+export type RealBackendIsolation = ExternalRealBackendIsolation;
+
+export interface HeadlessBackendContext {
+  config: Config;
+  task: Task;
+  /** Absolute throwaway workspace path for this run. */
+  workspaceDir: string;
+  /**
+   * Present only for model-backed backends and only after the caller has
+   * explicitly asserted an isolation boundary.
+   */
+  realBackendIsolation?: RealBackendIsolation;
+  /** Convenience alias for realBackendIsolation.toolExecutor. */
+  toolExecutor?: IsolatedToolExecutor;
+}
+
+export function validateRealBackendIsolation(isolation: RealBackendIsolation | undefined): void {
+  if (!isolation) {
+    throw new Error(
+      'model-backed backend requires an isolated executor; pass realBackendIsolation with an explicit external isolation label',
+    );
+  }
+  if (isolation.kind !== 'external') {
+    throw new Error(`unsupported real backend isolation kind: ${(isolation as { kind?: unknown }).kind}`);
+  }
+  if (typeof isolation.label !== 'string' || isolation.label.trim().length === 0) {
+    throw new Error('realBackendIsolation.label is required');
+  }
+}

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -13,6 +13,8 @@ import {
 } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
+import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
+import { validateRealBackendIsolation } from './isolation.js';
 import { prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
 import { runVerification } from './evaluator.js';
 
@@ -28,7 +30,14 @@ export interface RunExperimentDeps {
    * FakeBackend, the only backend this build runs; real backends rejoin with
    * the isolated executor. Minimal usage is just `{ storageRoot }`.
    */
-  registerBackends?: (registry: BackendRegistry) => void;
+  registerBackends?: (registry: BackendRegistry, context: HeadlessBackendContext) => void | Promise<void>;
+  /**
+   * Required for every model-backed backend. This is deliberately explicit:
+   * a throwaway workspace is not a security boundary, so a real backend may run
+   * only when the caller provides an external isolation boundary such as a
+   * Harbor/Terminal-Bench environment or Docker workspace executor.
+   */
+  realBackendIsolation?: RealBackendIsolation;
   now?: () => number;
   newId?: () => string;
 }
@@ -38,9 +47,9 @@ export interface RunExperimentDeps {
  * stub FakeBackend qualifies. Every model-backed backend (`ai-sdk`,
  * `pi-agent`) can drive Bash/network, and the throwaway workspace is a copy,
  * not a jail, so running one in-process would hand the host (files, env incl.
- * API keys, network) to the config under test. Those run ONLY inside an
- * isolated executor — which this build does not ship yet (follow-up PR). Until
- * then a non-inert backend fails closed; see the preflight in runExperiment.
+ * API keys, network) to the config under test. Those run ONLY after the caller
+ * supplies an explicit external isolation boundary; otherwise the preflight in
+ * runExperiment fails closed.
  */
 export function backendNeedsIsolation(backend: BackendKind): boolean {
   return backend !== 'fake';
@@ -78,13 +87,13 @@ export async function runExperiment(
   task: Task,
   deps: RunExperimentDeps,
 ): Promise<ResultRecord> {
-  // Fail closed before any work starts: a model-backed backend would run the
-  // config under test on the host with no isolation. Refuse it until the
-  // executor ships; the inert FakeBackend is the only thing safe in-process.
   if (backendNeedsIsolation(config.backend)) {
-    throw new Error(
-      `@maka/headless: backend "${config.backend}" executes tools on the host and requires an isolated executor, which this build does not ship yet — only the inert "fake" backend runs in-process`,
-    );
+    validateRealBackendIsolation(deps.realBackendIsolation);
+    if (!deps.registerBackends) {
+      throw new Error(
+        `@maka/headless: backend "${config.backend}" requires registerBackends to wire an isolated backend factory`,
+      );
+    }
   }
   validateTaskVerification(task);
   const now = deps.now ?? Date.now;
@@ -94,7 +103,16 @@ export async function runExperiment(
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
     const backends = new BackendRegistry();
-    (deps.registerBackends ?? registerFakeBackend)(backends);
+    const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
+      deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
+    await registerBackends(backends, {
+      config,
+      task,
+      workspaceDir: workspace.dir,
+      ...(backendNeedsIsolation(config.backend)
+        ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
+        : {}),
+    });
 
     let invocation: InvocationResult | undefined;
     const manager = new SessionManager({
@@ -121,11 +139,10 @@ export async function runExperiment(
 
     const turnId = newId();
     // Drain the turn to completion. The trajectory + status come from the
-    // captured InvocationResult, not the streamed SessionEvents. Only the
-    // inert FakeBackend reaches this point (the preflight refuses the rest),
-    // so no real tool actually runs — but fail safe regardless: any permission
-    // request in-process is DENIED, because nothing here can honor host tool
-    // execution safely. Real tool use waits for the isolated executor.
+    // captured InvocationResult, not the streamed SessionEvents. If a backend
+    // still asks this generic runner for an interactive permission decision,
+    // fail safe and deny it; isolated eval backends should run with explicit
+    // non-interactive policy/tooling.
     for await (const event of manager.sendMessage(session.id, { turnId, text: task.instruction })) {
       if ((event as { type?: string }).type === 'permission_request') {
         const { requestId } = event as { requestId: string };
@@ -165,7 +182,10 @@ export async function runExperiment(
       // (⚠️) and the CLI exit code agree it was not a trustworthy run — not a
       // silent ⚠️-but-exit-0 that automation reads as success.
       ...(status === 'failed'
-        ? { error: invocation?.failure?.message ?? invocation?.failure?.class ?? 'run did not complete' }
+        ? {
+            error: invocation?.failure?.message ?? invocation?.failure?.class ?? 'run did not complete',
+            ...(invocation?.failure?.class ? { errorClass: invocation.failure.class } : {}),
+          }
         : {}),
     };
   } finally {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,0 +1,45 @@
+import type { MakaTool } from '@maka/runtime';
+import { buildBuiltinTools } from '@maka/runtime';
+import { z } from 'zod';
+import type { IsolatedToolExecutor } from './isolation.js';
+
+/**
+ * Build Maka's standard headless tool surface with Bash routed through an
+ * isolated executor. The pure file tools remain host-side but are path-confined
+ * to the throwaway workspace by @maka/runtime's builtin implementations; the
+ * dangerous part is process execution, which must not inherit host secrets or
+ * filesystem reachability.
+ */
+export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): MakaTool[] {
+  const pureTools = buildBuiltinTools().filter((tool) => tool.name !== 'Bash');
+  return [buildIsolatedBashTool(executor), ...pureTools];
+}
+
+export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Bash',
+    description: 'Run a shell command in the isolated headless task workspace.',
+    parameters: z.object({
+      command: z.string().describe('The shell command to execute'),
+      timeout_ms: z.number().int().positive().max(600_000).optional(),
+    }),
+    permissionRequired: true,
+    impl: async ({ command, timeout_ms }, { cwd, emitOutput }) => {
+      const result = await executor.exec({
+        command,
+        cwd,
+        timeoutMs: timeout_ms ?? 120_000,
+      });
+      if (result.stdout) emitOutput('stdout', result.stdout);
+      if (result.stderr) emitOutput('stderr', result.stderr);
+      return {
+        kind: 'terminal',
+        cwd,
+        cmd: command,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      };
+    },
+  };
+}

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -114,6 +114,60 @@ function flowTerminalEvent(
   };
 }
 
+function flowErrorEvent(ctx: InvocationContext, message: string): RuntimeEvent {
+  return {
+    id: ctx.newId(),
+    invocationId: ctx.invocationId,
+    runId: ctx.runId,
+    sessionId: ctx.sessionId,
+    turnId: ctx.turnId,
+    ts: ctx.now(),
+    ...(ctx.branch ? { branch: ctx.branch } : {}),
+    partial: false,
+    role: 'system',
+    author: 'system',
+    content: { kind: 'error', reason: 'tool_failed', message },
+  };
+}
+
+function flowTokenUsageEvent(ctx: InvocationContext, rawFinishReason: string): RuntimeEvent {
+  return {
+    id: ctx.newId(),
+    invocationId: ctx.invocationId,
+    runId: ctx.runId,
+    sessionId: ctx.sessionId,
+    turnId: ctx.turnId,
+    ts: ctx.now(),
+    ...(ctx.branch ? { branch: ctx.branch } : {}),
+    partial: false,
+    role: 'system',
+    author: 'system',
+    actions: { tokenUsage: { input: 1, output: 1, rawFinishReason } },
+  };
+}
+
+function flowPermissionDeniedEvent(ctx: InvocationContext): RuntimeEvent {
+  return {
+    id: ctx.newId(),
+    invocationId: ctx.invocationId,
+    runId: ctx.runId,
+    sessionId: ctx.sessionId,
+    turnId: ctx.turnId,
+    ts: ctx.now(),
+    ...(ctx.branch ? { branch: ctx.branch } : {}),
+    partial: false,
+    role: 'system',
+    author: 'user',
+    actions: {
+      permissionDecision: {
+        requestId: 'perm-1',
+        decision: 'deny',
+        rememberForTurn: true,
+      },
+    },
+  };
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -261,6 +315,52 @@ describe('RuntimeRunner', () => {
         (ev) => ev.content?.kind === 'text' && ev.content.text === 'cleanup-after-aborted',
       ),
     ).toBe(true);
+  });
+
+  test('non-terminal error content cannot be masked by a completed terminal event', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      flowErrorEvent(ctx, 'Operation failed'),
+      flowTerminalEvent(ctx, 'completed'),
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('tool_failed');
+    expect(result.failure?.message).toBe('Operation failed');
+    expect(result.events.at(-1)?.status).toBe('completed');
+  });
+
+  test('raw tool-calls finish reason marks a completed terminal event incomplete', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      flowTokenUsageEvent(ctx, 'tool-calls'),
+      flowTerminalEvent(ctx, 'completed'),
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('incomplete_tool_calls');
+    expect(result.failure?.message).toMatch(/tool-call step cap/);
+  });
+
+  test('denied permission decision marks a later completed terminal event failed', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      flowPermissionDeniedEvent(ctx),
+      flowTerminalEvent(ctx, 'completed'),
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('permission_denied');
+    expect(result.failure?.message).toBe('permission request perm-1 was denied');
   });
 
   test('a flow that throws maps to a failed result (user event retained)', async () => {

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -210,17 +210,17 @@ export class RuntimeRunner {
 
     // 5. Dispatch to the flow and collect canonical events. By default the
     //    first terminal event ends collection; when stopOnTerminal is false,
-    //    keep draining while remembering any non-completed terminal status.
-    //    A thrown error or a non-completed terminal status maps the result
-    //    to 'failed'.
+    //    keep draining while remembering any failure signal. A thrown error,
+    //    non-completed terminal status, denied permission, non-terminal error,
+    //    or incomplete model finish maps the result to 'failed'.
     let failure: InvocationFailure | undefined;
     let terminalSeen = false;
     try {
       for await (const ev of this.flow.run(ctx, flowInput)) {
         events.push(ev);
+        failure ??= failureFromRuntimeEvent(ev);
         if (isTerminalRuntimeEvent(ev)) {
           terminalSeen = true;
-          failure ??= failureFromTerminalEvent(ev);
           if (this.stopOnTerminal) {
             break;
           }
@@ -317,6 +317,35 @@ function buildFlowInput(request: InvocationRequest): FlowInput {
  * than 'completed'. A terminal event without an explicit status (e.g. one
  * that only carries actions.endInvocation) is treated as completed.
  */
+function failureFromRuntimeEvent(event: RuntimeEvent): InvocationFailure | undefined {
+  if (isTerminalRuntimeEvent(event)) {
+    const terminalFailure = failureFromTerminalEvent(event);
+    if (terminalFailure) return terminalFailure;
+  }
+
+  const content = event.content;
+  if (content?.kind === 'error') {
+    return {
+      class: content.reason ?? content.code ?? 'runtime_error',
+      message: content.message,
+    };
+  }
+
+  const permissionDecision = event.actions?.permissionDecision;
+  if (permissionDecision?.decision === 'deny') {
+    return {
+      class: 'permission_denied',
+      message: `permission request ${permissionDecision.requestId} was denied`,
+    };
+  }
+
+  const rawFinishReason = event.actions?.tokenUsage?.rawFinishReason;
+  const finishFailure = failureFromRawFinishReason(rawFinishReason);
+  if (finishFailure) return finishFailure;
+
+  return undefined;
+}
+
 function failureFromTerminalEvent(event: RuntimeEvent): InvocationFailure | undefined {
   const status: RuntimeEventStatus | undefined = event.status;
   if (status === undefined || status === 'completed') return undefined;
@@ -327,4 +356,22 @@ function failureFromTerminalEvent(event: RuntimeEvent): InvocationFailure | unde
     ...(message ? { message } : {}),
     terminalStatus: status,
   };
+}
+
+function failureFromRawFinishReason(rawFinishReason: string | undefined): InvocationFailure | undefined {
+  if (!rawFinishReason) return undefined;
+  const normalized = rawFinishReason.toLowerCase().replace(/_/g, '-');
+  if (normalized === 'tool-calls') {
+    return {
+      class: 'incomplete_tool_calls',
+      message: 'model stopped at the tool-call step cap before completing the invocation',
+    };
+  }
+  if (normalized === 'length' || normalized === 'max-tokens') {
+    return {
+      class: 'max_tokens',
+      message: 'model stopped at the token limit before completing the invocation',
+    };
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary

This PR lands the mergeable foundation from the Terminal-Bench / Harbor spike before we build the full autonomous task-agent product shape.

- Allows `@maka/headless` to run model-backed backends only when the caller explicitly supplies `realBackendIsolation` plus programmatic backend wiring.
- Adds `IsolatedToolExecutor` and isolated headless Bash/tool helpers so benchmark callers can route shell execution to Harbor/Docker/etc. instead of the host credential process.
- Keeps the CLI fail-closed by default: JSON specs still only wire the inert `fake` backend.
- Propagates runtime failure classes into headless `ResultRecord.errorClass`.
- Hardens `RuntimeRunner` so non-terminal error content, denied permissions, and incomplete finish reasons (`tool-calls`, `length`/`max_tokens`) cannot be masked by a later completed terminal event.

This intentionally does **not** implement the autonomous task loop yet. The next product step is a task-mode controller that feeds visible self-check observations back into the same agent loop while keeping the final benchmark verifier separate.

## Verification

- `npm run test --workspace packages/headless` (34/34)
- `npm run test --workspace packages/runtime` (547/547)
- `git diff --check`
