### PR TITLE
feat(runtime): defer agent tools

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -132,6 +132,7 @@ import {
   buildChildAgentTools,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  buildSubagentToolGroup,
   fetchProviderModels,
   getAIModel,
   buildProviderOptions,
@@ -561,8 +562,8 @@ const openGateway = new OpenGatewayService({
 });
 const backends = new BackendRegistry();
 const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
-// Unified tool availability (issue #37). The heavy-schema families (Rive,
-// Office, the embedded browser) form capability groups withheld from the
+// Unified tool availability (issue #37). Deferred capability groups (Rive,
+// Office, browser, agent orchestration) are withheld from the
 // per-turn prompt and loaded on demand via `load_tools`, keeping their schemas
 // off the wire until needed. Everything else (ungrouped) stays always-on.
 // Kill-switch: set MAKA_DISABLE_DEFERRED_TOOLS to any value to turn economy off
@@ -574,19 +575,19 @@ const officeTools = [buildOfficeDocumentTool(), buildOfficeDocumentEditTool()];
 // WebContentsView via the BrowserViewHost the desktop provides in registerIpc;
 // outside the app (no host) they report the browser as unavailable.
 const browserTools = buildBrowserTools();
-const heavyTools = [...riveTools, ...officeTools, ...browserTools];
+const agentTools = [buildSubagentSpawnTool(), ...buildSubagentProjectionTools()];
+const deferredTools = [...riveTools, ...officeTools, ...browserTools, ...agentTools];
 const toolAvailability: ToolAvailabilityConfig = {
   economy: economyEnabled,
   groups: [
     { id: 'rive', label: 'Rive', description: 'Durable multi-agent Rive workflows: validate/import/run/status, scheduler, retries.', toolNames: riveTools.map((tool) => tool.name) },
     { id: 'office', label: 'Office', description: 'Read and edit Office documents (Word, Excel, PowerPoint, PDF).', toolNames: officeTools.map((tool) => tool.name) },
     { id: 'browser', label: 'Browser', description: 'Drive the embedded browser: navigate, snapshot, click, type, wait, extract.', toolNames: browserTools.map((tool) => tool.name) },
+    buildSubagentToolGroup(),
   ],
 };
 const builtinTools = [
   ...buildBuiltinTools().filter((tool) => tool.name !== 'Edit'),
-  buildSubagentSpawnTool(),
-  ...buildSubagentProjectionTools(),
   // External reference lazy-skill pattern: the prompt lists available skills,
   // and this read-only tool loads the full SKILL.md only when the task matches.
   buildSkillAgentTool(workspaceRoot),
@@ -603,9 +604,9 @@ const builtinTools = [
     settingsStore,
     getPrivacyContext: getWorkspacePrivacyContext,
   }),
-  // The `load_tools` connector is built by ToolAvailabilityRuntime; the heavy
+  // The `load_tools` connector is built by ToolAvailabilityRuntime; deferred
   // group tools just need to be present so they are dispatchable once loaded.
-  ...heavyTools,
+  ...deferredTools,
 ];
 const childAgentTools = buildChildAgentTools(builtinTools);
 let lookupPricing = buildPricingLookup();

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -50,6 +50,7 @@ Programmatic sketch:
 
 ```ts
 import {
+  buildIsolatedHeadlessToolAvailability,
   buildIsolatedHeadlessTools,
   runExperiment,
   type IsolatedToolExecutor,
@@ -72,7 +73,8 @@ await runExperiment(config, task, {
   registerBackends(registry, context) {
     registry.register('ai-sdk', (ctx) => createAiSdkBackend({
       ...ctx,
-      tools: buildIsolatedHeadlessTools(context.toolExecutor!),
+      tools: [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))],
+      toolAvailability: buildIsolatedHeadlessToolAvailability(),
     }));
   },
 });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
-import { buildChildAgentTools } from '@maka/runtime';
-import { buildIsolatedBashTool, buildIsolatedHeadlessTools } from '../tools.js';
+import { buildChildAgentTools, LOAD_TOOLS_NAME, ToolAvailabilityRuntime } from '@maka/runtime';
+import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
 
 describe('isolated headless tools', () => {
   test('Bash delegates execution to the isolated executor', async () => {
@@ -56,5 +57,59 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('agent_output'));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
+  });
+
+  test('standard isolated tool availability defers parent-facing agent tools', () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const plan = new ToolAvailabilityRuntime(
+      tools,
+      buildIsolatedHeadlessToolAvailability(),
+      { name: 'invalid', description: 'invalid', parameters: {}, impl: () => ({}) },
+    ).prepare([]);
+
+    assert.ok(plan.activeTools.includes('Bash'));
+    assert.ok(plan.activeTools.includes('Read'));
+    assert.ok(plan.activeTools.includes(LOAD_TOOLS_NAME));
+    assert.ok(!plan.activeTools.includes('agent_spawn'));
+    assert.ok(!plan.activeTools.includes('agent_list'));
+    assert.ok(!plan.activeTools.includes('agent_output'));
+
+    const loaded = plan.prepareStep!({
+      steps: [{ toolCalls: [{ toolName: LOAD_TOOLS_NAME, input: { group: 'agent' } }] }],
+    }).activeTools;
+    assert.ok(loaded.includes('agent_spawn'));
+    assert.ok(loaded.includes('agent_list'));
+    assert.ok(loaded.includes('agent_output'));
+  });
+
+  test('standard isolated tool availability does not reintroduce agent tools into local-read children', () => {
+    const parentTools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const childTools = buildChildAgentTools(parentTools);
+    const plan = new ToolAvailabilityRuntime(
+      childTools,
+      buildIsolatedHeadlessToolAvailability(),
+      { name: 'invalid', description: 'invalid', parameters: {}, impl: () => ({}) },
+    ).prepare([]);
+
+    assert.deepEqual([...plan.activeTools].sort(), ['Glob', 'Grep', 'Read']);
+    assert.equal(plan.prepareStep, undefined);
+    assert.ok(!plan.activeTools.includes(LOAD_TOOLS_NAME));
+    assert.ok(!plan.activeTools.includes('agent_spawn'));
+  });
+
+  test('README real-backend sketch preserves child tool overrides', async () => {
+    const readme = await readFile(new URL('../../README.md', import.meta.url), 'utf8');
+
+    assert.ok(
+      readme.includes('tools: [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))],'),
+    );
   });
 });

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -121,4 +121,8 @@ export type {
   IsolatedToolExecutor,
   RealBackendIsolation,
 } from './isolation.js';
-export { buildIsolatedBashTool, buildIsolatedHeadlessTools } from './tools.js';
+export {
+  buildIsolatedBashTool,
+  buildIsolatedHeadlessToolAvailability,
+  buildIsolatedHeadlessTools,
+} from './tools.js';

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,6 +1,7 @@
-import type { MakaTool } from '@maka/runtime';
+import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   buildBuiltinTools,
+  buildSubagentToolGroup,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
 } from '@maka/runtime';
@@ -22,6 +23,13 @@ export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): Maka
     buildSubagentSpawnTool(),
     ...buildSubagentProjectionTools(),
   ];
+}
+
+export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig {
+  return {
+    economy: true,
+    groups: [buildSubagentToolGroup()],
+  };
 }
 
 export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool {

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -15,6 +15,15 @@ import {
   type ToolAvailabilityConfig,
 } from '../tool-availability.js';
 import { toolSchemaCharsForDiagnostics } from '../request-shape.js';
+import { LOCAL_READ_AGENT_ID } from '../agent-catalog.js';
+import {
+  AGENT_LIST_TOOL_NAME,
+  AGENT_OUTPUT_TOOL_NAME,
+  AGENT_SPAWN_TOOL_NAME,
+  buildSubagentProjectionTools,
+  buildSubagentSpawnTool,
+  buildSubagentToolGroup,
+} from '../subagent-tools.js';
 
 // End-to-end through the live AiSdkBackend: the availability config drives the
 // per-step prepareStep activation, the durable seed reconstructs prior-turn
@@ -28,6 +37,11 @@ const ZERO_USAGE: LanguageModelV3Usage = {
 const config: ToolAvailabilityConfig = {
   economy: true,
   groups: [{ id: 'browser', toolNames: ['browser_click'], label: 'Browser automation' }],
+};
+
+const agentConfig: ToolAvailabilityConfig = {
+  economy: true,
+  groups: [buildSubagentToolGroup()],
 };
 
 function tools(implCalls: string[]): MakaTool[] {
@@ -63,6 +77,48 @@ function backend(model: MockLanguageModelV3, implCalls: string[], opts: BackendO
     modelFactory: () => model,
     tools: tools(implCalls),
     ...(resolved ? { toolAvailability: resolved } : {}),
+    ...(opts.recordLlmCall ? { recordLlmCall: opts.recordLlmCall } : {}),
+    newId: () => `id-${++n}`,
+    now: () => 1,
+  });
+}
+
+function agentBackend(
+  model: MockLanguageModelV3,
+  spawnCalls: unknown[],
+  opts: BackendOpts & { permissionMode?: SessionHeader['permissionMode'] } = {},
+): AiSdkBackend {
+  let n = 0;
+  const resolved = opts.toolAvailability === null ? undefined : opts.toolAvailability ?? agentConfig;
+  return new AiSdkBackend({
+    sessionId: 'session-1',
+    header: header(opts.permissionMode),
+    appendMessage: async () => {},
+    connection: connection(),
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    permissionEngine: new PermissionEngine({ newId: () => 'perm', now: () => 1 }),
+    modelFactory: () => model,
+    tools: [
+      buildSubagentSpawnTool(),
+      ...buildSubagentProjectionTools(),
+    ],
+    ...(resolved ? { toolAvailability: resolved } : {}),
+    spawnChildAgent: async (input) => {
+      spawnCalls.push(input);
+      return {
+        agentId: input.spec.id,
+        agentName: input.spec.name,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        status: 'completed',
+        permissionMode: 'explore',
+        summary: 'done',
+        artifactIds: [],
+      };
+    },
+    listChildAgents: async () => ({ definitions: [], runs: [] }),
+    readChildAgentOutput: async (input) => ({ requested: input }),
     ...(opts.recordLlmCall ? { recordLlmCall: opts.recordLlmCall } : {}),
     newId: () => `id-${++n}`,
     now: () => 1,
@@ -205,6 +261,71 @@ describe('AiSdkBackend deferred tool loading', () => {
   });
 });
 
+describe('AiSdkBackend deferred agent tools', () => {
+  test('agent tools are hidden by default and visible after load_tools(agent)', async () => {
+    const captured: string[][] = [];
+    const spawnCalls: unknown[] = [];
+    await drain(agentBackend(loadAgentThenFinishModel(captured), spawnCalls).send({
+      turnId: 'turn-1',
+      text: 'load agents',
+      context: [],
+      runId: 'parent-run',
+    }));
+
+    assert.ok(captured[0].includes(LOAD_TOOLS_NAME), 'load_tools advertised');
+    assert.ok(!captured[0].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn hidden at step 0');
+    assert.ok(!captured[0].includes(AGENT_LIST_TOOL_NAME), 'agent_list hidden at step 0');
+    assert.ok(!captured[0].includes(AGENT_OUTPUT_TOOL_NAME), 'agent_output hidden at step 0');
+
+    assert.ok(captured[1].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn visible after loading the agent group');
+    assert.ok(captured[1].includes(AGENT_LIST_TOOL_NAME), 'agent_list visible after loading the agent group');
+    assert.ok(captured[1].includes(AGENT_OUTPUT_TOOL_NAME), 'agent_output visible after loading the agent group');
+  });
+
+  test('guard rejects same-step load_tools(agent)+agent_spawn before spawning a child', async () => {
+    const captured: string[][] = [];
+    const spawnCalls: unknown[] = [];
+    await drain(agentBackend(parallelLoadAgentAndSpawnModel(captured), spawnCalls).send({
+      turnId: 'turn-1',
+      text: 'load and spawn in one step',
+      context: [],
+      runId: 'parent-run',
+    }));
+
+    assert.ok(!captured[0].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn is not advertised at step 0');
+    assert.deepEqual(spawnCalls, [], 'agent_spawn must not run before the agent group is active');
+  });
+
+  test('deferred agent group is prompt economy only: loaded agent_spawn still uses its permission model', async () => {
+    const captured: string[][] = [];
+    const spawnCalls: unknown[] = [];
+    await drain(agentBackend(loadAgentThenSpawnModel(captured), spawnCalls, { permissionMode: 'execute' }).send({
+      turnId: 'turn-1',
+      text: 'load then spawn',
+      context: [],
+      runId: 'parent-run',
+    }));
+
+    assert.ok(captured[1].includes(AGENT_SPAWN_TOOL_NAME), 'agent_spawn is provider-visible only after load');
+    assert.equal(spawnCalls.length, 1, 'execute-mode permission still allows the loaded subagent tool to run');
+    assert.deepEqual(spawnCalls[0], {
+      parentRunId: 'parent-run',
+      spec: {
+        id: LOCAL_READ_AGENT_ID,
+        name: 'Local Read',
+        systemPrompt: [
+          'You are a foreground local-read child agent.',
+          'Use only the provided Read, Glob, and Grep tools.',
+          'Do not use shell, web, browser, write, or nested agent tools.',
+          'Return a concise answer with concrete file or symbol evidence.',
+        ].join('\n'),
+      },
+      prompt: 'Inspect the runtime tests.',
+      abortSignal: assertAbortSignal(spawnCalls[0]),
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Mock models
 // ---------------------------------------------------------------------------
@@ -305,6 +426,92 @@ function loadThenMiscasedClickModel(captured: string[][]): MockLanguageModelV3 {
   });
 }
 
+function loadAgentThenFinishModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const first = captured.length === 1;
+      const parts: LanguageModelV3StreamPart[] = first
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId: 'tc-load', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'agent' }) },
+            { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+          ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+function parallelLoadAgentAndSpawnModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const first = captured.length === 1;
+      const parts: LanguageModelV3StreamPart[] = first
+        ? [
+            { type: 'stream-start', warnings: [] },
+            { type: 'tool-call', toolCallId: 'tc-load', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'agent' }) },
+            { type: 'tool-call', toolCallId: 'tc-spawn', toolName: AGENT_SPAWN_TOOL_NAME, input: agentSpawnInput() },
+            { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+          ]
+        : [
+            { type: 'stream-start', warnings: [] },
+            { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+          ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+function loadAgentThenSpawnModel(captured: string[][]): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async ({ tools: stepTools }) => {
+      captured.push((stepTools ?? []).map((t) => t.name));
+      const step = captured.length;
+      const parts: LanguageModelV3StreamPart[] =
+        step === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tc-load', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'agent' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : step === 2
+            ? [
+                { type: 'stream-start', warnings: [] },
+                { type: 'tool-call', toolCallId: 'tc-spawn', toolName: AGENT_SPAWN_TOOL_NAME, input: agentSpawnInput() },
+                { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+              ];
+      return { stream: convertArrayToReadableStream(parts) };
+    },
+  });
+}
+
+function agentSpawnInput(): string {
+  return JSON.stringify({
+    agent: LOCAL_READ_AGENT_ID,
+    task: 'Inspect the runtime tests.',
+  });
+}
+
+function assertAbortSignal(value: unknown): AbortSignal {
+  assert.ok(
+    value &&
+      typeof value === 'object' &&
+      'abortSignal' in value &&
+      value.abortSignal instanceof AbortSignal,
+    'spawn input carries an AbortSignal',
+  );
+  return value.abortSignal;
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -326,7 +533,7 @@ async function drain(iterable: AsyncIterable<unknown>): Promise<void> {
   }
 }
 
-function header(): SessionHeader {
+function header(permissionMode: SessionHeader['permissionMode'] = 'ask'): SessionHeader {
   return {
     id: 'session-1',
     workspaceRoot: '/tmp/maka',
@@ -344,7 +551,7 @@ function header(): SessionHeader {
     llmConnectionSlug: 'c',
     connectionLocked: true,
     model: 'm',
-    permissionMode: 'ask',
+    permissionMode,
     schemaVersion: 1,
   };
 }

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -13,6 +13,8 @@ import {
   evaluateAgentDefinitionToolAccess,
 } from '../agent-catalog.js';
 import {
+  AGENT_TOOL_GROUP_ID,
+  AGENT_TOOL_NAMES,
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
@@ -20,11 +22,32 @@ import {
   buildSubagentListTool,
   buildSubagentOutputTool,
   buildSubagentSpawnTool,
+  buildSubagentToolGroup,
 } from '../subagent-tools.js';
 import { ToolRuntime, type MakaTool } from '../tool-runtime.js';
 import { expect } from '../test-helpers.js';
 
 describe('subagent tools', () => {
+  test('agent deferred group declares the parent-facing agent tools only', () => {
+    const group = buildSubagentToolGroup();
+
+    expect(group.id).toBe(AGENT_TOOL_GROUP_ID);
+    expect(group.label).toBe('Agent');
+    expect([...group.toolNames]).toEqual([...AGENT_TOOL_NAMES]);
+    expect([...group.toolNames]).toEqual([
+      AGENT_SPAWN_TOOL_NAME,
+      AGENT_LIST_TOOL_NAME,
+      AGENT_OUTPUT_TOOL_NAME,
+    ]);
+    expect(group.description).toMatch(/Spawn and inspect/);
+
+    const spawnTool = buildSubagentSpawnTool();
+    expect(spawnTool.permissionRequired).toBe(true);
+    expect(spawnTool.categoryHint).toBe('subagent');
+    expect(buildSubagentListTool().permissionRequired).toBe(false);
+    expect(buildSubagentOutputTool().permissionRequired).toBe(false);
+  });
+
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
     expect(LOCAL_READ_AGENT_DEFINITION.permissionMode).toBe('explore');

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -85,12 +85,15 @@ export {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
+  AGENT_TOOL_GROUP_ID,
+  AGENT_TOOL_NAMES,
   CHILD_AGENT_TOOL_NAMES,
   buildChildAgentTools,
   buildSubagentListTool,
   buildSubagentOutputTool,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  buildSubagentToolGroup,
 } from './subagent-tools.js';
 export {
   deriveToolArtifactCandidates,

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -6,10 +6,17 @@ import {
   buildToolsForAgentDefinition,
   requireBuiltinAgentDefinition,
 } from './agent-catalog.js';
+import type { ToolGroup } from './tool-availability.js';
 
 export const AGENT_SPAWN_TOOL_NAME = 'agent_spawn';
 export const AGENT_LIST_TOOL_NAME = 'agent_list';
 export const AGENT_OUTPUT_TOOL_NAME = 'agent_output';
+export const AGENT_TOOL_GROUP_ID = 'agent';
+export const AGENT_TOOL_NAMES = [
+  AGENT_SPAWN_TOOL_NAME,
+  AGENT_LIST_TOOL_NAME,
+  AGENT_OUTPUT_TOOL_NAME,
+] as const;
 export const CHILD_AGENT_TOOL_NAMES = LOCAL_READ_AGENT_DEFINITION.tools;
 
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
@@ -109,4 +116,13 @@ export function buildSubagentOutputTool(): MakaTool<
 
 export function buildSubagentProjectionTools(): MakaTool[] {
   return [buildSubagentListTool(), buildSubagentOutputTool()];
+}
+
+export function buildSubagentToolGroup(): ToolGroup {
+  return {
+    id: AGENT_TOOL_GROUP_ID,
+    label: 'Agent',
+    description: 'Spawn and inspect foreground child agents.',
+    toolNames: AGENT_TOOL_NAMES,
+  };
 }


### PR DESCRIPTION
## Summary
- add a reusable deferred `agent` tool group for `agent_spawn`, `agent_list`, and `agent_output`
- wire desktop tool availability so agent tools load through `load_tools({ group: 'agent' })`
- cover default hidden surface, same-turn guard, loaded use, and unchanged local-read child toolset semantics

Closes #52 when the broader issue accepts this slice.

## Verification
- `npm run -w @maka/runtime test`
- `npm run -w @maka/headless test`
- `npm run typecheck`
- `git diff --check`