### PR TITLE
feat(runtime): add agent spawn profile

### DIFF
--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -15,7 +15,7 @@ import {
   type ToolAvailabilityConfig,
 } from '../tool-availability.js';
 import { toolSchemaCharsForDiagnostics } from '../request-shape.js';
-import { LOCAL_READ_AGENT_ID } from '../agent-catalog.js';
+import { LOCAL_READ_AGENT_ID, LOCAL_READ_AGENT_PROFILE } from '../agent-catalog.js';
 import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
@@ -496,7 +496,7 @@ function loadAgentThenSpawnModel(captured: string[][]): MockLanguageModelV3 {
 
 function agentSpawnInput(): string {
   return JSON.stringify({
-    agent: LOCAL_READ_AGENT_ID,
+    profile: LOCAL_READ_AGENT_PROFILE,
     task: 'Inspect the runtime tests.',
   });
 }

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -9,8 +9,10 @@ import { PermissionEngine } from '../permission-engine.js';
 import {
   LOCAL_READ_AGENT_ID,
   LOCAL_READ_AGENT_DEFINITION,
+  LOCAL_READ_AGENT_PROFILE,
   assertAgentDefinitionRunnable,
   evaluateAgentDefinitionToolAccess,
+  listBuiltinAgentDefinitions,
 } from '../agent-catalog.js';
 import {
   AGENT_TOOL_GROUP_ID,
@@ -50,12 +52,22 @@ describe('subagent tools', () => {
 
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
+    expect(LOCAL_READ_AGENT_DEFINITION.profile).toBe(LOCAL_READ_AGENT_PROFILE);
     expect(LOCAL_READ_AGENT_DEFINITION.permissionMode).toBe('explore');
     expect([...LOCAL_READ_AGENT_DEFINITION.tools]).toEqual(['Read', 'Glob', 'Grep']);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('Bash')).toBe(false);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('WebSearch')).toBe(false);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('WebFetch')).toBe(false);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('ExploreAgent')).toBe(false);
