### PR TITLE
feat(runtime/headless): fault-tolerant Edit via shared guarded fuzzy replacer (#92 P0)

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { exec as childExec } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -137,7 +137,7 @@ describe('isolated headless tools', () => {
     ]);
   });
 
-  test('file tools fall back to command-backed isolated operations', async () => {
+  test('sh-backed file tools fall back to command-backed isolated operations', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-fallback-'));
     await mkdir(join(cwd, 'src'));
     const absoluteFile = join(cwd, 'src', 'file.txt');
@@ -172,20 +172,76 @@ describe('isolated headless tools', () => {
     assert.deepEqual(await tool(tools, 'Read').impl({ path: absoluteFile, offset: 1, limit: 1 }, toolCtx(cwd)), {
       content: 'needle',
     });
-    assert.deepEqual(
-      await tool(tools, 'Edit').impl({ path: absoluteFile, old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
-      { ok: true, path: 'src/file.txt', replacements: 1 },
-    );
     assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: absoluteGlob }, toolCtx(cwd)), {
       files: ['src/file.txt'],
     });
     assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', path: absoluteSrc, glob: absoluteGlob }, toolCtx(cwd)), {
       matches: ['src/file.txt:2:needle'],
     });
-    assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hi\nneedle\n');
-    assert.ok(calls.length >= 5);
+    assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hello\nneedle\n');
+    // Edit is intentionally excluded here: it runs via `node -e` (covered by the
+    // dedicated Edit test below) while Read/Write/Glob/Grep stay POSIX-sh scripts
+    // that must work with only base coreutils on PATH (here pinned to /usr/bin:/bin).
+    assert.ok(calls.length >= 4);
     assert.ok(calls.every((command) => command.startsWith("sh -c '")));
     assert.ok(calls.every((command) => !command.includes('node -e')));
+  });
+
+  test('command-backed Edit runs the shared fuzzy matcher via node -e', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-'));
+    await mkdir(join(cwd, 'src'));
+    const file = join(cwd, 'src', 'f.ts');
+    // 4-space indented body on disk; the model's old_string uses 2-space indent.
+    await writeFile(file, 'function f() {\n    return 1;\n}\n', 'utf8');
+    await chmod(file, 0o600); // editing must preserve the original mode, not widen it
+    const calls: string[] = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        calls.push(input.command);
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    // Fuzzy: indentation drift is forgiven, and the matched span/strategy is reported.
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl(
+        { path: 'src/f.ts', old_string: 'function f() {\n  return 1;\n}', new_string: 'function f() {\n    return 2;\n}' },
+        toolCtx(cwd),
+      ),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'line-trimmed', startLine: 1, endLine: 3 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 2;\n}\n');
+
+    // Exact match still works and reports matchedVia: 'exact'.
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl({ path: 'src/f.ts', old_string: 'return 2;', new_string: 'return 3;' }, toolCtx(cwd)),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'exact', startLine: 2, endLine: 2 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 3;\n}\n');
+    assert.equal((await stat(file)).mode & 0o777, 0o600); // mode preserved across the tmp+rename
+
+    // Edit refuses to follow a symlink out of the workspace (mirrors existing_target()).
+    const outside = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-outside-'));
+    await writeFile(join(outside, 'secret.txt'), 'secret\n', 'utf8');
+    await symlink(join(outside, 'secret.txt'), join(cwd, 'src', 'link.txt'));
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl({ path: 'src/link.txt', old_string: 'secret', new_string: 'edited' }, toolCtx(cwd)),
+      /inside workspace/,
+    );
+    assert.equal(await readFile(join(outside, 'secret.txt'), 'utf8'), 'secret\n');
+
+    // Every Edit ran through node -e (the shared computeEditedSource), not sh.
+    assert.ok(calls.length >= 3);
+    assert.ok(calls.every((command) => command.startsWith("node -e '")));
   });
 
   test('command-backed file tools do not follow symlinks outside the isolated workspace', async () => {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -2,6 +2,7 @@ import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  COMPUTE_EDITED_SOURCE_FN_SOURCE,
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
@@ -121,12 +122,18 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
       if (executor.editFile) {
         return await executor.editFile({ cwd, path: normalizedPath, oldString: old_string, newString: new_string });
       }
-      await execFileCommand(executor, cwd, shellFileCommand(EDIT_SCRIPT, [
+      // Edit is the one file tool whose matching logic is non-trivial and must
+      // stay byte-identical to the in-process builtin Edit. Rather than keep a
+      // second (perl) matcher, it runs the SHARED computeEditedSource via
+      // `node -e` (node is guaranteed in the headless/Harbor environment); the
+      // other file tools stay on the POSIX-sh scripts. old/new are base64-encoded
+      // so arbitrary content survives argv transport unchanged.
+      const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
         normalizedPath,
-        old_string,
-        new_string,
+        Buffer.from(old_string, 'utf8').toString('base64'),
+        Buffer.from(new_string, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path: normalizedPath, replacements: 1 };
+      return { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
     },
   };
 }
@@ -196,6 +203,14 @@ function shellFileCommand(script: string, args: string[]): string {
   return ['sh', '-c', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
 }
 
+// Like shellFileCommand but runs the script with `node -e`. Used only by Edit,
+// whose matcher (computeEditedSource) is shared TypeScript that cannot be
+// expressed in POSIX sh. shellQuote escapes the embedded script (including its
+// single quotes) so the serialized function survives transport intact.
+function nodeFileCommand(script: string, args: string[]): string {
+  return ['node', '-e', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
+}
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -207,6 +222,26 @@ function numberArg(value: number | undefined): string {
 function parseLineArray(stdout: string): string[] {
   if (!stdout) return [];
   return stdout.replace(/\n$/, '').split('\n').filter((line) => line.length > 0);
+}
+
+// EDIT_SCRIPT applies the edit and THEN prints this metadata, so the file is
+// already changed by the time we parse. matchedVia / line range are best-effort
+// observability; a malformed payload must not turn a successful edit into a
+// reported failure, so this fails open to {} (a protocol regression is caught by
+// tests, which assert the metadata is present on success).
+function parseEditMeta(stdout: string): { matchedVia?: string; startLine?: number; endLine?: number } {
+  try {
+    const parsed: unknown = JSON.parse(stdout || '{}');
+    if (!parsed || typeof parsed !== 'object') return {};
+    const { matchedVia, startLine, endLine } = parsed as Record<string, unknown>;
+    return {
+      matchedVia: typeof matchedVia === 'string' ? matchedVia : undefined,
+      startLine: typeof startLine === 'number' ? startLine : undefined,
+      endLine: typeof endLine === 'number' ? endLine : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function globPatternToEre(pattern: string): string {
@@ -350,33 +385,63 @@ target=$(writable_target "$1" 'Write path') || exit 1
 printf '%s' "$2" > "$target"
 `;
 
-const EDIT_SCRIPT = `${COMMON_SHELL_HELPERS}
-root=$(pwd -P) || exit 1
-target=$(existing_target "$1" 'Edit path') || exit 1
-tmp=$(mktemp "$target.maka-edit.XXXXXX") || exit 1
-perl -0 -e '
-  use strict;
-  use warnings;
-  my ($old, $new, $target, $tmp) = @ARGV;
-  die "old_string must not be empty\n" if $old eq "";
-  open my $in, "<:raw", $target or die "$target: $!\n";
-  local $/;
-  my $content = <$in>;
-  close $in;
-  my $count = () = $content =~ /\\Q$old\\E/g;
-  die "old_string not found in $target\n" if $count == 0;
-  die "old_string is not unique in $target ($count matches)\n" if $count > 1;
-  $content =~ s/\\Q$old\\E/$new/;
-  open my $out, ">:raw", $tmp or die "$tmp: $!\n";
-  print {$out} $content;
-  close $out;
-' "$2" "$3" "$target" "$tmp"
-rc=$?
-if [ "$rc" -ne 0 ]; then
-  rm -f "$tmp"
-  exit "$rc"
-fi
-mv "$tmp" "$target"
+// Edit runs as a `node -e` script (not sh) so it can embed the shared
+// computeEditedSource matcher verbatim — keeping a single source of truth with
+// the in-process builtin Edit instead of a divergent perl reimplementation.
+// Path containment mirrors COMMON_SHELL_HELPERS' existing_target(): reject a
+// symlinked target outright and require the resolved path to stay inside the
+// workspace root. Keep this policy in lockstep with existing_target().
+const EDIT_SCRIPT = `const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const computeEditedSource = ${COMPUTE_EDITED_SOURCE_FN_SOURCE};
+function inside(root, target) {
+  const rel = path.relative(root, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+function editTarget(root, inputPath, label) {
+  const target = path.join(root, inputPath);
+  let stat;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') throw new Error(label + ' does not exist: ' + inputPath);
+    throw error;
+  }
+  if (stat.isSymbolicLink()) throw new Error(label + ' must stay inside workspace');
+  const real = stat.isDirectory()
+    ? fs.realpathSync(target)
+    : path.join(fs.realpathSync(path.dirname(target)), path.basename(target));
+  if (!inside(root, real)) throw new Error(label + ' must stay inside workspace');
+  return real;
+}
+try {
+  const [inputPath, oldBase64, newBase64] = process.argv.slice(1);
+  const root = fs.realpathSync(process.cwd());
+  const target = editTarget(root, inputPath, 'Edit path');
+  const oldString = Buffer.from(oldBase64, 'base64').toString('utf8');
+  const newString = Buffer.from(newBase64, 'base64').toString('utf8');
+  const current = fs.readFileSync(target, 'utf8');
+  const result = computeEditedSource(current, oldString, newString, inputPath);
+  // Atomic write (tmp + rename), matching the prior perl EDIT_SCRIPT, so a crash
+  // mid-write can never leave a torn file — only the old or the new content. The
+  // temp name is unpredictable (crypto) and created with 'wx' (O_CREAT|O_EXCL),
+  // so a pre-planted symlink at the temp path can neither be guessed nor
+  // followed — equivalent to the old mktemp ...XXXXXX guarantees. Preserve the
+  // original file's permission bits (chmod is not subject to umask) so editing a
+  // restricted or executable file does not silently change its mode on rename.
+  const targetMode = fs.statSync(target).mode & 0o777;
+  const tmp = target + '.maka-edit.' + crypto.randomBytes(8).toString('hex');
+  fs.writeFileSync(tmp, result.content, { encoding: 'utf8', flag: 'wx' });
+  fs.chmodSync(tmp, targetMode);
+  fs.renameSync(tmp, target);
+  process.stdout.write(JSON.stringify({ matchedVia: result.matchedVia, startLine: result.startLine, endLine: result.endLine }));
+} catch (error) {
+  // Surface a clean message (matching the prior perl die behavior) instead of a
+  // node [eval] stack trace; execFileCommand propagates stderr to the model.
+  process.stderr.write(error && error.message ? error.message : String(error));
+  process.exit(1);
+}
 `;
 
 const GLOB_SCRIPT = `${COMMON_SHELL_HELPERS}

--- a/packages/runtime/src/__tests__/edit-replace.test.ts
+++ b/packages/runtime/src/__tests__/edit-replace.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from '../edit-replace.js';
+
+describe('computeEditedSource — exact match', () => {
+  test('replaces the single occurrence and reports an exact match + line range', () => {
+    assert.deepEqual(computeEditedSource('hello world', 'world', 'Maka', 'a.txt'), {
+      content: 'hello Maka',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+
+  test('reports the matched multi-line range (1-based, inclusive)', () => {
+    const content = 'a\nb\nTARGET1\nTARGET2\nc\n';
+    const result = computeEditedSource(content, 'TARGET1\nTARGET2', 'X', 'a.txt');
+    assert.equal(result.content, 'a\nb\nX\nc\n');
+    assert.equal(result.startLine, 3);
+    assert.equal(result.endLine, 4);
+  });
+
+  test('inserts new_string literally (no $-pattern interpretation)', () => {
+    const result = computeEditedSource('const x = old;', 'old', '$&value', 'a.txt');
+    assert.equal(result.content, 'const x = $&value;');
+  });
+
+  test('throws with the where label when old_string is absent', () => {
+    assert.throws(() => computeEditedSource('hello', 'absent', 'x', 'src/a.txt'), /old_string not found in src\/a\.txt/);
+  });
+
+  test('throws with the match count when old_string is not unique', () => {
+    assert.throws(() => computeEditedSource('a a a', 'a', 'b', 'b.txt'), /old_string is not unique in b\.txt \(3 matches\)/);
+  });
+
+  test('rejects identical old_string and new_string', () => {
+    assert.throws(() => computeEditedSource('abc', 'abc', 'abc', 'b.txt'), /identical/);
+  });
+
+  test('rejects an empty old_string', () => {
+    assert.throws(() => computeEditedSource('abc', '', 'x', 'b.txt'), /must not be empty/);
+  });
+});
+
+describe('computeEditedSource — fuzzy cascade', () => {
+  test('line-trimmed: tolerates indentation drift on a multi-line block', () => {
+    const content = 'function f() {\n    return 1;\n}\n'; // 4-space body
+    const oldString = 'function f() {\n  return 1;\n}'; // model used 2-space body
+    const result = computeEditedSource(content, oldString, 'function f() {\n    return 2;\n}', 'f.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 3);
+  });
+
+  test('whitespace: tolerates collapsed internal whitespace', () => {
+    const content = 'const  x   =   1;';
+    const result = computeEditedSource(content, 'const x = 1;', 'const x = 2;', 'w.ts');
+    assert.equal(result.matchedVia, 'whitespace');
+    assert.equal(result.content, 'const x = 2;');
+  });
+
+  test('escape: tolerates literal backslash escapes in old_string', () => {
+    const content = 'line1\nline2';
+    const result = computeEditedSource(content, 'line1\\nline2', 'X', 'e.ts');
+    assert.equal(result.matchedVia, 'escape');
+    assert.equal(result.content, 'X');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test('line-trimmed: preserves a trailing newline in old_string (no extra blank line)', () => {
+    const content = '  abcde\n  fghij\n';
+    const result = computeEditedSource(content, 'abcde\nfghij\n', 'xxxxx\nyyyyy\n', 'n.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'xxxxx\nyyyyy\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test("a span's trailing newline is a terminator, not an extra line, for endLine", () => {
+    assert.deepEqual(computeEditedSource('abc\n', 'abc\n', 'def\n', 'r.ts'), {
+      content: 'def\n',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+});
+
+describe('computeEditedSource — anti-corruption guards', () => {
+  test('rejects multiple distinct fuzzy candidates instead of guessing', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n   x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}'; // matches both blocks by trimmed lines
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /different line-trimmed candidates/);
+  });
+
+  test('rejects a fuzzy span that occurs more than once', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n  x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}';
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /occurs more than once/);
+  });
+
+  test('rejects a too-short old_string for a non-exact match', () => {
+    const content = 'a   b';
+    assert.throws(() => computeEditedSource(content, 'a b', 'c', 's.ts'), /too short/);
+  });
+
+  test('a multi-line old_string never collapses onto a single line (whitespace)', () => {
+    const content = 'header\nalpha beta\nfooter\n';
+    assert.throws(() => computeEditedSource(content, 'alpha\nbeta', 'X', 'w.ts'), /not found/);
+  });
+});
+
+describe('computeEditedSource — serialized embedding', () => {
+  test('serialized source is standalone and reproduces the full cascade', () => {
+    assert.equal(typeof COMPUTE_EDITED_SOURCE_FN_SOURCE, 'string');
+    const embedded = new Function(`return (${COMPUTE_EDITED_SOURCE_FN_SOURCE})`)() as typeof computeEditedSource;
+    // exercise a fuzzy path to prove nested helpers survive serialization
+    const result = embedded('function f() {\n    return 1;\n}\n', 'function f() {\n  return 1;\n}', 'function f() {\n    return 2;\n}', 'x.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
+  });
+});

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -11,6 +11,7 @@ import { exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { computeEditedSource } from './edit-replace.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -91,14 +92,16 @@ export function buildBuiltinTools(): MakaTool[] {
       impl: async ({ path, old_string, new_string }, { cwd }) => {
         const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
         const current = await fs.readFile(abs, 'utf8');
-        const count = current.split(old_string).length - 1;
-        if (count === 0) throw new Error(`old_string not found in ${path}`);
-        if (count > 1) {
-          throw new Error(`old_string is not unique in ${path} (${count} matches)`);
-        }
-        const next = current.replace(old_string, new_string);
-        await fs.writeFile(abs, next, 'utf8');
-        return { ok: true, path: abs, replacements: 1 };
+        const result = computeEditedSource(current, old_string, new_string, path);
+        await fs.writeFile(abs, result.content, 'utf8');
+        return {
+          ok: true,
+          path: abs,
+          replacements: 1,
+          matchedVia: result.matchedVia,
+          startLine: result.startLine,
+          endLine: result.endLine,
+        };
       },
     },
     {

--- a/packages/runtime/src/edit-replace.ts
+++ b/packages/runtime/src/edit-replace.ts
@@ -1,0 +1,260 @@
+// packages/runtime/src/edit-replace.ts
+//
+// Shared, fault-tolerant string-edit logic used by BOTH Edit tool
+// implementations:
+//   - the in-process builtin Edit tool (packages/runtime/src/builtin-tools.ts),
+//     which imports and calls computeEditedSource directly, and
+//   - the isolated headless Edit tool (packages/headless/src/tools.ts), which
+//     embeds COMPUTE_EDITED_SOURCE_FN_SOURCE into a `node -e` script that runs
+//     inside the isolated executor process (the actual benchmark path).
+//
+// CONSTRAINT: computeEditedSource must stay fully self-contained — no imports,
+// no references to module-scope bindings, every helper a nested *function
+// declaration* (hoisted, so order-independent), no generators — so that
+// `.toString()` yields a standalone definition that runs unchanged inside the
+// isolated process. This keeps a single source of truth for both call sites.
+//
+// SAFETY MODEL (the point of this module): exact-match drift (whitespace,
+// indentation, escaping) is forgiven, but a fuzzy match must never silently
+// land in the wrong place. Every fuzzy strategy here verifies the FULL span is
+// structurally equivalent to old_string (not just anchors), and a strategy is
+// only accepted when it produces exactly ONE candidate occurring exactly ONCE.
+// Any ambiguity throws instead of guessing.
+//
+// Strategies are adapted from opencode's edit.ts (sourced from cline diff-apply
+// + gemini-cli editCorrector). We keep the three distinctly-reachable full-span
+// matchers (line-trimmed, whitespace-normalized, escape-normalized) and omit:
+//   - indentation-flexible and trimmed-boundary, which are strictly shadowed by
+//     line-trimmed / whitespace-normalized here (they add no reachable match);
+//   - block-anchor and context-aware, which match on partial signal (first/last
+//     line + similarity) and need a tuned similarity threshold — deliberately
+//     deferred to keep wrong-location risk out.
+
+export type EditMatchStrategy =
+  | 'exact'
+  | 'line-trimmed'
+  | 'whitespace'
+  | 'escape';
+
+export interface EditMatch {
+  /** The full new file content after the replacement. */
+  content: string;
+  /** Which strategy located old_string ('exact' or a fuzzy strategy name). */
+  matchedVia: EditMatchStrategy;
+  /** 1-based first line of the matched span in the original source. */
+  startLine: number;
+  /** 1-based last line (inclusive) of the matched span in the original source. */
+  endLine: number;
+}
+
+/**
+ * Apply a single, unambiguous replacement of `oldString` with `newString` in
+ * `source`, tolerating whitespace/indentation/escape drift via a guarded fuzzy
+ * cascade. `where` is the caller's relative path, embedded in error messages.
+ *
+ * @returns the new content plus which strategy matched and the matched line
+ *   range (so the caller can show the model where the edit landed).
+ * @throws when old_string is absent, ambiguous, identical to new_string, too
+ *   short to fuzzy-match safely, or matches a disproportionately large span.
+ */
+export function computeEditedSource(
+  source: string,
+  oldString: string,
+  newString: string,
+  where: string,
+): EditMatch {
+  // Declared inside the function (not module scope) so .toString() carries it
+  // into the isolated EDIT_SCRIPT — module-scope references do not survive
+  // serialization. Minimum trimmed old_string length for a non-exact match.
+  const MIN_FUZZY_OLD_STRING_LENGTH = 5;
+
+  if (oldString === newString) {
+    throw new Error(`No changes to apply in ${where}: old_string and new_string are identical`);
+  }
+  if (oldString === '') {
+    throw new Error(`old_string must not be empty in ${where}`);
+  }
+
+  // Exact match first — preserves the prior behavior, including the informative
+  // match count, and short-circuits before any fuzzy work.
+  const exactCount = source.split(oldString).length - 1;
+  if (exactCount === 1) {
+    return finish(source, oldString, newString, 'exact');
+  }
+  if (exactCount > 1) {
+    throw new Error(`old_string is not unique in ${where} (${exactCount} matches)`);
+  }
+
+  // Fuzzy strategies, increasing tolerance. Each returns FULL-span candidates
+  // structurally equivalent to old_string; the loop below requires exactly one.
+  const strategies: Array<[EditMatchStrategy, (content: string, find: string) => string[]]> = [
+    ['line-trimmed', lineTrimmedSpans],
+    ['whitespace', whitespaceNormalizedSpans],
+    ['escape', escapeNormalizedSpans],
+  ];
+
+  for (const [name, finder] of strategies) {
+    const spans = dedupeInContent(source, finder(source, oldString));
+    if (spans.length === 0) continue;
+    if (spans.length > 1) {
+      throw new Error(
+        `old_string matched ${spans.length} different ${name} candidates in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    const span = spans[0];
+    if (source.indexOf(span) !== source.lastIndexOf(span)) {
+      throw new Error(
+        `old_string matched a ${name} span that occurs more than once in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    if (oldString.trim().length < MIN_FUZZY_OLD_STRING_LENGTH) {
+      throw new Error(
+        `old_string is too short for a non-exact match in ${where}; provide a longer, exact snippet`,
+      );
+    }
+    if (isDisproportionate(span, oldString)) {
+      throw new Error(
+        `Refusing ${name} match in ${where}: the matched span is much larger than old_string. Re-read the file and pass the exact text to replace.`,
+      );
+    }
+    return finish(source, span, newString, name);
+  }
+
+  throw new Error(
+    `old_string not found in ${where}; it must match the file's text including whitespace and indentation`,
+  );
+
+  // ---- nested helpers (kept inside for self-contained .toString() embedding) ----
+
+  function finish(
+    content: string,
+    span: string,
+    replacement: string,
+    matchedVia: EditMatchStrategy,
+  ): EditMatch {
+    const index = content.indexOf(span);
+    const before = content.slice(0, index);
+    const startLine = before.split('\n').length;
+    // A trailing newline in the span is the last line's terminator, not an
+    // extra line, so it must not bump endLine.
+    const spanLineCount = span.split('\n').length - (span.endsWith('\n') ? 1 : 0);
+    const endLine = startLine + Math.max(spanLineCount, 1) - 1;
+    // slice-join (not String.replace) so `$&`/`$1` in newString are literal.
+    const next = before + replacement + content.slice(index + span.length);
+    return { content: next, matchedVia, startLine, endLine };
+  }
+
+  function dedupeInContent(content: string, candidates: string[]): string[] {
+    const out: string[] = [];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      if (content.indexOf(candidate) === -1) continue;
+      if (out.indexOf(candidate) === -1) out.push(candidate);
+    }
+    return out;
+  }
+
+  function lineTrimmedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const originalLines = content.split('\n');
+    const findEndsWithNewline = find.endsWith('\n');
+    const searchLines = find.split('\n');
+    if (searchLines.length > 0 && searchLines[searchLines.length - 1] === '') {
+      searchLines.pop();
+    }
+    if (searchLines.length === 0) return out;
+    for (let i = 0; i <= originalLines.length - searchLines.length; i++) {
+      let matches = true;
+      for (let j = 0; j < searchLines.length; j++) {
+        if (originalLines[i + j].trim() !== searchLines[j].trim()) {
+          matches = false;
+          break;
+        }
+      }
+      if (!matches) continue;
+      let startIndex = 0;
+      for (let k = 0; k < i; k++) startIndex += originalLines[k].length + 1;
+      let endIndex = startIndex;
+      for (let k = 0; k < searchLines.length; k++) {
+        endIndex += originalLines[i + k].length;
+        if (k < searchLines.length - 1) endIndex += 1;
+      }
+      // If old_string ended with a newline, the matched span must include the
+      // file's newline after the last matched line; otherwise the replacement
+      // would drop or duplicate a line break. When there is no such newline
+      // (EOF with no trailing newline) this is not a faithful match — skip it.
+      if (findEndsWithNewline) {
+        const lastLine = i + searchLines.length - 1;
+        if (lastLine >= originalLines.length - 1) continue;
+        endIndex += 1;
+      }
+      out.push(content.substring(startIndex, endIndex));
+    }
+    return out;
+  }
+
+  function whitespaceNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const normalize = (text: string) => text.replace(/\s+/g, ' ').trim();
+    const normalizedFind = normalize(find);
+    if (normalizedFind === '') return out;
+    const lines = content.split('\n');
+    const findLines = find.split('\n');
+    if (findLines.length === 1) {
+      // Single-line old_string: match individual lines only. A multi-line
+      // old_string must never collapse onto one physical line — normalize()
+      // turns newlines into spaces, so an unguarded single-line scan would let
+      // `a\nb` match the line `a b`, which is a wrong-location edit.
+      for (let i = 0; i < lines.length; i++) {
+        if (normalize(lines[i]) === normalizedFind) out.push(lines[i]);
+      }
+    } else {
+      for (let i = 0; i <= lines.length - findLines.length; i++) {
+        const block = lines.slice(i, i + findLines.length).join('\n');
+        if (normalize(block) === normalizedFind) out.push(block);
+      }
+    }
+    return out;
+  }
+
+  function escapeNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const unescape = (str: string) =>
+      str.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (match: string, ch: string) => {
+        if (ch === 'n') return '\n';
+        if (ch === 't') return '\t';
+        if (ch === 'r') return '\r';
+        if (ch === "'") return "'";
+        if (ch === '"') return '"';
+        if (ch === '`') return '`';
+        if (ch === '\\') return '\\';
+        if (ch === '\n') return '\n';
+        if (ch === '$') return '$';
+        return match;
+      });
+    const unescapedFind = unescape(find);
+    if (content.includes(unescapedFind)) out.push(unescapedFind);
+    const lines = content.split('\n');
+    const findLines = unescapedFind.split('\n');
+    for (let i = 0; i <= lines.length - findLines.length; i++) {
+      const block = lines.slice(i, i + findLines.length).join('\n');
+      if (unescape(block) === unescapedFind) out.push(block);
+    }
+    return out;
+  }
+
+  function isDisproportionate(span: string, find: string): boolean {
+    const oldLines = find.split('\n').length;
+    const spanLines = span.split('\n').length;
+    if (spanLines >= Math.max(oldLines + 3, oldLines * 2)) return true;
+    if (oldLines === 1) return false;
+    return span.trim().length > Math.max(find.trim().length + 500, find.trim().length * 4);
+  }
+}
+
+/**
+ * Serialized source of computeEditedSource, captured once at module load for
+ * embedding into the isolated headless EDIT_SCRIPT. Using the live function's
+ * own source avoids drift between the in-process and serialized forms.
+ */
+export const COMPUTE_EDITED_SOURCE_FN_SOURCE: string = computeEditedSource.toString();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,6 +66,8 @@ export type {
 
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
+export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
+export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,


### PR DESCRIPTION
## What

Closes the keystone P0 from #92: make the **Edit** tool fault-tolerant so whitespace / indentation / escape drift in `old_string` no longer fails the edit — without ever silently editing the wrong location, and with a single matcher shared by both Edit implementations.

> Reworked onto current `main`. Since the first draft, `main` moved every isolated headless file tool from `node -e` to POSIX-sh scripts (commit `76446b2b`). This rework respects that direction: **only Edit** — the one file tool whose matching logic is non-trivial shared TypeScript — runs via `node -e`; **Read / Write / Glob / Grep stay on the sh scripts, untouched.**

Two atomic commits:

1. **`feat: add shared fault-tolerant Edit replacer and adopt it in builtin Edit`** — extract the matcher into one self-contained `computeEditedSource()` (`packages/runtime/src/edit-replace.ts`) and adopt it in the in-process builtin Edit, which gains the fuzzy cascade. The function is written fully self-contained so its `.toString()` can be embedded into the headless path — one source of truth for both call sites.
2. **`feat: route headless isolated Edit through the shared replacer via node -e`** — the benchmark/Harbor Edit path was exact-match-only (a perl `EDIT_SCRIPT`). It now embeds the serialized `computeEditedSource` into a `node -e` script (node is guaranteed in the headless/Harbor environment). No second matcher to keep in sync.

## Why Edit (and only Edit) uses node

Read=cat, Write=tee, Glob=find, Grep=rg are trivially expressed in POSIX sh and have no shared algorithm to keep in lockstep — they stay on `76446b2b`'s sh scripts. Edit is the only tool with a non-trivial fuzzy-match algorithm that must stay byte-identical to the desktop builtin, so it alone justifies embedding the shared TS via `node -e`. This keeps a true single source of truth for the matcher while leaving the rest of `76446b2b` intact.

## Cascade + safety model

After exact match: **line-trimmed → whitespace-normalized → escape-normalized** (adapted from opencode's `edit.ts`). Each verifies the **full span** is structurally equivalent to `old_string` (not just anchors).

Anti-corruption guards (the point of the change — a fuzzy match must never land in the wrong place):
- a fuzzy strategy is accepted only if it yields **exactly one** candidate occurring **exactly once**; any ambiguity throws instead of guessing
- reject `old_string === new_string` and empty `old_string`
- reject a too-short `old_string` (<5 trimmed chars) for non-exact matches
- reject disproportionately large matched spans
- returns `matchedVia` + matched line range so the model can see where the edit landed
- slice-join replacement (not `String.replace`) so `$&` / `$1` in `new_string` are inserted literally

## Headless node EDIT_SCRIPT specifics

- **Path containment mirrors the sh `existing_target()`** it sits beside: reject a symlinked target outright, resolve the parent's realpath, require the result to stay inside the workspace (kept in lockstep with the sh helper).
- **Atomic, safe write**: write to an unpredictable temp name (`crypto.randomBytes`) created with `flag: 'wx'` (`O_CREAT|O_EXCL`, so a pre-planted symlink can be neither guessed nor followed), preserve the original file's permission bits, then `rename` — equivalent to the old `mktemp ...XXXXXX` guarantees, with no torn-write or mode-widening window.
- **Clean errors**: a failed match surfaces `old_string not found in foo.txt`, not a node `[eval]` stack trace.

## Deliberate scope decisions

- **Two strategies deferred**: opencode's `block-anchor` and `context-aware` match on partial signal (first/last line + a similarity threshold) and are the main silent-wrong-location risk; they need a tuned similarity threshold (a product decision per #92). Omitted; can follow up.
- **Two strategies omitted as redundant**: `indentation-flexible` and `trimmed-boundary` are strictly shadowed by line-trimmed / whitespace here (no reachable additional match).
- **Desktop has no Edit tool** (`apps/desktop/src/main/main.ts:599` filters builtin Edit out), so this PR touches only runtime + headless — the two paths that exist.

## Review gate (codex, xhigh, scoped to this PR's 2 commits)

- **Round 1**: no P0/P1. P1 — the temp file used a predictable name (`process.pid`) and a non-exclusive write, so a pre-planted symlink could be followed out of the workspace (**fixed**: unpredictable name + `flag:'wx'`). P2 — temp file created without an explicit mode could widen a `0600` file to `0644` on rename (**fixed**: preserve the original mode via `chmod`).
- **Round 2 (fresh-eye): no P0/P1.** Verified the temp write is safe against symlink pre-planting and torn writes, `node -e ... --` argv indexing is correct, the EDIT_SCRIPT containment matches `existing_target()`, and there is no wrong-location edit risk. One P2 — `parseEditMeta` fail-opens on malformed stdout (**kept intentionally**: the edit is already applied before metadata is printed, so a malformed payload must not fail a successful edit; metadata is observability-only and a protocol regression is caught by the tests).

## Verification

- `@maka/runtime` 608 tests + `@maka/headless` 253 tests green, including a real `node -e` `EDIT_SCRIPT` fuzzy + exact + symlink-reject + mode-preservation integration test, and a serialization test that guards `computeEditedSource`'s self-containment.
- `npm run typecheck` exits 0 across all five workspaces.
