### PR TITLE
PR-S2 — horizontal Settings rows on Personalization (reference-style label-left / control-right)

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -2518,8 +2518,14 @@ function PersonalizationSettingsPage(props: {
 
   return (
     <div className="settingsStructuredPage">
-      <label className="settingsField">
+      {/* PR-S2 (2026-06-23): single-control rows use the
+          reference-style horizontal layout — label + description on
+          the left, control aligned right, 1 px hairline between
+          rows. Vertical layout is reserved for full-width controls
+          like the Textarea below. */}
+      <label className="settingsField" data-orient="horizontal">
         <span>显示名称</span>
+        <small>Maka 在聊天里会以这个名字称呼你。留空就用默认的「你」。</small>
         <Input
           type="text"
           value={displayName}
@@ -2531,7 +2537,6 @@ function PersonalizationSettingsPage(props: {
           disabled={saving}
           aria-label="显示名称"
         />
-        <small>Maka 在聊天里会以这个名字称呼你。留空就用默认的「你」。</small>
       </label>
 
       {/*
@@ -2540,8 +2545,9 @@ function PersonalizationSettingsPage(props: {
         choice wins over navigator.language; visual-smoke override
         wins over both (deterministic baselines).
       */}
-      <div className="settingsField">
+      <div className="settingsField" data-orient="horizontal">
         <span>界面语言</span>
+        <small>选择 Maka 界面的显示语言。保存后立即生效，重启后保持。</small>
         <Segmented
           value={uiLocale}
           options={[
@@ -2553,7 +2559,6 @@ function PersonalizationSettingsPage(props: {
           ariaLabel="界面语言"
           disabled={saving}
         />
-        <small>选择 Maka 界面的显示语言。保存后立即生效，重启后保持。</small>
       </div>
 
       <label className="settingsField">

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7271,6 +7271,53 @@ button:active {
   gap: 4px;
 }
 
+/* PR-S2 (2026-06-23): reference-style horizontal Settings row — label
+   stack on the left (title + description), control aligned right. Use
+   `<div className="settingsField" data-orient="horizontal">` on rows
+   whose control is a single inline element (Input, Switch, Segmented,
+   Select). Leave the default vertical stack for full-width controls
+   (Textarea, multi-line forms). The 1px hairline divider between rows
+   pulls the look closer to reference's flat divider list and away from
+   the previous "each row in its own implicit card" feel. */
+.settingsField[data-orient="horizontal"] {
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "label control"
+    "hint  control";
+  column-gap: 16px;
+  row-gap: 2px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+.settingsField[data-orient="horizontal"] > span {
+  grid-area: label;
+  align-self: end;
+}
+.settingsField[data-orient="horizontal"] > small {
+  grid-area: hint;
+  margin-top: 0;
+  align-self: start;
+}
+.settingsField[data-orient="horizontal"] > :not(span):not(small) {
+  grid-area: control;
+  justify-self: end;
+  align-self: center;
+  min-width: 0;
+}
+/* Allow inputs to take a comfortable cap width on horizontal rows so
+   the description column has space to breathe. */
+.settingsField[data-orient="horizontal"] > input,
+.settingsField[data-orient="horizontal"] > .settingsBaseSelectTrigger {
+  max-width: 280px;
+}
+/* The horizontal row above the first one shouldn't carry a top border;
+   below the last one the section footer takes over. The default
+   border-bottom is fine for the inter-row hairlines. */
+.settingsField[data-orient="horizontal"] + .settingsField[data-orient="horizontal"] {
+  border-top: 0;
+}
+
 .settingsField input,
 .settingsField textarea,
 .settingsFormGrid input,


### PR DESCRIPTION
Second in the Settings → reference alignment series. Aligns single-control rows on the Personalization page to the reference horizontal pattern.

## Pattern

Reference Settings pages use:
- label + description **left**
- control **right**, justified
- 1 px hairline divider between rows
- No card chrome per row (flat divider list)

Our `.settingsField` was a vertical grid (title / control / small). That read more like a form block than a settings row.

## What changes

- New `.settingsField[data-orient="horizontal"]` variant: 2-column grid, label + description on the left (stacked), control on the right (justified end), 1 px hairline bottom border, 12 px vertical padding, inputs capped at 280 px max-width so the description column has room to read.
- Personalization page: applied to the displayName `<Input>` row and the uiLocale `<Segmented>` row.
- Assistant-tone `<Textarea>` row stays vertical — full-width controls keep the default stack.

## Test plan

- [x] 1465 desktop tests pass
- [x] renderer + main typecheck clean
- [x] visual smoke (`settings-personalization`) re-captured; rows now show label / description on the left and the control flush right

## Next in series

- PR-S3: extend the horizontal row pattern to General / Theme pages, then Models / Usage / Memory / Voice / Open Gateway.
- PR-S4: CTA button tone alignment.
- PR-S5: protected-page card chrome → flat divider list to match the rest of the module.