### PR TITLE
feat(headless): Glob enumerates via ripgrep, falls back to find

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -402,6 +402,76 @@ describe('isolated headless tools', () => {
     assert.ok(calls.every((command) => !command.includes('node -e')));
   });
 
+  test('Glob rg path enumerates the same files as the find path', async (t) => {
+    try {
+      await execAsync('rg --version', { env: process.env });
+    } catch {
+      t.skip('ripgrep not installed');
+      return;
+    }
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-glob-rg-'));
+    await mkdir(join(cwd, 'sub'));
+    await writeFile(join(cwd, 'visible.txt'), '', 'utf8');
+    await writeFile(join(cwd, '.hidden.txt'), '', 'utf8'); // hidden -> kept by --hidden
+    await writeFile(join(cwd, '.gitignore'), 'ignored.txt\n', 'utf8');
+    await writeFile(join(cwd, 'ignored.txt'), '', 'utf8'); // gitignored -> kept by --no-ignore
+    await writeFile(join(cwd, 'real.txt'), '', 'utf8');
+    await symlink('real.txt', join(cwd, 'link.txt')); // file symlink -> excluded (parity with find -type f)
+    await writeFile(join(cwd, 'sub', 'deep.txt'), '', 'utf8');
+
+    const mkTools = (env: NodeJS.ProcessEnv) => buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, env, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+    const rgTools = mkTools(process.env); // rg on PATH -> rg --files branch
+    // Guarantee the find branch: a PATH with the coreutils GLOB_SCRIPT needs but
+    // NOT rg. A fixed '/usr/bin:/bin' would not do it — on some Linux CI rg lives
+    // in /usr/bin, so findTools would silently run rg and the parity check below
+    // would be vacuous.
+    const noRgBin = await mkdtemp(join(tmpdir(), 'maka-headless-norg-bin-'));
+    for (const bin of ['sh', 'find', 'sed', 'awk', 'sort', 'dirname', 'basename']) {
+      const resolved = (await execAsync(`command -v ${bin}`, { env: process.env })).stdout.trim();
+      await symlink(resolved, join(noRgBin, bin));
+    }
+    const findTools = mkTools({ ...process.env, PATH: noRgBin }); // no rg -> find branch
+
+    const glob = async (tools: ReturnType<typeof buildIsolatedHeadlessTools>) =>
+      ((await tool(tools, 'Glob').impl({ pattern: '*.txt' }, toolCtx(cwd))) as { files: string[] }).files.slice().sort();
+
+    const rgFiles = await glob(rgTools);
+    const findFiles = await glob(findTools);
+    assert.deepEqual(rgFiles, findFiles, 'rg and find enumerate the same files');
+    // *.txt matches top-level .txt only; hidden + gitignored kept, file symlink excluded.
+    assert.deepEqual(rgFiles, ['.hidden.txt', 'ignored.txt', 'real.txt', 'visible.txt']);
+
+    // >200 matches: rg and find traverse in different orders, so the 200-cap must
+    // be applied AFTER a deterministic sort or the truncated sets would diverge.
+    // Read .files raw (no test-side sort) to prove the script sorts before capping.
+    await mkdir(join(cwd, 'many'));
+    for (let i = 0; i < 250; i += 1) {
+      await writeFile(join(cwd, 'many', `f${String(i).padStart(3, '0')}.txt`), '', 'utf8');
+    }
+    const globRaw = async (tools: ReturnType<typeof buildIsolatedHeadlessTools>) =>
+      ((await tool(tools, 'Glob').impl({ pattern: 'many/*.txt' }, toolCtx(cwd))) as { files: string[] }).files;
+    const rgMany = await globRaw(rgTools);
+    const findMany = await globRaw(findTools);
+    assert.equal(rgMany.length, 200, 'capped at 200');
+    assert.deepEqual(rgMany, findMany, 'same capped set regardless of enumeration order');
+    // The cap is the sorted first 200 (f000..f199), not whatever each tool happened to enumerate first.
+    assert.equal(rgMany[0], 'many/f000.txt');
+    assert.equal(rgMany[199], 'many/f199.txt');
+  });
+
   test('Read (command path) numbers lines, caps by default, and guards binaries', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-'));
     await writeFile(join(cwd, 'big.txt'), Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join('\n') + '\n', 'utf8');

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -472,6 +472,57 @@ describe('isolated headless tools', () => {
     assert.equal(rgMany[199], 'many/f199.txt');
   });
 
+  test('the Glob rg branch pins its enumeration flags and checks rg exit (non-skippable safety net)', async () => {
+    let captured = '';
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        captured = input.command;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    await tool(tools, 'Glob').impl({ pattern: '*.txt' }, toolCtx('/workspace'));
+    // Pin the exact rg enumeration so --no-config (hermetic against a host
+    // RIPGREP_CONFIG_PATH) and --no-ignore/--hidden (find parity) cannot be
+    // silently dropped. Asserts the script text, so it runs with or without rg.
+    assert.match(captured, /rg --no-config --files --no-ignore --hidden -- "\$rel_base"/);
+    // ...and rg's exit code must be inspected: rc>1 is a real error, not "no files".
+    assert.match(captured, /rc=\$\?/);
+    assert.match(captured, /\[ "\$rc" -gt 1 \] &&/);
+  });
+
+  test('Glob surfaces a ripgrep runtime error instead of returning an empty list', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-glob-rgfail-'));
+    await writeFile(join(cwd, 'real.txt'), '', 'utf8');
+    // rg present but failing at runtime (exit 2). Prepending a fake rg to PATH
+    // shadows the real one; the script must not swallow the failure into an empty
+    // result — it surfaces the error (mirrors the Grep rg branch).
+    const binDir = await mkdtemp(join(tmpdir(), 'maka-headless-fakerg-'));
+    await writeFile(join(binDir, 'rg'), '#!/bin/sh\necho "rg: simulated failure" >&2\nexit 2\n', 'utf8');
+    await chmod(join(binDir, 'rg'), 0o755);
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+            maxBuffer: 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+    await assert.rejects(
+      () => tool(tools, 'Glob').impl({ pattern: '*.txt' }, toolCtx(cwd)) as Promise<unknown>,
+      /ripgrep failed \(exit 2\)/,
+    );
+  });
+
   test('Read (command path) numbers lines, caps by default, and guards binaries', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-'));
     await writeFile(join(cwd, 'big.txt'), Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join('\n') + '\n', 'utf8');

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -523,6 +523,55 @@ describe('isolated headless tools', () => {
     );
   });
 
