### PR TITLE
Dedupe renderer local storage guards

### DIFF
--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -72,6 +72,7 @@ import {
 } from '@maka/ui';
 import { ArtifactPreview } from './artifact-preview';
 import { nextArtifactListAction } from './artifact-list-keyboard';
+import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
 import { openPathFailureCopy } from './open-path';
 
 const COLLAPSE_KEY = 'maka-artifact-pane-collapsed-v1';
@@ -155,11 +156,7 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
   }, [sessionId, refresh]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem(COLLAPSE_KEY, collapsed ? '1' : '0');
-    } catch {
-      /* localStorage unavailable — collapse state resets next launch, no behaviour impact */
-    }
+    safeLocalStorageSet(COLLAPSE_KEY, collapsed ? '1' : '0');
   }, [collapsed]);
 
   const activeRecords = useMemo(
@@ -605,12 +602,7 @@ function KindIcon(props: { kind: ArtifactKind }) {
 }
 
 function readCollapsed(): boolean {
-  try {
-    const raw = localStorage.getItem(COLLAPSE_KEY);
-    return raw === '1';
-  } catch {
-    return false;
-  }
+  return safeLocalStorageGet(COLLAPSE_KEY) === '1';
 }
 
 function formatBytes(bytes: number): string {

--- a/apps/desktop/src/renderer/browser-storage.ts
+++ b/apps/desktop/src/renderer/browser-storage.ts
@@ -1,0 +1,15 @@
+export function safeLocalStorageGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeLocalStorageSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Storage may be unavailable in restricted or test renderer contexts.
+  }
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -103,6 +103,7 @@ import {
   recordSessionEventStreamChange,
   recordSessionEventStreamEvent,
 } from './session-event-health';
+import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
 import './styles.css';
 
 const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
@@ -1184,19 +1185,11 @@ function AppShell() {
   }, [activeId, activeSession?.status, activeStreaming.length, hasInFlightLiveTools, activePermission?.requestId]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem('maka-chat-list-width-v1', String(sessionListWidth));
-    } catch {
-      /* localStorage unavailable; width resets to the default next launch */
-    }
+    safeLocalStorageSet('maka-chat-list-width-v1', String(sessionListWidth));
   }, [sessionListWidth]);
 
   useEffect(() => {
-    try {
-      localStorage.setItem('maka-chat-list-collapsed-v1', sessionListCollapsed ? 'true' : 'false');
-    } catch {
-      /* localStorage unavailable; sidebar resets to the collapsed target-layout like rail */
-    }
+    safeLocalStorageSet('maka-chat-list-collapsed-v1', sessionListCollapsed ? 'true' : 'false');
   }, [sessionListCollapsed]);
 
   // Persist sidebar nav selection so the app remembers what bucket the user
