### PR TITLE
feat: compare Maka and Pi agent in headless Harbor

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -65,6 +65,8 @@ class MakaAgent(BaseInstalledAgent):
 
     async def install(self, environment: BaseEnvironment) -> None:
         maka_repo = self._resolved_flags.get("maka_repo", "/opt/maka-agent")
+        backend = self._resolved_flags.get("backend", "") or self._get_env("MAKA_BACKEND") or "ai-sdk"
+        pi_command = self._get_env("MAKA_PI_COMMAND") or "pi"
         run_cell = Path(maka_repo) / "packages" / "headless" / "harbor" / "run-cell.mjs"
         dist_index = Path(maka_repo) / "packages" / "headless" / "dist" / "index.js"
         await self.exec_as_root(
@@ -91,6 +93,13 @@ class MakaAgent(BaseInstalledAgent):
                 "fi"
             ),
         )
+        pi_probe = (
+            f" && PI_COMMAND={shlex.quote(pi_command)}"
+            " && command -v \"$PI_COMMAND\" >/dev/null 2>&1"
+            " && \"$PI_COMMAND\" --version"
+            if backend == "pi-agent"
+            else ""
+        )
         await self.exec_as_agent(
             environment,
             command=(
@@ -99,6 +108,7 @@ class MakaAgent(BaseInstalledAgent):
                 "test \"$NODE_MAJOR\" -ge 22 && "
                 f"test -f {shlex.quote(str(run_cell))} && "
                 f"test -f {shlex.quote(str(dist_index))}"
+                f"{pi_probe}"
             ),
         )
 
@@ -141,7 +151,7 @@ class MakaAgent(BaseInstalledAgent):
     def _cell_env(self, instruction_path: Any) -> dict[str, str]:
         system_prompt = self._resolved_flags.get("system_prompt", "") or self._get_env("MAKA_SYSTEM_PROMPT") or ""
         model = self.model_name or self._get_env("MAKA_MODEL") or "deepseek/deepseek-chat"
-        backend = self._resolved_flags.get("backend", "ai-sdk")
+        backend = self._resolved_flags.get("backend", "") or self._get_env("MAKA_BACKEND") or "ai-sdk"
         provider = self._resolved_flags.get("provider", "") or self._get_env("MAKA_PROVIDER") or ""
         env = {
             "MAKA_BACKEND": backend,
@@ -154,15 +164,41 @@ class MakaAgent(BaseInstalledAgent):
         if provider:
             env["MAKA_PROVIDER"] = provider
         for key in (
+            "MAKA_PI_COMMAND",
+            "MAKA_PI_PROVIDER",
+            "MAKA_PI_MODEL",
+            "PI_CODING_AGENT_DIR",
+            "PI_CODING_AGENT_SESSION_DIR",
+            "PI_PACKAGE_DIR",
+            "PI_OFFLINE",
+            "PI_TELEMETRY",
+        ):
+            value = self._get_env(key)
+            if value:
+                env[key] = value
+        for key in (
             "DEEPSEEK_API_KEY",
+            "DEEPSEEK_API_KEY_FILE",
             "DEEPSEEK_BASE_URL",
             "OPENAI_API_KEY",
+            "OPENAI_API_KEY_FILE",
             "OPENAI_BASE_URL",
             "MOONSHOT_API_KEY",
+            "MOONSHOT_API_KEY_FILE",
             "GOOGLE_API_KEY",
+            "GOOGLE_API_KEY_FILE",
             "ANTHROPIC_API_KEY",
+            "ANTHROPIC_API_KEY_FILE",
             "ZAI_API_KEY",
+            "ZAI_API_KEY_FILE",
             "ZAI_BASE_URL",
+            "ZAI_CODING_CN_API_KEY",
+            "ZAI_CODING_CN_API_KEY_FILE",
+            "XIAOMI_API_KEY",
+            "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+            "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+            "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+            "OPENCODE_API_KEY",
         ):
             value = self._get_env(key)
             if value:

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -267,6 +267,32 @@ with tempfile.TemporaryDirectory() as tmp:
     assert "test -f /opt/maka-agent/packages/headless/harbor/run-cell.mjs" in agent_probe_command, agent_probe_command
     assert "test -f /opt/maka-agent/packages/headless/dist/index.js" in agent_probe_command, agent_probe_command
 
+    pi_agent = MakaAgent(Path(tmp), extra_env={
+        "MAKA_BACKEND": "pi-agent",
+        "MAKA_PI_COMMAND": "/opt/pi/bin/pi",
+        "PI_CODING_AGENT_DIR": "/pi-agent",
+        "MAKA_PI_PROVIDER": "volcengine-plan",
+        "ZAI_CODING_CN_API_KEY": "zai-key",
+        "OPENAI_API_KEY_FILE": "/run/secrets/openai-key",
+    })
+    fake_pi_environment = types.SimpleNamespace(root_commands=[], agent_commands=[])
+    asyncio.run(pi_agent.install(fake_pi_environment))
+    pi_install_command = "\n".join(fake_pi_environment.root_commands)
+    assert "npm install -g" not in pi_install_command, pi_install_command
+    assert "npm prefix -g" not in pi_install_command, pi_install_command
+    pi_probe_command = "\n".join(fake_pi_environment.agent_commands)
+    assert "PI_COMMAND=/opt/pi/bin/pi" in pi_probe_command, pi_probe_command
+    assert "command -v \"$PI_COMMAND\"" in pi_probe_command, pi_probe_command
+    assert "\"$PI_COMMAND\" --version" in pi_probe_command, pi_probe_command
+    pi_agent._resolved_flags = {"backend": "pi-agent"}
+    pi_env = pi_agent._cell_env(Path("/logs/agent/instruction.txt"))
+    assert pi_env["MAKA_BACKEND"] == "pi-agent", pi_env
+    assert pi_env["MAKA_PI_COMMAND"] == "/opt/pi/bin/pi", pi_env
+    assert pi_env["PI_CODING_AGENT_DIR"] == "/pi-agent", pi_env
+    assert pi_env["MAKA_PI_PROVIDER"] == "volcengine-plan", pi_env
+    assert pi_env["ZAI_CODING_CN_API_KEY"] == "zai-key", pi_env
+    assert pi_env["OPENAI_API_KEY_FILE"] == "/run/secrets/openai-key", pi_env
+
     agent = MakaAgent(Path(tmp))
     context = AgentContext()
     agent._apply_cell_output(context, {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1,11 +1,19 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
-import { BackendRegistry, type AgentBackend, type BackendFactoryContext, type SessionStore } from '@maka/runtime';
+import {
+  BackendRegistry,
+  PermissionEngine,
+  PiAgentBackend,
+  type AgentBackend,
+  type BackendFactoryContext,
+  type PiAgentTransport,
+  type SessionStore,
+} from '@maka/runtime';
 import type { Config } from '../contracts.js';
 import type { HeadlessBackendContext, IsolatedToolExecutor } from '../isolation.js';
 import {
@@ -25,6 +33,21 @@ const config: Config = {
   model: 'fake-model',
   systemPrompt: 'You are a benchmark cell agent.',
 };
+
+function registerTestPiAgentBackend(
+  registry: BackendRegistry,
+  transportFactory: (input: { header: SessionHeader; store: SessionStore }) => PiAgentTransport,
+): void {
+  registry.register('pi-agent', (ctx) =>
+    new PiAgentBackend({
+      sessionId: ctx.sessionId,
+      header: ctx.header,
+      appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
+      permissionEngine: new PermissionEngine({ newId: () => 'perm-id', now: () => 123 }),
+      transport: transportFactory({ header: ctx.header, store: ctx.store }),
+    }),
+  );
+}
 
 class CellReportingBackend implements AgentBackend {
   readonly sessionId: string;
@@ -294,6 +317,279 @@ describe('runHarborCell', () => {
     });
   });
 
+  test('env entrypoint accepts pi-agent when a Pi backend registration is supplied', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const seenContexts: HeadlessBackendContext[] = [];
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through pi',
+        MAKA_MODEL: 'pi-test',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      }, {
+        registerBackends: (registry, context) => {
+          seenContexts.push(context);
+          registerTestPiAgentBackend(registry, ({ header }) => ({
+            async *send(input) {
+              assert.equal(input.cwd, workspaceDir);
+              assert.equal(input.text, 'solve through pi');
+              await writeFile(join(header.cwd, 'pi-cell-proof.txt'), 'ran via pi\n', 'utf8');
+              yield { type: 'text_complete', text: 'pi done' };
+              yield { type: 'complete' };
+            },
+          }));
+        },
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.equal(await readFile(join(workspaceDir, 'pi-cell-proof.txt'), 'utf8'), 'ran via pi\n');
+      assert.equal(seenContexts[0]?.config.backend, 'pi-agent');
+      assert.deepEqual(seenContexts[0]?.realBackendIsolation, {
+        kind: 'external',
+        label: 'Harbor task container',
+      });
+    });
+  });
+
+  test('env entrypoint keeps Pi-only model ids out of the Maka provider parser', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const seenContexts: HeadlessBackendContext[] = [];
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through pi',
+        MAKA_MODEL: 'volcengine/glm-5.2',
+        MAKA_PI_PROVIDER: 'volcengine-plan',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      }, {
+        registerBackends: (registry, context) => {
+          seenContexts.push(context);
+          registerTestPiAgentBackend(registry, () => ({
+            async *send() {
+              yield { type: 'text_complete', text: 'pi done' };
+              yield { type: 'complete' };
+            },
+          }));
+        },
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.equal(seenContexts[0]?.config.backend, 'pi-agent');
+      assert.equal(seenContexts[0]?.config.llmConnectionSlug, 'volcengine-plan');
+      assert.equal(seenContexts[0]?.config.model, 'volcengine/glm-5.2');
+    });
+  });
+
+  test('env entrypoint defaults the Pi connection slug when provider is omitted', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const seenContexts: HeadlessBackendContext[] = [];
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through pi',
+        MAKA_MODEL: 'glm-5.2',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      }, {
+        registerBackends: (registry, context) => {
+          seenContexts.push(context);
+          registerTestPiAgentBackend(registry, () => ({
+            async *send() {
+              yield { type: 'text_complete', text: 'pi done' };
+              yield { type: 'complete' };
+            },
+          }));
+        },
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.equal(seenContexts[0]?.config.llmConnectionSlug, 'pi-agent');
+      assert.equal(seenContexts[0]?.config.model, 'glm-5.2');
+    });
+  });
+
+  test('env entrypoint keeps fake backend config explicit', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const seenContexts: HeadlessBackendContext[] = [];
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'fake',
+        MAKA_INSTRUCTION: 'solve with fake',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      }, {
+        registerBackends: (registry, context) => {
+          seenContexts.push(context);
+          registry.register('fake', (ctx) => new CellReportingBackend({
+            sessionId: ctx.sessionId,
+            header: ctx.header,
+            store: ctx.store,
+          }));
+        },
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.equal(seenContexts[0]?.config.backend, 'fake');
+      assert.equal(seenContexts[0]?.config.llmConnectionSlug, 'fake');
+      assert.equal(seenContexts[0]?.config.model, 'fake');
+    });
+  });
+
+  test('env entrypoint registers the Pi CLI transport by default for pi-agent', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const piCommand = join(outputDir, 'fake-pi.mjs');
+      await writeFile(
+        piCommand,
+        `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+writeFileSync('pi-default-argv.json', JSON.stringify(process.argv.slice(2)));
+writeFileSync('pi-default-stdin.txt', readFileSync(0, 'utf8'));
+writeFileSync('pi-default-proof.txt', 'ran via default pi cli\\n');
+console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'pi ok' } }));
+console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7, cost: { total: 0.0003 } } }] }));
+`,
+        'utf8',
+      );
+      await chmod(piCommand, 0o755);
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through default pi transport',
+        MAKA_MODEL: 'pi-test',
+        MAKA_PI_COMMAND: piCommand,
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.equal(await readFile(join(workspaceDir, 'pi-default-proof.txt'), 'utf8'), 'ran via default pi cli\n');
+      const argv = JSON.parse(await readFile(join(workspaceDir, 'pi-default-argv.json'), 'utf8')) as string[];
+      assert.equal(argv.includes('--provider'), false);
+      assert.equal(argv.includes('pi-agent'), false);
+      assert.deepEqual(argv.slice(argv.indexOf('--model'), argv.indexOf('--model') + 2), ['--model', 'pi-test']);
+      assert.equal(argv.at(-1), '-p');
+      assert.equal(argv.includes('solve through default pi transport'), false);
+      assert.equal(await readFile(join(workspaceDir, 'pi-default-stdin.txt'), 'utf8'), 'solve through default pi transport');
+      assert.equal(result.output.tokenSummary.input, 5);
+      assert.equal(result.output.tokenSummary.output, 2);
+      assert.equal(result.output.tokenSummary.costUsd, 0.0003);
+    });
+  });
+
+  test('env entrypoint fails the Pi CLI cell on non-JSON stdout', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const piCommand = join(outputDir, 'fake-pi-noisy.mjs');
+      await writeFile(
+        piCommand,
+        `#!/usr/bin/env node
+console.log('not json');
+`,
+        'utf8',
+      );
+      await chmod(piCommand, 0o755);
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through noisy pi transport',
+        MAKA_MODEL: 'pi-test',
+        MAKA_PI_COMMAND: piCommand,
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      });
+
+      assert.equal(result.output.status, 'failed');
+      assert.equal(result.output.errorClass, 'pi_agent_transport_error');
+      assert.match(
+        await readFile(join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME), 'utf8'),
+        /pi emitted non-JSON stdout: not json/,
+      );
+    });
+  });
+
+  test('env entrypoint passes long Pi instructions through stdin instead of argv', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const piCommand = join(outputDir, 'fake-pi-long-prompt.mjs');
+      await writeFile(
+        piCommand,
+        `#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+const argv = process.argv.slice(2);
+const prompt = await new Promise((resolve) => {
+  let data = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { data += chunk; });
+  process.stdin.on('end', () => resolve(data));
+});
+writeFileSync('pi-long-argv.json', JSON.stringify(argv));
+writeFileSync('pi-long-prompt-length.txt', String(prompt.length));
+console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7 } }] }));
+`,
+        'utf8',
+      );
+      await chmod(piCommand, 0o755);
+      const instruction = `solve long prompt\n${'x'.repeat(128 * 1024)}`;
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: instruction,
+        MAKA_MODEL: 'pi-test',
+        MAKA_PI_COMMAND: piCommand,
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      });
+
+      assert.equal(result.output.status, 'completed');
+      const argv = JSON.parse(await readFile(join(workspaceDir, 'pi-long-argv.json'), 'utf8')) as string[];
+      assert.equal(argv.at(-1), '-p');
+      assert.equal(argv.includes(instruction), false);
+      assert.equal(await readFile(join(workspaceDir, 'pi-long-prompt-length.txt'), 'utf8'), String(instruction.length));
+    });
+  });
+
+  test('env entrypoint fails the Pi CLI cell when the process exits non-zero after agent_end', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const piCommand = join(outputDir, 'fake-pi-fails-late.mjs');
+      await writeFile(
+        piCommand,
+        `#!/usr/bin/env node
+console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7 } }] }));
+setTimeout(() => {
+  console.error('late pi failure');
+  process.exit(1);
+}, 25);
+`,
+        'utf8',
+      );
+      await chmod(piCommand, 0o755);
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through default pi transport',
+        MAKA_MODEL: 'pi-test',
+        MAKA_PI_COMMAND: piCommand,
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      });
+
+      assert.equal(result.output.status, 'failed');
+      assert.equal(result.output.errorClass, 'pi_agent_transport_error');
+      assert.match(
+        await readFile(join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME), 'utf8'),
+        /pi exited with code 1: late pi failure/,
+      );
+    });
+  });
+
   test('resolves ai-sdk connection env without constructing a network backend', () => {
     const gateway = resolveHarborCellAiSdkEnv({
       provider: 'openai-compatible',
@@ -320,6 +616,26 @@ describe('runHarborCell', () => {
     });
     assert.equal(deepseek.apiKey, 'fallback-key');
     assert.equal(deepseek.connection.baseUrl, 'https://fallback.example/v1');
+  });
+
+  test('resolves ai-sdk API keys from secret files without embedding the key in job env', async () => {
+    await withDirs(async ({ outputDir }) => {
+      const keyPath = join(outputDir, 'api-key');
+      await writeFile(keyPath, 'file-key\n', 'utf8');
+
+      const resolved = resolveHarborCellAiSdkEnv({
+        provider: 'openai-compatible',
+        model: 'glm-5.2',
+        env: {
+          OPENAI_API_KEY_FILE: keyPath,
+          OPENAI_BASE_URL: 'https://ark.example/api/coding/v3',
+        },
+        ts: 789,
+      });
+
+      assert.equal(resolved.apiKey, 'file-key');
+      assert.equal(resolved.connection.baseUrl, 'https://ark.example/api/coding/v3');
+    });
   });
 });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -483,6 +483,47 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
     });
   });
 
