### PR TITLE
feat(runtime/headless): bounded, recoverable Bash output (#92 P0)

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell-bash.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-bash.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { describe, test } from 'node:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHarborCellLocalToolExecutor } from '../harbor-cell.js';
+import { buildIsolatedBashTool } from '../tools.js';
+
+// These run the REAL local executor (actual child processes) — not a fake exec —
+// so they exercise the failure point the fake-executor tests cannot: before this
+// fix the executor used execAsync({ maxBuffer: 10MB }), so a command exceeding
+// 10MB was KILLED mid-run and only its first 10MB (the head) was returned. The
+// benchmark Bash path now streams into a bounded tail and runs to completion.
+
+const toolCtx = (cwd: string) => ({
+  sessionId: 's',
+  turnId: 't',
+  cwd,
+  toolCallId: 'tool-1',
+  abortSignal: new AbortController().signal,
+  emitOutput: () => {},
+});
+
+describe('Harbor local executor Bash (real spawn, >10MB)', () => {
+  test('keeps a bounded TAIL of >10MB stdout instead of being killed at the old maxBuffer (P1)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-bash-big-'));
+    const bash = buildIsolatedBashTool(createHarborCellLocalToolExecutor());
+    // ~20MB of stdout, well past the retired 10MB maxBuffer, bracketed by sentinels.
+    const result = (await bash.impl(
+      { command: 'echo HEAD_SENTINEL; seq 1 3000000; echo TAIL_SENTINEL' },
+      toolCtx(cwd),
+    )) as { exitCode: number; stdout: string };
+
+    assert.equal(result.exitCode, 0); // ran to completion — not killed by maxBuffer
+    assert.ok(result.stdout.includes('TAIL_SENTINEL'), 'true tail retained');
+    assert.ok(!result.stdout.includes('HEAD_SENTINEL'), 'head dropped — it is a tail, not the head');
+    assert.ok(result.stdout.includes('truncated'), 'model-budget truncation marker present');
+  });
+
+  test('keeps a bounded TAIL of >10MB stderr without being killed', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-bash-bigerr-'));
+    const bash = buildIsolatedBashTool(createHarborCellLocalToolExecutor());
+    const result = (await bash.impl(
+      { command: '{ echo HEAD_SENTINEL; seq 1 3000000; echo TAIL_SENTINEL; } 1>&2' },
+      toolCtx(cwd),
+    )) as { exitCode: number; stderr: string };
+
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.stderr.includes('TAIL_SENTINEL'), 'true stderr tail retained');
+    assert.ok(!result.stderr.includes('HEAD_SENTINEL'), 'stderr head dropped');
+    assert.ok(result.stderr.includes('truncated'), 'stderr truncation marker present');
+  });
+});

