### PR TITLE
Add task isolation permission inbox hardening

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -223,6 +223,31 @@ describe('runAutonomousTask', () => {
     });
   });
 
+  test('maxRuntimeSteps can park for budget extension in desktop mode', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'runtime-step-cap-park',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        budget: { maxAttempts: 3, maxRuntimeSteps: 1 },
+        interventionPolicy: { mode: 'park', allowBudgetExtensionRequests: true },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 1);
+      assert.equal(result.projection.status, 'needs_approval');
+      assert.equal(result.projection.parked?.reason, 'budget_extension');
+      assert.equal(result.projection.inboxItems[0]?.kind, 'budget_extension');
+      assert.equal(result.projection.events.some((event) => event.type === 'task_run_budget_exhausted'), false);
+    });
+  });
+
   test('maxWallTimeMs fails closed before starting another attempt', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const task: Task = {

--- a/packages/headless/src/__tests__/permission-grants.test.ts
+++ b/packages/headless/src/__tests__/permission-grants.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  commandResourceScope,
+  hashNormalizedArgs,
+  matchPermissionGrant,
+  normalizePermissionArgs,
+} from '../permission-grants.js';
+import type { TaskPermissionGrant, TaskPermissionRequest } from '../task-contracts.js';
+
+const request: TaskPermissionRequest = {
+  schemaVersion: 1,
+  requestId: 'req-1',
+  taskRunId: 'run-1',
+  attemptId: 'attempt-1',
+  toolCallId: 'tool-call-1',
+  toolName: 'Bash',
+  normalizedArgsHash: hashNormalizedArgs({ command: 'echo ok', nested: { b: 2, a: 1 } }),
+  resourceScope: commandResourceScope('echo ok'),
+  reason: 'shell command',
+  preview: { argKeys: ['command'] },
+  requestedAt: 100,
+  expiresAt: 200,
+};
+
+function grant(overrides: Partial<TaskPermissionGrant> = {}): TaskPermissionGrant {
+  return {
+    schemaVersion: 1,
+    grantId: 'grant-1',
+    requestId: 'req-1',
+    taskRunId: 'run-1',
+    attemptId: 'attempt-1',
+    toolCallId: 'tool-call-1',
+    toolName: 'Bash',
+    normalizedArgsHash: request.normalizedArgsHash,
+    resourceScope: request.resourceScope,
+    decision: 'allow',
+    actor: { kind: 'test', id: 'unit' },
+    source: 'test_fixture',
+    decidedAt: 110,
+    expiresAt: 190,
+    ...overrides,
+  };
+}
+
+describe('permission grant helpers', () => {
+  test('normalizes and hashes args with stable recursive key ordering', () => {
+    assert.deepEqual(
+      normalizePermissionArgs({ z: 1, a: { d: true, b: ['x', { y: 2, x: 1 }] } }),
+      { a: { b: ['x', { x: 1, y: 2 }], d: true }, z: 1 },
+    );
+    assert.equal(
+      hashNormalizedArgs({ b: 2, a: { d: 4, c: 3 } }),
+      hashNormalizedArgs({ a: { c: 3, d: 4 }, b: 2 }),
+    );
+  });
+
+  test('matches only narrow unexpired allow grants', () => {
+    assert.equal(matchPermissionGrant(request, [grant()], 150)?.grantId, 'grant-1');
+    assert.equal(matchPermissionGrant(request, [grant({ decision: 'deny' })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ taskRunId: 'other-run' })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ attemptId: 'other-attempt' })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ toolCallId: 'other-tool-call' })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ toolName: 'Edit' })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ normalizedArgsHash: hashNormalizedArgs({ command: 'whoami' }) })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ resourceScope: { kind: 'tool', value: 'Bash', mode: 'execute' } })], 150), undefined);
+    assert.equal(matchPermissionGrant(request, [grant({ expiresAt: 149 })], 150), undefined);
+  });
+
+  test('summarizes command resource scope without embedding raw command text', () => {
+    const secretCommand = 'curl -H "Authorization: Bearer SECRET_TOKEN_123456" https://example.test';
+    const scope = commandResourceScope(secretCommand);
+
+    assert.equal(scope.kind, 'command');
+    assert.equal(scope.mode, 'execute');
+    assert.match(scope.value, /^bash-command:sha256:[a-f0-9]{16}$/);
+    assert.equal(scope.value.includes('curl'), false);
+    assert.equal(scope.value.includes('Authorization'), false);
+    assert.equal(scope.value.includes('SECRET_TOKEN_123456'), false);
+    assert.equal(scope.value.includes('example.test'), false);
+  });
+
+  test('allows short-lived cross-attempt grants only when attemptId is omitted', () => {
+    assert.equal(matchPermissionGrant(request, [grant({ attemptId: undefined })], 150)?.grantId, 'grant-1');
+  });
+});

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -7,7 +7,9 @@ import { BackendRegistry, FakeBackend, SessionManager, type AgentBackend, type S
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { Config, Task } from '../contracts.js';
+import { commandResourceScope, hashNormalizedArgs } from '../permission-grants.js';
 import { runTaskOnce } from '../task-agent-controller.js';
+import type { TaskPermissionGrant } from '../task-contracts.js';
 
 const fakeConfig: Config = {
   id: 'fake-cfg',
@@ -191,7 +193,7 @@ class PermissionRequestBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
   readonly sessionId: string;
 
-  constructor(sessionId: string, private readonly onRespond: () => void) {
+  constructor(sessionId: string, private readonly onRespond: () => void, private readonly command: string) {
     this.sessionId = sessionId;
   }
 
@@ -207,7 +209,7 @@ class PermissionRequestBackend implements AgentBackend {
       toolName: 'Bash',
       category: 'shell_unsafe',
       reason: 'shell_dangerous',
-      args: { command: 'rm -rf /tmp/example' },
+      args: { command: this.command },
     };
     yield { type: 'complete', id: 'permission-complete', turnId: input.turnId, ts, stopReason: 'permission_handoff' };
   }
@@ -220,8 +222,8 @@ class PermissionRequestBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
-const registerPermissionRequestBackend = (onRespond: () => void) => (registry: BackendRegistry): void => {
-  registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId, onRespond));
+const registerPermissionRequestBackend = (onRespond: () => void, command = 'rm -rf /tmp/example') => (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId, onRespond, command));
 };
 
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
@@ -265,6 +267,9 @@ describe('runTaskOnce', () => {
           [
             'task_run_created',
             'task_run_queued',
+            'isolation_policy_recorded',
+            'workspace_lease_recorded',
+            'tool_executor_identity_recorded',
             'task_run_started',
             'task_attempt_started',
             'feedback_observed',
@@ -275,6 +280,9 @@ describe('runTaskOnce', () => {
             'task_run_completed',
           ],
         );
+        assert.equal(result.projection.isolation?.mode, 'inert_fake_backend');
+        assert.equal(result.projection.workspaceLease?.taskRunId, result.taskRunId);
+        assert.equal(result.projection.toolExecutors[0]?.isolationMode, 'inert_fake_backend');
       } finally {
         SessionManager.prototype.sendMessage = original;
       }
@@ -428,6 +436,134 @@ describe('runTaskOnce', () => {
         result.projection.events.some((event) => event.type === 'task_run_policy_denied'),
         'expected a policy-denied terminal task event',
       );
+      assert.equal(result.projection.permissionRequests.length, 1);
+      assert.equal(result.projection.permissionRequests[0]?.toolName, 'Bash');
+      assert.equal(result.projection.permissionRequests[0]?.resourceScope.kind, 'command');
+      assert.equal(result.projection.inboxItems[0]?.kind, 'approval_request');
+      assert.equal(result.projection.inboxItems[0]?.status, 'resolved');
+      assert.ok(
+        result.projection.events.some((event) => event.type === 'permission_decision_recorded' && event.decision === 'deny'),
+        'expected a fail-closed permission denial event',
+      );
+    });
+  });
+
+  test('does not treat post-hoc matching permission grants as runtime authorization', async () => {
+    await withDirs(async (_fixtureDir, storageRoot) => {
+      let respondCalls = 0;
+      const taskRunId = 'grant-run';
+      const command = 'rm -rf /tmp/example';
+      const grant: TaskPermissionGrant = {
+        schemaVersion: 1,
+        grantId: 'grant-posthoc',
+        requestId: 'permission-request-1',
+        taskRunId,
+        attemptId: `${taskRunId}-attempt-1`,
+        toolCallId: 'tool-1',
+        toolName: 'Bash',
+        normalizedArgsHash: hashNormalizedArgs({ command }),
+        resourceScope: commandResourceScope(command),
+        decision: 'allow',
+        actor: { kind: 'test', id: 'unit' },
+        source: 'test_fixture',
+        decidedAt: 10,
+        expiresAt: Number.MAX_SAFE_INTEGER,
+      };
+      const task: Task = {
+        id: 'permission-grant-posthoc',
+        instruction: 'run a dangerous command',
+        workspaceDir: _fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        taskRunId,
+        registerBackends: registerPermissionRequestBackend(() => {
+          respondCalls += 1;
+        }, command),
+        permissionGrants: [grant],
+      });
+
+      assert.equal(respondCalls, 0);
+      assert.equal(result.resultRecord.status, 'failed');
+      assert.equal(result.resultRecord.errorClass, 'policy_denied');
+      assert.equal(result.projection.status, 'policy_denied');
+      assert.equal(result.projection.permissionGrants.length, 1);
+      assert.equal(result.projection.permissionGrants[0]?.grantId, 'grant-posthoc');
+      assert.equal(
+        result.projection.events.some((event) => event.type === 'permission_decision_recorded' && event.decision === 'allow'),
+        false,
+      );
+      const denyDecision = result.projection.events.find((event) => event.type === 'permission_decision_recorded');
+      assert.ok(denyDecision);
+      if (denyDecision.type !== 'permission_decision_recorded') {
+        throw new Error('expected permission_decision_recorded event');
+      }
+      assert.equal(denyDecision.decision, 'deny');
+      assert.match(denyDecision.reason ?? '', /post-hoc permission requests/);
+    });
+  });
+
+  test('redacts bash permission scopes and inbox previews while preserving args hash', async () => {
+    await withDirs(async (_fixtureDir, storageRoot) => {
+      const secret = 'SECRET_TOKEN_123456';
+      const command = `printf ${secret} > /tmp/secret-output`;
+      const task: Task = {
+        id: 'permission-redaction',
+        instruction: 'request permission',
+        workspaceDir: _fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerPermissionRequestBackend(() => {}, command),
+      });
+
+      const request = result.projection.permissionRequests[0];
+      assert.ok(request);
+      assert.equal(request.normalizedArgsHash, hashNormalizedArgs({ command }));
+      assert.deepEqual(request.resourceScope, commandResourceScope(command));
+      const serializedPermissionFacts = JSON.stringify({
+        permissionRequests: result.projection.permissionRequests,
+        inboxItems: result.projection.inboxItems,
+        permissionEvents: result.projection.events.filter((event) =>
+          event.type === 'permission_request_recorded' ||
+          event.type === 'task_inbox_item_recorded' ||
+          event.type === 'task_inbox_item_resolved',
+        ),
+      });
+      assert.equal(serializedPermissionFacts.includes(secret), false);
+      assert.equal(serializedPermissionFacts.includes(command), false);
+      assert.match(serializedPermissionFacts, new RegExp(request.normalizedArgsHash));
+    });
+  });
+
+  test('parks permission requests in desktop intervention mode without verifying', async () => {
+    await withDirs(async (_fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'permission-park',
+        instruction: 'run a dangerous command',
+        workspaceDir: _fixtureDir,
+        verification: { command: 'false', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerPermissionRequestBackend(() => {}),
+        interventionPolicy: { mode: 'park' },
+      });
+
+      assert.equal(result.resultRecord.status, 'failed');
+      assert.equal(result.resultRecord.errorClass, 'needs_approval');
+      assert.equal(result.projection.status, 'needs_approval');
+      assert.equal(result.projection.parked?.reason, 'approval');
+      assert.equal(result.projection.latestVerifierResult, undefined);
+      assert.equal(result.projection.latestScoreResult, undefined);
+      assert.equal(result.projection.attempts[0]?.status, 'needs_approval');
+      assert.equal(result.projection.inboxItems[0]?.kind, 'approval_request');
+      assert.equal(result.projection.inboxItems[0]?.status, 'open');
     });
   });
 

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -90,6 +90,150 @@ describe('TaskRunStore', () => {
     });
   });
 
