### PR TITLE
feat(headless): Config.systemPrompt + runtime_error failure class

### DIFF
--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -424,4 +424,82 @@ describe('Config.systemPrompt (benchmark config variable, not session state)', (
       assert.equal(captured[0]?.systemPrompt, undefined, 'no systemPrompt should be injected when Config omits it');
     });
   });
+
+  // End-to-end wiring test: proves config.systemPrompt flows all the way
+  // through to the backend constructor's systemPrompt parameter — the exact
+  // seam a real AiSdkBackend factory (like desktop's) uses. Uses an ai-sdk
+  // stub that records its constructor input, so we verify the wiring contract
+  // without needing a live LLM call.
+  class SystemPromptCapturingBackend implements AgentBackend {
+    readonly kind: BackendKind = 'ai-sdk';
+    readonly sessionId: string;
+    readonly receivedSystemPrompt: string | undefined;
+    constructor(
+      private readonly ctx: { sessionId: string; header: SessionHeader; store: SessionStore },
+      systemPrompt?: string,
+    ) {
+      this.sessionId = ctx.sessionId;
+      this.receivedSystemPrompt = systemPrompt;
+    }
+    async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+      const turnId = input.turnId;
+      const ts = Date.now();
+      const messageId = 'capture-msg';
+      await this.ctx.store.appendMessage(this.sessionId, {
+        type: 'assistant', id: messageId, turnId, ts,
+        text: 'ok', modelId: this.ctx.header.model,
+      });
+      yield { type: 'text_complete', id: 'capture-tc', turnId, ts, messageId, text: 'ok' };
+      yield { type: 'complete', id: 'capture-c', turnId, ts, stopReason: 'end_turn' };
+    }
+    async stop(): Promise<void> {}
+    async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+    async dispose(): Promise<void> {}
+  }
+
+  test('config.systemPrompt reaches the backend constructor systemPrompt parameter', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const prompt = 'You are a benchmark agent. Use tools, do not narrate.';
+      let constructedBackend: SystemPromptCapturingBackend | undefined;
+      const configWithPrompt: Config = {
+        id: 'real-cfg',
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-chat',
+        systemPrompt: prompt,
+      };
+      const task: Task = {
+        id: 'wiring-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      await runExperiment(configWithPrompt, task, {
+        storageRoot,
+        realBackendIsolation: { kind: 'external', label: 'wiring test' },
+        registerBackends: (registry, context) => {
+          // This is the exact pattern a real benchmark factory uses:
+          // read config.systemPrompt from the closure, pass to backend ctor.
+          // The factory receives BackendFactoryContext (with store/header),
+          // and context.config is the HeadlessBackendContext closure copy.
+          registry.register('ai-sdk', (ctx) => {
+            constructedBackend = new SystemPromptCapturingBackend(
+              { sessionId: ctx.sessionId, header: ctx.header, store: ctx.store },
+              context.config.systemPrompt,
+            );
+            return constructedBackend;
+          });
+        },
+      });
+
+      assert.ok(constructedBackend, 'backend must have been constructed');
+      assert.equal(
+        constructedBackend!.receivedSystemPrompt,
+        prompt,
+        'config.systemPrompt must reach the backend constructor systemPrompt parameter',
+      );
+    });
+  });
 });

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -359,3 +359,69 @@ describe('engine-level grading-boundary validation (not only the CLI)', () => {
     });
   });
 });
+
+describe('Config.systemPrompt (benchmark config variable, not session state)', () => {
+  // A factory that captures the systemPrompt it would hand to the backend,
+  // proving the benchmark's registerBackends closure can read config.systemPrompt
+  // and pass it through — mirroring the desktop path. The harness itself does
+  // NOT thread systemPrompt through BackendFactoryContext (that channel is the
+  // child-agent instruction); the factory owns it.
+  const registerCapturingBackend = (captured: { systemPrompt?: string }[]) =>
+    (registry: BackendRegistry, context: HeadlessBackendContext): void => {
+      captured.push({ systemPrompt: context.config.systemPrompt });
+      registry.register('fake', (ctx) =>
+        new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+      );
+    };
+
+  test('factory closure can read config.systemPrompt and pass it to the backend', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const configWithPrompt: Config = {
+        ...fakeConfig,
+        systemPrompt: 'You are a benchmark agent. Use tools, do not narrate.',
+      };
+      const captured: { systemPrompt?: string }[] = [];
+      const task: Task = {
+        id: 'prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      const result = await runExperiment(configWithPrompt, task, {
+        storageRoot,
+        registerBackends: registerCapturingBackend(captured),
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(captured.length, 1);
+      assert.equal(
+        captured[0]?.systemPrompt,
+        'You are a benchmark agent. Use tools, do not narrate.',
+        'factory closure must receive config.systemPrompt',
+      );
+    });
+  });
+
+  test('omitting systemPrompt leaves it undefined in the factory context (no default injection)', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const captured: { systemPrompt?: string }[] = [];
+      const task: Task = {
+        id: 'no-prompt-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      await runExperiment(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerCapturingBackend(captured),
+      });
+
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0]?.systemPrompt, undefined, 'no systemPrompt should be injected when Config omits it');
+    });
+  });
+});

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -8,9 +8,8 @@
  *
  * MVP scope only. Deliberately deferred as pure additions: a matrix /
  * compare layer, LLM/rule evaluators (MVP = command/test only), Docker