--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { describe, test } from 'node:test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHarborCellLocalToolExecutor } from '../harbor-cell.js';
+import { buildIsolatedHeadlessTools } from '../tools.js';
+
+// Real local executor (actual child processes). Regression guard for the
+// bounded-tail change: Read/Glob/Grep run through the SAME executor.exec as Bash,
+// so when Bash's bounded tail was (briefly) the default exec semantics, a large
+// file or result was silently head-dropped to a tail. Read must return the FULL
+// file, head-first — only Bash opts into a bounded tail.
+
+const toolCtx = (cwd: string) => ({
+  sessionId: 's',
+  turnId: 't',
+  cwd,
+  toolCallId: 'tool-1',
+  abortSignal: new AbortController().signal,
+  emitOutput: () => {},
+});
+
+function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string) {
+  const found = tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not found`);
+  return found;
+}
+
+describe('Harbor local executor file tools (real spawn)', () => {
+  test('Read returns the FULL file head-first, not a bounded tail (P1 regression)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-read-'));
+    // ~2MB (under the 10MB exec cap) bracketed by markers. A bounded tail would
+    // silently drop HEAD_MARKER; Read must return the whole file.
+    const body = 'HEAD_MARKER\n' + 'a'.repeat(2 * 1024 * 1024) + '\nTAIL_MARKER\n';
+    await writeFile(join(cwd, 'big.txt'), body, 'utf8');
+    const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
+
+    const result = (await tool(tools, 'Read').impl({ path: 'big.txt' }, toolCtx(cwd))) as { content: string };
+
+    assert.ok(result.content.includes('HEAD_MARKER'), 'head retained — Read is not tail-bounded');
+    assert.ok(result.content.includes('TAIL_MARKER'), 'tail retained');
+    assert.ok(result.content.length >= 2 * 1024 * 1024, 'full file content returned, not a 1MB tail');
+    // (Glob/Grep share the same command-backed executor.exec with no boundedTail
+    //  flag — see the "only Bash opts into bounded-tail" contract test — so this
+    //  full-output guarantee covers them too without generating MBs of matches.)
+  });
+});

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -39,7 +39,7 @@ describe('isolated headless tools', () => {
       },
     );
 
-    assert.deepEqual(calls, [{ command: 'npm test', cwd: '/workspace', timeoutMs: 12_000 }]);
+    assert.deepEqual(calls, [{ command: 'npm test', cwd: '/workspace', timeoutMs: 12_000, boundedTail: true }]);
     assert.deepEqual(emitted, [
       { stream: 'stdout', chunk: 'out\n' },
       { stream: 'stderr', chunk: 'err\n' },
@@ -54,7 +54,7 @@ describe('isolated headless tools', () => {
     });
   });
 
-  test('Bash bounds large executor output for the model but emits the full stream', async () => {
+  test('Bash surfaces the executor result to history and bounds it for the model', async () => {
     const big = Array.from({ length: 5000 }, (_, i) => `line${i + 1}`).join('\n') + '\n';
     const emitted: Array<{ stream: string; chunk: string }> = [];
     const bash = buildIsolatedBashTool({
@@ -75,13 +75,37 @@ describe('isolated headless tools', () => {
       },
     ) as { stdout: string };
 
-    // The full stream is still surfaced live (history / UI), unbounded.
+    // emitOutput surfaces whatever the executor RETURNS to history (there is no
+    // live per-chunk channel across the executor boundary — see the Harbor tests
+    // for the real bounded path). The model-facing result is bounded further.
     assert.equal(emitted.find((event) => event.stream === 'stdout')?.chunk, big);
-    // The model-facing result is bounded: tail kept, marker present, smaller.
     assert.ok(result.stdout.includes('line5000'));
     assert.ok(result.stdout.includes('truncated'));
     assert.ok(!result.stdout.includes('line1\n'));
     assert.ok(result.stdout.length < big.length);
+  });
+
+  test('only Bash opts into bounded-tail; Read/Glob/Grep request full output', async () => {
+    // Records the boundedTail flag of every exec() and returns empty output, so
+    // the command-backed Read/Glob/Grep complete without running anything.
+    const seen: Array<{ boundedTail: unknown }> = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        seen.push({ boundedTail: (input as { boundedTail?: boolean }).boundedTail });
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    await tool(tools, 'Bash').impl({ command: 'echo hi' }, toolCtx('/workspace'));
+    await tool(tools, 'Read').impl({ path: 'src/f.txt' }, toolCtx('/workspace'));
+    await tool(tools, 'Glob').impl({ pattern: '**/*.txt' }, toolCtx('/workspace'));
+    await tool(tools, 'Grep').impl({ pattern: 'hello' }, toolCtx('/workspace'));
+
+    assert.equal(seen[0].boundedTail, true, 'Bash opts into bounded tail');
+    assert.ok(
+      seen.slice(1).every((call) => !call.boundedTail),
+      'Read/Glob/Grep must request full output, not a bounded tail',
+    );
   });
 
   test('standard isolated tool surface exposes externalized file tools to local-read children', () => {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -54,6 +54,36 @@ describe('isolated headless tools', () => {
     });
   });
 
+  test('Bash bounds large executor output for the model but emits the full stream', async () => {
+    const big = Array.from({ length: 5000 }, (_, i) => `line${i + 1}`).join('\n') + '\n';
+    const emitted: Array<{ stream: string; chunk: string }> = [];
+    const bash = buildIsolatedBashTool({
+      async exec() {
+        return { exitCode: 0, stdout: big, stderr: '' };
+      },
+    });
+
+    const result = await bash.impl(
+      { command: 'noisy' },
+      {
+        sessionId: 's',
+        turnId: 't',
+        cwd: '/workspace',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: (stream, chunk) => emitted.push({ stream, chunk }),
+      },
+    ) as { stdout: string };
+
+    // The full stream is still surfaced live (history / UI), unbounded.
+    assert.equal(emitted.find((event) => event.stream === 'stdout')?.chunk, big);
+    // The model-facing result is bounded: tail kept, marker present, smaller.
+    assert.ok(result.stdout.includes('line5000'));
+    assert.ok(result.stdout.includes('truncated'));
+    assert.ok(!result.stdout.includes('line1\n'));
+    assert.ok(result.stdout.length < big.length);
+  });
+
   test('standard isolated tool surface exposes externalized file tools to local-read children', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,5 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { exec as nodeExec } from 'node:child_process';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 import type {
   BackendKind,
   LlmConnection,
@@ -36,6 +38,8 @@ import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools, type
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
+const execAsync = promisify(nodeExec);
+const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 export interface RunHarborCellInput {
   config: Config;
@@ -335,25 +339,46 @@ export function buildHarborCellAiSdkTools(
 export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = process.env): IsolatedToolExecutor {
   const childEnv = childProcessEnv(env);
   return {
-    exec: async ({ command, cwd, timeoutMs }) => {
+    exec: async ({ command, cwd, timeoutMs, boundedTail }) => {
+      if (boundedTail) {
+        // Bash opted in: stream into a bounded tail (shared with the in-process
+        // builtin Bash) instead of execAsync({ maxBuffer }). A command whose
+        // output passes 10MB is no longer KILLED with only its head returned —
+        // it runs to completion and we keep the last ~1MB (the recoverable tail).
+        try {
+          const result = await runShellWithBoundedTail(command, {
+            cwd,
+            env: childEnv,
+            timeoutMs: timeoutMs ?? 120_000,
+          });
+          return {
+            exitCode: result.timedOut ? 124 : result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          };
+        } catch (error) {
+          // runShellWithBoundedTail only rejects when the process cannot be
+          // spawned at all (e.g. the shell binary is missing).
+          return {
+            exitCode: shellErrorExitCode(error),
+            stdout: shellErrorText(error, 'stdout'),
+            stderr: shellErrorText(error, 'stderr') || shellErrorMessage(error),
+          };
+        }
+      }
+      // Default (Read/Glob/Grep/Edit fallbacks): FULL output up to the buffer
+      // cap. These must return complete, head-first content — a bounded tail
+      // would silently drop the head of a file or search result and the model
+      // would edit code from a partial view.
       try {
-        // Stream into a bounded tail (shared with the in-process builtin Bash)
-        // instead of execAsync({ maxBuffer }): a command whose output passes the
-        // old 10MB buffer is no longer KILLED with only its head returned — it
-        // runs to completion and we keep the last ~1MB (the recoverable tail).
-        const result = await runShellWithBoundedTail(command, {
+        const result = await execAsync(command, {
           cwd,
           env: childEnv,
-          timeoutMs: timeoutMs ?? 120_000,
+          timeout: timeoutMs ?? 120_000,
+          maxBuffer: HARBOR_CELL_TOOL_MAX_BUFFER_BYTES,
         });
-        return {
-          exitCode: result.timedOut ? 124 : result.exitCode,
-          stdout: result.stdout,
-          stderr: result.stderr,
-        };
+        return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
       } catch (error) {
-        // runShellWithBoundedTail only rejects when the process cannot be
-        // spawned at all (e.g. the shell binary is missing).
         return {
           exitCode: shellErrorExitCode(error),
           stdout: shellErrorText(error, 'stdout'),

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,7 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { exec as nodeExec } from 'node:child_process';
 import { join } from 'node:path';
-import { promisify } from 'node:util';
 import type {
   BackendKind,
   LlmConnection,
@@ -17,6 +15,7 @@ import {
   buildProviderOptions,
   getAIModel,
   getBuiltinPricing,
+  runShellWithBoundedTail,
   type MakaTool,
   type InvocationResult,
 } from '@maka/runtime';
@@ -37,8 +36,6 @@ import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools, type
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
-const execAsync = promisify(nodeExec);
-const HARBOR_CELL_TOOL_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 
 export interface RunHarborCellInput {
   config: Config;
@@ -340,14 +337,23 @@ export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = proces
   return {
     exec: async ({ command, cwd, timeoutMs }) => {
       try {
-        const result = await execAsync(command, {
+        // Stream into a bounded tail (shared with the in-process builtin Bash)
+        // instead of execAsync({ maxBuffer }): a command whose output passes the
+        // old 10MB buffer is no longer KILLED with only its head returned — it
+        // runs to completion and we keep the last ~1MB (the recoverable tail).
+        const result = await runShellWithBoundedTail(command, {
           cwd,
           env: childEnv,
-          timeout: timeoutMs ?? 120_000,
-          maxBuffer: HARBOR_CELL_TOOL_MAX_BUFFER_BYTES,
+          timeoutMs: timeoutMs ?? 120_000,
         });
-        return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+        return {
+          exitCode: result.timedOut ? 124 : result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        };
       } catch (error) {
+        // runShellWithBoundedTail only rejects when the process cannot be
+        // spawned at all (e.g. the shell binary is missing).
         return {
           exitCode: shellErrorExitCode(error),
           stdout: shellErrorText(error, 'stdout'),

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -14,6 +14,14 @@ export interface IsolatedCommandInput {
   command: string;
   cwd: string;
   timeoutMs?: number;
+  /**
+   * Bash-only opt-in. When true the executor keeps just the recoverable TAIL of
+   * a large output and never kills the command for output size. Omitted/false
+   * (the default) preserves FULL output up to the executor's buffer cap — so the
+   * Read/Glob/Grep command fallbacks return complete, head-first content instead
+   * of a silently head-dropped tail. Only buildIsolatedBashTool sets this.
+   */
+  boundedTail?: boolean;
 }
 
 export interface IsolatedCommandResult {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -81,16 +81,21 @@ export function buildIsolatedBashTool(
         cwd,
         timeoutMs: timeout_ms ?? 120_000,
       };
+      // boundedTail: Bash is the one caller that wants a recoverable tail of a
+      // huge, never-killed output. Read/Glob/Grep deliberately omit it so they
+      // get full, head-first content from the executor.
       const result = await executor.exec({
         command: input.command,
         cwd: input.cwd,
         timeoutMs: input.timeoutMs,
+        boundedTail: true,
       });
+      // The isolated executor returns a single (already tail-bounded) result —
+      // there is no live per-chunk channel across the executor boundary, so we
+      // surface that result to history here, then bound it further for the model.
       if (result.stdout) emitOutput('stdout', result.stdout);
       if (result.stderr) emitOutput('stderr', result.stderr);
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Bash', input, result }, ctx);
-      // Bound what the model sees: a chatty command's full output would flood
-      // the context. The full stream is still emitted live via emitOutput above.
       return {
         kind: 'terminal',
         cwd,

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -3,6 +3,7 @@ import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
   COMPUTE_EDITED_SOURCE_FN_SOURCE,
+  truncateToolOutput,
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
@@ -88,13 +89,15 @@ export function buildIsolatedBashTool(
       if (result.stdout) emitOutput('stdout', result.stdout);
       if (result.stderr) emitOutput('stderr', result.stderr);
       await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Bash', input, result }, ctx);
+      // Bound what the model sees: a chatty command's full output would flood
+      // the context. The full stream is still emitted live via emitOutput above.
       return {
         kind: 'terminal',
         cwd,
         cmd: command,
         exitCode: result.exitCode,
-        stdout: result.stdout,
-        stderr: result.stderr,
+        stdout: truncateToolOutput(result.stdout, { direction: 'tail' }).content,
+        stderr: truncateToolOutput(result.stderr, { direction: 'tail' }).content,
       };
     },
   };

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1457,7 +1457,16 @@ describe('AiSdkBackend error surfaces', () => {
       { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
     );
 
-    assert.deepEqual(result, { error: '命令退出码 2' });
+    // In-turn result now folds in a redacted, bounded tail of stderr/stdout so
+    // the model can see *why* the command failed (the full structured content
+    // still goes to session history, asserted below).
+    assert.deepEqual(result, {
+      error: [
+        '命令退出码 2',
+        '--- stderr ---\nstderr before failure',
+        '--- stdout ---\nstdout before failure\nAuthorization: Bearer [redacted]',
+      ].join('\n\n'),
+    });
     assert.equal(messages[0]?.isError, true);
     assert.deepEqual(messages[0]?.content, events.find((event) => event.type === 'tool_result')?.content);
     assert.deepEqual(messages[0]?.content, {

--- a/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
+++ b/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { BashTailBuffer } from '../bash-tail-buffer.js';
+
+describe('BashTailBuffer', () => {
+  test('returns everything when under the cap', () => {
+    const buf = new BashTailBuffer(100);
+    buf.push('hello\n');
+    buf.push('world');
+    assert.equal(buf.value(), 'hello\nworld');
+  });
+
+  test('bounds retained output to the cap and keeps whole tail lines', () => {
+    const buf = new BashTailBuffer(20);
+    for (let i = 0; i < 100; i++) buf.push(`line${i}\n`);
+    const value = buf.value();
+    assert.ok(value.length <= 20);
+    assert.ok(value.endsWith('line99\n')); // tail preserved
+    assert.ok(value.startsWith('line')); // starts at a line boundary, not mid-line
+  });
+
+  test('drops the partial leading line so a sliced secret prefix cannot survive', () => {
+    // The first line would be cut mid-secret; the buffer must drop it whole so a
+    // later redaction pass never sees a secret with its prefix sliced off.
+    const buf = new BashTailBuffer(10);
+    buf.push('SECRETXYZ\n');
+    buf.push('KEEP1\nKEEP2\n');
+    const value = buf.value();
+    assert.equal(value, 'KEEP2\n');
+    assert.ok(!value.includes('SECRET'));
+  });
+
+  test('drops a single oversized line with no newline (no safe redaction boundary)', () => {
+    // A single line larger than the cap has no line boundary to cut on; keeping
+    // a byte-slice could hand redaction a secret with its prefix sliced off, so
+    // it is dropped entirely. Pathological case — the common single line is
+    // under the cap and never sliced.
+    const buf = new BashTailBuffer(5);
+    buf.push('Authorization: Bearer sk-live-secret-token-value'); // one giant line
+    assert.equal(buf.value(), '');
+  });
+
+  test('keeps discarding continuation chunks of a dropped oversized line until a newline', () => {
+    // The oversized line arrives across multiple chunks (stdout does not split on
+    // line boundaries). After the prefix is dropped, the suffix chunk must stay
+    // discarded — otherwise redaction would later see a secret with no prefix.
+    const buf = new BashTailBuffer(20);
+    buf.push('Authorization: Bearer sk-live-' + 'A'.repeat(30)); // oversized prefix dropped
+    buf.push('secret_tail'); // continuation of the SAME line
+    assert.equal(buf.value(), '');
+    buf.push(' more\nKEEP\n'); // newline terminates the compromised line; resume after it
+    assert.equal(buf.value(), 'KEEP\n');
+  });
+});

--- a/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
+++ b/packages/runtime/src/__tests__/bash-tail-buffer.test.ts
@@ -38,6 +38,15 @@ describe('BashTailBuffer', () => {
     const buf = new BashTailBuffer(5);
     buf.push('Authorization: Bearer sk-live-secret-token-value'); // one giant line
     assert.equal(buf.value(), '');
+    // It also flags the unsafe drop so callers can mark the empty result.
+    assert.equal(buf.hasDroppedUnsafe(), true);
+  });
+
+  test('does not flag a safe drop (partial leading line trimmed at a newline)', () => {
+    const buf = new BashTailBuffer(8);
+    buf.push('aaaa\nbbbb\ncccc\n'); // sliced at a newline boundary — safe, not unsafe
+    assert.ok(buf.value().length <= 8);
+    assert.equal(buf.hasDroppedUnsafe(), false);
   });
 
   test('keeps discarding continuation chunks of a dropped oversized line until a newline', () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -66,6 +66,56 @@ describe('builtin Bash streaming output', () => {
     await expectRejects(Promise.resolve(run), /Command aborted/);
     expect(events.some((event) => event.stream === 'stdout' && event.chunk.includes('started'))).toBe(true);
   });
+
+  test('large output is bounded to a tail instead of being discarded', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-'));
+    const bash = buildBuiltinTools().find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    const result = await bash.impl(
+      { command: "awk 'BEGIN{for(i=1;i<=5000;i++)print \"line\"i}'", timeout_ms: 10_000 },
+      {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        cwd,
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      },
+    ) as { exitCode: number; stdout: string };
+
+    expect(result.exitCode).toBe(0); // no reject — the old code threw away everything past the cap
+    expect(result.stdout.includes('line5000')).toBe(true); // tail preserved
+    expect(result.stdout.includes('truncated')).toBe(true); // truncation marker present
+    expect(result.stdout.includes('line1\n')).toBe(false); // head dropped, not the whole output
+  });
+
+  test('a failing command surfaces stdout/stderr on the rejection error', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-'));
+    const bash = buildBuiltinTools().find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    let err: { code?: number; stdout?: string; stderr?: string } | null = null;
+    try {
+      await bash.impl(
+        { command: 'printf "out-data"; printf "err-data" >&2; exit 3', timeout_ms: 5_000 },
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          cwd,
+          toolCallId: 'tool-1',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        },
+      );
+    } catch (e: unknown) {
+      err = e as { code?: number; stdout?: string; stderr?: string };
+    }
+
+    expect(err?.code).toBe(3);
+    expect(err?.stdout).toBe('out-data');
+    expect(err?.stderr).toBe('err-data');
+  });
 });
 
 describe('builtin read tools path containment', () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -116,6 +116,35 @@ describe('builtin Bash streaming output', () => {
     expect(err?.stdout).toBe('out-data');
     expect(err?.stderr).toBe('err-data');
   });
+
+  test('a timed-out command still surfaces the stdout/stderr captured before the timeout', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-'));
+    const bash = buildBuiltinTools().find((tool) => tool.name === 'Bash');
+    if (!bash) throw new Error('Bash tool missing');
+
+    let err: { code?: number; stdout?: string; stderr?: string } | null = null;
+    try {
+      await bash.impl(
+        { command: 'printf "out-before"; printf "err-before" >&2; sleep 5', timeout_ms: 200 },
+        {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          cwd,
+          toolCallId: 'tool-1',
+          abortSignal: new AbortController().signal,
+          emitOutput: () => {},
+        },
+      );
+    } catch (e: unknown) {
+      err = e as { code?: number; stdout?: string; stderr?: string };
+    }
+
+    // Without the fix the model would see a bare "timed out" with no logs; now
+    // the error carries a code (124) and the bounded tail captured pre-timeout.
+    expect(err?.code).toBe(124);
+    expect(err?.stdout).toBe('out-before');
+    expect(err?.stderr).toBe('err-before');
+  });
 });
 
 describe('builtin read tools path containment', () => {

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -37,6 +37,16 @@ describe('runShellWithBoundedTail', () => {
     assert.equal(r.exitCode, 124);
   });
 
+  test('surfaces a safety marker (not bare empty) when an oversized no-newline line is dropped', async () => {
+    // One 500-char line with no newline, cap 50: BashTailBuffer drops it whole
+    // (no safe truncation boundary), so without a marker the result would look
+    // like the command produced nothing.
+    const r = await runShellWithBoundedTail("head -c 500 /dev/zero | tr '\\0' x", base({ maxRetainedChars: 50 }));
+    assert.equal(r.exitCode, 0);
+    assert.ok(!r.stdout.includes('xxxx'), 'dropped content is not leaked');
+    assert.ok(r.stdout.includes('omitted for safety'), 'a recoverable safety marker is present');
+  });
+
   test('emits every chunk live via emitOutput', async () => {
     const seen: Array<[string, string]> = [];
     await runShellWithBoundedTail(

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -56,4 +56,26 @@ describe('runShellWithBoundedTail', () => {
     assert.ok(seen.some(([s, c]) => s === 'stdout' && c.includes('aaa')));
     assert.ok(seen.some(([s, c]) => s === 'stderr' && c.includes('bbb')));
   });
+
+  test('caps live emitOutput per stream with a single suppressed marker (result keeps full tail)', async () => {
+    const seen: Array<[string, string]> = [];
+    const r = await runShellWithBoundedTail(
+      "printf 'HEAD\\n'; seq 1 2000; printf 'TAIL\\n'",
+      base({
+        maxLiveEmitChars: 20, // tiny cap so the stream trips it almost immediately
+        emitOutput: (s: 'stdout' | 'stderr', c: string) => seen.push([s, c]),
+      }),
+    );
+    assert.equal(r.exitCode, 0);
+    const stdoutEmits = seen.filter(([s]) => s === 'stdout');
+    const markers = stdoutEmits.filter(([, c]) => c.includes('live output suppressed'));
+    assert.equal(markers.length, 1, 'exactly one suppressed marker, not one per chunk');
+    const liveChars = stdoutEmits
+      .filter(([, c]) => !c.includes('live output suppressed'))
+      .reduce((n, [, c]) => n + c.length, 0);
+    assert.ok(liveChars <= 20, `live emit bounded to cap, got ${liveChars}`);
+    // The suppressed LIVE feed does not lose the result: the retained tail still
+    // carries the real output (the last bytes the command produced).
+    assert.ok(r.stdout.includes('TAIL'), 'retained tail keeps the command output');
+  });
 });

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -79,6 +79,9 @@ describe('runShellWithBoundedTail', () => {
     assert.equal(r.exitCode, 0);
     assert.ok(!r.stdout.includes('xxxx'), 'dropped content is not leaked');
     assert.ok(r.stdout.includes('omitted for safety'), 'a recoverable safety marker is present');
+    // Shares the recovery hint with truncateToolOutput: re-run only when safe.
+    assert.ok(r.stdout.includes('safe to re-run'), 'recovery guidance is conditioned on safety');
+    assert.ok(r.stdout.includes('side effects'), 'warns about repeating side effects');
   });
 
   test('emits every chunk live via emitOutput', async () => {

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { runShellWithBoundedTail } from '../shell-exec.js';
 
 const base = (over: Record<string, unknown> = {}) => ({ cwd: process.cwd(), timeoutMs: 30_000, ...over });
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('runShellWithBoundedTail', () => {
   test('returns full small output and exit 0 without throwing', async () => {
@@ -35,6 +39,36 @@ describe('runShellWithBoundedTail', () => {
     const r = await runShellWithBoundedTail('sleep 5', base({ timeoutMs: 150 }));
     assert.equal(r.timedOut, true);
     assert.equal(r.exitCode, 124);
+  });
+
+  test('on timeout, escalates SIGTERM->SIGKILL and resolves only after the child is actually dead', async () => {
+    // A child that traps/ignores SIGTERM would, under the old "kill then resolve
+    // immediately" path, keep running (and emitting) after we told the caller
+    // "timed out". Now we wait for the child to actually exit (SIGKILL after the
+    // grace) before resolving — proven by the heartbeat file no longer growing.
+    const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-kill-'));
+    const beat = join(dir, 'beat');
+    const cmd = `trap '' TERM; while true; do echo STILL; echo x >> '${beat}'; sleep 0.02; done`;
+    const emits: string[] = [];
+    try {
+      const r = await runShellWithBoundedTail(
+        cmd,
+        base({ timeoutMs: 100, killGraceMs: 150, emitOutput: (_s: string, c: string) => emits.push(c) }),
+      );
+      assert.equal(r.timedOut, true);
+      assert.equal(r.exitCode, 124);
+      const sizeAtResolve = (await fs.stat(beat)).size;
+      const emitsAtResolve = emits.length;
+      await delay(300); // a live child would append ~15 more lines in this window
+      const sizeLater = (await fs.stat(beat)).size;
+      assert.ok(
+        sizeLater - sizeAtResolve <= 2, // tolerate at most one in-flight append
+        `child kept writing after resolve (grew ${sizeLater - sizeAtResolve} bytes) — not actually killed`,
+      );
+      assert.equal(emits.length, emitsAtResolve, 'no emitOutput after resolve');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   test('surfaces a safety marker (not bare empty) when an oversized no-newline line is dropped', async () => {

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -71,6 +71,28 @@ describe('runShellWithBoundedTail', () => {
     }
   });
 
+  test('on timeout, kills the whole process tree so a child holding the pipe cannot hang the runner', async () => {
+    // The shell spawns a grandchild (node) that inherits stdout and never exits.
+    // Killing only the shell PID would leave it holding the pipe, so 'close'
+    // would never fire and this test would HANG. Killing the process group lets
+    // 'close' fire and the grandchild is actually gone.
+    const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-tree-'));
+    const pidFile = join(dir, 'child.pid');
+    const cmd =
+      `node -e 'require("fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setInterval(() => {}, 1000)'`;
+    try {
+      const r = await runShellWithBoundedTail(cmd, base({ timeoutMs: 200, killGraceMs: 150 }));
+      assert.equal(r.timedOut, true);
+      assert.equal(r.exitCode, 124);
+      await delay(150); // let the OS reap the killed tree
+      const childPid = Number((await fs.readFile(pidFile, 'utf8')).trim());
+      assert.ok(Number.isInteger(childPid) && childPid > 0, 'grandchild recorded its pid');
+      assert.throws(() => process.kill(childPid, 0), /ESRCH/, 'grandchild was killed with the tree');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('surfaces a safety marker (not bare empty) when an oversized no-newline line is dropped', async () => {
     // One 500-char line with no newline, cap 50: BashTailBuffer drops it whole
     // (no safe truncation boundary), so without a marker the result would look

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { runShellWithBoundedTail } from '../shell-exec.js';
+
+const base = (over: Record<string, unknown> = {}) => ({ cwd: process.cwd(), timeoutMs: 30_000, ...over });
+
+describe('runShellWithBoundedTail', () => {
+  test('returns full small output and exit 0 without throwing', async () => {
+    const r = await runShellWithBoundedTail("printf 'hello\\nworld\\n'", base());
+    assert.deepEqual(
+      { exitCode: r.exitCode, stdout: r.stdout, stderr: r.stderr, timedOut: r.timedOut, aborted: r.aborted },
+      { exitCode: 0, stdout: 'hello\nworld\n', stderr: '', timedOut: false, aborted: false },
+    );
+  });
+
+  test('keeps only the bounded, line-aligned TAIL of large output (never killed by size)', async () => {
+    const r = await runShellWithBoundedTail(
+      "printf 'HEADMARK\\n'; seq 1 50; printf 'TAILMARK\\n'",
+      base({ maxRetainedChars: 12 }),
+    );
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes('TAILMARK'), 'tail retained');
+    assert.ok(!r.stdout.includes('HEADMARK'), 'head dropped — it is a tail');
+    assert.ok(r.stdout.length <= 12, `tail bounded to cap, got ${r.stdout.length}`);
+  });
+
+  test('captures stderr and a non-zero exit code as data (does not reject)', async () => {
+    const r = await runShellWithBoundedTail("printf 'oops\\n' >&2; exit 3", base());
+    assert.equal(r.exitCode, 3);
+    assert.equal(r.stderr, 'oops\n');
+    assert.equal(r.stdout, '');
+  });
+
+  test('times out a slow command, kills it, and reports timedOut', async () => {
+    const r = await runShellWithBoundedTail('sleep 5', base({ timeoutMs: 150 }));
+    assert.equal(r.timedOut, true);
+    assert.equal(r.exitCode, 124);
+  });
+
+  test('emits every chunk live via emitOutput', async () => {
+    const seen: Array<[string, string]> = [];
+    await runShellWithBoundedTail(
+      "printf 'aaa'; printf 'bbb' >&2",
+      base({ emitOutput: (s: 'stdout' | 'stderr', c: string) => seen.push([s, c]) }),
+    );
+    assert.ok(seen.some(([s, c]) => s === 'stdout' && c.includes('aaa')));
+    assert.ok(seen.some(([s, c]) => s === 'stderr' && c.includes('bbb')));
+  });
+});

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { runShellWithBoundedTail } from '../shell-exec.js';
+import { runShellWithBoundedTail, killWindowsTree } from '../shell-exec.js';
 
 const base = (over: Record<string, unknown> = {}) => ({ cwd: process.cwd(), timeoutMs: 30_000, ...over });
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -136,5 +136,38 @@ describe('runShellWithBoundedTail', () => {
     // The suppressed LIVE feed does not lose the result: the retained tail still
     // carries the real output (the last bytes the command produced).
     assert.ok(r.stdout.includes('TAIL'), 'retained tail keeps the command output');
+  });
+
+  test('killWindowsTree swallows a taskkill spawn failure instead of crashing', async () => {
+    // On non-Windows hosts `taskkill` is absent, so spawn emits an async 'error'
+    // (ENOENT). Without the error listener that would be an unhandled 'error'
+    // event and crash the process — so this exercises the exact safety path the
+    // Windows branch relies on. Reaching the assertion means it was swallowed.
+    killWindowsTree(999_999); // bogus pid; taskkill is missing here regardless
+    await delay(150); // let the async spawn-failure 'error' fire
+    assert.ok(true, 'no unhandled error propagated from the taskkill spawn failure');
+  });
+
+  test('Windows: timeout kills the process tree via taskkill', { skip: process.platform !== 'win32' }, async () => {
+    // Windows analogue of the POSIX process-tree test above; runs only on a
+    // Windows runner. A grandchild that holds stdout open would hang the runner
+    // unless taskkill /T kills the whole tree.
+    const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-win-'));
+    const pidFile = join(dir, 'child.pid');
+    const cmd =
+      'node -e "require(\'fs\').writeFileSync(process.env.MAKA_PIDOUT, String(process.pid)); setInterval(() => {}, 1000)"';
+    try {
+      const r = await runShellWithBoundedTail(
+        cmd,
+        base({ timeoutMs: 500, killGraceMs: 200, env: { ...process.env, MAKA_PIDOUT: pidFile } }),
+      );
+      assert.equal(r.timedOut, true);
+      assert.equal(r.exitCode, 124);
+      await delay(300);
+      const childPid = Number((await fs.readFile(pidFile, 'utf8')).trim());
+      assert.throws(() => process.kill(childPid, 0), /ESRCH/, 'grandchild was killed via taskkill /T');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/runtime/src/__tests__/tool-output.test.ts
+++ b/packages/runtime/src/__tests__/tool-output.test.ts
@@ -34,6 +34,13 @@ describe('truncateToolOutput', () => {
     assert.ok(!result.content.includes('line6'));
   });
 
+  test('marker caveats re-running so it does not encourage repeating side effects', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line${i}`).join('\n');
+    const marker = truncateToolOutput(text, { maxLines: 3, direction: 'tail' }).content;
+    assert.ok(marker.includes('safe to re-run'), 'recovery guidance is conditioned on safety');
+    assert.ok(marker.includes('side effects'), 'warns about repeating side effects');
+  });
+
   test('truncates by bytes and reports the bytes unit', () => {
     const text = Array.from({ length: 50 }, () => 'x'.repeat(100)).join('\n');
     const result = truncateToolOutput(text, { maxLines: 10_000, maxBytes: 250, direction: 'head' });

--- a/packages/runtime/src/__tests__/tool-output.test.ts
+++ b/packages/runtime/src/__tests__/tool-output.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { truncateToolOutput } from '../tool-output.js';
+
+describe('truncateToolOutput', () => {
+  test('returns text unchanged when within line and byte budgets', () => {
+    const text = 'a\nb\nc';
+    assert.deepEqual(truncateToolOutput(text, { maxLines: 10, maxBytes: 1000 }), {
+      content: text,
+      truncated: false,
+      removed: 0,
+      unit: 'lines',
+    });
+  });
+
+  test('keeps the head and reports removed lines when over the line budget', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line${i}`).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 100_000, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'lines');
+    assert.equal(result.removed, 6);
+    assert.ok(result.content.startsWith('line0\nline1\nline2\nline3'));
+    assert.ok(result.content.includes('6 lines truncated'));
+    assert.ok(!result.content.includes('line4'));
+  });
+
+  test('keeps the tail with the marker at the top when direction is tail', () => {
+    const text = Array.from({ length: 10 }, (_, i) => `line${i}`).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 3, maxBytes: 100_000, direction: 'tail' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.removed, 7);
+    assert.ok(result.content.endsWith('line7\nline8\nline9'));
+    assert.ok(result.content.startsWith('...7 lines truncated'));
+    assert.ok(!result.content.includes('line6'));
+  });
+
+  test('truncates by bytes and reports the bytes unit', () => {
+    const text = Array.from({ length: 50 }, () => 'x'.repeat(100)).join('\n');
+    const result = truncateToolOutput(text, { maxLines: 10_000, maxBytes: 250, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+    assert.ok(result.removed > 0);
+    assert.ok(Buffer.byteLength(result.content.split('\n\n')[0], 'utf8') <= 250);
+  });
+
+  test('counts multi-byte characters by UTF-8 byte length', () => {
+    // Each '世' is 3 UTF-8 bytes; a 4-char line is 12 bytes + newline.
+    const text = Array.from({ length: 6 }, () => '世界世界').join('\n');
+    const result = truncateToolOutput(text, { maxLines: 10_000, maxBytes: 20, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+  });
+
+  test('does not truncate when exactly at the line budget and within bytes', () => {
+    const text = 'a\nb\nc\nd';
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 1000 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('does not report a truncation when only a trailing newline exceeds the byte budget', () => {
+    // Content fits exactly; the lone trailing newline pushes total bytes one over.
+    const text = 'x'.repeat(100) + '\n';
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('a single trailing newline is a terminator, not an extra line', () => {
+    // 4 real lines + terminating newline must still count as 4 lines.
+    const text = 'a\nb\nc\nd\n';
+    const result = truncateToolOutput(text, { maxLines: 4, maxBytes: 1000 });
+    assert.equal(result.truncated, false);
+    assert.equal(result.content, text);
+  });
+
+  test('keeps a byte-safe slice of a single oversized line instead of dropping it', () => {
+    const text = 'x'.repeat(500);
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100, direction: 'head' });
+    assert.equal(result.truncated, true);
+    assert.equal(result.unit, 'bytes');
+    const preview = result.content.split('\n\n')[0];
+    assert.equal(preview, 'x'.repeat(100)); // line not dropped — head slice kept
+    assert.ok(result.content.includes('truncated'));
+  });
+
+  test('byte-safe single-line slice does not split a multi-byte character', () => {
+    const text = '世'.repeat(200); // 3 bytes each = 600 bytes on one line
+    const result = truncateToolOutput(text, { maxLines: 2000, maxBytes: 100, direction: 'tail' });
+    assert.equal(result.truncated, true);
+    const preview = result.content.split('\n\n').pop() ?? '';
+    assert.ok(!preview.includes('�')); // no replacement char from a mid-char cut
+    assert.ok(Buffer.byteLength(preview, 'utf8') <= 100);
+    assert.ok(preview.length > 0);
+  });
+});

--- a/packages/runtime/src/bash-tail-buffer.ts
+++ b/packages/runtime/src/bash-tail-buffer.ts
@@ -1,0 +1,73 @@
+// packages/runtime/src/bash-tail-buffer.ts
+//
+// Memory-bounded tail accumulator for streaming shell output. A runaway command
+// must not be able to grow the captured result without limit (the old Bash path
+// instead discarded ALL output past a hard cap), so we retain only the last
+// `cap` characters.
+//
+// SECURITY: the retained tail is later passed through redactSecrets before it
+// reaches the model / UI. redactSecrets matches on full tokens and their
+// prefixes (e.g. `Authorization: Bearer …`, `sk-…`), so a tail that begins in
+// the MIDDLE of a secret-bearing line would defeat redaction and leak the
+// suffix. To prevent that, when the buffer actually drops content it also drops
+// the (partial) leading line, so the retained tail always starts at a line
+// boundary and redaction sees whole lines.
+
+export class BashTailBuffer {
+  private chunks: string[] = [];
+  private retained = 0;
+  // True when we dropped an unterminated oversized line: subsequent chunks are
+  // still part of that compromised line and must be discarded until the next
+  // newline, otherwise a continuation chunk (a secret's severed suffix) would
+  // be retained as if it were a clean line and defeat downstream redaction.
+  private insideDroppedLine = false;
+
+  constructor(private readonly cap: number) {}
+
+  push(chunk: string): void {
+    if (!chunk) return;
+    if (this.insideDroppedLine) {
+      const nl = chunk.indexOf('\n');
+      if (nl < 0) return; // whole chunk is still the dropped line — discard it
+      this.insideDroppedLine = false;
+      chunk = chunk.slice(nl + 1); // resume from the first clean line boundary
+      if (!chunk) return;
+    }
+    this.chunks.push(chunk);
+    this.retained += chunk.length;
+    // Amortize: allow growth to 2x cap before compacting back to cap so appends
+    // stay ~O(1) rather than re-slicing the whole buffer on every chunk.
+    if (this.retained > this.cap * 2) this.trim();
+  }
+
+  value(): string {
+    this.trim();
+    return this.chunks[0] ?? '';
+  }
+
+  private trim(): void {
+    if (this.chunks.length <= 1 && this.retained <= this.cap) return;
+    const joined = this.chunks.join('');
+    let kept = joined.length > this.cap ? joined.slice(joined.length - this.cap) : joined;
+    if (kept.length < joined.length) {
+      // We sliced mid-stream. Drop the partial leading line so the retained tail
+      // starts at a line boundary and downstream redaction never sees a secret
+      // whose prefix was cut off (see SECURITY note above). With no newline the
+      // whole tail is one partial line we cannot make safe — drop it entirely
+      // rather than risk leaking a severed secret. (A single line larger than
+      // the cap is pathological; the common single-line case is <= cap and is
+      // never sliced here.)
+      const nl = kept.indexOf('\n');
+      if (nl >= 0) {
+        kept = kept.slice(nl + 1);
+      } else {
+        // No line boundary in the retained tail: drop it and stay "inside" the
+        // dropped line so its continuation chunks are discarded until a newline.
+        kept = '';
+        this.insideDroppedLine = true;
+      }
+    }
+    this.chunks = kept ? [kept] : [];
+    this.retained = kept.length;
+  }
+}

--- a/packages/runtime/src/bash-tail-buffer.ts
+++ b/packages/runtime/src/bash-tail-buffer.ts
@@ -21,8 +21,18 @@ export class BashTailBuffer {
   // newline, otherwise a continuation chunk (a secret's severed suffix) would
   // be retained as if it were a clean line and defeat downstream redaction.
   private insideDroppedLine = false;
+  // Latches true once we drop an oversized no-newline line entirely (the case
+  // above). Callers surface a marker so a result that looks empty is not
+  // mistaken for "the command produced nothing" — content existed but could not
+  // be safely truncated.
+  private droppedUnsafe = false;
 
   constructor(private readonly cap: number) {}
+
+  /** Whether an oversized, unsafe-to-truncate line was dropped from the tail. */
+  hasDroppedUnsafe(): boolean {
+    return this.droppedUnsafe;
+  }
 
   push(chunk: string): void {
     if (!chunk) return;
@@ -65,6 +75,7 @@ export class BashTailBuffer {
         // dropped line so its continuation chunks are discarded until a newline.
         kept = '';
         this.insideDroppedLine = true;
+        this.droppedUnsafe = true;
       }
     }
     this.chunks = kept ? [kept] : [];

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -7,13 +7,13 @@
 
 import { z } from 'zod';
 import { promises as fs } from 'node:fs';
-import { exec, spawn } from 'node:child_process';
+import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { computeEditedSource } from './edit-replace.js';
 import { truncateToolOutput } from './tool-output.js';
-import { BashTailBuffer } from './bash-tail-buffer.js';
+import { runShellWithBoundedTail } from './shell-exec.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -22,11 +22,6 @@ import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext };
 
 const execAsync = promisify(exec);
-// Per-stream cap on the output retained in memory for the result. A runaway
-// command no longer fails (the old behavior discarded ALL output past 10MB);
-// instead we keep the last ~1MB and let truncateToolOutput trim that to the
-// model budget. The full stream is still emitted live via emitOutput.
-const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 
 export function buildBuiltinTools(): MakaTool[] {
   return [
@@ -165,6 +160,10 @@ export function buildBuiltinTools(): MakaTool[] {
   ];
 }
 
+// Thin wrapper over the shared runShellWithBoundedTail (the one place a shell
+// command actually runs — see shell-exec.ts). Keeps the builtin's contract:
+// throw on timeout / abort / non-zero exit (with stdout+stderr+code attached),
+// stream live via emitOutput, and return the bounded tail on success.
 async function runStreamingShell(
   command: string,
   options: {
@@ -174,68 +173,20 @@ async function runStreamingShell(
     emitOutput: (stream: 'stdout' | 'stderr', chunk: string) => void;
   },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return await new Promise((resolvePromise, reject) => {
-    const child = spawn(command, {
-      cwd: options.cwd,
-      shell: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const stdoutBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
-    const stderrBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
-    let settled = false;
-
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      rejectOnce(new Error(`Command timed out after ${options.timeout}ms`));
-    }, options.timeout);
-
-    const abort = () => {
-      child.kill('SIGTERM');
-      rejectOnce(new Error('Command aborted'));
-    };
-    if (options.abortSignal.aborted) abort();
-    else options.abortSignal.addEventListener('abort', abort, { once: true });
-
-    child.stdout?.setEncoding('utf8');
-    child.stderr?.setEncoding('utf8');
-    child.stdout?.on('data', (chunk: string) => append('stdout', chunk));
-    child.stderr?.on('data', (chunk: string) => append('stderr', chunk));
-    child.on('error', rejectOnce);
-    child.on('close', (code, signal) => {
-      if (settled) return;
-      cleanup();
-      const exitCode = code ?? (signal ? 128 : 1);
-      const stdout = stdoutBuf.value();
-      const stderr = stderrBuf.value();
-      if (exitCode !== 0) {
-        const error = new Error(`Command failed with exit code ${exitCode}`);
-        Object.assign(error, { stdout, stderr, code: exitCode });
-        settled = true;
-        reject(error);
-        return;
-      }
-      settled = true;
-      resolvePromise({ stdout, stderr, exitCode });
-    });
-
-    function append(stream: 'stdout' | 'stderr', chunk: string): void {
-      if (stream === 'stdout') stdoutBuf.push(chunk);
-      else stderrBuf.push(chunk);
-      options.emitOutput(stream, chunk);
-    }
-
-    function rejectOnce(error: Error): void {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    }
-
-    function cleanup(): void {
-      clearTimeout(timer);
-      options.abortSignal.removeEventListener('abort', abort);
-    }
+  const result = await runShellWithBoundedTail(command, {
+    cwd: options.cwd,
+    timeoutMs: options.timeout,
+    abortSignal: options.abortSignal,
+    emitOutput: options.emitOutput,
   });
+  if (result.timedOut) throw new Error(`Command timed out after ${options.timeout}ms`);
+  if (result.aborted) throw new Error('Command aborted');
+  if (result.exitCode !== 0) {
+    const error = new Error(`Command failed with exit code ${result.exitCode}`);
+    Object.assign(error, { stdout: result.stdout, stderr: result.stderr, code: result.exitCode });
+    throw error;
+  }
+  return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
 }
 
 function shellEscape(arg: string): string {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -179,14 +179,25 @@ async function runStreamingShell(
     abortSignal: options.abortSignal,
     emitOutput: options.emitOutput,
   });
-  if (result.timedOut) throw new Error(`Command timed out after ${options.timeout}ms`);
-  if (result.aborted) throw new Error('Command aborted');
-  if (result.exitCode !== 0) {
-    const error = new Error(`Command failed with exit code ${result.exitCode}`);
-    Object.assign(error, { stdout: result.stdout, stderr: result.stderr, code: result.exitCode });
-    throw error;
-  }
+  // Attach the captured (bounded) stdout/stderr + an exit code to EVERY failure,
+  // not just non-zero exit. coerceTerminalFailure only folds the tail into the
+  // model-facing result when error.code is a number, so without a code on
+  // timeout/abort the model would be blind to the logs leading up to the failure
+  // (124 = timeout, 130 = aborted, both conventional).
+  if (result.timedOut) throw terminalError(`Command timed out after ${options.timeout}ms`, result, 124);
+  if (result.aborted) throw terminalError('Command aborted', result, 130);
+  if (result.exitCode !== 0) throw terminalError(`Command failed with exit code ${result.exitCode}`, result, result.exitCode);
   return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+}
+
+function terminalError(
+  message: string,
+  result: { stdout: string; stderr: string },
+  code: number,
+): Error {
+  const error = new Error(message);
+  Object.assign(error, { stdout: result.stdout, stderr: result.stderr, code });
+  return error;
 }
 
 function shellEscape(arg: string): string {

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -12,6 +12,8 @@ import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { computeEditedSource } from './edit-replace.js';
+import { truncateToolOutput } from './tool-output.js';
+import { BashTailBuffer } from './bash-tail-buffer.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -20,7 +22,11 @@ import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext };
 
 const execAsync = promisify(exec);
-const BASH_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+// Per-stream cap on the output retained in memory for the result. A runaway
+// command no longer fails (the old behavior discarded ALL output past 10MB);
+// instead we keep the last ~1MB and let truncateToolOutput trim that to the
+// model budget. The full stream is still emitted live via emitOutput.
+const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 
 export function buildBuiltinTools(): MakaTool[] {
   return [
@@ -44,8 +50,8 @@ export function buildBuiltinTools(): MakaTool[] {
           cwd,
           cmd: command,
           exitCode: result.exitCode,
-          stdout: result.stdout,
-          stderr: result.stderr,
+          stdout: truncateToolOutput(result.stdout, { direction: 'tail' }).content,
+          stderr: truncateToolOutput(result.stderr, { direction: 'tail' }).content,
         };
       },
     },
@@ -174,9 +180,8 @@ async function runStreamingShell(
       shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    let stdout = '';
-    let stderr = '';
-    let outputBytes = 0;
+    const stdoutBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
+    const stderrBuf = new BashTailBuffer(BASH_MAX_RETAINED_CHARS);
     let settled = false;
 
     const timer = setTimeout(() => {
@@ -200,6 +205,8 @@ async function runStreamingShell(
       if (settled) return;
       cleanup();
       const exitCode = code ?? (signal ? 128 : 1);
+      const stdout = stdoutBuf.value();
+      const stderr = stderrBuf.value();
       if (exitCode !== 0) {
         const error = new Error(`Command failed with exit code ${exitCode}`);
         Object.assign(error, { stdout, stderr, code: exitCode });
@@ -212,14 +219,8 @@ async function runStreamingShell(
     });
 
     function append(stream: 'stdout' | 'stderr', chunk: string): void {
-      outputBytes += Buffer.byteLength(chunk, 'utf8');
-      if (outputBytes > BASH_MAX_OUTPUT_BYTES) {
-        child.kill('SIGTERM');
-        rejectOnce(new Error(`Command output exceeded ${BASH_MAX_OUTPUT_BYTES} bytes`));
-        return;
-      }
-      if (stream === 'stdout') stdout += chunk;
-      else stderr += chunk;
+      if (stream === 'stdout') stdoutBuf.push(chunk);
+      else stderrBuf.push(chunk);
       options.emitOutput(stream, chunk);
     }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -68,6 +68,8 @@ export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
 export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
 export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
+export { truncateToolOutput } from './tool-output.js';
+export type { TruncateToolOutputOptions, TruncatedToolOutput } from './tool-output.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -70,6 +70,8 @@ export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-rep
 export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export { truncateToolOutput } from './tool-output.js';
 export type { TruncateToolOutputOptions, TruncatedToolOutput } from './tool-output.js';
+export { runShellWithBoundedTail, BASH_MAX_RETAINED_CHARS } from './shell-exec.js';
+export type { BoundedShellOptions, BoundedShellResult } from './shell-exec.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -1,0 +1,128 @@
+// packages/runtime/src/shell-exec.ts
+//
+// Single shared shell runner for BOTH Bash paths — the in-process builtin Bash
+// tool (builtin-tools.ts) and the Harbor/local isolated executor
+// (headless/harbor-cell.ts).
+//
+// WHY THIS EXISTS: the builtin streamed via spawn with a memory-bounded tail,
+// but the Harbor executor used execAsync({ maxBuffer }). A command whose output
+// passed maxBuffer was KILLED mid-run and only its first maxBuffer bytes (the
+// HEAD) were returned — so the benchmark path never delivered the recoverable,
+// bounded TAIL the builtin did, and reported a wrong (killed) exit code. This
+// module is the one place a shell command runs: it streams stdout/stderr into a
+// BashTailBuffer (keeping only the last `maxRetainedChars` per stream) and lets
+// the command run to completion regardless of output size.
+//
+// It is the dumb core: it always RESOLVES with { exitCode, stdout, stderr,
+// timedOut, aborted }, rejecting only when the process cannot be spawned at all.
+// Each caller maps that to its own contract — the builtin throws on
+// timeout/abort/non-zero; the Harbor executor returns the result verbatim.
+
+import { spawn } from 'node:child_process';
+import { BashTailBuffer } from './bash-tail-buffer.js';
+
+// Per-stream cap on the output RETAINED for the result (~1MB). The full stream
+// is still delivered live via emitOutput; this only bounds what is kept to
+// return. The tool layer (truncateToolOutput) trims this further to the model's
+// budget. Shared so both Bash paths retain identically.
+export const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
+
+export interface BoundedShellOptions {
+  cwd: string;
+  /** Hard wall-clock cap; the child is SIGTERM'd and `timedOut` is set. */
+  timeoutMs: number;
+  /** Per-stream retained-tail cap in characters. Defaults to BASH_MAX_RETAINED_CHARS. */
+  maxRetainedChars?: number;
+  /** Child environment. Defaults to the parent process env (spawn's default). */
+  env?: NodeJS.ProcessEnv;
+  /** Aborts the child (sets `aborted`). */
+  abortSignal?: AbortSignal;
+  /** Receives every raw chunk live, before tail-bounding. */
+  emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
+}
+
+export interface BoundedShellResult {
+  exitCode: number;
+  /** Last `maxRetainedChars` of stdout (line-aligned; see BashTailBuffer). */
+  stdout: string;
+  /** Last `maxRetainedChars` of stderr. */
+  stderr: string;
+  /** The command exceeded timeoutMs and was killed. */
+  timedOut: boolean;
+  /** The abortSignal fired and the command was killed. */
+  aborted: boolean;
+}
+
+/**
+ * Run `command` in a shell, streaming output into a memory-bounded tail. Never
+ * kills the command for producing too much output — it keeps only the last
+ * `maxRetainedChars` per stream. Resolves with the result (including timeout /
+ * abort flags); rejects only when the process cannot be spawned.
+ */
+export function runShellWithBoundedTail(
+  command: string,
+  options: BoundedShellOptions,
+): Promise<BoundedShellResult> {
+  const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
+  return new Promise<BoundedShellResult>((resolvePromise, reject) => {
+    const child = spawn(command, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const stdoutBuf = new BashTailBuffer(cap);
+    const stderrBuf = new BashTailBuffer(cap);
+    let settled = false;
+
+    const timer = setTimeout(() => finish({ timedOut: true }), options.timeoutMs);
+
+    const abort = () => finish({ aborted: true });
+    if (options.abortSignal) {
+      if (options.abortSignal.aborted) abort();
+      else options.abortSignal.addEventListener('abort', abort, { once: true });
+    }
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => append('stdout', chunk));
+    child.stderr?.on('data', (chunk: string) => append('stderr', chunk));
+    child.on('error', (error: Error) => {
+      // The process could not be spawned at all (e.g. the shell binary is
+      // missing). This is exceptional — reject so callers surface it.
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    });
+    child.on('close', (code, signal) => finish({ exitCode: code ?? (signal ? 128 : 1) }));
+
+    function append(stream: 'stdout' | 'stderr', chunk: string): void {
+      if (stream === 'stdout') stdoutBuf.push(chunk);
+      else stderrBuf.push(chunk);
+      options.emitOutput?.(stream, chunk);
+    }
+
+    // Settle once. On timeout/abort we kill and resolve immediately (with the
+    // tail captured so far) rather than waiting for 'close', so a child that
+    // ignores SIGTERM cannot hang the promise. A later 'close' is a no-op.
+    function finish(outcome: { exitCode?: number; timedOut?: boolean; aborted?: boolean }): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (outcome.timedOut || outcome.aborted) child.kill('SIGTERM');
+      resolvePromise({
+        exitCode: outcome.exitCode ?? (outcome.timedOut ? 124 : outcome.aborted ? 130 : 1),
+        stdout: stdoutBuf.value(),
+        stderr: stderrBuf.value(),
+        timedOut: !!outcome.timedOut,
+        aborted: !!outcome.aborted,
+      });
+    }
+
+    function cleanup(): void {
+      clearTimeout(timer);
+      if (options.abortSignal) options.abortSignal.removeEventListener('abort', abort);
+    }
+  });
+}

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -20,6 +20,7 @@
 
 import { spawn } from 'node:child_process';
 import { BashTailBuffer } from './bash-tail-buffer.js';
+import { OUTPUT_RECOVERY_HINT } from './tool-output.js';
 
 // Per-stream cap on the output RETAINED for the result (~1MB). This only bounds
 // what is kept to return. The tool layer (truncateToolOutput) trims this further
@@ -51,8 +52,8 @@ const LIVE_OUTPUT_SUPPRESSED_MARKER =
 // command whose only output was one giant line would look like it produced
 // nothing. Carries no dropped content — just a recoverable notice.
 const UNSAFE_DROP_MARKER =
-  '[a single line larger than the output limit was omitted for safety; ' +
-  're-run with output redirected to a file (e.g. `cmd > out.txt 2>&1`) to inspect it]';
+  '[a single line larger than the output limit was omitted for safety. '
+  + OUTPUT_RECOVERY_HINT + ']';
 
 function withUnsafeDropMarker(buf: BashTailBuffer): string {
   const text = buf.value(); // value() trims first, so the drop flag is current after it

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -27,6 +27,21 @@ import { BashTailBuffer } from './bash-tail-buffer.js';
 // budget. Shared so both Bash paths retain identically.
 export const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 
+// Appended to a stream when BashTailBuffer dropped an oversized line that had no
+// newline to truncate at (dropped whole for redaction safety). Without it, a
+// command whose only output was one giant line would look like it produced
+// nothing. Carries no dropped content — just a recoverable notice.
+const UNSAFE_DROP_MARKER =
+  '[a single line larger than the output limit was omitted for safety; ' +
+  're-run with output redirected to a file (e.g. `cmd > out.txt 2>&1`) to inspect it]';
+
+function withUnsafeDropMarker(buf: BashTailBuffer): string {
+  const text = buf.value(); // value() trims first, so the drop flag is current after it
+  if (!buf.hasDroppedUnsafe()) return text;
+  // Append (not prepend) so a later tail-keeping truncateToolOutput retains it.
+  return text ? `${text}\n${UNSAFE_DROP_MARKER}` : UNSAFE_DROP_MARKER;
+}
+
 export interface BoundedShellOptions {
   cwd: string;
   /** Hard wall-clock cap; the child is SIGTERM'd and `timedOut` is set. */
@@ -113,8 +128,8 @@ export function runShellWithBoundedTail(
       if (outcome.timedOut || outcome.aborted) child.kill('SIGTERM');
       resolvePromise({
         exitCode: outcome.exitCode ?? (outcome.timedOut ? 124 : outcome.aborted ? 130 : 1),
-        stdout: stdoutBuf.value(),
-        stderr: stderrBuf.value(),
+        stdout: withUnsafeDropMarker(stdoutBuf),
+        stderr: withUnsafeDropMarker(stderrBuf),
         timedOut: !!outcome.timedOut,
         aborted: !!outcome.aborted,
       });

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -114,6 +114,13 @@ export function runShellWithBoundedTail(
       env: options.env,
       shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
+      // POSIX: make the shell its own process-group leader (setsid) so we can
+      // signal the WHOLE tree on timeout/abort. Killing only the shell PID would
+      // leave its children running — and if one keeps the stdout/stderr pipe
+      // open, 'close' never fires and the runner hangs. Not unref'd: we keep
+      // tracking it until it exits. Windows has no process groups; we use
+      // taskkill /T instead (see terminateTree).
+      detached: process.platform !== 'win32',
     });
     const stdoutBuf = new BashTailBuffer(cap);
     const stderrBuf = new BashTailBuffer(cap);
@@ -184,8 +191,30 @@ export function runShellWithBoundedTail(
     function beginTermination(reason: { timedOut?: boolean; aborted?: boolean }): void {
       if (termination || settled) return;
       termination = reason;
-      child.kill('SIGTERM');
-      killTimer = setTimeout(() => child.kill('SIGKILL'), graceMs);
+      terminateTree('SIGTERM');
+      killTimer = setTimeout(() => terminateTree('SIGKILL'), graceMs);
+    }
+
+    // Signal the shell AND every process it launched. POSIX: the shell is a
+    // process-group leader (detached above), so a negative PID targets the whole
+    // group. Windows: no groups/SIGTERM — taskkill /T /F force-kills the tree in
+    // one shot (the later SIGKILL call is then a harmless no-op on a dead PID).
+    function terminateTree(signal: 'SIGTERM' | 'SIGKILL'): void {
+      const pid = child.pid;
+      if (!pid) return;
+      if (process.platform === 'win32') {
+        try {
+          spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+        } catch { /* nothing more we can do */ }
+        return;
+      }
+      try {
+        process.kill(-pid, signal); // negative PID → the child's process group
+      } catch {
+        // Group already gone, or it never became a group leader — fall back to
+        // the single PID so we at least signal the shell itself.
+        try { child.kill(signal); } catch { /* already exited */ }
+      }
     }
 
     // Settle once, on 'close'. exitCode reflects how we terminated: 124 timeout,

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -34,6 +34,12 @@ export const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
 // chunks keep flowing into the retained tail buffer.
 export const BASH_MAX_LIVE_EMIT_CHARS = 1024 * 1024;
 
+// Grace period after SIGTERM (on timeout/abort) before escalating to SIGKILL. A
+// well-behaved child exits on SIGTERM and 'close' fires well within this window;
+// a child that traps/ignores SIGTERM is force-killed so the promise still
+// settles promptly (bounded by this) rather than hanging.
+export const SIGKILL_GRACE_MS = 2000;
+
 // Emitted once per stream when live forwarding is suppressed. The full output is
 // not lost — it still feeds the retained tail and the returned result.
 const LIVE_OUTPUT_SUPPRESSED_MARKER =
@@ -67,6 +73,8 @@ export interface BoundedShellOptions {
   env?: NodeJS.ProcessEnv;
   /** Aborts the child (sets `aborted`). */
   abortSignal?: AbortSignal;
+  /** Grace after SIGTERM before SIGKILL on timeout/abort. Defaults to SIGKILL_GRACE_MS. */
+  killGraceMs?: number;
   /** Receives every raw chunk live, before tail-bounding. */
   emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
 }
@@ -86,8 +94,11 @@ export interface BoundedShellResult {
 /**
  * Run `command` in a shell, streaming output into a memory-bounded tail. Never
  * kills the command for producing too much output — it keeps only the last
- * `maxRetainedChars` per stream. Resolves with the result (including timeout /
- * abort flags); rejects only when the process cannot be spawned.
+ * `maxRetainedChars` per stream. On timeout/abort it SIGTERMs (then SIGKILLs
+ * after a grace period) and resolves only once the child has actually exited, so
+ * it never reports "timed out" while the process keeps running in the
+ * background. Resolves with the result (including timeout / abort flags); rejects
+ * only when the process cannot be spawned.
  */
 export function runShellWithBoundedTail(
   command: string,
@@ -95,6 +106,7 @@ export function runShellWithBoundedTail(
 ): Promise<BoundedShellResult> {
   const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
   const liveCap = options.maxLiveEmitChars ?? BASH_MAX_LIVE_EMIT_CHARS;
+  const graceMs = options.killGraceMs ?? SIGKILL_GRACE_MS;
   return new Promise<BoundedShellResult>((resolvePromise, reject) => {
     const child = spawn(command, {
       cwd: options.cwd,
@@ -109,14 +121,10 @@ export function runShellWithBoundedTail(
     // stream passes liveCap we emit one marker and stop forwarding it live.
     let liveEmitted = { stdout: 0, stderr: 0 };
     let liveSuppressed = { stdout: false, stderr: false };
-
-    const timer = setTimeout(() => finish({ timedOut: true }), options.timeoutMs);
-
-    const abort = () => finish({ aborted: true });
-    if (options.abortSignal) {
-      if (options.abortSignal.aborted) abort();
-      else options.abortSignal.addEventListener('abort', abort, { once: true });
-    }
+    // Set when timeout/abort begins terminating the child. 'close' is the single
+    // resolve point, so this remembers WHY we resolve once the child is gone.
+    let termination: { timedOut?: boolean; aborted?: boolean } | null = null;
+    let killTimer: NodeJS.Timeout | undefined;
 
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
@@ -130,9 +138,20 @@ export function runShellWithBoundedTail(
       cleanup();
       reject(error);
     });
-    child.on('close', (code, signal) => finish({ exitCode: code ?? (signal ? 128 : 1) }));
+    // 'close' fires only after the process has exited AND its stdio has closed,
+    // so resolving here guarantees the child is gone and no further output can
+    // arrive — even when we triggered the kill ourselves.
+    child.on('close', (code, signal) => resolveOnce(code, signal));
+
+    const timer = setTimeout(() => beginTermination({ timedOut: true }), options.timeoutMs);
+    const abort = () => beginTermination({ aborted: true });
+    if (options.abortSignal) {
+      if (options.abortSignal.aborted) abort();
+      else options.abortSignal.addEventListener('abort', abort, { once: true });
+    }
 
     function append(stream: 'stdout' | 'stderr', chunk: string): void {
+      if (settled) return; // never capture or emit after we have resolved
       // Always retain (the result keeps the bounded tail regardless of live cap).
       if (stream === 'stdout') stdoutBuf.push(chunk);
       else stderrBuf.push(chunk);
@@ -156,25 +175,36 @@ export function runShellWithBoundedTail(
       liveSuppressed[stream] = true;
     }
 
-    // Settle once. On timeout/abort we kill and resolve immediately (with the
-    // tail captured so far) rather than waiting for 'close', so a child that
-    // ignores SIGTERM cannot hang the promise. A later 'close' is a no-op.
-    function finish(outcome: { exitCode?: number; timedOut?: boolean; aborted?: boolean }): void {
+    // Begin terminating a still-running child (timeout or abort). SIGTERM first
+    // so a well-behaved child can flush and exit; if it ignores SIGTERM, SIGKILL
+    // after a grace period guarantees it dies. We do NOT resolve here — 'close'
+    // is the single resolve point, so the promise settles only once the child is
+    // actually gone (no zombie left running, no output after resolve).
+    function beginTermination(reason: { timedOut?: boolean; aborted?: boolean }): void {
+      if (termination || settled) return;
+      termination = reason;
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => child.kill('SIGKILL'), graceMs);
+    }
+
+    // Settle once, on 'close'. exitCode reflects how we terminated: 124 timeout,
+    // 130 abort, else the child's own code (or 128+signal when signal-killed).
+    function resolveOnce(code: number | null, signal: NodeJS.Signals | null): void {
       if (settled) return;
       settled = true;
       cleanup();
-      if (outcome.timedOut || outcome.aborted) child.kill('SIGTERM');
       resolvePromise({
-        exitCode: outcome.exitCode ?? (outcome.timedOut ? 124 : outcome.aborted ? 130 : 1),
+        exitCode: termination ? (termination.timedOut ? 124 : 130) : (code ?? (signal ? 128 : 1)),
         stdout: withUnsafeDropMarker(stdoutBuf),
         stderr: withUnsafeDropMarker(stderrBuf),
-        timedOut: !!outcome.timedOut,
-        aborted: !!outcome.aborted,
+        timedOut: !!termination?.timedOut,
+        aborted: !!termination?.aborted,
       });
     }
 
     function cleanup(): void {
       clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
       if (options.abortSignal) options.abortSignal.removeEventListener('abort', abort);
     }
   });

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -21,11 +21,24 @@
 import { spawn } from 'node:child_process';
 import { BashTailBuffer } from './bash-tail-buffer.js';
 
-// Per-stream cap on the output RETAINED for the result (~1MB). The full stream
-// is still delivered live via emitOutput; this only bounds what is kept to
-// return. The tool layer (truncateToolOutput) trims this further to the model's
-// budget. Shared so both Bash paths retain identically.
+// Per-stream cap on the output RETAINED for the result (~1MB). This only bounds
+// what is kept to return. The tool layer (truncateToolOutput) trims this further
+// to the model's budget. Shared so both Bash paths retain identically.
 export const BASH_MAX_RETAINED_CHARS = 1024 * 1024;
+
+// Per-stream cap on output forwarded LIVE via emitOutput (~1MB). The command is
+// never killed for size and the full recoverable tail is still RETAINED (above),
+// but a runaway command printing tens of MB must not flood the event stream /
+// UI with per-chunk deltas (tool-output-delta has no aggregate cap). Once a
+// stream passes this, we emit one suppressed marker and stop forwarding live;
+// chunks keep flowing into the retained tail buffer.
+export const BASH_MAX_LIVE_EMIT_CHARS = 1024 * 1024;
+
+// Emitted once per stream when live forwarding is suppressed. The full output is
+// not lost — it still feeds the retained tail and the returned result.
+const LIVE_OUTPUT_SUPPRESSED_MARKER =
+  '[live output suppressed: too much output to stream live; the command keeps ' +
+  'running and its result still contains the most recent output]';
 
 // Appended to a stream when BashTailBuffer dropped an oversized line that had no
 // newline to truncate at (dropped whole for redaction safety). Without it, a
@@ -48,6 +61,8 @@ export interface BoundedShellOptions {
   timeoutMs: number;
   /** Per-stream retained-tail cap in characters. Defaults to BASH_MAX_RETAINED_CHARS. */
   maxRetainedChars?: number;
+  /** Per-stream cap on LIVE emitOutput forwarding. Defaults to BASH_MAX_LIVE_EMIT_CHARS. */
+  maxLiveEmitChars?: number;
   /** Child environment. Defaults to the parent process env (spawn's default). */
   env?: NodeJS.ProcessEnv;
   /** Aborts the child (sets `aborted`). */
@@ -79,6 +94,7 @@ export function runShellWithBoundedTail(
   options: BoundedShellOptions,
 ): Promise<BoundedShellResult> {
   const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
+  const liveCap = options.maxLiveEmitChars ?? BASH_MAX_LIVE_EMIT_CHARS;
   return new Promise<BoundedShellResult>((resolvePromise, reject) => {
     const child = spawn(command, {
       cwd: options.cwd,
@@ -89,6 +105,10 @@ export function runShellWithBoundedTail(
     const stdoutBuf = new BashTailBuffer(cap);
     const stderrBuf = new BashTailBuffer(cap);
     let settled = false;
+    // Per-stream live-forwarding budget (see BASH_MAX_LIVE_EMIT_CHARS). Once a
+    // stream passes liveCap we emit one marker and stop forwarding it live.
+    let liveEmitted = { stdout: 0, stderr: 0 };
+    let liveSuppressed = { stdout: false, stderr: false };
 
     const timer = setTimeout(() => finish({ timedOut: true }), options.timeoutMs);
 
@@ -113,9 +133,27 @@ export function runShellWithBoundedTail(
     child.on('close', (code, signal) => finish({ exitCode: code ?? (signal ? 128 : 1) }));
 
     function append(stream: 'stdout' | 'stderr', chunk: string): void {
+      // Always retain (the result keeps the bounded tail regardless of live cap).
       if (stream === 'stdout') stdoutBuf.push(chunk);
       else stderrBuf.push(chunk);
-      options.emitOutput?.(stream, chunk);
+      emitLive(stream, chunk);
+    }
+
+    // Forward a chunk to the live emitOutput feed, bounded per stream so a
+    // runaway command cannot flood the event queue. The retained tail above is
+    // untouched by this cap.
+    function emitLive(stream: 'stdout' | 'stderr', chunk: string): void {
+      const emit = options.emitOutput;
+      if (!emit || liveSuppressed[stream]) return;
+      if (liveEmitted[stream] + chunk.length <= liveCap) {
+        emit(stream, chunk);
+        liveEmitted[stream] += chunk.length;
+        return;
+      }
+      // First chunk to cross the cap: emit one marker, then go silent for this
+      // stream.
+      emit(stream, LIVE_OUTPUT_SUPPRESSED_MARKER);
+      liveSuppressed[stream] = true;
     }
 
     // Settle once. On timeout/abort we kill and resolve immediately (with the

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -203,9 +203,7 @@ export function runShellWithBoundedTail(
       const pid = child.pid;
       if (!pid) return;
       if (process.platform === 'win32') {
-        try {
-          spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
-        } catch { /* nothing more we can do */ }
+        killWindowsTree(pid);
         return;
       }
       try {
@@ -238,4 +236,24 @@ export function runShellWithBoundedTail(
       if (options.abortSignal) options.abortSignal.removeEventListener('abort', abort);
     }
   });
+}
+
+/**
+ * Force-kill a process tree on Windows, which has no process groups or SIGTERM
+ * semantics (POSIX uses `process.kill(-pid)` on the detached group instead).
+ * `taskkill /T` walks the tree by PID, `/F` forces it. Best-effort and untested
+ * on non-Windows CI — exported so the error-handling path can be exercised on
+ * any platform.
+ *
+ * The spawned taskkill MUST have an 'error' listener: a child process with no
+ * 'error' handler turns an async spawn failure (e.g. taskkill not on PATH) into
+ * an unhandled 'error' event that can crash the host process.
+ */
+export function killWindowsTree(pid: number): void {
+  try {
+    const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+    killer.on('error', () => { /* taskkill unavailable / failed — nothing more we can do */ });
+  } catch {
+    /* synchronous spawn failure — nothing more we can do */
+  }
 }

--- a/packages/runtime/src/tool-output.ts
+++ b/packages/runtime/src/tool-output.ts
@@ -1,0 +1,147 @@
+// packages/runtime/src/tool-output.ts
+//
+// Shared, model-facing truncation for tool output (Bash stdout/stderr today).
+//
+// WHY: an unbounded tool result either floods the model's context (a chatty
+// command's full output) or, worse, gets discarded outright when a hard byte
+// cap is hit (the old Bash behavior threw away *all* output past 10MB, failing
+// otherwise-finished work). Both hurt pass@1. This bounds what the model sees
+// to a line/byte budget, keeps the most useful slice, and tells the model the
+// output was cut and how to recover the rest.
+//
+// We deliberately do NOT spill the full output to a host-side file the way
+// opencode does: the benchmark Bash path runs through an isolated executor that
+// abstracts the filesystem away, so there is no shared location the host can
+// write and the model can later read. Instead the truncation marker points the
+// model at the portable recovery it can always perform itself — re-run the
+// command redirecting to a file, then Read/Grep that file.
+//
+// Adapted from opencode's truncate.output() (packages/opencode/src/tool/
+// truncate.ts): same byte+line budget and head/tail windowing, minus the file
+// spill + retention machinery.
+
+export interface TruncateToolOutputOptions {
+  /** Max retained lines before truncation kicks in. Default 2000. */
+  maxLines?: number;
+  /** Max retained UTF-8 bytes before truncation kicks in. Default 50KB. */
+  maxBytes?: number;
+  /**
+   * Which end to KEEP. 'head' keeps the start (default, good for generic
+   * output); 'tail' keeps the end (good for shell logs, where the failing
+   * summary is usually last).
+   */
+  direction?: 'head' | 'tail';
+}
+
+export interface TruncatedToolOutput {
+  /** The bounded text, including an inline truncation marker when cut. */
+  content: string;
+  /** Whether any content was removed. */
+  truncated: boolean;
+  /** How much was removed (lines or bytes — see `unit`). 0 when not truncated. */
+  removed: number;
+  /** What `removed` counts. */
+  unit: 'lines' | 'bytes';
+}
+
+const DEFAULT_MAX_LINES = 2000;
+const DEFAULT_MAX_BYTES = 50 * 1024;
+
+function utf8Len(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+/**
+ * Keep at most `maxBytes` UTF-8 bytes of a single line, from the head or tail.
+ * Cutting mid-character is avoided: Buffer.toString replaces the partial
+ * multi-byte sequence at the boundary with U+FFFD, which we strip.
+ */
+function sliceLineByBytes(line: string, maxBytes: number, keep: 'head' | 'tail'): string {
+  const buf = Buffer.from(line, 'utf8');
+  if (buf.length <= maxBytes) return line;
+  const slice = keep === 'head' ? buf.subarray(0, maxBytes) : buf.subarray(buf.length - maxBytes);
+  const decoded = slice.toString('utf8');
+  return keep === 'head' ? decoded.replace(/�+$/, '') : decoded.replace(/^�+/, '');
+}
+
+/**
+ * Bound `text` to a line/byte budget for inclusion in a tool result the model
+ * reads. Returns the text unchanged when it already fits. When it does not, the
+ * kept window (head or tail) is returned with an inline marker naming how much
+ * was dropped and how to recover the omitted portion.
+ */
+export function truncateToolOutput(
+  text: string,
+  options: TruncateToolOutputOptions = {},
+): TruncatedToolOutput {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const direction = options.direction ?? 'head';
+
+  const totalBytes = utf8Len(text);
+  // A single trailing newline terminates the last line; it is not an extra
+  // empty line, so it must not count against the line budget.
+  const body = text.endsWith('\n') ? text.slice(0, -1) : text;
+  const lines = body.split('\n');
+  if (lines.length <= maxLines && totalBytes <= maxBytes) {
+    return { content: text, truncated: false, removed: 0, unit: 'lines' };
+  }
+
+  const out: string[] = [];
+  let bytes = 0;
+  let hitBytes = false;
+
+  if (direction === 'head') {
+    for (let i = 0; i < lines.length && i < maxLines; i++) {
+      const size = utf8Len(lines[i]) + (i > 0 ? 1 : 0);
+      if (bytes + size > maxBytes) {
+        hitBytes = true;
+        break;
+      }
+      out.push(lines[i]);
+      bytes += size;
+    }
+  } else {
+    for (let i = lines.length - 1; i >= 0 && out.length < maxLines; i--) {
+      const size = utf8Len(lines[i]) + (out.length > 0 ? 1 : 0);
+      if (bytes + size > maxBytes) {
+        hitBytes = true;
+        break;
+      }
+      out.unshift(lines[i]);
+      bytes += size;
+    }
+  }
+
+  // The boundary line alone exceeds the byte budget. Rather than show only a
+  // marker (the common single-huge-line case: minified file, base64, one-line
+  // JSON/stack trace), keep a byte-safe slice of that line.
+  let preview: string;
+  if (out.length === 0) {
+    const line = direction === 'head' ? lines[0] : lines[lines.length - 1];
+    preview = sliceLineByBytes(line, maxBytes, direction);
+    bytes = utf8Len(preview);
+    hitBytes = true;
+  } else {
+    preview = out.join('\n');
+  }
+
+  const removed = hitBytes ? Math.max(0, totalBytes - bytes) : lines.length - out.length;
+  if (removed <= 0) {
+    // Nothing was actually dropped — e.g. content fits but a lone trailing
+    // newline pushed totalBytes one over the byte budget. Don't emit a
+    // misleading "0 ... truncated" marker.
+    return { content: text, truncated: false, removed: 0, unit: 'lines' };
+  }
+  const unit: 'lines' | 'bytes' = hitBytes ? 'bytes' : 'lines';
+  const marker =
+    `...${removed} ${unit} truncated. ` +
+    'Re-run the command redirecting to a file (e.g. `cmd > out.txt 2>&1`) ' +
+    'then Read or Grep that file for the omitted portion...';
+
+  const content = direction === 'head'
+    ? `${preview}\n\n${marker}`
+    : `${marker}\n\n${preview}`;
+
+  return { content, truncated: true, removed, unit };
+}

--- a/packages/runtime/src/tool-output.ts
+++ b/packages/runtime/src/tool-output.ts
@@ -13,8 +13,9 @@
 // opencode does: the benchmark Bash path runs through an isolated executor that
 // abstracts the filesystem away, so there is no shared location the host can
 // write and the model can later read. Instead the truncation marker points the
-// model at the portable recovery it can always perform itself — re-run the
-// command redirecting to a file, then Read/Grep that file.
+// model at the portable recovery it can perform itself — re-run the command
+// (only when it is safe to repeat) redirecting to a file, then Read/Grep that
+// file; otherwise work from the kept window.
 //
 // Adapted from opencode's truncate.output() (packages/opencode/src/tool/
 // truncate.ts): same byte+line budget and head/tail windowing, minus the file
@@ -136,8 +137,9 @@ export function truncateToolOutput(
   const unit: 'lines' | 'bytes' = hitBytes ? 'bytes' : 'lines';
   const marker =
     `...${removed} ${unit} truncated. ` +
-    'Re-run the command redirecting to a file (e.g. `cmd > out.txt 2>&1`) ' +
-    'then Read or Grep that file for the omitted portion...';
+    'If the command is safe to re-run, redirect it to a file (e.g. `cmd > out.txt 2>&1`) ' +
+    'then Read or Grep that file for the omitted portion. ' +
+    'If re-running could repeat side effects, work from the kept output above instead...';
 
   const content = direction === 'head'
     ? `${preview}\n\n${marker}`

--- a/packages/runtime/src/tool-output.ts
+++ b/packages/runtime/src/tool-output.ts
@@ -48,6 +48,16 @@ export interface TruncatedToolOutput {
 const DEFAULT_MAX_LINES = 2000;
 const DEFAULT_MAX_BYTES = 50 * 1024;
 
+// Single recovery instruction shared by every "output was omitted" marker (the
+// byte/line truncation marker here and the oversized-line drop marker in
+// shell-exec). Conditioned on safety so it never encourages repeating a
+// side-effecting command. Keep both "safe to re-run" and "side effects" phrasing
+// — markers and their tests rely on it.
+export const OUTPUT_RECOVERY_HINT =
+  'If the command is safe to re-run, redirect its output to a file '
+  + '(e.g. `cmd > out.txt 2>&1`) then Read or Grep that file for the omitted portion. '
+  + 'If re-running could repeat side effects, do not.';
+
 function utf8Len(text: string): number {
   return Buffer.byteLength(text, 'utf8');
 }
@@ -136,10 +146,8 @@ export function truncateToolOutput(
   }
   const unit: 'lines' | 'bytes' = hitBytes ? 'bytes' : 'lines';
   const marker =
-    `...${removed} ${unit} truncated. ` +
-    'If the command is safe to re-run, redirect it to a file (e.g. `cmd > out.txt 2>&1`) ' +
-    'then Read or Grep that file for the omitted portion. ' +
-    'If re-running could repeat side effects, work from the kept output above instead...';
+    `...${removed} ${unit} truncated. ${OUTPUT_RECOVERY_HINT} `
+    + 'Otherwise work from the kept output above.';
 
   const content = direction === 'head'
     ? `${preview}\n\n${marker}`

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -25,6 +25,7 @@ import {
   type ToolArtifactRecorder,
 } from './tool-artifacts.js';
 import { createToolOutputDeltaEmitter } from './tool-output-delta.js';
+import { truncateToolOutput } from './tool-output.js';
 import type { RunTraceLike } from './run-trace.js';
 
 export interface MakaTool<P = any, R = unknown> {
@@ -663,17 +664,34 @@ function coerceTerminalFailure(
   const command = args && typeof args === 'object' && typeof (args as { command?: unknown }).command === 'string'
     ? (args as { command: string }).command
     : '';
+  const stdout = redactSecrets(String(error.stdout ?? ''));
+  const stderr = redactSecrets(String(error.stderr ?? ''));
   return {
     content: {
       kind: 'terminal',
       cwd,
       cmd: redactSecrets(command),
       exitCode: error.code,
-      stdout: redactSecrets(String(error.stdout ?? '')),
-      stderr: redactSecrets(String(error.stderr ?? '')),
+      stdout,
+      stderr,
     },
-    message: `命令退出码 ${error.code}`,
+    // The in-turn result the model acts on is just this message (the structured
+    // content above goes to session history). Without the actual output the
+    // model is blind to *why* the command failed, so fold in a bounded tail of
+    // stderr/stdout — the tail is where shell errors land.
+    message: buildTerminalFailureMessage(error.code, stdout, stderr),
   };
+}
+
+function buildTerminalFailureMessage(code: number, stdout: string, stderr: string): string {
+  const parts = [`命令退出码 ${code}`];
+  const view = (text: string) =>
+    truncateToolOutput(text, { maxLines: 40, maxBytes: 1500, direction: 'tail' }).content.trim();
+  const stderrView = view(stderr);
+  if (stderrView) parts.push(`--- stderr ---\n${stderrView}`);
+  const stdoutView = view(stdout);
+  if (stdoutView) parts.push(`--- stdout ---\n${stdoutView}`);
+  return parts.join('\n\n');
 }
 
 function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecord['status'] {


### PR DESCRIPTION
## What

Closes the **Bash overflow** + **in-turn feedback** P0s from #92. Two atomic commits:

1. **`feat(runtime): add shared truncateToolOutput helper`** — a self-contained helper (`packages/runtime/src/tool-output.ts`) that bounds model-facing output to a line/byte budget (default 2000 lines / 50KB), keeps the head or tail, and embeds a recovery marker when content is dropped. Pure helper + unit tests; no wiring.
2. **`feat(runtime/headless): bounded, recoverable Bash output`** — wires it across both Bash paths and fixes the failure feedback.

## The three fixes (all move pass@1)

- **No more discard-on-overflow.** `runStreamingShell` used to reject and throw away a command's *entire* output past a 10MB cap, failing otherwise-finished work. It now retains a memory-bounded tail (`BashTailBuffer`, ~1MB/stream, amortized trimming) and returns the truncated tail. The full stream is still emitted live via `emitOutput`.
- **No more context flood.** Both Bash paths — runtime builtin (`builtin-tools.ts`) and the **benchmark** isolated path (`packages/headless/src/tools.ts`, the actual pass@1 path) — truncate returned stdout/stderr to the model budget (`tail` direction, since shell errors land at the end).
- **Failed Bash now shows *why*.** Within an agentic turn the model previously saw only `命令退出码 N` for a failed Bash (the structured `{exitCode,stdout,stderr}` went to session history, not the immediate result). `coerceTerminalFailure` now folds a **redacted**, bounded tail of stderr/stdout into the in-turn message so the model can recover in-turn.

## Safety model

- **Redaction is never defeated by truncation.** `BashTailBuffer` drops the partial leading line on trim so the retained tail starts at a line boundary, and `coerceTerminalFailure` redacts the tail (whole lines) *before* truncating the message. A single line larger than the cap has no safe boundary and is dropped entirely; if such a line streams across multiple chunks, an `insideDroppedLine` state keeps discarding its continuation until the next newline — so a secret whose prefix was sliced off can never reach the model/UI with only its suffix.
- **Byte/line accounting is faithful:** a trailing newline is treated as a terminator (not an extra line), a single oversized line is kept as a UTF-8-safe byte slice rather than dropped to a bare marker, and a lone trailing newline that just tips the byte budget does not produce a misleading "0 truncated" marker.

## Deliberate scope decision (please confirm)

**No host-side file spill** (opencode's `truncate.output()` writes the full output to a file and returns `outputPath`). The benchmark Bash path runs through an isolated executor that abstracts the filesystem away, so there is no shared location the host can write and the model can later read. Instead the truncation marker points the model at the portable recovery it can always perform itself — re-run redirecting to a file, then `Read`/`Grep` it. Auto-spill can be a follow-up if benchmarks show the model struggling to recover truncated output.

## Maps to #92 (P0)

- [x] Bash overflow: keep tail instead of reject-and-discard
- [x] Return truncated stdout/stderr to the in-turn Bash failure result
- [x] Bound model-facing Bash output on the benchmark (headless) + runtime paths
- [ ] loop-gate → separate PR (C)
- [ ] Read / Grep / Glob / file-lock → separate PRs (D–G)

## Review gate (codex, xhigh, read-only, scoped to this PR's diff)

Five rounds to fresh-eye-clean:
- **R1:** 2 P1 — single oversized line dropped to a bare marker; trailing newline counted as an extra line (off-by-one false truncation). Both fixed.
- **R2:** 1 P0 — `TailBuffer` cut mid-line, so a secret with its prefix sliced off survived redaction. Fixed: drop the partial leading line (line-boundary tail).
- **R3:** 1 P0 — the single-line-no-newline case still kept a severed slice. Fixed: drop it entirely. (+ 1 P2 "0 truncated" accounting, fixed.)
- **R4:** 1 P0 — an oversized line split across `push()` calls leaked its continuation chunk. Fixed: `insideDroppedLine` state machine.
- **R5 (fresh-eye): no P0/P1**, nothing blocking.

## Verification

- `@maka/runtime` 608 tests + `@maka/headless` 242 tests green (new: `BashTailBuffer` memory bound + redaction-safety + streaming continuation; `truncateToolOutput` budgets/edges; builtin Bash no-discard + failure-surfaces-output; ai-sdk-backend in-turn enrichment; headless large-output bounding with full-stream emit).
- `npm run build` + `npm run typecheck` exit 0 across all workspaces.

