### PR TITLE
fix(headless): run Harbor adapter in task workdir

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -66,6 +66,22 @@ class MakaAgent(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
+                "set -euo pipefail; "
+                "NODE_MAJOR=$(node -p 'process.versions.node.split(\".\")[0]' 2>/dev/null || echo 0); "
+                "if [ \"$NODE_MAJOR\" -lt 22 ]; then "
+                "  if command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y curl ca-certificates; "
+                "  elif command -v yum >/dev/null 2>&1; then yum install -y curl ca-certificates; "
+                "  fi; "
+                "  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; "
+                "  export NVM_DIR=\"$HOME/.nvm\"; "
+                "  . \"$NVM_DIR/nvm.sh\"; "
+                "  nvm install 22; "
+                "  nvm alias default 22; "
+                "  for bin in node npm npx; do "
+                "    BIN_PATH=\"$(. \"$NVM_DIR/nvm.sh\" && which \"$bin\")\"; "
+                "    ln -sf \"$BIN_PATH\" \"/usr/local/bin/$bin\"; "
+                "  done; "
+                "fi; "
                 "node --version && "
                 f"test -f {shlex.quote(str(run_cell))} && "
                 f"test -f {shlex.quote(str(dist_index))}"

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1,4 +1,4 @@
-"""Harbor adapter for running a Maka RuntimeRunner cell in-place at /app."""
+"""Harbor adapter for running a Maka RuntimeRunner cell in the task workdir."""
 
 import json
 import shlex
@@ -108,7 +108,6 @@ class MakaAgent(BaseInstalledAgent):
         run_log_path = agent_dir / self._RUN_LOG_FILENAME
         shell_script = (
             "set -o pipefail; "
-            f"cd /app && "
             f"node {shlex.quote(run_cell_path)} "
             f"2>&1 | tee {shlex.quote(run_log_path.as_posix())}"
         )
@@ -135,7 +134,6 @@ class MakaAgent(BaseInstalledAgent):
             "MAKA_MODEL": model,
             "MAKA_INSTRUCTION_FILE": instruction_path.as_posix(),
             "MAKA_SYSTEM_PROMPT": system_prompt,
-            "MAKA_WORKDIR": "/app",
             "MAKA_OUTPUT_DIR": EnvironmentPaths.agent_dir.as_posix(),
             "MAKA_STORAGE_ROOT": (EnvironmentPaths.agent_dir / "maka-storage").as_posix(),
         }

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -63,7 +63,7 @@ class MakaAgent(BaseInstalledAgent):
         maka_repo = self._resolved_flags.get("maka_repo", "/opt/maka-agent")
         run_cell = Path(maka_repo) / "packages" / "headless" / "harbor" / "run-cell.mjs"
         dist_index = Path(maka_repo) / "packages" / "headless" / "dist" / "index.js"
