### PR TITLE
feat(runtime/headless): fault-tolerant Edit via shared guarded fuzzy replacer (#92 P0)

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -170,7 +170,7 @@ describe('isolated headless tools', () => {
     });
     assert.deepEqual(
       await tool(tools, 'Edit').impl({ path: absoluteFile, old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
-      { ok: true, path: 'src/file.txt', replacements: 1 },
+      { ok: true, path: 'src/file.txt', replacements: 1, matchedVia: 'exact', startLine: 1, endLine: 1 },
     );
     assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: absoluteGlob }, toolCtx(cwd)), {
       files: ['src/file.txt'],
@@ -181,6 +181,37 @@ describe('isolated headless tools', () => {
     assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hi\nneedle\n');
     assert.ok(calls.length >= 5);
     assert.ok(calls.every((command) => command.startsWith("node -e '")));
+  });
+
+  test('command-backed Edit applies the fuzzy cascade inside the isolated process', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-fuzzy-'));
+    await mkdir(join(cwd, 'src'));
+    const file = join(cwd, 'src', 'f.ts');
+    // 4-space indented body on disk; the model's old_string uses 2-space indent.
+    await writeFile(file, 'function f() {\n    return 1;\n}\n', 'utf8');
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl(
+        { path: 'src/f.ts', old_string: 'function f() {\n  return 1;\n}', new_string: 'function f() {\n    return 2;\n}' },
+        toolCtx(cwd),
+      ),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'line-trimmed', startLine: 1, endLine: 3 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 2;\n}\n');
   });
 
   test('command-backed file tools do not follow symlinks outside the isolated workspace', async () => {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -2,6 +2,7 @@ import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  COMPUTE_EDITED_SOURCE_FN_SOURCE,
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
@@ -304,16 +305,14 @@ fs.writeFileSync(target, Buffer.from(contentBase64, 'base64'));
 `;
 
 const EDIT_SCRIPT = `${COMMON_NODE_HELPERS}
+const computeEditedSource = ${COMPUTE_EDITED_SOURCE_FN_SOURCE};
 const [inputPath, oldBase64, nextBase64] = process.argv.slice(1);
 const root = workspaceRoot();
 const target = existingTarget(root, inputPath, 'Edit path');
 const oldString = Buffer.from(oldBase64, 'base64').toString('utf8');
 const newString = Buffer.from(nextBase64, 'base64').toString('utf8');
 const current = fs.readFileSync(target, 'utf8');
-const count = current.split(oldString).length - 1;
-if (count === 0) throw new Error('old_string not found in ' + inputPath);
-if (count > 1) throw new Error('old_string is not unique in ' + inputPath + ' (' + count + ' matches)');
-fs.writeFileSync(target, current.replace(oldString, newString), 'utf8');
+fs.writeFileSync(target, computeEditedSource(current, oldString, newString, inputPath), 'utf8');
 `;
 
 const GLOB_SCRIPT = `${COMMON_NODE_HELPERS}

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -122,12 +122,12 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
       if (executor.editFile) {
         return await executor.editFile({ cwd, path: normalizedPath, oldString: old_string, newString: new_string });
       }
-      await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
+      const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
         normalizedPath,
         Buffer.from(old_string, 'utf8').toString('base64'),
         Buffer.from(new_string, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path: normalizedPath, replacements: 1 };
+      return { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
     },
   };
 }
@@ -209,6 +209,26 @@ function parseStringArray(stdout: string, label: string): string[] {
     throw new Error(`${label} command returned an invalid string array`);
   }
   return parsed;