+  test('env entrypoint passes only Pi provider env to the Pi CLI child', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const piCommand = join(outputDir, 'fake-pi-env.mjs');
+      await writeFile(
+        piCommand,
+        `#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+writeFileSync('pi-env.json', JSON.stringify({
+  openai: process.env.OPENAI_API_KEY,
+  anthropic: process.env.ANTHROPIC_API_KEY,
+  google: process.env.GOOGLE_API_KEY,
+  xiaomi: process.env.XIAOMI_TOKEN_PLAN_CN_API_KEY,
+}));
+console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', usage: { input: 5, output: 2, totalTokens: 7 } }] }));
+`,
+        'utf8',
+      );
+      await chmod(piCommand, 0o755);
+
+      const result = await runHarborCellFromEnv({
+        MAKA_BACKEND: 'pi-agent',
+        MAKA_INSTRUCTION: 'solve through scoped pi env',
+        MAKA_MODEL: 'pi-test',
+        MAKA_PI_COMMAND: piCommand,
+        MAKA_PI_PROVIDER: 'volcengine-plan',
+        OPENAI_API_KEY: 'openai-key',
+        ANTHROPIC_API_KEY: 'anthropic-key',
+        GOOGLE_API_KEY: 'google-key',
+        XIAOMI_TOKEN_PLAN_CN_API_KEY: 'xiaomi-key',
+        MAKA_WORKDIR: workspaceDir,
+        MAKA_OUTPUT_DIR: outputDir,
+        MAKA_STORAGE_ROOT: storageRoot,
+      });
+
+      assert.equal(result.output.status, 'completed');
+      assert.deepEqual(JSON.parse(await readFile(join(workspaceDir, 'pi-env.json'), 'utf8')), {
+        xiaomi: 'xiaomi-key',
+      });
+    });
+  });
+
   test('env entrypoint fails the Pi CLI cell on non-JSON stdout', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const piCommand = join(outputDir, 'fake-pi-noisy.mjs');
@@ -512,6 +553,51 @@ console.log('not json');
         /pi emitted non-JSON stdout: not json/,
       );
     });
+  });
+
+  test('env entrypoint fails the Pi CLI cell when stdout ends before agent_end', async () => {
+    const cases = [
+      { name: 'empty', body: '' },
+      {
+        name: 'wrapper-only',
+        body: `
+console.log(JSON.stringify({ type: 'session', id: 'session-1' }));
+console.log(JSON.stringify({ type: 'turn_start' }));
+`,
+      },
+      {
+        name: 'text-without-terminal',
+        body: `
+console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'partial' } }));
+`,
+      },
+    ];
+
+    for (const scenario of cases) {
+      await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+        const piCommand = join(outputDir, `fake-pi-${scenario.name}.mjs`);
+        await writeFile(piCommand, `#!/usr/bin/env node\n${scenario.body}`, 'utf8');
+        await chmod(piCommand, 0o755);
+
+        const result = await runHarborCellFromEnv({
+          MAKA_BACKEND: 'pi-agent',
+          MAKA_INSTRUCTION: `solve through incomplete pi transport: ${scenario.name}`,
+          MAKA_MODEL: 'pi-test',
+          MAKA_PI_COMMAND: piCommand,
+          MAKA_WORKDIR: workspaceDir,
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_STORAGE_ROOT: storageRoot,
+        });
+
+        assert.equal(result.output.status, 'failed', scenario.name);
+        assert.equal(result.output.errorClass, 'pi_agent_transport_error', scenario.name);
+        assert.match(
+          await readFile(join(outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME), 'utf8'),
+          /pi exited before agent_end/,
+          scenario.name,
+        );
+      });
+    }
   });
 
   test('env entrypoint passes long Pi instructions through stdin instead of argv', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -346,10 +346,9 @@ describe('runHarborCell', () => {
       assert.equal(result.output.status, 'completed');
       assert.equal(await readFile(join(workspaceDir, 'pi-cell-proof.txt'), 'utf8'), 'ran via pi\n');
       assert.equal(seenContexts[0]?.config.backend, 'pi-agent');
-      assert.deepEqual(seenContexts[0]?.realBackendIsolation, {
-        kind: 'external',
-        label: 'Harbor task container',
-      });
+      assert.equal(seenContexts[0]?.realBackendIsolation?.kind, 'external');
+      assert.equal(seenContexts[0]?.realBackendIsolation?.label, 'Harbor task container');
+      assert.equal(typeof seenContexts[0]?.realBackendIsolation?.toolExecutor?.exec, 'function');
     });
   });
 
@@ -463,6 +462,7 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
         MAKA_INSTRUCTION: 'solve through default pi transport',
         MAKA_MODEL: 'pi-test',
         MAKA_PI_COMMAND: piCommand,
+        MAKA_PI_PROVIDER: 'deepseek',
         MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
         MAKA_STORAGE_ROOT: storageRoot,
@@ -471,7 +471,7 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
       assert.equal(result.output.status, 'completed');
       assert.equal(await readFile(join(workspaceDir, 'pi-default-proof.txt'), 'utf8'), 'ran via default pi cli\n');
       const argv = JSON.parse(await readFile(join(workspaceDir, 'pi-default-argv.json'), 'utf8')) as string[];
