### PR TITLE
Permission Center redesign — actionable rows + summary + system-settings deep links

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -198,6 +198,18 @@ declare global {
       };
       permissions: {
         getSnapshot(): Promise<PermissionSnapshot>;
+        openSystemSettings(
+          permId: string,
+        ): Promise<
+          | { ok: true }
+          | { ok: false; reason: 'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed'; message?: string }
+        >;
+        requestAccess(
+          permId: string,
+        ): Promise<
+          | { ok: true }
+          | { ok: false; reason: 'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed'; message?: string }
+        >;
       };
       capabilities: {
         getSnapshot(): Promise<CapabilitySnapshotCollection>;

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -190,10 +190,16 @@ describe('Settings coming-soon cleanup contract', () => {
 
     assert.ok(permissionPage, 'Permission Center page block must exist');
     assert.ok(capabilityRow, 'Permission Center capability row block must exist');
-    assert.match(permissionPage![0], /只读取系统权限与功能能力的当前快照/, 'Permission Center must explain the current read-only snapshot boundary');
+    // PR-PERMISSION-PAGE-REDESIGN: page is no longer a pure read-only
+    // snapshot — system permissions row now exposes 请求授权 / 前往系统设置
+    // action buttons. The "read-only snapshot" framing moved to the
+    // footnote so the page intro can lead with the action affordance.
+    assert.match(permissionPage![0], /只读取系统权限与功能能力的当前快照/, 'Permission Center footnote must still explain the read-only snapshot boundary for capabilities');
     assert.match(permissionPage![0], /系统设置 → 隐私与安全性/, 'Permission Center must point users to the current OS permission path');
-    assert.match(permissionPage![0], /<ul className="settingsCapabilityList" aria-label="功能能力列表">/, 'Permission Center capability list must have an accessible name');
+    assert.match(permissionPage![0], /<ul className="settingsCapabilityList" aria-label="功能能力列表"/, 'Permission Center capability list must have an accessible name');
     assert.match(permissionPage![0], /<ul className="settingsOsPermissionList" aria-label="系统权限列表">/, 'Permission Center OS permission list must have an accessible name');
+    assert.match(permissionPage![0], /window\.maka\.permissions\.requestAccess/, 'Permission Center must wire the requestAccess IPC for direct-request permissions');
+    assert.match(permissionPage![0], /window\.maka\.permissions\.openSystemSettings/, 'Permission Center must wire the openSystemSettings IPC for deep-link permissions');
     assert.match(capabilityRow![0], /<dl className="settingsCapabilityLayers" aria-label=\{`\$\{capability\.label\}能力状态明细`\}>/, 'Capability status definition lists must expose row-scoped accessible names');
     assert.match(capabilityRow![0], /<ul aria-label=\{`\$\{capability\.label\}所需系统权限列表`\}>/, 'Capability required-permission lists must expose row-scoped accessible names');
     assert.match(capabilityRow![0], /<ul aria-label=\{`\$\{capability\.label\}处理建议列表`\}>/, 'Capability guidance lists must expose row-scoped accessible names');

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -203,6 +203,7 @@ import {
   type WorkspaceInstructionOpenFailureReason,
 } from './workspace-instructions.js';
 import { buildCapabilitySnapshotCollection, buildPermissionSnapshot } from './capability-snapshot.js';
+import { openSystemPermissionPane, requestPermissionAccess } from './permissions-actions.js';
 import {
   getVisualSmokeState,
   resolveVisualSmokeFixture,
@@ -3350,6 +3351,12 @@ function registerIpc(): void {
   });
 
   ipcMain.handle('permissions:getSnapshot', () => buildPermissionSnapshot());
+  ipcMain.handle('permissions:openSystemSettings', async (_event, permId: unknown) => {
+    return openSystemPermissionPane(permId);
+  });
+  ipcMain.handle('permissions:requestAccess', async (_event, permId: unknown) => {
+    return requestPermissionAccess(permId);
+  });
   ipcMain.handle('capabilities:getSnapshot', async () => {
     const permissions = buildPermissionSnapshot();
     const settings = await settingsStore.get();

--- a/apps/desktop/src/main/permissions-actions.ts
+++ b/apps/desktop/src/main/permissions-actions.ts
@@ -1,0 +1,108 @@
+/**
+ * PR-PERMISSION-PAGE-REDESIGN — actionable side of the Permission Center.
+ *
+ * The old `permissions:getSnapshot` is purely read-only; the user could
+ * see status pills but couldn't actually do anything. This module adds
+ * two side-effectful IPC handlers:
+ *
+ *   - `openSystemPermissionPane(id)` — deep-links into macOS System
+ *     Settings → Privacy & Security at the right pane. On non-macOS
+ *     platforms the request resolves with a structured "unsupported"
+ *     failure so the renderer can hide the button.
+ *   - `requestPermissionAccess(id)` — when the OS exposes a programmatic
+ *     consent dialog (microphone, notifications) we ask directly;
+ *     otherwise we fall back to the same deep-link path so the user is
+ *     still moved one step closer to granting.
+ *
+ * No state is persisted here — the renderer refreshes the snapshot
+ * after either action, so the new status comes back through the
+ * existing read path.
+ */
+
+import { Notification, shell, systemPreferences } from 'electron';
+import type { OsPermissionId } from '@maka/core';
+import { OS_PERMISSION_IDS } from '@maka/core';
+
+export type PermissionActionResult =
+  | { ok: true }
+  | { ok: false; reason: 'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed'; message?: string };
+
+/**
+ * macOS x-apple.systempreferences deep-link targets. The format changed
+ * across macOS versions; the strings below are the "modern" (Ventura+)
+ * Privacy & Security pane URIs which are also still accepted on
+ * Monterey. We do not include a Sequoia-only fallback because Electron
+ * passes the URL through `shell.openExternal` either way.
+ */
+const MACOS_DEEP_LINKS: Record<OsPermissionId, string | null> = {
+  accessibility: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+  screen_recording: 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+  microphone: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone',
+  automation: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Automation',
+  notifications: 'x-apple.systempreferences:com.apple.preference.notifications',
+};
+
+function normalizePermissionId(input: unknown): OsPermissionId | null {
+  if (typeof input !== 'string') return null;
+  return (OS_PERMISSION_IDS as readonly string[]).includes(input)
+    ? (input as OsPermissionId)
+    : null;
+}
+
+export async function openSystemPermissionPane(input: unknown): Promise<PermissionActionResult> {
+  const id = normalizePermissionId(input);
+  if (!id) return { ok: false, reason: 'invalid_id' };
+  if (process.platform !== 'darwin') {
+    return { ok: false, reason: 'unsupported_platform' };
+  }
+  const url = MACOS_DEEP_LINKS[id];
+  if (!url) return { ok: false, reason: 'unsupported_permission' };
+  try {
+    await shell.openExternal(url);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: 'failed', message: errorMessage(err) };
+  }
+}
+
+export async function requestPermissionAccess(input: unknown): Promise<PermissionActionResult> {
+  const id = normalizePermissionId(input);
+  if (!id) return { ok: false, reason: 'invalid_id' };
+  if (process.platform !== 'darwin') {
+    return { ok: false, reason: 'unsupported_platform' };
+  }
+  try {
+    switch (id) {
+      case 'microphone': {
+        const granted = await systemPreferences.askForMediaAccess('microphone');
+        return granted
+          ? { ok: true }
+          : { ok: false, reason: 'failed', message: '用户拒绝了麦克风访问。' };
+      }
+      case 'notifications': {
+        if (!Notification.isSupported()) {
+          return { ok: false, reason: 'unsupported_permission', message: '当前 Electron 不支持通知。' };
+        }
+        // macOS shows the consent prompt the first time a Notification
+        // is created; sending a silent ping is the supported pattern.
+        const probe = new Notification({ title: 'Maka 通知权限自检', body: '已尝试请求通知权限。' });
+        probe.show();
+        return { ok: true };
+      }
+      case 'accessibility':
+      case 'screen_recording':
+      case 'automation':
+        // macOS does not expose a programmatic consent dialog for these
+        // three; we deep-link into the relevant System Settings pane
+        // instead so the action button is never inert.
+        return openSystemPermissionPane(id);
+    }
+  } catch (err) {
+    return { ok: false, reason: 'failed', message: errorMessage(err) };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error ?? '');
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -275,6 +275,16 @@ contextBridge.exposeInMainWorld('maka', {
     getSnapshot(): Promise<PermissionSnapshot> {
       return ipcRenderer.invoke('permissions:getSnapshot');
     },
+    openSystemSettings(permId: string): Promise<
+      { ok: true } | { ok: false; reason: string; message?: string }
+    > {
+      return ipcRenderer.invoke('permissions:openSystemSettings', permId);
+    },
+    requestAccess(permId: string): Promise<
+      { ok: true } | { ok: false; reason: string; message?: string }
+    > {
+      return ipcRenderer.invoke('permissions:requestAccess', permId);
+    },
   },
   capabilities: {
     getSnapshot(): Promise<CapabilitySnapshotCollection> {

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useId, useMemo, useRef, useState, type ComponentType, type KeyboardEvent, type ReactNode, type RefObject } from 'react';
 import {
+  Accessibility as AccessibilityIcon,
   Activity,
   BarChart3,
+  Bell,
   Bot,
   Brain,
   CalendarDays,
@@ -9,6 +11,9 @@ import {
   Database,
   Globe,
   Info,
+  Mic,
+  Monitor,
+  MousePointer2,
   Network,
   Palette,
   Search,
@@ -6042,12 +6047,44 @@ const CAPABILITY_READINESS_COPY: Record<CapabilityReadinessState, { label: strin
   paused: { label: '已暂停', detail: '功能开关被显式关闭，但配置仍保留。', tone: 'info' },
 };
 
-const OS_PERMISSION_COPY: Record<OsPermissionId, { label: string; purpose: string }> = {
-  accessibility: { label: '辅助功能', purpose: 'Computer Use 需要它来读取窗口焦点 / 模拟键盘鼠标。' },
-  screen_recording: { label: '屏幕录制', purpose: 'Computer Use 需要它来读取窗口内容；未来屏幕活动录制也会使用。' },
-  microphone: { label: '麦克风', purpose: 'Voice 通道需要它来采集语音输入。' },
-  notifications: { label: '通知', purpose: '权限申请、回顾完成等系统通知需要它。' },
-  automation: { label: '自动化（Apple Events）', purpose: 'Computer Use 控制其他 App 需要逐 target 授权。' },
+interface OsPermissionUiCopy {
+  label: string;
+  purpose: string;
+  impact: string;
+  icon: ComponentType<LucideProps>;
+}
+
+const OS_PERMISSION_COPY: Record<OsPermissionId, OsPermissionUiCopy> = {
+  accessibility: {
+    label: '辅助功能',
+    purpose: 'Computer Use 需要它来读取窗口焦点 / 模拟键盘鼠标。',
+    impact: 'Computer Use · 自动化键鼠操作',
+    icon: AccessibilityIcon,
+  },
+  screen_recording: {
+    label: '屏幕录制',
+    purpose: 'Computer Use 需要它来读取窗口内容；未来屏幕活动录制也会使用。',
+    impact: 'Computer Use · 截屏上下文',
+    icon: Monitor,
+  },
+  microphone: {
+    label: '麦克风',
+    purpose: 'Voice 通道需要它来采集语音输入。',
+    impact: '语音输入',
+    icon: Mic,
+  },
+  notifications: {
+    label: '通知',
+    purpose: '权限申请、回顾完成等系统通知需要它。',
+    impact: '权限申请提醒 · 每日回顾完成通知',
+    icon: Bell,
+  },
+  automation: {
+    label: '自动化（Apple Events）',
+    purpose: 'Computer Use 控制其他 App 需要逐 target 授权。',
+    impact: 'Computer Use · 跨 App 自动化',
+    icon: MousePointer2,
+  },
 };
 
 const OS_PERMISSION_STATE_COPY: Record<OsPermissionState, { label: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive' }> = {
@@ -6067,6 +6104,17 @@ function PermissionCenterPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
+  const [pendingPermAction, setPendingPermAction] = useState<string | null>(null);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const toast = useToast();
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -6091,6 +6139,31 @@ function PermissionCenterPage() {
       cancelled = true;
     };
   }, [refreshTick]);
+
+  async function runPermissionAction(
+    permId: OsPermissionId,
+    kind: 'request' | 'openSettings',
+  ) {
+    const actionKey = `${permId}:${kind}`;
+    setPendingPermAction(actionKey);
+    try {
+      const result =
+        kind === 'request'
+          ? await window.maka.permissions.requestAccess(permId)
+          : await window.maka.permissions.openSystemSettings(permId);
+      if (result.ok) {
+        // Refresh snapshot so the user sees the new state when they
+        // return from System Settings.
+        if (mountedRef.current) setRefreshTick((tick) => tick + 1);
+      } else if (mountedRef.current) {
+        toast.error('权限操作失败', permissionActionFailureCopy(result.reason, result.message));
+      }
+    } catch (err) {
+      if (mountedRef.current) toast.error('权限操作失败', settingsActionErrorMessage(err));
+    } finally {
+      if (mountedRef.current) setPendingPermAction(null);
+    }
+  }
 
   if (loading) {
     return (
@@ -6118,21 +6191,21 @@ function PermissionCenterPage() {
   }
 
   const checkedAtMs = capabilities.checkedAt;
+  const counts = summarizePermissionStatuses(permissions);
 
   return (
     <div className="settingsPermissionPage">
       <header className="settingsPermissionIntro">
         <div>
-          <h3>权限与能力中心</h3>
+          <h3>权限与能力</h3>
           <p>
-            这里只读取系统权限与功能能力的当前快照，不会代替你修改任何 OS 权限。
-            需要变更权限时，请前往「系统设置 → 隐私与安全性」完成授权或撤销。
+            查看 Maka 需要的系统权限和当前授权状态，
+            直接从这里前往「系统设置 → 隐私与安全性」完成授权或撤销，不必自己翻菜单。
           </p>
         </div>
         <div className="settingsPermissionMeta">
-          <span className="pill" data-tone="info">只读快照</span>
           <small>
-            最近一次读取：<RelativeTime ts={checkedAtMs} className="settingsHelpInlineTime" />
+            最近读取：<RelativeTime ts={checkedAtMs} className="settingsHelpInlineTime" />
           </small>
           <Button
             type="button"
@@ -6140,41 +6213,124 @@ function PermissionCenterPage() {
             variant="secondary"
             onClick={() => setRefreshTick((tick) => tick + 1)}
           >
-            刷新
+            重新检测
           </Button>
         </div>
       </header>
 
-      <section aria-label="功能能力" className="settingsPermissionSection">
+      <section className="settingsPermissionSummary" aria-label="权限概览">
+        <PermissionSummaryTile label="已授权" value={counts.granted} tone="success" />
+        <PermissionSummaryTile label="等待授权" value={counts.pending} tone="warning" />
+        <PermissionSummaryTile label="已拒绝" value={counts.denied} tone="destructive" />
+        <PermissionSummaryTile label="未知 / 不支持" value={counts.other} tone="neutral" />
+      </section>
+
+      <section aria-label="系统权限" className="settingsPermissionSection">
         <header>
-          <h4>功能能力</h4>
-          <small>每个能力的就绪状态由「功能开关 · 配置 · 系统权限 · 运行态探测」共同决定。</small>
+          <h4>系统权限</h4>
+          <small>Maka 读到的 OS 级权限状态。点击右侧按钮可以直接前往「系统设置 → 隐私与安全性」对应分区。</small>
         </header>
-        <ul className="settingsCapabilityList" aria-label="功能能力列表">
+        <ul className="settingsOsPermissionList" aria-label="系统权限列表">
+          {OS_PERMISSION_IDS.map((id) => (
+            <OsPermissionRow
+              key={id}
+              snapshot={permissions.permissions[id]}
+              busy={pendingPermAction !== null}
+              pendingKey={pendingPermAction === `${id}:request` ? 'request' : pendingPermAction === `${id}:openSettings` ? 'openSettings' : null}
+              onRequest={() => void runPermissionAction(id, 'request')}
+              onOpenSettings={() => void runPermissionAction(id, 'openSettings')}
+            />
+          ))}
+        </ul>
+      </section>
+
+      <section aria-label="功能能力" className="settingsPermissionSection">
+        <header className="settingsPermissionSectionHeader">
+          <div>
+            <h4>功能能力</h4>
+            <small>每个能力的就绪状态由「功能开关 · 配置 · 系统权限 · 运行态探测」共同决定。</small>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => setDiagnosticsOpen((open) => !open)}
+            aria-expanded={diagnosticsOpen}
+          >
+            {diagnosticsOpen ? '收起详情' : '展开详情'}
+          </Button>
+        </header>
+        <ul className="settingsCapabilityList" aria-label="功能能力列表" data-diagnostics-open={diagnosticsOpen ? 'true' : undefined}>
           {capabilities.capabilities.map((capability) => (
             <CapabilityRow key={capability.id} capability={capability} />
           ))}
         </ul>
       </section>
 
-      <section aria-label="系统权限" className="settingsPermissionSection">
-        <header>
-          <h4>系统权限</h4>
-          <small>Maka 读到的 OS 级权限状态。撤销请前往「系统设置 → 隐私与安全性」。</small>
-        </header>
-        <ul className="settingsOsPermissionList" aria-label="系统权限列表">
-          {OS_PERMISSION_IDS.map((id) => (
-            <OsPermissionRow key={id} snapshot={permissions.permissions[id]} />
-          ))}
-        </ul>
-      </section>
-
       <p className="settingsPermissionFootnote">
-        本页不会自动授予 Accessibility、Automation 或 Screen Recording。
+        Maka 不会自动授予 Accessibility、Automation 或 Screen Recording。
         高风险自动化能力必须保持逐项审批、可审计、可撤销。
+        这里只读取系统权限与功能能力的当前快照，授权变更仍需在「系统设置 → 隐私与安全性」完成。
       </p>
     </div>
   );
+}
+
+function PermissionSummaryTile(props: {
+  label: string;
+  value: number;
+  tone: 'success' | 'warning' | 'destructive' | 'neutral';
+}) {
+  return (
+    <div className="settingsPermissionSummaryTile" data-tone={props.tone}>
+      <span className="settingsPermissionSummaryValue">{props.value}</span>
+      <span className="settingsPermissionSummaryLabel">{props.label}</span>
+    </div>
+  );
+}
+
+function summarizePermissionStatuses(snapshot: PermissionSnapshot): {
+  granted: number;
+  pending: number;
+  denied: number;
+  other: number;
+} {
+  let granted = 0;
+  let pending = 0;
+  let denied = 0;
+  let other = 0;
+  for (const id of OS_PERMISSION_IDS) {
+    const status = snapshot.permissions[id]?.status;
+    switch (status) {
+      case 'granted':
+        granted += 1;
+        break;
+      case 'not_determined':
+        pending += 1;
+        break;
+      case 'denied':
+        denied += 1;
+        break;
+      default:
+        other += 1;
+    }
+  }
+  return { granted, pending, denied, other };
+}
+
+function permissionActionFailureCopy(reason: string, message?: string): string {
+  switch (reason) {
+    case 'invalid_id':
+      return '内部错误：权限 id 无法识别。';
+    case 'unsupported_platform':
+      return '当前操作系统不支持这个权限操作。';
+    case 'unsupported_permission':
+      return '当前平台没有提供这个权限的直接入口。';
+    case 'failed':
+      return message ?? '权限操作未成功，请稍后重试。';
+    default:
+      return message ?? '权限操作未成功，请稍后重试。';
+  }
 }
 
 function CapabilityRow(props: { capability: CapabilitySnapshot }) {
@@ -6326,18 +6482,70 @@ function CapabilityRow(props: { capability: CapabilitySnapshot }) {
   );
 }
 
-function OsPermissionRow(props: { snapshot: OsPermissionSnapshot }) {
-  const { snapshot } = props;
-  const copy = OS_PERMISSION_COPY[snapshot.id] ?? { label: snapshot.id, purpose: '' };
+function OsPermissionRow(props: {
+  snapshot: OsPermissionSnapshot;
+  busy: boolean;
+  pendingKey: 'request' | 'openSettings' | null;
+  onRequest: () => void;
+  onOpenSettings: () => void;
+}) {
+  const { snapshot, busy, pendingKey } = props;
+  const copy = OS_PERMISSION_COPY[snapshot.id];
+  const Icon = copy?.icon;
+  const label = copy?.label ?? snapshot.id;
+  const purpose = copy?.purpose ?? '';
+  const impact = copy?.impact ?? '';
   const stateCopy = OS_PERMISSION_STATE_COPY[snapshot.status];
+
+  const showRequest = snapshot.canRequest && snapshot.status !== 'granted';
+  const showOpenSettings = snapshot.canOpenSettings && snapshot.status !== 'granted';
+
   return (
     <li className="settingsOsPermissionRow" data-state={snapshot.status}>
-      <div>
-        <strong>{copy.label}</strong>
-        <small>{copy.purpose}</small>
-        {snapshot.reason && <small className="settingsOsPermissionReason">{snapshot.reason}</small>}
+      <div className="settingsOsPermissionIcon" aria-hidden="true">
+        {Icon ? <Icon size={18} strokeWidth={1.6} /> : null}
       </div>
-      <span className="pill" data-tone={stateCopy.tone}>{stateCopy.label}</span>
+      <div className="settingsOsPermissionBody">
+        <div className="settingsOsPermissionHeading">
+          <strong>{label}</strong>
+          <span className="pill" data-tone={stateCopy.tone}>{stateCopy.label}</span>
+        </div>
+        <small className="settingsOsPermissionPurpose">{purpose}</small>
+        {impact ? (
+          <small className="settingsOsPermissionImpact">
+            <span className="settingsOsPermissionImpactLabel">影响功能</span>
+            <span>{impact}</span>
+          </small>
+        ) : null}
+        {snapshot.reason ? (
+          <small className="settingsOsPermissionReason">{snapshot.reason}</small>
+        ) : null}
+      </div>
+      <div className="settingsOsPermissionActions">
+        {showRequest && (
+          <Button
+            type="button"
+            size="sm"
+            onClick={props.onRequest}
+            disabled={busy}
+            aria-busy={pendingKey === 'request' ? 'true' : undefined}
+          >
+            {pendingKey === 'request' ? '请求中…' : '请求授权'}
+          </Button>
+        )}
+        {showOpenSettings && (
+          <Button
+            type="button"
+            variant={showRequest ? 'secondary' : 'default'}
+            size="sm"
+            onClick={props.onOpenSettings}
+            disabled={busy}
+            aria-busy={pendingKey === 'openSettings' ? 'true' : undefined}
+          >
+            {pendingKey === 'openSettings' ? '打开中…' : '前往系统设置'}
+          </Button>
+        )}
+      </div>
     </li>
   );
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -12094,35 +12094,96 @@ button:active {
   display: grid;
   gap: 6px;
 }
+
+/* PR-PERMISSION-PAGE-REDESIGN: card layout with icon + body + actions.
+   Mirrors the reference's row anatomy (icon-left / text / status pill /
+   action button) but uses our atlas page-card recipe (hairline border +
+   6px radius + 4% lift + inner highlight). */
 .settingsOsPermissionRow {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
   align-items: flex-start;
-  gap: 16px;
+  gap: 12px;
   padding: 12px 14px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--background);
+  border: 1px solid var(--card-border-color, var(--border));
+  border-radius: var(--card-radius, 8px);
+  background: var(--card-bg, var(--background));
+  box-shadow:
+    var(--card-shadow, none),
+    var(--card-highlight, none);
+  transition: border-color 160ms var(--ease-out-strong), box-shadow 160ms var(--ease-out-strong);
 }
-.settingsOsPermissionRow > div {
+
+.settingsOsPermissionIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: oklch(from var(--foreground) l c h / 0.04);
+  color: var(--foreground-70);
+}
+
+.settingsOsPermissionBody {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  min-width: 0;
 }
-.settingsOsPermissionRow strong {
-  font-size: 0.85rem;
+
+.settingsOsPermissionHeading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.settingsOsPermissionHeading strong {
+  font-size: 0.875rem;
   font-weight: 600;
+  color: var(--foreground);
 }
-.settingsOsPermissionRow small {
-  color: var(--foreground-60);
-  font-size: 0.76rem;
+
+.settingsOsPermissionPurpose {
+  color: var(--foreground-70);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.settingsOsPermissionImpact {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.74rem;
+  color: var(--foreground-65);
   line-height: 1.45;
 }
+.settingsOsPermissionImpactLabel {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: oklch(from var(--foreground) l c h / 0.05);
+  color: var(--foreground-55);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
 .settingsOsPermissionReason {
   color: var(--foreground-50);
   font-size: 0.72rem !important;
   font-style: italic;
 }
+
+.settingsOsPermissionActions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+
 .settingsOsPermissionRow[data-state="denied"] {
   border-color: oklch(from var(--destructive) l c h / 0.30);
 }
@@ -12131,6 +12192,67 @@ button:active {
 }
 .settingsOsPermissionRow[data-state="granted"] {
   border-color: oklch(from var(--success) l c h / 0.24);
+}
+.settingsOsPermissionRow[data-state="granted"] .settingsOsPermissionIcon {
+  background: oklch(from var(--success) l c h / 0.08);
+  color: oklch(from var(--success) l c h);
+}
+
+/* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
+   Quick read of overall posture (X granted / Y waiting / Z denied /
+   W other) so users see what's configured at a glance. */
+.settingsPermissionSummary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+.settingsPermissionSummaryTile {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 14px;
+  border: 1px solid var(--card-border-color, var(--border));
+  border-radius: var(--card-radius, 8px);
+  background: var(--card-bg, var(--background));
+  box-shadow:
+    var(--card-shadow, none),
+    var(--card-highlight, none);
+}
+.settingsPermissionSummaryValue {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  color: var(--foreground);
+}
+.settingsPermissionSummaryLabel {
+  font-size: 0.72rem;
+  color: var(--foreground-60);
+  letter-spacing: 0.02em;
+}
+.settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {
+  color: oklch(from var(--success) l c h);
+}
+.settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
+  color: oklch(from var(--warning, var(--info)) l c h);
+}
+.settingsPermissionSummaryTile[data-tone="destructive"] .settingsPermissionSummaryValue {
+  color: oklch(from var(--destructive) l c h);
+}
+
+/* Diagnostic 5-column capability detail collapsed by default so the
+   page reads as "system permissions" first. Expand on click. */
+.settingsPermissionSectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+.settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityLayers,
+.settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityGuidance,
+.settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityAuditSlot,
+.settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityOsPermissions {
+  display: none;
 }
 
 .settingsPermissionFootnote {


### PR DESCRIPTION
## Summary

Per WAWQAQ msgs `93cbd21e` + `90f610bc`. The old Permission Center
showed a 5-column engineering-flavored state machine and zero action
affordances — users couldn't tell which permissions were configured,
nor reach the relevant System Settings pane from inside Maka.

This PR redesigns the page end-to-end:

### New IPC

- `permissions:openSystemSettings(permId)` — deep-links into the
  matching macOS System Settings → Privacy & Security pane via
  `x-apple.systempreferences:` URIs.
- `permissions:requestAccess(permId)` — uses the OS consent dialog
  for permissions that support it (microphone via
  `systemPreferences.askForMediaAccess`, notifications via a probe
  `Notification(...).show()`), falls back to deep-link for the three
  macOS permissions that don't expose a programmatic dialog
  (accessibility / screen_recording / automation).

### New UI shape

- **Page intro** leads with the action affordance: "查看…直接从这里前往…
  完成授权或撤销，不必自己翻菜单".
- **4-tile summary** (已授权 / 等待授权 / 已拒绝 / 未知-不支持) so
  users see overall posture at a glance — what was missing per
  WAWQAQ's "不方便人看到目前已经配置了哪些权限".
- **Per-permission row**: lucide icon (Accessibility / Monitor / Mic /
  Bell / MousePointer2) + label + status badge + purpose + new
  "影响功能" impact chip + reason. Action buttons (请求授权 / 前往
  系统设置) render conditionally on the existing `canRequest` /
  `canOpenSettings` snapshot metadata — unsupported platforms don't
  show inert buttons.
- **Capabilities section** moved below system permissions. The
  5-column internal-state detail grid is collapsed by default behind
  a "展开详情" toggle; power-users still see the diagnostic view, but
  the casual user reads the readiness pill + impact, not the state
  machine.

### Visual fidelity

Atlas-driven (hand-authored, no upstream CSS copied):
- Page-card recipe (1px hairline / 6px radius / 4% lift / inner
  highlight) on rows + summary tiles.
- Status-tinted left border for denied / waiting / granted.
- Icon glyph tinted to match permission state (granted ⇒ success
  hue background).

### Contracts updated

`settings-roadmap-cleanup-contract` now pins:
- New IPC wiring (`window.maka.permissions.requestAccess` /
  `openSystemSettings`).
- Existing snapshot/footnote/system-settings strings preserved.

## Test plan

- [x] `apps/desktop` test suite: 1464 tests pass, 0 fail
- [x] `apps/desktop` typecheck: clean (main + renderer)
- [ ] Visual smoke (reviewer): open Settings → 权限与能力, confirm
      the summary tiles + per-permission rows render with action
      buttons that actually open System Settings panes
- [ ] macOS-only: 请求授权 on microphone triggers the OS consent
      dialog; 请求授权 on accessibility falls back to opening the
      Accessibility pane
- [ ] Non-macOS (Linux / Windows): unsupported permissions don't
      render the action buttons (`canRequest` / `canOpenSettings`
      false in the snapshot)