### PR TITLE
Add autonomous task loop v1

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -1,0 +1,276 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { BackendRegistry, FakeBackend, SessionManager, type SessionStore, type AgentBackend } from '@maka/runtime';
+import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
+import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
+import type { Config, Task } from '../contracts.js';
+import { runAutonomousTask } from '../autonomous-agent-loop.js';
+
+const fakeConfig: Config = {
+  id: 'fake-cfg',
+  backend: 'fake',
+  llmConnectionSlug: 'fake',
+  model: 'fake-model',
+};
+
+const registerFakeBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) =>
+    new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+  );
+};
+
+class PermissionRequestBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const ts = Date.now();
+    yield {
+      type: 'permission_request',
+      id: 'permission-request-event',
+      turnId: input.turnId,
+      ts,
+      requestId: 'permission-request-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'rm -rf /tmp/example' },
+    };
+    yield { type: 'complete', id: 'permission-complete', turnId: input.turnId, ts, stopReason: 'permission_handoff' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerPermissionRequestBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId));
+};
+
+async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
+  const fixtureDir = await mkdtemp(join(tmpdir(), 'maka-autonomous-loop-fx-'));
+  const storageRoot = await mkdtemp(join(tmpdir(), 'maka-autonomous-loop-store-'));
+  try {
+    return await fn(fixtureDir, storageRoot);
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+    await rm(storageRoot, { recursive: true, force: true });
+  }
+}
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
+}
+
+describe('runAutonomousTask', () => {
+  test('uses RuntimeRunner path without SessionManager.sendMessage', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const original = SessionManager.prototype.sendMessage;
+      SessionManager.prototype.sendMessage = async function* () {
+        throw new Error('autonomous loop must not use interactive sendMessage');
+      } as typeof original;
+      try {
+        const task: Task = {
+          id: 'no-send-message',
+          instruction: 'do the thing',
+          workspaceDir: fixtureDir,
+          verification: { command: 'test -f marker.txt', protectedPaths: [] },
+        };
+
+        const result = await runAutonomousTask(fakeConfig, task, {
+          storageRoot,
+          registerBackends: registerFakeBackend,
+          budget: { maxAttempts: 2 },
+          newId: idFactory(),
+        });
+
+        assert.equal(result.attempts.length, 1);
+        assert.equal(result.resultRecord.passed, true);
+        assert.equal(result.projection.status, 'completed');
+      } finally {
+        SessionManager.prototype.sendMessage = original;
+      }
+    });
+  });
+
+  test('runs one passing attempt and records stop decision', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const task: Task = {
+        id: 'pass-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 3 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 1);
+      assert.equal(result.resultRecord.passed, true);
+      assert.equal(result.projection.status, 'completed');
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'passed');
+      assert.equal(result.projection.decisions[0]?.decision, 'stop');
+      assert.equal(result.projection.decisions[0]?.reason, 'authoritative verification passed');
+      assert.equal(result.projection.feedback.some((entry) => entry.source === 'verifier'), true);
+      assert.deepEqual(
+        result.projection.events
+          .filter((event) => event.type.startsWith('task_run_'))
+          .map((event) => event.type),
+        [
+          'task_run_created',
+          'task_run_queued',
+          'task_run_started',
+          'task_run_verifying',
+          'task_run_completed',
+        ],
+      );
+    });
+  });
+
+  test('continues after verifier failure until maxAttempts records budget terminal', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'verify-fails',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 2 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 2);
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.projection.status, 'budget_exhausted');
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'verification_failed');
+      assert.deepEqual(result.projection.decisions.map((decision) => decision.decision), ['continue', 'stop']);
+      assert.equal(result.projection.error?.class, 'budget_exhausted');
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'task_run_budget_exhausted').length,
+        1,
+      );
+    });
+  });
+
+  test('self-check pass-like language is non-authoritative when verifier fails', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'self-check-does-not-score',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 1 },
+        selfCheck: {
+          observe: () => ({ summary: 'self-check passed: looks solved', details: { passed: true } }),
+        },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.projection.selfChecks[0]?.summary, 'self-check passed: looks solved');
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.projection.result?.passed, false);
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'verification_failed');
+      assert.notEqual(result.projection.latestScoreResult?.taxonomy, 'passed');
+      assert.equal(result.projection.status, 'budget_exhausted');
+    });
+  });
+
+  test('maxRuntimeSteps fails closed after an over-cap attempt', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'runtime-step-cap',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 3, maxRuntimeSteps: 1 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 1);
+      assert.equal(result.projection.status, 'budget_exhausted');
+      assert.equal(result.projection.decisions[0]?.reason, 'runtime step cap reached');
+      assert.equal(result.projection.error?.class, 'budget_exhausted');
+    });
+  });
+
+  test('maxWallTimeMs fails closed before starting another attempt', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'wall-cap',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+      let t = 0;
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 3, maxWallTimeMs: 1 },
+        now: () => {
+          t += 10;
+          return t;
+        },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 0);
+      assert.equal(result.projection.status, 'budget_exhausted');
+      assert.equal(result.projection.feedback[0]?.source, 'system');
+      assert.equal(result.projection.error?.class, 'budget_exhausted');
+    });
+  });
+
+  test('non-retryable policy-denied taxonomy stops without continuation', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'policy-denied',
+        instruction: 'run a dangerous command',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerPermissionRequestBackend,
+        budget: { maxAttempts: 3 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 1);
+      assert.equal(result.projection.status, 'policy_denied');
+      assert.equal(result.projection.decisions[0]?.decision, 'stop');
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'policy_denied');
+    });
+  });
+});

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -1,0 +1,696 @@
+import { randomUUID } from 'node:crypto';
+import type { Config, ResultRecord, Task } from './contracts.js';
+import { validateRealBackendIsolation } from './isolation.js';
+import {
+  backendNeedsIsolation,
+  validateTaskVerification,
+} from './runner.js';
+import {
+  runTaskOnce,
+  type RunTaskOnceDeps,
+  type RunTaskOnceResult,
+} from './task-agent-controller.js';
+import {
+  taxonomyFromResultRecord,
+  type AutonomousDecision,
+  type AutonomousResultTaxonomy,
+  type FeedbackObservation,
+  type SelfCheckObservation,
+  type TaskEvent,
+  type TaskRunError,
+  type TaskRunResult,
+} from './task-contracts.js';
+import {
+  createTaskRunStore,
+  type TaskRunProjection,
+  type TaskRunStore,
+} from './task-run-store.js';
+import { taskDefinitionFromTask } from './task-run-adapter.js';
+
+export interface AutonomousLoopBudget {
+  maxAttempts: number;
+  maxRuntimeSteps?: number;
+  maxWallTimeMs?: number;
+}
+
+export interface LoopBudgetSnapshot {
+  attemptsUsed: number;
+  maxAttempts: number;
+  runtimeStepsUsed: number;
+  maxRuntimeSteps?: number;
+  elapsedMs: number;
+  maxWallTimeMs?: number;
+}
+
+export interface SelfCheckPolicy {
+  observe(input: SelfCheckInput): SelfCheckOutput | Promise<SelfCheckOutput>;
+}
+
+export interface SelfCheckInput {
+  config: Config;
+  task: Task;
+  attempt: RunTaskOnceResult;
+  budget: LoopBudgetSnapshot;
+}
+
+export interface SelfCheckOutput {
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+export interface FeedbackPromptInput {
+  config: Config;
+  task: Task;
+  attempt: RunTaskOnceResult;
+  budget: LoopBudgetSnapshot;
+  feedback: readonly FeedbackObservation[];
+  selfCheck?: SelfCheckObservation;
+}
+
+export interface AutonomousDecisionInput {
+  config: Config;
+  task: Task;
+  attempt: RunTaskOnceResult;
+  budget: LoopBudgetSnapshot;
+  selfCheck?: SelfCheckObservation;
+}
+
+export interface AutonomousDecisionPolicyResult {
+  decision: AutonomousDecision['decision'];
+  reason?: string;
+  instructionOverride?: string;
+  details?: Record<string, unknown>;
+}
+
+export type AutonomousDecisionPolicy = (
+  input: AutonomousDecisionInput,
+) => AutonomousDecisionPolicyResult | Promise<AutonomousDecisionPolicyResult>;
+
+export interface RunAutonomousTaskOptions extends RunTaskOnceDeps {
+  budget: AutonomousLoopBudget;
+  selfCheck?: false | SelfCheckPolicy;
+  feedbackPrompt?: (input: FeedbackPromptInput) => string;
+  decision?: AutonomousDecisionPolicy;
+}
+
+export interface RunAutonomousTaskResult {
+  taskRunId: string;
+  attempts: RunTaskOnceResult[];
+  projection: TaskRunProjection;
+  /** Latest authoritative attempt result; loop/cap terminal status lives in projection. */
+  resultRecord: ResultRecord;
+}
+
+export class AutonomousAgentLoop {
+  constructor(private readonly deps: RunAutonomousTaskOptions) {}
+
+  run(config: Config, task: Task): Promise<RunAutonomousTaskResult> {
+    return runAutonomousTask(config, task, this.deps);
+  }
+}
+
+export async function runAutonomousTask(
+  config: Config,
+  task: Task,
+  options: RunAutonomousTaskOptions,
+): Promise<RunAutonomousTaskResult> {
+  const now = options.now ?? Date.now;
+  const newId = options.newId ?? randomUUID;
+  const taskRunId = options.taskRunId ?? newId();
+  const taskRunStore = options.taskRunStore ?? createTaskRunStore(options.storageRoot);
+  const startedAt = now();
+  const attempts: RunTaskOnceResult[] = [];
+
+  await appendTaskEvent(taskRunStore, taskRunId, {
+    type: 'task_run_created',
+    id: newId(),
+    taskRunId,
+    ts: startedAt,
+    taskId: task.id,
+    configId: config.id,
+    taskDefinition: taskDefinitionFromTask(task),
+  });
+  await appendTaskEvent(taskRunStore, taskRunId, {
+    type: 'task_run_queued',
+    id: newId(),
+    taskRunId,
+    ts: now(),
+    taskId: task.id,
+    configId: config.id,
+    taskDefinition: taskDefinitionFromTask(task),
+  });
+
+  const budgetError = validateBudget(options.budget);
+  if (budgetError) {
+    const finishedAt = now();
+    const resultRecord = syntheticResultRecord(config, task, taskRunId, 'setup_failed', budgetError, startedAt, finishedAt);
+    await appendTaskEvent(taskRunStore, taskRunId, terminalEventFromResultRecord(resultRecord, taskRunId, newId));
+    return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord };
+  }
+
+  try {
+    if (backendNeedsIsolation(config.backend)) {
+      validateRealBackendIsolation(options.realBackendIsolation);
+      if (!options.registerBackends) {
+        throw new Error(
+          `@maka/headless: backend "${config.backend}" requires registerBackends to wire an isolated backend factory`,
+        );
+      }
+    }
+    validateTaskVerification(task);
+  } catch (error) {
+    const finishedAt = now();
+    const resultRecord = syntheticResultRecord(
+      config,
+      task,
+      taskRunId,
+      'setup_failed',
+      error instanceof Error ? error.message : String(error),
+      startedAt,
+      finishedAt,
+    );
+    await appendTaskEvent(taskRunStore, taskRunId, terminalEventFromResultRecord(resultRecord, taskRunId, newId));
+    return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord };
+  }
+
+  let instructionOverride: string | undefined = options.instructionOverride;
+  let runtimeStepsUsed = 0;
+  let latestResultRecord: ResultRecord | undefined;
+
+  while (attempts.length < options.budget.maxAttempts) {
+    const beforeAttemptBudget = budgetSnapshot(options.budget, attempts.length, runtimeStepsUsed, startedAt, now());
+    if (isWallTimeExhausted(beforeAttemptBudget)) {
+      await appendSystemFeedback(
+        taskRunStore,
+        taskRunId,
+        undefined,
+        now,
+        newId,
+        'wall time cap reached before attempt',
+        { budget: beforeAttemptBudget },
+      );
+      const finishedAt = now();
+      const resultRecord = latestResultRecord ?? syntheticResultRecord(
+        config,
+        task,
+        taskRunId,
+        'budget_exhausted',
+        'wall time cap reached before attempt',
+        startedAt,
+        finishedAt,
+      );
+      await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, beforeAttemptBudget, 'wall time cap reached before attempt');
+      return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord };
+    }
+
+    const attemptNumber = attempts.length + 1;
+    const attemptId = `${taskRunId}-attempt-${attemptNumber}`;
+    const attempt = await runTaskOnce(config, task, {
+      ...options,
+      taskRunStore,
+      taskRunId,
+      attemptId,
+      createTaskRun: false,
+      closeTaskRun: false,
+      ...(instructionOverride ? { instructionOverride } : {}),
+    });
+    attempts.push(attempt);
+    latestResultRecord = attempt.resultRecord;
+    runtimeStepsUsed += attempt.resultRecord.steps;
+
+    const afterAttemptBudget = budgetSnapshot(options.budget, attempts.length, runtimeStepsUsed, startedAt, now());
+    const selfCheck = isWallTimeExhausted(afterAttemptBudget)
+      ? undefined
+      : await maybeRecordSelfCheck(options.selfCheck, {
+          config,
+          task,
+          attempt,
+          budget: afterAttemptBudget,
+        }, taskRunStore, taskRunId, attemptId, now, newId);
+    const verifierFeedback = await appendVerifierFeedback(
+      taskRunStore,
+      taskRunId,
+      attemptId,
+      now,
+      newId,
+      attempt.resultRecord,
+      attempt.projection.latestVerifierResult?.id,
+      attempt.projection.latestScoreResult?.id,
+    );
+    if (selfCheck) {
+      await appendSystemFeedback(
+        taskRunStore,
+        taskRunId,
+        attemptId,
+        now,
+        newId,
+        'self-check recorded as advisory feedback',
+        { selfCheckId: selfCheck.id, selfCheckSummary: selfCheck.summary },
+      );
+    }
+
+    const defaultDecision = defaultDecisionForAttempt(attempt, afterAttemptBudget);
+    const policyDecision = options.decision
+      ? await options.decision({ config, task, attempt, budget: afterAttemptBudget, selfCheck })
+      : defaultDecision;
+    const decision = enforceCaps(policyDecision, attempt, afterAttemptBudget);
+    const nextInstruction = decision.instructionOverride ?? options.feedbackPrompt?.({
+      config,
+      task,
+      attempt,
+      budget: afterAttemptBudget,
+      feedback: [verifierFeedback],
+      ...(selfCheck ? { selfCheck } : {}),
+    }) ?? defaultContinuationPrompt(task, attempt, selfCheck);
+
+    await appendDecision(
+      taskRunStore,
+      taskRunId,
+      attemptId,
+      now,
+      newId,
+      decision,
+      attempt,
+      afterAttemptBudget,
+      selfCheck,
+    );
+
+    if (decision.decision === 'continue' || decision.decision === 'retry') {
+      instructionOverride = nextInstruction;
+      continue;
+    }
+
+    if (shouldBudgetTerminal(decision, attempt, afterAttemptBudget)) {
+      await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, afterAttemptBudget, decision.reason ?? 'loop budget exhausted');
+    } else {
+      await appendTaskEvent(taskRunStore, taskRunId, terminalEventFromResultRecord(attempt.resultRecord, taskRunId, newId, {
+        verifierResultId: attempt.projection.latestVerifierResult?.id,
+        scoreResultId: attempt.projection.latestScoreResult?.id,
+      }));
+    }
+    return {
+      taskRunId,
+      attempts,
+      projection: await taskRunStore.project(taskRunId),
+      resultRecord: attempt.resultRecord,
+    };
+  }
+
+  const exhaustedBudget = budgetSnapshot(options.budget, attempts.length, runtimeStepsUsed, startedAt, now());
+  if (latestResultRecord?.passed) {
+    const latestAttempt = attempts[attempts.length - 1];
+    await appendTaskEvent(taskRunStore, taskRunId, terminalEventFromResultRecord(latestResultRecord, taskRunId, newId, {
+      verifierResultId: latestAttempt?.projection.latestVerifierResult?.id,
+      scoreResultId: latestAttempt?.projection.latestScoreResult?.id,
+    }));
+    return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord: latestResultRecord };
+  }
+  await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, exhaustedBudget, 'max attempts exhausted');
+  const resultRecord = latestResultRecord ?? syntheticResultRecord(
+    config,
+    task,
+    taskRunId,
+    'budget_exhausted',
+    'max attempts exhausted',
+    startedAt,
+    now(),
+  );
+  return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord };
+}
+
+function validateBudget(budget: AutonomousLoopBudget): string | undefined {
+  if (!Number.isInteger(budget.maxAttempts) || budget.maxAttempts < 1) {
+    return 'budget.maxAttempts must be a positive integer';
+  }
+  if (budget.maxRuntimeSteps !== undefined && (!Number.isInteger(budget.maxRuntimeSteps) || budget.maxRuntimeSteps < 1)) {
+    return 'budget.maxRuntimeSteps must be a positive integer when provided';
+  }
+  if (budget.maxWallTimeMs !== undefined && (!Number.isInteger(budget.maxWallTimeMs) || budget.maxWallTimeMs < 1)) {
+    return 'budget.maxWallTimeMs must be a positive integer when provided';
+  }
+  return undefined;
+}
+
+function budgetSnapshot(
+  budget: AutonomousLoopBudget,
+  attemptsUsed: number,
+  runtimeStepsUsed: number,
+  startedAt: number,
+  currentTime: number,
+): LoopBudgetSnapshot {
+  return {
+    attemptsUsed,
+    maxAttempts: budget.maxAttempts,
+    runtimeStepsUsed,
+    ...(budget.maxRuntimeSteps !== undefined ? { maxRuntimeSteps: budget.maxRuntimeSteps } : {}),
+    elapsedMs: Math.max(0, currentTime - startedAt),
+    ...(budget.maxWallTimeMs !== undefined ? { maxWallTimeMs: budget.maxWallTimeMs } : {}),
+  };
+}
+
+function isWallTimeExhausted(budget: LoopBudgetSnapshot): boolean {
+  return budget.maxWallTimeMs !== undefined && budget.elapsedMs >= budget.maxWallTimeMs;
+}
+
+function defaultDecisionForAttempt(
+  attempt: RunTaskOnceResult,
+  budget: LoopBudgetSnapshot,
+): AutonomousDecisionPolicyResult {
+  const taxonomy = taxonomyFromResultRecord(attempt.resultRecord);
+  if (attempt.resultRecord.passed && taxonomy === 'passed') {
+    return { decision: 'stop', reason: 'authoritative verification passed' };
+  }
+  if (isNonRetryable(taxonomy)) {
+    return { decision: taxonomy === 'aborted' || taxonomy === 'cancelled' ? 'abort' : 'stop', reason: `${taxonomy} is not retryable` };
+  }
+  if (budget.attemptsUsed >= budget.maxAttempts) {
+    return { decision: 'stop', reason: 'max attempts exhausted' };
+  }
+  if (budget.maxRuntimeSteps !== undefined && budget.runtimeStepsUsed >= budget.maxRuntimeSteps) {
+    return { decision: 'stop', reason: 'runtime step cap reached' };
+  }
+  if (isWallTimeExhausted(budget)) {
+    return { decision: 'stop', reason: 'wall time cap reached' };
+  }
+  return { decision: 'continue', reason: `${taxonomy} can be retried while budget remains` };
+}
+
+function enforceCaps(
+  decision: AutonomousDecisionPolicyResult,
+  attempt: RunTaskOnceResult,
+  budget: LoopBudgetSnapshot,
+): AutonomousDecisionPolicyResult {
+  if (decision.decision !== 'continue' && decision.decision !== 'retry') return decision;
+  if (attempt.resultRecord.passed) return { ...decision, decision: 'stop', reason: 'authoritative verification passed' };
+  if (budget.attemptsUsed >= budget.maxAttempts) return { ...decision, decision: 'stop', reason: 'max attempts exhausted' };
+  if (budget.maxRuntimeSteps !== undefined && budget.runtimeStepsUsed >= budget.maxRuntimeSteps) {
+    return { ...decision, decision: 'stop', reason: 'runtime step cap reached' };
+  }
+  if (isWallTimeExhausted(budget)) return { ...decision, decision: 'stop', reason: 'wall time cap reached' };
+  return decision;
+}
+
+function shouldBudgetTerminal(
+  decision: AutonomousDecisionPolicyResult,
+  attempt: RunTaskOnceResult,
+  budget: LoopBudgetSnapshot,
+): boolean {
+  if (attempt.resultRecord.passed) return false;
+  if (decision.reason?.includes('max attempts') || decision.reason?.includes('cap')) return true;
+  if (budget.attemptsUsed >= budget.maxAttempts) return true;
+  if (budget.maxRuntimeSteps !== undefined && budget.runtimeStepsUsed >= budget.maxRuntimeSteps) return true;
+  return isWallTimeExhausted(budget);
+}
+
+function isNonRetryable(taxonomy: AutonomousResultTaxonomy): boolean {
+  return taxonomy === 'policy_denied' ||
+    taxonomy === 'blocked' ||
+    taxonomy === 'aborted' ||
+    taxonomy === 'cancelled' ||
+    taxonomy === 'setup_failed' ||
+    taxonomy === 'infra_failed';
+}
+
+async function maybeRecordSelfCheck(
+  policy: false | SelfCheckPolicy | undefined,
+  input: SelfCheckInput,
+  store: TaskRunStore,
+  taskRunId: string,
+  attemptId: string,
+  now: () => number,
+  newId: () => string,
+): Promise<SelfCheckObservation | undefined> {
+  if (!policy) return undefined;
+  const output = await policy.observe(input);
+  const ts = now();
+  const observation: SelfCheckObservation = {
+    id: newId(),
+    taskRunId,
+    attemptId,
+    ts,
+    summary: output.summary.slice(0, 1000),
+    ...(output.details ? { details: output.details } : {}),
+  };
+  await appendTaskEvent(store, taskRunId, {
+    type: 'self_check_observed',
+    id: newId(),
+    taskRunId,
+    ts,
+    observation,
+  });
+  return observation;
+}
+
+async function appendVerifierFeedback(
+  store: TaskRunStore,
+  taskRunId: string,
+  attemptId: string,
+  now: () => number,
+  newId: () => string,
+  record: ResultRecord,
+  verifierResultId: string | undefined,
+  scoreResultId: string | undefined,
+): Promise<FeedbackObservation> {
+  const taxonomy = taxonomyFromResultRecord(record);
+  const ts = now();
+  const observation: FeedbackObservation = {
+    id: newId(),
+    taskRunId,
+    attemptId,
+    ts,
+    source: 'verifier',
+    summary: record.passed ? 'verification passed' : `verification did not pass: ${taxonomy}`,
+    details: {
+      passed: record.passed,
+      taxonomy,
+      status: record.status,
+      exitCode: record.exitCode,
+      steps: record.steps,
+      ...(record.error ? { error: record.error } : {}),
+      ...(record.errorClass ? { errorClass: record.errorClass } : {}),
+      ...(verifierResultId ? { verifierResultId } : {}),
+      ...(scoreResultId ? { scoreResultId } : {}),
+    },
+  };
+  await appendTaskEvent(store, taskRunId, {
+    type: 'feedback_observed',
+    id: newId(),
+    taskRunId,
+    ts,
+    observation,
+  });
+  return observation;
+}
+
+async function appendSystemFeedback(
+  store: TaskRunStore,
+  taskRunId: string,
+  attemptId: string | undefined,
+  now: () => number,
+  newId: () => string,
+  summary: string,
+  details: Record<string, unknown>,
+): Promise<void> {
+  const ts = now();
+  const observation: FeedbackObservation = {
+    id: newId(),
+    taskRunId,
+    ...(attemptId ? { attemptId } : {}),
+    ts,
+    source: 'system',
+    summary,
+    details,
+  };
+  await appendTaskEvent(store, taskRunId, {
+    type: 'feedback_observed',
+    id: newId(),
+    taskRunId,
+    ts,
+    observation,
+  });
+}
+
+async function appendDecision(
+  store: TaskRunStore,
+  taskRunId: string,
+  attemptId: string,
+  now: () => number,
+  newId: () => string,
+  decision: AutonomousDecisionPolicyResult,
+  attempt: RunTaskOnceResult,
+  budget: LoopBudgetSnapshot,
+  selfCheck: SelfCheckObservation | undefined,
+): Promise<void> {
+  const ts = now();
+  const recorded: AutonomousDecision = {
+    id: newId(),
+    taskRunId,
+    attemptId,
+    ts,
+    decision: decision.decision,
+    ...(decision.reason ? { reason: decision.reason } : {}),
+    details: {
+      attemptNumber: budget.attemptsUsed,
+      budget,
+      latestScoreId: attempt.projection.latestScoreResult?.id,
+      latestVerifierId: attempt.projection.latestVerifierResult?.id,
+      latestTaxonomy: taxonomyFromResultRecord(attempt.resultRecord),
+      selfCheckContributed: Boolean(selfCheck),
+      ...(selfCheck ? { selfCheckId: selfCheck.id } : {}),
+      ...(decision.details ? decision.details : {}),
+    },
+  };
+  await appendTaskEvent(store, taskRunId, {
+    type: 'autonomous_decision_recorded',
+    id: newId(),
+    taskRunId,
+    ts,
+    decision: recorded,
+  });
+}
+
+async function appendBudgetTerminal(
+  store: TaskRunStore,
+  taskRunId: string,
+  now: () => number,
+  newId: () => string,
+  budget: LoopBudgetSnapshot,
+  reason: string,
+): Promise<void> {
+  const ts = now();
+  await appendTaskEvent(store, taskRunId, {
+    type: 'task_run_budget_exhausted',
+    id: newId(),
+    taskRunId,
+    ts,
+    finishedAt: ts,
+    error: {
+      message: reason,
+      class: 'budget_exhausted',
+      details: { budget },
+    },
+  });
+}
+
+function terminalEventFromResultRecord(
+  record: ResultRecord,
+  taskRunId: string,
+  newId: () => string,
+  refs: { verifierResultId?: string; scoreResultId?: string } = {},
+): TaskEvent {
+  const taxonomy = taxonomyFromResultRecord(record);
+  const result: TaskRunResult = {
+    passed: record.passed,
+    taxonomy,
+    ...(refs.verifierResultId ? { verifierResultId: refs.verifierResultId } : {}),
+    ...(refs.scoreResultId ? { scoreResultId: refs.scoreResultId } : {}),
+  };
+  const base = { id: newId(), taskRunId, ts: record.finishedAt, finishedAt: record.finishedAt };
+  if (record.status === 'completed') {
+    return { type: 'task_run_completed', ...base, result };
+  }
+
+  const error = errorFromResultRecord(record, taxonomy);
+  switch (taxonomy) {
+    case 'agent_incomplete':
+      return { type: 'task_run_incomplete', ...base, error };
+    case 'blocked':
+      return { type: 'task_run_blocked', ...base, error };
+    case 'policy_denied':
+      return { type: 'task_run_policy_denied', ...base, error };
+    case 'budget_exhausted':
+      return { type: 'task_run_budget_exhausted', ...base, error };
+    case 'aborted':
+      return { type: 'task_run_aborted', ...base, error };
+    case 'cancelled':
+      return { type: 'task_run_cancelled', ...base, error };
+    case 'passed':
+    case 'verification_failed':
+    case 'verification_error':
+    case 'agent_failed':
+    case 'setup_failed':
+    case 'infra_failed':
+      return { type: 'task_run_failed', ...base, error };
+  }
+}
+
+function syntheticResultRecord(
+  config: Config,
+  task: Task,
+  taskRunId: string,
+  taxonomy: AutonomousResultTaxonomy,
+  message: string,
+  startedAt: number,
+  finishedAt: number,
+): ResultRecord {
+  return {
+    taskId: task.id,
+    configId: config.id,
+    sessionId: taskRunId,
+    runId: taskRunId,
+    status: 'failed',
+    passed: false,
+    exitCode: null,
+    steps: 0,
+    durationMs: finishedAt - startedAt,
+    startedAt,
+    finishedAt,
+    error: message,
+    errorClass: taxonomy,
+  };
+}
+
+function errorFromResultRecord(record: ResultRecord, taxonomy: AutonomousResultTaxonomy): TaskRunError {
+  return {
+    message: record.error ?? errorMessageFromTaxonomy(taxonomy),
+    ...(record.errorClass ? { class: record.errorClass } : { class: taxonomy }),
+  };
+}
+
+function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
+  switch (taxonomy) {
+    case 'agent_failed':
+      return 'agent run failed';
+    case 'agent_incomplete':
+      return 'agent run incomplete';
+    case 'setup_failed':
+      return 'task setup failed';
+    case 'infra_failed':
+      return 'infrastructure failed';
+    case 'verification_error':
+      return 'verification errored';
+    case 'policy_denied':
+      return 'task run denied by policy';
+    case 'budget_exhausted':
+      return 'task run budget exhausted';
+    case 'aborted':
+      return 'task run aborted';
+    case 'blocked':
+      return 'task run blocked';
+    case 'cancelled':
+      return 'task run cancelled';
+    case 'verification_failed':
+      return 'verification failed';
+    case 'passed':
+      return 'task run failed';
+  }
+}
+
+function defaultContinuationPrompt(
+  task: Task,
+  attempt: RunTaskOnceResult,
+  selfCheck: SelfCheckObservation | undefined,
+): string {
+  const taxonomy = taxonomyFromResultRecord(attempt.resultRecord);
+  const selfCheckLine = selfCheck ? `\nAdvisory self-check: ${selfCheck.summary}` : '';
+  return `${task.instruction}
+
+Previous autonomous attempt did not pass authoritative verification.
+Verifier taxonomy: ${taxonomy}.
+Verification exit code: ${attempt.resultRecord.exitCode ?? 'none'}.
+Continue from that feedback and produce a corrected solution.${selfCheckLine}`;
+}
+
+function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {
+  return store.appendEvent(taskRunId, event);
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -49,6 +49,20 @@ export {
 } from './task-run-adapter.js';
 export type { RunTaskOnceDeps, RunTaskOnceResult } from './task-agent-controller.js';
 export { runTaskOnce, TaskAgentController } from './task-agent-controller.js';
+export type {
+  AutonomousDecisionInput,
+  AutonomousDecisionPolicy,
+  AutonomousDecisionPolicyResult,
+  AutonomousLoopBudget,
+  FeedbackPromptInput,
+  LoopBudgetSnapshot,
+  RunAutonomousTaskOptions,
+  RunAutonomousTaskResult,
+  SelfCheckInput,
+  SelfCheckOutput,
+  SelfCheckPolicy,
+} from './autonomous-agent-loop.js';
+export { AutonomousAgentLoop, runAutonomousTask } from './autonomous-agent-loop.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export { readResults, writeResults, toComparisonTable } from './results.js';

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -58,6 +58,9 @@ export interface RunTaskOnceDeps extends RunExperimentDeps {
   agentRunStore?: AgentRunStore;
   taskRunId?: string;
   attemptId?: string;
+  createTaskRun?: boolean;
+  closeTaskRun?: boolean;
+  instructionOverride?: string;
   permissionMode?: 'execute';
 }
 
@@ -96,30 +99,35 @@ export async function runTaskOnce(
   const newId = deps.newId ?? randomUUID;
   const taskRunId = deps.taskRunId ?? newId();
   const attemptId = deps.attemptId ?? `${taskRunId}-attempt-1`;
+  const instruction = deps.instructionOverride ?? task.instruction;
+  const createTaskRun = deps.createTaskRun ?? true;
+  const closeTaskRun = deps.closeTaskRun ?? true;
   const taskRunStore = deps.taskRunStore ?? createTaskRunStore(deps.storageRoot);
   const sessionStore = deps.sessionStore ?? createSessionStore(deps.storageRoot);
   const agentRunStore = deps.agentRunStore ?? createAgentRunStore(deps.storageRoot);
   const runtimeEventStore = deps.runtimeEventStore ?? createRuntimeEventStore(deps.storageRoot);
   const startedAt = now();
 
-  await appendTaskEvent(taskRunStore, taskRunId, {
-    type: 'task_run_created',
-    id: newId(),
-    taskRunId,
-    ts: startedAt,
-    taskId: task.id,
-    configId: config.id,
-    taskDefinition: taskDefinitionFromTask(task),
-  });
-  await appendTaskEvent(taskRunStore, taskRunId, {
-    type: 'task_run_queued',
-    id: newId(),
-    taskRunId,
-    ts: now(),
-    taskId: task.id,
-    configId: config.id,
-    taskDefinition: taskDefinitionFromTask(task),
-  });
+  if (createTaskRun) {
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_run_created',
+      id: newId(),
+      taskRunId,
+      ts: startedAt,
+      taskId: task.id,
+      configId: config.id,
+      taskDefinition: taskDefinitionFromTask(task),
+    });
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'task_run_queued',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      taskId: task.id,
+      configId: config.id,
+      taskDefinition: taskDefinitionFromTask(task),
+    });
+  }
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
@@ -148,7 +156,7 @@ export async function runTaskOnce(
     const run = new AgentRun({
       sessionId: header.id,
       header,
-      userInput: { turnId, text: task.instruction },
+      userInput: { turnId, text: instruction },
       store: sessionStore,
       runStore: agentRunStore,
       runtimeEventStore,
@@ -182,8 +190,8 @@ export async function runTaskOnce(
     try {
       runtimeInvocation = await runRuntimeAttempt({
         run,
-        task,
         header,
+        instruction,
         now,
         newId,
       });
@@ -280,11 +288,13 @@ export async function runTaskOnce(
       status: attemptStatusFromResult(resultRecord.status, taxonomy),
       ...(resultRecord.status === 'failed' ? { error: errorFromResultRecord(resultRecord, taxonomy) } : {}),
     });
-    await appendTaskEvent(
-      taskRunStore,
-      taskRunId,
-      terminalEventFromResult(resultRecord, taxonomy, runResult, taskRunId, newId),
-    );
+    if (closeTaskRun) {
+      await appendTaskEvent(
+        taskRunStore,
+        taskRunId,
+        terminalEventFromResult(resultRecord, taxonomy, runResult, taskRunId, newId),
+      );
+    }
 
     return {
       taskRunId,
@@ -300,8 +310,8 @@ export async function runTaskOnce(
 
 interface RunRuntimeAttemptInput {
   run: AgentRun;
-  task: Task;
   header: SessionHeader;
+  instruction: string;
   now: () => number;
   newId: () => string;
 }
@@ -341,7 +351,7 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<Invocat
     sessionId: input.header.id,
     runId: input.run.runId,
     turnId: input.run.turnId,
-    text: input.task.instruction,
+    text: input.instruction,
     context: begin.backendInput.context,
     ...(begin.backendInput.runtimeContext !== undefined ? { runtimeContext: begin.backendInput.runtimeContext } : {}),
     ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),


### PR DESCRIPTION
## Summary
- add `AutonomousAgentLoop` / `runAutonomousTask()` in `@maka/headless` for a bounded preflight -> runtime attempt -> self-check -> feedback -> decision loop
- compose through the existing `runTaskOnce()` / `AgentRun + RuntimeRunner` path, with default-preserving attempt controls for parent loop ownership
- enforce max attempts, runtime-step caps, and wall-clock caps with budget terminal events; keep visible self-check advisory and non-authoritative
- preserve existing `runExperiment()`, `runMatrix()`, and CLI JSONL/table behavior

## Stack note
This branch is stacked on PR #47 (`TaskAgentController` single attempt). If PR #47 merges first, this PR should rebase/retarget down to the single loop commit.

## Rive
- workflow: `wfrun_b14490c4388c4a8693452b0da412c403`
- scheduler: `sched_376fce5634b44d5f8a19a7dbb134c5da`
- artifacts: `/tmp/rive-maka-autonomous-agent-loop-v1-20260618/output/`
- reviewer verdict: `PATCH_REQUIRED`; fixed the blocker by adding a loop-level `SessionManager.sendMessage` regression test

## Verification
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build && node --test packages/headless/dist/__tests__/autonomous-agent-loop.test.js`
- `npm --workspace @maka/headless test` (63 tests, 18 suites)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
