### PR TITLE
Polish command palette chrome

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -63,6 +63,42 @@ describe('Command palette accessibility and visible copy', () => {
     );
   });
 
+  it('keeps command palette chrome compact, non-selectable, and tactile without blocking text entry', async () => {
+    const styles = await readRepo('apps/desktop/src/renderer/styles.css');
+    const modalStyle = styles.match(/\.maka-palette-modal\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    const inputStyle = styles.match(/\.maka-palette-input\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    const rowStyle = styles.match(/\.maka-palette-item\s*\{[\s\S]*?\}/)?.[0] ?? '';
+
+    assert.match(modalStyle, /width:\s*min\(584px, calc\(100vw - 32px\)\);/);
+    assert.match(modalStyle, /border:\s*1px solid var\(--border\);/);
+    assert.match(modalStyle, /border-radius:\s*8px;/);
+    assert.match(
+      styles,
+      /\.maka-palette-modal,[\s\S]*?\.maka-palette-footer\s*\{[\s\S]*user-select:\s*none;/,
+      'Palette modal/list/rows/footer should behave as app chrome, not accidental selectable text',
+    );
+    assert.match(inputStyle, /user-select:\s*text;/, 'Palette input text must stay selectable/editable');
+    assert.match(rowStyle, /min-height:\s*28px;/);
+    assert.match(rowStyle, /grid-template-columns:\s*18px minmax\(0, 1fr\) auto;/);
+    assert.match(rowStyle, /transform:\s*translateY\(0\);/);
+    assert.match(rowStyle, /transform 140ms var\(--ease-out-strong\)/);
+    assert.match(
+      styles,
+      /\.maka-palette-item:hover:not\(\[data-disabled="true"\]\)\s*\{[\s\S]*background:\s*var\(--foreground-5\);/,
+      'Palette rows need a hover state independent of keyboard active state',
+    );
+    assert.match(
+      styles,
+      /\.maka-palette-item:active:not\(\[data-disabled="true"\]\)\s*\{[\s\S]*transform:\s*translateY\(1px\);/,
+      'Palette rows need tactile pressed feedback',
+    );
+    assert.match(styles, /\.maka-palette-item:focus-visible\s*\{[\s\S]*outline:\s*2px solid var\(--ring\);/);
+    assert.match(styles, /\.maka-palette-item\[data-pending="true"\]\s*\{[\s\S]*cursor:\s*progress;/);
+    assert.match(styles, /\.maka-palette-item\[data-active="true"\]::before\s*\{[\s\S]*var\(--accent\)/);
+    assert.match(styles, /\.maka-palette-icon\s*\{[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;/);
+    assert.match(styles, /\.maka-palette-hint\s*\{[\s\S]*font-variant-numeric:\s*tabular-nums;/);
+  });
+
   it('has a visual-smoke opener for the command palette input shell', async () => {
     const main = await readRepo('apps/desktop/src/renderer/main.tsx');
     const core = await readRepo('packages/core/src/visual-smoke.ts');

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -5034,12 +5034,27 @@ button:active {
 }
 
 .maka-palette-modal {
-  width: min(560px, calc(100vw - 48px));
-  max-height: 64vh;
+  width: min(584px, calc(100vw - 32px));
+  max-height: min(620px, 68vh);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
-  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.05);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow:
+    0 1px 2px oklch(from var(--foreground) l c h / 0.05),
+    0 18px 48px oklch(from var(--foreground) l c h / 0.12),
+    inset 0 1px 0 oklch(1 0 0 / 0.05);
+}
+
+.maka-palette-modal,
+.maka-palette-list,
+.maka-palette-group-label,
+.maka-palette-item,
+.maka-palette-hint,
+.maka-palette-footer {
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .maka-palette-input-wrap {
@@ -5054,6 +5069,8 @@ button:active {
   color: var(--foreground);
   font-size: 12px;
   line-height: 1.4;
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .maka-palette-input::placeholder {
@@ -5107,15 +5124,15 @@ button:active {
 .maka-palette-list {
   border-top: 1px solid var(--border);
   overflow-y: auto;
-  padding: 6px 6px 8px;
+  padding: 5px 6px 7px;
 }
 
 .maka-palette-group + .maka-palette-group {
-  margin-top: 6px;
+  margin-top: 4px;
 }
 
 .maka-palette-group-label {
-  padding: 4px 8px 2px;
+  padding: 4px 8px 3px;
   color: var(--foreground-50);
   font-size: 10px;
   font-weight: 600;
@@ -5124,19 +5141,41 @@ button:active {
 }
 
 .maka-palette-item {
+  position: relative;
   width: 100%;
+  min-height: 28px;
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   border: 0;
   border-radius: 6px;
   background: transparent;
   color: var(--foreground);
-  padding: 4px 8px;
+  padding: 5px 8px;
   text-align: left;
   font-size: 11px;
-  transition: background-color 150ms var(--ease-out-strong);
+  cursor: default;
+  transform: translateY(0);
+  transition:
+    background-color 140ms var(--ease-out-strong),
+    color 140ms var(--ease-out-strong),
+    opacity 140ms var(--ease-out-strong),
+    transform 140ms var(--ease-out-strong);
+}
+
+.maka-palette-item::before {
+  content: "";
+  position: absolute;
+  inset: 5px auto 5px 3px;
+  width: 2px;
+  border-radius: 999px;
+  background: transparent;
+  transition: background-color 140ms var(--ease-out-strong);
+}
+
+.maka-palette-item:hover:not([data-disabled="true"]) {
+  background: var(--foreground-5);
 }
 
 .maka-palette-item[data-active="true"] {
@@ -5144,13 +5183,43 @@ button:active {
   color: var(--foreground);
 }
 
+.maka-palette-item[data-active="true"]::before {
+  background: oklch(from var(--accent) l c h / 0.72);
+}
+
+.maka-palette-item:active:not([data-disabled="true"]) {
+  transform: translateY(1px);
+}
+
+.maka-palette-item:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.maka-palette-item[data-disabled="true"] {
+  color: var(--foreground-50);
+  cursor: default;
+  opacity: 0.72;
+}
+
+.maka-palette-item[data-pending="true"] {
+  cursor: progress;
+}
+
 .maka-palette-icon {
   display: grid;
   place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
   color: var(--foreground-50);
+  transition:
+    background-color 140ms var(--ease-out-strong),
+    color 140ms var(--ease-out-strong);
 }
 
 .maka-palette-item[data-active="true"] .maka-palette-icon {
+  background: oklch(from var(--accent) l c h / 0.10);
   color: var(--accent);
 }
 
@@ -5167,6 +5236,11 @@ button:active {
   color: var(--foreground-50);
   font-size: 10px;
   font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.maka-palette-item[data-pending="true"] .maka-palette-hint {
+  color: var(--accent);
 }
 
 .maka-palette-empty {


### PR DESCRIPTION
## Summary
- tighten command palette modal chrome to the reference-style bordered card treatment
- make palette chrome non-selectable while preserving input text selection
- add tactile row hover/active/focus/pending states, active rail, compact icon tile, and tabular command hints
- lock the new command-palette styling contract in the existing accessibility/copy test

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop test -- command-palette-a11y-copy-contract (runs full desktop test suite: 1465/1465 pass, check-console/check-a11y clean)
- npm run build (passes; existing Vite chunk-size warning)
- npm --workspace @maka/desktop run screenshots:single command-palette-open (8/8 variants captured)
- git diff --check