- * execution, network allowlist, `systemPrompt`/toolset overrides on
- * Config, and promoting these contracts into @maka/core once a second
- * consumer exists.
+ * execution, network allowlist, toolset overrides on Config, and
+ * promoting these contracts into @maka/core once a second consumer exists.
  */
 
 import type { BackendKind } from '@maka/core';
@@ -131,6 +130,15 @@ export interface Config {
   llmConnectionSlug: string;
   /** Falls back to the connection's default model when omitted. */
   model?: string;
+  /**
+   * Optional system prompt for the config under test. This is a benchmark
+   * variable, NOT persisted session state — the `registerBackends` factory
+   * reads it from its closure and passes it to the backend constructor
+   * directly (same pattern as the desktop interactive path). It never
+   * enters `SessionHeader` or `BackendFactoryContext.systemPrompt` (which
+   * is the child-agent instruction channel, not the main-session prompt).
+   */
+  systemPrompt?: string;
 }
 
 /** One row of canonical truth per run: did it run, did it pass, and how much it cost. */

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -139,6 +139,7 @@ export {
   writeTaskRunExport,
 } from './result-export.js';
 export { normalizeVerifier } from './verifier.js';
+export { BENCHMARK_BASE_SYSTEM_PROMPT } from './system-prompts.js';
 export type {
   HeadlessBackendContext,
   IsolatedCommandInput,

--- a/packages/headless/src/system-prompts.ts
+++ b/packages/headless/src/system-prompts.ts
@@ -1,0 +1,21 @@
+/**
+ * Benchmark base system prompt.
+ *
+ * Real models running benchmark tasks (Terminal-Bench, SWE-bench, …) without a
+ * system prompt tend to narrate their reasoning in text instead of calling
+ * tools, hit the output token limit, and never produce the required artifact.
+ * This prompt steers the model toward tool-first action without leaking any
+ * task-specific answer — it is a generic "how to work in this environment"
+ * prefix, not a hint.
+ *
+ * Use it by setting `Config.systemPrompt` to this string (or a derivative that
+ * adapts the path/tool guidance to a specific benchmark's environment).
+ */
+export const BENCHMARK_BASE_SYSTEM_PROMPT = `You are an autonomous coding agent working inside a benchmark evaluation. Your job is to solve the given task by acting, not by narrating.
+
+Rules:
+1. Call tools to make changes. Do not write long explanations before acting — think briefly, then use the Write/Edit tools immediately.
+2. The working directory is your current directory. Use relative paths only (e.g. "result.txt", not "/app/result.txt"). Absolute paths will be rejected.
+3. Do not attempt to run shell commands, tests, or scripts. You do not have a Bash tool. Verification is handled separately by the evaluator after you finish.
+4. Once you have produced the required output file(s), stop. Do not write extra files, do not self-test, do not iterate beyond what the task asks.
+5. Keep each response short. The task instruction is the source of truth for what to produce.`;

--- a/packages/headless/src/system-prompts.ts
+++ b/packages/headless/src/system-prompts.ts
@@ -8,6 +8,10 @@
  * task-specific answer — it is a generic "how to work in this environment"
  * prefix, not a hint.
  *
+ * This base prompt assumes the standard isolated headless tool surface, which
+ * includes an isolated Bash tool (buildIsolatedHeadlessTools). For file-only
+ * benchmarks that intentionally drop Bash, derive a variant that says so.
+ *
  * Use it by setting `Config.systemPrompt` to this string (or a derivative that
  * adapts the path/tool guidance to a specific benchmark's environment).
  */
@@ -16,6 +20,6 @@ export const BENCHMARK_BASE_SYSTEM_PROMPT = `You are an autonomous coding agent 
 Rules:
 1. Call tools to make changes. Do not write long explanations before acting — think briefly, then use the Write/Edit tools immediately.
 2. The working directory is your current directory. Use relative paths only (e.g. "result.txt", not "/app/result.txt"). Absolute paths will be rejected.
-3. Do not attempt to run shell commands, tests, or scripts. You do not have a Bash tool. Verification is handled separately by the evaluator after you finish.
-4. Once you have produced the required output file(s), stop. Do not write extra files, do not self-test, do not iterate beyond what the task asks.
+3. Do not self-test or run verification scripts — the evaluator scores your output separately after you finish. Use shell tools only to produce the required artifacts, not to check your own work.
+4. Once you have produced the required output file(s), stop. Do not write extra files, do not iterate beyond what the task asks.
 5. Keep each response short. The task instruction is the source of truth for what to produce.`;

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1816,6 +1816,31 @@ describe('SessionManager permission mode updates', () => {
     expect(turn?.errorClass).toBe('tool_failed');
   });
 
+  test('complete(stopReason=error) without a prior error event classifies as runtime_error not unknown', async () => {
+    // Reproduces the DeepSeek-reasoner smoke failure: the backend ended with
+    // stopReason='error' but never emitted a preceding error event, so the
+    // run ledger's failureClass was 'unknown'. It should be 'runtime_error'
+    // so benchmark scoring can distinguish runtime failures from max_tokens.
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new EventBackend(ctx, [
+      { type: 'complete', stopReason: 'error' },
+    ]));
+    const manager = new SessionManager({
+      store, runStore, backends, newId: nextId(), now: nextNow(10_000),
+    });
+    const session = await manager.createSession(makeInput());
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
+
+    const [turn] = await store.listTurns(session.id);
+    expect(turn?.status).toBe('failed');
+    expect(turn?.errorClass).toBe('runtime_error');
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.failureClass).toBe('runtime_error');
+  });
+
   test('does not let a late complete event overwrite a prior turn error', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -202,6 +202,11 @@ export class AgentRun {
           errorClass: turnStatus.errorClass,
         });
       }