-        await self.exec_as_agent(
+        await self.exec_as_root(
             environment,
             command=(
                 "set -euo pipefail; "

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -71,18 +71,28 @@ class MakaAgent(BaseInstalledAgent):
                 "if [ \"$NODE_MAJOR\" -lt 22 ]; then "
                 "  if command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y curl ca-certificates; "
                 "  elif command -v yum >/dev/null 2>&1; then yum install -y curl ca-certificates; "
+                "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache curl ca-certificates; "
                 "  fi; "
-                "  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash; "
-                "  export NVM_DIR=\"$HOME/.nvm\"; "
+                "  export NVM_DIR=\"/usr/local/nvm\"; "
+                "  mkdir -p \"$NVM_DIR\"; "
+                "  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | PROFILE=/dev/null bash; "
                 "  . \"$NVM_DIR/nvm.sh\"; "
                 "  nvm install 22; "
                 "  nvm alias default 22; "
+                "  chmod -R a+rX \"$NVM_DIR\"; "
                 "  for bin in node npm npx; do "
                 "    BIN_PATH=\"$(. \"$NVM_DIR/nvm.sh\" && which \"$bin\")\"; "
                 "    ln -sf \"$BIN_PATH\" \"/usr/local/bin/$bin\"; "
                 "  done; "
-                "fi; "
+                "fi"
+            ),
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
                 "node --version && "
+                "NODE_MAJOR=$(node -p 'process.versions.node.split(\".\")[0]') && "
+                "test \"$NODE_MAJOR\" -ge 22 && "
                 f"test -f {shlex.quote(str(run_cell))} && "
                 f"test -f {shlex.quote(str(dist_index))}"
             ),

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -89,6 +89,10 @@ class BaseInstalledAgent:
     def version(self):
         return "test"
 
+    async def exec_as_agent(self, environment, command, **kwargs):
+        environment.commands.append(command)
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
 class CliFlag:
     def __init__(self, *args, **kwargs):
         pass
@@ -146,8 +150,17 @@ utils_mod.format_trajectory_json = lambda value: json.dumps(value)
 
 sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
 from maka_agent import MakaAgent
+import asyncio
 
 with tempfile.TemporaryDirectory() as tmp:
+    install_agent = MakaAgent(Path(tmp))
+    install_agent._resolved_flags = {"maka_repo": "/opt/maka-agent"}
+    fake_environment = types.SimpleNamespace(commands=[])
+    asyncio.run(install_agent.install(fake_environment))
+    install_command = "\n".join(fake_environment.commands)
+    assert "nvm install 22" in install_command, install_command
+    assert "nvm.sh" in install_command, install_command
+
     agent = MakaAgent(Path(tmp))
     context = AgentContext()
     agent._apply_cell_output(context, {

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -30,6 +30,8 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /upload_file\(local_instruction_path, instruction_path\.as_posix\(\)\)/);
     assert.match(source, /bash -lc/);
     assert.match(source, /set -o pipefail/);
+    assert.doesNotMatch(source, /cd \/app/);
+    assert.doesNotMatch(source, /"MAKA_WORKDIR": "\/app"/);
     assert.match(source, /Maka cell did not write/);
     assert.match(source, /Maka cell output is not valid JSON/);
     assert.match(source, /_read_cell_output\(required=True\)/);
@@ -180,5 +182,6 @@ with tempfile.TemporaryDirectory() as tmp:
     gateway_env = gateway_agent._cell_env(Path("/logs/agent/instruction.txt"))
     assert gateway_env["MAKA_PROVIDER"] == "openai-compatible", gateway_env
     assert gateway_env["MAKA_MODEL"] == "anthropic/claude-sonnet-4-5", gateway_env
+    assert "MAKA_WORKDIR" not in gateway_env, gateway_env
 `;
 }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -10,10 +10,12 @@ const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)))
 describe('Harbor adapter contract', () => {
   test('run-cell.mjs delegates to the shared env entrypoint', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-cell.mjs');
+    const cellSource = await readRepoFile('packages/headless/src/harbor-cell.ts');
 
     assert.match(source, /^#!\/usr\/bin\/env node/);
     assert.match(source, /runHarborCellFromEnv/);
     assert.match(source, /process\.env/);
+    assert.match(cellSource, /env\.MAKA_WORKDIR \?\? process\.cwd\(\)/);
   });
 
   test('maka_agent.py invokes run-cell with the shared artifact contract', async () => {
@@ -91,8 +93,12 @@ class BaseInstalledAgent:
     def version(self):
         return "test"
 
+    async def exec_as_root(self, environment, command, **kwargs):
+        environment.root_commands.append(command)
+        return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
+
     async def exec_as_agent(self, environment, command, **kwargs):
-        environment.commands.append(command)
+        environment.agent_commands.append(command)
         return types.SimpleNamespace(stdout="", stderr="", exit_code=0)
 
 class CliFlag:
@@ -157,11 +163,12 @@ import asyncio
 with tempfile.TemporaryDirectory() as tmp:
     install_agent = MakaAgent(Path(tmp))
     install_agent._resolved_flags = {"maka_repo": "/opt/maka-agent"}
-    fake_environment = types.SimpleNamespace(commands=[])
+    fake_environment = types.SimpleNamespace(root_commands=[], agent_commands=[])
     asyncio.run(install_agent.install(fake_environment))
-    install_command = "\n".join(fake_environment.commands)
+    install_command = "\n".join(fake_environment.root_commands)
     assert "nvm install 22" in install_command, install_command
     assert "nvm.sh" in install_command, install_command
+    assert fake_environment.agent_commands == [], fake_environment.agent_commands
 
     agent = MakaAgent(Path(tmp))
     context = AgentContext()

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -167,8 +167,14 @@ with tempfile.TemporaryDirectory() as tmp:
     asyncio.run(install_agent.install(fake_environment))
     install_command = "\n".join(fake_environment.root_commands)
     assert "nvm install 22" in install_command, install_command
+    assert "/usr/local/nvm" in install_command, install_command
     assert "nvm.sh" in install_command, install_command
-    assert fake_environment.agent_commands == [], fake_environment.agent_commands
+    assert "chmod -R a+rX" in install_command, install_command
+    agent_probe_command = "\n".join(fake_environment.agent_commands)
+    assert "node --version" in agent_probe_command, agent_probe_command
+    assert "NODE_MAJOR" in agent_probe_command, agent_probe_command
+    assert "test -f /opt/maka-agent/packages/headless/harbor/run-cell.mjs" in agent_probe_command, agent_probe_command
+    assert "test -f /opt/maka-agent/packages/headless/dist/index.js" in agent_probe_command, agent_probe_command
 
     agent = MakaAgent(Path(tmp))
     context = AgentContext()

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -134,6 +134,32 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('env entrypoint defaults to the process cwd when MAKA_WORKDIR is absent', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const instructionFile = join(outputDir, 'instruction.txt');
+      await writeFile(instructionFile, 'solve from current cwd\n', 'utf8');
+
+      const originalCwd = process.cwd();
+      process.chdir(workspaceDir);
+      try {
+        const result = await runHarborCellFromEnv({
+          MAKA_BACKEND: 'fake',
+          MAKA_INSTRUCTION_FILE: instructionFile,
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_STORAGE_ROOT: storageRoot,
+          MAKA_SYSTEM_PROMPT: config.systemPrompt!,
+        }, {
+          registerBackends: registerCellBackend,
+        });
+
+        assert.equal(result.output.status, 'completed');
+        assert.equal(await readFile(join(workspaceDir, 'cell-proof.txt'), 'utf8'), 'ran in place\n');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+  });
+
   test('writes a failed cell artifact when the backend stream throws', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const result = await runHarborCell({


### PR DESCRIPTION
## Summary

- install Node 22 in Harbor task containers when the image only has an older Node runtime
- install the runtime as root into `/usr/local/nvm`, then verify Node and repo files as the agent user
- run the Maka Harbor cell from the task image's own `WORKDIR` instead of assuming `/app`
- extend Harbor adapter/cell tests for Node setup, agent-user probing, and cwd fallback behavior

## Verification

- `npm run -w @maka/headless test -- --test-name-pattern "Harbor adapter contract|env entrypoint defaults"`
- Real Harbor smoke with the in-repo adapter, Mimo, and `n_concurrent_trials=2`:
  - job: `/Users/yuhan/.local/maka-eval/jobs/maka-repo-adapter-mimo-fixgit-prove-rootprobe-20260620-175311`
  - `fix-git`: reward `1.0`
  - `prove-plus-comm`: reward `1.0`
  - exceptions: `0`
  - mean: `1.0`

## Review

- Final fresh-eye review: no P0/P1 and no worthwhile P2/P3 remaining
- Final Claude review: no P0/P1 blockers
