### PR TITLE
feat(runtime): serialize file writes per path with a shared KeyedMutex

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -875,6 +875,73 @@ describe('isolated headless tools', () => {
     assert.deepEqual([...(await readFile(file))], [0xff, 0x58, 0x59, 0x5a, 0xfe]);
   });
 
+  test('concurrent Edits to the same file serialize — no lost update', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-lock-'));
+    const file = join(cwd, 'data.txt');
+    const n = 20;
+    const markers = Array.from({ length: n }, (_, i) => `marker-${String(i).padStart(2, '0')}`);
+    await writeFile(file, `${markers.join('\n')}\n`, 'utf8');
+    // No executor.editFile -> EDIT_SCRIPT (read whole file -> temp -> rename). Run
+    // through the real shell so the read-modify-write actually hits disk.
+    const tools = execBackedTools();
+    // Fire all edits concurrently. Each rewrites the whole file, so without the
+    // per-path lock the last rename would clobber the others and most edits vanish.
+    const results = await Promise.all(markers.map((m, i) =>
+      tool(tools, 'Edit').impl({ path: file, old_string: m, new_string: `done-${String(i).padStart(2, '0')}` }, toolCtx(cwd)),
+    ));
+    assert.ok(results.every((r: any) => r.ok === true && r.replacements === 1));
+    const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
+    assert.equal(await readFile(file, 'utf8'), expected, 'every concurrent edit landed');
+  });
+
+  test('concurrent Edits via different path spellings serialize on one key', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-lockkey-'));
+    const file = join(cwd, 'data.txt');
+    const n = 20;
+    const markers = Array.from({ length: n }, (_, i) => `marker-${String(i).padStart(2, '0')}`);
+    await writeFile(file, `${markers.join('\n')}\n`, 'utf8');
+    const tools = execBackedTools();
+    // Alternate the spelling of the same file. Without lexical key normalization
+    // 'data.txt' and './data.txt' hash to different mutex keys, so the two groups
+    // run concurrently and clobber each other; normalization collapses them.
+    const results = await Promise.all(markers.map((m, i) =>
+      tool(tools, 'Edit').impl(
+        { path: i % 2 === 0 ? 'data.txt' : './data.txt', old_string: m, new_string: `done-${String(i).padStart(2, '0')}` },
+        toolCtx(cwd),
+      ),
+    ));
+    assert.ok(results.every((r: any) => r.ok === true));
+    const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
+    assert.equal(await readFile(file, 'utf8'), expected, 'every edit landed despite mixed path spellings');
+  });
+
+  test('a Write and an Edit on the same file serialize — they never overlap at the executor boundary', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-write-edit-'));
+    // Both Write (WRITE_SCRIPT) and Edit (EDIT_SCRIPT) reach the filesystem through
+    // executor.exec; with no native writeFile hook each is exactly one exec call.
+    // The spy counts concurrently-active exec calls. Sharing one fileWriteKey the
+    // two must run strictly one-at-a-time (max 1 active); without the lock they
+    // overlap (2 active) and their read-modify-write could lose an update. The two
+    // setImmediate yields force an overlap window when serialization is absent.
+    let active = 0;
+    let maxActive = 0;
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+        active -= 1;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+    await Promise.all([
+      tool(tools, 'Write').impl({ path: 'data.txt', content: 'WRITTEN\n' }, toolCtx(cwd)),
+      tool(tools, 'Edit').impl({ path: 'data.txt', old_string: 'a', new_string: 'b' }, toolCtx(cwd)),
+    ]);
+    assert.equal(maxActive, 1, 'Write and Edit on one path must not run concurrently');
+  });
+
   test('command-backed file tools do not follow symlinks outside the isolated workspace', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-symlink-'));
     const outside = await mkdtemp(join(tmpdir(), 'maka-headless-tools-outside-'));
@@ -986,6 +1053,23 @@ describe('isolated headless tools', () => {
     );
   });
 });
