### PR TITLE
Scrub reference product name from source (visual-smoke fixture + atlas notes)

### DIFF
--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -690,7 +690,7 @@ async function writeDailyReviewArchives(workspaceRoot: string, now: number): Pro
       errorCount: 1,
     },
     sections: {
-      summary: '深度分析覆盖最近一轮 Maka UI 打磨：QoderWork 参考学习、权限中心重画、Daily Review 从聚合面板走向可保存报告。',
+      summary: '深度分析覆盖最近一轮 Maka UI 打磨：参考布局学习、权限中心重画、Daily Review 从聚合面板走向可保存报告。',
       gaps: '第一性原理层面需要把“模块页 shell / Settings row / 状态 pill / 操作按钮”抽成真实组件，否则后续仍会在 CSS 中继续堆叠局部规则。',
       usage: '高频动作是读取源码、运行 contract、构建 renderer、生成 visual-smoke 截图。失败成本主要来自多处页面壳层行为不统一。',
       code: '下一步优先建立模块页 PageShell、SettingsActionRow 和 StatusPill primitives，再迁移 Daily Review、权限中心、计划任务和技能页。',

--- a/notes/reference-atlas.md
+++ b/notes/reference-atlas.md
@@ -572,7 +572,7 @@ Phase 2C (next big PR): wire the deep findings into code.
 
 ## 13. Deep-RE Round 3 — Sidebar, Composer, Banners, Resize Handle
 
-Follow-up after WAWQAQ msg f31b4611 ("还是多研究 qoderwork 的代码 和前端
+Follow-up after WAWQAQ msg f31b4611 ("还是多研究 参考布局 的代码 和前端
 设计，一定要深入挖掘他们的设计和代码"). Three days into the RE program
 and most surface-level patterns are caught (atlas §1–§12). This round
 focuses on the structural state machines and the smaller specialized
@@ -842,7 +842,7 @@ changes. Items 8-10 are bigger (new IPC / new dialog mounting).
 
 ## 15. Deep-RE Round 5 — Fonts, hero, blur-layer (§15)
 
-Following WAWQAQ msg 500eddc9 ("一定要多做、多分析…深度抄袭和学习 qoderwork
+Following WAWQAQ msg 500eddc9 ("一定要多做、多分析…深度抄袭和学习 参考
 界面 布局"). This round catches typography + visual-effect patterns I
 hadn't decoded.
 


### PR DESCRIPTION
## Summary

Naming hygiene rule violation found while reviewing today's visual-smoke captures. The Daily Review deep-analysis archive seeded by `visual-smoke-fixture.ts:693` embeds the literal reference product name in its `summary` field, so the `module-daily-review` PNG renders it verbatim. Plus two stale quoted snippets in `notes/reference-atlas.md` carry the lowercase form from earlier WAWQAQ messages.

Per `project_reference_layout_lane.md` (naming hygiene rule, 2026-06-20): "code, comments, AND commit messages must NEVER contain any third-party project name. Use neutral terms."

## Changes

- `apps/desktop/src/main/visual-smoke-fixture.ts:693` — `QoderWork 参考学习` → `参考布局学习`.
- `notes/reference-atlas.md:575` + `:845` — quoted snippets keep their shape but the brand token swaps to a neutral noun (`参考布局` / `参考` / `参考界面`).

No production behavior changes; fixture text and notes only. Existing 1464 desktop tests remain green.

## Test plan

- [x] `git grep -i qoderwork` returns 0 matches in source after the change
- [x] Visual smoke re-captured `module-daily-review` — archive summary no longer contains the brand token