+
+    expect(listBuiltinAgentDefinitions()).toEqual([{
+      id: LOCAL_READ_AGENT_ID,
+      profile: LOCAL_READ_AGENT_PROFILE,
+      name: 'Local Read',
+      description: 'Read-only repository exploration with file and text search tools only.',
+      permissionMode: 'explore',
+      tools: ['Read', 'Glob', 'Grep'],
+    }]);
   });
 
   test('agent definition policy evaluates each tool through allowlist and category policy', () => {
@@ -145,13 +157,13 @@ describe('subagent tools', () => {
     }
   });
 
-  test('agent_spawn delegates a catalog agent and task through the narrow context capability', async () => {
+  test('agent_spawn delegates an explicit profile and task through the narrow context capability', async () => {
     const tool = buildSubagentSpawnTool();
     const abortController = new AbortController();
     const calls: unknown[] = [];
 
     const result = await tool.impl({
-      agent: LOCAL_READ_AGENT_ID,
+      profile: LOCAL_READ_AGENT_PROFILE,
       task: 'Inspect the runtime tests.',
     }, {
       sessionId: 'session-1',
@@ -197,16 +209,18 @@ describe('subagent tools', () => {
     });
   });
 
-  test('agent_spawn rejects an unknown catalog id without spawning a child', async () => {
+  test('agent_spawn rejects legacy agent ids and unknown profiles without spawning a child', async () => {
     const tool = buildSubagentSpawnTool();
     const schema = tool.parameters as { safeParse(input: unknown): { success: boolean } };
 
-    expect(schema.safeParse({ agent: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(true);
+    expect(schema.safeParse({ profile: LOCAL_READ_AGENT_PROFILE, task: 'Inspect the repo.' }).success).toBe(true);
+    expect(schema.safeParse({ agent: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(false);
+    expect(schema.safeParse({ profile: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(false);
     expect(schema.safeParse({ agent_name: 'Researcher', instructions: 'Read only.', prompt: 'Inspect.' }).success).toBe(false);
 
     await expectRejects(
       Promise.resolve(tool.impl({
-        agent: 'implementation',
+        profile: 'implementation',
         task: 'Edit files.',
       }, {
         sessionId: 'session-1',
@@ -219,7 +233,7 @@ describe('subagent tools', () => {
           throw new Error('spawn should not be called');
         },
       })),
-      /Unknown agent "implementation"/,
+      /Unknown agent profile "implementation"/,
     );
   });
 

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -7,9 +7,11 @@ import {
 import type { MakaTool } from './tool-runtime.js';
 
 export const LOCAL_READ_AGENT_ID = 'local-read';
+export const LOCAL_READ_AGENT_PROFILE = 'local_read';
 
 export interface AgentDefinition {
   id: string;
+  profile: string;
   name: string;
   description: string;
   permissionMode: PermissionMode;
@@ -20,6 +22,7 @@ export interface AgentDefinition {
 
 export interface AgentDefinitionListItem {
   id: string;
+  profile: string;
   name: string;
   description: string;
   permissionMode: PermissionMode;
@@ -28,6 +31,7 @@ export interface AgentDefinitionListItem {
 
 export const LOCAL_READ_AGENT_DEFINITION: AgentDefinition = {
   id: LOCAL_READ_AGENT_ID,
+  profile: LOCAL_READ_AGENT_PROFILE,
   name: 'Local Read',
   description: 'Read-only repository exploration with file and text search tools only.',
   permissionMode: 'explore',
@@ -56,6 +60,7 @@ const modeRank: Record<PermissionMode, number> = {
 export function listBuiltinAgentDefinitions(): AgentDefinitionListItem[] {
   return BUILTIN_AGENT_DEFINITIONS.map((definition) => ({
     id: definition.id,
+    profile: definition.profile,
     name: definition.name,
     description: definition.description,
     permissionMode: definition.permissionMode,
@@ -67,11 +72,24 @@ export function getBuiltinAgentDefinition(id: string): AgentDefinition | undefin
   return BUILTIN_AGENT_DEFINITIONS.find((definition) => definition.id === id);
 }
 
+export function getBuiltinAgentDefinitionByProfile(profile: string): AgentDefinition | undefined {
+  return BUILTIN_AGENT_DEFINITIONS.find((definition) => definition.profile === profile);
+}
+
 export function requireBuiltinAgentDefinition(id: string): AgentDefinition {
   const definition = getBuiltinAgentDefinition(id);
   if (!definition) {
     const available = BUILTIN_AGENT_DEFINITIONS.map((agent) => agent.id).join(', ');
     throw new Error(`Unknown agent "${id}". Available agents: ${available}.`);
+  }
+  return definition;
+}
+
+export function requireBuiltinAgentDefinitionByProfile(profile: string): AgentDefinition {
+  const definition = getBuiltinAgentDefinitionByProfile(profile);
+  if (!definition) {
+    const available = BUILTIN_AGENT_DEFINITIONS.map((agent) => agent.profile).join(', ');
+    throw new Error(`Unknown agent profile "${profile}". Available profiles: ${available}.`);
   }
   return definition;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -70,12 +70,15 @@ export {
   BUILTIN_AGENT_DEFINITIONS,
   LOCAL_READ_AGENT_DEFINITION,
   LOCAL_READ_AGENT_ID,
+  LOCAL_READ_AGENT_PROFILE,
   assertAgentDefinitionRunnable,
   buildToolsForAgentDefinition,
   evaluateAgentDefinitionToolAccess,
   getBuiltinAgentDefinition,
+  getBuiltinAgentDefinitionByProfile,
   listBuiltinAgentDefinitions,
   requireBuiltinAgentDefinition,
+  requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
 export type {
   AgentDefinition,

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -3,8 +3,9 @@ import type { ToolResultContent } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 import {
   LOCAL_READ_AGENT_DEFINITION,
+  LOCAL_READ_AGENT_PROFILE,
   buildToolsForAgentDefinition,
-  requireBuiltinAgentDefinition,
+  requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
 import type { ToolGroup } from './tool-availability.js';
 
@@ -27,7 +28,7 @@ export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
 
 export function buildSubagentSpawnTool(): MakaTool<
   {
-    agent: string;
+    profile: string;
     task: string;
   },
   unknown
@@ -37,7 +38,7 @@ export function buildSubagentSpawnTool(): MakaTool<
     displayName: 'Agent',
     description: 'Run a foreground catalog child agent for a bounded task and return its explicit result.',
     parameters: z.object({
-      agent: z.string().min(1).max(80).describe('Built-in agent id, such as "local-read".'),
+      profile: z.enum([LOCAL_READ_AGENT_PROFILE]).describe('Child agent profile, currently "local_read".'),
       task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
     }),
     permissionRequired: true,
@@ -46,7 +47,7 @@ export function buildSubagentSpawnTool(): MakaTool<
       if (!ctx.spawnChildAgent) {
         throw new Error('spawnChildAgent capability is unavailable in this runtime context');
       }
-      const definition = requireBuiltinAgentDefinition(input.agent);
+      const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
       const result = await ctx.spawnChildAgent({
         spec: {
           id: definition.id,


### PR DESCRIPTION
## Summary
- add an explicit local_read profile to the built-in agent catalog and agent_list definitions
- change parent-facing agent_spawn input to use profile + task instead of a free-form agent id
- keep persisted child run agentId as local-read and keep local-read tool isolation unchanged

Continues the #52 subagent profile split after PR #56.

## Verification
- npm run -w @maka/runtime test
- npm run -w @maka/headless test
- npm run typecheck
- git diff --check
- fresh-eye reviewer subagent: no P0/P1/P2/P3 findings