### PR TITLE
PR-S1 — Settings nav group label muted to match reference voice

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -6881,14 +6881,19 @@ button:active {
 }
 
 .settingsNavGroupLabel {
+  /* PR-SETTINGS-SHELL-ALIGN (2026-06-23): match the reference Settings
+     nav group label voice — quaternary text tier, smaller size, no
+     uppercase. The previous `foreground-45` + 12 px / 600 read as a
+     subsection title; the new tier reads as a "muted divider" so the
+     nav items themselves carry the visual weight. */
   display: flex;
   align-items: center;
-  font-size: 12px;
+  font-size: 10.5px;
   font-weight: 600;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: none;
-  color: var(--foreground-45);
-  padding: 7px 10px 3px;
+  color: var(--foreground-35);
+  padding: 9px 10px 2px;
 }
 
 .settingsNavGroupLabel::after {


### PR DESCRIPTION
First in the Settings → reference alignment series. Subtle nav chrome tuning so the group dividers (基础 / AI / 集成 / 数据 / 其他) read as quaternary-tier muted dividers, not subsection titles.

## Context

Reference RE notes posted to thread #maka-dev-kabi:747ef2ea. Key finding: the reference Settings nav uses a `text-quaternary` color tier for its group titles — the labels are present but visually receded so the active nav row itself carries the strongest visual weight.

## What changes

- `.settingsNavGroupLabel` — color `foreground-45` → `foreground-35` (one tier lighter), font-size 12 → 10.5 px, padding tightened, + a small `0.04 em` letter-spacing to keep readability at the smaller size.

No nav-item, sidebar-width (240 px), or content-area changes — the shell geometry is already on-spec. Active-row filled-background via `--settings-nav-row-selected-bg` token is untouched.

## Test plan

- [x] 1465 desktop tests pass
- [x] renderer + main typecheck clean
- [x] visual smoke (`settings-personalization`) re-captured

## Next in the series

- PR-S2: convert single-control rows on General / Personalization / Theme from vertical to horizontal (label left / control right).
- PR-S3: same for Models / Usage / Memory / Voice / Open Gateway.
- PR-S4: CTA button tone alignment.
- PR-S5: protected-page card chrome → flat divider list to match the rest of the module.