### PR TITLE
Expose Harbor native file tools to models

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -228,11 +228,16 @@ class MakaAgent(BaseInstalledAgent):
             "maka_cache_write_input_tokens": _optional_int(token_summary, "cacheWriteInput"),
             "maka_estimated_cost_usd": _optional_float(token_summary, "costUsd"),
             "maka_pricing_source": token_summary.get("pricingSource") if isinstance(token_summary, dict) else None,
+            "maka_provider_visible_tool_count": _optional_int(output.get("toolSummary"), "providerVisibleToolCount"),
+            "maka_actual_tool_calls": _optional_int(output.get("toolSummary"), "actualToolCalls"),
+            "maka_actual_tool_names": _optional_string_list(output.get("toolSummary"), "actualToolNames"),
+            "maka_actual_tool_call_counts": _optional_dict(output.get("toolSummary"), "actualToolCallCounts"),
         }
         self._write_trajectory(output)
 
     def _write_trajectory(self, output: dict[str, Any]) -> None:
         token_summary = output.get("tokenSummary")
+        tool_summary = output.get("toolSummary")
         final_metrics = FinalMetrics(
             total_prompt_tokens=_optional_int(token_summary, "input"),
             total_completion_tokens=_optional_int(token_summary, "output"),
@@ -249,6 +254,10 @@ class MakaAgent(BaseInstalledAgent):
                 "cache_write_input_tokens": _optional_int(token_summary, "cacheWriteInput"),
                 "estimated_cost_usd": _optional_float(token_summary, "costUsd"),
                 "pricing_source": token_summary.get("pricingSource") if isinstance(token_summary, dict) else None,
+                "provider_visible_tool_count": _optional_int(tool_summary, "providerVisibleToolCount"),
+                "actual_tool_calls": _optional_int(tool_summary, "actualToolCalls"),
+                "actual_tool_names": _optional_string_list(tool_summary, "actualToolNames"),
+                "actual_tool_call_counts": _optional_dict(tool_summary, "actualToolCallCounts"),
             },
         )
         trajectory = Trajectory(
@@ -279,6 +288,22 @@ def _optional_float(value: Any, key: str) -> float | None:
         return None
     raw = value.get(key)
     return float(raw) if isinstance(raw, (int, float)) and not isinstance(raw, bool) else None
+
+
+def _optional_string_list(value: Any, key: str) -> list[str] | None:
+    if not isinstance(value, dict):
+        return None
+    raw = value.get(key)
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        return None
+    return raw
+
+
+def _optional_dict(value: Any, key: str) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    raw = value.get(key)
+    return raw if isinstance(raw, dict) else None
 
 
 def _apply_trial_pricing(agent: MakaAgent, token_summary: dict[str, Any]) -> None:

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -25,8 +25,19 @@ describe('Harbor cell output contract', () => {
             total: 17,
             costUsd: 0.00123,
             systemPromptHash: 'sha256:prompt-a',
+            promptSegments: [
+              { kind: 'tool_schema', chars: 700, estimatedTokens: 175, toolCount: 6 },
+            ],
           },
         },
+      }),
+      runtimeEvent({
+        id: 'call-read',
+        content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'vm.js' } },
+      }),
+      runtimeEvent({
+        id: 'call-bash',
+        content: { kind: 'function_call', id: 'tool-2', name: 'Bash', args: { command: 'node vm.js' } },
       }),
       runtimeEvent({
         id: 'usage-2',
@@ -78,7 +89,13 @@ describe('Harbor cell output contract', () => {
         costUsd: 0.00523,
         pricingSource: 'runtime',
       },
-      steps: 3,
+      toolSummary: {
+        providerVisibleToolCount: 6,
+        actualToolCalls: 2,
+        actualToolNames: ['Bash', 'Read'],
+        actualToolCallCounts: { Bash: 1, Read: 1 },
+      },
+      steps: 5,
       durationMs: 150,
       startedAt: 100,
       finishedAt: 250,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -701,6 +701,12 @@ function harborOutput(input: {
       runtimeEventsPath: `/logs/${input.taskId}/runtime-events.jsonl`,
       ...(input.omitPromptHash ? {} : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
       tokenSummary: input.tokenSummary ?? tokenSummary({ input: 1, output: 2, reasoning: 0, total: 3, costUsd: 0.02 }),
+      toolSummary: {
+        providerVisibleToolCount: 0,
+        actualToolCalls: 0,
+        actualToolNames: [],
+        actualToolCallCounts: {},
+      },
       steps: 2,
       durationMs: 40,
       startedAt: 20,

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -5,10 +5,12 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
-import { BackendRegistry, type AgentBackend, type SessionStore } from '@maka/runtime';
+import { BackendRegistry, type AgentBackend, type BackendFactoryContext, type SessionStore } from '@maka/runtime';
 import type { Config } from '../contracts.js';
-import type { HeadlessBackendContext } from '../isolation.js';
+import type { HeadlessBackendContext, IsolatedToolExecutor } from '../isolation.js';
 import {
+  buildAiSdkCellBackendRegistration,
+  buildHarborCellAiSdkTools,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
   resolveHarborCellAiSdkEnv,
@@ -207,11 +209,63 @@ describe('runHarborCell', () => {
       assert.equal(seenContexts[0].config.llmConnectionSlug, 'openai');
       assert.equal(seenContexts[0].config.model, 'gpt-4o-mini');
       assert.equal(seenContexts[0].config.systemPrompt, 'Use the benchmark prompt.');
-      assert.deepEqual(seenContexts[0].realBackendIsolation, {
-        kind: 'external',
-        label: 'Harbor task container',
-      });
+      assert.equal(seenContexts[0].realBackendIsolation?.kind, 'external');
+      assert.equal(seenContexts[0].realBackendIsolation?.label, 'Harbor task container');
+      assert.equal(typeof seenContexts[0].realBackendIsolation?.toolExecutor?.exec, 'function');
+      assert.equal(typeof seenContexts[0].toolExecutor?.exec, 'function');
     });
+  });
+
+  test('Harbor ai-sdk backend registration exposes native file tools to the provider schema', async () => {
+    await withDirs(async ({ workspaceDir }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (backend as unknown as {
+        input: {
+          tools: Array<{ name: string; permissionRequired?: boolean }>;
+          systemPrompt?: string;
+        };
+      }).input;
+      const toolNames = backendInput.tools.map((tool) => tool.name);
+
+      for (const expected of ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep']) {
+        assert.ok(toolNames.includes(expected), `expected provider schema tool ${expected}`);
+      }
+      assert.equal(backendInput.tools.find((tool) => tool.name === 'Bash')?.permissionRequired, false);
+      assert.equal(backendInput.tools.find((tool) => tool.name === 'Write')?.permissionRequired, false);
+      assert.match(backendInput.systemPrompt ?? '', /Prefer Read, Glob, and Grep/);
+    });
+  });
+
+  test('Harbor tool builder keeps the six container-native tools non-interactive', () => {
+    const tools = buildHarborCellAiSdkTools(fakeToolExecutor());
+    const names = tools.map((tool) => tool.name);
+
+    for (const expected of ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep']) {
+      assert.ok(names.includes(expected), `expected Harbor tool ${expected}`);
+      assert.equal(tools.find((tool) => tool.name === expected)?.permissionRequired, false);
+    }
   });
 
   test('env entrypoint keeps slashful model ids when provider is explicit', async () => {
@@ -268,6 +322,43 @@ describe('runHarborCell', () => {
     assert.equal(deepseek.connection.baseUrl, 'https://fallback.example/v1');
   });
 });
+
+function fakeToolExecutor(): IsolatedToolExecutor {
+  return {
+    async exec() {
+      return { exitCode: 0, stdout: '', stderr: '' };
+    },
+  };
+}
+
+function backendContext(workspaceDir: string): BackendFactoryContext {
+  return {
+    sessionId: 'session-1',
+    workspaceRoot: workspaceDir,
+    header: {
+      id: 'session-1',
+      cwd: workspaceDir,
+      workspaceRoot: workspaceDir,
+      createdAt: 123,
+      lastUsedAt: 123,
+      name: 'harbor cell test',
+      isFlagged: false,
+      labels: [],
+      isArchived: false,
+      status: 'active',
+      hasUnread: false,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'openai',
+      connectionLocked: true,
+      model: 'gpt-4o-mini',
+      permissionMode: 'execute',
+      schemaVersion: 1,
+    },
+    store: {
+      appendMessage: async () => {},
+    } as unknown as SessionStore,
+  };
+}
 
 async function withDirs<T>(
   fn: (dirs: { workspaceDir: string; outputDir: string; storageRoot: string }) => Promise<T>,

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -24,6 +24,13 @@ export interface HarborCellRuntimeRefs {
   turnId: string;
 }
 
+export interface HarborCellToolSummary {
+  providerVisibleToolCount: number;
+  actualToolCalls: number;
+  actualToolNames: string[];
+  actualToolCallCounts: Record<string, number>;
+}
+
 export interface HarborCellOutput {
   schemaVersion: typeof HARBOR_CELL_OUTPUT_SCHEMA_VERSION;
   status: InvocationResult['status'];
@@ -31,6 +38,7 @@ export interface HarborCellOutput {
   runtimeEventsPath: string;
   promptHash?: string;
   tokenSummary: HarborCellTokenSummary;
+  toolSummary: HarborCellToolSummary;
   steps: number;
   durationMs: number;
   startedAt: number;
@@ -50,6 +58,7 @@ export function buildHarborCellOutput(input: {
     runtimeEventsPath: input.runtimeEventsPath,
     ...promptHashField(invocation.events),
     tokenSummary: summarizeCellTokens(invocation.events),
+    toolSummary: summarizeCellTools(invocation.events),
     steps: invocation.events.length,
     durationMs: invocation.finishedAt - invocation.startedAt,
     startedAt: invocation.startedAt,
@@ -76,6 +85,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
   const runtimeEventsPath = requireString(value.runtimeEventsPath, 'runtimeEventsPath');
   const promptHash = 'promptHash' in value ? requireOptionalString(value.promptHash, 'promptHash') : undefined;
   const tokenSummary = validateTokenSummary(value.tokenSummary);
+  const toolSummary = validateToolSummary(value.toolSummary);
   const steps = requireNumber(value.steps, 'steps');
   const durationMs = requireNumber(value.durationMs, 'durationMs');
   const startedAt = requireNumber(value.startedAt, 'startedAt');
@@ -88,6 +98,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeEventsPath,
     ...(promptHash !== undefined ? { promptHash } : {}),
     tokenSummary,
+    toolSummary,
     steps,
     durationMs,
     startedAt,
@@ -146,6 +157,32 @@ export function summarizeCellTokens(events: readonly RuntimeEvent[]): HarborCell
   return summary;
 }
 
+export function summarizeCellTools(events: readonly RuntimeEvent[]): HarborCellToolSummary {
+  const counts = new Map<string, number>();
+  let providerVisibleToolCount = 0;
+  for (const event of events) {
+    const content = event.content;
+    if (content?.kind === 'function_call') {
+      counts.set(content.name, (counts.get(content.name) ?? 0) + 1);
+    }
+    const promptSegments = event.actions?.tokenUsage?.promptSegments;
+    if (promptSegments) {
+      for (const segment of promptSegments) {
+        if (segment.kind === 'tool_schema' && typeof segment.toolCount === 'number') {
+          providerVisibleToolCount = Math.max(providerVisibleToolCount, segment.toolCount);
+        }
+      }
+    }
+  }
+  const sorted = [...counts.entries()].sort(([a], [b]) => a.localeCompare(b));
+  return {
+    providerVisibleToolCount,
+    actualToolCalls: sorted.reduce((sum, [, count]) => sum + count, 0),
+    actualToolNames: sorted.map(([name]) => name),
+    actualToolCallCounts: Object.fromEntries(sorted),
+  };
+}
+
 function promptHashField(events: readonly RuntimeEvent[]): Pick<HarborCellOutput, 'promptHash'> {
   for (const event of events) {
     const hash = event.actions?.tokenUsage?.systemPromptHash;
@@ -174,6 +211,33 @@ function validateTokenSummary(value: unknown): HarborCellTokenSummary {
       requireOptionalStringUnion(value.pricingSource, 'tokenSummary.pricingSource', ['runtime'] as const)
       ?? 'runtime',
   };
+}
+
+function validateToolSummary(value: unknown): HarborCellToolSummary {
+  if (!isRecord(value)) throw new Error('toolSummary must be a JSON object');
+  const actualToolCallCounts = validateToolCallCounts(value.actualToolCallCounts);
+  return {
+    providerVisibleToolCount: requireNumber(value.providerVisibleToolCount, 'toolSummary.providerVisibleToolCount'),
+    actualToolCalls: requireNumber(value.actualToolCalls, 'toolSummary.actualToolCalls'),
+    actualToolNames: validateStringArray(value.actualToolNames, 'toolSummary.actualToolNames'),
+    actualToolCallCounts,
+  };
+}
+
+function validateToolCallCounts(value: unknown): Record<string, number> {
+  if (!isRecord(value)) throw new Error('toolSummary.actualToolCallCounts must be a JSON object');
+  const counts: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    counts[key] = requireNumber(raw, `toolSummary.actualToolCallCounts.${key}`);
+  }
+  return counts;
+}
+
+function validateStringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+  return [...value];
 }
 
 function validateRuntimeRefs(value: unknown): HarborCellRuntimeRefs {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,5 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { exec as nodeExec } from 'node:child_process';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 import type {
   BackendKind,
   LlmConnection,
@@ -11,10 +13,10 @@ import {
   BackendRegistry,
   PermissionEngine,
   SessionManager,
-  buildBuiltinTools,
   buildProviderOptions,
   getAIModel,
   getBuiltinPricing,
+  type MakaTool,
   type InvocationResult,
 } from '@maka/runtime';
 import {
@@ -25,12 +27,15 @@ import {
 import { registerFakeBackend } from './backends.js';
 import { buildHarborCellOutput, validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
 import type { Config, Task } from './contracts.js';
-import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
-import { validateRealBackendIsolation } from './isolation.js';
+import type { HeadlessBackendContext, IsolatedToolExecutor, RealBackendIsolation } from './isolation.js';
+import { ISOLATED_HEADLESS_TOOL_NAMES, validateRealBackendIsolation } from './isolation.js';
 import { backendNeedsIsolation } from './runner.js';
+import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from './tools.js';
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
+const execAsync = promisify(nodeExec);
+const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 export interface RunHarborCellInput {
   config: Config;
@@ -94,7 +99,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     task,
     workspaceDir: input.cwd,
     ...(backendNeedsIsolation(input.config.backend)
-      ? { realBackendIsolation: input.realBackendIsolation }
+      ? { realBackendIsolation: input.realBackendIsolation, toolExecutor: input.realBackendIsolation?.toolExecutor }
       : {}),
   });
 
@@ -182,19 +187,27 @@ export async function runHarborCellFromEnv(
     outputDir,
     storageRoot: env.MAKA_STORAGE_ROOT ?? join(outputDir, 'maka-storage'),
     ...(registerBackends ? { registerBackends } : {}),
-    ...(backendNeedsIsolation(backend) ? { realBackendIsolation: { kind: 'external', label: 'Harbor task container' } } : {}),
+    ...(backendNeedsIsolation(backend)
+      ? {
+          realBackendIsolation: {
+            kind: 'external',
+            label: 'Harbor task container',
+            toolExecutor: createHarborCellLocalToolExecutor(env),
+          },
+        }
+      : {}),
     ...(options.now ? { now: options.now } : {}),
     ...(options.newId ? { newId: options.newId } : {}),
   });
 }
 
-function buildAiSdkCellBackendRegistration(input: {
+export function buildAiSdkCellBackendRegistration(input: {
   provider: ProviderType;
   model: string;
   env: RunHarborCellEnv;
   now: () => number;
   newId: () => string;
-}): RunHarborCellInput['registerBackends'] {
+}): NonNullable<RunHarborCellInput['registerBackends']> {
   const { connection, apiKey } = resolveHarborCellAiSdkEnv({
     provider: input.provider,
     model: input.model,
@@ -203,6 +216,9 @@ function buildAiSdkCellBackendRegistration(input: {
   });
   const permissionEngine = new PermissionEngine({ newId: input.newId, now: input.now });
   return (registry, context) => {
+    if (!context.toolExecutor) {
+      throw new Error('Harbor ai-sdk backend requires an isolated tool executor');
+    }
     registry.register('ai-sdk', (ctx) =>
       new AiSdkBackend({
         sessionId: ctx.sessionId,
@@ -213,9 +229,10 @@ function buildAiSdkCellBackendRegistration(input: {
         modelId: input.model,
         permissionEngine,
         modelFactory: getAIModel,
-        tools: buildBuiltinTools(),
+        tools: buildHarborCellAiSdkTools(context.toolExecutor!),
+        toolAvailability: buildIsolatedHeadlessToolAvailability(),
         providerOptions: buildProviderOptions(connection, input.model),
-        systemPrompt: context.config.systemPrompt,
+        systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
         lookupPricing: getBuiltinPricing,
         newId: input.newId,
         now: input.now,
@@ -223,6 +240,77 @@ function buildAiSdkCellBackendRegistration(input: {
       }),
     );
   };
+}
+
+export function buildHarborCellAiSdkTools(executor: IsolatedToolExecutor): MakaTool[] {
+  const nonInteractiveToolNames = new Set<string>(ISOLATED_HEADLESS_TOOL_NAMES);
+  return buildIsolatedHeadlessTools(executor).map((tool) => (
+    nonInteractiveToolNames.has(tool.name)
+      ? { ...tool, permissionRequired: false }
+      : tool
+  ));
+}
+
+export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = process.env): IsolatedToolExecutor {
+  const childEnv = childProcessEnv(env);
+  return {
+    exec: async ({ command, cwd, timeoutMs }) => {
+      try {
+        const result = await execAsync(command, {
+          cwd,
+          env: childEnv,
+          timeout: timeoutMs ?? 120_000,
+          maxBuffer: HARBOR_CELL_TOOL_MAX_BUFFER_BYTES,
+        });
+        return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+      } catch (error) {
+        return {
+          exitCode: shellErrorExitCode(error),
+          stdout: shellErrorText(error, 'stdout'),
+          stderr: shellErrorText(error, 'stderr') || shellErrorMessage(error),
+        };
+      }
+    },
+  };
+}
+
+function harborCellSystemPrompt(configPrompt: string | undefined): string {
+  return [
+    [
+      'You are Maka Runtime running inside an isolated Harbor benchmark task container.',
+      'Prefer Read, Glob, and Grep for file inspection and search.',
+      'Prefer Edit and Write for file changes.',
+      'Use Bash for running programs, tests, and shell-specific debugging only.',
+    ].join('\n'),
+    configPrompt,
+  ].filter((part): part is string => typeof part === 'string' && part.trim().length > 0).join('\n\n');
+}
+
+function childProcessEnv(env: RunHarborCellEnv): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) childEnv[key] = value;
+  }
+  return childEnv;
+}
+
+function shellErrorExitCode(error: unknown): number {
+  if (isRecord(error) && typeof error.code === 'number') return error.code;
+  if (isRecord(error) && typeof error.signal === 'string') return 124;
+  return 1;
+}
+
+function shellErrorText(error: unknown, field: 'stdout' | 'stderr'): string {
+  if (isRecord(error) && typeof error[field] === 'string') return error[field];
+  return '';
+}
+
+function shellErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 export function resolveHarborCellAiSdkEnv(input: {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -6,11 +6,13 @@ export type {
   HarborCellOutput,
   HarborCellRuntimeRefs,
   HarborCellTokenSummary,
+  HarborCellToolSummary,
 } from './cell-output.js';
 export {
   HARBOR_CELL_OUTPUT_SCHEMA_VERSION,
   buildHarborCellOutput,
   summarizeCellTokens,
+  summarizeCellTools,
   validateHarborCellOutput,
 } from './cell-output.js';
 export type {
@@ -20,6 +22,9 @@ export type {
   RunHarborCellResult,
 } from './harbor-cell.js';
 export {
+  buildAiSdkCellBackendRegistration,
+  buildHarborCellAiSdkTools,
+  createHarborCellLocalToolExecutor,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
   runHarborCell,


### PR DESCRIPTION
## Summary
- wire the committed Harbor cell ai-sdk path through the isolated headless tool surface instead of generic/Bash-oriented tooling
- make Harbor benchmark tools non-interactive inside the external isolation boundary and prompt models to prefer Read/Glob/Grep/Edit/Write over Bash for file work
- add Harbor cell tool adoption summary fields and pass them through trial metadata/trajectory extras
- add regression coverage that the real ai-sdk backend registration provider schema includes Bash, Read, Write, Edit, Glob, and Grep

## Verification
- npm run typecheck --workspace @maka/headless
- npm test --workspace @maka/headless
- python3 -m py_compile packages/headless/harbor/maka_agent.py
- git diff --check