### PR TITLE
收敛 Runtime flow 类型与 session projection helper

### DIFF
--- a/docs/runtime-v2-implementation-notes.md
+++ b/docs/runtime-v2-implementation-notes.md
@@ -82,11 +82,11 @@ removed so runner and flow code share the same identity/provider spine.
   (the backend emits `abort` then a trailing `complete`, and the flow emits
   both). Coalescing into a single terminal event is a runner/projection
   concern.
-- **`AgentFlowLike` vs `AgentFlow`:** the runner defines a local
-  `AgentFlowLike` (`run(ctx, request)`) that predates the formal
-  `AgentFlow` (`run(ctx, input: FlowInput)`). Their second parameters
-  differ, so they are not cleanly assignable today. Convergence is a
-  SessionManager-delegation task.
+- **Flow runnable surface:** `RuntimeRunner` depends on the centrally owned
+  `RunnableAgentFlow` (`Pick<AgentFlow, 'run'>`) so it remains decoupled from
+  flow metadata (`kind`, `sessionId`) while sharing the formal `AgentFlow.run`
+  signature. The old `AgentFlowLike` name remains as a deprecated compatibility
+  alias.
 
 ## Verification snapshot
 

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -3,7 +3,6 @@ import { expect } from '../test-helpers.js';
 import {
   RuntimeRunner,
   runtimeGateFromCallback,
-  type AgentFlowLike,
   type RuntimeGate,
 } from '../runtime-runner.js';
 import type { AttachmentRef } from '@maka/core/events';
@@ -16,7 +15,7 @@ import type {
   RuntimeEvent,
   RuntimeEventStatus,
 } from '@maka/core/runtime-event';
-import type { AgentFlow } from '../agent-flow.js';
+import type { AgentFlow, RunnableAgentFlow } from '../agent-flow.js';
 
 // ============================================================================
 // Test fakes / helpers
@@ -60,7 +59,7 @@ void _flowContextIsCanonicalContext;
  * Fake flow that runs a script to produce its events. The script receives
  * the InvocationContext so events can line up with the invocation spine.
  */
