### PR TITLE
Add container-native headless file tools

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -43,9 +43,12 @@ default**:
   explicit assertion that tool execution is already outside the host credential
   process (for example Harbor / Terminal-Bench or a Docker workspace executor).
 - If the caller wants Maka's standard tool surface, use
-  `buildIsolatedHeadlessTools(executor)`: it replaces `Bash` with a command
-  executor supplied by the isolation boundary, while keeping path-confined pure
-  file tools in the throwaway workspace.
+  `buildIsolatedHeadlessTools(executor)`: it routes `Bash` plus
+  `Read`/`Write`/`Edit`/`Glob`/`Grep` through the supplied isolation boundary.
+  Executors can implement native file-operation methods, or rely on the
+  command-backed fallback when the isolated workspace has `node` available.
+  The headless helper rejects absolute paths, `..` escapes, and absolute glob
+  patterns before dispatching file operations.
 
 (An *operational* mode — intentionally running a trusted agent that *may* touch
 the host — can slot into this same entry later. That is a different, explicit
@@ -65,6 +68,11 @@ const executor: IsolatedToolExecutor = {
   async exec(input) {
     // Route to Harbor/Docker/etc. Do not inherit host env/secrets.
     return { exitCode: 0, stdout: '', stderr: '' };
+  },
+  async readFile(input) {
+    // Optional: implement native external workspace file reads instead of the
+    // command-backed fallback.
+    return { content: '' };
   },
 };
 

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -1,5 +1,7 @@
 """Harbor adapter for running a Maka RuntimeRunner cell in the task workdir."""
 
+from __future__ import annotations
+
 import json
 import shlex
 from pathlib import Path

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -1,5 +1,7 @@
 """Harbor OpenCode adapter wrapper with Maka benchmark cost metadata."""
 
+from __future__ import annotations
+
 import os
 import shlex
 from contextlib import contextmanager

--- a/packages/headless/harbor/trial_pricing.py
+++ b/packages/headless/harbor/trial_pricing.py
@@ -1,5 +1,7 @@
 """Shared trial pricing helpers for Harbor benchmark adapters."""
 
+from __future__ import annotations
+
 import math
 from typing import Any, Callable, TypedDict
 

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -167,7 +167,7 @@ describe('TaskRunStore', () => {
           executorId: 'exec-1',
           taskRunId,
           attemptId: 'a-1',
-          toolNames: ['Bash'],
+          toolNames: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'],
           isolationMode: 'external',
           label: 'unit isolation',
         },

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,16 +1,18 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { exec as childExec } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 import {
-  AGENT_WORKSPACE_WORKTREE,
   buildChildAgentTools,
-  IMPLEMENTATION_AGENT_ID,
-  listBuiltinAgentDefinitions,
   LOAD_TOOLS_NAME,
-  WEB_RESEARCH_AGENT_ID,
   ToolAvailabilityRuntime,
 } from '@maka/runtime';
 import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
+
+const execAsync = promisify(childExec);
 
 describe('isolated headless tools', () => {
   test('Bash delegates execution to the isolated executor', async () => {
@@ -50,7 +52,7 @@ describe('isolated headless tools', () => {
     });
   });
 
-  test('standard isolated tool surface keeps local-read child tools shell-free', () => {
+  test('standard isolated tool surface exposes externalized file tools to local-read children', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -66,21 +68,161 @@ describe('isolated headless tools', () => {
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
-    const definitions = listBuiltinAgentDefinitions({
-      parentPermissionMode: 'execute',
-      tools: buildChildAgentTools(tools),
+  });
+
+  test('Read, Write, Edit, Glob, and Grep delegate to native isolated executor methods', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-host-'));
+    await writeFile(join(cwd, 'target.txt'), 'host\n', 'utf8');
+    const calls: Array<{ name: string; input: unknown }> = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        throw new Error('file tools must use native isolated methods when available');
+      },
+      async readFile(input) {
+        calls.push({ name: 'Read', input });
+        return { content: 'container\n' };
+      },
+      async writeFile(input) {
+        calls.push({ name: 'Write', input });
+        return { ok: true, path: input.path, bytes: Buffer.byteLength(input.content, 'utf8') };
+      },
+      async editFile(input) {
+        calls.push({ name: 'Edit', input });
+        return { ok: true, path: input.path, replacements: 1 };
+      },
+      async globFiles(input) {
+        calls.push({ name: 'Glob', input });
+        return { files: ['container.txt'] };
+      },
+      async grepFiles(input) {
+        calls.push({ name: 'Grep', input });
+        return { matches: ['container.txt:1:needle'] };
+      },
     });
-    assert.deepEqual(definitions.find((definition) => definition.id === WEB_RESEARCH_AGENT_ID)?.availability, {
-      status: 'unavailable',
-      reason: 'missing_tools',
-      missingTools: ['WebSearch'],
+
+    assert.deepEqual(await tool(tools, 'Read').impl({ path: 'target.txt', offset: 1, limit: 2 }, toolCtx(cwd)), {
+      content: 'container\n',
     });
-    assert.deepEqual(definitions.find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)?.availability, {
-      status: 'unavailable',
-      reason: 'workspace_isolation_unavailable',
-      workspace: AGENT_WORKSPACE_WORKTREE,
-      requiredRuntime: 'worktree_child_executor',
+    assert.deepEqual(await tool(tools, 'Write').impl({ path: 'target.txt', content: 'external\n' }, toolCtx(cwd)), {
+      ok: true,
+      path: 'target.txt',
+      bytes: 9,
     });
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl({ path: 'target.txt', old_string: 'host', new_string: 'external' }, toolCtx(cwd)),
+      { ok: true, path: 'target.txt', replacements: 1 },
+    );
+    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: '*.txt', cwd: 'src' }, toolCtx(cwd)), {
+      files: ['container.txt'],
+    });
+    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', path: 'src', glob: '*.txt' }, toolCtx(cwd)), {
+      matches: ['container.txt:1:needle'],
+    });
+
+    assert.equal(await readFile(join(cwd, 'target.txt'), 'utf8'), 'host\n');
+    assert.deepEqual(calls, [
+      { name: 'Read', input: { cwd, path: 'target.txt', offset: 1, limit: 2 } },
+      { name: 'Write', input: { cwd, path: 'target.txt', content: 'external\n' } },
+      { name: 'Edit', input: { cwd, path: 'target.txt', oldString: 'host', newString: 'external' } },
+      { name: 'Glob', input: { cwd, pattern: '*.txt', searchCwd: 'src' } },
+      { name: 'Grep', input: { cwd, pattern: 'needle', path: 'src', glob: '*.txt' } },
+    ]);
+  });
+
+  test('file tools fall back to command-backed isolated operations', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-fallback-'));
+    await mkdir(join(cwd, 'src'));
+    const calls: string[] = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        calls.push(input.command);
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    assert.deepEqual(await tool(tools, 'Write').impl({ path: 'src/file.txt', content: 'hello\nneedle\n' }, toolCtx(cwd)), {
+      ok: true,
+      path: 'src/file.txt',
+      bytes: 13,
+    });
+    assert.deepEqual(await tool(tools, 'Read').impl({ path: 'src/file.txt', offset: 1, limit: 1 }, toolCtx(cwd)), {
+      content: 'needle',
+    });
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl({ path: 'src/file.txt', old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
+      { ok: true, path: 'src/file.txt', replacements: 1 },
+    );
+    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: '**/*.txt' }, toolCtx(cwd)), {
+      files: ['src/file.txt'],
+    });
+    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', glob: '**/*.txt' }, toolCtx(cwd)), {
+      matches: ['src/file.txt:2:needle'],
+    });
+    assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hi\nneedle\n');
+    assert.ok(calls.length >= 5);
+    assert.ok(calls.every((command) => command.startsWith("node -e '")));
+  });
+
+  test('command-backed file tools do not follow symlinks outside the isolated workspace', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-symlink-'));
+    const outside = await mkdtemp(join(tmpdir(), 'maka-headless-tools-outside-'));
+    await mkdir(join(cwd, 'src'));
+    await writeFile(join(outside, 'secret.txt'), 'outside needle\n', 'utf8');
+    await symlink(join(outside, 'secret.txt'), join(cwd, 'src', 'link.txt'));
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    await assert.rejects(
+      async () => await tool(tools, 'Write').impl({ path: 'src/link.txt', content: 'overwrite\n' }, toolCtx(cwd)),
+      /inside workspace/,
+    );
+    await assert.rejects(async () => await tool(tools, 'Read').impl({ path: 'src/link.txt' }, toolCtx(cwd)), /inside workspace/);
+    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'outside', glob: '**/*.txt' }, toolCtx(cwd)), {
+      matches: [],
+    });
+    assert.equal(await readFile(join(outside, 'secret.txt'), 'utf8'), 'outside needle\n');
+  });
+
+  test('isolated file tools reject path escapes before executor invocation', async () => {
+    let calls = 0;
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        calls += 1;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    const ctx = toolCtx('/workspace');
+
+    await assert.rejects(async () => await tool(tools, 'Read').impl({ path: '/etc/passwd' }, ctx), /inside the isolated workspace/);
+    await assert.rejects(async () => await tool(tools, 'Write').impl({ path: '../x', content: '' }, ctx), /inside the isolated workspace/);
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl({ path: 'nested/../../x', old_string: 'a', new_string: 'b' }, ctx),
+      /inside the isolated workspace/,
+    );
+    await assert.rejects(async () => await tool(tools, 'Glob').impl({ pattern: '/tmp/*.txt' }, ctx), /inside the isolated workspace/);
+    await assert.rejects(async () => await tool(tools, 'Grep').impl({ pattern: 'x', glob: '../*.txt' }, ctx), /inside the isolated workspace/);
+    assert.equal(calls, 0);
   });
 
   test('standard isolated tool availability defers parent-facing agent tools', () => {
@@ -137,3 +279,20 @@ describe('isolated headless tools', () => {
     );
   });
 });
