### PR TITLE
feat(headless): add prompt candidate loop

### DIFF
--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -108,6 +108,7 @@ describe('prompt candidate loop', () => {
           heldOutDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: {
+            systemPromptGitPath: 'system_prompt.md',
             changedFiles: async () => ['system_prompt.md', 'program.md'],
             commit: async () => {
               committed = true;
@@ -153,6 +154,46 @@ describe('prompt candidate loop', () => {
       );
 
       assert.equal(await readFile(outsidePath, 'utf8'), 'outside prompt\n');
+    });
+  });
+
+  test('rejects changes to a different system_prompt.md path', async () => {
+    await withDir(async (dir) => {
+      const promptDir = join(dir, 'prompts');
+      await mkdir(promptDir);
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(promptDir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let committed = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: {
+            systemPromptGitPath: 'prompts/system_prompt.md',
+            changedFiles: async () => ['system_prompt.md'],
+            commit: async () => {
+              committed = true;
+              return 'commit-1';
+            },
+          },
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /only prompts\/system_prompt.md may change/,
+      );
+
+      assert.equal(committed, false);
     });
   });
 
@@ -260,6 +301,7 @@ describe('prompt candidate loop', () => {
 
 function gitNoop() {
   return {
+    systemPromptGitPath: 'system_prompt.md',
     changedFiles: async () => ['system_prompt.md'],
     commit: async () => 'commit-1',
   };

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -121,6 +121,38 @@ describe('prompt candidate loop', () => {
       );
 
       assert.equal(committed, false);
+    });
+  });
+
+  test('rejects a symlinked system prompt before writing outside the repo', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const outsidePath = join(dir, '..', 'outside-system-prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(outsidePath, 'outside prompt\n', 'utf8');
+      await symlink(outsidePath, systemPromptPath);
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: gitNoop(),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /system_prompt.md must be a regular file/,
+      );
+
+      assert.equal(await readFile(outsidePath, 'utf8'), 'outside prompt\n');
     });
   });
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -623,6 +623,46 @@ describe('prompt candidate loop', () => {
       assert.equal(await readFile(systemPromptPath, 'utf8'), 'manual prompt edit\n');
     });
   });
+
+  test('CLI git adapter rejects an untracked system prompt before candidate writes', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      await writeFile(systemPromptPath, 'untracked prompt draft\n', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /system_prompt.md must be tracked before candidate round/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'untracked prompt draft\n');
+    });
+  });
 });
 
 function gitNoop(gitRootPath = process.cwd()) {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -27,7 +27,7 @@ describe('prompt candidate loop', () => {
       const resultsJsonlPath = join(dir, 'results.jsonl');
       await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
       await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
-      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\nheld-out-secret\ttrue\n', 'utf8');
 
       let seenInput: MetaAgentPromptInput | undefined;
       await runPromptCandidateRound({

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { hashSystemPrompt } from '../fixed-prompt-controller.js';
+import {
+  runPromptCandidateRound,
+  type MetaAgentPromptInput,
+  type MetaAgentPromptResult,
+} from '../prompt-candidate-loop.js';
+
+describe('prompt candidate loop', () => {
+  test('passes only program, results TSV, and held-in digests to the meta-agent', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let seenInput: MetaAgentPromptInput | undefined;
+      await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath,
+        heldInDigests: [
+          {
+            taskId: 'task-a',
+            errorClass: 'verification_failed',
+            summary: 'last command missed the requested output',
+          },
+        ],
+        heldOutDigests: [
+          {
+            taskId: 'held-out-secret',
+            errorClass: 'verification_failed',
+            summary: 'do not leak this held-out trajectory',
+          },
+        ],
+        metaAgent: async (input): Promise<MetaAgentPromptResult> => {
+          seenInput = input;
+          return { systemPrompt: 'candidate prompt\n', summary: 'tightened output instruction' };
+        },
+        git: gitNoop(),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.ok(seenInput);
+      assert.equal(seenInput.program, 'Improve the prompt conservatively.\n');
+      assert.equal(seenInput.resultsTsv, 'task_id\tpassed\ntask-a\tfalse\n');
+      assert.equal(seenInput.currentSystemPrompt, 'original prompt\n');
+      assert.deepEqual(seenInput.heldInDigests.map((digest) => digest.taskId), ['task-a']);
+      assert.equal(JSON.stringify(seenInput).includes('held-out-secret'), false);
+      assert.equal(JSON.stringify(seenInput).includes('do not leak'), false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'candidate prompt\n');
+
+      const events = (await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').map((line) => JSON.parse(line));
+      assert.deepEqual(events, [
+        {
+          schemaVersion: 1,
+          type: 'prompt_candidate_committed',
+          id: 'id-1',
+          ts: 100,
+          runId: 'run-1',
+          roundId: 'round-1',
+          commitSha: 'commit-1',
+          summary: 'tightened output instruction',
+          promptHash: hashSystemPrompt('candidate prompt\n'),
+        },
+      ]);
+    });
+  });
+
+  test('fails closed when the prompt edit changes files outside system_prompt.md', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let committed = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          heldOutDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: {
+            changedFiles: async () => ['system_prompt.md', 'program.md'],
+            commit: async () => {
+              committed = true;
+              return 'commit-1';
+            },
+          },
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /only system_prompt.md may change/,
+      );
+
+      assert.equal(committed, false);
+    });
+  });
+});
+
+function gitNoop() {
+  return {
+    changedFiles: async () => ['system_prompt.md'],
+    commit: async () => 'commit-1',
+  };
+}
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
+}
+
+async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-prompt-candidate-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -5,7 +5,9 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { hashSystemPrompt } from '../fixed-prompt-controller.js';
 import {
+  createScriptedMetaAgent,
   extractTrajectoryDigest,
+  renderMetaAgentPrompt,
   runPromptCandidateRound,
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
@@ -144,6 +146,43 @@ describe('prompt candidate loop', () => {
         ],
       });
       assert.equal(JSON.stringify(digest).includes('long raw content'), false);
