### PR TITLE
feat(headless): add fixed prompt WAL controller

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -91,6 +91,42 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('ignores a torn final WAL line when resuming', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(
+        resultsJsonlPath,
+        `${JSON.stringify(taskCompletedEvent({ taskId: 'task-a' }))}\n{"schemaVersion":`,
+        'utf8',
+      );
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-b']);
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
   test('derives results TSV from replayed task events', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -127,6 +127,35 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('retries infra-failed WAL events on resume', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskInfraFailedEvent({ taskId: 'task-a' }))}\n`, 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a']);
+      assert.equal(result.events[0]?.type, 'task_completed');
+    });
+  });
+
   test('derives results TSV from replayed task events', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -330,6 +359,24 @@ function taskCompletedEvent(input: { taskId: string; promptHash?: string }): Fix
     durationMs: 50,
     runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
     harbor: { reward: 1 },
+  };
+}
+
+function taskInfraFailedEvent(input: { taskId: string }): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_infra_failed',
+    id: `event-${input.taskId}`,
+    ts: 10,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: 'infra_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'infra_error',
+    error: 'container crashed',
   };
 }
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { Config } from '../contracts.js';
 import {
+  hashSystemPrompt,
   readHarborTaskRunOutput,
   runFixedPromptController,
   type FixedPromptWalEvent,
@@ -157,6 +158,62 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.errorClass, 'verification_failed');
     });
   });
+
+  test('records zero cost with tokens as a plumbing failure', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            tokenSummary: { input: 2, output: 1, reasoning: 0, total: 3, costUsd: 0 },
+          }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.errorClass, 'zero_cost_with_tokens');
+      assert.equal(result.totalTokens, 3);
+      assert.equal(result.totalCostUsd, 0);
+    });
+  });
+
+  test('records prompt hash mismatches as plumbing failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({ taskId: 'task-a', promptHash: 'sha256:wrong' }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'prompt_hash_mismatch');
+      assert.equal(result.events[0]?.promptHash, 'sha256:wrong');
+      assert.equal(result.events[0]?.expectedPromptHash, hashSystemPrompt('fixed prompt\n'));
+    });
+  });
 });
 
 function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
@@ -181,15 +238,20 @@ function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
   };
 }
 
-function harborOutput(input: { taskId: string; reward?: number }): HarborTaskRunOutput {
+function harborOutput(input: {
+  taskId: string;
+  reward?: number;
+  promptHash?: string;
+  tokenSummary?: HarborTaskRunOutput['cell']['tokenSummary'];
+}): HarborTaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1 },
     cell: {
       schemaVersion: 1,
       status: 'completed',
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
-      promptHash: 'sha256:prompt',
-      tokenSummary: { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
+      promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n'),
+      tokenSummary: input.tokenSummary ?? { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
       steps: 2,
       durationMs: 40,
       startedAt: 20,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -124,6 +124,29 @@ describe('fixed prompt controller', () => {
 
       assert.deepEqual(calls, ['task-b']);
       assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+
+      const secondCalls: string[] = [];
+      const second = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        harborRunner: async ({ task }) => {
+          secondCalls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 101,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(secondCalls, []);
+      assert.deepEqual(second.taskIds, ['task-a', 'task-b']);
     });
   });
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { Config } from '../contracts.js';
 import {
+  readHarborTaskRunOutput,
   runFixedPromptController,
   type FixedPromptWalEvent,
   type HarborTaskRunOutput,
@@ -85,6 +86,77 @@ describe('fixed prompt controller', () => {
       );
     });
   });
+
+  test('records Harbor runner failures as infra events', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => {
+          throw new Error('container crashed before result.json');
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.taskId, 'task-a');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.scored, false);
+      assert.equal(result.events[0]?.errorClass, 'infra_error');
+      assert.match(await readFile(resultsJsonlPath, 'utf8'), /"type":"task_infra_failed"/);
+    });
+  });
+
+  test('reads Harbor reward and Maka cell output artifacts', async () => {
+    await withDir(async (dir) => {
+      const harborResultPath = join(dir, 'result.json');
+      const cellOutputPath = join(dir, 'maka-cell-output.json');
+      await writeFile(harborResultPath, JSON.stringify({ reward: 0 }), 'utf8');
+      await writeFile(cellOutputPath, JSON.stringify(harborOutput({ taskId: 'task-a' }).cell), 'utf8');
+
+      const output = await readHarborTaskRunOutput({ harborResultPath, cellOutputPath });
+
+      assert.equal(output.harbor.reward, 0);
+      assert.equal(output.cell.status, 'completed');
+      assert.equal(output.cell.runtimeRefs.sessionId, 'session-task-a');
+    });
+  });
+
+  test('classifies completed Harbor reward failures as benchmark failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({ taskId: 'task-a', reward: 0 }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'verification_failed');
+    });
+  });
 });
 
 function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
@@ -109,9 +181,9 @@ function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
   };
 }
 
-function harborOutput(input: { taskId: string }): HarborTaskRunOutput {
+function harborOutput(input: { taskId: string; reward?: number }): HarborTaskRunOutput {
   return {
-    harbor: { reward: 1 },
+    harbor: { reward: input.reward ?? 1 },
     cell: {
       schemaVersion: 1,
       status: 'completed',

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -351,7 +351,12 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', omitPromptHash: true }),
+        harborRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            omitPromptHash: true,
+            tokenSummary: { input: 0, output: 0, reasoning: 0, total: 0, costUsd: 0 },
+          }),
         now: () => 100,
         newId: idFactory(),
       });

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -56,6 +56,41 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('reruns completed WAL events whose prompt hash is stale', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(
+        resultsJsonlPath,
+        `${JSON.stringify(taskCompletedEvent({ taskId: 'task-a', promptHash: 'sha256:stale' }))}\n`,
+        'utf8',
+      );
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a']);
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.promptHash, hashSystemPrompt('fixed prompt\n'));
+      assert.equal((await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').length, 2);
+    });
+  });
+
   test('derives results TSV from replayed task events', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -81,7 +116,7 @@ describe('fixed prompt controller', () => {
         await readFile(resultsTsvPath, 'utf8'),
         [
           'task_id\tstatus\tpassed\tscored\teligible\terror_class\tprompt_hash\ttokens\tcost_usd\truntime_events_path',
-          'task-a\tcompleted\ttrue\ttrue\ttrue\t\tsha256:prompt\t5\t0.01\t/logs/task-a/runtime-events.jsonl',
+          `task-a\tcompleted\ttrue\ttrue\ttrue\t\t${hashSystemPrompt('fixed prompt\n')}\t5\t0.01\t/logs/task-a/runtime-events.jsonl`,
           '',
         ].join('\n'),
       );
@@ -214,9 +249,33 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.expectedPromptHash, hashSystemPrompt('fixed prompt\n'));
     });
   });
+
+  test('records missing prompt hashes with tokens as plumbing failures', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({ taskId: 'task-a', omitPromptHash: true }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_prompt_hash');
+      assert.equal(result.events[0]?.expectedPromptHash, hashSystemPrompt('fixed prompt\n'));
+    });
+  });
 });
 
-function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
+function taskCompletedEvent(input: { taskId: string; promptHash?: string }): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
     type: 'task_completed',
@@ -229,7 +288,7 @@ function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
     passed: true,
     scored: true,
     eligible: true,
-    promptHash: 'sha256:prompt',
+    promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n'),
     tokenSummary: { input: 2, output: 3, reasoning: 0, total: 5, costUsd: 0.01 },
     steps: 4,
     durationMs: 50,
@@ -242,6 +301,7 @@ function harborOutput(input: {
   taskId: string;
   reward?: number;
   promptHash?: string;
+  omitPromptHash?: boolean;
   tokenSummary?: HarborTaskRunOutput['cell']['tokenSummary'];
 }): HarborTaskRunOutput {
   return {
@@ -250,7 +310,7 @@ function harborOutput(input: {
       schemaVersion: 1,
       status: 'completed',
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
-      promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n'),
+      ...(input.omitPromptHash ? {} : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
       tokenSummary: input.tokenSummary ?? { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
       steps: 2,
       durationMs: 40,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { appendFile, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { Config } from '../contracts.js';
+import {
+  runFixedPromptController,
+  type FixedPromptWalEvent,
+  type HarborTaskRunOutput,
+} from '../fixed-prompt-controller.js';
+
+const config: Config = {
+  id: 'cfg-fixed',
+  backend: 'fake',
+  llmConnectionSlug: 'fake',
+  model: 'fake-model',
+};
+
+describe('fixed prompt controller', () => {
+  test('resumes from completed task events in the WAL', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskCompletedEvent({ taskId: 'task-a' }))}\n`, 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        harborRunner: async ({ task }): Promise<HarborTaskRunOutput> => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-b']);
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+
+      const lines = (await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n');
+      assert.equal(lines.length, 2);
+      assert.equal(JSON.parse(lines[1]!).taskId, 'task-b');
+    });
+  });
+
+  test('derives results TSV from replayed task events', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskCompletedEvent({ taskId: 'task-a' }))}\n`, 'utf8');
+
+      await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath,
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({ taskId: 'unused' }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(
+        await readFile(resultsTsvPath, 'utf8'),
+        [
+          'task_id\tstatus\tpassed\tscored\teligible\terror_class\tprompt_hash\ttokens\tcost_usd\truntime_events_path',
+          'task-a\tcompleted\ttrue\ttrue\ttrue\t\tsha256:prompt\t5\t0.01\t/logs/task-a/runtime-events.jsonl',
+          '',
+        ].join('\n'),
+      );
+    });
+  });
+});
+
+function taskCompletedEvent(input: { taskId: string }): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_completed',
+    id: `event-${input.taskId}`,
+    ts: 10,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: 'completed',
+    passed: true,
+    scored: true,
+    eligible: true,
+    promptHash: 'sha256:prompt',
+    tokenSummary: { input: 2, output: 3, reasoning: 0, total: 5, costUsd: 0.01 },
+    steps: 4,
+    durationMs: 50,
+    runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
+    harbor: { reward: 1 },
+  };
+}
+
+function harborOutput(input: { taskId: string }): HarborTaskRunOutput {
+  return {
+    harbor: { reward: 1 },
+    cell: {
+      schemaVersion: 1,
+      status: 'completed',
+      runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
+      promptHash: 'sha256:prompt',
+      tokenSummary: { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
+      steps: 2,
+      durationMs: 40,
+      startedAt: 20,
+      finishedAt: 60,
+      runtimeRefs: {
+        invocationId: `inv-${input.taskId}`,
+        sessionId: `session-${input.taskId}`,
+        runId: `run-${input.taskId}`,
+        turnId: `turn-${input.taskId}`,
+      },
+    },
+  };
+}
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
+}
+
+async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-fixed-prompt-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -122,7 +122,7 @@ describe('fixed prompt controller', () => {
     await withDir(async (dir) => {
       const harborResultPath = join(dir, 'result.json');
       const cellOutputPath = join(dir, 'maka-cell-output.json');
-      await writeFile(harborResultPath, JSON.stringify({ reward: 0 }), 'utf8');
+      await writeFile(harborResultPath, JSON.stringify({ verifier_result: { rewards: { reward: 0 } } }), 'utf8');
       await writeFile(cellOutputPath, JSON.stringify(harborOutput({ taskId: 'task-a' }).cell), 'utf8');
 
       const output = await readHarborTaskRunOutput({ harborResultPath, cellOutputPath });

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -173,10 +173,19 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
     if (isNotFound(error)) return [];
     throw error;
   }
-  return raw
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as FixedPromptWalEvent);
+  const lines = raw.split('\n');
+  const events: FixedPromptWalEvent[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (line.trim().length === 0) continue;
+    try {
+      events.push(JSON.parse(line) as FixedPromptWalEvent);
+    } catch (error) {
+      if (index === lines.length - 1 && !raw.endsWith('\n')) break;
+      throw error;
+    }
+  }
+  return events;
 }
 
 export async function readHarborTaskRunOutput(

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -429,7 +429,6 @@ function terminalTaskEvents(
     if (!eventMatchesPrompt(event, expectedPromptHash)) continue;
     if (
       event.type === 'task_completed'
-      || event.type === 'task_infra_failed'
       || event.type === 'task_plumbing_failed'
     ) {
       byTask.set(event.taskId, event);

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { validateHarborCellOutput, type HarborCellOutput, type HarborCellTokenSummary } from './cell-output.js';
@@ -72,7 +72,35 @@ export interface FixedPromptTaskInfraFailedEvent {
   error: string;
 }
 
-export type FixedPromptWalEvent = FixedPromptTaskCompletedEvent | FixedPromptTaskInfraFailedEvent;
+export interface FixedPromptTaskPlumbingFailedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_plumbing_failed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  taskId: string;
+  status: 'plumbing_failed';
+  passed: false;
+  scored: false;
+  eligible: false;
+  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch';
+  error: string;
+  promptHash?: string;
+  expectedPromptHash?: string;
+  tokenSummary: HarborCellTokenSummary;
+  steps: number;
+  durationMs: number;
+  runtimeEventsPath: string;
+  harbor: {
+    reward: number;
+  };
+}
+
+export type FixedPromptWalEvent =
+  | FixedPromptTaskCompletedEvent
+  | FixedPromptTaskInfraFailedEvent
+  | FixedPromptTaskPlumbingFailedEvent;
 
 export interface RunFixedPromptControllerInput {
   runId: string;
@@ -101,6 +129,7 @@ export async function runFixedPromptController(
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
   const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
+  const expectedPromptHash = hashSystemPrompt(systemPrompt);
   const config = { ...input.config, systemPrompt };
   const events = await readFixedPromptWal(input.resultsJsonlPath);
   const completed = terminalTaskEvents(events, input.runId, input.roundId);
@@ -113,6 +142,7 @@ export async function runFixedPromptController(
       task,
       config,
       systemPrompt,
+      expectedPromptHash,
       id: newId(),
       ts: now(),
     });
@@ -129,8 +159,8 @@ export async function runFixedPromptController(
   return {
     taskIds: resultEvents.map((event) => event.taskId),
     events: resultEvents,
-    totalTokens: sum(resultEvents.map((event) => event.type === 'task_completed' ? event.tokenSummary.total : 0)),
-    totalCostUsd: sum(resultEvents.map((event) => event.type === 'task_completed' ? event.tokenSummary.costUsd : 0)),
+    totalTokens: sum(resultEvents.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.total : 0)),
+    totalCostUsd: sum(resultEvents.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0)),
     resultsTsvPath: input.resultsTsvPath,
   };
 }
@@ -189,10 +219,10 @@ export async function writeFixedPromptResultsTsv(
     String(event.scored),
     String(event.eligible),
     event.errorClass ?? '',
-    event.type === 'task_completed' ? event.promptHash ?? '' : '',
-    String(event.type === 'task_completed' ? event.tokenSummary.total : 0),
-    String(event.type === 'task_completed' ? event.tokenSummary.costUsd : 0),
-    event.type === 'task_completed' ? event.runtimeEventsPath : '',
+    event.type !== 'task_infra_failed' ? event.promptHash ?? '' : '',
+    String(event.type !== 'task_infra_failed' ? event.tokenSummary.total : 0),
+    String(event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0),
+    event.type !== 'task_infra_failed' ? event.runtimeEventsPath : '',
   ]);
   const body = [header, ...rows].map((row) => row.map(tsvCell).join('\t')).join('\n');
   await writeFile(path, `${body}\n`, 'utf8');
@@ -203,6 +233,7 @@ async function runTaskAndBuildEvent(input: {
   task: FixedPromptTask;
   config: Config;
   systemPrompt: string;
+  expectedPromptHash: string;
   id: string;
   ts: number;
 }): Promise<FixedPromptWalEvent> {
@@ -214,8 +245,9 @@ async function runTaskAndBuildEvent(input: {
       config: input.config,
       systemPrompt: input.systemPrompt,
     });
-    return taskCompletedEvent({
+    return taskEventFromOutput({
       output,
+      expectedPromptHash: input.expectedPromptHash,
       taskId: input.task.id,
       runId: input.input.runId,
       roundId: input.input.roundId,
@@ -232,6 +264,26 @@ async function runTaskAndBuildEvent(input: {
       ts: input.ts,
     });
   }
+}
+
+function taskEventFromOutput(input: {
+  output: HarborTaskRunOutput;
+  expectedPromptHash: string;
+  taskId: string;
+  runId: string;
+  roundId: string;
+  id: string;
+  ts: number;
+}): FixedPromptTaskCompletedEvent | FixedPromptTaskPlumbingFailedEvent {
+  const plumbingFailure = classifyPlumbingFailure(input.output, input.expectedPromptHash);
+  if (plumbingFailure) {
+    return taskPlumbingFailedEvent({
+      ...input,
+      errorClass: plumbingFailure.errorClass,
+      error: plumbingFailure.error,
+    });
+  }
+  return taskCompletedEvent(input);
 }
 
 function taskCompletedEvent(input: {
@@ -269,6 +321,62 @@ function taskCompletedEvent(input: {
   };
 }
 
+function taskPlumbingFailedEvent(input: {
+  output: HarborTaskRunOutput;
+  expectedPromptHash: string;
+  taskId: string;
+  runId: string;
+  roundId: string;
+  id: string;
+  ts: number;
+  errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
+  error: string;
+}): FixedPromptTaskPlumbingFailedEvent {
+  return {
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+    type: 'task_plumbing_failed',
+    id: input.id,
+    ts: input.ts,
+    runId: input.runId,
+    roundId: input.roundId,
+    taskId: input.taskId,
+    status: 'plumbing_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: input.errorClass,
+    error: input.error,
+    ...(input.output.cell.promptHash ? { promptHash: input.output.cell.promptHash } : {}),
+    expectedPromptHash: input.expectedPromptHash,
+    tokenSummary: input.output.cell.tokenSummary,
+    steps: input.output.cell.steps,
+    durationMs: input.output.cell.durationMs,
+    runtimeEventsPath: input.output.cell.runtimeEventsPath,
+    harbor: {
+      reward: input.output.harbor.reward,
+    },
+  };
+}
+
+function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash: string): {
+  errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
+  error: string;
+} | undefined {
+  if (output.cell.promptHash !== undefined && output.cell.promptHash !== expectedPromptHash) {
+    return {
+      errorClass: 'prompt_hash_mismatch',
+      error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
+    };
+  }
+  if (output.cell.tokenSummary.total > 0 && output.cell.tokenSummary.costUsd === 0) {
+    return {
+      errorClass: 'zero_cost_with_tokens',
+      error: 'Harbor cell reported token usage but zero costUsd',
+    };
+  }
+  return undefined;
+}
+
 function taskInfraFailedEvent(input: {
   error: unknown;
   taskId: string;
@@ -302,7 +410,13 @@ function terminalTaskEvents(
   const byTask = new Map<string, FixedPromptWalEvent>();
   for (const event of events) {
     if (event.runId !== runId || event.roundId !== roundId) continue;
-    if (event.type === 'task_completed' || event.type === 'task_infra_failed') byTask.set(event.taskId, event);
+    if (
+      event.type === 'task_completed'
+      || event.type === 'task_infra_failed'
+      || event.type === 'task_plumbing_failed'
+    ) {
+      byTask.set(event.taskId, event);
+    }
   }
   return byTask;
 }
@@ -313,6 +427,10 @@ function tsvCell(value: string): string {
 
 function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+export function hashSystemPrompt(systemPrompt: string): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(systemPrompt)).digest('hex')}`;
 }
 
 async function readJsonObject(path: string): Promise<Record<string, unknown>> {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -84,7 +84,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   passed: false;
   scored: false;
   eligible: false;
-  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch';
+  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash';
   error: string;
   promptHash?: string;
   expectedPromptHash?: string;
@@ -132,7 +132,7 @@ export async function runFixedPromptController(
   const expectedPromptHash = hashSystemPrompt(systemPrompt);
   const config = { ...input.config, systemPrompt };
   const events = await readFixedPromptWal(input.resultsJsonlPath);
-  const completed = terminalTaskEvents(events, input.runId, input.roundId);
+  const completed = terminalTaskEvents(events, input.runId, input.roundId, expectedPromptHash);
 
   for (const task of input.tasks) {
     if (completed.has(task.id)) continue;
@@ -362,6 +362,12 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
   errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
   error: string;
 } | undefined {
+  if (output.cell.tokenSummary.total > 0 && output.cell.promptHash === undefined) {
+    return {
+      errorClass: 'missing_prompt_hash',
+      error: `Harbor cell did not report prompt hash ${expectedPromptHash}`,
+    };
+  }
   if (output.cell.promptHash !== undefined && output.cell.promptHash !== expectedPromptHash) {
     return {
       errorClass: 'prompt_hash_mismatch',
@@ -406,10 +412,12 @@ function terminalTaskEvents(
   events: readonly FixedPromptWalEvent[],
   runId: string,
   roundId: string,
+  expectedPromptHash: string,
 ): Map<string, FixedPromptWalEvent> {
   const byTask = new Map<string, FixedPromptWalEvent>();
   for (const event of events) {
     if (event.runId !== runId || event.roundId !== roundId) continue;
+    if (!eventMatchesPrompt(event, expectedPromptHash)) continue;
     if (
       event.type === 'task_completed'
       || event.type === 'task_infra_failed'
@@ -419,6 +427,12 @@ function terminalTaskEvents(
     }
   }
   return byTask;
+}
+
+function eventMatchesPrompt(event: FixedPromptWalEvent, expectedPromptHash: string): boolean {
+  if (event.type === 'task_infra_failed') return true;
+  if (event.promptHash === expectedPromptHash) return true;
+  return event.type === 'task_plumbing_failed' && event.expectedPromptHash === expectedPromptHash;
 }
 
 function tsvCell(value: string): string {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import type { HarborCellOutput, HarborCellTokenSummary } from './cell-output.js';
+import { validateHarborCellOutput, type HarborCellOutput, type HarborCellTokenSummary } from './cell-output.js';
 import type { Config } from './contracts.js';
 
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
@@ -28,6 +28,11 @@ export interface HarborTaskRunInput {
 
 export type HarborTaskRunner = (input: HarborTaskRunInput) => Promise<HarborTaskRunOutput>;
 
+export interface ReadHarborTaskRunOutputInput {
+  harborResultPath: string;
+  cellOutputPath: string;
+}
+
 export interface FixedPromptTaskCompletedEvent {
   schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
   type: 'task_completed';
@@ -51,7 +56,23 @@ export interface FixedPromptTaskCompletedEvent {
   };
 }
 
-export type FixedPromptWalEvent = FixedPromptTaskCompletedEvent;
+export interface FixedPromptTaskInfraFailedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_infra_failed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  taskId: string;
+  status: 'infra_failed';
+  passed: false;
+  scored: false;
+  eligible: false;
+  errorClass: 'infra_error';
+  error: string;
+}
+
+export type FixedPromptWalEvent = FixedPromptTaskCompletedEvent | FixedPromptTaskInfraFailedEvent;
 
 export interface RunFixedPromptControllerInput {
   runId: string;
@@ -82,23 +103,16 @@ export async function runFixedPromptController(
   const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const config = { ...input.config, systemPrompt };
   const events = await readFixedPromptWal(input.resultsJsonlPath);
-  const completed = completedTaskEvents(events, input.runId, input.roundId);
+  const completed = terminalTaskEvents(events, input.runId, input.roundId);
 
   for (const task of input.tasks) {
     if (completed.has(task.id)) continue;
 
-    const output = await input.harborRunner({
-      runId: input.runId,
-      roundId: input.roundId,
+    const event = await runTaskAndBuildEvent({
+      input,
       task,
       config,
       systemPrompt,
-    });
-    const event = taskCompletedEvent({
-      output,
-      taskId: task.id,
-      runId: input.runId,
-      roundId: input.roundId,
       id: newId(),
       ts: now(),
     });
@@ -115,8 +129,8 @@ export async function runFixedPromptController(
   return {
     taskIds: resultEvents.map((event) => event.taskId),
     events: resultEvents,
-    totalTokens: sum(resultEvents.map((event) => event.tokenSummary.total)),
-    totalCostUsd: sum(resultEvents.map((event) => event.tokenSummary.costUsd)),
+    totalTokens: sum(resultEvents.map((event) => event.type === 'task_completed' ? event.tokenSummary.total : 0)),
+    totalCostUsd: sum(resultEvents.map((event) => event.type === 'task_completed' ? event.tokenSummary.costUsd : 0)),
     resultsTsvPath: input.resultsTsvPath,
   };
 }
@@ -133,6 +147,17 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
     .split('\n')
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as FixedPromptWalEvent);
+}
+
+export async function readHarborTaskRunOutput(
+  input: ReadHarborTaskRunOutputInput,
+): Promise<HarborTaskRunOutput> {
+  return {
+    harbor: {
+      reward: harborReward(await readJsonObject(input.harborResultPath)),
+    },
+    cell: validateHarborCellOutput(await readJsonObject(input.cellOutputPath)),
+  };
 }
 
 export async function appendFixedPromptWalEvent(path: string, event: FixedPromptWalEvent): Promise<void> {
@@ -164,13 +189,49 @@ export async function writeFixedPromptResultsTsv(
     String(event.scored),
     String(event.eligible),
     event.errorClass ?? '',
-    event.promptHash ?? '',
-    String(event.tokenSummary.total),
-    String(event.tokenSummary.costUsd),
-    event.runtimeEventsPath,
+    event.type === 'task_completed' ? event.promptHash ?? '' : '',
+    String(event.type === 'task_completed' ? event.tokenSummary.total : 0),
+    String(event.type === 'task_completed' ? event.tokenSummary.costUsd : 0),
+    event.type === 'task_completed' ? event.runtimeEventsPath : '',
   ]);
   const body = [header, ...rows].map((row) => row.map(tsvCell).join('\t')).join('\n');
   await writeFile(path, `${body}\n`, 'utf8');
+}
+
+async function runTaskAndBuildEvent(input: {
+  input: RunFixedPromptControllerInput;
+  task: FixedPromptTask;
+  config: Config;
+  systemPrompt: string;
+  id: string;
+  ts: number;
+}): Promise<FixedPromptWalEvent> {
+  try {
+    const output = await input.input.harborRunner({
+      runId: input.input.runId,
+      roundId: input.input.roundId,
+      task: input.task,
+      config: input.config,
+      systemPrompt: input.systemPrompt,
+    });
+    return taskCompletedEvent({
+      output,
+      taskId: input.task.id,
+      runId: input.input.runId,
+      roundId: input.input.roundId,
+      id: input.id,
+      ts: input.ts,
+    });
+  } catch (error) {
+    return taskInfraFailedEvent({
+      error,
+      taskId: input.task.id,
+      runId: input.input.runId,
+      roundId: input.input.roundId,
+      id: input.id,
+      ts: input.ts,
+    });
+  }
 }
 
 function taskCompletedEvent(input: {
@@ -182,6 +243,8 @@ function taskCompletedEvent(input: {
   ts: number;
 }): FixedPromptTaskCompletedEvent {
   const { output } = input;
+  const passed = output.cell.status === 'completed' && output.harbor.reward > 0;
+  const errorClass = output.cell.errorClass ?? (passed ? undefined : 'verification_failed');
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'task_completed',
@@ -191,10 +254,10 @@ function taskCompletedEvent(input: {
     roundId: input.roundId,
     taskId: input.taskId,
     status: output.cell.status,
-    passed: output.cell.status === 'completed' && output.harbor.reward > 0,
+    passed,
     scored: output.cell.status === 'completed',
     eligible: true,
-    ...(output.cell.errorClass ? { errorClass: output.cell.errorClass } : {}),
+    ...(errorClass ? { errorClass } : {}),
     ...(output.cell.promptHash ? { promptHash: output.cell.promptHash } : {}),
     tokenSummary: output.cell.tokenSummary,
     steps: output.cell.steps,
@@ -206,7 +269,32 @@ function taskCompletedEvent(input: {
   };
 }
 
-function completedTaskEvents(
+function taskInfraFailedEvent(input: {
+  error: unknown;
+  taskId: string;
+  runId: string;
+  roundId: string;
+  id: string;
+  ts: number;
+}): FixedPromptTaskInfraFailedEvent {
+  return {
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+    type: 'task_infra_failed',
+    id: input.id,
+    ts: input.ts,
+    runId: input.runId,
+    roundId: input.roundId,
+    taskId: input.taskId,
+    status: 'infra_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'infra_error',
+    error: errorMessage(input.error),
+  };
+}
+
+function terminalTaskEvents(
   events: readonly FixedPromptWalEvent[],
   runId: string,
   roundId: string,
@@ -214,7 +302,7 @@ function completedTaskEvents(
   const byTask = new Map<string, FixedPromptWalEvent>();
   for (const event of events) {
     if (event.runId !== runId || event.roundId !== roundId) continue;
-    if (event.type === 'task_completed') byTask.set(event.taskId, event);
+    if (event.type === 'task_completed' || event.type === 'task_infra_failed') byTask.set(event.taskId, event);
   }
   return byTask;
 }
@@ -227,10 +315,42 @@ function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
 }
 
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  const value = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  if (!isRecord(value)) throw new Error(`${path} must contain a JSON object`);
+  return value;
+}
+
+function harborReward(value: Record<string, unknown>): number {
+  const direct = numericField(value, 'reward') ?? numericField(value, 'score');
+  if (direct !== undefined) return direct;
+  const metrics = isRecord(value.metrics) ? value.metrics : undefined;
+  const nested = metrics ? numericField(metrics, 'reward') ?? numericField(metrics, 'score') : undefined;
+  if (nested !== undefined) return nested;
+  throw new Error('Harbor result must include a numeric reward or score');
+}
+
+function numericField(value: Record<string, unknown>, field: string): number | undefined {
+  const raw = value[field];
+  if (raw === undefined) return undefined;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error(`Harbor result field ${field} must be a finite number`);
+  }
+  return raw;
+}
+
 function randomId(): string {
   return randomUUID();
 }
 
 function isNotFound(error: unknown): boolean {
   return typeof error === 'object' && error !== null && (error as { code?: string }).code === 'ENOENT';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -372,7 +372,7 @@ function classifyPlumbingFailure(output: HarborTaskRunOutput, expectedPromptHash
   errorClass: FixedPromptTaskPlumbingFailedEvent['errorClass'];
   error: string;
 } | undefined {
-  if (output.cell.tokenSummary.total > 0 && output.cell.promptHash === undefined) {
+  if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
     return {
       errorClass: 'missing_prompt_hash',
       error: `Harbor cell did not report prompt hash ${expectedPromptHash}`,

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -445,6 +445,12 @@ function harborReward(value: Record<string, unknown>): number {
   const metrics = isRecord(value.metrics) ? value.metrics : undefined;
   const nested = metrics ? numericField(metrics, 'reward') ?? numericField(metrics, 'score') : undefined;
   if (nested !== undefined) return nested;
+  const verifierResult = isRecord(value.verifier_result) ? value.verifier_result : undefined;
+  const verifierRewards = verifierResult && isRecord(verifierResult.rewards) ? verifierResult.rewards : undefined;
+  const verifierReward = verifierRewards
+    ? numericField(verifierRewards, 'reward') ?? numericField(verifierRewards, 'score')
+    : undefined;
+  if (verifierReward !== undefined) return verifierReward;
   throw new Error('Harbor result must include a numeric reward or score');
 }
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from 'node:crypto';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { HarborCellOutput, HarborCellTokenSummary } from './cell-output.js';
+import type { Config } from './contracts.js';
+
+export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
+
+export interface FixedPromptTask {
+  id: string;
+  path: string;
+}
+
+export interface HarborTaskRunOutput {
+  harbor: {
+    reward: number;
+  };
+  cell: HarborCellOutput;
+}
+
+export interface HarborTaskRunInput {
+  runId: string;
+  roundId: string;
+  task: FixedPromptTask;
+  config: Config;
+  systemPrompt: string;
+}
+
+export type HarborTaskRunner = (input: HarborTaskRunInput) => Promise<HarborTaskRunOutput>;
+
+export interface FixedPromptTaskCompletedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'task_completed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  taskId: string;
+  status: HarborCellOutput['status'];
+  passed: boolean;
+  scored: boolean;
+  eligible: boolean;
+  errorClass?: string;
+  promptHash?: string;
+  tokenSummary: HarborCellTokenSummary;
+  steps: number;
+  durationMs: number;
+  runtimeEventsPath: string;
+  harbor: {
+    reward: number;
+  };
+}
+
+export type FixedPromptWalEvent = FixedPromptTaskCompletedEvent;
+
+export interface RunFixedPromptControllerInput {
+  runId: string;
+  roundId: string;
+  config: Config;
+  systemPromptPath: string;
+  resultsJsonlPath: string;
+  resultsTsvPath: string;
+  tasks: readonly FixedPromptTask[];
+  harborRunner: HarborTaskRunner;
+  now?: () => number;
+  newId?: () => string;
+}
+
+export interface FixedPromptControllerResult {
+  taskIds: string[];
+  events: FixedPromptWalEvent[];
+  totalTokens: number;
+  totalCostUsd: number;
+  resultsTsvPath: string;
+}
+
+export async function runFixedPromptController(
+  input: RunFixedPromptControllerInput,
+): Promise<FixedPromptControllerResult> {
+  const now = input.now ?? Date.now;
+  const newId = input.newId ?? randomId;
+  const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
+  const config = { ...input.config, systemPrompt };
+  const events = await readFixedPromptWal(input.resultsJsonlPath);
+  const completed = completedTaskEvents(events, input.runId, input.roundId);
+
+  for (const task of input.tasks) {
+    if (completed.has(task.id)) continue;
+
+    const output = await input.harborRunner({
+      runId: input.runId,
+      roundId: input.roundId,
+      task,
+      config,
+      systemPrompt,
+    });
+    const event = taskCompletedEvent({
+      output,
+      taskId: task.id,
+      runId: input.runId,
+      roundId: input.roundId,
+      id: newId(),
+      ts: now(),
+    });
+    await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
+    events.push(event);
+    completed.set(task.id, event);
+  }
+
+  const resultEvents = input.tasks
+    .map((task) => completed.get(task.id))
+    .filter((event): event is FixedPromptWalEvent => event !== undefined);
+  await writeFixedPromptResultsTsv(input.resultsTsvPath, resultEvents);
+
+  return {
+    taskIds: resultEvents.map((event) => event.taskId),
+    events: resultEvents,
+    totalTokens: sum(resultEvents.map((event) => event.tokenSummary.total)),
+    totalCostUsd: sum(resultEvents.map((event) => event.tokenSummary.costUsd)),
+    resultsTsvPath: input.resultsTsvPath,
+  };
+}
+
+export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEvent[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (error) {
+    if (isNotFound(error)) return [];
+    throw error;
+  }
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as FixedPromptWalEvent);
+}
+
+export async function appendFixedPromptWalEvent(path: string, event: FixedPromptWalEvent): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(event)}\n`, 'utf8');
+}
+
+export async function writeFixedPromptResultsTsv(
+  path: string,
+  events: readonly FixedPromptWalEvent[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const header = [
+    'task_id',
+    'status',
+    'passed',
+    'scored',
+    'eligible',
+    'error_class',
+    'prompt_hash',
+    'tokens',
+    'cost_usd',
+    'runtime_events_path',
+  ];
+  const rows = events.map((event) => [
+    event.taskId,
+    event.status,
+    String(event.passed),
+    String(event.scored),
+    String(event.eligible),
+    event.errorClass ?? '',
+    event.promptHash ?? '',
+    String(event.tokenSummary.total),
+    String(event.tokenSummary.costUsd),
+    event.runtimeEventsPath,
+  ]);
+  const body = [header, ...rows].map((row) => row.map(tsvCell).join('\t')).join('\n');
+  await writeFile(path, `${body}\n`, 'utf8');
+}
+
+function taskCompletedEvent(input: {
+  output: HarborTaskRunOutput;
+  taskId: string;
+  runId: string;
+  roundId: string;
+  id: string;
+  ts: number;
+}): FixedPromptTaskCompletedEvent {
+  const { output } = input;
+  return {
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+    type: 'task_completed',
+    id: input.id,
+    ts: input.ts,
+    runId: input.runId,
+    roundId: input.roundId,
+    taskId: input.taskId,
+    status: output.cell.status,
+    passed: output.cell.status === 'completed' && output.harbor.reward > 0,
+    scored: output.cell.status === 'completed',
+    eligible: true,
+    ...(output.cell.errorClass ? { errorClass: output.cell.errorClass } : {}),
+    ...(output.cell.promptHash ? { promptHash: output.cell.promptHash } : {}),
+    tokenSummary: output.cell.tokenSummary,
+    steps: output.cell.steps,
+    durationMs: output.cell.durationMs,
+    runtimeEventsPath: output.cell.runtimeEventsPath,
+    harbor: {
+      reward: output.harbor.reward,
+    },
+  };
+}
+
+function completedTaskEvents(
+  events: readonly FixedPromptWalEvent[],
+  runId: string,
+  roundId: string,
+): Map<string, FixedPromptWalEvent> {
+  const byTask = new Map<string, FixedPromptWalEvent>();
+  for (const event of events) {
+    if (event.runId !== runId || event.roundId !== roundId) continue;
+    if (event.type === 'task_completed') byTask.set(event.taskId, event);
+  }
+  return byTask;
+}
+
+function tsvCell(value: string): string {
+  return value.replace(/\t/g, ' ').replace(/\r?\n/g, ' ');
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function randomId(): string {
+  return randomUUID();
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && (error as { code?: string }).code === 'ENOENT';
+}

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, truncate, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { validateHarborCellOutput, type HarborCellOutput, type HarborCellTokenSummary } from './cell-output.js';
 import type { Config } from './contracts.js';
@@ -201,6 +201,7 @@ export async function readHarborTaskRunOutput(
 
 export async function appendFixedPromptWalEvent(path: string, event: FixedPromptWalEvent): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
+  await truncateTornWalTail(path);
   await appendFile(path, `${JSON.stringify(event)}\n`, 'utf8');
 }
 
@@ -449,6 +450,19 @@ function tsvCell(value: string): string {
 
 function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+async function truncateTornWalTail(path: string): Promise<void> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (error) {
+    if (isNotFound(error)) return;
+    throw error;
+  }
+  if (raw.length === 0 || raw.endsWith('\n')) return;
+  const lastNewline = raw.lastIndexOf('\n');
+  await truncate(path, lastNewline < 0 ? 0 : lastNewline + 1);
 }
 
 export function hashSystemPrompt(systemPrompt: string): string {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -30,6 +30,7 @@ export type {
   FixedPromptTask,
   FixedPromptTaskCompletedEvent,
   FixedPromptTaskInfraFailedEvent,
+  FixedPromptTaskPlumbingFailedEvent,
   FixedPromptWalEvent,
   HarborTaskRunInput,
   HarborTaskRunOutput,
@@ -40,6 +41,7 @@ export type {
 export {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   appendFixedPromptWalEvent,
+  hashSystemPrompt,
   readHarborTaskRunOutput,
   readFixedPromptWal,
   runFixedPromptController,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -29,15 +29,18 @@ export type {
   FixedPromptControllerResult,
   FixedPromptTask,
   FixedPromptTaskCompletedEvent,
+  FixedPromptTaskInfraFailedEvent,
   FixedPromptWalEvent,
   HarborTaskRunInput,
   HarborTaskRunOutput,
   HarborTaskRunner,
+  ReadHarborTaskRunOutputInput,
   RunFixedPromptControllerInput,
 } from './fixed-prompt-controller.js';
 export {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   appendFixedPromptWalEvent,
+  readHarborTaskRunOutput,
   readFixedPromptWal,
   runFixedPromptController,
   writeFixedPromptResultsTsv,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -26,6 +26,23 @@ export {
   runHarborCellFromEnv,
 } from './harbor-cell.js';
 export type {
+  FixedPromptControllerResult,
+  FixedPromptTask,
+  FixedPromptTaskCompletedEvent,
+  FixedPromptWalEvent,
+  HarborTaskRunInput,
+  HarborTaskRunOutput,
+  HarborTaskRunner,
+  RunFixedPromptControllerInput,
+} from './fixed-prompt-controller.js';
+export {
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
+  appendFixedPromptWalEvent,
+  readFixedPromptWal,
+  runFixedPromptController,
+  writeFixedPromptResultsTsv,
+} from './fixed-prompt-controller.js';
+export type {
   BenchmarkAdapter,
   BenchmarkAdapterRegistry,
   BenchmarkInstanceRef,


### PR DESCRIPTION
## Summary
- add the PR3 fixed-prompt controller surface with append-only WAL events and resume/reconcile by task id
- derive `results.tsv` from WAL and aggregate tokens/cost
- classify Harbor infra failures, benchmark verification failures, zero-cost token plumbing failures, and prompt hash mismatches separately

## Verification
- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`
- `npm run -w @maka/headless build`
- `git diff --check`

Part of #64.

Non-goals: meta-agent prompt editing, acceptance policy, real API-key eval, and hardcoded Harbor CLI assumptions beyond the injected task runner seam.