### PR TITLE
Add task agent single-attempt facade

### DIFF
--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -1,0 +1,372 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { BackendRegistry, FakeBackend, SessionManager, type AgentBackend, type SessionStore } from '@maka/runtime';
+import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
+import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
+import type { Config, Task } from '../contracts.js';
+import { runTaskOnce } from '../task-agent-controller.js';
+
+const fakeConfig: Config = {
+  id: 'fake-cfg',
+  backend: 'fake',
+  llmConnectionSlug: 'fake',
+  model: 'fake-model',
+};
+
+const registerFakeBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) =>
+    new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+  );
+};
+
+class ReportingBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: { sessionId: string; header: SessionHeader; store: SessionStore }) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const { turnId } = input;
+    const ts = Date.now();
+    const messageId = 'reporting-message';
+    await this.ctx.store.appendMessage(this.sessionId, {
+      type: 'assistant',
+      id: messageId,
+      turnId,
+      ts,
+      text: 'done',
+      modelId: this.ctx.header.model,
+    });
+    yield { type: 'text_complete', id: 'report-text', turnId, ts, messageId, text: 'done' };
+    yield {
+      type: 'tool_result',
+      id: 'report-artifact',
+      turnId,
+      ts,
+      toolUseId: 'tool-1',
+      isError: false,
+      content: {
+        kind: 'archived_tool_result',
+        status: 'not_loaded',
+        runtimeEventId: 'runtime-old',
+        toolCallId: 'tool-1',
+        toolName: 'bash',
+        artifactId: 'artifact-1',
+        originalEstimatedTokens: 12,
+        originalBytes: 34,
+        rewriteVersion: 1,
+        reason: 'stale_tool_result_pruned_before_compact',
+      },
+    };
+    yield {
+      type: 'token_usage',
+      id: 'report-usage',
+      turnId,
+      ts,
+      input: 10,
+      output: 5,
+      reasoning: 2,
+      total: 17,
+      costUsd: 0.123,
+      contextBudget: { policyName: 'unit-budget', droppedTurns: 1 } as never,
+    };
+    yield { type: 'complete', id: 'report-complete', turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerReportingBackend = (registry: BackendRegistry): void => {
+  registry.register('ai-sdk', (ctx) =>
+    new ReportingBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+  );
+};
+
+class FailingBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'error',
+      id: 'fail-error',
+      turnId: input.turnId,
+      ts,
+      recoverable: false,
+      reason: 'backend_failed',
+      message: 'backend exploded',
+    };
+    yield { type: 'complete', id: 'fail-complete', turnId: input.turnId, ts, stopReason: 'error' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerFailingBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new FailingBackend(ctx.sessionId));
+};
+
+class IncompleteBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'token_usage',
+      id: 'incomplete-usage',
+      turnId: input.turnId,
+      ts,
+      input: 1,
+      output: 2,
+      rawFinishReason: 'tool_calls',
+    };
+    yield { type: 'complete', id: 'incomplete-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerIncompleteBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new IncompleteBackend(ctx.sessionId));
+};
+
+class PermissionRequestBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(sessionId: string, private readonly onRespond: () => void) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'permission_request',
+      id: 'permission-request-event',
+      turnId: input.turnId,
+      ts,
+      requestId: 'permission-request-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'rm -rf /tmp/example' },
+    };
+    yield { type: 'complete', id: 'permission-complete', turnId: input.turnId, ts, stopReason: 'permission_handoff' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {
+    this.onRespond();
+    throw new Error('headless task facade must not answer interactive permission requests');
+  }
+  async dispose(): Promise<void> {}
+}
+
+const registerPermissionRequestBackend = (onRespond: () => void) => (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId, onRespond));
+};
+
+async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
+  const fixtureDir = await mkdtemp(join(tmpdir(), 'maka-task-controller-fx-'));
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-controller-store-'));
+  try {
+    return await fn(fixtureDir, storageRoot);
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+    await rm(storageRoot, { recursive: true, force: true });
+  }
+}
+
+describe('runTaskOnce', () => {
+  test('uses RuntimeRunner path without SessionManager.sendMessage and writes a passing ledger', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const original = SessionManager.prototype.sendMessage;
+      SessionManager.prototype.sendMessage = async function* () {
+        throw new Error('interactive sendMessage path must not be used');
+      } as typeof original;
+      try {
+        const task: Task = {
+          id: 'pass-task',
+          instruction: 'do the thing',
+          workspaceDir: fixtureDir,
+          verification: { command: 'test -f marker.txt', protectedPaths: [] },
+        };
+
+        const result = await runTaskOnce(fakeConfig, task, {
+          storageRoot,
+          registerBackends: registerFakeBackend,
+        });
+
+        assert.equal(result.resultRecord.status, 'completed');
+        assert.equal(result.resultRecord.passed, true);
+        assert.equal(result.projection.status, 'completed');
+        assert.equal(result.projection.latestScoreResult?.passed, true);
+        assert.deepEqual(
+          result.projection.events.map((event) => event.type),
+          [
+            'task_run_created',
+            'task_run_queued',
+            'task_run_started',
+            'task_attempt_started',
+            'feedback_observed',
+            'task_run_verifying',
+            'verifier_result_recorded',
+            'score_result_recorded',
+            'task_attempt_completed',
+            'task_run_completed',
+          ],
+        );
+      } finally {
+        SessionManager.prototype.sendMessage = original;
+      }
+    });
+  });
+
+  test('records a failing verifier as a completed task run with passed=false', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'verify-fails',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+      });
+
+      assert.equal(result.resultRecord.status, 'completed');
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.projection.status, 'completed');
+      assert.equal(result.projection.result?.passed, false);
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'verification_failed');
+    });
+  });
+
+  test('maps backend failure and incomplete runtime to terminal failure taxonomy', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const task: Task = {
+        id: 'backend-fails',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      const failed = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        taskRunId: 'backend-failure-run',
+        registerBackends: registerFailingBackend,
+      });
+      assert.equal(failed.resultRecord.status, 'failed');
+      assert.equal(failed.projection.status, 'failed');
+      assert.equal(failed.projection.latestScoreResult?.taxonomy, 'agent_failed');
+      assert.equal(failed.projection.error?.class, 'backend_failed');
+
+      const incomplete = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        taskRunId: 'incomplete-run',
+        registerBackends: registerIncompleteBackend,
+      });
+      assert.equal(incomplete.resultRecord.status, 'failed');
+      assert.equal(incomplete.projection.status, 'incomplete');
+      assert.equal(incomplete.projection.latestScoreResult?.taxonomy, 'agent_incomplete');
+    });
+  });
+
+  test('fails closed on permission requests without answering the interactive permission API', async () => {
+    await withDirs(async (_fixtureDir, storageRoot) => {
+      let respondCalls = 0;
+      const task: Task = {
+        id: 'permission-handoff',
+        instruction: 'run a dangerous command',
+        workspaceDir: _fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerPermissionRequestBackend(() => {
+          respondCalls += 1;
+        }),
+      });
+
+      assert.equal(respondCalls, 0);
+      assert.equal(result.resultRecord.status, 'failed');
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.resultRecord.errorClass, 'policy_denied');
+      assert.equal(result.projection.status, 'policy_denied');
+      assert.equal(result.projection.latestVerifierResult?.exitCode, 0);
+      assert.equal(result.projection.latestScoreResult?.passed, false);
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'policy_denied');
+      assert.ok(
+        result.projection.events.some((event) => event.type === 'task_run_policy_denied'),
+        'expected a policy-denied terminal task event',
+      );
+    });
+  });
+
+  test('persists runtime refs, isolation, budget, and artifact metadata', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const task: Task = {
+        id: 'metadata-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+      const config: Config = {
+        id: 'real-cfg',
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'test',
+        model: 'test-model',
+      };
+
+      const result = await runTaskOnce(config, task, {
+        storageRoot,
+        registerBackends: registerReportingBackend,
+        realBackendIsolation: { kind: 'external', label: 'unit isolation' },
+      });
+
+      const feedback = result.projection.feedback.find((entry) => entry.source === 'runtime');
+      assert.ok(feedback?.details);
+      assert.equal((feedback.details.isolation as { label?: string }).label, 'unit isolation');
+      assert.equal((feedback.details.runtimeRefs as { runId?: string }).runId, result.invocation.runId);
+      assert.ok((feedback.details.runtimeRefs as { runtimeEventIds?: string[] }).runtimeEventIds?.includes('report-usage'));
+      assert.deepEqual(feedback.details.artifactRefs, [
+        { runtimeEventId: 'report-artifact', artifactId: 'artifact-1', toolCallId: 'tool-1' },
+      ]);
+      assert.equal(((feedback.details.budget as { totals: { input: number } }).totals.input), 10);
+      assert.deepEqual(result.projection.latestScoreResult?.details?.artifactRefs, feedback.details.artifactRefs);
+
+      const runtimeEventsPath = join(storageRoot, 'sessions', result.invocation.sessionId, 'runs', result.invocation.runId, 'runtime-events.jsonl');
+      const runtimeEvents = await readFile(runtimeEventsPath, 'utf8');
+      assert.match(runtimeEvents, /report-usage/);
+      assert.match(runtimeEvents, /report-artifact/);
+    });
+  });
+});

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -47,6 +47,8 @@ export {
   taskDefinitionFromTask,
   taskEventsFromResultRecord,
 } from './task-run-adapter.js';
