### PR TITLE
Add benchmark official artifact truth

### DIFF
--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -42,7 +42,7 @@ describe('maka-headless CLI', () => {
       const outDir = join(dir, 'out');
 
       const run = await runCli(['eval', specPath, '--out', outDir]);
-      assert.equal(run.code, 0, run.stderr);
+      assert.equal(run.code, 0);
 
       const records = await readResults(join(outDir, 'results.jsonl'));
       assert.equal(records.length, 1);
@@ -187,12 +187,12 @@ describe('maka-headless CLI', () => {
         outDir,
         '--include-events',
       ]);
-      assert.equal(run.code, 0, run.stderr);
+      assert.equal(run.code, 1);
       assert.match(run.stdout, /taskRunId: task-run-1/);
 
       const inspect = await runCli(['task', 'inspect', 'task-run-1', '--store', join(outDir, 'runs'), '--json']);
       assert.equal(inspect.code, 0, inspect.stderr);
-      assert.equal(JSON.parse(inspect.stdout).taxonomy, 'passed');
+      assert.equal(JSON.parse(inspect.stdout).taxonomy, 'verification_failed');
 
       const exportDir = join(dir, 'manual-export');
       const exported = await runCli([
@@ -209,6 +209,8 @@ describe('maka-headless CLI', () => {
       const taskRunJson = JSON.parse(await readFile(join(exportDir, 'task-run.json'), 'utf8'));
       assert.equal(taskRunJson.verifier.kind, 'terminal_bench');
       assert.equal(taskRunJson.verifier.benchmark.instanceId, 'tb-local');
+      assert.equal(taskRunJson.verifier.authority.authoritative, false);
+      assert.equal(taskRunJson.verifier.benchmark.verificationPlaceholder, true);
       assert.match(await readFile(join(exportDir, 'events.jsonl'), 'utf8'), /verifier_result_recorded/);
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/__tests__/harbor-official-artifacts.test.ts
+++ b/packages/headless/src/__tests__/harbor-official-artifacts.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  harborOfficialVerifierOutputFromArtifacts,
+  readHarborOfficialVerifierOutput,
+} from '../harbor-official-artifacts.js';
+
+describe('Harbor official verifier artifacts', () => {
+  test('maps Harbor reward result and container artifacts to official verifier output', () => {
+    const output = harborOfficialVerifierOutputFromArtifacts({
+      resultJson: { verifier_result: { rewards: { reward: 1 } } },
+      details: { instanceId: 'terminal-bench/example' },
+      artifacts: [
+        {
+          kind: 'container_workspace',
+          workspacePath: '/app',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+        {
+          kind: 'workspace_diff',
+          path: '/logs/artifacts/submission.diff',
+          workspacePath: '/app',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+        {
+          kind: 'source_code',
+          path: '/logs/artifacts/app/vm.js',
+          workspacePath: '/app/vm.js',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+        {
+          kind: 'generated_output',
+          path: '/logs/artifacts/frame.bmp',
+          workspacePath: '/app/frame.bmp',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+        {
+          kind: 'benchmark_manifest',
+          path: '/logs/artifacts/manifest.json',
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+        },
+      ],
+    });
+
+    assert.equal(output.kind, 'terminal_bench');
+    assert.equal(output.passed, true);
+    assert.equal(output.exitCode, 0);
+    assert.equal(output.score, 1);
+    assert.equal(output.authority?.source, 'official_harbor_verifier');
+    assert.equal(output.details?.official, true);
+    assert.equal(output.artifacts?.[0]?.workspacePath, '/app');
+    assert.equal(output.artifacts?.[2]?.workspacePath, '/app/vm.js');
+  });
+
+  test('reads result.json, reward.txt, and CTRF-style summaries from paths', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-harbor-official-'));
+    try {
+      const resultJsonPath = join(dir, 'result.json');
+      const rewardPath = join(dir, 'reward.txt');
+      const ctrfJsonPath = join(dir, 'ctrf.json');
+      await writeFile(resultJsonPath, JSON.stringify({ taskId: 'example' }), 'utf8');
+      await writeFile(rewardPath, '1\n', 'utf8');
+      await writeFile(ctrfJsonPath, JSON.stringify({ results: { summary: { tests: 3, passed: 3, failed: 0 } } }), 'utf8');
+
+      const output = await readHarborOfficialVerifierOutput({ resultJsonPath, rewardPath, ctrfJsonPath });
+
+      assert.equal(output.passed, true);
+      assert.equal(output.score, 1);
+      assert.deepEqual(output.details?.ctrf, { passed: true, score: 1, maxScore: 1, tests: 3, failed: 0 });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('treats an explicit official pass flag as a verifier signal', () => {
+    const output = harborOfficialVerifierOutputFromArtifacts({ resultJson: { passed: false } });
+
+    assert.equal(output.passed, false);
+    assert.equal(output.exitCode, 1);
+    assert.equal(output.errorClass, 'verification_failed');
+    assert.equal(output.authority?.source, 'official_harbor_verifier');
+    assert.equal(output.authority?.authoritative, true);
+  });
+
+  test('keeps missing official signals non-authoritative', () => {
+    const output = harborOfficialVerifierOutputFromArtifacts({});
+
+    assert.equal(output.passed, false);
+    assert.equal(output.exitCode, null);
+    assert.equal(output.errorClass, 'missing_official_verifier');
+    assert.equal(output.authority?.source, 'system');
+    assert.equal(output.authority?.authoritative, false);
+    assert.equal(output.details?.official, false);
+  });
+});

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { taskRunExportFromProjection, writeTaskRunExport } from '../result-export.js';
+import { renderTaskRunMarkdown, taskRunExportFromProjection, writeTaskRunExport } from '../result-export.js';
 import type { TaskEvent } from '../task-contracts.js';
 import { projectTaskRun } from '../task-run-store.js';
 
@@ -54,8 +54,40 @@ describe('task run export', () => {
           exitCode: 0,
           score: 1,
           maxScore: 1,
+          authority: { source: 'official_harbor_verifier', authoritative: true },
           submittedSnapshotId: 'snapshot-1',
           details: { adapter: 'terminal-bench', instanceId: 'tb-1' },
+        },
+      },
+      {
+        type: 'task_run_artifact_recorded',
+        id: 'e5a',
+        taskRunId: 'run-1',
+        ts: 4,
+        artifact: {
+          schemaVersion: 1,
+          artifactId: 'artifact-workspace',
+          taskRunId: 'run-1',
+          ts: 4,
+          kind: 'container_workspace',
+          workspacePath: '/app',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+      },
+      {
+        type: 'task_run_artifact_recorded',
+        id: 'e5b',
+        taskRunId: 'run-1',
+        ts: 4,
+        artifact: {
+          schemaVersion: 1,
+          artifactId: 'artifact-diff',
+          taskRunId: 'run-1',
+          ts: 4,
+          kind: 'workspace_diff',
+          path: '/logs/artifacts/submission.diff',
+          workspacePath: '/app',
+          authority: { source: 'container_capture', authoritative: true },
         },
       },
       {
@@ -73,6 +105,7 @@ describe('task run export', () => {
           score: 1,
           maxScore: 1,
           taxonomy: 'passed',
+          authority: { source: 'official_harbor_verifier', authoritative: true },
           details: {
             runtimeRefs: { runtimeEventIds: ['runtime-1'] },
             budget: { totals: { total: 3 } },
@@ -89,11 +122,268 @@ describe('task run export', () => {
     assert.equal(exported.taskRun.taskRunId, 'run-1');
     assert.deepEqual(exported.runtime.trajectoryRefs.runtimeEventIds, ['runtime-1']);
     assert.deepEqual(exported.workspace.submittedSnapshot, { id: 'snapshot-1', manifestHash: 'sha256:abc' });
-    assert.equal(exported.workspace.diff.status, 'not_captured');
+    assert.equal(exported.workspace.primaryWorkspacePath, '/app');
+    assert.equal(exported.workspace.diff.status, 'present');
+    assert.equal(exported.workspace.diff.path, '/logs/artifacts/submission.diff');
+    assert.equal(exported.artifacts.primaryWorkspacePath, '/app');
+    assert.equal(exported.artifacts.byKind.workspace_diff?.[0]?.path, '/logs/artifacts/submission.diff');
     assert.equal(exported.verifier?.benchmark?.instanceId, 'tb-1');
     assert.deepEqual(exported.budget, { totals: { total: 3 } });
     assert.equal(exported.isolation.policy?.mode, 'inert_fake_backend');
     assert.equal(exported.taxonomy.value, 'passed');
+    assert.equal(exported.legacyResultRecord.passed, true);
+    const markdown = renderTaskRunMarkdown(exported);
+    assert.match(markdown, /verifier_authority: official_harbor_verifier authoritative=true/);
+    assert.match(markdown, /artifacts: 2/);
+    assert.match(markdown, /workspace_diff/);
+  });
+
+  test('exports official verifier truth over a non-authoritative placeholder result', async () => {
+    const events: TaskEvent[] = [
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-official', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e2',
+        taskRunId: 'run-official',
+        ts: 2,
+        result: {
+          id: 'placeholder-verifier',
+          taskRunId: 'run-official',
+          ts: 2,
+          kind: 'terminal_bench',
+          passed: false,
+          exitCode: null,
+          errorClass: 'unsupported_adapter',
+          authority: { source: 'self_check', authoritative: false },
+          details: { verificationPlaceholder: true },
+        },
+      },
+      {
+        type: 'score_result_recorded',
+        id: 'e3',
+        taskRunId: 'run-official',
+        ts: 2,
+        result: {
+          id: 'placeholder-score',
+          taskRunId: 'run-official',
+          ts: 2,
+          passed: false,
+          scored: false,
+          eligible: false,
+          taxonomy: 'unsupported_adapter',
+          errorClass: 'unsupported_adapter',
+          authority: { source: 'self_check', authoritative: false },
+        },
+      },
+      { type: 'task_run_completed', id: 'e4', taskRunId: 'run-official', ts: 3, finishedAt: 3 },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e5',
+        taskRunId: 'run-official',
+        ts: 4,
+        result: {
+          id: 'official-verifier',
+          taskRunId: 'run-official',
+          ts: 4,
+          kind: 'terminal_bench',
+          passed: true,
+          exitCode: 0,
+          score: 1,
+          maxScore: 1,
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+          details: { source: 'harbor', official: true },
+        },
+      },
+      {
+        type: 'score_result_recorded',
+        id: 'e6',
+        taskRunId: 'run-official',
+        ts: 4,
+        result: {
+          id: 'official-score',
+          taskRunId: 'run-official',
+          ts: 4,
+          passed: true,
+          scored: true,
+          eligible: true,
+          score: 1,
+          maxScore: 1,
+          taxonomy: 'passed',
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+        },
+      },
+    ];
+
+    const exported = taskRunExportFromProjection(projectTaskRun(events, 'run-official'));
+
+    assert.equal(exported.taxonomy.passed, true);
+    assert.equal(exported.verifier?.id, 'official-verifier');
+    assert.equal(exported.verifier?.authority?.source, 'official_harbor_verifier');
+    assert.equal(exported.legacyResultRecord.passed, true);
+    assert.equal(projectTaskRun(events, 'run-official').verifierResults[0]?.authority?.authoritative, false);
+
+    const dir = await mkdtemp(join(tmpdir(), 'maka-task-export-official-'));
+    try {
+      const written = await writeTaskRunExport(dir, projectTaskRun(events, 'run-official'));
+      const compact = JSON.parse(await readFile(written.files.resultJson, 'utf8'));
+      assert.equal(compact.verifier.authority.source, 'official_harbor_verifier');
+      assert.equal(compact.verifier.authority.authoritative, true);
+      const markdown = await readFile(written.files.resultMd, 'utf8');
+      assert.match(markdown, /verifier_authority: official_harbor_verifier authoritative=true/);
+      assert.match(markdown, /artifacts: 0/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not pair an official verifier with a stale placeholder score', () => {
+    const events: TaskEvent[] = [
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-verifier-only', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'score_result_recorded',
+        id: 'e2',
+        taskRunId: 'run-verifier-only',
+        ts: 2,
+        result: {
+          id: 'placeholder-score',
+          taskRunId: 'run-verifier-only',
+          ts: 2,
+          passed: false,
+          scored: false,
+          eligible: false,
+          taxonomy: 'unsupported_adapter',
+          errorClass: 'unsupported_adapter',
+          authority: { source: 'self_check', authoritative: false },
+        },
+      },
+      { type: 'task_run_completed', id: 'e3', taskRunId: 'run-verifier-only', ts: 3, finishedAt: 3 },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e4',
+        taskRunId: 'run-verifier-only',
+        ts: 4,
+        result: {
+          id: 'official-verifier',
+          taskRunId: 'run-verifier-only',
+          ts: 4,
+          kind: 'terminal_bench',
+          passed: true,
+          exitCode: 0,
+          score: 1,
+          maxScore: 1,
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+          details: { source: 'harbor', official: true },
+        },
+      },
+    ];
+
+    const projection = projectTaskRun(events, 'run-verifier-only');
+    const exported = taskRunExportFromProjection(projection);
+
+    assert.equal(projection.latestVerifierResult?.id, 'official-verifier');
+    assert.equal(projection.latestScoreResult, undefined);
+    assert.equal(exported.score, undefined);
+    assert.equal(exported.taxonomy.value, 'passed');
+    assert.equal(exported.taxonomy.passed, true);
+    assert.equal(exported.legacyResultRecord.passed, true);
+  });
+
+  test('keeps official verifier truth when a later placeholder is recorded', () => {
+    const events: TaskEvent[] = [
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-reverse', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e2',
+        taskRunId: 'run-reverse',
+        ts: 2,
+        result: {
+          id: 'official-verifier',
+          taskRunId: 'run-reverse',
+          ts: 2,
+          kind: 'terminal_bench',
+          passed: true,
+          exitCode: 0,
+          score: 1,
+          maxScore: 1,
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+          details: { source: 'harbor', official: true },
+        },
+      },
+      {
+        type: 'score_result_recorded',
+        id: 'e3',
+        taskRunId: 'run-reverse',
+        ts: 2,
+        result: {
+          id: 'official-score',
+          taskRunId: 'run-reverse',
+          ts: 2,
+          passed: true,
+          scored: true,
+          eligible: true,
+          score: 1,
+          maxScore: 1,
+          taxonomy: 'passed',
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+        },
+      },
+      {
+        type: 'task_run_completed',
+        id: 'e4',
+        taskRunId: 'run-reverse',
+        ts: 2,
+        finishedAt: 2,
+        result: {
+          passed: true,
+          taxonomy: 'passed',
+          verifierResultId: 'official-verifier',
+          scoreResultId: 'official-score',
+        },
+      },
+      {
+        type: 'verifier_result_recorded',
+        id: 'e5',
+        taskRunId: 'run-reverse',
+        ts: 3,
+        result: {
+          id: 'placeholder-verifier',
+          taskRunId: 'run-reverse',
+          ts: 3,
+          kind: 'terminal_bench',
+          passed: false,
+          exitCode: null,
+          errorClass: 'unsupported_adapter',
+          authority: { source: 'self_check', authoritative: false },
+          details: { verificationPlaceholder: true },
+        },
+      },
+      {
+        type: 'score_result_recorded',
+        id: 'e6',
+        taskRunId: 'run-reverse',
+        ts: 3,
+        result: {
+          id: 'placeholder-score',
+          taskRunId: 'run-reverse',
+          ts: 3,
+          passed: false,
+          scored: false,
+          eligible: false,
+          taxonomy: 'unsupported_adapter',
+          errorClass: 'unsupported_adapter',
+          authority: { source: 'self_check', authoritative: false },
+        },
+      },
+    ];
+
+    const projection = projectTaskRun(events, 'run-reverse');
+    const exported = taskRunExportFromProjection(projection);
+
+    assert.equal(projection.status, 'completed');
+    assert.equal(projection.latestVerifierResult?.id, 'official-verifier');
+    assert.equal(projection.latestScoreResult?.id, 'official-score');
+    assert.equal(exported.verifier?.id, 'official-verifier');
+    assert.equal(exported.taxonomy.passed, true);
     assert.equal(exported.legacyResultRecord.passed, true);
   });
 

--- a/packages/headless/src/__tests__/scorer.test.ts
+++ b/packages/headless/src/__tests__/scorer.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { Config, SubmittedSnapshot, Task } from '../contracts.js';
+import { defaultFinalScorer } from '../scorer.js';
+import type { VerifierResult } from '../task-contracts.js';
+
+const config: Config = { id: 'cfg', backend: 'fake', llmConnectionSlug: 'fake' };
+const task: Task = { id: 'task', instruction: 'solve', workspaceDir: '/tmp/workspace' };
+const submittedSnapshot: SubmittedSnapshot = {
+  id: 'snapshot',
+  workspaceRoot: '/tmp/workspace',
+  snapshotPath: '/tmp/snapshot',
+  artifactRefs: [],
+  createdAt: 1,
+};
+
+describe('defaultFinalScorer', () => {
+  test('does not let a non-authoritative placeholder mask runner failure taxonomy', () => {
+    const verifierResult: VerifierResult = {
+      id: 'verifier',
+      taskRunId: 'run',
+      ts: 1,
+      kind: 'terminal_bench',
+      passed: false,
+      exitCode: 1,
+      errorClass: 'verification_failed',
+      authority: { source: 'self_check', authoritative: false },
+      details: { verificationPlaceholder: true },
+    };
+
+    const score = defaultFinalScorer({
+      config,
+      task,
+      runnerCompleted: false,
+      runnerStatus: 'failed',
+      invocationFailure: { class: 'incomplete_tool_calls', message: 'model stopped mid-tool-call' },
+      submittedSnapshot,
+      verifierResult,
+    });
+
+    assert.equal(score.taxonomy, 'agent_incomplete');
+    assert.equal(score.errorClass, 'incomplete_tool_calls');
+  });
+});

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -346,6 +346,81 @@ describe('runTaskOnce', () => {
     });
   });
 
+  test('records official Harbor verifier result and container artifacts from benchmark adapter', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const task: Task = {
+        id: 'terminal-bench-official',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verifier: {
+          kind: 'terminal_bench',
+          adapter: 'terminal-bench',
+          instanceId: 'terminal-bench/example',
+          protectedPaths: [],
+        },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerFakeBackend,
+        benchmarkAdapters: {
+          'terminal-bench': {
+            name: 'terminal-bench',
+            runVerifier: () => ({
+              kind: 'terminal_bench',
+              passed: true,
+              exitCode: 0,
+              score: 1,
+              maxScore: 1,
+              authority: { source: 'official_harbor_verifier', authoritative: true },
+              details: { source: 'harbor', official: true, instanceId: 'terminal-bench/example' },
+              artifacts: [
+                {
+                  kind: 'container_workspace',
+                  workspacePath: '/app',
+                  authority: { source: 'container_capture', authoritative: true },
+                },
+                {
+                  kind: 'workspace_diff',
+                  path: '/logs/artifacts/submission.diff',
+                  workspacePath: '/app',
+                  authority: { source: 'container_capture', authoritative: true },
+                },
+                {
+                  kind: 'source_code',
+                  path: '/logs/artifacts/app/vm.js',
+                  workspacePath: '/app/vm.js',
+                  authority: { source: 'container_capture', authoritative: true },
+                },
+                {
+                  kind: 'generated_output',
+                  path: '/logs/artifacts/frame.bmp',
+                  workspacePath: '/app/frame.bmp',
+                  authority: { source: 'container_capture', authoritative: true },
+                },
+                {
+                  kind: 'benchmark_manifest',
+                  path: '/logs/artifacts/manifest.json',
+                  authority: { source: 'official_harbor_verifier', authoritative: true },
+                },
+              ],
+            }),
+          },
+        },
+      });
+
+      assert.equal(result.resultRecord.passed, true);
+      assert.equal(result.resultRecord.scored, true);
+      assert.equal(result.projection.latestVerifierResult?.authority?.source, 'official_harbor_verifier');
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'passed');
+      assert.equal(result.projection.artifacts.length, 5);
+      assert.equal(result.projection.artifacts[0]?.workspacePath, '/app');
+      assert.equal(result.projection.artifacts[2]?.workspacePath, '/app/vm.js');
+      assert.equal(result.projection.artifacts[3]?.path, '/logs/artifacts/frame.bmp');
+      assert.equal(result.projection.artifacts[4]?.kind, 'benchmark_manifest');
+    });
+  });
+
   test('freezes submitted workspace before restoring protected paths for verifier', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       await writeFile(join(fixtureDir, 'src.mjs'), 'export const add = (a, b) => a - b;\n', 'utf8');

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -90,6 +90,31 @@ describe('TaskRunStore', () => {
     });
   });
 
+  test('projects first-class task-run artifacts', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId: 'tr-artifact', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'task_run_artifact_recorded',
+        id: 'e-2',
+        taskRunId: 'tr-artifact',
+        ts: 2,
+        artifact: {
+          schemaVersion: 1,
+          artifactId: 'artifact-workspace',
+          taskRunId: 'tr-artifact',
+          ts: 2,
+          kind: 'container_workspace',
+          workspacePath: '/app',
+          authority: { source: 'container_capture', authoritative: true },
+        },
+      },
+    ], 'tr-artifact');
+
+    assert.equal(projection.artifacts.length, 1);
+    assert.equal(projection.artifacts[0]?.workspacePath, '/app');
+    assert.equal(projection.artifacts[0]?.authority.source, 'container_capture');
+  });
+
   test('projects isolation, permission, inbox, and needs_approval facts', () => {
     const taskRunId = 'tr-approval';
     const request = {

--- a/packages/headless/src/__tests__/verifier.test.ts
+++ b/packages/headless/src/__tests__/verifier.test.ts
@@ -60,6 +60,8 @@ describe('benchmark verifiers', () => {
       assert.equal(result.exitCode, 0);
       assert.equal(result.score, 1);
       assert.equal(result.maxScore, 1);
+      assert.equal(result.authority?.source, 'self_check');
+      assert.equal(result.authority?.authoritative, false);
       assert.equal(result.submittedSnapshotId, 'snapshot-1');
       assert.deepEqual(result.details, {
         adapter: 'terminal-bench',
@@ -67,6 +69,7 @@ describe('benchmark verifiers', () => {
         datasetPath: '/datasets/local',
         testCommand: 'test -f marker.txt',
         timedOut: false,
+        verificationPlaceholder: true,
       });
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -101,6 +104,75 @@ describe('benchmark verifiers', () => {
       assert.equal(result.passed, false);
       assert.equal(result.exitCode, null);
       assert.equal(result.errorClass, 'unsupported_adapter');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects benchmark artifacts for a different task run or attempt', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-tbench-verifier-'));
+    try {
+      await assert.rejects(
+        runVerifier({
+          verifier: { kind: 'terminal_bench', adapter: 'terminal-bench', instanceId: 'official' },
+          taskRunId: 'run-current',
+          attemptId: 'attempt-current',
+          ts: 100,
+          id: 'verifier-official',
+          workspaceDir: dir,
+          benchmarkAdapters: {
+            'terminal-bench': {
+              name: 'terminal-bench',
+              runVerifier: () => ({
+                kind: 'terminal_bench',
+                passed: true,
+                exitCode: 0,
+                authority: { source: 'official_harbor_verifier', authoritative: true },
+                artifacts: [
+                  {
+                    taskRunId: 'run-other',
+                    kind: 'container_workspace',
+                    workspacePath: '/app',
+                    authority: { source: 'container_capture', authoritative: true },
+                  },
+                ],
+              }),
+            },
+          },
+        }),
+        /taskRunId mismatch/,
+      );
+
+      await assert.rejects(
+        runVerifier({
+          verifier: { kind: 'terminal_bench', adapter: 'terminal-bench', instanceId: 'official' },
+          taskRunId: 'run-current',
+          attemptId: 'attempt-current',
+          ts: 100,
+          id: 'verifier-official',
+          workspaceDir: dir,
+          benchmarkAdapters: {
+            'terminal-bench': {
+              name: 'terminal-bench',
+              runVerifier: () => ({
+                kind: 'terminal_bench',
+                passed: true,
+                exitCode: 0,
+                authority: { source: 'official_harbor_verifier', authoritative: true },
+                artifacts: [
+                  {
+                    attemptId: 'attempt-other',
+                    kind: 'container_workspace',
+                    workspacePath: '/app',
+                    authority: { source: 'container_capture', authoritative: true },
+                  },
+                ],
+              }),
+            },
+          },
+        }),
+        /attemptId mismatch/,
+      );
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/benchmark-adapters.ts
+++ b/packages/headless/src/benchmark-adapters.ts
@@ -1,4 +1,5 @@
 import type { Task, VerifierSpec } from './contracts.js';
+import type { TaskRunArtifactAuthority, TaskRunArtifactDescriptor } from './task-contracts.js';
 
 export interface BenchmarkInstanceRef {
   adapter: string;
@@ -30,6 +31,8 @@ export interface BenchmarkVerifierOutput {
   errorClass?: string;
   score?: number;
   maxScore?: number;
+  authority?: TaskRunArtifactAuthority;
+  artifacts?: TaskRunArtifactDescriptor[];
   details?: Record<string, unknown>;
 }
 

--- a/packages/headless/src/harbor-official-artifacts.ts
+++ b/packages/headless/src/harbor-official-artifacts.ts
@@ -1,0 +1,166 @@
+import { readFile } from 'node:fs/promises';
+import type { VerifierSpec } from './contracts.js';
+import type { BenchmarkVerifierOutput } from './benchmark-adapters.js';
+import type { TaskRunArtifactDescriptor } from './task-contracts.js';
+
+export interface HarborOfficialArtifactInput {
+  kind?: Exclude<VerifierSpec['kind'], 'command'>;
+  resultJson?: unknown;
+  rewardText?: string;
+  ctrfJson?: unknown;
+  stdout?: string;
+  stderr?: string;
+  durationMs?: number;
+  artifacts?: TaskRunArtifactDescriptor[];
+  details?: Record<string, unknown>;
+}
+
+export interface ReadHarborOfficialArtifactInput extends Omit<HarborOfficialArtifactInput, 'resultJson' | 'rewardText' | 'ctrfJson'> {
+  resultJsonPath?: string;
+  rewardPath?: string;
+  ctrfJsonPath?: string;
+}
+
+export async function readHarborOfficialVerifierOutput(
+  input: ReadHarborOfficialArtifactInput,
+): Promise<BenchmarkVerifierOutput> {
+  return harborOfficialVerifierOutputFromArtifacts({
+    ...input,
+    ...(input.resultJsonPath ? { resultJson: await readJsonFile(input.resultJsonPath) } : {}),
+    ...(input.rewardPath ? { rewardText: await readFile(input.rewardPath, 'utf8') } : {}),
+    ...(input.ctrfJsonPath ? { ctrfJson: await readJsonFile(input.ctrfJsonPath) } : {}),
+  });
+}
+
+export function harborOfficialVerifierOutputFromArtifacts(input: HarborOfficialArtifactInput): BenchmarkVerifierOutput {
+  const result = recordValue(input.resultJson) ? input.resultJson : undefined;
+  const ctrf = ctrfSummary(input.ctrfJson);
+  const score = numericPath(result, ['reward'])
+    ?? numericPath(result, ['score'])
+    ?? numericPath(result, ['metrics', 'reward'])
+    ?? numericPath(result, ['metrics', 'score'])
+    ?? numericPath(result, ['verifier_result', 'rewards', 'reward'])
+    ?? numericPath(result, ['verifier_result', 'rewards', 'score'])
+    ?? numericReward(input.rewardText)
+    ?? ctrf?.score;
+  const maxScore = numericPath(result, ['maxScore'])
+    ?? numericPath(result, ['max_score'])
+    ?? numericPath(result, ['metrics', 'maxScore'])
+    ?? numericPath(result, ['metrics', 'max_score'])
+    ?? ctrf?.maxScore
+    ?? 1;
+  const explicitPassed = booleanPath(result, ['passed'])
+    ?? booleanPath(result, ['success'])
+    ?? booleanPath(result, ['verifier_result', 'passed']);
+  const passed = explicitPassed
+    ?? ctrf?.passed
+    ?? (score !== undefined ? score > 0 : false);
+  const error = stringPath(result, ['error'])
+    ?? stringPath(result, ['message'])
+    ?? stringPath(result, ['verifier_result', 'error']);
+
+  if (score === undefined && explicitPassed === undefined && error === undefined && ctrf === undefined) {
+    return {
+      kind: input.kind ?? 'terminal_bench',
+      passed: false,
+      exitCode: null,
+      ...(input.durationMs !== undefined ? { durationMs: input.durationMs } : {}),
+      ...(input.stdout ? { stdout: input.stdout } : {}),
+      ...(input.stderr ? { stderr: input.stderr } : {}),
+      error: 'Harbor official verifier output did not include a reward, score, pass flag, error, or CTRF summary',
+      errorClass: 'missing_official_verifier',
+      maxScore,
+      authority: { source: 'system', authoritative: false, label: 'missing Harbor official verifier output' },
+      ...(input.artifacts ? { artifacts: input.artifacts } : {}),
+      details: {
+        source: 'harbor',
+        official: false,
+        missingOfficialVerifier: true,
+        ...(input.details ?? {}),
+      },
+    };
+  }
+
+  return {
+    kind: input.kind ?? 'terminal_bench',
+    passed,
+    exitCode: passed ? 0 : 1,
+    ...(input.durationMs !== undefined ? { durationMs: input.durationMs } : {}),
+    ...(input.stdout ? { stdout: input.stdout } : {}),
+    ...(input.stderr ? { stderr: input.stderr } : {}),
+    ...(error ? { error } : {}),
+    ...(passed ? {} : { errorClass: 'verification_failed' }),
+    ...(score !== undefined ? { score } : {}),
+    maxScore,
+    authority: { source: 'official_harbor_verifier', authoritative: true, label: 'Harbor official verifier' },
+    ...(input.artifacts ? { artifacts: input.artifacts } : {}),
+    details: {
+      source: 'harbor',
+      official: true,
+      ...(input.details ?? {}),
+      ...(score !== undefined ? { reward: score } : {}),
+      ...(ctrf ? { ctrf } : {}),
+    },
+  };
+}
+
+async function readJsonFile(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+function ctrfSummary(value: unknown): { passed: boolean; score: number; maxScore: number; tests?: number; failed?: number } | undefined {
+  if (!recordValue(value) || !recordValue(value.results) || !recordValue(value.results.summary)) return undefined;
+  const summary = value.results.summary;
+  const tests = numericField(summary, 'tests');
+  const failed = numericField(summary, 'failed') ?? 0;
+  const passedTests = numericField(summary, 'passed');
+  if (tests === undefined && passedTests === undefined) return undefined;
+  const maxScore = tests ?? ((passedTests ?? 0) + failed);
+  const passed = failed === 0 && maxScore > 0;
+  return {
+    passed,
+    score: passed ? 1 : 0,
+    maxScore: 1,
+    ...(tests !== undefined ? { tests } : {}),
+    failed,
+  };
+}
+
+function numericReward(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function numericPath(value: Record<string, unknown> | undefined, path: string[]): number | undefined {
+  const leaf = pathValue(value, path);
+  return typeof leaf === 'number' && Number.isFinite(leaf) ? leaf : undefined;
+}
+
+function booleanPath(value: Record<string, unknown> | undefined, path: string[]): boolean | undefined {
+  const leaf = pathValue(value, path);
+  return typeof leaf === 'boolean' ? leaf : undefined;
+}
+
+function stringPath(value: Record<string, unknown> | undefined, path: string[]): string | undefined {
+  const leaf = pathValue(value, path);
+  return typeof leaf === 'string' && leaf.length > 0 ? leaf : undefined;
+}
+
+function pathValue(value: Record<string, unknown> | undefined, path: string[]): unknown {
+  let current: unknown = value;
+  for (const segment of path) {
+    if (!recordValue(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function numericField(value: Record<string, unknown>, key: string): number | undefined {
+  const field = value[key];
+  return typeof field === 'number' && Number.isFinite(field) ? field : undefined;
+}
+
+function recordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -26,6 +26,14 @@ export {
   runHarborCellFromEnv,
 } from './harbor-cell.js';
 export type {
+  HarborOfficialArtifactInput,
+  ReadHarborOfficialArtifactInput,
+} from './harbor-official-artifacts.js';
+export {
+  harborOfficialVerifierOutputFromArtifacts,
+  readHarborOfficialVerifierOutput,
+} from './harbor-official-artifacts.js';
+export type {
   FixedPromptControllerStopReason,
   FixedPromptControllerResult,
   FixedPromptTask,
@@ -165,6 +173,12 @@ export type {
   TaskInboxKind,
   TaskInboxStatus,
   TaskInterventionPolicy,
+  TaskRunArtifact,
+  TaskRunArtifactAuthority,
+  TaskRunArtifactAuthoritySource,
+  TaskRunArtifactDescriptor,
+  TaskRunArtifactKind,
+  TaskRunArtifactRecordedEvent,
   TaskIsolationFacts,
   TaskPermissionGrant,
   TaskPermissionRequest,

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -39,7 +39,13 @@ export interface TaskRunExport {
   workspace: {
     lease?: TaskRunProjection['workspaceLease'];
     submittedSnapshot?: unknown;
+    primaryWorkspacePath?: string;
     diff: { status: 'present' | 'not_captured'; artifactRef?: string; path?: string; hash?: string };
+  };
+  artifacts: {
+    primaryWorkspacePath?: string;
+    items: TaskRunProjection['artifacts'];
+    byKind: Record<string, TaskRunProjection['artifacts']>;
   };
   verifier?: VerifierResult & { benchmark?: Record<string, unknown> };
   score?: ScoreResult;
@@ -117,6 +123,7 @@ export function taskRunExportFromProjection(
   const runtimeEventIds = runtimeEventIdsFrom(runtimeRefs);
   const benchmark = verifierBenchmark(verifier);
   const taxonomy = score?.taxonomy ?? projection.result?.taxonomy ?? legacyResultRecord.errorClass ?? projection.status;
+  const primaryWorkspacePath = primaryWorkspacePathFromArtifacts(projection.artifacts);
 
   return {
     schemaVersion: 'maka.task_run_export.v1',
@@ -145,7 +152,13 @@ export function taskRunExportFromProjection(
     workspace: {
       lease: projection.workspaceLease,
       submittedSnapshot: scoreDetails.submittedSnapshot ?? submittedSnapshotRef(verifier),
-      diff: diffMetadata(scoreDetails),
+      ...(primaryWorkspacePath ? { primaryWorkspacePath } : {}),
+      diff: diffMetadata(scoreDetails, projection.artifacts),
+    },
+    artifacts: {
+      ...(primaryWorkspacePath ? { primaryWorkspacePath } : {}),
+      items: projection.artifacts,
+      byKind: artifactsByKind(projection.artifacts),
     },
     verifier: verifier
       ? {
@@ -196,10 +209,20 @@ export function renderTaskRunMarkdown(exported: TaskRunExport): string {
     `- verifier: ${verifier ? md(verifier.kind) : 'none'}`,
     `- verifier_exit_code: ${verifier?.exitCode ?? 'null'}`,
     `- score: ${scoreValue(score)}`,
+    `- verifier_authority: ${authorityValue(verifier?.authority)}`,
     `- submitted_snapshot: ${snapshotValue(exported.workspace.submittedSnapshot)}`,
     `- diff: ${exported.workspace.diff.status}`,
+    `- artifacts: ${exported.artifacts.items.length}`,
     '',
   ];
+  if (exported.artifacts.items.length > 0) {
+    lines.push(
+      '## artifacts',
+      '',
+      ...exported.artifacts.items.map((artifact) => `- ${md(artifact.kind)} ${md(artifact.workspacePath ?? artifact.path ?? artifact.artifactRef ?? artifact.artifactId)}`),
+      '',
+    );
+  }
   if (verifier?.stdout) {
     lines.push('## verifier_stdout', '', fence(verifier.stdout), '');
   }
@@ -224,11 +247,13 @@ function compactResultView(exported: TaskRunExport): Record<string, unknown> {
           passed: exported.verifier.passed,
           exitCode: exported.verifier.exitCode ?? null,
           errorClass: exported.verifier.errorClass,
+          authority: exported.verifier.authority,
           benchmark: exported.verifier.benchmark,
         }
       : undefined,
     score: exported.score,
     workspace: exported.workspace,
+    artifacts: exported.artifacts,
     legacyResultRecord: exported.legacyResultRecord,
   };
 }
@@ -246,15 +271,39 @@ function submittedSnapshotRef(verifier: VerifierResult | undefined): Record<stri
   return verifier?.submittedSnapshotId ? { id: verifier.submittedSnapshotId } : undefined;
 }
 
-function diffMetadata(details: Record<string, unknown>): TaskRunExport['workspace']['diff'] {
+function diffMetadata(
+  details: Record<string, unknown>,
+  artifacts: TaskRunProjection['artifacts'],
+): TaskRunExport['workspace']['diff'] {
   const diff = details.diff;
-  if (!recordValue(diff)) return { status: 'not_captured' };
+  if (!recordValue(diff)) {
+    const artifact = artifacts.find((item) => item.kind === 'workspace_diff');
+    if (!artifact) return { status: 'not_captured' };
+    return {
+      status: 'present',
+      ...(artifact.artifactRef ? { artifactRef: artifact.artifactRef } : {}),
+      ...(artifact.path ? { path: artifact.path } : {}),
+      ...(artifact.hash ? { hash: artifact.hash } : {}),
+    };
+  }
   return {
     status: 'present',
     ...(typeof diff.artifactRef === 'string' ? { artifactRef: diff.artifactRef } : {}),
     ...(typeof diff.path === 'string' ? { path: diff.path } : {}),
     ...(typeof diff.hash === 'string' ? { hash: diff.hash } : {}),
   };
+}
+
+function primaryWorkspacePathFromArtifacts(artifacts: TaskRunProjection['artifacts']): string | undefined {
+  return artifacts.find((artifact) => artifact.kind === 'container_workspace' && artifact.workspacePath)?.workspacePath;
+}
+
+function artifactsByKind(artifacts: TaskRunProjection['artifacts']): Record<string, TaskRunProjection['artifacts']> {
+  const grouped: Record<string, TaskRunProjection['artifacts']> = {};
+  for (const artifact of artifacts) {
+    grouped[artifact.kind] = [...(grouped[artifact.kind] ?? []), artifact];
+  }
+  return grouped;
 }
 
 function verifierBenchmark(verifier: VerifierResult | undefined): Record<string, unknown> | undefined {
@@ -275,6 +324,11 @@ function scoreValue(score: ScoreResult | undefined): string {
   if (!score) return 'none';
   if (score.score !== undefined || score.maxScore !== undefined) return `${score.score ?? 'unknown'}/${score.maxScore ?? 'unknown'}`;
   return score.passed ? 'pass' : 'fail';
+}
+
+function authorityValue(authority: VerifierResult['authority']): string {
+  if (!authority) return 'none';
+  return `${authority.source} authoritative=${authority.authoritative ? 'true' : 'false'}`;
 }
 
 function snapshotValue(value: unknown): string {

--- a/packages/headless/src/scorer.ts
+++ b/packages/headless/src/scorer.ts
@@ -51,6 +51,21 @@ export const defaultFinalScorer: FinalScorer = (input) => {
     };
   }
 
+  if (verifier && verifier.kind !== 'command' && verifier.authority?.authoritative === false) {
+    return {
+      passed: false,
+      scored: false,
+      eligible: true,
+      taxonomy: 'verification_failed',
+      errorClass: 'non_authoritative_verifier',
+      excludedReason: 'official benchmark verifier result is missing',
+      details: {
+        verifierAuthority: verifier.authority,
+        verificationPlaceholder: verifier.details?.verificationPlaceholder === true,
+      },
+    };
+  }
+
   if (!verifier) {
     return {
       passed: false,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -371,6 +371,7 @@ export async function runTaskOnce(
       ...(finalScore.errorClass ? { errorClass: finalScore.errorClass } : {}),
       ...(finalScore.excludedReason ? { excludedReason: finalScore.excludedReason } : {}),
       taxonomy,
+      ...(verifierResult.authority ? { authority: verifierResult.authority } : {}),
       details: {
         steps: resultRecord.steps,
         invocationStatus: invocation.status,
@@ -399,6 +400,15 @@ export async function runTaskOnce(
       ts: finishedAt,
       result: verifierResult,
     });
+    for (const artifact of verifierResult.artifacts ?? []) {
+      await appendTaskEvent(taskRunStore, taskRunId, {
+        type: 'task_run_artifact_recorded',
+        id: newId(),
+        taskRunId,
+        ts: artifact.ts,
+        artifact,
+      });
+    }
     await appendTaskEvent(taskRunStore, taskRunId, {
       type: 'score_result_recorded',
       id: newId(),

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -186,6 +186,53 @@ export interface AutonomousDecision {
   details?: Record<string, unknown>;
 }
 
+export type TaskRunArtifactKind =
+  | 'container_workspace'
+  | 'workspace_diff'
+  | 'source_code'
+  | 'generated_output'
+  | 'benchmark_manifest'
+  | 'benchmark_repro'
+  | 'submitted_snapshot'
+  | 'runtime_trace'
+  | 'other';
+
+export type TaskRunArtifactAuthoritySource =
+  | 'official_harbor_verifier'
+  | 'self_check'
+  | 'container_capture'
+  | 'runtime'
+  | 'system';
+
+export interface TaskRunArtifactAuthority {
+  source: TaskRunArtifactAuthoritySource;
+  authoritative: boolean;
+  label?: string;
+}
+
+export interface TaskRunArtifact {
+  schemaVersion: 1;
+  artifactId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  kind: TaskRunArtifactKind;
+  authority: TaskRunArtifactAuthority;
+  label?: string;
+  path?: string;
+  workspacePath?: string;
+  artifactRef?: string;
+  hash?: string;
+  mimeType?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type TaskRunArtifactDescriptor = Omit<TaskRunArtifact, 'schemaVersion' | 'artifactId' | 'taskRunId' | 'ts'> & {
+  artifactId?: string;
+  taskRunId?: string;
+  ts?: number;
+};
+
 export interface VerifierResult {
   id: string;
   taskRunId: string;
@@ -203,6 +250,8 @@ export interface VerifierResult {
   errorClass?: string;
   score?: number;
   maxScore?: number;
+  authority?: TaskRunArtifactAuthority;
+  artifacts?: TaskRunArtifact[];
   details?: Record<string, unknown>;
   submittedSnapshotId?: string;
   scoringWorkspaceId?: string;
@@ -221,6 +270,7 @@ export interface ScoreResult {
   score?: number;
   maxScore?: number;
   taxonomy: AutonomousResultTaxonomy;
+  authority?: TaskRunArtifactAuthority;
   details?: Record<string, unknown>;
 }
 
@@ -406,6 +456,11 @@ export interface VerifierResultRecordedEvent extends BaseTaskEvent {
   result: VerifierResult;
 }
 
+export interface TaskRunArtifactRecordedEvent extends BaseTaskEvent {
+  type: 'task_run_artifact_recorded';
+  artifact: TaskRunArtifact;
+}
+
 export interface ScoreResultRecordedEvent extends BaseTaskEvent {
   type: 'score_result_recorded';
   result: ScoreResult;
@@ -537,6 +592,7 @@ export type TaskEvent =
   | FeedbackObservedEvent
   | AutonomousDecisionRecordedEvent
   | VerifierResultRecordedEvent
+  | TaskRunArtifactRecordedEvent
   | ScoreResultRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -12,6 +12,7 @@ import type {
   ScoreResult,
   SelfCheckObservation,
   TaskAttempt,
+  TaskRunArtifact,
   TaskEvent,
   TaskRun,
   TaskRunError,
@@ -27,6 +28,7 @@ export interface TaskRunProjection extends TaskRun {
   selfChecks: SelfCheckObservation[];
   feedback: FeedbackObservation[];
   decisions: AutonomousDecision[];
+  artifacts: TaskRunArtifact[];
   verifierResults: VerifierResult[];
   scoreResults: ScoreResult[];
   toolExecutors: ToolExecutorIdentity[];
@@ -68,6 +70,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     selfChecks: [],
     feedback: [],
     decisions: [],
+    artifacts: [],
     verifierResults: [],
     scoreResults: [],
     toolExecutors: [],
@@ -132,6 +135,9 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       case 'verifier_result_recorded':
         projection.verifierResults.push(event.result);
         projection.latestVerifierResult = event.result;
+        break;
+      case 'task_run_artifact_recorded':
+        projection.artifacts.push(event.artifact);
         break;
       case 'score_result_recorded':
         projection.scoreResults.push(event.result);
@@ -254,6 +260,13 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
 
   projection.attempts = [...attempts.values()];
   projection.inboxItems = [...inboxItems.values()];
+  projection.latestVerifierResult = preferredVerifierResult(projection.verifierResults);
+  projection.latestScoreResult = preferredScoreResult(projection.scoreResults, projection.latestVerifierResult);
+  if (projection.latestScoreResult) {
+    projection.result = resultFromScore(projection.latestScoreResult, projection.latestVerifierResult);
+  } else if (projection.latestVerifierResult) {
+    projection.result = resultFromVerifier(projection.latestVerifierResult);
+  }
   return projection;
 }
 
@@ -368,6 +381,35 @@ function resultFromScore(score: ScoreResult | undefined, verifier: VerifierResul
     ...(verifier ? { verifierResultId: verifier.id } : {}),
     scoreResultId: score.id,
   };
+}
+
+function resultFromVerifier(verifier: VerifierResult): TaskRunResult {
+  return {
+    passed: verifier.passed,
+    taxonomy: verifier.passed ? 'passed' : 'verification_failed',
+    verifierResultId: verifier.id,
+  };
+}
+
+function preferredVerifierResult(results: readonly VerifierResult[]): VerifierResult | undefined {
+  return preferredByAuthority(results);
+}
+
+function preferredScoreResult(results: readonly ScoreResult[], verifier: VerifierResult | undefined): ScoreResult | undefined {
+  if (verifier?.authority?.authoritative === true && !results.some((result) => result.authority?.authoritative === true)) {
+    return undefined;
+  }
+  return preferredByAuthority(results);
+}
+
+function preferredByAuthority<T extends { authority?: { authoritative: boolean }; ts: number }>(
+  results: readonly T[],
+): T | undefined {
+  const authoritative = results.filter((result) => result.authority?.authoritative === true);
+  if (authoritative.length > 0) return authoritative[authoritative.length - 1];
+  const nonPlaceholder = results.filter((result) => result.authority?.authoritative !== false);
+  if (nonPlaceholder.length > 0) return nonPlaceholder[nonPlaceholder.length - 1];
+  return results[results.length - 1];
 }
 
 function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: number): number {

--- a/packages/headless/src/terminal-bench-adapter.ts
+++ b/packages/headless/src/terminal-bench-adapter.ts
@@ -14,7 +14,8 @@ export async function runTerminalBenchTestCommand(input: {
       exitCode: null,
       error: 'terminal_bench verifier adapter is not implemented',
       errorClass: 'unsupported_adapter',
-      details: terminalBenchDetails(input.verifier),
+      authority: { source: 'self_check', authoritative: false, label: 'unsupported local benchmark placeholder' },
+      details: { ...terminalBenchDetails(input.verifier), verificationPlaceholder: true },
     };
   }
 
@@ -36,10 +37,12 @@ export async function runTerminalBenchTestCommand(input: {
     ...(errorClass ? { errorClass } : {}),
     score: evaluation.passed ? 1 : 0,
     maxScore: 1,
+    authority: { source: 'self_check', authoritative: false, label: 'local Terminal-Bench testCommand self-check' },
     details: {
       ...terminalBenchDetails(input.verifier),
       testCommand: command,
       timedOut: evaluation.timedOut,
+      verificationPlaceholder: true,
     },
   };
 }

--- a/packages/headless/src/verifier.ts
+++ b/packages/headless/src/verifier.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, join } from 'node:path';
 import type { Task, TaskVerification, VerifierSpec } from './contracts.js';
 import { runVerification, type EvaluationResult } from './evaluator.js';
-import type { VerifierResult } from './task-contracts.js';
+import type { TaskRunArtifact, TaskRunArtifactDescriptor, VerifierResult } from './task-contracts.js';
 import { resolveBenchmarkAdapter, type BenchmarkAdapterRegistry, type BenchmarkVerifierOutput } from './benchmark-adapters.js';
 import { runTerminalBenchTestCommand, terminalBenchDetails } from './terminal-bench-adapter.js';
 
@@ -96,7 +96,10 @@ export async function runVerifier(input: {
       exitCode: null,
       error: `${input.verifier.kind} verifier adapter is not implemented`,
       errorClass: 'unsupported_adapter',
-      details: input.verifier.kind === 'terminal_bench' ? terminalBenchDetails(input.verifier) : undefined,
+      authority: { source: 'self_check', authoritative: false, label: 'unsupported local benchmark placeholder' },
+      details: input.verifier.kind === 'terminal_bench'
+        ? { ...terminalBenchDetails(input.verifier), verificationPlaceholder: true }
+        : { verificationPlaceholder: true },
       submittedSnapshotId: input.submittedSnapshotId,
       scoringWorkspaceId: input.scoringWorkspaceId,
     };
@@ -147,10 +150,52 @@ function verifierResultFromBenchmarkOutput(input: {
     errorClass: input.output.errorClass,
     score: input.output.score,
     maxScore: input.output.maxScore,
+    authority: input.output.authority,
+    artifacts: materializeArtifacts({
+      descriptors: input.output.artifacts,
+      verifierResultId: input.id,
+      taskRunId: input.taskRunId,
+      attemptId: input.attemptId,
+      ts: input.ts,
+    }),
     details: input.output.details,
     submittedSnapshotId: input.submittedSnapshotId,
     scoringWorkspaceId: input.scoringWorkspaceId,
   };
+}
+
+function materializeArtifacts(input: {
+  descriptors: TaskRunArtifactDescriptor[] | undefined;
+  verifierResultId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+}): TaskRunArtifact[] | undefined {
+  if (!input.descriptors || input.descriptors.length === 0) return undefined;
+  return input.descriptors.map((descriptor, index) => {
+    if (descriptor.taskRunId && descriptor.taskRunId !== input.taskRunId) {
+      throw new Error(`benchmark artifact taskRunId mismatch: ${descriptor.taskRunId} !== ${input.taskRunId}`);
+    }
+    if (descriptor.attemptId && descriptor.attemptId !== input.attemptId) {
+      throw new Error(`benchmark artifact attemptId mismatch: ${descriptor.attemptId} !== ${input.attemptId ?? '<none>'}`);
+    }
+    return {
+      schemaVersion: 1,
+      artifactId: descriptor.artifactId ?? `${input.verifierResultId}:artifact-${index + 1}`,
+      taskRunId: input.taskRunId,
+      ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+      ts: descriptor.ts ?? input.ts,
+      kind: descriptor.kind,
+      authority: descriptor.authority,
+      ...(descriptor.label ? { label: descriptor.label } : {}),
+      ...(descriptor.path ? { path: descriptor.path } : {}),
+      ...(descriptor.workspacePath ? { workspacePath: descriptor.workspacePath } : {}),
+      ...(descriptor.artifactRef ? { artifactRef: descriptor.artifactRef } : {}),
+      ...(descriptor.hash ? { hash: descriptor.hash } : {}),
+      ...(descriptor.mimeType ? { mimeType: descriptor.mimeType } : {}),
+      ...(descriptor.metadata ? { metadata: descriptor.metadata } : {}),
+    };
+  });
 }
 
 export function verifierResultFromEvaluation(input: {


### PR DESCRIPTION
## Summary
- Replaces closed PR #83 after upstream `main` was force-updated; this branch is rebuilt from latest upstream `main` (`da1a40f1`).
- Carries verifier authority through benchmark adapters, task-run events, projections, exports, and Markdown summaries.
- Keeps Terminal-Bench local placeholders explicitly non-authoritative while preferring official Harbor verifier truth.
- Records container workspace/diff/source/output/manifest artifacts as first-class task-run artifacts and validates adapter artifact identity.

## Verification
- `git diff --check upstream/main..HEAD`
- `npm run typecheck --workspace @maka/headless`
- `npm test --workspace @maka/headless` (218/218)

## Notes
- Full workspace `npm run typecheck` still fails on pre-existing UI/Desktop drift unrelated to this headless change: missing `overlayscrollbars`, stale desktop/UI prop mismatches, and missing `PrimitiveTabs` / `OverlayScrollArea` exports.