-      assert.equal(argv.includes('--provider'), false);
+      assert.deepEqual(argv.slice(argv.indexOf('--provider'), argv.indexOf('--provider') + 2), ['--provider', 'deepseek']);
       assert.equal(argv.includes('pi-agent'), false);
       assert.deepEqual(argv.slice(argv.indexOf('--model'), argv.indexOf('--model') + 2), ['--model', 'pi-test']);
       assert.equal(argv.at(-1), '-p');
@@ -480,6 +480,27 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
       assert.equal(result.output.tokenSummary.input, 5);
       assert.equal(result.output.tokenSummary.output, 2);
       assert.equal(result.output.tokenSummary.costUsd, 0.0003);
+    });
+  });
+
+  test('env entrypoint fails fast when default Pi CLI provider is omitted', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const keyPath = join(outputDir, 'deepseek-key');
+      await writeFile(keyPath, 'deepseek-key\n', 'utf8');
+
+      await assert.rejects(
+        runHarborCellFromEnv({
+          MAKA_BACKEND: 'pi-agent',
+          MAKA_INSTRUCTION: 'solve through default pi transport',
+          MAKA_MODEL: 'pi-test',
+          MAKA_PI_COMMAND: join(outputDir, 'pi'),
+          DEEPSEEK_API_KEY_FILE: keyPath,
+          MAKA_WORKDIR: workspaceDir,
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_STORAGE_ROOT: storageRoot,
+        }),
+        /MAKA_PI_PROVIDER is required when using the default Pi CLI transport/,
+      );
     });
   });
 
@@ -541,6 +562,7 @@ console.log('not json');
         MAKA_INSTRUCTION: 'solve through noisy pi transport',
         MAKA_MODEL: 'pi-test',
         MAKA_PI_COMMAND: piCommand,
+        MAKA_PI_PROVIDER: 'deepseek',
         MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
         MAKA_STORAGE_ROOT: storageRoot,
@@ -584,6 +606,7 @@ console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { ty
           MAKA_INSTRUCTION: `solve through incomplete pi transport: ${scenario.name}`,
           MAKA_MODEL: 'pi-test',
           MAKA_PI_COMMAND: piCommand,
+          MAKA_PI_PROVIDER: 'deepseek',
           MAKA_WORKDIR: workspaceDir,
           MAKA_OUTPUT_DIR: outputDir,
           MAKA_STORAGE_ROOT: storageRoot,
@@ -628,6 +651,7 @@ console.log(JSON.stringify({ type: 'agent_end', messages: [{ role: 'assistant', 
         MAKA_INSTRUCTION: instruction,
         MAKA_MODEL: 'pi-test',
         MAKA_PI_COMMAND: piCommand,
+        MAKA_PI_PROVIDER: 'deepseek',
         MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
         MAKA_STORAGE_ROOT: storageRoot,
@@ -662,6 +686,7 @@ setTimeout(() => {
         MAKA_INSTRUCTION: 'solve through default pi transport',
         MAKA_MODEL: 'pi-test',
         MAKA_PI_COMMAND: piCommand,
+        MAKA_PI_PROVIDER: 'deepseek',
         MAKA_WORKDIR: workspaceDir,
         MAKA_OUTPUT_DIR: outputDir,
         MAKA_STORAGE_ROOT: storageRoot,
@@ -704,25 +729,6 @@ setTimeout(() => {
     assert.equal(deepseek.connection.baseUrl, 'https://fallback.example/v1');
   });
 
-  test('resolves ai-sdk API keys from secret files without embedding the key in job env', async () => {
-    await withDirs(async ({ outputDir }) => {
-      const keyPath = join(outputDir, 'api-key');
-      await writeFile(keyPath, 'file-key\n', 'utf8');
-
-      const resolved = resolveHarborCellAiSdkEnv({
-        provider: 'openai-compatible',
-        model: 'glm-5.2',
-        env: {
-          OPENAI_API_KEY_FILE: keyPath,
-          OPENAI_BASE_URL: 'https://ark.example/api/coding/v3',
-        },
-        ts: 789,
-      });
-
-      assert.equal(resolved.apiKey, 'file-key');
-      assert.equal(resolved.connection.baseUrl, 'https://ark.example/api/coding/v3');
-    });
-  });
 });
 
 function fakeToolExecutor(): IsolatedToolExecutor {

--- a/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
+++ b/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
@@ -1,0 +1,321 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough, Readable } from 'node:stream';
+import { describe, test } from 'node:test';
+
+import { PiCliJsonTransport, type PiCliJsonSpawn } from '../pi-cli-json-transport.js';
+
+describe('PiCliJsonTransport', () => {
+  test('spawns pi JSON mode and maps text, tools, and usage into PiAgentFrames', async () => {
+    const child = testChild(Readable.from([
+      `${JSON.stringify({ type: 'session', id: 'session-1' })}\n`,
+      `${JSON.stringify({ type: 'agent_start' })}\n`,
+      `${JSON.stringify({ type: 'turn_start' })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_start' },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'thinking' },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_end' },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_start' },
+      })}\n`,
+      `${JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hi' } })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_end' },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: {
+          type: 'toolcall_start',
+          partial: {
+            content: [
+              {
+                type: 'toolCall',
+                id: 'call-1',
+                name: 'write',
+                arguments: { path: 'solved.txt' },
+              },
+            ],
+          },
+        },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: {
+          type: 'toolcall_end',
+          partial: {
+            content: [
+              {
+                type: 'toolCall',
+                id: 'call-1',
+                name: 'write',
+                arguments: { path: 'solved.txt', content: 'ok' },
+              },
+            ],
+          },
+        },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_start',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'write',
+          isError: false,
+          content: [{ type: 'text', text: 'partial result' }],
+        },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'message_end',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'write',
+          isError: false,
+          content: [{ type: 'text', text: 'Successfully wrote solved.txt' }],
+        },
+      })}\n`,
+      `${JSON.stringify({
+        type: 'agent_end',
+        messages: [
+          {
+            role: 'assistant',
+            usage: {
+              input: 12,
+              output: 3,
+              cacheRead: 4,
+              cacheWrite: 5,
+              totalTokens: 24,
+              cost: { total: 0.00045 },
+            },
+          },
+          {
+            role: 'assistant',
+            usage: {
+              input: 6,
+              output: 2,
+              cacheRead: 1,
+              cacheWrite: 0,
+              totalTokens: 9,
+              cost: { total: 0.0001 },
+            },
+          },
+        ],
+      })}\n`,
+      `${JSON.stringify({ type: 'turn_end' })}\n`,
+    ]));
+
+    const calls: Array<{ command: string; args: string[]; options: unknown }> = [];
+    let capturedPrompt = '';
+    child.stdin.on('data', (chunk) => {
+      capturedPrompt += String(chunk);
+    });
+    const spawn: PiCliJsonSpawn = (command, args, options) => {
+      calls.push({ command, args: [...args], options });
+      queueMicrotask(() => child.emit('close', 0, null));
+      return child;
+    };
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', provider: 'volcengine', spawn });
+
+    const frames = [];
+    for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+      frames.push(frame);
+    }
+
+    assert.deepEqual(calls[0]?.args, [
+      '--mode',
+      'json',
+      '--no-context-files',
+      '--no-session',
+      '--provider',
+      'volcengine',
+      '--model',
+      'glm-5.2',
+      '-p',
+    ]);
+    assert.equal(capturedPrompt, 'solve it');
+    assert.deepEqual((calls[0]?.options as { cwd?: string }).cwd, '/tmp/task');
+    assert.deepEqual(frames, [
+      { type: 'text_delta', text: 'hi' },
+      { type: 'tool_start', toolUseId: 'call-1', toolName: 'write', args: { path: 'solved.txt', content: 'ok' } },
+      {
+        type: 'tool_result',
+        toolUseId: 'call-1',
+        isError: false,
+        content: { kind: 'text', text: 'Successfully wrote solved.txt' },
+      },
+      {
+        type: 'token_usage',
+        input: 18,
+        output: 5,
+        cacheHitInput: 5,
+        cacheWriteInput: 5,
+        total: 33,
+        costUsd: 0.00055,
+      },
+      { type: 'complete' },
+    ]);
+  });
+
+  test('waits for the Pi process to close before yielding complete', async () => {
+    const stdout = new PassThrough();
+    const child = testChild(stdout);
+
+    let markSpawned: () => void = () => {};
+    const spawned = new Promise<void>((resolve) => {
+      markSpawned = resolve;
+    });
+    const spawn: PiCliJsonSpawn = () => {
+      markSpawned();
+      return child;
+    };
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn });
+    const frames: unknown[] = [];
+    const done = (async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        frames.push(frame);
+      }
+    })();
+
+    await spawned;
+    stdout.write(`${agentEndLine()}\n`);
+    stdout.end();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.deepEqual(frames.map((frame) => (frame as { type?: string }).type), ['token_usage']);
+
+    child.emit('close', 0, null);
+    await done;
+
+    assert.deepEqual(frames.map((frame) => (frame as { type?: string }).type), ['token_usage', 'complete']);
+  });
+
+  test('fails instead of completing when Pi exits non-zero after agent_end', async () => {
+    const child = testChild(Readable.from([`${agentEndLine()}\n`]), Readable.from(['late failure']));
+
+    const spawn: PiCliJsonSpawn = () => {
+      setImmediate(() => child.emit('close', 1, null));
+      return child;
+    };
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn });
+    const frames: unknown[] = [];
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        frames.push(frame);
+      }
+    }, /pi exited with code 1: late failure/);
+
+    assert.deepEqual(frames.map((frame) => (frame as { type?: string }).type), ['token_usage']);
+  });
+
+  test('fails closed on unsupported Pi JSON events', async () => {
+    const child = testChild(Readable.from([`${JSON.stringify({ type: 'new_protocol_event' })}\n`]));
+
+    const spawn: PiCliJsonSpawn = () => {
+      setImmediate(() => child.emit('close', 0, null));
+      return child;
+    };
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn });
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        void frame;
+      }
+    }, /pi emitted unsupported JSON event: new_protocol_event/);
+  });
+
+  test('fails closed when text_delta is missing a string delta', async () => {
+    const child = testChild(Readable.from([
+      `${JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta' } })}\n`,
+    ]));
+
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn: () => child });
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        void frame;
+      }
+    }, /pi text_delta missing string delta/);
+  });
+
+  test('fails closed when toolcall_end is missing a valid tool call', async () => {
+    const child = testChild(Readable.from([
+      `${JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: {
+          type: 'toolcall_end',
+          partial: { content: [{ type: 'toolCall', id: 'call-1', arguments: { path: 'x' } }] },
+        },
+      })}\n`,
+    ]));
+
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn: () => child });
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        void frame;
+      }
+    }, /pi toolcall_end missing valid tool call/);
+  });
+
+  test('kills the Pi process when stdout parsing fails before close', async () => {
+    const child = testChild(Readable.from([`${JSON.stringify({ type: 'new_protocol_event' })}\n`]));
+    const killSignals: Array<NodeJS.Signals | number | undefined> = [];
+    child.kill = (signal) => {
+      killSignals.push(signal);
+      return true;
+    };
+
+    const transport = new PiCliJsonTransport({ command: 'pi-test', model: 'glm-5.2', spawn: () => child });
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        void frame;
+      }
+    }, /pi emitted unsupported JSON event: new_protocol_event/);
+
+    assert.deepEqual(killSignals, ['SIGTERM']);
+  });
+});
+
+type TestPiChild = EventEmitter & {
+  stdin: PassThrough;
+  stdout: Readable;
+  stderr: Readable;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+};
+
+function testChild(stdout: Readable, stderr: Readable = Readable.from([])): TestPiChild {
+  const child = new EventEmitter() as TestPiChild;
+  child.stdin = new PassThrough();
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = () => true;
+  return child;
+}
+
+function agentEndLine(): string {
+  return JSON.stringify({
+    type: 'agent_end',
+    messages: [
+      {
+        role: 'assistant',
+        usage: {
+          input: 1,
+          output: 2,
+          totalTokens: 3,
+        },
+      },
+    ],
+  });
+}