+
+function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string) {
+  const found = tools.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`missing tool ${name}`);
+  return found;
+}
+
+function toolCtx(cwd: string) {
+  return {
+    sessionId: 's',
+    turnId: 't',
+    cwd,
+    toolCallId: 'tool-1',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -258,11 +258,29 @@ export type {
   HeadlessBackendContext,
   IsolatedCommandInput,
   IsolatedCommandResult,
+  IsolatedEditFileInput,
+  IsolatedEditFileResult,
+  IsolatedGlobInput,
+  IsolatedGlobResult,
+  IsolatedGrepInput,
+  IsolatedGrepResult,
+  IsolatedReadFileInput,
+  IsolatedReadFileResult,
   IsolatedToolExecutor,
+  IsolatedWriteFileInput,
+  IsolatedWriteFileResult,
   RealBackendIsolation,
 } from './isolation.js';
 export {
+  ISOLATED_HEADLESS_TOOL_NAMES,
+} from './isolation.js';
+export {
   buildIsolatedBashTool,
+  buildIsolatedEditTool,
+  buildIsolatedGlobTool,
+  buildIsolatedGrepTool,
   buildIsolatedHeadlessToolAvailability,
   buildIsolatedHeadlessTools,
+  buildIsolatedReadTool,
+  buildIsolatedWriteTool,
 } from './tools.js';

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -17,6 +17,65 @@ export interface IsolatedCommandResult {
   stderr: string;
 }
 
+export interface IsolatedReadFileInput {
+  cwd: string;
+  path: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface IsolatedReadFileResult {
+  content: string;
+}
+
+export interface IsolatedWriteFileInput {
+  cwd: string;
+  path: string;
+  content: string;
+}
+
+export interface IsolatedWriteFileResult {
+  ok: boolean;
+  path: string;
+  bytes: number;
+}
+
+export interface IsolatedEditFileInput {
+  cwd: string;
+  path: string;
+  oldString: string;
+  newString: string;
+}
+
+export interface IsolatedEditFileResult {
+  ok: boolean;
+  path: string;
+  replacements: number;
+}
+
+export interface IsolatedGlobInput {
+  cwd: string;
+  pattern: string;
+  searchCwd?: string;
+}
+
+export interface IsolatedGlobResult {
+  files: string[];
+}
+
+export interface IsolatedGrepInput {
+  cwd: string;
+  pattern: string;
+  path?: string;
+  glob?: string;
+}
+
+export interface IsolatedGrepResult {
+  matches: string[];
+}
+
+export const ISOLATED_HEADLESS_TOOL_NAMES = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'] as const;
+
 /**
  * Executes agent-visible shell commands outside the host credential process.
  *
@@ -28,6 +87,17 @@ export interface IsolatedCommandResult {
  */
 export interface IsolatedToolExecutor {
   exec(input: IsolatedCommandInput): Promise<IsolatedCommandResult>;
+  /**
+   * Optional native file operations for executors that can address their
+   * external workspace without shelling through exec. If omitted,
+   * buildIsolatedHeadlessTools falls back to command-backed operations inside
+   * the isolated boundary.
+   */
+  readFile?(input: IsolatedReadFileInput): Promise<IsolatedReadFileResult>;
+  writeFile?(input: IsolatedWriteFileInput): Promise<IsolatedWriteFileResult>;
+  editFile?(input: IsolatedEditFileInput): Promise<IsolatedEditFileResult>;
+  globFiles?(input: IsolatedGlobInput): Promise<IsolatedGlobResult>;
+  grepFiles?(input: IsolatedGrepInput): Promise<IsolatedGrepResult>;
 }
 
 export interface ExternalRealBackendIsolation {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -26,6 +26,7 @@ import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import type { HeadlessBackendContext } from './isolation.js';
 import {
+  ISOLATED_HEADLESS_TOOL_NAMES,
   taskIsolationFacts,
   toolExecutorIdentity,
   validateRealBackendIsolation,
@@ -202,7 +203,7 @@ export async function runTaskOnce(
         taskRunId,
         attemptId,
         isolation: deps.realBackendIsolation,
-        toolNames: deps.realBackendIsolation?.toolExecutor ? ['Bash'] : ['registered_backend'],
+        toolNames: deps.realBackendIsolation?.toolExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'],
       }),
     });
     const backends = new BackendRegistry();

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -1,7 +1,5 @@
 import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
-  buildBuiltinTools,
-  buildSubagentToolGroup,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
 } from '@maka/runtime';
@@ -9,17 +7,17 @@ import { z } from 'zod';
 import type { IsolatedToolExecutor } from './isolation.js';
 
 /**
- * Build Maka's standard headless tool surface with Bash routed through an
- * isolated executor. The pure file tools remain host-side but are path-confined
- * to the throwaway workspace by @maka/runtime's builtin implementations; the
- * dangerous part is process execution, which must not inherit host secrets or
- * filesystem reachability.
+ * Build Maka's standard headless tool surface with shell and file operations
+ * routed through the isolated executor boundary.
  */
 export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): MakaTool[] {
-  const pureTools = buildBuiltinTools().filter((tool) => tool.name !== 'Bash');
   return [
     buildIsolatedBashTool(executor),
-    ...pureTools,
+    buildIsolatedReadTool(executor),
+    buildIsolatedWriteTool(executor),
+    buildIsolatedEditTool(executor),
+    buildIsolatedGlobTool(executor),
+    buildIsolatedGrepTool(executor),
     buildSubagentSpawnTool(),
     ...buildSubagentProjectionTools(),
   ];
@@ -28,7 +26,12 @@ export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): Maka
 export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig {
   return {
     economy: true,
-    groups: [buildSubagentToolGroup()],
+    groups: [{
+      id: 'agent',
+      label: 'Agent',
+      description: 'Spawn and inspect foreground child agents.',
+      toolNames: ['agent_spawn', 'agent_list', 'agent_output'],
+    }],
   };
 }
 
