### PR TITLE
Add autonomous task run ledger contracts

### DIFF
--- a/packages/headless/src/__tests__/task-run-adapter.test.ts
+++ b/packages/headless/src/__tests__/task-run-adapter.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { ResultRecord, Task } from '../contracts.js';
+import { taxonomyFromResultRecord } from '../task-contracts.js';
+import {
+  resultRecordFromTaskRunProjection,
+  taskDefinitionFromTask,
+  taskEventsFromResultRecord,
+} from '../task-run-adapter.js';
+import { projectTaskRun } from '../task-run-store.js';
+
+const task: Task = {
+  id: 'task-1',
+  instruction: 'fix it',
+  workspaceDir: '/tmp/fixture',
+  verification: { command: 'npm test', timeoutMs: 5000, protectedPaths: ['test.mjs'] },
+};
+
+function record(extra: Partial<ResultRecord> = {}): ResultRecord {
+  return {
+    taskId: 'task-1',
+    configId: 'cfg-1',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    status: 'completed',
+    passed: true,
+    exitCode: 0,
+    steps: 4,
+    durationMs: 30,
+    startedAt: 10,
+    finishedAt: 40,
+    ...extra,
+  };
+}
+
+function eventIdFactory(): () => string {
+  let i = 0;
+  return () => `e-${++i}`;
+}
+
+describe('taskDefinitionFromTask', () => {
+  test('maps the existing Task contract one-to-one', () => {
+    const definition = taskDefinitionFromTask(task);
+    assert.deepEqual(definition, {
+      id: 'task-1',
+      instruction: 'fix it',
+      workspaceDir: '/tmp/fixture',
+      verification: { command: 'npm test', timeoutMs: 5000, protectedPaths: ['test.mjs'] },
+    });
+    assert.notEqual(definition.verification.protectedPaths, task.verification.protectedPaths);
+  });
+});
+
+describe('taskEventsFromResultRecord', () => {
+  test('maps completed passing results through passed taxonomy and back to ResultRecord', () => {
+    const original = record();
+    const events = taskEventsFromResultRecord(original, { task, eventId: eventIdFactory() });
+    const projection = projectTaskRun(events, 'run-1');
+
+    assert.equal(taxonomyFromResultRecord(original), 'passed');
+    assert.equal(projection.latestScoreResult?.taxonomy, 'passed');
+    assert.deepEqual(resultRecordFromTaskRunProjection(projection), original);
+  });
+
+  test('maps completed verification failures as completed but not passed', () => {
+    const original = record({ passed: false, exitCode: 1 });
+    const events = taskEventsFromResultRecord(original, { eventId: eventIdFactory() });
+    const projection = projectTaskRun(events, 'run-1');
+    const compatible = resultRecordFromTaskRunProjection(projection);
+
+    assert.equal(taxonomyFromResultRecord(original), 'verification_failed');
+    assert.equal(projection.latestScoreResult?.taxonomy, 'verification_failed');
+    assert.equal(compatible.status, 'completed');
+    assert.equal(compatible.passed, false);
+    assert.equal(compatible.exitCode, 1);
+  });
+
+  test('keeps completed verifier errors compatible with ResultRecord status semantics', () => {
+    const original = record({ passed: false, exitCode: null });
+    const events = taskEventsFromResultRecord(original, { eventId: eventIdFactory() });
+    const projection = projectTaskRun(events, 'run-1');
+    const compatible = resultRecordFromTaskRunProjection(projection);
+
+    assert.equal(taxonomyFromResultRecord(original), 'verification_error');
+    assert.equal(projection.latestScoreResult?.taxonomy, 'verification_error');
+    assert.equal(projection.verifierResults.length, 1);
+    assert.deepEqual(compatible, original);
+  });
+
+  test('maps backend failures as agent_failed and preserves old error fields', () => {
+    const original = record({
+      status: 'failed',
+      passed: false,
+      exitCode: null,
+      error: 'backend blew up',
+      errorClass: 'backend_failed',
+    });
+    const events = taskEventsFromResultRecord(original, { eventId: eventIdFactory() });
+    const projection = projectTaskRun(events, 'run-1');
+
+    assert.equal(taxonomyFromResultRecord(original), 'agent_failed');
+    assert.equal(projection.latestScoreResult?.taxonomy, 'agent_failed');
+    assert.equal(projection.verifierResults.length, 0);
+    assert.deepEqual(resultRecordFromTaskRunProjection(projection), original);
+  });
+
+  test('maps matrix-level thrown failures as setup_failed', () => {
+    const original = record({
+      sessionId: '',
+      runId: '',
+      status: 'failed',
+      passed: false,
+      exitCode: null,
+      steps: 0,
+      error: 'fixture missing',
+    });
+    const events = taskEventsFromResultRecord(original, { eventId: eventIdFactory(), taskRunId: 'matrix-failure' });
+    const projection = projectTaskRun(events, 'matrix-failure');
+
+    assert.equal(taxonomyFromResultRecord(original), 'setup_failed');
+    assert.equal(projection.latestScoreResult?.taxonomy, 'setup_failed');
+    assert.equal(projection.verifierResults.length, 0);
+    assert.deepEqual(resultRecordFromTaskRunProjection(projection), original);
+  });
+
+  test('maps incomplete, policy, budget, aborted, blocked, and infra failures explicitly', () => {
+    const cases = [
+      ['incomplete_tool_calls', 'agent_incomplete', 'incomplete'],
+      ['permission_denied', 'policy_denied', 'policy_denied'],
+      ['max_steps_exceeded', 'budget_exhausted', 'budget_exhausted'],
+      ['user_aborted', 'aborted', 'aborted'],
+      ['blocked_waiting_permission', 'blocked', 'blocked'],
+      ['infra_failure', 'infra_failed', 'failed'],
+    ] as const;
+
+    for (const [errorClass, taxonomy, status] of cases) {
+      const original = record({
+        status: 'failed',
+        passed: false,
+        exitCode: null,
+        error: errorClass,
+        errorClass,
+      });
+      const projection = projectTaskRun(taskEventsFromResultRecord(original, { eventId: eventIdFactory() }), 'run-1');
+      assert.equal(taxonomyFromResultRecord(original), taxonomy);
+      assert.equal(projection.latestScoreResult?.taxonomy, taxonomy);
+      assert.equal(projection.status, status);
+      assert.deepEqual(resultRecordFromTaskRunProjection(projection), original);
+    }
+  });
+
+  test('maps cancelled projections into failed ResultRecord compatibility', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-c', ts: 10, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'task_run_started', id: 'e-2', taskRunId: 'tr-c', ts: 11, sessionId: 's-1', agentRunId: 'r-1' },
+      { type: 'task_run_cancelled', id: 'e-3', taskRunId: 'tr-c', ts: 20 },
+    ], 'tr-c');
+
+    assert.deepEqual(resultRecordFromTaskRunProjection(projection), {
+      taskId: 'task-1',
+      configId: 'cfg-1',
+      sessionId: 's-1',
+      runId: 'r-1',
+      status: 'failed',
+      passed: false,
+      exitCode: null,
+      steps: 3,
+      durationMs: 9,
+      startedAt: 11,
+      finishedAt: 20,
+      error: 'task run cancelled',
+      errorClass: 'cancelled',
+    });
+  });
+});

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { appendFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { TaskEvent } from '../task-contracts.js';
+import { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from '../task-run-store.js';
+
+function eventIdFactory(): () => string {
+  let i = 0;
+  return () => `e-${++i}`;
+}
+
+function completedEvents(taskRunId = 'tr-1'): TaskEvent[] {
+  const id = eventIdFactory();
+  return [
+    { type: 'task_run_created', id: id(), taskRunId, ts: 10, taskId: 'task-1', configId: 'cfg-1' },
+    { type: 'task_run_started', id: id(), taskRunId, ts: 11, startedAt: 11, sessionId: 's-1', agentRunId: 'r-1' },
+    { type: 'task_attempt_started', id: id(), taskRunId, ts: 12, attemptId: 'a-1', sessionId: 's-1', agentRunId: 'r-1' },
+    {
+      type: 'self_check_observed',
+      id: id(),
+      taskRunId,
+      ts: 13,
+      observation: { id: 'self-1', taskRunId, attemptId: 'a-1', ts: 13, summary: 'looks solved' },
+    },
+    {
+      type: 'feedback_observed',
+      id: id(),
+      taskRunId,
+      ts: 14,
+      observation: { id: 'fb-1', taskRunId, attemptId: 'a-1', ts: 14, source: 'verifier', summary: 'tests passed' },
+    },
+    {
+      type: 'autonomous_decision_recorded',
+      id: id(),
+      taskRunId,
+      ts: 15,
+      decision: { id: 'd-1', taskRunId, attemptId: 'a-1', ts: 15, decision: 'stop', reason: 'verification passed' },
+    },
+    {
+      type: 'verifier_result_recorded',
+      id: id(),
+      taskRunId,
+      ts: 20,
+      result: { id: 'v-1', taskRunId, attemptId: 'a-1', ts: 20, kind: 'command', passed: true, exitCode: 0 },
+    },
+    {
+      type: 'score_result_recorded',
+      id: id(),
+      taskRunId,
+      ts: 21,
+      result: { id: 'score-1', taskRunId, attemptId: 'a-1', ts: 21, passed: true, taxonomy: 'passed' },
+    },
+    { type: 'task_attempt_completed', id: id(), taskRunId, ts: 22, attemptId: 'a-1', finishedAt: 22, status: 'completed' },
+    { type: 'task_run_completed', id: id(), taskRunId, ts: 23, finishedAt: 23 },
+  ];
+}
+
+describe('TaskRunStore', () => {
+  test('appends and replays events in order', async () => {
+    const store = createInMemoryTaskRunStore();
+    const events = completedEvents();
+    for (const event of events) await store.appendEvent(event.taskRunId, event);
+
+    assert.deepEqual(await store.readEvents('tr-1'), events);
+  });
+
+  test('projects status, attempts, observations, verifier, and score from replay', async () => {
+    const store = createInMemoryTaskRunStore();
+    for (const event of completedEvents()) await store.appendEvent(event.taskRunId, event);
+
+    const projection = await store.project('tr-1');
+    assert.equal(projection.status, 'completed');
+    assert.equal(projection.taskId, 'task-1');
+    assert.equal(projection.configId, 'cfg-1');
+    assert.equal(projection.sessionId, 's-1');
+    assert.equal(projection.agentRunId, 'r-1');
+    assert.equal(projection.attempts[0]?.status, 'completed');
+    assert.equal(projection.selfChecks[0]?.summary, 'looks solved');
+    assert.equal(projection.feedback[0]?.summary, 'tests passed');
+    assert.equal(projection.decisions[0]?.decision, 'stop');
+    assert.equal(projection.latestVerifierResult?.exitCode, 0);
+    assert.equal(projection.latestScoreResult?.taxonomy, 'passed');
+    assert.deepEqual(projection.result, {
+      passed: true,
+      taxonomy: 'passed',
+      verifierResultId: 'v-1',
+      scoreResultId: 'score-1',
+    });
+  });
+
+  test('projects failed and cancelled terminal events', () => {
+    const failed = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-f', ts: 1, taskId: 'task-f', configId: 'cfg' },
+      { type: 'task_run_failed', id: 'e-2', taskRunId: 'tr-f', ts: 2, error: { message: 'backend blew up', class: 'backend_failed' } },
+    ], 'tr-f');
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.error?.message, 'backend blew up');
+
+    const cancelled = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-c', ts: 1, taskId: 'task-c', configId: 'cfg' },
+      { type: 'task_run_cancelled', id: 'e-2', taskRunId: 'tr-c', ts: 2 },
+    ], 'tr-c');
+    assert.equal(cancelled.status, 'cancelled');
+    assert.equal(cancelled.error?.class, 'cancelled');
+  });
+
+  test('projects queued, verifying, incomplete, blocked, policy, budget, and aborted states', () => {
+    const queued = projectTaskRun([
+      { type: 'task_run_queued', id: 'e-1', taskRunId: 'tr-q', ts: 1, taskId: 'task-q', configId: 'cfg' },
+    ], 'tr-q');
+    assert.equal(queued.status, 'queued');
+    assert.equal(queued.taskId, 'task-q');
+
+    const verifying = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-v', ts: 1, taskId: 'task-v', configId: 'cfg' },
+      { type: 'task_run_started', id: 'e-2', taskRunId: 'tr-v', ts: 2 },
+      { type: 'task_run_verifying', id: 'e-3', taskRunId: 'tr-v', ts: 3 },
+    ], 'tr-v');
+    assert.equal(verifying.status, 'verifying');
+
+    const terminalCases: Array<[TaskEvent, string, string]> = [
+      [{ type: 'task_run_incomplete', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'incomplete', 'agent_incomplete'],
+      [{ type: 'task_run_blocked', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'blocked', 'blocked'],
+      [{ type: 'task_run_policy_denied', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'policy_denied', 'policy_denied'],
+      [{ type: 'task_run_budget_exhausted', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'budget_exhausted', 'budget_exhausted'],
+      [{ type: 'task_run_aborted', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'aborted', 'aborted'],
+    ];
+
+    for (const [terminalEvent, status, errorClass] of terminalCases) {
+      const projection = projectTaskRun([
+        { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-x', ts: 1, taskId: 'task-x', configId: 'cfg' },
+        terminalEvent,
+      ], 'tr-x');
+      assert.equal(projection.status, status);
+      assert.equal(projection.error?.class, errorClass);
+    }
+  });
+
+  test('uses the last terminal event and records a warning', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-1', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'task_run_failed', id: 'e-2', taskRunId: 'tr-1', ts: 2, error: { message: 'first terminal' } },
+      { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
+    ], 'tr-1');
+
+    assert.equal(projection.status, 'completed');
+    assert.match(projection.warnings[0] ?? '', /multiple terminal/);
+  });
+
+  test('serializes concurrent appends for one task run', async () => {
+    const store = createInMemoryTaskRunStore();
+    const events = completedEvents('tr-concurrent');
+
+    await Promise.all(events.map((event) => store.appendEvent('tr-concurrent', event)));
+
+    assert.deepEqual(await store.readEvents('tr-concurrent'), events);
+  });
+
+  test('event_corrupt stays in replay and surfaces as a projection warning', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-1', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'event_corrupt', id: 'e-corrupt', taskRunId: 'tr-1', ts: 2, raw: '{', error: 'invalid json' },
+      { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
+    ], 'tr-1');
+
+    assert.equal(projection.events.length, 3);
+    assert.match(projection.warnings[0] ?? '', /corrupt event/);
+    assert.equal(projection.status, 'completed');
+  });
+
+  test('file-backed store appends and replays events after restart', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = createTaskRunStore(storageRoot);
+      const events = completedEvents('tr-file');
+      for (const event of events) await store.appendEvent(event.taskRunId, event);
+
+      const restarted = createTaskRunStore(storageRoot);
+      assert.deepEqual(await restarted.readEvents('tr-file'), events);
+      assert.equal((await restarted.project('tr-file')).status, 'completed');
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('file-backed store surfaces corrupt durable lines and ignores partial tail', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = createTaskRunStore(storageRoot);
+      const events = completedEvents('tr-corrupt');
+      await store.appendEvent('tr-corrupt', events[0] as TaskEvent);
+
+      await appendFile(
+        join(storageRoot, 'task-runs', 'tr-corrupt.jsonl'),
+        'not-json\n{"type":"task_run_completed","id":"partial"',
+        'utf8',
+      );
+
+      const replayed = await store.readEvents('tr-corrupt');
+      assert.equal(replayed.length, 2);
+      assert.equal(replayed[1]?.type, 'event_corrupt');
+      assert.match((replayed[1] as { error?: string }).error ?? '', /Unexpected/);
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -3,6 +3,50 @@
 // (backends.ts) are internals the runner owns, not part of the API. Minimal
 // usage is `runExperiment(config, task, { storageRoot })`.
 export type { Config, Task, TaskVerification, ResultRecord } from './contracts.js';
+export type {
+  AutonomousDecision,
+  AutonomousResultTaxonomy,
+  FeedbackObservation,
+  ResultTaxonomy,
+  ScoreResult,
+  SelfCheckObservation,
+  TaskAttempt,
+  TaskAttemptStatus,
+  TaskDefinition,
+  TaskEvent,
+  TaskEventCorrupt,
+  TaskRunAbortedEvent,
+  TaskRunBlockedEvent,
+  TaskRunBudgetExhaustedEvent,
+  TaskRunCancelledEvent,
+  TaskRunCompletedEvent,
+  TaskRunCreatedEvent,
+  TaskRunFailedEvent,
+  TaskRunIncompleteEvent,
+  TaskRunPolicyDeniedEvent,
+  TaskRunQueuedEvent,
+  TaskRunStartedEvent,
+  TaskRunVerifyingEvent,
+  TaskRun,
+  TaskRunError,
+  TaskRunResult,
+  TaskRunStatus,
+  VerifierResult,
+} from './task-contracts.js';
+export {
+  TASK_RUN_TERMINAL_STATUSES,
+  isFailureTaxonomy,
+  isTerminalTaskRunStatus,
+  taxonomyFromResultRecord,
+} from './task-contracts.js';
+export type { TaskRunProjection, TaskRunStore } from './task-run-store.js';
+export { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from './task-run-store.js';
+export type { TaskEventsFromResultRecordOptions } from './task-run-adapter.js';
+export {
+  resultRecordFromTaskRunProjection,
+  taskDefinitionFromTask,
+  taskEventsFromResultRecord,
+} from './task-run-adapter.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export { readResults, writeResults, toComparisonTable } from './results.js';

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -1,0 +1,340 @@
+import type { ResultRecord, TaskVerification } from './contracts.js';
+
+export type TaskRunStatus =
+  | 'queued'
+  | 'created'
+  | 'running'
+  | 'verifying'
+  | 'completed'
+  | 'failed'
+  | 'incomplete'
+  | 'blocked'
+  | 'policy_denied'
+  | 'budget_exhausted'
+  | 'aborted'
+  | 'cancelled';
+export type TaskAttemptStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'incomplete'
+  | 'blocked'
+  | 'policy_denied'
+  | 'budget_exhausted'
+  | 'aborted'
+  | 'cancelled';
+
+export const TASK_RUN_TERMINAL_STATUSES = [
+  'completed',
+  'failed',
+  'incomplete',
+  'blocked',
+  'policy_denied',
+  'budget_exhausted',
+  'aborted',
+  'cancelled',
+] as const;
+
+export function isTerminalTaskRunStatus(status: TaskRunStatus): boolean {
+  return (TASK_RUN_TERMINAL_STATUSES as readonly TaskRunStatus[]).includes(status);
+}
+
+export type AutonomousResultTaxonomy =
+  | 'passed'
+  | 'verification_failed'
+  | 'verification_error'
+  | 'agent_failed'
+  | 'agent_incomplete'
+  | 'setup_failed'
+  | 'infra_failed'
+  | 'policy_denied'
+  | 'budget_exhausted'
+  | 'aborted'
+  | 'blocked'
+  | 'cancelled';
+
+export type ResultTaxonomy = AutonomousResultTaxonomy;
+
+export function taxonomyFromResultRecord(record: ResultRecord): AutonomousResultTaxonomy {
+  if (record.status === 'completed') {
+    if (record.passed) return 'passed';
+    return record.exitCode === null ? 'verification_error' : 'verification_failed';
+  }
+
+  const errorClass = record.errorClass?.toLowerCase() ?? '';
+  const error = record.error?.toLowerCase() ?? '';
+  const failureText = `${errorClass} ${error}`;
+  if (includesAny(failureText, ['cancelled', 'canceled'])) return 'cancelled';
+  if (includesAny(failureText, ['abort', 'aborted'])) return 'aborted';
+  if (includesAny(failureText, ['budget', 'limit', 'limits_exceeded', 'max_steps', 'max_tokens'])) {
+    return 'budget_exhausted';
+  }
+  if (includesAny(failureText, ['blocked', 'waiting_permission'])) return 'blocked';
+  if (includesAny(failureText, ['policy', 'permission', 'denied'])) return 'policy_denied';
+  if (includesAny(failureText, ['incomplete', 'tool_calls', 'no_submit', 'truncated'])) return 'agent_incomplete';
+  if (includesAny(failureText, ['setup', 'fixture', 'config', 'preflight'])) return 'setup_failed';
+  if (includesAny(failureText, ['infra', 'infrastructure', 'harbor', 'container', 'docker', 'fetch', 'materialize', 'network'])) {
+    return 'infra_failed';
+  }
+  if (errorClass.includes('backend') || errorClass.includes('agent') || errorClass.includes('runtime') || record.sessionId || record.runId) {
+    return 'agent_failed';
+  }
+  return 'setup_failed';
+}
+
+export function isFailureTaxonomy(taxonomy: AutonomousResultTaxonomy): boolean {
+  return taxonomy !== 'passed';
+}
+
+function includesAny(value: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+export interface TaskDefinition {
+  id: string;
+  instruction: string;
+  workspaceDir: string;
+  verification: TaskVerification;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TaskRunError {
+  message: string;
+  class?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface TaskRunResult {
+  passed: boolean;
+  taxonomy: AutonomousResultTaxonomy;
+  verifierResultId?: string;
+  scoreResultId?: string;
+}
+
+export interface TaskRun {
+  taskRunId: string;
+  taskId: string;
+  configId: string;
+  status: TaskRunStatus;
+  startedAt?: number;
+  finishedAt?: number;
+  sessionId?: string;
+  agentRunId?: string;
+  result?: TaskRunResult;
+  error?: TaskRunError;
+}
+
+export interface TaskAttempt {
+  attemptId: string;
+  taskRunId: string;
+  startedAt: number;
+  finishedAt?: number;
+  status: TaskAttemptStatus;
+  sessionId?: string;
+  agentRunId?: string;
+  error?: TaskRunError;
+}
+
+export interface SelfCheckObservation {
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+export interface FeedbackObservation {
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  source: 'verifier' | 'human' | 'runtime' | 'system';
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+export interface AutonomousDecision {
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  decision: 'continue' | 'retry' | 'stop' | 'abort';
+  reason?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface VerifierResult {
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  kind: 'command';
+  passed: boolean;
+  exitCode: number | null;
+  command?: string;
+  durationMs?: number;
+  error?: string;
+}
+
+export interface ScoreResult {
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  passed: boolean;
+  score?: number;
+  maxScore?: number;
+  taxonomy: AutonomousResultTaxonomy;
+  details?: Record<string, unknown>;
+}
+
+interface BaseTaskEvent {
+  id: string;
+  taskRunId: string;
+  ts: number;
+}
+
+export interface TaskRunCreatedEvent extends BaseTaskEvent {
+  type: 'task_run_created';
+  taskId: string;
+  configId: string;
+  taskDefinition?: TaskDefinition;
+  sourceResultRecord?: ResultRecord;
+}
+
+export interface TaskRunQueuedEvent extends BaseTaskEvent {
+  type: 'task_run_queued';
+  taskId: string;
+  configId: string;
+  taskDefinition?: TaskDefinition;
+}
+
+export interface TaskRunStartedEvent extends BaseTaskEvent {
+  type: 'task_run_started';
+  startedAt?: number;
+  sessionId?: string;
+  agentRunId?: string;
+}
+
+export interface TaskRunVerifyingEvent extends BaseTaskEvent {
+  type: 'task_run_verifying';
+  startedAt?: number;
+}
+
+export interface TaskAttemptStartedEvent extends BaseTaskEvent {
+  type: 'task_attempt_started';
+  attemptId: string;
+  startedAt?: number;
+  sessionId?: string;
+  agentRunId?: string;
+}
+
+export interface SelfCheckObservedEvent extends BaseTaskEvent {
+  type: 'self_check_observed';
+  observation: SelfCheckObservation;
+}
+
+export interface FeedbackObservedEvent extends BaseTaskEvent {
+  type: 'feedback_observed';
+  observation: FeedbackObservation;
+}
+
+export interface AutonomousDecisionRecordedEvent extends BaseTaskEvent {
+  type: 'autonomous_decision_recorded';
+  decision: AutonomousDecision;
+}
+
+export interface VerifierResultRecordedEvent extends BaseTaskEvent {
+  type: 'verifier_result_recorded';
+  result: VerifierResult;
+}
+
+export interface ScoreResultRecordedEvent extends BaseTaskEvent {
+  type: 'score_result_recorded';
+  result: ScoreResult;
+}
+
+export interface TaskAttemptCompletedEvent extends BaseTaskEvent {
+  type: 'task_attempt_completed';
+  attemptId: string;
+  finishedAt?: number;
+  status: Exclude<TaskAttemptStatus, 'running'>;
+  error?: TaskRunError;
+}
+
+export interface TaskRunCompletedEvent extends BaseTaskEvent {
+  type: 'task_run_completed';
+  finishedAt?: number;
+  result?: TaskRunResult;
+}
+
+export interface TaskRunFailedEvent extends BaseTaskEvent {
+  type: 'task_run_failed';
+  finishedAt?: number;
+  error: TaskRunError;
+}
+
+export interface TaskRunIncompleteEvent extends BaseTaskEvent {
+  type: 'task_run_incomplete';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskRunBlockedEvent extends BaseTaskEvent {
+  type: 'task_run_blocked';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskRunPolicyDeniedEvent extends BaseTaskEvent {
+  type: 'task_run_policy_denied';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskRunBudgetExhaustedEvent extends BaseTaskEvent {
+  type: 'task_run_budget_exhausted';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskRunAbortedEvent extends BaseTaskEvent {
+  type: 'task_run_aborted';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskRunCancelledEvent extends BaseTaskEvent {
+  type: 'task_run_cancelled';
+  finishedAt?: number;
+  error?: TaskRunError;
+}
+
+export interface TaskEventCorrupt extends BaseTaskEvent {
+  type: 'event_corrupt';
+  raw?: string;
+  error: string;
+}
+
+export type TaskEvent =
+  | TaskRunCreatedEvent
+  | TaskRunQueuedEvent
+  | TaskRunStartedEvent
+  | TaskRunVerifyingEvent
+  | TaskAttemptStartedEvent
+  | SelfCheckObservedEvent
+  | FeedbackObservedEvent
+  | AutonomousDecisionRecordedEvent
+  | VerifierResultRecordedEvent
+  | ScoreResultRecordedEvent
+  | TaskAttemptCompletedEvent
+  | TaskRunCompletedEvent
+  | TaskRunFailedEvent
+  | TaskRunIncompleteEvent
+  | TaskRunBlockedEvent
+  | TaskRunPolicyDeniedEvent
+  | TaskRunBudgetExhaustedEvent
+  | TaskRunAbortedEvent
+  | TaskRunCancelledEvent
+  | TaskEventCorrupt;

--- a/packages/headless/src/task-run-adapter.ts
+++ b/packages/headless/src/task-run-adapter.ts
@@ -1,0 +1,314 @@
+import { randomUUID } from 'node:crypto';
+import type { ResultRecord, Task } from './contracts.js';
+import {
+  taxonomyFromResultRecord,
+  type AutonomousResultTaxonomy,
+  type ScoreResult,
+  type TaskAttemptStatus,
+  type TaskDefinition,
+  type TaskEvent,
+  type TaskRunError,
+  type TaskRunResult,
+  type VerifierResult,
+} from './task-contracts.js';
+import type { TaskRunProjection } from './task-run-store.js';
+
+export interface TaskEventsFromResultRecordOptions {
+  task?: Task;
+  taskRunId?: string;
+  attemptId?: string;
+  eventId?: () => string;
+}
+
+export function taskDefinitionFromTask(task: Task): TaskDefinition {
+  return {
+    id: task.id,
+    instruction: task.instruction,
+    workspaceDir: task.workspaceDir,
+    verification: {
+      command: task.verification.command,
+      ...(task.verification.timeoutMs === undefined ? {} : { timeoutMs: task.verification.timeoutMs }),
+      protectedPaths: [...task.verification.protectedPaths],
+    },
+  };
+}
+
+export function taskEventsFromResultRecord(
+  record: ResultRecord,
+  options: TaskEventsFromResultRecordOptions = {},
+): TaskEvent[] {
+  const eventId = options.eventId ?? randomUUID;
+  const taskRunId = options.taskRunId ?? (record.runId || `${record.configId}-${record.taskId}-${record.startedAt}`);
+  const attemptId = options.attemptId ?? `${taskRunId}-attempt-1`;
+  const taxonomy = taxonomyFromResultRecord(record);
+  const shouldRecordVerifier = record.status === 'completed' || record.exitCode !== null || taxonomy === 'verification_error';
+  const verifierResult: VerifierResult | undefined = shouldRecordVerifier
+    ? {
+        id: eventId(),
+        taskRunId,
+        attemptId,
+        ts: record.finishedAt,
+        kind: 'command',
+        passed: record.status === 'completed' && record.passed,
+        exitCode: record.exitCode,
+        ...(options.task ? { command: options.task.verification.command } : {}),
+        ...(record.error ? { error: record.error } : {}),
+      }
+    : undefined;
+  const scoreResult: ScoreResult = {
+    id: eventId(),
+    taskRunId,
+    attemptId,
+    ts: record.finishedAt,
+    passed: record.status === 'completed' && record.passed,
+    taxonomy,
+    details: { steps: record.steps },
+  };
+  const result: TaskRunResult = {
+    passed: scoreResult.passed,
+    taxonomy,
+    ...(verifierResult ? { verifierResultId: verifierResult.id } : {}),
+    scoreResultId: scoreResult.id,
+  };
+  const events: TaskEvent[] = [
+    {
+      type: 'task_run_created',
+      id: eventId(),
+      taskRunId,
+      ts: record.startedAt,
+      taskId: record.taskId,
+      configId: record.configId,
+      ...(options.task ? { taskDefinition: taskDefinitionFromTask(options.task) } : {}),
+      sourceResultRecord: record,
+    },
+    {
+      type: 'task_run_started',
+      id: eventId(),
+      taskRunId,
+      ts: record.startedAt,
+      startedAt: record.startedAt,
+      ...(record.sessionId ? { sessionId: record.sessionId } : {}),
+      ...(record.runId ? { agentRunId: record.runId } : {}),
+    },
+    {
+      type: 'task_attempt_started',
+      id: eventId(),
+      taskRunId,
+      ts: record.startedAt,
+      attemptId,
+      startedAt: record.startedAt,
+      ...(record.sessionId ? { sessionId: record.sessionId } : {}),
+      ...(record.runId ? { agentRunId: record.runId } : {}),
+    },
+  ];
+
+  if (verifierResult) {
+    events.push({ type: 'verifier_result_recorded', id: eventId(), taskRunId, ts: record.finishedAt, result: verifierResult });
+  }
+  events.push({ type: 'score_result_recorded', id: eventId(), taskRunId, ts: record.finishedAt, result: scoreResult });
+  events.push({
+    type: 'task_attempt_completed',
+    id: eventId(),
+    taskRunId,
+    ts: record.finishedAt,
+    attemptId,
+    finishedAt: record.finishedAt,
+    status: attemptStatusFromResult(record.status, taxonomy),
+    ...(record.status === 'failed' ? { error: errorFromResultRecord(record, taxonomy) } : {}),
+  });
+
+  events.push(terminalEventFromResult(record, taxonomy, result, taskRunId, eventId));
+
+  return events;
+}
+
+function attemptStatusFromResult(
+  status: ResultRecord['status'],
+  taxonomy: AutonomousResultTaxonomy,
+): Exclude<TaskAttemptStatus, 'running'> {
+  if (status === 'completed') return 'completed';
+  switch (taxonomy) {
+    case 'agent_incomplete':
+      return 'incomplete';
+    case 'blocked':
+      return 'blocked';
+    case 'policy_denied':
+      return 'policy_denied';
+    case 'budget_exhausted':
+      return 'budget_exhausted';
+    case 'aborted':
+      return 'aborted';
+    case 'cancelled':
+      return 'cancelled';
+    case 'passed':
+    case 'verification_failed':
+    case 'verification_error':
+    case 'agent_failed':
+    case 'setup_failed':
+    case 'infra_failed':
+      return 'failed';
+  }
+}
+
+function terminalEventFromResult(
+  record: ResultRecord,
+  taxonomy: AutonomousResultTaxonomy,
+  result: TaskRunResult,
+  taskRunId: string,
+  eventId: () => string,
+): TaskEvent {
+  const base = { id: eventId(), taskRunId, ts: record.finishedAt, finishedAt: record.finishedAt };
+  if (record.status === 'completed') {
+    return { type: 'task_run_completed', ...base, result };
+  }
+
+  const error = errorFromResultRecord(record, taxonomy);
+  switch (taxonomy) {
+    case 'agent_incomplete':
+      return { type: 'task_run_incomplete', ...base, error };
+    case 'blocked':
+      return { type: 'task_run_blocked', ...base, error };
+    case 'policy_denied':
+      return { type: 'task_run_policy_denied', ...base, error };
+    case 'budget_exhausted':
+      return { type: 'task_run_budget_exhausted', ...base, error };
+    case 'aborted':
+      return { type: 'task_run_aborted', ...base, error };
+    case 'cancelled':
+      return { type: 'task_run_cancelled', ...base, error };
+    case 'passed':
+    case 'verification_failed':
+    case 'verification_error':
+    case 'agent_failed':
+    case 'setup_failed':
+    case 'infra_failed':
+      return { type: 'task_run_failed', ...base, error };
+  }
+}
+
+export function resultRecordFromTaskRunProjection(projection: TaskRunProjection): ResultRecord {
+  const base = projection.sourceResultRecord ?? baseResultRecord(projection);
+  const latestScore = projection.latestScoreResult;
+  const taxonomy = latestScore?.taxonomy ?? projection.result?.taxonomy;
+  const passed = latestScore?.passed ?? projection.result?.passed ?? projection.latestVerifierResult?.passed ?? false;
+  const exitCode = projection.latestVerifierResult?.exitCode ?? base.exitCode;
+
+  if (projection.status === 'completed') {
+    const { error: _error, errorClass: _errorClass, ...completedBase } = base;
+    return {
+      ...completedBase,
+      status: 'completed',
+      passed,
+      exitCode,
+    };
+  }
+
+  const failureClass = legacyFailureClass(projection.status, taxonomy);
+  if (failureClass) {
+    const errorClass = projection.error?.class ?? base.errorClass ?? (projection.sourceResultRecord ? undefined : failureClass);
+    return {
+      ...base,
+      status: 'failed',
+      passed: false,
+      exitCode,
+      error: projection.error?.message ?? base.error ?? errorMessageFromTaxonomy(taxonomy, projection.status),
+      ...(errorClass ? { errorClass } : {}),
+    };
+  }
+
+  return {
+    ...base,
+    status: 'failed',
+    passed: false,
+    exitCode,
+    error: base.error ?? `task run is ${projection.status}`,
+    errorClass: base.errorClass ?? 'non_terminal',
+  };
+}
+
+function legacyFailureClass(
+  status: TaskRunProjection['status'],
+  taxonomy: AutonomousResultTaxonomy | undefined,
+): string | undefined {
+  switch (status) {
+    case 'failed':
+      return taxonomy ?? 'failed';
+    case 'incomplete':
+      return 'agent_incomplete';
+    case 'blocked':
+      return 'blocked';
+    case 'policy_denied':
+      return 'policy_denied';
+    case 'budget_exhausted':
+      return 'budget_exhausted';
+    case 'aborted':
+      return 'aborted';
+    case 'cancelled':
+      return 'cancelled';
+    case 'queued':
+    case 'created':
+    case 'running':
+    case 'verifying':
+    case 'completed':
+      return undefined;
+  }
+}
+
+function baseResultRecord(projection: TaskRunProjection): ResultRecord {
+  const startedAt = projection.startedAt ?? projection.events[0]?.ts ?? 0;
+  const finishedAt = projection.finishedAt ?? projection.events.at(-1)?.ts ?? startedAt;
+  return {
+    taskId: projection.taskId,
+    configId: projection.configId,
+    sessionId: projection.sessionId ?? '',
+    runId: projection.agentRunId ?? projection.taskRunId,
+    status: 'failed',
+    passed: false,
+    exitCode: projection.latestVerifierResult?.exitCode ?? null,
+    steps: projection.events.length,
+    durationMs: finishedAt - startedAt,
+    startedAt,
+    finishedAt,
+  };
+}
+
+function errorFromResultRecord(record: ResultRecord, taxonomy: AutonomousResultTaxonomy): TaskRunError {
+  return {
+    message: record.error ?? errorMessageFromTaxonomy(taxonomy),
+    ...(record.errorClass ? { class: record.errorClass } : {}),
+  };
+}
+
+function errorMessageFromTaxonomy(
+  taxonomy: AutonomousResultTaxonomy | undefined,
+  status?: TaskRunProjection['status'],
+): string {
+  switch (taxonomy) {
+    case 'agent_failed':
+      return 'agent run failed';
+    case 'agent_incomplete':
+      return 'agent run incomplete';
+    case 'setup_failed':
+      return 'task setup failed';
+    case 'infra_failed':
+      return 'infrastructure failed';
+    case 'verification_error':
+      return 'verification errored';
+    case 'policy_denied':
+      return 'task run denied by policy';
+    case 'budget_exhausted':
+      return 'task run budget exhausted';
+    case 'aborted':
+      return 'task run aborted';
+    case 'blocked':
+      return 'task run blocked';
+    case 'cancelled':
+      return 'task run cancelled';
+    case 'verification_failed':
+      return 'verification failed';
+    case 'passed':
+    case undefined:
+      if (status) return `task run is ${status}`;
+      return 'task run failed';
+  }
+}

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -1,0 +1,322 @@
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ResultRecord } from './contracts.js';
+import type {
+  AutonomousDecision,
+  FeedbackObservation,
+  ScoreResult,
+  SelfCheckObservation,
+  TaskAttempt,
+  TaskEvent,
+  TaskRun,
+  TaskRunError,
+  TaskRunResult,
+  VerifierResult,
+} from './task-contracts.js';
+
+export interface TaskRunProjection extends TaskRun {
+  events: TaskEvent[];
+  attempts: TaskAttempt[];
+  selfChecks: SelfCheckObservation[];
+  feedback: FeedbackObservation[];
+  decisions: AutonomousDecision[];
+  verifierResults: VerifierResult[];
+  scoreResults: ScoreResult[];
+  warnings: string[];
+  latestVerifierResult?: VerifierResult;
+  latestScoreResult?: ScoreResult;
+  sourceResultRecord?: ResultRecord;
+}
+
+export interface TaskRunStore {
+  appendEvent(taskRunId: string, event: TaskEvent): Promise<void>;
+  readEvents(taskRunId: string): Promise<TaskEvent[]>;
+  project(taskRunId: string): Promise<TaskRunProjection>;
+}
+
+export function createInMemoryTaskRunStore(initialEvents: readonly TaskEvent[] = []): TaskRunStore {
+  return new InMemoryTaskRunStore(initialEvents);
+}
+
+export function createTaskRunStore(storageRoot: string): TaskRunStore {
+  return new FileTaskRunStore(storageRoot);
+}
+
+export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string): TaskRunProjection {
+  const projectedTaskRunId = taskRunId ?? events[0]?.taskRunId ?? '';
+  const projection: TaskRunProjection = {
+    taskRunId: projectedTaskRunId,
+    taskId: '',
+    configId: '',
+    status: 'queued',
+    events: [],
+    attempts: [],
+    selfChecks: [],
+    feedback: [],
+    decisions: [],
+    verifierResults: [],
+    scoreResults: [],
+    warnings: [],
+  };
+  const attempts = new Map<string, TaskAttempt>();
+  let terminalEvents = 0;
+
+  for (const event of events) {
+    if (projectedTaskRunId && event.taskRunId !== projectedTaskRunId) {
+      projection.warnings.push(`ignored event ${event.id}: taskRunId ${event.taskRunId} does not match ${projectedTaskRunId}`);
+      continue;
+    }
+    projection.events.push(event);
+
+    switch (event.type) {
+      case 'task_run_created':
+        projection.taskId = event.taskId;
+        projection.configId = event.configId;
+        projection.status = 'created';
+        projection.sourceResultRecord = event.sourceResultRecord;
+        break;
+      case 'task_run_queued':
+        projection.taskId = event.taskId;
+        projection.configId = event.configId;
+        projection.status = 'queued';
+        break;
+      case 'task_run_started':
+        projection.status = 'running';
+        projection.startedAt = event.startedAt ?? event.ts;
+        setOptionalRefs(projection, event.sessionId, event.agentRunId);
+        break;
+      case 'task_run_verifying':
+        projection.status = 'verifying';
+        break;
+      case 'task_attempt_started': {
+        const attempt: TaskAttempt = {
+          attemptId: event.attemptId,
+          taskRunId: event.taskRunId,
+          startedAt: event.startedAt ?? event.ts,
+          status: 'running',
+          ...(event.sessionId ? { sessionId: event.sessionId } : {}),
+          ...(event.agentRunId ? { agentRunId: event.agentRunId } : {}),
+        };
+        attempts.set(event.attemptId, attempt);
+        setOptionalRefs(projection, event.sessionId, event.agentRunId);
+        break;
+      }
+      case 'self_check_observed':
+        projection.selfChecks.push(event.observation);
+        break;
+      case 'feedback_observed':
+        projection.feedback.push(event.observation);
+        break;
+      case 'autonomous_decision_recorded':
+        projection.decisions.push(event.decision);
+        break;
+      case 'verifier_result_recorded':
+        projection.verifierResults.push(event.result);
+        projection.latestVerifierResult = event.result;
+        break;
+      case 'score_result_recorded':
+        projection.scoreResults.push(event.result);
+        projection.latestScoreResult = event.result;
+        projection.result = resultFromScore(event.result, projection.latestVerifierResult);
+        break;
+      case 'task_attempt_completed':
+        attempts.set(event.attemptId, {
+          ...(attempts.get(event.attemptId) ?? {
+            attemptId: event.attemptId,
+            taskRunId: event.taskRunId,
+            startedAt: event.ts,
+          }),
+          status: event.status,
+          finishedAt: event.finishedAt ?? event.ts,
+          ...(event.error ? { error: event.error } : {}),
+        });
+        break;
+      case 'task_run_completed':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'completed';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.result = event.result ?? projection.result ?? resultFromScore(projection.latestScoreResult, projection.latestVerifierResult);
+        break;
+      case 'task_run_failed':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'failed';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error;
+        break;
+      case 'task_run_incomplete':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'incomplete';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run incomplete', class: 'agent_incomplete' };
+        break;
+      case 'task_run_blocked':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'blocked';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run blocked', class: 'blocked' };
+        break;
+      case 'task_run_policy_denied':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'policy_denied';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run denied by policy', class: 'policy_denied' };
+        break;
+      case 'task_run_budget_exhausted':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'budget_exhausted';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run budget exhausted', class: 'budget_exhausted' };
+        break;
+      case 'task_run_aborted':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'aborted';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run aborted', class: 'aborted' };
+        break;
+      case 'task_run_cancelled':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'cancelled';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run cancelled', class: 'cancelled' };
+        break;
+      case 'event_corrupt':
+        projection.warnings.push(`corrupt event ${event.id}: ${event.error}`);
+        break;
+    }
+  }
+
+  projection.attempts = [...attempts.values()];
+  return projection;
+}
+
+class InMemoryTaskRunStore implements TaskRunStore {
+  private readonly events = new Map<string, TaskEvent[]>();
+  private readonly queues = new Map<string, Promise<void>>();
+
+  constructor(initialEvents: readonly TaskEvent[]) {
+    for (const event of initialEvents) {
+      const events = this.events.get(event.taskRunId) ?? [];
+      events.push(event);
+      this.events.set(event.taskRunId, events);
+    }
+  }
+
+  async appendEvent(taskRunId: string, event: TaskEvent): Promise<void> {
+    if (event.taskRunId !== taskRunId) {
+      throw new Error(`taskRunId mismatch: append target ${taskRunId}, event ${event.taskRunId}`);
+    }
+
+    const previous = this.queues.get(taskRunId) ?? Promise.resolve();
+    const next = previous.then(() => {
+      const events = this.events.get(taskRunId) ?? [];
+      events.push(event);
+      this.events.set(taskRunId, events);
+    });
+    this.queues.set(taskRunId, next.catch(() => undefined));
+    await next;
+  }
+
+  async readEvents(taskRunId: string): Promise<TaskEvent[]> {
+    return [...(this.events.get(taskRunId) ?? [])];
+  }
+
+  async project(taskRunId: string): Promise<TaskRunProjection> {
+    return projectTaskRun(await this.readEvents(taskRunId), taskRunId);
+  }
+}
+
+class FileTaskRunStore implements TaskRunStore {
+  private readonly queues = new Map<string, Promise<void>>();
+
+  constructor(private readonly storageRoot: string) {}
+
+  async appendEvent(taskRunId: string, event: TaskEvent): Promise<void> {
+    if (event.taskRunId !== taskRunId) {
+      throw new Error(`taskRunId mismatch: append target ${taskRunId}, event ${event.taskRunId}`);
+    }
+
+    const previous = this.queues.get(taskRunId) ?? Promise.resolve();
+    const next = previous.then(async () => {
+      await mkdir(this.taskRunDir(), { recursive: true });
+      await appendFile(this.taskRunPath(taskRunId), `${JSON.stringify(event)}\n`, 'utf8');
+    });
+    this.queues.set(taskRunId, next.catch(() => undefined));
+    await next;
+  }
+
+  async readEvents(taskRunId: string): Promise<TaskEvent[]> {
+    let content: string;
+    try {
+      content = await readFile(this.taskRunPath(taskRunId), 'utf8');
+    } catch (error) {
+      if (isNotFound(error)) return [];
+      throw error;
+    }
+
+    const lines = content.endsWith('\n') ? content.split('\n') : content.split('\n').slice(0, -1);
+    const events: TaskEvent[] = [];
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (!line) continue;
+      try {
+        events.push(JSON.parse(line) as TaskEvent);
+      } catch (error) {
+        events.push({
+          type: 'event_corrupt',
+          id: `corrupt-${i + 1}`,
+          taskRunId,
+          ts: 0,
+          raw: line,
+          error: errorMessage(error),
+        });
+      }
+    }
+    return events;
+  }
+
+  async project(taskRunId: string): Promise<TaskRunProjection> {
+    return projectTaskRun(await this.readEvents(taskRunId), taskRunId);
+  }
+
+  private taskRunDir(): string {
+    return join(this.storageRoot, 'task-runs');
+  }
+
+  private taskRunPath(taskRunId: string): string {
+    return join(this.taskRunDir(), `${safeFileId(taskRunId)}.jsonl`);
+  }
+}
+
+function setOptionalRefs(projection: TaskRunProjection, sessionId: string | undefined, agentRunId: string | undefined): void {
+  if (sessionId) projection.sessionId = sessionId;
+  if (agentRunId) projection.agentRunId = agentRunId;
+}
+
+function resultFromScore(score: ScoreResult | undefined, verifier: VerifierResult | undefined): TaskRunResult | undefined {
+  if (!score) return undefined;
+  return {
+    passed: score.passed,
+    taxonomy: score.taxonomy,
+    ...(verifier ? { verifierResultId: verifier.id } : {}),
+    scoreResultId: score.id,
+  };
+}
+
+function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: number): number {
+  if (terminalEvents > 0) {
+    projection.warnings.push('multiple terminal task run events observed; last terminal event wins');
+  }
+  return terminalEvents + 1;
+}
+
+function safeFileId(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '_') || '_';
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === 'ENOENT';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- add @maka/headless task-run contracts for TaskDefinition, TaskRun, attempts, events, observations, decisions, verifier results, score results, statuses, and autonomous result taxonomy
- add replay projection plus in-memory and file-backed append-only TaskRunStore implementations
- add compatibility adapters for existing Task / ResultRecord semantics, including explicit incomplete/policy/budget/blocked/infra taxonomy and skipped verifier handling

## Verification
- npm --workspace @maka/headless run typecheck
- npm --workspace @maka/headless test
- npm run typecheck --workspaces --if-present
- git diff --check