### PR TITLE
feat(headless): harden prompt evaluation loop

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -241,6 +241,81 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('stops when infra failures exceed the configured rate', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+          { id: 'task-d', path: '/bench/task-d' },
+          { id: 'task-e', path: '/bench/task-e' },
+        ],
+        maxInfraFailureRate: 0.2,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          throw new Error(`container crashed for ${task.id}`);
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a', 'task-b']);
+      assert.equal(result.stopReason, 'infra_failure_rate_exceeded');
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+      assert.equal((await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').length, 2);
+    });
+  });
+
+  test('stops when cost exceeds the configured ceiling', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+        ],
+        costCeilingUsd: 0.03,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({
+            taskId: task.id,
+            tokenSummary: { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a', 'task-b']);
+      assert.equal(result.stopReason, 'cost_ceiling_exceeded');
+      assert.equal(result.totalCostUsd, 0.04);
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
   test('reads Harbor reward and Maka cell output artifacts', async () => {
     await withDir(async (dir) => {
       const harborResultPath = join(dir, 'result.json');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -316,6 +316,45 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('runs concurrent tasks while recording deterministic task order', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+        ],
+        maxConcurrency: 2,
+        harborRunner: async ({ task }) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await delay(task.id === 'task-a' ? 20 : 0);
+          inFlight -= 1;
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(maxInFlight, 2);
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b', 'task-c']);
+      const events = (await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').map((line) => JSON.parse(line));
+      assert.deepEqual(events.map((event) => event.taskId), ['task-a', 'task-b', 'task-c']);
+    });
+  });
+
   test('reads Harbor reward and Maka cell output artifacts', async () => {
     await withDir(async (dir) => {
       const harborResultPath = join(dir, 'result.json');
@@ -515,6 +554,10 @@ function harborOutput(input: {
 function idFactory(): () => string {
   let i = 0;
   return () => `id-${++i}`;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -278,6 +278,44 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('preserves infra stop after WAL resume', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskInfraFailedEvent({ taskId: 'task-a' }))}\n`, 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskInfraFailedEvent({ taskId: 'task-b' }))}\n`, 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+          { id: 'task-d', path: '/bench/task-d' },
+          { id: 'task-e', path: '/bench/task-e' },
+        ],
+        maxInfraFailureRate: 0.2,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, []);
+      assert.equal(result.stopReason, 'infra_failure_rate_exceeded');
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
   test('stops when cost exceeds the configured ceiling', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -278,6 +278,50 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('checks infra failure rate between tasks even when concurrency is configured', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+          { id: 'task-d', path: '/bench/task-d' },
+          { id: 'task-e', path: '/bench/task-e' },
+        ],
+        maxConcurrency: 3,
+        maxInfraFailureRate: 0.2,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await delay(1);
+          inFlight -= 1;
+          throw new Error(`container crashed for ${task.id}`);
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(maxInFlight, 1);
+      assert.deepEqual(calls, ['task-a', 'task-b']);
+      assert.equal(result.stopReason, 'infra_failure_rate_exceeded');
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
   test('preserves infra stop after WAL resume', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -351,6 +395,87 @@ describe('fixed prompt controller', () => {
       assert.equal(result.stopReason, 'cost_ceiling_exceeded');
       assert.equal(result.totalCostUsd, 0.04);
       assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
+  test('checks the cost ceiling between tasks even when concurrency is configured', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+          { id: 'task-c', path: '/bench/task-c' },
+        ],
+        maxConcurrency: 3,
+        costCeilingUsd: 0.03,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await delay(1);
+          inFlight -= 1;
+          return harborOutput({
+            taskId: task.id,
+            tokenSummary: { input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(maxInFlight, 1);
+      assert.deepEqual(calls, ['task-a', 'task-b']);
+      assert.equal(result.stopReason, 'cost_ceiling_exceeded');
+      assert.equal(result.totalCostUsd, 0.04);
+      assert.deepEqual(result.taskIds, ['task-a', 'task-b']);
+    });
+  });
+
+  test('preserves cost stop after WAL resume at the configured ceiling', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await appendFile(resultsJsonlPath, `${JSON.stringify(taskCompletedEvent({ taskId: 'task-a' }))}\n`, 'utf8');
+
+      const calls: string[] = [];
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        costCeilingUsd: 0.01,
+        harborRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({ taskId: task.id });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, []);
+      assert.equal(result.stopReason, 'cost_ceiling_exceeded');
+      assert.equal(result.totalCostUsd, 0.01);
+      assert.deepEqual(result.taskIds, ['task-a']);
     });
   });
 

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -9,6 +9,7 @@ import {
   decidePromptAcceptance,
   promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
+  selectStablePromptTasks,
   summarizePromptAcceptancePartition,
 } from '../prompt-acceptance-policy.js';
 import type {
@@ -152,6 +153,43 @@ describe('prompt acceptance policy', () => {
       }),
       /baseline held-in run 1 is incomplete/,
     );
+  });
+
+  test('selects stable fast tasks from baseline runs', () => {
+    const result = selectStablePromptTasks({
+      taskIds: ['stable-fast', 'flaky', 'infra', 'slow'],
+      baselineRuns: [
+        [
+          completed('stable-fast', false, { durationMs: 100 }),
+          completed('flaky', true, { durationMs: 100 }),
+          completed('infra', true, { durationMs: 100 }),
+          completed('slow', false, { durationMs: 1_000 }),
+        ],
+        [
+          completed('stable-fast', false, { durationMs: 120 }),
+          completed('flaky', false, { durationMs: 100 }),
+          infraFailed('infra'),
+          completed('slow', false, { durationMs: 1_200 }),
+        ],
+        [
+          completed('stable-fast', false, { durationMs: 110 }),
+          completed('flaky', true, { durationMs: 100 }),
+          completed('infra', true, { durationMs: 100 }),
+          completed('slow', false, { durationMs: 1_100 }),
+        ],
+      ],
+      maxPassRateSpread: 0,
+      maxDurationMs: 500,
+    });
+
+    assert.deepEqual(result, {
+      selectedTaskIds: ['stable-fast'],
+      rejectedTaskIds: [
+        { taskId: 'flaky', reason: 'unstable_outcome' },
+        { taskId: 'infra', reason: 'incomplete' },
+        { taskId: 'slow', reason: 'too_slow' },
+      ],
+    });
   });
 
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {

--- a/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
+++ b/packages/headless/src/__tests__/prompt-acceptance-policy.test.ts
@@ -9,6 +9,7 @@ import {
   decidePromptAcceptance,
   promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
+  PROMPT_REWARD_HACK_QUARANTINE_REASON,
   selectStablePromptTasks,
   summarizePromptAcceptancePartition,
 } from '../prompt-acceptance-policy.js';
@@ -192,6 +193,21 @@ describe('prompt acceptance policy', () => {
     });
   });
 
+  test('rejects stable task selection without baseline evidence', () => {
+    const result = selectStablePromptTasks({
+      taskIds: ['task-a', 'task-b'],
+      baselineRuns: [],
+    });
+
+    assert.deepEqual(result, {
+      selectedTaskIds: [],
+      rejectedTaskIds: [
+        { taskId: 'task-a', reason: 'incomplete' },
+        { taskId: 'task-b', reason: 'incomplete' },
+      ],
+    });
+  });
+
   test('keeps candidates that improve held-in beyond noise without falling below the held-out original floor', () => {
     const heldInTaskIds = ['in-a', 'in-b', 'in-c', 'in-d'];
     const heldOutTaskIds = ['out-a', 'out-b'];
@@ -208,6 +224,7 @@ describe('prompt acceptance policy', () => {
       originalHeldOutPassEligibleRate: 1,
       heldInPassRateNoiseBand: 0.05,
       heldOutPassRateNoiseBand: 0.05,
+      rewardHackScan: { decision: 'clean' },
       originalEvents: [
         completed('out-a', true),
         completed('out-b', true),
@@ -470,6 +487,65 @@ describe('prompt acceptance policy', () => {
     assert.deepEqual(decision.metrics.candidate.heldIn.plumbingFailedTaskIds, ['in-b']);
   });
 
+  test('discards reward-hack quarantined candidates before metric keep', async () => {
+    await withDir(async (dir) => {
+      const rewardHackScan = {
+        decision: 'quarantine' as const,
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      };
+      const decision = decidePromptAcceptance({
+        ...baseDecisionInput(),
+        rewardHackScan,
+      });
+
+      assert.equal(decision.decision, 'discard');
+      assert.equal(decision.reason, PROMPT_REWARD_HACK_QUARANTINE_REASON);
+      assert.equal(decision.lastKeptCommitSha, 'kept-1');
+      assert.deepEqual(decision.rewardHackScan, rewardHackScan);
+
+      await appendPromptAcceptanceDecision({
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        id: 'decision-1',
+        ts: 100,
+        result: decision,
+      });
+      const [event] = await readFixedPromptWal(join(dir, 'results.jsonl'));
+      assert.equal(event?.type, 'prompt_candidate_decided');
+      assert.equal(event?.reason, PROMPT_REWARD_HACK_QUARANTINE_REASON);
+      assert.deepEqual(event?.rewardHackScan, rewardHackScan);
+    });
+  });
+
+  test('discards candidates when reward-hack scan evidence is missing', async () => {
+    await withDir(async (dir) => {
+      const input = baseDecisionInput();
+      delete (input as { rewardHackScan?: unknown }).rewardHackScan;
+
+      const decision = decidePromptAcceptance(input);
+
+      assert.equal(decision.decision, 'discard');
+      assert.equal(decision.reason, PROMPT_REWARD_HACK_QUARANTINE_REASON);
+      assert.deepEqual(decision.rewardHackScan, {
+        decision: 'quarantine',
+        reason: 'scan_missing',
+      });
+
+      await appendPromptAcceptanceDecision({
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        id: 'decision-1',
+        ts: 100,
+        result: decision,
+      });
+      const [event] = await readFixedPromptWal(join(dir, 'results.jsonl'));
+      assert.equal(event?.type, 'prompt_candidate_decided');
+      assert.deepEqual(event?.rewardHackScan, {
+        decision: 'quarantine',
+        reason: 'scan_missing',
+      });
+    });
+  });
+
   test('discards candidates that fall below the held-out original floor', () => {
     const decision = decidePromptAcceptance({
       ...baseDecisionInput(),
@@ -577,6 +653,7 @@ function baseDecisionInput() {
     originalHeldOutPassEligibleRate: 1,
     heldInPassRateNoiseBand: 0.05,
     heldOutPassRateNoiseBand: 0.05,
+    rewardHackScan: { decision: 'clean' as const },
     originalEvents: [completed('out-a', true)],
     lastKeptEvents: [completed('in-a', true), completed('in-b', false)],
     candidateEvents: [completed('in-a', true), completed('in-b', true), completed('out-a', true)],

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -12,6 +12,7 @@ import {
   extractTrajectoryDigest,
   renderMetaAgentPrompt,
   runPromptCandidateRound,
+  scanRuntimeEventsForRewardHack,
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
 } from '../prompt-candidate-loop.js';
@@ -496,6 +497,58 @@ describe('prompt candidate loop', () => {
         ],
       });
       assert.equal(JSON.stringify(digest).includes('long raw content'), false);
+    });
+  });
+
+  test('quarantines function calls containing verifier expected output', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(runtimeEvent('call-1', 'Bash', { command: 'echo EXPECTED_SECRET > /tmp/out' })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+    });
+  });
+
+  test('quarantines when raw runtime events are unavailable', async () => {
+    await withDir(async (dir) => {
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath: join(dir, 'missing-runtime-events.jsonl'),
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'runtime_events_unreadable',
+      });
+    });
+  });
+
+  test('keeps clean function calls that only reference verifier filenames', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(runtimeEvent('call-1', 'Bash', { command: 'cat tests/test_outputs.py' })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, { decision: 'clean' });
     });
   });
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -250,6 +250,48 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('rejects symlinked held-out artifacts visible from the agent cwd', async () => {
+    await withDir(async (dir) => {
+      const agentDir = join(dir, 'agent-cwd');
+      const controllerDir = join(dir, 'controller');
+      await mkdir(agentDir, { recursive: true });
+      await mkdir(controllerDir, { recursive: true });
+      const programPath = join(agentDir, 'program.md');
+      const systemPromptPath = join(agentDir, 'system_prompt.md');
+      const resultsTsvPath = join(agentDir, 'results.tsv');
+      const heldOutEventsPath = join(controllerDir, 'held-out-runtime-events.jsonl');
+      const visibleHeldOutLinkPath = join(agentDir, 'held-out-link.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(heldOutEventsPath, '', 'utf8');
+      await symlink(heldOutEventsPath, visibleHeldOutLinkPath);
+
+      let metaAgentCalled = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: agentDir,
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(controllerDir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          heldOutArtifactPaths: [visibleHeldOutLinkPath],
+          metaAgent: async () => {
+            metaAgentCalled = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(agentDir),
+        }),
+        /controller-only artifacts must stay outside agent cwd: held-out-link\.jsonl/,
+      );
+      assert.equal(metaAgentCalled, false);
+    });
+  });
+
   test('fails closed when the prompt edit changes files outside system_prompt.md', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
@@ -546,6 +588,50 @@ describe('prompt candidate loop', () => {
       const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
       await writeFile(runtimeEventsPath, [
         JSON.stringify(runtimeEvent('call-1', 'Bash', { command: 'echo EXPECTED_SECRET > /tmp/out' })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+    });
+  });
+
+  test('quarantines model-visible tool results containing verifier expected output', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(functionResponseRuntimeEvent('call-1', 'Bash', {
+          stdout: 'EXPECTED_SECRET\n',
+        })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+    });
+  });
+
+  test('quarantines model-visible text containing verifier expected output', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(textRuntimeEvent('The expected answer is EXPECTED_SECRET.')),
         '',
       ].join('\n'), 'utf8');
 
@@ -944,6 +1030,36 @@ function runtimeEvent(id: string, name: string, args: unknown) {
     role: 'model',
     author: 'agent',
     content: { kind: 'function_call', id, name, args },
+  };
+}
+
+function functionResponseRuntimeEvent(id: string, name: string, result: unknown) {
+  return {
+    id: `response-${id}`,
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'tool',
+    author: 'tool',
+    content: { kind: 'function_response', id, name, result },
+  };
+}
+
+function textRuntimeEvent(text: string) {
+  return {
+    id: 'text-1',
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'text', text },
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -34,6 +34,7 @@ describe('prompt candidate loop', () => {
       await runPromptCandidateRound({
         runId: 'run-1',
         roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
         programPath,
         systemPromptPath,
         resultsTsvPath,
@@ -101,6 +102,7 @@ describe('prompt candidate loop', () => {
       await runPromptCandidateRound({
         runId: 'run-1',
         roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
         programPath,
         systemPromptPath,
         resultsTsvPath,
@@ -151,6 +153,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -187,6 +190,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -206,6 +210,127 @@ describe('prompt candidate loop', () => {
       );
 
       assert.equal(called, false);
+    });
+  });
+
+  test('requires an agent cwd before exposing controller artifacts', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(dir),
+        } as unknown as Parameters<typeof runPromptCandidateRound>[0]),
+        /agentCwdPath is required before exposing controller artifacts/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('requires an agent cwd when held-out artifact paths are provided', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const heldOutEventsPath = join(dir, 'held-out-runtime-events.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(heldOutEventsPath, '', 'utf8');
+
+      let called = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          heldOutArtifactPaths: [heldOutEventsPath],
+          metaAgent: async () => {
+            called = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(dir),
+        } as unknown as Parameters<typeof runPromptCandidateRound>[0]),
+        /agentCwdPath is required before exposing controller artifacts/,
+      );
+
+      assert.equal(called, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('allows controller artifacts outside agent cwd with unrelated symlinks present', async () => {
+    await withDir(async (dir) => {
+      const agentDir = join(dir, 'agent-cwd');
+      const controllerDir = join(dir, 'controller');
+      const sharedDir = join(dir, 'shared');
+      await mkdir(agentDir, { recursive: true });
+      await mkdir(controllerDir, { recursive: true });
+      await mkdir(sharedDir, { recursive: true });
+      const programPath = join(agentDir, 'program.md');
+      const systemPromptPath = join(agentDir, 'system_prompt.md');
+      const resultsTsvPath = join(controllerDir, 'results.tsv');
+      const resultsJsonlPath = join(controllerDir, 'results.jsonl');
+      const heldOutEventsPath = join(controllerDir, 'held-out-runtime-events.jsonl');
+      const sharedNotePath = join(sharedDir, 'note.md');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\nheld-out-task\ttrue\n', 'utf8');
+      await writeFile(heldOutEventsPath, '', 'utf8');
+      await writeFile(sharedNotePath, 'unrelated shared note\n', 'utf8');
+      await symlink(sharedNotePath, join(agentDir, 'shared-note.md'));
+
+      let seenInput: MetaAgentPromptInput | undefined;
+      const result = await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        agentCwdPath: agentDir,
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath,
+        heldInTaskIds: ['task-a'],
+        heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+        heldOutArtifactPaths: [heldOutEventsPath],
+        metaAgent: async (input): Promise<MetaAgentPromptResult> => {
+          seenInput = input;
+          return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+        },
+        git: gitNoop(agentDir),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.commitSha, 'commit-1');
+      assert.equal(seenInput?.resultsTsv, 'task_id\tpassed\ntask-a\tfalse\n');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'candidate prompt\n');
+      const events = (await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').map((line) => JSON.parse(line));
+      assert.equal(events[0]?.type, 'prompt_candidate_committed');
     });
   });
 
@@ -388,6 +513,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -436,6 +562,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -471,6 +598,7 @@ describe('prompt candidate loop', () => {
           runPromptCandidateRound({
             runId: 'run-1',
             roundId: 'round-1',
+            agentCwdPath: await testAgentCwd(dir),
             programPath,
             systemPromptPath,
             resultsTsvPath,
@@ -516,6 +644,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -566,6 +695,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath: programPath,
           resultsTsvPath,
@@ -603,6 +733,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -735,6 +866,29 @@ describe('prompt candidate loop', () => {
       const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
       await writeFile(runtimeEventsPath, [
         JSON.stringify(thinkingRuntimeEvent('Remember EXPECTED_SECRET for the next answer.')),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+    });
+  });
+
+  test('quarantines model-visible errors containing verifier expected output', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(errorRuntimeEvent('Tool error mentioned EXPECTED_SECRET.', {
+          stdout: 'EXPECTED_SECRET',
+        })),
         '',
       ].join('\n'), 'utf8');
 
@@ -896,6 +1050,7 @@ describe('prompt candidate loop', () => {
       const result = await runPromptCandidateRound({
         runId: 'run-1',
         roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
         programPath,
         systemPromptPath,
         resultsTsvPath,
@@ -921,6 +1076,94 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('CLI git adapter rejects edits to pre-existing dirty files during a candidate round', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const scratchPath = join(dir, 'scratch.tmp');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      await writeFile(scratchPath, 'pre-existing scratch\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
+          heldInDigests: [],
+          metaAgent: async () => {
+            await writeFile(scratchPath, 'candidate side edit\n', 'utf8');
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /only system_prompt.md may change/,
+      );
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'initial');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('CLI git adapter rejects deletion of pre-existing dirty files during a candidate round', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const scratchPath = join(dir, 'scratch.tmp');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+      await writeFile(scratchPath, 'pre-existing scratch\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
+          heldInDigests: [],
+          metaAgent: async () => {
+            await rm(scratchPath);
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /only system_prompt.md may change/,
+      );
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'initial');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
   test('CLI git adapter rejects non-prompt edits made during a candidate round', async () => {
     await withDir(async (dir) => {
       await execFileAsync('git', ['init'], { cwd: dir });
@@ -939,6 +1182,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -958,6 +1202,51 @@ describe('prompt candidate loop', () => {
 
       const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
       assert.equal(subject.stdout.trim(), 'initial');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('CLI git adapter rejects HEAD movement during a candidate round', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      const notesPath = join(dir, 'notes.md');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
+          heldInDigests: [],
+          metaAgent: async () => {
+            await writeFile(notesPath, 'side commit\n', 'utf8');
+            await execFileAsync('git', ['add', 'notes.md'], { cwd: dir });
+            await execFileAsync('git', ['commit', '-m', 'side edit'], { cwd: dir });
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /candidate round HEAD moved before prompt commit/,
+      );
+
+      const subjects = await execFileAsync('git', ['log', '--format=%s', '--max-count=2'], { cwd: dir });
+      assert.deepEqual(subjects.stdout.trim().split('\n'), ['side edit', 'initial']);
       assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
@@ -982,6 +1271,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -1021,6 +1311,7 @@ describe('prompt candidate loop', () => {
       const result = await runPromptCandidateRound({
         runId: 'run-1',
         roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
         programPath,
         systemPromptPath: join(dir, 'system_prompt.md'),
         resultsTsvPath,
@@ -1058,6 +1349,7 @@ describe('prompt candidate loop', () => {
       const result = await runPromptCandidateRound({
         runId: 'run-1',
         roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
         programPath,
         systemPromptPath,
         resultsTsvPath,
@@ -1097,6 +1389,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -1138,6 +1431,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -1179,6 +1473,7 @@ describe('prompt candidate loop', () => {
         runPromptCandidateRound({
           runId: 'run-1',
           roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
           programPath,
           systemPromptPath,
           resultsTsvPath,
@@ -1277,6 +1572,27 @@ function thinkingRuntimeEvent(text: string) {
     author: 'agent',
     content: { kind: 'thinking', text },
   };
+}
+
+function errorRuntimeEvent(message: string, details?: unknown) {
+  return {
+    id: 'error-1',
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'tool',
+    author: 'tool',
+    content: { kind: 'error', message, details },
+  };
+}
+
+async function testAgentCwd(dir: string): Promise<string> {
+  const agentCwdPath = join(dir, 'agent-cwd');
+  await mkdir(agentCwdPath, { recursive: true });
+  return agentCwdPath;
 }
 
 async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -218,7 +218,7 @@ describe('prompt candidate loop', () => {
       const programPath = join(agentDir, 'program.md');
       const systemPromptPath = join(agentDir, 'system_prompt.md');
       const resultsTsvPath = join(agentDir, 'results.tsv');
-      const heldOutEventsPath = join(agentDir, 'held-out-runtime-events.jsonl');
+      const heldOutEventsPath = join(controllerDir, 'held-out-runtime-events.jsonl');
       await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
       await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
       await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
@@ -244,7 +244,7 @@ describe('prompt candidate loop', () => {
           },
           git: gitNoop(agentDir),
         }),
-        /controller-only artifacts must stay outside agent cwd: held-out-runtime-events\.jsonl/,
+        /controller-only artifacts must stay outside agent cwd: results\.tsv/,
       );
       assert.equal(metaAgentCalled, false);
     });
@@ -258,7 +258,7 @@ describe('prompt candidate loop', () => {
       await mkdir(controllerDir, { recursive: true });
       const programPath = join(agentDir, 'program.md');
       const systemPromptPath = join(agentDir, 'system_prompt.md');
-      const resultsTsvPath = join(agentDir, 'results.tsv');
+      const resultsTsvPath = join(controllerDir, 'results.tsv');
       const heldOutEventsPath = join(controllerDir, 'held-out-runtime-events.jsonl');
       const visibleHeldOutLinkPath = join(agentDir, 'held-out-link.jsonl');
       await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
@@ -287,6 +287,88 @@ describe('prompt candidate loop', () => {
           git: gitNoop(agentDir),
         }),
         /controller-only artifacts must stay outside agent cwd: held-out-link\.jsonl/,
+      );
+      assert.equal(metaAgentCalled, false);
+    });
+  });
+
+  test('rejects agent-cwd symlinks to controller artifacts', async () => {
+    await withDir(async (dir) => {
+      const agentDir = join(dir, 'agent-cwd');
+      const controllerDir = join(dir, 'controller');
+      await mkdir(agentDir, { recursive: true });
+      await mkdir(controllerDir, { recursive: true });
+      const programPath = join(agentDir, 'program.md');
+      const systemPromptPath = join(agentDir, 'system_prompt.md');
+      const resultsTsvPath = join(controllerDir, 'results.tsv');
+      const resultsJsonlPath = join(controllerDir, 'results.jsonl');
+      const visibleResultsLinkPath = join(agentDir, 'results-link.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(resultsJsonlPath, '', 'utf8');
+      await symlink(resultsJsonlPath, visibleResultsLinkPath);
+
+      let metaAgentCalled = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: agentDir,
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath,
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => {
+            metaAgentCalled = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(agentDir),
+        }),
+        /controller-only artifacts must stay outside agent cwd: results-link\.jsonl/,
+      );
+      assert.equal(metaAgentCalled, false);
+    });
+  });
+
+  test('rejects agent-cwd directory symlinks that contain controller artifacts', async () => {
+    await withDir(async (dir) => {
+      const agentDir = join(dir, 'agent-cwd');
+      const controllerDir = join(dir, 'controller');
+      await mkdir(agentDir, { recursive: true });
+      await mkdir(controllerDir, { recursive: true });
+      const programPath = join(agentDir, 'program.md');
+      const systemPromptPath = join(agentDir, 'system_prompt.md');
+      const resultsTsvPath = join(controllerDir, 'results.tsv');
+      const resultsJsonlPath = join(controllerDir, 'results.jsonl');
+      const visibleControllerLinkPath = join(agentDir, 'controller-link');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(resultsJsonlPath, '', 'utf8');
+      await symlink(controllerDir, visibleControllerLinkPath);
+
+      let metaAgentCalled = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: agentDir,
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath,
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => {
+            metaAgentCalled = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(agentDir),
+        }),
+        /controller-only artifacts must stay outside agent cwd: controller-link/,
       );
       assert.equal(metaAgentCalled, false);
     });
@@ -648,6 +730,27 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('quarantines replayed thinking containing verifier expected output', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(thinkingRuntimeEvent('Remember EXPECTED_SECRET for the next answer.')),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+        matchedPatterns: ['EXPECTED_SECRET'],
+      });
+    });
+  });
+
   test('quarantines when raw runtime events are unavailable', async () => {
     await withDir(async (dir) => {
       const result = await scanRuntimeEventsForRewardHack({
@@ -658,6 +761,63 @@ describe('prompt candidate loop', () => {
       assert.deepEqual(result, {
         decision: 'quarantine',
         reason: 'runtime_events_unreadable',
+      });
+    });
+  });
+
+  test('quarantines when runtime events are empty', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, '', 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'runtime_events_empty',
+      });
+    });
+  });
+
+  test('quarantines when verifier patterns are empty', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify(runtimeEvent('call-1', 'Bash', { command: 'echo hello' })),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['', '   '],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'no_verifier_patterns',
+      });
+    });
+  });
+
+  test('quarantines when runtime events contain no model-visible content', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
+      await writeFile(runtimeEventsPath, [
+        JSON.stringify({ id: 'event-1', content: { kind: 'metrics', costUsd: 0.01 } }),
+        '',
+      ].join('\n'), 'utf8');
+
+      const result = await scanRuntimeEventsForRewardHack({
+        runtimeEventsPath,
+        verifierPatterns: ['EXPECTED_SECRET'],
+      });
+
+      assert.deepEqual(result, {
+        decision: 'quarantine',
+        reason: 'no_model_visible_events',
       });
     });
   });
@@ -758,6 +918,47 @@ describe('prompt candidate loop', () => {
       assert.match(status.stdout, /^A  notes\.md$/m);
       assert.match(status.stdout, /^\?\? scratch\.tmp$/m);
       assert.equal(result.commitSha.length, 40);
+    });
+  });
+
+  test('CLI git adapter rejects non-prompt edits made during a candidate round', async () => {
+    await withDir(async (dir) => {
+      await execFileAsync('git', ['init'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+      await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await execFileAsync('git', ['add', '.'], { cwd: dir });
+      await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: dir });
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: [],
+          heldInDigests: [],
+          metaAgent: async () => {
+            await writeFile(programPath, 'tampered program\n', 'utf8');
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /only system_prompt.md may change/,
+      );
+
+      const subject = await execFileAsync('git', ['log', '-1', '--format=%s'], { cwd: dir });
+      assert.equal(subject.stdout.trim(), 'initial');
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
 
@@ -1060,6 +1261,21 @@ function textRuntimeEvent(text: string) {
     role: 'model',
     author: 'agent',
     content: { kind: 'text', text },
+  };
+}
+
+function thinkingRuntimeEvent(text: string) {
+  return {
+    id: 'thinking-1',
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'thinking', text },
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -209,6 +209,47 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('rejects physically visible held-out artifacts before calling the meta-agent', async () => {
+    await withDir(async (dir) => {
+      const agentDir = join(dir, 'agent-cwd');
+      const controllerDir = join(dir, 'controller');
+      await mkdir(agentDir, { recursive: true });
+      await mkdir(controllerDir, { recursive: true });
+      const programPath = join(agentDir, 'program.md');
+      const systemPromptPath = join(agentDir, 'system_prompt.md');
+      const resultsTsvPath = join(agentDir, 'results.tsv');
+      const heldOutEventsPath = join(agentDir, 'held-out-runtime-events.jsonl');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+      await writeFile(heldOutEventsPath, '', 'utf8');
+
+      let metaAgentCalled = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: agentDir,
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(controllerDir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          heldOutDigests: [{ taskId: 'held-out-task', summary: 'hidden held-out task' }],
+          heldOutArtifactPaths: [heldOutEventsPath],
+          metaAgent: async () => {
+            metaAgentCalled = true;
+            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          },
+          git: gitNoop(agentDir),
+        }),
+        /controller-only artifacts must stay outside agent cwd: held-out-runtime-events\.jsonl/,
+      );
+      assert.equal(metaAgentCalled, false);
+    });
+  });
+
   test('fails closed when the prompt edit changes files outside system_prompt.md', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { FixedPromptWalEvent } from '../fixed-prompt-controller.js';
+import {
+  promptStructuralSmokeReport,
+  renderPromptStructuralSmokeMarkdown,
+} from '../prompt-structural-smoke.js';
+
+describe('prompt structural smoke report', () => {
+  test('passes after ten unattended discard decisions under budget', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise'));
+      events.push(completedEvent(`round-${index}`, `task-${index}`, 0.1));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'pass');
+    assert.equal(report.observedRounds, 10);
+    assert.equal(report.decisions.keep, 0);
+    assert.equal(report.decisions.discard, 10);
+    assert.equal(report.totalCostUsd, 1);
+    assert.deepEqual(report.failures, []);
+
+    const markdown = renderPromptStructuralSmokeMarkdown(report);
+    assert.match(markdown, /# Prompt Structural Smoke/);
+    assert.match(markdown, /- status: pass/);
+    assert.match(markdown, /- rounds: 10 \/ 10/);
+    assert.match(markdown, /- cost_usd: 1 \/ 30/);
+  });
+
+  test('fails when structural smoke evidence is incomplete or unsafe', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 8; index += 1) {
+      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise'));
+      events.push(completedEvent(`round-${index}`, `task-${index}`, 4));
+    }
+    events.push(decisionEvent('round-9', 'discard', 'reward_hack_quarantined'));
+    events.push(completedEvent('round-9', 'task-9', 4));
+    events.push(plumbingFailedEvent('round-9', 'task-9'));
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, [
+      'minimum_rounds_not_met',
+      'cost_ceiling_exceeded',
+      'plumbing_failures_present',
+      'reward_hack_quarantine_present',
+    ]);
+    assert.equal(report.observedRounds, 9);
+    assert.equal(report.totalCostUsd, 37);
+
+    const markdown = renderPromptStructuralSmokeMarkdown(report);
+    assert.match(markdown, /## failures/);
+    assert.match(markdown, /- cost_ceiling_exceeded/);
+  });
+});
+
+function decisionEvent(
+  roundId: string,
+  decision: 'keep' | 'discard',
+  reason: string,
+): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'prompt_candidate_decided',
+    id: `decision-${roundId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    decision,
+    reason,
+    candidateCommitSha: `candidate-${roundId}`,
+    previousLastKeptCommitSha: 'kept-0',
+    lastKeptCommitSha: decision === 'keep' ? `candidate-${roundId}` : 'kept-0',
+    previousHeldInReferencePassEligibleRate: 0.5,
+    heldInReferencePassEligibleRate: 0.5,
+    originalCommitSha: 'original-0',
+    originalHeldOutPassEligibleRate: 0.5,
+    heldInPassRateNoiseBand: 0.05,
+    heldOutPassRateNoiseBand: 0.05,
+    metrics: {},
+  };
+}
+
+function completedEvent(roundId: string, taskId: string, costUsd: number): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_completed',
+    id: `task-${roundId}-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    taskId,
+    status: 'completed',
+    passed: false,
+    scored: true,
+    eligible: true,
+    tokenSummary: { input: 1, output: 1, reasoning: 0, total: 2, costUsd },
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
+    harbor: { reward: 0 },
+  };
+}
+
+function plumbingFailedEvent(roundId: string, taskId: string): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_plumbing_failed',
+    id: `plumbing-${roundId}-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    taskId,
+    status: 'plumbing_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'prompt_hash_mismatch',
+    error: 'prompt hash mismatch',
+    tokenSummary: { input: 1, output: 1, reasoning: 0, total: 2, costUsd: 1 },
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
+    harbor: { reward: 0 },
+  };
+}

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -10,8 +10,10 @@ describe('prompt structural smoke report', () => {
   test('passes after ten unattended discard decisions under budget', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
-      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
-      events.push(completedEvent(`round-${index}`, `task-${index}`, 0.1));
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
     }
 
     const report = promptStructuralSmokeReport({
@@ -37,14 +39,17 @@ describe('prompt structural smoke report', () => {
   test('fails when structural smoke evidence is incomplete or unsafe', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 8; index += 1) {
-      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
-      events.push(completedEvent(`round-${index}`, `task-${index}`, 4));
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 4));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
     }
+    events.push(committedEvent('round-9'));
+    events.push(completedEvent('round-9', 'task-9', 4));
     events.push(decisionEvent('round-9', 'discard', 'reward_hack_quarantined', 'run-1', {
       decision: 'quarantine',
       reason: 'verifier_pattern',
     }));
-    events.push(completedEvent('round-9', 'task-9', 4));
     events.push(plumbingFailedEvent('round-9', 'task-9'));
 
     const report = promptStructuralSmokeReport({
@@ -100,6 +105,7 @@ describe('prompt structural smoke report', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
       events.push(decisionEvent(roundId, 'discard', 'coverage_regressed', 'run-1', { decision: 'clean' }));
       events.push(infraFailedEvent(roundId, `task-${index}`));
     }
@@ -130,6 +136,7 @@ describe('prompt structural smoke report', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
+      events.push(committedEvent(roundId, 'run-current'));
       events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-old'));
       events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-current', { decision: 'clean' }));
     }
@@ -160,13 +167,15 @@ describe('prompt structural smoke report', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 5; index += 1) {
       const roundId = `round-${index}`;
-      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-a', { decision: 'clean' }));
+      events.push(committedEvent(roundId, 'run-a'));
       events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-a'));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-a', { decision: 'clean' }));
     }
     for (let index = 6; index <= 10; index += 1) {
       const roundId = `round-${index}`;
-      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-b', { decision: 'clean' }));
+      events.push(committedEvent(roundId, 'run-b'));
       events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-b'));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-b', { decision: 'clean' }));
     }
 
     const report = promptStructuralSmokeReport({
@@ -183,8 +192,9 @@ describe('prompt structural smoke report', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
-      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise'));
+      events.push(committedEvent(roundId));
       events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise'));
     }
 
     const report = promptStructuralSmokeReport({
@@ -201,11 +211,12 @@ describe('prompt structural smoke report', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
       const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
       events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', {
         decision: 'quarantine',
         reason: 'verifier_pattern',
       }));
-      events.push(completedEvent(roundId, `task-${index}`, 0.1));
     }
 
     const report = promptStructuralSmokeReport({
@@ -217,7 +228,201 @@ describe('prompt structural smoke report', () => {
     assert.equal(report.status, 'fail');
     assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
   });
+
+  test('fails when reward-hack scan has an unknown decision', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', {
+        decision: 'skipped',
+      } as unknown as PromptCandidateRewardHackScan));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.equal(report.quarantineCount, 10);
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
+  });
+
+  test('fails when reward-hack scan evidence is null', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      const event = decisionEvent(
+        roundId,
+        'discard',
+        'held_in_within_noise',
+        'run-1',
+        { decision: 'clean' },
+      );
+      (event as { rewardHackScan: unknown }).rewardHackScan = null;
+      events.push(event);
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.equal(report.quarantineCount, 10);
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
+  });
+
+  test('fails when task evidence is appended after decision rounds', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when task evidence uses a different prompt hash from the committed candidate', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-1', `sha256:stale-${roundId}`));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when matching task evidence has no prior candidate commit', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when matching task evidence predates the candidate commit', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(committedEvent(roundId));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
 });
+
+function committedEvent(
+  roundId: string,
+  runId = 'run-1',
+  promptHash = promptHashForRound(roundId),
+): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'prompt_candidate_committed',
+    id: `commit-${roundId}`,
+    ts: 1,
+    runId,
+    roundId,
+    commitSha: `candidate-${roundId}`,
+    summary: `candidate ${roundId}`,
+    promptHash,
+  };
+}
 
 function decisionEvent(
   roundId: string,
@@ -254,6 +459,7 @@ function completedEvent(
   taskId: string,
   costUsd: number,
   runId = 'run-1',
+  promptHash = promptHashForRound(roundId),
 ): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
@@ -267,12 +473,17 @@ function completedEvent(
     passed: false,
     scored: true,
     eligible: true,
+    promptHash,
     tokenSummary: { input: 1, output: 1, reasoning: 0, total: 2, costUsd },
     steps: 1,
     durationMs: 10,
     runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
     harbor: { reward: 0 },
   };
+}
+
+function promptHashForRound(roundId: string): string {
+  return `sha256:${roundId}`;
 }
 
 function plumbingFailedEvent(roundId: string, taskId: string): FixedPromptWalEvent {

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -156,6 +156,29 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(report.failures, ['task_evidence_missing']);
   });
 
+  test('fails when decision rounds span multiple runs', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 5; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-a', { decision: 'clean' }));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-a'));
+    }
+    for (let index = 6; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-b', { decision: 'clean' }));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-b'));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['multiple_runs_present']);
+  });
+
   test('fails when decision rounds have no reward-hack scan evidence', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
@@ -172,6 +195,27 @@ describe('prompt structural smoke report', () => {
 
     assert.equal(report.status, 'fail');
     assert.deepEqual(report.failures, ['reward_hack_scan_missing']);
+  });
+
+  test('fails when reward-hack scan quarantines despite a mismatched reason', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', {
+        decision: 'quarantine',
+        reason: 'verifier_pattern',
+      }));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['reward_hack_quarantine_present']);
   });
 });
 

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { FixedPromptWalEvent } from '../fixed-prompt-controller.js';
+import type { FixedPromptWalEvent, PromptCandidateRewardHackScan } from '../fixed-prompt-controller.js';
 import {
   promptStructuralSmokeReport,
   renderPromptStructuralSmokeMarkdown,
@@ -10,7 +10,7 @@ describe('prompt structural smoke report', () => {
   test('passes after ten unattended discard decisions under budget', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {
-      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise'));
+      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
       events.push(completedEvent(`round-${index}`, `task-${index}`, 0.1));
     }
 
@@ -37,10 +37,13 @@ describe('prompt structural smoke report', () => {
   test('fails when structural smoke evidence is incomplete or unsafe', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 8; index += 1) {
-      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise'));
+      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
       events.push(completedEvent(`round-${index}`, `task-${index}`, 4));
     }
-    events.push(decisionEvent('round-9', 'discard', 'reward_hack_quarantined'));
+    events.push(decisionEvent('round-9', 'discard', 'reward_hack_quarantined', 'run-1', {
+      decision: 'quarantine',
+      reason: 'verifier_pattern',
+    }));
     events.push(completedEvent('round-9', 'task-9', 4));
     events.push(plumbingFailedEvent('round-9', 'task-9'));
 
@@ -64,19 +67,127 @@ describe('prompt structural smoke report', () => {
     assert.match(markdown, /## failures/);
     assert.match(markdown, /- cost_ceiling_exceeded/);
   });
+
+  test('fails when decision rounds have no task evidence', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      events.push(decisionEvent(`round-${index}`, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when decision rounds have only infra failures', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(decisionEvent(roundId, 'discard', 'coverage_regressed', 'run-1', { decision: 'clean' }));
+      events.push(infraFailedEvent(roundId, `task-${index}`));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when task evidence belongs to a different run', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(completedEvent(roundId, `task-${index}`, 0.1, 'run-old'));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-current', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.roundsWithoutTaskEvidence, [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+      'round-6',
+      'round-7',
+      'round-8',
+      'round-9',
+      'round-10',
+    ]);
+    assert.deepEqual(report.failures, ['task_evidence_missing']);
+  });
+
+  test('fails when decision rounds have no reward-hack scan evidence', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise'));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 30,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['reward_hack_scan_missing']);
+  });
 });
 
 function decisionEvent(
   roundId: string,
   decision: 'keep' | 'discard',
   reason: string,
+  runId = 'run-1',
+  rewardHackScan?: PromptCandidateRewardHackScan,
 ): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
     type: 'prompt_candidate_decided',
     id: `decision-${roundId}`,
     ts: 1,
-    runId: 'run-1',
+    runId,
     roundId,
     decision,
     reason,
@@ -89,17 +200,23 @@ function decisionEvent(
     originalHeldOutPassEligibleRate: 0.5,
     heldInPassRateNoiseBand: 0.05,
     heldOutPassRateNoiseBand: 0.05,
+    ...(rewardHackScan ? { rewardHackScan } : {}),
     metrics: {},
   };
 }
 
-function completedEvent(roundId: string, taskId: string, costUsd: number): FixedPromptWalEvent {
+function completedEvent(
+  roundId: string,
+  taskId: string,
+  costUsd: number,
+  runId = 'run-1',
+): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
     type: 'task_completed',
     id: `task-${roundId}-${taskId}`,
     ts: 1,
-    runId: 'run-1',
+    runId,
     roundId,
     taskId,
     status: 'completed',
@@ -134,5 +251,23 @@ function plumbingFailedEvent(roundId: string, taskId: string): FixedPromptWalEve
     durationMs: 10,
     runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
     harbor: { reward: 0 },
+  };
+}
+
+function infraFailedEvent(roundId: string, taskId: string): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_infra_failed',
+    id: `infra-${roundId}-${taskId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    taskId,
+    status: 'infra_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: 'infra_error',
+    error: 'container crashed',
   };
 }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -150,10 +150,16 @@ export interface RunFixedPromptControllerInput {
   resultsJsonlPath: string;
   resultsTsvPath: string;
   tasks: readonly FixedPromptTask[];
+  maxInfraFailureRate?: number;
+  costCeilingUsd?: number;
   harborRunner: HarborTaskRunner;
   now?: () => number;
   newId?: () => string;
 }
+
+export type FixedPromptControllerStopReason =
+  | 'infra_failure_rate_exceeded'
+  | 'cost_ceiling_exceeded';
 
 export interface FixedPromptControllerResult {
   taskIds: string[];
@@ -161,6 +167,7 @@ export interface FixedPromptControllerResult {
   totalTokens: number;
   totalCostUsd: number;
   resultsTsvPath: string;
+  stopReason?: FixedPromptControllerStopReason;
 }
 
 export async function runFixedPromptController(
@@ -173,8 +180,15 @@ export async function runFixedPromptController(
   const config = { ...input.config, systemPrompt };
   const events = await readFixedPromptWal(input.resultsJsonlPath);
   const completed = terminalTaskEvents(events, input.runId, input.roundId, expectedPromptHash);
+  let stopReason = controllerStopReason({
+    events: [...completed.values()],
+    taskCount: input.tasks.length,
+    maxInfraFailureRate: input.maxInfraFailureRate,
+    costCeilingUsd: input.costCeilingUsd,
+  });
 
   for (const task of input.tasks) {
+    if (stopReason) break;
     if (completed.has(task.id)) continue;
 
     const event = await runTaskAndBuildEvent({
@@ -189,6 +203,12 @@ export async function runFixedPromptController(
     await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
     events.push(event);
     completed.set(task.id, event);
+    stopReason = controllerStopReason({
+      events: [...completed.values()],
+      taskCount: input.tasks.length,
+      maxInfraFailureRate: input.maxInfraFailureRate,
+      costCeilingUsd: input.costCeilingUsd,
+    });
   }
 
   const resultEvents = input.tasks
@@ -202,6 +222,7 @@ export async function runFixedPromptController(
     totalTokens: sum(resultEvents.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.total : 0)),
     totalCostUsd: sum(resultEvents.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0)),
     resultsTsvPath: input.resultsTsvPath,
+    ...(stopReason ? { stopReason } : {}),
   };
 }
 
@@ -498,6 +519,33 @@ function tsvCell(value: string): string {
 
 function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+function controllerStopReason(input: {
+  events: readonly FixedPromptTaskWalEvent[];
+  taskCount: number;
+  maxInfraFailureRate?: number;
+  costCeilingUsd?: number;
+}): FixedPromptControllerStopReason | undefined {
+  if (
+    input.maxInfraFailureRate !== undefined
+    && infraFailureRate(input.events, input.taskCount) > input.maxInfraFailureRate
+  ) {
+    return 'infra_failure_rate_exceeded';
+  }
+  if (input.costCeilingUsd !== undefined && taskEventsCostUsd(input.events) > input.costCeilingUsd) {
+    return 'cost_ceiling_exceeded';
+  }
+  return undefined;
+}
+
+function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount: number): number {
+  if (taskCount <= 0) return 0;
+  return events.filter((event) => event.type === 'task_infra_failed').length / taskCount;
+}
+
+function taskEventsCostUsd(events: readonly FixedPromptTaskWalEvent[]): number {
+  return sum(events.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0));
 }
 
 async function truncateTornWalTail(path: string): Promise<void> {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -152,6 +152,7 @@ export interface RunFixedPromptControllerInput {
   tasks: readonly FixedPromptTask[];
   maxInfraFailureRate?: number;
   costCeilingUsd?: number;
+  maxConcurrency?: number;
   harborRunner: HarborTaskRunner;
   now?: () => number;
   newId?: () => string;
@@ -186,12 +187,17 @@ export async function runFixedPromptController(
     maxInfraFailureRate: input.maxInfraFailureRate,
     costCeilingUsd: input.costCeilingUsd,
   });
+  const maxConcurrency = normalizeMaxConcurrency(input.maxConcurrency);
 
-  for (const task of input.tasks) {
+  for (let index = 0; index < input.tasks.length;) {
     if (stopReason) break;
-    if (completed.has(task.id)) continue;
-
-    const event = await runTaskAndBuildEvent({
+    const batch: FixedPromptTask[] = [];
+    while (batch.length < maxConcurrency && index < input.tasks.length) {
+      const task = input.tasks[index++]!;
+      if (!completed.has(task.id)) batch.push(task);
+    }
+    if (batch.length === 0) continue;
+    const batchEvents = await Promise.all(batch.map((task) => runTaskAndBuildEvent({
       input,
       task,
       config,
@@ -199,10 +205,12 @@ export async function runFixedPromptController(
       expectedPromptHash,
       id: newId(),
       ts: now(),
-    });
-    await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
-    events.push(event);
-    completed.set(task.id, event);
+    })));
+    for (const event of batchEvents) {
+      await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
+      events.push(event);
+      completed.set(event.taskId, event);
+    }
     stopReason = controllerStopReason({
       events: [...completed.values()],
       taskCount: input.tasks.length,
@@ -546,6 +554,14 @@ function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount:
 
 function taskEventsCostUsd(events: readonly FixedPromptTaskWalEvent[]): number {
   return sum(events.map((event) => event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0));
+}
+
+function normalizeMaxConcurrency(value: number | undefined): number {
+  if (value === undefined) return 1;
+  if (!Number.isFinite(value) || value < 1) {
+    throw new Error('maxConcurrency must be at least 1');
+  }
+  return Math.floor(value);
 }
 
 async function truncateTornWalTail(path: string): Promise<void> {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -193,7 +193,7 @@ export async function runFixedPromptController(
     maxInfraFailureRate: input.maxInfraFailureRate,
     costCeilingUsd: input.costCeilingUsd,
   });
-  const maxConcurrency = normalizeMaxConcurrency(input.maxConcurrency);
+  const maxConcurrency = hasStopGuard(input) ? 1 : normalizeMaxConcurrency(input.maxConcurrency);
 
   for (let index = 0; index < input.tasks.length;) {
     if (stopReason) break;
@@ -565,10 +565,14 @@ function controllerStopReason(input: {
   ) {
     return 'infra_failure_rate_exceeded';
   }
-  if (input.costCeilingUsd !== undefined && taskEventsCostUsd(input.events) > input.costCeilingUsd) {
+  if (input.costCeilingUsd !== undefined && taskEventsCostUsd(input.events) >= input.costCeilingUsd) {
     return 'cost_ceiling_exceeded';
   }
   return undefined;
+}
+
+function hasStopGuard(input: RunFixedPromptControllerInput): boolean {
+  return input.maxInfraFailureRate !== undefined || input.costCeilingUsd !== undefined;
 }
 
 function infraFailureRate(events: readonly FixedPromptTaskWalEvent[], taskCount: number): number {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -109,6 +109,10 @@ export interface PromptCandidateCommittedEvent {
   promptHash: string;
 }
 
+export type PromptCandidateRewardHackScan =
+  | { decision: 'clean' }
+  | { decision: 'quarantine'; reason: string; matchedPatterns?: readonly string[] };
+
 export interface PromptCandidateDecisionEvent {
   schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
   type: 'prompt_candidate_decided';
@@ -127,6 +131,7 @@ export interface PromptCandidateDecisionEvent {
   originalHeldOutPassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
+  rewardHackScan?: PromptCandidateRewardHackScan;
   metrics: unknown;
 }
 
@@ -181,8 +186,9 @@ export async function runFixedPromptController(
   const config = { ...input.config, systemPrompt };
   const events = await readFixedPromptWal(input.resultsJsonlPath);
   const completed = terminalTaskEvents(events, input.runId, input.roundId, expectedPromptHash);
+  const stopEvidence = roundTaskEvents(events, input.runId, input.roundId, expectedPromptHash);
   let stopReason = controllerStopReason({
-    events: [...completed.values()],
+    events: [...stopEvidence.values()],
     taskCount: input.tasks.length,
     maxInfraFailureRate: input.maxInfraFailureRate,
     costCeilingUsd: input.costCeilingUsd,
@@ -210,17 +216,19 @@ export async function runFixedPromptController(
       await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
       events.push(event);
       completed.set(event.taskId, event);
+      stopEvidence.set(event.taskId, event);
     }
     stopReason = controllerStopReason({
-      events: [...completed.values()],
+      events: [...stopEvidence.values()],
       taskCount: input.tasks.length,
       maxInfraFailureRate: input.maxInfraFailureRate,
       costCeilingUsd: input.costCeilingUsd,
     });
   }
 
+  const resultByTask = stopReason ? stopEvidence : completed;
   const resultEvents = input.tasks
-    .map((task) => completed.get(task.id))
+    .map((task) => resultByTask.get(task.id))
     .filter((event): event is FixedPromptTaskWalEvent => event !== undefined);
   await writeFixedPromptResultsTsv(input.resultsTsvPath, resultEvents);
 
@@ -504,6 +512,22 @@ function terminalTaskEvents(
     ) {
       byTask.set(event.taskId, event);
     }
+  }
+  return byTask;
+}
+
+function roundTaskEvents(
+  events: readonly FixedPromptWalEvent[],
+  runId: string,
+  roundId: string,
+  expectedPromptHash: string,
+): Map<string, FixedPromptTaskWalEvent> {
+  const byTask = new Map<string, FixedPromptTaskWalEvent>();
+  for (const event of events) {
+    if (!isTaskEvent(event)) continue;
+    if (event.runId !== runId || event.roundId !== roundId) continue;
+    if (!eventMatchesPrompt(event, expectedPromptHash)) continue;
+    byTask.set(event.taskId, event);
   }
   return byTask;
 }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -26,6 +26,7 @@ export {
   runHarborCellFromEnv,
 } from './harbor-cell.js';
 export type {
+  FixedPromptControllerStopReason,
   FixedPromptControllerResult,
   FixedPromptTask,
   FixedPromptTaskCompletedEvent,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -106,6 +106,15 @@ export {
   summarizePromptAcceptancePartition,
 } from './prompt-acceptance-policy.js';
 export type {
+  PromptStructuralSmokeFailure,
+  PromptStructuralSmokeReport,
+  PromptStructuralSmokeReportInput,
+} from './prompt-structural-smoke.js';
+export {
+  promptStructuralSmokeReport,
+  renderPromptStructuralSmokeMarkdown,
+} from './prompt-structural-smoke.js';
+export type {
   BenchmarkAdapter,
   BenchmarkAdapterRegistry,
   BenchmarkInstanceRef,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -61,6 +61,8 @@ export type {
   MetaAgentCompletionInput,
   PromptCandidateGit,
   PromptCandidateRoundResult,
+  RewardHackScanInput,
+  RewardHackScanResult,
   RunPromptCandidateRoundInput,
   TrajectoryDigest,
   TrajectoryToolCallDigest,
@@ -73,6 +75,7 @@ export {
   parseMetaAgentResult,
   renderMetaAgentPrompt,
   runPromptCandidateRound,
+  scanRuntimeEventsForRewardHack,
 } from './prompt-candidate-loop.js';
 export type {
   AppendPromptAcceptanceDecisionInput,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -39,6 +39,7 @@ export type {
   HarborTaskRunner,
   PromptCandidateCommittedEvent,
   PromptCandidateDecisionEvent,
+  PromptCandidateRewardHackScan,
   ReadHarborTaskRunOutputInput,
   RunFixedPromptControllerInput,
 } from './fixed-prompt-controller.js';
@@ -97,6 +98,7 @@ export type {
   StablePromptTaskSelectionResult,
 } from './prompt-acceptance-policy.js';
 export {
+  PROMPT_REWARD_HACK_QUARANTINE_REASON,
   appendPromptAcceptanceDecision,
   calibratePromptAcceptanceBaseline,
   decidePromptAcceptance,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -91,6 +91,9 @@ export type {
   PromptAcceptanceReason,
   PromptAcceptanceResult,
   PromptAcceptanceState,
+  SelectStablePromptTasksInput,
+  StablePromptTaskRejectionReason,
+  StablePromptTaskSelectionResult,
 } from './prompt-acceptance-policy.js';
 export {
   appendPromptAcceptanceDecision,
@@ -98,6 +101,7 @@ export {
   decidePromptAcceptance,
   promptAcceptanceNoiseBand,
   promptAcceptanceStateFromWal,
+  selectStablePromptTasks,
   summarizePromptAcceptancePartition,
 } from './prompt-acceptance-policy.js';
 export type {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -1,6 +1,7 @@
 import {
   appendFixedPromptWalEvent,
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
+  type FixedPromptTaskCompletedEvent,
   type FixedPromptWalEvent,
   type FixedPromptTaskWalEvent,
   type PromptCandidateDecisionEvent,
@@ -130,6 +131,26 @@ export interface PromptAcceptanceState {
   }>;
 }
 
+export type StablePromptTaskRejectionReason =
+  | 'incomplete'
+  | 'unstable_outcome'
+  | 'too_slow';
+
+export interface SelectStablePromptTasksInput {
+  taskIds: readonly string[];
+  baselineRuns: readonly (readonly FixedPromptTaskWalEvent[])[];
+  maxPassRateSpread?: number;
+  maxDurationMs?: number;
+}
+
+export interface StablePromptTaskSelectionResult {
+  selectedTaskIds: string[];
+  rejectedTaskIds: Array<{
+    taskId: string;
+    reason: StablePromptTaskRejectionReason;
+  }>;
+}
+
 export function calibratePromptAcceptanceBaseline(
   input: CalibratePromptAcceptanceBaselineInput,
 ): PromptAcceptanceBaseline {
@@ -189,6 +210,41 @@ export function promptAcceptanceNoiseBand(input: PromptAcceptanceNoiseBandInput)
   const wilson = wilsonHalfWidth(input.sampleSize, input.passRate, zScore);
   const differenceWidth = wilson * Math.sqrt(1 + 1 / input.baselineRunCount);
   return Math.max(differenceWidth, observedSpread);
+}
+
+export function selectStablePromptTasks(
+  input: SelectStablePromptTasksInput,
+): StablePromptTaskSelectionResult {
+  const maxPassRateSpread = input.maxPassRateSpread ?? 0;
+  const selectedTaskIds: string[] = [];
+  const rejectedTaskIds: StablePromptTaskSelectionResult['rejectedTaskIds'] = [];
+  const baselineRunsByTask = input.baselineRuns.map((run) => new Map(run.map((event) => [event.taskId, event])));
+  for (const taskId of input.taskIds) {
+    const events = baselineRunsByTask.map((run) => run.get(taskId));
+    const completedEvents = events.filter(isStableBaselineEvent);
+    if (completedEvents.length !== events.length) {
+      rejectedTaskIds.push({ taskId, reason: 'incomplete' });
+      continue;
+    }
+    const maxDurationMs = input.maxDurationMs;
+    if (maxDurationMs !== undefined && completedEvents.some((event) => event.durationMs > maxDurationMs)) {
+      rejectedTaskIds.push({ taskId, reason: 'too_slow' });
+      continue;
+    }
+    const passRates = completedEvents.map((event) => event.passed ? 1 : 0);
+    if (Math.max(...passRates) - Math.min(...passRates) > maxPassRateSpread) {
+      rejectedTaskIds.push({ taskId, reason: 'unstable_outcome' });
+      continue;
+    }
+    selectedTaskIds.push(taskId);
+  }
+  return { selectedTaskIds, rejectedTaskIds };
+}
+
+function isStableBaselineEvent(
+  event: FixedPromptTaskWalEvent | undefined,
+): event is FixedPromptTaskCompletedEvent {
+  return event?.type === 'task_completed' && event.eligible && event.scored;
 }
 
 export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): PromptAcceptanceResult {

--- a/packages/headless/src/prompt-acceptance-policy.ts
+++ b/packages/headless/src/prompt-acceptance-policy.ts
@@ -5,16 +5,20 @@ import {
   type FixedPromptWalEvent,
   type FixedPromptTaskWalEvent,
   type PromptCandidateDecisionEvent,
+  type PromptCandidateRewardHackScan,
 } from './fixed-prompt-controller.js';
 
 export type PromptAcceptanceDecision = 'keep' | 'discard';
+
+export const PROMPT_REWARD_HACK_QUARANTINE_REASON = 'reward_hack_quarantined';
 
 export type PromptAcceptanceReason =
   | 'held_in_improved'
   | 'held_in_within_noise'
   | 'held_in_regressed'
   | 'coverage_regressed'
-  | 'held_out_regressed';
+  | 'held_out_regressed'
+  | typeof PROMPT_REWARD_HACK_QUARANTINE_REASON;
 
 export interface PromptAcceptancePartitionSummary {
   taskCount: number;
@@ -95,6 +99,7 @@ export interface DecidePromptAcceptanceInput {
   originalEvents: readonly FixedPromptTaskWalEvent[];
   lastKeptEvents: readonly FixedPromptTaskWalEvent[];
   candidateEvents: readonly FixedPromptTaskWalEvent[];
+  rewardHackScan?: PromptCandidateRewardHackScan;
 }
 
 export interface PromptAcceptanceResult {
@@ -111,6 +116,7 @@ export interface PromptAcceptanceResult {
   originalHeldOutPassEligibleRate: number | null;
   heldInPassRateNoiseBand: number;
   heldOutPassRateNoiseBand: number;
+  rewardHackScan: PromptCandidateRewardHackScan;
   metrics: PromptAcceptanceMetrics;
 }
 
@@ -218,6 +224,12 @@ export function selectStablePromptTasks(
   const maxPassRateSpread = input.maxPassRateSpread ?? 0;
   const selectedTaskIds: string[] = [];
   const rejectedTaskIds: StablePromptTaskSelectionResult['rejectedTaskIds'] = [];
+  if (input.baselineRuns.length === 0) {
+    return {
+      selectedTaskIds,
+      rejectedTaskIds: input.taskIds.map((taskId) => ({ taskId, reason: 'incomplete' })),
+    };
+  }
   const baselineRunsByTask = input.baselineRuns.map((run) => new Map(run.map((event) => [event.taskId, event])));
   for (const taskId of input.taskIds) {
     const events = baselineRunsByTask.map((run) => run.get(taskId));
@@ -231,8 +243,8 @@ export function selectStablePromptTasks(
       rejectedTaskIds.push({ taskId, reason: 'too_slow' });
       continue;
     }
-    const passRates = completedEvents.map((event) => event.passed ? 1 : 0);
-    if (Math.max(...passRates) - Math.min(...passRates) > maxPassRateSpread) {
+    const passIndicators = completedEvents.map((event) => event.passed ? 1 : 0);
+    if (Math.max(...passIndicators) - Math.min(...passIndicators) > maxPassRateSpread) {
       rejectedTaskIds.push({ taskId, reason: 'unstable_outcome' });
       continue;
     }
@@ -248,6 +260,7 @@ function isStableBaselineEvent(
 }
 
 export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): PromptAcceptanceResult {
+  const rewardHackScan = normalizeRewardHackScan(input.rewardHackScan);
   const metrics: PromptAcceptanceMetrics = {
     original: {
       heldOut: summarizePromptAcceptancePartition(input.originalEvents, input.heldOutTaskIds),
@@ -265,6 +278,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     originalHeldOutPassEligibleRate: input.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
+    rewardHackScan,
   });
   const decision: PromptAcceptanceDecision = reason === 'held_in_improved' ? 'keep' : 'discard';
   const heldInReferencePassEligibleRate = nextHeldInReferencePassEligibleRate({
@@ -287,6 +301,7 @@ export function decidePromptAcceptance(input: DecidePromptAcceptanceInput): Prom
     originalHeldOutPassEligibleRate: input.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.heldOutPassRateNoiseBand,
+    rewardHackScan,
     metrics,
   };
 }
@@ -411,6 +426,7 @@ function promptCandidateDecisionEvent(
     originalHeldOutPassEligibleRate: input.result.originalHeldOutPassEligibleRate,
     heldInPassRateNoiseBand: input.result.heldInPassRateNoiseBand,
     heldOutPassRateNoiseBand: input.result.heldOutPassRateNoiseBand,
+    rewardHackScan: input.result.rewardHackScan,
     metrics: input.result.metrics,
   };
 }
@@ -422,6 +438,7 @@ function acceptanceReason(
     originalHeldOutPassEligibleRate: number | null;
     heldInPassRateNoiseBand: number;
     heldOutPassRateNoiseBand: number;
+    rewardHackScan: PromptCandidateRewardHackScan;
   },
 ): PromptAcceptanceReason {
   const heldInCandidate = metrics.candidate.heldIn;
@@ -429,6 +446,9 @@ function acceptanceReason(
   const heldOutCandidate = metrics.candidate.heldOut;
   const heldOutReference = metrics.original.heldOut;
 
+  if (input.rewardHackScan.decision === 'quarantine') {
+    return PROMPT_REWARD_HACK_QUARANTINE_REASON;
+  }
   if (
     hasBlockingTaskFailure(heldInReference)
     || hasBlockingTaskFailure(heldOutReference)
@@ -468,6 +488,10 @@ function acceptanceReason(
     return 'held_in_regressed';
   }
   return 'held_in_within_noise';
+}
+
+function normalizeRewardHackScan(scan: PromptCandidateRewardHackScan | undefined): PromptCandidateRewardHackScan {
+  return scan ?? { decision: 'quarantine', reason: 'scan_missing' };
 }
 
 function nextHeldInReferencePassEligibleRate(input: {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -32,6 +32,16 @@ export interface ExtractTrajectoryDigestInput {
   verifierSummary: string;
 }
 
+export interface RewardHackScanInput {
+  runtimeEventsPath: string;
+  verifierPatterns: readonly string[];
+}
+
+export type RewardHackScanResult =
+  | { decision: 'clean' }
+  | { decision: 'quarantine'; reason: 'runtime_events_unreadable' }
+  | { decision: 'quarantine'; reason: 'verifier_pattern'; matchedPatterns: readonly string[] };
+
 export interface MetaAgentPromptInput {
   runId: string;
   roundId: string;
@@ -199,6 +209,35 @@ export async function extractTrajectoryDigest(
     summary: input.verifierSummary,
     ...(recentToolCalls.length > 0 ? { recentToolCalls } : {}),
   };
+}
+
+export async function scanRuntimeEventsForRewardHack(
+  input: RewardHackScanInput,
+): Promise<RewardHackScanResult> {
+  let events: unknown[];
+  try {
+    events = await readRuntimeEventsJsonl(input.runtimeEventsPath);
+  } catch {
+    return { decision: 'quarantine', reason: 'runtime_events_unreadable' };
+  }
+
+  const patterns = input.verifierPatterns.filter((pattern) => pattern.length > 0);
+  const matchedPatterns = new Set<string>();
+  for (const event of events) {
+    for (const value of functionCallArgStrings(event)) {
+      for (const pattern of patterns) {
+        if (value.includes(pattern)) matchedPatterns.add(pattern);
+      }
+    }
+  }
+  if (matchedPatterns.size > 0) {
+    return {
+      decision: 'quarantine',
+      reason: 'verifier_pattern',
+      matchedPatterns: [...matchedPatterns].sort((a, b) => a.localeCompare(b)),
+    };
+  }
+  return { decision: 'clean' };
 }
 
 export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): MetaAgent {
@@ -429,6 +468,20 @@ function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefine
     name: content.name,
     argsPreview: argsPreview(content.args),
   };
+}
+
+function functionCallArgStrings(event: unknown): readonly string[] {
+  if (!isRecord(event) || !isRecord(event.content)) return [];
+  const content = event.content;
+  if (content.kind !== 'function_call') return [];
+  return stringValues(content.args);
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap((item) => stringValues(item));
+  if (isRecord(value)) return Object.values(value).flatMap((item) => stringValues(item));
+  return [];
 }
 
 function argsPreview(args: unknown): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { execFile, execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
-import { lstat, readFile, realpath, writeFile } from 'node:fs/promises';
+import { lstat, readdir, readFile, readlink, realpath, writeFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
@@ -40,6 +40,9 @@ export interface RewardHackScanInput {
 export type RewardHackScanResult =
   | { decision: 'clean' }
   | { decision: 'quarantine'; reason: 'runtime_events_unreadable' }
+  | { decision: 'quarantine'; reason: 'runtime_events_empty' }
+  | { decision: 'quarantine'; reason: 'no_verifier_patterns' }
+  | { decision: 'quarantine'; reason: 'no_model_visible_events' }
   | { decision: 'quarantine'; reason: 'verifier_pattern'; matchedPatterns: readonly string[] };
 
 export interface MetaAgentPromptInput {
@@ -101,6 +104,11 @@ export interface RunPromptCandidateRoundInput {
   newId?: () => string;
 }
 
+interface ArtifactTargetPath {
+  absolutePath: string;
+  realPath: string;
+}
+
 export interface PromptCandidateRoundResult {
   systemPrompt: string;
   summary: string;
@@ -117,7 +125,7 @@ export async function runPromptCandidateRound(
   if (input.agentCwdPath !== undefined) {
     await assertControllerOnlyArtifactsOutsideAgentCwd(
       input.agentCwdPath,
-      [input.resultsJsonlPath, ...(input.heldOutArtifactPaths ?? [])],
+      [input.resultsTsvPath, input.resultsJsonlPath, ...(input.heldOutArtifactPaths ?? [])],
     );
   }
   await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
@@ -210,18 +218,56 @@ async function assertControllerOnlyArtifactsOutsideAgentCwd(
   const agentCwdAbsolutePath = resolve(agentCwdPath);
   const agentCwdRealPath = await realpath(agentCwdPath);
   const visibleArtifacts = new Set<string>();
+  const artifactTargetPaths: ArtifactTargetPath[] = [];
   for (const artifactPath of artifactPaths) {
     const artifactAbsolutePath = resolve(artifactPath);
     if (artifactAbsolutePath === agentCwdAbsolutePath || isPathInside(agentCwdAbsolutePath, artifactAbsolutePath)) {
       visibleArtifacts.add(normalizeGitPath(relative(agentCwdAbsolutePath, artifactAbsolutePath) || basename(artifactPath)));
     }
     const artifactRealPath = await realOrParentResolvedPath(artifactPath);
+    artifactTargetPaths.push({ absolutePath: artifactAbsolutePath, realPath: artifactRealPath });
     if (artifactRealPath === agentCwdRealPath || isPathInside(agentCwdRealPath, artifactRealPath)) {
       visibleArtifacts.add(normalizeGitPath(relative(agentCwdRealPath, artifactRealPath) || basename(artifactPath)));
     }
   }
+  await addSymlinkedControllerArtifacts(agentCwdAbsolutePath, agentCwdAbsolutePath, artifactTargetPaths, visibleArtifacts);
   if (visibleArtifacts.size > 0) {
     throw new Error(`controller-only artifacts must stay outside agent cwd: ${[...visibleArtifacts].join(', ')}`);
+  }
+}
+
+async function addSymlinkedControllerArtifacts(
+  agentCwdPath: string,
+  currentPath: string,
+  artifactPaths: readonly ArtifactTargetPath[],
+  visibleArtifacts: Set<string>,
+): Promise<void> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = resolve(currentPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      const targetPath = resolve(dirname(entryPath), await readlink(entryPath));
+      let targetRealPath: string | undefined;
+      try {
+        targetRealPath = await realpath(entryPath);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+      if (artifactPaths.some((artifactPath) => (
+        artifactPath.absolutePath === targetPath
+        || artifactPath.realPath === targetPath
+        || artifactPath.realPath === targetRealPath
+        || isPathInside(targetPath, artifactPath.absolutePath)
+        || isPathInside(targetPath, artifactPath.realPath)
+        || (targetRealPath !== undefined && isPathInside(targetRealPath, artifactPath.realPath))
+      ))) {
+        visibleArtifacts.add(normalizeGitPath(relative(agentCwdPath, entryPath)));
+      }
+      continue;
+    }
+    if (entry.isDirectory()) {
+      await addSymlinkedControllerArtifacts(agentCwdPath, entryPath, artifactPaths, visibleArtifacts);
+    }
   }
 }
 
@@ -260,15 +306,20 @@ export async function scanRuntimeEventsForRewardHack(
     return { decision: 'quarantine', reason: 'runtime_events_unreadable' };
   }
 
-  const patterns = input.verifierPatterns.filter((pattern) => pattern.length > 0);
+  const patterns = input.verifierPatterns.filter((pattern) => pattern.trim().length > 0);
+  if (patterns.length === 0) return { decision: 'quarantine', reason: 'no_verifier_patterns' };
+  if (events.length === 0) return { decision: 'quarantine', reason: 'runtime_events_empty' };
   const matchedPatterns = new Set<string>();
+  let visibleValues = 0;
   for (const event of events) {
     for (const value of modelVisibleStrings(event)) {
+      visibleValues += 1;
       for (const pattern of patterns) {
         if (value.includes(pattern)) matchedPatterns.add(pattern);
       }
     }
   }
+  if (visibleValues === 0) return { decision: 'quarantine', reason: 'no_model_visible_events' };
   if (matchedPatterns.size > 0) {
     return {
       decision: 'quarantine',
@@ -396,6 +447,7 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
     ? realpathSync(input.systemPromptPath)
     : realpathSync(resolve(input.cwd, input.systemPromptPath));
   const systemPromptGitPath = toGitRelativePath(gitRootPath, systemPromptPath);
+  let statusBaseline: Set<string> | undefined;
   return {
     gitRootPath,
     systemPromptGitPath,
@@ -410,19 +462,11 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       if (worktreeDirty || indexDirty) {
         throw new Error('system_prompt.md must be clean before candidate round');
       }
+      statusBaseline = new Set(await gitStatusFiles(gitRootPath));
     },
     async changedFiles(): Promise<readonly string[]> {
-      const { stdout } = await execFileAsync('git', [
-        'status',
-        '--porcelain',
-        '--untracked-files=all',
-        '--',
-        systemPromptGitPath,
-      ], { cwd: gitRootPath });
-      return stdout
-        .split('\n')
-        .map((line) => line.slice(3).trim())
-        .filter((line) => line.length > 0);
+      const baseline = statusBaseline ?? new Set<string>();
+      return (await gitStatusFiles(gitRootPath)).filter((path) => !baseline.has(path));
     },
     async commit(message: string): Promise<string> {
       await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
@@ -460,6 +504,26 @@ async function hasGitDiff(cwd: string, args: readonly string[]): Promise<boolean
   } catch {
     return true;
   }
+}
+
+async function gitStatusFiles(cwd: string): Promise<readonly string[]> {
+  const { stdout } = await execFileAsync('git', [
+    'status',
+    '--porcelain',
+    '--untracked-files=all',
+  ], { cwd });
+  return stdout
+    .split('\n')
+    .map((line) => statusPath(line))
+    .filter((path): path is string => path !== undefined);
+}
+
+function statusPath(line: string): string | undefined {
+  const path = line.slice(3).trim();
+  if (path.length === 0) return undefined;
+  const renameSeparator = ' -> ';
+  const renameIndex = path.indexOf(renameSeparator);
+  return renameIndex === -1 ? path : path.slice(renameIndex + renameSeparator.length);
 }
 
 function findGitRoot(cwd: string): string {
@@ -513,6 +577,7 @@ function modelVisibleStrings(event: unknown): readonly string[] {
   if (!isRecord(event) || !isRecord(event.content)) return [];
   const content = event.content;
   if (content.kind === 'text' && typeof content.text === 'string') return [content.text];
+  if (content.kind === 'thinking' && typeof content.text === 'string') return [content.text];
   if (content.kind === 'function_call') return stringValues(content.args);
   if (content.kind === 'function_response') return stringValues(content.result);
   return [];

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -207,16 +207,21 @@ async function assertControllerOnlyArtifactsOutsideAgentCwd(
   agentCwdPath: string,
   artifactPaths: readonly string[],
 ): Promise<void> {
+  const agentCwdAbsolutePath = resolve(agentCwdPath);
   const agentCwdRealPath = await realpath(agentCwdPath);
-  const visibleArtifacts: string[] = [];
+  const visibleArtifacts = new Set<string>();
   for (const artifactPath of artifactPaths) {
+    const artifactAbsolutePath = resolve(artifactPath);
+    if (artifactAbsolutePath === agentCwdAbsolutePath || isPathInside(agentCwdAbsolutePath, artifactAbsolutePath)) {
+      visibleArtifacts.add(normalizeGitPath(relative(agentCwdAbsolutePath, artifactAbsolutePath) || basename(artifactPath)));
+    }
     const artifactRealPath = await realOrParentResolvedPath(artifactPath);
     if (artifactRealPath === agentCwdRealPath || isPathInside(agentCwdRealPath, artifactRealPath)) {
-      visibleArtifacts.push(normalizeGitPath(relative(agentCwdRealPath, artifactRealPath) || basename(artifactPath)));
+      visibleArtifacts.add(normalizeGitPath(relative(agentCwdRealPath, artifactRealPath) || basename(artifactPath)));
     }
   }
-  if (visibleArtifacts.length > 0) {
-    throw new Error(`controller-only artifacts must stay outside agent cwd: ${visibleArtifacts.join(', ')}`);
+  if (visibleArtifacts.size > 0) {
+    throw new Error(`controller-only artifacts must stay outside agent cwd: ${[...visibleArtifacts].join(', ')}`);
   }
 }
 
@@ -258,7 +263,7 @@ export async function scanRuntimeEventsForRewardHack(
   const patterns = input.verifierPatterns.filter((pattern) => pattern.length > 0);
   const matchedPatterns = new Set<string>();
   for (const event of events) {
-    for (const value of functionCallArgStrings(event)) {
+    for (const value of modelVisibleStrings(event)) {
       for (const pattern of patterns) {
         if (value.includes(pattern)) matchedPatterns.add(pattern);
       }
@@ -504,11 +509,13 @@ function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefine
   };
 }
 
-function functionCallArgStrings(event: unknown): readonly string[] {
+function modelVisibleStrings(event: unknown): readonly string[] {
   if (!isRecord(event) || !isRecord(event.content)) return [];
   const content = event.content;
-  if (content.kind !== 'function_call') return [];
-  return stringValues(content.args);
+  if (content.kind === 'text' && typeof content.text === 'string') return [content.text];
+  if (content.kind === 'function_call') return stringValues(content.args);
+  if (content.kind === 'function_response') return stringValues(content.result);
+  return [];
 }
 
 function stringValues(value: unknown): string[] {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { execFile, execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { lstat, readFile, realpath, writeFile } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
   appendFixedPromptWalEvent,
@@ -86,6 +86,7 @@ export interface CreateCliPromptCandidateGitInput {
 export interface RunPromptCandidateRoundInput {
   runId: string;
   roundId: string;
+  agentCwdPath?: string;
   programPath: string;
   systemPromptPath: string;
   resultsTsvPath: string;
@@ -93,6 +94,7 @@ export interface RunPromptCandidateRoundInput {
   heldInTaskIds: readonly string[];
   heldInDigests: readonly TrajectoryDigest[];
   heldOutDigests?: readonly TrajectoryDigest[];
+  heldOutArtifactPaths?: readonly string[];
   metaAgent: MetaAgent;
   git: PromptCandidateGit;
   now?: () => number;
@@ -112,6 +114,12 @@ export async function runPromptCandidateRound(
   const newId = input.newId ?? randomId;
   assertHeldInDigestsBelongToHeldInTasks(input.heldInTaskIds, input.heldInDigests);
   assertHeldInAndHeldOutDisjoint(input.heldInTaskIds, input.heldOutDigests ?? []);
+  if (input.agentCwdPath !== undefined) {
+    await assertControllerOnlyArtifactsOutsideAgentCwd(
+      input.agentCwdPath,
+      [input.resultsJsonlPath, ...(input.heldOutArtifactPaths ?? [])],
+    );
+  }
   await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   await input.git.assertSystemPromptClean();
@@ -192,6 +200,32 @@ function assertHeldInDigestsBelongToHeldInTasks(
   const outside = heldInDigests.find((digest) => !heldInTasks.has(digest.taskId));
   if (outside) {
     throw new Error(`held-in digests must belong to held-in task set: ${outside.taskId}`);
+  }
+}
+
+async function assertControllerOnlyArtifactsOutsideAgentCwd(
+  agentCwdPath: string,
+  artifactPaths: readonly string[],
+): Promise<void> {
+  const agentCwdRealPath = await realpath(agentCwdPath);
+  const visibleArtifacts: string[] = [];
+  for (const artifactPath of artifactPaths) {
+    const artifactRealPath = await realOrParentResolvedPath(artifactPath);
+    if (artifactRealPath === agentCwdRealPath || isPathInside(agentCwdRealPath, artifactRealPath)) {
+      visibleArtifacts.push(normalizeGitPath(relative(agentCwdRealPath, artifactRealPath) || basename(artifactPath)));
+    }
+  }
+  if (visibleArtifacts.length > 0) {
+    throw new Error(`controller-only artifacts must stay outside agent cwd: ${visibleArtifacts.join(', ')}`);
+  }
+}
+
+async function realOrParentResolvedPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    return resolve(await realpath(dirname(path)), basename(path));
   }
 }
 
@@ -491,4 +525,8 @@ function argsPreview(args: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === 'ENOENT';
 }

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { execFile, execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { lstat, readdir, readFile, readlink, realpath, writeFile } from 'node:fs/promises';
@@ -89,7 +89,7 @@ export interface CreateCliPromptCandidateGitInput {
 export interface RunPromptCandidateRoundInput {
   runId: string;
   roundId: string;
-  agentCwdPath?: string;
+  agentCwdPath: string;
   programPath: string;
   systemPromptPath: string;
   resultsTsvPath: string;
@@ -122,12 +122,14 @@ export async function runPromptCandidateRound(
   const newId = input.newId ?? randomId;
   assertHeldInDigestsBelongToHeldInTasks(input.heldInTaskIds, input.heldInDigests);
   assertHeldInAndHeldOutDisjoint(input.heldInTaskIds, input.heldOutDigests ?? []);
-  if (input.agentCwdPath !== undefined) {
-    await assertControllerOnlyArtifactsOutsideAgentCwd(
-      input.agentCwdPath,
-      [input.resultsTsvPath, input.resultsJsonlPath, ...(input.heldOutArtifactPaths ?? [])],
-    );
+  const heldOutArtifactPaths = input.heldOutArtifactPaths ?? [];
+  if (input.agentCwdPath === undefined) {
+    throw new Error('agentCwdPath is required before exposing controller artifacts');
   }
+  await assertControllerOnlyArtifactsOutsideAgentCwd(
+    input.agentCwdPath,
+    [input.resultsTsvPath, input.resultsJsonlPath, ...heldOutArtifactPaths],
+  );
   await assertSystemPromptPathMatchesGit(input.systemPromptPath, input.git);
   await assertRegularSystemPromptFile(input.systemPromptPath, input.git.gitRootPath);
   await input.git.assertSystemPromptClean();
@@ -447,7 +449,8 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
     ? realpathSync(input.systemPromptPath)
     : realpathSync(resolve(input.cwd, input.systemPromptPath));
   const systemPromptGitPath = toGitRelativePath(gitRootPath, systemPromptPath);
-  let statusBaseline: Set<string> | undefined;
+  let statusBaseline: ReadonlyMap<string, string> | undefined;
+  let headBaseline: string | undefined;
   return {
     gitRootPath,
     systemPromptGitPath,
@@ -462,13 +465,22 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       if (worktreeDirty || indexDirty) {
         throw new Error('system_prompt.md must be clean before candidate round');
       }
-      statusBaseline = new Set(await gitStatusFiles(gitRootPath));
+      [statusBaseline, headBaseline] = await Promise.all([
+        gitStatusSnapshot(gitRootPath),
+        gitHeadSha(gitRootPath),
+      ]);
     },
     async changedFiles(): Promise<readonly string[]> {
-      const baseline = statusBaseline ?? new Set<string>();
-      return (await gitStatusFiles(gitRootPath)).filter((path) => !baseline.has(path));
+      await assertGitHeadUnchanged(gitRootPath, headBaseline);
+      const baseline = statusBaseline ?? new Map<string, string>();
+      const current = await gitStatusSnapshot(gitRootPath);
+      const paths = new Set([...baseline.keys(), ...current.keys()]);
+      return [...paths].filter((path) => (
+        baseline.get(path) !== current.get(path)
+      ));
     },
     async commit(message: string): Promise<string> {
+      await assertGitHeadUnchanged(gitRootPath, headBaseline);
       await execFileAsync('git', ['add', '--', systemPromptGitPath], { cwd: gitRootPath });
       await execFileAsync('git', ['commit', '-m', message, '--', systemPromptGitPath], { cwd: gitRootPath });
       const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: gitRootPath });
@@ -486,6 +498,19 @@ export function createCliPromptCandidateGit(input: CreateCliPromptCandidateGitIn
       await execFileAsync('git', ['restore', '--staged', '--worktree', '--', systemPromptGitPath], { cwd: gitRootPath });
     },
   };
+}
+
+async function assertGitHeadUnchanged(cwd: string, baseline: string | undefined): Promise<void> {
+  if (baseline === undefined) return;
+  const current = await gitHeadSha(cwd);
+  if (current !== baseline) {
+    throw new Error('candidate round HEAD moved before prompt commit');
+  }
+}
+
+async function gitHeadSha(cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd });
+  return stdout.trim();
 }
 
 async function isGitTracked(cwd: string, path: string): Promise<boolean> {
@@ -516,6 +541,38 @@ async function gitStatusFiles(cwd: string): Promise<readonly string[]> {
     .split('\n')
     .map((line) => statusPath(line))
     .filter((path): path is string => path !== undefined);
+}
+
+async function gitStatusSnapshot(cwd: string): Promise<ReadonlyMap<string, string>> {
+  const snapshot = new Map<string, string>();
+  for (const path of await gitStatusFiles(cwd)) {
+    snapshot.set(path, await gitStatusFingerprint(cwd, path));
+  }
+  return snapshot;
+}
+
+async function gitStatusFingerprint(cwd: string, path: string): Promise<string> {
+  const [fileHash, worktreeDiff, indexDiff] = await Promise.all([
+    fileFingerprint(resolve(cwd, path)),
+    gitDiffFingerprint(cwd, ['diff', '--binary', '--', path]),
+    gitDiffFingerprint(cwd, ['diff', '--cached', '--binary', '--', path]),
+  ]);
+  return [fileHash, worktreeDiff, indexDiff].join('\0');
+}
+
+async function fileFingerprint(path: string): Promise<string> {
+  try {
+    const content = await readFile(path);
+    return createHash('sha256').update(content).digest('hex');
+  } catch (error) {
+    if (isNotFound(error)) return 'missing';
+    throw error;
+  }
+}
+
+async function gitDiffFingerprint(cwd: string, args: readonly string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', [...args], { cwd, encoding: 'buffer' });
+  return createHash('sha256').update(stdout).digest('hex');
 }
 
 function statusPath(line: string): string | undefined {
@@ -580,6 +637,7 @@ function modelVisibleStrings(event: unknown): readonly string[] {
   if (content.kind === 'thinking' && typeof content.text === 'string') return [content.text];
   if (content.kind === 'function_call') return stringValues(content.args);
   if (content.kind === 'function_response') return stringValues(content.result);
+  if (content.kind === 'error') return stringValues([content.message, content.details]);
   return [];
 }
 

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -1,0 +1,123 @@
+import type { FixedPromptTaskWalEvent, FixedPromptWalEvent } from './fixed-prompt-controller.js';
+
+export type PromptStructuralSmokeFailure =
+  | 'minimum_rounds_not_met'
+  | 'cost_ceiling_exceeded'
+  | 'plumbing_failures_present'
+  | 'reward_hack_quarantine_present';
+
+export interface PromptStructuralSmokeReportInput {
+  events: readonly FixedPromptWalEvent[];
+  minimumRounds?: number;
+  costCeilingUsd?: number;
+}
+
+export interface PromptStructuralSmokeReport {
+  schemaVersion: 'maka.prompt_structural_smoke.v1';
+  status: 'pass' | 'fail';
+  minimumRounds: number;
+  observedRounds: number;
+  decisions: {
+    keep: number;
+    discard: number;
+  };
+  taskEvents: {
+    completed: number;
+    infraFailed: number;
+    plumbingFailed: number;
+  };
+  quarantineCount: number;
+  totalCostUsd: number;
+  costCeilingUsd?: number;
+  failures: PromptStructuralSmokeFailure[];
+}
+
+export function promptStructuralSmokeReport(
+  input: PromptStructuralSmokeReportInput,
+): PromptStructuralSmokeReport {
+  const minimumRounds = input.minimumRounds ?? 10;
+  const decisionEvents = input.events.filter((event) => event.type === 'prompt_candidate_decided');
+  const taskEvents = input.events.filter(isTaskWalEvent);
+  const observedRounds = new Set(decisionEvents.map((event) => event.roundId)).size;
+  const quarantineCount = decisionEvents.filter((event) => isQuarantineReason(event.reason)).length;
+  const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
+    event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0
+  ))));
+  const failures: PromptStructuralSmokeFailure[] = [];
+  if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');
+  if (input.costCeilingUsd !== undefined && totalCostUsd > input.costCeilingUsd) {
+    failures.push('cost_ceiling_exceeded');
+  }
+  if (taskEvents.some((event) => event.type === 'task_plumbing_failed')) {
+    failures.push('plumbing_failures_present');
+  }
+  if (quarantineCount > 0) failures.push('reward_hack_quarantine_present');
+
+  return {
+    schemaVersion: 'maka.prompt_structural_smoke.v1',
+    status: failures.length === 0 ? 'pass' : 'fail',
+    minimumRounds,
+    observedRounds,
+    decisions: {
+      keep: decisionEvents.filter((event) => event.decision === 'keep').length,
+      discard: decisionEvents.filter((event) => event.decision === 'discard').length,
+    },
+    taskEvents: {
+      completed: taskEvents.filter((event) => event.type === 'task_completed').length,
+      infraFailed: taskEvents.filter((event) => event.type === 'task_infra_failed').length,
+      plumbingFailed: taskEvents.filter((event) => event.type === 'task_plumbing_failed').length,
+    },
+    quarantineCount,
+    totalCostUsd,
+    ...(input.costCeilingUsd !== undefined ? { costCeilingUsd: input.costCeilingUsd } : {}),
+    failures,
+  };
+}
+
+export function renderPromptStructuralSmokeMarkdown(report: PromptStructuralSmokeReport): string {
+  const lines = [
+    '# Prompt Structural Smoke',
+    '',
+    `- status: ${report.status}`,
+    `- rounds: ${report.observedRounds} / ${report.minimumRounds}`,
+    `- decisions: keep=${report.decisions.keep}, discard=${report.decisions.discard}`,
+    `- task_events: ${taskEventsSummary(report)}`,
+    `- reward_hack_quarantine: ${report.quarantineCount}`,
+    `- cost_usd: ${report.totalCostUsd}${costCeilingSuffix(report)}`,
+    '',
+  ];
+  if (report.failures.length > 0) {
+    lines.push('## failures', '', ...report.failures.map((failure) => `- ${failure}`), '');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function isTaskWalEvent(event: FixedPromptWalEvent): event is FixedPromptTaskWalEvent {
+  return event.type === 'task_completed'
+    || event.type === 'task_infra_failed'
+    || event.type === 'task_plumbing_failed';
+}
+
+function isQuarantineReason(reason: string): boolean {
+  return reason.includes('quarantine') || reason.includes('reward_hack');
+}
+
+function taskEventsSummary(report: PromptStructuralSmokeReport): string {
+  return [
+    `completed=${report.taskEvents.completed}`,
+    `infra_failed=${report.taskEvents.infraFailed}`,
+    `plumbing_failed=${report.taskEvents.plumbingFailed}`,
+  ].join(', ');
+}
+
+function costCeilingSuffix(report: PromptStructuralSmokeReport): string {
+  return report.costCeilingUsd === undefined ? '' : ` / ${report.costCeilingUsd}`;
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function roundCost(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -46,11 +46,7 @@ export function promptStructuralSmokeReport(
   const completedTaskEvents = taskEvents.filter((event) => event.type === 'task_completed');
   const observedRounds = new Set(decisionEvents.map((event) => event.roundId)).size;
   const observedRunCount = new Set(decisionEvents.map((event) => event.runId)).size;
-  const taskEvidenceRounds = new Set(completedTaskEvents.map(roundEvidenceKey));
-  const decisionRounds = new Map(decisionEvents.map((event) => [roundEvidenceKey(event), event.roundId]));
-  const roundsWithoutTaskEvidence = [...decisionRounds]
-    .filter(([key]) => !taskEvidenceRounds.has(key))
-    .map(([, roundId]) => roundId)
+  const roundsWithoutTaskEvidence = roundsWithoutPriorTaskEvidence(input.events)
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const missingRewardHackScanCount = decisionEvents.filter((event) => event.rewardHackScan === undefined).length;
@@ -121,9 +117,59 @@ function roundEvidenceKey(event: { runId: string; roundId: string }): string {
   return `${event.runId}\0${event.roundId}`;
 }
 
-function isQuarantineDecision(event: { reason: string; rewardHackScan?: { decision: string } }): boolean {
+function roundsWithoutPriorTaskEvidence(events: readonly FixedPromptWalEvent[]): string[] {
+  const candidatePromptHashes = new Map<string, string>();
+  const candidateKeysByRoundAndPromptHash = new Map<string, Set<string>>();
+  const taskEvidenceCandidates = new Set<string>();
+  const missingRounds = new Map<string, string>();
+  for (const event of events) {
+    const roundKey = roundEvidenceKey(event);
+    if (event.type === 'prompt_candidate_committed') {
+      const candidateKey = candidateEvidenceKey(event);
+      candidatePromptHashes.set(candidateKey, event.promptHash);
+      const roundPromptHashKey = roundPromptHashEvidenceKey(event, event.promptHash);
+      const candidateKeys = candidateKeysByRoundAndPromptHash.get(roundPromptHashKey) ?? new Set<string>();
+      candidateKeys.add(candidateKey);
+      candidateKeysByRoundAndPromptHash.set(roundPromptHashKey, candidateKeys);
+    }
+    if (event.type === 'task_completed' && event.promptHash !== undefined) {
+      const candidateKeys = candidateKeysByRoundAndPromptHash.get(roundPromptHashEvidenceKey(event, event.promptHash));
+      for (const candidateKey of candidateKeys ?? []) {
+        taskEvidenceCandidates.add(candidateKey);
+      }
+    }
+    if (event.type === 'prompt_candidate_decided') {
+      const candidateKey = decisionCandidateEvidenceKey(event);
+      if (!candidatePromptHashes.has(candidateKey) || !taskEvidenceCandidates.has(candidateKey)) {
+        missingRounds.set(roundKey, event.roundId);
+      }
+    }
+  }
+  return [...missingRounds.values()];
+}
+
+function candidateEvidenceKey(event: { runId: string; roundId: string; commitSha: string }): string {
+  return `${event.runId}\0${event.roundId}\0${event.commitSha}`;
+}
+
+function decisionCandidateEvidenceKey(event: { runId: string; roundId: string; candidateCommitSha: string }): string {
+  return `${event.runId}\0${event.roundId}\0${event.candidateCommitSha}`;
+}
+
+function roundPromptHashEvidenceKey(event: { runId: string; roundId: string }, promptHash: string): string {
+  return `${roundEvidenceKey(event)}\0${promptHash}`;
+}
+
+function isQuarantineDecision(event: { reason: string; rewardHackScan?: unknown }): boolean {
   return event.reason === PROMPT_REWARD_HACK_QUARANTINE_REASON
-    || event.rewardHackScan?.decision === 'quarantine';
+    || (event.rewardHackScan !== undefined && !isCleanRewardHackScan(event.rewardHackScan));
+}
+
+function isCleanRewardHackScan(scan: unknown): boolean {
+  return typeof scan === 'object'
+    && scan !== null
+    && 'decision' in scan
+    && scan.decision === 'clean';
 }
 
 function taskEventsSummary(report: PromptStructuralSmokeReport): string {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -3,6 +3,7 @@ import { PROMPT_REWARD_HACK_QUARANTINE_REASON } from './prompt-acceptance-policy
 
 export type PromptStructuralSmokeFailure =
   | 'minimum_rounds_not_met'
+  | 'multiple_runs_present'
   | 'task_evidence_missing'
   | 'cost_ceiling_exceeded'
   | 'plumbing_failures_present'
@@ -44,19 +45,21 @@ export function promptStructuralSmokeReport(
   const taskEvents = input.events.filter(isTaskWalEvent);
   const completedTaskEvents = taskEvents.filter((event) => event.type === 'task_completed');
   const observedRounds = new Set(decisionEvents.map((event) => event.roundId)).size;
+  const observedRunCount = new Set(decisionEvents.map((event) => event.runId)).size;
   const taskEvidenceRounds = new Set(completedTaskEvents.map(roundEvidenceKey));
   const decisionRounds = new Map(decisionEvents.map((event) => [roundEvidenceKey(event), event.roundId]));
   const roundsWithoutTaskEvidence = [...decisionRounds]
     .filter(([key]) => !taskEvidenceRounds.has(key))
     .map(([, roundId]) => roundId)
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
-  const quarantineCount = decisionEvents.filter((event) => isQuarantineReason(event.reason)).length;
+  const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const missingRewardHackScanCount = decisionEvents.filter((event) => event.rewardHackScan === undefined).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
     event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0
   ))));
   const failures: PromptStructuralSmokeFailure[] = [];
   if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');
+  if (observedRunCount > 1) failures.push('multiple_runs_present');
   if (roundsWithoutTaskEvidence.length > 0) failures.push('task_evidence_missing');
   if (input.costCeilingUsd !== undefined && totalCostUsd > input.costCeilingUsd) {
     failures.push('cost_ceiling_exceeded');
@@ -118,8 +121,9 @@ function roundEvidenceKey(event: { runId: string; roundId: string }): string {
   return `${event.runId}\0${event.roundId}`;
 }
 
-function isQuarantineReason(reason: string): boolean {
-  return reason === PROMPT_REWARD_HACK_QUARANTINE_REASON;
+function isQuarantineDecision(event: { reason: string; rewardHackScan?: { decision: string } }): boolean {
+  return event.reason === PROMPT_REWARD_HACK_QUARANTINE_REASON
+    || event.rewardHackScan?.decision === 'quarantine';
 }
 
 function taskEventsSummary(report: PromptStructuralSmokeReport): string {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -1,9 +1,12 @@
 import type { FixedPromptTaskWalEvent, FixedPromptWalEvent } from './fixed-prompt-controller.js';
+import { PROMPT_REWARD_HACK_QUARANTINE_REASON } from './prompt-acceptance-policy.js';
 
 export type PromptStructuralSmokeFailure =
   | 'minimum_rounds_not_met'
+  | 'task_evidence_missing'
   | 'cost_ceiling_exceeded'
   | 'plumbing_failures_present'
+  | 'reward_hack_scan_missing'
   | 'reward_hack_quarantine_present';
 
 export interface PromptStructuralSmokeReportInput {
@@ -27,6 +30,7 @@ export interface PromptStructuralSmokeReport {
     plumbingFailed: number;
   };
   quarantineCount: number;
+  roundsWithoutTaskEvidence: string[];
   totalCostUsd: number;
   costCeilingUsd?: number;
   failures: PromptStructuralSmokeFailure[];
@@ -38,19 +42,29 @@ export function promptStructuralSmokeReport(
   const minimumRounds = input.minimumRounds ?? 10;
   const decisionEvents = input.events.filter((event) => event.type === 'prompt_candidate_decided');
   const taskEvents = input.events.filter(isTaskWalEvent);
+  const completedTaskEvents = taskEvents.filter((event) => event.type === 'task_completed');
   const observedRounds = new Set(decisionEvents.map((event) => event.roundId)).size;
+  const taskEvidenceRounds = new Set(completedTaskEvents.map(roundEvidenceKey));
+  const decisionRounds = new Map(decisionEvents.map((event) => [roundEvidenceKey(event), event.roundId]));
+  const roundsWithoutTaskEvidence = [...decisionRounds]
+    .filter(([key]) => !taskEvidenceRounds.has(key))
+    .map(([, roundId]) => roundId)
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   const quarantineCount = decisionEvents.filter((event) => isQuarantineReason(event.reason)).length;
+  const missingRewardHackScanCount = decisionEvents.filter((event) => event.rewardHackScan === undefined).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
     event.type !== 'task_infra_failed' ? event.tokenSummary.costUsd : 0
   ))));
   const failures: PromptStructuralSmokeFailure[] = [];
   if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');
+  if (roundsWithoutTaskEvidence.length > 0) failures.push('task_evidence_missing');
   if (input.costCeilingUsd !== undefined && totalCostUsd > input.costCeilingUsd) {
     failures.push('cost_ceiling_exceeded');
   }
   if (taskEvents.some((event) => event.type === 'task_plumbing_failed')) {
     failures.push('plumbing_failures_present');
   }
+  if (missingRewardHackScanCount > 0) failures.push('reward_hack_scan_missing');
   if (quarantineCount > 0) failures.push('reward_hack_quarantine_present');
 
   return {
@@ -63,11 +77,12 @@ export function promptStructuralSmokeReport(
       discard: decisionEvents.filter((event) => event.decision === 'discard').length,
     },
     taskEvents: {
-      completed: taskEvents.filter((event) => event.type === 'task_completed').length,
+      completed: completedTaskEvents.length,
       infraFailed: taskEvents.filter((event) => event.type === 'task_infra_failed').length,
       plumbingFailed: taskEvents.filter((event) => event.type === 'task_plumbing_failed').length,
     },
     quarantineCount,
+    roundsWithoutTaskEvidence,
     totalCostUsd,
     ...(input.costCeilingUsd !== undefined ? { costCeilingUsd: input.costCeilingUsd } : {}),
     failures,
@@ -82,6 +97,7 @@ export function renderPromptStructuralSmokeMarkdown(report: PromptStructuralSmok
     `- rounds: ${report.observedRounds} / ${report.minimumRounds}`,
     `- decisions: keep=${report.decisions.keep}, discard=${report.decisions.discard}`,
     `- task_events: ${taskEventsSummary(report)}`,
+    `- rounds_without_task_evidence: ${report.roundsWithoutTaskEvidence.length}`,
     `- reward_hack_quarantine: ${report.quarantineCount}`,
     `- cost_usd: ${report.totalCostUsd}${costCeilingSuffix(report)}`,
     '',
@@ -98,8 +114,12 @@ function isTaskWalEvent(event: FixedPromptWalEvent): event is FixedPromptTaskWal
     || event.type === 'task_plumbing_failed';
 }
 
+function roundEvidenceKey(event: { runId: string; roundId: string }): string {
+  return `${event.runId}\0${event.roundId}`;
+}
+
 function isQuarantineReason(reason: string): boolean {
-  return reason.includes('quarantine') || reason.includes('reward_hack');
+  return reason === PROMPT_REWARD_HACK_QUARANTINE_REASON;
 }
 
 function taskEventsSummary(report: PromptStructuralSmokeReport): string {


### PR DESCRIPTION
Refs #64.

## Summary

PR6 adds the V1 safety and scale hardening layer for the harness RSI loop:

- reward-hack scanner over model-visible runtime events, with fail-closed quarantine paths
- prompt candidate artifact isolation for controller-only results and held-out artifacts, including cwd and symlink checks
- stable task selection and baseline evidence guards
- fixed-prompt controller stop guards for infra rate and cost ceiling, plus deterministic guarded concurrency
- structural smoke report that binds prompt commit, task evidence, decision order, prompt hash, candidate commit hash, and scan evidence
- CLI git containment for dirty baseline drift, side edits, deleted side files, and HEAD drift

## Commit Boundaries

This is intentionally not one large commit. The branch has 9 review-sized commits:

1. reward-hack scanner
2. prompt artifact isolation
3. stable prompt task selection
4. infra/budget stop guards
5. deterministic concurrency
6. structural smoke report
7. smoke evidence hardening
8. isolation guard hardening
9. guarded round evidence binding

## Verification

- `npm run -w @maka/headless test` — 197 tests pass
- `npm run -w @maka/headless typecheck`
- `npm run -w @maka/headless build`
- `git diff --check origin/main...HEAD`

## Review Gate

- fresh-eye final review: PASS, no P0/P1, no worthwhile pre-merge P2/P3
- Claude final review: PASS, no P0/P1

Claude noted that the exported hardening primitives are not yet composed into a full unattended RSI orchestrator. I treated that as a follow-up integration check, not a PR6 blocker: missing scan evidence already fails closed in acceptance/smoke, and this PR's agreed scope is the V1 hardening layer plus structural smoke/report.

Real API-key eval is intentionally deferred until after PR6 lands, so it can run once against the merged implementation.
