### PR TITLE
Add verifier/scorer benchmark contract

### DIFF
--- a/packages/headless/src/__tests__/results.test.ts
+++ b/packages/headless/src/__tests__/results.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { ResultRecord } from '../contracts.js';
-import { readResults, toComparisonTable, writeResults } from '../results.js';
+import { readResults, summarizeMatrix, toComparisonTable, writeResults } from '../results.js';
 
 function record(taskId: string, configId: string, passed: boolean, extra: Partial<ResultRecord> = {}): ResultRecord {
   return {
@@ -72,5 +72,74 @@ describe('toComparisonTable', () => {
     const table = toComparisonTable([record('a|b', 'c|d', true)]);
     assert.match(table, /a\\\|b/);
     assert.match(table, /c\\\|d/);
+  });
+});
+
+describe('summarizeMatrix', () => {
+  test('uses official denominator fields and excludes setup failures', () => {
+    const summary = summarizeMatrix([
+      record('pass', 'a', true, { scored: true, eligible: true }),
+      record('fail', 'a', false, { scored: true, eligible: true, errorClass: 'verification_failed' }),
+      record('runner-error', 'a', false, {
+        status: 'failed',
+        runnerCompleted: false,
+        scored: false,
+        eligible: true,
+        error: 'backend exploded',
+        errorClass: 'agent_failed',
+      }),
+      record('bad-setup', 'a', false, {
+        status: 'failed',
+        runnerCompleted: false,
+        scored: false,
+        eligible: false,
+        excludedReason: 'invalid_setup',
+        error: 'bad fixture',
+        errorClass: 'invalid_setup',
+      }),
+    ]);
+
+    assert.equal(summary.total, 4);
+    assert.equal(summary.eligible, 3);
+    assert.equal(summary.scored, 2);
+    assert.equal(summary.pass, 1);
+    assert.equal(summary.fail, 1);
+    assert.equal(summary.error, 1);
+    assert.equal(summary.excluded, 1);
+    assert.equal(summary.officialPassRate, 0.5);
+    assert.equal(summary.coverageRate, 2 / 3);
+  });
+
+  test('aggregates structured error classes and taxonomy counts', () => {
+    const summary = summarizeMatrix([
+      record('a', 'cfg', false, { scored: true, eligible: true, errorClass: 'verification_failed' }),
+      record('b', 'cfg', false, {
+        status: 'failed',
+        scored: false,
+        eligible: true,
+        error: 'verification timed out',
+        errorClass: 'verification_error',
+        exitCode: null,
+      }),
+      record('c', 'cfg', false, {
+        status: 'failed',
+        scored: false,
+        eligible: false,
+        excludedReason: 'unsupported_adapter',
+        error: 'adapter is not implemented',
+        errorClass: 'unsupported_adapter',
+        exitCode: null,
+      }),
+    ]);
+
+    assert.deepEqual(summary.byErrorClass, {
+      verification_failed: 1,
+      verification_error: 1,
+      unsupported_adapter: 1,
+    });
+    assert.equal(summary.byTaxonomy.verification_failed, 1);
+    assert.equal(summary.byTaxonomy.verification_error, 1);
+    assert.equal(summary.byTaxonomy.unsupported_adapter, 1);
+    assert.equal(summary.error, 1);
   });
 });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -89,6 +89,42 @@ const registerReportingBackend = (registry: BackendRegistry): void => {
   );
 };
 
+class ProtectedTamperBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: { sessionId: string; header: SessionHeader; store: SessionStore }) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const { turnId } = input;
+    const ts = Date.now();
+    const messageId = 'tamper-message';
+    await writeFile(join(this.ctx.header.cwd, 'check.mjs'), 'process.exit(0);\n', 'utf8');
+    await this.ctx.store.appendMessage(this.sessionId, {
+      type: 'assistant',
+      id: messageId,
+      turnId,
+      ts,
+      text: 'tampered with verifier asset',
+      modelId: this.ctx.header.model,
+    });
+    yield { type: 'text_complete', id: 'tamper-text', turnId, ts, messageId, text: 'tampered with verifier asset' };
+    yield { type: 'complete', id: 'tamper-complete', turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerProtectedTamperBackend = (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) =>
+    new ProtectedTamperBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+  );
+};
+
 class FailingBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
   readonly sessionId: string;
@@ -261,9 +297,74 @@ describe('runTaskOnce', () => {
 
       assert.equal(result.resultRecord.status, 'completed');
       assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.resultRecord.runnerCompleted, true);
+      assert.equal(result.resultRecord.scored, true);
+      assert.equal(result.resultRecord.eligible, true);
       assert.equal(result.projection.status, 'completed');
       assert.equal(result.projection.result?.passed, false);
       assert.equal(result.projection.latestScoreResult?.taxonomy, 'verification_failed');
+    });
+  });
+
+  test('records benchmark adapter hooks as unsupported instead of silently scoring', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'terminal-bench-hook',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verifier: {
+          kind: 'terminal_bench',
+          adapter: 'terminal-bench',
+          instanceId: 'terminal-bench/example',
+          protectedPaths: [],
+        },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+      });
+
+      assert.equal(result.resultRecord.status, 'completed');
+      assert.equal(result.resultRecord.runnerCompleted, true);
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.resultRecord.scored, false);
+      assert.equal(result.resultRecord.eligible, false);
+      assert.equal(result.resultRecord.errorClass, 'unsupported_adapter');
+      assert.equal(result.projection.status, 'completed');
+      assert.equal(result.projection.latestVerifierResult?.kind, 'terminal_bench');
+      assert.equal(result.projection.latestVerifierResult?.errorClass, 'unsupported_adapter');
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'unsupported_adapter');
+    });
+  });
+
+  test('freezes submitted workspace before restoring protected paths for verifier', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'src.mjs'), 'export const add = (a, b) => a - b;\n', 'utf8');
+      await writeFile(
+        join(fixtureDir, 'check.mjs'),
+        "import { add } from './src.mjs';\nprocess.exit(add(2, 3) === 5 ? 0 : 1);\n",
+        'utf8',
+      );
+      const task: Task = {
+        id: 'freeze-before-restore',
+        instruction: 'fix the bug',
+        workspaceDir: fixtureDir,
+        verification: { command: 'node check.mjs', protectedPaths: ['check.mjs'] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerProtectedTamperBackend,
+      });
+
+      assert.equal(result.resultRecord.status, 'completed');
+      assert.equal(result.resultRecord.passed, false);
+      assert.equal(result.resultRecord.scored, true);
+      assert.equal(result.projection.latestVerifierResult?.exitCode, 1);
+      const snapshot = result.projection.latestScoreResult?.details?.submittedSnapshot as { snapshotPath?: string } | undefined;
+      assert.ok(snapshot?.snapshotPath, 'expected submitted snapshot metadata in score details');
+      assert.equal(await readFile(join(snapshot.snapshotPath, 'check.mjs'), 'utf8'), 'process.exit(0);\n');
     });
   });
 