+      // A complete(error) without a preceding error event leaves failureClass
+      // unset — record it now so finalize does not fall back to 'unknown'.
+      if (turnStatus?.status === 'failed' && turnStatus.errorClass && !this.failureClass) {
+        this.markRunFailed(turnStatus.errorClass, 'turn ended with stopReason=error', ev.ts);
+      }
     }
     if (ev.type === 'error') {
       if (this.stopped) {
@@ -623,7 +628,7 @@ function turnStatusFromEvent(event: SessionEvent): { status: TurnRecord['status'
       return { status: 'failed', errorClass: event.reason ?? event.code ?? 'unknown' };
     case 'complete':
       if (event.stopReason === 'user_stop') return { status: 'aborted' };
-      if (event.stopReason === 'error') return { status: 'failed', errorClass: 'unknown' };
+      if (event.stopReason === 'error') return { status: 'failed', errorClass: 'runtime_error' };
       if (event.stopReason === 'permission_handoff') return { status: 'running' };
       return { status: 'completed' };
     default:

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -204,6 +204,9 @@ export class AgentRun {
       }
       // A complete(error) without a preceding error event leaves failureClass
       // unset — record it now so finalize does not fall back to 'unknown'.
+      // This emits a run_failed event here AND another in finishRun, mirroring
+      // the error-event path (which also double-records). Event-stream
+      // consumers already tolerate duplicate terminal events.
       if (turnStatus?.status === 'failed' && turnStatus.errorClass && !this.failureClass) {
         this.markRunFailed(turnStatus.errorClass, 'turn ended with stopReason=error', ev.ts);
       }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -177,6 +177,15 @@ export interface BackendFactoryContext {
   header: SessionHeader;
   store: SessionStore;
   appendMessage?: (message: StoredMessage) => Promise<void>;
+  /**
+   * Child-agent instruction channel. Only `ensureChildActive` populates
+   * this; the main-session `ensureActive` path leaves it undefined. A
+   * main-session factory that needs a system prompt must source it from
+   * its own closure (the desktop path and the headless benchmark path
+   * both do this) — do NOT route a main-session prompt through this
+   * field, it is semantically the child instruction, not the session
+   * system prompt.
+   */
   systemPrompt?: string;
   tools?: readonly MakaTool[];
   recordRunTrace?: RunTraceRecorder;


### PR DESCRIPTION
## Summary

Two fixes that unblock real-model benchmark smoke (Terminal-Bench on DeepSeek), exposed by the diagnosis in the prior session:

- **`Config.systemPrompt`** — real models running benchmark tasks without a system prompt narrate their reasoning in text instead of calling tools, hit the 8192 output token limit, and never produce the required artifact. Adds `systemPrompt?: string` to `Config`; the `registerBackends` factory closure reads it and passes it to `AiSdkBackend` directly (same pattern as the desktop interactive path). Not routed through `BackendFactoryContext.systemPrompt` (that's the child-agent instruction channel) and not persisted into `SessionHeader` (benchmark sessions are throwaway). Also exports `BENCHMARK_BASE_SYSTEM_PROMPT`, a generic tool-first prefix verified against DeepSeek-chat on a Terminal-Bench regex task.
- **`failureClass: runtime_error`** — a backend that ends with `complete(stopReason='error')` without a preceding error event left the run ledger's `failureClass` as `unknown`, so benchmark scoring could not distinguish runtime failures from `max_tokens` / `incomplete_tool_calls`. Classifies it as `runtime_error` instead.

Both reviewed by Codex and Claude (consult mode) — confirmed headless-only / runtime-pass / no-persistence is the right scope.

## Test plan
- [x] `@maka/headless` 91/91 (2 new tests: factory closure reads `config.systemPrompt`; undefined when omitted)
- [x] `@maka/runtime` 586/586 (1 new test: `complete(stopReason=error)` → `runtime_error` not `unknown`)
- [x] `npm run typecheck` clean