### PR TITLE
fix(runtime): map failed terminal without error content to runtime_error

### DIFF
--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -339,6 +339,52 @@ describe('failed runs surface as an error (not a silent ⚠️ + exit 0)', () =>
       assert.equal(result.passed, false);
     });
   });
+
+  test('complete(stopReason=error) with no preceding error event classifies as runtime_error in ResultRecord', async () => {
+    // Reproduces the DeepSeek-reasoner smoke: the backend ended with
+    // stopReason='error' but never emitted a preceding error event. The
+    // benchmark ResultRecord.errorClass must read 'runtime_error' (not
+    // 'failed' or 'unknown') so scoring can distinguish runtime failures
+    // from max_tokens / incomplete_tool_calls / verification_failed.
+    class BareErrorCompleteBackend implements AgentBackend {
+      readonly kind: BackendKind = 'fake';
+      readonly sessionId: string;
+      constructor(private readonly ctx: { sessionId: string; header: SessionHeader; store: SessionStore }) {
+        this.sessionId = ctx.sessionId;
+      }
+      async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+        const { turnId } = input;
+        const ts = Date.now();
+        // NO preceding error event — just a bare complete(error).
+        yield { type: 'complete', id: 'bare-err-c', turnId, ts, stopReason: 'error' };
+      }
+      async stop(): Promise<void> {}
+      async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+      async dispose(): Promise<void> {}
+    }
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
+      const task: Task = {
+        id: 'bare-error',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f marker.txt', protectedPaths: [] },
+      };
+
+      const result = await runExperiment(fakeConfig, task, {
+        storageRoot,
+        registerBackends: (registry) => {
+          registry.register('fake', (ctx) =>
+            new BareErrorCompleteBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
+          );
+        },
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.errorClass, 'runtime_error');
+      assert.equal(result.passed, false);
+    });
+  });
 });
 
 describe('engine-level grading-boundary validation (not only the CLI)', () => {

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -412,8 +412,45 @@ describe('RuntimeRunner', () => {
     const result = await runner.run(makeRequest());
 
     expect(result.status).toBe('failed');
-    expect(result.failure?.class).toBe('failed');
+    // No reason/code on the error content → classifies as runtime_error
+    // (not the bare 'failed'), message still surfaces.
+    expect(result.failure?.class).toBe('runtime_error');
     expect(result.failure?.message).toBe('provider 500');
+    expect(result.failure?.terminalStatus).toBe('failed');
+  });
+
+  test('a failed terminal event with a reason code uses that code as the class', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [
+      {
+        ...flowTerminalEvent(ctx, 'failed'),
+        content: { kind: 'error', reason: 'tool_failed', message: 'Tool execution failed' },
+      },
+    ]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('tool_failed');
+    expect(result.failure?.message).toBe('Tool execution failed');
+    expect(result.failure?.terminalStatus).toBe('failed');
+  });
+
+  test('a failed terminal event with no error content classifies as runtime_error not failed', async () => {
+    // Reproduces complete(stopReason=error) with no preceding error event:
+    // the terminal RuntimeEvent has status='failed' but no error content.
+    // Previously this returned class='failed', indistinguishable from other
+    // failures; now it returns 'runtime_error' so benchmark scoring can
+    // distinguish runtime failures from max_tokens / incomplete_tool_calls.
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [flowTerminalEvent(ctx, 'failed')]);
+    const runner = new RuntimeRunner({ flow, providers });
+
+    const result = await runner.run(makeRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.failure?.class).toBe('runtime_error');
     expect(result.failure?.terminalStatus).toBe('failed');
   });
 

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -346,6 +346,21 @@ function failureFromTerminalEvent(event: RuntimeEvent): InvocationFailure | unde
   const status: RuntimeEventStatus | undefined = event.status;
   if (status === undefined || status === 'completed') return undefined;
   const content = event.content;
+  // A failed terminal event may carry an error content (reason/code) from
+  // the provider or backend. Prefer that precise class over the bare status.
+  // A failed terminal with NO error content (e.g. complete(stopReason=error)
+  // with no preceding error event) classifies as 'runtime_error' — not the
+  // bare 'failed' — so benchmark scoring can distinguish it from other
+  // failure modes and the run ledger stays consistent with the invocation.
+  if (status === 'failed') {
+    const message = content?.kind === 'error' ? content.message : undefined;
+    const classFromContent = content?.kind === 'error' ? (content.reason ?? content.code) : undefined;
+    return {
+      class: classFromContent ?? 'runtime_error',
+      ...(message ? { message } : {}),
+      terminalStatus: status,
+    };
+  }
   const message = content?.kind === 'error' ? content.message : undefined;
   return {
     class: status,


### PR DESCRIPTION
## Summary

Fresh-eye review of PR #62 (Codex P1 / Claude P3) found that the `runtime_error` classification only reached the **AgentRunStore ledger**, not the **InvocationResult.failure.class** that benchmark `ResultRecord` reads. A `complete(stopReason=error)` with no preceding error event still surfaced as `errorClass='failed'` in `ResultRecord` — indistinguishable from other failures.

**Root cause**: `failureFromTerminalEvent` returned `class=status` (i.e. `'failed'`) for any failed terminal, ignoring error content. The error-content branch (which extracts `content.reason`) was unreachable for terminal events because the terminal check ran first.

**Fix**: in `failureFromTerminalEvent`, when `status='failed'`:
- with error content reason/code → use that (e.g. `'tool_failed'`)
- without error content → `'runtime_error'` (not `'failed'`)

This makes the invocation path consistent with the run ledger, so `ResultRecord.errorClass` reads `'runtime_error'` for the bare-error scenario.

## Test plan
- [x] `@maka/runtime` 588/588 (updated locked test, +2 new: reason-code test, bare-failed-terminal test)
- [x] `@maka/headless` 93/93 (+1 end-to-end: `ResultRecord.errorClass='runtime_error'` for backend emitting only `complete(stopReason=error)`)
- [x] `npm run typecheck` clean