+}
+
+// EDIT_SCRIPT applies the edit and THEN prints this metadata, so by the time we
+// parse it the file is already changed. matchedVia / line range are best-effort
+// observability; a malformed payload must not turn a successful edit into a
+// reported failure, so this fails open to {} (a protocol regression is caught by
+// tests, which assert the metadata is present).
+function parseEditMeta(stdout: string): { matchedVia?: string; startLine?: number; endLine?: number } {
+  try {
+    const parsed: unknown = JSON.parse(stdout || '{}');
+    if (!parsed || typeof parsed !== 'object') return {};
+    const { matchedVia, startLine, endLine } = parsed as Record<string, unknown>;
+    return {
+      matchedVia: typeof matchedVia === 'string' ? matchedVia : undefined,
+      startLine: typeof startLine === 'number' ? startLine : undefined,
+      endLine: typeof endLine === 'number' ? endLine : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function normalizeWorkspacePath(inputPath: string, cwd: string, label: string): string {
@@ -312,7 +332,9 @@ const target = existingTarget(root, inputPath, 'Edit path');
 const oldString = Buffer.from(oldBase64, 'base64').toString('utf8');
 const newString = Buffer.from(nextBase64, 'base64').toString('utf8');
 const current = fs.readFileSync(target, 'utf8');
-fs.writeFileSync(target, computeEditedSource(current, oldString, newString, inputPath), 'utf8');
+const result = computeEditedSource(current, oldString, newString, inputPath);
+fs.writeFileSync(target, result.content, 'utf8');
+process.stdout.write(JSON.stringify({ matchedVia: result.matchedVia, startLine: result.startLine, endLine: result.endLine }));
 `;
 
 const GLOB_SCRIPT = `${COMMON_NODE_HELPERS}

--- a/packages/runtime/src/__tests__/edit-replace.test.ts
+++ b/packages/runtime/src/__tests__/edit-replace.test.ts
@@ -2,34 +2,123 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from '../edit-replace.js';
 
-describe('computeEditedSource (exact match)', () => {
-  test('replaces the single occurrence and returns the new content', () => {
-    assert.equal(
-      computeEditedSource('hello world', 'world', 'Maka', 'a.txt'),
-      'hello Maka',
-    );
+describe('computeEditedSource — exact match', () => {
+  test('replaces the single occurrence and reports an exact match + line range', () => {
+    assert.deepEqual(computeEditedSource('hello world', 'world', 'Maka', 'a.txt'), {
+      content: 'hello Maka',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
   });
 
-  test('throws with the where label when old_string is not found', () => {
-    assert.throws(
-      () => computeEditedSource('hello', 'absent', 'x', 'src/a.txt'),
-      /^Error: old_string not found in src\/a\.txt$/,
-    );
+  test('reports the matched multi-line range (1-based, inclusive)', () => {
+    const content = 'a\nb\nTARGET1\nTARGET2\nc\n';
+    const result = computeEditedSource(content, 'TARGET1\nTARGET2', 'X', 'a.txt');
+    assert.equal(result.content, 'a\nb\nX\nc\n');
+    assert.equal(result.startLine, 3);
+    assert.equal(result.endLine, 4);
+  });
+
+  test('inserts new_string literally (no $-pattern interpretation)', () => {
+    const result = computeEditedSource('const x = old;', 'old', '$&value', 'a.txt');
+    assert.equal(result.content, 'const x = $&value;');
+  });
+
+  test('throws with the where label when old_string is absent', () => {
+    assert.throws(() => computeEditedSource('hello', 'absent', 'x', 'src/a.txt'), /old_string not found in src\/a\.txt/);
   });
 
   test('throws with the match count when old_string is not unique', () => {
-    assert.throws(
-      () => computeEditedSource('a a a', 'a', 'b', 'b.txt'),
-      /^Error: old_string is not unique in b\.txt \(3 matches\)$/,
-    );
+    assert.throws(() => computeEditedSource('a a a', 'a', 'b', 'b.txt'), /old_string is not unique in b\.txt \(3 matches\)/);
   });
 
-  test('serialized source embeds standalone and reproduces the function', () => {
+  test('rejects identical old_string and new_string', () => {
+    assert.throws(() => computeEditedSource('abc', 'abc', 'abc', 'b.txt'), /identical/);
+  });
+
+  test('rejects an empty old_string', () => {
+    assert.throws(() => computeEditedSource('abc', '', 'x', 'b.txt'), /must not be empty/);
+  });
+});
+
+describe('computeEditedSource — fuzzy cascade', () => {
+  test('line-trimmed: tolerates indentation drift on a multi-line block', () => {
+    const content = 'function f() {\n    return 1;\n}\n'; // 4-space body
+    const oldString = 'function f() {\n  return 1;\n}'; // model used 2-space body
+    const result = computeEditedSource(content, oldString, 'function f() {\n    return 2;\n}', 'f.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 3);
+  });
+
+  test('whitespace: tolerates collapsed internal whitespace', () => {
+    const content = 'const  x   =   1;';
+    const result = computeEditedSource(content, 'const x = 1;', 'const x = 2;', 'w.ts');
+    assert.equal(result.matchedVia, 'whitespace');
+    assert.equal(result.content, 'const x = 2;');
+  });
+
+  test('escape: tolerates literal backslash escapes in old_string', () => {
+    const content = 'line1\nline2';
+    const result = computeEditedSource(content, 'line1\\nline2', 'X', 'e.ts');
+    assert.equal(result.matchedVia, 'escape');
+    assert.equal(result.content, 'X');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test('line-trimmed: preserves a trailing newline in old_string (no extra blank line)', () => {
+    const content = '  abcde\n  fghij\n';
+    const result = computeEditedSource(content, 'abcde\nfghij\n', 'xxxxx\nyyyyy\n', 'n.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'xxxxx\nyyyyy\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test("a span's trailing newline is a terminator, not an extra line, for endLine", () => {
+    assert.deepEqual(computeEditedSource('abc\n', 'abc\n', 'def\n', 'r.ts'), {
+      content: 'def\n',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+});
+
+describe('computeEditedSource — anti-corruption guards', () => {
+  test('rejects multiple distinct fuzzy candidates instead of guessing', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n   x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}'; // matches both blocks by trimmed lines
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /different line-trimmed candidates/);
+  });
+
+  test('rejects a fuzzy span that occurs more than once', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n  x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}';
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /occurs more than once/);
+  });
+
+  test('rejects a too-short old_string for a non-exact match', () => {
+    const content = 'a   b';
+    assert.throws(() => computeEditedSource(content, 'a b', 'c', 's.ts'), /too short/);
+  });
+
+  test('a multi-line old_string never collapses onto a single line (whitespace)', () => {
+    const content = 'header\nalpha beta\nfooter\n';
+    assert.throws(() => computeEditedSource(content, 'alpha\nbeta', 'X', 'w.ts'), /not found/);
+  });
+});
+
+describe('computeEditedSource — serialized embedding', () => {
+  test('serialized source is standalone and reproduces the full cascade', () => {
     assert.equal(typeof COMPUTE_EDITED_SOURCE_FN_SOURCE, 'string');
-    // The isolated headless Edit tool runs this source inside `node -e`; verify
-    // it parses to a function with identical behavior to the in-process one.
     const embedded = new Function(`return (${COMPUTE_EDITED_SOURCE_FN_SOURCE})`)() as typeof computeEditedSource;
-    assert.equal(embedded('one two', 'two', 'three', 'x.txt'), 'one three');
-    assert.throws(() => embedded('z', 'absent', 'x', 'x.txt'), /old_string not found in x\.txt/);
+    // exercise a fuzzy path to prove nested helpers survive serialization
+    const result = embedded('function f() {\n    return 1;\n}\n', 'function f() {\n  return 1;\n}', 'function f() {\n    return 2;\n}', 'x.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
   });
 });

--- a/packages/runtime/src/__tests__/edit-replace.test.ts
+++ b/packages/runtime/src/__tests__/edit-replace.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from '../edit-replace.js';
+
+describe('computeEditedSource (exact match)', () => {
+  test('replaces the single occurrence and returns the new content', () => {
+    assert.equal(
+      computeEditedSource('hello world', 'world', 'Maka', 'a.txt'),
+      'hello Maka',
+    );
+  });
+
+  test('throws with the where label when old_string is not found', () => {
+    assert.throws(
+      () => computeEditedSource('hello', 'absent', 'x', 'src/a.txt'),
+      /^Error: old_string not found in src\/a\.txt$/,
+    );
+  });
+
+  test('throws with the match count when old_string is not unique', () => {
+    assert.throws(
+      () => computeEditedSource('a a a', 'a', 'b', 'b.txt'),
+      /^Error: old_string is not unique in b\.txt \(3 matches\)$/,
+    );
+  });
+
+  test('serialized source embeds standalone and reproduces the function', () => {
+    assert.equal(typeof COMPUTE_EDITED_SOURCE_FN_SOURCE, 'string');
+    // The isolated headless Edit tool runs this source inside `node -e`; verify
+    // it parses to a function with identical behavior to the in-process one.
+    const embedded = new Function(`return (${COMPUTE_EDITED_SOURCE_FN_SOURCE})`)() as typeof computeEditedSource;
+    assert.equal(embedded('one two', 'two', 'three', 'x.txt'), 'one three');
+    assert.throws(() => embedded('z', 'absent', 'x', 'x.txt'), /old_string not found in x\.txt/);
+  });
+});

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -92,9 +92,16 @@ export function buildBuiltinTools(): MakaTool[] {
       impl: async ({ path, old_string, new_string }, { cwd }) => {
         const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
         const current = await fs.readFile(abs, 'utf8');
-        const next = computeEditedSource(current, old_string, new_string, path);
-        await fs.writeFile(abs, next, 'utf8');
-        return { ok: true, path: abs, replacements: 1 };
+        const result = computeEditedSource(current, old_string, new_string, path);
+        await fs.writeFile(abs, result.content, 'utf8');
+        return {
+          ok: true,
+          path: abs,
+          replacements: 1,
+          matchedVia: result.matchedVia,
+          startLine: result.startLine,
+          endLine: result.endLine,
+        };
       },
     },
     {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -11,6 +11,7 @@ import { exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { computeEditedSource } from './edit-replace.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -91,12 +92,7 @@ export function buildBuiltinTools(): MakaTool[] {
       impl: async ({ path, old_string, new_string }, { cwd }) => {
         const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
         const current = await fs.readFile(abs, 'utf8');
-        const count = current.split(old_string).length - 1;
-        if (count === 0) throw new Error(`old_string not found in ${path}`);
-        if (count > 1) {
-          throw new Error(`old_string is not unique in ${path} (${count} matches)`);
-        }
-        const next = current.replace(old_string, new_string);
+        const next = computeEditedSource(current, old_string, new_string, path);
         await fs.writeFile(abs, next, 'utf8');
         return { ok: true, path: abs, replacements: 1 };
       },

--- a/packages/runtime/src/edit-replace.ts
+++ b/packages/runtime/src/edit-replace.ts
@@ -1,38 +1,255 @@
 // packages/runtime/src/edit-replace.ts
 //
-// Shared string-edit logic used by BOTH Edit tool implementations:
+// Shared, fault-tolerant string-edit logic used by BOTH Edit tool
+// implementations:
 //   - the in-process builtin Edit tool (packages/runtime/src/builtin-tools.ts),
 //     which imports and calls computeEditedSource directly, and
 //   - the isolated headless Edit tool (packages/headless/src/tools.ts), which
 //     embeds COMPUTE_EDITED_SOURCE_FN_SOURCE into a `node -e` script that runs
-//     inside the isolated executor process.
+//     inside the isolated executor process (the actual benchmark path).
 //
 // CONSTRAINT: computeEditedSource must stay fully self-contained — no imports,
-// no references to module-scope bindings, every helper nested inside — so that
+// no references to module-scope bindings, every helper a nested *function
+// declaration* (hoisted, so order-independent), no generators — so that
 // `.toString()` yields a standalone definition that runs unchanged inside the
 // isolated process. This keeps a single source of truth for both call sites.
 //
-// Commit 1 is exact-match only and preserves the prior behavior byte-for-byte
-// (including String.prototype.replace's `$`-pattern handling in new_string and
-// the exact error-message text). Later commits extend the matching strategy
-// here so both call sites gain it from one place.
+// SAFETY MODEL (the point of this module): exact-match drift (whitespace,
+// indentation, escaping) is forgiven, but a fuzzy match must never silently
+// land in the wrong place. Every fuzzy strategy here verifies the FULL span is
+// structurally equivalent to old_string (not just anchors), and a strategy is
+// only accepted when it produces exactly ONE candidate occurring exactly ONCE.
+// Any ambiguity throws instead of guessing.
+//
+// Strategies are adapted from opencode's edit.ts (sourced from cline diff-apply
+// + gemini-cli editCorrector). We keep the three distinctly-reachable full-span
+// matchers (line-trimmed, whitespace-normalized, escape-normalized) and omit:
+//   - indentation-flexible and trimmed-boundary, which are strictly shadowed by
+//     line-trimmed / whitespace-normalized here (they add no reachable match);
+//   - block-anchor and context-aware, which match on partial signal (first/last
+//     line + similarity) and need a tuned similarity threshold — deliberately
+//     deferred to keep wrong-location risk out.
+
+export type EditMatchStrategy =
+  | 'exact'
+  | 'line-trimmed'
+  | 'whitespace'
+  | 'escape';
+
+export interface EditMatch {
+  /** The full new file content after the replacement. */
+  content: string;
+  /** Which strategy located old_string ('exact' or a fuzzy strategy name). */
+  matchedVia: EditMatchStrategy;
+  /** 1-based first line of the matched span in the original source. */
+  startLine: number;
+  /** 1-based last line (inclusive) of the matched span in the original source. */
+  endLine: number;
+}
 
 /**
- * Apply an exact, unique string replacement to `source`.
+ * Apply a single, unambiguous replacement of `oldString` with `newString` in
+ * `source`, tolerating whitespace/indentation/escape drift via a guarded fuzzy
+ * cascade. `where` is the caller's relative path, embedded in error messages.
  *
- * @param where label embedded in error messages (the caller's relative path).
- * @throws if `oldString` is absent or matches more than once.
+ * @returns the new content plus which strategy matched and the matched line
+ *   range (so the caller can show the model where the edit landed).
+ * @throws when old_string is absent, ambiguous, identical to new_string, too
+ *   short to fuzzy-match safely, or matches a disproportionately large span.
  */
 export function computeEditedSource(
   source: string,
   oldString: string,
   newString: string,
   where: string,
-): string {
-  const count = source.split(oldString).length - 1;
-  if (count === 0) throw new Error(`old_string not found in ${where}`);
-  if (count > 1) throw new Error(`old_string is not unique in ${where} (${count} matches)`);
-  return source.replace(oldString, newString);
+): EditMatch {
+  // Declared inside the function (not module scope) so .toString() carries it
+  // into the isolated EDIT_SCRIPT — module-scope references do not survive
+  // serialization. Minimum trimmed old_string length for a non-exact match.
+  const MIN_FUZZY_OLD_STRING_LENGTH = 5;
+
+  if (oldString === newString) {
+    throw new Error(`No changes to apply in ${where}: old_string and new_string are identical`);
+  }
+  if (oldString === '') {
+    throw new Error(`old_string must not be empty in ${where}`);
+  }
+
+  // Exact match first — preserves the prior behavior, including the informative
+  // match count, and short-circuits before any fuzzy work.
+  const exactCount = source.split(oldString).length - 1;
+  if (exactCount === 1) {
+    return finish(source, oldString, newString, 'exact');
+  }
+  if (exactCount > 1) {
+    throw new Error(`old_string is not unique in ${where} (${exactCount} matches)`);
+  }
+
+  // Fuzzy strategies, increasing tolerance. Each returns FULL-span candidates
+  // structurally equivalent to old_string; the loop below requires exactly one.
+  const strategies: Array<[EditMatchStrategy, (content: string, find: string) => string[]]> = [
+    ['line-trimmed', lineTrimmedSpans],
+    ['whitespace', whitespaceNormalizedSpans],
+    ['escape', escapeNormalizedSpans],
+  ];
+
+  for (const [name, finder] of strategies) {
+    const spans = dedupeInContent(source, finder(source, oldString));
+    if (spans.length === 0) continue;
+    if (spans.length > 1) {
+      throw new Error(
+        `old_string matched ${spans.length} different ${name} candidates in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    const span = spans[0];
+    if (source.indexOf(span) !== source.lastIndexOf(span)) {
+      throw new Error(
+        `old_string matched a ${name} span that occurs more than once in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    if (oldString.trim().length < MIN_FUZZY_OLD_STRING_LENGTH) {
+      throw new Error(
+        `old_string is too short for a non-exact match in ${where}; provide a longer, exact snippet`,
+      );
+    }
+    if (isDisproportionate(span, oldString)) {
+      throw new Error(
+        `Refusing ${name} match in ${where}: the matched span is much larger than old_string. Re-read the file and pass the exact text to replace.`,
+      );
+    }
+    return finish(source, span, newString, name);
+  }
+
+  throw new Error(
+    `old_string not found in ${where}; it must match the file's text including whitespace and indentation`,
+  );
+
+  // ---- nested helpers (kept inside for self-contained .toString() embedding) ----
+
+  function finish(
+    content: string,
+    span: string,
+    replacement: string,
+    matchedVia: EditMatchStrategy,
+  ): EditMatch {
+    const index = content.indexOf(span);
+    const before = content.slice(0, index);
+    const startLine = before.split('\n').length;
+    // A trailing newline in the span is the last line's terminator, not an
+    // extra line, so it must not bump endLine.
+    const spanLineCount = span.split('\n').length - (span.endsWith('\n') ? 1 : 0);
+    const endLine = startLine + Math.max(spanLineCount, 1) - 1;
+    // slice-join (not String.replace) so `$&`/`$1` in newString are literal.
+    const next = before + replacement + content.slice(index + span.length);
+    return { content: next, matchedVia, startLine, endLine };
+  }
+
+  function dedupeInContent(content: string, candidates: string[]): string[] {
+    const out: string[] = [];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      if (content.indexOf(candidate) === -1) continue;
+      if (out.indexOf(candidate) === -1) out.push(candidate);
+    }
+    return out;
+  }
+
+  function lineTrimmedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const originalLines = content.split('\n');
+    const findEndsWithNewline = find.endsWith('\n');
+    const searchLines = find.split('\n');
+    if (searchLines.length > 0 && searchLines[searchLines.length - 1] === '') {
+      searchLines.pop();
+    }
+    if (searchLines.length === 0) return out;
+    for (let i = 0; i <= originalLines.length - searchLines.length; i++) {
+      let matches = true;
+      for (let j = 0; j < searchLines.length; j++) {
+        if (originalLines[i + j].trim() !== searchLines[j].trim()) {
+          matches = false;
+          break;
+        }
+      }
+      if (!matches) continue;
+      let startIndex = 0;
+      for (let k = 0; k < i; k++) startIndex += originalLines[k].length + 1;
+      let endIndex = startIndex;
+      for (let k = 0; k < searchLines.length; k++) {
+        endIndex += originalLines[i + k].length;
+        if (k < searchLines.length - 1) endIndex += 1;
+      }
+      // If old_string ended with a newline, the matched span must include the
+      // file's newline after the last matched line; otherwise the replacement
+      // would drop or duplicate a line break. When there is no such newline
+      // (EOF with no trailing newline) this is not a faithful match — skip it.
+      if (findEndsWithNewline) {
+        const lastLine = i + searchLines.length - 1;
+        if (lastLine >= originalLines.length - 1) continue;
+        endIndex += 1;
+      }
+      out.push(content.substring(startIndex, endIndex));
+    }
+    return out;
+  }
+
+  function whitespaceNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const normalize = (text: string) => text.replace(/\s+/g, ' ').trim();
+    const normalizedFind = normalize(find);
+    if (normalizedFind === '') return out;
+    const lines = content.split('\n');
+    const findLines = find.split('\n');
+    if (findLines.length === 1) {
+      // Single-line old_string: match individual lines only. A multi-line
+      // old_string must never collapse onto one physical line — normalize()
+      // turns newlines into spaces, so an unguarded single-line scan would let
+      // `a\nb` match the line `a b`, which is a wrong-location edit.
+      for (let i = 0; i < lines.length; i++) {
+        if (normalize(lines[i]) === normalizedFind) out.push(lines[i]);
+      }
+    } else {
+      for (let i = 0; i <= lines.length - findLines.length; i++) {
+        const block = lines.slice(i, i + findLines.length).join('\n');
+        if (normalize(block) === normalizedFind) out.push(block);
+      }
+    }
+    return out;
+  }
+
+  function escapeNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const unescape = (str: string) =>
+      str.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (match: string, ch: string) => {
+        if (ch === 'n') return '\n';
+        if (ch === 't') return '\t';
+        if (ch === 'r') return '\r';
+        if (ch === "'") return "'";
+        if (ch === '"') return '"';
+        if (ch === '`') return '`';
+        if (ch === '\\') return '\\';
+        if (ch === '\n') return '\n';
+        if (ch === '$') return '$';
+        return match;
+      });
+    const unescapedFind = unescape(find);
+    if (content.includes(unescapedFind)) out.push(unescapedFind);
+    const lines = content.split('\n');
+    const findLines = unescapedFind.split('\n');
+    for (let i = 0; i <= lines.length - findLines.length; i++) {
+      const block = lines.slice(i, i + findLines.length).join('\n');
+      if (unescape(block) === unescapedFind) out.push(block);
+    }
+    return out;
+  }
+
+  function isDisproportionate(span: string, find: string): boolean {
+    const oldLines = find.split('\n').length;
+    const spanLines = span.split('\n').length;
+    if (spanLines >= Math.max(oldLines + 3, oldLines * 2)) return true;
+    if (oldLines === 1) return false;
+    return span.trim().length > Math.max(find.trim().length + 500, find.trim().length * 4);
+  }
 }
 
 /**

--- a/packages/runtime/src/edit-replace.ts
+++ b/packages/runtime/src/edit-replace.ts
@@ -1,0 +1,43 @@
+// packages/runtime/src/edit-replace.ts
+//
+// Shared string-edit logic used by BOTH Edit tool implementations:
+//   - the in-process builtin Edit tool (packages/runtime/src/builtin-tools.ts),
+//     which imports and calls computeEditedSource directly, and
+//   - the isolated headless Edit tool (packages/headless/src/tools.ts), which
+//     embeds COMPUTE_EDITED_SOURCE_FN_SOURCE into a `node -e` script that runs
+//     inside the isolated executor process.
+//
+// CONSTRAINT: computeEditedSource must stay fully self-contained — no imports,
+// no references to module-scope bindings, every helper nested inside — so that
+// `.toString()` yields a standalone definition that runs unchanged inside the
+// isolated process. This keeps a single source of truth for both call sites.
+//
+// Commit 1 is exact-match only and preserves the prior behavior byte-for-byte
+// (including String.prototype.replace's `$`-pattern handling in new_string and
+// the exact error-message text). Later commits extend the matching strategy
+// here so both call sites gain it from one place.
+
+/**
+ * Apply an exact, unique string replacement to `source`.
+ *
+ * @param where label embedded in error messages (the caller's relative path).
+ * @throws if `oldString` is absent or matches more than once.
+ */
+export function computeEditedSource(
+  source: string,
+  oldString: string,
+  newString: string,
+  where: string,
+): string {
+  const count = source.split(oldString).length - 1;
+  if (count === 0) throw new Error(`old_string not found in ${where}`);
+  if (count > 1) throw new Error(`old_string is not unique in ${where} (${count} matches)`);
+  return source.replace(oldString, newString);
+}
+
+/**
+ * Serialized source of computeEditedSource, captured once at module load for
+ * embedding into the isolated headless EDIT_SCRIPT. Using the live function's
+ * own source avoids drift between the in-process and serialized forms.
+ */
+export const COMPUTE_EDITED_SOURCE_FN_SOURCE: string = computeEditedSource.toString();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -67,6 +67,7 @@ export type {
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
 export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
+export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,6 +66,7 @@ export type {
 
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
+export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,


### PR DESCRIPTION
## What

Closes the keystone P0 from #92: make the **Edit** tool fault-tolerant so whitespace / indentation / escape drift in `old_string` no longer fails the edit — without ever silently editing the wrong location.

Two atomic commits:

1. **`refactor: extract shared computeEditedSource`** — both Edit implementations duplicated exact-match logic: the in-process builtin Edit (`packages/runtime/src/builtin-tools.ts`) and the isolated headless Edit (`packages/headless/src/tools.ts`), whose `EDIT_SCRIPT` runs inside the executor via `node -e` and **is the actual benchmark path**. Extracted into one self-contained `computeEditedSource()` in `packages/runtime/src/edit-replace.ts`; the builtin calls it, the headless `EDIT_SCRIPT` embeds its serialized source (`.toString()`). Behavior unchanged (exact-match only); existing suites prove it.
2. **`feat: fault-tolerant Edit via guarded fuzzy replacer cascade`** — adds the guarded fuzzy cascade in the shared function, so both paths gain it from one place.

## Cascade + safety model

After exact match: **line-trimmed → whitespace-normalized → escape-normalized** (adapted from opencode's `edit.ts`). Each verifies the **full span** is structurally equivalent to `old_string` (not just anchors).

Anti-corruption guards (the point of the change — a fuzzy match must never land in the wrong place):
- a fuzzy strategy is accepted only if it yields **exactly one** candidate occurring **exactly once**; any ambiguity throws instead of guessing
- reject `old_string === new_string` and empty `old_string`
- reject a too-short `old_string` (<5 trimmed chars) for non-exact matches
- reject disproportionately large matched spans
- returns `matchedVia` + matched line range so the model can see where the edit landed
- slice-join replacement (not `String.replace`) so `$&` / `$1` in `new_string` are inserted literally (fixes a latent bug)

## Deliberate scope decisions (please confirm)

- **Two strategies deferred**: opencode's `block-anchor` and `context-aware` match on partial signal (first/last line + a similarity threshold) and are the main silent-wrong-location risk; they need a tuned similarity threshold, which #92 flags as a product decision. Omitted here; can follow up.
- **Two strategies omitted as redundant**: `indentation-flexible` and `trimmed-boundary` are strictly shadowed by line-trimmed / whitespace here (no reachable additional match).
- **Desktop has no Edit tool** (`apps/desktop/src/main/main.ts:589` filters builtin Edit out), so this PR touches only runtime + headless — the two paths that exist.

## Maps to #92 (P0)

- [x] Extract a shared `replace()` applied on the benchmark (headless) + runtime paths
- [x] Replacer cascade (exact → line-trimmed → whitespace → escape; anchor/similarity deferred)
- [x] Anti-silent-corruption guards (unique-match, multi-candidate fail, short-string reject, disproportionate reject, `matchedVia`, line range)
- [x] Regression tests (indentation drift, whitespace, escape, trailing-newline, multi-candidate rejection, short-string rejection, `$`-literal, serialization)
- [ ] loop-gate → separate PR (C)
- [ ] Bash overflow spill → separate PR (B)

## Review gate (codex, xhigh, scoped to this PR's 2 commits)

- **Round 1** found **2 P0** silent-wrong-location bugs — both fixed and folded into commit 2:
  - `whitespace` let a multi-line `old_string` collapse onto one physical line → single-line scan now only runs for single-line `old_string`.
  - `line-trimmed` dropped `old_string`'s trailing newline → a trailing newline now requires the file's newline after the last matched line, else the match is rejected.
- **Round 2 (fresh-eye): no P0/P1.** Two P2s: `endLine` over-counted a trailing-newline line (**fixed**); `parseEditMeta` fail-open (**kept intentionally** — the edit is already applied before metadata is printed, so a malformed payload must not fail a successful edit; documented + test-guarded).

## Verification

- `@maka/runtime` 607 tests + `@maka/headless` 242 tests green, including a real `node -e` `EDIT_SCRIPT` fuzzy integration test and a serialization test that caught (and now guards) a self-containment regression.
- `npm run build` + `npm run typecheck` exit 0 across all workspaces.