### PR TITLE
Trim renderer session helpers

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -80,13 +80,8 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     assert.match(hero, /`恢复 \$\{hiddenSuggestions\.length\} 项`/);
     assert.match(main, /window\.maka\.onboarding\.setMilestone\(FIRST_RUN_TASK_SUGGESTION_MILESTONES\[id\], 'skipped'\)/);
     assert.match(main, /window\.maka\.onboarding\.clearMilestone\(FIRST_RUN_TASK_SUGGESTION_MILESTONES\[id\]\)/);
-    assert.match(
-      main,
-      /function firstRunSuggestionActionErrorMessage\(error: unknown, fallback: string\): string \{[\s\S]*generalizedErrorMessageChinese\(error, fallback\)/,
-      'first-run suggestion thrown failures should use generalized fallback copy instead of raw backend/path details',
-    );
-    assert.match(main, /toastApi\.error\('隐藏建议失败', firstRunSuggestionActionErrorMessage\(error, '任务建议暂时无法隐藏，请稍后重试。'\)\)/);
-    assert.match(main, /toastApi\.error\('恢复建议失败', firstRunSuggestionActionErrorMessage\(error, '任务建议暂时无法恢复，请稍后重试。'\)\)/);
+    assert.match(main, /toastApi\.error\('隐藏建议失败', generalizedErrorMessageChinese\(error, '任务建议暂时无法隐藏，请稍后重试。'\)\)/);
+    assert.match(main, /toastApi\.error\('恢复建议失败', generalizedErrorMessageChinese\(error, '任务建议暂时无法恢复，请稍后重试。'\)\)/);
     assert.doesNotMatch(main, /toastApi\.error\('隐藏建议失败', cleanErrorMessage\(error\)\)/);
     assert.doesNotMatch(main, /toastApi\.error\('恢复建议失败', cleanErrorMessage\(error\)\)/);
     assert.match(readyBlock, /const \[pendingSuggestionAction, setPendingSuggestionAction\] = useState<string \| null>\(null\)/);

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -154,10 +154,10 @@ describe('permission response IPC boundary', () => {
     const stop = renderer.match(/async function stop\(\)\s*\{[\s\S]*?\n  \}/);
     assert.ok(stop, 'stop() must exist in main.tsx');
     assert.match(renderer, /const stopPendingRef = useRef<Set<string>>\(new Set\(\)\);/);
-    assert.match(renderer, /function addPendingStop\(sessionId: string\): boolean \{[\s\S]*?stopPendingRef\.current\.has\(sessionId\)[\s\S]*?stopPendingRef\.current\.add\(sessionId\)/);
-    assert.match(renderer, /function clearPendingStop\(sessionId: string\): void \{[\s\S]*?stopPendingRef\.current\.delete\(sessionId\)/);
+    assert.match(renderer, /function addPendingSessionAction\([\s\S]*?pendingRef\.current\.has\(sessionId\)[\s\S]*?pendingRef\.current\.add\(sessionId\)[\s\S]*?setPendingBySession/);
+    assert.match(renderer, /function clearPendingSessionAction\([\s\S]*?pendingRef\.current\.delete\(sessionId\)[\s\S]*?omitSessionKey\(current, sessionId\)/);
     assert.match(stop[0], /const sessionId = activeIdRef\.current;/);
-    assert.match(stop[0], /if \(!sessionId \|\| !addPendingStop\(sessionId\)\) return;/);
+    assert.match(stop[0], /if \(!sessionId \|\| !addPendingSessionAction\(sessionId, stopPendingRef, setStopPendingBySession\)\) return;/);
     assert.match(stop[0], /try\s*\{[\s\S]*?await window\.maka\.sessions\.stop/);
     assert.match(stop[0], /await window\.maka\.sessions\.stop\(sessionId, \{ source: 'stop_button' \}\);/);
     assert.match(
@@ -170,7 +170,7 @@ describe('permission response IPC boundary', () => {
       /toastApi\.error\('停止失败', cleanErrorMessage\(error\)\)/,
       'stop failure feedback must not expose raw IPC/provider/storage details',
     );
-    assert.match(stop[0], /finally \{[\s\S]*?clearPendingStop\(sessionId\);[\s\S]*?\}/);
+    assert.match(stop[0], /finally \{[\s\S]*?clearPendingSessionAction\(sessionId, stopPendingRef, setStopPendingBySession\);[\s\S]*?\}/);
     const respond = renderer.match(/async function respondToPermission\([\s\S]*?\n  \}/);
     assert.ok(respond, 'respondToPermission() must exist');
     assert.match(respond[0], /const sessionId = activeIdRef\.current;/);

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -88,7 +88,7 @@ describe('renderer startup fail-soft contract', () => {
     );
     assert.match(
       refreshSkills,
-      /try \{[\s\S]*window\.maka\.skills\.list\(\)[\s\S]*setSkills\(next\)[\s\S]*\} catch \(error\) \{[\s\S]*if \(options\.shouldShowError\?\.\(\) \?\? true\) \{[\s\S]*toastApi\.error\('刷新技能失败', skillsActionErrorMessage\(error, '刷新技能失败，请稍后重试。'\)\);[\s\S]*\}/,
+      /try \{[\s\S]*window\.maka\.skills\.list\(\)[\s\S]*setSkills\(next\)[\s\S]*\} catch \(error\) \{[\s\S]*if \(options\.shouldShowError\?\.\(\) \?\? true\) \{[\s\S]*toastApi\.error\('刷新技能失败', generalizedErrorMessageChinese\(error, '刷新技能失败，请稍后重试。'\)\);[\s\S]*\}/,
       'skills refresh failures must be visible and must preserve the existing list',
     );
     assert.doesNotMatch(

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -34,13 +34,13 @@ describe('active session message lifecycle contract', () => {
       'late active-session reads may set messages only while the same session is still active',
     );
     assert.match(
-      src,
-      /function messageLoadActionErrorMessage\(error: unknown, fallback: string\): string \{[\s\S]*generalizedErrorMessageChinese\(error, fallback\)/,
+      activeReadCatch,
+      /const message = generalizedErrorMessageChinese\(error, '对话内容暂时无法读取，请稍后重试。'\);/,
       'message read failures should use generalized fallback copy instead of raw backend/path details',
     );
     assert.match(
       activeReadCatch,
-      /\.catch\(\(error\) => \{[\s\S]*const message = messageLoadActionErrorMessage\(error, '对话内容暂时无法读取，请稍后重试。'\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[activeId\]: message \}\)\);[\s\S]*toastApi\.error\('读取对话失败', message\)/,
+      /\.catch\(\(error\) => \{[\s\S]*const message = generalizedErrorMessageChinese\(error, '对话内容暂时无法读取，请稍后重试。'\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[activeId\]: message \}\)\);[\s\S]*toastApi\.error\('读取对话失败', message\)/,
       'active-session read failures must set a visible per-session load error after the old chat body has already been cleared',
     );
     assert.doesNotMatch(activeReadCatch, /const message = cleanErrorMessage\(error\)/);
@@ -56,7 +56,7 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       refreshMessages,
-      /try \{[\s\S]*readMessages\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*\} catch \(error\) \{[\s\S]*const message = messageLoadActionErrorMessage\(error, '对话内容暂时无法刷新，请稍后重试。'\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
+      /try \{[\s\S]*readMessages\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*\} catch \(error\) \{[\s\S]*const message = generalizedErrorMessageChinese\(error, '对话内容暂时无法刷新，请稍后重试。'\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
       'shared refreshMessages path must surface read failures through the same per-session load error state',
     );
     assert.doesNotMatch(refreshMessages, /const message = cleanErrorMessage\(error\)/);
@@ -72,12 +72,12 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       src,
-      /function addPendingMessageRetry\(sessionId: string\): boolean \{[\s\S]*messageRetryPendingRef\.current\.has\(sessionId\)[\s\S]*messageRetryPendingRef\.current\.add\(sessionId\)[\s\S]*setMessageRetryPendingBySession/,
+      /function addPendingSessionAction\([\s\S]*pendingRef\.current\.has\(sessionId\)[\s\S]*pendingRef\.current\.add\(sessionId\)[\s\S]*setPendingBySession/,
       'manual message-load retry must use a ref-backed same-frame duplicate guard',
     );
     assert.match(
       retryMessages,
-      /if \(!addPendingMessageRetry\(sessionId\)\) return;[\s\S]*await refreshMessages\(sessionId\);[\s\S]*finally \{[\s\S]*clearPendingMessageRetry\(sessionId\)/,
+      /if \(!addPendingSessionAction\(sessionId, messageRetryPendingRef, setMessageRetryPendingBySession\)\) return;[\s\S]*await refreshMessages\(sessionId\);[\s\S]*finally \{[\s\S]*clearPendingSessionAction\(sessionId, messageRetryPendingRef, setMessageRetryPendingBySession\)/,
       'manual retry must clear its pending state even when refreshMessages fails',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -398,7 +398,7 @@ name: Writer
     );
     assert.match(
       refreshBlock,
-      /if \(options\.shouldShowError\?\.\(\) \?\? true\) \{[\s\S]*toastApi\.error\('刷新技能失败', skillsActionErrorMessage\(error, '刷新技能失败，请稍后重试。'\)\);[\s\S]*\}/,
+      /if \(options\.shouldShowError\?\.\(\) \?\? true\) \{[\s\S]*toastApi\.error\('刷新技能失败', generalizedErrorMessageChinese\(error, '刷新技能失败，请稍后重试。'\)\);[\s\S]*\}/,
       'startup/subscription Skills refresh failures must remain visible by default',
     );
     assert.match(
@@ -424,11 +424,10 @@ name: Writer
     const folderBlock = renderer.match(/async function openSkillsFolder\(\)[\s\S]*?async function openSkill/)?.[0] ?? '';
     const openBlock = renderer.match(/async function openSkill\(skillId: string\)[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(renderer, /function skillsActionErrorMessage\(error: unknown, fallback: string\): string \{[\s\S]*generalizedErrorMessageChinese\(error, fallback\)/);
     assert.match(createBlock, /try \{[\s\S]*window\.maka\.skills\.createStarter\(\)/);
     assert.match(
       createBlock,
-      /catch \(error\) \{[\s\S]*if \(isSkillsSurfaceActive\(\)\) \{[\s\S]*toastApi\.error\('无法创建示例技能', skillsActionErrorMessage\(error, '无法创建示例技能，请稍后重试。'\)\);[\s\S]*\}/,
+      /catch \(error\) \{[\s\S]*if \(isSkillsSurfaceActive\(\)\) \{[\s\S]*toastApi\.error\('无法创建示例技能', generalizedErrorMessageChinese\(error, '无法创建示例技能，请稍后重试。'\)\);[\s\S]*\}/,
     );
     assert.doesNotMatch(createBlock, /toastApi\.error\('无法创建示例技能', cleanErrorMessage\(error\)\)/);
     assert.match(folderBlock, /try \{[\s\S]*window\.maka\.app\.openPath\('skills'\)/);
@@ -437,7 +436,7 @@ name: Writer
     assert.match(openBlock, /try \{[\s\S]*window\.maka\.skills\.open\(skillId, 'file'\)/);
     assert.match(
       openBlock,
-      /catch \(error\) \{[\s\S]*if \(isSkillsSurfaceActive\(\)\) \{[\s\S]*toastApi\.error\('无法打开 Skill', skillsActionErrorMessage\(error, '无法打开 Skill，请稍后重试。'\)\);[\s\S]*\}/,
+      /catch \(error\) \{[\s\S]*if \(isSkillsSurfaceActive\(\)\) \{[\s\S]*toastApi\.error\('无法打开 Skill', generalizedErrorMessageChinese\(error, '无法打开 Skill，请稍后重试。'\)\);[\s\S]*\}/,
     );
     assert.doesNotMatch(openBlock, /toastApi\.error\('无法打开 Skill', cleanErrorMessage\(error\)\)/);
   });

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -617,46 +617,32 @@ function AppShell() {
       pendingSessionRowActionsRef.current.delete(key);
     }
   }
-  function addPendingMessageRetry(sessionId: string): boolean {
-    if (messageRetryPendingRef.current.has(sessionId)) return false;
-    messageRetryPendingRef.current.add(sessionId);
-    setMessageRetryPendingBySession((current) => ({ ...current, [sessionId]: true }));
-    return true;
-  }
-  function clearPendingMessageRetry(sessionId: string): void {
-    if (!messageRetryPendingRef.current.has(sessionId)) return;
-    messageRetryPendingRef.current.delete(sessionId);
-    setMessageRetryPendingBySession((current) => {
-      if (!current[sessionId]) return current;
-      const next = { ...current };
-      delete next[sessionId];
-      return next;
-    });
-  }
-
-  function addPendingStop(sessionId: string): boolean {
-    if (stopPendingRef.current.has(sessionId)) return false;
-    stopPendingRef.current.add(sessionId);
-    setStopPendingBySession((current) => ({ ...current, [sessionId]: true }));
-    return true;
-  }
-
-  function clearPendingStop(sessionId: string): void {
-    if (!stopPendingRef.current.has(sessionId)) return;
-    stopPendingRef.current.delete(sessionId);
-    setStopPendingBySession((current) => {
-      if (!current[sessionId]) return current;
-      const next = { ...current };
-      delete next[sessionId];
-      return next;
-    });
-  }
-
   function omitSessionKey<T>(current: Record<string, T>, sessionId: string): Record<string, T> {
     if (!(sessionId in current)) return current;
     const next = { ...current };
     delete next[sessionId];
     return next;
+  }
+
+  function addPendingSessionAction(
+    sessionId: string,
+    pendingRef: { current: Set<string> },
+    setPendingBySession: (updater: (current: Record<string, boolean>) => Record<string, boolean>) => void,
+  ): boolean {
+    if (pendingRef.current.has(sessionId)) return false;
+    pendingRef.current.add(sessionId);
+    setPendingBySession((current) => ({ ...current, [sessionId]: true }));
+    return true;
+  }
+
+  function clearPendingSessionAction(
+    sessionId: string,
+    pendingRef: { current: Set<string> },
+    setPendingBySession: (updater: (current: Record<string, boolean>) => Record<string, boolean>) => void,
+  ): void {
+    if (!pendingRef.current.has(sessionId)) return;
+    pendingRef.current.delete(sessionId);
+    setPendingBySession((current) => omitSessionKey(current, sessionId));
   }
 
   function clearSessionRendererState(sessionId: string): void {
@@ -1123,7 +1109,7 @@ function AppShell() {
       })
       .catch((error) => {
         if (!disposed && activeIdRef.current === activeId) {
-          const message = messageLoadActionErrorMessage(error, '对话内容暂时无法读取，请稍后重试。');
+          const message = generalizedErrorMessageChinese(error, '对话内容暂时无法读取，请稍后重试。');
           setMessageLoadErrorBySession((current) => ({ ...current, [activeId]: message }));
           toastApi.error('读取对话失败', message);
         }
@@ -1779,7 +1765,7 @@ function AppShell() {
       setSkills(next);
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
-        toastApi.error('刷新技能失败', skillsActionErrorMessage(error, '刷新技能失败，请稍后重试。'));
+        toastApi.error('刷新技能失败', generalizedErrorMessageChinese(error, '刷新技能失败，请稍后重试。'));
       }
     }
   }
@@ -1809,7 +1795,7 @@ function AppShell() {
       }
     } catch (error) {
       if (isSkillsSurfaceActive()) {
-        toastApi.error('无法创建示例技能', skillsActionErrorMessage(error, '无法创建示例技能，请稍后重试。'));
+        toastApi.error('无法创建示例技能', generalizedErrorMessageChinese(error, '无法创建示例技能，请稍后重试。'));
       }
     }
   }
@@ -1833,7 +1819,7 @@ function AppShell() {
       }
     } catch (error) {
       if (isSkillsSurfaceActive()) {
-        toastApi.error('无法打开 Skill', skillsActionErrorMessage(error, '无法打开 Skill，请稍后重试。'));
+        toastApi.error('无法打开 Skill', generalizedErrorMessageChinese(error, '无法打开 Skill，请稍后重试。'));
       }
     }
   }
@@ -2026,7 +2012,7 @@ function AppShell() {
 
   async function stop() {
     const sessionId = activeIdRef.current;
-    if (!sessionId || !addPendingStop(sessionId)) return;
+    if (!sessionId || !addPendingSessionAction(sessionId, stopPendingRef, setStopPendingBySession)) return;
     try {
       await window.maka.sessions.stop(sessionId, { source: 'stop_button' });
     } catch (error) {
@@ -2038,7 +2024,7 @@ function AppShell() {
       // actually interrupted and can retry.
       if (activeIdRef.current === sessionId) toastApi.error('停止失败', sessionControlActionErrorMessage(error));
     } finally {
-      clearPendingStop(sessionId);
+      clearPendingSessionAction(sessionId, stopPendingRef, setStopPendingBySession);
     }
   }
 
@@ -2069,18 +2055,18 @@ function AppShell() {
       }
     } catch (error) {
       if (activeIdRef.current === sessionId) {
-        const message = messageLoadActionErrorMessage(error, '对话内容暂时无法刷新，请稍后重试。');
+        const message = generalizedErrorMessageChinese(error, '对话内容暂时无法刷新，请稍后重试。');
         setMessageLoadErrorBySession((current) => ({ ...current, [sessionId]: message }));
         toastApi.error('刷新对话失败', message);
       }
     }
   }
   async function retryMessages(sessionId: string) {
-    if (!addPendingMessageRetry(sessionId)) return;
+    if (!addPendingSessionAction(sessionId, messageRetryPendingRef, setMessageRetryPendingBySession)) return;
     try {
       await refreshMessages(sessionId);
     } finally {
-      clearPendingMessageRetry(sessionId);
+      clearPendingSessionAction(sessionId, messageRetryPendingRef, setMessageRetryPendingBySession);
     }
   }
 
@@ -2466,7 +2452,7 @@ function AppShell() {
       await window.maka.onboarding.setMilestone(FIRST_RUN_TASK_SUGGESTION_MILESTONES[id], 'skipped');
       onboarding.refresh();
     } catch (error) {
-      toastApi.error('隐藏建议失败', firstRunSuggestionActionErrorMessage(error, '任务建议暂时无法隐藏，请稍后重试。'));
+      toastApi.error('隐藏建议失败', generalizedErrorMessageChinese(error, '任务建议暂时无法隐藏，请稍后重试。'));
     }
   }
 
@@ -2477,7 +2463,7 @@ function AppShell() {
       }
       onboarding.refresh();
     } catch (error) {
-      toastApi.error('恢复建议失败', firstRunSuggestionActionErrorMessage(error, '任务建议暂时无法恢复，请稍后重试。'));
+      toastApi.error('恢复建议失败', generalizedErrorMessageChinese(error, '任务建议暂时无法恢复，请稍后重试。'));
     }
   }
 
@@ -3612,10 +3598,6 @@ function sessionControlActionErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。');
 }
 
-function messageLoadActionErrorMessage(error: unknown, fallback: string): string {
-  return generalizedErrorMessageChinese(error, fallback);
-}
-
 function sendActionErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '消息暂时无法发送，请稍后重试。');
 }
@@ -3626,14 +3608,6 @@ function composerImportActionErrorMessage(error: unknown): string {
 
 function quickChatActionErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '对话暂时无法开始，请稍后重试。');
-}
-
-function firstRunSuggestionActionErrorMessage(error: unknown, fallback: string): string {
-  return generalizedErrorMessageChinese(error, fallback);
-}
-
-function skillsActionErrorMessage(error: unknown, fallback: string): string {
-  return generalizedErrorMessageChinese(error, fallback);
 }
 
 function cleanErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary
- replace duplicated stop/retry pending add/clear helpers with one ref-backed `addPendingSessionAction` / `clearPendingSessionAction` pair
- inline three one-line renderer error-message forwarders into `generalizedErrorMessageChinese`
- update source-grep contracts to lock the semantic guard/error behavior instead of the deleted wrapper names

## Verification
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test -- session-message-lifecycle-contract permission-response-ipc-boundary skills renderer-startup-fail-soft-contract first-run-task-suggestions` (runs full 1464/1464 with check-console/check-a11y clean)
- `npm run build`
- `git diff --check`
