### PR TITLE
Drop browser-style session tab from chat header

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -4190,102 +4190,11 @@ button:active {
   -webkit-app-region: drag;
 }
 
-.maka-chat-tab {
-  height: 26px;
-  max-width: min(300px, 50vw);
-  min-width: 120px;
-  display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 0;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 6px;
-  background: oklch(from var(--foreground) l c h / 0.05);
-  box-shadow: none;
-  color: var(--foreground);
-  font-size: 12px;
-  font-weight: 500;
-  -webkit-app-region: no-drag;
-}
-
-.maka-chat-tab-icon {
-  width: 14px;
-  height: 14px;
-  color: var(--foreground-50);
-}
-
-/* Real provider brand mark replaces the generic MessageSquare icon when
-   the chat has a real connection. The ProviderLogo already renders an
-   inline 32px square via .providerLogo[data-compact]; we just resize. */
-.maka-chat-tab-provider {
-  width: 14px;
-  height: 14px;
-  display: inline-grid;
-  place-items: center;
-}
-
-.maka-chat-tab-provider .providerLogo {
-  width: 14px;
-  height: 14px;
-  /* 28% ratio matching the md / sm anchors (PR-UI-13). Previously 6px
-   * (33%) which made the chat-tab badge feel rounder than the sidebar
-   * chip and onboarding card. */
-  border-radius: 5px;
-  box-shadow: inset 0 0 0 0.5px oklch(1 0 0 / 0.4);
-}
-
-.maka-chat-tab-provider .providerLogo svg {
-  /* Anchor to the same 72% inner ratio as md / sm so the brand mark
-   * reads the same at every size. */
-  width: 72%;
-  height: 72%;
-}
-
-.maka-chat-tab span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.maka-chat-tab .maka-chat-tab-backend {
-  color: var(--foreground-45, var(--foreground-40));
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.maka-chat-tab-plus {
-  width: 22px;
-  height: 22px;
-  display: grid;
-  place-items: center;
-  margin: 0 2px 3px 2px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--foreground-50);
-  -webkit-app-region: no-drag;
-  transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
-}
-
-.maka-chat-tab-plus:hover {
-  background: var(--hover);
-  color: var(--foreground);
-}
-
-.maka-chat-tab-plus:focus-visible {
-  outline: none;
-  background: var(--hover);
-  color: var(--foreground);
-  box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.14);
-}
-
-.maka-chat-tab-plus svg {
-  width: 14px;
-  height: 14px;
-}
+/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
+   browser-style session tab + the duplicate "新建对话" plus button at
+   the top-left of the chat header are removed. ~95 LOC of .maka-chat-tab*
+   rules came out with them. Session name + model live in the sidebar;
+   create-session lives in the sidebar new-task button. */
 
 .maka-chat-header-spacer {
   flex: 1;

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4348,11 +4348,13 @@ export function ChatView(props: {
   if (!props.activeSession) {
     return (
       <main className="maka-main detailPane agents-chat-panel agents-chat-view-root">
-        <header className="maka-chat-header">
-          <ChatTab title="新建对话" />
-          <button className="maka-chat-tab-plus" type="button" aria-label="新建对话" onClick={props.onNew}>
-            <Plus strokeWidth={1.5} aria-hidden="true" />
-          </button>
+        {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
+            browser-style session tab + the duplicate "新建对话" plus
+            button were removed. The session name lives in the sidebar;
+            the new-task button at the top of the sidebar is the
+            canonical create-session entry point. The chat header
+            keeps the permission-mode switcher only. */}
+        <header className="maka-chat-header" data-empty="true">
           <span className="maka-chat-header-spacer" />
           <PermissionModeSwitcher mode="ask" disabled disabledReason="新建对话后再切换模式。" />
         </header>
@@ -4372,20 +4374,13 @@ export function ChatView(props: {
 
   return (
     <main className="maka-main detailPane agents-chat-panel agents-chat-view-root">
+      {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d): no more browser-style
+          session tab in the chat header. Session name + model live in
+          the sidebar; the new-task button at the top of the sidebar is
+          the canonical create-session entry. The chat header is now
+          just a thin chrome strip carrying the permission-mode
+          switcher and the per-session memory/mode chips. */}
       <header className="maka-chat-header">
-        <ChatTab
-          title={props.activeSession.name}
-          subtitle={props.activeModelLabel ?? props.activeConnectionLabel}
-          subtitleHint={props.activeConnectionLabel && props.activeModelLabel
-            ? `本会话固定模型：${props.activeConnectionLabel} · ${props.activeModelLabel}。设置里的默认模型只影响新建会话。`
-            : undefined}
-          providerMark={props.activeProviderType && props.renderProviderMark
-            ? props.renderProviderMark(props.activeProviderType)
-            : undefined}
-        />
-        <button className="maka-chat-tab-plus" type="button" aria-label="新建对话" onClick={props.onNew}>
-          <Plus strokeWidth={1.5} aria-hidden="true" />
-        </button>
         <span className="maka-chat-header-spacer" />
         {props.memoryActive && (
           <button
@@ -6165,22 +6160,6 @@ function MessageMeta(props: { role: string; userLabel?: string; ts?: number }) {
   );
 }
 
-function ChatTab(props: {
-  title: string;
-  subtitle?: string;
-  subtitleHint?: string;
-  providerMark?: ReactNode;
-}) {
-  return (
-    <div className="maka-chat-tab" title={props.subtitleHint ? `${props.title} · ${props.subtitleHint}` : props.title}>
-      {props.providerMark
-        ? <span className="maka-chat-tab-provider" aria-hidden="true">{props.providerMark}</span>
-        : <MessageSquare className="maka-chat-tab-icon" strokeWidth={1.5} />}
-      <span>{props.title}</span>
-      {props.subtitle && <span className="maka-chat-tab-backend">{props.subtitle}</span>}
-    </div>
-  );
-}
 
 const COMPOSER_MAX_HEIGHT = 240;
 


### PR DESCRIPTION
## Summary

Per WAWQAQ msg `d401938d` (2026-06-23):
> 现在这个是侧边栏处于收缩状态，怎么左上角还有一个像浏览器一样的那种标签栏？不是之前就删了吗？他是没有必要的呀。

The chat header was still rendering a browser-style "tab" with the active session name + model + a duplicate "新建对话" + button. With a collapsed sidebar this read as an extra chrome strip at the top-left for no reason — the session name lives in the sidebar, and the new-task button at the top of the sidebar (`+ 新任务`) is the canonical create-session entry.

## What changes

- `<ChatTab>` JSX removed in both the empty-session and active-session branches of the chat header.
- The adjacent `<button className="maka-chat-tab-plus">` (duplicate new-session entry) removed.
- The `function ChatTab(...)` definition removed (now orphan).
- ~95 LOC of `.maka-chat-tab*` CSS rules removed.

The chat header is now a thin chrome strip carrying just the permission-mode switcher and per-session memory/mode chips. Window drag region and the sidebar collapse / search / new-task icons in the sidebar header are untouched.

Net diff: **18 insertions / 130 deletions** across 2 files.

## Test plan

- [x] `apps/desktop` test suite: 1465 / 1465 pass
- [x] Renderer + main typecheck clean
- [x] `turn-narrative` visual smoke re-captured — chat panel top-left is now clean (just the sidebar/search/new-task icons; no more session tab)