### PR TITLE
feat(headless): Read numbers lines, caps output, guards binaries (#92 P1)

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -28,25 +28,33 @@ function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string
 }
 
 describe('Harbor local executor file tools (real spawn)', () => {
-  test('Read returns the head of the file under its byte budget, not a bounded tail (P1 regression)', async () => {
+  test('Read enforces its 50KB byte budget exactly, with a resumable offset (P1 regression)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-read-'));
-    // ~1.2MB across many lines, far past Read's ~50KB byte budget. HEAD_MARKER is
-    // line 1, TAIL_MARKER the last line. Head-first Read returns the first
-    // budget-worth of lines (HEAD_MARKER present, TAIL_MARKER not yet reached) plus
-    // a continuation hint; a bounded tail would keep the END and drop HEAD_MARKER.
-    const filler = Array.from({ length: 1500 }, (_, i) => `line${i + 1}:` + 'a'.repeat(800)).join('\n');
-    const body = 'HEAD_MARKER\n' + filler + '\nTAIL_MARKER\n'; // 1502 lines, ~1.2MB
-    await writeFile(join(cwd, 'big.txt'), body, 'utf8');
+    // Fixed 92-char lines -> each output line is exactly "%6d\t" + 92 + "\n" = 100
+    // bytes, so the 51200-byte budget stops precisely after line 512. HEAD is line 1,
+    // TAIL line 1000 (far past the budget): head-first Read keeps HEAD and drops TAIL;
+    // a bounded tail would do the opposite.
+    const N = 1000;
+    const lines = Array.from({ length: N }, (_, i) =>
+      (i === 0 ? 'HEAD' : i === N - 1 ? 'TAIL' : `line${i + 1}`).padEnd(92, '.'));
+    await writeFile(join(cwd, 'big.txt'), lines.join('\n') + '\n', 'utf8');
     const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
 
     const result = (await tool(tools, 'Read').impl({ path: 'big.txt' }, toolCtx(cwd))) as { content: string };
 
-    assert.ok(result.content.includes('HEAD_MARKER'), 'head retained — Read is not tail-bounded');
-    assert.ok(!result.content.includes('TAIL_MARKER'), 'tail beyond the byte budget is not returned');
-    assert.ok(result.content.length < 64 * 1024, 'output bounded by the ~50KB byte budget, not the full ~1.2MB file');
-    assert.ok(/pass offset=\d+ to read more/.test(result.content), 'continuation hint tells the model how to resume');
+    assert.ok(result.content.includes('HEAD'), 'head retained — Read is not tail-bounded');
+    assert.ok(!result.content.includes('TAIL'), 'tail beyond the byte budget is not returned');
+    // 512 lines x 100 bytes = 51200; the only extra is the one-line continuation hint.
+    assert.ok(result.content.length <= 51200 + 80, 'output stays within the 50KB budget plus the hint');
+    assert.ok(result.content.length >= 51200 - 100, 'the full budget is used (512 lines), not a smaller cap');
+    const hint = result.content.match(/pass offset=(\d+) to read more/);
+    assert.equal(hint?.[1], '512', 'hint offset equals the last emitted line number');
+
+    // Resume from the hint offset: the next page must start at the very next line.
+    const next = (await tool(tools, 'Read').impl({ path: 'big.txt', offset: 512 }, toolCtx(cwd))) as { content: string };
+    assert.ok(next.content.startsWith('   513\t'), 'resuming at offset=512 continues from line 513 — no gap or overlap');
     // (Glob/Grep share the same command-backed executor.exec with no boundedTail
     //  flag — see the "only Bash opts into bounded-tail" contract test — so this
-    //  full-output guarantee covers them too without generating MBs of matches.)
+    //  head-first guarantee covers them too without generating MBs of matches.)
   });
 });

