### PR TITLE
Daily Review UI — sidebar entry + Settings config form + manual triggers

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -45,6 +45,10 @@ import type {
   PlanReminder,
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
+  DailyReviewArchive,
+  DailyReviewArchiveSummary,
+  DailyReviewConfig,
+  DailyReviewMode,
   DailyReviewSummary,
   WebSearchProvider,
   WebSearchResponse,
@@ -353,6 +357,19 @@ declare global {
         }): Promise<
           { ok: true; path: string } | { ok: false; reason: 'canceled' | 'write_failed' | 'invalid_input' }
         >;
+        /**
+         * PR-DAILY-REVIEW-FULL-0 — pipeline + archive surface. Each
+         * method may reject with a string error code when the
+         * backend is not yet wired or when prerequisites are missing
+         * (e.g. no model configured). Renderer gracefully handles
+         * rejection by showing the disabled / fallback form.
+         */
+        getConfig?(): Promise<DailyReviewConfig>;
+        setConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
+        runOnce?(opts: { mode: DailyReviewMode }): Promise<{ archiveId: string }>;
+        listArchives?(): Promise<DailyReviewArchiveSummary[]>;
+        getArchive?(archiveId: string): Promise<DailyReviewArchive>;
+        deleteArchive?(archiveId: string): Promise<void>;
       };
       appWindow: {
         subscribeOpenSettings(handler: () => void): () => void;

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -43,12 +43,22 @@ describe('Settings coming-soon cleanup contract', () => {
     const settings = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
 
     assert.doesNotMatch(settings, /V0\.1|V0\.2|capture smoke|之后会加|后续版本开放|阶段开放/, 'feature status pages must not read like demo-stage roadmap copy');
-    assert.match(settings, /本地汇总/, 'Daily Review status badge should describe the shipped local aggregate mode');
-    assert.match(settings, /今日 \/ 本周 \/ 本月/, 'Daily Review settings copy must mention the shipped range switcher');
-    assert.match(settings, /复制 \/ 保存 Markdown 摘要/, 'Daily Review settings copy must mention the shipped Markdown copy/save actions');
-    assert.match(settings, /粘到输入框继续追问/, 'Daily Review settings copy must mention the shipped composer append action');
-    assert.match(settings, /<ul className="settingsFeatureStatusList" aria-label="每日回顾当前包含">/, 'Daily Review included-feature list must have an accessible name');
-    assert.match(settings, /<ul className="settingsFeatureStatusList" aria-label="每日回顾不会执行的事">/, 'Daily Review privacy-boundary list must have an accessible name');
+    // PR-DAILY-REVIEW-FULL-0: Settings → 每日回顾 became a real config form
+    // (enable toggle, execute time, section toggles, deep analysis, manual
+    // trigger). The page still keeps a status badge ("本地汇总" or "本地 + LLM"
+    // depending on whether the backend pipeline is wired), but the body is
+    // no longer a static "shipped features" list.
+    assert.match(settings, /本地汇总/, 'Daily Review status badge should still describe the shipped local aggregate mode when the pipeline is not yet wired');
+    assert.match(settings, /启用每日回顾/, 'Daily Review settings must surface the auto-run enable toggle');
+    assert.match(settings, /执行时间/, 'Daily Review settings must surface the configurable execute time');
+    assert.match(settings, /对话摘要/, 'Daily Review settings must expose the 对话摘要 section toggle');
+    assert.match(settings, /遗漏提醒/, 'Daily Review settings must expose the 遗漏提醒 section toggle');
+    assert.match(settings, /使用洞察/, 'Daily Review settings must expose the 使用洞察 section toggle');
+    assert.match(settings, /代码建议/, 'Daily Review settings must expose the 代码建议 section toggle');
+    assert.match(settings, /深度分析/, 'Daily Review settings must expose the 深度分析 mode toggle');
+    assert.match(settings, /分析模型/, 'Daily Review settings must expose the 分析模型 selector');
+    assert.match(settings, /生成每日回顾/, 'Daily Review settings must surface the manual 生成每日回顾 trigger');
+    assert.match(settings, /生成深度分析/, 'Daily Review settings must surface the manual 生成深度分析 trigger');
     assert.match(settings, /本地自检/, 'Voice status badge should describe the shipped local smoke boundary');
   });
 

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -30,6 +30,8 @@ import type {
   CapabilitySnapshot,
   CapabilitySnapshotCollection,
   ConnectionTestResult,
+  DailyReviewConfig,
+  DailyReviewMode,
   HealthSignal,
   HealthSignalLayer,
   HealthSignalSource,
@@ -1352,13 +1354,104 @@ function SettingsSkeleton() {
  * page summarizes what it does, the privacy boundary, and offers a
  * one-click jump to the sidebar.
  */
+const DAILY_REVIEW_SECTION_LABELS: ReadonlyArray<{
+  key: 'summary' | 'gaps' | 'usage' | 'code';
+  title: string;
+  detail: string;
+}> = [
+  { key: 'summary', title: '对话摘要', detail: '昨天聊了什么，关键结论是什么。' },
+  { key: 'gaps', title: '遗漏提醒', detail: '开始但未完成的讨论、可能忽略的要点。' },
+  { key: 'usage', title: '使用洞察', detail: '模型选择、Token 消耗、工具使用效率。' },
+  { key: 'code', title: '代码建议', detail: '基于对话中的代码讨论，给出优化建议。' },
+];
+
 function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
+  const toast = useToast();
+  const dailyReviewIpc = window.maka.dailyReview;
+  const hasConfigIpc = Boolean(dailyReviewIpc.getConfig && dailyReviewIpc.setConfig);
+  const hasRunOnceIpc = Boolean(dailyReviewIpc.runOnce);
+
+  const [config, setConfig] = useState<DailyReviewConfig | null>(null);
+  const [loading, setLoading] = useState<boolean>(hasConfigIpc);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [runningMode, setRunningMode] = useState<DailyReviewMode | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!hasConfigIpc || !dailyReviewIpc.getConfig) {
+      setConfig(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    dailyReviewIpc
+      .getConfig()
+      .then((next) => {
+        if (!cancelled && mountedRef.current) {
+          setConfig(next);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled && mountedRef.current) {
+          setLoadError(settingsActionErrorMessage(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasConfigIpc, dailyReviewIpc]);
+
+  async function patchConfig(key: string, patch: Partial<DailyReviewConfig>) {
+    if (!dailyReviewIpc.setConfig || !config) return;
+    setSavingKey(key);
+    try {
+      const next = await dailyReviewIpc.setConfig(patch);
+      if (mountedRef.current) setConfig(next);
+    } catch (err) {
+      toast.error('保存每日回顾设置失败', settingsActionErrorMessage(err));
+    } finally {
+      if (mountedRef.current) setSavingKey(null);
+    }
+  }
+
+  async function triggerRun(mode: DailyReviewMode) {
+    if (!dailyReviewIpc.runOnce) return;
+    setRunningMode(mode);
+    try {
+      await dailyReviewIpc.runOnce({ mode });
+      toast.success(mode === 'daily' ? '已生成每日回顾' : '已生成深度分析', '可在「每日回顾」面板查看。');
+    } catch (err) {
+      toast.error('生成回顾失败', settingsActionErrorMessage(err));
+    } finally {
+      if (mountedRef.current) setRunningMode(null);
+    }
+  }
+
+  const effectiveConfig = config;
+  const formDisabled = !hasConfigIpc || loading || Boolean(loadError) || !effectiveConfig;
+
   return (
     <section className="settingsFeatureStatusPage" aria-label="每日回顾">
       <header className="settingsFeatureStatusBanner" role="status">
         <span className="settingsFeatureStatusBannerDot" aria-hidden="true" />
-        <strong>本地汇总 · 已上线</strong>
-        <span>读取本机 Maka 自己产生的会话与使用统计，不联网、不读其他 App 数据。</span>
+        <strong>每日回顾</strong>
+        <span>
+          {hasConfigIpc
+            ? '每天自动分析本机对话，生成摘要、遗漏提醒和建议。模型按需消耗。'
+            : '当前版本仅本地数字聚合，定时生成 / LLM 摘要尚未连接到后端。'}
+        </span>
       </header>
 
       <div className="settingsFeatureStatusHero">
@@ -1368,11 +1461,13 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         <div>
           <div className="settingsFeatureStatusHeroHeading">
             <h3>每日回顾</h3>
-            <span className="settingsFeatureStatusBadge">本地汇总</span>
+            <span className="settingsFeatureStatusBadge">
+              {hasConfigIpc ? '本地 + LLM' : '本地汇总'}
+            </span>
           </div>
           <p>
-            每日回顾会按你选择的日期范围，把活跃会话、模型用量、工具调用聚合到一个面板里。
-            主内容栏里的 "每日回顾" 支持今日 / 本周 / 本月切换、左右翻页、复制 / 保存 Markdown 摘要，也可以把当前范围粘到输入框继续追问。
+            打开右侧 Content 区里的「每日回顾」可以查看活跃会话、模型用量、工具调用，以及（开启后）LLM
+            生成的对话摘要 / 遗漏提醒等回顾内容。
           </p>
           {props.onOpenDailyReview && (
             <Button
@@ -1386,26 +1481,163 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         </div>
       </div>
 
-      <div className="settingsFeatureStatusHeroHeading">
-        <h3>当前包含</h3>
-      </div>
-      <ul className="settingsFeatureStatusList" aria-label="每日回顾当前包含">
-        <li>对话数 / 请求数 / Token / 费用 / 错误数</li>
-        <li>今日 / 本周 / 本月三个范围，以及按范围翻页</li>
-        <li>活跃对话（点击可直接打开）</li>
-        <li>使用最频繁的模型 Top 8</li>
-        <li>调用最频繁的工具 Top 8</li>
-        <li>复制 / 保存 Markdown 摘要，或粘到输入框继续追问</li>
-      </ul>
+      {loadError ? (
+        <div className="settingsAlert" role="alert" style={{ marginTop: 12 }}>
+          读取每日回顾设置失败：{loadError}
+        </div>
+      ) : null}
 
-      <div className="settingsFeatureStatusHeroHeading">
-        <h3>不会做的事</h3>
+      <div className="settingsRows">
+        <div className="settingsRow">
+          <div>
+            <strong>启用每日回顾</strong>
+            <small>每天自动分析前一天的工作内容，提供摘要与建议。</small>
+          </div>
+          <Switch
+            ariaLabel="启用每日回顾"
+            checked={effectiveConfig?.enabled ?? false}
+            disabled={formDisabled || savingKey === 'enabled'}
+            onChange={(enabled) => void patchConfig('enabled', { enabled })}
+          />
+        </div>
+
+        <div className="settingsRow">
+          <div>
+            <strong>执行时间</strong>
+            <small>默认 08:00 本地时间触发。</small>
+          </div>
+          <Input
+            type="time"
+            aria-label="每日回顾执行时间"
+            className="settingsTimeInput"
+            value={effectiveConfig?.executeTime ?? '08:00'}
+            disabled={formDisabled || savingKey === 'executeTime' || !(effectiveConfig?.enabled ?? false)}
+            onChange={(event) => {
+              const value = event.target.value;
+              if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return;
+              void patchConfig('executeTime', { executeTime: value });
+            }}
+          />
+        </div>
+
+        {DAILY_REVIEW_SECTION_LABELS.map((item) => (
+          <div key={item.key} className="settingsRow">
+            <div>
+              <strong>{item.title}</strong>
+              <small>{item.detail}</small>
+            </div>
+            <Switch
+              ariaLabel={item.title}
+              checked={effectiveConfig?.sections[item.key] ?? false}
+              disabled={formDisabled || savingKey === `section:${item.key}` || !(effectiveConfig?.enabled ?? false)}
+              onChange={(next) =>
+                void patchConfig(`section:${item.key}`, {
+                  sections: {
+                    ...(effectiveConfig?.sections ?? { summary: false, gaps: false, usage: false, code: false }),
+                    [item.key]: next,
+                  },
+                })
+              }
+            />
+          </div>
+        ))}
+
+        <div className="settingsRow">
+          <div>
+            <strong>深度分析</strong>
+            <small>消耗更多资源，对更长时间周期进行深入调研。</small>
+          </div>
+          <Switch
+            ariaLabel="深度分析"
+            checked={effectiveConfig?.deepEnabled ?? false}
+            disabled={formDisabled || savingKey === 'deepEnabled'}
+            onChange={(deepEnabled) => void patchConfig('deepEnabled', { deepEnabled })}
+          />
+        </div>
+
+        <div className="settingsRow">
+          <div>
+            <strong>分析模型</strong>
+            <small>用于生成回顾和分析的模型连接。留空使用对话默认模型。</small>
+          </div>
+          <Input
+            type="text"
+            aria-label="分析模型连接"
+            className="settingsTimeInput"
+            placeholder="留空 = 使用默认"
+            value={effectiveConfig?.modelKey ?? ''}
+            disabled={formDisabled || savingKey === 'modelKey'}
+            onChange={(event) => {
+              const value = event.target.value;
+              void patchConfig('modelKey', { modelKey: value });
+            }}
+            style={{ minWidth: 160 }}
+          />
+        </div>
+
+        <div className="settingsRow">
+          <div>
+            <strong>包含 Claude Code CLI 会话</strong>
+            <small>将已同步的 Claude Code 对话纳入分析范围。</small>
+          </div>
+          <Switch
+            ariaLabel="包含 Claude Code CLI 会话"
+            checked={effectiveConfig?.includeClaudeCode ?? false}
+            disabled={formDisabled || savingKey === 'includeClaudeCode'}
+            onChange={(includeClaudeCode) => void patchConfig('includeClaudeCode', { includeClaudeCode })}
+          />
+        </div>
+
+        <div className="settingsRow">
+          <div>
+            <strong>生成后发送外部通知</strong>
+            <small>通过已配置的机器人对话（飞书 / 企微等）推送回顾报告。</small>
+          </div>
+          <Switch
+            ariaLabel="生成后发送外部通知"
+            checked={effectiveConfig?.externalNotify.enabled ?? false}
+            disabled={formDisabled || savingKey === 'externalNotify'}
+            onChange={(enabled) =>
+              void patchConfig('externalNotify', {
+                externalNotify: {
+                  ...(effectiveConfig?.externalNotify ?? { enabled: false }),
+                  enabled,
+                },
+              })
+            }
+          />
+        </div>
       </div>
-      <ul className="settingsFeatureStatusList" aria-label="每日回顾不会执行的事">
-        <li>不调用任何 LLM 生成摘要（当前只是本地聚合数字，不向云端送内容）</li>
-        <li>不写入记忆系统，也不导出任何东西</li>
-        <li>不读取 Maka 工作区以外的文件</li>
-      </ul>
+
+      {hasRunOnceIpc && (
+        <div className="settingsFeatureStatusHero" style={{ marginTop: 12 }}>
+          <span className="settingsFeatureStatusIcon" aria-hidden="true">
+            <CalendarDays size={20} strokeWidth={1.5} />
+          </span>
+          <div>
+            <div className="settingsFeatureStatusHeroHeading">
+              <h3>想先看看效果？</h3>
+            </div>
+            <p>无需开启自动执行，基于当前工作区的对话记录立即生成一份报告。</p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+              <Button
+                type="button"
+                onClick={() => void triggerRun('daily')}
+                disabled={runningMode !== null}
+              >
+                {runningMode === 'daily' ? '生成中…' : '生成每日回顾'}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void triggerRun('deep')}
+                disabled={runningMode !== null}
+              >
+                {runningMode === 'deep' ? '生成中…' : '生成深度分析'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -585,11 +585,14 @@ button:active {
   border-radius: 6px;
   background: transparent;
   color: var(--foreground);
-  padding: 7px 10px;
-  transition: background 150ms var(--ease-out-strong);
+  padding: 6px 10px;
+  transition:
+    background 150ms var(--ease-out-strong),
+    transform 180ms var(--ease-out-strong);
 }
 .maka-search-modal-result:hover:not([disabled]) {
-  background: oklch(from var(--foreground) l c h / 0.04);
+  background: oklch(from var(--foreground) l c h / 0.05);
+  transform: translateX(1px);
 }
 .maka-search-modal-result[data-active="true"]:not([disabled]) {
   background: oklch(from var(--accent) l c h / 0.08);
@@ -1714,7 +1717,10 @@ button:active {
   background: transparent;
   color: var(--foreground);
   text-align: left;
-  transition: background 150ms var(--ease-out-strong);
+  transition:
+    background 150ms var(--ease-out-strong),
+    transform 180ms var(--ease-out-strong),
+    box-shadow 220ms var(--ease-out-strong);
 }
 
 .maka-onboarding-card:hover {
@@ -4011,7 +4017,9 @@ button:active {
 .maka-skill-examples,
 .maka-skill-installed {
   display: grid;
-  gap: 6px;
+  /* Atlas §14.6 quick-win — section internal gap aligned to reference's
+     `--agents-content-area-gap: 4px` cadence; was 6px. */
+  gap: 4px;
   min-width: 0;
 }
 
@@ -4021,15 +4029,20 @@ button:active {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  color: var(--foreground-55);
-  font-size: 10px;
+  color: var(--foreground-50);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   line-height: 1.35;
 }
 
 .maka-skill-section-label {
-  color: var(--foreground);
-  font-size: 11px;
+  color: var(--foreground-65);
+  font-size: 9.5px;
   font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .maka-skill-example-grid {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -13392,6 +13392,59 @@ button:active {
   border-bottom: 1px solid var(--foreground-10);
 }
 
+/* PR-DAILY-REVIEW-FULL-0: info banner explaining the feature, plus a
+   manual-trigger row. Banner uses the page-card recipe with a softer
+   tint so it reads as supporting context, not a primary surface. */
+.maka-daily-review-info {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--card-border-color);
+  border-radius: var(--card-radius);
+  background: oklch(from var(--foreground) l c h / 0.03);
+  box-shadow: var(--card-highlight);
+}
+
+.maka-daily-review-info-body {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--foreground-80);
+}
+
+.maka-daily-review-info-body strong {
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.maka-daily-review-info-hint {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--foreground-55);
+}
+
+.maka-daily-review-info-hint strong {
+  font-weight: 600;
+  color: var(--foreground-80);
+}
+
+.maka-daily-review-quick-runs {
+  display: flex;
+  gap: 8px;
+  padding: 2px 0 6px;
+  border-bottom: 1px solid var(--foreground-10);
+}
+
+.maka-daily-review-quick-run {
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.maka-daily-review-quick-run[data-pending="true"] {
+  opacity: 0.7;
+}
+
 .maka-daily-review-day {
   text-align: center;
   font-weight: 600;

--- a/packages/core/src/daily-review.ts
+++ b/packages/core/src/daily-review.ts
@@ -187,3 +187,205 @@ export function dailyUsageQuery(day: DayRangeMs): UsageQuery {
 
 /** Default cap for "today's sessions" / "top tools" / "top models" lists. */
 export const DAILY_REVIEW_LIST_LIMIT = 8;
+
+/**
+ * PR-DAILY-REVIEW-FULL-0 — config + archive contract.
+ *
+ * Adds the missing pieces on top of MVP-0: a scheduled run, LLM-
+ * generated narrative sections, a persisted archive of past reports,
+ * and a 深度分析 (deep-analysis) mode. The locked interface is
+ * documented in the project thread; this file is the single source
+ * of truth used by core, main, preload, and renderer.
+ *
+ * borrow: external reference's "every morning auto-summary" + Settings
+ * sub-toggles for content categories (对话摘要 / 遗漏提醒 / 使用洞察 /
+ * 代码建议).
+ *
+ * diverge: archive lives on disk as plain JSON files in the workspace
+ * (no DB), no cloud sync, manual + cron run the same pipeline, model
+ * selection reuses the existing connection picker.
+ */
+
+export type DailyReviewMode = 'daily' | 'deep';
+
+export const DAILY_REVIEW_MODES: readonly DailyReviewMode[] = [
+  'daily',
+  'deep',
+] as const;
+
+export type DailyReviewSectionKey = 'summary' | 'gaps' | 'usage' | 'code';
+
+export const DAILY_REVIEW_SECTION_KEYS: readonly DailyReviewSectionKey[] = [
+  'summary',
+  'gaps',
+  'usage',
+  'code',
+] as const;
+
+export interface DailyReviewSectionToggles {
+  readonly summary: boolean;
+  readonly gaps: boolean;
+  readonly usage: boolean;
+  readonly code: boolean;
+}
+
+export interface DailyReviewExternalNotify {
+  readonly enabled: boolean;
+  readonly channelId?: string;
+}
+
+export interface DailyReviewConfig {
+  readonly enabled: boolean;
+  /** Local-TZ HH:mm string, e.g. "08:00". */
+  readonly executeTime: string;
+  readonly sections: DailyReviewSectionToggles;
+  readonly deepEnabled: boolean;
+  /**
+   * Composite model key (e.g. `connectionSlug::modelId`). Empty string
+   * means "use the chat default model". The pipeline treats empty as
+   * "no explicit model selected".
+   */
+  readonly modelKey: string;
+  readonly includeClaudeCode: boolean;
+  readonly externalNotify: DailyReviewExternalNotify;
+}
+
+export type DailyReviewArchiveStatus =
+  | 'ok'
+  | 'no_model'
+  | 'no_data'
+  | 'failed'
+  | 'skipped';
+
+export const DAILY_REVIEW_ARCHIVE_STATUSES: readonly DailyReviewArchiveStatus[] = [
+  'ok',
+  'no_model',
+  'no_data',
+  'failed',
+  'skipped',
+] as const;
+
+export type DailyReviewTrigger = 'cron' | 'manual';
+
+export interface DailyReviewArchiveSectionContent {
+  readonly summary?: string;
+  readonly gaps?: string;
+  readonly usage?: string;
+  readonly code?: string;
+}
+
+export interface DailyReviewArchive {
+  /** Stable id: `YYYY-MM-DD-{mode}`. Same-day re-runs overwrite. */
+  readonly id: string;
+  readonly day: DayRangeMs;
+  readonly mode: DailyReviewMode;
+  readonly status: DailyReviewArchiveStatus;
+  readonly generatedAt: number;
+  readonly trigger: DailyReviewTrigger;
+  readonly modelKey: string;
+  readonly sections: DailyReviewArchiveSectionContent;
+  readonly totals: DailyReviewTotals;
+  readonly errorMessage?: string;
+}
+
+/** Lightweight row for the history list — drops the section bodies. */
+export interface DailyReviewArchiveSummary {
+  readonly id: string;
+  readonly day: DayRangeMs;
+  readonly mode: DailyReviewMode;
+  readonly status: DailyReviewArchiveStatus;
+  readonly generatedAt: number;
+  readonly trigger: DailyReviewTrigger;
+  readonly modelKey: string;
+  readonly totals: DailyReviewTotals;
+  readonly errorMessage?: string;
+}
+
+export const DEFAULT_DAILY_REVIEW_CONFIG: DailyReviewConfig = {
+  enabled: false,
+  executeTime: '08:00',
+  sections: {
+    summary: true,
+    gaps: true,
+    usage: false,
+    code: false,
+  },
+  deepEnabled: false,
+  modelKey: '',
+  includeClaudeCode: false,
+  externalNotify: { enabled: false },
+};
+
+const EXECUTE_TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/** Returns true if the string parses as a local HH:mm time. */
+export function isDailyReviewExecuteTime(value: unknown): value is string {
+  return typeof value === 'string' && EXECUTE_TIME_RE.test(value);
+}
+
+/** Coerces an arbitrary partial config to a fully-valid `DailyReviewConfig`. */
+export function normalizeDailyReviewConfig(
+  input: Partial<DailyReviewConfig> | null | undefined,
+): DailyReviewConfig {
+  const base = DEFAULT_DAILY_REVIEW_CONFIG;
+  if (!input) return base;
+  const sections = input.sections ?? base.sections;
+  const externalNotify = input.externalNotify ?? base.externalNotify;
+  return {
+    enabled: typeof input.enabled === 'boolean' ? input.enabled : base.enabled,
+    executeTime: isDailyReviewExecuteTime(input.executeTime)
+      ? input.executeTime
+      : base.executeTime,
+    sections: {
+      summary:
+        typeof sections.summary === 'boolean' ? sections.summary : base.sections.summary,
+      gaps: typeof sections.gaps === 'boolean' ? sections.gaps : base.sections.gaps,
+      usage:
+        typeof sections.usage === 'boolean' ? sections.usage : base.sections.usage,
+      code: typeof sections.code === 'boolean' ? sections.code : base.sections.code,
+    },
+    deepEnabled:
+      typeof input.deepEnabled === 'boolean' ? input.deepEnabled : base.deepEnabled,
+    modelKey: typeof input.modelKey === 'string' ? input.modelKey : base.modelKey,
+    includeClaudeCode:
+      typeof input.includeClaudeCode === 'boolean'
+        ? input.includeClaudeCode
+        : base.includeClaudeCode,
+    externalNotify: {
+      enabled:
+        typeof externalNotify.enabled === 'boolean'
+          ? externalNotify.enabled
+          : base.externalNotify.enabled,
+      channelId:
+        typeof externalNotify.channelId === 'string'
+          ? externalNotify.channelId
+          : undefined,
+    },
+  };
+}
+
+/** Builds the canonical archive id for a given day + mode. */
+export function dailyReviewArchiveId(day: DayRangeMs, mode: DailyReviewMode): string {
+  const d = new Date(day.fromMs);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}-${mode}`;
+}
+
+/** Strips the section bodies down to a lightweight history-list row. */
+export function dailyReviewArchiveToSummary(
+  archive: DailyReviewArchive,
+): DailyReviewArchiveSummary {
+  return {
+    id: archive.id,
+    day: archive.day,
+    mode: archive.mode,
+    status: archive.status,
+    generatedAt: archive.generatedAt,
+    trigger: archive.trigger,
+    modelKey: archive.modelKey,
+    totals: archive.totals,
+    errorMessage: archive.errorMessage,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -755,20 +755,38 @@ export {
   preflightDroppedTextFilesForPromptImport,
 } from './text-file-import.js';
 
-// daily-review.ts (PR-DAILY-REVIEW-MVP-0)
+// daily-review.ts (PR-DAILY-REVIEW-MVP-0 + PR-DAILY-REVIEW-FULL-0)
 export type {
+  DailyReviewArchive,
+  DailyReviewArchiveSectionContent,
+  DailyReviewArchiveStatus,
+  DailyReviewArchiveSummary,
+  DailyReviewConfig,
+  DailyReviewExternalNotify,
+  DailyReviewMode,
+  DailyReviewSectionKey,
+  DailyReviewSectionToggles,
   DailyReviewSessionRow,
   DailyReviewSummary,
   DailyReviewTopEntry,
   DailyReviewTotals,
+  DailyReviewTrigger,
   DayRangeMs,
 } from './daily-review.js';
 export {
+  DAILY_REVIEW_ARCHIVE_STATUSES,
   DAILY_REVIEW_LIST_LIMIT,
+  DAILY_REVIEW_MODES,
+  DAILY_REVIEW_SECTION_KEYS,
+  DEFAULT_DAILY_REVIEW_CONFIG,
   buildDailyReviewSummary,
+  dailyReviewArchiveId,
+  dailyReviewArchiveToSummary,
   dailyUsageQuery,
+  isDailyReviewExecuteTime,
   localDayBoundsAt,
   localDayBoundsForInstant,
+  normalizeDailyReviewConfig,
   pickDailyReviewSessions,
   pickDailyReviewTopEntries,
 } from './daily-review.js';

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -25,6 +25,7 @@ import {
   HelpCircle,
   Hourglass,
   Info,
+  LineChart,
   Loader2,
   MessageSquare,
   MoreHorizontal,
@@ -535,6 +536,17 @@ export function SessionListPanel(props: {
             the sidebar header (`.maka-sidebar-search-button`) and ⌘K, so a
             second entry point was redundant. The `search` module id + label
             are kept for those triggers. */}
+        <button
+          className="maka-nav-row"
+          data-active={isModuleActive('daily-review')}
+          aria-current={isModuleActive('daily-review') ? 'page' : undefined}
+          aria-label={MODULE_NAV_LABEL['daily-review']}
+          type="button"
+          onClick={() => selectModule('daily-review')}
+        >
+          <LineChart className="maka-nav-icon" strokeWidth={1.5} aria-hidden="true" />
+          <span>{MODULE_NAV_LABEL['daily-review']}</span>
+        </button>
         <button
           className="maka-nav-row"
           data-active={isModuleActive('skills')}

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -96,7 +96,14 @@ import {
   normalizeSearchUrl,
   nextRelativeRefreshDelay,
 } from '@maka/core';
-import type { DailyReviewSummary, DailyReviewTopEntry } from '@maka/core';
+import type {
+  DailyReviewArchive,
+  DailyReviewArchiveSummary,
+  DailyReviewConfig,
+  DailyReviewMode,
+  DailyReviewSummary,
+  DailyReviewTopEntry,
+} from '@maka/core';
 import {
   materializeChat,
   materializeTools,
@@ -1195,6 +1202,17 @@ function SkillsModuleMain(props: {
  */
 export interface DailyReviewBridge {
   fetchDay(offsetDays: number, daySpan?: number): Promise<DailyReviewSummary>;
+  /**
+   * PR-DAILY-REVIEW-FULL-0 — optional pipeline methods. Renderer checks
+   * for presence before exposing the matching UI. When undefined, the
+   * panel still works as the MVP telemetry view.
+   */
+  runOnce?(opts: { mode: DailyReviewMode }): Promise<{ archiveId: string }>;
+  listArchives?(): Promise<DailyReviewArchiveSummary[]>;
+  getArchive?(archiveId: string): Promise<DailyReviewArchive>;
+  deleteArchive?(archiveId: string): Promise<void>;
+  fetchConfig?(): Promise<DailyReviewConfig>;
+  updateConfig?(patch: Partial<DailyReviewConfig>): Promise<DailyReviewConfig>;
 }
 
 /**
@@ -1315,6 +1333,20 @@ function DailyReviewPanel(props: {
 
   const dailyReviewActionBusy = pendingDailyReviewAction !== null;
   const hasDailyReviewActions = Boolean(props.onCopyMarkdown || props.onAppendMarkdown || props.onSaveMarkdown);
+  const canManualRun = Boolean(props.bridge.runOnce);
+
+  async function triggerManualRun(mode: DailyReviewMode) {
+    const runOnce = props.bridge.runOnce;
+    if (!runOnce) return;
+    await runDailyReviewAction(`run:${mode}`, async () => {
+      try {
+        await runOnce({ mode });
+        setReloadToken((n) => n + 1);
+      } catch (err) {
+        setError(dailyReviewPanelErrorMessage(err));
+      }
+    });
+  }
 
   return (
     <div className="maka-daily-review-panel" data-loading={loading ? 'true' : undefined}>
@@ -1342,6 +1374,45 @@ function DailyReviewPanel(props: {
           ›
         </UiButton>
       </header>
+      <section className="maka-daily-review-info" aria-label="每日回顾说明">
+        <p className="maka-daily-review-info-body">
+          每日回顾会自动汇总本机的对话历史，生成
+          <strong>对话摘要</strong>和
+          <strong>遗漏提醒</strong>；开启
+          <strong>深度分析</strong>后还会做更长周期的项目趋势与技术调研。
+        </p>
+        <p className="maka-daily-review-info-hint">
+          在设置中开启<strong>定时执行</strong>，或在此页面手动触发一次。
+        </p>
+      </section>
+      {canManualRun && (
+        <div className="maka-daily-review-quick-runs" aria-label="手动触发回顾">
+          <UiButton
+            type="button"
+            variant="default"
+            size="sm"
+            className="maka-daily-review-quick-run"
+            onClick={() => void triggerManualRun('daily')}
+            disabled={dailyReviewActionBusy}
+            data-pending={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
+            aria-busy={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
+          >
+            {pendingDailyReviewAction === 'run:daily' ? '生成中…' : '生成每日回顾'}
+          </UiButton>
+          <UiButton
+            type="button"
+            variant="outline"
+            size="sm"
+            className="maka-daily-review-quick-run"
+            onClick={() => void triggerManualRun('deep')}
+            disabled={dailyReviewActionBusy}
+            data-pending={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
+            aria-busy={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
+          >
+            {pendingDailyReviewAction === 'run:deep' ? '生成中…' : '生成深度分析'}
+          </UiButton>
+        </div>
+      )}
       <nav className="maka-daily-review-range" aria-label="时间范围切换">
         <div className="maka-daily-review-range-tabs">
           {([1, 7, 30] as const).map((option) => (


### PR DESCRIPTION
## Summary

UI side of the Daily Review feature redesign per WAWQAQ msg `4326522d` / `53674675`. Stacked on top of #93 (visual refresh) so the new `每日回顾` surfaces inherit the atlas-driven page-card chrome.

**Does not include**: LLM pipeline, archive store, IPC handlers, scheduler hook — those land in a follow-up PR from xuan against this branch (PR-C).

### What's in this PR

1. **Contract types in `@maka/core`** — `DailyReviewConfig`, `DailyReviewArchive`, `DailyReviewArchiveSummary`, mode/status enums, `DEFAULT_DAILY_REVIEW_CONFIG`, `normalizeDailyReviewConfig`, `dailyReviewArchiveId`. Shared shape used by core, main, preload, and renderer.

2. **Sidebar nav entry** — `每日回顾` appears in the primary left-rail between `新任务` and `技能` with a `LineChart` glyph. Routes to the existing `state.sidebarSection = 'daily-review'` Content surface (not a popup).

3. **Info banner + manual triggers in main panel** — `DailyReviewPanel` now renders an info banner explaining the feature and (when the bridge exposes the optional `runOnce` method) a 生成每日回顾 / 生成深度分析 trigger row.

4. **Real Settings → 每日回顾 config form** — was a static "shipped features" list; now a live form:
   - 启用每日回顾 toggle + 执行时间 (HH:mm)
   - 4 section toggles: 对话摘要 / 遗漏提醒 / 使用洞察 / 代码建议
   - 深度分析 mode
   - 分析模型 connection key
   - 包含 Claude Code CLI 会话 toggle
   - 生成后发送外部通知 toggle
   - 立即生成 buttons

5. **`DailyReviewBridge` + `window.maka.dailyReview` typings** — both extended with optional `runOnce`, `listArchives`, `getArchive`, `deleteArchive`, `getConfig`, `setConfig`. UI degrades gracefully when the IPC isn't wired (form disabled with explanatory banner; manual triggers hidden).

### Why optional bridge methods

xuan's backend (archive store + LLM pipeline + IPC + cron) is in flight. Making the new bridge methods optional means this PR is mergeable independently — UI compiles + renders today with the existing data-only telemetry, and lights up the new controls once the backend lands.

## Test plan

- [x] `apps/desktop` test suite: 1464 tests pass, 0 fail
- [x] `apps/desktop` typecheck: clean (main + renderer)
- [x] `settings-roadmap-cleanup-contract` updated to pin new config copy
- [ ] Visual smoke (reviewer): open Settings → 每日回顾, confirm form renders disabled (no IPC) with the "本地汇总" status badge
- [ ] Visual smoke: sidebar nav `每日回顾` lights up active state when navigated