--- a/packages/headless/src/__tests__/task-run-adapter.test.ts
+++ b/packages/headless/src/__tests__/task-run-adapter.test.ts
@@ -15,6 +15,7 @@ const task: Task = {
   workspaceDir: '/tmp/fixture',
   verification: { command: 'npm test', timeoutMs: 5000, protectedPaths: ['test.mjs'] },
 };
+const legacyVerification = task.verification!;
 
 function record(extra: Partial<ResultRecord> = {}): ResultRecord {
   return {
@@ -47,7 +48,7 @@ describe('taskDefinitionFromTask', () => {
       workspaceDir: '/tmp/fixture',
       verification: { command: 'npm test', timeoutMs: 5000, protectedPaths: ['test.mjs'] },
     });
-    assert.notEqual(definition.verification.protectedPaths, task.verification.protectedPaths);
+    assert.notEqual(definition.verification.protectedPaths, legacyVerification.protectedPaths);
   });
 });
 

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -608,6 +608,9 @@ function terminalEventFromResultRecord(
     case 'verification_failed':
     case 'verification_error':
     case 'agent_failed':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
     case 'setup_failed':
     case 'infra_failed':
       return { type: 'task_run_failed', ...base, error };
@@ -653,6 +656,12 @@ function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
       return 'agent run failed';
     case 'agent_incomplete':
       return 'agent run incomplete';
+    case 'invalid_setup':
+      return 'invalid setup';
+    case 'unsupported_adapter':
+      return 'unsupported verifier adapter';
+    case 'isolation_required':
+      return 'isolated executor required';
     case 'setup_failed':
       return 'task setup failed';
     case 'infra_failed':

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -29,9 +29,14 @@ export interface Task {
    * never mutated — the agent only ever touches the throwaway copy.
    */
   workspaceDir: string;
-  /** How the run is scored. Lives on the Task, never the Config, so a
-   *  config under test cannot grade itself. */
-  verification: TaskVerification;
+  /**
+   * Legacy command verifier. Still accepted as an alias for
+   * `verifier: { kind: "command", ...verification }`.
+   */
+  verification?: TaskVerification;
+  /** How the run is officially verified. Lives on the Task, never the Config. */
+  verifier?: VerifierSpec;
+  benchmark?: BenchmarkContract;
 }
 
 export interface TaskVerification {
@@ -56,6 +61,58 @@ export interface TaskVerification {
   protectedPaths: string[];
 }
 
+export type VerifierSpec =
+  | CommandVerifierSpec
+  | TerminalBenchVerifierSpec
+  | SweBenchVerifierSpec;
+
+export interface CommandVerifierSpec {
+  kind: 'command';
+  command: string;
+  timeoutMs?: number;
+  protectedPaths: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface TerminalBenchVerifierSpec {
+  kind: 'terminal_bench';
+  adapter: 'terminal-bench';
+  instanceId: string;
+  protectedPaths?: string[];
+  adapterOptions?: Record<string, unknown>;
+}
+
+export interface SweBenchVerifierSpec {
+  kind: 'swe_bench';
+  adapter: 'swe-bench';
+  instanceId: string;
+  protectedPaths?: string[];
+  adapterOptions?: Record<string, unknown>;
+}
+
+export interface BenchmarkContract {
+  source?: 'local' | 'terminal_bench' | 'swe_bench';
+  instanceId?: string;
+  official?: boolean;
+  denominator?: 'scored_only' | 'eligible';
+  metadata?: Record<string, unknown>;
+}
+
+export interface SubmittedSnapshot {
+  id: string;
+  workspaceRoot: string;
+  snapshotPath: string;
+  artifactRefs: Array<Record<string, unknown>>;
+  createdAt: number;
+  manifestHash?: string;
+}
+
+export interface ArtifactFreezeResult {
+  submittedSnapshot: SubmittedSnapshot;
+  warnings?: string[];
+}
+
 /**
  * The variable under test. References Maka's existing model/connection
  * selection — it does NOT invent a model format. The toolset is a
@@ -77,8 +134,20 @@ export interface ResultRecord {
   runId: string;
   /** Did the agent invocation finish (vs. error out mid-run)? */
   status: 'completed' | 'failed';
+  /** Explicit runner status; legacy `status` is preserved for JSONL readers. */
+  runnerCompleted?: boolean;
   /** Did the Task's verification command pass? */
   passed: boolean;
+  /** Whether the final scorer produced an official pass/fail for this cell. */
+  scored?: boolean;
+  /** Whether this cell belongs in the official benchmark denominator. */
+  eligible?: boolean;
+  /** Why a cell was excluded from the official denominator. */
+  excludedReason?: string;
+  verifierKind?: VerifierSpec['kind'];
+  scoreResultId?: string;
+  verifierResultId?: string;
+  submittedSnapshotId?: string;
   /** Verification command exit code (null if it never ran / errored to spawn). */
   exitCode: number | null;
   /** Trajectory length proxy: number of RuntimeEvents emitted. */

--- a/packages/headless/src/evaluator.ts
+++ b/packages/headless/src/evaluator.ts
@@ -40,12 +40,13 @@ export function runVerification(
   command: string,
   cwd: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  env?: Record<string, string>,
 ): Promise<EvaluationResult> {
   return new Promise((resolve) => {
     // detached: the shell becomes its own process-group leader so a
     // timeout can kill the WHOLE tree (backgrounded grandchildren
     // included), not just the shell.
-    const child = spawn(command, { cwd, shell: true, detached: true });
+    const child = spawn(command, { cwd, shell: true, detached: true, env: env ? { ...process.env, ...env } : undefined });
     let stdout = '';
     let stderr = '';
     let timedOut = false;

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -2,7 +2,20 @@
 // (sandbox.ts), the verification runner (evaluator.ts), and the backend wiring
 // (backends.ts) are internals the runner owns, not part of the API. Minimal
 // usage is `runExperiment(config, task, { storageRoot })`.
-export type { Config, Task, TaskVerification, ResultRecord } from './contracts.js';
+export type {
+  ArtifactFreezeResult,
+  BenchmarkContract,
+  CommandVerifierSpec,
+  Config,
+  ResultRecord,
+  SubmittedSnapshot,
+  SweBenchVerifierSpec,
+  Task,
+  TaskVerification,
+  TerminalBenchVerifierSpec,
+  VerifierSpec,
+} from './contracts.js';
+export type { FinalScore, FinalScorer, FinalScorerInput } from './scorer.js';
 export type {
   AutonomousDecision,
   AutonomousResultTaxonomy,
@@ -65,7 +78,9 @@ export type {
 export { AutonomousAgentLoop, runAutonomousTask } from './autonomous-agent-loop.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
-export { readResults, writeResults, toComparisonTable } from './results.js';
+export { defaultFinalScorer } from './scorer.js';
+export { readResults, summarizeMatrix, writeResults, toComparisonTable, type MatrixSummary } from './results.js';
+export { normalizeVerifier } from './verifier.js';
 export type {
   HeadlessBackendContext,
   IsolatedCommandInput,

--- a/packages/headless/src/matrix.ts
+++ b/packages/headless/src/matrix.ts
@@ -36,18 +36,35 @@ export async function runMatrix(
 
 function failedRecord(config: Config, task: Task, error: unknown): ResultRecord {
   const now = Date.now();
+  const errorClass = classifyMatrixFailure(error);
   return {
     taskId: task.id,
     configId: config.id,
     sessionId: '',
     runId: '',
     status: 'failed',
+    runnerCompleted: false,
     passed: false,
+    scored: false,
+    eligible: false,
+    excludedReason: errorClass,
     exitCode: null,
     steps: 0,
     durationMs: 0,
     startedAt: now,
     finishedAt: now,
     error: error instanceof Error ? error.message : String(error),
+    errorClass,
   };
+}
+
+function classifyMatrixFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const text = message.toLowerCase();
+  if (text.includes('unsupported_adapter')) return 'unsupported_adapter';
+  if (text.includes('isolated executor')) return 'isolation_required';
+  if (text.includes('protectedpaths') || text.includes('verifier') || text.includes('verification') || text.includes('fixture')) {
+    return 'invalid_setup';
+  }
+  return 'setup_failed';
 }

--- a/packages/headless/src/results.ts
+++ b/packages/headless/src/results.ts
@@ -1,6 +1,21 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { ResultRecord } from './contracts.js';
+import { taxonomyFromResultRecord, type AutonomousResultTaxonomy } from './task-contracts.js';
+
+export interface MatrixSummary {
+  total: number;
+  eligible: number;
+  scored: number;
+  pass: number;
+  fail: number;
+  error: number;
+  excluded: number;
+  officialPassRate: number | null;
+  coverageRate: number | null;
+  byErrorClass: Record<string, number>;
+  byTaxonomy: Record<AutonomousResultTaxonomy | string, number>;
+}
 
 /**
  * ResultRecord JSONL is the canonical truth — one record per line. Every
@@ -51,6 +66,70 @@ export function toComparisonTable(records: ResultRecord[]): string {
   const footer = `| **pass rate** | ${passRate.join(' | ')} |`;
 
   return [header, divider, ...rows, footer].join('\n') + '\n';
+}
+
+export function summarizeMatrix(records: ResultRecord[]): MatrixSummary {
+  const summary: MatrixSummary = {
+    total: records.length,
+    eligible: 0,
+    scored: 0,
+    pass: 0,
+    fail: 0,
+    error: 0,
+    excluded: 0,
+    officialPassRate: null,
+    coverageRate: null,
+    byErrorClass: {},
+    byTaxonomy: {},
+  };
+
+  for (const record of records) {
+    const normalized = normalizeForSummary(record);
+    if (normalized.eligible) summary.eligible += 1;
+    else summary.excluded += 1;
+
+    if (normalized.scored) {
+      summary.scored += 1;
+      if (record.passed) summary.pass += 1;
+      else summary.fail += 1;
+    } else if (normalized.eligible) {
+      summary.error += 1;
+    }
+
+    if (normalized.errorClass) increment(summary.byErrorClass, normalized.errorClass);
+    increment(summary.byTaxonomy, normalized.taxonomy);
+  }
+
+  summary.officialPassRate = summary.scored > 0 ? summary.pass / summary.scored : null;
+  summary.coverageRate = summary.eligible > 0 ? summary.scored / summary.eligible : null;
+  return summary;
+}
+
+function normalizeForSummary(record: ResultRecord): {
+  eligible: boolean;
+  scored: boolean;
+  errorClass?: string;
+  taxonomy: string;
+} {
+  const taxonomy = taxonomyFromResultRecord(record);
+  const eligible = record.eligible ?? !record.excludedReason;
+  const scored = record.scored ?? legacyScored(record);
+  return {
+    eligible,
+    scored,
+    errorClass: record.errorClass,
+    taxonomy,
+  };
+}
+
+function legacyScored(record: ResultRecord): boolean {
+  if (record.status !== 'completed') return false;
+  if (record.exitCode === null) return false;
+  return !record.error;
+}
+
+function increment(target: Record<string, number>, key: string): void {
+  target[key] = (target[key] ?? 0) + 1;
 }
 
 function cell(record: ResultRecord | undefined): string {

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { isAbsolute } from 'node:path';
 import type { BackendKind } from '@maka/core';
 import {
   BackendRegistry,
@@ -16,9 +15,10 @@ import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
 import { validateRealBackendIsolation } from './isolation.js';
-import { prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
-import { runVerification } from './evaluator.js';
+import { freezeSubmittedWorkspace, prepareScoringWorkspace, prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
+import { defaultFinalScorer } from './scorer.js';
 import { buildIsolatedHeadlessTools } from './tools.js';
+import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 
 export interface RunExperimentDeps {
   /**
@@ -65,17 +65,7 @@ export function backendNeedsIsolation(backend: BackendKind): boolean {
  * field. The CLI reuses this; there is no second, divergent check.
  */
 export function validateTaskVerification(task: Task): void {
-  const protectedPaths = task.verification?.protectedPaths;
-  if (!Array.isArray(protectedPaths)) {
-    throw new Error(
-      `task "${task.id}": verification.protectedPaths is required (an array; use [] when the verification reads nothing the agent can forge)`,
-    );
-  }
-  for (const rel of protectedPaths) {
-    if (typeof rel !== 'string' || isAbsolute(rel) || rel.split(/[\\/]+/).includes('..')) {
-      throw new Error(`task "${task.id}": protectedPaths entry must be a workspace-relative path: ${String(rel)}`);
-    }
-  }
+  normalizeVerifier(task);
 }
 
 /**
@@ -104,6 +94,7 @@ export async function runExperiment(
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
+    const verifier = normalizeVerifier(task);
     const backends = new BackendRegistry();
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
       deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
@@ -155,44 +146,67 @@ export async function runExperiment(
       }
     }
 
-    // Clean-room grading: restore the verification assets from the pristine
-    // fixture so anything the agent wrote over its own test is reverted
-    // before it is graded.
-    await restoreProtectedPaths(task.workspaceDir, workspace.dir, task.verification.protectedPaths);
-
-    const evaluation = await runVerification(
-      task.verification.command,
-      workspace.dir,
-      task.verification.timeoutMs,
-    );
-    const finishedAt = now();
     const status = invocation?.status ?? 'failed';
+    const runnerCompleted = status === 'completed';
+    const frozen = await freezeSubmittedWorkspace({ workspaceDir: workspace.dir, now, newId });
+    const scoringWorkspace = await prepareScoringWorkspace(frozen.submittedSnapshot);
+    try {
+      await restoreProtectedPaths(task.workspaceDir, scoringWorkspace.dir, verifierProtectedPaths(verifier));
+      const verifierStartedAt = now();
+      const verifierResult = await runVerifier({
+        verifier,
+        taskRunId: invocation?.runId ?? turnId,
+        ts: verifierStartedAt,
+        id: newId(),
+        workspaceDir: scoringWorkspace.dir,
+        submittedSnapshotId: frozen.submittedSnapshot.id,
+        scoringWorkspaceId: scoringWorkspace.dir,
+      });
+      const finalScore = defaultFinalScorer({
+        config,
+        task,
+        runnerCompleted,
+        runnerStatus: status,
+        invocationFailure: invocation?.failure,
+        submittedSnapshot: frozen.submittedSnapshot,
+        verifierResult,
+      });
+      const finishedAt = now();
 
-    return {
-      taskId: task.id,
-      configId: config.id,
-      sessionId: session.id,
-      runId: invocation?.runId ?? turnId,
-      status,
-      // Only a completed run can "pass" — a crashed/errored run that happens
-      // to leave a green fixture must not read as a pass.
-      passed: status === 'completed' && evaluation.passed,
-      exitCode: evaluation.exitCode,
-      steps: invocation?.events.length ?? 0,
-      durationMs: finishedAt - startedAt,
-      startedAt,
-      finishedAt,
-      // A failed invocation (the backend reported failure without throwing, or
-      // no result was captured) must carry an `error` so the comparison table
-      // (⚠️) and the CLI exit code agree it was not a trustworthy run — not a
-      // silent ⚠️-but-exit-0 that automation reads as success.
-      ...(status === 'failed'
-        ? {
-            error: invocation?.failure?.message ?? invocation?.failure?.class ?? 'run did not complete',
-            ...(invocation?.failure?.class ? { errorClass: invocation.failure.class } : {}),
-          }
-        : {}),
-    };
+      return {
+        taskId: task.id,
+        configId: config.id,
+        sessionId: session.id,
+        runId: invocation?.runId ?? turnId,
+        status,
+        runnerCompleted,
+        passed: finalScore.passed,
+        scored: finalScore.scored,
+        eligible: finalScore.eligible,
+        ...(finalScore.excludedReason ? { excludedReason: finalScore.excludedReason } : {}),
+        verifierKind: verifierResult.kind,
+        verifierResultId: verifierResult.id,
+        scoreResultId: newId(),
+        submittedSnapshotId: frozen.submittedSnapshot.id,
+        exitCode: verifierResult.exitCode ?? null,
+        steps: invocation?.events.length ?? 0,
+        durationMs: finishedAt - startedAt,
+        startedAt,
+        finishedAt,
+        ...(!finalScore.scored && finalScore.errorClass
+          ? { error: finalScore.excludedReason ?? invocation?.failure?.message ?? finalScore.errorClass }
+          : status === 'failed'
+            ? { error: invocation?.failure?.message ?? invocation?.failure?.class ?? 'run did not complete' }
+            : {}),
+        ...(finalScore.errorClass
+          ? { errorClass: finalScore.errorClass }
+          : invocation?.failure?.class
+            ? { errorClass: invocation.failure.class }
+            : {}),
+      };
+    } finally {
+      await scoringWorkspace.cleanup();
+    }
   } finally {
     await workspace.cleanup();
   }

--- a/packages/headless/src/sandbox.ts
+++ b/packages/headless/src/sandbox.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import { cp, lstat, mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
+import type { ArtifactFreezeResult, SubmittedSnapshot } from './contracts.js';
 
 /**
  * A throwaway copy of a task fixture. The copy keeps a run from mutating
@@ -35,6 +37,45 @@ export async function prepareWorkspace(fixtureDir: string): Promise<PreparedWork
   } catch (error) {
     // mkdtemp already created the dir, but the runner only registers its
     // cleanup after we return — so clean up here if the copy fails.
+    await rm(dir, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    dir,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+export async function freezeSubmittedWorkspace(input: {
+  workspaceDir: string;
+  artifactRefs?: Array<Record<string, unknown>>;
+  now?: () => number;
+  newId?: () => string;
+}): Promise<ArtifactFreezeResult> {
+  const id = input.newId?.() ?? randomUUID();
+  const snapshotPath = await mkdtemp(join(tmpdir(), 'maka-headless-submitted-'));
+  try {
+    await cp(await realpath(input.workspaceDir), snapshotPath, { recursive: true });
+  } catch (error) {
+    await rm(snapshotPath, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    submittedSnapshot: {
+      id,
+      workspaceRoot: input.workspaceDir,
+      snapshotPath,
+      artifactRefs: input.artifactRefs ? [...input.artifactRefs] : [],
+      createdAt: input.now?.() ?? Date.now(),
+    },
+  };
+}
+
+export async function prepareScoringWorkspace(snapshot: SubmittedSnapshot): Promise<PreparedWorkspace> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-headless-score-'));
+  try {
+    await cp(await realpath(snapshot.snapshotPath), dir, { recursive: true });
+  } catch (error) {
     await rm(dir, { recursive: true, force: true });
     throw error;
   }

--- a/packages/headless/src/scorer.ts
+++ b/packages/headless/src/scorer.ts
@@ -1,0 +1,92 @@
+import type { Config, SubmittedSnapshot, Task } from './contracts.js';
+import type { AutonomousResultTaxonomy, VerifierResult } from './task-contracts.js';
+
+export interface FinalScorerInput {
+  config: Config;
+  task: Task;
+  runnerCompleted: boolean;
+  runnerStatus: 'completed' | 'failed';
+  invocationFailure?: { class?: string; message?: string };
+  submittedSnapshot: SubmittedSnapshot;
+  verifierResult?: VerifierResult;
+}
+
+export interface FinalScore {
+  passed: boolean;
+  scored: boolean;
+  eligible: boolean;
+  taxonomy: AutonomousResultTaxonomy;
+  errorClass?: string;
+  excludedReason?: string;
+  details?: Record<string, unknown>;
+}
+
+export type FinalScorer = (input: FinalScorerInput) => FinalScore;
+
+export const defaultFinalScorer: FinalScorer = (input) => {
+  const verifier = input.verifierResult;
+
+  if (verifier?.errorClass === 'unsupported_adapter') {
+    return {
+      passed: false,
+      scored: false,
+      eligible: false,
+      taxonomy: 'unsupported_adapter',
+      errorClass: 'unsupported_adapter',
+      excludedReason: verifier.error ?? 'unsupported verifier adapter',
+    };
+  }
+
+  if (!input.runnerCompleted) {
+    const taxonomy = taxonomyFromFailureClass(input.invocationFailure?.class);
+    return {
+      passed: false,
+      scored: false,
+      eligible: true,
+      taxonomy,
+      errorClass: input.invocationFailure?.class ?? taxonomy,
+      details: input.invocationFailure?.message ? { failureMessage: input.invocationFailure.message } : undefined,
+    };
+  }
+
+  if (!verifier) {
+    return {
+      passed: false,
+      scored: false,
+      eligible: true,
+      taxonomy: 'verification_error',
+      errorClass: 'verification_error',
+    };
+  }
+
+  if (verifier.errorClass === 'verification_error' || verifier.exitCode === null) {
+    return {
+      passed: false,
+      scored: false,
+      eligible: true,
+      taxonomy: 'verification_error',
+      errorClass: 'verification_error',
+      details: verifier.error ? { verifierError: verifier.error } : undefined,
+    };
+  }
+
+  return {
+    passed: verifier.passed,
+    scored: true,
+    eligible: true,
+    taxonomy: verifier.passed ? 'passed' : 'verification_failed',
+    ...(verifier.passed ? {} : { errorClass: 'verification_failed' }),
+  };
+};
+
+function taxonomyFromFailureClass(errorClass: string | undefined): AutonomousResultTaxonomy {
+  const normalized = errorClass?.toLowerCase() ?? '';
+  if (normalized.includes('cancel')) return 'cancelled';
+  if (normalized.includes('abort')) return 'aborted';
+  if (normalized.includes('budget') || normalized.includes('limit') || normalized.includes('max_tokens')) return 'budget_exhausted';
+  if (normalized.includes('blocked')) return 'blocked';
+  if (normalized.includes('policy') || normalized.includes('permission') || normalized.includes('denied')) return 'policy_denied';
+  if (normalized.includes('incomplete') || normalized.includes('tool_calls') || normalized.includes('truncated')) return 'agent_incomplete';
+  if (normalized.includes('infra')) return 'infra_failed';
+  return 'agent_failed';
+}

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -26,8 +26,9 @@ import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import type { HeadlessBackendContext } from './isolation.js';
 import { validateRealBackendIsolation } from './isolation.js';
-import { prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
-import { runVerification } from './evaluator.js';
+import { freezeSubmittedWorkspace, prepareScoringWorkspace, prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
+import { defaultFinalScorer } from './scorer.js';
+import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 import {
   backendNeedsIsolation,
   type RunExperimentDeps,
@@ -107,6 +108,7 @@ export async function runTaskOnce(
   const agentRunStore = deps.agentRunStore ?? createAgentRunStore(deps.storageRoot);
   const runtimeEventStore = deps.runtimeEventStore ?? createRuntimeEventStore(deps.storageRoot);
   const startedAt = now();
+  const verifier = normalizeVerifier(task);
 
   if (createTaskRun) {
     await appendTaskEvent(taskRunStore, taskRunId, {
@@ -210,51 +212,78 @@ export async function runTaskOnce(
       ts: now(),
       startedAt: now(),
     });
-    await restoreProtectedPaths(task.workspaceDir, workspace.dir, task.verification.protectedPaths);
-    const evaluation = await runVerification(
-      task.verification.command,
-      workspace.dir,
-      task.verification.timeoutMs,
-    );
-
+    const runnerCompleted = invocation.status === 'completed';
+    const frozen = await freezeSubmittedWorkspace({
+      workspaceDir: workspace.dir,
+      artifactRefs: runtimeSummary.artifactRefs,
+      now,
+      newId,
+    });
+    const scoringWorkspace = await prepareScoringWorkspace(frozen.submittedSnapshot);
+    let verifierResult: VerifierResult;
+    try {
+      await restoreProtectedPaths(task.workspaceDir, scoringWorkspace.dir, verifierProtectedPaths(verifier));
+      const verifierStartedAt = now();
+      verifierResult = await runVerifier({
+        verifier,
+        taskRunId,
+        attemptId,
+        ts: verifierStartedAt,
+        id: newId(),
+        workspaceDir: scoringWorkspace.dir,
+        submittedSnapshotId: frozen.submittedSnapshot.id,
+        scoringWorkspaceId: scoringWorkspace.dir,
+      });
+    } finally {
+      await scoringWorkspace.cleanup();
+    }
+    const finalScore = defaultFinalScorer({
+      config,
+      task,
+      runnerCompleted,
+      runnerStatus: invocation.status,
+      invocationFailure: invocation.failure,
+      submittedSnapshot: frozen.submittedSnapshot,
+      verifierResult,
+    });
     const finishedAt = now();
+    const scoreResultId = newId();
     const resultRecord = resultRecordFromInvocation({
       config,
       task,
       sessionId: header.id,
       invocation,
-      evaluation,
+      verifierResult,
+      finalScore,
+      submittedSnapshotId: frozen.submittedSnapshot.id,
+      scoreResultId,
       startedAt,
       finishedAt,
     });
-    const taxonomy = taxonomyFromResultRecord(resultRecord);
-    const verifierResult: VerifierResult = {
-      id: newId(),
-      taskRunId,
-      attemptId,
-      ts: finishedAt,
-      kind: 'command',
-      passed: resultRecord.status === 'completed' && evaluation.passed,
-      exitCode: evaluation.exitCode,
-      command: task.verification.command,
-      ...(evaluation.timedOut ? { error: 'verification timed out' } : {}),
-    };
+    const taxonomy = finalScore.taxonomy;
     const scoreResult: ScoreResult = {
-      id: newId(),
+      id: scoreResultId,
       taskRunId,
       attemptId,
       ts: finishedAt,
-      passed: resultRecord.status === 'completed' && evaluation.passed,
+      passed: finalScore.passed,
+      scored: finalScore.scored,
+      eligible: finalScore.eligible,
+      ...(finalScore.errorClass ? { errorClass: finalScore.errorClass } : {}),
+      ...(finalScore.excludedReason ? { excludedReason: finalScore.excludedReason } : {}),
       taxonomy,
       details: {
         steps: resultRecord.steps,
         invocationStatus: invocation.status,
         ...(invocation.failure?.class ? { runtimeFailureClass: invocation.failure.class } : {}),
-        verifierExitCode: evaluation.exitCode,
+        verifierExitCode: verifierResult.exitCode ?? null,
         runtimeRefs: runtimeSummary.runtimeRefs,
         artifactRefs: runtimeSummary.artifactRefs,
+        submittedSnapshot: frozen.submittedSnapshot,
+        scoringWorkspaceContract: 'v1_copy_snapshot_then_restore_protected_paths_in_disposable_scoring_workspace',
         isolation: runtimeSummary.isolation,
         budget: runtimeSummary.budget,
+        ...(finalScore.details ? { finalScore: finalScore.details } : {}),
       },
     };
     const runResult: TaskRunResult = {
@@ -471,7 +500,10 @@ function resultRecordFromInvocation(input: {
   task: Task;
   sessionId: string;
   invocation: InvocationResult;
-  evaluation: Awaited<ReturnType<typeof runVerification>>;
+  verifierResult: VerifierResult;
+  finalScore: ReturnType<typeof defaultFinalScorer>;
+  submittedSnapshotId: string;
+  scoreResultId: string;
   startedAt: number;
   finishedAt: number;
 }): ResultRecord {
@@ -482,16 +514,26 @@ function resultRecordFromInvocation(input: {
     sessionId: input.sessionId,
     runId: input.invocation.runId,
     status,
-    passed: status === 'completed' && input.evaluation.passed,
-    exitCode: input.evaluation.exitCode,
+    runnerCompleted: status === 'completed',
+    passed: input.finalScore.passed,
+    scored: input.finalScore.scored,
+    eligible: input.finalScore.eligible,
+    ...(input.finalScore.excludedReason ? { excludedReason: input.finalScore.excludedReason } : {}),
+    verifierKind: input.verifierResult.kind,
+    verifierResultId: input.verifierResult.id,
+    scoreResultId: input.scoreResultId,
+    submittedSnapshotId: input.submittedSnapshotId,
+    exitCode: input.verifierResult.exitCode ?? null,
     steps: input.invocation.events.length,
     durationMs: input.finishedAt - input.startedAt,
     startedAt: input.startedAt,
     finishedAt: input.finishedAt,
-    ...(status === 'failed'
+    ...(input.finalScore.errorClass ? { errorClass: input.finalScore.errorClass } : {}),
+    ...(!input.finalScore.scored && input.finalScore.errorClass
+      ? { error: input.finalScore.excludedReason ?? input.invocation.failure?.message ?? input.finalScore.errorClass }
+      : status === 'failed'
       ? {
           error: input.invocation.failure?.message ?? input.invocation.failure?.class ?? 'run did not complete',
-          ...(input.invocation.failure?.class ? { errorClass: input.invocation.failure.class } : {}),
         }
       : {}),
   };
@@ -641,6 +683,9 @@ function attemptStatusFromResult(
     case 'verification_failed':
     case 'verification_error':
     case 'agent_failed':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
     case 'setup_failed':
     case 'infra_failed':
       return 'failed';
@@ -677,6 +722,9 @@ function terminalEventFromResult(
     case 'verification_failed':
     case 'verification_error':
     case 'agent_failed':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
     case 'setup_failed':
     case 'infra_failed':
       return { type: 'task_run_failed', ...base, error };
@@ -696,6 +744,12 @@ function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
       return 'agent run failed';
     case 'agent_incomplete':
       return 'agent run incomplete';
+    case 'invalid_setup':
+      return 'invalid setup';
+    case 'unsupported_adapter':
+      return 'unsupported verifier adapter';
+    case 'isolation_required':
+      return 'isolated executor required';
     case 'setup_failed':
       return 'task setup failed';
     case 'infra_failed':

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -1,4 +1,4 @@
-import type { ResultRecord, TaskVerification } from './contracts.js';
+import type { ResultRecord, TaskVerification, VerifierSpec } from './contracts.js';
 
 export type TaskRunStatus =
   | 'queued'
@@ -45,6 +45,9 @@ export type AutonomousResultTaxonomy =
   | 'verification_error'
   | 'agent_failed'
   | 'agent_incomplete'
+  | 'invalid_setup'
+  | 'unsupported_adapter'
+  | 'isolation_required'
   | 'setup_failed'
   | 'infra_failed'
   | 'policy_denied'
@@ -58,6 +61,9 @@ export type ResultTaxonomy = AutonomousResultTaxonomy;
 export function taxonomyFromResultRecord(record: ResultRecord): AutonomousResultTaxonomy {
   if (record.status === 'completed') {
     if (record.passed) return 'passed';
+    if (record.errorClass === 'unsupported_adapter') return 'unsupported_adapter';
+    if (record.errorClass === 'invalid_setup') return 'invalid_setup';
+    if (record.errorClass === 'isolation_required') return 'isolation_required';
     return record.exitCode === null ? 'verification_error' : 'verification_failed';
   }
 
@@ -72,6 +78,11 @@ export function taxonomyFromResultRecord(record: ResultRecord): AutonomousResult
   if (includesAny(failureText, ['blocked', 'waiting_permission'])) return 'blocked';
   if (includesAny(failureText, ['policy', 'permission', 'denied'])) return 'policy_denied';
   if (includesAny(failureText, ['incomplete', 'tool_calls', 'no_submit', 'truncated'])) return 'agent_incomplete';
+  if (includesAny(failureText, ['verification_error'])) return 'verification_error';
+  if (includesAny(failureText, ['verification_failed'])) return 'verification_failed';
+  if (includesAny(failureText, ['unsupported_adapter'])) return 'unsupported_adapter';
+  if (includesAny(failureText, ['invalid_setup'])) return 'invalid_setup';
+  if (includesAny(failureText, ['isolation_required', 'isolated executor'])) return 'isolation_required';
   if (includesAny(failureText, ['setup', 'fixture', 'config', 'preflight'])) return 'setup_failed';
   if (includesAny(failureText, ['infra', 'infrastructure', 'harbor', 'container', 'docker', 'fetch', 'materialize', 'network'])) {
     return 'infra_failed';
@@ -169,12 +180,18 @@ export interface VerifierResult {
   taskRunId: string;
   attemptId?: string;
   ts: number;
-  kind: 'command';
+  kind: VerifierSpec['kind'];
   passed: boolean;
-  exitCode: number | null;
+  exitCode?: number | null;
   command?: string;
   durationMs?: number;
+  stdout?: string;
+  stderr?: string;
+  timedOut?: boolean;
   error?: string;
+  errorClass?: string;
+  submittedSnapshotId?: string;
+  scoringWorkspaceId?: string;
 }
 
 export interface ScoreResult {
@@ -183,6 +200,10 @@ export interface ScoreResult {
   attemptId?: string;
   ts: number;
   passed: boolean;
+  scored?: boolean;
+  eligible?: boolean;
+  errorClass?: string;
+  excludedReason?: string;
   score?: number;
   maxScore?: number;
   taxonomy: AutonomousResultTaxonomy;

--- a/packages/headless/src/task-run-adapter.ts
+++ b/packages/headless/src/task-run-adapter.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { ResultRecord, Task } from './contracts.js';
+import { normalizeVerifier } from './verifier.js';
 import {
   taxonomyFromResultRecord,
   type AutonomousResultTaxonomy,
@@ -21,15 +22,21 @@ export interface TaskEventsFromResultRecordOptions {
 }
 
 export function taskDefinitionFromTask(task: Task): TaskDefinition {
+  const verifier = normalizeVerifier(task);
   return {
     id: task.id,
     instruction: task.instruction,
     workspaceDir: task.workspaceDir,
-    verification: {
-      command: task.verification.command,
-      ...(task.verification.timeoutMs === undefined ? {} : { timeoutMs: task.verification.timeoutMs }),
-      protectedPaths: [...task.verification.protectedPaths],
-    },
+    verification: verifier.kind === 'command'
+      ? {
+          command: verifier.command,
+          ...(verifier.timeoutMs === undefined ? {} : { timeoutMs: verifier.timeoutMs }),
+          protectedPaths: [...verifier.protectedPaths],
+        }
+      : {
+          command: verifier.kind,
+          protectedPaths: verifier.protectedPaths ? [...verifier.protectedPaths] : [],
+        },
   };
 }
 
@@ -42,6 +49,7 @@ export function taskEventsFromResultRecord(
   const attemptId = options.attemptId ?? `${taskRunId}-attempt-1`;
   const taxonomy = taxonomyFromResultRecord(record);
   const shouldRecordVerifier = record.status === 'completed' || record.exitCode !== null || taxonomy === 'verification_error';
+  const verifier = options.task ? normalizeVerifier(options.task) : undefined;
   const verifierResult: VerifierResult | undefined = shouldRecordVerifier
     ? {
         id: eventId(),
@@ -51,7 +59,7 @@ export function taskEventsFromResultRecord(
         kind: 'command',
         passed: record.status === 'completed' && record.passed,
         exitCode: record.exitCode,
-        ...(options.task ? { command: options.task.verification.command } : {}),
+        ...(verifier?.kind === 'command' ? { command: verifier.command } : {}),
         ...(record.error ? { error: record.error } : {}),
       }
     : undefined;
@@ -144,6 +152,9 @@ function attemptStatusFromResult(
     case 'verification_failed':
     case 'verification_error':
     case 'agent_failed':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
     case 'setup_failed':
     case 'infra_failed':
       return 'failed';
@@ -180,6 +191,9 @@ function terminalEventFromResult(
     case 'verification_failed':
     case 'verification_error':
     case 'agent_failed':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
     case 'setup_failed':
     case 'infra_failed':
       return { type: 'task_run_failed', ...base, error };
@@ -288,6 +302,12 @@ function errorMessageFromTaxonomy(
       return 'agent run failed';
     case 'agent_incomplete':
       return 'agent run incomplete';
+    case 'invalid_setup':
+      return 'invalid setup';
+    case 'unsupported_adapter':
+      return 'unsupported verifier adapter';
+    case 'isolation_required':
+      return 'isolated executor required';
     case 'setup_failed':
       return 'task setup failed';
     case 'infra_failed':

--- a/packages/headless/src/verifier.ts
+++ b/packages/headless/src/verifier.ts
@@ -1,0 +1,146 @@
+import { isAbsolute, join } from 'node:path';
+import type { Task, TaskVerification, VerifierSpec } from './contracts.js';
+import { runVerification, type EvaluationResult } from './evaluator.js';
+import type { VerifierResult } from './task-contracts.js';
+
+export function normalizeVerifier(task: Task): VerifierSpec {
+  const verifier = task.verifier ?? verifierFromLegacy(task.verification);
+  if (!verifier) {
+    throw new Error(`task "${task.id}": verifier or verification is required`);
+  }
+
+  switch (verifier.kind) {
+    case 'command':
+      if (typeof verifier.command !== 'string' || verifier.command.trim().length === 0) {
+        throw new Error(`task "${task.id}": command verifier requires a non-empty command`);
+      }
+      validateProtectedPaths(task.id, verifier.protectedPaths);
+      return {
+        ...verifier,
+        protectedPaths: [...verifier.protectedPaths],
+        ...(verifier.env ? { env: { ...verifier.env } } : {}),
+      };
+    case 'terminal_bench':
+      if (verifier.adapter !== 'terminal-bench' || !verifier.instanceId) {
+        throw new Error(`task "${task.id}": terminal_bench verifier requires adapter and instanceId`);
+      }
+      validateProtectedPaths(task.id, verifier.protectedPaths ?? []);
+      return { ...verifier, protectedPaths: verifier.protectedPaths ? [...verifier.protectedPaths] : undefined };
+    case 'swe_bench':
+      if (verifier.adapter !== 'swe-bench' || !verifier.instanceId) {
+        throw new Error(`task "${task.id}": swe_bench verifier requires adapter and instanceId`);
+      }
+      validateProtectedPaths(task.id, verifier.protectedPaths ?? []);
+      return { ...verifier, protectedPaths: verifier.protectedPaths ? [...verifier.protectedPaths] : undefined };
+  }
+}
+
+export function verifierProtectedPaths(verifier: VerifierSpec): string[] {
+  return verifier.protectedPaths ? [...verifier.protectedPaths] : [];
+}
+
+export async function runVerifier(input: {
+  verifier: VerifierSpec;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  id: string;
+  workspaceDir: string;
+  submittedSnapshotId?: string;
+  scoringWorkspaceId?: string;
+}): Promise<VerifierResult> {
+  if (input.verifier.kind !== 'command') {
+    return {
+      id: input.id,
+      taskRunId: input.taskRunId,
+      ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+      ts: input.ts,
+      kind: input.verifier.kind,
+      passed: false,
+      exitCode: null,
+      error: `${input.verifier.kind} verifier adapter is not implemented`,
+      errorClass: 'unsupported_adapter',
+      submittedSnapshotId: input.submittedSnapshotId,
+      scoringWorkspaceId: input.scoringWorkspaceId,
+    };
+  }
+
+  const startedAt = Date.now();
+  const cwd = input.verifier.cwd ? join(input.workspaceDir, input.verifier.cwd) : input.workspaceDir;
+  const evaluation = await runVerification(
+    input.verifier.command,
+    cwd,
+    input.verifier.timeoutMs,
+    input.verifier.env,
+  );
+  return verifierResultFromEvaluation({
+    evaluation,
+    command: input.verifier.command,
+    id: input.id,
+    taskRunId: input.taskRunId,
+    attemptId: input.attemptId,
+    ts: input.ts,
+    durationMs: Date.now() - startedAt,
+    submittedSnapshotId: input.submittedSnapshotId,
+    scoringWorkspaceId: input.scoringWorkspaceId,
+  });
+}
+
+export function verifierResultFromEvaluation(input: {
+  evaluation: EvaluationResult;
+  command?: string;
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  durationMs?: number;
+  submittedSnapshotId?: string;
+  scoringWorkspaceId?: string;
+}): VerifierResult {
+  const errorClass = input.evaluation.timedOut || input.evaluation.exitCode === null
+    ? 'verification_error'
+    : input.evaluation.passed
+      ? undefined
+      : 'verification_failed';
+  return {
+    id: input.id,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    ts: input.ts,
+    kind: 'command',
+    passed: input.evaluation.passed,
+    exitCode: input.evaluation.exitCode,
+    command: input.command,
+    durationMs: input.durationMs,
+    stdout: input.evaluation.stdout,
+    stderr: input.evaluation.stderr,
+    timedOut: input.evaluation.timedOut,
+    ...(errorClass ? { errorClass } : {}),
+    ...(input.evaluation.timedOut ? { error: 'verification timed out' } : {}),
+    submittedSnapshotId: input.submittedSnapshotId,
+    scoringWorkspaceId: input.scoringWorkspaceId,
+  };
+}
+
+function verifierFromLegacy(verification: TaskVerification | undefined): VerifierSpec | undefined {
+  if (!verification) return undefined;
+  return {
+    kind: 'command',
+    command: verification.command,
+    ...(verification.timeoutMs === undefined ? {} : { timeoutMs: verification.timeoutMs }),
+    protectedPaths: verification.protectedPaths,
+  };
+}
+
+function validateProtectedPaths(taskId: string, protectedPaths: unknown): asserts protectedPaths is string[] {
+  if (!Array.isArray(protectedPaths)) {
+    throw new Error(
+      `task "${taskId}": verification.protectedPaths is required (an array; use [] when the verification reads nothing the agent can forge)`,
+    );
+  }
+  for (const rel of protectedPaths) {
+    if (typeof rel !== 'string' || isAbsolute(rel) || rel.split(/[\\/]+/).includes('..')) {
+      throw new Error(`task "${taskId}": protectedPaths entry must be a workspace-relative path: ${String(rel)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the verifier/scorer benchmark contract layer on top of the autonomous task loop stack:

- Adds `VerifierSpec` with implemented command verifier and typed `terminal_bench` / `swe_bench` adapter hooks.
- Adds `FinalScorer` / `defaultFinalScorer` so runner completion is separate from official scoring pass.
- Freezes submitted workspace state before scoring, then verifies in a disposable scoring workspace after restoring protected paths.
- Extends `ResultRecord`, task-run verifier/score events, and matrix summaries with scored/eligible/excluded/errorClass metadata.
- Adds official denominator summary via `summarizeMatrix()` with pass/fail/error/excluded counts and structured error/taxonomy aggregation.
- Keeps legacy `Task.verification`, `runExperiment()`, `runMatrix()`, CLI JSONL, and comparison table behavior compatible.

## Stack Note

PR #47 and PR #48 have merged. This branch is rebased on current `upstream/main` and now contains only commit `1b093ce1` for this verifier/scorer benchmark contract PR.

## Rive Run

- Workflow: `wfrun_6d06788e3c9e4a819a8441315139896b`
- Scheduler: `sched_a6769f56a2c940d484ee31ee1dd9362d`
- Artifacts: `/tmp/rive-maka-verifier-scorer-benchmark-contract-20260618/output/`
- Reviewer verdict: `ACCEPT`
- Final steward patch after review: fixed result timestamp placement so verifier/scorer time is included, and added a regression for unsupported benchmark adapter hooks.

## Verification

- `npm run typecheck --workspace @maka/headless`
- `npm test --workspace @maka/headless` (67 tests, 19 suites)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Follow-ups

- Make submitted snapshot/artifact freeze durable and content-addressed when replay/audit retention becomes required.
- Optionally persist `summarizeMatrix()` as a CLI `summary.json` artifact once downstream automation consumes the matrix-level denominator/errorClass report directly.
