### PR TITLE
feat(headless): add prompt acceptance policy

### DIFF
--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -59,6 +59,27 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.metrics.candidate.heldOut.passEligibleRate, 1);
   });
 
+  test('keeps held-in improvements when no held-out floor is configured', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldOutTaskIds: [],
+      originalEvents: [],
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'keep');
+    assert.equal(decision.reason, 'held_in_improved');
+    assert.equal(decision.metrics.original.heldOut.coverageRate, null);
+    assert.equal(decision.metrics.candidate.heldOut.coverageRate, null);
+  });
+
   test('summarizes pass over eligible separately from coverage', () => {
     const summary = summarizePromptAcceptancePartition([
       completed('task-a', true),

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -5,7 +5,9 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import {
   appendPromptAcceptanceDecision,
+  calibratePromptAcceptanceBaseline,
   decidePromptAcceptance,
+  promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
   summarizePromptAcceptancePartition,
 } from '../prompt-acceptance-policy.js';
@@ -16,6 +18,64 @@ import type {
 import { readFixedPromptWal } from '../fixed-prompt-controller.js';
 
 describe('prompt acceptance policy', () => {
+  test('calibrates separate held-in and held-out noise bands from baseline runs', () => {
+    const baseline = calibratePromptAcceptanceBaseline({
+      heldInTaskIds: ['in-a', 'in-b', 'in-c', 'in-d'],
+      heldOutTaskIds: ['out-a', 'out-b'],
+      baselineRuns: [
+        {
+          heldInEvents: [
+            completed('in-a', true),
+            completed('in-b', true),
+            completed('in-c', false),
+            completed('in-d', false),
+          ],
+          heldOutEvents: [
+            completed('out-a', true),
+            completed('out-b', false),
+          ],
+        },
+        {
+          heldInEvents: [
+            completed('in-a', true),
+            completed('in-b', true),
+            completed('in-c', true),
+            completed('in-d', false),
+          ],
+          heldOutEvents: [
+            completed('out-a', true),
+            completed('out-b', true),
+          ],
+        },
+      ],
+    });
+
+    assert.equal(baseline.heldIn.meanPassEligibleRate, 0.625);
+    assert.equal(baseline.heldIn.observedSpread, 0.125);
+    assert.equal(baseline.heldIn.referencePassEligibleRate, 0.625);
+    assert.equal(baseline.heldOut.originalPassEligibleRate, 0.75);
+    assert.equal(baseline.heldOut.observedSpread, 0.25);
+    assert.equal(
+      baseline.heldIn.noiseBand,
+      promptAcceptanceNoiseBand({
+        sampleSize: 4,
+        passRate: 0.625,
+        baselineRunCount: 2,
+        observedSpread: 0.125,
+      }),
+    );
+    assert.equal(
+      baseline.heldOut.noiseBand,
+      promptAcceptanceNoiseBand({
+        sampleSize: 2,
+        passRate: 0.75,
+        baselineRunCount: 2,
+        observedSpread: 0.25,
+      }),
+    );
+    assert.notEqual(baseline.heldIn.noiseBand, baseline.heldOut.noiseBand);
+  });
+
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {
     const heldInTaskIds = ['in-a', 'in-b', 'in-c', 'in-d'];
     const heldOutTaskIds = ['out-a', 'out-b'];

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -215,8 +215,10 @@ describe('prompt acceptance policy', () => {
       scored: 2,
       passed: 2,
       passEligibleRate: 2 / 3,
-      coverageRate: 0.5,
-      unscoredTaskIds: ['task-c', 'task-d'],
+      coverageRate: 2 / 3,
+      unscoredTaskIds: ['task-c'],
+      infraFailedTaskIds: ['task-d'],
+      plumbingFailedTaskIds: [],
       missingTaskIds: [],
     });
   });
@@ -268,7 +270,7 @@ describe('prompt acceptance policy', () => {
       coverageNoiseBand: 0,
       lastKeptEvents: [
         completed('in-a', true),
-        completed('in-b', false),
+        infraFailed('in-b'),
       ],
       candidateEvents: [
         completed('in-a', true),
@@ -279,7 +281,7 @@ describe('prompt acceptance policy', () => {
 
     assert.equal(decision.decision, 'discard');
     assert.equal(decision.reason, 'coverage_regressed');
-    assert.deepEqual(decision.metrics.candidate.heldIn.unscoredTaskIds, ['in-b']);
+    assert.deepEqual(decision.metrics.candidate.heldIn.infraFailedTaskIds, ['in-b']);
   });
 
   test('discards candidates that fall below the held-out original floor', () => {

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -88,7 +88,9 @@ describe('prompt acceptance policy', () => {
       originalCommitSha: 'original-0',
       heldInTaskIds,
       heldOutTaskIds,
-      passRateNoiseBand: 0.05,
+      previousHeldInReferencePassEligibleRate: 0.25,
+      heldInPassRateNoiseBand: 0.05,
+      heldOutPassRateNoiseBand: 0.05,
       coverageNoiseBand: 0,
       originalEvents: [
         completed('out-a', true),
@@ -113,10 +115,65 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.decision, 'keep');
     assert.equal(decision.reason, 'held_in_improved');
     assert.equal(decision.lastKeptCommitSha, 'candidate-2');
+    assert.equal(decision.heldInReferencePassEligibleRate, 0.7);
     assert.equal(decision.metrics.lastKept.heldIn.passEligibleRate, 0.25);
     assert.equal(decision.metrics.candidate.heldIn.passEligibleRate, 0.75);
     assert.equal(decision.metrics.original.heldOut.passEligibleRate, 1);
     assert.equal(decision.metrics.candidate.heldOut.passEligibleRate, 1);
+  });
+
+  test('keeps against the monotonic held-in reference instead of a lucky last-kept run', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldInTaskIds: ['in-a', 'in-b', 'in-c', 'in-d'],
+      previousHeldInReferencePassEligibleRate: 0.5,
+      heldInPassRateNoiseBand: 0.05,
+      heldOutPassRateNoiseBand: 0.05,
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('in-c', true),
+        completed('in-d', true),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('in-c', true),
+        completed('in-d', false),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'keep');
+    assert.equal(decision.reason, 'held_in_improved');
+    assert.equal(decision.heldInReferencePassEligibleRate, 0.7);
+  });
+
+  test('uses separate held-in and held-out pass-rate noise bands', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldOutTaskIds: ['out-a', 'out-b', 'out-c', 'out-d'],
+      previousHeldInReferencePassEligibleRate: 0.25,
+      heldInPassRateNoiseBand: 0.05,
+      heldOutPassRateNoiseBand: 0.3,
+      originalEvents: [
+        completed('out-a', true),
+        completed('out-b', true),
+        completed('out-c', true),
+        completed('out-d', true),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('out-a', true),
+        completed('out-b', true),
+        completed('out-c', true),
+        completed('out-d', false),
+      ],
+    });
+
+    assert.equal(decision.decision, 'keep');
+    assert.equal(decision.reason, 'held_in_improved');
   });
 
   test('keeps held-in improvements when no held-out floor is configured', () => {
@@ -124,6 +181,9 @@ describe('prompt acceptance policy', () => {
       ...baseDecisionInput(),
       heldOutTaskIds: [],
       originalEvents: [],
+      previousHeldInReferencePassEligibleRate: 0.5,
+      heldInPassRateNoiseBand: 0.05,
+      heldOutPassRateNoiseBand: 0.05,
       lastKeptEvents: [
         completed('in-a', true),
         completed('in-b', false),
@@ -164,7 +224,8 @@ describe('prompt acceptance policy', () => {
   test('discards flat held-in changes inside the noise band', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
-      passRateNoiseBand: 0.1,
+      previousHeldInReferencePassEligibleRate: 0.45,
+      heldInPassRateNoiseBand: 0.1,
       lastKeptEvents: [
         completed('in-a', true),
         completed('in-b', false),
@@ -184,7 +245,8 @@ describe('prompt acceptance policy', () => {
   test('discards held-in regressions', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
-      passRateNoiseBand: 0.05,
+      previousHeldInReferencePassEligibleRate: 1,
+      heldInPassRateNoiseBand: 0.05,
       lastKeptEvents: [
         completed('in-a', true),
         completed('in-b', true),
@@ -260,6 +322,7 @@ describe('prompt acceptance policy', () => {
         roundId: 'round-3',
         candidateCommitSha: 'candidate-3',
         previousLastKeptCommitSha: keep.lastKeptCommitSha,
+        previousHeldInReferencePassEligibleRate: keep.heldInReferencePassEligibleRate,
         candidateEvents: [
           completed('in-a', true),
           completed('in-b', false),
@@ -281,6 +344,7 @@ describe('prompt acceptance policy', () => {
       ]);
       assert.deepEqual(promptAcceptanceStateFromWal(events, 'original-0'), {
         lastKeptCommitSha: 'candidate-2',
+        heldInReferencePassEligibleRate: 0.95,
         decisions: [
           { roundId: 'round-2', decision: 'keep', candidateCommitSha: 'candidate-2' },
           { roundId: 'round-3', decision: 'discard', candidateCommitSha: 'candidate-3' },
@@ -299,7 +363,9 @@ function baseDecisionInput() {
     originalCommitSha: 'original-0',
     heldInTaskIds: ['in-a', 'in-b'],
     heldOutTaskIds: ['out-a'],
-    passRateNoiseBand: 0.05,
+    previousHeldInReferencePassEligibleRate: 0.5,
+    heldInPassRateNoiseBand: 0.05,
+    heldOutPassRateNoiseBand: 0.05,
     coverageNoiseBand: 0,
     originalEvents: [completed('out-a', true)],
     lastKeptEvents: [completed('in-a', true), completed('in-b', false)],

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -89,6 +89,7 @@ describe('prompt acceptance policy', () => {
       heldInTaskIds,
       heldOutTaskIds,
       previousHeldInReferencePassEligibleRate: 0.25,
+      originalHeldOutPassEligibleRate: 1,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.05,
       originalEvents: [
@@ -126,6 +127,7 @@ describe('prompt acceptance policy', () => {
       ...baseDecisionInput(),
       heldInTaskIds: ['in-a', 'in-b', 'in-c', 'in-d'],
       previousHeldInReferencePassEligibleRate: 0.5,
+      originalHeldOutPassEligibleRate: 1,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.05,
       lastKeptEvents: [
@@ -153,6 +155,7 @@ describe('prompt acceptance policy', () => {
       ...baseDecisionInput(),
       heldOutTaskIds: ['out-a', 'out-b', 'out-c', 'out-d'],
       previousHeldInReferencePassEligibleRate: 0.25,
+      originalHeldOutPassEligibleRate: 1,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.3,
       originalEvents: [
@@ -181,6 +184,7 @@ describe('prompt acceptance policy', () => {
       heldOutTaskIds: [],
       originalEvents: [],
       previousHeldInReferencePassEligibleRate: 0.5,
+      originalHeldOutPassEligibleRate: null,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.05,
       lastKeptEvents: [
@@ -345,6 +349,28 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.reason, 'held_out_regressed');
   });
 
+  test('uses the calibrated held-out original mean instead of one original run', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldOutTaskIds: ['out-a', 'out-b'],
+      originalHeldOutPassEligibleRate: 0.75,
+      heldOutPassRateNoiseBand: 0.1,
+      originalEvents: [
+        completed('out-a', true),
+        completed('out-b', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('out-a', true),
+        completed('out-b', false),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'held_out_regressed');
+  });
+
   test('records KEEP and DISCARD decisions in the WAL and resumes last kept commit', async () => {
     await withDir(async (dir) => {
       const resultsJsonlPath = join(dir, 'results.jsonl');
@@ -403,6 +429,7 @@ function baseDecisionInput() {
     heldInTaskIds: ['in-a', 'in-b'],
     heldOutTaskIds: ['out-a'],
     previousHeldInReferencePassEligibleRate: 0.5,
+    originalHeldOutPassEligibleRate: 1,
     heldInPassRateNoiseBand: 0.05,
     heldOutPassRateNoiseBand: 0.05,
     originalEvents: [completed('out-a', true)],

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -1,13 +1,19 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import {
+  appendPromptAcceptanceDecision,
   decidePromptAcceptance,
+  promptAcceptanceStateFromWal,
   summarizePromptAcceptancePartition,
 } from '../prompt-acceptance-policy.js';
 import type {
   FixedPromptTaskCompletedEvent,
   FixedPromptTaskWalEvent,
 } from '../fixed-prompt-controller.js';
+import { readFixedPromptWal } from '../fixed-prompt-controller.js';
 
 describe('prompt acceptance policy', () => {
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {
@@ -156,6 +162,51 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.decision, 'discard');
     assert.equal(decision.reason, 'held_out_regressed');
   });
+
+  test('records KEEP and DISCARD decisions in the WAL and resumes last kept commit', async () => {
+    await withDir(async (dir) => {
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const keep = decidePromptAcceptance(baseDecisionInput());
+      await appendPromptAcceptanceDecision({
+        resultsJsonlPath,
+        id: 'decision-1',
+        ts: 100,
+        result: keep,
+      });
+
+      const discard = decidePromptAcceptance({
+        ...baseDecisionInput(),
+        roundId: 'round-3',
+        candidateCommitSha: 'candidate-3',
+        previousLastKeptCommitSha: keep.lastKeptCommitSha,
+        candidateEvents: [
+          completed('in-a', true),
+          completed('in-b', false),
+          completed('out-a', true),
+        ],
+      });
+      await appendPromptAcceptanceDecision({
+        resultsJsonlPath,
+        id: 'decision-2',
+        ts: 101,
+        result: discard,
+      });
+
+      const events = await readFixedPromptWal(resultsJsonlPath);
+      assert.equal(events.length, 2);
+      assert.deepEqual(events.map((event) => event.type), [
+        'prompt_candidate_decided',
+        'prompt_candidate_decided',
+      ]);
+      assert.deepEqual(promptAcceptanceStateFromWal(events, 'original-0'), {
+        lastKeptCommitSha: 'candidate-2',
+        decisions: [
+          { roundId: 'round-2', decision: 'keep', candidateCommitSha: 'candidate-2' },
+          { roundId: 'round-3', decision: 'discard', candidateCommitSha: 'candidate-3' },
+        ],
+      });
+    });
+  });
 });
 
 function baseDecisionInput() {
@@ -217,4 +268,13 @@ function infraFailed(taskId: string): FixedPromptTaskWalEvent {
     errorClass: 'infra_error',
     error: 'container crashed',
   };
+}
+
+async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-prompt-acceptance-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -91,7 +91,6 @@ describe('prompt acceptance policy', () => {
       previousHeldInReferencePassEligibleRate: 0.25,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.05,
-      coverageNoiseBand: 0,
       originalEvents: [
         completed('out-a', true),
         completed('out-b', true),
@@ -267,7 +266,6 @@ describe('prompt acceptance policy', () => {
   test('discards candidate coverage degradation, including infra failures', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
-      coverageNoiseBand: 0,
       lastKeptEvents: [
         completed('in-a', true),
         infraFailed('in-b'),
@@ -282,6 +280,45 @@ describe('prompt acceptance policy', () => {
     assert.equal(decision.decision, 'discard');
     assert.equal(decision.reason, 'coverage_regressed');
     assert.deepEqual(decision.metrics.candidate.heldIn.infraFailedTaskIds, ['in-b']);
+  });
+
+  test('discards any coverage degradation without a noise allowance', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldInTaskIds: ['in-a', 'in-b', 'in-c'],
+      previousHeldInReferencePassEligibleRate: 0.5,
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+        completed('in-c', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('in-c', false, { scored: false, errorClass: 'max_tokens' }),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'coverage_regressed');
+  });
+
+  test('discards when a configured held-out floor is missing its original reference', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldOutTaskIds: ['out-a'],
+      originalEvents: [],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'coverage_regressed');
+    assert.deepEqual(decision.metrics.original.heldOut.missingTaskIds, ['out-a']);
   });
 
   test('discards candidates that fall below the held-out original floor', () => {
@@ -368,7 +405,6 @@ function baseDecisionInput() {
     previousHeldInReferencePassEligibleRate: 0.5,
     heldInPassRateNoiseBand: 0.05,
     heldOutPassRateNoiseBand: 0.05,
-    coverageNoiseBand: 0,
     originalEvents: [completed('out-a', true)],
     lastKeptEvents: [completed('in-a', true), completed('in-b', false)],
     candidateEvents: [completed('in-a', true), completed('in-b', true), completed('out-a', true)],

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -325,6 +325,35 @@ describe('prompt acceptance policy', () => {
     assert.deepEqual(decision.metrics.original.heldOut.missingTaskIds, ['out-a']);
   });
 
+  test('discards candidates with missing task results', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      candidateEvents: [
+        completed('in-a', true),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'coverage_regressed');
+    assert.deepEqual(decision.metrics.candidate.heldIn.missingTaskIds, ['in-b']);
+  });
+
+  test('discards candidates with plumbing failures', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      candidateEvents: [
+        completed('in-a', true),
+        plumbingFailed('in-b'),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'coverage_regressed');
+    assert.deepEqual(decision.metrics.candidate.heldIn.plumbingFailedTaskIds, ['in-b']);
+  });
+
   test('discards candidates that fall below the held-out original floor', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
@@ -479,6 +508,31 @@ function infraFailed(taskId: string): FixedPromptTaskWalEvent {
     eligible: false,
     errorClass: 'infra_error',
     error: 'container crashed',
+  };
+}
+
+function plumbingFailed(taskId: string): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_plumbing_failed',
+    id: `event-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId,
+    status: 'plumbing_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'prompt_hash_mismatch',
+    error: 'prompt hash mismatch',
+    promptHash: 'actual',
+    expectedPromptHash: 'expected',
+    tokenSummary: { input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 },
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: `/logs/${taskId}.jsonl`,
+    harbor: { reward: 0 },
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  decidePromptAcceptance,
+  summarizePromptAcceptancePartition,
+} from '../prompt-acceptance-policy.js';
+import type {
+  FixedPromptTaskCompletedEvent,
+  FixedPromptTaskWalEvent,
+} from '../fixed-prompt-controller.js';
+
+describe('prompt acceptance policy', () => {
+  test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {
+    const heldInTaskIds = ['in-a', 'in-b', 'in-c', 'in-d'];
+    const heldOutTaskIds = ['out-a', 'out-b'];
+
+    const decision = decidePromptAcceptance({
+      runId: 'run-1',
+      roundId: 'round-2',
+      candidateCommitSha: 'candidate-2',
+      previousLastKeptCommitSha: 'kept-1',
+      originalCommitSha: 'original-0',
+      heldInTaskIds,
+      heldOutTaskIds,
+      passRateNoiseBand: 0.05,
+      coverageNoiseBand: 0,
+      originalEvents: [
+        completed('out-a', true),
+        completed('out-b', true),
+      ],
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+        completed('in-c', false),
+        completed('in-d', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('in-c', true),
+        completed('in-d', false),
+        completed('out-a', true),
+        completed('out-b', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'keep');
+    assert.equal(decision.reason, 'held_in_improved');
+    assert.equal(decision.lastKeptCommitSha, 'candidate-2');
+    assert.equal(decision.metrics.lastKept.heldIn.passEligibleRate, 0.25);
+    assert.equal(decision.metrics.candidate.heldIn.passEligibleRate, 0.75);
+    assert.equal(decision.metrics.original.heldOut.passEligibleRate, 1);
+    assert.equal(decision.metrics.candidate.heldOut.passEligibleRate, 1);
+  });
+
+  test('summarizes pass over eligible separately from coverage', () => {
+    const summary = summarizePromptAcceptancePartition([
+      completed('task-a', true),
+      completed('task-b', false),
+      completed('task-c', true, { scored: false }),
+      infraFailed('task-d'),
+    ], ['task-a', 'task-b', 'task-c', 'task-d']);
+
+    assert.deepEqual(summary, {
+      taskCount: 4,
+      observed: 4,
+      eligible: 3,
+      scored: 2,
+      passed: 2,
+      passEligibleRate: 2 / 3,
+      coverageRate: 0.5,
+      unscoredTaskIds: ['task-c', 'task-d'],
+      missingTaskIds: [],
+    });
+  });
+
+  test('discards flat held-in changes inside the noise band', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      passRateNoiseBand: 0.1,
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'held_in_within_noise');
+    assert.equal(decision.lastKeptCommitSha, 'kept-1');
+  });
+
+  test('discards held-in regressions', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      passRateNoiseBand: 0.05,
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'held_in_regressed');
+  });
+
+  test('discards candidate coverage degradation, including infra failures', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      coverageNoiseBand: 0,
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        infraFailed('in-b'),
+        completed('out-a', true),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'coverage_regressed');
+    assert.deepEqual(decision.metrics.candidate.heldIn.unscoredTaskIds, ['in-b']);
+  });
+
+  test('discards candidates that fall below the held-out original floor', () => {
+    const decision = decidePromptAcceptance({
+      ...baseDecisionInput(),
+      heldOutTaskIds: ['out-a', 'out-b'],
+      originalEvents: [
+        completed('out-a', true),
+        completed('out-b', true),
+      ],
+      lastKeptEvents: [
+        completed('in-a', true),
+        completed('in-b', false),
+      ],
+      candidateEvents: [
+        completed('in-a', true),
+        completed('in-b', true),
+        completed('out-a', true),
+        completed('out-b', false),
+      ],
+    });
+
+    assert.equal(decision.decision, 'discard');
+    assert.equal(decision.reason, 'held_out_regressed');
+  });
+});
+
+function baseDecisionInput() {
+  return {
+    runId: 'run-1',
+    roundId: 'round-2',
+    candidateCommitSha: 'candidate-2',
+    previousLastKeptCommitSha: 'kept-1',
+    originalCommitSha: 'original-0',
+    heldInTaskIds: ['in-a', 'in-b'],
+    heldOutTaskIds: ['out-a'],
+    passRateNoiseBand: 0.05,
+    coverageNoiseBand: 0,
+    originalEvents: [completed('out-a', true)],
+    lastKeptEvents: [completed('in-a', true), completed('in-b', false)],
+    candidateEvents: [completed('in-a', true), completed('in-b', true), completed('out-a', true)],
+  };
+}
+
+function completed(
+  taskId: string,
+  passed: boolean,
+  overrides: Partial<FixedPromptTaskCompletedEvent> = {},
+): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_completed',
+    id: `event-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId,
+    status: 'completed',
+    passed,
+    scored: true,
+    eligible: true,
+    tokenSummary: { input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 },
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: `/logs/${taskId}.jsonl`,
+    harbor: { reward: passed ? 1 : 0 },
+    ...overrides,
+  };
+}
+
+function infraFailed(taskId: string): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_infra_failed',
+    id: `event-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId,
+    status: 'infra_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'infra_error',
+    error: 'container crashed',
+  };
+}

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -95,6 +95,63 @@ describe('prompt acceptance policy', () => {
       }),
       /baseline held-in run 1 is incomplete/,
     );
+
+    assert.throws(
+      () => calibratePromptAcceptanceBaseline({
+        heldInTaskIds: ['in-a', 'in-b'],
+        heldOutTaskIds: ['out-a', 'out-b'],
+        baselineRuns: [
+          {
+            heldInEvents: [
+              completed('in-a', true),
+              completed('in-b', false),
+            ],
+            heldOutEvents: [
+              completed('out-a', true),
+            ],
+          },
+        ],
+      }),
+      /baseline held-out run 1 is incomplete/,
+    );
+
+    assert.throws(
+      () => calibratePromptAcceptanceBaseline({
+        heldInTaskIds: ['in-a', 'in-b'],
+        heldOutTaskIds: ['out-a'],
+        baselineRuns: [
+          {
+            heldInEvents: [
+              completed('in-a', true),
+              infraFailed('in-b'),
+            ],
+            heldOutEvents: [
+              completed('out-a', true),
+            ],
+          },
+        ],
+      }),
+      /baseline held-in run 1 is incomplete/,
+    );
+
+    assert.throws(
+      () => calibratePromptAcceptanceBaseline({
+        heldInTaskIds: ['in-a', 'in-b'],
+        heldOutTaskIds: ['out-a'],
+        baselineRuns: [
+          {
+            heldInEvents: [
+              completed('in-a', true),
+              completed('in-b', false, { scored: false, errorClass: 'max_tokens' }),
+            ],
+            heldOutEvents: [
+              completed('out-a', true),
+            ],
+          },
+        ],
+      }),
+      /baseline held-in run 1 is incomplete/,
+    );
   });
 
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -76,6 +76,27 @@ describe('prompt acceptance policy', () => {
     assert.notEqual(baseline.heldIn.noiseBand, baseline.heldOut.noiseBand);
   });
 
+  test('rejects incomplete baseline calibration runs', () => {
+    assert.throws(
+      () => calibratePromptAcceptanceBaseline({
+        heldInTaskIds: ['in-a', 'in-b'],
+        heldOutTaskIds: ['out-a', 'out-b'],
+        baselineRuns: [
+          {
+            heldInEvents: [
+              completed('in-a', true),
+              plumbingFailed('in-b'),
+            ],
+            heldOutEvents: [
+              completed('out-a', true),
+            ],
+          },
+        ],
+      }),
+      /baseline held-in run 1 is incomplete/,
+    );
+  });
+
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {
     const heldInTaskIds = ['in-a', 'in-b', 'in-c', 'in-d'];
     const heldOutTaskIds = ['out-a', 'out-b'];

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -121,7 +121,12 @@ export interface PromptCandidateDecisionEvent {
   candidateCommitSha: string;
   previousLastKeptCommitSha: string;
   lastKeptCommitSha: string;
+  previousHeldInReferencePassEligibleRate: number | null;
+  heldInReferencePassEligibleRate: number | null;
   originalCommitSha: string;
+  heldInPassRateNoiseBand: number;
+  heldOutPassRateNoiseBand: number;
+  coverageNoiseBand: number;
   metrics: unknown;
 }
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -124,6 +124,7 @@ export interface PromptCandidateDecisionEvent {
   previousHeldInReferencePassEligibleRate: number | null;
   heldInReferencePassEligibleRate: number | null;
   originalCommitSha: string;
+  originalHeldOutPassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
   metrics: unknown;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -109,11 +109,28 @@ export interface PromptCandidateCommittedEvent {
   promptHash: string;
 }
 
+export interface PromptCandidateDecisionEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'prompt_candidate_decided';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  decision: 'keep' | 'discard';
+  reason: string;
+  candidateCommitSha: string;
+  previousLastKeptCommitSha: string;
+  lastKeptCommitSha: string;
+  originalCommitSha: string;
+  metrics: unknown;
+}
+
 export type FixedPromptWalEvent =
   | FixedPromptTaskCompletedEvent
   | FixedPromptTaskInfraFailedEvent
   | FixedPromptTaskPlumbingFailedEvent
-  | PromptCandidateCommittedEvent;
+  | PromptCandidateCommittedEvent
+  | PromptCandidateDecisionEvent;
 
 export type FixedPromptTaskWalEvent =
   | FixedPromptTaskCompletedEvent
@@ -457,7 +474,7 @@ function terminalTaskEvents(
   return byTask;
 }
 
-function eventMatchesPrompt(event: FixedPromptWalEvent, expectedPromptHash: string): boolean {
+function eventMatchesPrompt(event: FixedPromptTaskWalEvent, expectedPromptHash: string): boolean {
   if (event.type === 'task_infra_failed') return true;
   if (event.promptHash === expectedPromptHash) return true;
   return event.type === 'task_plumbing_failed' && event.expectedPromptHash === expectedPromptHash;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -126,7 +126,6 @@ export interface PromptCandidateDecisionEvent {
   originalCommitSha: string;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
-  coverageNoiseBand: number;
   metrics: unknown;
 }
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -76,9 +76,14 @@ export {
 } from './prompt-candidate-loop.js';
 export type {
   AppendPromptAcceptanceDecisionInput,
+  CalibratePromptAcceptanceBaselineInput,
   DecidePromptAcceptanceInput,
+  PromptAcceptanceBaseline,
+  PromptAcceptanceBaselinePartition,
+  PromptAcceptanceBaselineRun,
   PromptAcceptanceDecision,
   PromptAcceptanceMetrics,
+  PromptAcceptanceNoiseBandInput,
   PromptAcceptancePartitionSummary,
   PromptAcceptanceReason,
   PromptAcceptanceResult,
@@ -86,7 +91,9 @@ export type {
 } from './prompt-acceptance-policy.js';
 export {
   appendPromptAcceptanceDecision,
+  calibratePromptAcceptanceBaseline,
   decidePromptAcceptance,
+  promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
   summarizePromptAcceptancePartition,
 } from './prompt-acceptance-policy.js';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -74,6 +74,18 @@ export {
   runPromptCandidateRound,
 } from './prompt-candidate-loop.js';
 export type {
+  DecidePromptAcceptanceInput,
+  PromptAcceptanceDecision,
+  PromptAcceptanceMetrics,
+  PromptAcceptancePartitionSummary,
+  PromptAcceptanceReason,
+  PromptAcceptanceResult,
+} from './prompt-acceptance-policy.js';
+export {
+  decidePromptAcceptance,
+  summarizePromptAcceptancePartition,
+} from './prompt-acceptance-policy.js';
+export type {
   BenchmarkAdapter,
   BenchmarkAdapterRegistry,
   BenchmarkInstanceRef,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -37,6 +37,7 @@ export type {
   HarborTaskRunOutput,
   HarborTaskRunner,
   PromptCandidateCommittedEvent,
+  PromptCandidateDecisionEvent,
   ReadHarborTaskRunOutputInput,
   RunFixedPromptControllerInput,
 } from './fixed-prompt-controller.js';
@@ -74,15 +75,19 @@ export {
   runPromptCandidateRound,
 } from './prompt-candidate-loop.js';
 export type {
+  AppendPromptAcceptanceDecisionInput,
   DecidePromptAcceptanceInput,
   PromptAcceptanceDecision,
   PromptAcceptanceMetrics,
   PromptAcceptancePartitionSummary,
   PromptAcceptanceReason,
   PromptAcceptanceResult,
+  PromptAcceptanceState,
 } from './prompt-acceptance-policy.js';
 export {
+  appendPromptAcceptanceDecision,
   decidePromptAcceptance,
+  promptAcceptanceStateFromWal,
   summarizePromptAcceptancePartition,
 } from './prompt-acceptance-policy.js';
 export type {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -216,5 +216,5 @@ function improved(candidate: number | null, reference: number | null, noiseBand:
 }
 
 function regressed(candidate: number | null, reference: number | null, noiseBand: number): boolean {
-  return candidate === null || (reference !== null && candidate < reference - noiseBand);
+  return reference !== null && (candidate === null || candidate < reference - noiseBand);
 }

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -40,6 +40,43 @@ export interface PromptAcceptanceMetrics {
   };
 }
 
+export interface PromptAcceptanceBaselineRun {
+  heldInEvents: readonly FixedPromptTaskWalEvent[];
+  heldOutEvents: readonly FixedPromptTaskWalEvent[];
+}
+
+export interface PromptAcceptanceBaselinePartition {
+  taskCount: number;
+  baselineRunCount: number;
+  meanPassEligibleRate: number | null;
+  observedSpread: number;
+  noiseBand: number;
+}
+
+export interface PromptAcceptanceBaseline {
+  heldIn: PromptAcceptanceBaselinePartition & {
+    referencePassEligibleRate: number | null;
+  };
+  heldOut: PromptAcceptanceBaselinePartition & {
+    originalPassEligibleRate: number | null;
+  };
+}
+
+export interface CalibratePromptAcceptanceBaselineInput {
+  heldInTaskIds: readonly string[];
+  heldOutTaskIds: readonly string[];
+  baselineRuns: readonly PromptAcceptanceBaselineRun[];
+  zScore?: number;
+}
+
+export interface PromptAcceptanceNoiseBandInput {
+  sampleSize: number;
+  passRate: number | null;
+  baselineRunCount: number;
+  observedSpread?: number;
+  zScore?: number;
+}
+
 export interface DecidePromptAcceptanceInput {
   runId: string;
   roundId: string;
@@ -83,6 +120,40 @@ export interface PromptAcceptanceState {
   }>;
 }
 
+export function calibratePromptAcceptanceBaseline(
+  input: CalibratePromptAcceptanceBaselineInput,
+): PromptAcceptanceBaseline {
+  const heldIn = calibratePartitionBaseline(
+    input.baselineRuns.map((run) => summarizePromptAcceptancePartition(run.heldInEvents, input.heldInTaskIds)),
+    input.zScore,
+  );
+  const heldOut = calibratePartitionBaseline(
+    input.baselineRuns.map((run) => summarizePromptAcceptancePartition(run.heldOutEvents, input.heldOutTaskIds)),
+    input.zScore,
+  );
+  return {
+    heldIn: {
+      ...heldIn,
+      referencePassEligibleRate: heldIn.meanPassEligibleRate,
+    },
+    heldOut: {
+      ...heldOut,
+      originalPassEligibleRate: heldOut.meanPassEligibleRate,
+    },
+  };
+}
+
+export function promptAcceptanceNoiseBand(input: PromptAcceptanceNoiseBandInput): number {
+  const observedSpread = input.observedSpread ?? 0;
+  if (input.sampleSize <= 0 || input.passRate === null || input.baselineRunCount <= 0) {
+    return observedSpread;
+  }
+  const zScore = input.zScore ?? 1.96;
+  const wilson = wilsonHalfWidth(input.sampleSize, input.passRate, zScore);
+  const differenceWidth = wilson * Math.sqrt(1 + 1 / input.baselineRunCount);
+  return Math.max(differenceWidth, observedSpread);
+}
+
 export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): PromptAcceptanceResult {
   const metrics: PromptAcceptanceMetrics = {
     original: {
@@ -109,6 +180,45 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     originalCommitSha: input.originalCommitSha,
     metrics,
   };
+}
+
+function calibratePartitionBaseline(
+  summaries: readonly PromptAcceptancePartitionSummary[],
+  zScore: number | undefined,
+): PromptAcceptanceBaselinePartition {
+  const passRates = summaries
+    .map((summary) => summary.passEligibleRate)
+    .filter((rate): rate is number => rate !== null);
+  const meanPassEligibleRate = mean(passRates);
+  const observedSpread = meanPassEligibleRate === null
+    ? 0
+    : Math.max(0, ...passRates.map((rate) => Math.abs(rate - meanPassEligibleRate)));
+  const sampleSize = Math.max(0, ...summaries.map((summary) => summary.eligible));
+  return {
+    taskCount: Math.max(0, ...summaries.map((summary) => summary.taskCount)),
+    baselineRunCount: summaries.length,
+    meanPassEligibleRate,
+    observedSpread,
+    noiseBand: promptAcceptanceNoiseBand({
+      sampleSize,
+      passRate: meanPassEligibleRate,
+      baselineRunCount: summaries.length,
+      observedSpread,
+      zScore,
+    }),
+  };
+}
+
+function wilsonHalfWidth(sampleSize: number, passRate: number, zScore: number): number {
+  const z2 = zScore * zScore;
+  const denominator = 1 + z2 / sampleSize;
+  const inner = passRate * (1 - passRate) / sampleSize + z2 / (4 * sampleSize * sampleSize);
+  return zScore * Math.sqrt(inner) / denominator;
+}
+
+function mean(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
 export async function appendPromptAcceptanceDecision(

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -24,6 +24,8 @@ export interface PromptAcceptancePartitionSummary {
   passEligibleRate: number | null;
   coverageRate: number | null;
   unscoredTaskIds: string[];
+  infraFailedTaskIds: string[];
+  plumbingFailedTaskIds: string[];
   missingTaskIds: string[];
 }
 
@@ -291,10 +293,15 @@ export function summarizePromptAcceptancePartition(
     scored: scored.length,
     passed: passed.length,
     passEligibleRate: eligible.length > 0 ? passed.length / eligible.length : null,
-    coverageRate: taskIds.length > 0 ? scored.length / taskIds.length : null,
+    coverageRate: eligible.length > 0 ? scored.length / eligible.length : null,
     unscoredTaskIds: taskIds.filter((taskId) => {
       const event = byTask.get(taskId);
-      return event !== undefined && !event.scored;
+      return event !== undefined && event.eligible && !event.scored;
+    }),
+    infraFailedTaskIds: taskIds.filter((taskId) => byTask.get(taskId)?.type === 'task_infra_failed'),
+    plumbingFailedTaskIds: taskIds.filter((taskId) => {
+      const event = byTask.get(taskId);
+      return event !== undefined && event.type === 'task_plumbing_failed';
     }),
     missingTaskIds: taskIds.filter((taskId) => !byTask.has(taskId)),
   };
@@ -339,6 +346,9 @@ function acceptanceReason(
   const heldOutCandidate = metrics.candidate.heldOut;
   const heldOutReference = metrics.original.heldOut;
 
+  if (hasBlockingTaskFailure(heldInCandidate) || hasBlockingTaskFailure(heldOutCandidate)) {
+    return 'coverage_regressed';
+  }
   if (regressed(heldInCandidate.coverageRate, heldInReference.coverageRate, input.coverageNoiseBand)) {
     return 'coverage_regressed';
   }
@@ -382,6 +392,12 @@ function nextHeldInReferencePassEligibleRate(input: {
   return input.previousReference === null
     ? bankedReference
     : Math.max(input.previousReference, bankedReference);
+}
+
+function hasBlockingTaskFailure(summary: PromptAcceptancePartitionSummary): boolean {
+  return summary.missingTaskIds.length > 0
+    || summary.infraFailedTaskIds.length > 0
+    || summary.plumbingFailedTaskIds.length > 0;
 }
 
 function improved(candidate: number | null, reference: number | null, noiseBand: number): boolean {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -88,6 +88,7 @@ export interface DecidePromptAcceptanceInput {
   heldInTaskIds: readonly string[];
   heldOutTaskIds: readonly string[];
   previousHeldInReferencePassEligibleRate: number | null;
+  originalHeldOutPassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
   originalEvents: readonly FixedPromptTaskWalEvent[];
@@ -106,6 +107,7 @@ export interface PromptAcceptanceResult {
   previousHeldInReferencePassEligibleRate: number | null;
   heldInReferencePassEligibleRate: number | null;
   originalCommitSha: string;
+  originalHeldOutPassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
   metrics: PromptAcceptanceMetrics;
@@ -177,6 +179,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
   };
   const reason = acceptanceReason(metrics, {
     previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
+    originalHeldOutPassEligibleRate: input.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
   });
@@ -198,6 +201,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
     heldInReferencePassEligibleRate,
     originalCommitSha: input.originalCommitSha,
+    originalHeldOutPassEligibleRate: input.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
     metrics,
@@ -321,6 +325,7 @@ function promptCandidateDecisionEvent(
     previousHeldInReferencePassEligibleRate: input.result.previousHeldInReferencePassEligibleRate,
     heldInReferencePassEligibleRate: input.result.heldInReferencePassEligibleRate,
     originalCommitSha: input.result.originalCommitSha,
+    originalHeldOutPassEligibleRate: input.result.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.result.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.result.heldOutPassRateNoiseBand,
     metrics: input.result.metrics,
@@ -331,6 +336,7 @@ function acceptanceReason(
   metrics: PromptAcceptanceMetrics,
   input: {
     previousHeldInReferencePassEligibleRate: number | null;
+    originalHeldOutPassEligibleRate: number | null;
     heldInPassRateNoiseBand: number;
     heldOutPassRateNoiseBand: number;
   },
@@ -354,7 +360,10 @@ function acceptanceReason(
   if (coverageRegressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate)) {
     return 'coverage_regressed';
   }
-  if (regressed(heldOutCandidate.passEligibleRate, heldOutReference.passEligibleRate, input.heldOutPassRateNoiseBand)) {
+  if (heldOutCandidate.taskCount > 0 && input.originalHeldOutPassEligibleRate === null) {
+    return 'coverage_regressed';
+  }
+  if (regressed(heldOutCandidate.passEligibleRate, input.originalHeldOutPassEligibleRate, input.heldOutPassRateNoiseBand)) {
     return 'held_out_regressed';
   }
   if (

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -85,7 +85,9 @@ export interface DecidePromptAcceptanceInput {
   originalCommitSha: string;
   heldInTaskIds: readonly string[];
   heldOutTaskIds: readonly string[];
-  passRateNoiseBand: number;
+  previousHeldInReferencePassEligibleRate: number | null;
+  heldInPassRateNoiseBand: number;
+  heldOutPassRateNoiseBand: number;
   coverageNoiseBand: number;
   originalEvents: readonly FixedPromptTaskWalEvent[];
   lastKeptEvents: readonly FixedPromptTaskWalEvent[];
@@ -100,7 +102,12 @@ export interface PromptAcceptanceResult {
   candidateCommitSha: string;
   previousLastKeptCommitSha: string;
   lastKeptCommitSha: string;
+  previousHeldInReferencePassEligibleRate: number | null;
+  heldInReferencePassEligibleRate: number | null;
   originalCommitSha: string;
+  heldInPassRateNoiseBand: number;
+  heldOutPassRateNoiseBand: number;
+  coverageNoiseBand: number;
   metrics: PromptAcceptanceMetrics;
 }
 
@@ -113,6 +120,7 @@ export interface AppendPromptAcceptanceDecisionInput {
 
 export interface PromptAcceptanceState {
   lastKeptCommitSha: string;
+  heldInReferencePassEligibleRate: number | null;
   decisions: Array<{
     roundId: string;
     decision: PromptAcceptanceDecision;
@@ -167,8 +175,19 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
       heldOut: summarizePromptAcceptancePartition(input.candidateEvents, input.heldOutTaskIds),
     },
   };
-  const reason = acceptanceReason(metrics, input.passRateNoiseBand, input.coverageNoiseBand);
+  const reason = acceptanceReason(metrics, {
+    previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
+    heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
+    heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
+    coverageNoiseBand: input.coverageNoiseBand,
+  });
   const decision: PromptAcceptanceDecision = reason === 'held_in_improved' ? 'keep' : 'discard';
+  const heldInReferencePassEligibleRate = nextHeldInReferencePassEligibleRate({
+    decision,
+    previousReference: input.previousHeldInReferencePassEligibleRate,
+    candidatePassEligibleRate: metrics.candidate.heldIn.passEligibleRate,
+    noiseBand: input.heldInPassRateNoiseBand,
+  });
   return {
     runId: input.runId,
     roundId: input.roundId,
@@ -177,7 +196,12 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     candidateCommitSha: input.candidateCommitSha,
     previousLastKeptCommitSha: input.previousLastKeptCommitSha,
     lastKeptCommitSha: decision === 'keep' ? input.candidateCommitSha : input.previousLastKeptCommitSha,
+    previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
+    heldInReferencePassEligibleRate,
     originalCommitSha: input.originalCommitSha,
+    heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
+    heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
+    coverageNoiseBand: input.coverageNoiseBand,
     metrics,
   };
 }
@@ -232,19 +256,22 @@ export async function appendPromptAcceptanceDecision(
 export function promptAcceptanceStateFromWal(
   events: readonly FixedPromptWalEvent[],
   initialLastKeptCommitSha: string,
+  initialHeldInReferencePassEligibleRate: number | null = null,
 ): PromptAcceptanceState {
   const decisions: PromptAcceptanceState['decisions'] = [];
   let lastKeptCommitSha = initialLastKeptCommitSha;
+  let heldInReferencePassEligibleRate = initialHeldInReferencePassEligibleRate;
   for (const event of events) {
     if (event.type !== 'prompt_candidate_decided') continue;
     lastKeptCommitSha = event.lastKeptCommitSha;
+    heldInReferencePassEligibleRate = event.heldInReferencePassEligibleRate;
     decisions.push({
       roundId: event.roundId,
       decision: event.decision,
       candidateCommitSha: event.candidateCommitSha,
     });
   }
-  return { lastKeptCommitSha, decisions };
+  return { lastKeptCommitSha, heldInReferencePassEligibleRate, decisions };
 }
 
 export function summarizePromptAcceptancePartition(
@@ -288,37 +315,73 @@ function promptCandidateDecisionEvent(
     candidateCommitSha: input.result.candidateCommitSha,
     previousLastKeptCommitSha: input.result.previousLastKeptCommitSha,
     lastKeptCommitSha: input.result.lastKeptCommitSha,
+    previousHeldInReferencePassEligibleRate: input.result.previousHeldInReferencePassEligibleRate,
+    heldInReferencePassEligibleRate: input.result.heldInReferencePassEligibleRate,
     originalCommitSha: input.result.originalCommitSha,
+    heldInPassRateNoiseBand: input.result.heldInPassRateNoiseBand,
+    heldOutPassRateNoiseBand: input.result.heldOutPassRateNoiseBand,
+    coverageNoiseBand: input.result.coverageNoiseBand,
     metrics: input.result.metrics,
   };
 }
 
 function acceptanceReason(
   metrics: PromptAcceptanceMetrics,
-  passRateNoiseBand: number,
-  coverageNoiseBand: number,
+  input: {
+    previousHeldInReferencePassEligibleRate: number | null;
+    heldInPassRateNoiseBand: number;
+    heldOutPassRateNoiseBand: number;
+    coverageNoiseBand: number;
+  },
 ): PromptAcceptanceReason {
   const heldInCandidate = metrics.candidate.heldIn;
   const heldInReference = metrics.lastKept.heldIn;
   const heldOutCandidate = metrics.candidate.heldOut;
   const heldOutReference = metrics.original.heldOut;
 
-  if (regressed(heldInCandidate.coverageRate, heldInReference.coverageRate, coverageNoiseBand)) {
+  if (regressed(heldInCandidate.coverageRate, heldInReference.coverageRate, input.coverageNoiseBand)) {
     return 'coverage_regressed';
   }
-  if (regressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate, coverageNoiseBand)) {
+  if (regressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate, input.coverageNoiseBand)) {
     return 'coverage_regressed';
   }
-  if (regressed(heldOutCandidate.passEligibleRate, heldOutReference.passEligibleRate, passRateNoiseBand)) {
+  if (regressed(heldOutCandidate.passEligibleRate, heldOutReference.passEligibleRate, input.heldOutPassRateNoiseBand)) {
     return 'held_out_regressed';
   }
-  if (improved(heldInCandidate.passEligibleRate, heldInReference.passEligibleRate, passRateNoiseBand)) {
+  if (
+    improved(
+      heldInCandidate.passEligibleRate,
+      input.previousHeldInReferencePassEligibleRate,
+      input.heldInPassRateNoiseBand,
+    )
+  ) {
     return 'held_in_improved';
   }
-  if (regressed(heldInCandidate.passEligibleRate, heldInReference.passEligibleRate, passRateNoiseBand)) {
+  if (
+    regressed(
+      heldInCandidate.passEligibleRate,
+      input.previousHeldInReferencePassEligibleRate,
+      input.heldInPassRateNoiseBand,
+    )
+  ) {
     return 'held_in_regressed';
   }
   return 'held_in_within_noise';
+}
+
+function nextHeldInReferencePassEligibleRate(input: {
+  decision: PromptAcceptanceDecision;
+  previousReference: number | null;
+  candidatePassEligibleRate: number | null;
+  noiseBand: number;
+}): number | null {
+  if (input.decision !== 'keep' || input.candidatePassEligibleRate === null) {
+    return input.previousReference;
+  }
+  const bankedReference = input.candidatePassEligibleRate - input.noiseBand;
+  return input.previousReference === null
+    ? bankedReference
+    : Math.max(input.previousReference, bankedReference);
 }
 
 function improved(candidate: number | null, reference: number | null, noiseBand: number): boolean {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -1,0 +1,152 @@
+import type { FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
+
+export type PromptAcceptanceDecision = 'keep' | 'discard';
+
+export type PromptAcceptanceReason =
+  | 'held_in_improved'
+  | 'held_in_within_noise'
+  | 'held_in_regressed'
+  | 'coverage_regressed'
+  | 'held_out_regressed';
+
+export interface PromptAcceptancePartitionSummary {
+  taskCount: number;
+  observed: number;
+  eligible: number;
+  scored: number;
+  passed: number;
+  passEligibleRate: number | null;
+  coverageRate: number | null;
+  unscoredTaskIds: string[];
+  missingTaskIds: string[];
+}
+
+export interface PromptAcceptanceMetrics {
+  original: {
+    heldOut: PromptAcceptancePartitionSummary;
+  };
+  lastKept: {
+    heldIn: PromptAcceptancePartitionSummary;
+  };
+  candidate: {
+    heldIn: PromptAcceptancePartitionSummary;
+    heldOut: PromptAcceptancePartitionSummary;
+  };
+}
+
+export interface DecidePromptAcceptanceInput {
+  runId: string;
+  roundId: string;
+  candidateCommitSha: string;
+  previousLastKeptCommitSha: string;
+  originalCommitSha: string;
+  heldInTaskIds: readonly string[];
+  heldOutTaskIds: readonly string[];
+  passRateNoiseBand: number;
+  coverageNoiseBand: number;
+  originalEvents: readonly FixedPromptTaskWalEvent[];
+  lastKeptEvents: readonly FixedPromptTaskWalEvent[];
+  candidateEvents: readonly FixedPromptTaskWalEvent[];
+}
+
+export interface PromptAcceptanceResult {
+  runId: string;
+  roundId: string;
+  decision: PromptAcceptanceDecision;
+  reason: PromptAcceptanceReason;
+  candidateCommitSha: string;
+  previousLastKeptCommitSha: string;
+  lastKeptCommitSha: string;
+  originalCommitSha: string;
+  metrics: PromptAcceptanceMetrics;
+}
+
+export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): PromptAcceptanceResult {
+  const metrics: PromptAcceptanceMetrics = {
+    original: {
+      heldOut: summarizePromptAcceptancePartition(input.originalEvents, input.heldOutTaskIds),
+    },
+    lastKept: {
+      heldIn: summarizePromptAcceptancePartition(input.lastKeptEvents, input.heldInTaskIds),
+    },
+    candidate: {
+      heldIn: summarizePromptAcceptancePartition(input.candidateEvents, input.heldInTaskIds),
+      heldOut: summarizePromptAcceptancePartition(input.candidateEvents, input.heldOutTaskIds),
+    },
+  };
+  const reason = acceptanceReason(metrics, input.passRateNoiseBand, input.coverageNoiseBand);
+  const decision: PromptAcceptanceDecision = reason === 'held_in_improved' ? 'keep' : 'discard';
+  return {
+    runId: input.runId,
+    roundId: input.roundId,
+    decision,
+    reason,
+    candidateCommitSha: input.candidateCommitSha,
+    previousLastKeptCommitSha: input.previousLastKeptCommitSha,
+    lastKeptCommitSha: decision === 'keep' ? input.candidateCommitSha : input.previousLastKeptCommitSha,
+    originalCommitSha: input.originalCommitSha,
+    metrics,
+  };
+}
+
+export function summarizePromptAcceptancePartition(
+  events: readonly FixedPromptTaskWalEvent[],
+  taskIds: readonly string[],
+): PromptAcceptancePartitionSummary {
+  const byTask = new Map(events.map((event) => [event.taskId, event]));
+  const selected = taskIds.map((taskId) => byTask.get(taskId));
+  const observed = selected.filter((event): event is FixedPromptTaskWalEvent => event !== undefined);
+  const eligible = observed.filter((event) => event.eligible);
+  const scored = observed.filter((event) => event.scored);
+  const passed = observed.filter((event) => event.passed);
+  return {
+    taskCount: taskIds.length,
+    observed: observed.length,
+    eligible: eligible.length,
+    scored: scored.length,
+    passed: passed.length,
+    passEligibleRate: eligible.length > 0 ? passed.length / eligible.length : null,
+    coverageRate: taskIds.length > 0 ? scored.length / taskIds.length : null,
+    unscoredTaskIds: taskIds.filter((taskId) => {
+      const event = byTask.get(taskId);
+      return event !== undefined && !event.scored;
+    }),
+    missingTaskIds: taskIds.filter((taskId) => !byTask.has(taskId)),
+  };
+}
+
+function acceptanceReason(
+  metrics: PromptAcceptanceMetrics,
+  passRateNoiseBand: number,
+  coverageNoiseBand: number,
+): PromptAcceptanceReason {
+  const heldInCandidate = metrics.candidate.heldIn;
+  const heldInReference = metrics.lastKept.heldIn;
+  const heldOutCandidate = metrics.candidate.heldOut;
+  const heldOutReference = metrics.original.heldOut;
+
+  if (regressed(heldInCandidate.coverageRate, heldInReference.coverageRate, coverageNoiseBand)) {
+    return 'coverage_regressed';
+  }
+  if (regressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate, coverageNoiseBand)) {
+    return 'coverage_regressed';
+  }
+  if (regressed(heldOutCandidate.passEligibleRate, heldOutReference.passEligibleRate, passRateNoiseBand)) {
+    return 'held_out_regressed';
+  }
+  if (improved(heldInCandidate.passEligibleRate, heldInReference.passEligibleRate, passRateNoiseBand)) {
+    return 'held_in_improved';
+  }
+  if (regressed(heldInCandidate.passEligibleRate, heldInReference.passEligibleRate, passRateNoiseBand)) {
+    return 'held_in_regressed';
+  }
+  return 'held_in_within_noise';
+}
+
+function improved(candidate: number | null, reference: number | null, noiseBand: number): boolean {
+  return candidate !== null && reference !== null && candidate > reference + noiseBand;
+}
+
+function regressed(candidate: number | null, reference: number | null, noiseBand: number): boolean {
+  return candidate === null || (reference !== null && candidate < reference - noiseBand);
+}

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -90,7 +90,6 @@ export interface DecidePromptAcceptanceInput {
   previousHeldInReferencePassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
-  coverageNoiseBand: number;
   originalEvents: readonly FixedPromptTaskWalEvent[];
   lastKeptEvents: readonly FixedPromptTaskWalEvent[];
   candidateEvents: readonly FixedPromptTaskWalEvent[];
@@ -109,7 +108,6 @@ export interface PromptAcceptanceResult {
   originalCommitSha: string;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
-  coverageNoiseBand: number;
   metrics: PromptAcceptanceMetrics;
 }
 
@@ -181,7 +179,6 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     previousHeldInReferencePassEligibleRate: input.previousHeldInReferencePassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
-    coverageNoiseBand: input.coverageNoiseBand,
   });
   const decision: PromptAcceptanceDecision = reason === 'held_in_improved' ? 'keep' : 'discard';
   const heldInReferencePassEligibleRate = nextHeldInReferencePassEligibleRate({
@@ -203,7 +200,6 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     originalCommitSha: input.originalCommitSha,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
-    coverageNoiseBand: input.coverageNoiseBand,
     metrics,
   };
 }
@@ -327,7 +323,6 @@ function promptCandidateDecisionEvent(
     originalCommitSha: input.result.originalCommitSha,
     heldInPassRateNoiseBand: input.result.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.result.heldOutPassRateNoiseBand,
-    coverageNoiseBand: input.result.coverageNoiseBand,
     metrics: input.result.metrics,
   };
 }
@@ -338,7 +333,6 @@ function acceptanceReason(
     previousHeldInReferencePassEligibleRate: number | null;
     heldInPassRateNoiseBand: number;
     heldOutPassRateNoiseBand: number;
-    coverageNoiseBand: number;
   },
 ): PromptAcceptanceReason {
   const heldInCandidate = metrics.candidate.heldIn;
@@ -346,13 +340,18 @@ function acceptanceReason(
   const heldOutCandidate = metrics.candidate.heldOut;
   const heldOutReference = metrics.original.heldOut;
 
-  if (hasBlockingTaskFailure(heldInCandidate) || hasBlockingTaskFailure(heldOutCandidate)) {
+  if (
+    hasBlockingTaskFailure(heldInReference)
+    || hasBlockingTaskFailure(heldOutReference)
+    || hasBlockingTaskFailure(heldInCandidate)
+    || hasBlockingTaskFailure(heldOutCandidate)
+  ) {
     return 'coverage_regressed';
   }
-  if (regressed(heldInCandidate.coverageRate, heldInReference.coverageRate, input.coverageNoiseBand)) {
+  if (coverageRegressed(heldInCandidate.coverageRate, heldInReference.coverageRate)) {
     return 'coverage_regressed';
   }
-  if (regressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate, input.coverageNoiseBand)) {
+  if (coverageRegressed(heldOutCandidate.coverageRate, heldOutReference.coverageRate)) {
     return 'coverage_regressed';
   }
   if (regressed(heldOutCandidate.passEligibleRate, heldOutReference.passEligibleRate, input.heldOutPassRateNoiseBand)) {
@@ -406,4 +405,8 @@ function improved(candidate: number | null, reference: number | null, noiseBand:
 
 function regressed(candidate: number | null, reference: number | null, noiseBand: number): boolean {
   return reference !== null && (candidate === null || candidate < reference - noiseBand);
+}
+
+function coverageRegressed(candidate: number | null, reference: number | null): boolean {
+  return reference !== null && (candidate === null || candidate < reference);
 }

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -1,4 +1,10 @@
-import type { FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
+import {
+  appendFixedPromptWalEvent,
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
+  type FixedPromptWalEvent,
+  type FixedPromptTaskWalEvent,
+  type PromptCandidateDecisionEvent,
+} from './fixed-prompt-controller.js';
 
 export type PromptAcceptanceDecision = 'keep' | 'discard';
 
@@ -61,6 +67,22 @@ export interface PromptAcceptanceResult {
   metrics: PromptAcceptanceMetrics;
 }
 
+export interface AppendPromptAcceptanceDecisionInput {
+  resultsJsonlPath: string;
+  id: string;
+  ts: number;
+  result: PromptAcceptanceResult;
+}
+
+export interface PromptAcceptanceState {
+  lastKeptCommitSha: string;
+  decisions: Array<{
+    roundId: string;
+    decision: PromptAcceptanceDecision;
+    candidateCommitSha: string;
+  }>;
+}
+
 export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): PromptAcceptanceResult {
   const metrics: PromptAcceptanceMetrics = {
     original: {
@@ -89,6 +111,32 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
   };
 }
 
+export async function appendPromptAcceptanceDecision(
+  input: AppendPromptAcceptanceDecisionInput,
+): Promise<PromptCandidateDecisionEvent> {
+  const event = promptCandidateDecisionEvent(input);
+  await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
+  return event;
+}
+
+export function promptAcceptanceStateFromWal(
+  events: readonly FixedPromptWalEvent[],
+  initialLastKeptCommitSha: string,
+): PromptAcceptanceState {
+  const decisions: PromptAcceptanceState['decisions'] = [];
+  let lastKeptCommitSha = initialLastKeptCommitSha;
+  for (const event of events) {
+    if (event.type !== 'prompt_candidate_decided') continue;
+    lastKeptCommitSha = event.lastKeptCommitSha;
+    decisions.push({
+      roundId: event.roundId,
+      decision: event.decision,
+      candidateCommitSha: event.candidateCommitSha,
+    });
+  }
+  return { lastKeptCommitSha, decisions };
+}
+
 export function summarizePromptAcceptancePartition(
   events: readonly FixedPromptTaskWalEvent[],
   taskIds: readonly string[],
@@ -112,6 +160,26 @@ export function summarizePromptAcceptancePartition(
       return event !== undefined && !event.scored;
     }),
     missingTaskIds: taskIds.filter((taskId) => !byTask.has(taskId)),
+  };
+}
+
+function promptCandidateDecisionEvent(
+  input: AppendPromptAcceptanceDecisionInput,
+): PromptCandidateDecisionEvent {
+  return {
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+    type: 'prompt_candidate_decided',
+    id: input.id,
+    ts: input.ts,
+    runId: input.result.runId,
+    roundId: input.result.roundId,
+    decision: input.result.decision,
+    reason: input.result.reason,
+    candidateCommitSha: input.result.candidateCommitSha,
+    previousLastKeptCommitSha: input.result.previousLastKeptCommitSha,
+    lastKeptCommitSha: input.result.lastKeptCommitSha,
+    originalCommitSha: input.result.originalCommitSha,
+    metrics: input.result.metrics,
   };
 }
 

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -133,12 +133,22 @@ export interface PromptAcceptanceState {
 export function calibratePromptAcceptanceBaseline(
   input: CalibratePromptAcceptanceBaselineInput,
 ): PromptAcceptanceBaseline {
+  const heldInSummaries = input.baselineRuns.map((run) => summarizePromptAcceptancePartition(
+    run.heldInEvents,
+    input.heldInTaskIds,
+  ));
+  const heldOutSummaries = input.baselineRuns.map((run) => summarizePromptAcceptancePartition(
+    run.heldOutEvents,
+    input.heldOutTaskIds,
+  ));
+  assertCompleteBaselineSummaries(heldInSummaries, 'held-in');
+  assertCompleteBaselineSummaries(heldOutSummaries, 'held-out');
   const heldIn = calibratePartitionBaseline(
-    input.baselineRuns.map((run) => summarizePromptAcceptancePartition(run.heldInEvents, input.heldInTaskIds)),
+    heldInSummaries,
     input.zScore,
   );
   const heldOut = calibratePartitionBaseline(
-    input.baselineRuns.map((run) => summarizePromptAcceptancePartition(run.heldOutEvents, input.heldOutTaskIds)),
+    heldOutSummaries,
     input.zScore,
   );
   return {
@@ -151,6 +161,22 @@ export function calibratePromptAcceptanceBaseline(
       originalPassEligibleRate: heldOut.meanPassEligibleRate,
     },
   };
+}
+
+function assertCompleteBaselineSummaries(
+  summaries: readonly PromptAcceptancePartitionSummary[],
+  partitionName: string,
+): void {
+  summaries.forEach((summary, index) => {
+    if (
+      summary.observed !== summary.taskCount
+      || summary.missingTaskIds.length > 0
+      || summary.infraFailedTaskIds.length > 0
+      || summary.plumbingFailedTaskIds.length > 0
+    ) {
+      throw new Error(`baseline ${partitionName} run ${index + 1} is incomplete`);
+    }
+  });
 }
 
 export function promptAcceptanceNoiseBand(input: PromptAcceptanceNoiseBandInput): number {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -171,6 +171,7 @@ function assertCompleteBaselineSummaries(
     if (
       summary.observed !== summary.taskCount
       || summary.missingTaskIds.length > 0
+      || summary.unscoredTaskIds.length > 0
       || summary.infraFailedTaskIds.length > 0
       || summary.plumbingFailedTaskIds.length > 0
     ) {


### PR DESCRIPTION
## Summary
- add PR5 prompt acceptance policy metrics for held-in / held-out partitions, pass-over-eligible scoring, dual noise bands, and coverage guards
- add KEEP / DISCARD decisions with last-kept commit promotion semantics
- record prompt acceptance decisions in the fixed-prompt WAL and resume last kept commit from WAL replay

## Verification
- npm run -w @maka/headless test
- npm run -w @maka/headless typecheck
- npm run -w @maka/headless build
- git diff --check origin/main...HEAD

Part of #64.

Non-goals: reward-hack quarantine, physical held-out isolation checks, deterministic concurrency, budget ceilings, infra-stop orchestration, and real API-key eval.