+export type { RunTaskOnceDeps, RunTaskOnceResult } from './task-agent-controller.js';
+export { runTaskOnce, TaskAgentController } from './task-agent-controller.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export { readResults, writeResults, toComparisonTable } from './results.js';

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -1,0 +1,718 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  AgentRunStore,
+  RuntimeEvent,
+  RuntimeEventStore,
+  SessionBlockedReason,
+  SessionHeader,
+  SessionStatus,
+  StoredMessage,
+} from '@maka/core';
+import {
+  AgentRun,
+  AiSdkFlow,
+  BackendRegistry,
+  RuntimeRunner,
+  type AgentRunActiveSession,
+  type InvocationResult,
+  type SessionStore,
+} from '@maka/runtime';
+import {
+  createAgentRunStore,
+  createRuntimeEventStore,
+  createSessionStore,
+} from '@maka/storage';
+import type { Config, ResultRecord, Task } from './contracts.js';
+import { registerFakeBackend } from './backends.js';
+import type { HeadlessBackendContext } from './isolation.js';
+import { validateRealBackendIsolation } from './isolation.js';
+import { prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
+import { runVerification } from './evaluator.js';
+import {
+  backendNeedsIsolation,
+  type RunExperimentDeps,
+  validateTaskVerification,
+} from './runner.js';
+import {
+  taxonomyFromResultRecord,
+  type AutonomousResultTaxonomy,
+  type FeedbackObservation,
+  type ScoreResult,
+  type TaskAttemptStatus,
+  type TaskEvent,
+  type TaskRunError,
+  type TaskRunResult,
+  type VerifierResult,
+} from './task-contracts.js';
+import {
+  createTaskRunStore,
+  type TaskRunProjection,
+  type TaskRunStore,
+} from './task-run-store.js';
+import { taskDefinitionFromTask } from './task-run-adapter.js';
+
+export interface RunTaskOnceDeps extends RunExperimentDeps {
+  taskRunStore?: TaskRunStore;
+  runtimeEventStore?: RuntimeEventStore;
+  sessionStore?: SessionStore;
+  agentRunStore?: AgentRunStore;
+  taskRunId?: string;
+  attemptId?: string;
+  permissionMode?: 'execute';
+}
+
+export interface RunTaskOnceResult {
+  taskRunId: string;
+  attemptId: string;
+  resultRecord: ResultRecord;
+  projection: TaskRunProjection;
+  invocation: InvocationResult;
+}
+
+export class TaskAgentController {
+  constructor(private readonly deps: RunTaskOnceDeps) {}
+
+  runOnce(config: Config, task: Task): Promise<RunTaskOnceResult> {
+    return runTaskOnce(config, task, this.deps);
+  }
+}
+
+export async function runTaskOnce(
+  config: Config,
+  task: Task,
+  deps: RunTaskOnceDeps,
+): Promise<RunTaskOnceResult> {
+  if (backendNeedsIsolation(config.backend)) {
+    validateRealBackendIsolation(deps.realBackendIsolation);
+    if (!deps.registerBackends) {
+      throw new Error(
+        `@maka/headless: backend "${config.backend}" requires registerBackends to wire an isolated backend factory`,
+      );
+    }
+  }
+  validateTaskVerification(task);
+
+  const now = deps.now ?? Date.now;
+  const newId = deps.newId ?? randomUUID;
+  const taskRunId = deps.taskRunId ?? newId();
+  const attemptId = deps.attemptId ?? `${taskRunId}-attempt-1`;
+  const taskRunStore = deps.taskRunStore ?? createTaskRunStore(deps.storageRoot);
+  const sessionStore = deps.sessionStore ?? createSessionStore(deps.storageRoot);
+  const agentRunStore = deps.agentRunStore ?? createAgentRunStore(deps.storageRoot);
+  const runtimeEventStore = deps.runtimeEventStore ?? createRuntimeEventStore(deps.storageRoot);
+  const startedAt = now();
+
+  await appendTaskEvent(taskRunStore, taskRunId, {
+    type: 'task_run_created',
+    id: newId(),
+    taskRunId,
+    ts: startedAt,
+    taskId: task.id,
+    configId: config.id,
+    taskDefinition: taskDefinitionFromTask(task),
+  });
+  await appendTaskEvent(taskRunStore, taskRunId, {
+    type: 'task_run_queued',
+    id: newId(),
+    taskRunId,
+    ts: now(),
+    taskId: task.id,
+    configId: config.id,
+    taskDefinition: taskDefinitionFromTask(task),
+  });
+
+  const workspace = await prepareWorkspace(task.workspaceDir);
+  try {
+    const backends = new BackendRegistry();
+    const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
+      deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
+    await registerBackends(backends, {
+      config,
+      task,
+      workspaceDir: workspace.dir,
+      ...(backendNeedsIsolation(config.backend)
+        ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
+        : {}),
+    });
+
+    const header = await sessionStore.create({
+      cwd: workspace.dir,
+      backend: config.backend,
+      llmConnectionSlug: config.llmConnectionSlug,
+      model: config.model,
+      permissionMode: deps.permissionMode ?? 'execute',
+      name: `task:${config.id}:${task.id}`,
+    });
+    const turnId = newId();
+    const active = createSingleRunActiveSession(backends, sessionStore, now, newId);
+    const run = new AgentRun({
+      sessionId: header.id,
+      header,
+      userInput: { turnId, text: task.instruction },
+      store: sessionStore,
+      runStore: agentRunStore,
+      runtimeEventStore,
+      newId,
+      now,
+      hooks: active.hooks,
+    });
+    active.bindRun(run);
+
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_run_started',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      startedAt,
+      sessionId: header.id,
+      agentRunId: run.runId,
+    });
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_attempt_started',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      attemptId,
+      startedAt,
+      sessionId: header.id,
+      agentRunId: run.runId,
+    });
+
+    let runtimeInvocation: InvocationResult;
+    try {
+      runtimeInvocation = await runRuntimeAttempt({
+        run,
+        task,
+        header,
+        now,
+        newId,
+      });
+    } finally {
+      await active.dispose();
+    }
+    const invocation = normalizeHeadlessInvocation(runtimeInvocation);
+
+    const runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
+    await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
+
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_run_verifying',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      startedAt: now(),
+    });
+    await restoreProtectedPaths(task.workspaceDir, workspace.dir, task.verification.protectedPaths);
+    const evaluation = await runVerification(
+      task.verification.command,
+      workspace.dir,
+      task.verification.timeoutMs,
+    );
+
+    const finishedAt = now();
+    const resultRecord = resultRecordFromInvocation({
+      config,
+      task,
+      sessionId: header.id,
+      invocation,
+      evaluation,
+      startedAt,
+      finishedAt,
+    });
+    const taxonomy = taxonomyFromResultRecord(resultRecord);
+    const verifierResult: VerifierResult = {
+      id: newId(),
+      taskRunId,
+      attemptId,
+      ts: finishedAt,
+      kind: 'command',
+      passed: resultRecord.status === 'completed' && evaluation.passed,
+      exitCode: evaluation.exitCode,
+      command: task.verification.command,
+      ...(evaluation.timedOut ? { error: 'verification timed out' } : {}),
+    };
+    const scoreResult: ScoreResult = {
+      id: newId(),
+      taskRunId,
+      attemptId,
+      ts: finishedAt,
+      passed: resultRecord.status === 'completed' && evaluation.passed,
+      taxonomy,
+      details: {
+        steps: resultRecord.steps,
+        invocationStatus: invocation.status,
+        ...(invocation.failure?.class ? { runtimeFailureClass: invocation.failure.class } : {}),
+        verifierExitCode: evaluation.exitCode,
+        runtimeRefs: runtimeSummary.runtimeRefs,
+        artifactRefs: runtimeSummary.artifactRefs,
+        isolation: runtimeSummary.isolation,
+        budget: runtimeSummary.budget,
+      },
+    };
+    const runResult: TaskRunResult = {
+      passed: scoreResult.passed,
+      taxonomy,
+      verifierResultId: verifierResult.id,
+      scoreResultId: scoreResult.id,
+    };
+
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'verifier_result_recorded',
+      id: newId(),
+      taskRunId,
+      ts: finishedAt,
+      result: verifierResult,
+    });
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'score_result_recorded',
+      id: newId(),
+      taskRunId,
+      ts: finishedAt,
+      result: scoreResult,
+    });
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_attempt_completed',
+      id: newId(),
+      taskRunId,
+      ts: finishedAt,
+      attemptId,
+      finishedAt,
+      status: attemptStatusFromResult(resultRecord.status, taxonomy),
+      ...(resultRecord.status === 'failed' ? { error: errorFromResultRecord(resultRecord, taxonomy) } : {}),
+    });
+    await appendTaskEvent(
+      taskRunStore,
+      taskRunId,
+      terminalEventFromResult(resultRecord, taxonomy, runResult, taskRunId, newId),
+    );
+
+    return {
+      taskRunId,
+      attemptId,
+      resultRecord,
+      projection: await taskRunStore.project(taskRunId),
+      invocation,
+    };
+  } finally {
+    await workspace.cleanup();
+  }
+}
+
+interface RunRuntimeAttemptInput {
+  run: AgentRun;
+  task: Task;
+  header: SessionHeader;
+  now: () => number;
+  newId: () => string;
+}
+
+async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<InvocationResult> {
+  let begin;
+  try {
+    begin = await input.run.begin();
+  } catch (error) {
+    await input.run.recordFailure(error);
+    await input.run.finalize();
+    throw error;
+  }
+
+  const flow = new AiSdkFlow({
+    backend: begin.backend,
+    drainAfterTerminal: true,
+    onSessionEvent: async (sessionEvent, runtimeEvent) => {
+      await input.run.recordSessionEvent(sessionEvent);
+      await input.run.recordRuntimeEvents([runtimeEvent]);
+    },
+    onError: async (error) => {
+      await input.run.recordFailure(error);
+    },
+    onFinally: async () => {
+      await input.run.finalize();
+    },
+  });
+  const runner = new RuntimeRunner({
+    flow,
+    providers: { newId: input.newId, now: input.now },
+    onInitialRuntimeEvent: (event) => input.run.recordRuntimeEvents([event]),
+    stopOnTerminal: false,
+  });
+
+  const invocation = await runner.run({
+    sessionId: input.header.id,
+    runId: input.run.runId,
+    turnId: input.run.turnId,
+    text: input.task.instruction,
+    context: begin.backendInput.context,
+    ...(begin.backendInput.runtimeContext !== undefined ? { runtimeContext: begin.backendInput.runtimeContext } : {}),
+    ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
+    source: 'test',
+    lineage: input.run.lineage,
+  });
+  await input.run.finalize();
+  return invocation;
+}
+
+type AgentRunHooks = ConstructorParameters<typeof AgentRun>[0]['hooks'];
+
+function createSingleRunActiveSession(
+  backends: BackendRegistry,
+  store: SessionStore,
+  now: () => number,
+  newId: () => string,
+): {
+  hooks: AgentRunHooks;
+  bindRun(run: AgentRun): void;
+  dispose(): Promise<void>;
+} {
+  let boundRun: AgentRun | undefined;
+  let active: AgentRunActiveSession | undefined;
+  const bindRun = (run: AgentRun) => {
+    boundRun = run;
+  };
+  return {
+    bindRun,
+    hooks: {
+      ensureActive: async (sessionId, header) => {
+        if (active) {
+          active.cachedHeader = header;
+          return active;
+        }
+        const backend = await backends.build(header.backend, {
+          sessionId,
+          workspaceRoot: header.workspaceRoot,
+          header,
+          store,
+          recordRunTrace: (event) => boundRun?.recordRunTrace(event),
+        });
+        active = {
+          sessionId,
+          backend,
+          cachedHeader: header,
+          activeRuns: new Map(),
+          turnToRunId: new Map(),
+        };
+        return active;
+      },
+      registerRun: (targetActive, run) => {
+        targetActive.activeRuns.set(run.runId, run);
+        targetActive.turnToRunId.set(run.turnId, run.runId);
+      },
+      unregisterRun: (targetActive, run) => {
+        targetActive.activeRuns.delete(run.runId);
+        if (targetActive.turnToRunId.get(run.turnId) === run.runId) {
+          targetActive.turnToRunId.delete(run.turnId);
+        }
+      },
+      updateHeader: async (sessionId, patch) => store.updateHeader(sessionId, patch),
+      updateStatus: async (sessionId, status, blockedReason, ts = now()) => {
+        await store.updateHeader(sessionId, statusPatch(status, ts, blockedReason));
+      },
+      appendTurnState: async (sessionId, turnId, status, lineage, options = {}) => {
+        const ts = options.ts ?? now();
+        const runLineage = lineage ?? {};
+        await store.appendMessage(sessionId, {
+          type: 'turn_state',
+          id: newId(),
+          turnId,
+          ts,
+          status,
+          ...(runLineage.parentTurnId ? { parentTurnId: runLineage.parentTurnId } : {}),
+          ...(runLineage.retriedFromTurnId ? { retriedFromTurnId: runLineage.retriedFromTurnId } : {}),
+          ...(runLineage.regeneratedFromTurnId ? { regeneratedFromTurnId: runLineage.regeneratedFromTurnId } : {}),
+          ...(runLineage.branchOfTurnId ? { branchOfTurnId: runLineage.branchOfTurnId } : {}),
+          ...(runLineage.parentSessionId ? { parentSessionId: runLineage.parentSessionId } : {}),
+          ...(status === 'aborted' ? { abortedAt: ts } : {}),
+          ...(status === 'aborted' && options.abortSource ? { abortSource: options.abortSource } : {}),
+          ...(status === 'failed' ? { errorClass: options.errorClass ?? 'unknown' } : {}),
+          partialOutputRetained: await turnHasRetainedOutput(store, sessionId, turnId),
+        });
+      },
+    },
+    dispose: async () => {
+      const backend = active?.backend;
+      active = undefined;
+      if (backend) await backend.dispose().catch(() => {});
+    },
+  };
+}
+
+function statusPatch(
+  status: SessionStatus,
+  ts: number,
+  blockedReason?: SessionBlockedReason,
+): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
+  return {
+    status,
+    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
+    statusUpdatedAt: ts,
+  };
+}
+
+async function turnHasRetainedOutput(store: SessionStore, sessionId: string, turnId: string): Promise<boolean> {
+  const messages = await store.readMessages(sessionId).catch((): StoredMessage[] => []);
+  return messages.some((message) =>
+    (message.type === 'assistant' && message.turnId === turnId && message.text.trim().length > 0) ||
+    (message.type === 'tool_result' && message.turnId === turnId),
+  );
+}
+
+function resultRecordFromInvocation(input: {
+  config: Config;
+  task: Task;
+  sessionId: string;
+  invocation: InvocationResult;
+  evaluation: Awaited<ReturnType<typeof runVerification>>;
+  startedAt: number;
+  finishedAt: number;
+}): ResultRecord {
+  const status = input.invocation.status;
+  return {
+    taskId: input.task.id,
+    configId: input.config.id,
+    sessionId: input.sessionId,
+    runId: input.invocation.runId,
+    status,
+    passed: status === 'completed' && input.evaluation.passed,
+    exitCode: input.evaluation.exitCode,
+    steps: input.invocation.events.length,
+    durationMs: input.finishedAt - input.startedAt,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    ...(status === 'failed'
+      ? {
+          error: input.invocation.failure?.message ?? input.invocation.failure?.class ?? 'run did not complete',
+          ...(input.invocation.failure?.class ? { errorClass: input.invocation.failure.class } : {}),
+        }
+      : {}),
+  };
+}
+
+function normalizeHeadlessInvocation(invocation: InvocationResult): InvocationResult {
+  const permissionRequestEvent = invocation.events.find((event) => event.actions?.permissionRequest);
+  if (!permissionRequestEvent) return invocation;
+
+  const request = permissionRequestEvent.actions?.permissionRequest;
+  return {
+    ...invocation,
+    status: 'failed',
+    failure: {
+      class: 'policy_denied',
+      message: request?.requestId
+        ? `headless task run cannot satisfy permission request ${request.requestId}`
+        : 'headless task run cannot satisfy an interactive permission request',
+    },
+  };
+}
+
+interface RuntimeSummary {
+  runtimeRefs: {
+    invocationId: string;
+    sessionId: string;
+    runId: string;
+    turnId: string;
+    runtimeEventIds: string[];
+  };
+  artifactRefs: Array<Record<string, unknown>>;
+  isolation: Record<string, unknown>;
+  budget: Record<string, unknown>;
+}
+
+function summarizeRuntime(invocation: InvocationResult, isolation: RunExperimentDeps['realBackendIsolation']): RuntimeSummary {
+  return {
+    runtimeRefs: {
+      invocationId: invocation.invocationId,
+      sessionId: invocation.sessionId,
+      runId: invocation.runId,
+      turnId: invocation.turnId,
+      runtimeEventIds: invocation.events.map((event) => event.id),
+    },
+    artifactRefs: collectArtifactRefs(invocation.events),
+    isolation: isolation ? { kind: isolation.kind, label: isolation.label } : { kind: 'inert_fake_backend' },
+    budget: summarizeBudget(invocation),
+  };
+}
+
+async function appendRuntimeFeedback(
+  store: TaskRunStore,
+  taskRunId: string,
+  attemptId: string,
+  now: () => number,
+  newId: () => string,
+  summary: RuntimeSummary,
+): Promise<void> {
+  const ts = now();
+  const observation: FeedbackObservation = {
+    id: newId(),
+    taskRunId,
+    attemptId,
+    ts,
+    source: 'runtime',
+    summary: 'runtime invocation completed',
+    details: { ...summary },
+  };
+  await appendTaskEvent(store, taskRunId, {
+    type: 'feedback_observed',
+    id: newId(),
+    taskRunId,
+    ts,
+    observation,
+  });
+}
+
+function collectArtifactRefs(events: readonly RuntimeEvent[]): Array<Record<string, unknown>> {
+  const refs: Array<Record<string, unknown>> = [];
+  for (const event of events) {
+    if (event.refs?.artifactId) {
+      refs.push({ runtimeEventId: event.id, artifactId: event.refs.artifactId });
+    }
+    if (event.actions?.artifactDelta) {
+      refs.push({ runtimeEventId: event.id, artifactDelta: event.actions.artifactDelta });
+    }
+    const result = event.content?.kind === 'function_response' ? event.content.result : undefined;
+    if (isRecord(result) && typeof result.artifactId === 'string') {
+      refs.push({
+        runtimeEventId: event.id,
+        artifactId: result.artifactId,
+        toolCallId: event.refs?.toolCallId,
+      });
+    }
+  }
+  return refs;
+}
+
+function summarizeBudget(invocation: InvocationResult): Record<string, unknown> {
+  const totals = {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    total: 0,
+    costUsd: 0,
+  };
+  const contextBudget: unknown[] = [];
+  const rawFinishReasons: string[] = [];
+  for (const event of invocation.events) {
+    const usage = event.actions?.tokenUsage;
+    if (!usage) continue;
+    totals.input += usage.input ?? 0;
+    totals.output += usage.output ?? 0;
+    totals.reasoning += usage.reasoning ?? 0;
+    totals.total += usage.total ?? 0;
+    totals.costUsd += usage.costUsd ?? 0;
+    if (usage.contextBudget) contextBudget.push(usage.contextBudget);
+    if (usage.rawFinishReason) rawFinishReasons.push(usage.rawFinishReason);
+  }
+  return {
+    totals,
+    ...(contextBudget.length > 0 ? { contextBudget } : {}),
+    ...(rawFinishReasons.length > 0 ? { rawFinishReasons } : {}),
+    ...(invocation.failure?.class ? { failureClass: invocation.failure.class } : {}),
+  };
+}
+
+function attemptStatusFromResult(
+  status: ResultRecord['status'],
+  taxonomy: AutonomousResultTaxonomy,
+): Exclude<TaskAttemptStatus, 'running'> {
+  if (status === 'completed') return 'completed';
+  switch (taxonomy) {
+    case 'agent_incomplete':
+      return 'incomplete';
+    case 'blocked':
+      return 'blocked';
+    case 'policy_denied':
+      return 'policy_denied';
+    case 'budget_exhausted':
+      return 'budget_exhausted';
+    case 'aborted':
+      return 'aborted';
+    case 'cancelled':
+      return 'cancelled';
+    case 'passed':
+    case 'verification_failed':
+    case 'verification_error':
+    case 'agent_failed':
+    case 'setup_failed':
+    case 'infra_failed':
+      return 'failed';
+  }
+}
+
+function terminalEventFromResult(
+  record: ResultRecord,
+  taxonomy: AutonomousResultTaxonomy,
+  result: TaskRunResult,
+  taskRunId: string,
+  eventId: () => string,
+): TaskEvent {
+  const base = { id: eventId(), taskRunId, ts: record.finishedAt, finishedAt: record.finishedAt };
+  if (record.status === 'completed') {
+    return { type: 'task_run_completed', ...base, result };
+  }
+
+  const error = errorFromResultRecord(record, taxonomy);
+  switch (taxonomy) {
+    case 'agent_incomplete':
+      return { type: 'task_run_incomplete', ...base, error };
+    case 'blocked':
+      return { type: 'task_run_blocked', ...base, error };
+    case 'policy_denied':
+      return { type: 'task_run_policy_denied', ...base, error };
+    case 'budget_exhausted':
+      return { type: 'task_run_budget_exhausted', ...base, error };
+    case 'aborted':
+      return { type: 'task_run_aborted', ...base, error };
+    case 'cancelled':
+      return { type: 'task_run_cancelled', ...base, error };
+    case 'passed':
+    case 'verification_failed':
+    case 'verification_error':
+    case 'agent_failed':
+    case 'setup_failed':
+    case 'infra_failed':
+      return { type: 'task_run_failed', ...base, error };
+  }
+}
+
+function errorFromResultRecord(record: ResultRecord, taxonomy: AutonomousResultTaxonomy): TaskRunError {
+  return {
+    message: record.error ?? errorMessageFromTaxonomy(taxonomy),
+    ...(record.errorClass ? { class: record.errorClass } : {}),
+  };
+}
+
+function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
+  switch (taxonomy) {
+    case 'agent_failed':
+      return 'agent run failed';
+    case 'agent_incomplete':
+      return 'agent run incomplete';
+    case 'setup_failed':
+      return 'task setup failed';
+    case 'infra_failed':
+      return 'infrastructure failed';
+    case 'verification_error':
+      return 'verification errored';
+    case 'policy_denied':
+      return 'task run denied by policy';
+    case 'budget_exhausted':
+      return 'task run budget exhausted';
+    case 'aborted':
+      return 'task run aborted';
+    case 'blocked':
+      return 'task run blocked';
+    case 'cancelled':
+      return 'task run cancelled';
+    case 'verification_failed':
+      return 'verification failed';
+    case 'passed':
+      return 'task run failed';
+  }
+}
+
+function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {
+  return store.appendEvent(taskRunId, event);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -273,6 +273,11 @@ export type {
   RuntimeKernelDeps,
   RuntimeKernelLike,
 } from './runtime-kernel.js';
+export { AgentRun } from './agent-run.js';
+export type {
+  AgentRunActiveSession,
+  AgentRunLineage,
+} from './agent-run.js';
 
 // agent-run-inspect.ts — internal AgentRun/RuntimeEvent source-health view.
 export {


### PR DESCRIPTION
## Summary
- add a headless TaskAgentController/runTaskOnce facade that runs one task through AgentRun + RuntimeRunner instead of the interactive SessionManager.sendMessage path
- persist task-run events, runtime refs, artifact refs, isolation metadata, budget usage, verifier result, and score result into the task-run ledger
- fail closed on interactive permission requests in headless task mode, including the permission_handoff edge, without calling respondToPermission

## Rive
- workflow: wfrun_a290a8b9d6814d68ae3a868d64a00c11
- scheduler: sched_3b4133b235ea48f088bd450b2ae65bb0
- artifacts: /tmp/rive-maka-task-agent-controller-single-attempt-20260618/output/

## Verification
- npm --workspace @maka/runtime run build
- npm --workspace @maka/headless run typecheck
- npm --workspace @maka/headless run build
- node --test packages/headless/dist/__tests__/task-agent-controller.test.js
- npm --workspace @maka/headless test
- npm run typecheck
- npm run build
- git diff --check