+
+function execBackedTools(env: NodeJS.ProcessEnv = process.env) {
+  return buildIsolatedHeadlessTools({
+    async exec(input) {
+      try {
+        const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, env, maxBuffer: 1024 * 1024 });
+        return { exitCode: 0, stdout, stderr };
+      } catch (error: any) {
+        return {
+          exitCode: typeof error?.code === 'number' ? error.code : 1,
+          stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+          stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+        };
+      }
+    },
+  });
+}
 
 function tool(tools: ReturnType<typeof buildIsolatedHeadlessTools>, name: string) {
   const found = tools.find((candidate) => candidate.name === name);

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -5,6 +5,7 @@ import {
   COMPUTE_EDITED_SOURCE_FN_SOURCE,
   truncateToolOutput,
 } from '@maka/runtime';
+import { withFileWriteLock } from '@maka/runtime/file-write-lock';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
@@ -18,6 +19,16 @@ export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
 }
 
+// Key Write and Edit on a JSON [cwd, path] pair (JSON.stringify so no path
+// character can pose as the separator) and serialize them with the shared
+// withFileWriteLock — see its definition for why concurrent writes are serialized
+// and which aliases a lexical key cannot merge. The path is lexically normalized
+// so spellings of one file ("a.txt", "./a.txt", "d//a.txt") share a key. Keying
+// stays lexical here by necessity: the executor boundary hides the filesystem
+// (which may be remote, with its own symlink / hard-link / case-fold semantics),
+// so the executor — not this layer — owns canonicalization.
+const fileWriteKey = (cwd: string, normalizedPath: string) =>
+  JSON.stringify([pathPosix.normalize(cwd), pathPosix.normalize(normalizedPath)]);
 /**
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
@@ -147,18 +158,20 @@ export function buildIsolatedWriteTool(
       const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Write path');
       const input = { cwd, path: normalizedPath, content };
-      if (executor.writeFile) {
-        const result = await executor.writeFile(input);
+      return await withFileWriteLock(fileWriteKey(cwd, normalizedPath), async () => {
+        if (executor.writeFile) {
+          const result = await executor.writeFile(input);
+          await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
+          return result;
+        }
+        await execFileCommand(executor, cwd, shellFileCommand(WRITE_SCRIPT, [
+          normalizedPath,
+          content,
+        ]));
+        const result = { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
         await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
         return result;
-      }
-      await execFileCommand(executor, cwd, shellFileCommand(WRITE_SCRIPT, [
-        normalizedPath,
-        content,
-      ]));
-      const result = { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
-      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
-      return result;
+      });
     },
   };
 }
@@ -185,20 +198,22 @@ export function buildIsolatedEditTool(
       const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Edit path');
       const input = { cwd, path: normalizedPath, oldString: old_string, newString: new_string };
-      // Edit ALWAYS runs the shared computeEditedSource — unlike Read/Write/Glob/
-      // Grep it has NO native-executor fast path, because its matching logic is
-      // non-trivial and must stay the single source of truth with the in-process
-      // builtin Edit. It runs via `node -e` (node is guaranteed in the headless/
-      // Harbor environment); the other file tools stay on the POSIX-sh scripts.
-      // old/new are base64-encoded so arbitrary content survives argv transport.
-      const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
-        normalizedPath,
-        Buffer.from(old_string, 'utf8').toString('base64'),
-        Buffer.from(new_string, 'utf8').toString('base64'),
-      ]));
-      const result = { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
-      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Edit', input, result }, ctx);
-      return result;
+      return await withFileWriteLock(fileWriteKey(cwd, normalizedPath), async () => {
+        // Edit ALWAYS runs the shared computeEditedSource — unlike Read/Write/Glob/
+        // Grep it has NO native-executor fast path, because its matching logic is
+        // non-trivial and must stay the single source of truth with the in-process
+        // builtin Edit. It runs via `node -e` (node is guaranteed in the headless/
+        // Harbor environment); the other file tools stay on the POSIX-sh scripts.
+        // old/new are base64-encoded so arbitrary content survives argv transport.
+        const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
+          normalizedPath,
+          Buffer.from(old_string, 'utf8').toString('base64'),
+          Buffer.from(new_string, 'utf8').toString('base64'),
+        ]));
+        const result = { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Edit', input, result }, ctx);
+        return result;
+      });
     },
   };
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,6 +20,7 @@
     "./model-fetcher": "./dist/model-fetcher.js",
     "./materializer": "./dist/materializer.js",
     "./async-queue": "./dist/async-queue.js",
+    "./file-write-lock": "./dist/file-write-lock.js",
     "./session-manager": "./dist/session-manager.js",
     "./fake-backend": "./dist/fake-backend.js",
     "./network/proxy-env": "./dist/network/proxy-env.js",

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -216,6 +216,64 @@ describe('builtin write tools path containment', () => {
     await runTool(edit, { path: 'inside.txt', old_string: 'world', new_string: 'Maka' }, root);
     expect(await readFile(join(root, 'inside.txt'), 'utf8')).toBe('hello Maka');
   });
+
+  test('concurrent Edits to the same file serialize — no lost update', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-edit-lock-'));
+    const n = 20;
+    const markers = Array.from({ length: n }, (_, i) => `marker-${String(i).padStart(2, '0')}`);
+    await writeFile(join(root, 'data.txt'), `${markers.join('\n')}\n`, 'utf8');
+    const edit = tool('Edit');
+    // Each Edit is a read-modify-write (fs.readFile -> replace -> fs.writeFile).
+    // Fired concurrently without the per-path lock, the writes clobber each other
+    // and most edits are lost; the lock serializes them so every one lands.
+    const results = await Promise.all(markers.map((m, i) =>
+      runTool(edit, { path: 'data.txt', old_string: m, new_string: `done-${String(i).padStart(2, '0')}` }, root),
+    ));
+    expect(results.every((r) => (r as { ok: boolean; replacements: number }).ok === true
+      && (r as { replacements: number }).replacements === 1)).toBe(true);
+    const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
+    expect(await readFile(join(root, 'data.txt'), 'utf8')).toBe(expected);
+  });
+
+  test('concurrent Edits via different path spellings serialize on one key', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-edit-spelling-'));
+    const n = 20;
+    const markers = Array.from({ length: n }, (_, i) => `marker-${String(i).padStart(2, '0')}`);
+    await writeFile(join(root, 'data.txt'), `${markers.join('\n')}\n`, 'utf8');
+    const edit = tool('Edit');
+    // Alternate the spelling of the same file. The key resolves both spellings to
+    // one absolute path, so all edits share a lock; without that collapse the two
+    // groups would run concurrently and clobber each other.
+    const results = await Promise.all(markers.map((m, i) =>
+      runTool(edit, { path: i % 2 === 0 ? 'data.txt' : './data.txt', old_string: m, new_string: `done-${String(i).padStart(2, '0')}` }, root),
+    ));
+    expect(results.every((r) => (r as { ok: boolean }).ok === true)).toBe(true);
+    const expected = `${Array.from({ length: n }, (_, i) => `done-${String(i).padStart(2, '0')}`).join('\n')}\n`;
+    expect(await readFile(join(root, 'data.txt'), 'utf8')).toBe(expected);
+  });
+
+  test('Write then Edit on one file resolves inside the lock — the fresh file is found', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-write-edit-'));
+    const write = tool('Write');
+    const edit = tool('Edit');
+    // Edit now resolves its target inside the lock (containment + existence check
+    // moved in). This guards that flow: a Write creates a brand-new file, then an
+    // Edit on the same path still resolves and rewrites it.
+    await runTool(write, { path: 'fresh.txt', content: 'hello world\n' }, root);
+    await runTool(edit, { path: 'fresh.txt', old_string: 'world', new_string: 'Maka' }, root);
+    expect(await readFile(join(root, 'fresh.txt'), 'utf8')).toBe('hello Maka\n');
+  });
+
+  test('a failing Edit releases the lock for the next op on the same file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-edit-wedge-'));
+    await writeFile(join(root, 'data.txt'), 'hello world\n', 'utf8');
+    const edit = tool('Edit');
+    // An Edit whose old_string is absent rejects; the lock must not wedge, so the
+    // next Edit on the same file still runs.
+    await expectRejects(runTool(edit, { path: 'data.txt', old_string: 'absent', new_string: 'x' }, root), /./);
+    await runTool(edit, { path: 'data.txt', old_string: 'world', new_string: 'Maka' }, root);
+    expect(await readFile(join(root, 'data.txt'), 'utf8')).toBe('hello Maka\n');
+  });
 });
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/runtime/src/__tests__/file-write-lock.test.ts
+++ b/packages/runtime/src/__tests__/file-write-lock.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for withFileWriteLock — per-key serialization that makes file-mutating
+ * tools race-free when the AI SDK runs a step's tool calls concurrently.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withFileWriteLock } from '../file-write-lock.js';
+
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+describe('withFileWriteLock', () => {
+  test('serializes tasks sharing a key, in submission order', async () => {
+    const events: string[] = [];
+    const task = (id: string) => withFileWriteLock('serialize', async () => {
+      events.push(`${id}:start`);
+      await tick();
+      await tick();
+      events.push(`${id}:end`);
+    });
+    await Promise.all([task('a'), task('b'), task('c')]);
+    // No interleaving: each task fully completes before the next starts.
+    assert.deepEqual(events, [
+      'a:start', 'a:end',
+      'b:start', 'b:end',
+      'c:start', 'c:end',
+    ]);
+  });
+
+  test('different keys run concurrently', async () => {
+    const events: string[] = [];
+    const task = (key: string, id: string) => withFileWriteLock(key, async () => {
+      events.push(`${id}:start`);
+      await tick();
+      events.push(`${id}:end`);
+    });
+    await Promise.all([task('concurrent-x', 'a'), task('concurrent-y', 'b')]);
+    // Both start before either ends — they did not serialize against each other.
+    assert.equal(events[0], 'a:start');
+    assert.equal(events[1], 'b:start');
+    assert.deepEqual(events.slice(2).sort(), ['a:end', 'b:end']);
+  });
+
+  test('no lost update: serialized read-modify-write over a shared cell', async () => {
+    const cell = { value: 0 };
+    // Each task reads, yields, then writes read+1. Unserialized, concurrent tasks
+    // would all read the same value and the final count would be < N.
+    const bump = () => withFileWriteLock('cell', async () => {
+      const seen = cell.value;
+      await tick();
+      cell.value = seen + 1;
+    });
+    await Promise.all(Array.from({ length: 20 }, bump));
+    assert.equal(cell.value, 20);
+  });
+
+  test('a rejecting task does not wedge the key', async () => {
+    const order: string[] = [];
+    const failing = withFileWriteLock('wedge', async () => {
+      order.push('fail');
+      throw new Error('boom');
+    });
+    await assert.rejects(failing, /boom/);
+    const after = await withFileWriteLock('wedge', async () => {
+      order.push('after');
+      return 'ok';
+    });
+    assert.equal(after, 'ok');
+    assert.deepEqual(order, ['fail', 'after']);
+  });
+
+  test('returns the task result and propagates its rejection to the caller', async () => {
+    assert.equal(await withFileWriteLock('result', async () => 42), 42);
+    await assert.rejects(withFileWriteLock('result', async () => { throw new Error('nope'); }), /nope/);
+  });
+});

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -20,12 +20,23 @@ import { runShellWithBoundedTail } from './shell-exec.js';
 // builtin-tools directly.
 import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext };
+import { withFileWriteLock } from './file-write-lock.js';
 
 const execAsync = promisify(exec);
 // Generous wall-clock cap for the ripgrep-backed Grep tool. A search should be
 // near-instant; this only bounds a pathological hang now that the stream
 // watchdog is paused during tool execution.
 const GREP_TIMEOUT_MS = 120_000;
+
+// Key Write and Edit on the lexically resolved absolute path so both lock the
+// same file and spellings ("a", "./a", "d//a") collapse onto one key. realpath
+// canonicalizes only the cwd (which always exists); the path itself stays lexical,
+// so the key is stable across the file's creation and never splits it mid-flight.
+// (withFileWriteLock documents why concurrent writes are serialized and which
+// aliases a lexical key does not merge.)
+async function fileWriteLockKey(cwd: string, inputPath: string): Promise<string> {
+  return resolve(await fs.realpath(cwd), inputPath);
+}
 
 export function buildBuiltinTools(): MakaTool[] {
   return [
@@ -79,9 +90,15 @@ export function buildBuiltinTools(): MakaTool[] {
       parameters: z.object({ path: z.string(), content: z.string() }),
       permissionRequired: true,
       impl: async ({ path, content }, { cwd }) => {
-        const abs = await resolveWritableInsideCwd(cwd, path, 'Write');
-        await fs.writeFile(abs, content, 'utf8');
-        return { ok: true, path: abs, bytes: Buffer.byteLength(content, 'utf8') };
+        // Resolve inside the lock so the containment check and the write are one
+        // atomic critical section per file (no concurrent op can alter the target
+        // between them). The key is lexical, so it is stable whether or not the
+        // file exists yet.
+        return await withFileWriteLock(await fileWriteLockKey(cwd, path), async () => {
+          const abs = await resolveWritableInsideCwd(cwd, path, 'Write');
+          await fs.writeFile(abs, content, 'utf8');
+          return { ok: true, path: abs, bytes: Buffer.byteLength(content, 'utf8') };
+        });
       },
     },
     {
@@ -99,18 +116,24 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: true,
       impl: async ({ path, old_string, new_string }, { cwd }) => {
-        const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
-        const current = await fs.readFile(abs, 'utf8');
-        const result = computeEditedSource(current, old_string, new_string, path);
-        await fs.writeFile(abs, result.content, 'utf8');
-        return {
-          ok: true,
-          path: abs,
-          replacements: 1,
-          matchedVia: result.matchedVia,
-          startLine: result.startLine,
-          endLine: result.endLine,
-        };
+        // Resolve + read + write all inside the lock so the read-modify-write is
+        // one atomic critical section per file. The key is lexical (stable across
+        // creation), so a Write that creates this file and a following Edit share
+        // the lock rather than racing.
+        return await withFileWriteLock(await fileWriteLockKey(cwd, path), async () => {
+          const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
+          const current = await fs.readFile(abs, 'utf8');
+          const result = computeEditedSource(current, old_string, new_string, path);
+          await fs.writeFile(abs, result.content, 'utf8');
+          return {
+            ok: true,
+            path: abs,
+            replacements: 1,
+            matchedVia: result.matchedVia,
+            startLine: result.startLine,
+            endLine: result.endLine,
+          };
+        });
       },
     },
     {

--- a/packages/runtime/src/file-write-lock.ts
+++ b/packages/runtime/src/file-write-lock.ts
@@ -1,0 +1,45 @@
+// packages/runtime/src/file-write-lock.ts
+// Serialize file-mutating tools (Write/Edit) per file. The AI SDK runs a single
+// step's tool calls concurrently, so two edits to one file would race on the
+// read-modify-write (read -> replace -> write back) and silently lose an update.
+// withFileWriteLock(key, fn) runs work sharing a key strictly one-at-a-time, in
+// submission order; distinct keys run concurrently. Callers pass a key that
+// uniquely identifies the target file within their tool surface (the builtin
+// tools key on the resolved absolute path; the headless tools key on a
+// JSON [cwd, path] pair, since the executor boundary hides — and may relocate —
+// the filesystem). A failed task never wedges its key, and keys are reclaimed
+// once their chain drains, so the map stays bounded.
+//
+// Keying is lexical, so one file reached under two names — via a symlinked parent
+// dir, a hard link, or a case-insensitive filesystem ("a.txt" vs "A.txt") — takes
+// two keys and is not merged. This matches opencode's lexical (path.resolve)
+// per-file Semaphore. (Bash is not serialized either — a per-file lock cannot key
+// arbitrary shell.)
+
+const tails = new Map<string, Promise<void>>();
+
+/**
+ * Runs `fn` exclusively for `key`: it waits until any prior work for `key`
+ * settles, then runs, then releases the key for the next waiter. Distinct keys
+ * never block each other.
+ *
+ * @internal Low-level primitive shared with the headless tools via the
+ * `@maka/runtime/file-write-lock` subpath. Not part of the public runtime API —
+ * file tools own the keying, so an external caller would only be sharing this
+ * one process-global queue by accident.
+ */
+export function withFileWriteLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = tails.get(key) ?? Promise.resolve();
+  // Run fn after prev settles either way: a prior failed task must not wedge the
+  // key. `prev.then(fn, fn)` ignores prev's outcome and just sequences.
+  const run = prev.then(fn, fn);
+  // The next waiter chains off `tail`, which tracks completion only (swallowing
+  // result and error) so one task's rejection never propagates down the chain.
+  const tail = run.then(() => {}, () => {});
+  tails.set(key, tail);
+  void tail.then(() => {
+    // Drop the key once nobody chained after us, so the map stays bounded.
+    if (tails.get(key) === tail) tails.delete(key);
+  });
+  return run;
+}