+  test('projects isolation, permission, inbox, and needs_approval facts', () => {
+    const taskRunId = 'tr-approval';
+    const request = {
+      schemaVersion: 1 as const,
+      requestId: 'req-1',
+      taskRunId,
+      attemptId: 'a-1',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      normalizedArgsHash: 'abc123',
+      resourceScope: { kind: 'command' as const, value: 'rm file', mode: 'execute' as const },
+      reason: 'dangerous command',
+      preview: { argKeys: ['command'] },
+      requestedAt: 3,
+      expiresAt: 100,
+    };
+    const grant = {
+      schemaVersion: 1 as const,
+      grantId: 'grant-1',
+      requestId: 'req-1',
+      taskRunId,
+      attemptId: 'a-1',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      normalizedArgsHash: 'abc123',
+      resourceScope: request.resourceScope,
+      decision: 'allow' as const,
+      actor: { kind: 'test' as const },
+      source: 'test_fixture' as const,
+      decidedAt: 4,
+      expiresAt: 100,
+    };
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'isolation_policy_recorded',
+        id: 'e-2',
+        taskRunId,
+        ts: 2,
+        facts: {
+          schemaVersion: 1,
+          backendKind: 'ai-sdk',
+          required: true,
+          mode: 'external',
+          label: 'unit isolation',
+          assertionSource: 'headless_deps',
+          validatedAt: 2,
+        },
+      },
+      {
+        type: 'workspace_lease_recorded',
+        id: 'e-3',
+        taskRunId,
+        ts: 2,
+        lease: {
+          schemaVersion: 1,
+          leaseId: 'lease-1',
+          taskRunId,
+          attemptId: 'a-1',
+          sourceWorkspaceDir: '/src',
+          workspaceDir: '/tmp/work',
+          leaseKind: 'throwaway_copy',
+          writable: true,
+          cleanupPolicy: 'cleanup_on_finally',
+          createdAt: 2,
+        },
+      },
+      {
+        type: 'tool_executor_identity_recorded',
+        id: 'e-4',
+        taskRunId,
+        ts: 2,
+        identity: {
+          schemaVersion: 1,
+          executorId: 'exec-1',
+          taskRunId,
+          attemptId: 'a-1',
+          toolNames: ['Bash'],
+          isolationMode: 'external',
+          label: 'unit isolation',
+        },
+      },
+      { type: 'task_attempt_started', id: 'e-5', taskRunId, ts: 2, attemptId: 'a-1' },
+      { type: 'permission_request_recorded', id: 'e-6', taskRunId, ts: 3, request },
+      { type: 'permission_grant_recorded', id: 'e-7', taskRunId, ts: 4, grant },
+      {
+        type: 'task_inbox_item_recorded',
+        id: 'e-8',
+        taskRunId,
+        ts: 5,
+        item: {
+          schemaVersion: 1,
+          inboxItemId: 'inbox-1',
+          taskRunId,
+          attemptId: 'a-1',
+          kind: 'approval_request',
+          status: 'open',
+          title: 'Approval required',
+          reason: 'dangerous command',
+          createdAt: 5,
+          relatedRequestId: 'req-1',
+        },
+      },
+      { type: 'task_run_needs_approval', id: 'e-9', taskRunId, ts: 6, attemptId: 'a-1', reason: 'approval', inboxItemId: 'inbox-1' },
+    ], taskRunId);
+
+    assert.equal(projection.status, 'needs_approval');
+    assert.equal(projection.attempts[0]?.status, 'needs_approval');
+    assert.equal(projection.isolation?.label, 'unit isolation');
+    assert.equal(projection.workspaceLease?.workspaceDir, '/tmp/work');
+    assert.equal(projection.toolExecutors[0]?.executorId, 'exec-1');
+    assert.equal(projection.permissionRequests[0]?.normalizedArgsHash, 'abc123');
+    assert.equal(projection.permissionGrants[0]?.grantId, 'grant-1');
+    assert.equal(projection.inboxItems[0]?.status, 'open');
+    assert.deepEqual(projection.parked, { reason: 'approval', inboxItemId: 'inbox-1', since: 6 });
+  });
+
+  test('terminal events override open inbox parked state', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-terminal', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'task_inbox_item_recorded',
+        id: 'e-2',
+        taskRunId: 'tr-terminal',
+        ts: 2,
+        item: {
+          schemaVersion: 1,
+          inboxItemId: 'inbox-1',
+          taskRunId: 'tr-terminal',
+          kind: 'approval_request',
+          status: 'open',
+          title: 'Approval required',
+          reason: 'permission',
+          createdAt: 2,
+        },
+      },
+      { type: 'task_run_needs_approval', id: 'e-3', taskRunId: 'tr-terminal', ts: 3, reason: 'approval', inboxItemId: 'inbox-1' },
+      { type: 'task_run_policy_denied', id: 'e-4', taskRunId: 'tr-terminal', ts: 4 },
+    ], 'tr-terminal');
+
+    assert.equal(projection.status, 'policy_denied');
+    assert.equal(projection.parked, undefined);
+  });
+
   test('projects failed and cancelled terminal events', () => {
     const failed = projectTaskRun([
       { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-f', ts: 1, taskId: 'task-f', configId: 'cfg' },

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -5,6 +5,7 @@ import {
   backendNeedsIsolation,
   validateTaskVerification,
 } from './runner.js';
+import { budgetExtensionInboxItem } from './task-inbox.js';
 import {
   runTaskOnce,
   type RunTaskOnceDeps,
@@ -17,6 +18,7 @@ import {
   type FeedbackObservation,
   type SelfCheckObservation,
   type TaskEvent,
+  type TaskInterventionPolicy,
   type TaskRunError,
   type TaskRunResult,
 } from './task-contracts.js';
@@ -199,7 +201,15 @@ export async function runAutonomousTask(
         startedAt,
         finishedAt,
       );
-      await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, beforeAttemptBudget, 'wall time cap reached before attempt');
+      await appendBudgetTerminal(
+        taskRunStore,
+        taskRunId,
+        now,
+        newId,
+        beforeAttemptBudget,
+        'wall time cap reached before attempt',
+        options.interventionPolicy,
+      );
       return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord };
     }
 
@@ -281,7 +291,15 @@ export async function runAutonomousTask(
     }
 
     if (shouldBudgetTerminal(decision, attempt, afterAttemptBudget)) {
-      await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, afterAttemptBudget, decision.reason ?? 'loop budget exhausted');
+      await appendBudgetTerminal(
+        taskRunStore,
+        taskRunId,
+        now,
+        newId,
+        afterAttemptBudget,
+        decision.reason ?? 'loop budget exhausted',
+        options.interventionPolicy,
+      );
     } else {
       await appendTaskEvent(taskRunStore, taskRunId, terminalEventFromResultRecord(attempt.resultRecord, taskRunId, newId, {
         verifierResultId: attempt.projection.latestVerifierResult?.id,
@@ -305,7 +323,15 @@ export async function runAutonomousTask(
     }));
     return { taskRunId, attempts, projection: await taskRunStore.project(taskRunId), resultRecord: latestResultRecord };
   }
-  await appendBudgetTerminal(taskRunStore, taskRunId, now, newId, exhaustedBudget, 'max attempts exhausted');
+  await appendBudgetTerminal(
+    taskRunStore,
+    taskRunId,
+    now,
+    newId,
+    exhaustedBudget,
+    'max attempts exhausted',
+    options.interventionPolicy,
+  );
   const resultRecord = latestResultRecord ?? syntheticResultRecord(
     config,
     task,
@@ -556,8 +582,34 @@ async function appendBudgetTerminal(
   newId: () => string,
   budget: LoopBudgetSnapshot,
   reason: string,
+  policy: TaskInterventionPolicy | undefined = undefined,
 ): Promise<void> {
   const ts = now();
+  if (policy?.mode === 'park' && policy.allowBudgetExtensionRequests) {
+    const item = budgetExtensionInboxItem({
+      inboxItemId: newId(),
+      taskRunId,
+      reason,
+      createdAt: ts,
+      budget: { ...budget },
+    });
+    await appendTaskEvent(store, taskRunId, {
+      type: 'task_inbox_item_recorded',
+      id: newId(),
+      taskRunId,
+      ts,
+      item,
+    });
+    await appendTaskEvent(store, taskRunId, {
+      type: 'task_run_needs_approval',
+      id: newId(),
+      taskRunId,
+      ts,
+      reason: 'budget_extension',
+      inboxItemId: item.inboxItemId,
+    });
+    return;
+  }
   await appendTaskEvent(store, taskRunId, {
     type: 'task_run_budget_exhausted',
     id: newId(),

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -19,7 +19,16 @@ export type { FinalScore, FinalScorer, FinalScorerInput } from './scorer.js';
 export type {
   AutonomousDecision,
   AutonomousResultTaxonomy,
+  EnvNetworkSecretPolicy,
   FeedbackObservation,
+  HeadlessInterventionMode,
+  IsolationPolicyRecordedEvent,
+  PermissionDecision,
+  PermissionDecisionRecordedEvent,
+  PermissionDecisionSource,
+  PermissionGrantRecordedEvent,
+  PermissionRequestRecordedEvent,
+  PermissionResourceScope,
   ResultTaxonomy,
   ScoreResult,
   SelfCheckObservation,
@@ -28,6 +37,15 @@ export type {
   TaskDefinition,
   TaskEvent,
   TaskEventCorrupt,
+  TaskInboxItem,
+  TaskInboxItemRecordedEvent,
+  TaskInboxItemResolvedEvent,
+  TaskInboxKind,
+  TaskInboxStatus,
+  TaskInterventionPolicy,
+  TaskIsolationFacts,
+  TaskPermissionGrant,
+  TaskPermissionRequest,
   TaskRunAbortedEvent,
   TaskRunBlockedEvent,
   TaskRunBudgetExhaustedEvent,
@@ -36,6 +54,8 @@ export type {
   TaskRunCreatedEvent,
   TaskRunFailedEvent,
   TaskRunIncompleteEvent,
+  TaskRunNeedsApprovalEvent,
+  TaskRunParkedState,
   TaskRunPolicyDeniedEvent,
   TaskRunQueuedEvent,
   TaskRunStartedEvent,
@@ -44,7 +64,11 @@ export type {
   TaskRunError,
   TaskRunResult,
   TaskRunStatus,
+  ToolExecutorIdentity,
+  ToolExecutorIdentityRecordedEvent,
   VerifierResult,
+  WorkspaceLeaseRecordedEvent,
+  WorkspaceLeaseFacts,
 } from './task-contracts.js';
 export {
   TASK_RUN_TERMINAL_STATUSES,
@@ -52,6 +76,15 @@ export {
   isTerminalTaskRunStatus,
   taxonomyFromResultRecord,
 } from './task-contracts.js';
+export {
+  commandResourceScope,
+  hashNormalizedArgs,
+  matchPermissionGrant,
+  normalizePermissionArgs,
+  permissionPreview,
+  resourceScopeEquals,
+  type NormalizedPermissionArgs,
+} from './permission-grants.js';
 export type { TaskRunProjection, TaskRunStore } from './task-run-store.js';
 export { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from './task-run-store.js';
 export type { TaskEventsFromResultRecordOptions } from './task-run-adapter.js';

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,4 +1,9 @@
 import type { Config, Task } from './contracts.js';
+import type {
+  EnvNetworkSecretPolicy,
+  TaskIsolationFacts,
+  ToolExecutorIdentity,
+} from './task-contracts.js';
 
 export interface IsolatedCommandInput {
   command: string;
@@ -69,4 +74,59 @@ export function validateRealBackendIsolation(isolation: RealBackendIsolation | u
   if (typeof isolation.label !== 'string' || isolation.label.trim().length === 0) {
     throw new Error('realBackendIsolation.label is required');
   }
+}
+
+export function defaultEnvNetworkSecretPolicy(isolation: RealBackendIsolation | undefined): EnvNetworkSecretPolicy {
+  if (isolation) {
+    return {
+      schemaVersion: 1,
+      env: 'inherit_none',
+      network: 'unrestricted_external_boundary',
+      secrets: 'brokered_by_executor',
+    };
+  }
+  return {
+    schemaVersion: 1,
+    env: 'inherit_none',
+    network: 'disabled',
+    secrets: 'none',
+  };
+}
+
+export function taskIsolationFacts(input: {
+  backendKind: string;
+  required: boolean;
+  isolation?: RealBackendIsolation;
+  assertionSource?: TaskIsolationFacts['assertionSource'];
+  validatedAt: number;
+}): TaskIsolationFacts {
+  return {
+    schemaVersion: 1,
+    backendKind: input.backendKind,
+    required: input.required,
+    mode: input.isolation ? 'external' : 'inert_fake_backend',
+    ...(input.isolation ? { label: input.isolation.label } : {}),
+    assertionSource: input.assertionSource ?? 'headless_deps',
+    validatedAt: input.validatedAt,
+  };
+}
+
+export function toolExecutorIdentity(input: {
+  executorId: string;
+  taskRunId: string;
+  attemptId?: string;
+  isolation?: RealBackendIsolation;
+  toolNames?: string[];
+}): ToolExecutorIdentity {
+  const isolationMode = input.isolation ? 'external' : 'inert_fake_backend';
+  return {
+    schemaVersion: 1,
+    executorId: input.executorId,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    toolNames: input.toolNames ?? ['headless_runtime'],
+    isolationMode,
+    label: input.isolation?.label ?? 'fake backend inert tool boundary',
+    commandPolicy: defaultEnvNetworkSecretPolicy(input.isolation),
+  };
 }

--- a/packages/headless/src/permission-grants.ts
+++ b/packages/headless/src/permission-grants.ts
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto';
+import type {
+  PermissionResourceScope,
+  TaskPermissionGrant,
+  TaskPermissionRequest,
+} from './task-contracts.js';
+
+export type NormalizedPermissionArgs =
+  | null
+  | string
+  | number
+  | boolean
+  | NormalizedPermissionArgs[]
+  | { [key: string]: NormalizedPermissionArgs };
+
+export function normalizePermissionArgs(value: unknown): NormalizedPermissionArgs {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (Array.isArray(value)) return value.map((entry) => normalizePermissionArgs(entry));
+  if (typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const normalized: { [key: string]: NormalizedPermissionArgs } = {};
+    for (const key of Object.keys(source).sort()) {
+      const entry = source[key];
+      if (entry === undefined || typeof entry === 'function' || typeof entry === 'symbol') continue;
+      normalized[key] = normalizePermissionArgs(entry);
+    }
+    return normalized;
+  }
+  return null;
+}
+
+export function hashNormalizedArgs(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(normalizePermissionArgs(value)))
+    .digest('hex');
+}
+
+export function commandResourceScope(command: string): PermissionResourceScope {
+  const normalized = command.replace(/\s+/g, ' ').trim();
+  const digest = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return { kind: 'command', value: `bash-command:sha256:${digest}`, mode: 'execute' };
+}
+
+export function matchPermissionGrant(
+  request: TaskPermissionRequest,
+  grants: readonly TaskPermissionGrant[],
+  now: number,
+): TaskPermissionGrant | undefined {
+  return grants.find((grant) =>
+    grant.decision === 'allow' &&
+    grant.taskRunId === request.taskRunId &&
+    (grant.attemptId === undefined || grant.attemptId === request.attemptId) &&
+    (grant.toolCallId === undefined || grant.toolCallId === request.toolCallId) &&
+    grant.toolName === request.toolName &&
+    grant.normalizedArgsHash === request.normalizedArgsHash &&
+    resourceScopeEquals(grant.resourceScope, request.resourceScope) &&
+    grant.expiresAt > now,
+  );
+}
+
+export function resourceScopeEquals(a: PermissionResourceScope, b: PermissionResourceScope): boolean {
+  return a.kind === b.kind && a.value === b.value && a.mode === b.mode;
+}
+
+export function permissionPreview(args: unknown): Record<string, unknown> {
+  if (typeof args !== 'object' || args === null || Array.isArray(args)) {
+    return { argType: Array.isArray(args) ? 'array' : typeof args };
+  }
+  const keys = Object.keys(args as Record<string, unknown>).sort();
+  return {
+    argKeys: keys.slice(0, 50),
+    truncated: keys.length > 50,
+  };
+}

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -25,9 +25,20 @@ import {
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import type { HeadlessBackendContext } from './isolation.js';
-import { validateRealBackendIsolation } from './isolation.js';
+import {
+  taskIsolationFacts,
+  toolExecutorIdentity,
+  validateRealBackendIsolation,
+} from './isolation.js';
+import {
+  commandResourceScope,
+  hashNormalizedArgs,
+  matchPermissionGrant,
+  permissionPreview,
+} from './permission-grants.js';
 import { freezeSubmittedWorkspace, prepareScoringWorkspace, prepareWorkspace, restoreProtectedPaths } from './sandbox.js';
 import { defaultFinalScorer } from './scorer.js';
+import { approvalRequestInboxItem } from './task-inbox.js';
 import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 import {
   backendNeedsIsolation,
@@ -38,9 +49,13 @@ import {
   taxonomyFromResultRecord,
   type AutonomousResultTaxonomy,
   type FeedbackObservation,
+  type PermissionResourceScope,
   type ScoreResult,
   type TaskAttemptStatus,
   type TaskEvent,
+  type TaskInterventionPolicy,
+  type TaskPermissionGrant,
+  type TaskPermissionRequest,
   type TaskRunError,
   type TaskRunResult,
   type VerifierResult,
@@ -63,6 +78,8 @@ export interface RunTaskOnceDeps extends RunExperimentDeps {
   closeTaskRun?: boolean;
   instructionOverride?: string;
   permissionMode?: 'execute';
+  interventionPolicy?: TaskInterventionPolicy;
+  permissionGrants?: readonly TaskPermissionGrant[];
 }
 
 export interface RunTaskOnceResult {
@@ -86,7 +103,8 @@ export async function runTaskOnce(
   task: Task,
   deps: RunTaskOnceDeps,
 ): Promise<RunTaskOnceResult> {
-  if (backendNeedsIsolation(config.backend)) {
+  const isolationRequired = backendNeedsIsolation(config.backend);
+  if (isolationRequired) {
     validateRealBackendIsolation(deps.realBackendIsolation);
     if (!deps.registerBackends) {
       throw new Error(
@@ -103,6 +121,7 @@ export async function runTaskOnce(
   const instruction = deps.instructionOverride ?? task.instruction;
   const createTaskRun = deps.createTaskRun ?? true;
   const closeTaskRun = deps.closeTaskRun ?? true;
+  const interventionPolicy = deps.interventionPolicy ?? DEFAULT_INTERVENTION_POLICY;
   const taskRunStore = deps.taskRunStore ?? createTaskRunStore(deps.storageRoot);
   const sessionStore = deps.sessionStore ?? createSessionStore(deps.storageRoot);
   const agentRunStore = deps.agentRunStore ?? createAgentRunStore(deps.storageRoot);
@@ -130,9 +149,62 @@ export async function runTaskOnce(
       taskDefinition: taskDefinitionFromTask(task),
     });
   }
+  await appendTaskEvent(taskRunStore, taskRunId, {
+    type: 'isolation_policy_recorded',
+    id: newId(),
+    taskRunId,
+    ts: now(),
+    facts: taskIsolationFacts({
+      backendKind: config.backend,
+      required: isolationRequired,
+      isolation: deps.realBackendIsolation,
+      validatedAt: now(),
+    }),
+  });
+  for (const grant of deps.permissionGrants ?? []) {
+    if (grant.taskRunId !== taskRunId) continue;
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'permission_grant_recorded',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      grant,
+    });
+  }
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'workspace_lease_recorded',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      lease: {
+        schemaVersion: 1,
+        leaseId: newId(),
+        taskRunId,
+        attemptId,
+        sourceWorkspaceDir: task.workspaceDir,
+        workspaceDir: workspace.dir,
+        leaseKind: 'throwaway_copy',
+        writable: true,
+        cleanupPolicy: 'cleanup_on_finally',
+        createdAt: now(),
+      },
+    });
+    await appendTaskEvent(taskRunStore, taskRunId, {
+      type: 'tool_executor_identity_recorded',
+      id: newId(),
+      taskRunId,
+      ts: now(),
+      identity: toolExecutorIdentity({
+        executorId: newId(),
+        taskRunId,
+        attemptId,
+        isolation: deps.realBackendIsolation,
+        toolNames: deps.realBackendIsolation?.toolExecutor ? ['Bash'] : ['registered_backend'],
+      }),
+    });
     const backends = new BackendRegistry();
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
       deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
@@ -200,7 +272,30 @@ export async function runTaskOnce(
     } finally {
       await active.dispose();
     }
-    const invocation = normalizeHeadlessInvocation(runtimeInvocation);
+    const permissionHandling = await handlePermissionIntervention({
+      invocation: runtimeInvocation,
+      store: taskRunStore,
+      taskRunId,
+      attemptId,
+      now,
+      newId,
+      policy: interventionPolicy,
+      config,
+      task,
+      sessionId: header.id,
+      startedAt,
+      closeTaskRun,
+    });
+    if (permissionHandling.parked) {
+      return {
+        taskRunId,
+        attemptId,
+        resultRecord: permissionHandling.resultRecord,
+        projection: await taskRunStore.project(taskRunId),
+        invocation: permissionHandling.invocation,
+      };
+    }
+    const invocation = permissionHandling.invocation;
 
     const runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
@@ -335,6 +430,213 @@ export async function runTaskOnce(
   } finally {
     await workspace.cleanup();
   }
+}
+
+const DEFAULT_INTERVENTION_POLICY: TaskInterventionPolicy = { mode: 'fail_closed' };
+const DEFAULT_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface PermissionInterventionInput {
+  invocation: InvocationResult;
+  store: TaskRunStore;
+  taskRunId: string;
+  attemptId: string;
+  now: () => number;
+  newId: () => string;
+  policy: TaskInterventionPolicy;
+  config: Config;
+  task: Task;
+  sessionId: string;
+  startedAt: number;
+  closeTaskRun: boolean;
+}
+
+type PermissionInterventionResult =
+  | { parked: false; invocation: InvocationResult }
+  | { parked: true; invocation: InvocationResult; resultRecord: ResultRecord };
+
+async function handlePermissionIntervention(input: PermissionInterventionInput): Promise<PermissionInterventionResult> {
+  const permissionRequestEvent = input.invocation.events.find((event) => event.actions?.permissionRequest);
+  const rawRequest = permissionRequestEvent?.actions?.permissionRequest;
+  if (!rawRequest) {
+    return { parked: false, invocation: input.invocation };
+  }
+
+  const requestedAt = input.now();
+  const request = permissionRequestFromRuntime({
+    rawRequest,
+    taskRunId: input.taskRunId,
+    attemptId: input.attemptId,
+    requestedAt,
+    expiresAt: requestedAt + (input.policy.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS),
+  });
+  await appendTaskEvent(input.store, input.taskRunId, {
+    type: 'permission_request_recorded',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    ts: requestedAt,
+    request,
+  });
+
+  const projection = await input.store.project(input.taskRunId);
+  const postHocGrant = matchPermissionGrant(request, projection.permissionGrants, requestedAt);
+  const failClosedDenyReason = postHocGrant
+    ? 'matching permission grant was observed only after runtime emitted a permission handoff; headless cannot safely resume post-hoc permission requests'
+    : 'headless fail-closed policy denied interactive permission request';
+
+  const inboxItem = approvalRequestInboxItem({
+    inboxItemId: input.newId(),
+    request,
+    createdAt: requestedAt,
+  });
+  await appendTaskEvent(input.store, input.taskRunId, {
+    type: 'task_inbox_item_recorded',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    ts: requestedAt,
+    item: inboxItem,
+  });
+
+  if (input.policy.mode === 'park') {
+    await appendTaskEvent(input.store, input.taskRunId, {
+      type: 'task_attempt_completed',
+      id: input.newId(),
+      taskRunId: input.taskRunId,
+      ts: requestedAt,
+      attemptId: input.attemptId,
+      finishedAt: requestedAt,
+      status: 'needs_approval',
+      error: {
+        message: `task run needs approval for ${request.toolName}`,
+        class: 'needs_approval',
+      },
+    });
+    if (input.closeTaskRun) {
+      await appendTaskEvent(input.store, input.taskRunId, {
+        type: 'task_run_needs_approval',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts: requestedAt,
+        attemptId: input.attemptId,
+        reason: 'approval',
+        inboxItemId: inboxItem.inboxItemId,
+      });
+    }
+    return {
+      parked: true,
+      invocation: input.invocation,
+      resultRecord: syntheticPermissionResultRecord({
+        config: input.config,
+        task: input.task,
+        sessionId: input.sessionId,
+        runId: input.invocation.runId,
+        startedAt: input.startedAt,
+        finishedAt: requestedAt,
+        steps: input.invocation.events.length,
+        errorClass: 'needs_approval',
+        error: `task run needs approval for ${request.toolName}`,
+      }),
+    };
+  }
+
+  await appendTaskEvent(input.store, input.taskRunId, {
+    type: 'permission_decision_recorded',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    ts: requestedAt,
+    requestId: request.requestId,
+    decision: 'deny',
+    source: 'ci_policy',
+    decidedAt: requestedAt,
+    reason: failClosedDenyReason,
+  });
+  await appendTaskEvent(input.store, input.taskRunId, {
+    type: 'task_inbox_item_resolved',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    ts: requestedAt,
+    inboxItemId: inboxItem.inboxItemId,
+    status: 'resolved',
+    resolution: {
+      decision: 'deny',
+      actorId: 'ci_policy',
+      resolvedAt: requestedAt,
+      reason: failClosedDenyReason,
+    },
+  });
+
+  return { parked: false, invocation: normalizeHeadlessInvocation(input.invocation) };
+}
+
+function permissionRequestFromRuntime(input: {
+  rawRequest: {
+    requestId?: string;
+    toolUseId?: string;
+    toolName?: string;
+    reason?: string;
+    category?: string;
+    args?: unknown;
+  };
+  taskRunId: string;
+  attemptId: string;
+  requestedAt: number;
+  expiresAt: number;
+}): TaskPermissionRequest {
+  const args = input.rawRequest.args;
+  const toolName = input.rawRequest.toolName ?? 'unknown_tool';
+  const toolCallId = input.rawRequest.toolUseId ?? input.rawRequest.requestId ?? 'unknown_tool_call';
+  return {
+    schemaVersion: 1,
+    requestId: input.rawRequest.requestId ?? `${input.taskRunId}:${input.attemptId}:${toolCallId}`,
+    taskRunId: input.taskRunId,
+    attemptId: input.attemptId,
+    toolCallId,
+    toolName,
+    normalizedArgsHash: hashNormalizedArgs(args),
+    resourceScope: permissionScope(toolName, args),
+    reason: input.rawRequest.reason ?? input.rawRequest.category ?? 'permission required',
+    preview: permissionPreview(args),
+    requestedAt: input.requestedAt,
+    expiresAt: input.expiresAt,
+  };
+}
+
+function permissionScope(toolName: string, args: unknown): PermissionResourceScope {
+  if (toolName.toLowerCase() === 'bash' && isRecord(args) && typeof args.command === 'string') {
+    return commandResourceScope(args.command);
+  }
+  return { kind: 'tool', value: toolName, mode: 'execute' };
+}
+
+function syntheticPermissionResultRecord(input: {
+  config: Config;
+  task: Task;
+  sessionId: string;
+  runId: string;
+  startedAt: number;
+  finishedAt: number;
+  steps: number;
+  errorClass: string;
+  error: string;
+}): ResultRecord {
+  return {
+    taskId: input.task.id,
+    configId: input.config.id,
+    sessionId: input.sessionId,
+    runId: input.runId,
+    status: 'failed',
+    runnerCompleted: false,
+    passed: false,
+    scored: false,
+    eligible: false,
+    excludedReason: input.error,
+    exitCode: null,
+    steps: input.steps,
+    durationMs: input.finishedAt - input.startedAt,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    error: input.error,
+    errorClass: input.errorClass,
+  };
 }
 
 interface RunRuntimeAttemptInput {

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -11,6 +11,7 @@ export type TaskRunStatus =
   | 'blocked'
   | 'policy_denied'
   | 'budget_exhausted'
+  | 'needs_approval'
   | 'aborted'
   | 'cancelled';
 export type TaskAttemptStatus =
@@ -21,6 +22,7 @@ export type TaskAttemptStatus =
   | 'blocked'
   | 'policy_denied'
   | 'budget_exhausted'
+  | 'needs_approval'
   | 'aborted'
   | 'cancelled';
 
@@ -57,6 +59,15 @@ export type AutonomousResultTaxonomy =
   | 'cancelled';
 
 export type ResultTaxonomy = AutonomousResultTaxonomy;
+
+export type HeadlessInterventionMode = 'fail_closed' | 'park';
+
+export interface TaskInterventionPolicy {
+  mode: HeadlessInterventionMode;
+  approvalTimeoutMs?: number;
+  allowBudgetExtensionRequests?: boolean;
+  allowAmbiguousFailureTriage?: boolean;
+}
 
 export function taxonomyFromResultRecord(record: ResultRecord): AutonomousResultTaxonomy {
   if (record.status === 'completed') {
@@ -210,6 +221,127 @@ export interface ScoreResult {
   details?: Record<string, unknown>;
 }
 
+export interface EnvNetworkSecretPolicy {
+  schemaVersion: 1;
+  env: 'inherit_none' | 'allowlist';
+  envAllowlist?: string[];
+  network: 'disabled' | 'allowlist' | 'unrestricted_external_boundary';
+  networkAllowlist?: string[];
+  secrets: 'none' | 'brokered_by_executor' | 'explicit_allowlist';
+  secretRefs?: string[];
+}
+
+export interface TaskIsolationFacts {
+  schemaVersion: 1;
+  backendKind: string;
+  required: boolean;
+  mode: 'inert_fake_backend' | 'external';
+  label?: string;
+  assertionSource: 'headless_deps' | 'test_fixture' | 'desktop' | 'ci';
+  validatedAt: number;
+}
+
+export interface WorkspaceLeaseFacts {
+  schemaVersion: 1;
+  leaseId: string;
+  taskRunId: string;
+  attemptId?: string;
+  sourceWorkspaceDir: string;
+  workspaceDir: string;
+  leaseKind: 'throwaway_copy';
+  writable: boolean;
+  cleanupPolicy: 'cleanup_on_finally';
+  createdAt: number;
+  releasedAt?: number;
+}
+
+export interface ToolExecutorIdentity {
+  schemaVersion: 1;
+  executorId: string;
+  taskRunId: string;
+  attemptId?: string;
+  toolNames: string[];
+  isolationMode: 'external' | 'inert_fake_backend';
+  label: string;
+  commandPolicy?: EnvNetworkSecretPolicy;
+}
+
+export type PermissionDecision = 'allow' | 'deny' | 'timeout' | 'expired';
+export type PermissionDecisionSource = 'ci_policy' | 'desktop_user' | 'test_fixture' | 'policy_engine';
+
+export interface PermissionResourceScope {
+  kind: 'workspace_path' | 'network' | 'secret' | 'command' | 'tool' | 'budget';
+  value: string;
+  mode?: 'read' | 'write' | 'execute' | 'connect' | 'reveal' | 'extend';
+}
+
+export interface TaskPermissionRequest {
+  schemaVersion: 1;
+  requestId: string;
+  taskRunId: string;
+  attemptId: string;
+  toolCallId: string;
+  toolName: string;
+  normalizedArgsHash: string;
+  resourceScope: PermissionResourceScope;
+  reason: string;
+  preview: Record<string, unknown>;
+  requestedAt: number;
+  expiresAt: number;
+}
+
+export interface TaskPermissionGrant {
+  schemaVersion: 1;
+  grantId: string;
+  requestId: string;
+  taskRunId: string;
+  attemptId?: string;
+  toolCallId?: string;
+  toolName: string;
+  normalizedArgsHash: string;
+  resourceScope: PermissionResourceScope;
+  decision: PermissionDecision;
+  actor: { kind: 'user' | 'system' | 'test'; id?: string };
+  source: PermissionDecisionSource;
+  decidedAt: number;
+  expiresAt: number;
+  reason?: string;
+}
+
+export type TaskInboxKind =
+  | 'approval_request'
+  | 'ambiguous_failure_triage'
+  | 'budget_extension'
+  | 'claim_to_chat';
+
+export type TaskInboxStatus = 'open' | 'claimed' | 'resolved' | 'dismissed' | 'expired';
+
+export interface TaskInboxItem {
+  schemaVersion: 1;
+  inboxItemId: string;
+  taskRunId: string;
+  attemptId?: string;
+  kind: TaskInboxKind;
+  status: TaskInboxStatus;
+  title: string;
+  reason: string;
+  createdAt: number;
+  expiresAt?: number;
+  relatedRequestId?: string;
+  relatedGrantId?: string;
+  relatedVerifierResultId?: string;
+  relatedScoreResultId?: string;
+  claim?: { actorId: string; claimedAt: number; chatRef?: string };
+  resolution?: { decision: string; actorId?: string; resolvedAt: number; reason?: string };
+  preview?: Record<string, unknown>;
+}
+
+export interface TaskRunParkedState {
+  reason: 'approval' | 'ambiguous_failure' | 'budget_extension' | 'claim_to_chat';
+  inboxItemId: string;
+  since: number;
+}
+
 interface BaseTaskEvent {
   id: string;
   taskRunId: string;
@@ -274,6 +406,60 @@ export interface VerifierResultRecordedEvent extends BaseTaskEvent {
 export interface ScoreResultRecordedEvent extends BaseTaskEvent {
   type: 'score_result_recorded';
   result: ScoreResult;
+}
+
+export interface IsolationPolicyRecordedEvent extends BaseTaskEvent {
+  type: 'isolation_policy_recorded';
+  facts: TaskIsolationFacts;
+}
+
+export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
+  type: 'workspace_lease_recorded';
+  lease: WorkspaceLeaseFacts;
+}
+
+export interface ToolExecutorIdentityRecordedEvent extends BaseTaskEvent {
+  type: 'tool_executor_identity_recorded';
+  identity: ToolExecutorIdentity;
+}
+
+export interface PermissionRequestRecordedEvent extends BaseTaskEvent {
+  type: 'permission_request_recorded';
+  request: TaskPermissionRequest;
+}
+
+export interface PermissionGrantRecordedEvent extends BaseTaskEvent {
+  type: 'permission_grant_recorded';
+  grant: TaskPermissionGrant;
+}
+
+export interface PermissionDecisionRecordedEvent extends BaseTaskEvent {
+  type: 'permission_decision_recorded';
+  requestId: string;
+  grant?: TaskPermissionGrant;
+  decision: PermissionDecision;
+  source: PermissionDecisionSource;
+  decidedAt: number;
+  reason?: string;
+}
+
+export interface TaskInboxItemRecordedEvent extends BaseTaskEvent {
+  type: 'task_inbox_item_recorded';
+  item: TaskInboxItem;
+}
+
+export interface TaskInboxItemResolvedEvent extends BaseTaskEvent {
+  type: 'task_inbox_item_resolved';
+  inboxItemId: string;
+  status: Exclude<TaskInboxStatus, 'open'>;
+  resolution?: NonNullable<TaskInboxItem['resolution']>;
+}
+
+export interface TaskRunNeedsApprovalEvent extends BaseTaskEvent {
+  type: 'task_run_needs_approval';
+  attemptId?: string;
+  reason: TaskRunParkedState['reason'];
+  inboxItemId: string;
 }
 
 export interface TaskAttemptCompletedEvent extends BaseTaskEvent {
@@ -349,6 +535,15 @@ export type TaskEvent =
   | AutonomousDecisionRecordedEvent
   | VerifierResultRecordedEvent
   | ScoreResultRecordedEvent
+  | IsolationPolicyRecordedEvent
+  | WorkspaceLeaseRecordedEvent
+  | ToolExecutorIdentityRecordedEvent
+  | PermissionRequestRecordedEvent
+  | PermissionGrantRecordedEvent
+  | PermissionDecisionRecordedEvent
+  | TaskInboxItemRecordedEvent
+  | TaskInboxItemResolvedEvent
+  | TaskRunNeedsApprovalEvent
   | TaskAttemptCompletedEvent
   | TaskRunCompletedEvent
   | TaskRunFailedEvent

--- a/packages/headless/src/task-inbox.ts
+++ b/packages/headless/src/task-inbox.ts
@@ -1,0 +1,53 @@
+import type {
+  TaskInboxItem,
+  TaskPermissionRequest,
+} from './task-contracts.js';
+
+export function approvalRequestInboxItem(input: {
+  inboxItemId: string;
+  request: TaskPermissionRequest;
+  createdAt: number;
+}): TaskInboxItem {
+  return {
+    schemaVersion: 1,
+    inboxItemId: input.inboxItemId,
+    taskRunId: input.request.taskRunId,
+    attemptId: input.request.attemptId,
+    kind: 'approval_request',
+    status: 'open',
+    title: `Approval required for ${input.request.toolName}`,
+    reason: input.request.reason,
+    createdAt: input.createdAt,
+    expiresAt: input.request.expiresAt,
+    relatedRequestId: input.request.requestId,
+    preview: {
+      toolName: input.request.toolName,
+      toolCallId: input.request.toolCallId,
+      normalizedArgsHash: input.request.normalizedArgsHash,
+      resourceScope: input.request.resourceScope,
+      ...input.request.preview,
+    },
+  };
+}
+
+export function budgetExtensionInboxItem(input: {
+  inboxItemId: string;
+  taskRunId: string;
+  attemptId?: string;
+  reason: string;
+  createdAt: number;
+  budget: Record<string, unknown>;
+}): TaskInboxItem {
+  return {
+    schemaVersion: 1,
+    inboxItemId: input.inboxItemId,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    kind: 'budget_extension',
+    status: 'open',
+    title: 'Budget extension requested',
+    reason: input.reason,
+    createdAt: input.createdAt,
+    preview: { budget: input.budget },
+  };
+}

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -4,6 +4,11 @@ import type { ResultRecord } from './contracts.js';
 import type {
   AutonomousDecision,
   FeedbackObservation,
+  TaskInboxItem,
+  TaskIsolationFacts,
+  TaskPermissionGrant,
+  TaskPermissionRequest,
+  TaskRunParkedState,
   ScoreResult,
   SelfCheckObservation,
   TaskAttempt,
@@ -11,7 +16,9 @@ import type {
   TaskRun,
   TaskRunError,
   TaskRunResult,
+  ToolExecutorIdentity,
   VerifierResult,
+  WorkspaceLeaseFacts,
 } from './task-contracts.js';
 
 export interface TaskRunProjection extends TaskRun {
@@ -22,9 +29,16 @@ export interface TaskRunProjection extends TaskRun {
   decisions: AutonomousDecision[];
   verifierResults: VerifierResult[];
   scoreResults: ScoreResult[];
+  toolExecutors: ToolExecutorIdentity[];
+  permissionGrants: TaskPermissionGrant[];
+  permissionRequests: TaskPermissionRequest[];
+  inboxItems: TaskInboxItem[];
   warnings: string[];
   latestVerifierResult?: VerifierResult;
   latestScoreResult?: ScoreResult;
+  isolation?: TaskIsolationFacts;
+  workspaceLease?: WorkspaceLeaseFacts;
+  parked?: TaskRunParkedState;
   sourceResultRecord?: ResultRecord;
 }
 
@@ -56,9 +70,14 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     decisions: [],
     verifierResults: [],
     scoreResults: [],
+    toolExecutors: [],
+    permissionGrants: [],
+    permissionRequests: [],
+    inboxItems: [],
     warnings: [],
   };
   const attempts = new Map<string, TaskAttempt>();
+  const inboxItems = new Map<string, TaskInboxItem>();
   let terminalEvents = 0;
 
   for (const event of events) {
@@ -118,6 +137,54 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         projection.scoreResults.push(event.result);
         projection.latestScoreResult = event.result;
         projection.result = resultFromScore(event.result, projection.latestVerifierResult);
+        break;
+      case 'isolation_policy_recorded':
+        projection.isolation = event.facts;
+        break;
+      case 'workspace_lease_recorded':
+        projection.workspaceLease = event.lease;
+        break;
+      case 'tool_executor_identity_recorded':
+        projection.toolExecutors.push(event.identity);
+        break;
+      case 'permission_request_recorded':
+        projection.permissionRequests.push(event.request);
+        break;
+      case 'permission_grant_recorded':
+        projection.permissionGrants.push(event.grant);
+        break;
+      case 'permission_decision_recorded':
+        break;
+      case 'task_inbox_item_recorded':
+        inboxItems.set(event.item.inboxItemId, event.item);
+        break;
+      case 'task_inbox_item_resolved': {
+        const previous = inboxItems.get(event.inboxItemId);
+        if (previous) {
+          inboxItems.set(event.inboxItemId, {
+            ...previous,
+            status: event.status,
+            ...(event.resolution ? { resolution: event.resolution } : {}),
+          });
+        }
+        if (projection.parked?.inboxItemId === event.inboxItemId && terminalEvents === 0) {
+          delete projection.parked;
+        }
+        break;
+      }
+      case 'task_run_needs_approval':
+        if (terminalEvents === 0) {
+          projection.status = 'needs_approval';
+          projection.parked = { reason: event.reason, inboxItemId: event.inboxItemId, since: event.ts };
+          if (event.attemptId) {
+            const previous = attempts.get(event.attemptId);
+            attempts.set(event.attemptId, {
+              ...(previous ?? { attemptId: event.attemptId, taskRunId: event.taskRunId, startedAt: event.ts }),
+              status: 'needs_approval',
+              finishedAt: event.ts,
+            });
+          }
+        }
         break;
       case 'task_attempt_completed':
         attempts.set(event.attemptId, {
@@ -186,6 +253,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
   }
 
   projection.attempts = [...attempts.values()];
+  projection.inboxItems = [...inboxItems.values()];
   return projection;
 }
 
@@ -306,6 +374,7 @@ function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: numbe
   if (terminalEvents > 0) {
     projection.warnings.push('multiple terminal task run events observed; last terminal event wins');
   }
+  delete projection.parked;
   return terminalEvents + 1;
 }
 


### PR DESCRIPTION
## Summary

This PR hardens the autonomous task-run ledger around isolation, permission, and human-handoff state.

- Records real-backend isolation, env/network/secret policy, workspace lease, and tool executor identity as task-run facts.
- Adds task-scoped permission request/grant/decision contracts with normalized args hash, resource scope, actor/source, and expiry.
- Adds a task-run `TaskInbox` projection for approval requests and budget-extension parking.
- Keeps headless CI fail-closed by default while allowing desktop callers to park runs in `needs_approval`.

Rive orchestration used the requested three-node flow:

- workflow run: `wfrun_00aa8e6d732045a4a7ab25e938878011`
- scheduler: `sched_820ac0a6bd164cc9970feedc57285dd5`
- root work: `work_68f11209bde648b19ebd6c410b192ef0`
- artifacts: `/tmp/rive-maka-isolation-permission-task-inbox-20260619/output/`

## Steward fixes after Rive review

Rive review returned `PATCH_REQUIRED`. I patched the two blockers plus both read-model nits:

- Matching permission grants are no longer treated as post-hoc runtime authorization. If the runtime has already emitted a permission handoff, headless now denies/parks instead of recording an allow and proceeding to scoring.
- Bash permission `resourceScope` is now a redaction-safe digest label; exact binding stays on `normalizedArgsHash`.
- Terminal events now clear stale `parked` projection state.
- `permission_decision_recorded` no longer duplicates grants into the projected grant list.

## Verification

- `npm run typecheck --workspace @maka/headless`
- `npm test --workspace @maka/headless` (77 tests, 20 suites, 0 failures)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `git diff --cached --check`

## Notes

This PR deliberately does not implement runtime-integrated grant resume. Grants are now safely recorded and matchable, but headless will not pretend a post-hoc grant executed the requested tool. A future desktop/runtime PR can feed grants into the parked runtime permission request before tool execution.
