### PR TITLE
Inline renderer error fallbacks

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -162,7 +162,7 @@ describe('permission response IPC boundary', () => {
     assert.match(stop[0], /await window\.maka\.sessions\.stop\(sessionId, \{ source: 'stop_button' \}\);/);
     assert.match(
       stop[0],
-      /catch \(error\)[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.error\('停止失败', sessionControlActionErrorMessage\(error\)\);/,
+      /catch \(error\)[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.error\('停止失败', generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\);/,
       'stop failure feedback must not leak onto a different active session',
     );
     assert.doesNotMatch(
@@ -183,18 +183,13 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       respond[0],
-      /catch \(error\)[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.error\('响应失败', sessionControlActionErrorMessage\(error\)\);/,
+      /catch \(error\)[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.error\('响应失败', generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\);/,
       'permission response failure feedback must not leak onto a different active session',
     );
     assert.doesNotMatch(
       respond[0],
       /toastApi\.error\('响应失败', cleanErrorMessage\(error\)\)/,
       'permission response failure feedback must not expose raw IPC/provider/storage details',
-    );
-    assert.match(
-      renderer,
-      /function sessionControlActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)/,
-      'session control visible failures must use a generalized Chinese fallback',
     );
   });
 
@@ -309,13 +304,8 @@ describe('permission response IPC boundary', () => {
     );
     assert.ok(refreshSessions, 'refreshSessions() must exist');
     assert.match(
-      renderer,
-      /function sessionListActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '刷新会话列表失败，请稍后重试。'\)/,
-      'session list refresh failures should use generalized fallback copy instead of raw backend/path details',
-    );
-    assert.match(
       refreshSessions[0],
-      /try \{[\s\S]*window\.maka\.sessions\.list\(\)[\s\S]*sessionsRef\.current = next[\s\S]*setSessions\(next\)[\s\S]*return next[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新会话列表失败', sessionListActionErrorMessage\(error\)\)[\s\S]*return sessionsRef\.current/,
+      /try \{[\s\S]*window\.maka\.sessions\.list\(\)[\s\S]*sessionsRef\.current = next[\s\S]*setSessions\(next\)[\s\S]*return next[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新会话列表失败', generalizedErrorMessageChinese\(error, '刷新会话列表失败，请稍后重试。'\)\)[\s\S]*return sessionsRef\.current/,
       'refreshSessions() is called fire-and-forget and must catch list failures without dropping the current list',
     );
     assert.doesNotMatch(refreshSessions[0], /toastApi\.error\('刷新会话列表失败', cleanErrorMessage\(error\)\)/);
@@ -354,11 +344,6 @@ describe('permission response IPC boundary', () => {
       /async function handleQuickChatSubmit\(prompt: string, mode\?: QuickChatMode\): Promise<boolean> \{[\s\S]*?\n  \}/,
     );
     assert.ok(quickChatHandler, 'handleQuickChatSubmit() must exist');
-    assert.match(
-      renderer,
-      /function quickChatActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '对话暂时无法开始，请稍后重试。'\)/,
-      'quick chat thrown failures should use a generalized fallback instead of raw backend/path details',
-    );
     assert.match(
       renderer,
       /const quickChatPendingRef = useRef\(false\)/,
@@ -401,7 +386,11 @@ describe('permission response IPC boundary', () => {
       /toastApi\.error\('开始对话失败', result\.message\);[\s\S]*?return false;/,
       'send failures must return false so the first-run composer keeps the user draft',
     );
-    assert.match(quickChatHandler[0], /toastApi\.error\('开始对话失败', quickChatActionErrorMessage\(error\)\);[\s\S]*?return false;/);
+    assert.match(
+      quickChatHandler[0],
+      /toastApi\.error\('开始对话失败', generalizedErrorMessageChinese\(error, '对话暂时无法开始，请稍后重试。'\)\);[\s\S]*?return false;/,
+      'quick chat thrown failures should use a generalized fallback instead of raw backend/path details',
+    );
     assert.doesNotMatch(quickChatHandler[0], /toastApi\.error\('开始对话失败', cleanErrorMessage\(error\)\)/);
     assert.match(
       quickChatHandler[0],
@@ -451,7 +440,7 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       sendBlock,
-      /catch \(error\) \{[\s\S]*removeOptimisticUserMessage\(optimisticSessionId, optimisticTurnId\)[\s\S]*toastApi\.error\('发送失败', sendActionErrorMessage\(error\)\)/,
+      /catch \(error\) \{[\s\S]*removeOptimisticUserMessage\(optimisticSessionId, optimisticTurnId\)[\s\S]*toastApi\.error\('发送失败', generalizedErrorMessageChinese\(error, '消息暂时无法发送，请稍后重试。'\)\)/,
       'send readiness failures must remove the optimistic user turn instead of leaving a fake message behind',
     );
     assert.match(
@@ -461,7 +450,7 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       sendBlock,
-      /if \(!sendStillOwnsCurrentSurface\) return false;[\s\S]*if \(isNoRealConnectionError\(error\)\) \{[\s\S]*const reason = noRealConnectionReasonFromError\(error\);[\s\S]*showModelSetupToast\(noRealConnectionSetupDescription\(reason\), reason\);[\s\S]*\} else \{[\s\S]*toastApi\.error\('发送失败', sendActionErrorMessage\(error\)\)/,
+      /if \(!sendStillOwnsCurrentSurface\) return false;[\s\S]*if \(isNoRealConnectionError\(error\)\) \{[\s\S]*const reason = noRealConnectionReasonFromError\(error\);[\s\S]*showModelSetupToast\(noRealConnectionSetupDescription\(reason\), reason\);[\s\S]*\} else \{[\s\S]*toastApi\.error\('发送失败', generalizedErrorMessageChinese\(error, '消息暂时无法发送，请稍后重试。'\)\)/,
       'both model-setup feedback and generic send-failure toast must be guarded by the active-session owner check',
     );
     assert.doesNotMatch(
@@ -489,11 +478,6 @@ describe('permission response IPC boundary', () => {
       modelSetupToast,
       /onClick: openSettings|openSettings\(\);/,
       'model-setup feedback should not only open Settings because that can restore an unrelated previous section',
-    );
-    assert.match(
-      renderer,
-      /function sendActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '消息暂时无法发送，请稍后重试。'\)/,
-      'generic send visible failures must use a generalized Chinese fallback',
     );
     assert.match(
       refreshUntilTurn,

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -16,13 +16,8 @@ describe('renderer startup fail-soft contract', () => {
 
     assert.match(mountEffect, /void refreshAppInfo\(\)/);
     assert.match(
-      main,
-      /function appInfoActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '项目路径暂时无法读取，请稍后重试。'\)/,
-      'app-info refresh failures should use generalized fallback copy instead of raw path/system details',
-    );
-    assert.match(
       refreshAppInfo,
-      /try \{[\s\S]*window\.maka\.app\.info\(\)[\s\S]*setAppInfo\(\{ projectPath: next\.projectPath, projectGit: next\.projectGit \}\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('读取项目路径失败', appInfoActionErrorMessage\(error\)\)/,
+      /try \{[\s\S]*window\.maka\.app\.info\(\)[\s\S]*setAppInfo\(\{ projectPath: next\.projectPath, projectGit: next\.projectGit \}\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('读取项目路径失败', generalizedErrorMessageChinese\(error, '项目路径暂时无法读取，请稍后重试。'\)\)/,
       'app-info refresh failures must be visible and preserve the last known project badge',
     );
     assert.doesNotMatch(refreshAppInfo, /toastApi\.error\('读取项目路径失败', cleanErrorMessage\(error\)\)/);
@@ -33,13 +28,8 @@ describe('renderer startup fail-soft contract', () => {
     );
     assert.match(mountEffect, /void refreshMemoryActive\('载入本地记忆状态失败'\)/);
     assert.match(
-      main,
-      /function memoryActiveActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '本地记忆状态暂时无法刷新，请稍后重试。'\)/,
-      'memory-active refresh failures should use generalized fallback copy instead of raw storage details',
-    );
-    assert.match(
       refreshMemoryActive,
-      /try \{[\s\S]*window\.maka\.memory\.getState\(\)[\s\S]*setMemoryActive\(next\.agentReadEnabled && next\.status === 'ok' && next\.content\.trim\(\)\.length > 0\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(failureTitle, memoryActiveActionErrorMessage\(error\)\)/,
+      /try \{[\s\S]*window\.maka\.memory\.getState\(\)[\s\S]*setMemoryActive\(next\.agentReadEnabled && next\.status === 'ok' && next\.content\.trim\(\)\.length > 0\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(failureTitle, generalizedErrorMessageChinese\(error, '本地记忆状态暂时无法刷新，请稍后重试。'\)\)/,
       'memory-active refresh failures must be visible without exposing raw storage details and preserve the last known header pill state',
     );
     assert.doesNotMatch(refreshMemoryActive, /toastApi\.error\(failureTitle, cleanErrorMessage\(error\)\)/);
@@ -50,13 +40,8 @@ describe('renderer startup fail-soft contract', () => {
     );
     assert.match(mountEffect, /void refreshShellSettings\(\)/);
     assert.match(
-      main,
-      /function shellSettingsActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)/,
-      'startup shell settings failures should use generalized fallback copy instead of raw storage/system details',
-    );
-    assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyDensity\(den\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', shellSettingsActionErrorMessage\(error\)\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyDensity\(den\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);
@@ -66,13 +51,8 @@ describe('renderer startup fail-soft contract', () => {
       'startup shell settings failures must not force default language/theme/density/palette over unknown persisted settings',
     );
     assert.match(
-      main,
-      /function connectionsActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '模型连接暂时无法刷新，请稍后重试。'\)/,
-      'connection refresh failures should use generalized fallback copy instead of raw provider/storage details',
-    );
-    assert.match(
       refreshConnections,
-      /try \{[\s\S]*window\.maka\.connections\.list\(\)[\s\S]*window\.maka\.connections\.getDefault\(\)[\s\S]*setConnections\(next\)[\s\S]*setDefaultConnection\(nextDefault\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新模型连接失败', connectionsActionErrorMessage\(error\)\)/,
+      /try \{[\s\S]*window\.maka\.connections\.list\(\)[\s\S]*window\.maka\.connections\.getDefault\(\)[\s\S]*setConnections\(next\)[\s\S]*setDefaultConnection\(nextDefault\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新模型连接失败', generalizedErrorMessageChinese\(error, '模型连接暂时无法刷新，请稍后重试。'\)\)/,
       'startup / connections:event refreshConnections is fire-and-forget and must catch IPC failures without exposing raw provider/storage details',
     );
     assert.doesNotMatch(refreshConnections, /toastApi\.error\('刷新模型连接失败', cleanErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -63,7 +63,7 @@ describe('session open routing contract', () => {
     );
     assert.match(
       handlerBlock,
-      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) toastApi\.error\('操作失败', turnFooterActionErrorMessage\(error\)\);[\s\S]*\} finally \{[\s\S]*clearPendingTurnAction\(key\);[\s\S]*\}/,
+      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) toastApi\.error\('操作失败', generalizedErrorMessageChinese\(error, '对话操作失败，请稍后重试。'\)\);[\s\S]*\} finally \{[\s\S]*clearPendingTurnAction\(key\);[\s\S]*\}/,
       'turn footer failures must not toast after the user leaves the source session',
     );
     assert.doesNotMatch(
@@ -75,11 +75,6 @@ describe('session open routing contract', () => {
       catchBlock,
       /clearPendingTurnAction\(key\);/,
       'pending turn actions must not be cleared only by the error path',
-    );
-    assert.match(
-      main,
-      /function turnFooterActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '对话操作失败，请稍后重试。'\)/,
-      'turn footer action failures must be generalized before visible toast feedback',
     );
     assert.doesNotMatch(
       handlerBlock,

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -10,17 +10,12 @@ describe('session row actions fail soft', () => {
   it('surfaces sidebar session action failures instead of leaving fire-and-forget rejections', async () => {
     const main = await readFile(join(process.cwd(), 'src/renderer/main.tsx'), 'utf8');
 
-    assert.match(main, /async function runSessionRowAction\([\s\S]*errorTitle: string,[\s\S]*try \{[\s\S]*await action\(\);[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, sessionRowActionErrorMessage\(error\)\)/);
+    assert.match(main, /async function runSessionRowAction\([\s\S]*errorTitle: string,[\s\S]*try \{[\s\S]*await action\(\);[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\)/);
     assert.match(main, /async function flagSession\(sessionId: string, flagged: boolean\) \{[\s\S]*runSessionRowAction\(sessionId, 'flag', flagged \? '标记会话失败' : '取消标记失败'[\s\S]*window\.maka\.sessions\.setFlagged\(sessionId, flagged\)[\s\S]*refreshSessions\(\)/);
     assert.match(main, /async function archiveSession\(sessionId: string\) \{[\s\S]*runSessionRowAction\(sessionId, 'archive', '归档会话失败'[\s\S]*window\.maka\.sessions\.archive\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setActiveId\(undefined\)[\s\S]*setMessages\(\[\]\)[\s\S]*refreshSessions\(\)/);
     assert.match(main, /async function unarchiveSession\(sessionId: string\) \{[\s\S]*runSessionRowAction\(sessionId, 'archive', '恢复会话失败'[\s\S]*window\.maka\.sessions\.unarchive\(sessionId\)[\s\S]*refreshSessions\(\)/);
     assert.match(main, /async function renameSession\(sessionId: string, name: string\) \{[\s\S]*runSessionRowAction\(sessionId, 'rename', '重命名会话失败'[\s\S]*window\.maka\.sessions\.rename\(sessionId, name\)[\s\S]*refreshSessions\(\)/);
     assert.match(main, /async function deleteSession\(sessionId: string\) \{[\s\S]*runSessionRowAction\(sessionId, 'delete', '删除会话失败'[\s\S]*toastApi\.confirm\([\s\S]*window\.maka\.sessions\.remove\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setActiveId\(undefined\)[\s\S]*setMessages\(\[\]\)[\s\S]*refreshSessions\(\)[\s\S]*toastApi\.success\(`已删除 \$\{name\}`\)/);
-    assert.match(
-      main,
-      /function sessionRowActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)/,
-      'sidebar row action failures must be generalized before visible toast feedback',
-    );
     assert.doesNotMatch(
       main,
       /toastApi\.error\((?:flagged \? '标记会话失败' : '取消标记失败'|'归档会话失败'|'恢复会话失败'|'重命名会话失败'|'删除会话失败'), cleanErrorMessage\(error\)\)/,
@@ -34,7 +29,7 @@ describe('session row actions fail soft', () => {
     assert.match(main, /const pendingSessionRowActionsRef = useRef<Set<string>>\(new Set\(\)\);/);
     assert.match(main, /const sessionPrefix = `\$\{sessionId\}:`;/);
     assert.match(main, /Array\.from\(pendingSessionRowActionsRef\.current\)\.some\(\(key\) => key\.startsWith\(sessionPrefix\)\)/);
-    assert.match(main, /pendingSessionRowActionsRef\.current\.add\(key\);[\s\S]*catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, sessionRowActionErrorMessage\(error\)\)[\s\S]*finally \{[\s\S]*pendingSessionRowActionsRef\.current\.delete\(key\);/);
+    assert.match(main, /pendingSessionRowActionsRef\.current\.add\(key\);[\s\S]*catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\)[\s\S]*finally \{[\s\S]*pendingSessionRowActionsRef\.current\.delete\(key\);/);
     assert.match(main, /rowActions=\{\{[\s\S]*onToggleFlag: \(sessionId, next\) => flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => deleteSession\(sessionId\),/);
     assert.doesNotMatch(main, /onDelete: \(sessionId\) => void deleteSession\(sessionId\)/);
     assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void flagSession\(sessionId, next\)/);

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -84,13 +84,8 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     );
     assert.match(
       renderer,
-      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) toastApi\.error\('切换模型失败', sessionModelActionErrorMessage\(error\)\);[\s\S]*\} finally/,
+      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) toastApi\.error\('切换模型失败', generalizedErrorMessageChinese\(error, '模型暂时无法切换，请稍后重试。'\)\);[\s\S]*\} finally/,
       'model switch failure toast must not surface stale failures after the user switches sessions',
-    );
-    assert.match(
-      renderer,
-      /function sessionModelActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '模型暂时无法切换，请稍后重试。'\)/,
-      'model switch failures must be generalized before visible toast feedback',
     );
     assert.doesNotMatch(
       renderer,

--- a/apps/desktop/src/main/__tests__/text-file-import.test.ts
+++ b/apps/desktop/src/main/__tests__/text-file-import.test.ts
@@ -342,11 +342,10 @@ describe('text file context import', () => {
     assert.match(mainSource, /preflightDroppedTextFilesForPromptImport\(preflightInputs\)/);
     assert.match(mainSource, /window\.maka\.context\.importDroppedTextFiles\(payloads\)/);
     assert.match(
-      mainSource,
-      /function composerImportActionErrorMessage\(error: unknown\): string \{[\s\S]*generalizedErrorMessageChinese\(error, '导入文件内容失败，请稍后重试。'\)/,
+      droppedPromptBlock,
+      /toastApi\.error\('导入文件失败', generalizedErrorMessageChinese\(error, '导入文件内容失败，请稍后重试。'\)\)/,
       'Composer import thrown failures should use a generalized fallback instead of raw backend/path details',
     );
-    assert.match(droppedPromptBlock, /toastApi\.error\('导入文件失败', composerImportActionErrorMessage\(error\)\)/);
     assert.doesNotMatch(droppedPromptBlock, /toastApi\.error\('导入文件失败', cleanErrorMessage\(error\)\)/);
     assert.ok(
       mainSource.indexOf('preflightDroppedTextFilesForPromptImport(preflightInputs)') < mainSource.indexOf('text: await file.text()'),

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -155,25 +155,9 @@ function openPathActionErrorMessage(error: unknown, key: 'workspace' | 'project'
   return generalizedErrorMessageChinese(error, `无法打开${openPathActionLabel(key)}，请稍后重试。`);
 }
 
-function appInfoActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。');
-}
-
 function selectProjectDirectoryFailureCopy(reason: 'missing-selection'): string {
   if (reason === 'missing-selection') return '没有读取到选中的目录，请重新选择。';
   return '工作目录暂时无法切换，请稍后重试。';
-}
-
-function shellSettingsActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。');
-}
-
-function connectionsActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '模型连接暂时无法刷新，请稍后重试。');
-}
-
-function memoryActiveActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '本地记忆状态暂时无法刷新，请稍后重试。');
 }
 
 function commandPaletteConnectionTestFailureMessage(result: ConnectionTestResult): string {
@@ -612,7 +596,7 @@ function AppShell() {
     try {
       await action();
     } catch (error) {
-      toastApi.error(errorTitle, sessionRowActionErrorMessage(error));
+      toastApi.error(errorTitle, generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。'));
     } finally {
       pendingSessionRowActionsRef.current.delete(key);
     }
@@ -825,7 +809,7 @@ function AppShell() {
         await refreshSessions();
       }
     } catch (error) {
-      if (activeIdRef.current === sessionId) toastApi.error('操作失败', turnFooterActionErrorMessage(error));
+      if (activeIdRef.current === sessionId) toastApi.error('操作失败', generalizedErrorMessageChinese(error, '对话操作失败，请稍后重试。'));
     } finally {
       clearPendingTurnAction(key);
     }
@@ -1196,7 +1180,7 @@ function AppShell() {
       setSessions(next);
       return next;
     } catch (error) {
-      toastApi.error('刷新会话列表失败', sessionListActionErrorMessage(error));
+      toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
       return sessionsRef.current;
     }
   }
@@ -1222,7 +1206,7 @@ function AppShell() {
       applyDensity(den);
       applyThemePalette(palette);
     } catch (error) {
-      toastApi.error('载入外观设置失败', shellSettingsActionErrorMessage(error));
+      toastApi.error('载入外观设置失败', generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。'));
     }
   }
 
@@ -1545,7 +1529,7 @@ function AppShell() {
       }
       await refreshSessions();
     } catch (error) {
-      if (activeIdRef.current === sessionId) toastApi.error('切换模型失败', sessionModelActionErrorMessage(error));
+      if (activeIdRef.current === sessionId) toastApi.error('切换模型失败', generalizedErrorMessageChinese(error, '模型暂时无法切换，请稍后重试。'));
     } finally {
       pendingSessionModelChangesRef.current.delete(sessionId);
       setPendingSessionModelBySession((current) => {
@@ -1589,7 +1573,7 @@ function AppShell() {
       setConnections(next);
       setDefaultConnection(nextDefault);
     } catch (error) {
-      toastApi.error('刷新模型连接失败', connectionsActionErrorMessage(error));
+      toastApi.error('刷新模型连接失败', generalizedErrorMessageChinese(error, '模型连接暂时无法刷新，请稍后重试。'));
     }
   }
 
@@ -1598,7 +1582,7 @@ function AppShell() {
       const next = await window.maka.app.info();
       setAppInfo({ projectPath: next.projectPath, projectGit: next.projectGit });
     } catch (error) {
-      toastApi.error('读取项目路径失败', appInfoActionErrorMessage(error));
+      toastApi.error('读取项目路径失败', generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。'));
     }
   }
 
@@ -1614,7 +1598,7 @@ function AppShell() {
       setAppInfo({ projectPath: result.projectPath, projectGit: result.projectGit });
       toastApi.success('已切换工作目录', basenameFromPath(result.projectPath));
     } catch (error) {
-      toastApi.error('选择工作目录失败', appInfoActionErrorMessage(error));
+      toastApi.error('选择工作目录失败', generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。'));
     }
   }
 
@@ -1775,7 +1759,7 @@ function AppShell() {
       const next = await window.maka.memory.getState();
       setMemoryActive(next.agentReadEnabled && next.status === 'ok' && next.content.trim().length > 0);
     } catch (error) {
-      toastApi.error(failureTitle, memoryActiveActionErrorMessage(error));
+      toastApi.error(failureTitle, generalizedErrorMessageChinese(error, '本地记忆状态暂时无法刷新，请稍后重试。'));
     }
   }
 
@@ -1905,7 +1889,7 @@ function AppShell() {
         const reason = noRealConnectionReasonFromError(error);
         showModelSetupToast(noRealConnectionSetupDescription(reason), reason);
       } else {
-        toastApi.error('发送失败', sendActionErrorMessage(error));
+        toastApi.error('发送失败', generalizedErrorMessageChinese(error, '消息暂时无法发送，请稍后重试。'));
       }
       return false;
     }
@@ -1978,7 +1962,7 @@ function AppShell() {
       if (shouldShowFeedback()) toastApi.success('已导入文件内容', `${result.name}${result.truncated ? ' · 已截断' : ''}`);
       return result.prompt;
     } catch (error) {
-      if (shouldShowFeedback()) toastApi.error('导入文件失败', composerImportActionErrorMessage(error));
+      if (shouldShowFeedback()) toastApi.error('导入文件失败', generalizedErrorMessageChinese(error, '导入文件内容失败，请稍后重试。'));
       return undefined;
     }
   }
@@ -2022,7 +2006,7 @@ function AppShell() {
       // UnhandledPromiseRejection and the user would see nothing.
       // Surface it as a toast so the user knows the model wasn't
       // actually interrupted and can retry.
-      if (activeIdRef.current === sessionId) toastApi.error('停止失败', sessionControlActionErrorMessage(error));
+      if (activeIdRef.current === sessionId) toastApi.error('停止失败', generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。'));
     } finally {
       clearPendingSessionAction(sessionId, stopPendingRef, setStopPendingBySession);
     }
@@ -2037,7 +2021,7 @@ function AppShell() {
       // Same fire-and-forget call site as stop() — wrap so a failed
       // permission response (main process busy / session dropped)
       // surfaces instead of dying as UnhandledPromiseRejection.
-      if (activeIdRef.current === sessionId) toastApi.error('响应失败', sessionControlActionErrorMessage(error));
+      if (activeIdRef.current === sessionId) toastApi.error('响应失败', generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。'));
     }
   }
 
@@ -2439,7 +2423,7 @@ function AppShell() {
         return false;
       }
     } catch (error) {
-      toastApi.error('开始对话失败', quickChatActionErrorMessage(error));
+      toastApi.error('开始对话失败', generalizedErrorMessageChinese(error, '对话暂时无法开始，请稍后重试。'));
       return false;
     } finally {
       quickChatPendingRef.current = false;
@@ -3576,38 +3560,6 @@ function noRealConnectionSetupDescription(reason: string | undefined): string {
 
 function sessionEventErrorMessage(event: Extract<SessionEvent, { type: 'error' }>): string {
   return generalizedErrorMessageChinese(new Error(event.message), '对话运行失败，请稍后重试。');
-}
-
-function turnFooterActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '对话操作失败，请稍后重试。');
-}
-
-function sessionRowActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。');
-}
-
-function sessionListActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。');
-}
-
-function sessionModelActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '模型暂时无法切换，请稍后重试。');
-}
-
-function sessionControlActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '会话操作失败，请稍后重试。');
-}
-
-function sendActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '消息暂时无法发送，请稍后重试。');
-}
-
-function composerImportActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '导入文件内容失败，请稍后重试。');
-}
-
-function quickChatActionErrorMessage(error: unknown): string {
-  return generalizedErrorMessageChinese(error, '对话暂时无法开始，请稍后重试。');
 }
 
 function cleanErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary
- delete 12 fixed-fallback renderer error helper functions from `main.tsx`
- inline the same `generalizedErrorMessageChinese` fallback copy at each callsite
- update source-grep contracts to lock fail-soft behavior and generalized copy instead of helper symbol names

## Verification
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test -- renderer-startup-fail-soft-contract session-sticky-model-contract session-open-routing-contract text-file-import permission-response-ipc-boundary session-row-actions-fail-soft-contract` (runs full 1464/1464 with check-console/check-a11y clean)
- `npm run build`
- `git diff --check`
