### PR TITLE
Polish Daily Review archives and settings

### DIFF
--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -2,6 +2,7 @@ import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type {
   ArtifactRecord,
+  DailyReviewArchive,
   LlmConnection,
   PermissionRequestEvent,
   PlanReminder,
@@ -503,6 +504,9 @@ export async function seedVisualSmokeFixture(input: {
   if (input.fixture.scenario === 'plan-reminders') {
     await writePlanReminders(input.workspaceRoot, now);
   }
+  if (input.fixture.scenario === 'module-daily-review' || input.fixture.scenario === 'settings-daily-review') {
+    await writeDailyReviewArchives(input.workspaceRoot, now);
+  }
 }
 
 /**
@@ -644,6 +648,58 @@ async function writePlanReminders(workspaceRoot: string, now: number): Promise<v
     },
   ];
   await writeJson(join(workspaceRoot, 'plan-reminders.json'), reminders);
+}
+
+async function writeDailyReviewArchives(workspaceRoot: string, now: number): Promise<void> {
+  const dayFromMs = Date.UTC(2026, 4, 21, 0, 0, 0);
+  const dayToMs = Date.UTC(2026, 4, 22, 0, 0, 0);
+  const daily: DailyReviewArchive = {
+    id: '2026-05-21-daily',
+    day: { fromMs: dayFromMs, toMs: dayToMs },
+    mode: 'daily',
+    status: 'ok',
+    generatedAt: now - 10 * 60_000,
+    trigger: 'manual',
+    modelKey: 'zai-live::glm-4.5',
+    totals: {
+      sessionCount: 8,
+      requestCount: 34,
+      totalTokens: 128_640,
+      costUsd: 1.82,
+      errorCount: 1,
+    },
+    sections: {
+      summary: '今天主要围绕 Maka 桌面端的侧边栏、权限中心和每日回顾展开，重点是把入口、报告保存和设置项接到真实运行链路。',
+      gaps: '权限中心按钮已经接入系统设置跳转；每日回顾外部通知仍缺少报告自动推送运行时，需要保持不可用状态而不是展示假开关。',
+      usage: '模型请求集中在 UI 逆向与合约验证，工具调用以文件检索、构建和截图 smoke 为主。',
+      code: '建议继续收敛 Settings 与模块页的 shared page shell，减少同类 surface 在 styles.css 里的重复规则。',
+    },
+  };
+  const deep: DailyReviewArchive = {
+    ...daily,
+    id: '2026-05-21-deep',
+    mode: 'deep',
+    generatedAt: now - 5 * 60_000,
+    trigger: 'cron',
+    totals: {
+      ...daily.totals,
+      sessionCount: 12,
+      requestCount: 58,
+      totalTokens: 211_300,
+      costUsd: 3.94,
+      errorCount: 1,
+    },
+    sections: {
+      summary: '深度分析覆盖最近一轮 Maka UI 打磨：QoderWork 参考学习、权限中心重画、Daily Review 从聚合面板走向可保存报告。',
+      gaps: '第一性原理层面需要把“模块页 shell / Settings row / 状态 pill / 操作按钮”抽成真实组件，否则后续仍会在 CSS 中继续堆叠局部规则。',
+      usage: '高频动作是读取源码、运行 contract、构建 renderer、生成 visual-smoke 截图。失败成本主要来自多处页面壳层行为不统一。',
+      code: '下一步优先建立模块页 PageShell、SettingsActionRow 和 StatusPill primitives，再迁移 Daily Review、权限中心、计划任务和技能页。',
+    },
+  };
+  const archiveDir = join(workspaceRoot, 'daily-reviews', 'archive');
+  await mkdir(archiveDir, { recursive: true });
+  await writeJson(join(archiveDir, `${daily.id}.json`), daily);
+  await writeJson(join(archiveDir, `${deep.id}.json`), deep);
 }
 
 async function writeSettings(workspaceRoot: string): Promise<void> {

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -81,7 +81,7 @@ import {
   webSearchCredentialStatusFromResponse,
 } from '@maka/core';
 import { BOT_PROVIDERS, MAX_ALLOWED_USER_IDS, createDefaultSettings, parseAllowedUserIdsFromText } from '@maka/core/settings';
-import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
+import { CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS, PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import {
   Button,
   DialogContent,
@@ -1370,6 +1370,63 @@ const DAILY_REVIEW_SECTION_LABELS: ReadonlyArray<{
   { key: 'code', title: '代码建议', detail: '基于对话中的代码讨论，给出优化建议。' },
 ];
 
+const DAILY_REVIEW_DEFAULT_MODEL_VALUE = '__maka_daily_review_default_model__';
+
+function buildDailyReviewModelOptions(
+  connections: readonly LlmConnection[],
+  defaultConnectionSlug: string | null,
+  currentModelKey: string,
+): Array<readonly [string, string]> {
+  const defaultConnection = defaultConnectionSlug
+    ? connections.find((connection) => connection.slug === defaultConnectionSlug)
+    : null;
+  const options: Array<readonly [string, string]> = [
+    [
+      DAILY_REVIEW_DEFAULT_MODEL_VALUE,
+      defaultConnection
+        ? `使用对话默认模型（${defaultConnection.name} · ${defaultConnection.defaultModel || '默认模型'}）`
+        : '使用对话默认模型',
+    ],
+  ];
+  const seenKeys = new Set<string>();
+  for (const connection of connections) {
+    const defaults = PROVIDER_DEFAULTS[connection.providerType];
+    if (!connection.enabled || defaults.backendKind !== 'ai-sdk') continue;
+    if (
+      defaults.authKind === 'oauth_token' &&
+      connection.providerType !== 'claude-subscription' &&
+      connection.providerType !== 'codex-subscription'
+    ) {
+      continue;
+    }
+    const rawModels = connection.models?.length
+      ? connection.models.map((model) => model.id)
+      : connection.defaultModel
+        ? [connection.defaultModel]
+        : defaults.fallbackModels;
+    const safeModels = connection.providerType === 'codex-subscription'
+      ? rawModels.filter((model) => !CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS.has(model.trim()))
+      : rawModels;
+    for (const rawModel of safeModels) {
+      const model = rawModel.trim();
+      if (!model) continue;
+      const key = `${connection.slug}::${model}`;
+      if (seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      options.push([key, `${connection.name} · ${model}`]);
+    }
+  }
+  const trimmedCurrent = currentModelKey.trim();
+  if (
+    trimmedCurrent &&
+    trimmedCurrent !== DAILY_REVIEW_DEFAULT_MODEL_VALUE &&
+    !options.some(([value]) => value === trimmedCurrent)
+  ) {
+    options.push([trimmedCurrent, `当前自定义模型：${trimmedCurrent}`]);
+  }
+  return options;
+}
+
 function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
   const toast = useToast();
   const dailyReviewIpc = window.maka.dailyReview;
@@ -1381,6 +1438,9 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [savingKey, setSavingKey] = useState<string | null>(null);
   const [runningMode, setRunningMode] = useState<DailyReviewMode | null>(null);
+  const [modelConnections, setModelConnections] = useState<LlmConnection[]>([]);
+  const [defaultConnectionSlug, setDefaultConnectionSlug] = useState<string | null>(null);
+  const [modelLoadError, setModelLoadError] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -1418,6 +1478,33 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
     };
   }, [hasConfigIpc, dailyReviewIpc]);
 
+  useEffect(() => {
+    let cancelled = false;
+    async function reloadModelConnections() {
+      try {
+        const [connections, defaultSlug] = await Promise.all([
+          window.maka.connections.list(),
+          window.maka.connections.getDefault(),
+        ]);
+        if (cancelled || !mountedRef.current) return;
+        setModelConnections(connections);
+        setDefaultConnectionSlug(defaultSlug);
+        setModelLoadError(null);
+      } catch (err) {
+        if (cancelled || !mountedRef.current) return;
+        setModelLoadError(settingsActionErrorMessage(err));
+      }
+    }
+    void reloadModelConnections();
+    const unsubscribe = window.maka.connections.subscribeEvents(() => {
+      void reloadModelConnections();
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
   async function patchConfig(key: string, patch: Partial<DailyReviewConfig>) {
     if (!dailyReviewIpc.setConfig || !config) return;
     setSavingKey(key);
@@ -1446,6 +1533,13 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
 
   const effectiveConfig = config;
   const formDisabled = !hasConfigIpc || loading || Boolean(loadError) || !effectiveConfig;
+  const modelOptions = useMemo(
+    () => buildDailyReviewModelOptions(modelConnections, defaultConnectionSlug, effectiveConfig?.modelKey ?? ''),
+    [defaultConnectionSlug, effectiveConfig?.modelKey, modelConnections],
+  );
+  const selectedModelValue = effectiveConfig?.modelKey?.trim()
+    ? effectiveConfig.modelKey.trim()
+    : DAILY_REVIEW_DEFAULT_MODEL_VALUE;
 
   return (
     <section className="settingsFeatureStatusPage" aria-label="每日回顾">
@@ -1563,20 +1657,21 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         <div className="settingsRow">
           <div>
             <strong>分析模型</strong>
-            <small>用于生成回顾和分析的模型连接。留空使用对话默认模型。</small>
+            <small>
+              用于生成回顾和分析的模型连接；默认跟随当前对话默认模型。
+              {modelLoadError ? ` 模型列表读取失败：${modelLoadError}` : ''}
+            </small>
           </div>
-          <Input
-            type="text"
-            aria-label="分析模型连接"
-            className="settingsTimeInput"
-            placeholder="留空 = 使用默认"
-            value={effectiveConfig?.modelKey ?? ''}
-            disabled={formDisabled || savingKey === 'modelKey'}
-            onChange={(event) => {
-              const value = event.target.value;
-              void patchConfig('modelKey', { modelKey: value });
+          <SettingsSelect
+            value={selectedModelValue}
+            ariaLabel="分析模型连接"
+            options={modelOptions}
+            disabled={formDisabled || savingKey === 'modelKey' || modelOptions.length === 0}
+            onChange={(value) => {
+              void patchConfig('modelKey', {
+                modelKey: value === DAILY_REVIEW_DEFAULT_MODEL_VALUE ? '' : value,
+              });
             }}
-            style={{ minWidth: 160 }}
           />
         </div>
 
@@ -1596,20 +1691,15 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         <div className="settingsRow">
           <div>
             <strong>生成后发送外部通知</strong>
-            <small>通过已配置的机器人对话（飞书 / 企微等）推送回顾报告。</small>
+            <small>
+              当前运行时尚未接入报告自动推送。机器人通道可以在「机器人对话」里配置，但每日回顾不会假装已发送。
+            </small>
           </div>
           <Switch
             ariaLabel="生成后发送外部通知"
-            checked={effectiveConfig?.externalNotify.enabled ?? false}
-            disabled={formDisabled || savingKey === 'externalNotify'}
-            onChange={(enabled) =>
-              void patchConfig('externalNotify', {
-                externalNotify: {
-                  ...(effectiveConfig?.externalNotify ?? { enabled: false }),
-                  enabled,
-                },
-              })
-            }
+            checked={false}
+            disabled={true}
+            onChange={() => undefined}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -3569,6 +3569,11 @@ button:active {
   overflow: auto;
 }
 
+.maka-module-main[data-module="daily-review"] {
+  grid-template-rows: auto auto;
+  align-content: start;
+}
+
 .maka-module-main-header {
   width: min(100%, 900px);
   margin-inline: auto;
@@ -3697,14 +3702,20 @@ button:active {
 
 @media (prefers-reduced-motion: reduce) {
   .maka-skill-library,
-  .maka-plan-shell {
+  .maka-plan-shell,
+  .maka-module-main .maka-daily-review-panel,
+  .maka-daily-review-panel {
     animation: none;
   }
 }
 
 [data-maka-visual-smoke="true"] .maka-skill-library,
-[data-maka-visual-smoke="true"] .maka-plan-shell {
+[data-maka-visual-smoke="true"] .maka-plan-shell,
+[data-maka-visual-smoke="true"] .maka-module-main .maka-daily-review-panel,
+[data-maka-visual-smoke="true"] .maka-daily-review-panel {
   animation: none;
+  opacity: 1;
+  transform: none;
 }
 
 [data-maka-visual-smoke="true"] .maka-plan-card-grid > article,
@@ -13567,6 +13578,179 @@ button:active {
   opacity: 0.7;
 }
 
+.maka-daily-review-archives {
+  display: grid;
+  gap: 6px;
+  padding: 8px 0 10px;
+  border-bottom: 1px solid var(--foreground-10);
+}
+
+.maka-daily-review-archives-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.maka-daily-review-archive-count {
+  font-size: 11px;
+  color: var(--foreground-45);
+  font-variant-numeric: tabular-nums;
+}
+
+.maka-daily-review-archive-layout {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.34fr) minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+}
+
+.maka-daily-review-archive-list {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.maka-daily-review-archive-row {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+  padding: 6px 8px;
+  text-align: left;
+  transition:
+    background 120ms var(--ease-out-strong),
+    border-color 120ms var(--ease-out-strong);
+}
+
+.maka-daily-review-archive-row:hover {
+  background: oklch(from var(--foreground) l c h / 0.04);
+}
+
+.maka-daily-review-archive-row[data-active="true"] {
+  background: oklch(from var(--accent) l c h / 0.10);
+  border-color: oklch(from var(--accent) l c h / 0.18);
+}
+
+.maka-daily-review-archive-row-title {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-daily-review-archive-row-meta {
+  color: var(--foreground-50);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-daily-review-archive-body {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--card-border-color);
+  border-radius: var(--card-radius);
+  background: oklch(from var(--foreground) l c h / 0.025);
+  box-shadow: var(--card-highlight);
+}
+
+.maka-daily-review-archive-body[data-empty="true"],
+.maka-daily-review-archive-empty {
+  color: var(--foreground-50);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.maka-daily-review-archive-body-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.maka-daily-review-archive-body-header h4 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.maka-daily-review-archive-body-header p {
+  margin: 2px 0 0;
+  color: var(--foreground-50);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.maka-daily-review-archive-status {
+  flex: none;
+  border: 1px solid var(--foreground-10);
+  border-radius: 999px;
+  color: var(--foreground-55);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 7px;
+  white-space: nowrap;
+}
+
+.maka-daily-review-archive-status[data-status="ok"] {
+  border-color: oklch(from var(--success, var(--accent)) l c h / 0.26);
+  color: var(--success, var(--accent));
+}
+
+.maka-daily-review-archive-status[data-status="failed"],
+.maka-daily-review-archive-status[data-status="no_model"] {
+  border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.30);
+  color: var(--destructive, var(--warning, var(--foreground)));
+}
+
+.maka-daily-review-archive-error {
+  margin: 0;
+  color: var(--destructive, var(--foreground));
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.maka-daily-review-archive-sections {
+  display: grid;
+  gap: 8px;
+}
+
+.maka-daily-review-archive-section {
+  display: grid;
+  gap: 3px;
+}
+
+.maka-daily-review-archive-section h5 {
+  margin: 0;
+  color: var(--foreground-55);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.maka-daily-review-archive-section p {
+  margin: 0;
+  color: var(--foreground-80);
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .maka-daily-review-day {
   text-align: center;
   font-weight: 600;
@@ -13637,6 +13821,10 @@ button:active {
 
 @media (max-width: 720px) {
   .maka-daily-review-range {
+    grid-template-columns: 1fr;
+  }
+
+  .maka-daily-review-archive-layout {
     grid-template-columns: 1fr;
   }
 }
@@ -13767,6 +13955,16 @@ button:active {
   display: grid;
   gap: 8px;
   padding: 8px 4px;
+}
+
+.maka-daily-review-summary-empty {
+  position: static;
+  left: auto;
+  top: auto;
+  width: 100%;
+  transform: none;
+  min-height: 120px;
+  align-content: center;
 }
 
 /* =============================================================================

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -1230,6 +1230,27 @@ type DailyReviewMarkdownActionInput = {
   label: string;
   summary: DailyReviewSummary;
 };
+type DailyReviewArchiveSectionKey = keyof DailyReviewArchive['sections'];
+
+const DAILY_REVIEW_ARCHIVE_SECTION_LABEL: Record<DailyReviewArchiveSectionKey, string> = {
+  summary: '对话摘要',
+  gaps: '遗漏提醒',
+  usage: '使用洞察',
+  code: '代码建议',
+};
+
+const DAILY_REVIEW_ARCHIVE_STATUS_LABEL: Record<DailyReviewArchive['status'], string> = {
+  ok: '已生成',
+  no_model: '缺少模型',
+  no_data: '无数据',
+  failed: '生成失败',
+  skipped: '已跳过',
+};
+
+const DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL: Record<DailyReviewArchive['trigger'], string> = {
+  cron: '定时',
+  manual: '手动',
+};
 
 function dailyReviewScopeKey(offsetDays: number, range: DailyReviewRange): string {
   return `${offsetDays}:${range}`;
@@ -1253,11 +1274,18 @@ function DailyReviewPanel(props: {
   const [loading, setLoading] = useState(true);
   const [reloadToken, setReloadToken] = useState(0);
   const [pendingDailyReviewAction, setPendingDailyReviewAction] = useState<string | null>(null);
+  const [archives, setArchives] = useState<DailyReviewArchiveSummary[]>([]);
+  const [selectedArchiveId, setSelectedArchiveId] = useState<string | null>(null);
+  const [selectedArchive, setSelectedArchive] = useState<DailyReviewArchive | null>(null);
+  const [archiveLoading, setArchiveLoading] = useState(false);
+  const [archiveError, setArchiveError] = useState<string | null>(null);
+  const [archiveReloadToken, setArchiveReloadToken] = useState(0);
   const dailyReviewMountedRef = useRef(true);
   const summaryScopeKeyRef = useRef<string | null>(null);
   const pendingDailyReviewActionRef = useRef<string | null>(null);
   const currentSummaryScopeKey = dailyReviewScopeKey(offsetDays, range);
   const visibleSummary = summaryScopeKey === currentSummaryScopeKey ? summary : null;
+  const canLoadArchives = Boolean(props.bridge.listArchives && props.bridge.getArchive);
 
   useEffect(() => {
     dailyReviewMountedRef.current = true;
@@ -1295,6 +1323,61 @@ function DailyReviewPanel(props: {
       cancelled = true;
     };
   }, [offsetDays, range, reloadToken, props.bridge]);
+
+  useEffect(() => {
+    const listArchives = props.bridge.listArchives;
+    if (!listArchives) {
+      setArchives([]);
+      setSelectedArchiveId(null);
+      setSelectedArchive(null);
+      return;
+    }
+    let cancelled = false;
+    setArchiveError(null);
+    listArchives()
+      .then((next) => {
+        if (cancelled) return;
+        setArchives(next);
+        setSelectedArchiveId((current) => {
+          if (current && next.some((archive) => archive.id === current)) return current;
+          return next[0]?.id ?? null;
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setArchiveError(dailyReviewPanelErrorMessage(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [archiveReloadToken, props.bridge]);
+
+  useEffect(() => {
+    const getArchive = props.bridge.getArchive;
+    if (!getArchive || !selectedArchiveId) {
+      setSelectedArchive(null);
+      setArchiveLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setArchiveLoading(true);
+    setArchiveError(null);
+    getArchive(selectedArchiveId)
+      .then((next) => {
+        if (cancelled) return;
+        setSelectedArchive(next);
+        setArchiveLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setSelectedArchive(null);
+        setArchiveError(dailyReviewPanelErrorMessage(err));
+        setArchiveLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [archiveReloadToken, selectedArchiveId, props.bridge]);
 
   const dayLabel = (() => {
     if (range === 1) {
@@ -1340,7 +1423,9 @@ function DailyReviewPanel(props: {
     if (!runOnce) return;
     await runDailyReviewAction(`run:${mode}`, async () => {
       try {
-        await runOnce({ mode });
+        const result = await runOnce({ mode });
+        setSelectedArchiveId(result.archiveId);
+        setArchiveReloadToken((n) => n + 1);
         setReloadToken((n) => n + 1);
       } catch (err) {
         setError(dailyReviewPanelErrorMessage(err));
@@ -1412,6 +1497,59 @@ function DailyReviewPanel(props: {
             {pendingDailyReviewAction === 'run:deep' ? '生成中…' : '生成深度分析'}
           </UiButton>
         </div>
+      )}
+      {canLoadArchives && (
+        <section className="maka-daily-review-archives" aria-label="已生成报告">
+          <div className="maka-daily-review-archives-header">
+            <h4 className="maka-daily-review-section-title">已生成报告</h4>
+            <span className="maka-daily-review-archive-count">{archives.length} 份</span>
+          </div>
+          {archiveError && (
+            <Alert variant="warning" className="maka-daily-review-alert">
+              <AlertDescription>回顾报告读取失败：{archiveError}</AlertDescription>
+              <AlertAction>
+                <UiButton
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="maka-daily-review-alert-retry"
+                  onClick={() => setArchiveReloadToken((n) => n + 1)}
+                  disabled={archiveLoading}
+                >
+                  重试
+                </UiButton>
+              </AlertAction>
+            </Alert>
+          )}
+          {archives.length === 0 && !archiveError ? (
+            <p className="maka-daily-review-archive-empty">
+              还没有生成报告。点击上方按钮后，报告会保存到本机并显示在这里。
+            </p>
+          ) : (
+            <div className="maka-daily-review-archive-layout">
+              <div className="maka-daily-review-archive-list" role="list" aria-label="回顾报告历史">
+                {archives.map((archive) => (
+                  <button
+                    key={archive.id}
+                    type="button"
+                    className="maka-daily-review-archive-row"
+                    data-active={selectedArchiveId === archive.id ? 'true' : undefined}
+                    onClick={() => setSelectedArchiveId(archive.id)}
+                    role="listitem"
+                  >
+                    <span className="maka-daily-review-archive-row-title">
+                      {formatDailyReviewArchiveTitle(archive)}
+                    </span>
+                    <span className="maka-daily-review-archive-row-meta">
+                      {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]} · {archive.totals.sessionCount} 对话 · {formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <DailyReviewArchiveBody archive={selectedArchive} loading={archiveLoading} />
+            </div>
+          )}
+        </section>
       )}
       <nav className="maka-daily-review-range" aria-label="时间范围切换">
         <div className="maka-daily-review-range-tabs">
@@ -1517,6 +1655,7 @@ function DailyReviewPanel(props: {
           title="读取失败"
           body={error}
           cta={{ label: '重试', onClick: () => setReloadToken((n) => n + 1) }}
+          extraClassName="maka-daily-review-summary-empty"
         />
       ) : !visibleSummary ? (
         <div className="maka-daily-review-loading" aria-busy="true">
@@ -1529,6 +1668,7 @@ function DailyReviewPanel(props: {
           Icon={CalendarDays}
           title={emptyActivityTitle}
           body={emptyActivityBody}
+          extraClassName="maka-daily-review-summary-empty"
         />
       ) : (
         <>
@@ -1596,6 +1736,80 @@ function DailyReviewPanel(props: {
 
 function dailyReviewPanelErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '每日回顾暂时不可用，请稍后重试。');
+}
+
+function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loading: boolean }) {
+  if (props.loading) {
+    return (
+      <div className="maka-daily-review-archive-body" aria-busy="true">
+        <div className="maka-skeleton maka-skeleton-line" style={{ width: '58%' }} />
+        <div className="maka-skeleton maka-skeleton-line" style={{ width: '92%' }} />
+        <div className="maka-skeleton maka-skeleton-line" style={{ width: '74%' }} />
+      </div>
+    );
+  }
+  if (!props.archive) {
+    return (
+      <div className="maka-daily-review-archive-body" data-empty="true">
+        选择一份报告查看生成内容。
+      </div>
+    );
+  }
+  const archive = props.archive;
+  const sections = (Object.keys(DAILY_REVIEW_ARCHIVE_SECTION_LABEL) as DailyReviewArchiveSectionKey[])
+    .map((key) => {
+      const content = archive.sections[key]?.trim();
+      return content ? { key, content } : null;
+    })
+    .filter((entry): entry is { key: DailyReviewArchiveSectionKey; content: string } => entry !== null);
+  return (
+    <article className="maka-daily-review-archive-body" aria-label={formatDailyReviewArchiveTitle(archive)}>
+      <header className="maka-daily-review-archive-body-header">
+        <div>
+          <h4>{formatDailyReviewArchiveTitle(archive)}</h4>
+          <p>
+            {DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL[archive.trigger]}生成 · {formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}
+            {archive.modelKey ? ` · ${archive.modelKey}` : ' · 默认对话模型'}
+          </p>
+        </div>
+        <span className="maka-daily-review-archive-status" data-status={archive.status}>
+          {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}
+        </span>
+      </header>
+      {archive.errorMessage && (
+        <p className="maka-daily-review-archive-error">{archive.errorMessage}</p>
+      )}
+      {sections.length > 0 ? (
+        <div className="maka-daily-review-archive-sections">
+          {sections.map((section) => (
+            <section key={section.key} className="maka-daily-review-archive-section">
+              <h5>{DAILY_REVIEW_ARCHIVE_SECTION_LABEL[section.key]}</h5>
+              <p>{section.content}</p>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <p className="maka-daily-review-archive-empty">
+          这份报告没有生成正文内容。
+        </p>
+      )}
+    </article>
+  );
+}
+
+function formatDailyReviewArchiveTitle(archive: DailyReviewArchive | DailyReviewArchiveSummary): string {
+  const d = new Date(archive.day.fromMs);
+  const date = d.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit' });
+  return `${date} · ${archive.mode === 'deep' ? '深度分析' : '每日回顾'}`;
+}
+
+function formatDailyReviewArchiveGeneratedAt(generatedAt: number): string {
+  return new Date(generatedAt).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 /**
@@ -4089,7 +4303,11 @@ export function ChatView(props: {
 
   if (props.mode === 'daily-review') {
     return (
-      <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="每日回顾">
+      <main
+        className="maka-main detailPane maka-module-main agents-chat-panel"
+        data-module="daily-review"
+        aria-label="每日回顾"
+      >
         <header className="maka-module-main-header">
           <div>
             <h2>每日回顾</h2>


### PR DESCRIPTION
## Summary
- render saved Daily Review archives in the main Daily Review module, including archive list, status/trigger/model metadata, generated sections, and manual run selection refresh
- replace the Daily Review settings raw model key input with a real connection/model selector and keep legacy custom values selectable
- disable the external notification switch until the runtime has a real report push path, and seed Daily Review archives for visual smoke coverage
- fix Daily Review module visual-smoke/reduced-motion animation handling and keep its internal empty state in normal flow

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop test (1464/1464; check-console/check-a11y clean)
- npm --workspace @maka/ui run build
- npm --workspace @maka/desktop run build
- npm run build
- node scripts/capture-screenshots.mjs --scenario module-daily-review --variant light-1280-motion
- node scripts/capture-screenshots.mjs --scenario settings-daily-review --variant light-1280-motion

Vite still reports the existing chunk-size warning.