### PR TITLE
Add contributor mailmap for likun666661 identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# Canonical contributor identities.
+#
+# Historical commits were authored with the local name/email pair below.
+# Keep shared history immutable, but make Git/GitHub contributor views fold
+# those commits under the canonical GitHub identity.
+likun666661 <90952590+likun666661@users.noreply.github.com> likun <kunli@alva.xyz>


### PR DESCRIPTION
## Summary
- Add a .mailmap entry that folds historical `likun <kunli@alva.xyz>` commits into the canonical GitHub identity `likun666661 <90952590+likun666661@users.noreply.github.com>`.
- Keep shared history immutable while making contributor views and local Git summaries align with the GitHub account identity.

## Verification
- `git check-mailmap 'likun <kunli@alva.xyz>'`
- `git shortlog -sne HEAD` shows `likun666661 <90952590+likun666661@users.noreply.github.com>` with 81 commits
- `git diff --check upstream/main..HEAD`