### PR TITLE
Accept workspace absolute paths in Harbor file tools

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -100,22 +100,30 @@ describe('isolated headless tools', () => {
       },
     });
 
-    assert.deepEqual(await tool(tools, 'Read').impl({ path: 'target.txt', offset: 1, limit: 2 }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Read').impl({ path: join(cwd, 'target.txt'), offset: 1, limit: 2 }, toolCtx(cwd)), {
       content: 'container\n',
     });
-    assert.deepEqual(await tool(tools, 'Write').impl({ path: 'target.txt', content: 'external\n' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Write').impl({ path: join(cwd, 'target.txt'), content: 'external\n' }, toolCtx(cwd)), {
       ok: true,
       path: 'target.txt',
       bytes: 9,
     });
     assert.deepEqual(
-      await tool(tools, 'Edit').impl({ path: 'target.txt', old_string: 'host', new_string: 'external' }, toolCtx(cwd)),
+      await tool(tools, 'Edit').impl({
+        path: join(cwd, 'target.txt'),
+        old_string: 'host',
+        new_string: 'external',
+      }, toolCtx(cwd)),
       { ok: true, path: 'target.txt', replacements: 1 },
     );
-    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: '*.txt', cwd: 'src' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: `${cwd}/*.txt`, cwd: join(cwd, 'src') }, toolCtx(cwd)), {
       files: ['container.txt'],
     });
-    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', path: 'src', glob: '*.txt' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Grep').impl({
+      pattern: 'needle',
+      path: join(cwd, 'src'),
+      glob: `${cwd}/*.txt`,
+    }, toolCtx(cwd)), {
       matches: ['container.txt:1:needle'],
     });
 
