### PR TITLE
Add contributor mailmap for agent commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# Canonical contributor identities.
+#
+# Historical local agent commits were authored with the host user's git config.
+# Keep shared history immutable, but make Git/GitHub contributor views fold
+# those commits under the agent identity used for future local commits.
+samuel <90952590+likun666661@users.noreply.github.com> likun <kunli@alva.xyz>


### PR DESCRIPTION
## Summary
- add a repository .mailmap entry for historical local agent commits authored as `likun <kunli@alva.xyz>`
- canonicalize those commits to `samuel <90952590+likun666661@users.noreply.github.com>` without rewriting shared history
- update this repo's local git config for future samuel commits to use the canonical noreply email

## Verification
- `git check-mailmap 'likun <kunli@alva.xyz>'`
- `git shortlog -sne HEAD` shows samuel with 46 commits
- `git diff --check upstream/main..HEAD`

Note: GitHub may take time to refresh contributor views after merge. If GitHub's contributors graph does not honor .mailmap for this repository, the destructive alternative is history rewrite, or the account-owner route is to add the historical `kunli@alva.xyz` address to the intended GitHub account.