+    });
+  });
+
+  test('scripted meta-agent renders a fixed prompt and parses JSON output', async () => {
+    const input: MetaAgentPromptInput = {
+      runId: 'run-1',
+      roundId: 'round-1',
+      program: 'Improve conservatively.',
+      currentSystemPrompt: 'original prompt',
+      resultsTsv: 'task_id\tpassed\ntask-a\tfalse\n',
+      heldInDigests: [
+        {
+          taskId: 'task-a',
+          errorClass: 'verification_failed',
+          summary: 'missing expected line',
+          recentToolCalls: [{ name: 'Bash', argsPreview: 'command' }],
+        },
+      ],
+    };
+    const prompt = renderMetaAgentPrompt(input);
+    assert.match(prompt, /Improve conservatively/);
+    assert.match(prompt, /task-a/);
+    assert.match(prompt, /original prompt/);
+
+    const metaAgent = createScriptedMetaAgent({
+      complete: async ({ prompt: renderedPrompt }) => {
+        assert.equal(renderedPrompt, prompt);
+        return JSON.stringify({
+          systemPrompt: 'candidate prompt\n',
+          summary: 'ask for exact output line',
+        });
+      },
+    });
+
+    assert.deepEqual(await metaAgent(input), {
+      systemPrompt: 'candidate prompt\n',
+      summary: 'ask for exact output line',
     });
   });
 });

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -37,6 +37,7 @@ describe('prompt candidate loop', () => {
         systemPromptPath,
         resultsTsvPath,
         resultsJsonlPath,
+        heldInTaskIds: ['task-a'],
         heldInDigests: [
           {
             taskId: 'task-a',
@@ -86,6 +87,55 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('filters results TSV by held-in tasks independently from trajectory digests', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\npassed-task\ttrue\nfailed-task\tfalse\nheld-out-secret\ttrue\n', 'utf8');
+
+      let seenInput: MetaAgentPromptInput | undefined;
+      await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: ['passed-task', 'failed-task'],
+        heldInDigests: [
+          {
+            taskId: 'failed-task',
+            errorClass: 'verification_failed',
+            summary: 'missing expected line',
+          },
+        ],
+        heldOutDigests: [
+          {
+            taskId: 'held-out-secret',
+            errorClass: 'verification_failed',
+            summary: 'do not leak this held-out trajectory',
+          },
+        ],
+        metaAgent: async (input): Promise<MetaAgentPromptResult> => {
+          seenInput = input;
+          return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+        },
+        git: gitNoop(dir),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.ok(seenInput);
+      assert.equal(seenInput.resultsTsv, 'task_id\tpassed\npassed-task\ttrue\nfailed-task\tfalse\n');
+      assert.deepEqual(seenInput.heldInDigests.map((digest) => digest.taskId), ['failed-task']);
+      assert.equal(JSON.stringify(seenInput).includes('held-out-secret'), false);
+      assert.equal(JSON.stringify(seenInput).includes('do not leak'), false);
+    });
+  });
+
   test('rejects overlapping held-in and held-out task digests', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
@@ -104,6 +154,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
           heldInDigests: [{ taskId: 'task-a', summary: 'held-in summary' }],
           heldOutDigests: [{ taskId: 'task-a', summary: 'held-out summary' }],
           metaAgent: async () => {
@@ -139,6 +190,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           heldOutDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
@@ -185,6 +237,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: gitNoop(dir),
@@ -219,6 +272,7 @@ describe('prompt candidate loop', () => {
             systemPromptPath,
             resultsTsvPath,
             resultsJsonlPath: join(dir, 'results.jsonl'),
+            heldInTaskIds: [],
             heldInDigests: [],
             metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
             git: {
@@ -262,6 +316,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: {
@@ -310,6 +365,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath: programPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => {
             called = true;
@@ -346,6 +402,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: {
@@ -463,6 +520,7 @@ describe('prompt candidate loop', () => {
         systemPromptPath,
         resultsTsvPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: [],
         heldInDigests: [],
         metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
         git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
@@ -503,6 +561,7 @@ describe('prompt candidate loop', () => {
         systemPromptPath: join(dir, 'system_prompt.md'),
         resultsTsvPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: [],
         heldInDigests: [],
         metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
         git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath: 'system_prompt.md' }),
@@ -539,6 +598,7 @@ describe('prompt candidate loop', () => {
         systemPromptPath,
         resultsTsvPath,
         resultsJsonlPath: join(packageDir, 'results.jsonl'),
+        heldInTaskIds: [],
         heldInDigests: [],
         metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
         git: createCliPromptCandidateGit({ cwd: packageDir, systemPromptPath: 'system_prompt.md' }),
@@ -577,6 +637,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
@@ -617,6 +678,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => {
             called = true;
@@ -657,6 +719,7 @@ describe('prompt candidate loop', () => {
           systemPromptPath,
           resultsTsvPath,
           resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
           heldInDigests: [],
           metaAgent: async () => {
             called = true;

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -86,6 +86,41 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('rejects overlapping held-in and held-out task digests', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [{ taskId: 'task-a', summary: 'held-in summary' }],
+          heldOutDigests: [{ taskId: 'task-a', summary: 'held-out summary' }],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(dir),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /held-in and held-out task sets must be disjoint/,
+      );
+
+      assert.equal(called, false);
+    });
+  });
+
   test('fails closed when the prompt edit changes files outside system_prompt.md', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -136,6 +136,42 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('rejects trajectory digests outside the held-in task set before calling the meta-agent', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'held-out-secret', summary: 'do not leak this trajectory' }],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(dir),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /held-in digests must belong to held-in task set: held-out-secret/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
   test('rejects overlapping held-in and held-out task digests', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -410,6 +410,42 @@ describe('prompt candidate loop', () => {
       assert.equal(result.commitSha.length, 40);
     });
   });
+
+  test('CLI git adapter uses repo-root paths when cwd is a subdirectory', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const packageDir = join(dir, 'packages', 'headless');
+      await mkdir(packageDir, { recursive: true });
+      const programPath = join(packageDir, 'program.md');
+      const systemPromptPath = join(packageDir, 'system_prompt.md');
+      const resultsTsvPath = join(packageDir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      const result = await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(packageDir, 'results.jsonl'),
+        heldInDigests: [],
+        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        git: createCliPromptCandidateGit({ cwd: packageDir, systemPromptPath: 'system_prompt.md' }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'candidate prompt round-1');
+      assert.equal(result.commitSha.length, 40);
+    });
+  });
 });
 
 function gitNoop(gitRootPath = process.cwd()) {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -55,7 +55,7 @@ describe('prompt candidate loop', () => {
           seenInput = input;
           return { systemPrompt: 'candidate prompt\n', summary: 'tightened output instruction' };
         },
-        git: gitNoop(),
+        git: gitNoop(dir),
         now: () => 100,
         newId: idFactory(),
       });
@@ -108,6 +108,7 @@ describe('prompt candidate loop', () => {
           heldOutDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: {
+            gitRootPath: dir,
             systemPromptGitPath: 'system_prompt.md',
             changedFiles: async () => ['system_prompt.md', 'program.md'],
             commit: async () => {
@@ -147,7 +148,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath: join(dir, 'results.jsonl'),
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
-          git: gitNoop(),
+          git: gitNoop(dir),
           now: () => 100,
           newId: idFactory(),
         }),
@@ -155,6 +156,46 @@ describe('prompt candidate loop', () => {
       );
 
       assert.equal(await readFile(outsidePath, 'utf8'), 'outside prompt\n');
+    });
+  });
+
+  test('rejects a system prompt through a symlinked parent before writing outside the repo', async () => {
+    await withDir(async (dir) => {
+      await withDir(async (outsideDir) => {
+        const programPath = join(dir, 'program.md');
+        const promptLinkPath = join(dir, 'prompts');
+        const outsidePath = join(outsideDir, 'system_prompt.md');
+        const systemPromptPath = join(promptLinkPath, 'system_prompt.md');
+        const resultsTsvPath = join(dir, 'results.tsv');
+        await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+        await writeFile(outsidePath, 'outside prompt\n', 'utf8');
+        await symlink(outsideDir, promptLinkPath);
+        await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+        await assert.rejects(
+          runPromptCandidateRound({
+            runId: 'run-1',
+            roundId: 'round-1',
+            programPath,
+            systemPromptPath,
+            resultsTsvPath,
+            resultsJsonlPath: join(dir, 'results.jsonl'),
+            heldInDigests: [],
+            metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+            git: {
+              gitRootPath: dir,
+              systemPromptGitPath: 'prompts/system_prompt.md',
+              changedFiles: async () => ['prompts/system_prompt.md'],
+              commit: async () => 'commit-1',
+            },
+            now: () => 100,
+            newId: idFactory(),
+          }),
+          /system_prompt.md must stay inside the git cwd/,
+        );
+
+        assert.equal(await readFile(outsidePath, 'utf8'), 'outside prompt\n');
+      });
     });
   });
 
@@ -181,6 +222,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
           git: {
+            gitRootPath: dir,
             systemPromptGitPath: 'prompts/system_prompt.md',
             changedFiles: async () => ['system_prompt.md'],
             commit: async () => {
@@ -333,8 +375,9 @@ describe('prompt candidate loop', () => {
   });
 });
 
-function gitNoop() {
+function gitNoop(gitRootPath = process.cwd()) {
   return {
+    gitRootPath,
     systemPromptGitPath: 'system_prompt.md',
     changedFiles: async () => ['system_prompt.md'],
     commit: async () => 'commit-1',

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -297,6 +297,39 @@ describe('prompt candidate loop', () => {
       assert.equal(result.commitSha.length, 40);
     });
   });
+
+  test('CLI git adapter resolves a relative system prompt path from cwd', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(join(dir, 'system_prompt.md'), 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      const result = await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        programPath,
+        systemPromptPath: join(dir, 'system_prompt.md'),
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInDigests: [],
+        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath: 'system_prompt.md' }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'candidate prompt round-1');
+      assert.equal(result.commitSha.length, 40);
+    });
+  });
 });
 
 function gitNoop() {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { hashSystemPrompt } from '../fixed-prompt-controller.js';
 import {
+  extractTrajectoryDigest,
   runPromptCandidateRound,
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
@@ -115,6 +116,36 @@ describe('prompt candidate loop', () => {
       assert.equal(committed, false);
     });
   });
+
+  test('extracts a bounded digest from raw runtime events', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(runtimeEvent('call-1', 'Read', { path: '/app/first.txt' })),
+        JSON.stringify(runtimeEvent('call-2', 'Bash', { command: 'pytest -q' })),
+        JSON.stringify(runtimeEvent('call-3', 'Write', { path: '/app/out.txt', content: 'long raw content that should not appear' })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const digest = await extractTrajectoryDigest({
+        taskId: 'task-a',
+        errorClass: 'verification_failed',
+        runtimeEventsPath,
+        verifierSummary: 'expected output missing',
+      });
+
+      assert.deepEqual(digest, {
+        taskId: 'task-a',
+        errorClass: 'verification_failed',
+        summary: 'expected output missing',
+        recentToolCalls: [
+          { name: 'Bash', argsPreview: 'command' },
+          { name: 'Write', argsPreview: 'content,path' },
+        ],
+      });
+      assert.equal(JSON.stringify(digest).includes('long raw content'), false);
+    });
+  });
 });
 
 function gitNoop() {
@@ -127,6 +158,21 @@ function gitNoop() {
 function idFactory(): () => string {
   let i = 0;
   return () => `id-${++i}`;
+}
+
+function runtimeEvent(id: string, name: string, args: unknown) {
+  return {
+    id,
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'function_call', id, name, args },
+  };
 }
 
 async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -115,6 +115,9 @@ describe('prompt candidate loop', () => {
               committed = true;
               return 'commit-1';
             },
+            restoreSystemPrompt: async () => {
+              await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+            },
           },
           now: () => 100,
           newId: idFactory(),
@@ -187,6 +190,9 @@ describe('prompt candidate loop', () => {
               systemPromptGitPath: 'prompts/system_prompt.md',
               changedFiles: async () => ['prompts/system_prompt.md'],
               commit: async () => 'commit-1',
+              restoreSystemPrompt: async () => {
+                await writeFile(systemPromptPath, 'outside prompt\n', 'utf8');
+              },
             },
             now: () => 100,
             newId: idFactory(),
@@ -229,6 +235,9 @@ describe('prompt candidate loop', () => {
               committed = true;
               return 'commit-1';
             },
+            restoreSystemPrompt: async () => {
+              await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+            },
           },
           now: () => 100,
           newId: idFactory(),
@@ -249,6 +258,7 @@ describe('prompt candidate loop', () => {
       await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
       await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
 
+      let restored = false;
       await assert.rejects(
         runPromptCandidateRound({
           runId: 'run-1',
@@ -266,6 +276,10 @@ describe('prompt candidate loop', () => {
             commit: async () => {
               throw new Error('commit rejected');
             },
+            restoreSystemPrompt: async () => {
+              restored = true;
+              await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+            },
           },
           now: () => 100,
           newId: idFactory(),
@@ -273,6 +287,7 @@ describe('prompt candidate loop', () => {
         /commit rejected/,
       );
 
+      assert.equal(restored, true);
       assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
@@ -446,6 +461,47 @@ describe('prompt candidate loop', () => {
       assert.equal(result.commitSha.length, 40);
     });
   });
+
+  test('CLI git adapter restores worktree and index when commit fails', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      const hookPath = join(dir, '.git', 'hooks', 'pre-commit');
+      await writeFile(hookPath, '#!/bin/sh\nexit 1\n', 'utf8');
+      await chmod(hookPath, 0o755);
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+      );
+
+      const cached = await execFileAsync('git', ['diff', '--cached', '--', 'system_prompt.md'], { cwd: dir });
+      const worktree = await execFileAsync('git', ['diff', '--', 'system_prompt.md'], { cwd: dir });
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+      assert.equal(cached.stdout, '');
+      assert.equal(worktree.stdout, '');
+    });
+  });
 });
 
 function gitNoop(gitRootPath = process.cwd()) {
@@ -454,6 +510,7 @@ function gitNoop(gitRootPath = process.cwd()) {
     systemPromptGitPath: 'system_prompt.md',
     changedFiles: async () => ['system_prompt.md'],
     commit: async () => 'commit-1',
+    restoreSystemPrompt: async () => {},
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -287,6 +287,47 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('rejects mismatched input and git system prompt paths before writing', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath: programPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /system prompt path must match git prompt path/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(programPath, 'utf8'), 'Improve the prompt conservatively.\n');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
   test('restores the original prompt when committing the candidate fails', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -122,6 +122,7 @@ describe('prompt candidate loop', () => {
       );
 
       assert.equal(committed, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -452,6 +452,9 @@ describe('prompt candidate loop', () => {
       await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
       await execFileAsync('git', ['add', '.'], { cwd: dir });
       await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      await writeFile(join(dir, 'notes.md'), 'staged unrelated note\n', 'utf8');
+      await execFileAsync('git', ['add', 'notes.md'], { cwd: dir });
+      await writeFile(join(dir, 'scratch.tmp'), 'untracked unrelated output\n', 'utf8');
 
       const result = await runPromptCandidateRound({
         runId: 'run-1',
@@ -468,7 +471,14 @@ describe('prompt candidate loop', () => {
       });
 
       const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      const committedFiles = await execFileAsync('git', ['show', '--name-only', '--format=', 'HEAD'], { cwd: dir });
+      const stagedFiles = await execFileAsync('git', ['diff', '--cached', '--name-only'], { cwd: dir });
+      const status = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: dir });
       assert.equal(subject.stdout.trim(), 'candidate prompt round-1');
+      assert.deepEqual(committedFiles.stdout.trim().split('\n').filter(Boolean), ['system_prompt.md']);
+      assert.deepEqual(stagedFiles.stdout.trim().split('\n').filter(Boolean), ['notes.md']);
+      assert.match(status.stdout, /^A  notes\.md$/m);
+      assert.match(status.stdout, /^\?\? scratch\.tmp$/m);
       assert.equal(result.commitSha.length, 40);
     });
   });

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -145,6 +145,7 @@ describe('prompt candidate loop', () => {
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'system_prompt.md',
+            assertSystemPromptClean: async () => {},
             changedFiles: async () => ['system_prompt.md', 'program.md'],
             commit: async () => {
               committed = true;
@@ -223,6 +224,7 @@ describe('prompt candidate loop', () => {
             git: {
               gitRootPath: dir,
               systemPromptGitPath: 'prompts/system_prompt.md',
+              assertSystemPromptClean: async () => {},
               changedFiles: async () => ['prompts/system_prompt.md'],
               commit: async () => 'commit-1',
               restoreSystemPrompt: async () => {
@@ -265,6 +267,7 @@ describe('prompt candidate loop', () => {
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'prompts/system_prompt.md',
+            assertSystemPromptClean: async () => {},
             changedFiles: async () => ['system_prompt.md'],
             commit: async () => {
               committed = true;
@@ -307,6 +310,7 @@ describe('prompt candidate loop', () => {
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'system_prompt.md',
+            assertSystemPromptClean: async () => {},
             changedFiles: async () => ['system_prompt.md'],
             commit: async () => {
               throw new Error('commit rejected');
@@ -537,12 +541,54 @@ describe('prompt candidate loop', () => {
       assert.equal(worktree.stdout, '');
     });
   });
+
+  test('CLI git adapter rejects a dirty system prompt before candidate writes', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      await writeFile(systemPromptPath, 'manual prompt edit\n', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /system_prompt.md must be clean before candidate round/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'manual prompt edit\n');
+    });
+  });
 });
 
 function gitNoop(gitRootPath = process.cwd()) {
   return {
     gitRootPath,
     systemPromptGitPath: 'system_prompt.md',
+    assertSystemPromptClean: async () => {},
     changedFiles: async () => ['system_prompt.md'],
     commit: async () => 'commit-1',
     restoreSystemPrompt: async () => {},

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -240,6 +240,43 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('restores the original prompt when committing the candidate fails', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: {
+            gitRootPath: dir,
+            systemPromptGitPath: 'system_prompt.md',
+            changedFiles: async () => ['system_prompt.md'],
+            commit: async () => {
+              throw new Error('commit rejected');
+            },
+          },
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /commit rejected/,
+      );
+
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
   test('extracts a bounded digest from raw runtime events', async () => {
     await withDir(async (dir) => {
       const runtimeEventsPath = join(dir, 'runtime-events.jsonl');

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -239,6 +239,7 @@ describe('prompt candidate loop', () => {
               committed = true;
               return 'commit-1';
             },
+            rollbackCommit: async () => {},
             restoreSystemPrompt: async () => {
               await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
             },
@@ -317,6 +318,7 @@ describe('prompt candidate loop', () => {
               assertSystemPromptClean: async () => {},
               changedFiles: async () => ['prompts/system_prompt.md'],
               commit: async () => 'commit-1',
+              rollbackCommit: async () => {},
               restoreSystemPrompt: async () => {
                 await writeFile(systemPromptPath, 'outside prompt\n', 'utf8');
               },
@@ -364,6 +366,7 @@ describe('prompt candidate loop', () => {
               committed = true;
               return 'commit-1';
             },
+            rollbackCommit: async () => {},
             restoreSystemPrompt: async () => {
               await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
             },
@@ -449,6 +452,7 @@ describe('prompt candidate loop', () => {
             commit: async () => {
               throw new Error('commit rejected');
             },
+            rollbackCommit: async () => {},
             restoreSystemPrompt: async () => {
               restored = true;
               await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
@@ -574,6 +578,49 @@ describe('prompt candidate loop', () => {
       assert.match(status.stdout, /^A  notes\.md$/m);
       assert.match(status.stdout, /^\?\? scratch\.tmp$/m);
       assert.equal(result.commitSha.length, 40);
+    });
+  });
+
+  test('CLI git adapter rolls back the prompt commit when WAL append fails', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await mkdir(resultsJsonlPath);
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath,
+          heldInTaskIds: [],
+          heldInDigests: [],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+      );
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      const cached = await execFileAsync('git', ['diff', '--cached', '--', 'system_prompt.md'], { cwd: dir });
+      const worktree = await execFileAsync('git', ['diff', '--', 'system_prompt.md'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'initial');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+      assert.equal(cached.stdout, '');
+      assert.equal(worktree.stdout, '');
     });
   });
 
@@ -781,6 +828,7 @@ function gitNoop(gitRootPath = process.cwd()) {
     assertSystemPromptClean: async () => {},
     changedFiles: async () => ['system_prompt.md'],
     commit: async () => 'commit-1',
+    rollbackCommit: async () => {},
     restoreSystemPrompt: async () => {},
   };
 }

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
 import { hashSystemPrompt } from '../fixed-prompt-controller.js';
 import {
+  createCliPromptCandidateGit,
   createScriptedMetaAgent,
   extractTrajectoryDigest,
   renderMetaAgentPrompt,
@@ -12,6 +15,8 @@ import {
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
 } from '../prompt-candidate-loop.js';
+
+const execFileAsync = promisify(execFile);
 
 describe('prompt candidate loop', () => {
   test('passes only program, results TSV, and held-in digests to the meta-agent', async () => {
@@ -183,6 +188,40 @@ describe('prompt candidate loop', () => {
     assert.deepEqual(await metaAgent(input), {
       systemPrompt: 'candidate prompt\n',
       summary: 'ask for exact output line',
+    });
+  });
+
+  test('CLI git adapter commits only system_prompt.md with the round message', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      const result = await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInDigests: [],
+        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'candidate prompt round-1');
+      assert.equal(result.commitSha.length, 40);
     });
   });
 });

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -97,7 +97,25 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   };
 }
 
+export interface PromptCandidateCommittedEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'prompt_candidate_committed';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  commitSha: string;
+  summary: string;
+  promptHash: string;
+}
+
 export type FixedPromptWalEvent =
+  | FixedPromptTaskCompletedEvent
+  | FixedPromptTaskInfraFailedEvent
+  | FixedPromptTaskPlumbingFailedEvent
+  | PromptCandidateCommittedEvent;
+
+export type FixedPromptTaskWalEvent =
   | FixedPromptTaskCompletedEvent
   | FixedPromptTaskInfraFailedEvent
   | FixedPromptTaskPlumbingFailedEvent;
@@ -117,7 +135,7 @@ export interface RunFixedPromptControllerInput {
 
 export interface FixedPromptControllerResult {
   taskIds: string[];
-  events: FixedPromptWalEvent[];
+  events: FixedPromptTaskWalEvent[];
   totalTokens: number;
   totalCostUsd: number;
   resultsTsvPath: string;
@@ -153,7 +171,7 @@ export async function runFixedPromptController(
 
   const resultEvents = input.tasks
     .map((task) => completed.get(task.id))
-    .filter((event): event is FixedPromptWalEvent => event !== undefined);
+    .filter((event): event is FixedPromptTaskWalEvent => event !== undefined);
   await writeFixedPromptResultsTsv(input.resultsTsvPath, resultEvents);
 
   return {
@@ -207,7 +225,7 @@ export async function appendFixedPromptWalEvent(path: string, event: FixedPrompt
 
 export async function writeFixedPromptResultsTsv(
   path: string,
-  events: readonly FixedPromptWalEvent[],
+  events: readonly FixedPromptTaskWalEvent[],
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const header = [
@@ -246,7 +264,7 @@ async function runTaskAndBuildEvent(input: {
   expectedPromptHash: string;
   id: string;
   ts: number;
-}): Promise<FixedPromptWalEvent> {
+}): Promise<FixedPromptTaskWalEvent> {
   try {
     const output = await input.input.harborRunner({
       runId: input.input.runId,
@@ -423,9 +441,10 @@ function terminalTaskEvents(
   runId: string,
   roundId: string,
   expectedPromptHash: string,
-): Map<string, FixedPromptWalEvent> {
-  const byTask = new Map<string, FixedPromptWalEvent>();
+): Map<string, FixedPromptTaskWalEvent> {
+  const byTask = new Map<string, FixedPromptTaskWalEvent>();
   for (const event of events) {
+    if (!isTaskEvent(event)) continue;
     if (event.runId !== runId || event.roundId !== roundId) continue;
     if (!eventMatchesPrompt(event, expectedPromptHash)) continue;
     if (
@@ -442,6 +461,13 @@ function eventMatchesPrompt(event: FixedPromptWalEvent, expectedPromptHash: stri
   if (event.type === 'task_infra_failed') return true;
   if (event.promptHash === expectedPromptHash) return true;
   return event.type === 'task_plumbing_failed' && event.expectedPromptHash === expectedPromptHash;
+}
+
+function isTaskEvent(event: FixedPromptWalEvent): event is
+  FixedPromptTaskWalEvent {
+  return event.type === 'task_completed'
+    || event.type === 'task_infra_failed'
+    || event.type === 'task_plumbing_failed';
 }
 
 function tsvCell(value: string): string {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -31,10 +31,12 @@ export type {
   FixedPromptTaskCompletedEvent,
   FixedPromptTaskInfraFailedEvent,
   FixedPromptTaskPlumbingFailedEvent,
+  FixedPromptTaskWalEvent,
   FixedPromptWalEvent,
   HarborTaskRunInput,
   HarborTaskRunOutput,
   HarborTaskRunner,
+  PromptCandidateCommittedEvent,
   ReadHarborTaskRunOutputInput,
   RunFixedPromptControllerInput,
 } from './fixed-prompt-controller.js';
@@ -47,6 +49,19 @@ export {
   runFixedPromptController,
   writeFixedPromptResultsTsv,
 } from './fixed-prompt-controller.js';
+export type {
+  MetaAgent,
+  MetaAgentPromptInput,
+  MetaAgentPromptResult,
+  PromptCandidateGit,
+  PromptCandidateRoundResult,
+  RunPromptCandidateRoundInput,
+  TrajectoryDigest,
+} from './prompt-candidate-loop.js';
+export {
+  assertOnlySystemPromptChanged,
+  runPromptCandidateRound,
+} from './prompt-candidate-loop.js';
 export type {
   BenchmarkAdapter,
   BenchmarkAdapterRegistry,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -54,6 +54,9 @@ export type {
   MetaAgentPromptInput,
   MetaAgentPromptResult,
   ExtractTrajectoryDigestInput,
+  CreateScriptedMetaAgentInput,
+  MetaAgentCompletion,
+  MetaAgentCompletionInput,
   PromptCandidateGit,
   PromptCandidateRoundResult,
   RunPromptCandidateRoundInput,
@@ -62,7 +65,10 @@ export type {
 } from './prompt-candidate-loop.js';
 export {
   assertOnlySystemPromptChanged,
+  createScriptedMetaAgent,
   extractTrajectoryDigest,
+  parseMetaAgentResult,
+  renderMetaAgentPrompt,
   runPromptCandidateRound,
 } from './prompt-candidate-loop.js';
 export type {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -55,6 +55,7 @@ export type {
   MetaAgentPromptResult,
   ExtractTrajectoryDigestInput,
   CreateScriptedMetaAgentInput,
+  CreateCliPromptCandidateGitInput,
   MetaAgentCompletion,
   MetaAgentCompletionInput,
   PromptCandidateGit,
@@ -65,6 +66,7 @@ export type {
 } from './prompt-candidate-loop.js';
 export {
   assertOnlySystemPromptChanged,
+  createCliPromptCandidateGit,
   createScriptedMetaAgent,
   extractTrajectoryDigest,
   parseMetaAgentResult,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -53,13 +53,16 @@ export type {
   MetaAgent,
   MetaAgentPromptInput,
   MetaAgentPromptResult,
+  ExtractTrajectoryDigestInput,
   PromptCandidateGit,
   PromptCandidateRoundResult,
   RunPromptCandidateRoundInput,
   TrajectoryDigest,
+  TrajectoryToolCallDigest,
 } from './prompt-candidate-loop.js';
 export {
   assertOnlySystemPromptChanged,
+  extractTrajectoryDigest,
   runPromptCandidateRound,
 } from './prompt-candidate-loop.js';
 export type {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
-import { readFile, writeFile } from 'node:fs/promises';
+import { lstat, readFile, writeFile } from 'node:fs/promises';
 import { basename, relative } from 'node:path';
 import { promisify } from 'node:util';
 import {
@@ -92,6 +92,7 @@ export async function runPromptCandidateRound(
 ): Promise<PromptCandidateRoundResult> {
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
+  await assertRegularSystemPromptFile(input.systemPromptPath);
   const program = await readFile(input.programPath, 'utf8');
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const resultsTsv = filterResultsTsvForHeldIn(
@@ -240,6 +241,13 @@ export function assertOnlySystemPromptChanged(
   const unexpected = changedFiles.filter((file) => !allowed.has(normalizeChangedPath(file)));
   if (unexpected.length > 0) {
     throw new Error(`only system_prompt.md may change; unexpected files: ${unexpected.join(', ')}`);
+  }
+}
+
+async function assertRegularSystemPromptFile(systemPromptPath: string): Promise<void> {
+  const stat = await lstat(systemPromptPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error('system_prompt.md must be a regular file');
   }
 }
 

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -302,6 +302,9 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
     gitRootPath,
     systemPromptGitPath,
     async assertSystemPromptClean(): Promise<void> {
+      if (!(await isGitTracked(gitRootPath, systemPromptGitPath))) {
+        throw new Error('system_prompt.md must be tracked before candidate round');
+      }
       const [worktreeDirty, indexDirty] = await Promise.all([
         hasGitDiff(gitRootPath, ['diff', '--quiet', '--', systemPromptGitPath]),
         hasGitDiff(gitRootPath, ['diff', '--cached', '--quiet', '--', systemPromptGitPath]),
@@ -327,6 +330,15 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });
     },
   };
+}
+
+async function isGitTracked(cwd: string, path: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['ls-files', '--error-unmatch', '--', path], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function hasGitDiff(cwd: string, args: readonly string[]): Promise<boolean> {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { lstat, readFile, writeFile } from 'node:fs/promises';
-import { basename, relative } from 'node:path';
+import { relative } from 'node:path';
 import { promisify } from 'node:util';
 import {
   appendFixedPromptWalEvent,
@@ -57,6 +57,7 @@ export interface CreateScriptedMetaAgentInput {
 }
 
 export interface PromptCandidateGit {
+  systemPromptGitPath: string;
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
 }
@@ -109,7 +110,7 @@ export async function runPromptCandidateRound(
   });
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
-  assertOnlySystemPromptChanged(await input.git.changedFiles(), input.systemPromptPath);
+  assertOnlySystemPromptChanged(await input.git.changedFiles(), input.git.systemPromptGitPath);
   const commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
   await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
     runId: input.runId,
@@ -231,16 +232,12 @@ function promptCandidateCommittedEvent(input: {
 
 export function assertOnlySystemPromptChanged(
   changedFiles: readonly string[],
-  systemPromptPath: string,
+  systemPromptGitPath: string,
 ): void {
-  const allowed = new Set([
-    normalizeChangedPath(systemPromptPath),
-    basename(systemPromptPath),
-    'system_prompt.md',
-  ]);
-  const unexpected = changedFiles.filter((file) => !allowed.has(normalizeChangedPath(file)));
+  const allowed = normalizeGitPath(systemPromptGitPath);
+  const unexpected = changedFiles.filter((file) => normalizeGitPath(file) !== allowed);
   if (unexpected.length > 0) {
-    throw new Error(`only system_prompt.md may change; unexpected files: ${unexpected.join(', ')}`);
+    throw new Error(`only ${allowed} may change; unexpected files: ${unexpected.join(', ')}`);
   }
 }
 
@@ -254,6 +251,7 @@ async function assertRegularSystemPromptFile(systemPromptPath: string): Promise<
 export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitInput): PromptCandidateGit {
   const systemPromptGitPath = relative(input.cwd, input.systemPromptPath).split('\\').join('/');
   return {
+    systemPromptGitPath,
     async changedFiles(): Promise<readonly string[]> {
       const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: input.cwd });
       return stdout
@@ -270,14 +268,9 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
   };
 }
 
-function normalizeChangedPath(path: string): string {
-  const cwdRelative = relative(process.cwd(), path);
-  const normalized = (cwdRelative && !cwdRelative.startsWith('..') ? cwdRelative : path).split('\\').join('/');
-  return stripLeadingDotSlash(normalized);
-}
-
-function stripLeadingDotSlash(path: string): string {
+function normalizeGitPath(path: string): string {
   let current = path;
+  current = current.split('\\').join('/');
   while (current.startsWith('./')) current = current.slice(2);
   return current;
 }

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -94,7 +94,10 @@ export async function runPromptCandidateRound(
   const newId = input.newId ?? randomId;
   const program = await readFile(input.programPath, 'utf8');
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
-  const resultsTsv = await readFile(input.resultsTsvPath, 'utf8');
+  const resultsTsv = filterResultsTsvForHeldIn(
+    await readFile(input.resultsTsvPath, 'utf8'),
+    input.heldInDigests,
+  );
   const result = await input.metaAgent({
     runId: input.runId,
     roundId: input.roundId,
@@ -161,6 +164,32 @@ export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
     JSON.stringify(input.heldInDigests, null, 2),
     '',
   ].join('\n');
+}
+
+export function filterResultsTsvForHeldIn(
+  resultsTsv: string,
+  heldInDigests: readonly TrajectoryDigest[],
+): string {
+  const hasTrailingNewline = resultsTsv.endsWith('\n');
+  const lines = resultsTsv.split(/\r?\n/);
+  if (lines.at(-1) === '') lines.pop();
+  if (lines.length === 0) return '';
+
+  const header = lines[0];
+  const taskIdIndex = header.split('\t').indexOf('task_id');
+  if (taskIdIndex === -1) {
+    throw new Error('results TSV must include a task_id column');
+  }
+
+  const heldInTaskIds = new Set(heldInDigests.map((digest) => digest.taskId));
+  const filtered = [
+    header,
+    ...lines.slice(1).filter((line) => {
+      const columns = line.split('\t');
+      return heldInTaskIds.has(columns[taskIdIndex] ?? '');
+    }),
+  ];
+  return `${filtered.join('\n')}${hasTrailingNewline ? '\n' : ''}`;
 }
 
 export function parseMetaAgentResult(raw: string): MetaAgentPromptResult {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename, relative } from 'node:path';
+import {
+  appendFixedPromptWalEvent,
+  hashSystemPrompt,
+  type PromptCandidateCommittedEvent,
+} from './fixed-prompt-controller.js';
+
+export interface TrajectoryDigest {
+  taskId: string;
+  errorClass?: string;
+  summary: string;
+}
+
+export interface MetaAgentPromptInput {
+  runId: string;
+  roundId: string;
+  program: string;
+  currentSystemPrompt: string;
+  resultsTsv: string;
+  heldInDigests: readonly TrajectoryDigest[];
+}
+
+export interface MetaAgentPromptResult {
+  systemPrompt: string;
+  summary: string;
+}
+
+export type MetaAgent = (input: MetaAgentPromptInput) => Promise<MetaAgentPromptResult>;
+
+export interface PromptCandidateGit {
+  changedFiles(): Promise<readonly string[]>;
+  commit(message: string): Promise<string>;
+}
+
+export interface RunPromptCandidateRoundInput {
+  runId: string;
+  roundId: string;
+  programPath: string;
+  systemPromptPath: string;
+  resultsTsvPath: string;
+  resultsJsonlPath: string;
+  heldInDigests: readonly TrajectoryDigest[];
+  heldOutDigests?: readonly TrajectoryDigest[];
+  metaAgent: MetaAgent;
+  git: PromptCandidateGit;
+  now?: () => number;
+  newId?: () => string;
+}
+
+export interface PromptCandidateRoundResult {
+  systemPrompt: string;
+  summary: string;
+  commitSha: string;
+}
+
+export async function runPromptCandidateRound(
+  input: RunPromptCandidateRoundInput,
+): Promise<PromptCandidateRoundResult> {
+  const now = input.now ?? Date.now;
+  const newId = input.newId ?? randomId;
+  const program = await readFile(input.programPath, 'utf8');
+  const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
+  const resultsTsv = await readFile(input.resultsTsvPath, 'utf8');
+  const result = await input.metaAgent({
+    runId: input.runId,
+    roundId: input.roundId,
+    program,
+    currentSystemPrompt,
+    resultsTsv,
+    heldInDigests: input.heldInDigests,
+  });
+
+  await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
+  assertOnlySystemPromptChanged(await input.git.changedFiles(), input.systemPromptPath);
+  const commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
+  await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
+    runId: input.runId,
+    roundId: input.roundId,
+    id: newId(),
+    ts: now(),
+    commitSha,
+    summary: result.summary,
+    systemPrompt: result.systemPrompt,
+  }));
+  return {
+    systemPrompt: result.systemPrompt,
+    summary: result.summary,
+    commitSha,
+  };
+}
+
+function promptCandidateCommittedEvent(input: {
+  runId: string;
+  roundId: string;
+  id: string;
+  ts: number;
+  commitSha: string;
+  summary: string;
+  systemPrompt: string;
+}): PromptCandidateCommittedEvent {
+  return {
+    schemaVersion: 1,
+    type: 'prompt_candidate_committed',
+    id: input.id,
+    ts: input.ts,
+    runId: input.runId,
+    roundId: input.roundId,
+    commitSha: input.commitSha,
+    summary: input.summary,
+    promptHash: hashSystemPrompt(input.systemPrompt),
+  };
+}
+
+export function assertOnlySystemPromptChanged(
+  changedFiles: readonly string[],
+  systemPromptPath: string,
+): void {
+  const allowed = new Set([
+    normalizeChangedPath(systemPromptPath),
+    basename(systemPromptPath),
+    'system_prompt.md',
+  ]);
+  const unexpected = changedFiles.filter((file) => !allowed.has(normalizeChangedPath(file)));
+  if (unexpected.length > 0) {
+    throw new Error(`only system_prompt.md may change; unexpected files: ${unexpected.join(', ')}`);
+  }
+}
+
+function normalizeChangedPath(path: string): string {
+  const cwdRelative = relative(process.cwd(), path);
+  const normalized = (cwdRelative && !cwdRelative.startsWith('..') ? cwdRelative : path).split('\\').join('/');
+  return stripLeadingDotSlash(normalized);
+}
+
+function stripLeadingDotSlash(path: string): string {
+  let current = path;
+  while (current.startsWith('./')) current = current.slice(2);
+  return current;
+}
+
+function randomId(): string {
+  return randomUUID();
+}

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -42,6 +42,16 @@ export interface MetaAgentPromptResult {
 
 export type MetaAgent = (input: MetaAgentPromptInput) => Promise<MetaAgentPromptResult>;
 
+export interface MetaAgentCompletionInput {
+  prompt: string;
+}
+
+export type MetaAgentCompletion = (input: MetaAgentCompletionInput) => Promise<string>;
+
+export interface CreateScriptedMetaAgentInput {
+  complete: MetaAgentCompletion;
+}
+
 export interface PromptCandidateGit {
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
@@ -118,6 +128,44 @@ export async function extractTrajectoryDigest(
     summary: input.verifierSummary,
     ...(recentToolCalls.length > 0 ? { recentToolCalls } : {}),
   };
+}
+
+export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): MetaAgent {
+  return async (promptInput) => {
+    const raw = await input.complete({ prompt: renderMetaAgentPrompt(promptInput) });
+    return parseMetaAgentResult(raw);
+  };
+}
+
+export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
+  return [
+    'You are improving one system prompt for benchmark tasks.',
+    'Return JSON only: {"systemPrompt":"...","summary":"..."}.',
+    '',
+    '# Program',
+    input.program,
+    '# Current System Prompt',
+    input.currentSystemPrompt,
+    '# Results TSV',
+    input.resultsTsv,
+    '# Held-In Digests',
+    JSON.stringify(input.heldInDigests, null, 2),
+    '',
+  ].join('\n');
+}
+
+export function parseMetaAgentResult(raw: string): MetaAgentPromptResult {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isRecord(parsed)) throw new Error('meta-agent output must be a JSON object');
+  const systemPrompt = parsed.systemPrompt;
+  const summary = parsed.summary;
+  if (typeof systemPrompt !== 'string' || systemPrompt.length === 0) {
+    throw new Error('meta-agent output systemPrompt must be a non-empty string');
+  }
+  if (typeof summary !== 'string' || summary.length === 0) {
+    throw new Error('meta-agent output summary must be a non-empty string');
+  }
+  return { systemPrompt, summary };
 }
 
 function promptCandidateCommittedEvent(input: {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { execFile } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
 import { lstat, readFile, realpath, writeFile } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
@@ -263,24 +264,32 @@ async function assertRegularSystemPromptFile(systemPromptPath: string, gitRootPa
 }
 
 export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitInput): PromptCandidateGit {
-  const systemPromptGitPath = toGitRelativePath(input.cwd, input.systemPromptPath);
+  const gitRootPath = realpathSync(findGitRoot(input.cwd));
+  const systemPromptPath = isAbsolute(input.systemPromptPath)
+    ? realpathSync(input.systemPromptPath)
+    : realpathSync(resolve(input.cwd, input.systemPromptPath));
+  const systemPromptGitPath = toGitRelativePath(gitRootPath, systemPromptPath);
   return {
-    gitRootPath: input.cwd,
+    gitRootPath,
     systemPromptGitPath,
     async changedFiles(): Promise<readonly string[]> {
-      const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: input.cwd });
+      const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: gitRootPath });
       return stdout
         .split('\n')
         .map((line) => line.slice(3).trim())
         .filter((line) => line.length > 0);
     },
     async commit(message: string): Promise<string> {
-      await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: input.cwd });
-      await execFileAsync('git', ['commit', '-m', message], { cwd: input.cwd });
-      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: input.cwd });
+      await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
+      await execFileAsync('git', ['commit', '-m', message], { cwd: gitRootPath });
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
       return stdout.trim();
     },
   };
+}
+
+function findGitRoot(cwd: string): string {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd, encoding: 'utf8' }).trim();
 }
 
 function isPathInside(rootPath: string, targetPath: string): boolean {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -64,6 +64,7 @@ export interface PromptCandidateGit {
   assertSystemPromptClean(): Promise<void>;
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
+  rollbackCommit(commitSha: string): Promise<void>;
   restoreSystemPrompt(): Promise<void>;
 }
 
@@ -128,15 +129,20 @@ export async function runPromptCandidateRound(
     await input.git.restoreSystemPrompt();
     throw error;
   }
-  await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
-    runId: input.runId,
-    roundId: input.roundId,
-    id: newId(),
-    ts: now(),
-    commitSha,
-    summary: result.summary,
-    systemPrompt: result.systemPrompt,
-  }));
+  try {
+    await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
+      runId: input.runId,
+      roundId: input.roundId,
+      id: newId(),
+      ts: now(),
+      commitSha,
+      summary: result.summary,
+      systemPrompt: result.systemPrompt,
+    }));
+  } catch (error) {
+    await input.git.rollbackCommit(commitSha);
+    throw error;
+  }
   return {
     systemPrompt: result.systemPrompt,
     summary: result.summary,
@@ -345,6 +351,14 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       await execFileAsync('git', ['commit', '-m', message, '--', systemPromptGitPath], { cwd: gitRootPath });
       const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
       return stdout.trim();
+    },
+    async rollbackCommit(commitSha: string): Promise<void> {
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
+      if (stdout.trim() !== commitSha) {
+        throw new Error('candidate prompt commit cannot be rolled back because HEAD moved');
+      }
+      await execFileAsync('git', ['reset', '--soft', `${commitSha}^`], { cwd: gitRootPath });
+      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });
     },
     async restoreSystemPrompt(): Promise<void> {
       await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -314,7 +314,13 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       }
     },
     async changedFiles(): Promise<readonly string[]> {
-      const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: gitRootPath });
+      const { stdout } = await execFileAsync('git', [
+        'status',
+        '--porcelain',
+        '--untracked-files=all',
+        '--',
+        systemPromptGitPath,
+      ], { cwd: gitRootPath });
       return stdout
         .split('\n')
         .map((line) => line.slice(3).trim())
@@ -322,7 +328,7 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
     },
     async commit(message: string): Promise<string> {
       await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
-      await execFileAsync('git', ['commit', '-m', message], { cwd: gitRootPath });
+      await execFileAsync('git', ['commit', '-m', message, '--', systemPromptGitPath], { cwd: gitRootPath });
       const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
       return stdout.trim();
     },

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -6,6 +6,7 @@ import { isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
   appendFixedPromptWalEvent,
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
   hashSystemPrompt,
   type PromptCandidateCommittedEvent,
 } from './fixed-prompt-controller.js';
@@ -256,7 +257,7 @@ function promptCandidateCommittedEvent(input: {
   systemPrompt: string;
 }): PromptCandidateCommittedEvent {
   return {
-    schemaVersion: 1,
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
     type: 'prompt_candidate_committed',
     id: input.id,
     ts: input.ts,

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -111,13 +111,14 @@ export async function runPromptCandidateRound(
   });
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
+  let commitSha: string;
   try {
     assertOnlySystemPromptChanged(await input.git.changedFiles(), input.git.systemPromptGitPath);
+    commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
   } catch (error) {
     await writeFile(input.systemPromptPath, currentSystemPrompt, 'utf8');
     throw error;
   }
-  const commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
   await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
     runId: input.runId,
     roundId: input.roundId,

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -110,7 +110,12 @@ export async function runPromptCandidateRound(
   });
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
-  assertOnlySystemPromptChanged(await input.git.changedFiles(), input.git.systemPromptGitPath);
+  try {
+    assertOnlySystemPromptChanged(await input.git.changedFiles(), input.git.systemPromptGitPath);
+  } catch (error) {
+    await writeFile(input.systemPromptPath, currentSystemPrompt, 'utf8');
+    throw error;
+  }
   const commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
   await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
     runId: input.runId,

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -98,6 +98,7 @@ export async function runPromptCandidateRound(
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
   assertHeldInAndHeldOutDisjoint(input.heldInDigests, input.heldOutDigests ?? []);
+  await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   await input.git.assertSystemPromptClean();
   const program = await readFile(input.programPath, 'utf8');
@@ -138,6 +139,19 @@ export async function runPromptCandidateRound(
     summary: result.summary,
     commitSha,
   };
+}
+
+async function assertSystemPromptPathMatchesGit(
+  systemPromptPath: string,
+  git: PromptCandidateGit,
+): Promise<void> {
+  const [inputRealPath, gitRealPath] = await Promise.all([
+    realpath(systemPromptPath),
+    realpath(resolve(git.gitRootPath, git.systemPromptGitPath)),
+  ]);
+  if (inputRealPath !== gitRealPath) {
+    throw new Error('system prompt path must match git prompt path');
+  }
 }
 
 function assertHeldInAndHeldOutDisjoint(

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -60,6 +60,7 @@ export interface CreateScriptedMetaAgentInput {
 export interface PromptCandidateGit {
   gitRootPath: string;
   systemPromptGitPath: string;
+  assertSystemPromptClean(): Promise<void>;
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
   restoreSystemPrompt(): Promise<void>;
@@ -98,6 +99,7 @@ export async function runPromptCandidateRound(
   const newId = input.newId ?? randomId;
   assertHeldInAndHeldOutDisjoint(input.heldInDigests, input.heldOutDigests ?? []);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
+  await input.git.assertSystemPromptClean();
   const program = await readFile(input.programPath, 'utf8');
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const resultsTsv = filterResultsTsvForHeldIn(
@@ -285,6 +287,15 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
   return {
     gitRootPath,
     systemPromptGitPath,
+    async assertSystemPromptClean(): Promise<void> {
+      const [worktreeDirty, indexDirty] = await Promise.all([
+        hasGitDiff(gitRootPath, ['diff', '--quiet', '--', systemPromptGitPath]),
+        hasGitDiff(gitRootPath, ['diff', '--cached', '--quiet', '--', systemPromptGitPath]),
+      ]);
+      if (worktreeDirty || indexDirty) {
+        throw new Error('system_prompt.md must be clean before candidate round');
+      }
+    },
     async changedFiles(): Promise<readonly string[]> {
       const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: gitRootPath });
       return stdout
@@ -302,6 +313,15 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });
     },
   };
+}
+
+async function hasGitDiff(cwd: string, args: readonly string[]): Promise<boolean> {
+  try {
+    await execFileAsync('git', [...args], { cwd });
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 function findGitRoot(cwd: string): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename, relative } from 'node:path';
+import { promisify } from 'node:util';
 import {
   appendFixedPromptWalEvent,
   hashSystemPrompt,
   type PromptCandidateCommittedEvent,
 } from './fixed-prompt-controller.js';
+
+const execFileAsync = promisify(execFile);
 
 export interface TrajectoryDigest {
   taskId: string;
@@ -55,6 +59,11 @@ export interface CreateScriptedMetaAgentInput {
 export interface PromptCandidateGit {
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
+}
+
+export interface CreateCliPromptCandidateGitInput {
+  cwd: string;
+  systemPromptPath: string;
 }
 
 export interface RunPromptCandidateRoundInput {
@@ -203,6 +212,25 @@ export function assertOnlySystemPromptChanged(
   if (unexpected.length > 0) {
     throw new Error(`only system_prompt.md may change; unexpected files: ${unexpected.join(', ')}`);
   }
+}
+
+export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitInput): PromptCandidateGit {
+  const systemPromptGitPath = relative(input.cwd, input.systemPromptPath).split('\\').join('/');
+  return {
+    async changedFiles(): Promise<readonly string[]> {
+      const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: input.cwd });
+      return stdout
+        .split('\n')
+        .map((line) => line.slice(3).trim())
+        .filter((line) => line.length > 0);
+    },
+    async commit(message: string): Promise<string> {
+      await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: input.cwd });
+      await execFileAsync('git', ['commit', '-m', message], { cwd: input.cwd });
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: input.cwd });
+      return stdout.trim();
+    },
+  };
 }
 
 function normalizeChangedPath(path: string): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -78,6 +78,7 @@ export interface RunPromptCandidateRoundInput {
   systemPromptPath: string;
   resultsTsvPath: string;
   resultsJsonlPath: string;
+  heldInTaskIds: readonly string[];
   heldInDigests: readonly TrajectoryDigest[];
   heldOutDigests?: readonly TrajectoryDigest[];
   metaAgent: MetaAgent;
@@ -97,7 +98,7 @@ export async function runPromptCandidateRound(
 ): Promise<PromptCandidateRoundResult> {
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
-  assertHeldInAndHeldOutDisjoint(input.heldInDigests, input.heldOutDigests ?? []);
+  assertHeldInAndHeldOutDisjoint(input.heldInTaskIds, input.heldOutDigests ?? []);
   await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   await input.git.assertSystemPromptClean();
@@ -105,7 +106,7 @@ export async function runPromptCandidateRound(
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const resultsTsv = filterResultsTsvForHeldIn(
     await readFile(input.resultsTsvPath, 'utf8'),
-    input.heldInDigests,
+    input.heldInTaskIds,
   );
   const result = await input.metaAgent({
     runId: input.runId,
@@ -155,11 +156,11 @@ async function assertSystemPromptPathMatchesGit(
 }
 
 function assertHeldInAndHeldOutDisjoint(
-  heldInDigests: readonly TrajectoryDigest[],
+  heldInTaskIds: readonly string[],
   heldOutDigests: readonly TrajectoryDigest[],
 ): void {
-  const heldInTaskIds = new Set(heldInDigests.map((digest) => digest.taskId));
-  const overlap = heldOutDigests.find((digest) => heldInTaskIds.has(digest.taskId));
+  const heldInTasks = new Set(heldInTaskIds);
+  const overlap = heldOutDigests.find((digest) => heldInTasks.has(digest.taskId));
   if (overlap) {
     throw new Error(`held-in and held-out task sets must be disjoint: ${overlap.taskId}`);
   }
@@ -207,7 +208,7 @@ export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
 
 export function filterResultsTsvForHeldIn(
   resultsTsv: string,
-  heldInDigests: readonly TrajectoryDigest[],
+  heldInTaskIds: readonly string[],
 ): string {
   const hasTrailingNewline = resultsTsv.endsWith('\n');
   const lines = resultsTsv.split(/\r?\n/);
@@ -220,12 +221,12 @@ export function filterResultsTsvForHeldIn(
     throw new Error('results TSV must include a task_id column');
   }
 
-  const heldInTaskIds = new Set(heldInDigests.map((digest) => digest.taskId));
+  const heldInTasks = new Set(heldInTaskIds);
   const filtered = [
     header,
     ...lines.slice(1).filter((line) => {
       const columns = line.split('\t');
-      return heldInTaskIds.has(columns[taskIdIndex] ?? '');
+      return heldInTasks.has(columns[taskIdIndex] ?? '');
     }),
   ];
   return `${filtered.join('\n')}${hasTrailingNewline ? '\n' : ''}`;

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
-import { lstat, readFile, writeFile } from 'node:fs/promises';
+import { lstat, readFile, realpath, writeFile } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
@@ -57,6 +57,7 @@ export interface CreateScriptedMetaAgentInput {
 }
 
 export interface PromptCandidateGit {
+  gitRootPath: string;
   systemPromptGitPath: string;
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
@@ -93,7 +94,7 @@ export async function runPromptCandidateRound(
 ): Promise<PromptCandidateRoundResult> {
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
-  await assertRegularSystemPromptFile(input.systemPromptPath);
+  await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   const program = await readFile(input.programPath, 'utf8');
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const resultsTsv = filterResultsTsvForHeldIn(
@@ -246,16 +247,24 @@ export function assertOnlySystemPromptChanged(
   }
 }
 
-async function assertRegularSystemPromptFile(systemPromptPath: string): Promise<void> {
+async function assertRegularSystemPromptFile(systemPromptPath: string, gitRootPath: string): Promise<void> {
   const stat = await lstat(systemPromptPath);
   if (!stat.isFile() || stat.isSymbolicLink()) {
     throw new Error('system_prompt.md must be a regular file');
+  }
+  const [promptRealPath, gitRootRealPath] = await Promise.all([
+    realpath(systemPromptPath),
+    realpath(gitRootPath),
+  ]);
+  if (!isPathInside(gitRootRealPath, promptRealPath)) {
+    throw new Error('system_prompt.md must stay inside the git cwd');
   }
 }
 
 export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitInput): PromptCandidateGit {
   const systemPromptGitPath = toGitRelativePath(input.cwd, input.systemPromptPath);
   return {
+    gitRootPath: input.cwd,
     systemPromptGitPath,
     async changedFiles(): Promise<readonly string[]> {
       const { stdout } = await execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], { cwd: input.cwd });
@@ -271,6 +280,11 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       return stdout.trim();
     },
   };
+}
+
+function isPathInside(rootPath: string, targetPath: string): boolean {
+  const relativePath = relative(rootPath, targetPath).split('\\').join('/');
+  return relativePath !== '' && relativePath !== '..' && !relativePath.startsWith('../') && !isAbsolute(relativePath);
 }
 
 function toGitRelativePath(cwd: string, path: string): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { lstat, readFile, writeFile } from 'node:fs/promises';
-import { relative } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
   appendFixedPromptWalEvent,
@@ -249,7 +249,7 @@ async function assertRegularSystemPromptFile(systemPromptPath: string): Promise<
 }
 
 export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitInput): PromptCandidateGit {
-  const systemPromptGitPath = relative(input.cwd, input.systemPromptPath).split('\\').join('/');
+  const systemPromptGitPath = toGitRelativePath(input.cwd, input.systemPromptPath);
   return {
     systemPromptGitPath,
     async changedFiles(): Promise<readonly string[]> {
@@ -266,6 +266,15 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       return stdout.trim();
     },
   };
+}
+
+function toGitRelativePath(cwd: string, path: string): string {
+  const absolutePath = isAbsolute(path) ? path : resolve(cwd, path);
+  const relativePath = relative(cwd, absolutePath).split('\\').join('/');
+  if (relativePath === '' || relativePath === '..' || relativePath.startsWith('../')) {
+    throw new Error('system_prompt.md must be inside the git cwd');
+  }
+  return relativePath;
 }
 
 function normalizeGitPath(path: string): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -62,6 +62,7 @@ export interface PromptCandidateGit {
   systemPromptGitPath: string;
   changedFiles(): Promise<readonly string[]>;
   commit(message: string): Promise<string>;
+  restoreSystemPrompt(): Promise<void>;
 }
 
 export interface CreateCliPromptCandidateGitInput {
@@ -117,7 +118,7 @@ export async function runPromptCandidateRound(
     assertOnlySystemPromptChanged(await input.git.changedFiles(), input.git.systemPromptGitPath);
     commitSha = await input.git.commit(`candidate prompt ${input.roundId}`);
   } catch (error) {
-    await writeFile(input.systemPromptPath, currentSystemPrompt, 'utf8');
+    await input.git.restoreSystemPrompt();
     throw error;
   }
   await appendFixedPromptWalEvent(input.resultsJsonlPath, promptCandidateCommittedEvent({
@@ -284,6 +285,9 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       await execFileAsync('git', ['commit', '-m', message], { cwd: gitRootPath });
       const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
       return stdout.trim();
+    },
+    async restoreSystemPrompt(): Promise<void> {
+      await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });
     },
   };
 }

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -11,6 +11,19 @@ export interface TrajectoryDigest {
   taskId: string;
   errorClass?: string;
   summary: string;
+  recentToolCalls?: readonly TrajectoryToolCallDigest[];
+}
+
+export interface TrajectoryToolCallDigest {
+  name: string;
+  argsPreview: string;
+}
+
+export interface ExtractTrajectoryDigestInput {
+  taskId: string;
+  errorClass?: string;
+  runtimeEventsPath: string;
+  verifierSummary: string;
 }
 
 export interface MetaAgentPromptInput {
@@ -91,6 +104,22 @@ export async function runPromptCandidateRound(
   };
 }
 
+export async function extractTrajectoryDigest(
+  input: ExtractTrajectoryDigestInput,
+): Promise<TrajectoryDigest> {
+  const events = await readRuntimeEventsJsonl(input.runtimeEventsPath);
+  const recentToolCalls = events
+    .map((event) => functionCallDigest(event))
+    .filter((call): call is TrajectoryToolCallDigest => call !== undefined)
+    .slice(-2);
+  return {
+    taskId: input.taskId,
+    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+    summary: input.verifierSummary,
+    ...(recentToolCalls.length > 0 ? { recentToolCalls } : {}),
+  };
+}
+
 function promptCandidateCommittedEvent(input: {
   runId: string;
   roundId: string;
@@ -142,4 +171,31 @@ function stripLeadingDotSlash(path: string): string {
 
 function randomId(): string {
   return randomUUID();
+}
+
+async function readRuntimeEventsJsonl(path: string): Promise<unknown[]> {
+  const raw = await readFile(path, 'utf8');
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefined {
+  if (!isRecord(event) || !isRecord(event.content)) return undefined;
+  const content = event.content;
+  if (content.kind !== 'function_call' || typeof content.name !== 'string') return undefined;
+  return {
+    name: content.name,
+    argsPreview: argsPreview(content.args),
+  };
+}
+
+function argsPreview(args: unknown): string {
+  if (!isRecord(args)) return typeof args;
+  return Object.keys(args).sort((a, b) => a.localeCompare(b)).join(',');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -99,6 +99,7 @@ export async function runPromptCandidateRound(
 ): Promise<PromptCandidateRoundResult> {
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
+  assertHeldInDigestsBelongToHeldInTasks(input.heldInTaskIds, input.heldInDigests);
   assertHeldInAndHeldOutDisjoint(input.heldInTaskIds, input.heldOutDigests ?? []);
   await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
@@ -164,6 +165,17 @@ function assertHeldInAndHeldOutDisjoint(
   const overlap = heldOutDigests.find((digest) => heldInTasks.has(digest.taskId));
   if (overlap) {
     throw new Error(`held-in and held-out task sets must be disjoint: ${overlap.taskId}`);
+  }
+}
+
+function assertHeldInDigestsBelongToHeldInTasks(
+  heldInTaskIds: readonly string[],
+  heldInDigests: readonly TrajectoryDigest[],
+): void {
+  const heldInTasks = new Set(heldInTaskIds);
+  const outside = heldInDigests.find((digest) => !heldInTasks.has(digest.taskId));
+  if (outside) {
+    throw new Error(`held-in digests must belong to held-in task set: ${outside.taskId}`);
   }
 }
 

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -96,6 +96,7 @@ export async function runPromptCandidateRound(
 ): Promise<PromptCandidateRoundResult> {
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
+  assertHeldInAndHeldOutDisjoint(input.heldInDigests, input.heldOutDigests ?? []);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   const program = await readFile(input.programPath, 'utf8');
   const currentSystemPrompt = await readFile(input.systemPromptPath, 'utf8');
@@ -135,6 +136,17 @@ export async function runPromptCandidateRound(
     summary: result.summary,
     commitSha,
   };
+}
+
+function assertHeldInAndHeldOutDisjoint(
+  heldInDigests: readonly TrajectoryDigest[],
+  heldOutDigests: readonly TrajectoryDigest[],
+): void {
+  const heldInTaskIds = new Set(heldInDigests.map((digest) => digest.taskId));
+  const overlap = heldOutDigests.find((digest) => heldInTaskIds.has(digest.taskId));
+  if (overlap) {
+    throw new Error(`held-in and held-out task sets must be disjoint: ${overlap.taskId}`);
+  }
 }
 
 export async function extractTrajectoryDigest(


### PR DESCRIPTION
## Summary
- add the PR4 prompt candidate loop with meta-agent read containment, strict `system_prompt.md` write guard, and prompt candidate WAL commit records
- add held-in trajectory digest extraction from raw runtime events without forwarding raw trajectories or held-out data
- add a scripted meta-agent JSON prompt wrapper and a CLI git adapter that commits only `system_prompt.md` for the round

## Verification
- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`
- `git diff --check`

Part of #64.

Non-goals: statistical KEEP/DISCARD policy, baseline calibration, held-out acceptance gates, reward-hack quarantine, and real API-key eval.