### PR TITLE
feat(runtime): formalize agent profile contracts

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1356,6 +1356,7 @@ describe('SessionManager permission mode updates', () => {
     const manager = new SessionManager({
       store,
       runStore, runtimeEventStore: runStore, backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       listArtifactsForTurn: async (_sessionId, turnId) => turnId === 'child-turn'
         ? [{
             id: 'artifact-1',
@@ -1406,6 +1407,9 @@ describe('SessionManager permission mode updates', () => {
 
     const list = await manager.listChildAgents(session.id);
     expect(list.definitions.map((agent) => agent.id)).toEqual([LOCAL_READ_AGENT_ID]);
+    expect(list.definitions[0]?.availability).toEqual({ status: 'available' });
+    expect(list.definitions[0]?.contract.defaultWriteBack).toBe('summary');
+    expect(list.definitions[0]?.contract.workspace).toBe('same_workspace');
     expect(list.runs.map((agent) => agent.runId)).toEqual(['child-run']);
     expect(list.runs[0]?.agentId).toBe(LOCAL_READ_AGENT_ID);
     expect(list.runs[0]?.agentName).toBe('Researcher');

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -7,10 +7,15 @@ import type { SessionEvent } from '@maka/core/events';
 import { buildBuiltinTools } from '../builtin-tools.js';
 import { PermissionEngine } from '../permission-engine.js';
 import {
+  AGENT_CONTEXT_ISOLATED,
+  AGENT_INVOCATION_FOREGROUND,
+  AGENT_WORKSPACE_SAME_WORKSPACE,
+  AGENT_WRITE_BACK_SUMMARY,
   LOCAL_READ_AGENT_ID,
   LOCAL_READ_AGENT_DEFINITION,
   LOCAL_READ_AGENT_PROFILE,
   assertAgentDefinitionRunnable,
+  evaluateAgentDefinitionAvailability,
   evaluateAgentDefinitionToolAccess,
   listBuiltinAgentDefinitions,
 } from '../agent-catalog.js';
@@ -53,6 +58,14 @@ describe('subagent tools', () => {
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
     expect(LOCAL_READ_AGENT_DEFINITION.profile).toBe(LOCAL_READ_AGENT_PROFILE);
+    expect(LOCAL_READ_AGENT_DEFINITION.contract).toEqual({
+      capability: 'local_read',
+      invocation: AGENT_INVOCATION_FOREGROUND,
+      context: AGENT_CONTEXT_ISOLATED,
+      workspace: AGENT_WORKSPACE_SAME_WORKSPACE,
+      defaultWriteBack: AGENT_WRITE_BACK_SUMMARY,
+      supportedWriteBack: [AGENT_WRITE_BACK_SUMMARY],
+    });
     expect(LOCAL_READ_AGENT_DEFINITION.permissionMode).toBe('explore');
     expect([...LOCAL_READ_AGENT_DEFINITION.tools]).toEqual(['Read', 'Glob', 'Grep']);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('Bash')).toBe(false);
@@ -60,14 +73,54 @@ describe('subagent tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('WebFetch')).toBe(false);
     expect(LOCAL_READ_AGENT_DEFINITION.tools.includes('ExploreAgent')).toBe(false);
 
-    expect(listBuiltinAgentDefinitions()).toEqual([{
+    expect(listBuiltinAgentDefinitions({
+      parentPermissionMode: 'ask',
+      tools: [
+        testCatalogTool('Read', 'read'),
+        testCatalogTool('Glob', 'read'),
+        testCatalogTool('Grep', 'read'),
+      ],
+    })).toEqual([{
       id: LOCAL_READ_AGENT_ID,
       profile: LOCAL_READ_AGENT_PROFILE,
       name: 'Local Read',
       description: 'Read-only repository exploration with file and text search tools only.',
       permissionMode: 'explore',
       tools: ['Read', 'Glob', 'Grep'],
+      contract: LOCAL_READ_AGENT_DEFINITION.contract,
+      availability: { status: 'available' },
     }]);
+  });
+
+  test('agent definition availability reports missing tools and parent permission mismatches without running', () => {
+    expect(evaluateAgentDefinitionAvailability({
+      parentPermissionMode: 'ask',
+      definition: LOCAL_READ_AGENT_DEFINITION,
+      tools: [testCatalogTool('Read', 'read')],
+    })).toEqual({
+      status: 'unavailable',
+      reason: 'missing_tools',
+      missingTools: ['Glob', 'Grep'],
+    });
+
+    expect(evaluateAgentDefinitionAvailability({
+      parentPermissionMode: 'explore',
+      definition: {
+        ...LOCAL_READ_AGENT_DEFINITION,
+        id: 'writer',
+        permissionMode: 'execute',
+      },
+      tools: [
+        testCatalogTool('Read', 'read'),
+        testCatalogTool('Glob', 'read'),
+        testCatalogTool('Grep', 'read'),
+      ],
+    })).toEqual({
+      status: 'unavailable',
+      reason: 'parent_permission_mode',
+      parentPermissionMode: 'explore',
+      requiredPermissionMode: 'execute',
+    });
   });
 
   test('agent definition policy evaluates each tool through allowlist and category policy', () => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -264,9 +264,35 @@ describe('subagent tools', () => {
 
   test('agent_spawn rejects legacy agent ids and unknown profiles without spawning a child', async () => {
     const tool = buildSubagentSpawnTool();
-    const schema = tool.parameters as { safeParse(input: unknown): { success: boolean } };
+    const schema = tool.parameters as {
+      safeParse(input: unknown): { success: boolean; data?: unknown };
+    };
 
     expect(schema.safeParse({ profile: LOCAL_READ_AGENT_PROFILE, task: 'Inspect the repo.' }).success).toBe(true);
+    expect(schema.safeParse({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect the repo.',
+      write_back: AGENT_WRITE_BACK_SUMMARY,
+      isolation: AGENT_WORKSPACE_SAME_WORKSPACE,
+    })).toEqual({
+      success: true,
+      data: {
+        profile: LOCAL_READ_AGENT_PROFILE,
+        task: 'Inspect the repo.',
+        write_back: AGENT_WRITE_BACK_SUMMARY,
+        isolation: AGENT_WORKSPACE_SAME_WORKSPACE,
+      },
+    });
+    expect(schema.safeParse({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect the repo.',
+      write_back: 'patch',
+    }).success).toBe(false);
+    expect(schema.safeParse({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect the repo.',
+      isolation: 'worktree',
+    }).success).toBe(false);
     expect(schema.safeParse({ agent: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(false);
     expect(schema.safeParse({ profile: LOCAL_READ_AGENT_ID, task: 'Inspect the repo.' }).success).toBe(false);
     expect(schema.safeParse({ agent_name: 'Researcher', instructions: 'Read only.', prompt: 'Inspect.' }).success).toBe(false);

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -8,12 +8,53 @@ import type { MakaTool } from './tool-runtime.js';
 
 export const LOCAL_READ_AGENT_ID = 'local-read';
 export const LOCAL_READ_AGENT_PROFILE = 'local_read';
+export const AGENT_INVOCATION_FOREGROUND = 'foreground';
+export const AGENT_CONTEXT_ISOLATED = 'isolated';
+export const AGENT_WORKSPACE_SAME_WORKSPACE = 'same_workspace';
+export const AGENT_WRITE_BACK_SUMMARY = 'summary';
+
+export type AgentProfile = typeof LOCAL_READ_AGENT_PROFILE;
+export type AgentCapability = 'local_read';
+export type AgentInvocationMode = typeof AGENT_INVOCATION_FOREGROUND;
+export type AgentContextMode = typeof AGENT_CONTEXT_ISOLATED;
+export type AgentWorkspaceMode = typeof AGENT_WORKSPACE_SAME_WORKSPACE | 'worktree' | 'sandbox';
+export type AgentWriteBackMode = typeof AGENT_WRITE_BACK_SUMMARY | 'decision' | 'artifact' | 'patch';
+
+export interface AgentProfileContract {
+  capability: AgentCapability;
+  invocation: AgentInvocationMode;
+  context: AgentContextMode;
+  workspace: AgentWorkspaceMode;
+  defaultWriteBack: AgentWriteBackMode;
+  supportedWriteBack: readonly AgentWriteBackMode[];
+}
+
+export type AgentDefinitionAvailability =
+  | { status: 'unknown' }
+  | { status: 'available' }
+  | {
+      status: 'unavailable';
+      reason: 'parent_permission_mode';
+      parentPermissionMode: PermissionMode;
+      requiredPermissionMode: PermissionMode;
+    }
+  | {
+      status: 'unavailable';
+      reason: 'missing_tools';
+      missingTools: string[];
+    }
+  | {
+      status: 'unavailable';
+      reason: 'non_allow_tool_policy';
+      blockedTools: Array<{ name: string; category: ToolCategory; decision: PolicyDecision }>;
+    };
 
 export interface AgentDefinition {
   id: string;
-  profile: string;
+  profile: AgentProfile;
   name: string;
   description: string;
+  contract: AgentProfileContract;
   permissionMode: PermissionMode;
   tools: readonly string[];
   categoryPolicy: Readonly<Partial<Record<ToolCategory, PolicyDecision>>>;
@@ -22,11 +63,18 @@ export interface AgentDefinition {
 
 export interface AgentDefinitionListItem {
   id: string;
-  profile: string;
+  profile: AgentProfile;
   name: string;
   description: string;
+  contract: AgentProfileContract;
+  availability: AgentDefinitionAvailability;
   permissionMode: PermissionMode;
   tools: string[];
+}
+
+export interface AgentDefinitionListOptions {
+  parentPermissionMode?: PermissionMode;
+  tools?: readonly MakaTool[];
 }
 
 export const LOCAL_READ_AGENT_DEFINITION: AgentDefinition = {
@@ -34,6 +82,14 @@ export const LOCAL_READ_AGENT_DEFINITION: AgentDefinition = {
   profile: LOCAL_READ_AGENT_PROFILE,
   name: 'Local Read',
   description: 'Read-only repository exploration with file and text search tools only.',
+  contract: {
+    capability: 'local_read',
+    invocation: AGENT_INVOCATION_FOREGROUND,
+    context: AGENT_CONTEXT_ISOLATED,
+    workspace: AGENT_WORKSPACE_SAME_WORKSPACE,
+    defaultWriteBack: AGENT_WRITE_BACK_SUMMARY,
+    supportedWriteBack: [AGENT_WRITE_BACK_SUMMARY],
+  },
   permissionMode: 'explore',
   tools: ['Read', 'Glob', 'Grep'],
   categoryPolicy: {
@@ -57,12 +113,20 @@ const modeRank: Record<PermissionMode, number> = {
   execute: 2,
 };
 
-export function listBuiltinAgentDefinitions(): AgentDefinitionListItem[] {
+export function listBuiltinAgentDefinitions(options: AgentDefinitionListOptions = {}): AgentDefinitionListItem[] {
   return BUILTIN_AGENT_DEFINITIONS.map((definition) => ({
     id: definition.id,
     profile: definition.profile,
     name: definition.name,
     description: definition.description,
+    contract: definition.contract,
+    availability: options.parentPermissionMode && options.tools
+      ? evaluateAgentDefinitionAvailability({
+          parentPermissionMode: options.parentPermissionMode,
+          definition,
+          tools: options.tools,
+        })
+      : { status: 'unknown' },
     permissionMode: definition.permissionMode,
     tools: [...definition.tools],
   }));
@@ -106,6 +170,42 @@ export function evaluateAgentDefinitionToolAccess(
   };
 }
 
+export function evaluateAgentDefinitionAvailability(input: {
+  parentPermissionMode: PermissionMode;
+  definition: AgentDefinition;
+  tools: readonly MakaTool[];
+}): AgentDefinitionAvailability {
+  const { parentPermissionMode, definition, tools } = input;
+  if (modeRank[definition.permissionMode] > modeRank[parentPermissionMode]) {
+    return {
+      status: 'unavailable',
+      reason: 'parent_permission_mode',
+      parentPermissionMode,
+      requiredPermissionMode: definition.permissionMode,
+    };
+  }
+
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  const missingTools = definition.tools.filter((name) => !byName.has(name));
+  if (missingTools.length > 0) {
+    return { status: 'unavailable', reason: 'missing_tools', missingTools };
+  }
+
+  const blockedTools = definition.tools
+    .map((name) => {
+      const tool = byName.get(name);
+      return tool ? { name, ...evaluateAgentDefinitionToolAccess(definition, tool) } : undefined;
+    })
+    .filter((item): item is { name: string; category: ToolCategory; decision: PolicyDecision } =>
+      item !== undefined && item.decision !== 'allow'
+    );
+  if (blockedTools.length > 0) {
+    return { status: 'unavailable', reason: 'non_allow_tool_policy', blockedTools };
+  }
+
+  return { status: 'available' };
+}
+
 export function buildToolsForAgentDefinition(
   tools: readonly MakaTool[],
   definition: AgentDefinition = LOCAL_READ_AGENT_DEFINITION,
@@ -128,28 +228,19 @@ export function assertAgentDefinitionRunnable(input: {
   tools: readonly MakaTool[];
 }): void {
   const { parentPermissionMode, definition, tools } = input;
-  if (modeRank[definition.permissionMode] > modeRank[parentPermissionMode]) {
+  const availability = evaluateAgentDefinitionAvailability({ parentPermissionMode, definition, tools });
+  if (availability.status !== 'unavailable') return;
+
+  if (availability.reason === 'parent_permission_mode') {
     throw new Error(
-      `Agent "${definition.id}" cannot run in parent permission mode "${parentPermissionMode}" because it requires "${definition.permissionMode}".`,
+      `Agent "${definition.id}" cannot run in parent permission mode "${availability.parentPermissionMode}" because it requires "${availability.requiredPermissionMode}".`,
     );
   }
-
-  const byName = new Map(tools.map((tool) => [tool.name, tool]));
-  const missing = definition.tools.filter((name) => !byName.has(name));
-  if (missing.length > 0) {
-    throw new Error(`Agent "${definition.id}" is unavailable: missing tools: ${missing.join(', ')}`);
+  if (availability.reason === 'missing_tools') {
+    throw new Error(`Agent "${definition.id}" is unavailable: missing tools: ${availability.missingTools.join(', ')}`);
   }
-
-  const nonAllow = definition.tools
-    .map((name) => {
-      const tool = byName.get(name);
-      return tool ? { name, ...evaluateAgentDefinitionToolAccess(definition, tool) } : undefined;
-    })
-    .filter((item): item is { name: string; category: ToolCategory; decision: PolicyDecision } =>
-      item !== undefined && item.decision !== 'allow'
-    );
-  if (nonAllow.length > 0) {
-    const details = nonAllow.map((item) => `${item.name}:${item.decision}`).join(', ');
+  if (availability.reason === 'non_allow_tool_policy') {
+    const details = availability.blockedTools.map((item) => `${item.name}:${item.decision}`).join(', ');
     throw new Error(`Agent "${definition.id}" is unavailable: non-allow tool policy: ${details}`);
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -67,12 +67,17 @@ export type {
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
 export {
+  AGENT_CONTEXT_ISOLATED,
+  AGENT_INVOCATION_FOREGROUND,
+  AGENT_WORKSPACE_SAME_WORKSPACE,
+  AGENT_WRITE_BACK_SUMMARY,
   BUILTIN_AGENT_DEFINITIONS,
   LOCAL_READ_AGENT_DEFINITION,
   LOCAL_READ_AGENT_ID,
   LOCAL_READ_AGENT_PROFILE,
   assertAgentDefinitionRunnable,
   buildToolsForAgentDefinition,
+  evaluateAgentDefinitionAvailability,
   evaluateAgentDefinitionToolAccess,
   getBuiltinAgentDefinition,
   getBuiltinAgentDefinitionByProfile,
@@ -81,8 +86,17 @@ export {
   requireBuiltinAgentDefinitionByProfile,
 } from './agent-catalog.js';
 export type {
+  AgentCapability,
   AgentDefinition,
+  AgentDefinitionAvailability,
   AgentDefinitionListItem,
+  AgentDefinitionListOptions,
+  AgentContextMode,
+  AgentInvocationMode,
+  AgentProfile,
+  AgentProfileContract,
+  AgentWorkspaceMode,
+  AgentWriteBackMode,
 } from './agent-catalog.js';
 export {
   AGENT_LIST_TOOL_NAME,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -471,7 +471,11 @@ export class SessionManager {
   }
 
   async listChildAgents(sessionId: string): Promise<AgentListResult> {
-    const definitions = listBuiltinAgentDefinitions();
+    const header = await this.deps.store.readHeader(sessionId);
+    const definitions = listBuiltinAgentDefinitions({
+      parentPermissionMode: header.permissionMode,
+      tools: this.deps.childTools ?? [],
+    });
     if (!this.deps.runStore) return { definitions, runs: [] };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     return {

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { ToolResultContent } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 import {
+  AGENT_WORKSPACE_SAME_WORKSPACE,
+  AGENT_WRITE_BACK_SUMMARY,
   LOCAL_READ_AGENT_DEFINITION,
   LOCAL_READ_AGENT_PROFILE,
   buildToolsForAgentDefinition,
@@ -30,6 +32,8 @@ export function buildSubagentSpawnTool(): MakaTool<
   {
     profile: string;
     task: string;
+    write_back?: string;
+    isolation?: string;
   },
   unknown
 > {
@@ -40,6 +44,10 @@ export function buildSubagentSpawnTool(): MakaTool<
     parameters: z.object({
       profile: z.enum([LOCAL_READ_AGENT_PROFILE]).describe('Child agent profile, currently "local_read".'),
       task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
+      write_back: z.enum([AGENT_WRITE_BACK_SUMMARY]).optional()
+        .describe('Requested child write-back mode. local_read currently supports only "summary".'),
+      isolation: z.enum([AGENT_WORKSPACE_SAME_WORKSPACE]).optional()
+        .describe('Requested child workspace isolation. local_read currently runs in the same workspace with isolated context.'),
     }),
     permissionRequired: true,
     categoryHint: 'subagent',


### PR DESCRIPTION
## Summary
- add explicit built-in agent profile contracts and availability diagnostics
- thread contract availability through agent_list/listChildAgents
- align agent_spawn input with the local_read write-back and isolation contract

Related to #52.

## Verification
- npm run -w @maka/runtime test
- npm run -w @maka/headless test
- npm run typecheck
- git diff --check

## Review
- fresh-eye subagent review: no P0/P1/P2/P3 findings