@@ -60,3 +63,292 @@ export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool 
     },
   };
 }
+
+export function buildIsolatedReadTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Read',
+    description: 'Read a file from the isolated headless task workspace.',
+    parameters: z.object({
+      path: z.string(),
+      offset: z.number().int().nonnegative().optional(),
+      limit: z.number().int().positive().optional(),
+    }),
+    permissionRequired: false,
+    impl: async ({ path, offset, limit }, { cwd }) => {
+      assertRelativePath(path, 'Read path');
+      if (executor.readFile) return await executor.readFile({ cwd, path, offset, limit });
+      const stdout = await execFileCommand(executor, cwd, nodeFileCommand(READ_SCRIPT, [
+        path,
+        numberArg(offset),
+        numberArg(limit),
+      ]));
+      return { content: stdout };
+    },
+  };
+}
+
+export function buildIsolatedWriteTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Write',
+    description: 'Write content to a file in the isolated headless task workspace.',
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    permissionRequired: true,
+    impl: async ({ path, content }, { cwd }) => {
+      assertRelativePath(path, 'Write path');
+      if (executor.writeFile) return await executor.writeFile({ cwd, path, content });
+      await execFileCommand(executor, cwd, nodeFileCommand(WRITE_SCRIPT, [
+        path,
+        Buffer.from(content, 'utf8').toString('base64'),
+      ]));
+      return { ok: true, path, bytes: Buffer.byteLength(content, 'utf8') };
+    },
+  };
+}
+
+export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Edit',
+    description: 'Replace an exact string in a file in the isolated headless task workspace.',
+    parameters: z.object({
+      path: z.string(),
+      old_string: z.string(),
+      new_string: z.string(),
+    }),
+    permissionRequired: true,
+    impl: async ({ path, old_string, new_string }, { cwd }) => {
+      assertRelativePath(path, 'Edit path');
+      if (executor.editFile) {
+        return await executor.editFile({ cwd, path, oldString: old_string, newString: new_string });
+      }
+      await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
+        path,
+        Buffer.from(old_string, 'utf8').toString('base64'),
+        Buffer.from(new_string, 'utf8').toString('base64'),
+      ]));
+      return { ok: true, path, replacements: 1 };
+    },
+  };
+}
+
+export function buildIsolatedGlobTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Glob',
+    description: 'Find files in the isolated headless task workspace matching a glob pattern.',
+    parameters: z.object({
+      pattern: z.string(),
+      cwd: z.string().optional(),
+    }),
+    permissionRequired: false,
+    impl: async ({ pattern, cwd: relCwd }, { cwd }) => {
+      assertRelativeGlobPattern(pattern, 'Glob pattern');
+      if (relCwd !== undefined) assertRelativePath(relCwd, 'Glob cwd');
+      if (executor.globFiles) return await executor.globFiles({ cwd, pattern, searchCwd: relCwd });
+      const stdout = await execFileCommand(executor, cwd, nodeFileCommand(GLOB_SCRIPT, [pattern, relCwd ?? '']));
+      return { files: parseStringArray(stdout, 'Glob') };
+    },
+  };
+}
+
+export function buildIsolatedGrepTool(executor: IsolatedToolExecutor): MakaTool {
+  return {
+    name: 'Grep',
+    description: 'Search file contents with a regex in the isolated headless task workspace.',
+    parameters: z.object({
+      pattern: z.string(),
+      path: z.string().optional(),
+      glob: z.string().optional(),
+    }),
+    permissionRequired: false,
+    impl: async ({ pattern, path, glob }, { cwd }) => {
+      if (path !== undefined) assertRelativePath(path, 'Grep path');
+      if (glob !== undefined) assertRelativeGlobPattern(glob, 'Grep glob');
+      if (executor.grepFiles) return await executor.grepFiles({ cwd, pattern, path, glob });
+      const stdout = await execFileCommand(executor, cwd, nodeFileCommand(GREP_SCRIPT, [
+        pattern,
+        path ?? '',
+        glob ?? '',
+      ]));
+      return { matches: parseStringArray(stdout, 'Grep') };
+    },
+  };
+}
+
+async function execFileCommand(executor: IsolatedToolExecutor, cwd: string, command: string): Promise<string> {
+  const result = await executor.exec({ command, cwd, timeoutMs: 120_000 });
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.trim() || `isolated file command failed with exit code ${result.exitCode}`);
+  }
+  return result.stdout;
+}
+
+function nodeFileCommand(script: string, args: string[]): string {
+  return ['node', '-e', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function numberArg(value: number | undefined): string {
+  return value === undefined ? '' : String(value);
+}
+
+function parseStringArray(stdout: string, label: string): string[] {
+  const parsed: unknown = JSON.parse(stdout || '[]');
+  if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+    throw new Error(`${label} command returned an invalid string array`);
+  }
+  return parsed;
+}
+
+function assertRelativePath(inputPath: string, label: string): void {
+  if (
+    inputPath.length === 0
+    || inputPath.startsWith('/')
+    || /^[A-Za-z]:[\\/]/.test(inputPath)
+    || inputPath.split(/[\\/]+/).includes('..')
+  ) {
+    throw new Error(`${label} must stay inside the isolated workspace`);
+  }
+}
+
+function assertRelativeGlobPattern(pattern: string, label: string): void {
+  if (
+    pattern.length === 0
+    || pattern.startsWith('/')
+    || /^[A-Za-z]:[\\/]/.test(pattern)
+    || pattern.split(/[\\/]+/).includes('..')
+  ) {
+    throw new Error(`${label} must stay inside the isolated workspace`);
+  }
+}
+
+const COMMON_NODE_HELPERS = String.raw`
+const fs = require('fs');
+const path = require('path');
+function inside(root, target) {
+  const rel = path.relative(root, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+function workspaceRoot() {
+  return fs.realpathSync(process.cwd());
+}
+function existingTarget(root, inputPath, label) {
+  const target = fs.realpathSync(path.resolve(root, inputPath));
+  if (!inside(root, target)) throw new Error(label + ' must stay inside workspace');
+  return target;
+}
+function writableTarget(root, inputPath, label) {
+  const target = path.resolve(root, inputPath);
+  const parent = fs.realpathSync(path.dirname(target));
+  if (!inside(root, parent)) throw new Error(label + ' must stay inside workspace');
+  try {
+    const existing = fs.realpathSync(target);
+    if (!inside(root, existing)) throw new Error(label + ' must stay inside workspace');
+  } catch (error) {
+    if (!error || error.code !== 'ENOENT') throw error;
+  }
+  return target;
+}
+`;
+
+const READ_SCRIPT = `${COMMON_NODE_HELPERS}
+const [inputPath, offsetRaw, limitRaw] = process.argv.slice(1);
+const root = workspaceRoot();
+const target = existingTarget(root, inputPath, 'Read path');
+let content = fs.readFileSync(target, 'utf8');
+if (offsetRaw || limitRaw) {
+  const lines = content.split('\\n');
+  const start = offsetRaw ? Number(offsetRaw) : 0;
+  const end = limitRaw ? start + Number(limitRaw) : lines.length;
+  content = lines.slice(start, end).join('\\n');
+}
+process.stdout.write(content);
+`;
+
+const WRITE_SCRIPT = `${COMMON_NODE_HELPERS}
+const [inputPath, contentBase64] = process.argv.slice(1);
+const root = workspaceRoot();
+const target = writableTarget(root, inputPath, 'Write path');
+fs.writeFileSync(target, Buffer.from(contentBase64, 'base64'));
+`;
+
+const EDIT_SCRIPT = `${COMMON_NODE_HELPERS}
+const [inputPath, oldBase64, nextBase64] = process.argv.slice(1);
+const root = workspaceRoot();
+const target = existingTarget(root, inputPath, 'Edit path');
+const oldString = Buffer.from(oldBase64, 'base64').toString('utf8');
+const newString = Buffer.from(nextBase64, 'base64').toString('utf8');
+const current = fs.readFileSync(target, 'utf8');
+const count = current.split(oldString).length - 1;
+if (count === 0) throw new Error('old_string not found in ' + inputPath);
+if (count > 1) throw new Error('old_string is not unique in ' + inputPath + ' (' + count + ' matches)');
+fs.writeFileSync(target, current.replace(oldString, newString), 'utf8');
+`;
+
+const GLOB_SCRIPT = `${COMMON_NODE_HELPERS}
+const [pattern, searchCwd] = process.argv.slice(1);
+const root = workspaceRoot();
+const base = searchCwd ? existingTarget(root, searchCwd, 'Glob cwd') : root;
+const files = [];
+for (const entry of fs.globSync(pattern, { cwd: base })) {
+  files.push(typeof entry === 'string' ? entry : entry.name);
+  if (files.length >= 200) break;
+}
+process.stdout.write(JSON.stringify(files));
+`;
+
+const GREP_SCRIPT = `${COMMON_NODE_HELPERS}
+const [pattern, inputPath, globPattern] = process.argv.slice(1);
+const root = workspaceRoot();
+const start = inputPath ? existingTarget(root, inputPath, 'Grep path') : root;
+const regex = new RegExp(pattern);
+const matches = [];
+const perFile = new Map();
+const globRegex = globPattern ? globToRegExp(globPattern) : null;
+function globToRegExp(glob) {
+  let out = '^';
+  for (let i = 0; i < glob.length; i += 1) {
+    const ch = glob[i];
+    const next = glob[i + 1];
+    if (ch === '*' && next === '*') {
+      out += '.*';
+      i += 1;
+    } else if (ch === '*') {
+      out += '[^/]*';
+    } else if (ch === '?') {
+      out += '[^/]';
+    } else {
+      out += ch.replace(/[|\\{}()[\\]^$+?.]/g, '\\$&');
+    }
+  }
+  return new RegExp(out + '$');
+}
+function shouldSearch(file) {
+  if (!globRegex) return true;
+  return globRegex.test(path.relative(root, file).split(path.sep).join('/'));
+}
+function visit(file) {
+  if (matches.length >= 200) return;
+  const stat = fs.lstatSync(file);
+  if (stat.isSymbolicLink()) return;
+  const real = fs.realpathSync(file);
+  if (!inside(root, real)) return;
+  if (stat.isDirectory()) {
+    for (const child of fs.readdirSync(file)) visit(path.join(file, child));
+    return;
+  }
+  if (!stat.isFile() || !shouldSearch(file)) return;
+  const rel = path.relative(root, file).split(path.sep).join('/');
+  const lines = fs.readFileSync(file, 'utf8').split('\\n');
+  for (let i = 0; i < lines.length && matches.length < 200; i += 1) {
+    if (!regex.test(lines[i])) continue;
+    const seen = perFile.get(file) ?? 0;
+    if (seen >= 50) break;
+    perFile.set(file, seen + 1);
+    matches.push(rel + ':' + (i + 1) + ':' + lines[i]);
+  }
+}
+visit(start);
+process.stdout.write(JSON.stringify(matches));
+`;


### PR DESCRIPTION
## Summary
- route headless Read/Write/Edit/Glob/Grep through the isolated executor boundary alongside Bash
- add optional native IsolatedToolExecutor file-operation methods with command-backed fallback inside the isolated cwd
- record the full isolated headless tool surface in task-run executor facts and document the new behavior
- keep Harbor Python adapters compatible with the local Python 3.9 test environment

## Rive
- workflow: maka.container-native-headless-tools@1
- run: wfrun_4dc735375c74472caa5a6357f532a288
- reviewer verdict: ACCEPT
- final steward patch: tightened command-backed symlink containment and added regression coverage

## Verification
- npm run typecheck --workspace @maka/headless
- npm test --workspace @maka/headless (207 tests)
- python3 -m py_compile packages/headless/harbor/trial_pricing.py packages/headless/harbor/maka_agent.py packages/headless/harbor/opencode_agent.py
- git diff --check

## Known unrelated check result
- full workspace npm run typecheck still fails on pre-existing UI/Desktop issues: missing overlayscrollbars, SettingsModal/ProvidersPanel exports, and desktop renderer prop mismatches