### PR TITLE
Add heavy-task progress run state

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -7,6 +7,7 @@ import { BackendRegistry, FakeBackend, SessionManager, type SessionStore, type A
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { Config, Task } from '../contracts.js';
+import type { HeadlessBackendContext } from '../isolation.js';
 import { runAutonomousTask } from '../autonomous-agent-loop.js';
 
 const fakeConfig: Config = {
@@ -54,6 +55,50 @@ class PermissionRequestBackend implements AgentBackend {
 
 const registerPermissionRequestBackend = (registry: BackendRegistry): void => {
   registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId));
+};
+
+class PromptCapturingProgressBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(
+    sessionId: string,
+    private readonly progress: HeadlessBackendContext['heavyTaskProgress'],
+    private readonly prompts: string[],
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.prompts.push(input.text);
+    if (this.prompts.length === 1 && this.progress) {
+      const toolCtx = {
+        sessionId: this.sessionId,
+        turnId: input.turnId,
+        cwd: '/workspace',
+        toolCallId: 'progress-tool-call',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      };
+      await this.progress.recordInventory({
+        summary: 'Inspected public task files.',
+        items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+      }, toolCtx);
+      await this.progress.recordTodos({
+        items: [{ id: 'fix', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
+      }, toolCtx);
+    }
+    const ts = Date.now();
+    yield { type: 'complete', id: `progress-complete-${this.prompts.length}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerPromptCapturingProgressBackend = (prompts: string[]) => (registry: BackendRegistry, context: HeadlessBackendContext): void => {
+  registry.register('fake', (ctx) => new PromptCapturingProgressBackend(ctx.sessionId, context.heavyTaskProgress, prompts));
 };
 
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
@@ -169,6 +214,34 @@ describe('runAutonomousTask', () => {
         result.projection.events.filter((event) => event.type === 'task_run_budget_exhausted').length,
         1,
       );
+    });
+  });
+
+  test('heavy-task continuation prompt includes compact progress from replay', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'README.md'), 'public notes\n', 'utf8');
+      const prompts: string[] = [];
+      const task: Task = {
+        id: 'heavy-progress-retry',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask({ ...fakeConfig, heavyTaskMode: true }, task, {
+        storageRoot,
+        registerBackends: registerPromptCapturingProgressBackend(prompts),
+        budget: { maxAttempts: 2 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 2);
+      assert.equal(result.projection.latestHeavyTaskInventory?.items[0]?.path, 'README.md');
+      assert.equal(result.projection.latestHeavyTaskTodos?.items[0]?.id, 'fix');
+      assert.match(prompts[1] ?? '', /Heavy-task progress state from prior task-run events/);
+      assert.match(prompts[1] ?? '', /Inventory summary: Inspected public task files/);
+      assert.match(prompts[1] ?? '', /Active todo: fix/);
+      assert.equal((prompts[1]?.match(/Heavy-task progress state/g) ?? []).length, 1);
     });
   });
 

--- a/packages/headless/src/__tests__/heavy-task-policy.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-policy.test.ts
@@ -117,7 +117,8 @@ describe('heavy-task policy', () => {
     assert.match(prompt, /Base benchmark prompt/);
     assert.match(prompt, /Heavy-task benchmark policy/);
     assert.match(prompt, /inspect public task files/);
-    assert.match(prompt, /structured progress/);
+    assert.match(prompt, /inventory_submit/);
+    assert.match(prompt, /todo_update/);
     assert.match(prompt, /public, task-derived semantic checks/);
     assert.match(prompt, /Official benchmark scoring remains external and authoritative/);
   });

--- a/packages/headless/src/__tests__/heavy-task-progress.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-progress.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  buildHeavyTaskProgressTools,
+  createHeavyTaskProgressRecorder,
+  heavyTaskInventorySubmitSchema,
+  heavyTaskTodoUpdateSchema,
+  renderHeavyTaskProgressForPrompt,
+} from '../heavy-task-progress.js';
+import type { HeavyTaskInventoryState, HeavyTaskTodoState } from '../task-contracts.js';
+import { createInMemoryTaskRunStore } from '../task-run-store.js';
+
+const toolContext = {
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  cwd: '/workspace',
+  toolCallId: 'tool-1',
+  abortSignal: new AbortController().signal,
+  emitOutput: () => {},
+};
+
+describe('heavy-task progress tools', () => {
+  test('inventory_submit records a typed inventory event and returns structured state', async () => {
+    const store = createInMemoryTaskRunStore();
+    const tools = buildHeavyTaskProgressTools(createHeavyTaskProgressRecorder({
+      taskRunId: 'run-1',
+      attemptId: 'attempt-1',
+      store,
+      now: () => 123,
+      newId: idFactory(),
+    }));
+    const inventorySubmit = tools.find((tool) => tool.name === 'inventory_submit');
+    assert.ok(inventorySubmit);
+
+    const result = await inventorySubmit.impl({
+      summary: 'Inspected public source files.',
+      items: [
+        { path: 'src/app.js', kind: 'file', status: 'observed', purpose: 'main app entry' },
+        { path: 'build-output.log', kind: 'artifact', status: 'planned' },
+      ],
+      openQuestions: ['Need to inspect README.md'],
+    }, toolContext) as { accepted: boolean; inventory: HeavyTaskInventoryState };
+
+    assert.equal(result.accepted, true);
+    assert.equal(result.inventory.taskRunId, 'run-1');
+    assert.equal(result.inventory.source.toolCallId, 'tool-1');
+    const events = await store.readEvents('run-1');
+    assert.equal(events[0]?.type, 'heavy_task_inventory_recorded');
+  });
+
+  test('todo_update records a typed todo snapshot and rejects corrupt progress state', async () => {
+    const store = createInMemoryTaskRunStore();
+    const tools = buildHeavyTaskProgressTools(createHeavyTaskProgressRecorder({
+      taskRunId: 'run-2',
+      store,
+      now: () => 456,
+      newId: idFactory(),
+    }));
+    const todoUpdate = tools.find((tool) => tool.name === 'todo_update');
+    assert.ok(todoUpdate);
+
+    const result = await todoUpdate.impl({
+      items: [
+        { id: 'inspect', content: 'Inspect public files', status: 'completed', priority: 'high' },
+        { id: 'edit', content: 'Patch implementation', status: 'in_progress', priority: 'high' },
+      ],
+    }, toolContext) as { accepted: boolean; todos: HeavyTaskTodoState };
+
+    assert.equal(result.accepted, true);
+    assert.equal(result.todos.items[1]?.status, 'in_progress');
+    assert.throws(() => heavyTaskTodoUpdateSchema.parse({
+      items: [
+        { id: 'same', content: 'First', status: 'pending', priority: 'medium' },
+        { id: 'same', content: 'Second', status: 'pending', priority: 'low' },
+      ],
+    }), /duplicate todo id/);
+    assert.throws(() => heavyTaskTodoUpdateSchema.parse({
+      items: [
+        { id: 'one', content: 'First', status: 'in_progress', priority: 'medium' },
+        { id: 'two', content: 'Second', status: 'in_progress', priority: 'low' },
+      ],
+    }), /at most one todo item/);
+    assert.throws(() => heavyTaskInventorySubmitSchema.parse({
+      summary: 'x'.repeat(2_001),
+      items: [],
+    }));
+  });
+
+  test('renders compact replay state for prompts', () => {
+    const rendered = renderHeavyTaskProgressForPrompt({
+      latestHeavyTaskInventory: {
+        schemaVersion: 1,
+        inventoryId: 'inventory-1',
+        taskRunId: 'run-3',
+        ts: 1,
+        summary: 'Inspected source and README.',
+        items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+        source: { kind: 'model_tool', toolCallId: 'tool-1' },
+      },
+      latestHeavyTaskTodos: {
+        schemaVersion: 1,
+        todoSetId: 'todos-1',
+        taskRunId: 'run-3',
+        ts: 2,
+        items: [{ id: 'edit', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
+        source: { kind: 'model_tool', toolCallId: 'tool-2' },
+      },
+    });
+
+    assert.match(rendered ?? '', /Heavy-task progress state/);
+    assert.match(rendered ?? '', /README\.md/);
+    assert.match(rendered ?? '', /Active todo: edit/);
+  });
+});
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
+}

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -172,6 +172,57 @@ describe('task run export', () => {
     ], 'run-default'));
 
     assert.equal(exported.policy, undefined);
+    assert.equal(exported.progress, undefined);
+  });
+
+  test('exports heavy-task progress snapshots and compact result progress', async () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-progress', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'heavy_task_inventory_recorded',
+        id: 'e2',
+        taskRunId: 'run-progress',
+        ts: 2,
+        inventory: {
+          schemaVersion: 1,
+          inventoryId: 'inventory-1',
+          taskRunId: 'run-progress',
+          ts: 2,
+          summary: 'Inspected public files',
+          items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-1' },
+        },
+      },
+      {
+        type: 'heavy_task_todos_recorded',
+        id: 'e3',
+        taskRunId: 'run-progress',
+        ts: 3,
+        todos: {
+          schemaVersion: 1,
+          todoSetId: 'todos-1',
+          taskRunId: 'run-progress',
+          ts: 3,
+          items: [{ id: 'edit', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-2' },
+        },
+      },
+    ], 'run-progress');
+    const exported = taskRunExportFromProjection(projection, { exportedAt: '2026-06-19T00:00:00.000Z' });
+
+    assert.equal(exported.progress?.inventory?.latest.inventoryId, 'inventory-1');
+    assert.equal(exported.progress?.inventory?.historyCount, 1);
+    assert.equal(exported.progress?.todos?.latest.todoSetId, 'todos-1');
+    assert.equal(exported.progress?.todos?.historyCount, 1);
+
+    const outDir = await mkdtemp(join(tmpdir(), 'maka-progress-export-'));
+    try {
+      const written = await writeTaskRunExport(outDir, projection, { exportedAt: '2026-06-19T00:00:00.000Z' });
+      const compact = JSON.parse(await readFile(written.files.resultJson, 'utf8')) as { progress?: unknown };
+      assert.deepEqual(compact.progress, exported.progress);
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
   });
 
   test('exports official verifier truth over a non-authoritative placeholder result', async () => {

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -7,9 +7,11 @@ import { BackendRegistry, FakeBackend, SessionManager, type AgentBackend, type S
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { Config, Task } from '../contracts.js';
+import type { HeadlessBackendContext } from '../isolation.js';
 import { commandResourceScope, hashNormalizedArgs } from '../permission-grants.js';
 import { runTaskOnce } from '../task-agent-controller.js';
 import type { TaskPermissionGrant } from '../task-contracts.js';
+import { buildIsolatedHeadlessTools } from '../tools.js';
 
 const fakeConfig: Config = {
   id: 'fake-cfg',
@@ -226,6 +228,59 @@ const registerPermissionRequestBackend = (onRespond: () => void, command = 'rm -
   registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId, onRespond, command));
 };
 
+class ProgressToolBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: {
+    sessionId: string;
+    header: SessionHeader;
+    tools: ReturnType<typeof buildIsolatedHeadlessTools>;
+  }) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    const inventorySubmit = this.ctx.tools.find((tool) => tool.name === 'inventory_submit');
+    const todoUpdate = this.ctx.tools.find((tool) => tool.name === 'todo_update');
+    assert.ok(inventorySubmit);
+    assert.ok(todoUpdate);
+    const toolCtx = {
+      sessionId: this.sessionId,
+      turnId: input.turnId,
+      cwd: this.ctx.header.cwd,
+      toolCallId: 'progress-tool-call',
+      abortSignal: new AbortController().signal,
+      emitOutput: () => {},
+    };
+    await inventorySubmit.impl({
+      summary: 'Inspected public files.',
+      items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+    }, toolCtx);
+    await todoUpdate.impl({
+      items: [{ id: 'edit', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
+    }, toolCtx);
+    const ts = Date.now();
+    yield { type: 'complete', id: 'progress-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerProgressToolBackend = (seen: HeadlessBackendContext[]) => (registry: BackendRegistry, context: HeadlessBackendContext): void => {
+  seen.push(context);
+  assert.ok(context.toolExecutor);
+  registry.register('ai-sdk', (ctx) => new ProgressToolBackend({
+    sessionId: ctx.sessionId,
+    header: ctx.header,
+    tools: buildIsolatedHeadlessTools(context.toolExecutor!, {
+      ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+    }),
+  }));
+};
+
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
   const fixtureDir = await mkdtemp(join(tmpdir(), 'maka-task-controller-fx-'));
   const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-controller-store-'));
@@ -313,6 +368,56 @@ describe('runTaskOnce', () => {
       assert.equal(result.projection.latestVerifierResult?.authority, undefined);
       assert.equal(result.projection.latestScoreResult?.taxonomy, 'passed');
       assert.equal(result.resultRecord.passed, true);
+      assert.ok(!result.projection.toolExecutors[0]?.toolNames.includes('inventory_submit'));
+      assert.ok(!result.projection.toolExecutors[0]?.toolNames.includes('todo_update'));
+    });
+  });
+
+  test('enabled heavy-task run exposes progress tools and records submitted snapshots', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      await writeFile(join(fixtureDir, 'README.md'), 'public task notes\n', 'utf8');
+      const seenContexts: HeadlessBackendContext[] = [];
+      const config: Config = {
+        ...fakeConfig,
+        backend: 'ai-sdk',
+        heavyTaskMode: true,
+      };
+      const task: Task = {
+        id: 'progress-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f README.md', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(config, task, {
+        storageRoot,
+        registerBackends: registerProgressToolBackend(seenContexts),
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+
+      assert.equal(seenContexts[0]?.heavyTaskMode?.enabled, true);
+      assert.ok(seenContexts[0]?.heavyTaskProgress);
+      assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('inventory_submit'));
+      assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('todo_update'));
+      assert.equal(result.projection.latestHeavyTaskInventory?.summary, 'Inspected public files.');
+      assert.equal(result.projection.latestHeavyTaskInventory?.items[0]?.path, 'README.md');
+      assert.equal(result.projection.latestHeavyTaskTodos?.items[0]?.status, 'in_progress');
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'heavy_task_inventory_recorded').length,
+        1,
+      );
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'heavy_task_todos_recorded').length,
+        1,
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -142,6 +142,78 @@ describe('TaskRunStore', () => {
     });
   });
 
+  test('projects heavy-task inventory and todo snapshots from replay order', () => {
+    const taskRunId = 'tr-progress';
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'heavy_task_inventory_recorded',
+        id: 'e-2',
+        taskRunId,
+        ts: 2,
+        inventory: {
+          schemaVersion: 1,
+          inventoryId: 'inventory-1',
+          taskRunId,
+          ts: 2,
+          summary: 'Initial inventory',
+          items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-1' },
+        },
+      },
+      {
+        type: 'heavy_task_todos_recorded',
+        id: 'e-3',
+        taskRunId,
+        ts: 3,
+        todos: {
+          schemaVersion: 1,
+          todoSetId: 'todos-1',
+          taskRunId,
+          ts: 3,
+          items: [{ id: 'inspect', content: 'Inspect files', status: 'in_progress', priority: 'high' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-2' },
+        },
+      },
+      {
+        type: 'heavy_task_inventory_recorded',
+        id: 'e-4',
+        taskRunId,
+        ts: 4,
+        inventory: {
+          schemaVersion: 1,
+          inventoryId: 'inventory-2',
+          taskRunId,
+          ts: 4,
+          summary: 'Updated inventory',
+          items: [{ path: 'src/app.js', kind: 'file', status: 'planned' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-3' },
+        },
+      },
+      {
+        type: 'heavy_task_todos_recorded',
+        id: 'e-5',
+        taskRunId,
+        ts: 5,
+        todos: {
+          schemaVersion: 1,
+          todoSetId: 'todos-2',
+          taskRunId,
+          ts: 5,
+          items: [{ id: 'edit', content: 'Patch implementation', status: 'pending', priority: 'medium' }],
+          source: { kind: 'model_tool', toolCallId: 'tool-4' },
+        },
+      },
+    ], taskRunId);
+
+    assert.equal(projection.heavyTaskInventory.length, 2);
+    assert.equal(projection.latestHeavyTaskInventory?.inventoryId, 'inventory-2');
+    assert.equal(projection.latestHeavyTaskInventory?.items[0]?.path, 'src/app.js');
+    assert.equal(projection.heavyTaskTodoStates.length, 2);
+    assert.equal(projection.latestHeavyTaskTodos?.todoSetId, 'todos-2');
+    assert.equal(projection.latestHeavyTaskTodos?.items[0]?.id, 'edit');
+  });
+
   test('projects isolation, permission, inbox, and needs_approval facts', () => {
     const taskRunId = 'tr-approval';
     const request = {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -65,9 +65,47 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('agent_spawn'));
     assert.ok(names.includes('agent_list'));
     assert.ok(names.includes('agent_output'));
+    assert.ok(!names.includes('inventory_submit'));
+    assert.ok(!names.includes('todo_update'));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
+  });
+
+  test('progress tools are included only when heavy-task progress is enabled', () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    }, {
+      heavyTaskProgress: {
+        async recordInventory(input) {
+          return {
+            schemaVersion: 1,
+            inventoryId: 'inventory-1',
+            taskRunId: 'run-1',
+            ts: 1,
+            summary: input.summary,
+            items: input.items,
+            source: { kind: 'model_tool', toolCallId: 'tool-1' },
+          };
+        },
+        async recordTodos(input) {
+          return {
+            schemaVersion: 1,
+            todoSetId: 'todos-1',
+            taskRunId: 'run-1',
+            ts: 1,
+            items: input.items,
+            source: { kind: 'model_tool', toolCallId: 'tool-1' },
+          };
+        },
+      },
+    });
+
+    const names = tools.map((tool) => tool.name);
+    assert.ok(names.includes('inventory_submit'));
+    assert.ok(names.includes('todo_update'));
   });
 
   test('Read, Write, Edit, Glob, and Grep delegate to native isolated executor methods', async () => {

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { validateRealBackendIsolation } from './isolation.js';
+import { resolveHeavyTaskMode } from './heavy-task-policy.js';
+import { renderHeavyTaskProgressForPrompt } from './heavy-task-progress.js';
 import {
   backendNeedsIsolation,
   validateTaskVerification,
@@ -271,7 +273,7 @@ export async function runAutonomousTask(
       budget: afterAttemptBudget,
       feedback: [verifierFeedback],
       ...(selfCheck ? { selfCheck } : {}),
-    }) ?? defaultContinuationPrompt(task, attempt, selfCheck);
+    }) ?? defaultContinuationPrompt(config, task, attempt, selfCheck);
 
     await appendDecision(
       taskRunStore,
@@ -738,18 +740,23 @@ function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
 }
 
 function defaultContinuationPrompt(
+  config: Config,
   task: Task,
   attempt: RunTaskOnceResult,
   selfCheck: SelfCheckObservation | undefined,
 ): string {
   const taxonomy = taxonomyFromResultRecord(attempt.resultRecord);
   const selfCheckLine = selfCheck ? `\nAdvisory self-check: ${selfCheck.summary}` : '';
+  const progressBlock = resolveHeavyTaskMode(config, task).enabled
+    ? renderHeavyTaskProgressForPrompt(attempt.projection)
+    : undefined;
+  const progressLine = progressBlock ? `\n\n${progressBlock}` : '';
   return `${task.instruction}
 
 Previous autonomous attempt did not pass authoritative verification.
 Verifier taxonomy: ${taxonomy}.
 Verification exit code: ${attempt.resultRecord.exitCode ?? 'none'}.
-Continue from that feedback and produce a corrected solution.${selfCheckLine}`;
+Continue from that feedback and produce a corrected solution.${selfCheckLine}${progressLine}`;
 }
 
 function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {

--- a/packages/headless/src/heavy-task-policy.ts
+++ b/packages/headless/src/heavy-task-policy.ts
@@ -81,8 +81,9 @@ export function buildHeavyTaskSystemPromptPolicy(
   return [
     `Heavy-task benchmark policy (${selection.policyVersion})`,
     '',
-    '- Work like a persistent engineer on a long-running task: inspect public task files and workspace state before editing, keep compact progress notes when useful, and preserve evidence that helps continue the work.',
-    '- Maintain structured progress in public workspace artifacts or concise notes when the task benefits from it; do not invent dedicated progress tools that are not available.',
+    '- Work like a persistent engineer on a long-running task: inspect public task files and workspace state before editing, keep compact evidence that helps continue the work, and avoid relying on assistant prose as durable state.',
+    '- Use inventory_submit to submit a structured inventory snapshot after initial public inspection and whenever the important workspace/artifact inventory changes.',
+    '- Use todo_update to submit the full current todo/progress snapshot as work advances. Keep at most one item in_progress, and treat todo completion as advisory progress rather than benchmark success.',
     '- You may run public, task-derived semantic checks such as visible tests, builds, sample commands, or artifact inspections. Treat those checks as advisory engineering feedback.',
     '- Official benchmark scoring remains external and authoritative. Do not claim success solely from your own checks, and do not replace verifier results with self-checks.',
     `- Do not seek, infer, read, or rely on forbidden evaluator material: ${FORBIDDEN_HEAVY_TASK_POLICY_TERMS.join(', ')}.`,

--- a/packages/headless/src/heavy-task-progress.ts
+++ b/packages/headless/src/heavy-task-progress.ts
@@ -1,0 +1,204 @@
+import type { MakaTool, MakaToolContext } from '@maka/runtime';
+import { z } from 'zod';
+import type {
+  HeavyTaskInventoryState,
+  HeavyTaskTodoState,
+  TaskEvent,
+} from './task-contracts.js';
+import type { TaskRunStore } from './task-run-store.js';
+
+export const HEAVY_TASK_PROGRESS_TOOL_NAMES = ['inventory_submit', 'todo_update'] as const;
+
+const MAX_SUMMARY_CHARS = 2_000;
+const MAX_ITEM_CHARS = 1_000;
+const MAX_PATH_CHARS = 500;
+const MAX_INVENTORY_ITEMS = 100;
+const MAX_TODO_ITEMS = 100;
+const MAX_OPEN_QUESTIONS = 25;
+
+export const heavyTaskInventoryItemSchema = z.object({
+  path: z.string().trim().min(1).max(MAX_PATH_CHARS),
+  kind: z.enum(['file', 'directory', 'artifact', 'command', 'unknown']),
+  status: z.enum(['observed', 'planned', 'unknown']),
+  purpose: z.string().trim().min(1).max(MAX_ITEM_CHARS).optional(),
+  evidence: z.string().trim().min(1).max(MAX_ITEM_CHARS).optional(),
+}).strict();
+
+export const heavyTaskInventorySubmitSchema = z.object({
+  summary: z.string().trim().min(1).max(MAX_SUMMARY_CHARS),
+  items: z.array(heavyTaskInventoryItemSchema).max(MAX_INVENTORY_ITEMS),
+  openQuestions: z.array(z.string().trim().min(1).max(MAX_ITEM_CHARS)).max(MAX_OPEN_QUESTIONS).optional(),
+}).strict();
+
+export const heavyTaskTodoItemSchema = z.object({
+  id: z.string().trim().min(1).max(80).regex(/^[A-Za-z0-9._:-]+$/),
+  content: z.string().trim().min(1).max(MAX_ITEM_CHARS),
+  status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']),
+  priority: z.enum(['high', 'medium', 'low']),
+  evidence: z.string().trim().min(1).max(MAX_ITEM_CHARS).optional(),
+}).strict();
+
+export const heavyTaskTodoUpdateSchema = z.object({
+  items: z.array(heavyTaskTodoItemSchema).max(MAX_TODO_ITEMS),
+}).strict().superRefine((value, ctx) => {
+  const ids = new Set<string>();
+  let inProgress = 0;
+  for (const item of value.items) {
+    if (ids.has(item.id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['items'],
+        message: `duplicate todo id: ${item.id}`,
+      });
+    }
+    ids.add(item.id);
+    if (item.status === 'in_progress') inProgress += 1;
+  }
+  if (inProgress > 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['items'],
+      message: 'at most one todo item may be in_progress',
+    });
+  }
+});
+
+export type HeavyTaskInventorySubmitInput = z.infer<typeof heavyTaskInventorySubmitSchema>;
+export type HeavyTaskTodoUpdateInput = z.infer<typeof heavyTaskTodoUpdateSchema>;
+
+export interface HeavyTaskProgressRecorder {
+  recordInventory(input: HeavyTaskInventorySubmitInput, ctx: MakaToolContext): Promise<HeavyTaskInventoryState>;
+  recordTodos(input: HeavyTaskTodoUpdateInput, ctx: MakaToolContext): Promise<HeavyTaskTodoState>;
+}
+
+export function createHeavyTaskProgressRecorder(input: {
+  taskRunId: string;
+  attemptId?: string;
+  store: TaskRunStore;
+  now: () => number;
+  newId: () => string;
+}): HeavyTaskProgressRecorder {
+  return {
+    async recordInventory(args, ctx) {
+      const ts = input.now();
+      const inventory: HeavyTaskInventoryState = {
+        schemaVersion: 1,
+        inventoryId: input.newId(),
+        taskRunId: input.taskRunId,
+        ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+        ts,
+        summary: args.summary,
+        items: args.items,
+        ...(args.openQuestions ? { openQuestions: args.openQuestions } : {}),
+        source: sourceFromContext(ctx),
+      };
+      await input.store.appendEvent(input.taskRunId, {
+        type: 'heavy_task_inventory_recorded',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts,
+        inventory,
+      });
+      return inventory;
+    },
+    async recordTodos(args, ctx) {
+      const ts = input.now();
+      const todos: HeavyTaskTodoState = {
+        schemaVersion: 1,
+        todoSetId: input.newId(),
+        taskRunId: input.taskRunId,
+        ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+        ts,
+        items: args.items,
+        source: sourceFromContext(ctx),
+      };
+      await input.store.appendEvent(input.taskRunId, {
+        type: 'heavy_task_todos_recorded',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts,
+        todos,
+      });
+      return todos;
+    },
+  };
+}
+
+export function buildHeavyTaskProgressTools(recorder: HeavyTaskProgressRecorder): MakaTool[] {
+  return [
+    {
+      name: 'inventory_submit',
+      description: 'Submit a full structured inventory snapshot for this heavy-task run.',
+      parameters: heavyTaskInventorySubmitSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const inventory = await recorder.recordInventory(heavyTaskInventorySubmitSchema.parse(args), ctx);
+        return { accepted: true, inventory };
+      },
+    },
+    {
+      name: 'todo_update',
+      description: 'Submit the full current todo/progress snapshot for this heavy-task run.',
+      parameters: heavyTaskTodoUpdateSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const todos = await recorder.recordTodos(heavyTaskTodoUpdateSchema.parse(args), ctx);
+        return { accepted: true, todos };
+      },
+    },
+  ];
+}
+
+export function renderHeavyTaskProgressForPrompt(projection: {
+  latestHeavyTaskInventory?: HeavyTaskInventoryState;
+  latestHeavyTaskTodos?: HeavyTaskTodoState;
+}): string | undefined {
+  const inventory = projection.latestHeavyTaskInventory;
+  const todos = projection.latestHeavyTaskTodos;
+  if (!inventory && !todos) return undefined;
+
+  const lines = [
+    'Heavy-task progress state from prior task-run events:',
+  ];
+  if (inventory) {
+    lines.push(`- Inventory summary: ${oneLine(inventory.summary, 240)}`);
+    for (const item of inventory.items.slice(0, 12)) {
+      const purpose = item.purpose ? ` - ${oneLine(item.purpose, 120)}` : '';
+      lines.push(`  - ${item.kind}:${item.status} ${oneLine(item.path, 120)}${purpose}`);
+    }
+    if (inventory.items.length > 12) {
+      lines.push(`  - ${inventory.items.length - 12} more inventory item(s) omitted`);
+    }
+    if (inventory.openQuestions?.length) {
+      lines.push(`- Open questions: ${inventory.openQuestions.slice(0, 5).map((value) => oneLine(value, 120)).join('; ')}`);
+    }
+  }
+  if (todos) {
+    const active = todos.items.find((item) => item.status === 'in_progress');
+    lines.push(`- Active todo: ${active ? active.id : 'none'}`);
+    for (const item of todos.items.slice(0, 12)) {
+      lines.push(`  - [${item.status}] (${item.priority}) ${item.id}: ${oneLine(item.content, 160)}`);
+    }
+    if (todos.items.length > 12) {
+      lines.push(`  - ${todos.items.length - 12} more todo item(s) omitted`);
+    }
+  }
+  lines.push('Use inventory_submit and todo_update to refresh this state when it changes.');
+  return lines.join('\n');
+}
+
+function sourceFromContext(ctx: MakaToolContext): HeavyTaskInventoryState['source'] {
+  return {
+    kind: 'model_tool',
+    toolCallId: ctx.toolCallId,
+    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+  };
+}
+
+function oneLine(value: string, maxChars: number): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  return clean.length <= maxChars ? clean : `${clean.slice(0, maxChars - 3)}...`;
+}
+
+export type HeavyTaskProgressEvent = Extract<TaskEvent, { type: 'heavy_task_inventory_recorded' | 'heavy_task_todos_recorded' }>;

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -156,6 +156,14 @@ export type {
   AutonomousResultTaxonomy,
   EnvNetworkSecretPolicy,
   FeedbackObservation,
+  HeavyTaskInventoryItem,
+  HeavyTaskInventoryRecordedEvent,
+  HeavyTaskInventoryState,
+  HeavyTaskModeRecordedEvent,
+  HeavyTaskProgressSource,
+  HeavyTaskTodoItem,
+  HeavyTaskTodoState,
+  HeavyTaskTodosRecordedEvent,
   HeadlessInterventionMode,
   IsolationPolicyRecordedEvent,
   PermissionDecision,
@@ -283,6 +291,21 @@ export {
   type HeavyTaskModeSelection,
   type HeavyTaskModeTriggerSource,
 } from './heavy-task-policy.js';
+export type {
+  HeavyTaskInventorySubmitInput,
+  HeavyTaskProgressRecorder,
+  HeavyTaskTodoUpdateInput,
+} from './heavy-task-progress.js';
+export {
+  buildHeavyTaskProgressTools,
+  createHeavyTaskProgressRecorder,
+  heavyTaskInventoryItemSchema,
+  heavyTaskInventorySubmitSchema,
+  heavyTaskTodoItemSchema,
+  heavyTaskTodoUpdateSchema,
+  HEAVY_TASK_PROGRESS_TOOL_NAMES,
+  renderHeavyTaskProgressForPrompt,
+} from './heavy-task-progress.js';
 export type {
   HeadlessBackendContext,
   IsolatedCommandInput,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,4 +1,6 @@
 import type { Config, Task } from './contracts.js';
+import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
+import type { HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import type {
   EnvNetworkSecretPolicy,
   TaskIsolationFacts,
@@ -130,6 +132,10 @@ export interface HeadlessBackendContext {
   realBackendIsolation?: RealBackendIsolation;
   /** Convenience alias for realBackendIsolation.toolExecutor. */
   toolExecutor?: IsolatedToolExecutor;
+  /** Heavy-task selection resolved for this task run. */
+  heavyTaskMode?: HeavyTaskModeSelection;
+  /** Present only when heavy-task mode is enabled for task-run backed tooling. */
+  heavyTaskProgress?: HeavyTaskProgressRecorder;
 }
 
 export function validateRealBackendIsolation(isolation: RealBackendIsolation | undefined): void {

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -53,6 +53,16 @@ export interface TaskRunExport {
   policy?: {
     heavyTask?: TaskRunProjection['heavyTaskMode'];
   };
+  progress?: {
+    inventory?: {
+      latest: NonNullable<TaskRunProjection['latestHeavyTaskInventory']>;
+      historyCount: number;
+    };
+    todos?: {
+      latest: NonNullable<TaskRunProjection['latestHeavyTaskTodos']>;
+      historyCount: number;
+    };
+  };
   isolation: {
     policy?: TaskRunProjection['isolation'];
     toolExecutors: TaskRunProjection['toolExecutors'];
@@ -128,6 +138,7 @@ export function taskRunExportFromProjection(
   const taxonomy = score?.taxonomy ?? projection.result?.taxonomy ?? legacyResultRecord.errorClass ?? projection.status;
   const primaryWorkspacePath = primaryWorkspacePathFromArtifacts(projection.artifacts);
   const policy = projection.heavyTaskMode?.enabled ? { heavyTask: projection.heavyTaskMode } : undefined;
+  const progress = progressFromProjection(projection);
 
   return {
     schemaVersion: 'maka.task_run_export.v1',
@@ -173,6 +184,7 @@ export function taskRunExportFromProjection(
     score,
     budget: recordValue(scoreDetails.budget) ? scoreDetails.budget as Record<string, unknown> : undefined,
     policy,
+    progress,
     isolation: {
       policy: projection.isolation,
       toolExecutors: projection.toolExecutors,
@@ -258,6 +270,7 @@ function compactResultView(exported: TaskRunExport): Record<string, unknown> {
       : undefined,
     score: exported.score,
     policy: exported.policy,
+    progress: exported.progress,
     workspace: exported.workspace,
     artifacts: exported.artifacts,
     legacyResultRecord: exported.legacyResultRecord,
@@ -266,6 +279,23 @@ function compactResultView(exported: TaskRunExport): Record<string, unknown> {
 
 function runtimeRefsFromFeedback(projection: TaskRunProjection): unknown {
   return projection.feedback.find((observation) => recordValue(observation.details?.runtimeRefs))?.details?.runtimeRefs;
+}
+
+function progressFromProjection(projection: TaskRunProjection): TaskRunExport['progress'] {
+  const progress: NonNullable<TaskRunExport['progress']> = {};
+  if (projection.latestHeavyTaskInventory) {
+    progress.inventory = {
+      latest: projection.latestHeavyTaskInventory,
+      historyCount: projection.heavyTaskInventory.length,
+    };
+  }
+  if (projection.latestHeavyTaskTodos) {
+    progress.todos = {
+      latest: projection.latestHeavyTaskTodos,
+      historyCount: projection.heavyTaskTodoStates.length,
+    };
+  }
+  return progress.inventory || progress.todos ? progress : undefined;
 }
 
 function runtimeEventIdsFrom(runtimeRefs: unknown): string[] {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -25,6 +25,11 @@ import {
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import { configWithHeavyTaskPolicy, resolveHeavyTaskMode } from './heavy-task-policy.js';
+import {
+  createHeavyTaskProgressRecorder,
+  HEAVY_TASK_PROGRESS_TOOL_NAMES,
+  renderHeavyTaskProgressForPrompt,
+} from './heavy-task-progress.js';
 import type { HeadlessBackendContext } from './isolation.js';
 import {
   ISOLATED_HEADLESS_TOOL_NAMES,
@@ -120,7 +125,6 @@ export async function runTaskOnce(
   const newId = deps.newId ?? randomUUID;
   const taskRunId = deps.taskRunId ?? newId();
   const attemptId = deps.attemptId ?? `${taskRunId}-attempt-1`;
-  const instruction = deps.instructionOverride ?? task.instruction;
   const createTaskRun = deps.createTaskRun ?? true;
   const closeTaskRun = deps.closeTaskRun ?? true;
   const interventionPolicy = deps.interventionPolicy ?? DEFAULT_INTERVENTION_POLICY;
@@ -132,6 +136,13 @@ export async function runTaskOnce(
   const verifier = normalizeVerifier(task);
   const heavyTaskMode = resolveHeavyTaskMode(config, task);
   const effectiveConfig = configWithHeavyTaskPolicy(config, heavyTaskMode);
+  const priorProgressPrompt = heavyTaskMode.enabled
+    ? renderHeavyTaskProgressForPrompt(await taskRunStore.project(taskRunId))
+    : undefined;
+  const instruction = withOptionalProgressPrompt(deps.instructionOverride ?? task.instruction, priorProgressPrompt);
+  const heavyTaskProgress = heavyTaskMode.enabled
+    ? createHeavyTaskProgressRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
+    : undefined;
 
   if (createTaskRun) {
     await appendTaskEvent(taskRunStore, taskRunId, {
@@ -213,7 +224,7 @@ export async function runTaskOnce(
         taskRunId,
         attemptId,
         isolation: deps.realBackendIsolation,
-        toolNames: deps.realBackendIsolation?.toolExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'],
+        toolNames: toolNamesForIdentity(Boolean(deps.realBackendIsolation?.toolExecutor), heavyTaskMode.enabled),
       }),
     });
     const backends = new BackendRegistry();
@@ -223,6 +234,8 @@ export async function runTaskOnce(
       config: effectiveConfig,
       task,
       workspaceDir: workspace.dir,
+      heavyTaskMode,
+      ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),
@@ -458,6 +471,19 @@ export async function runTaskOnce(
 
 const DEFAULT_INTERVENTION_POLICY: TaskInterventionPolicy = { mode: 'fail_closed' };
 const DEFAULT_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+
+function withOptionalProgressPrompt(instruction: string, progressPrompt: string | undefined): string {
+  if (!progressPrompt || instruction.includes('Heavy-task progress state from prior task-run events:')) {
+    return instruction;
+  }
+  return `${instruction}\n\n${progressPrompt}`;
+}
+
+function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: boolean): string[] {
+  const names = hasIsolatedExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'];
+  if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES);
+  return names;
+}
 
 interface PermissionInterventionInput {
   invocation: InvocationResult;

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -282,6 +282,51 @@ export interface HeavyTaskModeFacts {
   policyVersion: string;
 }
 
+export interface HeavyTaskProgressSource {
+  kind: 'model_tool';
+  toolCallId: string;
+  sessionId?: string;
+  turnId?: string;
+}
+
+export interface HeavyTaskInventoryItem {
+  path: string;
+  kind: 'file' | 'directory' | 'artifact' | 'command' | 'unknown';
+  status: 'observed' | 'planned' | 'unknown';
+  purpose?: string;
+  evidence?: string;
+}
+
+export interface HeavyTaskInventoryState {
+  schemaVersion: 1;
+  inventoryId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  summary: string;
+  items: HeavyTaskInventoryItem[];
+  openQuestions?: string[];
+  source: HeavyTaskProgressSource;
+}
+
+export interface HeavyTaskTodoItem {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  priority: 'high' | 'medium' | 'low';
+  evidence?: string;
+}
+
+export interface HeavyTaskTodoState {
+  schemaVersion: 1;
+  todoSetId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  items: HeavyTaskTodoItem[];
+  source: HeavyTaskProgressSource;
+}
+
 export interface EnvNetworkSecretPolicy {
   schemaVersion: 1;
   env: 'inherit_none' | 'allowlist';
@@ -484,6 +529,16 @@ export interface HeavyTaskModeRecordedEvent extends BaseTaskEvent {
   facts: HeavyTaskModeFacts;
 }
 
+export interface HeavyTaskInventoryRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_inventory_recorded';
+  inventory: HeavyTaskInventoryState;
+}
+
+export interface HeavyTaskTodosRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_todos_recorded';
+  todos: HeavyTaskTodoState;
+}
+
 export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
   type: 'workspace_lease_recorded';
   lease: WorkspaceLeaseFacts;
@@ -608,6 +663,8 @@ export type TaskEvent =
   | TaskRunArtifactRecordedEvent
   | ScoreResultRecordedEvent
   | HeavyTaskModeRecordedEvent
+  | HeavyTaskInventoryRecordedEvent
+  | HeavyTaskTodosRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent
   | ToolExecutorIdentityRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -4,8 +4,10 @@ import type { ResultRecord } from './contracts.js';
 import type {
   AutonomousDecision,
   FeedbackObservation,
+  HeavyTaskInventoryState,
   TaskInboxItem,
   HeavyTaskModeFacts,
+  HeavyTaskTodoState,
   TaskIsolationFacts,
   TaskPermissionGrant,
   TaskPermissionRequest,
@@ -40,6 +42,10 @@ export interface TaskRunProjection extends TaskRun {
   latestVerifierResult?: VerifierResult;
   latestScoreResult?: ScoreResult;
   heavyTaskMode?: HeavyTaskModeFacts;
+  heavyTaskInventory: HeavyTaskInventoryState[];
+  latestHeavyTaskInventory?: HeavyTaskInventoryState;
+  heavyTaskTodoStates: HeavyTaskTodoState[];
+  latestHeavyTaskTodos?: HeavyTaskTodoState;
   isolation?: TaskIsolationFacts;
   workspaceLease?: WorkspaceLeaseFacts;
   parked?: TaskRunParkedState;
@@ -80,6 +86,8 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     permissionRequests: [],
     inboxItems: [],
     warnings: [],
+    heavyTaskInventory: [],
+    heavyTaskTodoStates: [],
   };
   const attempts = new Map<string, TaskAttempt>();
   const inboxItems = new Map<string, TaskInboxItem>();
@@ -148,6 +156,14 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         break;
       case 'heavy_task_mode_recorded':
         projection.heavyTaskMode = event.facts;
+        break;
+      case 'heavy_task_inventory_recorded':
+        projection.heavyTaskInventory.push(event.inventory);
+        projection.latestHeavyTaskInventory = event.inventory;
+        break;
+      case 'heavy_task_todos_recorded':
+        projection.heavyTaskTodoStates.push(event.todos);
+        projection.latestHeavyTaskTodos = event.todos;
         break;
       case 'isolation_policy_recorded':
         projection.isolation = event.facts;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -5,14 +5,22 @@ import {
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
+import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import type { IsolatedToolExecutor } from './isolation.js';
+
+export interface BuildIsolatedHeadlessToolsOptions {
+  heavyTaskProgress?: HeavyTaskProgressRecorder;
+}
 
 /**
  * Build Maka's standard headless tool surface with shell and file operations
  * routed through the isolated executor boundary.
  */
-export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): MakaTool[] {
-  return [
+export function buildIsolatedHeadlessTools(
+  executor: IsolatedToolExecutor,
+  options: BuildIsolatedHeadlessToolsOptions = {},
+): MakaTool[] {
+  const tools = [
     buildIsolatedBashTool(executor),
     buildIsolatedReadTool(executor),
     buildIsolatedWriteTool(executor),
@@ -22,6 +30,10 @@ export function buildIsolatedHeadlessTools(executor: IsolatedToolExecutor): Maka
     buildSubagentSpawnTool(),
     ...buildSubagentProjectionTools(),
   ];
+  if (options.heavyTaskProgress) {
+    tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));
+  }
+  return tools;
 }
 
 export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig {


### PR DESCRIPTION
## Summary

Adds P0-b for issue #102: heavy-task inventory/todo progress becomes first-class, opt-in task-run state instead of prompt-only guidance.

- add gated `inventory_submit` and `todo_update` tools for heavy-task runs
- persist `heavy_task_inventory_recorded` and `heavy_task_todos_recorded` ledger events
- replay latest inventory/todo state into projections and task-run exports
- inject compact replayed progress into heavy-task continuation/resume prompts
- keep progress advisory only; no scorer/verifier/taxonomy/write-gate changes

## Rive

Workflow: `maka.issue102-heavy-task-p0b`
Run: `wfrun_05c7eba9674649e9a03df5dca813401f`
Root work: `work_7b28a20ca5f34893bba73e70f6913273`
Artifacts: `/tmp/rive-maka-issue102-p0b-20260623/output/`

Nodes:
- design reader: `work_63f956d86a834ae7944e47d99b7cc331`
- code writer: `work_b6c094933ce647b4851944878f00a286`
- reviewer: `work_e39cfbcf26cf4a9f853692497b973a82` (ACCEPT)

## Verification

- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/task-agent-controller.test.js`
- `npm --workspace @maka/headless test` (260 tests, 35 suites)

## Notes

P0-a PR #121 is merged, and this branch was rebased onto current `upstream/main` before opening the PR.
