### PR TITLE
Chat toolbar polish — composer placeholder + permission-mode pill density

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4578,16 +4578,22 @@ button:active {
 }
 
 .maka-mode-switcher-option {
+  /* PR-CHAT-TOOLBAR-POLISH (2026-06-23): density tuned down so the
+     mode pill (只读 / 确认 / 执行) reads as a peer of the top-right
+     icon buttons (问题反馈 / 网格 / ? / 设置) instead of dominating
+     the chrome strip. -1 px font, -1 px vertical padding, slightly
+     tighter horizontal padding to match a 24-px chip rhythm. */
   display: inline-flex;
   align-items: center;
   border: 0;
   border-radius: 999px;
   background: transparent;
   color: var(--foreground-60);
-  padding: 3px 11px;
-  font-size: 12px;
+  padding: 2px 9px;
+  font-size: 11.5px;
   font-weight: 500;
   white-space: nowrap;
+  letter-spacing: 0.005em;
   transition: background 140ms ease, color 140ms ease;
 }
 

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -6203,7 +6203,7 @@ const COMPOSER_COPY_BY_LOCALE: Record<UiLocale, {
   streamingHintInterrupt: string;
 }> = {
   zh: {
-    placeholder: '描述任务，/ 快捷调用，@ 添加上下文，标准模式经济高效',
+    placeholder: '描述任务  /  快捷调用  @  添加上下文',
     textareaAriaLabel: '消息输入框',
     awaitingPermission: '等待你确认权限…',
     sending: '正在发送…',


### PR DESCRIPTION
## Summary

First Chat-lane polish PR per WAWQAQ's "@yuejing UI 你来 + 全部都要打磨". Two small refinements visible on every chat surface.

### Composer placeholder shortened

Was: `描述任务，/ 快捷调用，@ 添加上下文，标准模式经济高效`
Now: `描述任务  /  快捷调用  @  添加上下文`

The trailing "标准模式经济高效" advertised the active permission mode — but that's already visible in the mode pill at the top-right. The slash/at hints now read as syntax affordances, not a paragraph. En-locale placeholder was already concise; unchanged.

### Permission mode pill (只读 / 确认 / 执行) density tuned down

So it reads as a peer of the top-right icon buttons (问题反馈 / 网格 / ? / 设置) instead of dominating the chrome strip.

- `font-size: 12px → 11.5px`
- `padding: 3px 11px → 2px 9px`
- `letter-spacing: 0.005em` for readability at the smaller size

Same 24-px chip rhythm as the toolbar icons.

## Test plan

- [x] `apps/desktop` test suite: 1465 / 1465 pass
- [x] Renderer + main typecheck clean
- [x] `turn-narrative` visual smoke re-captured — composer placeholder reads correctly, mode pill sits at the same height as the toolbar icons