### PR TITLE
feat(runtime): add local-read agent catalog

### DIFF
--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -26,6 +26,7 @@ export interface AgentRunHeader {
   updatedAt: number;
   completedAt?: number;
   parentRunId?: string;
+  agentId?: string;
   agentName?: string;
   parentTurnId?: string;
   retriedFromTurnId?: string;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -9,7 +9,7 @@
  * Connection-setup events live in ./connections.ts (separate channel).
  */
 
-import type { PermissionRequest, PermissionResponse, ToolCategory } from './permission.js';
+import type { PermissionMode, PermissionRequest, PermissionResponse, ToolCategory } from './permission.js';
 import type {
   CacheMissInputSource,
   ContextBudgetDiagnostic,
@@ -248,11 +248,12 @@ export type ToolResultContent =
     }
   | {
       kind: 'subagent';
+      agentId?: string;
       agentName: string;
       turnId: string;
       runId?: string;
       status: 'completed' | 'failed' | 'cancelled' | 'running' | 'waiting_permission';
-      permissionMode: 'explore';
+      permissionMode: PermissionMode;
       summary: string;
       artifactIds: readonly string[];
       startedAt?: number;

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -32,6 +32,7 @@ export interface UserMessageInput {
   text: string;
   attachments?: AttachmentRef[];
   parentRunId?: string;
+  agentId?: string;
   agentName?: string;
   parentTurnId?: string;
   retriedFromTurnId?: string;
@@ -41,6 +42,7 @@ export interface UserMessageInput {
 }
 
 export interface AgentSpec {
+  id: string;
   name: string;
   systemPrompt: string;
 }

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -41,7 +41,7 @@ describe('isolated headless tools', () => {
     });
   });
 
-  test('standard isolated tool surface replaces only Bash', () => {
+  test('standard isolated tool surface keeps local-read child tools shell-free', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -55,6 +55,6 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('agent_list'));
     assert.ok(names.includes('agent_output'));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
-    assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Bash', 'Read', 'Glob', 'Grep']);
+    assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -29,6 +29,10 @@ import type { RuntimeKernelLike } from '../runtime-kernel.js';
 import { RuntimeReadModel } from '../runtime-read-model.js';
 import type { AgentBackend, MakaTool } from '../ai-sdk-backend.js';
 import type { InvocationResult } from '../invocation-context.js';
+import {
+  LOCAL_READ_AGENT_DEFINITION,
+  LOCAL_READ_AGENT_ID,
+} from '../agent-catalog.js';
 
 describe('SessionManager permission mode updates', () => {
   test('updates header, rebuilds active backend, and writes an audit note', async () => {
@@ -1117,7 +1121,7 @@ describe('SessionManager permission mode updates', () => {
     expect(childInput.runtimeContext).toBe(undefined);
   });
 
-  test('startChildTurn uses a separate explore backend with the child system prompt', async () => {
+  test('startChildTurn uses a separate explore backend with the catalog child definition', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -1129,7 +1133,14 @@ describe('SessionManager permission mode updates', () => {
       backendInstances.push(backend);
       return backend;
     });
-    const childTools = [testTool('Read'), testTool('Bash')];
+    const childTools = [
+      testTool('Read'),
+      testTool('Bash'),
+      testTool('Glob'),
+      testTool('WebSearch'),
+      testTool('Grep'),
+      testTool('ExploreAgent'),
+    ];
     const manager = new SessionManager({
       store,
       runStore, runtimeEventStore: runStore, backends,
@@ -1148,15 +1159,16 @@ describe('SessionManager permission mode updates', () => {
       turnId: 'child-turn',
       parentRunId: parentRun.runId,
       spec: {
-        name: 'Researcher',
-        systemPrompt: 'You are a read-only child researcher.',
+        id: LOCAL_READ_AGENT_ID,
+        name: 'Injected Name',
+        systemPrompt: 'Injected child prompt.',
       },
       prompt: 'inspect the repo',
     }));
 
     expect(contexts.map((ctx) => ctx.header.permissionMode)).toEqual(['ask', 'explore']);
-    expect(contexts[1]?.systemPrompt).toBe('You are a read-only child researcher.');
-    expect(contexts[1]?.tools?.map((tool) => tool.name)).toEqual(['Read', 'Bash']);
+    expect(contexts[1]?.systemPrompt).toBe(LOCAL_READ_AGENT_DEFINITION.systemPrompt);
+    expect(contexts[1]?.tools?.map((tool) => tool.name)).toEqual(['Read', 'Glob', 'Grep']);
     expect(backendInstances).toHaveLength(2);
     expect(backendInstances[0] === backendInstances[1]).toBe(false);
     expect(backendInstances[1]?.sendInputs[0]?.context).toEqual([]);
@@ -1164,7 +1176,8 @@ describe('SessionManager permission mode updates', () => {
 
     const childRun = (await runStore.listSessionRuns(session.id)).find((run) => run.turnId === 'child-turn');
     expect(childRun?.parentRunId).toBe(parentRun.runId);
-    expect(childRun?.agentName).toBe('Researcher');
+    expect(childRun?.agentId).toBe(LOCAL_READ_AGENT_ID);
+    expect(childRun?.agentName).toBe(LOCAL_READ_AGENT_DEFINITION.name);
     expect(childRun?.permissionMode).toBe('explore');
 
     const childMessages = (await store.readMessages(session.id)).filter((message) =>
@@ -1181,6 +1194,7 @@ describe('SessionManager permission mode updates', () => {
     const manager = new SessionManager({
       store,
       runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       listArtifactsForTurn: async (_sessionId, turnId) => turnId === 'child-turn'
         ? [{
             id: 'artifact-1',
@@ -1206,10 +1220,12 @@ describe('SessionManager permission mode updates', () => {
     const result = await manager.spawnChildAgent(session.id, {
       turnId: 'child-turn',
       parentRunId: parentRun.runId,
-      spec: { name: 'Researcher', systemPrompt: 'read only' },
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Injected Name', systemPrompt: 'read only' },
       prompt: 'inspect',
     });
 
+    expect(result.agentId).toBe(LOCAL_READ_AGENT_ID);
+    expect(result.agentName).toBe(LOCAL_READ_AGENT_DEFINITION.name);
     expect(result.artifactIds).toEqual(['artifact-1']);
   });
 
@@ -1221,6 +1237,7 @@ describe('SessionManager permission mode updates', () => {
     const manager = new SessionManager({
       store,
       runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       newId: nextId(),
       now: nextNow(6_844),
       runtimeSource: 'test',
@@ -1233,7 +1250,7 @@ describe('SessionManager permission mode updates', () => {
     const result = await manager.spawnChildAgent(session.id, {
       turnId: 'child-turn',
       parentRunId: parentRun.runId,
-      spec: { name: 'Researcher', systemPrompt: 'read only' },
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
       prompt: 'produce a large report',
     });
 
@@ -1259,6 +1276,7 @@ describe('SessionManager permission mode updates', () => {
     const manager = new SessionManager({
       store,
       runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       newId: nextId(),
       now: nextNow(6_845),
       runtimeSource: 'test',
@@ -1271,7 +1289,7 @@ describe('SessionManager permission mode updates', () => {
     const child = manager.startChildTurn(session.id, {
       turnId: 'child-turn',
       parentRunId: parentRun.runId,
-      spec: { name: 'Researcher', systemPrompt: 'read only' },
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Researcher', systemPrompt: 'read only' },
       prompt: 'inspect slowly',
     })[Symbol.asyncIterator]();
     await child.next();
@@ -1289,7 +1307,48 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).permissionMode).toBe('execute');
   });
 
-  test('agent projections list child runs and read output artifacts by child turn', async () => {
+  test('spawnChildAgent fails closed instead of running a degraded catalog agent', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const backendInstances: TestBackend[] = [];
+    backends.register('fake', (ctx) => {
+      const backend = new TestBackend(ctx);
+      backendInstances.push(backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read')],
+      newId: nextId(),
+      now: nextNow(6_847),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    await expectRejects(
+      manager.spawnChildAgent(session.id, {
+        turnId: 'child-turn',
+        parentRunId: parentRun.runId,
+        spec: {
+          id: LOCAL_READ_AGENT_ID,
+          name: LOCAL_READ_AGENT_DEFINITION.name,
+          systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
+        },
+        prompt: 'inspect',
+      }),
+      /Agent "local-read" is unavailable: missing tools: Glob, Grep/,
+    );
+
+    expect(backendInstances).toHaveLength(1);
+    expect((await runStore.listSessionRuns(session.id)).some((run) => run.turnId === 'child-turn')).toBe(false);
+  });
+
+  test('agent projections list catalog definitions separately from child runs and read output artifacts by child turn', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -1336,6 +1395,7 @@ describe('SessionManager permission mode updates', () => {
       updatedAt: 130,
       completedAt: 130,
       parentRunId: 'parent-run',
+      agentId: LOCAL_READ_AGENT_ID,
       agentName: 'Researcher',
       permissionMode: 'explore',
     }), [
@@ -1345,9 +1405,11 @@ describe('SessionManager permission mode updates', () => {
     ]);
 
     const list = await manager.listChildAgents(session.id);
-    expect(list.agents.map((agent) => agent.runId)).toEqual(['child-run']);
-    expect(list.agents[0]?.agentName).toBe('Researcher');
-    expect(list.agents[0]?.durationMs).toBe(10);
+    expect(list.definitions.map((agent) => agent.id)).toEqual([LOCAL_READ_AGENT_ID]);
+    expect(list.runs.map((agent) => agent.runId)).toEqual(['child-run']);
+    expect(list.runs[0]?.agentId).toBe(LOCAL_READ_AGENT_ID);
+    expect(list.runs[0]?.agentName).toBe('Researcher');
+    expect(list.runs[0]?.durationMs).toBe(10);
 
     const output = await manager.readChildAgentOutput(session.id, { runId: 'child-run' });
     expect(output.header.runId).toBe('child-run');
@@ -1377,6 +1439,7 @@ describe('SessionManager permission mode updates', () => {
       updatedAt: 200,
       completedAt: 200,
       parentRunId: 'parent-run',
+      agentId: LOCAL_READ_AGENT_ID,
       agentName: 'Researcher',
       permissionMode: 'explore',
     });
@@ -1435,6 +1498,7 @@ describe('SessionManager permission mode updates', () => {
       updatedAt: 130,
       completedAt: 130,
       parentRunId: 'parent-run',
+      agentId: LOCAL_READ_AGENT_ID,
       agentName: 'Researcher',
       permissionMode: 'explore',
     }));

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -7,6 +7,12 @@ import type { SessionEvent } from '@maka/core/events';
 import { buildBuiltinTools } from '../builtin-tools.js';
 import { PermissionEngine } from '../permission-engine.js';
 import {
+  LOCAL_READ_AGENT_ID,
+  LOCAL_READ_AGENT_DEFINITION,
+  assertAgentDefinitionRunnable,
+  evaluateAgentDefinitionToolAccess,
+} from '../agent-catalog.js';
+import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
@@ -19,7 +25,56 @@ import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
 import { expect } from '../test-helpers.js';
 
 describe('subagent tools', () => {
-  test('child agent toolset keeps only local non-prompting tools', () => {
+  test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
+    expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
+    expect(LOCAL_READ_AGENT_DEFINITION.permissionMode).toBe('explore');
+    expect([...LOCAL_READ_AGENT_DEFINITION.tools]).toEqual(['Read', 'Glob', 'Grep']);
+    expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('Bash')).toBe(false);
+    expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('WebSearch')).toBe(false);
+    expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('WebFetch')).toBe(false);
+    expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('ExploreAgent')).toBe(false);
+  });
+
+  test('agent definition policy evaluates each tool through allowlist and category policy', () => {
+    expect(evaluateAgentDefinitionToolAccess(LOCAL_READ_AGENT_DEFINITION, testCatalogTool('Read', 'read'))).toEqual({
+      category: 'read',
+      decision: 'allow',
+    });
+    expect(evaluateAgentDefinitionToolAccess(LOCAL_READ_AGENT_DEFINITION, testCatalogTool('Write', 'file_write'))).toEqual({
+      category: 'file_write',
+      decision: 'block',
+    });
+    expect(evaluateAgentDefinitionToolAccess({
+      ...LOCAL_READ_AGENT_DEFINITION,
+      id: 'web-review',
+      tools: ['WebSearch'],
+      categoryPolicy: { web_read: 'prompt' },
+    }, testCatalogTool('WebSearch', 'web_read'))).toEqual({
+      category: 'web_read',
+      decision: 'prompt',
+    });
+  });
+
+  test('agent definition cannot require broader permissions than the parent turn', async () => {
+    await expectRejects(
+      Promise.resolve().then(() => assertAgentDefinitionRunnable({
+        parentPermissionMode: 'explore',
+        definition: {
+          ...LOCAL_READ_AGENT_DEFINITION,
+          id: 'writer',
+          permissionMode: 'execute',
+        },
+        tools: [
+          testCatalogTool('Read', 'read'),
+          testCatalogTool('Glob', 'read'),
+          testCatalogTool('Grep', 'read'),
+        ],
+      })),
+      /cannot run in parent permission mode "explore" because it requires "execute"/,
+    );
+  });
+
+  test('child agent toolset keeps only local-read allowlisted tools', () => {
     const tools = buildChildAgentTools([
       ...buildBuiltinTools(),
       {
@@ -36,9 +91,16 @@ describe('subagent tools', () => {
         categoryHint: 'web_read',
         impl: async () => ({}),
       },
+      {
+        name: 'ExploreAgent',
+        description: 'deterministic exploration',
+        parameters: {},
+        categoryHint: 'subagent',
+        impl: async () => ({}),
+      },
     ]);
 
-    expect(tools.map((tool) => tool.name)).toEqual(['Bash', 'Read', 'Glob', 'Grep']);
+    expect(tools.map((tool) => tool.name)).toEqual(['Read', 'Glob', 'Grep']);
   });
 
   test('child agent toolset enforces explore-mode read-only behavior without prompting', async () => {
@@ -52,30 +114,22 @@ describe('subagent tools', () => {
       await runTool(runtime, tools, 'Read', { path: 'notes.txt' }, events);
       await runTool(runtime, tools, 'Glob', { pattern: '*.txt' }, events);
       await runTool(runtime, tools, 'Grep', { pattern: 'SUBAGENT_CHILD_TOOL_MARKER' }, events);
-      await runTool(runtime, tools, 'Bash', { command: 'pwd' }, events);
-      const unsafe = await runTool(runtime, tools, 'Bash', { command: 'node -e "console.log(1)"' }, events);
 
       expect(events.some((event) => event.type === 'permission_request')).toBe(false);
-      expect((unsafe as { error?: string }).error).toBeDefined();
-      expect(events.some((event) =>
-        event.type === 'tool_result' &&
-        event.toolUseId === 'tool-Bash-node -e "console.log(1)"' &&
-        event.isError
-      )).toBe(true);
+      expect(tools.has('Bash')).toBe(false);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
   });
 
-  test('agent_spawn delegates through the narrow tool context capability', async () => {
+  test('agent_spawn delegates a catalog agent and task through the narrow context capability', async () => {
     const tool = buildSubagentSpawnTool();
     const abortController = new AbortController();
     const calls: unknown[] = [];
 
     const result = await tool.impl({
-      agent_name: 'Researcher',
-      instructions: 'Stay read-only.',
-      prompt: 'Inspect the runtime tests.',
+      agent: LOCAL_READ_AGENT_ID,
+      task: 'Inspect the runtime tests.',
     }, {
       sessionId: 'session-1',
       turnId: 'parent-turn',
@@ -86,6 +140,7 @@ describe('subagent tools', () => {
       spawnChildAgent: async (input) => {
         calls.push(input);
         return {
+          agentId: input.spec.id,
           agentName: input.spec.name,
           turnId: 'child-turn',
           status: 'completed',
@@ -101,20 +156,48 @@ describe('subagent tools', () => {
     expect(tool.permissionRequired).toBe(true);
     expect(calls).toEqual([{
       spec: {
-        name: 'Researcher',
-        systemPrompt: 'Stay read-only.',
+        id: LOCAL_READ_AGENT_ID,
+        name: 'Local Read',
+        systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
       },
       prompt: 'Inspect the runtime tests.',
     }]);
     expect(result).toEqual({
       kind: 'subagent',
-      agentName: 'Researcher',
+      agentId: LOCAL_READ_AGENT_ID,
+      agentName: 'Local Read',
       turnId: 'child-turn',
       status: 'completed',
       permissionMode: 'explore',
       summary: 'done',
       artifactIds: [],
     });
+  });
+
+  test('agent_spawn rejects an unknown catalog id without spawning a child', async () => {
+    const tool = buildSubagentSpawnTool();
+    const schema = tool.parameters as { safeParse(input: unknown): { success: boolean } };
+
+    expect(schema.safeParse({ agent: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(true);
+    expect(schema.safeParse({ agent_name: 'Researcher', instructions: 'Read only.', prompt: 'Inspect.' }).success).toBe(false);
+
+    await expectRejects(
+      Promise.resolve(tool.impl({
+        agent: 'implementation',
+        task: 'Edit files.',
+      }, {
+        sessionId: 'session-1',
+        turnId: 'parent-turn',
+        cwd: '/tmp/cwd',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        spawnChildAgent: async () => {
+          throw new Error('spawn should not be called');
+        },
+      })),
+      /Unknown agent "implementation"/,
+    );
   });
 
   test('agent projection tools delegate through read-only context capabilities', async () => {
@@ -128,7 +211,10 @@ describe('subagent tools', () => {
       toolCallId: 'tool-list',
       abortSignal: new AbortController().signal,
       emitOutput: () => {},
-      listChildAgents: async () => ({ agents: [{ runId: 'child-run', turnId: 'child-turn' }] }),
+      listChildAgents: async () => ({
+        definitions: [{ id: LOCAL_READ_AGENT_ID }],
+        runs: [{ runId: 'child-run', turnId: 'child-turn' }],
+      }),
     });
     const output = await outputTool.impl({ run_id: 'child-run' }, {
       sessionId: 'session-1',
@@ -144,7 +230,10 @@ describe('subagent tools', () => {
     expect(outputTool.name).toBe(AGENT_OUTPUT_TOOL_NAME);
     expect(listTool.permissionRequired).toBe(false);
     expect(outputTool.permissionRequired).toBe(false);
-    expect(list).toEqual({ agents: [{ runId: 'child-run', turnId: 'child-turn' }] });
+    expect(list).toEqual({
+      definitions: [{ id: LOCAL_READ_AGENT_ID }],
+      runs: [{ runId: 'child-run', turnId: 'child-turn' }],
+    });
     expect(output).toEqual({ requested: { runId: 'child-run' } });
   });
 
@@ -190,6 +279,26 @@ async function runTool(
     toolCallId: `tool-${name}-${typeof args === 'object' && args && 'command' in args ? (args as { command: string }).command : 'read'}`,
     abortSignal: new AbortController().signal,
   });
+}
+
+function testCatalogTool(name: string, categoryHint: MakaTool['categoryHint']): MakaTool {
+  return {
+    name,
+    description: name,
+    parameters: {},
+    categoryHint,
+    impl: async () => ({}),
+  };
+}
+
+async function expectRejects(promise: Promise<unknown>, pattern: RegExp): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error instanceof Error ? error.message : String(error)).toMatch(pattern);
+    return;
+  }
+  throw new Error('Expected promise to reject');
 }
 
 function childHeader(cwd: string): SessionHeader {

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -1,0 +1,141 @@
+import {
+  BUILTIN_TOOL_CATEGORY,
+  type PermissionMode,
+  type PolicyDecision,
+  type ToolCategory,
+} from '@maka/core/permission';
+import type { MakaTool } from './tool-runtime.js';
+
+export const LOCAL_READ_AGENT_ID = 'local-read';
+
+export interface AgentDefinition {
+  id: string;
+  name: string;
+  description: string;
+  permissionMode: PermissionMode;
+  tools: readonly string[];
+  categoryPolicy: Readonly<Partial<Record<ToolCategory, PolicyDecision>>>;
+  systemPrompt: string;
+}
+
+export interface AgentDefinitionListItem {
+  id: string;
+  name: string;
+  description: string;
+  permissionMode: PermissionMode;
+  tools: string[];
+}
+
+export const LOCAL_READ_AGENT_DEFINITION: AgentDefinition = {
+  id: LOCAL_READ_AGENT_ID,
+  name: 'Local Read',
+  description: 'Read-only repository exploration with file and text search tools only.',
+  permissionMode: 'explore',
+  tools: ['Read', 'Glob', 'Grep'],
+  categoryPolicy: {
+    read: 'allow',
+  },
+  systemPrompt: [
+    'You are a foreground local-read child agent.',
+    'Use only the provided Read, Glob, and Grep tools.',
+    'Do not use shell, web, browser, write, or nested agent tools.',
+    'Return a concise answer with concrete file or symbol evidence.',
+  ].join('\n'),
+};
+
+export const BUILTIN_AGENT_DEFINITIONS: readonly AgentDefinition[] = [
+  LOCAL_READ_AGENT_DEFINITION,
+];
+
+const modeRank: Record<PermissionMode, number> = {
+  explore: 0,
+  ask: 1,
+  execute: 2,
+};
+
+export function listBuiltinAgentDefinitions(): AgentDefinitionListItem[] {
+  return BUILTIN_AGENT_DEFINITIONS.map((definition) => ({
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    permissionMode: definition.permissionMode,
+    tools: [...definition.tools],
+  }));
+}
+
+export function getBuiltinAgentDefinition(id: string): AgentDefinition | undefined {
+  return BUILTIN_AGENT_DEFINITIONS.find((definition) => definition.id === id);
+}
+
+export function requireBuiltinAgentDefinition(id: string): AgentDefinition {
+  const definition = getBuiltinAgentDefinition(id);
+  if (!definition) {
+    const available = BUILTIN_AGENT_DEFINITIONS.map((agent) => agent.id).join(', ');
+    throw new Error(`Unknown agent "${id}". Available agents: ${available}.`);
+  }
+  return definition;
+}
+
+export function evaluateAgentDefinitionToolAccess(
+  definition: AgentDefinition,
+  tool: Pick<MakaTool, 'name' | 'categoryHint'>,
+): { category: ToolCategory; decision: PolicyDecision } {
+  const category = categoryForTool(tool);
+  if (!definition.tools.includes(tool.name)) return { category, decision: 'block' };
+  return {
+    category,
+    decision: definition.categoryPolicy[category] ?? 'block',
+  };
+}
+
+export function buildToolsForAgentDefinition(
+  tools: readonly MakaTool[],
+  definition: AgentDefinition = LOCAL_READ_AGENT_DEFINITION,
+): MakaTool[] {
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  const out: MakaTool[] = [];
+  for (const name of definition.tools) {
+    const tool = byName.get(name);
+    if (!tool) continue;
+    if (evaluateAgentDefinitionToolAccess(definition, tool).decision === 'allow') {
+      out.push(tool);
+    }
+  }
+  return out;
+}
+
+export function assertAgentDefinitionRunnable(input: {
+  parentPermissionMode: PermissionMode;
+  definition: AgentDefinition;
+  tools: readonly MakaTool[];
+}): void {
+  const { parentPermissionMode, definition, tools } = input;
+  if (modeRank[definition.permissionMode] > modeRank[parentPermissionMode]) {
+    throw new Error(
+      `Agent "${definition.id}" cannot run in parent permission mode "${parentPermissionMode}" because it requires "${definition.permissionMode}".`,
+    );
+  }
+
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  const missing = definition.tools.filter((name) => !byName.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Agent "${definition.id}" is unavailable: missing tools: ${missing.join(', ')}`);
+  }
+
+  const nonAllow = definition.tools
+    .map((name) => {
+      const tool = byName.get(name);
+      return tool ? { name, ...evaluateAgentDefinitionToolAccess(definition, tool) } : undefined;
+    })
+    .filter((item): item is { name: string; category: ToolCategory; decision: PolicyDecision } =>
+      item !== undefined && item.decision !== 'allow'
+    );
+  if (nonAllow.length > 0) {
+    const details = nonAllow.map((item) => `${item.name}:${item.decision}`).join(', ');
+    throw new Error(`Agent "${definition.id}" is unavailable: non-allow tool policy: ${details}`);
+  }
+}
+
+function categoryForTool(tool: Pick<MakaTool, 'name' | 'categoryHint'>): ToolCategory {
+  return tool.categoryHint ?? BUILTIN_TOOL_CATEGORY[tool.name] ?? 'custom_tool';
+}

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -296,6 +296,7 @@ export class AgentRun {
       createdAt,
       updatedAt: createdAt,
       ...this.lineage,
+      ...(this.input.userInput.agentId ? { agentId: this.input.userInput.agentId } : {}),
       ...(this.input.userInput.agentName ? { agentName: this.input.userInput.agentName } : {}),
     };
     try {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -67,6 +67,21 @@ export type {
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
 export {
+  BUILTIN_AGENT_DEFINITIONS,
+  LOCAL_READ_AGENT_DEFINITION,
+  LOCAL_READ_AGENT_ID,
+  assertAgentDefinitionRunnable,
+  buildToolsForAgentDefinition,
+  evaluateAgentDefinitionToolAccess,
+  getBuiltinAgentDefinition,
+  listBuiltinAgentDefinitions,
+  requireBuiltinAgentDefinition,
+} from './agent-catalog.js';
+export type {
+  AgentDefinition,
+  AgentDefinitionListItem,
+} from './agent-catalog.js';
+export {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -21,6 +21,11 @@ import {
   normalizeStopSessionSource,
   turnHasRetainedOutput as messagesHaveRetainedOutput,
 } from './session-projection-helpers.js';
+import {
+  assertAgentDefinitionRunnable,
+  buildToolsForAgentDefinition,
+  requireBuiltinAgentDefinition,
+} from './agent-catalog.js';
 
 export interface RuntimeKernelLike {
   startTurn(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
@@ -92,16 +97,25 @@ export class RuntimeKernel implements RuntimeKernelLike {
     input: ChildAgentTurnInput,
   ): AsyncIterable<SessionEvent> {
     const parentHeader = await this.deps.store.readHeader(sessionId);
+    const definition = requireBuiltinAgentDefinition(input.spec.id);
+    const availableChildTools = this.deps.childTools ?? [];
+    assertAgentDefinitionRunnable({
+      parentPermissionMode: parentHeader.permissionMode,
+      definition,
+      tools: availableChildTools,
+    });
+    const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
     const childHeader: SessionHeader = {
       ...parentHeader,
-      permissionMode: 'explore',
+      permissionMode: definition.permissionMode,
       connectionLocked: true,
     };
     const userInput: UserMessageInput = {
       turnId: input.turnId,
       text: input.prompt,
       parentRunId: input.parentRunId,
-      agentName: input.spec.name,
+      agentId: definition.id,
+      agentName: definition.name,
     };
     const activeKey = childActiveKey(sessionId, input.turnId);
     const run = new AgentRun({
@@ -116,7 +130,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       recordSessionMessages: false,
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
-          this.ensureChildActive(activeKey, targetSessionId, nextHeader, input.spec.systemPrompt),
+          this.ensureChildActive(activeKey, targetSessionId, nextHeader, definition.systemPrompt, childTools),
         registerRun: (active, activeRun) => this.registerRun(active, activeRun),
         unregisterRun: (active, activeRun) => this.unregisterChildRun(activeKey, active, activeRun),
         updateHeader: async (_targetSessionId, patch) => ({ ...childHeader, ...patch }),
@@ -308,6 +322,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     sessionId: string,
     header: SessionHeader,
     systemPrompt: string,
+    tools: readonly MakaTool[],
   ): Promise<ActiveSession> {
     const existing = this.childActive.get(activeKey);
     if (existing) {
@@ -321,7 +336,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       store: this.deps.store,
       appendMessage: async () => {},
       systemPrompt,
-      tools: this.deps.childTools ?? [],
+      tools,
       recordRunTrace: (event) => {
         const active = this.childActive.get(activeKey);
         const runId = active?.turnToRunId.get(event.turnId);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -69,6 +69,11 @@ import {
   buildTurnStateMessage,
   turnHasRetainedOutput as messagesHaveRetainedOutput,
 } from './session-projection-helpers.js';
+import {
+  listBuiltinAgentDefinitions,
+  requireBuiltinAgentDefinition,
+  type AgentDefinitionListItem,
+} from './agent-catalog.js';
 
 export interface StopSessionInput {
   source?: 'stop_button';
@@ -83,11 +88,12 @@ export interface SpawnChildAgentInput {
 }
 
 export interface SpawnChildAgentResult {
+  agentId: string;
   agentName: string;
   turnId: string;
   runId?: string;
   status: 'completed' | 'failed' | 'cancelled' | 'running' | 'waiting_permission';
-  permissionMode: 'explore';
+  permissionMode: PermissionMode;
   summary: string;
   artifactIds: string[];
   startedAt: number;
@@ -103,6 +109,7 @@ export interface AgentListItem {
   runId: string;
   turnId: string;
   parentRunId: string;
+  agentId?: string;
   agentName?: string;
   status: AgentRunHeader['status'];
   permissionMode: AgentRunHeader['permissionMode'];
@@ -114,7 +121,8 @@ export interface AgentListItem {
 }
 
 export interface AgentListResult {
-  agents: AgentListItem[];
+  definitions: AgentDefinitionListItem[];
+  runs: AgentListItem[];
 }
 
 export interface AgentOutputInput {
@@ -411,6 +419,7 @@ export class SessionManager {
     sessionId: string,
     input: SpawnChildAgentInput,
   ): Promise<SpawnChildAgentResult> {
+    const definition = requireBuiltinAgentDefinition(input.spec.id);
     const turnId = input.turnId ?? this.deps.newId();
     const startedAt = this.deps.now();
     const summary = new ChildAgentSummaryAccumulator();
@@ -445,11 +454,12 @@ export class SessionManager {
       ? await this.deps.listArtifactsForTurn(sessionId, turnId)
       : [];
     return {
-      agentName: input.spec.name,
+      agentId: definition.id,
+      agentName: definition.name,
       turnId,
       ...(run?.runId ? { runId: run.runId } : {}),
       status: run ? agentRunStatusForSpawnResult(run.status) : summary.status(aborted),
-      permissionMode: 'explore',
+      permissionMode: definition.permissionMode,
       summary: summary.text(),
       artifactIds: artifacts.map((artifact) => artifact.id),
       startedAt,
@@ -461,15 +471,18 @@ export class SessionManager {
   }
 
   async listChildAgents(sessionId: string): Promise<AgentListResult> {
-    if (!this.deps.runStore) return { agents: [] };
+    const definitions = listBuiltinAgentDefinitions();
+    if (!this.deps.runStore) return { definitions, runs: [] };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     return {
-      agents: runs
+      definitions,
+      runs: runs
         .filter((run): run is AgentRunHeader & { parentRunId: string } => !!run.parentRunId)
         .map((run) => ({
           runId: run.runId,
           turnId: run.turnId,
           parentRunId: run.parentRunId,
+          ...(run.agentId ? { agentId: run.agentId } : {}),
           ...(run.agentName ? { agentName: run.agentName } : {}),
           status: run.status,
           permissionMode: run.permissionMode,

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -1,36 +1,37 @@
 import { z } from 'zod';
 import type { ToolResultContent } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
+import {
+  LOCAL_READ_AGENT_DEFINITION,
+  buildToolsForAgentDefinition,
+  requireBuiltinAgentDefinition,
+} from './agent-catalog.js';
 
 export const AGENT_SPAWN_TOOL_NAME = 'agent_spawn';
 export const AGENT_LIST_TOOL_NAME = 'agent_list';
 export const AGENT_OUTPUT_TOOL_NAME = 'agent_output';
-export const CHILD_AGENT_TOOL_NAMES = ['Bash', 'Read', 'Glob', 'Grep'] as const;
-
-const childAgentToolNameSet = new Set<string>(CHILD_AGENT_TOOL_NAMES);
+export const CHILD_AGENT_TOOL_NAMES = LOCAL_READ_AGENT_DEFINITION.tools;
 
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
 
 export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
-  return tools.filter((tool) => childAgentToolNameSet.has(tool.name));
+  return buildToolsForAgentDefinition(tools, LOCAL_READ_AGENT_DEFINITION);
 }
 
 export function buildSubagentSpawnTool(): MakaTool<
   {
-    agent_name: string;
-    instructions: string;
-    prompt: string;
+    agent: string;
+    task: string;
   },
   unknown
 > {
   return {
     name: AGENT_SPAWN_TOOL_NAME,
     displayName: 'Agent',
-    description: 'Run a foreground read-only child agent for a bounded task and return its explicit result.',
+    description: 'Run a foreground catalog child agent for a bounded task and return its explicit result.',
     parameters: z.object({
-      agent_name: z.string().min(1).max(80).describe('Short display name for the child agent.'),
-      instructions: z.string().min(1).max(12_000).describe('Additional role instructions for the child agent. These do not override session policy.'),
-      prompt: z.string().min(1).max(60_000).describe('Delegation prompt for the child agent.'),
+      agent: z.string().min(1).max(80).describe('Built-in agent id, such as "local-read".'),
+      task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
     }),
     permissionRequired: true,
     categoryHint: 'subagent',
@@ -38,12 +39,14 @@ export function buildSubagentSpawnTool(): MakaTool<
       if (!ctx.spawnChildAgent) {
         throw new Error('spawnChildAgent capability is unavailable in this runtime context');
       }
+      const definition = requireBuiltinAgentDefinition(input.agent);
       const result = await ctx.spawnChildAgent({
         spec: {
-          name: input.agent_name,
-          systemPrompt: input.instructions,
+          id: definition.id,
+          name: definition.name,
+          systemPrompt: definition.systemPrompt,
         },
-        prompt: input.prompt,
+        prompt: input.task,
       }) as Omit<SubagentToolResult, 'kind'>;
       return {
         kind: 'subagent',
@@ -57,7 +60,7 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
   return {
     name: AGENT_LIST_TOOL_NAME,
     displayName: 'Agent List',
-    description: 'List child agent runs for the current session.',
+    description: 'List available agent catalog definitions and child agent runs for the current session.',
     parameters: z.object({}),
     permissionRequired: false,
     categoryHint: 'read',


### PR DESCRIPTION
## Summary
- add a built-in agent catalog with the first `local-read` definition
- change `agent_spawn` to `agent_spawn({ agent, task })` and record `agentId` on child runs
- make `agent_list` return catalog `definitions` separately from child `runs`
- fail closed for unknown/degraded catalog agents and remove raw `Bash` from the local-read child toolset

Related to #52.

## Verification
- `npm run -w @maka/runtime test`
- `npm run -w @maka/headless test`
- `npm run typecheck`
- `git diff --check`
