### PR TITLE
feat(headless): Grep prefers ripgrep, falls back to find/awk (#92 P1)

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -456,6 +456,49 @@ describe('isolated headless tools', () => {
     assert.ok(calls.every((command) => !command.includes('node -e')));
   });
 
+  test('Grep prefers ripgrep when on PATH and skips binary files', async (t) => {
+    try {
+      await execAsync('rg --version', { env: process.env });
+    } catch {
+      t.skip('ripgrep not installed');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-grep-rg-'));
+    await mkdir(join(cwd, 'src'));
+    await writeFile(join(cwd, 'src', 'file.txt'), 'hello\nneedle\n', 'utf8');
+    // A binary file that contains the needle: ripgrep detects the NUL bytes and
+    // skips it, where the find/awk fallback would match its bytes. A clean
+    // result therefore proves the ripgrep path ran.
+    await writeFile(join(cwd, 'src', 'data.bin'), Buffer.concat([Buffer.from([0, 1, 2, 0]), Buffer.from('needle\n')]));
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: process.env, // full PATH so rg resolves
+            maxBuffer: 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx(cwd)), {
+      matches: ['src/file.txt:2:needle'],
+    });
+    // Single-file search must still carry the path prefix (rg --with-filename).
+    assert.deepEqual(
+      await tool(tools, 'Grep').impl({ pattern: 'needle', path: join(cwd, 'src', 'file.txt') }, toolCtx(cwd)),
+      { matches: ['src/file.txt:2:needle'] },
+    );
+  });
+
   test('command-backed Edit runs the shared fuzzy matcher via node -e', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-'));
     await mkdir(join(cwd, 'src'));

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -579,7 +579,7 @@ describe('isolated headless tools', () => {
     assert.deepEqual(result.matches, ['{a,c}.txt:1:needle'], 'glob uses the literal fallback dialect, not rg brace-expansion');
   });
 
-  test('the ripgrep Grep invocation pins --no-config and --no-follow (non-skippable safety net)', async () => {
+  test('the ripgrep Grep branch pins its safety flags and never re-grows --glob (non-skippable safety net)', async () => {
     let captured = '';
     const tools = buildIsolatedHeadlessTools({
       async exec(input) {
@@ -588,9 +588,14 @@ describe('isolated headless tools', () => {
       },
     });
     await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx('/workspace'));
-    // Pin the exact rg arg prefix (not just a comment mention) so the config- and
+    // Pin the exact rg invocation (not just a comment mention) so the config- and
     // symlink-escape guards cannot be silently dropped — runs with or without rg.
-    assert.match(captured, /set -- --no-config --no-follow /);
+    assert.match(captured, /rg --no-config --no-follow .* -e "\$grep_pattern" -- "\$search"/);
+    // The rg branch is gated on no-glob; every glob must route through the fallback
+    // dialect, so this assertion holds even on a machine without rg installed.
+    assert.match(captured, /\[ -z "\$glob" \] && command -v rg/);
+    // ...and the deleted dynamic --glob assembly must never come back into rg.
+    assert.doesNotMatch(captured, /--glob "\$glob"/);
   });
 
   test('command-backed Edit runs the shared fuzzy matcher via node -e', async () => {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -499,6 +499,100 @@ describe('isolated headless tools', () => {
     );
   });
 
+  test('Grep with rg ignores RIPGREP_CONFIG_PATH and will not follow a symlink out of the workspace', async (t) => {
+    try {
+      await execAsync('rg --version', { env: process.env });
+    } catch {
+      t.skip('ripgrep not installed');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-grep-cfg-'));
+    await mkdir(join(cwd, 'src'));
+    await writeFile(join(cwd, 'src', 'file.txt'), 'hello\nneedle\n', 'utf8');
+    // A file OUTSIDE the workspace, reachable only by following a symlink.
+    const outside = await mkdtemp(join(tmpdir(), 'maka-headless-grep-outside-'));
+    await writeFile(join(outside, 'secret.txt'), 'needle\n', 'utf8');
+    await symlink(join(outside, 'secret.txt'), join(cwd, 'src', 'evil.txt'));
+    // An rg config that turns symlink-following ON. --no-config must make rg
+    // ignore it; without --no-config rg would read it, follow src/evil.txt, and
+    // leak the external file — exactly the workspace-escape this guards against.
+    const rgConfig = join(await mkdtemp(join(tmpdir(), 'maka-headless-rgcfg-')), 'rg.conf');
+    await writeFile(rgConfig, '--follow\n', 'utf8');
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: { ...process.env, RIPGREP_CONFIG_PATH: rgConfig }, // host passes it through (childProcessEnv)
+            maxBuffer: 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    const result = (await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx(cwd))) as { matches: string[] };
+    assert.ok(result.matches.includes('src/file.txt:2:needle'), 'the in-workspace match is still returned');
+    assert.ok(
+      !result.matches.some((m) => m.includes('evil.txt')),
+      'the symlink out of the workspace is not followed despite RIPGREP_CONFIG_PATH=--follow',
+    );
+  });
+
+  test('Grep routes glob filters through the fallback dialect, not ripgrep --glob (parity with/without rg)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-grep-glob-'));
+    // Three root files all containing the needle. The glob "{a,c}.txt" diverges by
+    // dialect: ripgrep's --glob brace-expands it to a.txt/c.txt, while the
+    // fallback's globPatternToEre treats { } , as literals and matches only the
+    // file literally named "{a,c}.txt". The fix routes every glob through the
+    // fallback, so the result is the literal file in BOTH rg-present and
+    // rg-absent environments — this assertion fails if rg ever handles the glob.
+    await writeFile(join(cwd, 'a.txt'), 'needle\n', 'utf8');
+    await writeFile(join(cwd, 'c.txt'), 'needle\n', 'utf8');
+    await writeFile(join(cwd, '{a,c}.txt'), 'needle\n', 'utf8');
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: process.env, // full PATH: if rg is installed, it is a candidate
+            maxBuffer: 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    const result = (await tool(tools, 'Grep').impl({ pattern: 'needle', glob: '{a,c}.txt' }, toolCtx(cwd))) as { matches: string[] };
+    assert.deepEqual(result.matches, ['{a,c}.txt:1:needle'], 'glob uses the literal fallback dialect, not rg brace-expansion');
+  });
+
+  test('the ripgrep Grep invocation pins --no-config and --no-follow (non-skippable safety net)', async () => {
+    let captured = '';
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        captured = input.command;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    await tool(tools, 'Grep').impl({ pattern: 'needle' }, toolCtx('/workspace'));
+    // Pin the exact rg arg prefix (not just a comment mention) so the config- and
+    // symlink-escape guards cannot be silently dropped — runs with or without rg.
+    assert.match(captured, /set -- --no-config --no-follow /);
+  });
+
   test('command-backed Edit runs the shared fuzzy matcher via node -e', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-'));
     await mkdir(join(cwd, 'src'));

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -622,37 +622,36 @@ if [ -n "$input_path" ]; then
 else
   start=$root
 fi
-# Prefer ripgrep for the common case: gitignore-aware, skips binaries and hidden
-# files, fast, and a far richer regex than awk. Output stays "<relpath>:<line>:
-# <text>" and the per-file (50) / total (200) caps are preserved. rg is used only
-# when no glob is requested — its gitignore-style --glob is a different dialect
-# from the fallback's ERE, so routing every glob through the single fallback path
-# keeps results identical with or without rg installed — and otherwise the POSIX
-# find/awk walk runs. existing_target above already enforced the inside-workspace
-# + no-symlink-escape invariant for the search root in both paths; input_path is
-# workspace-relative so rg, run from root, emits workspace-relative paths.
+# Prefer rg for the common no-glob case: faster, skips binaries, and a far richer
+# regex than awk. rg's gitignore-style --glob is a different dialect from the
+# fallback's ERE, so routing every glob through the single fallback path keeps
+# results identical with or without rg installed; otherwise the POSIX find/awk
+# walk runs. Output stays "<relpath>:<line>:<text>" and the per-file (50) / total
+# (200) caps are preserved. existing_target above already enforced the inside-
+# workspace + no-symlink-escape invariant for the search root in both paths;
+# input_path is workspace-relative so rg, run from root, emits workspace-relative
+# paths.
 if [ -z "$glob" ] && command -v rg >/dev/null 2>&1; then
-  # --no-config: ignore RIPGREP_CONFIG_PATH so a host-set rg config cannot inject
-  #   flags (e.g. --follow) that would break the no-workspace-escape invariant.
-  # --no-follow: never traverse symlinks, matching the find/awk fallback (find
-  #   without -L), so a workspace-internal symlink cannot leak external files.
-  # --no-ignore --hidden: search the same file set as the fallback, so results do
-  #   not depend on whether rg happens to be installed. rg still skips binaries
-  #   and brings a far richer regex than awk, which are the real wins.
-  # --with-filename keeps the filename on single-file searches so the
-  # "<relpath>:<line>:<text>" contract holds in every case.
-  set -- --no-config --no-follow --line-number --no-heading --with-filename --color never --no-ignore --hidden --max-count 50
-  set -- "$@" -e "$grep_pattern"
   # Always pass an explicit path: with none, rg reads from its (never-closing)
   # stdin pipe and hangs. "." searches the whole workspace; rg prefixes those
   # hits with "./", stripped below to the bare relative-path contract.
   search=$input_path
   [ -n "$search" ] || search=.
+  # The rg arg list is fixed — no glob is routed here, so nothing is assembled
+  # dynamically (and --glob is never re-grown into this branch):
+  # --no-config: ignore RIPGREP_CONFIG_PATH so a host-set rg config cannot inject
+  #   flags (e.g. --follow) that would break the no-workspace-escape invariant.
+  # --no-follow: never traverse symlinks, matching the find/awk fallback (find
+  #   without -L), so a workspace-internal symlink cannot leak external files.
+  # --no-ignore --hidden: search the same file set as the fallback, so results do
+  #   not depend on whether rg happens to be installed (rg still skips binaries).
+  # --with-filename keeps the filename on single-file searches so the
+  #   "<relpath>:<line>:<text>" contract holds in every case.
   # Capture only stdout; rg's stderr flows through to the script's stderr so a
   # real error is surfaced to the agent (via the executor) instead of swallowed.
   # rg exit: 0 = matched, 1 = no match (-> empty result), >1 = a real error (bad
   # regex, I/O) that must surface instead of masquerading as "no hits".
-  matches=$(rg "$@" -- "$search")
+  matches=$(rg --no-config --no-follow --line-number --no-heading --with-filename --color never --no-ignore --hidden --max-count 50 -e "$grep_pattern" -- "$search")
   rc=$?
   [ "$rc" -gt 1 ] && { echo "ripgrep failed (exit $rc)" >&2; exit "$rc"; }
   printf '%s\n' "$matches" | sed 's#^\\./##' | awk 'NR <= 200'

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -615,31 +615,61 @@ const GREP_SCRIPT = `${COMMON_SHELL_HELPERS}
 root=$(pwd -P) || exit 1
 grep_pattern=$1
 input_path=$2
+glob=$3
 glob_re=$4
 if [ -n "$input_path" ]; then
   start=$(existing_target "$input_path" 'Grep path') || exit 1
 else
   start=$root
 fi
-if [ -f "$start" ]; then
-  file_list=$start
+# Prefer ripgrep: gitignore-aware, skips binaries and hidden files, fast, and a
+# far richer regex than awk. Output stays "<relpath>:<line>:<text>" and the
+# per-file (50) / total (200) caps are preserved. When rg is not on PATH (minimal
+# task images) fall back to the POSIX find/awk walk, which searches every file.
+# existing_target above already enforced the inside-workspace + no-symlink-escape
+# invariant for the search root in both paths; input_path is workspace-relative
+# so rg, run from root, emits workspace-relative paths to match the contract.
+if command -v rg >/dev/null 2>&1; then
+  # --no-ignore --hidden: search the same file set as the find/awk fallback, so
+  # results do not depend on whether rg happens to be installed. rg still skips
+  # binaries and brings a far richer regex than awk, which are the real wins.
+  # --with-filename keeps the filename on single-file searches so the
+  # "<relpath>:<line>:<text>" contract holds in every case.
+  set -- --line-number --no-heading --with-filename --color never --no-ignore --hidden --max-count 50
+  [ -n "$glob" ] && set -- "$@" --glob "$glob"
+  set -- "$@" -e "$grep_pattern"
+  # Always pass an explicit path: with none, rg reads from its (never-closing)
+  # stdin pipe and hangs. "." searches the whole workspace; rg prefixes those
+  # hits with "./", stripped below to the bare relative-path contract.
+  search=$input_path
+  [ -n "$search" ] || search=.
+  matches=$(rg "$@" -- "$search" 2>/dev/null)
+  rc=$?
+  # rg exit: 0 = matched, 1 = no match (-> empty result), >1 = a real error
+  # (bad regex/glob, I/O) that must surface instead of masquerading as "no hits".
+  [ "$rc" -gt 1 ] && { echo "ripgrep failed (exit $rc)" >&2; exit "$rc"; }
+  printf '%s\n' "$matches" | sed 's#^\\./##' | awk 'NR <= 200'
 else
-  file_list=$(find "$start" -type f -print)
-fi
-printf '%s\n' "$file_list" | while IFS= read -r file; do
-  [ -n "$file" ] || continue
-  rel=$file
-  prefix=$root/
-  case "$rel" in "$prefix"*) rel=\${rel#"$prefix"} ;; esac
-  if [ -n "$glob_re" ]; then
-    printf '%s\n' "$rel" | awk -v re="$glob_re" 'BEGIN { ok = 1 } $0 ~ re { ok = 0 } END { exit ok }' || continue
+  if [ -f "$start" ]; then
+    file_list=$start
+  else
+    file_list=$(find "$start" -type f -print)
   fi
-  awk -v rel="$rel" -v pattern="$grep_pattern" '
-    $0 ~ pattern {
-      print rel ":" NR ":" $0
-      count += 1
-      if (count >= 50) exit
-    }
-  ' "$file"
-done | awk 'NR <= 200'
+  printf '%s\n' "$file_list" | while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    rel=$file
+    prefix=$root/
+    case "$rel" in "$prefix"*) rel=\${rel#"$prefix"} ;; esac
+    if [ -n "$glob_re" ]; then
+      printf '%s\n' "$rel" | awk -v re="$glob_re" 'BEGIN { ok = 1 } $0 ~ re { ok = 0 } END { exit ok }' || continue
+    fi
+    awk -v rel="$rel" -v pattern="$grep_pattern" '
+      $0 ~ pattern {
+        print rel ":" NR ":" $0
+        count += 1
+        if (count >= 50) exit
+      }
+    ' "$file"
+  done | awk 'NR <= 200'
+fi
 `;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -622,31 +622,38 @@ if [ -n "$input_path" ]; then
 else
   start=$root
 fi
-# Prefer ripgrep: gitignore-aware, skips binaries and hidden files, fast, and a
-# far richer regex than awk. Output stays "<relpath>:<line>:<text>" and the
-# per-file (50) / total (200) caps are preserved. When rg is not on PATH (minimal
-# task images) fall back to the POSIX find/awk walk, which searches every file.
-# existing_target above already enforced the inside-workspace + no-symlink-escape
-# invariant for the search root in both paths; input_path is workspace-relative
-# so rg, run from root, emits workspace-relative paths to match the contract.
-if command -v rg >/dev/null 2>&1; then
-  # --no-ignore --hidden: search the same file set as the find/awk fallback, so
-  # results do not depend on whether rg happens to be installed. rg still skips
-  # binaries and brings a far richer regex than awk, which are the real wins.
+# Prefer ripgrep for the common case: gitignore-aware, skips binaries and hidden
+# files, fast, and a far richer regex than awk. Output stays "<relpath>:<line>:
+# <text>" and the per-file (50) / total (200) caps are preserved. rg is used only
+# when no glob is requested — its gitignore-style --glob is a different dialect
+# from the fallback's ERE, so routing every glob through the single fallback path
+# keeps results identical with or without rg installed — and otherwise the POSIX
+# find/awk walk runs. existing_target above already enforced the inside-workspace
+# + no-symlink-escape invariant for the search root in both paths; input_path is
+# workspace-relative so rg, run from root, emits workspace-relative paths.
+if [ -z "$glob" ] && command -v rg >/dev/null 2>&1; then
+  # --no-config: ignore RIPGREP_CONFIG_PATH so a host-set rg config cannot inject
+  #   flags (e.g. --follow) that would break the no-workspace-escape invariant.
+  # --no-follow: never traverse symlinks, matching the find/awk fallback (find
+  #   without -L), so a workspace-internal symlink cannot leak external files.
+  # --no-ignore --hidden: search the same file set as the fallback, so results do
+  #   not depend on whether rg happens to be installed. rg still skips binaries
+  #   and brings a far richer regex than awk, which are the real wins.
   # --with-filename keeps the filename on single-file searches so the
   # "<relpath>:<line>:<text>" contract holds in every case.
-  set -- --line-number --no-heading --with-filename --color never --no-ignore --hidden --max-count 50
-  [ -n "$glob" ] && set -- "$@" --glob "$glob"
+  set -- --no-config --no-follow --line-number --no-heading --with-filename --color never --no-ignore --hidden --max-count 50
   set -- "$@" -e "$grep_pattern"
   # Always pass an explicit path: with none, rg reads from its (never-closing)
   # stdin pipe and hangs. "." searches the whole workspace; rg prefixes those
   # hits with "./", stripped below to the bare relative-path contract.
   search=$input_path
   [ -n "$search" ] || search=.
-  matches=$(rg "$@" -- "$search" 2>/dev/null)
+  # Capture only stdout; rg's stderr flows through to the script's stderr so a
+  # real error is surfaced to the agent (via the executor) instead of swallowed.
+  # rg exit: 0 = matched, 1 = no match (-> empty result), >1 = a real error (bad
+  # regex, I/O) that must surface instead of masquerading as "no hits".
+  matches=$(rg "$@" -- "$search")
   rc=$?
-  # rg exit: 0 = matched, 1 = no match (-> empty result), >1 = a real error
-  # (bad regex/glob, I/O) that must surface instead of masquerading as "no hits".
   [ "$rc" -gt 1 ] && { echo "ripgrep failed (exit $rc)" >&2; exit "$rc"; }
   printf '%s\n' "$matches" | sed 's#^\\./##' | awk 'NR <= 200'
 else


### PR DESCRIPTION
Part of #92 (close the tool-layer gap vs opencode). Upgrades the isolated/benchmark **Grep** engine from a `find` + `awk` walk to **ripgrep** when available.

## What

`GREP_SCRIPT` (run via `sh -c` inside the isolated executor) now prefers `rg` when it is on PATH, and falls back to the original `find`/`awk` walk verbatim when it is not (minimal task images). Output is unchanged: an array of `<relpath>:<line>:<text>`, with the per-file (50) and total (200) caps preserved.

## Why

The find/awk walk had no binary-file skipping (it matched bytes inside binaries) and only awk's ERE regex. ripgrep brings a far richer regex, binary skipping, and speed.

## Design choices

- **`--no-ignore --hidden`**: rg searches the *same file set* as the fallback, so a benchmark's results do not depend on whether `rg` happens to be installed on the host. I deliberately did **not** make Grep gitignore-aware here: that would make the same task behave differently with/without rg and could hide files a task needs. Parity first.
- **`--with-filename`**: keeps the path prefix on single-file searches (rg otherwise omits it for one file).
- **Explicit path always** (`.` for the whole workspace): with no path, rg reads from its never-closing stdin pipe and hangs; the `./` it then prefixes is stripped to keep the bare relative-path contract.
- **rg exit > 1** (bad regex/glob, I/O) surfaces as an error instead of masquerading as "no matches".
- The existing inside-workspace + no-symlink-escape validation (`existing_target`) runs before both paths; `input_path`/`glob` are already workspace-relative (normalized in TS). rg does not follow symlinks (no `--follow`), so it cannot escape the workspace.

## Known, intended difference

When `rg` is present, binary files are skipped; the fallback's awk would match their bytes. Searching binaries for text is rarely useful, so this is treated as an improvement rather than something to equalize.

## Tests

`packages/headless/src/__tests__/tools.test.ts`: the existing fallback test runs with a restricted PATH (no rg) and still exercises the find/awk branch unchanged; a new test runs with full PATH and proves the rg path ran by asserting a binary file containing the needle is skipped, plus a single-file search that keeps its path prefix.

Full `@maka/headless` suite: 242 pass / 0 fail.

## Review

Passed the codex gate. Round 1: 2 P1 (single-file filename prefix, file-set parity) + 1 P2 (masked rg error), all fixed. Round 2 raised one P1 that is a false positive (it assumed an absolute `input_path`, but the TS layer normalizes it to workspace-relative before the script; the absolute-input test proves relative output), so no code change.