--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -30,17 +30,21 @@ function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string
 describe('Harbor local executor file tools (real spawn)', () => {
   test('Read returns the FULL file head-first, not a bounded tail (P1 regression)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-read-'));
-    // ~2MB (under the 10MB exec cap) bracketed by markers. A bounded tail would
-    // silently drop HEAD_MARKER; Read must return the whole file.
-    const body = 'HEAD_MARKER\n' + 'a'.repeat(2 * 1024 * 1024) + '\nTAIL_MARKER\n';
+    // >1MB spread over many lines, each well under Read's 2000-col per-line clip
+    // and the whole file under its 2000-line cap, so nothing is clipped or capped.
+    // A bounded tail would keep only the last ~1MB and silently drop HEAD_MARKER on
+    // line 1; head-first Read returns the whole file, head and tail.
+    const filler = Array.from({ length: 1500 }, (_, i) => `line${i + 1}:` + 'a'.repeat(800)).join('\n');
+    const body = 'HEAD_MARKER\n' + filler + '\nTAIL_MARKER\n'; // 1502 lines, ~1.2MB, under both caps
     await writeFile(join(cwd, 'big.txt'), body, 'utf8');
     const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
 
     const result = (await tool(tools, 'Read').impl({ path: 'big.txt' }, toolCtx(cwd))) as { content: string };
 
     assert.ok(result.content.includes('HEAD_MARKER'), 'head retained — Read is not tail-bounded');
-    assert.ok(result.content.includes('TAIL_MARKER'), 'tail retained');
-    assert.ok(result.content.length >= 2 * 1024 * 1024, 'full file content returned, not a 1MB tail');
+    assert.ok(result.content.includes('TAIL_MARKER'), 'tail retained — whole file returned');
+    assert.ok(result.content.length > 1024 * 1024, 'full content returned, far past a 1MB tail window');
+    assert.ok(!result.content.includes('truncated'), 'under both caps — nothing clipped or dropped');
     // (Glob/Grep share the same command-backed executor.exec with no boundedTail
     //  flag — see the "only Bash opts into bounded-tail" contract test — so this
     //  full-output guarantee covers them too without generating MBs of matches.)

--- a/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell-file-tools.test.ts
@@ -28,23 +28,23 @@ function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string
 }
 
 describe('Harbor local executor file tools (real spawn)', () => {
-  test('Read returns the FULL file head-first, not a bounded tail (P1 regression)', async () => {
+  test('Read returns the head of the file under its byte budget, not a bounded tail (P1 regression)', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-harbor-read-'));
-    // >1MB spread over many lines, each well under Read's 2000-col per-line clip
-    // and the whole file under its 2000-line cap, so nothing is clipped or capped.
-    // A bounded tail would keep only the last ~1MB and silently drop HEAD_MARKER on
-    // line 1; head-first Read returns the whole file, head and tail.
+    // ~1.2MB across many lines, far past Read's ~50KB byte budget. HEAD_MARKER is
+    // line 1, TAIL_MARKER the last line. Head-first Read returns the first
+    // budget-worth of lines (HEAD_MARKER present, TAIL_MARKER not yet reached) plus
+    // a continuation hint; a bounded tail would keep the END and drop HEAD_MARKER.
     const filler = Array.from({ length: 1500 }, (_, i) => `line${i + 1}:` + 'a'.repeat(800)).join('\n');
-    const body = 'HEAD_MARKER\n' + filler + '\nTAIL_MARKER\n'; // 1502 lines, ~1.2MB, under both caps
+    const body = 'HEAD_MARKER\n' + filler + '\nTAIL_MARKER\n'; // 1502 lines, ~1.2MB
     await writeFile(join(cwd, 'big.txt'), body, 'utf8');
     const tools = buildIsolatedHeadlessTools(createHarborCellLocalToolExecutor());
 
     const result = (await tool(tools, 'Read').impl({ path: 'big.txt' }, toolCtx(cwd))) as { content: string };
 
     assert.ok(result.content.includes('HEAD_MARKER'), 'head retained — Read is not tail-bounded');
-    assert.ok(result.content.includes('TAIL_MARKER'), 'tail retained — whole file returned');
-    assert.ok(result.content.length > 1024 * 1024, 'full content returned, far past a 1MB tail window');
-    assert.ok(!result.content.includes('truncated'), 'under both caps — nothing clipped or dropped');
+    assert.ok(!result.content.includes('TAIL_MARKER'), 'tail beyond the byte budget is not returned');
+    assert.ok(result.content.length < 64 * 1024, 'output bounded by the ~50KB byte budget, not the full ~1.2MB file');
+    assert.ok(/pass offset=\d+ to read more/.test(result.content), 'continuation hint tells the model how to resume');
     // (Glob/Grep share the same command-backed executor.exec with no boundedTail
     //  flag — see the "only Bash opts into bounded-tail" contract test — so this
     //  full-output guarantee covers them too without generating MBs of matches.)

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -13,6 +13,7 @@ import {
 import { createHeavyTaskEvidenceRecorder } from '../heavy-task-evidence.js';
 import { createInMemoryTaskRunStore } from '../task-run-store.js';
 import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
+import type { IsolatedToolExecutor } from '../isolation.js';
 
 const execAsync = promisify(childExec);
 
@@ -192,17 +193,13 @@ describe('isolated headless tools', () => {
     assert.ok(!names.includes('check_record'));
   });
 
-  test('Read, Write, Glob, and Grep delegate to native isolated executor methods', async () => {
+  test('Write, Glob, and Grep delegate to native isolated executor methods', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-host-'));
     await writeFile(join(cwd, 'target.txt'), 'host\n', 'utf8');
     const calls: Array<{ name: string; input: unknown }> = [];
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         throw new Error('file tools must use native isolated methods when available');
-      },
-      async readFile(input) {
-        calls.push({ name: 'Read', input });
-        return { content: 'container\n' };
       },
       async writeFile(input) {
         calls.push({ name: 'Write', input });
@@ -218,9 +215,6 @@ describe('isolated headless tools', () => {
       },
     });
 
-    assert.deepEqual(await tool(tools, 'Read').impl({ path: join(cwd, 'target.txt'), offset: 1, limit: 2 }, toolCtx(cwd)), {
-      content: 'container\n',
-    });
     assert.deepEqual(await tool(tools, 'Write').impl({ path: join(cwd, 'target.txt'), content: 'external\n' }, toolCtx(cwd)), {
       ok: true,
       path: 'target.txt',
@@ -239,11 +233,38 @@ describe('isolated headless tools', () => {
 
     assert.equal(await readFile(join(cwd, 'target.txt'), 'utf8'), 'host\n');
     assert.deepEqual(calls, [
-      { name: 'Read', input: { cwd, path: 'target.txt', offset: 1, limit: 2 } },
       { name: 'Write', input: { cwd, path: 'target.txt', content: 'external\n' } },
       { name: 'Glob', input: { cwd, pattern: '*.txt', searchCwd: 'src' } },
       { name: 'Grep', input: { cwd, pattern: 'needle', path: 'src', glob: '*.txt' } },
     ]);
+  });
+
+  test('Read ignores any native readFile hook and always formats via READ_SCRIPT', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-nofastpath-'));
+    await writeFile(join(cwd, 'f.txt'), 'alpha\nbeta\n', 'utf8');
+    // An executor that DOES expose a native readFile returning raw, unformatted
+    // bytes. Read must ignore it and run READ_SCRIPT, so the result is line-numbered
+    // — a regression guard against re-introducing a Read native fast path.
+    const executor: IsolatedToolExecutor = {
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, env: process.env, maxBuffer: 4 * 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    };
+    (executor as { readFile?: () => Promise<{ content: string }> }).readFile = async () => ({ content: 'RAW-NATIVE-BYPASS\n' });
+    const tools = buildIsolatedHeadlessTools(executor);
+
+    const r = (await tool(tools, 'Read').impl({ path: join(cwd, 'f.txt') }, toolCtx(cwd))) as { content: string };
+    assert.equal(r.content, '     1\talpha\n     2\tbeta\n', 'formatted via READ_SCRIPT, not the raw native readFile');
+    assert.ok(!r.content.includes('RAW-NATIVE-BYPASS'), 'the native readFile result is never used');
   });
 
   test('Edit ignores native file ops and always runs the shared replacer', async () => {
@@ -267,7 +288,6 @@ describe('isolated headless tools', () => {
           };
         }
       },
-      async readFile() { nativeCalls.push('readFile'); return { content: '' }; },
       async writeFile(input) { nativeCalls.push('writeFile'); return { ok: true, path: input.path, bytes: 0 }; },
       async globFiles() { nativeCalls.push('globFiles'); return { files: [] }; },
       async grepFiles() { nativeCalls.push('grepFiles'); return { matches: [] }; },
@@ -302,10 +322,12 @@ describe('isolated headless tools', () => {
         if (input.command.startsWith("node -e '")) {
           return { exitCode: 0, stdout: '{"matchedVia":"exact","startLine":1,"endLine":1}', stderr: '' };
         }
+        // Read now runs through READ_SCRIPT (no native fast path); the script
+        // carries the distinctive 'Read path' label, so stub its content here.
+        if (input.command.includes('Read path')) {
+          return { exitCode: 0, stdout: `read src/file.ts\n${'r'.repeat(5_000)}`, stderr: '' };
+        }
         return { exitCode: 2, stdout: `large stdout\n${'x'.repeat(5_000)}`, stderr: 'short stderr\n' };
-      },
-      async readFile(input) {
-        return { content: `read ${input.path}\n${'r'.repeat(5_000)}` };
       },
       async writeFile(input) {
         return { ok: true, path: input.path, bytes: Buffer.byteLength(input.content, 'utf8') };

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -363,7 +363,7 @@ describe('isolated headless tools', () => {
       bytes: 13,
     });
     assert.deepEqual(await tool(tools, 'Read').impl({ path: absoluteFile, offset: 1, limit: 1 }, toolCtx(cwd)), {
-      content: 'needle',
+      content: '     2\tneedle\n', // cat -n: absolute line number + tab + content
     });
     assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: absoluteGlob }, toolCtx(cwd)), {
       files: ['src/file.txt'],
@@ -378,6 +378,47 @@ describe('isolated headless tools', () => {
     assert.ok(calls.length >= 4);
     assert.ok(calls.every((command) => command.startsWith("sh -c '")));
     assert.ok(calls.every((command) => !command.includes('node -e')));
+  });
+
+  test('Read (command path) numbers lines, caps by default, and guards binaries', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-'));
+    await writeFile(join(cwd, 'big.txt'), Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join('\n') + '\n', 'utf8');
+    await writeFile(join(cwd, 'data.bin'), Buffer.from([0, 1, 2, 0, 65, 66])); // 6 bytes, contains NUL
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, env: process.env, maxBuffer: 4 * 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    // Default read: cat -n numbering from line 1, capped at 2000 with a continuation hint.
+    const def = (await tool(tools, 'Read').impl({ path: join(cwd, 'big.txt') }, toolCtx(cwd))) as { content: string };
+    assert.ok(def.content.startsWith('     1\tline1\n'), 'numbers from line 1');
+    assert.ok(def.content.includes('  2000\tline2000\n'), 'shows up to the 2000-line cap');
+    assert.ok(!def.content.includes('line2001'), 'does not exceed the cap');
+    assert.ok(def.content.includes('truncated at line 2000'), 'hints how to continue');
+
+    // Offset keeps absolute line numbers; reading the tail shows no hint.
+    const tail = (await tool(tools, 'Read').impl({ path: join(cwd, 'big.txt'), offset: 2498, limit: 2 }, toolCtx(cwd))) as { content: string };
+    assert.equal(tail.content, '  2499\tline2499\n  2500\tline2500\n');
+
+    // Binary guard.
+    const bin = (await tool(tools, 'Read').impl({ path: join(cwd, 'data.bin') }, toolCtx(cwd))) as { content: string };
+    assert.equal(bin.content, '[binary file: 6 bytes, contents omitted]');
+
+    // Binary guard must hold when an invalid high byte precedes the NUL: in a
+    // UTF-8 locale BSD/macOS tr would otherwise abort and misclassify it as text.
+    await writeFile(join(cwd, 'highbyte.bin'), Buffer.from([0xff, 0x00, 0x41]));
+    const highBin = (await tool(tools, 'Read').impl({ path: join(cwd, 'highbyte.bin') }, toolCtx(cwd))) as { content: string };
+    assert.equal(highBin.content, '[binary file: 3 bytes, contents omitted]');
   });
 
   test('Grep prefers ripgrep when on PATH and skips binary files', async (t) => {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -421,6 +421,30 @@ describe('isolated headless tools', () => {
     assert.equal(highBin.content, '[binary file: 3 bytes, contents omitted]');
   });
 
+  test('Read clips an over-long single line at 2000 bytes with a marker', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-clip-'));
+    await writeFile(join(cwd, 'long.txt'), 'X'.repeat(2500) + '\n', 'utf8'); // one 2500-byte line
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, env: process.env, maxBuffer: 4 * 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    const r = (await tool(tools, 'Read').impl({ path: join(cwd, 'long.txt') }, toolCtx(cwd))) as { content: string };
+    assert.ok(r.content.startsWith('     1\t'), 'line-number prefix present');
+    assert.ok(r.content.includes('... [line truncated]'), 'clip marker present');
+    assert.equal(r.content.match(/X/g)?.length, 2000, 'only the first 2000 bytes kept, clipped tail dropped');
+  });
+
   test('Grep prefers ripgrep when on PATH and skips binary files', async (t) => {
     try {
       await execAsync('rg --version', { env: process.env });

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -108,12 +108,14 @@ export interface IsolatedToolExecutor {
    * buildIsolatedHeadlessTools falls back to command-backed operations inside
    * the isolated boundary.
    *
-   * Edit deliberately has NO native hook: its matching logic is non-trivial and
-   * must stay the single source of truth with the in-process builtin Edit, so it
-   * always runs the shared computeEditedSource via `node -e` (see
-   * buildIsolatedEditTool) regardless of which native ops an executor provides.
+   * Read and Edit deliberately have NO native hook. Read must always run through
+   * READ_SCRIPT so every result carries the line-number / line+byte-cap / binary-
+   * guard contract (#92); a native pass-through would bypass it. Edit's matching
+   * logic must stay the single source of truth with the in-process builtin Edit,
+   * so it always runs the shared computeEditedSource via `node -e` (see
+   * buildIsolatedEditTool). Both hold regardless of which native ops an executor
+   * provides.
    */
-  readFile?(input: IsolatedReadFileInput): Promise<IsolatedReadFileResult>;
   writeFile?(input: IsolatedWriteFileInput): Promise<IsolatedWriteFileResult>;
   globFiles?(input: IsolatedGlobInput): Promise<IsolatedGlobResult>;
   grepFiles?(input: IsolatedGrepInput): Promise<IsolatedGrepResult>;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -120,11 +120,8 @@ export function buildIsolatedReadTool(
       const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Read path');
       const input = { cwd, path: normalizedPath, offset, limit };
-      if (executor.readFile) {
-        const result = await executor.readFile(input);
-        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Read', input, result }, ctx);
-        return result;
-      }
+      // Read has no native fast path: every result must go through READ_SCRIPT so
+      // it carries the line-number / line+byte-cap / binary-guard contract (#92).
       const stdout = await execFileCommand(executor, cwd, shellFileCommand(READ_SCRIPT, [
         normalizedPath,
         numberArg(offset),

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -468,21 +468,28 @@ if [ "\${nul:-0}" -gt 0 ]; then
   exit 0
 fi
 # cat -n style: each line carries its absolute 1-based number; over-long lines are
-# clipped; at most "limit" lines from "offset" are shown, with a hint when more
-# remain so the model knows to continue with a larger offset.
+# clipped at maxcol bytes. Output stops at the line cap ("limit" lines from
+# "offset") OR a ~50KB byte budget, whichever comes first — both keep a large file
+# from flooding the model's context (#92) — with a hint giving the offset to resume.
 # LC_ALL=C so awk treats the file as bytes and never aborts on invalid UTF-8 in a
-# non-NUL file; line content is emitted byte-for-byte, length()/maxcol count bytes.
+# non-NUL file; line content is byte-for-byte and length()/maxcol/maxbytes count bytes.
 LC_ALL=C awk -v start="$offset" -v limit="$limit" '
-  BEGIN { first = start + 1; last = start + limit; maxcol = 2000 }
+  BEGIN { first = start + 1; last = start + limit; maxcol = 2000; maxbytes = 51200 }
   NR < first { next }
-  NR <= last {
+  {
+    if (NR > last) { stopped = 1; exit }
     line = $0
     if (length(line) > maxcol) line = substr(line, 1, maxcol) "... [line truncated]"
-    printf "%6d\\t%s\\n", NR, line
-    next
+    out = sprintf("%6d\\t%s\\n", NR, line)
+    # Always emit at least one line (shown > 0 guard); otherwise stop before the
+    # budget is exceeded so total output stays under maxbytes.
+    if (shown > 0 && bytes + length(out) > maxbytes) { stopped = 1; exit }
+    printf "%s", out
+    bytes += length(out)
+    shown += 1
+    lastline = NR
   }
-  { more = 1; exit }
-  END { if (more) printf "... (truncated at line %d; pass offset=%d to read more)\\n", last, last }
+  END { if (stopped) printf "... (truncated at line %d; pass offset=%d to read more)\\n", lastline, lastline }
 ' "$target"
 `;
 

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -453,20 +453,37 @@ writable_target() {
 const READ_SCRIPT = `${COMMON_SHELL_HELPERS}
 root=$(pwd -P) || exit 1
 target=$(existing_target "$1" 'Read path') || exit 1
-offset=$2
-limit=$3
-if [ -z "$offset" ] && [ -z "$limit" ]; then
-  cat "$target"
-else
-  awk -v start="\${offset:-0}" -v limit="$limit" '
-    BEGIN { first = start + 1; last = limit == "" ? 0 : start + limit; wrote = 0 }
-    NR >= first && (last == 0 || NR <= last) {
-      if (wrote) printf "\\n"
-      printf "%s", $0
-      wrote = 1
-    }
-  ' "$target"
+offset=\${2:-0}
+limit=\${3:-2000}
+# Binary guard: a NUL byte in the head means this is not text. Dumping it would
+# flood the model with garbage (and command substitution strips NULs anyway), so
+# report it instead. Matches Claude Code / opencode behavior. LC_ALL=C is
+# mandatory: in a UTF-8 locale, BSD/macOS tr aborts on an invalid high byte
+# ("Illegal byte sequence") and, with no pipefail, the count silently becomes 0,
+# letting a binary file with a high byte before its first NUL slip through.
+nul=$(head -c 8192 "$target" | LC_ALL=C tr -dc '\\000' | wc -c | tr -d ' ')
+if [ "\${nul:-0}" -gt 0 ]; then
+  size=$(wc -c < "$target" | tr -d ' ')
+  printf '[binary file: %s bytes, contents omitted]' "$size"
+  exit 0
 fi
+# cat -n style: each line carries its absolute 1-based number; over-long lines are
+# clipped; at most "limit" lines from "offset" are shown, with a hint when more
+# remain so the model knows to continue with a larger offset.
+# LC_ALL=C so awk treats the file as bytes and never aborts on invalid UTF-8 in a
+# non-NUL file; line content is emitted byte-for-byte, length()/maxcol count bytes.
+LC_ALL=C awk -v start="$offset" -v limit="$limit" '
+  BEGIN { first = start + 1; last = start + limit; maxcol = 2000 }
+  NR < first { next }
+  NR <= last {
+    line = $0
+    if (length(line) > maxcol) line = substr(line, 1, maxcol) "... [line truncated]"
+    printf "%6d\\t%s\\n", NR, line
+    next
+  }
+  { more = 1; exit }
+  END { if (more) printf "... (truncated at line %d; pass offset=%d to read more)\\n", last, last }
+' "$target"
 `;
 
 const WRITE_SCRIPT = `${COMMON_SHELL_HELPERS}


### PR DESCRIPTION
Part of #92 (close the tool-layer gap vs opencode). Brings the isolated/benchmark **Read** tool up to Claude Code / opencode fidelity for **bounded, structured output**.

## Scope

Closes the bounded/structured-output sub-items of #92's Read row: line-number prefixes, a default line **and** byte cap, per-line clip, binary guard, and a continue-with-offset hint. The remaining #92 Read sub-item — **"did-you-mean" on a path miss** — is deliberately out of scope here (a separate path-miss-recovery concern) and tracked as a follow-up; this PR does not close it.

## What

`READ_SCRIPT` (run via `sh -c` inside the isolated executor) previously dumped raw file contents. It now:
- prefixes each line with its **absolute 1-based line number** (`cat -n` format), so offsets stay meaningful;
- caps output at **2000 lines OR a ~50KB byte budget**, whichever comes first, appending a hint to continue with a larger offset when more remains (both caps keep a large file from flooding the model's context);
- **clips over-long lines** (>2000 bytes) with a `... [line truncated]` marker;
- **guards binary files**: a NUL byte in the first 8 KB returns `[binary file: N bytes, contents omitted]` instead of flooding the context (command substitution strips NULs anyway).

## Why

A bare `cat` dumped entire files (blowing the context on a large file), gave the model no line anchors to cite in edits, and would spew binary garbage.

## Details

- **`LC_ALL=C`** on both the detection `tr` and the `awk`: in a UTF-8 locale, BSD/macOS `tr` aborts on an invalid high byte ("Illegal byte sequence") and, with no `pipefail`, the NUL count silently becomes 0, letting a binary file with a high byte before its first NUL slip through. Forcing a byte locale fixes that and stops `awk` choking on invalid bytes in a non-NUL file.
- The byte budget is accumulated inside the same `awk` output loop (always emitting at least one line), so total output stays under ~50KB and the continuation hint's `offset` equals the last emitted line — resume reads the next line with no gap or overlap.
- offset/limit are already validated ints in TS and passed positionally; `existing_target` validates the path is inside the workspace.

## Native fast-path divergence (non-blocking, tracked)

Formatting lives in the **script path**, which is the one the benchmark/Harbor executor uses. No executor provides the optional native `readFile` hook today. If one were added it would bypass the line-number/cap/binary-guard contract — so the proper fix is to have native return raw bytes and route every Read through one shared formatter. That is a cross-cutting executor-contract + public-API change (touches `IsolatedToolExecutor`, the exported `IsolatedReadFile*` types, `heavy-task-evidence`, and the shared 4-tool delegation test), so it is deferred to a focused follow-up rather than mixed into this Read-output PR.

## Acknowledged tradeoffs (non-blocking)

- The binary guard inspects the first 8 KB (a head NUL-guard, matching Claude Code/opencode), not the whole file.
- The 2000-byte line clip can land mid-multibyte-character on a very long line, showing one replacement char at the cut. Cosmetic, right before the truncation marker.

## Tests

`packages/headless/src/__tests__/tools.test.ts`: the script-path test asserts the `cat -n` format; new tests cover default-cap numbering + continuation hint, absolute line numbers under offset, the binary guard (incl. high-byte-before-NUL), and a precise per-line clip (one 2500-byte line → exactly 2000 bytes kept + marker). `harbor-cell-file-tools.test.ts` pins the ~50KB byte budget exactly (fixed-width lines stop at line 512) and verifies resume from the hint offset (next page starts at line 513, no gap/overlap). Full `@maka/headless` suite: **316 pass / 0 fail**. No CI in-repo (PR checks = 0); run locally via `npm run -w @maka/headless test`.