@@ -1204,11 +1197,7 @@ function AppShell() {
   // localStorage availability check — Vite dev sometimes runs through a
   // worker where it isn't defined.
   useEffect(() => {
-    try {
-      localStorage.setItem('maka-nav-selection-v1', JSON.stringify(navSelection));
-    } catch {
-      /* localStorage unavailable */
-    }
+    safeLocalStorageSet('maka-nav-selection-v1', JSON.stringify(navSelection));
   }, [navSelection]);
 
   async function refreshSessions(): Promise<SessionSummary[]> {
@@ -2412,11 +2401,7 @@ function AppShell() {
    * tabs without close/reopen.
    */
   function openSettingsSection(section: SettingsSection) {
-    try {
-      localStorage.setItem('maka-settings-section-v1', section);
-    } catch {
-      /* localStorage unavailable; fall back to whatever section the modal picks */
-    }
+    safeLocalStorageSet('maka-settings-section-v1', section);
     setSettingsRequestedSection(section);
     setSettingsOpen(true);
   }
@@ -3537,7 +3522,7 @@ function renderConversationMarkdown(sessionName: string, messages: StoredMessage
 
 function readNavSelection(): NavSelection {
   try {
-    const raw = localStorage.getItem('maka-nav-selection-v1');
+    const raw = safeLocalStorageGet('maka-nav-selection-v1');
     if (!raw) return { section: 'sessions', filter: 'chats' };
     const parsed = JSON.parse(raw) as { section?: string; filter?: string };
     // PR-SIDEBAR-IA-0 Phase 2 fixup (xuan `94c7bf0f`): fail-closed.
@@ -3563,23 +3548,15 @@ function readNavSelection(): NavSelection {
 }
 
 function readSessionListWidth(): number {
-  try {
-    const stored = Number(localStorage.getItem('maka-chat-list-width-v1'));
-    if (Number.isFinite(stored) && stored > 0) return clampSessionListWidth(stored);
-  } catch {
-    /* localStorage unavailable */
-  }
+  const stored = Number(safeLocalStorageGet('maka-chat-list-width-v1'));
+  if (Number.isFinite(stored) && stored > 0) return clampSessionListWidth(stored);
   return SESSION_LIST_EXPANDED_DEFAULT_WIDTH;
 }
 
 function readSessionListCollapsed(): boolean {
-  try {
-    const stored = localStorage.getItem('maka-chat-list-collapsed-v1');
-    if (stored === 'false') return false;
-    if (stored === 'true') return true;
-  } catch {
-    /* localStorage unavailable */
-  }
+  const stored = safeLocalStorageGet('maka-chat-list-collapsed-v1');
+  if (stored === 'false') return false;
+  if (stored === 'true') return true;
   return true;
 }
 
@@ -3738,19 +3715,15 @@ function countSessions(sessions: SessionSummary[]) {
 // "FOUC prevention via inline-script" pattern, but here it runs in the same
 // JS bundle as the rest of the renderer so we don't need to relax the CSP
 // `script-src 'self'` rule.
-try {
-  const cached = localStorage.getItem('maka-theme-v1');
-  const isDark =
-    cached === 'dark' ||
-    (cached !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-  if (isDark) {
-    document.documentElement.classList.add('dark');
-    document.documentElement.style.colorScheme = 'dark';
-  } else {
-    document.documentElement.style.colorScheme = 'light';
-  }
-} catch {
-  /* localStorage unavailable; fall back to default light theme */
+const cachedThemePreference = safeLocalStorageGet('maka-theme-v1');
+const shouldApplyDarkTheme =
+  cachedThemePreference === 'dark' ||
+  (cachedThemePreference !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+if (shouldApplyDarkTheme) {
+  document.documentElement.classList.add('dark');
+  document.documentElement.style.colorScheme = 'dark';
+} else {
+  document.documentElement.style.colorScheme = 'light';
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -108,6 +108,7 @@ import { ProvidersPanel } from './ProvidersPanel';
 import { PasswordInput } from './password-input';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { applyUiLocale, type UiLocalePreference } from '../theme';
+import { safeLocalStorageGet, safeLocalStorageSet } from '../browser-storage';
 import {
   deriveAccountAuthActions,
   presentAccountAuthState,
@@ -883,11 +884,7 @@ function SettingsSurface(props: {
   }, []);
 
   useEffect(() => {
-    try {
-      localStorage.setItem('maka-settings-section-v1', section);
-    } catch {
-      /* localStorage unavailable */
-    }
+    safeLocalStorageSet('maka-settings-section-v1', section);
   }, [section]);
   const [settings, setSettings] = useState<AppSettings>(() => createDefaultSettings());
   const [usageStats, setUsageStats] = useState<UsageStats | null>(null);
@@ -7008,14 +7005,10 @@ function SettingRow(props: { title: string; detail: string; value: string }) {
 }
 
 function readLastSettingsSection(): SettingsSection {
-  try {
-    const value = localStorage.getItem('maka-settings-section-v1');
-    if (!value) return 'models';
-    if (SETTINGS_NAV.some((item) => item.id === value)) {
-      return value as SettingsSection;
-    }
-  } catch {
-    /* fall through */
+  const value = safeLocalStorageGet('maka-settings-section-v1');
+  if (!value) return 'models';
+  if (SETTINGS_NAV.some((item) => item.id === value)) {
+    return value as SettingsSection;
   }
   return 'models';
 }

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -9,6 +9,7 @@
 // reads the attribute to swap a coherent set of `--ui-density-*` tokens.
 
 import type { ThemePalette, ThemePreference, UiDensity } from '@maka/core';
+import { safeLocalStorageSet } from './browser-storage';
 
 const DARK_CLASS = 'dark';
 
@@ -29,11 +30,7 @@ export function applyTheme(pref: ThemePreference): () => void {
 
   // Cache the user-facing preference (not the resolved light/dark). The
   // pre-React paint reapplies the auto → system-matchMedia branch itself.
-  try {
-    localStorage.setItem('maka-theme-v1', pref);
-  } catch {
-    /* localStorage unavailable; cached preference will fall back to default */
-  }
+  safeLocalStorageSet('maka-theme-v1', pref);
 
   if (pref === 'auto') {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
@@ -90,11 +87,7 @@ export function applyThemePalette(palette: ThemePalette): void {
   } else {
     root.setAttribute('data-maka-theme', palette);
   }
-  try {
-    localStorage.setItem('maka-theme-palette-v1', palette);
-  } catch {
-    /* localStorage unavailable; pre-React paint will fall back to default */
-  }
+  safeLocalStorageSet('maka-theme-palette-v1', palette);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a tiny renderer browser-storage helper for localStorage get/set degradation
- replace repeated localStorage try/catch blocks in shell, settings, theme, and artifact pane
- keep the same storage keys and fallback defaults while removing duplicated defensive boilerplate

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop test -- settings-form-a11y-contract artifact-pane (ran full 1464/1464 with check-console/check-a11y clean)
- npm run build (existing Vite chunk-size warning only)
- git diff --check