### PR TITLE
feat(runtime/headless): bounded, recoverable Bash output (#92 P0)

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -52,6 +52,36 @@ describe('isolated headless tools', () => {
     });
   });
 
+  test('Bash bounds large executor output for the model but emits the full stream', async () => {
+    const big = Array.from({ length: 5000 }, (_, i) => `line${i + 1}`).join('\n') + '\n';
+    const emitted: Array<{ stream: string; chunk: string }> = [];
+    const bash = buildIsolatedBashTool({
+      async exec() {
+        return { exitCode: 0, stdout: big, stderr: '' };
+      },
+    });
+
+    const result = await bash.impl(
+      { command: 'noisy' },
+      {
+        sessionId: 's',
+        turnId: 't',
+        cwd: '/workspace',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: (stream, chunk) => emitted.push({ stream, chunk }),
+      },
+    ) as { stdout: string };
+
+    // The full stream is still surfaced live (history / UI), unbounded.
+    assert.equal(emitted.find((event) => event.stream === 'stdout')?.chunk, big);
+    // The model-facing result is bounded: tail kept, marker present, smaller.
+    assert.ok(result.stdout.includes('line5000'));
+    assert.ok(result.stdout.includes('truncated'));
+    assert.ok(!result.stdout.includes('line1\n'));
+    assert.ok(result.stdout.length < big.length);
+  });
+
   test('standard isolated tool surface exposes externalized file tools to local-read children', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -2,6 +2,7 @@ import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  truncateToolOutput,
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
@@ -53,13 +54,15 @@ export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool 
       });
       if (result.stdout) emitOutput('stdout', result.stdout);
       if (result.stderr) emitOutput('stderr', result.stderr);