+  test('Glob rg success branch (fake rg) pins flags and applies ./-strip, ERE filter, sort, cap', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-glob-fakerg-ok-'));
+    const binDir = await mkdtemp(join(tmpdir(), 'maka-headless-fakerg-ok-'));
+    const argvLog = join(binDir, 'argv.txt');
+    // A fake rg that records its argv and prints a fixed `--files` listing in
+    // REVERSE order, with ./ prefixes and one non-.txt entry. This exercises the
+    // success branch end-to-end on a host with no real rg, so a regression in the
+    // pinned flags, ./ stripping, ERE filtering, sort, or the 200 cap is caught.
+    const rgScript = [
+      '#!/bin/sh',
+      `printf '%s ' "$@" > ${JSON.stringify(argvLog)}`,
+      'i=250',
+      `while [ "$i" -ge 1 ]; do printf './f%03d.txt\\n' "$i"; i=$((i - 1)); done`,
+      `printf '%s\\n' './notes.md' 'a.txt'`,
+      '',
+    ].join('\n');
+    await writeFile(join(binDir, 'rg'), rgScript, 'utf8');
+    await chmod(join(binDir, 'rg'), 0o755);
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, {
+            cwd: input.cwd,
+            env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+            maxBuffer: 1024 * 1024,
+          });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    const r = (await tool(tools, 'Glob').impl({ pattern: '*.txt' }, toolCtx(cwd))) as { files: string[] };
+    assert.equal(r.files.length, 200, 'capped at 200');
+    assert.equal(r.files[0], 'a.txt', 'sorted ascending despite reverse-order rg output');
+    assert.equal(r.files[1], 'f001.txt');
+    assert.equal(r.files[199], 'f199.txt');
+    assert.ok(!r.files.includes('notes.md'), '.md filtered out by the *.txt ERE');
+    assert.ok(!r.files.some((f) => f.startsWith('./')), 'leading ./ stripped from every path');
+    // rg was invoked with exactly the pinned safety flags.
+    const argv = await readFile(argvLog, 'utf8');
+    assert.match(argv, /--no-config --files --no-ignore --hidden --/);
+  });
+
   test('Read (command path) numbers lines, caps by default, and guards binaries', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-read-'));
     await writeFile(join(cwd, 'big.txt'), Array.from({ length: 2500 }, (_, i) => `line${i + 1}`).join('\n') + '\n', 'utf8');

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -613,18 +613,35 @@ if [ -n "$search_cwd" ]; then
 else
   base=$root
 fi
-find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
-  BEGIN { prefix = root "/"; count = 0 }
-  {
-    rel = $0
-    if (index(rel, prefix) == 1) rel = substr(rel, length(prefix) + 1)
-    if (rel ~ re) {
-      print rel
-      count += 1
-      if (count >= 200) exit
-    }
-  }
-'
+# Enumerate files with ripgrep when available (much faster than find on large
+# trees); fall back to find. --no-ignore --hidden keeps the file set identical
+# with or without rg, and the glob match stays the existing ERE, so membership
+# never depends on rg's glob dialect. Both branches search the SAME resolved base
+# (rel_base, derived from existing_target's symlink-resolved $base) and emit
+# root-relative paths, then sort under a fixed locale before the 200 cap, so the
+# truncated result is deterministic regardless of each tool's enumeration order.
+# rg gets an explicit relative path (so it never reads from its never-closing
+# stdin pipe) and runs from root so its output is root-relative; its "./" prefix
+# is stripped to match find's paths. --no-config makes rg hermetic: a stray
+# RIPGREP_CONFIG_PATH (e.g. a dev's global --follow/--sort/--glob) would
+# otherwise change rg's file set or output format while find is unaffected,
+# breaking the rg/find equivalence this script depends on.
+rel_base=.
+[ "$base" != "$root" ] && rel_base=\${base#"$root"/}
+{
+  if command -v rg >/dev/null 2>&1; then
+    ( cd "$root" && rg --no-config --files --no-ignore --hidden -- "$rel_base" 2>/dev/null ) | sed 's#^\\./##' | awk -v re="$pattern_re" '$0 ~ re'
+  else
+    find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
+      BEGIN { prefix = root "/" }
+      {
+        rel = $0
+        if (index(rel, prefix) == 1) rel = substr(rel, length(prefix) + 1)
+        if (rel ~ re) print rel
+      }
+    '
+  fi
+} | LC_ALL=C sort | awk 'NR <= 200'
 `;
 
 const GREP_SCRIPT = `${COMMON_SHELL_HELPERS}

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -615,30 +615,33 @@ else
 fi
 # Enumerate with ripgrep when present (fast), else POSIX find. Both branches emit
 # root-relative paths filtered by the shared ERE ($pattern_re) -- membership never
-# depends on rg's glob dialect -- and the merged output is sorted under a fixed
-# locale BEFORE the 200 cap, so a truncated result is the same set either way.
+# depends on rg's glob dialect -- then sort under a fixed locale BEFORE the 200 cap
+# so a truncated result is the same set either way. rg's listing goes to a temp
+# file (not a shell var) so the full set streams into the filter without being
+# buffered in memory, while its exit code is still checked in this shell: rc>1
+# surfaces a real error instead of "no files" (mirrors the Grep rg branch).
 # rg flags: --no-config keeps it hermetic (a host RIPGREP_CONFIG_PATH cannot
 # inject --follow/--glob); --no-ignore --hidden match find's file set; an explicit
-# path avoids rg's never-closing stdin; rc>1 surfaces a real error instead of
-# masquerading as "no files" (mirrors the Grep rg branch).
+# path avoids rg's never-closing stdin.
 rel_base=.
 [ "$base" != "$root" ] && rel_base=\${base#"$root"/}
 if command -v rg >/dev/null 2>&1; then
-  raw=$( cd "$root" && rg --no-config --files --no-ignore --hidden -- "$rel_base" )
+  list=$(mktemp) || exit 1
+  trap 'rm -f "$list"' EXIT
+  ( cd "$root" && rg --no-config --files --no-ignore --hidden -- "$rel_base" ) > "$list"
   rc=$?
   [ "$rc" -gt 1 ] && { echo "ripgrep failed (exit $rc)" >&2; exit "$rc"; }
-  files=$(printf '%s\n' "$raw" | sed 's#^\\./##' | awk -v re="$pattern_re" '$0 ~ re')
+  sed 's#^\\./##' "$list" | awk -v re="$pattern_re" '$0 ~ re' | LC_ALL=C sort | awk 'NR <= 200'
 else
-  files=$(find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
+  find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
     BEGIN { prefix = root "/" }
     {
       rel = $0
       if (index(rel, prefix) == 1) rel = substr(rel, length(prefix) + 1)
       if (rel ~ re) print rel
     }
-  ')
+  ' | LC_ALL=C sort | awk 'NR <= 200'
 fi
-printf '%s\n' "$files" | LC_ALL=C sort | awk 'NR <= 200'
 `;
 
 const GREP_SCRIPT = `${COMMON_SHELL_HELPERS}

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -613,35 +613,32 @@ if [ -n "$search_cwd" ]; then
 else
   base=$root
 fi
-# Enumerate files with ripgrep when available (much faster than find on large
-# trees); fall back to find. --no-ignore --hidden keeps the file set identical
-# with or without rg, and the glob match stays the existing ERE, so membership
-# never depends on rg's glob dialect. Both branches search the SAME resolved base
-# (rel_base, derived from existing_target's symlink-resolved $base) and emit
-# root-relative paths, then sort under a fixed locale before the 200 cap, so the
-# truncated result is deterministic regardless of each tool's enumeration order.
-# rg gets an explicit relative path (so it never reads from its never-closing
-# stdin pipe) and runs from root so its output is root-relative; its "./" prefix
-# is stripped to match find's paths. --no-config makes rg hermetic: a stray
-# RIPGREP_CONFIG_PATH (e.g. a dev's global --follow/--sort/--glob) would
-# otherwise change rg's file set or output format while find is unaffected,
-# breaking the rg/find equivalence this script depends on.
+# Enumerate with ripgrep when present (fast), else POSIX find. Both branches emit
+# root-relative paths filtered by the shared ERE ($pattern_re) -- membership never
+# depends on rg's glob dialect -- and the merged output is sorted under a fixed
+# locale BEFORE the 200 cap, so a truncated result is the same set either way.
+# rg flags: --no-config keeps it hermetic (a host RIPGREP_CONFIG_PATH cannot
+# inject --follow/--glob); --no-ignore --hidden match find's file set; an explicit
+# path avoids rg's never-closing stdin; rc>1 surfaces a real error instead of
+# masquerading as "no files" (mirrors the Grep rg branch).
 rel_base=.
 [ "$base" != "$root" ] && rel_base=\${base#"$root"/}
-{
-  if command -v rg >/dev/null 2>&1; then
-    ( cd "$root" && rg --no-config --files --no-ignore --hidden -- "$rel_base" 2>/dev/null ) | sed 's#^\\./##' | awk -v re="$pattern_re" '$0 ~ re'
-  else
-    find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
-      BEGIN { prefix = root "/" }
-      {
-        rel = $0
-        if (index(rel, prefix) == 1) rel = substr(rel, length(prefix) + 1)
-        if (rel ~ re) print rel
-      }
-    '
-  fi
-} | LC_ALL=C sort | awk 'NR <= 200'
+if command -v rg >/dev/null 2>&1; then
+  raw=$( cd "$root" && rg --no-config --files --no-ignore --hidden -- "$rel_base" )
+  rc=$?
+  [ "$rc" -gt 1 ] && { echo "ripgrep failed (exit $rc)" >&2; exit "$rc"; }
+  files=$(printf '%s\n' "$raw" | sed 's#^\\./##' | awk -v re="$pattern_re" '$0 ~ re')
+else
+  files=$(find "$base" -type f -print | awk -v root="$root" -v re="$pattern_re" '
+    BEGIN { prefix = root "/" }
+    {
+      rel = $0
+      if (index(rel, prefix) == 1) rel = substr(rel, length(prefix) + 1)
+      if (rel ~ re) print rel
+    }
+  ')
+fi
+printf '%s\n' "$files" | LC_ALL=C sort | awk 'NR <= 200'
 `;
 
 const GREP_SCRIPT = `${COMMON_SHELL_HELPERS}


### PR DESCRIPTION
## What

Part of the #92 tool-fidelity work (closing the tool-layer gap vs opencode). The isolated/benchmark `Glob` walked the workspace with `find -type f`, which is slow on large trees. `GLOB_SCRIPT` now enumerates with `rg --files` when ripgrep is on `PATH` and falls back to `find` otherwise.

## Why it stays equivalent

The user's standing decision for the rg-backed tools is determinism over gitignore-awareness: rg and find must return the **identical** file set so benchmark results never depend on which binary is installed.

- `rg --no-ignore --hidden` makes rg see the same files as `find` (hidden + gitignored + nested all included; file symlinks excluded — empirically `rg --files --no-ignore --hidden` matches `find -type f` membership exactly).
- The glob match itself stays the existing ERE applied in `awk`, so membership never depends on rg's glob dialect — only enumeration speed changes.
- `--no-config` makes rg hermetic: a stray `RIPGREP_CONFIG_PATH` (a dev's global `--follow`/`--sort`/`--glob`) cannot change rg's file set or output format while `find` is unaffected.
- rg is given an explicit relative path (so it never blocks on its never-closing stdin pipe) and runs from root so its output is root-relative; the `./` prefix is stripped to match find's paths.
- Both branches search the same symlink-resolved base (`rel_base`, derived from `existing_target`'s `$base`), so a search `cwd` reached through a symlinked parent resolves consistently.

## Deterministic cap

The 200-result cap is applied **after** a `LC_ALL=C sort` in both branches, not during enumeration. rg and find traverse in different orders, so capping mid-walk would return different first-200 subsets when more than 200 files match. Sorting first makes the truncated set deterministic and identical across both paths.

## Tests

- Strengthened the parity test to assert rg and find enumerate the same files (hidden, gitignored, nested kept; file symlink excluded).
- Added a >200-match workspace case proving rg and find return the same capped, sorted set (directly covering the sort-before-cap invariant).
- The find branch is pinned to a temp bin holding only the coreutils `GLOB_SCRIPT` needs (no rg), so the parity check stays real even where rg lives in `/usr/bin`.
- `npm run -w @maka/headless test` — 242 pass.

## Known follow-up (out of scope)

Filenames containing embedded newlines are split by the newline-delimited protocol shared across all file tools (`parseLineArray`, `GREP_SCRIPT`, and the pre-existing find-based Glob). Moving to NUL-delimited output is a separate cross-cutting concern; this PR preserves prior behavior. The merged `GREP_SCRIPT` (#110) would also benefit from `--no-config` — a small follow-up.