-class ScriptFlow implements AgentFlowLike {
+class ScriptFlow implements RunnableAgentFlow {
   readonly seen: InvocationContext[] = [];
   constructor(
     private readonly script: (ctx: InvocationContext) =>
@@ -76,7 +75,7 @@ class ScriptFlow implements AgentFlowLike {
 }
 
 /** Flow that throws on first iteration. */
-class ThrowingFlow implements AgentFlowLike {
+class ThrowingFlow implements RunnableAgentFlow {
   ran = false;
   constructor(private readonly error: unknown) {}
   async *run(): AsyncIterable<RuntimeEvent> {
@@ -433,7 +432,7 @@ describe('RuntimeRunner', () => {
   test('runtimeGateFromCallback adapts a sync callback', async () => {
     const providers = makeProviders();
     let flowCalled = false;
-    const flow: AgentFlowLike = {
+    const flow: RunnableAgentFlow = {
       async *run(): AsyncIterable<RuntimeEvent> {
         flowCalled = true;
       },
@@ -531,8 +530,8 @@ describe('RuntimeRunner', () => {
         content: { kind: 'text', text: 'previous' },
       },
     ];
-    let seenInput: Parameters<AgentFlowLike['run']>[1] | undefined;
-    const flow: AgentFlowLike = {
+    let seenInput: Parameters<RunnableAgentFlow['run']>[1] | undefined;
+    const flow: RunnableAgentFlow = {
       async *run(ctx, input) {
         seenInput = input;
         yield flowTerminalEvent(ctx, 'completed');
@@ -560,8 +559,8 @@ describe('RuntimeRunner', () => {
 
   test('flow input context defaults to an empty array', async () => {
     const providers = makeProviders();
-    let seenInput: Parameters<AgentFlowLike['run']>[1] | undefined;
-    const flow: AgentFlowLike = {
+    let seenInput: Parameters<RunnableAgentFlow['run']>[1] | undefined;
+    const flow: RunnableAgentFlow = {
       async *run(ctx, input) {
         seenInput = input;
         yield flowTerminalEvent(ctx, 'completed');

--- a/packages/runtime/src/__tests__/session-projection-helpers.test.ts
+++ b/packages/runtime/src/__tests__/session-projection-helpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, test } from 'node:test';
+import { expect } from '../test-helpers.js';
+import type { StoredMessage } from '@maka/core/session';
+import {
+  buildStatusPatch,
+  buildTurnStateMessage,
+  normalizeStopSessionSource,
+  turnHasRetainedOutput,
+} from '../session-projection-helpers.js';
+
+describe('session projection helpers', () => {
+  test('buildStatusPatch normalizes blocked reasons and clears non-blocked reasons', () => {
+    expect(buildStatusPatch('blocked', 100)).toEqual({
+      status: 'blocked',
+      blockedReason: 'unknown',
+      statusUpdatedAt: 100,
+    });
+    expect(buildStatusPatch('waiting_for_user', 101, 'permission_required')).toEqual({
+      status: 'waiting_for_user',
+      blockedReason: undefined,
+      statusUpdatedAt: 101,
+    });
+  });
+
+  test('buildTurnStateMessage preserves lineage and terminal status fields', () => {
+    expect(buildTurnStateMessage({
+      id: 'state-1',
+      turnId: 'turn-1',
+      ts: 100,
+      status: 'aborted',
+      lineage: {
+        parentTurnId: 'parent',
+        retriedFromTurnId: 'retry-source',
+        regeneratedFromTurnId: 'regen-source',
+        branchOfTurnId: 'branch-source',
+        parentSessionId: 'parent-session',
+      },
+      abortSource: 'renderer.stop_button',
+      partialOutputRetained: true,
+    })).toEqual({
+      type: 'turn_state',
+      id: 'state-1',
+      turnId: 'turn-1',
+      ts: 100,
+      status: 'aborted',
+      parentTurnId: 'parent',
+      retriedFromTurnId: 'retry-source',
+      regeneratedFromTurnId: 'regen-source',
+      branchOfTurnId: 'branch-source',
+      parentSessionId: 'parent-session',
+      abortedAt: 100,
+      abortSource: 'renderer.stop_button',
+      partialOutputRetained: true,
+    });
+
+    expect(buildTurnStateMessage({
+      id: 'state-2',
+      turnId: 'turn-2',
+      ts: 101,
+      status: 'failed',
+      partialOutputRetained: false,
+    })).toMatchObject({
+      type: 'turn_state',
+      id: 'state-2',
+      turnId: 'turn-2',
+      ts: 101,
+      status: 'failed',
+      errorClass: 'unknown',
+      partialOutputRetained: false,
+    });
+  });
+
+  test('turnHasRetainedOutput only treats visible assistant text and tool results as retained output', () => {
+    const messages: StoredMessage[] = [
+      { type: 'assistant', id: 'blank', turnId: 'turn-1', ts: 1, text: '   ', modelId: 'model' },
+      { type: 'assistant', id: 'other', turnId: 'turn-2', ts: 2, text: 'kept', modelId: 'model' },
+      {
+        type: 'tool_result',
+        id: 'tool',
+        turnId: 'turn-3',
+        ts: 3,
+        toolUseId: 'call-1',
+        isError: false,
+        content: { kind: 'text', text: 'ok' },
+      },
+    ];
+
+    expect(turnHasRetainedOutput(messages, 'turn-1')).toBe(false);
+    expect(turnHasRetainedOutput(messages, 'turn-2')).toBe(true);
+    expect(turnHasRetainedOutput(messages, 'turn-3')).toBe(true);
+  });
+
+  test('normalizeStopSessionSource maps renderer stop button source', () => {
+    expect(normalizeStopSessionSource('stop_button')).toBe('renderer.stop_button');
+    expect(normalizeStopSessionSource(undefined)).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -106,6 +106,12 @@ export interface AgentFlow {
   run(ctx: InvocationContext, input: FlowInput): AsyncIterable<RuntimeEvent>;
 }
 
+/**
+ * Narrow runnable flow surface for orchestration code that should not depend
+ * on flow metadata such as `kind` or `sessionId`.
+ */
+export type RunnableAgentFlow = Pick<AgentFlow, 'run'>;
+
 // ============================================================================
 // AgentFlowControl — optional lifecycle/steering surface
 // ============================================================================

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -18,6 +18,10 @@ import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { projectRuntimeEventsToStoredMessages } from './runtime-event-read-model.js';
+import {
+  buildStatusPatch,
+  normalizeStopSessionSource,
+} from './session-projection-helpers.js';
 
 export interface AgentRunActiveSession {
   sessionId: string;
@@ -247,7 +251,7 @@ export class AgentRun {
         lastUsedAt: lastTs,
         lastMessageAt: lastTs,
         hasUnread: true,
-        ...statusPatch(nextStatus.status, lastTs, nextStatus.blockedReason),
+        ...buildStatusPatch(nextStatus.status, lastTs, nextStatus.blockedReason),
       });
     } catch {
       // The user-visible turn already completed; preserve existing behavior.
@@ -568,18 +572,6 @@ function errorMessage(error: unknown): string {
   return redactTraceString(error instanceof Error ? error.message : String(error));
 }
 
-function statusPatch(
-  status: SessionStatus,
-  ts: number,
-  blockedReason?: SessionBlockedReason,
-): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
-  return {
-    status,
-    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
-    statusUpdatedAt: ts,
-  };
-}
-
 function isTerminalRunStatus(status: AgentRunHeader['status']): boolean {
   return status === 'completed' || status === 'failed' || status === 'cancelled';
 }
@@ -626,11 +618,4 @@ function blockedReasonFromErrorReason(reason: string | undefined): SessionBlocke
   if (reason === 'tool_failed') return 'tool_failed';
   if (reason === 'auth' || reason.includes('api_key') || reason.includes('connection')) return 'NO_REAL_CONNECTION';
   return 'unknown';
-}
-
-function normalizeStopSessionSource(source: StopSessionInput['source'] | undefined): string | undefined {
-  switch (source) {
-    case 'stop_button': return 'renderer.stop_button';
-    case undefined: return undefined;
-  }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -305,6 +305,7 @@ export type {
   AgentFlow,
   AgentFlowControl,
   FlowInput,
+  RunnableAgentFlow,
 } from './agent-flow.js';
 export { flowSupportsControl } from './agent-flow.js';
 

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -4,7 +4,6 @@ import type {
   SessionBlockedReason,
   SessionHeader,
   SessionStatus,
-  StoredMessage,
   SystemNoteMessage,
   TurnRecord,
 } from '@maka/core/session';
@@ -16,6 +15,12 @@ import type { AgentBackend } from './ai-sdk-backend.js';
 import type { InvocationResult, InvocationSource } from './invocation-context.js';
 import { RuntimeRunner } from './runtime-runner.js';
 import type { BackendRegistry, SessionStore, StopSessionInput } from './session-manager.js';
+import {
+  buildStatusPatch,
+  buildTurnStateMessage,
+  normalizeStopSessionSource,
+  turnHasRetainedOutput as messagesHaveRetainedOutput,
+} from './session-projection-helpers.js';
 
 export interface RuntimeKernelLike {
   startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
@@ -251,7 +256,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     blockedReason?: SessionBlockedReason,
     ts = this.deps.now(),
   ): Promise<void> {
-    await this.updateHeader(sessionId, statusPatch(status, ts, blockedReason));
+    await this.updateHeader(sessionId, buildStatusPatch(status, ts, blockedReason));
   }
 
   private async updateHeader(
@@ -271,49 +276,21 @@ export class RuntimeKernel implements RuntimeKernelLike {
     options: { ts?: number; errorClass?: string; abortSource?: string } = {},
   ): Promise<void> {
     const ts = options.ts ?? this.deps.now();
-    await this.deps.store.appendMessage(sessionId, {
-      type: 'turn_state',
+    await this.deps.store.appendMessage(sessionId, buildTurnStateMessage({
       id: this.deps.newId(),
       turnId,
       ts,
       status,
-      ...(lineage.parentTurnId ? { parentTurnId: lineage.parentTurnId } : {}),
-      ...(lineage.retriedFromTurnId ? { retriedFromTurnId: lineage.retriedFromTurnId } : {}),
-      ...(lineage.regeneratedFromTurnId ? { regeneratedFromTurnId: lineage.regeneratedFromTurnId } : {}),
-      ...(lineage.branchOfTurnId ? { branchOfTurnId: lineage.branchOfTurnId } : {}),
-      ...(lineage.parentSessionId ? { parentSessionId: lineage.parentSessionId } : {}),
-      ...(status === 'aborted' ? { abortedAt: ts } : {}),
-      ...(status === 'aborted' && options.abortSource ? { abortSource: options.abortSource } : {}),
-      ...(status === 'failed' ? { errorClass: options.errorClass ?? 'unknown' } : {}),
+      lineage,
+      ...(options.abortSource ? { abortSource: options.abortSource } : {}),
+      ...(options.errorClass !== undefined ? { errorClass: options.errorClass } : {}),
       partialOutputRetained: await this.turnHasRetainedOutput(sessionId, turnId),
-    });
+    }));
   }
 
   private async turnHasRetainedOutput(sessionId: string, turnId: string): Promise<boolean> {
     const messages = await this.deps.store.readMessages(sessionId).catch(() => []);
-    return messages.some((message) =>
-      (message.type === 'assistant' && message.turnId === turnId && message.text.trim().length > 0) ||
-      (message.type === 'tool_result' && message.turnId === turnId),
-    );
-  }
-}
-
-function statusPatch(
-  status: SessionStatus,
-  ts: number,
-  blockedReason?: SessionBlockedReason,
-): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
-  return {
-    status,
-    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
-    statusUpdatedAt: ts,
-  };
-}
-
-function normalizeStopSessionSource(source: StopSessionInput['source'] | undefined): string | undefined {
-  switch (source) {
-    case 'stop_button': return 'renderer.stop_button';
-    case undefined: return undefined;
+    return messagesHaveRetainedOutput(messages, turnId);
   }
 }
 

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -37,7 +37,7 @@ import type {
   InvocationResultStatus,
 } from './invocation-context.js';
 import { createDefaultInvocationProviders } from './invocation-context.js';
-import type { FlowInput } from './agent-flow.js';
+import type { FlowInput, RunnableAgentFlow } from './agent-flow.js';
 
 // ============================================================================
 // RuntimeGate — narrow preflight seam
@@ -77,25 +77,20 @@ export function runtimeGateFromCallback(
 }
 
 // ============================================================================
-// AgentFlowLike — local flow seam
+// AgentFlowLike — compatibility alias
 // ============================================================================
 
 /**
- * Minimal flow contract RuntimeRunner dispatches to. The formal AgentFlow
- * interface (AiSdkFlow node) will be assignable to this; it is defined
- * locally so this skeleton does not block on — or duplicate — the flow
- * node's public surface.
+ * @deprecated Use `RunnableAgentFlow` from `./agent-flow.js`.
  */
-export interface AgentFlowLike {
-  run(ctx: InvocationContext, input: FlowInput): AsyncIterable<RuntimeEvent>;
-}
+export type AgentFlowLike = RunnableAgentFlow;
 
 // ============================================================================
 // RuntimeRunnerDeps
 // ============================================================================
 
 export interface RuntimeRunnerDeps {
-  flow: AgentFlowLike;
+  flow: RunnableAgentFlow;
   /** Optional preflight gate; omitted means "always allow". */
   gate?: RuntimeGate;
   /** Injectable id/time providers. Defaults to crypto.randomUUID / Date.now. */
@@ -119,7 +114,7 @@ export interface RuntimeRunnerDeps {
 // ============================================================================
 
 export class RuntimeRunner {
-  private readonly flow: AgentFlowLike;
+  private readonly flow: RunnableAgentFlow;
   private readonly gate: RuntimeGate | undefined;
   private readonly providers: InvocationProviders;
   private readonly onInitialRuntimeEvent: RuntimeRunnerDeps['onInitialRuntimeEvent'];

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -62,6 +62,11 @@ import type {
   InvocationSource,
 } from './invocation-context.js';
 import { RuntimeKernel, type RuntimeKernelLike } from './runtime-kernel.js';
+import {
+  buildStatusPatch,
+  buildTurnStateMessage,
+  turnHasRetainedOutput as messagesHaveRetainedOutput,
+} from './session-projection-helpers.js';
 
 export interface StopSessionInput {
   source?: 'stop_button';
@@ -251,7 +256,7 @@ export class SessionManager {
     status: SessionStatus,
     blockedReason?: SessionBlockedReason,
   ): Promise<SessionSummary> {
-    const next = await this.deps.store.updateHeader(sessionId, statusPatch(status, this.deps.now(), blockedReason));
+    const next = await this.deps.store.updateHeader(sessionId, buildStatusPatch(status, this.deps.now(), blockedReason));
     this.runtimeKernel.updateCachedHeader(sessionId, next);
     return headerToSummary(next);
   }
@@ -409,7 +414,7 @@ export class SessionManager {
     blockedReason?: SessionBlockedReason,
     ts = this.deps.now(),
   ): Promise<void> {
-    await this.updateHeader(sessionId, statusPatch(status, ts, blockedReason));
+    await this.updateHeader(sessionId, buildStatusPatch(status, ts, blockedReason));
   }
 
   private async updateHeader(
@@ -429,30 +434,21 @@ export class SessionManager {
     options: { ts?: number; errorClass?: string; abortSource?: string } = {},
   ): Promise<void> {
     const ts = options.ts ?? this.deps.now();
-    await this.deps.store.appendMessage(sessionId, {
-      type: 'turn_state',
+    await this.deps.store.appendMessage(sessionId, buildTurnStateMessage({
       id: this.deps.newId(),
       turnId,
       ts,
       status,
-      ...(lineage.parentTurnId ? { parentTurnId: lineage.parentTurnId } : {}),
-      ...(lineage.retriedFromTurnId ? { retriedFromTurnId: lineage.retriedFromTurnId } : {}),
-      ...(lineage.regeneratedFromTurnId ? { regeneratedFromTurnId: lineage.regeneratedFromTurnId } : {}),
-      ...(lineage.branchOfTurnId ? { branchOfTurnId: lineage.branchOfTurnId } : {}),
-      ...(lineage.parentSessionId ? { parentSessionId: lineage.parentSessionId } : {}),
-      ...(status === 'aborted' ? { abortedAt: ts } : {}),
-      ...(status === 'aborted' && options.abortSource ? { abortSource: options.abortSource } : {}),
-      ...(status === 'failed' ? { errorClass: options.errorClass ?? 'unknown' } : {}),
+      lineage,
+      ...(options.abortSource ? { abortSource: options.abortSource } : {}),
+      ...(options.errorClass !== undefined ? { errorClass: options.errorClass } : {}),
       partialOutputRetained: await this.turnHasRetainedOutput(sessionId, turnId),
-    });
+    }));
   }
 
   private async turnHasRetainedOutput(sessionId: string, turnId: string): Promise<boolean> {
     const messages = await this.deps.store.readMessages(sessionId).catch(() => []);
-    return messages.some((message) =>
-      (message.type === 'assistant' && message.turnId === turnId && message.text.trim().length > 0) ||
-      (message.type === 'tool_result' && message.turnId === turnId),
-    );
+    return messagesHaveRetainedOutput(messages, turnId);
   }
 
   private async requireTurnForAction(
@@ -678,18 +674,6 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
 
 function changesBackendConfig(patch: Partial<SessionHeader>): boolean {
   return 'backend' in patch || 'llmConnectionSlug' in patch || 'model' in patch;
-}
-
-function statusPatch(
-  status: SessionStatus,
-  ts: number,
-  blockedReason?: SessionBlockedReason,
-): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
-  return {
-    status,
-    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
-    statusUpdatedAt: ts,
-  };
 }
 
 interface InterruptedTurnRecovery {

--- a/packages/runtime/src/session-projection-helpers.ts
+++ b/packages/runtime/src/session-projection-helpers.ts
@@ -1,0 +1,75 @@
+import type {
+  SessionBlockedReason,
+  SessionHeader,
+  SessionStatus,
+  StoredMessage,
+  TurnRecord,
+  TurnStateMessage,
+} from '@maka/core/session';
+
+export type TurnStateLineage = Partial<Pick<
+  TurnStateMessage,
+  'parentTurnId' | 'retriedFromTurnId' | 'regeneratedFromTurnId' | 'branchOfTurnId' | 'parentSessionId'
+>>;
+
+export interface BuildTurnStateMessageInput {
+  id: string;
+  turnId: string;
+  ts: number;
+  status: TurnRecord['status'];
+  lineage?: TurnStateLineage;
+  errorClass?: string;
+  abortSource?: string;
+  partialOutputRetained: boolean;
+}
+
+export function buildStatusPatch(
+  status: SessionStatus,
+  ts: number,
+  blockedReason?: SessionBlockedReason,
+): Pick<SessionHeader, 'status' | 'blockedReason' | 'statusUpdatedAt'> {
+  return {
+    status,
+    blockedReason: status === 'blocked' ? (blockedReason ?? 'unknown') : undefined,
+    statusUpdatedAt: ts,
+  };
+}
+
+export function buildTurnStateMessage(input: BuildTurnStateMessageInput): TurnStateMessage {
+  const lineage = input.lineage ?? {};
+  return {
+    type: 'turn_state',
+    id: input.id,
+    turnId: input.turnId,
+    ts: input.ts,
+    status: input.status,
+    ...(lineage.parentTurnId ? { parentTurnId: lineage.parentTurnId } : {}),
+    ...(lineage.retriedFromTurnId ? { retriedFromTurnId: lineage.retriedFromTurnId } : {}),
+    ...(lineage.regeneratedFromTurnId ? { regeneratedFromTurnId: lineage.regeneratedFromTurnId } : {}),
+    ...(lineage.branchOfTurnId ? { branchOfTurnId: lineage.branchOfTurnId } : {}),
+    ...(lineage.parentSessionId ? { parentSessionId: lineage.parentSessionId } : {}),
+    ...(input.status === 'aborted' ? { abortedAt: input.ts } : {}),
+    ...(input.status === 'aborted' && input.abortSource ? { abortSource: input.abortSource } : {}),
+    ...(input.status === 'failed' ? { errorClass: input.errorClass ?? 'unknown' } : {}),
+    partialOutputRetained: input.partialOutputRetained,
+  };
+}
+
+export function turnHasRetainedOutput(
+  messages: readonly StoredMessage[],
+  turnId: string,
+): boolean {
+  return messages.some((message) =>
+    (message.type === 'assistant' && message.turnId === turnId && message.text.trim().length > 0) ||
+    (message.type === 'tool_result' && message.turnId === turnId),
+  );
+}
+
+export function normalizeStopSessionSource(
+  source: 'stop_button' | undefined,
+): string | undefined {
+  switch (source) {
+    case 'stop_button': return 'renderer.stop_button';
+    case undefined: return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 `RunnableAgentFlow` 作为 RuntimeRunner 依赖的正式窄类型
- 保留 `AgentFlowLike` 作为 deprecated alias，避免破坏现有类型导入
- 抽取 `statusPatch`、`turn_state` 构造、retained output 判断和 stop source normalization 到共享 helper
- 更新相关测试与 runtime v2 实现说明

## Verification

- `git diff --check`
- 针对本次修改文件的窄范围 `tsc` 检查通过
- `npm --workspace @maka/runtime run typecheck` 目前仍被既有的 `context-budget` / `usage-stats` / `ai-sdk-backend` 类型错误阻塞