--- a/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
+++ b/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
@@ -311,6 +311,31 @@ describe('PiCliJsonTransport', () => {
 
     assert.deepEqual(killSignals, ['SIGTERM']);
   });
+
+  test('fails when stdin errors after stdout ends but before close', async () => {
+    const stdout = new PassThrough();
+    const child = testChild(stdout);
+    const transport = new PiCliJsonTransport({
+      command: 'pi-test',
+      model: 'glm-5.2',
+      spawn: () => child,
+    });
+    const frames: unknown[] = [];
+    const done = (async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        frames.push(frame);
+      }
+    })();
+
+    stdout.write(`${agentEndLine()}\n`);
+    stdout.end();
+    await new Promise((resolve) => setImmediate(resolve));
+    child.stdin.emit('error', new Error('late broken pipe'));
+    child.emit('close', 0, null);
+
+    await assert.rejects(done, /pi stdin write failed: late broken pipe/);
+    assert.deepEqual(frames.map((frame) => (frame as { type?: string }).type), ['token_usage']);
+  });
 });
 
 type TestPiChild = EventEmitter & {

--- a/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
+++ b/packages/headless/src/__tests__/pi-cli-json-transport.test.ts
@@ -286,6 +286,31 @@ describe('PiCliJsonTransport', () => {
 
     assert.deepEqual(killSignals, ['SIGTERM']);
   });
+
+  test('fails under control when stdin write emits an error', async () => {
+    const child = testChild(new PassThrough());
+    const killSignals: Array<NodeJS.Signals | number | undefined> = [];
+    child.kill = (signal) => {
+      killSignals.push(signal);
+      return true;
+    };
+    const transport = new PiCliJsonTransport({
+      command: 'pi-test',
+      model: 'glm-5.2',
+      spawn: () => {
+        setImmediate(() => child.stdin.emit('error', new Error('broken pipe')));
+        return child;
+      },
+    });
+
+    await assert.rejects(async () => {
+      for await (const frame of transport.send({ sessionId: 's1', turnId: 't1', cwd: '/tmp/task', text: 'solve it' })) {
+        void frame;
+      }
+    }, /pi stdin write failed: broken pipe/);
+
+    assert.deepEqual(killSignals, ['SIGTERM']);
+  });
 });
 
 type TestPiChild = EventEmitter & {

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -3,7 +3,15 @@ import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { BackendRegistry, FakeBackend, type AgentBackend, type SessionStore } from '@maka/runtime';
+import {
+  BackendRegistry,
+  FakeBackend,
+  PermissionEngine,
+  PiAgentBackend,
+  type AgentBackend,
+  type PiAgentTransport,
+  type SessionStore,
+} from '@maka/runtime';
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { Config, Task } from '../contracts.js';
@@ -15,6 +23,21 @@ const registerFakeBackend = (registry: BackendRegistry): void => {
     new FakeBackend({ sessionId: ctx.sessionId, header: ctx.header, store: ctx.store }),
   );
 };
