### PR TITLE
Aggregate AI SDK tool-loop usage

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1563,6 +1563,138 @@ describe('AiSdkBackend usage telemetry', () => {
     });
   });
 
+  test('records aggregate totalUsage across AI SDK tool-loop steps', async () => {
+    const messages: unknown[] = [];
+    const events: SessionEvent[] = [];
+    const llmRecords: LlmCallRecord[] = [];
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV3StreamPart[] = streamCalls === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: 'tool-1',
+                toolName: 'Read',
+                input: JSON.stringify({ path: 'notes.md' }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: {
+                  inputTokens: {
+                    total: 100,
+                    noCache: 70,
+                    cacheRead: 20,
+                    cacheWrite: 10,
+                  },
+                  outputTokens: {
+                    total: 5,
+                    text: 5,
+                    reasoning: 0,
+                  },
+                },
+              },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'done' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: {
+                  inputTokens: {
+                    total: 200,
+                    noCache: 100,
+                    cacheRead: 80,
+                    cacheWrite: 20,
+                  },
+                  outputTokens: {
+                    total: 7,
+                    text: 5,
+                    reasoning: 2,
+                  },
+                },
+              },
+            ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        messages.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordLlmCall: (record) => {
+        llmRecords.push(record);
+      },
+    });
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    const usageMessage = messages.find((message) =>
+      (message as { type?: string }).type === 'token_usage'
+    ) as {
+      input?: number;
+      output?: number;
+      cacheHitInput?: number;
+      cacheMissInput?: number;
+      cacheMissInputSource?: string;
+      cacheWriteInput?: number;
+      cacheRead?: number;
+      cacheCreation?: number;
+      reasoning?: number;
+      total?: number;
+      rawFinishReason?: string;
+    } | undefined;
+    const usageEvent = events.find((event) => event.type === 'token_usage') as
+      | Extract<SessionEvent, { type: 'token_usage' }>
+      | undefined;
+
+    assert.equal(streamCalls, 2);
+    assert.equal(usageMessage?.input, 300);
+    assert.equal(usageMessage?.output, 12);
+    assert.equal(usageMessage?.cacheHitInput, 100);
+    assert.equal(usageMessage?.cacheMissInput, 170);
+    assert.equal(usageMessage?.cacheMissInputSource, 'explicit');
+    assert.equal(usageMessage?.cacheWriteInput, 30);
+    assert.equal(usageMessage?.cacheRead, 100);
+    assert.equal(usageMessage?.cacheCreation, 30);
+    assert.equal(usageMessage?.reasoning, 2);
+    assert.equal(usageMessage?.total, 312);
+    assert.equal(usageMessage?.rawFinishReason, 'stop');
+    assert.equal(usageEvent?.input, 300);
+    assert.equal(llmRecords[0]?.inputTokens, 300);
+    assert.equal(llmRecords[0]?.outputTokens, 12);
+    assert.equal(llmRecords[0]?.cacheHitInputTokens, 100);
+    assert.equal(llmRecords[0]?.cacheMissInputTokens, 170);
+    assert.equal(llmRecords[0]?.cacheWriteInputTokens, 30);
+    assert.equal(llmRecords[0]?.reasoningTokens, 2);
+    assert.equal(llmRecords[0]?.totalTokens, 312);
+    assert.equal(llmRecords[0]?.rawFinishReason, 'stop');
+  });
+
   test('normalizes cache and reasoning tokens to messages, events, and telemetry', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -69,7 +69,7 @@ describe('ModelAdapter extraction contract', () => {
     assert.match(backend, /this\.modelAdapter\.resolveModel\(\)/);
     assert.match(backend, /this\.modelAdapter\.startStream\(/);
     assert.match(backend, /this\.modelAdapter\.handleStreamChunk\(/);
-    assert.match(backend, /normalizeAiSdkUsage\(await result\.usage,[\s\S]*?rawFinishReason[\s\S]*?\)/);
+    assert.match(backend, /normalizeAiSdkUsage\(await \(result\.totalUsage \?\? result\.usage\),[\s\S]*?rawFinishReason[\s\S]*?\)/);
     assert.match(backend, /this\.modelAdapter\.classifyError\(/);
     assert.match(
       backend,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -715,9 +715,10 @@ export class AiSdkBackend implements AgentBackend {
           } satisfies TextCompleteEvent);
         }
 
-        // Final usage event (await result.usage which resolves once stream ends).
+        // Final usage event. AI SDK `usage` is the last step only; `totalUsage`
+        // is the billing-relevant sum across all internal tool-loop steps.
         try {
-          tokenUsage = normalizeAiSdkUsage(await result.usage, { rawFinishReason });
+          tokenUsage = normalizeAiSdkUsage(await (result.totalUsage ?? result.usage), { rawFinishReason });
           if (tokenUsage) {
             const systemPromptHash = turnDiagnostics.requestShape.componentHashes.systemPromptHash;
             tokenUsageCostUsd = this.computeTokenUsageCostUsd(tokenUsage);

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -230,6 +230,7 @@ export interface AiSdkStreamChunk {
 export interface StreamTextResult {
   fullStream: AsyncIterable<AiSdkStreamChunk>;
   usage: Promise<AiSdkUsageLike | undefined>;
+  totalUsage?: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
 }
 


### PR DESCRIPTION
## Summary
- record AI SDK aggregate `totalUsage` when available instead of the per-step `usage` promise
- expose optional `totalUsage` on the runtime model-adapter result contract
- add a two-step tool-loop regression covering aggregate input/output/cache/reasoning telemetry

## Verification
- `npm run typecheck --workspace packages/runtime`
- `npm run test --workspace packages/runtime`
- `git diff --check`