+      // Bound what the model sees: a chatty command's full output would flood
+      // the context. The full stream is still emitted live via emitOutput above.
       return {
         kind: 'terminal',
         cwd,
         cmd: command,
         exitCode: result.exitCode,
-        stdout: result.stdout,
-        stderr: result.stderr,
+        stdout: truncateToolOutput(result.stdout, { direction: 'tail' }).content,
+        stderr: truncateToolOutput(result.stderr, { direction: 'tail' }).content,
       };
     },
   };

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1457,7 +1457,16 @@ describe('AiSdkBackend error surfaces', () => {
       { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
     );
 
-    assert.deepEqual(result, { error: '命令退出码 2' });
+    // In-turn result now folds in a redacted, bounded tail of stderr/stdout so
+    // the model can see *why* the command failed (the full structured content
+    // still goes to session history, asserted below).
+    assert.deepEqual(result, {
+      error: [
+        '命令退出码 2',
+        '--- stderr ---\nstderr before failure',
+        '--- stdout ---\nstdout before failure\nAuthorization: Bearer [redacted]',
+      ].join('\n\n'),
+    });
     assert.equal(messages[0]?.isError, true);
     assert.deepEqual(messages[0]?.content, events.find((event) => event.type === 'tool_result')?.content);
     assert.deepEqual(messages[0]?.content, {

--- a/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
+++ b/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { BashTailBuffer } from '../bash-tail-buffer.js';
+
+describe('BashTailBuffer', () => {
+  test('returns everything when under the cap', () => {
+    const buf = new BashTailBuffer(100);
+    buf.push('hello\n');
+    buf.push('world');
+    assert.equal(buf.value(), 'hello\nworld');
+  });
+
+  test('bounds retained output to the cap and keeps whole tail lines', () => {
+    const buf = new BashTailBuffer(20);
+    for (let i = 0; i < 100; i++) buf.push(`line${i}\n`);
+    const value = buf.value();
+    assert.ok(value.length <= 20);
+    assert.ok(value.endsWith('line99\n')); // tail preserved
+    assert.ok(value.startsWith('line')); // starts at a line boundary, not mid-line
+  });
+
+  test('drops the partial leading line so a sliced secret prefix cannot survive', () => {
+    // The first line would be cut mid-secret; the buffer must drop it whole so a
+    // later redaction pass never sees a secret with its prefix sliced off.
+    const buf = new BashTailBuffer(10);
+    buf.push('SECRETXYZ\n');
+    buf.push('KEEP1\nKEEP2\n');
+    const value = buf.value();
+    assert.equal(value, 'KEEP2\n');
+    assert.ok(!value.includes('SECRET'));
+  });
+
+  test('drops a single oversized line with no newline (no safe redaction boundary)', () => {
+    // A single line larger than the cap has no line boundary to cut on; keeping
+    // a byte-slice could hand redaction a secret with its prefix sliced off, so
+    // it is dropped entirely. Pathological case — the common single line is
+    // under the cap and never sliced.
+    const buf = new BashTailBuffer(5);
+    buf.push('Authorization: Bearer sk-live-secret-token-value'); // one giant line
+    assert.equal(buf.value(), '');
+  });
+
+  test('keeps discarding continuation chunks of a dropped oversized line until a newline', () => {
+    // The oversized line arrives across multiple chunks (stdout does not split on
+    // line boundaries). After the prefix is dropped, the suffix chunk must stay
+    // discarded — otherwise redaction would later see a secret with no prefix.
+    const buf = new BashTailBuffer(20);
+    buf.push('Authorization: Bearer sk-live-' + 'A'.repeat(30)); // oversized prefix dropped
+    buf.push('secret_tail'); // continuation of the SAME line
+    assert.equal(buf.value(), '');
+    buf.push(' more\nKEEP\n'); // newline terminates the compromised line; resume after it
+    assert.equal(buf.value(), 'KEEP\n');
+  });
+});

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -66,6 +66,56 @@ describe('builtin Bash streaming output', () => {
     await expectRejects(Promise.resolve(run), /Command aborted/);
     expect(events.some((event) => event.stream === 'stdout' && event.chunk.includes('started'))).toBe(true);
   });
+
+  test('large output is bounded to a tail instead of being discarded', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-'));
+    const bash = buildBuiltinTools().find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    const result = await bash.impl(
+      { command: "awk 'BEGIN{for(i=1;i<=5000;i++)print \"line\"i}'", timeout_ms: 10_000 },
+      {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        cwd,
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      },
+    ) as { exitCode: number; stdout: string };
+
+    expect(result.exitCode).toBe(0); // no reject — the old code threw away everything past the cap
+    expect(result.stdout.includes('line5000')).toBe(true); // tail preserved
+    expect(result.stdout.includes('truncated')).toBe(true); // truncation marker present
+    expect(result.stdout.includes('line1\n')).toBe(false); // head dropped, not the whole output
+  });
+
+  test('a failing command surfaces stdout/stderr on the rejection error', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-'));
+    const bash = buildBuiltinTools().find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    let err: { code?: number; stdout?: string; stderr?: string } | null = null;
+    try {
+      await bash.impl(
+        { command: 'printf "out-data"; printf "err-data" >&2; exit 3', timeout_ms: 5_000 },
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          cwd,
+          toolCallId: 'tool-1',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        },
+      );
+    } catch (e: unknown) {
+      err = e as { code?: number; stdout?: string; stderr?: string };
+    }
+
+    expect(err?.code).toBe(3);
+    expect(err?.stdout).toBe('out-data');
+    expect(err?.stderr).toBe('err-data');
+  });
 });
 
 describe('builtin read tools path containment', () => {

--- a/packages/runtime/src/__tests__/tool-output.test.ts
+++ b/packages/runtime/src/__tests__/tool-output.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { truncateToolOutput } from '../tool-output.js';
+
+describe('truncateToolOutput', () => {
+  test('returns text unchanged when within line and byte budgets', () => {
+    const text = 'a\nb\nc';
+    assert.deepEqual(truncateToolOutput(text, { maxLines: 10, maxBytes: 1000 }), {
+      content: text,
+      truncated: false,
+      removed: 0,
+      unit: 'lines',
+    });
+  });
+
+  test('keeps the head and reports removed lines when over the line budget', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line${i}`).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 100_000, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'lines');
+    assert.equal(result.removed, 6);
+    assert.ok(result.content.startsWith('line0\nline1\nline2\nline3'));
+    assert.ok(result.content.includes('6 lines truncated'));
+    assert.ok(!result.content.includes('line4'));
+  });
+
+  test('keeps the tail with the marker at the top when direction is tail', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line${i}`).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 3, maxBytes: 100_000, direction: 'tail' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.removed, 7);
+    assert.ok(result.content.endsWith('line7\nline8\nline9'));
+    assert.ok(result.content.startsWith('...7 lines truncated'));
+    assert.ok(!result.content.includes('line6'));
+  });
+
+  test('truncates by bytes and reports the bytes unit', () => {
+    const text = Array.from({ length: 50 }, () => 'x'.repeat(100)).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 10_000, maxBytes: 250, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+    assert.ok(result.removed > 0);
+    assert.ok(Buffer.byteLength(result.content.split('\n\n')[0], 'utf8') <= 250);
+  });
+
+  test('counts multi-byte characters by UTF-8 byte length', () => {
+    // Each '世' is 3 UTF-8 bytes; a 4-char line is 12 bytes + newline.
+    const text = Array.from({ length: 6 }, () => '世界世界').join('\n');
+    const result = truncateToolOutput(text, { maxLines: 10_000, maxBytes: 20, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+  });
+
+  test('does not truncate when exactly at the line budget and within bytes', () => {
+    const text = 'a\nb\nc\nd';
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 1000 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('does not report a truncation when only a trailing newline exceeds the byte budget', () => {
+    // Content fits exactly; the lone trailing newline pushes total bytes one over.
+    const text = 'x'.repeat(100) + '\n';
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('a single trailing newline is a terminator, not an extra line', () => {
+    // 4 real lines + terminating newline must still count as 4 lines.
+    const text = 'a\nb\nc\nd\n';
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 1000 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('keeps a byte-safe slice of a single oversized line instead of dropping it', () => {
+    const text = 'x'.repeat(500);
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+    const preview = result.content.split('\n\n')[0];
+    assert.equal(preview, 'x'.repeat(100)); // line not dropped — head slice kept
+    assert.ok(result.content.includes('truncated'));
+  });
+
+  test('byte-safe single-line slice does not split a multi-byte character', () => {
+    const text = '世'.repeat(200); // 3 bytes each = 600 bytes on one line
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100, direction: 'tail' });
+    assert.equal(result.truncated, true);
+    const preview = result.content.split('\n\n').pop() ?? '';
+    assert.ok(!preview.includes('�')); // no replacement char from a mid-char cut
+    assert.ok(Buffer.byteLength(preview, 'utf8') <= 100);
+    assert.ok(preview.length > 0);
+  });
+});

--- a/packages/runtime/src/bash-tail-buffer.ts
+++ b/packages/runtime/src/bash-tail-buffer.ts
@@ -1,0 +1,73 @@
+// packages/runtime/src/bash-tail-buffer.ts
+//
+// Memory-bounded tail accumulator for streaming shell output. A runaway command
+// must not be able to grow the captured result without limit (the old Bash path
+// instead discarded ALL output past a hard cap), so we retain only the last
+// `cap` characters.
+//
+// SECURITY: the retained tail is later passed through redactSecrets before it
+// reaches the model / UI. redactSecrets matches on full tokens and their
+// prefixes (e.g. `Authorization: Bearer …`, `sk-…`), so a tail that begins in
+// the MIDDLE of a secret-bearing line would defeat redaction and leak the
+// suffix. To prevent that, when the buffer actually drops content it also drops
+// the (partial) leading line, so the retained tail always starts at a line
+// boundary and redaction sees whole lines.
+
+export class BashTailBuffer {
+  private chunks: string[] = [];
+  private retained = 0;
+  // True when we dropped an unterminated oversized line: subsequent chunks are
+  // still part of that compromised line and must be discarded until the next
+  // newline, otherwise a continuation chunk (a secret's severed suffix) would
+  // be retained as if it were a clean line and defeat downstream redaction.
+  private insideDroppedLine = false;
+
+  constructor(private readonly cap: number) {}
+
+  push(chunk: string): void {
+    if (!chunk) return;
+    if (this.insideDroppedLine) {
+      const nl = chunk.indexOf('\n');
+      if (nl < 0) return; // whole chunk is still the dropped line — discard it
+      this.insideDroppedLine = false;
+      chunk = chunk.slice(nl + 1); // resume from the first clean line boundary
+      if (!chunk) return;
+    }
+    this.chunks.push(chunk);
+    this.retained += chunk.length;
+    // Amortize: allow growth to 2x cap before compacting back to cap so appends
+    // stay ~O(1) rather than re-slicing the whole buffer on every chunk.
+    if (this.retained > this.cap * 2) this.trim();
+  }
+
+  value(): string {
+    this.trim();
+    return this.chunks[0] ?? '';
+  }
+
+  private trim(): void {
+    if (this.chunks.length <= 1 && this.retained <= this.cap) return;
+    const joined = this.chunks.join('');
+    let kept = joined.length > this.cap ? joined.slice(joined.length - this.cap) : joined;
+    if (kept.length < joined.length) {
+      // We sliced mid-stream. Drop the partial leading line so the retained tail
+      // starts at a line boundary and downstream redaction never sees a secret
+      // whose prefix was cut off (see SECURITY note above). With no newline the
+      // whole tail is one partial line we cannot make safe — drop it entirely
+      // rather than risk leaking a severed secret. (A single line larger than
+      // the cap is pathological; the common single-line case is <= cap and is
+      // never sliced here.)
+      const nl = kept.indexOf('\n');
+      if (nl >= 0) {
+        kept = kept.slice(nl + 1);
+      } else {
+        // No line boundary in the retained tail: drop it and stay "inside" the
+        // dropped line so its continuation chunks are discarded until a newline.
+        kept = '';
+        this.insideDroppedLine = true;
+      }
+    }
+    this.chunks = kept ? [kept] : [];
+    this.retained = kept.length;
+  }
+}

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -11,6 +11,8 @@ import { exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { truncateToolOutput } from './tool-output.js';
+import { BashTailBuffer } from './bash-tail-buffer.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -19,7 +21,11 @@ import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext };
 
 const execAsync = promisify(exec);
-const BASH_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+// Per-stream cap on the output retained in memory for the result. A runaway
+// command no longer fails (the old behavior discarded ALL output past 10MB);
+// instead we keep the last ~1MB and let truncateToolOutput trim that to the
+// model budget. The full stream is still emitted live via emitOutput.
+const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 
 export function buildBuiltinTools(): MakaTool[] {
   return [
@@ -43,8 +49,8 @@ export function buildBuiltinTools(): MakaTool[] {
           cwd,
           cmd: command,
           exitCode: result.exitCode,
-          stdout: result.stdout,
-          stderr: result.stderr,
+          stdout: truncateToolOutput(result.stdout, { direction: 'tail' }).content,
+          stderr: truncateToolOutput(result.stderr, { direction: 'tail' }).content,
         };
       },
     },
@@ -167,9 +173,8 @@ async function runStreamingShell(
       shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    let stdout = '';
-    let stderr = '';
-    let outputBytes = 0;
+    const stdoutBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
+    const stderrBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
     let settled = false;
 
     const timer = setTimeout(() => {
@@ -193,6 +198,8 @@ async function runStreamingShell(
       if (settled) return;
       cleanup();
       const exitCode = code ?? (signal ? 128 : 1);
+      const stdout = stdoutBuf.value();
+      const stderr = stderrBuf.value();
       if (exitCode !== 0) {
         const error = new Error(`Command failed with exit code ${exitCode}`);
         Object.assign(error, { stdout, stderr, code: exitCode });
@@ -205,14 +212,8 @@ async function runStreamingShell(
     });
 
     function append(stream: 'stdout' | 'stderr', chunk: string): void {
-      outputBytes += Buffer.byteLength(chunk, 'utf8');
-      if (outputBytes > BASH_MAX_OUTPUT_BYTES) {
-        child.kill('SIGTERM');
-        rejectOnce(new Error(`Command output exceeded ${BASH_MAX_OUTPUT_BYTES} bytes`));
-        return;
-      }
-      if (stream === 'stdout') stdout += chunk;
-      else stderr += chunk;
+      if (stream === 'stdout') stdoutBuf.push(chunk);
+      else stderrBuf.push(chunk);
       options.emitOutput(stream, chunk);
     }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,6 +66,8 @@ export type {
 
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
+export { truncateToolOutput } from './tool-output.js';
+export type { TruncateToolOutputOptions, TruncatedToolOutput } from './tool-output.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,

--- a/packages/runtime/src/tool-output.ts
+++ b/packages/runtime/src/tool-output.ts
@@ -1,0 +1,147 @@
+// packages/runtime/src/tool-output.ts
+//
+// Shared, model-facing truncation for tool output (Bash stdout/stderr today).
+//
+// WHY: an unbounded tool result either floods the model's context (a chatty
+// command's full output) or, worse, gets discarded outright when a hard byte
+// cap is hit (the old Bash behavior threw away *all* output past 10MB, failing
+// otherwise-finished work). Both hurt pass@1. This bounds what the model sees
+// to a line/byte budget, keeps the most useful slice, and tells the model the
+// output was cut and how to recover the rest.
+//
+// We deliberately do NOT spill the full output to a host-side file the way
+// opencode does: the benchmark Bash path runs through an isolated executor that
+// abstracts the filesystem away, so there is no shared location the host can
+// write and the model can later read. Instead the truncation marker points the
+// model at the portable recovery it can always perform itself — re-run the
+// command redirecting to a file, then Read/Grep that file.
+//
+// Adapted from opencode's truncate.output() (packages/opencode/src/tool/
+// truncate.ts): same byte+line budget and head/tail windowing, minus the file
+// spill + retention machinery.
+
+export interface TruncateToolOutputOptions {
+  /** Max retained lines before truncation kicks in. Default 2000. */
+  maxLines?: number;
+  /** Max retained UTF-8 bytes before truncation kicks in. Default 50KB. */
+  maxBytes?: number;
+  /**
+   * Which end to KEEP. 'head' keeps the start (default, good for generic
+   * output); 'tail' keeps the end (good for shell logs, where the failing
+   * summary is usually last).
+   */
+  direction?: 'head' | 'tail';
+}
+
+export interface TruncatedToolOutput {
+  /** The bounded text, including an inline truncation marker when cut. */
+  content: string;
+  /** Whether any content was removed. */
+  truncated: boolean;
+  /** How much was removed (lines or bytes — see `unit`). 0 when not truncated. */
+  removed: number;
+  /** What `removed` counts. */
+  unit: 'lines' | 'bytes';
+}
+
+const DEFAULT_MAX_LINES = 2000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+
+function utf8Len(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+/**
+ * Keep at most `maxBytes` UTF-8 bytes of a single line, from the head or tail.
+ * Cutting mid-character is avoided: Buffer.toString replaces the partial
+ * multi-byte sequence at the boundary with U+FFFD, which we strip.
+ */
+function sliceLineByBytes(line: string, maxBytes: number, keep: 'head' | 'tail'): string {
+  const buf = Buffer.from(line, 'utf8');
+  if (buf.length <= maxBytes) return line;
+  const slice = keep === 'head' ? buf.subarray(0, maxBytes) : buf.subarray(buf.length - maxBytes);
+  const decoded = slice.toString('utf8');
+  return keep === 'head' ? decoded.replace(/�+$/, '') : decoded.replace(/^�+/, '');
+}
+
+/**
+ * Bound `text` to a line/byte budget for inclusion in a tool result the model
+ * reads. Returns the text unchanged when it already fits. When it does not, the
+ * kept window (head or tail) is returned with an inline marker naming how much
+ * was dropped and how to recover the omitted portion.
+ */
+export function truncateToolOutput(
+  text: string,
+  options: TruncateToolOutputOptions = {},
+): TruncatedToolOutput {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const direction = options.direction ?? 'head';
+
+  const totalBytes = utf8Len(text);
+  // A single trailing newline terminates the last line; it is not an extra
+  // empty line, so it must not count against the line budget.
+  const body = text.endsWith('\n') ? text.slice(0, -1) : text;
+  const lines = body.split('\n');
+  if (lines.length <= maxLines && totalBytes <= maxBytes) {
+    return { content: text, truncated: false, removed: 0, unit: 'lines' };
+  }
+
+  const out: string[] = [];
+  let bytes = 0;
+  let hitBytes = false;
+
+  if (direction === 'head') {
+    for (let i = 0; i < lines.length && i < maxLines; i++) {
+      const size = utf8Len(lines[i]) + (i > 0 ? 1 : 0);
+      if (bytes + size > maxBytes) {
+        hitBytes = true;
+        break;
+      }
+      out.push(lines[i]);
+      bytes += size;
+    }
+  } else {
+    for (let i = lines.length - 1; i >= 0 && out.length < maxLines; i--) {
+      const size = utf8Len(lines[i]) + (out.length > 0 ? 1 : 0);
+      if (bytes + size > maxBytes) {
+        hitBytes = true;
+        break;
+      }
+      out.unshift(lines[i]);
+      bytes += size;
+    }
+  }
+
+  // The boundary line alone exceeds the byte budget. Rather than show only a
+  // marker (the common single-huge-line case: minified file, base64, one-line
+  // JSON/stack trace), keep a byte-safe slice of that line.
+  let preview: string;
+  if (out.length === 0) {
+    const line = direction === 'head' ? lines[0] : lines[lines.length - 1];
+    preview = sliceLineByBytes(line, maxBytes, direction);
+    bytes = utf8Len(preview);
+    hitBytes = true;
+  } else {
+    preview = out.join('\n');
+  }
+
+  const removed = hitBytes ? Math.max(0, totalBytes - bytes) : lines.length - out.length;
+  if (removed <= 0) {
+    // Nothing was actually dropped — e.g. content fits but a lone trailing
+    // newline pushed totalBytes one over the byte budget. Don't emit a
+    // misleading "0 ... truncated" marker.
+    return { content: text, truncated: false, removed: 0, unit: 'lines' };
+  }
+  const unit: 'lines' | 'bytes' = hitBytes ? 'bytes' : 'lines';
+  const marker =
+    `...${removed} ${unit} truncated. ` +
+    'Re-run the command redirecting to a file (e.g. `cmd > out.txt 2>&1`) ' +
+    'then Read or Grep that file for the omitted portion...';
+
+  const content = direction === 'head'
+    ? `${preview}\n\n${marker}`
+    : `${marker}\n\n${preview}`;
+
+  return { content, truncated: true, removed, unit };
+}

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -25,6 +25,7 @@ import {
   type ToolArtifactRecorder,
 } from './tool-artifacts.js';
 import { createToolOutputDeltaEmitter } from './tool-output-delta.js';
+import { truncateToolOutput } from './tool-output.js';
 import type { RunTraceLike } from './run-trace.js';
 
 export interface MakaTool<P = any, R = unknown> {
@@ -663,17 +664,34 @@ function coerceTerminalFailure(
   const command = args && typeof args === 'object' && typeof (args as { command?: unknown }).command === 'string'
     ? (args as { command: string }).command
     : '';
+  const stdout = redactSecrets(String(error.stdout ?? ''));
+  const stderr = redactSecrets(String(error.stderr ?? ''));
   return {
     content: {
       kind: 'terminal',
       cwd,
       cmd: redactSecrets(command),
       exitCode: error.code,
-      stdout: redactSecrets(String(error.stdout ?? '')),
-      stderr: redactSecrets(String(error.stderr ?? '')),
+      stdout,
+      stderr,
     },
-    message: `命令退出码 ${error.code}`,
+    // The in-turn result the model acts on is just this message (the structured
+    // content above goes to session history). Without the actual output the
+    // model is blind to *why* the command failed, so fold in a bounded tail of
+    // stderr/stdout — the tail is where shell errors land.
+    message: buildTerminalFailureMessage(error.code, stdout, stderr),
   };
+}
+
+function buildTerminalFailureMessage(code: number, stdout: string, stderr: string): string {
+  const parts = [`命令退出码 ${code}`];
+  const view = (text: string) =>
+    truncateToolOutput(text, { maxLines: 40, maxBytes: 1500, direction: 'tail' }).content.trim();
+  const stderrView = view(stderr);
+  if (stderrView) parts.push(`--- stderr ---\n${stderrView}`);
+  const stdoutView = view(stdout);
+  if (stdoutView) parts.push(`--- stdout ---\n${stdoutView}`);
+  return parts.join('\n\n');
 }
 
 function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecord['status'] {


### PR DESCRIPTION
## What

Closes the **Bash overflow** + **in-turn feedback** P0s from #92. Two atomic commits:

1. **`feat(runtime): add shared truncateToolOutput helper`** — a self-contained helper (`packages/runtime/src/tool-output.ts`) that bounds model-facing output to a line/byte budget (default 2000 lines / 50KB), keeps the head or tail, and embeds a recovery marker when content is dropped. Pure helper + unit tests; no wiring.
2. **`feat(runtime/headless): bounded, recoverable Bash output`** — wires it across both Bash paths and fixes the failure feedback.

## The three fixes (all move pass@1)

- **No more discard-on-overflow.** `runStreamingShell` used to reject and throw away a command's *entire* output past a 10MB cap, failing otherwise-finished work. It now retains a memory-bounded tail (`BashTailBuffer`, ~1MB/stream, amortized trimming) and returns the truncated tail. The full stream is still emitted live via `emitOutput`.
- **No more context flood.** Both Bash paths — runtime builtin (`builtin-tools.ts`) and the **benchmark** isolated path (`packages/headless/src/tools.ts`, the actual pass@1 path) — truncate returned stdout/stderr to the model budget (`tail` direction, since shell errors land at the end).
- **Failed Bash now shows *why*.** Within an agentic turn the model previously saw only `命令退出码 N` for a failed Bash (the structured `{exitCode,stdout,stderr}` went to session history, not the immediate result). `coerceTerminalFailure` now folds a **redacted**, bounded tail of stderr/stdout into the in-turn message so the model can recover in-turn.

## Safety model

- **Redaction is never defeated by truncation.** `BashTailBuffer` drops the partial leading line on trim so the retained tail starts at a line boundary, and `coerceTerminalFailure` redacts the tail (whole lines) *before* truncating the message. A single line larger than the cap has no safe boundary and is dropped entirely; if such a line streams across multiple chunks, an `insideDroppedLine` state keeps discarding its continuation until the next newline — so a secret whose prefix was sliced off can never reach the model/UI with only its suffix.
- **Byte/line accounting is faithful:** a trailing newline is treated as a terminator (not an extra line), a single oversized line is kept as a UTF-8-safe byte slice rather than dropped to a bare marker, and a lone trailing newline that just tips the byte budget does not produce a misleading "0 truncated" marker.

## Deliberate scope decision (please confirm)

**No host-side file spill** (opencode's `truncate.output()` writes the full output to a file and returns `outputPath`). The benchmark Bash path runs through an isolated executor that abstracts the filesystem away, so there is no shared location the host can write and the model can later read. Instead the truncation marker points the model at the portable recovery it can always perform itself — re-run redirecting to a file, then `Read`/`Grep` it. Auto-spill can be a follow-up if benchmarks show the model struggling to recover truncated output.

## Maps to #92 (P0)

- [x] Bash overflow: keep tail instead of reject-and-discard
- [x] Return truncated stdout/stderr to the in-turn Bash failure result
- [x] Bound model-facing Bash output on the benchmark (headless) + runtime paths
- [ ] loop-gate → separate PR (C)
- [ ] Read / Grep / Glob / file-lock → separate PRs (D–G)

## Review gate (codex, xhigh, read-only, scoped to this PR's diff)

Five rounds to fresh-eye-clean:
- **R1:** 2 P1 — single oversized line dropped to a bare marker; trailing newline counted as an extra line (off-by-one false truncation). Both fixed.
- **R2:** 1 P0 — `TailBuffer` cut mid-line, so a secret with its prefix sliced off survived redaction. Fixed: drop the partial leading line (line-boundary tail).
- **R3:** 1 P0 — the single-line-no-newline case still kept a severed slice. Fixed: drop it entirely. (+ 1 P2 "0 truncated" accounting, fixed.)
- **R4:** 1 P0 — an oversized line split across `push()` calls leaked its continuation chunk. Fixed: `insideDroppedLine` state machine.
- **R5 (fresh-eye): no P0/P1**, nothing blocking.

## Verification

- `@maka/runtime` 608 tests + `@maka/headless` 242 tests green (new: `BashTailBuffer` memory bound + redaction-safety + streaming continuation; `truncateToolOutput` budgets/edges; builtin Bash no-discard + failure-surfaces-output; ai-sdk-backend in-turn enrichment; headless large-output bounding with full-stream emit).
- `npm run build` + `npm run typecheck` exit 0 across all workspaces.
