### PR TITLE
Add benchmark adapter reporting CLI

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -15,6 +15,11 @@ Config × Task  →  throwaway workspace  →  headless agent run  →  trajecto
 ```sh
 maka-headless eval <spec.json> [--out <dir>]   # run the grid → results.jsonl + comparison.md
 maka-headless compare <results.jsonl>          # print the comparison table
+maka-headless task run <spec.json> --task <id> --config <id> [--out <dir>]
+maka-headless task inspect <taskRunId> --store <out>/runs [--json]
+maka-headless task export <taskRunId> --store <out>/runs --out <dir> [--include-events]
+maka-headless task resume <taskRunId> --spec <spec.json> --out <dir> [--grant-file <json>]
+maka-headless task retry-failed <results.jsonl|out-dir> --spec <spec.json> --out <dir>
 ```
 
 Try it with the bundled fake-backend demo (no API key needed):
@@ -111,6 +116,38 @@ pristine fixture *after* the agent finishes and *before* the command runs — a
 model that rewrote its own test to pass has that edit reverted. Declare `[]`
 only when the verification reads nothing the agent can forge — as the bundled
 `examples/demo` does, checking a fixture file the agent has no reason to touch.
+
+Tasks may also use typed benchmark verifiers. Terminal-Bench is the first
+carrier, but it is an adapter hook rather than a runtime architecture:
+
+```jsonc
+{
+  "id": "terminal-bench-local",
+  "instruction": "Solve the task.",
+  "workspaceDir": "./fixtures/tb-task",
+  "verifier": {
+    "kind": "terminal_bench",
+    "adapter": "terminal-bench",
+    "instanceId": "local-task",
+    "datasetPath": "./terminal-bench",
+    "testCommand": "./run-tests.sh",
+    "protectedPaths": ["tests/", "run-tests.sh"]
+  }
+}
+```
+
+`testCommand` mode runs in Maka's disposable scoring workspace and needs no
+Docker, Harbor, or `tb` binary; because it is still a local command verifier,
+`protectedPaths` is required. Real Terminal-Bench harness execution is wired
+programmatically through `benchmarkAdapters` and an explicit external isolation
+record.
+
+`task run` writes append-only task-run JSONL under `<out>/runs/task-runs/`,
+updates compatibility `results.jsonl`, and writes a canonical export under
+`<out>/exports/<taskRunId>/`. Exports are projection-based: they include
+trajectory/runtime refs, submitted snapshot metadata, verifier output, score,
+budget, isolation, permission/inbox facts, taxonomy, and warnings. They do not
+embed environment variables, credentials, or hidden harness configuration.
 
 ## Exit code
 

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -146,4 +146,232 @@ describe('maka-headless CLI', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test('task run, inspect, and export operate on task-run store projections', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-task-cli-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      await writeFile(join(dir, 'fixture', 'marker.txt'), 'ok', 'utf8');
+      const spec = {
+        configs: [{ id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' }],
+        tasks: [
+          {
+            id: 'tb-pass',
+            instruction: 'go',
+            workspaceDir: 'fixture',
+            verifier: {
+              kind: 'terminal_bench',
+              adapter: 'terminal-bench',
+              instanceId: 'tb-local',
+              testCommand: 'test -f marker.txt',
+              protectedPaths: [],
+            },
+          },
+        ],
+      };
+      const specPath = join(dir, 'spec.json');
+      const outDir = join(dir, 'out');
+      await writeFile(specPath, JSON.stringify(spec), 'utf8');
+
+      const run = await runCli([
+        'task',
+        'run',
+        specPath,
+        '--task',
+        'tb-pass',
+        '--config',
+        'fake-cfg',
+        '--task-run-id',
+        'task-run-1',
+        '--out',
+        outDir,
+        '--include-events',
+      ]);
+      assert.equal(run.code, 0, run.stderr);
+      assert.match(run.stdout, /taskRunId: task-run-1/);
+
+      const inspect = await runCli(['task', 'inspect', 'task-run-1', '--store', join(outDir, 'runs'), '--json']);
+      assert.equal(inspect.code, 0, inspect.stderr);
+      assert.equal(JSON.parse(inspect.stdout).taxonomy, 'passed');
+
+      const exportDir = join(dir, 'manual-export');
+      const exported = await runCli([
+        'task',
+        'export',
+        'task-run-1',
+        '--store',
+        join(outDir, 'runs'),
+        '--out',
+        exportDir,
+        '--include-events',
+      ]);
+      assert.equal(exported.code, 0, exported.stderr);
+      const taskRunJson = JSON.parse(await readFile(join(exportDir, 'task-run.json'), 'utf8'));
+      assert.equal(taskRunJson.verifier.kind, 'terminal_bench');
+      assert.equal(taskRunJson.verifier.benchmark.instanceId, 'tb-local');
+      assert.match(await readFile(join(exportDir, 'events.jsonl'), 'utf8'), /verifier_result_recorded/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('task resume continues a parked needs_approval task run', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-task-resume-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      await writeFile(join(dir, 'fixture', 'marker.txt'), 'ok', 'utf8');
+      const spec = {
+        configs: [{ id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' }],
+        tasks: [
+          {
+            id: 'approval-task',
+            instruction: 'go',
+            workspaceDir: 'fixture',
+            verification: { command: 'test -f marker.txt', protectedPaths: [] },
+          },
+        ],
+      };
+      const specPath = join(dir, 'spec.json');
+      const outDir = join(dir, 'out');
+      const taskRunId = 'parked-run';
+      const firstAttemptId = `${taskRunId}-attempt-1`;
+      await writeFile(specPath, JSON.stringify(spec), 'utf8');
+      await mkdir(join(outDir, 'runs', 'task-runs'), { recursive: true });
+      await writeFile(join(outDir, 'runs', 'task-runs', `${taskRunId}.jsonl`), [
+        JSON.stringify({ type: 'task_run_created', id: 'e1', taskRunId, ts: 1, taskId: 'approval-task', configId: 'fake-cfg' }),
+        JSON.stringify({
+          type: 'task_run_started',
+          id: 'e2',
+          taskRunId,
+          ts: 2,
+          startedAt: 2,
+          sessionId: 'session-1',
+          agentRunId: 'agent-1',
+        }),
+        JSON.stringify({
+          type: 'task_attempt_started',
+          id: 'e3',
+          taskRunId,
+          ts: 2,
+          attemptId: firstAttemptId,
+          startedAt: 2,
+          sessionId: 'session-1',
+          agentRunId: 'agent-1',
+        }),
+        JSON.stringify({
+          type: 'task_inbox_item_recorded',
+          id: 'e4',
+          taskRunId,
+          ts: 3,
+          item: {
+            schemaVersion: 1,
+            inboxItemId: 'inbox-1',
+            taskRunId,
+            attemptId: firstAttemptId,
+            kind: 'approval_request',
+            status: 'open',
+            title: 'Approval required',
+            reason: 'Bash requires approval',
+            createdAt: 3,
+            relatedRequestId: 'request-1',
+          },
+        }),
+        JSON.stringify({
+          type: 'task_run_needs_approval',
+          id: 'e5',
+          taskRunId,
+          ts: 3,
+          attemptId: firstAttemptId,
+          reason: 'approval',
+          inboxItemId: 'inbox-1',
+        }),
+        '',
+      ].join('\n'), 'utf8');
+
+      const resumed = await runCli(['task', 'resume', taskRunId, '--spec', specPath, '--out', outDir]);
+      assert.equal(resumed.code, 0, resumed.stderr);
+      assert.match(resumed.stdout, /resumed: parked-run/);
+      assert.match(resumed.stdout, /status: completed/);
+
+      const inspect = await runCli(['task', 'inspect', taskRunId, '--store', join(outDir, 'runs'), '--json']);
+      assert.equal(inspect.code, 0, inspect.stderr);
+      const projected = JSON.parse(inspect.stdout);
+      assert.equal(projected.status, 'completed');
+      assert.equal(projected.taxonomy, 'passed');
+      assert.equal(projected.attempts, 2);
+      assert.equal(projected.parked, undefined);
+
+      const exported = JSON.parse(await readFile(join(outDir, 'exports', taskRunId, 'task-run.json'), 'utf8'));
+      assert.equal(exported.taskRun.status, 'completed');
+      assert.equal(exported.inbox.items[0].status, 'resolved');
+
+      const records = await readResults(join(outDir, 'results.jsonl'));
+      assert.equal(records.length, 1);
+      assert.equal(records[0]?.taskId, 'approval-task');
+      assert.equal(records[0]?.passed, true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('task retry-failed retries retryable failures and skips unsupported adapters', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-task-retry-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      const spec = {
+        configs: [{ id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' }],
+        tasks: [
+          { id: 'pass', instruction: 'go', workspaceDir: 'fixture', verification: { command: 'true', protectedPaths: [] } },
+          { id: 'retry-me', instruction: 'go', workspaceDir: 'fixture', verification: { command: 'true', protectedPaths: [] } },
+          { id: 'unsupported', instruction: 'go', workspaceDir: 'fixture', verification: { command: 'true', protectedPaths: [] } },
+        ],
+      };
+      const specPath = join(dir, 'spec.json');
+      const priorPath = join(dir, 'prior-results.jsonl');
+      await writeFile(specPath, JSON.stringify(spec), 'utf8');
+      await writeFile(priorPath, [
+        JSON.stringify(record('pass', 'fake-cfg', true)),
+        JSON.stringify(record('retry-me', 'fake-cfg', false, { errorClass: 'verification_failed', exitCode: 1 })),
+        JSON.stringify(record('unsupported', 'fake-cfg', false, {
+          errorClass: 'unsupported_adapter',
+          excludedReason: 'unsupported_adapter',
+          error: 'adapter missing',
+          exitCode: null,
+        })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const outDir = join(dir, 'out');
+      const result = await runCli(['task', 'retry-failed', priorPath, '--spec', specPath, '--out', outDir]);
+      assert.equal(result.code, 0, result.stderr);
+      assert.match(result.stdout, /retry retry-me/);
+      assert.match(result.stdout, /skip unsupported/);
+
+      const records = await readResults(join(outDir, 'results.jsonl'));
+      assert.equal(records.length, 4);
+      assert.equal(records.filter((r) => r.taskId === 'retry-me').length, 2);
+      assert.equal(records.at(-1)?.passed, true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
+
+function record(taskId: string, configId: string, passed: boolean, extra: Record<string, unknown> = {}) {
+  return {
+    taskId,
+    configId,
+    sessionId: `s-${taskId}`,
+    runId: `r-${taskId}`,
+    status: 'completed',
+    passed,
+    exitCode: passed ? 0 : 1,
+    steps: 1,
+    durationMs: 1,
+    startedAt: 1,
+    finishedAt: 2,
+    scored: true,
+    eligible: true,
+    ...extra,
+  };
+}

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { taskRunExportFromProjection, writeTaskRunExport } from '../result-export.js';
+import type { TaskEvent } from '../task-contracts.js';
+import { projectTaskRun } from '../task-run-store.js';
+
+describe('task run export', () => {
+  test('projects runtime, verifier, score, budget, isolation, inbox, and taxonomy', async () => {
+    const events: TaskEvent[] = [
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-1', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'task_run_started', id: 'e2', taskRunId: 'run-1', ts: 2, startedAt: 2, sessionId: 'session-1', agentRunId: 'agent-1' },
+      {
+        type: 'isolation_policy_recorded',
+        id: 'e3',
+        taskRunId: 'run-1',
+        ts: 2,
+        facts: {
+          schemaVersion: 1,
+          backendKind: 'fake',
+          required: false,
+          mode: 'inert_fake_backend',
+          assertionSource: 'test_fixture',
+          validatedAt: 2,
+        },
+      },
+      {
+        type: 'feedback_observed',
+        id: 'e4',
+        taskRunId: 'run-1',
+        ts: 3,
+        observation: {
+          id: 'feedback-1',
+          taskRunId: 'run-1',
+          ts: 3,
+          source: 'runtime',
+          summary: 'runtime invocation completed',
+          details: { runtimeRefs: { runtimeEventIds: ['runtime-1'] }, budget: { totals: { total: 3 } } },
+        },
+      },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e5',
+        taskRunId: 'run-1',
+        ts: 4,
+        result: {
+          id: 'verifier-1',
+          taskRunId: 'run-1',
+          ts: 4,
+          kind: 'terminal_bench',
+          passed: true,
+          exitCode: 0,
+          score: 1,
+          maxScore: 1,
+          submittedSnapshotId: 'snapshot-1',
+          details: { adapter: 'terminal-bench', instanceId: 'tb-1' },
+        },
+      },
+      {
+        type: 'score_result_recorded',
+        id: 'e6',
+        taskRunId: 'run-1',
+        ts: 5,
+        result: {
+          id: 'score-1',
+          taskRunId: 'run-1',
+          ts: 5,
+          passed: true,
+          scored: true,
+          eligible: true,
+          score: 1,
+          maxScore: 1,
+          taxonomy: 'passed',
+          details: {
+            runtimeRefs: { runtimeEventIds: ['runtime-1'] },
+            budget: { totals: { total: 3 } },
+            submittedSnapshot: { id: 'snapshot-1', manifestHash: 'sha256:abc' },
+          },
+        },
+      },
+      { type: 'task_run_completed', id: 'e7', taskRunId: 'run-1', ts: 6, finishedAt: 6 },
+    ];
+    const projection = projectTaskRun(events, 'run-1');
+    const exported = taskRunExportFromProjection(projection, { exportedAt: '2026-06-19T00:00:00.000Z' });
+
+    assert.equal(exported.schemaVersion, 'maka.task_run_export.v1');
+    assert.equal(exported.taskRun.taskRunId, 'run-1');
+    assert.deepEqual(exported.runtime.trajectoryRefs.runtimeEventIds, ['runtime-1']);
+    assert.deepEqual(exported.workspace.submittedSnapshot, { id: 'snapshot-1', manifestHash: 'sha256:abc' });
+    assert.equal(exported.workspace.diff.status, 'not_captured');
+    assert.equal(exported.verifier?.benchmark?.instanceId, 'tb-1');
+    assert.deepEqual(exported.budget, { totals: { total: 3 } });
+    assert.equal(exported.isolation.policy?.mode, 'inert_fake_backend');
+    assert.equal(exported.taxonomy.value, 'passed');
+    assert.equal(exported.legacyResultRecord.passed, true);
+  });
+
+  test('writes deterministic export files and optional events', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-task-export-'));
+    try {
+      const projection = projectTaskRun([
+        { type: 'task_run_created', id: 'e1', taskRunId: 'run-1', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      ], 'run-1');
+      const result = await writeTaskRunExport(dir, projection, {
+        includeEvents: true,
+        exportedAt: '2026-06-19T00:00:00.000Z',
+      });
+
+      assert.match(await readFile(result.files.taskRunJson, 'utf8'), /maka.task_run_export.v1/);
+      assert.match(await readFile(result.files.resultMd, 'utf8'), /# Task Run run-1/);
+      assert.equal(await readFile(result.files.eventsJsonl!, 'utf8'), '{"type":"task_run_created","id":"e1","taskRunId":"run-1","ts":1,"taskId":"task-1","configId":"cfg-1"}\n');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/headless/src/__tests__/verifier.test.ts
+++ b/packages/headless/src/__tests__/verifier.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { Task } from '../contracts.js';
+import { normalizeVerifier, runVerifier } from '../verifier.js';
+
+describe('benchmark verifiers', () => {
+  test('normalizes enriched Terminal-Bench verifier specs', () => {
+    const task: Task = {
+      id: 'tb-task',
+      instruction: 'solve',
+      workspaceDir: '/tmp/example',
+      verifier: {
+        kind: 'terminal_bench',
+        adapter: 'terminal-bench',
+        instanceId: 'hello-world',
+        dataset: 'terminal-bench-core',
+        taskDir: '/tmp/tb/hello-world',
+        taskDescriptionKey: 'base',
+        testCommand: 'true',
+        maxAgentTimeoutSec: 10,
+        maxTestTimeoutSec: 20,
+        protectedPaths: ['tests'],
+      },
+    };
+
+    const verifier = normalizeVerifier(task);
+    assert.equal(verifier.kind, 'terminal_bench');
+    assert.equal(verifier.dataset, 'terminal-bench-core');
+    assert.equal(verifier.testCommand, 'true');
+    assert.deepEqual(verifier.protectedPaths, ['tests']);
+  });
+
+  test('runs Terminal-Bench testCommand mode without Docker or Harbor', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-tbench-verifier-'));
+    try {
+      await writeFile(join(dir, 'marker.txt'), 'ok', 'utf8');
+      const result = await runVerifier({
+        verifier: {
+          kind: 'terminal_bench',
+          adapter: 'terminal-bench',
+          instanceId: 'local-task',
+          testCommand: 'test -f marker.txt',
+          protectedPaths: [],
+          datasetPath: '/datasets/local',
+        },
+        taskRunId: 'run-1',
+        attemptId: 'attempt-1',
+        ts: 100,
+        id: 'verifier-1',
+        workspaceDir: dir,
+        submittedSnapshotId: 'snapshot-1',
+        scoringWorkspaceId: 'scoring-1',
+      });
+
+      assert.equal(result.kind, 'terminal_bench');
+      assert.equal(result.passed, true);
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.score, 1);
+      assert.equal(result.maxScore, 1);
+      assert.equal(result.submittedSnapshotId, 'snapshot-1');
+      assert.deepEqual(result.details, {
+        adapter: 'terminal-bench',
+        instanceId: 'local-task',
+        datasetPath: '/datasets/local',
+        testCommand: 'test -f marker.txt',
+        timedOut: false,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('requires protectedPaths for local Terminal-Bench testCommand mode', () => {
+    assert.throws(() => normalizeVerifier({
+      id: 'tb-task',
+      instruction: 'solve',
+      workspaceDir: '/tmp/example',
+      verifier: {
+        kind: 'terminal_bench',
+        adapter: 'terminal-bench',
+        instanceId: 'local-task',
+        testCommand: 'true',
+      },
+    }), /protectedPaths/);
+  });
+
+  test('keeps missing non-command adapters explicit and unsupported', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-tbench-verifier-'));
+    try {
+      const result = await runVerifier({
+        verifier: { kind: 'terminal_bench', adapter: 'terminal-bench', instanceId: 'needs-real-adapter' },
+        taskRunId: 'run-1',
+        ts: 100,
+        id: 'verifier-unsupported',
+        workspaceDir: dir,
+      });
+
+      assert.equal(result.passed, false);
+      assert.equal(result.exitCode, null);
+      assert.equal(result.errorClass, 'unsupported_adapter');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/headless/src/benchmark-adapters.ts
+++ b/packages/headless/src/benchmark-adapters.ts
@@ -1,0 +1,51 @@
+import type { Task, VerifierSpec } from './contracts.js';
+
+export interface BenchmarkInstanceRef {
+  adapter: string;
+  dataset?: string;
+  datasetPath?: string;
+  instanceId: string;
+  taskDir?: string;
+  split?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BenchmarkVerifierInput {
+  verifier: Exclude<VerifierSpec, { kind: 'command' }>;
+  workspaceDir: string;
+  taskRunId: string;
+  attemptId?: string;
+  submittedSnapshotId?: string;
+  scoringWorkspaceId?: string;
+}
+
+export interface BenchmarkVerifierOutput {
+  kind: Exclude<VerifierSpec['kind'], 'command'>;
+  passed: boolean;
+  exitCode: number | null;
+  durationMs?: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+  errorClass?: string;
+  score?: number;
+  maxScore?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface BenchmarkAdapter {
+  readonly name: string;
+  taskFromInstance?(input: BenchmarkInstanceRef): Promise<Task> | Task;
+  runVerifier(input: BenchmarkVerifierInput): Promise<BenchmarkVerifierOutput> | BenchmarkVerifierOutput;
+}
+
+export type BenchmarkAdapterRegistry = Record<string, BenchmarkAdapter> | Map<string, BenchmarkAdapter>;
+
+export function resolveBenchmarkAdapter(
+  registry: BenchmarkAdapterRegistry | undefined,
+  name: string,
+): BenchmarkAdapter | undefined {
+  if (!registry) return undefined;
+  if (registry instanceof Map) return registry.get(name);
+  return registry[name];
+}

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
+import { randomUUID } from 'node:crypto';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
+import type { Config, ResultRecord, Task } from './contracts.js';
+import { runAutonomousTask } from './autonomous-agent-loop.js';
 import { runMatrix, type ExperimentSpec } from './matrix.js';
+import { planMatrixRetry, readMatrixPriorRecords } from './matrix-resume.js';
+import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
+import { runTaskOnce } from './task-agent-controller.js';
+import { isTerminalTaskRunStatus, type TaskPermissionGrant } from './task-contracts.js';
+import { createTaskRunStore, type TaskRunProjection } from './task-run-store.js';
 import { readResults, toComparisonTable, writeResults } from './results.js';
 
 /**
@@ -96,14 +104,230 @@ async function compareCommand(args: string[]): Promise<number> {
   return 0;
 }
 
+async function taskCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === 'run') return taskRunCommand(rest);
+  if (subcommand === 'inspect') return taskInspectCommand(rest);
+  if (subcommand === 'resume') return taskResumeCommand(rest);
+  if (subcommand === 'retry-failed') return taskRetryFailedCommand(rest);
+  if (subcommand === 'export') return taskExportCommand(rest);
+  printTaskUsage();
+  return 1;
+}
+
+async function taskRunCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['task', 'config', 'out', 'task-run-id', 'max-attempts'], ['autonomous', 'include-events']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless task run <spec.json> --task <id> --config <id> [--out <dir>] [--task-run-id <id>] [--autonomous] [--max-attempts N]`);
+    return 1;
+  }
+  const specPath = parsed.positional[0];
+  if (!specPath || !parsed.flags.task || !parsed.flags.config) {
+    console.error('usage: maka-headless task run <spec.json> --task <id> --config <id> [--out <dir>] [--task-run-id <id>] [--autonomous] [--max-attempts N]');
+    return 1;
+  }
+
+  try {
+    const spec = await loadSpec(specPath);
+    const task = requireTask(spec.tasks, parsed.flags.task);
+    const config = requireConfig(spec.configs, parsed.flags.config);
+    validateRunnableCell(config, task);
+    const outDir = resolve(parsed.flags.out ?? 'maka-headless-out');
+    const store = createTaskRunStore(join(outDir, 'runs'));
+    const common = {
+      storageRoot: join(outDir, 'runs'),
+      taskRunStore: store,
+      ...(parsed.flags['task-run-id'] ? { taskRunId: parsed.flags['task-run-id'] } : {}),
+    };
+    const run = parsed.bools.autonomous
+      ? await runAutonomousTask(config, task, {
+          ...common,
+          budget: { maxAttempts: positiveInt(parsed.flags['max-attempts'] ?? '1', '--max-attempts') },
+        })
+      : await runTaskOnce(config, task, common);
+    await appendResultRecord(outDir, run.resultRecord);
+    const exportDir = join(outDir, 'exports', run.taskRunId);
+    await writeTaskRunExport(exportDir, run.projection, { includeEvents: parsed.bools['include-events'] });
+    console.log(`taskRunId: ${run.taskRunId}\nstatus: ${run.projection.status}\nexport: ${exportDir}`);
+    return run.resultRecord.error ? 1 : 0;
+  } catch (error) {
+    console.error(`maka-headless task run: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
+async function taskInspectCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['store'], ['json']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless task inspect <taskRunId> --store <out>/runs [--json]`);
+    return 1;
+  }
+  const taskRunId = parsed.positional[0];
+  if (!taskRunId || !parsed.flags.store) {
+    console.error('usage: maka-headless task inspect <taskRunId> --store <out>/runs [--json]');
+    return 1;
+  }
+  const projection = await createTaskRunStore(resolve(parsed.flags.store)).project(taskRunId);
+  if (parsed.bools.json) {
+    process.stdout.write(`${JSON.stringify(compactInspect(projection), null, 2)}\n`);
+  } else {
+    printInspect(compactInspect(projection));
+  }
+  return 0;
+}
+
+async function taskExportCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['store', 'out'], ['include-events']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless task export <taskRunId> --store <out>/runs --out <dir> [--include-events]`);
+    return 1;
+  }
+  const taskRunId = parsed.positional[0];
+  if (!taskRunId || !parsed.flags.store || !parsed.flags.out) {
+    console.error('usage: maka-headless task export <taskRunId> --store <out>/runs --out <dir> [--include-events]');
+    return 1;
+  }
+  const projection = await createTaskRunStore(resolve(parsed.flags.store)).project(taskRunId);
+  const result = await writeTaskRunExport(resolve(parsed.flags.out), projection, {
+    includeEvents: parsed.bools['include-events'],
+  });
+  console.log(`export: ${result.files.taskRunJson}`);
+  return 0;
+}
+
+async function taskResumeCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['spec', 'out', 'grant-file']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless task resume <taskRunId> --spec <spec.json> --out <dir> [--grant-file <json>]`);
+    return 1;
+  }
+  const taskRunId = parsed.positional[0];
+  if (!taskRunId || !parsed.flags.spec || !parsed.flags.out) {
+    console.error('usage: maka-headless task resume <taskRunId> --spec <spec.json> --out <dir> [--grant-file <json>]');
+    return 1;
+  }
+  try {
+    const outDir = resolve(parsed.flags.out);
+    const store = createTaskRunStore(join(outDir, 'runs'));
+    const projection = await store.project(taskRunId);
+    if (isTerminalTaskRunStatus(projection.status)) {
+      console.error(`task run ${taskRunId} is terminal (${projection.status}); resume is unsupported`);
+      return 1;
+    }
+    if (projection.status !== 'needs_approval') {
+      console.error(`task run ${taskRunId} is ${projection.status}; PR50 resume only supports parked needs_approval runs`);
+      return 1;
+    }
+    const spec = await loadSpec(parsed.flags.spec);
+    const task = requireTask(spec.tasks, projection.taskId);
+    const config = requireConfig(spec.configs, projection.configId);
+    validateRunnableCell(config, task);
+    const grants = parsed.flags['grant-file']
+      ? JSON.parse(await readFile(resolve(parsed.flags['grant-file']), 'utf8')) as TaskPermissionGrant[]
+      : [];
+    if (projection.parked) {
+      const resolvedAt = Date.now();
+      await store.appendEvent(taskRunId, {
+        type: 'task_inbox_item_resolved',
+        id: randomUUID(),
+        taskRunId,
+        ts: resolvedAt,
+        inboxItemId: projection.parked.inboxItemId,
+        status: 'resolved',
+        resolution: {
+          decision: grants.length > 0 ? 'granted' : 'resume_requested',
+          actorId: 'maka-headless-cli',
+          resolvedAt,
+          reason: 'resumed by maka-headless task resume',
+        },
+      });
+    }
+    const attemptId = `${taskRunId}-attempt-${projection.attempts.length + 1}`;
+    const run = await runTaskOnce(config, task, {
+      storageRoot: join(outDir, 'runs'),
+      taskRunStore: store,
+      taskRunId,
+      attemptId,
+      createTaskRun: false,
+      permissionGrants: grants,
+    });
+    await appendResultRecord(outDir, run.resultRecord);
+    await writeTaskRunExport(join(outDir, 'exports', taskRunId), run.projection);
+    console.log(`resumed: ${taskRunId}\nstatus: ${run.projection.status}`);
+    return run.resultRecord.error ? 1 : 0;
+  } catch (error) {
+    console.error(`maka-headless task resume: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
+async function taskRetryFailedCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['spec', 'out', 'only-taxonomy']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless task retry-failed <results.jsonl|out-dir> --spec <spec.json> --out <dir> [--only-taxonomy name[,name]]`);
+    return 1;
+  }
+  const priorPath = parsed.positional[0];
+  if (!priorPath || !parsed.flags.spec || !parsed.flags.out) {
+    console.error('usage: maka-headless task retry-failed <results.jsonl|out-dir> --spec <spec.json> --out <dir> [--only-taxonomy name[,name]]');
+    return 1;
+  }
+
+  try {
+    const spec = await loadSpec(parsed.flags.spec);
+    const prior = await readMatrixPriorRecords(resolve(priorPath));
+    const outDir = resolve(parsed.flags.out);
+    const onlyTaxonomy = parsed.flags['only-taxonomy']?.split(',').map((value) => value.trim()).filter(Boolean);
+    const plan = planMatrixRetry(spec.tasks, spec.configs, prior, { retryFailed: true, onlyTaxonomy });
+    const records: ResultRecord[] = [...prior];
+    for (const decision of plan) {
+      if (decision.action !== 'retry') {
+        console.log(`skip ${decision.task.id} × ${decision.config.id}: ${decision.reason}`);
+        continue;
+      }
+      validateRunnableCell(decision.config, decision.task);
+      console.log(`retry ${decision.task.id} × ${decision.config.id}: ${decision.reason}`);
+      const run = await runTaskOnce(decision.config, decision.task, {
+        storageRoot: join(outDir, 'runs'),
+        taskRunStore: createTaskRunStore(join(outDir, 'runs')),
+      });
+      records.push(run.resultRecord);
+      await writeTaskRunExport(join(outDir, 'exports', run.taskRunId), run.projection);
+    }
+    await writeResults(join(outDir, 'results.jsonl'), records);
+    await writeFile(join(outDir, 'comparison.md'), toComparisonTable(records), 'utf8');
+    return records.some((record) => record.error && !prior.includes(record)) ? 1 : 0;
+  } catch (error) {
+    console.error(`maka-headless task retry-failed: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
 function mark(passed: boolean, error?: string): string {
   if (error) return '⚠️';
   return passed ? '✅' : '❌';
 }
 
-function parseArgs(args: string[], knownFlags: string[]): { positional: string[]; flags: Record<string, string> } {
+interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string>;
+  bools: Record<string, boolean>;
+}
+
+function parseArgs(args: string[], knownFlags: string[], boolFlags: string[] = []): ParsedArgs {
   const positional: string[] = [];
   const flags: Record<string, string> = {};
+  const bools: Record<string, boolean> = {};
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
     if (!arg.startsWith('--')) {
@@ -111,27 +335,125 @@ function parseArgs(args: string[], knownFlags: string[]): { positional: string[]
       continue;
     }
     const name = arg.slice(2);
+    if (boolFlags.includes(name)) {
+      bools[name] = true;
+      continue;
+    }
     if (!knownFlags.includes(name)) throw new Error(`unknown flag: ${arg}`);
     const value = args[i + 1];
     if (value === undefined || value.startsWith('--')) throw new Error(`flag ${arg} needs a value`);
     flags[name] = value;
     i++;
   }
-  return { positional, flags };
+  return { positional, flags, bools };
 }
 
 function printUsage(): void {
-  console.error('maka-headless — headless agent runner (eval mode)\n');
+  console.error('maka-headless — headless agent runner\n');
   console.error('  maka-headless eval <spec.json> [--out <dir>]   run configs × tasks, write results + table');
   console.error('  maka-headless compare <results.jsonl>          print the comparison table');
+  console.error('  maka-headless task <command> ...               run, inspect, resume, retry, export task runs');
+}
+
+function printTaskUsage(): void {
+  console.error('maka-headless task commands:\n');
+  console.error('  task run <spec.json> --task <id> --config <id> [--out <dir>] [--task-run-id <id>] [--autonomous] [--max-attempts N]');
+  console.error('  task inspect <taskRunId> --store <out>/runs [--json]');
+  console.error('  task resume <taskRunId> --spec <spec.json> --out <dir> [--grant-file <json>]');
+  console.error('  task retry-failed <results.jsonl|out-dir> --spec <spec.json> --out <dir> [--only-taxonomy name[,name]]');
+  console.error('  task export <taskRunId> --store <out>/runs --out <dir> [--include-events]');
 }
 
 async function main(argv: string[]): Promise<number> {
   const [cmd, ...rest] = argv;
   if (cmd === 'eval') return evalCommand(rest);
   if (cmd === 'compare') return compareCommand(rest);
+  if (cmd === 'task') return taskCommand(rest);
   printUsage();
   return cmd ? 1 : 0;
+}
+
+async function loadSpec(specPath: string): Promise<ExperimentSpec> {
+  const specFile = resolve(specPath);
+  const spec = JSON.parse(await readFile(specFile, 'utf8')) as ExperimentSpec;
+  const specDir = dirname(specFile);
+  return {
+    configs: spec.configs,
+    tasks: spec.tasks.map((task) => ({
+      ...task,
+      workspaceDir: isAbsolute(task.workspaceDir) ? task.workspaceDir : resolve(specDir, task.workspaceDir),
+    })),
+  };
+}
+
+function requireTask(tasks: readonly Task[], id: string): Task {
+  const task = tasks.find((candidate) => candidate.id === id);
+  if (!task) throw new Error(`task not found: ${id}`);
+  return task;
+}
+
+function requireConfig(configs: readonly Config[], id: string): Config {
+  const config = configs.find((candidate) => candidate.id === id);
+  if (!config) throw new Error(`config not found: ${id}`);
+  return config;
+}
+
+function validateRunnableCell(config: Config, task: Task): void {
+  if (backendNeedsIsolation(config.backend)) {
+    throw new Error(
+      `config "${config.id}": backend "${config.backend}" requires an isolated executor and programmatic backend wiring — the CLI only wires "fake" by default`,
+    );
+  }
+  validateTaskVerification(task);
+}
+
+async function appendResultRecord(outDir: string, record: ResultRecord): Promise<void> {
+  const path = join(outDir, 'results.jsonl');
+  const records = await readResults(path).catch((error): ResultRecord[] => {
+    if (typeof error === 'object' && error !== null && (error as { code?: string }).code === 'ENOENT') return [];
+    throw error;
+  });
+  records.push(record);
+  await writeResults(path, records);
+  await writeFile(join(outDir, 'comparison.md'), toComparisonTable(records), 'utf8');
+}
+
+function positiveInt(raw: string, flagName: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${flagName} must be a positive integer`);
+  return value;
+}
+
+function compactInspect(projection: TaskRunProjection): Record<string, unknown> {
+  const score = projection.latestScoreResult;
+  const verifier = projection.latestVerifierResult;
+  return {
+    taskRunId: projection.taskRunId,
+    taskId: projection.taskId,
+    configId: projection.configId,
+    status: projection.status,
+    terminal: isTerminalTaskRunStatus(projection.status),
+    taxonomy: score?.taxonomy ?? projection.result?.taxonomy,
+    passed: score?.passed ?? projection.result?.passed,
+    scored: score?.scored,
+    eligible: score?.eligible,
+    errorClass: score?.errorClass ?? verifier?.errorClass ?? projection.error?.class,
+    verifier: verifier
+      ? { id: verifier.id, kind: verifier.kind, exitCode: verifier.exitCode ?? null, passed: verifier.passed }
+      : undefined,
+    score: score ? { id: score.id, score: score.score, maxScore: score.maxScore } : undefined,
+    attempts: projection.attempts.length,
+    parked: projection.parked,
+    isolation: projection.isolation?.label ?? projection.isolation?.mode,
+    warnings: projection.warnings,
+  };
+}
+
+function printInspect(value: Record<string, unknown>): void {
+  for (const [key, item] of Object.entries(value)) {
+    if (item === undefined) continue;
+    process.stdout.write(`${key}: ${typeof item === 'object' ? JSON.stringify(item) : String(item)}\n`);
+  }
 }
 
 main(process.argv.slice(2))

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -79,6 +79,13 @@ export interface TerminalBenchVerifierSpec {
   kind: 'terminal_bench';
   adapter: 'terminal-bench';
   instanceId: string;
+  dataset?: string;
+  datasetPath?: string;
+  taskDir?: string;
+  taskDescriptionKey?: string;
+  testCommand?: string;
+  maxAgentTimeoutSec?: number;
+  maxTestTimeoutSec?: number;
   protectedPaths?: string[];
   adapterOptions?: Record<string, unknown>;
 }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -3,6 +3,14 @@
 // (backends.ts) are internals the runner owns, not part of the API. Minimal
 // usage is `runExperiment(config, task, { storageRoot })`.
 export type {
+  BenchmarkAdapter,
+  BenchmarkAdapterRegistry,
+  BenchmarkInstanceRef,
+  BenchmarkVerifierInput,
+  BenchmarkVerifierOutput,
+} from './benchmark-adapters.js';
+export { resolveBenchmarkAdapter } from './benchmark-adapters.js';
+export type {
   ArtifactFreezeResult,
   BenchmarkContract,
   CommandVerifierSpec,
@@ -111,8 +119,25 @@ export type {
 export { AutonomousAgentLoop, runAutonomousTask } from './autonomous-agent-loop.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
+export {
+  MATRIX_CELL_SEPARATOR,
+  isRetryableTaxonomy,
+  matrixCellKey,
+  planMatrixRetry,
+  readMatrixPriorRecords,
+  readTaskRunStoreRecords,
+  type MatrixCellDecision,
+  type MatrixRetryPlanOptions,
+} from './matrix-resume.js';
 export { defaultFinalScorer } from './scorer.js';
 export { readResults, summarizeMatrix, writeResults, toComparisonTable, type MatrixSummary } from './results.js';
+export type { TaskRunExport, WriteTaskRunExportOptions, WriteTaskRunExportResult } from './result-export.js';
+export {
+  exportContentHash,
+  renderTaskRunMarkdown,
+  taskRunExportFromProjection,
+  writeTaskRunExport,
+} from './result-export.js';
 export { normalizeVerifier } from './verifier.js';
 export type {
   HeadlessBackendContext,

--- a/packages/headless/src/matrix-resume.ts
+++ b/packages/headless/src/matrix-resume.ts
@@ -1,0 +1,128 @@
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Config, ResultRecord, Task } from './contracts.js';
+import { readResults } from './results.js';
+import {
+  isTerminalTaskRunStatus,
+  taxonomyFromResultRecord,
+  type AutonomousResultTaxonomy,
+} from './task-contracts.js';
+import { resultRecordFromTaskRunProjection } from './task-run-adapter.js';
+import { createTaskRunStore } from './task-run-store.js';
+
+export const MATRIX_CELL_SEPARATOR = '\u0000';
+
+export interface MatrixCellDecision {
+  task: Task;
+  config: Config;
+  key: string;
+  prior?: ResultRecord;
+  taxonomy?: AutonomousResultTaxonomy;
+  action: 'run' | 'skip' | 'retry';
+  reason: string;
+}
+
+export interface MatrixRetryPlanOptions {
+  retryFailed?: boolean;
+  onlyTaxonomy?: readonly string[];
+}
+
+export function matrixCellKey(taskId: string, configId: string): string {
+  return `${taskId}${MATRIX_CELL_SEPARATOR}${configId}`;
+}
+
+export function planMatrixRetry(
+  tasks: readonly Task[],
+  configs: readonly Config[],
+  priorRecords: readonly ResultRecord[],
+  options: MatrixRetryPlanOptions = {},
+): MatrixCellDecision[] {
+  const latest = latestRecordsByCell(priorRecords);
+  const only = options.onlyTaxonomy ? new Set(options.onlyTaxonomy) : undefined;
+  const decisions: MatrixCellDecision[] = [];
+  for (const task of tasks) {
+    for (const config of configs) {
+      const key = matrixCellKey(task.id, config.id);
+      const prior = latest.get(key);
+      if (!prior) {
+        decisions.push({ task, config, key, action: 'run', reason: 'no prior result' });
+        continue;
+      }
+      const taxonomy = taxonomyFromResultRecord(prior);
+      if (only && !only.has(taxonomy)) {
+        decisions.push({ task, config, key, prior, taxonomy, action: 'skip', reason: `taxonomy ${taxonomy} not selected` });
+        continue;
+      }
+      if (prior.passed) {
+        decisions.push({ task, config, key, prior, taxonomy, action: 'skip', reason: 'already passed' });
+        continue;
+      }
+      if (!options.retryFailed && prior.status === 'completed' && prior.scored !== false && prior.eligible !== false) {
+        decisions.push({ task, config, key, prior, taxonomy, action: 'skip', reason: 'completed benchmark result already recorded' });
+        continue;
+      }
+      if (isRetryableTaxonomy(taxonomy)) {
+        decisions.push({ task, config, key, prior, taxonomy, action: 'retry', reason: `retryable taxonomy ${taxonomy}` });
+      } else {
+        decisions.push({ task, config, key, prior, taxonomy, action: 'skip', reason: `non-retryable taxonomy ${taxonomy}` });
+      }
+    }
+  }
+  return decisions;
+}
+
+export function isRetryableTaxonomy(taxonomy: AutonomousResultTaxonomy): boolean {
+  return taxonomy === 'verification_failed' ||
+    taxonomy === 'verification_error' ||
+    taxonomy === 'agent_failed' ||
+    taxonomy === 'agent_incomplete' ||
+    taxonomy === 'budget_exhausted';
+}
+
+export async function readMatrixPriorRecords(inputPath: string): Promise<ResultRecord[]> {
+  const stats = await stat(inputPath);
+  if (!stats.isDirectory()) return readResults(inputPath);
+
+  const resultsPath = join(inputPath, 'results.jsonl');
+  try {
+    return await readResults(resultsPath);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+  }
+
+  return readTaskRunStoreRecords(join(inputPath, 'runs'));
+}
+
+export async function readTaskRunStoreRecords(storageRoot: string): Promise<ResultRecord[]> {
+  const taskRunDir = join(storageRoot, 'task-runs');
+  let entries: string[];
+  try {
+    entries = await readdir(taskRunDir);
+  } catch (error) {
+    if (isNotFound(error)) return [];
+    throw error;
+  }
+
+  const store = createTaskRunStore(storageRoot);
+  const records: ResultRecord[] = [];
+  for (const entry of entries.sort()) {
+    if (!entry.endsWith('.jsonl')) continue;
+    const taskRunId = entry.slice(0, -'.jsonl'.length);
+    const projection = await store.project(taskRunId);
+    if (!isTerminalTaskRunStatus(projection.status) && projection.status !== 'needs_approval') continue;
+    records.push(resultRecordFromTaskRunProjection(projection));
+  }
+  return records;
+}
+
+function latestRecordsByCell(records: readonly ResultRecord[]): Map<string, ResultRecord> {
+  const latest = new Map<string, ResultRecord>();
+  for (const record of records) {
+    latest.set(matrixCellKey(record.taskId, record.configId), record);
+  }
+  return latest;
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === 'ENOENT';
+}

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -1,0 +1,295 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ResultRecord } from './contracts.js';
+import {
+  isTerminalTaskRunStatus,
+  type AutonomousResultTaxonomy,
+  type ScoreResult,
+  type TaskEvent,
+  type VerifierResult,
+} from './task-contracts.js';
+import { resultRecordFromTaskRunProjection } from './task-run-adapter.js';
+import type { TaskRunProjection } from './task-run-store.js';
+
+export interface TaskRunExport {
+  schemaVersion: 'maka.task_run_export.v1';
+  exportedAt: string;
+  taskRun: {
+    taskRunId: string;
+    taskId: string;
+    configId: string;
+    status: TaskRunProjection['status'];
+    startedAt?: number;
+    finishedAt?: number;
+    result?: TaskRunProjection['result'];
+    error?: TaskRunProjection['error'];
+  };
+  runtime: {
+    sessionId?: string;
+    agentRunId?: string;
+    attempts: TaskRunProjection['attempts'];
+    runtimeRefs?: unknown;
+    trajectoryRefs: {
+      sessionId?: string;
+      agentRunId?: string;
+      runtimeEventIds?: string[];
+    };
+  };
+  workspace: {
+    lease?: TaskRunProjection['workspaceLease'];
+    submittedSnapshot?: unknown;
+    diff: { status: 'present' | 'not_captured'; artifactRef?: string; path?: string; hash?: string };
+  };
+  verifier?: VerifierResult & { benchmark?: Record<string, unknown> };
+  score?: ScoreResult;
+  budget?: Record<string, unknown>;
+  isolation: {
+    policy?: TaskRunProjection['isolation'];
+    toolExecutors: TaskRunProjection['toolExecutors'];
+    permissions: {
+      requests: TaskRunProjection['permissionRequests'];
+      grants: TaskRunProjection['permissionGrants'];
+    };
+  };
+  inbox: {
+    parked?: TaskRunProjection['parked'];
+    items: TaskRunProjection['inboxItems'];
+  };
+  taxonomy: {
+    value: AutonomousResultTaxonomy | string;
+    passed: boolean;
+    scored?: boolean;
+    eligible?: boolean;
+    errorClass?: string;
+    excludedReason?: string;
+  };
+  warnings: string[];
+  legacyResultRecord: ResultRecord;
+}
+
+export interface WriteTaskRunExportOptions {
+  includeEvents?: boolean;
+  exportedAt?: string;
+}
+
+export interface WriteTaskRunExportResult {
+  export: TaskRunExport;
+  files: {
+    taskRunJson: string;
+    resultJson: string;
+    resultMd: string;
+    eventsJsonl?: string;
+  };
+}
+
+export async function writeTaskRunExport(
+  outDir: string,
+  projection: TaskRunProjection,
+  options: WriteTaskRunExportOptions = {},
+): Promise<WriteTaskRunExportResult> {
+  await mkdir(outDir, { recursive: true });
+  const rendered = taskRunExportFromProjection(projection, { exportedAt: options.exportedAt });
+  const files: WriteTaskRunExportResult['files'] = {
+    taskRunJson: join(outDir, 'task-run.json'),
+    resultJson: join(outDir, 'result.json'),
+    resultMd: join(outDir, 'result.md'),
+  };
+  await writeFile(files.taskRunJson, `${JSON.stringify(rendered, null, 2)}\n`, 'utf8');
+  await writeFile(files.resultJson, `${JSON.stringify(compactResultView(rendered), null, 2)}\n`, 'utf8');
+  await writeFile(files.resultMd, renderTaskRunMarkdown(rendered), 'utf8');
+  if (options.includeEvents) {
+    files.eventsJsonl = join(outDir, 'events.jsonl');
+    await writeFile(files.eventsJsonl, eventsJsonl(projection.events), 'utf8');
+  }
+  return { export: rendered, files };
+}
+
+export function taskRunExportFromProjection(
+  projection: TaskRunProjection,
+  options: { exportedAt?: string } = {},
+): TaskRunExport {
+  const legacyResultRecord = resultRecordFromTaskRunProjection(projection);
+  const score = projection.latestScoreResult;
+  const verifier = projection.latestVerifierResult;
+  const scoreDetails = score?.details ?? {};
+  const runtimeRefs = scoreDetails.runtimeRefs ?? runtimeRefsFromFeedback(projection);
+  const runtimeEventIds = runtimeEventIdsFrom(runtimeRefs);
+  const benchmark = verifierBenchmark(verifier);
+  const taxonomy = score?.taxonomy ?? projection.result?.taxonomy ?? legacyResultRecord.errorClass ?? projection.status;
+
+  return {
+    schemaVersion: 'maka.task_run_export.v1',
+    exportedAt: options.exportedAt ?? new Date().toISOString(),
+    taskRun: {
+      taskRunId: projection.taskRunId,
+      taskId: projection.taskId,
+      configId: projection.configId,
+      status: projection.status,
+      startedAt: projection.startedAt,
+      finishedAt: projection.finishedAt,
+      result: projection.result,
+      error: projection.error,
+    },
+    runtime: {
+      sessionId: projection.sessionId,
+      agentRunId: projection.agentRunId,
+      attempts: projection.attempts,
+      runtimeRefs,
+      trajectoryRefs: {
+        sessionId: projection.sessionId,
+        agentRunId: projection.agentRunId,
+        ...(runtimeEventIds.length > 0 ? { runtimeEventIds } : {}),
+      },
+    },
+    workspace: {
+      lease: projection.workspaceLease,
+      submittedSnapshot: scoreDetails.submittedSnapshot ?? submittedSnapshotRef(verifier),
+      diff: diffMetadata(scoreDetails),
+    },
+    verifier: verifier
+      ? {
+          ...verifier,
+          ...(benchmark ? { benchmark } : {}),
+        }
+      : undefined,
+    score,
+    budget: recordValue(scoreDetails.budget) ? scoreDetails.budget as Record<string, unknown> : undefined,
+    isolation: {
+      policy: projection.isolation,
+      toolExecutors: projection.toolExecutors,
+      permissions: {
+        requests: projection.permissionRequests,
+        grants: projection.permissionGrants,
+      },
+    },
+    inbox: {
+      parked: projection.parked,
+      items: projection.inboxItems,
+    },
+    taxonomy: {
+      value: taxonomy,
+      passed: score?.passed ?? projection.result?.passed ?? legacyResultRecord.passed,
+      scored: score?.scored ?? legacyResultRecord.scored,
+      eligible: score?.eligible ?? legacyResultRecord.eligible,
+      errorClass: score?.errorClass ?? verifier?.errorClass ?? projection.error?.class ?? legacyResultRecord.errorClass,
+      excludedReason: score?.excludedReason ?? legacyResultRecord.excludedReason,
+    },
+    warnings: projection.warnings,
+    legacyResultRecord,
+  };
+}
+
+export function renderTaskRunMarkdown(exported: TaskRunExport): string {
+  const score = exported.score;
+  const verifier = exported.verifier;
+  const lines = [
+    `# Task Run ${md(exported.taskRun.taskRunId)}`,
+    '',
+    `- task: ${md(exported.taskRun.taskId)}`,
+    `- config: ${md(exported.taskRun.configId)}`,
+    `- status: ${md(exported.taskRun.status)}`,
+    `- taxonomy: ${md(String(exported.taxonomy.value))}`,
+    `- passed: ${exported.taxonomy.passed ? 'true' : 'false'}`,
+    `- scored: ${score?.scored === undefined ? 'unknown' : String(score.scored)}`,
+    `- eligible: ${score?.eligible === undefined ? 'unknown' : String(score.eligible)}`,
+    `- verifier: ${verifier ? md(verifier.kind) : 'none'}`,
+    `- verifier_exit_code: ${verifier?.exitCode ?? 'null'}`,
+    `- score: ${scoreValue(score)}`,
+    `- submitted_snapshot: ${snapshotValue(exported.workspace.submittedSnapshot)}`,
+    `- diff: ${exported.workspace.diff.status}`,
+    '',
+  ];
+  if (verifier?.stdout) {
+    lines.push('## verifier_stdout', '', fence(verifier.stdout), '');
+  }
+  if (verifier?.stderr) {
+    lines.push('## verifier_stderr', '', fence(verifier.stderr), '');
+  }
+  if (exported.warnings.length > 0) {
+    lines.push('## warnings', '', ...exported.warnings.map((warning) => `- ${md(warning)}`), '');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function compactResultView(exported: TaskRunExport): Record<string, unknown> {
+  return {
+    schemaVersion: exported.schemaVersion,
+    taskRun: exported.taskRun,
+    taxonomy: exported.taxonomy,
+    verifier: exported.verifier
+      ? {
+          id: exported.verifier.id,
+          kind: exported.verifier.kind,
+          passed: exported.verifier.passed,
+          exitCode: exported.verifier.exitCode ?? null,
+          errorClass: exported.verifier.errorClass,
+          benchmark: exported.verifier.benchmark,
+        }
+      : undefined,
+    score: exported.score,
+    workspace: exported.workspace,
+    legacyResultRecord: exported.legacyResultRecord,
+  };
+}
+
+function runtimeRefsFromFeedback(projection: TaskRunProjection): unknown {
+  return projection.feedback.find((observation) => recordValue(observation.details?.runtimeRefs))?.details?.runtimeRefs;
+}
+
+function runtimeEventIdsFrom(runtimeRefs: unknown): string[] {
+  if (!recordValue(runtimeRefs) || !Array.isArray(runtimeRefs.runtimeEventIds)) return [];
+  return runtimeRefs.runtimeEventIds.filter((value): value is string => typeof value === 'string');
+}
+
+function submittedSnapshotRef(verifier: VerifierResult | undefined): Record<string, unknown> | undefined {
+  return verifier?.submittedSnapshotId ? { id: verifier.submittedSnapshotId } : undefined;
+}
+
+function diffMetadata(details: Record<string, unknown>): TaskRunExport['workspace']['diff'] {
+  const diff = details.diff;
+  if (!recordValue(diff)) return { status: 'not_captured' };
+  return {
+    status: 'present',
+    ...(typeof diff.artifactRef === 'string' ? { artifactRef: diff.artifactRef } : {}),
+    ...(typeof diff.path === 'string' ? { path: diff.path } : {}),
+    ...(typeof diff.hash === 'string' ? { hash: diff.hash } : {}),
+  };
+}
+
+function verifierBenchmark(verifier: VerifierResult | undefined): Record<string, unknown> | undefined {
+  if (!verifier?.details) return undefined;
+  return verifier.details;
+}
+
+function eventsJsonl(events: readonly TaskEvent[]): string {
+  const body = events.map((event) => JSON.stringify(event)).join('\n');
+  return body.length > 0 ? `${body}\n` : '';
+}
+
+export function exportContentHash(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
+function scoreValue(score: ScoreResult | undefined): string {
+  if (!score) return 'none';
+  if (score.score !== undefined || score.maxScore !== undefined) return `${score.score ?? 'unknown'}/${score.maxScore ?? 'unknown'}`;
+  return score.passed ? 'pass' : 'fail';
+}
+
+function snapshotValue(value: unknown): string {
+  if (!recordValue(value)) return 'none';
+  return typeof value.id === 'string' ? value.id : exportContentHash(value);
+}
+
+function fence(value: string): string {
+  return `\`\`\`\n${value.replace(/```/g, '``\\`')}\n\`\`\``;
+}
+
+function md(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+function recordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -19,6 +19,7 @@ import { freezeSubmittedWorkspace, prepareScoringWorkspace, prepareWorkspace, re
 import { defaultFinalScorer } from './scorer.js';
 import { buildIsolatedHeadlessTools } from './tools.js';
 import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
+import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
 
 export interface RunExperimentDeps {
   /**
@@ -40,6 +41,7 @@ export interface RunExperimentDeps {
    * Harbor/Terminal-Bench environment or Docker workspace executor.
    */
   realBackendIsolation?: RealBackendIsolation;
+  benchmarkAdapters?: BenchmarkAdapterRegistry;
   now?: () => number;
   newId?: () => string;
 }
@@ -161,6 +163,7 @@ export async function runExperiment(
         workspaceDir: scoringWorkspace.dir,
         submittedSnapshotId: frozen.submittedSnapshot.id,
         scoringWorkspaceId: scoringWorkspace.dir,
+        benchmarkAdapters: deps.benchmarkAdapters,
       });
       const finalScore = defaultFinalScorer({
         config,

--- a/packages/headless/src/scorer.ts
+++ b/packages/headless/src/scorer.ts
@@ -18,6 +18,8 @@ export interface FinalScore {
   taxonomy: AutonomousResultTaxonomy;
   errorClass?: string;
   excludedReason?: string;
+  score?: number;
+  maxScore?: number;
   details?: Record<string, unknown>;
 }
 
@@ -75,6 +77,9 @@ export const defaultFinalScorer: FinalScorer = (input) => {
     scored: true,
     eligible: true,
     taxonomy: verifier.passed ? 'passed' : 'verification_failed',
+    ...(verifier.score !== undefined ? { score: verifier.score } : {}),
+    ...(verifier.maxScore !== undefined ? { maxScore: verifier.maxScore } : {}),
+    ...(verifier.details ? { details: { benchmark: verifier.details } } : {}),
     ...(verifier.passed ? {} : { errorClass: 'verification_failed' }),
   };
 };

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -328,6 +328,7 @@ export async function runTaskOnce(
         workspaceDir: scoringWorkspace.dir,
         submittedSnapshotId: frozen.submittedSnapshot.id,
         scoringWorkspaceId: scoringWorkspace.dir,
+        benchmarkAdapters: deps.benchmarkAdapters,
       });
     } finally {
       await scoringWorkspace.cleanup();
@@ -364,6 +365,8 @@ export async function runTaskOnce(
       passed: finalScore.passed,
       scored: finalScore.scored,
       eligible: finalScore.eligible,
+      ...(finalScore.score !== undefined ? { score: finalScore.score } : {}),
+      ...(finalScore.maxScore !== undefined ? { maxScore: finalScore.maxScore } : {}),
       ...(finalScore.errorClass ? { errorClass: finalScore.errorClass } : {}),
       ...(finalScore.excludedReason ? { excludedReason: finalScore.excludedReason } : {}),
       taxonomy,

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -201,6 +201,9 @@ export interface VerifierResult {
   timedOut?: boolean;
   error?: string;
   errorClass?: string;
+  score?: number;
+  maxScore?: number;
+  details?: Record<string, unknown>;
   submittedSnapshotId?: string;
   scoringWorkspaceId?: string;
 }

--- a/packages/headless/src/terminal-bench-adapter.ts
+++ b/packages/headless/src/terminal-bench-adapter.ts
@@ -1,0 +1,63 @@
+import type { TerminalBenchVerifierSpec } from './contracts.js';
+import { runVerification } from './evaluator.js';
+import type { BenchmarkVerifierOutput } from './benchmark-adapters.js';
+
+export async function runTerminalBenchTestCommand(input: {
+  verifier: TerminalBenchVerifierSpec;
+  workspaceDir: string;
+}): Promise<BenchmarkVerifierOutput> {
+  const command = input.verifier.testCommand;
+  if (!command || command.trim().length === 0) {
+    return {
+      kind: 'terminal_bench',
+      passed: false,
+      exitCode: null,
+      error: 'terminal_bench verifier adapter is not implemented',
+      errorClass: 'unsupported_adapter',
+      details: terminalBenchDetails(input.verifier),
+    };
+  }
+
+  const startedAt = Date.now();
+  const evaluation = await runVerification(command, input.workspaceDir, timeoutMs(input.verifier));
+  const errorClass = evaluation.timedOut || evaluation.exitCode === null
+    ? 'verification_error'
+    : evaluation.passed
+      ? undefined
+      : 'verification_failed';
+  return {
+    kind: 'terminal_bench',
+    passed: evaluation.passed,
+    exitCode: evaluation.exitCode,
+    durationMs: Date.now() - startedAt,
+    stdout: evaluation.stdout,
+    stderr: evaluation.stderr,
+    ...(evaluation.timedOut ? { error: 'verification timed out' } : {}),
+    ...(errorClass ? { errorClass } : {}),
+    score: evaluation.passed ? 1 : 0,
+    maxScore: 1,
+    details: {
+      ...terminalBenchDetails(input.verifier),
+      testCommand: command,
+      timedOut: evaluation.timedOut,
+    },
+  };
+}
+
+export function terminalBenchDetails(verifier: TerminalBenchVerifierSpec): Record<string, unknown> {
+  return {
+    adapter: verifier.adapter,
+    instanceId: verifier.instanceId,
+    ...(verifier.dataset ? { dataset: verifier.dataset } : {}),
+    ...(verifier.datasetPath ? { datasetPath: verifier.datasetPath } : {}),
+    ...(verifier.taskDir ? { taskDir: verifier.taskDir } : {}),
+    ...(verifier.taskDescriptionKey ? { taskDescriptionKey: verifier.taskDescriptionKey } : {}),
+    ...(verifier.maxAgentTimeoutSec !== undefined ? { maxAgentTimeoutSec: verifier.maxAgentTimeoutSec } : {}),
+    ...(verifier.maxTestTimeoutSec !== undefined ? { maxTestTimeoutSec: verifier.maxTestTimeoutSec } : {}),
+    ...(verifier.adapterOptions ? { adapterOptions: { ...verifier.adapterOptions } } : {}),
+  };
+}
+
+function timeoutMs(verifier: TerminalBenchVerifierSpec): number | undefined {
+  return verifier.maxTestTimeoutSec === undefined ? undefined : verifier.maxTestTimeoutSec * 1000;
+}

--- a/packages/headless/src/verifier.ts
+++ b/packages/headless/src/verifier.ts
@@ -2,6 +2,8 @@ import { isAbsolute, join } from 'node:path';
 import type { Task, TaskVerification, VerifierSpec } from './contracts.js';
 import { runVerification, type EvaluationResult } from './evaluator.js';
 import type { VerifierResult } from './task-contracts.js';
+import { resolveBenchmarkAdapter, type BenchmarkAdapterRegistry, type BenchmarkVerifierOutput } from './benchmark-adapters.js';
+import { runTerminalBenchTestCommand, terminalBenchDetails } from './terminal-bench-adapter.js';
 
 export function normalizeVerifier(task: Task): VerifierSpec {
   const verifier = task.verifier ?? verifierFromLegacy(task.verification);
@@ -24,7 +26,18 @@ export function normalizeVerifier(task: Task): VerifierSpec {
       if (verifier.adapter !== 'terminal-bench' || !verifier.instanceId) {
         throw new Error(`task "${task.id}": terminal_bench verifier requires adapter and instanceId`);
       }
-      validateProtectedPaths(task.id, verifier.protectedPaths ?? []);
+      validateOptionalString(task.id, verifier.dataset, 'dataset');
+      validateOptionalString(task.id, verifier.datasetPath, 'datasetPath');
+      validateOptionalString(task.id, verifier.taskDir, 'taskDir');
+      validateOptionalString(task.id, verifier.taskDescriptionKey, 'taskDescriptionKey');
+      validateOptionalString(task.id, verifier.testCommand, 'testCommand');
+      validateOptionalPositiveInteger(task.id, verifier.maxAgentTimeoutSec, 'maxAgentTimeoutSec');
+      validateOptionalPositiveInteger(task.id, verifier.maxTestTimeoutSec, 'maxTestTimeoutSec');
+      if (verifier.testCommand !== undefined) {
+        validateProtectedPaths(task.id, verifier.protectedPaths);
+      } else {
+        validateProtectedPaths(task.id, verifier.protectedPaths ?? []);
+      }
       return { ...verifier, protectedPaths: verifier.protectedPaths ? [...verifier.protectedPaths] : undefined };
     case 'swe_bench':
       if (verifier.adapter !== 'swe-bench' || !verifier.instanceId) {
@@ -48,8 +61,31 @@ export async function runVerifier(input: {
   workspaceDir: string;
   submittedSnapshotId?: string;
   scoringWorkspaceId?: string;
+  benchmarkAdapters?: BenchmarkAdapterRegistry;
 }): Promise<VerifierResult> {
   if (input.verifier.kind !== 'command') {
+    const output = input.verifier.kind === 'terminal_bench' && input.verifier.testCommand
+      ? await runTerminalBenchTestCommand({ verifier: input.verifier, workspaceDir: input.workspaceDir })
+      : await resolveBenchmarkAdapter(input.benchmarkAdapters, input.verifier.adapter)?.runVerifier({
+          verifier: input.verifier,
+          workspaceDir: input.workspaceDir,
+          taskRunId: input.taskRunId,
+          attemptId: input.attemptId,
+          submittedSnapshotId: input.submittedSnapshotId,
+          scoringWorkspaceId: input.scoringWorkspaceId,
+        });
+    if (output) {
+      return verifierResultFromBenchmarkOutput({
+        output,
+        id: input.id,
+        taskRunId: input.taskRunId,
+        attemptId: input.attemptId,
+        ts: input.ts,
+        submittedSnapshotId: input.submittedSnapshotId,
+        scoringWorkspaceId: input.scoringWorkspaceId,
+      });
+    }
+
     return {
       id: input.id,
       taskRunId: input.taskRunId,
@@ -60,6 +96,7 @@ export async function runVerifier(input: {
       exitCode: null,
       error: `${input.verifier.kind} verifier adapter is not implemented`,
       errorClass: 'unsupported_adapter',
+      details: input.verifier.kind === 'terminal_bench' ? terminalBenchDetails(input.verifier) : undefined,
       submittedSnapshotId: input.submittedSnapshotId,
       scoringWorkspaceId: input.scoringWorkspaceId,
     };
@@ -84,6 +121,36 @@ export async function runVerifier(input: {
     submittedSnapshotId: input.submittedSnapshotId,
     scoringWorkspaceId: input.scoringWorkspaceId,
   });
+}
+
+function verifierResultFromBenchmarkOutput(input: {
+  output: BenchmarkVerifierOutput;
+  id: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  submittedSnapshotId?: string;
+  scoringWorkspaceId?: string;
+}): VerifierResult {
+  return {
+    id: input.id,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    ts: input.ts,
+    kind: input.output.kind,
+    passed: input.output.passed,
+    exitCode: input.output.exitCode,
+    durationMs: input.output.durationMs,
+    stdout: input.output.stdout,
+    stderr: input.output.stderr,
+    error: input.output.error,
+    errorClass: input.output.errorClass,
+    score: input.output.score,
+    maxScore: input.output.maxScore,
+    details: input.output.details,
+    submittedSnapshotId: input.submittedSnapshotId,
+    scoringWorkspaceId: input.scoringWorkspaceId,
+  };
 }
 
 export function verifierResultFromEvaluation(input: {
@@ -142,5 +209,17 @@ function validateProtectedPaths(taskId: string, protectedPaths: unknown): assert
     if (typeof rel !== 'string' || isAbsolute(rel) || rel.split(/[\\/]+/).includes('..')) {
       throw new Error(`task "${taskId}": protectedPaths entry must be a workspace-relative path: ${String(rel)}`);
     }
+  }
+}
+
+function validateOptionalString(taskId: string, value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new Error(`task "${taskId}": terminal_bench verifier ${field} must be a string when provided`);
+  }
+}
+
+function validateOptionalPositiveInteger(taskId: string, value: unknown, field: string): void {
+  if (value !== undefined && (!Number.isInteger(value) || Number(value) < 1)) {
+    throw new Error(`task "${taskId}": terminal_bench verifier ${field} must be a positive integer when provided`);
   }
 }


### PR DESCRIPTION
## Summary
- Add benchmark adapter contracts plus Terminal-Bench as the first carrier, keeping it as an adapter hook instead of a Harbor-shaped architecture.
- Add projection-based task-run exports with runtime/trajectory refs, workspace snapshot/diff metadata, verifier output, score, budget, isolation, permission/inbox facts, taxonomy, warnings, and legacy result compatibility.
- Add `maka-headless task run/inspect/resume/retry-failed/export` plus matrix resume/retry-failed planning basics.
- Keep local Terminal-Bench `testCommand` mode explicit and safe by requiring `protectedPaths`; external harness mode stays adapter-driven.

## Rive
- Template: `maka.benchmark-adapters-reporting-cli@1`
- Workflow run: `wfrun_88c12cb8b1b943f381881eb80574a59a`
- Reviewer verdict: ACCEPT
- Final steward additions: direct `task resume` CLI regression, parked inbox resolution on resume, and local Terminal-Bench `protectedPaths` enforcement/regression.

## Verification
- `npm run build`
- `npm test --workspace @maka/headless`
- `npm run typecheck`
- `git diff --check`