### PR DESCRIPTION
## What

Part of the #92 tool-fidelity work — the P1 item "File lock / serialize writes to the same path (opencode per-file Semaphore)".

The AI SDK runs a step's tool calls concurrently, so a model emitting two `Edit`s (or an `Edit` and a `Write`) to the same file in one step races on the read-modify-write and silently loses an update. opencode prevents this with a per-file `Semaphore`; this adds the equivalent.

## How

- New `KeyedMutex` (`packages/runtime/src/keyed-mutex.ts`): serializes async work per key, runs distinct keys in parallel, recovers if a task throws (a failed edit never wedges the key), and reclaims keys once their chain drains so the map stays bounded.
- Applied to the file-mutating tools on both surfaces that write workspace files:
  - **runtime builtin** `Write` + `Edit` (`builtin-tools.ts`)
  - **benchmark/headless** `Write` + `Edit` (`headless/src/tools.ts`), covering both the `executor.editFile` path and the `EDIT_SCRIPT` read+temp+rename fallback.

`Edit` and `Write` share the same per-file key, so an `Edit` and a `Write` to the same file also serialize; different files stay parallel. The desktop app keeps this `Write` (now locked) and filters `Edit` out, so it inherits the protection; office/oauth/memory writers are separate single-writer paths.

## Key derivation