+
+function registerTestPiAgentBackend(
+  registry: BackendRegistry,
+  transportFactory: (input: { header: SessionHeader; store: SessionStore }) => PiAgentTransport,
+): void {
+  registry.register('pi-agent', (ctx) =>
+    new PiAgentBackend({
+      sessionId: ctx.sessionId,
+      header: ctx.header,
+      appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
+      permissionEngine: new PermissionEngine({ newId: () => 'perm-id', now: () => 123 }),
+      transport: transportFactory({ header: ctx.header, store: ctx.store }),
+    }),
+  );
+}
 
 /**
  * A malicious config: it rewrites the grading test in its own cwd to one
@@ -138,6 +161,13 @@ const fakeConfig: Config = {
   backend: 'fake',
   llmConnectionSlug: 'fake',
   model: 'fake-model',
+};
+
+const piConfig: Config = {
+  id: 'pi-cfg',
+  backend: 'pi-agent',
+  llmConnectionSlug: 'pi-agent',
+  model: 'pi-test',
 };
 
 async function fileExistsRecursive(root: string, name: string): Promise<boolean> {
@@ -311,6 +341,52 @@ describe('fail-closed (a model-backed backend does not run without isolation)', 
       assert.equal(contexts[0]?.realBackendIsolation?.label, 'unit-test isolated backend');
       assert.equal(contexts[0]?.config.id, 'real-cfg');
       assert.equal(contexts[0]?.task.id, 'real-task');
+    });
+  });
+
+  test('runs pi-agent through the headless backend bridge when isolated', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeBuggyFixture(fixtureDir);
+      const seen: HeadlessBackendContext[] = [];
+      const task: Task = {
+        id: 'pi-task',
+        instruction: 'solve the fixture',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f solved.txt', protectedPaths: [] },
+      };
+
+      const result = await runExperiment(piConfig, task, {
+        storageRoot,
+        realBackendIsolation: { kind: 'external', label: 'unit-test isolated pi transport' },
+        registerBackends: (registry, context) => {
+          seen.push(context);
+          registerTestPiAgentBackend(registry, ({ header }) => ({
+              async *send(sendInput) {
+                assert.equal(header.cwd, context.workspaceDir);
+                assert.equal(sendInput.text, 'solve the fixture');
+                yield {
+                  type: 'tool_start',
+                  toolUseId: 'tool-1',
+                  toolName: 'Bash',
+                  args: { command: 'touch solved.txt' },
+                };
+                await writeFile(join(header.cwd, 'solved.txt'), 'ok\n', 'utf8');
+                yield {
+                  type: 'tool_result',
+                  toolUseId: 'tool-1',
+                  content: { kind: 'text', text: 'created solved.txt' },
+                };
+                yield { type: 'text_complete', text: 'done' };
+                yield { type: 'complete' };
+              },
+          }));
+        },
+      });
+
+      assert.equal(result.status, 'completed');
+      assert.equal(result.passed, true);
+      assert.equal(seen[0]?.config.backend, 'pi-agent');
+      assert.equal(seen[0]?.realBackendIsolation?.label, 'unit-test isolated pi transport');
     });
   });
 });

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { exec as nodeExec } from 'node:child_process';
 import { join } from 'node:path';
@@ -12,6 +13,7 @@ import {
   AiSdkBackend,
   BackendRegistry,
   PermissionEngine,
+  PiAgentBackend,
   SessionManager,
   buildProviderOptions,
   getAIModel,
@@ -29,6 +31,7 @@ import { buildHarborCellOutput, validateHarborCellOutput, type HarborCellOutput 
 import type { Config, Task } from './contracts.js';
 import type { HeadlessBackendContext, IsolatedToolExecutor, RealBackendIsolation } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES, validateRealBackendIsolation } from './isolation.js';
+import { PiCliJsonTransport } from './pi-cli-json-transport.js';
 import { backendNeedsIsolation } from './runner.js';
 import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from './tools.js';
 
@@ -158,27 +161,69 @@ export async function runHarborCellFromEnv(
   options: RunHarborCellFromEnvOptions = {},
 ): Promise<RunHarborCellResult> {
   const now = options.now ?? Date.now;
+  const newId = options.newId ?? randomId;
   const outputDir = env.MAKA_OUTPUT_DIR ?? '/logs/agent';
-  const modelSpec = parseModelSpec(env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'deepseek/deepseek-chat', env.MAKA_PROVIDER);
   const backend = backendFromEnv(env.MAKA_BACKEND);
-  const config: Config = {
+  const baseConfig = {
     id: env.MAKA_CONFIG_ID ?? 'harbor-cell',
     backend,
-    llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
-    model: modelSpec.model,
     ...(env.MAKA_SYSTEM_PROMPT !== undefined ? { systemPrompt: env.MAKA_SYSTEM_PROMPT } : {}),
   };
-  const registerBackends = options.registerBackends ?? (
-    backend === 'fake'
-      ? undefined
-      : buildAiSdkCellBackendRegistration({
-          provider: modelSpec.provider,
-          model: modelSpec.model,
-          env,
-          now,
-          newId: options.newId ?? randomId,
-        })
-  );
+  let config: Config;
+  let registerBackends = options.registerBackends;
+
+  switch (backend) {
+    case 'ai-sdk': {
+      const modelSpec = parseModelSpec(env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'deepseek/deepseek-chat', env.MAKA_PROVIDER);
+      config = {
+        ...baseConfig,
+        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
+        model: modelSpec.model,
+      };
+      registerBackends ??= buildAiSdkCellBackendRegistration({
+        provider: modelSpec.provider,
+        model: modelSpec.model,
+        env,
+        now,
+        newId,
+      });
+      break;
+    }
+    case 'pi-agent': {
+      const model = env.MAKA_PI_MODEL ?? env.MAKA_MODEL ?? env.HARBOR_MODEL;
+      if (!model) throw new Error('MAKA_PI_MODEL, MAKA_MODEL, or HARBOR_MODEL must include a model id');
+      const piProvider = env.MAKA_PI_PROVIDER;
+      config = {
+        ...baseConfig,
+        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? piProvider ?? 'pi-agent',
+        model,
+      };
+      registerBackends ??= (registry) => {
+        registry.register('pi-agent', (ctx) =>
+          new PiAgentBackend({
+            sessionId: ctx.sessionId,
+            header: ctx.header,
+            appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
+            permissionEngine: new PermissionEngine({ newId, now }),
+            transport: new PiCliJsonTransport({
+              command: env.MAKA_PI_COMMAND ?? 'pi',
+              ...(piProvider ? { provider: piProvider } : {}),
+              model,
+              env: env as NodeJS.ProcessEnv,
+            }),
+          }),
+        );
+      };
+      break;
+    }
+    case 'fake':
+      config = {
+        ...baseConfig,
+        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
+        model: env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'fake',
+      };
+      break;
+  }
 
   return await runHarborCell({
     config,
@@ -333,7 +378,7 @@ async function instructionFromEnv(env: RunHarborCellEnv): Promise<string> {
 
 function backendFromEnv(value: string | undefined): BackendKind {
   if (!value) return 'ai-sdk';
-  if (value === 'fake' || value === 'ai-sdk') return value;
+  if (value === 'fake' || value === 'ai-sdk' || value === 'pi-agent') return value;
   throw new Error(`unsupported MAKA_BACKEND: ${value}`);
 }
 
@@ -396,23 +441,44 @@ function providerBaseUrl(provider: ProviderType, env: RunHarborCellEnv): string 
 function apiKeyFromEnv(provider: ProviderType, env: RunHarborCellEnv): string {
   switch (provider) {
     case 'deepseek':
-      return env.DEEPSEEK_API_KEY ?? env.OPENAI_API_KEY ?? '';
+      return env.DEEPSEEK_API_KEY
+        ?? secretFileValue(env.DEEPSEEK_API_KEY_FILE, 'DEEPSEEK_API_KEY_FILE')
+        ?? env.OPENAI_API_KEY
+        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
+        ?? '';
     case 'openai':
     case 'openai-compatible':
-      return env.OPENAI_API_KEY ?? '';
+      return env.OPENAI_API_KEY ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE') ?? '';
     case 'moonshot':
-      return env.MOONSHOT_API_KEY ?? env.OPENAI_API_KEY ?? '';
+      return env.MOONSHOT_API_KEY
+        ?? secretFileValue(env.MOONSHOT_API_KEY_FILE, 'MOONSHOT_API_KEY_FILE')
+        ?? env.OPENAI_API_KEY
+        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
+        ?? '';
     case 'zai-coding-plan':
-      return env.ZAI_API_KEY ?? env.OPENAI_API_KEY ?? '';
+      return env.ZAI_API_KEY
+        ?? secretFileValue(env.ZAI_API_KEY_FILE, 'ZAI_API_KEY_FILE')
+        ?? env.ZAI_CODING_CN_API_KEY
+        ?? secretFileValue(env.ZAI_CODING_CN_API_KEY_FILE, 'ZAI_CODING_CN_API_KEY_FILE')
+        ?? env.OPENAI_API_KEY
+        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
+        ?? '';
     case 'google':
-      return env.GOOGLE_API_KEY ?? '';
+      return env.GOOGLE_API_KEY ?? secretFileValue(env.GOOGLE_API_KEY_FILE, 'GOOGLE_API_KEY_FILE') ?? '';
     case 'anthropic':
     case 'kimi-coding-plan':
     case 'claude-subscription':
-      return env.ANTHROPIC_API_KEY ?? '';
+      return env.ANTHROPIC_API_KEY ?? secretFileValue(env.ANTHROPIC_API_KEY_FILE, 'ANTHROPIC_API_KEY_FILE') ?? '';
     default:
-      return env.OPENAI_API_KEY ?? '';
+      return env.OPENAI_API_KEY ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE') ?? '';
   }
+}
+
+function secretFileValue(path: string | undefined, key: string): string | undefined {
+  if (!path) return undefined;
+  const value = readFileSync(path, 'utf8').trim();
+  if (!value) throw new Error(`${key} must point to a non-empty file`);
+  return value;
 }
 
 function runtimeEventsJsonl(invocation: InvocationResult): string {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -75,6 +75,32 @@ export interface ResolvedHarborCellAiSdkEnv {
   apiKey: string;
 }
 
+const PI_BASE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'TMPDIR', 'TMP', 'TEMP', 'SHELL', 'SystemRoot', 'COMSPEC'];
+const PI_PROVIDER_ENV_RULES = [
+  { includes: ['volcengine'], prefixes: ['XIAOMI_', 'VOLCENGINE_'] },
+  { includes: ['deepseek'], keys: ['DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY_FILE', 'DEEPSEEK_BASE_URL'] },
+  { includes: ['openai'], keys: ['OPENAI_API_KEY', 'OPENAI_API_KEY_FILE', 'OPENAI_BASE_URL'] },
+  { includes: ['anthropic', 'claude'], keys: ['ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY_FILE'] },
+  {
+    includes: ['google', 'gemini'],
+    keys: [
+      'GOOGLE_API_KEY',
+      'GOOGLE_API_KEY_FILE',
+      'GEMINI_API_KEY',
+      'GOOGLE_GENERATIVE_AI_API_KEY',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'GOOGLE_CLOUD_PROJECT',
+      'GOOGLE_CLOUD_LOCATION',
+      'GOOGLE_GENAI_USE_VERTEXAI',
+    ],
+  },
+  { includes: ['moonshot', 'kimi'], keys: ['MOONSHOT_API_KEY', 'MOONSHOT_API_KEY_FILE', 'MOONSHOT_BASE_URL'] },
+  {
+    includes: ['zai'],
+    keys: ['ZAI_API_KEY', 'ZAI_API_KEY_FILE', 'ZAI_CODING_CN_API_KEY', 'ZAI_CODING_CN_API_KEY_FILE', 'ZAI_BASE_URL'],
+  },
+] satisfies Array<{ includes: string[]; keys?: string[]; prefixes?: string[] }>;
+
 export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarborCellResult> {
   if (backendNeedsIsolation(input.config.backend)) {
     validateRealBackendIsolation(input.realBackendIsolation);
@@ -360,51 +386,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function buildPiCliEnv(env: RunHarborCellEnv, provider: string | undefined): NodeJS.ProcessEnv {
   const result: NodeJS.ProcessEnv = {};
-  copyEnv(result, { ...process.env, ...env }, [
-    'PATH',
-    'HOME',
-    'USER',
-    'TMPDIR',
-    'TMP',
-    'TEMP',
-    'SHELL',
-    'SystemRoot',
-    'COMSPEC',
-  ]);
+  copyEnv(result, { ...process.env, ...env }, PI_BASE_ENV_KEYS);
   copyPrefixedEnv(result, env, 'PI_');
 
   const normalizedProvider = provider?.toLowerCase() ?? '';
-  if (normalizedProvider.includes('volcengine')) {
-    copyPrefixedEnv(result, env, 'XIAOMI_');
-    copyPrefixedEnv(result, env, 'VOLCENGINE_');
-  } else if (normalizedProvider.includes('deepseek')) {
-    copyEnv(result, env, ['DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY_FILE', 'DEEPSEEK_BASE_URL']);
-  } else if (normalizedProvider.includes('openai')) {
-    copyEnv(result, env, ['OPENAI_API_KEY', 'OPENAI_API_KEY_FILE', 'OPENAI_BASE_URL']);
-  } else if (normalizedProvider.includes('anthropic') || normalizedProvider.includes('claude')) {
-    copyEnv(result, env, ['ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY_FILE']);
-  } else if (normalizedProvider.includes('google') || normalizedProvider.includes('gemini')) {
-    copyEnv(result, env, [
-      'GOOGLE_API_KEY',
-      'GOOGLE_API_KEY_FILE',
-      'GEMINI_API_KEY',
-      'GOOGLE_GENERATIVE_AI_API_KEY',
-      'GOOGLE_APPLICATION_CREDENTIALS',
-      'GOOGLE_CLOUD_PROJECT',
-      'GOOGLE_CLOUD_LOCATION',
-      'GOOGLE_GENAI_USE_VERTEXAI',
-    ]);
-  } else if (normalizedProvider.includes('moonshot') || normalizedProvider.includes('kimi')) {
-    copyEnv(result, env, ['MOONSHOT_API_KEY', 'MOONSHOT_API_KEY_FILE', 'MOONSHOT_BASE_URL']);
-  } else if (normalizedProvider.includes('zai')) {
-    copyEnv(result, env, [
-      'ZAI_API_KEY',
-      'ZAI_API_KEY_FILE',
-      'ZAI_CODING_CN_API_KEY',
-      'ZAI_CODING_CN_API_KEY_FILE',
-      'ZAI_BASE_URL',
-    ]);
-  }
+  const rule = PI_PROVIDER_ENV_RULES.find((candidate) =>
+    candidate.includes.some((value) => normalizedProvider.includes(value)),
+  );
+  copyEnv(result, env, rule?.keys ?? []);
+  for (const prefix of rule?.prefixes ?? []) copyPrefixedEnv(result, env, prefix);
 
   return result;
 }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -209,7 +209,7 @@ export async function runHarborCellFromEnv(
               command: env.MAKA_PI_COMMAND ?? 'pi',
               ...(piProvider ? { provider: piProvider } : {}),
               model,
-              env: env as NodeJS.ProcessEnv,
+              env: buildPiCliEnv(env, piProvider),
             }),
           }),
         );
@@ -356,6 +356,70 @@ function shellErrorMessage(error: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function buildPiCliEnv(env: RunHarborCellEnv, provider: string | undefined): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {};
+  copyEnv(result, { ...process.env, ...env }, [
+    'PATH',
+    'HOME',
+    'USER',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'SHELL',
+    'SystemRoot',
+    'COMSPEC',
+  ]);
+  copyPrefixedEnv(result, env, 'PI_');
+
+  const normalizedProvider = provider?.toLowerCase() ?? '';
+  if (normalizedProvider.includes('volcengine')) {
+    copyPrefixedEnv(result, env, 'XIAOMI_');
+    copyPrefixedEnv(result, env, 'VOLCENGINE_');
+  } else if (normalizedProvider.includes('deepseek')) {
+    copyEnv(result, env, ['DEEPSEEK_API_KEY', 'DEEPSEEK_API_KEY_FILE', 'DEEPSEEK_BASE_URL']);
+  } else if (normalizedProvider.includes('openai')) {
+    copyEnv(result, env, ['OPENAI_API_KEY', 'OPENAI_API_KEY_FILE', 'OPENAI_BASE_URL']);
+  } else if (normalizedProvider.includes('anthropic') || normalizedProvider.includes('claude')) {
+    copyEnv(result, env, ['ANTHROPIC_API_KEY', 'ANTHROPIC_API_KEY_FILE']);
+  } else if (normalizedProvider.includes('google') || normalizedProvider.includes('gemini')) {
+    copyEnv(result, env, [
+      'GOOGLE_API_KEY',
+      'GOOGLE_API_KEY_FILE',
+      'GEMINI_API_KEY',
+      'GOOGLE_GENERATIVE_AI_API_KEY',
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'GOOGLE_CLOUD_PROJECT',
+      'GOOGLE_CLOUD_LOCATION',
+      'GOOGLE_GENAI_USE_VERTEXAI',
+    ]);
+  } else if (normalizedProvider.includes('moonshot') || normalizedProvider.includes('kimi')) {
+    copyEnv(result, env, ['MOONSHOT_API_KEY', 'MOONSHOT_API_KEY_FILE', 'MOONSHOT_BASE_URL']);
+  } else if (normalizedProvider.includes('zai')) {
+    copyEnv(result, env, [
+      'ZAI_API_KEY',
+      'ZAI_API_KEY_FILE',
+      'ZAI_CODING_CN_API_KEY',
+      'ZAI_CODING_CN_API_KEY_FILE',
+      'ZAI_BASE_URL',
+    ]);
+  }
+
+  return result;
+}
+
+function copyPrefixedEnv(target: NodeJS.ProcessEnv, source: RunHarborCellEnv, prefix: string): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (key.startsWith(prefix) && value !== undefined) target[key] = value;
+  }
+}
+
+function copyEnv(target: NodeJS.ProcessEnv, source: RunHarborCellEnv, keys: string[]): void {
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined) target[key] = value;
+  }
 }
 
 export function resolveHarborCellAiSdkEnv(input: {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { exec as nodeExec } from 'node:child_process';
 import { join } from 'node:path';
@@ -219,6 +218,9 @@ export async function runHarborCellFromEnv(
       const model = env.MAKA_PI_MODEL ?? env.MAKA_MODEL ?? env.HARBOR_MODEL;
       if (!model) throw new Error('MAKA_PI_MODEL, MAKA_MODEL, or HARBOR_MODEL must include a model id');
       const piProvider = env.MAKA_PI_PROVIDER;
+      if (!registerBackends && !piProvider) {
+        throw new Error('MAKA_PI_PROVIDER is required when using the default Pi CLI transport');
+      }
       config = {
         ...baseConfig,
         llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? piProvider ?? 'pi-agent',
@@ -496,43 +498,29 @@ function apiKeyFromEnv(provider: ProviderType, env: RunHarborCellEnv): string {
   switch (provider) {
     case 'deepseek':
       return env.DEEPSEEK_API_KEY
-        ?? secretFileValue(env.DEEPSEEK_API_KEY_FILE, 'DEEPSEEK_API_KEY_FILE')
         ?? env.OPENAI_API_KEY
-        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
         ?? '';
     case 'openai':
     case 'openai-compatible':
-      return env.OPENAI_API_KEY ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE') ?? '';
+      return env.OPENAI_API_KEY ?? '';
     case 'moonshot':
       return env.MOONSHOT_API_KEY
-        ?? secretFileValue(env.MOONSHOT_API_KEY_FILE, 'MOONSHOT_API_KEY_FILE')
         ?? env.OPENAI_API_KEY
-        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
         ?? '';
     case 'zai-coding-plan':
       return env.ZAI_API_KEY
-        ?? secretFileValue(env.ZAI_API_KEY_FILE, 'ZAI_API_KEY_FILE')
         ?? env.ZAI_CODING_CN_API_KEY
-        ?? secretFileValue(env.ZAI_CODING_CN_API_KEY_FILE, 'ZAI_CODING_CN_API_KEY_FILE')
         ?? env.OPENAI_API_KEY
-        ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE')
         ?? '';
     case 'google':
-      return env.GOOGLE_API_KEY ?? secretFileValue(env.GOOGLE_API_KEY_FILE, 'GOOGLE_API_KEY_FILE') ?? '';
+      return env.GOOGLE_API_KEY ?? '';
     case 'anthropic':
     case 'kimi-coding-plan':
     case 'claude-subscription':
-      return env.ANTHROPIC_API_KEY ?? secretFileValue(env.ANTHROPIC_API_KEY_FILE, 'ANTHROPIC_API_KEY_FILE') ?? '';
+      return env.ANTHROPIC_API_KEY ?? '';
     default:
-      return env.OPENAI_API_KEY ?? secretFileValue(env.OPENAI_API_KEY_FILE, 'OPENAI_API_KEY_FILE') ?? '';
+      return env.OPENAI_API_KEY ?? '';
   }
-}
-
-function secretFileValue(path: string | undefined, key: string): string | undefined {
-  if (!path) return undefined;
-  const value = readFileSync(path, 'utf8').trim();
-  if (!value) throw new Error(`${key} must point to a non-empty file`);
-  return value;
 }
 
 function runtimeEventsJsonl(invocation: InvocationResult): string {

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -1,0 +1,288 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { Readable, Writable } from 'node:stream';
+import type { PiAgentFrame, PiAgentSendInput, PiAgentTransport } from '@maka/runtime';
+
+export interface PiCliJsonSpawnOptions {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stdio: ['pipe', 'pipe', 'pipe'];
+}
+
+export interface PiCliJsonChild {
+  stdin: Writable;
+  stdout: Readable;
+  stderr: Readable;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  on(event: 'error', listener: (error: Error) => void): this;
+}
+
+export type PiCliJsonSpawn = (command: string, args: string[], options: PiCliJsonSpawnOptions) => PiCliJsonChild;
+
+export interface PiCliJsonTransportInput {
+  command?: string;
+  provider?: string;
+  model?: string;
+  env?: NodeJS.ProcessEnv;
+  spawn?: PiCliJsonSpawn;
+}
+
+interface PiUsageTotals {
+  input: number;
+  output: number;
+  cacheHitInput: number;
+  cacheWriteInput: number;
+  reasoning: number;
+  total: number;
+  costUsd: number;
+  sawUsage: boolean;
+  sawReasoning: boolean;
+  sawCost: boolean;
+}
+
+type PiTokenUsageFrame = Extract<PiAgentFrame, { type: 'token_usage' }>;
+
+export class PiCliJsonTransport implements PiAgentTransport {
+  private readonly input: Required<Pick<PiCliJsonTransportInput, 'command' | 'spawn'>> & Omit<PiCliJsonTransportInput, 'command' | 'spawn'>;
+  private child: PiCliJsonChild | null = null;
+
+  constructor(input: PiCliJsonTransportInput = {}) {
+    this.input = {
+      ...input,
+      command: input.command ?? 'pi',
+      spawn: input.spawn ?? ((command, args, options) => nodeSpawn(command, args, options) as PiCliJsonChild),
+    };
+  }
+
+  async *send(input: PiAgentSendInput): AsyncIterable<PiAgentFrame> {
+    const child = this.input.spawn(this.input.command, this.args(), {
+      cwd: input.cwd,
+      env: { ...process.env, ...(this.input.env ?? {}) },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.child = child;
+    child.stdin.end(input.text);
+    const close = childClose(child);
+    const stderr = collectStderr(child.stderr);
+    let closed = false;
+    let buffer = '';
+
+    try {
+      for await (const chunk of child.stdout) {
+        buffer += String(chunk);
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          for (const frame of framesFromLine(line)) yield frame;
+        }
+      }
+      if (buffer.trim()) {
+        for (const frame of framesFromLine(buffer)) yield frame;
+      }
+
+      const result = await close;
+      closed = true;
+      if (result.code !== 0) {
+        const details = await stderr;
+        throw new Error(`pi exited with code ${result.code ?? 'signal'}${details ? `: ${details}` : ''}`);
+      }
+      yield { type: 'complete' };
+    } finally {
+      if (!closed) {
+        void close.catch(() => undefined);
+        child.kill('SIGTERM');
+      }
+      this.child = null;
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.child?.kill('SIGTERM');
+  }
+
+  private args(): string[] {
+    const args = ['--mode', 'json', '--no-context-files', '--no-session'];
+    if (this.input.provider) args.push('--provider', this.input.provider);
+    if (this.input.model) args.push('--model', this.input.model);
+    args.push('-p');
+    return args;
+  }
+}
+
+function childClose(child: PiCliJsonChild): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    child.on('close', (code, signal) => resolve({ code, signal }));
+    child.on('error', reject);
+  });
+}
+
+async function collectStderr(stderr: Readable): Promise<string> {
+  let output = '';
+  for await (const chunk of stderr) {
+    output += String(chunk);
+    if (output.length > 4096) output = output.slice(-4096);
+  }
+  return output.trim();
+}
+
+function framesFromLine(line: string): PiAgentFrame[] {
+  if (!line.trim()) return [];
+  const event = parseJsonObject(line);
+
+  switch (event.type) {
+    case 'session':
+    case 'agent_start':
+    case 'turn_start':
+    case 'turn_end':
+    case 'message_start':
+      return [];
+
+    case 'message_update': {
+      const assistantEvent = record(event.assistantMessageEvent);
+      if (!assistantEvent) throw new Error('pi message_update missing assistantMessageEvent');
+      switch (assistantEvent.type) {
+        case 'thinking_start':
+        case 'thinking_delta':
+        case 'thinking_end':
+        case 'text_start':
+        case 'text_end':
+        case 'toolcall_start':
+          return [];
+        case 'text_delta': {
+          const textDelta = stringValue(assistantEvent.delta);
+          if (textDelta === undefined) throw new Error('pi text_delta missing string delta');
+          return [{ type: 'text_delta', text: textDelta }];
+        }
+        case 'toolcall_end': {
+          const toolCalls = toolCallsFromPartial(assistantEvent.partial);
+          if (toolCalls.length === 0) throw new Error('pi toolcall_end missing valid tool call');
+          return toolCalls;
+        }
+        default:
+          throw new Error(`pi emitted unsupported assistant event: ${assistantEvent.type ?? '<missing type>'}`);
+      }
+    }
+
+    case 'message_end': {
+      const message = record(event.message);
+      if (message?.role !== 'toolResult') return [];
+      const toolUseId = stringValue(message.toolCallId);
+      if (!toolUseId) throw new Error('pi toolResult message_end missing toolCallId');
+      return [{
+        type: 'tool_result',
+        toolUseId,
+        isError: message.isError === true,
+        content: { kind: 'text', text: textFromPiContent(message.content) },
+      }];
+    }
+
+    case 'agent_end': {
+      const usage = usageFromAgentEnd(event);
+      return usage ? [usage] : [];
+    }
+
+    default:
+      throw new Error(`pi emitted unsupported JSON event: ${event.type ?? '<missing type>'}`);
+  }
+}
+
+function toolCallsFromPartial(partial: unknown): Extract<PiAgentFrame, { type: 'tool_start' }>[] {
+  const content = record(partial)?.content;
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((item) => {
+    const value = record(item);
+    const toolUseId = stringValue(value?.id);
+    const toolName = stringValue(value?.name);
+    if (value?.type !== 'toolCall' || !toolUseId || !toolName) return [];
+    return [{ type: 'tool_start', toolUseId, toolName, args: value.arguments }];
+  });
+}
+
+function usageFromAgentEnd(event: Record<string, unknown>): PiTokenUsageFrame | null {
+  const messages = event.messages;
+  if (!Array.isArray(messages)) return null;
+  const totals: PiUsageTotals = {
+    input: 0,
+    output: 0,
+    cacheHitInput: 0,
+    cacheWriteInput: 0,
+    reasoning: 0,
+    total: 0,
+    costUsd: 0,
+    sawUsage: false,
+    sawReasoning: false,
+    sawCost: false,
+  };
+  for (const message of messages) {
+    if (record(message)?.role !== 'assistant') continue;
+    addUsage(totals, record(record(message)?.usage));
+  }
+  if (!totals.sawUsage) return null;
+  return {
+    type: 'token_usage',
+    input: totals.input,
+    output: totals.output,
+    cacheHitInput: totals.cacheHitInput,
+    cacheWriteInput: totals.cacheWriteInput,
+    total: totals.total,
+    ...(totals.sawReasoning ? { reasoning: totals.reasoning } : {}),
+    ...(totals.sawCost ? { costUsd: totals.costUsd } : {}),
+  };
+}
+
+function addUsage(totals: PiUsageTotals, usage: Record<string, unknown> | undefined): void {
+  if (!usage) return;
+  const input = numberValue(usage.input);
+  const output = numberValue(usage.output);
+  const total = numberValue(usage.totalTokens);
+  if (input !== undefined || output !== undefined || total !== undefined) totals.sawUsage = true;
+  totals.input += input ?? 0;
+  totals.output += output ?? 0;
+  totals.cacheHitInput += numberValue(usage.cacheRead) ?? 0;
+  totals.cacheWriteInput += numberValue(usage.cacheWrite) ?? 0;
+  const reasoning = numberValue(usage.reasoning);
+  if (reasoning !== undefined) {
+    totals.reasoning += reasoning;
+    totals.sawReasoning = true;
+  }
+  totals.total += total ?? (input ?? 0) + (output ?? 0);
+  const costTotal = numberValue(record(usage.cost)?.total);
+  if (costTotal !== undefined) {
+    totals.costUsd += costTotal;
+    totals.sawCost = true;
+  }
+}
+
+function textFromPiContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((item) => {
+      const value = record(item);
+      return value?.type === 'text' ? stringValue(value.text) ?? '' : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function parseJsonObject(line: string): Record<string, unknown> {
+  try {
+    const value = record(JSON.parse(line.trim()));
+    if (value) return value;
+  } catch {
+    // Throw below with the same bounded message for invalid JSON and non-object JSON.
+  }
+  throw new Error(`pi emitted non-JSON stdout: ${line.slice(0, 200)}`);
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -63,13 +63,15 @@ export class PiCliJsonTransport implements PiAgentTransport {
     this.child = child;
     const close = childClose(child);
     const stderr = collectStderr(child.stderr);
+    let stdinError: Error | undefined;
     let rejectStdin: (error: Error) => void = () => {};
     const stdinFailed = new Promise<never>((_, reject) => {
       rejectStdin = reject;
     });
     stdinFailed.catch(() => undefined);
     const onStdinError = (error: Error) => {
-      rejectStdin(new Error(`pi stdin write failed: ${error.message}`));
+      stdinError = new Error(`pi stdin write failed: ${error.message}`);
+      rejectStdin(stdinError);
     };
     child.stdin.once('error', onStdinError);
     try {
@@ -99,6 +101,7 @@ export class PiCliJsonTransport implements PiAgentTransport {
 
       const result = await close;
       closed = true;
+      if (stdinError) throw stdinError;
       if (result.code !== 0) {
         const details = await stderr;
         throw new Error(`pi exited with code ${result.code ?? 'signal'}${details ? `: ${details}` : ''}`);

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -40,16 +40,7 @@ interface PiUsageTotals {
   sawCost: boolean;
 }
 
-type PiTokenUsageFrame = {
-  type: 'token_usage';
-  input: number;
-  output: number;
-  cacheHitInput: number;
-  cacheWriteInput: number;
-  reasoning?: number;
-  total: number;
-  costUsd?: number;
-};
+type PiTokenUsageFrame = Extract<PiAgentFrame, { type: 'token_usage' }>;
 
 export class PiCliJsonTransport implements PiAgentTransport {
   private readonly input: Required<Pick<PiCliJsonTransportInput, 'command' | 'spawn'>> & Omit<PiCliJsonTransportInput, 'command' | 'spawn'>;

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -40,11 +40,6 @@ interface PiUsageTotals {
   sawCost: boolean;
 }
 
-interface PiMappedLine {
-  frames: PiAgentFrame[];
-  sawAgentEnd: boolean;
-}
-
 type PiTokenUsageFrame = {
   type: 'token_usage';
   input: number;
@@ -107,15 +102,16 @@ export class PiCliJsonTransport implements PiAgentTransport {
         const lines = buffer.split(/\r?\n/);
         buffer = lines.pop() ?? '';
         for (const line of lines) {
-          const mapped = framesFromLine(line);
-          if (mapped.sawAgentEnd) sawAgentEnd = true;
-          for (const frame of mapped.frames) yield frame;
+          if (!line.trim()) continue;
+          const event = parseJsonObject(line);
+          if (event.type === 'agent_end') sawAgentEnd = true;
+          for (const frame of framesFromEvent(event)) yield frame;
         }
       }
       if (buffer.trim()) {
-        const mapped = framesFromLine(buffer);
-        if (mapped.sawAgentEnd) sawAgentEnd = true;
-        for (const frame of mapped.frames) yield frame;
+        const event = parseJsonObject(buffer);
+        if (event.type === 'agent_end') sawAgentEnd = true;
+        for (const frame of framesFromEvent(event)) yield frame;
       }
 
       const result = await close;
@@ -166,17 +162,14 @@ async function collectStderr(stderr: Readable): Promise<string> {
   return output.trim();
 }
 
-function framesFromLine(line: string): PiMappedLine {
-  if (!line.trim()) return { frames: [], sawAgentEnd: false };
-  const event = parseJsonObject(line);
-
+function framesFromEvent(event: Record<string, unknown>): PiAgentFrame[] {
   switch (event.type) {
     case 'session':
     case 'agent_start':
     case 'turn_start':
     case 'turn_end':
     case 'message_start':
-      return { frames: [], sawAgentEnd: false };
+      return [];
 
     case 'message_update': {
       const assistantEvent = record(event.assistantMessageEvent);
@@ -188,16 +181,16 @@ function framesFromLine(line: string): PiMappedLine {
         case 'text_start':
         case 'text_end':
         case 'toolcall_start':
-          return { frames: [], sawAgentEnd: false };
+          return [];
         case 'text_delta': {
           const textDelta = stringValue(assistantEvent.delta);
           if (textDelta === undefined) throw new Error('pi text_delta missing string delta');
-          return { frames: [{ type: 'text_delta', text: textDelta }], sawAgentEnd: false };
+          return [{ type: 'text_delta', text: textDelta }];
         }
         case 'toolcall_end': {
           const toolCalls = toolCallsFromPartial(assistantEvent.partial);
           if (toolCalls.length === 0) throw new Error('pi toolcall_end missing valid tool call');
-          return { frames: toolCalls, sawAgentEnd: false };
+          return toolCalls;
         }
         default:
           throw new Error(`pi emitted unsupported assistant event: ${assistantEvent.type ?? '<missing type>'}`);
@@ -206,20 +199,20 @@ function framesFromLine(line: string): PiMappedLine {
 
     case 'message_end': {
       const message = record(event.message);
-      if (message?.role !== 'toolResult') return { frames: [], sawAgentEnd: false };
+      if (message?.role !== 'toolResult') return [];
       const toolUseId = stringValue(message.toolCallId);
       if (!toolUseId) throw new Error('pi toolResult message_end missing toolCallId');
-      return { frames: [{
+      return [{
         type: 'tool_result',
         toolUseId,
         isError: message.isError === true,
         content: { kind: 'text', text: textFromPiContent(message.content) },
-      }], sawAgentEnd: false };
+      }];
     }
 
     case 'agent_end': {
       const usage = usageFromAgentEnd(event);
-      return { frames: usage ? [usage] : [], sawAgentEnd: true };
+      return usage ? [usage] : [];
     }
 
     default:

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -40,7 +40,16 @@ interface PiUsageTotals {
   sawCost: boolean;
 }
 
-type PiTokenUsageFrame = Extract<PiAgentFrame, { type: 'token_usage' }>;
+type PiTokenUsageFrame = {
+  type: 'token_usage';
+  input: number;
+  output: number;
+  cacheHitInput: number;
+  cacheWriteInput: number;
+  reasoning?: number;
+  total: number;
+  costUsd?: number;
+};
 
 export class PiCliJsonTransport implements PiAgentTransport {
   private readonly input: Required<Pick<PiCliJsonTransportInput, 'command' | 'spawn'>> & Omit<PiCliJsonTransportInput, 'command' | 'spawn'>;

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -61,14 +61,31 @@ export class PiCliJsonTransport implements PiAgentTransport {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     this.child = child;
-    child.stdin.end(input.text);
     const close = childClose(child);
     const stderr = collectStderr(child.stderr);
+    let rejectStdin: (error: Error) => void = () => {};
+    const stdinFailed = new Promise<never>((_, reject) => {
+      rejectStdin = reject;
+    });
+    stdinFailed.catch(() => undefined);
+    const onStdinError = (error: Error) => {
+      rejectStdin(new Error(`pi stdin write failed: ${error.message}`));
+    };
+    child.stdin.once('error', onStdinError);
+    try {
+      child.stdin.end(input.text);
+    } catch (error) {
+      onStdinError(error instanceof Error ? error : new Error(String(error)));
+    }
     let closed = false;
     let buffer = '';
 
     try {
-      for await (const chunk of child.stdout) {
+      const stdout = child.stdout[Symbol.asyncIterator]();
+      while (true) {
+        const next = await Promise.race([stdout.next(), stdinFailed]);
+        if (next.done) break;
+        const chunk = next.value;
         buffer += String(chunk);
         const lines = buffer.split(/\r?\n/);
         buffer = lines.pop() ?? '';
@@ -93,6 +110,7 @@ export class PiCliJsonTransport implements PiAgentTransport {
         child.kill('SIGTERM');
       }
       this.child = null;
+      child.stdin.off('error', onStdinError);
     }
   }
 

--- a/packages/headless/src/pi-cli-json-transport.ts
+++ b/packages/headless/src/pi-cli-json-transport.ts
@@ -40,6 +40,11 @@ interface PiUsageTotals {
   sawCost: boolean;
 }
 
+interface PiMappedLine {
+  frames: PiAgentFrame[];
+  sawAgentEnd: boolean;
+}
+
 type PiTokenUsageFrame = {
   type: 'token_usage';
   input: number;
@@ -66,7 +71,7 @@ export class PiCliJsonTransport implements PiAgentTransport {
   async *send(input: PiAgentSendInput): AsyncIterable<PiAgentFrame> {
     const child = this.input.spawn(this.input.command, this.args(), {
       cwd: input.cwd,
-      env: { ...process.env, ...(this.input.env ?? {}) },
+      env: this.input.env ?? process.env,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     this.child = child;
@@ -90,6 +95,7 @@ export class PiCliJsonTransport implements PiAgentTransport {
     }
     let closed = false;
     let buffer = '';
+    let sawAgentEnd = false;
 
     try {
       const stdout = child.stdout[Symbol.asyncIterator]();
@@ -101,11 +107,15 @@ export class PiCliJsonTransport implements PiAgentTransport {
         const lines = buffer.split(/\r?\n/);
         buffer = lines.pop() ?? '';
         for (const line of lines) {
-          for (const frame of framesFromLine(line)) yield frame;
+          const mapped = framesFromLine(line);
+          if (mapped.sawAgentEnd) sawAgentEnd = true;
+          for (const frame of mapped.frames) yield frame;
         }
       }
       if (buffer.trim()) {
-        for (const frame of framesFromLine(buffer)) yield frame;
+        const mapped = framesFromLine(buffer);
+        if (mapped.sawAgentEnd) sawAgentEnd = true;
+        for (const frame of mapped.frames) yield frame;
       }
 
       const result = await close;
@@ -115,6 +125,7 @@ export class PiCliJsonTransport implements PiAgentTransport {
         const details = await stderr;
         throw new Error(`pi exited with code ${result.code ?? 'signal'}${details ? `: ${details}` : ''}`);
       }
+      if (!sawAgentEnd) throw new Error('pi exited before agent_end');
       yield { type: 'complete' };
     } finally {
       if (!closed) {
@@ -155,8 +166,8 @@ async function collectStderr(stderr: Readable): Promise<string> {
   return output.trim();
 }
 
-function framesFromLine(line: string): PiAgentFrame[] {
-  if (!line.trim()) return [];
+function framesFromLine(line: string): PiMappedLine {
+  if (!line.trim()) return { frames: [], sawAgentEnd: false };
   const event = parseJsonObject(line);
 
   switch (event.type) {
@@ -165,7 +176,7 @@ function framesFromLine(line: string): PiAgentFrame[] {
     case 'turn_start':
     case 'turn_end':
     case 'message_start':
-      return [];
+      return { frames: [], sawAgentEnd: false };
 
     case 'message_update': {
       const assistantEvent = record(event.assistantMessageEvent);
@@ -177,16 +188,16 @@ function framesFromLine(line: string): PiAgentFrame[] {
         case 'text_start':
         case 'text_end':
         case 'toolcall_start':
-          return [];
+          return { frames: [], sawAgentEnd: false };
         case 'text_delta': {
           const textDelta = stringValue(assistantEvent.delta);
           if (textDelta === undefined) throw new Error('pi text_delta missing string delta');
-          return [{ type: 'text_delta', text: textDelta }];
+          return { frames: [{ type: 'text_delta', text: textDelta }], sawAgentEnd: false };
         }
         case 'toolcall_end': {
           const toolCalls = toolCallsFromPartial(assistantEvent.partial);
           if (toolCalls.length === 0) throw new Error('pi toolcall_end missing valid tool call');
-          return toolCalls;
+          return { frames: toolCalls, sawAgentEnd: false };
         }
         default:
           throw new Error(`pi emitted unsupported assistant event: ${assistantEvent.type ?? '<missing type>'}`);
@@ -195,20 +206,20 @@ function framesFromLine(line: string): PiAgentFrame[] {
 
     case 'message_end': {
       const message = record(event.message);
-      if (message?.role !== 'toolResult') return [];
+      if (message?.role !== 'toolResult') return { frames: [], sawAgentEnd: false };
       const toolUseId = stringValue(message.toolCallId);
       if (!toolUseId) throw new Error('pi toolResult message_end missing toolCallId');
-      return [{
+      return { frames: [{
         type: 'tool_result',
         toolUseId,
         isError: message.isError === true,
         content: { kind: 'text', text: textFromPiContent(message.content) },
-      }];
+      }], sawAgentEnd: false };
     }
 
     case 'agent_end': {
       const usage = usageFromAgentEnd(event);
-      return usage ? [usage] : [];
+      return { frames: usage ? [usage] : [], sawAgentEnd: true };
     }
 
     default:

--- a/packages/runtime/src/__tests__/pi-agent-backend.test.ts
+++ b/packages/runtime/src/__tests__/pi-agent-backend.test.ts
@@ -46,6 +46,45 @@ describe('PiAgentBackend skeleton', () => {
     assert.equal(messages.some((message) => message.type === 'tool_result' && message.toolUseId === 'tool-1'), true);
   });
 
+  test('normalizes token usage frames to Maka events and storage records', async () => {
+    const messages: StoredMessage[] = [];
+    const backend = new PiAgentBackend({
+      sessionId: 'session-1',
+      header: header({ permissionMode: 'execute' }),
+      appendMessage: async (message) => { messages.push(message); },
+      permissionEngine: new PermissionEngine({ newId: nextId('perm'), now: nextNow(2_500) }),
+      transport: frames([
+        {
+          type: 'token_usage',
+          input: 10,
+          output: 4,
+          cacheHitInput: 2,
+          cacheWriteInput: 3,
+          total: 17,
+          costUsd: 0.0012,
+        },
+        { type: 'complete' },
+      ]),
+      newId: nextId('id'),
+      now: nextNow(2_600),
+    });
+
+    const events = await drain(backend.send({ turnId: 'turn-1', text: 'inspect', context: [] }));
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+
+    assert.equal(usage?.input, 10);
+    assert.equal(usage?.output, 4);
+    assert.equal(usage?.cacheHitInput, 2);
+    assert.equal(usage?.cacheRead, 2);
+    assert.equal(usage?.cacheWriteInput, 3);
+    assert.equal(usage?.cacheCreation, 3);
+    assert.equal(usage?.total, 17);
+    assert.equal(usage?.costUsd, 0.0012);
+    assert.equal(messages.some((message) => message.type === 'token_usage' && message.costUsd === 0.0012), true);
+  });
+
   test('parks ACP permission requests until respondToPermission resolves them', async () => {
     const messages: StoredMessage[] = [];
     const backend = new PiAgentBackend({

--- a/packages/runtime/src/pi-agent-backend.ts
+++ b/packages/runtime/src/pi-agent-backend.ts
@@ -7,6 +7,7 @@ import type {
   ToolOutputStream,
   ToolResultContent,
   ToolResultMessage,
+  TokenUsageMessage,
 } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import { redactSecrets } from '@maka/core/redaction';
@@ -44,6 +45,17 @@ export type PiAgentFrame =
   | { type: 'tool_start'; toolUseId: string; toolName: string; args?: unknown; displayName?: string; intent?: string }
   | { type: 'tool_output_delta'; toolUseId: string; stream?: ToolOutputStream; chunk: string }
   | { type: 'tool_result'; toolUseId: string; isError?: boolean; content?: ToolResultContent | unknown }
+  | {
+      type: 'token_usage';
+      input: number;
+      output: number;
+      cacheHitInput?: number;
+      cacheMissInput?: number;
+      cacheWriteInput?: number;
+      reasoning?: number;
+      total?: number;
+      costUsd?: number;
+    }
   | {
       type: 'permission_request';
       toolUseId: string;
@@ -181,6 +193,12 @@ export class PiAgentBackend implements AgentBackend {
               isError: Boolean(frame.isError),
               content,
             };
+            break;
+          }
+          case 'token_usage': {
+            const event = this.tokenUsageEvent(turnId, frame);
+            await this.input.appendMessage(event);
+            yield event;
             break;
           }
           case 'permission_request': {
@@ -415,6 +433,25 @@ export class PiAgentBackend implements AgentBackend {
     };
   }
 
+  private tokenUsageEvent(turnId: string, frame: Extract<PiAgentFrame, { type: 'token_usage' }>): TokenUsageMessage {
+    const cacheHitInput = frame.cacheHitInput ?? 0;
+    const cacheWriteInput = frame.cacheWriteInput ?? 0;
+    return {
+      type: 'token_usage',
+      id: this.newId(),
+      turnId,
+      ts: this.now(),
+      input: frame.input,
+      output: frame.output,
+      ...(cacheHitInput > 0 ? { cacheHitInput, cacheRead: cacheHitInput } : {}),
+      ...(frame.cacheMissInput !== undefined ? { cacheMissInput: frame.cacheMissInput, cacheMissInputSource: 'explicit' } : {}),
+      ...(cacheWriteInput > 0 ? { cacheWriteInput, cacheCreation: cacheWriteInput } : {}),
+      ...(frame.reasoning !== undefined ? { reasoning: frame.reasoning } : {}),
+      ...(frame.total !== undefined ? { total: frame.total } : {}),
+      ...(frame.costUsd !== undefined ? { costUsd: frame.costUsd } : {}),
+    };
+  }
+
   private abortEvent(turnId: string): SessionEvent {
     return { type: 'abort', id: this.newId(), turnId, ts: this.now(), reason: 'user_stop' };
   }
@@ -451,6 +488,22 @@ export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {
   if (type === 'tool_result' && typeof value.toolUseId === 'string') {
     return { type, toolUseId: value.toolUseId, isError: value.isError === true, content: value.content };
   }
+  if (type === 'token_usage') {
+    const input = finiteNumber(value.input);
+    const output = finiteNumber(value.output);
+    if (input === undefined || output === undefined) return null;
+    return {
+      type,
+      input,
+      output,
+      ...numberField('cacheHitInput', value.cacheHitInput),
+      ...numberField('cacheMissInput', value.cacheMissInput),
+      ...numberField('cacheWriteInput', value.cacheWriteInput),
+      ...numberField('reasoning', value.reasoning),
+      ...numberField('total', value.total),
+      ...numberField('costUsd', value.costUsd),
+    };
+  }
   if (type === 'permission_request' && typeof value.toolUseId === 'string' && typeof value.toolName === 'string') {
     return {
       type,
@@ -476,6 +529,15 @@ export function normalizePiAgentFrame(frame: unknown): PiAgentFrame | null {
     return { type, stopReason };
   }
   return null;
+}
+
+function numberField<K extends string>(key: K, value: unknown): { [P in K]?: number } {
+  const number = finiteNumber(value);
+  return number === undefined ? {} : { [key]: number } as { [P in K]?: number };
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function normalizeToolResultContent(content: unknown): ToolResultContent {


### PR DESCRIPTION
## Summary

- add a `pi-agent` headless backend bridge that maps Pi JSON-mode output into Maka runtime events and token usage
- allow Harbor cells to run Pi through the in-repo adapter, using a preinstalled Pi CLI selected by `MAKA_PI_COMMAND` and explicit `MAKA_PI_PROVIDER` credentials scoped to the Pi child process
- keep Pi-specific provider/model strings out of the AI SDK provider parser
- inline the only production Pi backend registration path inside Harbor cell wiring so `backends.ts` stays fake-only internal plumbing
- make Harbor cell config construction an explicit backend switch with non-empty `pi-agent` and `fake` slugs
- cover the Pi transport, Harbor env entrypoint, adapter wiring, and runtime backend behavior with focused tests

Supersedes closed PR #78 after `main` was rewritten/rebased.

## Review fixes

- Pi transport now emits tool calls only from `toolcall_end` and tool results only from `message_end`, so runtime traces keep final args/results instead of partial start payloads.
- `MAKA_BACKEND=pi-agent` no longer parses `MAKA_MODEL` through Maka's AI SDK provider whitelist.
- Harbor adapter no longer runs root-level `npm install -g` for Pi; benchmark images/specs must provide `pi` or set `MAKA_PI_COMMAND`.
- Pi CLI prompts are passed through stdin instead of argv, avoiding long-prompt argv limits and process-list prompt exposure.
- Pi transport now fails closed on unsupported/non-JSON stdout, missing `agent_end`, late non-zero exits, and stdin write errors before reporting completion.
- Pi CLI child env is scoped to non-secret runtime basics plus the selected Pi provider credentials, instead of inheriting the full Harbor/process environment.
- The default Pi CLI path now fails fast without `MAKA_PI_PROVIDER`; explicit test-registered Pi backends can still omit it because they own their transport wiring.
- AI SDK `_API_KEY_FILE` support is not included in this Pi bridge PR; it should land separately if needed.

## Verification

- `npm run -w @maka/runtime test` — 590 pass, 0 fail
- `npm run -w @maka/headless test` — 239 pass, 0 fail
- `git diff --check`

## Real Harbor smoke

Using the same `deepseek-v4-pro` model and DeepSeek API key for both Maka and Pi:

| task | Maka | Pi | result |
| --- | ---: | ---: | --- |
| fix-git | $0.000272 | $0.001959 | both pass |
| prove-plus-comm | $0.000416 | $0.003106 | both pass |
| regex-log | $0.001036 | $0.011134 | both pass |
| cobol-modernization | $0.001599 | $0.013240 | both pass |
| vulnerable-secret | $0.000371 | $0.003821 | both pass |

Across these five scored samples, both harnesses passed 5/5. Pi used about 9x the estimated cost under DeepSeek official `deepseek-v4-pro` pricing.

`filter-js-from-html` was excluded from the scored comparison because both agent cells completed but Harbor's Selenium verifier did not finish before the batch run was interrupted.

Note: these real Pi smoke runs used a container setup that made the Pi CLI available. After review hardening, the adapter verifies an existing Pi binary instead of installing it at root during adapter setup.