@@ -132,6 +140,9 @@ describe('isolated headless tools', () => {
   test('file tools fall back to command-backed isolated operations', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-fallback-'));
     await mkdir(join(cwd, 'src'));
+    const absoluteFile = join(cwd, 'src', 'file.txt');
+    const absoluteSrc = join(cwd, 'src');
+    const absoluteGlob = `${cwd}/**/*.txt`;
     const calls: string[] = [];
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
@@ -149,22 +160,22 @@ describe('isolated headless tools', () => {
       },
     });
 
-    assert.deepEqual(await tool(tools, 'Write').impl({ path: 'src/file.txt', content: 'hello\nneedle\n' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Write').impl({ path: absoluteFile, content: 'hello\nneedle\n' }, toolCtx(cwd)), {
       ok: true,
       path: 'src/file.txt',
       bytes: 13,
     });
-    assert.deepEqual(await tool(tools, 'Read').impl({ path: 'src/file.txt', offset: 1, limit: 1 }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Read').impl({ path: absoluteFile, offset: 1, limit: 1 }, toolCtx(cwd)), {
       content: 'needle',
     });
     assert.deepEqual(
-      await tool(tools, 'Edit').impl({ path: 'src/file.txt', old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
+      await tool(tools, 'Edit').impl({ path: absoluteFile, old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
       { ok: true, path: 'src/file.txt', replacements: 1 },
     );
-    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: '**/*.txt' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: absoluteGlob }, toolCtx(cwd)), {
       files: ['src/file.txt'],
     });
-    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', glob: '**/*.txt' }, toolCtx(cwd)), {
+    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', path: absoluteSrc, glob: absoluteGlob }, toolCtx(cwd)), {
       matches: ['src/file.txt:2:needle'],
     });
     assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hi\nneedle\n');

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -3,6 +3,7 @@ import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
 } from '@maka/runtime';
+import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
 import type { IsolatedToolExecutor } from './isolation.js';
 
@@ -75,10 +76,10 @@ export function buildIsolatedReadTool(executor: IsolatedToolExecutor): MakaTool 
     }),
     permissionRequired: false,
     impl: async ({ path, offset, limit }, { cwd }) => {
-      assertRelativePath(path, 'Read path');
-      if (executor.readFile) return await executor.readFile({ cwd, path, offset, limit });
+      const normalizedPath = normalizeWorkspacePath(path, cwd, 'Read path');
+      if (executor.readFile) return await executor.readFile({ cwd, path: normalizedPath, offset, limit });
       const stdout = await execFileCommand(executor, cwd, nodeFileCommand(READ_SCRIPT, [
-        path,
+        normalizedPath,
         numberArg(offset),
         numberArg(limit),
       ]));
@@ -94,13 +95,13 @@ export function buildIsolatedWriteTool(executor: IsolatedToolExecutor): MakaTool
     parameters: z.object({ path: z.string(), content: z.string() }),
     permissionRequired: true,
     impl: async ({ path, content }, { cwd }) => {
-      assertRelativePath(path, 'Write path');
-      if (executor.writeFile) return await executor.writeFile({ cwd, path, content });
+      const normalizedPath = normalizeWorkspacePath(path, cwd, 'Write path');
+      if (executor.writeFile) return await executor.writeFile({ cwd, path: normalizedPath, content });
       await execFileCommand(executor, cwd, nodeFileCommand(WRITE_SCRIPT, [
-        path,
+        normalizedPath,
         Buffer.from(content, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path, bytes: Buffer.byteLength(content, 'utf8') };
+      return { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
     },
   };
 }
@@ -116,16 +117,16 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
     }),
     permissionRequired: true,
     impl: async ({ path, old_string, new_string }, { cwd }) => {
-      assertRelativePath(path, 'Edit path');
+      const normalizedPath = normalizeWorkspacePath(path, cwd, 'Edit path');
       if (executor.editFile) {
-        return await executor.editFile({ cwd, path, oldString: old_string, newString: new_string });
+        return await executor.editFile({ cwd, path: normalizedPath, oldString: old_string, newString: new_string });
       }
       await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
-        path,
+        normalizedPath,
         Buffer.from(old_string, 'utf8').toString('base64'),
         Buffer.from(new_string, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path, replacements: 1 };
+      return { ok: true, path: normalizedPath, replacements: 1 };
     },
   };
 }
@@ -140,10 +141,13 @@ export function buildIsolatedGlobTool(executor: IsolatedToolExecutor): MakaTool 
     }),
     permissionRequired: false,
     impl: async ({ pattern, cwd: relCwd }, { cwd }) => {
-      assertRelativeGlobPattern(pattern, 'Glob pattern');
-      if (relCwd !== undefined) assertRelativePath(relCwd, 'Glob cwd');
-      if (executor.globFiles) return await executor.globFiles({ cwd, pattern, searchCwd: relCwd });
-      const stdout = await execFileCommand(executor, cwd, nodeFileCommand(GLOB_SCRIPT, [pattern, relCwd ?? '']));
+      const normalizedPattern = normalizeWorkspaceGlobPattern(pattern, cwd, 'Glob pattern');
+      const normalizedRelCwd = relCwd === undefined ? undefined : normalizeWorkspacePath(relCwd, cwd, 'Glob cwd');
+      if (executor.globFiles) return await executor.globFiles({ cwd, pattern: normalizedPattern, searchCwd: normalizedRelCwd });
+      const stdout = await execFileCommand(executor, cwd, nodeFileCommand(GLOB_SCRIPT, [
+        normalizedPattern,
+        normalizedRelCwd ?? '',
+      ]));
       return { files: parseStringArray(stdout, 'Glob') };
     },
   };
@@ -160,13 +164,18 @@ export function buildIsolatedGrepTool(executor: IsolatedToolExecutor): MakaTool 
     }),
     permissionRequired: false,
     impl: async ({ pattern, path, glob }, { cwd }) => {
-      if (path !== undefined) assertRelativePath(path, 'Grep path');
-      if (glob !== undefined) assertRelativeGlobPattern(glob, 'Grep glob');
-      if (executor.grepFiles) return await executor.grepFiles({ cwd, pattern, path, glob });
+      const normalizedPath = path === undefined ? undefined : normalizeWorkspacePath(path, cwd, 'Grep path');
+      const normalizedGlob = glob === undefined ? undefined : normalizeWorkspaceGlobPattern(glob, cwd, 'Grep glob');
+      if (executor.grepFiles) return await executor.grepFiles({
+        cwd,
+        pattern,
+        path: normalizedPath,
+        glob: normalizedGlob,
+      });
       const stdout = await execFileCommand(executor, cwd, nodeFileCommand(GREP_SCRIPT, [
         pattern,
-        path ?? '',
-        glob ?? '',
+        normalizedPath ?? '',
+        normalizedGlob ?? '',
       ]));
       return { matches: parseStringArray(stdout, 'Grep') };
     },
@@ -201,7 +210,38 @@ function parseStringArray(stdout: string, label: string): string[] {
   return parsed;
 }
 
-function assertRelativePath(inputPath: string, label: string): void {
+function normalizeWorkspacePath(inputPath: string, cwd: string, label: string): string {
+  assertNoDriveOrParentSegment(inputPath, label);
+  if (inputPath.startsWith('/')) {
+    return assertNormalizedRelativePath(
+      pathPosix.relative(normalizeWorkspaceRoot(cwd), pathPosix.normalize(inputPath)) || '.',
+      label,
+    );
+  }
+  return assertNormalizedRelativePath(inputPath, label);
+}
+
+function normalizeWorkspaceGlobPattern(pattern: string, cwd: string, label: string): string {
+  assertNoDriveOrParentSegment(pattern, label);
+  if (!pattern.startsWith('/')) return assertNormalizedRelativePath(pattern, label);
+  return assertNormalizedRelativePath(pathPosix.relative(normalizeWorkspaceRoot(cwd), pattern) || '.', label);
+}
+
+function normalizeWorkspaceRoot(cwd: string): string {
+  return pathPosix.normalize(cwd);
+}
+
+function assertNoDriveOrParentSegment(inputPath: string, label: string): void {
+  if (
+    inputPath.length === 0
+    || /^[A-Za-z]:[\\/]/.test(inputPath)
+    || inputPath.split(/[\\/]+/).includes('..')
+  ) {
+    throw new Error(`${label} must stay inside the isolated workspace`);
+  }
+}
+
+function assertNormalizedRelativePath(inputPath: string, label: string): string {
   if (
     inputPath.length === 0
     || inputPath.startsWith('/')
@@ -210,17 +250,7 @@ function assertRelativePath(inputPath: string, label: string): void {
   ) {
     throw new Error(`${label} must stay inside the isolated workspace`);
   }
-}
-
-function assertRelativeGlobPattern(pattern: string, label: string): void {
-  if (
-    pattern.length === 0
-    || pattern.startsWith('/')
-    || /^[A-Za-z]:[\\/]/.test(pattern)
-    || pattern.split(/[\\/]+/).includes('..')
-  ) {
-    throw new Error(`${label} must stay inside the isolated workspace`);
-  }
+  return inputPath;
 }
 
 const COMMON_NODE_HELPERS = String.raw`


### PR DESCRIPTION
## Summary
- accept workspace-internal absolute paths such as `/app/foo` for Harbor `Read`/`Write`/`Edit`/`Glob`/`Grep` by normalizing them before containment checks
- keep outside-workspace absolute paths and parent escapes rejected
- add native executor and command-backed fallback regression coverage

## Verification
- `npm test --workspace @maka/headless -- tools.test.ts`
- `npm run typecheck --workspace @maka/headless`
- `git diff --check upstream/main..HEAD`

Follow-up to merged PR #86.