Both surfaces key on the **lexically resolved path**, derived identically for `Write` and `Edit` so they lock the same file and spellings (`a`, `./a`, `d//a`) collapse to one key. The key is purely lexical (no `stat`/`realpath`), so it is **stable across a file's creation** and never splits one file across two keys mid-flight.

This was a deliberate iteration: an earlier `device:inode` key merged more aliases but was unstable across creation (a missing file keys lexically, then jumps to an inode key once created, so operations on either side of creation could bypass each other). Lexical keying has no such window and matches opencode.

## Known limitations (match opencode's lexical `path.resolve` Semaphore key)

- Aliases of one file addressed under **different names** — a final symlink, a hard link, or a symlinked parent dir — take different keys. (Same name, any spelling, always shares a key.)
- **Bash is not serialized** against file tools: a per-file lock cannot key arbitrary shell. opencode's per-file Semaphore likewise leaves shell uncoordinated.

## Tests

- `KeyedMutex` unit suite: serialization on a shared key, parallelism across distinct keys, no-lost-update over a shared cell, rejection recovery, result/rejection propagation, and key reclamation.
- Concurrent-`Edit` no-lost-update regression on **both** the headless (20 concurrent edits via the shell `EDIT_SCRIPT`) and runtime (20 concurrent direct-fs edits) paths.
- A mixed-spelling case (`data.txt` / `./data.txt`) proving the keys collapse.
- A key-derivation case proving spelling-collapse and stability across creation.
- `npm run -w @maka/runtime test` — 599 pass; `npm run -w @maka/headless test` — 243 pass; full typecheck clean.