### PR TITLE
Add heavy-task semantic self-check guard

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -268,7 +268,8 @@ describe('runHarborCell', () => {
 
       assert.equal(seenPrompts[0], config.systemPrompt);
       assert.match(seenPrompts[1] ?? '', /Heavy-task benchmark policy/);
-      assert.match(seenPrompts[1] ?? '', /public, task-derived semantic checks/);
+      assert.match(seenPrompts[1] ?? '', /self_check_submit/);
+      assert.match(seenPrompts[1] ?? '', /public, task-derived semantic self-check evidence/);
     });
   });
 

--- a/packages/headless/src/__tests__/heavy-task-policy.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-policy.test.ts
@@ -119,7 +119,9 @@ describe('heavy-task policy', () => {
     assert.match(prompt, /inspect public task files/);
     assert.match(prompt, /inventory_submit/);
     assert.match(prompt, /todo_update/);
-    assert.match(prompt, /public, task-derived semantic checks/);
+    assert.match(prompt, /self_check_submit/);
+    assert.match(prompt, /public, task-derived semantic self-check evidence/);
+    assert.match(prompt, /source guard rejects hidden, private, or evaluator-only material/);
     assert.match(prompt, /Official benchmark scoring remains external and authoritative/);
   });
 

--- a/packages/headless/src/__tests__/heavy-task-self-check.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  buildHeavyTaskSelfCheckTools,
+  createHeavyTaskSelfCheckRecorder,
+  heavyTaskSelfCheckSubmitSchema,
+  renderHeavyTaskSelfCheckForPrompt,
+  validateHeavyTaskPublicSelfCheck,
+} from '../heavy-task-self-check.js';
+import type { HeavyTaskSemanticSelfCheckState } from '../task-contracts.js';
+import { createInMemoryTaskRunStore } from '../task-run-store.js';
+
+const toolContext = {
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  cwd: '/workspace',
+  toolCallId: 'tool-1',
+  abortSignal: new AbortController().signal,
+  emitOutput: () => {},
+};
+
+describe('heavy-task semantic self-check tools', () => {
+  test('self_check_submit records accepted public semantic evidence', async () => {
+    const store = createInMemoryTaskRunStore();
+    const tools = buildHeavyTaskSelfCheckTools(createHeavyTaskSelfCheckRecorder({
+      taskRunId: 'run-1',
+      attemptId: 'attempt-1',
+      store,
+      now: () => 123,
+      newId: idFactory(),
+    }));
+    const selfCheckSubmit = tools.find((tool) => tool.name === 'self_check_submit');
+    assert.ok(selfCheckSubmit);
+
+    const result = await selfCheckSubmit.impl({
+      status: 'pass',
+      publicReason: 'npm test passed against public source files and generated build output.',
+      commandEvidence: [{
+        command: 'npm test',
+        exitCode: 0,
+        outputExcerpt: 'all public tests passed',
+        artifactRefs: ['build-output.log'],
+      }],
+      artifactEvidence: [{
+        path: 'README.md',
+        kind: 'file',
+        exists: true,
+        metadata: { inspected: 'public docs' },
+      }],
+    }, toolContext) as { accepted: true; selfCheck: HeavyTaskSemanticSelfCheckState };
+
+    assert.equal(result.accepted, true);
+    assert.equal(result.selfCheck.status, 'pass');
+    assert.equal(result.selfCheck.guard.status, 'accepted');
+    assert.equal(result.selfCheck.source.toolCallId, 'tool-1');
+    const events = await store.readEvents('run-1');
+    assert.equal(events[0]?.type, 'heavy_task_self_check_recorded');
+  });
+
+  test('rejects private or evaluator-only material before appending accepted state', async () => {
+    const privateInputs = [
+      { publicReason: 'Saw hidden/tests/private_case.py', commandEvidence: [{ command: 'npm test' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'cat hidden/tests/private_case.py' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', outputExcerpt: 'pytest assertion expected 42' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', artifactRefs: ['official-verifier-output.json'] }] },
+      { publicReason: 'public check', artifactEvidence: [{ path: 'evaluator-only/reference.txt', kind: 'file' }] },
+      { publicReason: 'public check', artifactEvidence: [{ path: 'build-output.log', kind: 'log', metadata: { note: 'private threshold 0.97' } }] },
+      { publicReason: 'scorer constant controls pass', commandEvidence: [{ command: 'npm test' }] },
+      { publicReason: 'private benchmark file identifier was used', commandEvidence: [{ command: 'npm test' }] },
+      { publicReason: 'AssertionError: assert 41 == 42', commandEvidence: [{ command: 'npm test' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test --threshold 0.97' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', outputExcerpt: 'E   AssertionError: assert 41 == 42' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', outputExcerpt: 'expected threshold 0.97' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', outputExcerpt: 'expected == 42 from evaluator fixture' }] },
+      { publicReason: 'public check', commandEvidence: [{ command: 'npm test', artifactRefs: ['expected-threshold-0.97.txt'] }] },
+      { publicReason: 'public check', artifactEvidence: [{ path: 'threshold-0.97.txt', kind: 'file' }] },
+      { publicReason: 'public check', artifactEvidence: [{ path: 'build-output.log', kind: 'log', metadata: { note: 'actual 41 expected 42' } }] },
+    ];
+
+    for (const input of privateInputs) {
+      const parsed = heavyTaskSelfCheckSubmitSchema.parse({ status: 'inconclusive', ...input });
+      const validation = validateHeavyTaskPublicSelfCheck(parsed, 456);
+      assert.equal(validation.ok, false, JSON.stringify(input));
+      assert.equal(validation.guard.status, 'rejected');
+      assert.match(validation.guard.publicReason, /Rejected/);
+      assert.doesNotMatch(validation.guard.publicReason, /private_case|0\.97|41|42|AssertionError|official-verifier-output/);
+    }
+
+    const store = createInMemoryTaskRunStore();
+    const recorder = createHeavyTaskSelfCheckRecorder({
+      taskRunId: 'run-private',
+      store,
+      now: () => 789,
+      newId: idFactory(),
+    });
+    const result = await recorder.recordSelfCheck(heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'fail',
+      publicReason: 'official-verifier-output.json says this failed',
+      commandEvidence: [{ command: 'npm test' }],
+    }), toolContext);
+    assert.equal(result.accepted, false);
+    assert.deepEqual(await store.readEvents('run-private'), []);
+  });
+
+  test('rejects malformed or oversized submissions', () => {
+    assert.throws(() => heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'pass',
+      publicReason: 'No evidence.',
+    }), /at least one/);
+    assert.throws(() => heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'maybe',
+      publicReason: 'public check',
+      commandEvidence: [{ command: 'npm test' }],
+    }));
+    assert.throws(() => heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'pass',
+      publicReason: 'x'.repeat(2_001),
+      commandEvidence: [{ command: 'npm test' }],
+    }));
+    assert.throws(() => heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'pass',
+      publicReason: 'public check',
+      commandEvidence: Array.from({ length: 26 }, () => ({ command: 'npm test' })),
+    }));
+    assert.throws(() => heavyTaskSelfCheckSubmitSchema.parse({
+      status: 'pass',
+      publicReason: 'public check',
+      artifactEvidence: [{
+        path: 'build-output.log',
+        kind: 'log',
+        metadata: { a: { b: { c: { d: 'too deep' } } } },
+      }],
+    }), /metadata/);
+  });
+
+  test('renders compact accepted self-check state for continuation prompts', () => {
+    const rendered = renderHeavyTaskSelfCheckForPrompt({
+      latestHeavyTaskSelfCheck: acceptedSelfCheck('self-check-1', 'pass', 'npm test passed on public files.'),
+    });
+
+    assert.match(rendered ?? '', /Heavy-task semantic self-check state/);
+    assert.match(rendered ?? '', /Latest advisory status: pass/);
+    assert.match(rendered ?? '', /self_check_submit/);
+  });
+});
+
+export function acceptedSelfCheck(
+  selfCheckId: string,
+  status: HeavyTaskSemanticSelfCheckState['status'],
+  publicReason: string,
+): HeavyTaskSemanticSelfCheckState {
+  return {
+    schemaVersion: 1,
+    selfCheckId,
+    taskRunId: 'run-self-check',
+    ts: 10,
+    status,
+    publicReason,
+    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+    artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
+    guard: {
+      status: 'accepted',
+      checkedAt: 10,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'tool-1' },
+  };
+}
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
+}

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -207,6 +207,52 @@ describe('task run export', () => {
           source: { kind: 'model_tool', toolCallId: 'tool-2' },
         },
       },
+      {
+        type: 'heavy_task_self_check_recorded',
+        id: 'e4',
+        taskRunId: 'run-progress',
+        ts: 4,
+        selfCheck: {
+          schemaVersion: 1,
+          selfCheckId: 'self-check-1',
+          taskRunId: 'run-progress',
+          ts: 4,
+          status: 'pass',
+          publicReason: 'npm test passed against public files.',
+          commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+          artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
+          guard: {
+            status: 'accepted',
+            checkedAt: 4,
+            categories: [],
+            publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+          },
+          source: { kind: 'model_tool', toolCallId: 'tool-3' },
+        },
+      },
+      {
+        type: 'heavy_task_self_check_recorded',
+        id: 'e5',
+        taskRunId: 'run-progress',
+        ts: 5,
+        selfCheck: {
+          schemaVersion: 1,
+          selfCheckId: 'self-check-private',
+          taskRunId: 'run-progress',
+          ts: 5,
+          status: 'fail',
+          publicReason: 'hidden/tests/private_case.py revealed a failure',
+          commandEvidence: [{ command: 'cat hidden/tests/private_case.py' }],
+          artifactEvidence: [{ path: 'official-verifier-output.json', kind: 'file' }],
+          guard: {
+            status: 'accepted',
+            checkedAt: 5,
+            categories: [],
+            publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+          },
+          source: { kind: 'model_tool', toolCallId: 'tool-4' },
+        },
+      },
     ], 'run-progress');
     const exported = taskRunExportFromProjection(projection, { exportedAt: '2026-06-19T00:00:00.000Z' });
 
@@ -214,12 +260,24 @@ describe('task run export', () => {
     assert.equal(exported.progress?.inventory?.historyCount, 1);
     assert.equal(exported.progress?.todos?.latest.todoSetId, 'todos-1');
     assert.equal(exported.progress?.todos?.historyCount, 1);
+    assert.equal(exported.progress?.selfChecks?.latest.selfCheckId, 'self-check-1');
+    assert.equal(exported.progress?.selfChecks?.historyCount, 1);
 
     const outDir = await mkdtemp(join(tmpdir(), 'maka-progress-export-'));
     try {
-      const written = await writeTaskRunExport(outDir, projection, { exportedAt: '2026-06-19T00:00:00.000Z' });
+      const written = await writeTaskRunExport(outDir, projection, {
+        exportedAt: '2026-06-19T00:00:00.000Z',
+        includeEvents: true,
+      });
       const compact = JSON.parse(await readFile(written.files.resultJson, 'utf8')) as { progress?: unknown };
       assert.deepEqual(compact.progress, exported.progress);
+      const taskRunJson = await readFile(written.files.taskRunJson, 'utf8');
+      const compactJson = await readFile(written.files.resultJson, 'utf8');
+      const eventsJsonl = await readFile(written.files.eventsJsonl!, 'utf8');
+      assert.doesNotMatch(taskRunJson, /private_case|official-verifier-output/);
+      assert.doesNotMatch(compactJson, /private_case|official-verifier-output/);
+      assert.doesNotMatch(eventsJsonl, /private_case|official-verifier-output/);
+      assert.match(eventsJsonl, /self-check-1/);
     } finally {
       await rm(outDir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -243,8 +243,10 @@ class ProgressToolBackend implements AgentBackend {
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
     const inventorySubmit = this.ctx.tools.find((tool) => tool.name === 'inventory_submit');
     const todoUpdate = this.ctx.tools.find((tool) => tool.name === 'todo_update');
+    const selfCheckSubmit = this.ctx.tools.find((tool) => tool.name === 'self_check_submit');
     assert.ok(inventorySubmit);
     assert.ok(todoUpdate);
+    assert.ok(selfCheckSubmit);
     const toolCtx = {
       sessionId: this.sessionId,
       turnId: input.turnId,
@@ -259,6 +261,12 @@ class ProgressToolBackend implements AgentBackend {
     }, toolCtx);
     await todoUpdate.impl({
       items: [{ id: 'edit', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
+    }, toolCtx);
+    await selfCheckSubmit.impl({
+      status: 'pass',
+      publicReason: 'npm test passed using public README.md-backed fixture state.',
+      commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+      artifactEvidence: [{ path: 'README.md', kind: 'file', exists: true }],
     }, toolCtx);
     const ts = Date.now();
     yield { type: 'complete', id: 'progress-complete', turnId: input.turnId, ts, stopReason: 'end_turn' };
@@ -277,6 +285,7 @@ const registerProgressToolBackend = (seen: HeadlessBackendContext[]) => (registr
     header: ctx.header,
     tools: buildIsolatedHeadlessTools(context.toolExecutor!, {
       ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+      ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
     }),
   }));
 };
@@ -370,6 +379,7 @@ describe('runTaskOnce', () => {
       assert.equal(result.resultRecord.passed, true);
       assert.ok(!result.projection.toolExecutors[0]?.toolNames.includes('inventory_submit'));
       assert.ok(!result.projection.toolExecutors[0]?.toolNames.includes('todo_update'));
+      assert.ok(!result.projection.toolExecutors[0]?.toolNames.includes('self_check_submit'));
     });
   });
 
@@ -405,17 +415,25 @@ describe('runTaskOnce', () => {
 
       assert.equal(seenContexts[0]?.heavyTaskMode?.enabled, true);
       assert.ok(seenContexts[0]?.heavyTaskProgress);
+      assert.ok(seenContexts[0]?.heavyTaskSelfCheck);
       assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('inventory_submit'));
       assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('todo_update'));
+      assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('self_check_submit'));
       assert.equal(result.projection.latestHeavyTaskInventory?.summary, 'Inspected public files.');
       assert.equal(result.projection.latestHeavyTaskInventory?.items[0]?.path, 'README.md');
       assert.equal(result.projection.latestHeavyTaskTodos?.items[0]?.status, 'in_progress');
+      assert.equal(result.projection.latestHeavyTaskSelfCheck?.status, 'pass');
+      assert.equal(result.projection.latestHeavyTaskSelfCheck?.guard.status, 'accepted');
       assert.equal(
         result.projection.events.filter((event) => event.type === 'heavy_task_inventory_recorded').length,
         1,
       );
       assert.equal(
         result.projection.events.filter((event) => event.type === 'heavy_task_todos_recorded').length,
+        1,
+      );
+      assert.equal(
+        result.projection.events.filter((event) => event.type === 'heavy_task_self_check_recorded').length,
         1,
       );
     });

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -3,7 +3,7 @@ import { appendFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { TaskEvent } from '../task-contracts.js';
+import type { HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
 import { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from '../task-run-store.js';
 
 function eventIdFactory(): () => string {
@@ -212,6 +212,32 @@ describe('TaskRunStore', () => {
     assert.equal(projection.heavyTaskTodoStates.length, 2);
     assert.equal(projection.latestHeavyTaskTodos?.todoSetId, 'todos-2');
     assert.equal(projection.latestHeavyTaskTodos?.items[0]?.id, 'edit');
+  });
+
+  test('projects only accepted public heavy-task self-checks from replay', () => {
+    const taskRunId = 'tr-self-check';
+    const accepted = acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed on public files.');
+    const rejectedGuard = {
+      ...acceptedSelfCheck(taskRunId, 'self-check-2', 'fail', 'official-verifier-output.json says failed'),
+      guard: {
+        status: 'rejected' as const,
+        checkedAt: 11,
+        categories: ['official_verifier_artifacts'],
+        publicReason: 'Rejected because submitted evidence referenced private, hidden, or evaluator-only material.',
+      },
+    };
+    const privatePayload = acceptedSelfCheck(taskRunId, 'self-check-3', 'inconclusive', 'hidden/tests/private_case.py revealed a failure.');
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'heavy_task_self_check_recorded', id: 'e-2', taskRunId, ts: 10, selfCheck: accepted },
+      { type: 'heavy_task_self_check_recorded', id: 'e-3', taskRunId, ts: 11, selfCheck: rejectedGuard as unknown as HeavyTaskSemanticSelfCheckState },
+      { type: 'heavy_task_self_check_recorded', id: 'e-4', taskRunId, ts: 12, selfCheck: privatePayload },
+    ], taskRunId);
+
+    assert.equal(projection.heavyTaskSelfChecks.length, 1);
+    assert.equal(projection.latestHeavyTaskSelfCheck?.selfCheckId, 'self-check-1');
+    assert.equal(projection.warnings.length, 2);
+    assert.match(projection.warnings.join('\n'), /source guard did not accept/);
   });
 
   test('projects isolation, permission, inbox, and needs_approval facts', () => {
@@ -475,3 +501,28 @@ describe('TaskRunStore', () => {
     }
   });
 });
+
+function acceptedSelfCheck(
+  taskRunId: string,
+  selfCheckId: string,
+  status: HeavyTaskSemanticSelfCheckState['status'],
+  publicReason: string,
+): HeavyTaskSemanticSelfCheckState {
+  return {
+    schemaVersion: 1,
+    selfCheckId,
+    taskRunId,
+    ts: 10,
+    status,
+    publicReason,
+    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+    artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
+    guard: {
+      status: 'accepted',
+      checkedAt: 10,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'tool-1' },
+  };
+}

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -67,12 +67,13 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('agent_output'));
     assert.ok(!names.includes('inventory_submit'));
     assert.ok(!names.includes('todo_update'));
+    assert.ok(!names.includes('self_check_submit'));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
   });
 
-  test('progress tools are included only when heavy-task progress is enabled', () => {
+  test('progress and self-check tools are included only when heavy-task recorders are enabled', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -101,11 +102,36 @@ describe('isolated headless tools', () => {
           };
         },
       },
+      heavyTaskSelfCheck: {
+        async recordSelfCheck(input) {
+          return {
+            accepted: true,
+            selfCheck: {
+              schemaVersion: 1,
+              selfCheckId: 'self-check-1',
+              taskRunId: 'run-1',
+              ts: 1,
+              status: input.status,
+              publicReason: input.publicReason,
+              commandEvidence: input.commandEvidence ?? [],
+              artifactEvidence: input.artifactEvidence ?? [],
+              guard: {
+                status: 'accepted',
+                checkedAt: 1,
+                categories: [],
+                publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+              },
+              source: { kind: 'model_tool', toolCallId: 'tool-1' },
+            },
+          };
+        },
+      },
     });
 
     const names = tools.map((tool) => tool.name);
     assert.ok(names.includes('inventory_submit'));
     assert.ok(names.includes('todo_update'));
+    assert.ok(names.includes('self_check_submit'));
   });
 
   test('Read, Write, Edit, Glob, and Grep delegate to native isolated executor methods', async () => {

--- a/packages/headless/src/heavy-task-policy.ts
+++ b/packages/headless/src/heavy-task-policy.ts
@@ -84,7 +84,8 @@ export function buildHeavyTaskSystemPromptPolicy(
     '- Work like a persistent engineer on a long-running task: inspect public task files and workspace state before editing, keep compact evidence that helps continue the work, and avoid relying on assistant prose as durable state.',
     '- Use inventory_submit to submit a structured inventory snapshot after initial public inspection and whenever the important workspace/artifact inventory changes.',
     '- Use todo_update to submit the full current todo/progress snapshot as work advances. Keep at most one item in_progress, and treat todo completion as advisory progress rather than benchmark success.',
-    '- You may run public, task-derived semantic checks such as visible tests, builds, sample commands, or artifact inspections. Treat those checks as advisory engineering feedback.',
+    '- Use self_check_submit to submit public, task-derived semantic self-check evidence from visible tests, builds, sample commands, or artifact inspections. Include public command/artifact evidence only.',
+    '- The self_check_submit source guard rejects hidden, private, or evaluator-only material before it can become accepted task-run state. Treat accepted checks as advisory engineering feedback.',
     '- Official benchmark scoring remains external and authoritative. Do not claim success solely from your own checks, and do not replace verifier results with self-checks.',
     `- Do not seek, infer, read, or rely on forbidden evaluator material: ${FORBIDDEN_HEAVY_TASK_POLICY_TERMS.join(', ')}.`,
   ].join('\n');

--- a/packages/headless/src/heavy-task-self-check.ts
+++ b/packages/headless/src/heavy-task-self-check.ts
@@ -1,0 +1,293 @@
+import type { MakaTool, MakaToolContext } from '@maka/runtime';
+import { z } from 'zod';
+import type {
+  HeavyTaskArtifactEvidence,
+  HeavyTaskCommandEvidence,
+  HeavyTaskSemanticSelfCheckState,
+  HeavyTaskSourceGuardResult,
+  TaskEvent,
+} from './task-contracts.js';
+import type { TaskRunStore } from './task-run-store.js';
+
+export const HEAVY_TASK_SELF_CHECK_TOOL_NAMES = ['self_check_submit'] as const;
+
+const MAX_REASON_CHARS = 2_000;
+const MAX_COMMAND_CHARS = 1_000;
+const MAX_OUTPUT_CHARS = 2_000;
+const MAX_PATH_CHARS = 500;
+const MAX_HASH_CHARS = 200;
+const MAX_EVIDENCE_ITEMS = 25;
+const MAX_ARTIFACT_REFS = 20;
+const MAX_METADATA_KEYS = 30;
+const MAX_METADATA_DEPTH = 3;
+const MAX_METADATA_STRING_CHARS = 500;
+const MAX_GUARD_STRING_CHARS = 2_000;
+
+const metadataValueSchema: z.ZodType<unknown> = z.lazy(() => z.union([
+  z.string().max(MAX_METADATA_STRING_CHARS),
+  z.number().finite(),
+  z.boolean(),
+  z.null(),
+  z.array(metadataValueSchema).max(MAX_METADATA_KEYS),
+  z.record(z.string(), metadataValueSchema),
+]));
+
+export const heavyTaskCommandEvidenceSchema = z.object({
+  command: z.string().trim().min(1).max(MAX_COMMAND_CHARS),
+  exitCode: z.number().int().optional().nullable(),
+  timedOut: z.boolean().optional(),
+  outputExcerpt: z.string().trim().min(1).max(MAX_OUTPUT_CHARS).optional(),
+  artifactRefs: z.array(z.string().trim().min(1).max(MAX_PATH_CHARS)).max(MAX_ARTIFACT_REFS).optional(),
+}).strict();
+
+export const heavyTaskArtifactEvidenceSchema = z.object({
+  path: z.string().trim().min(1).max(MAX_PATH_CHARS),
+  kind: z.enum(['file', 'directory', 'log', 'build_output', 'generated_output', 'other']),
+  exists: z.boolean().optional(),
+  sizeBytes: z.number().int().nonnegative().optional(),
+  hash: z.string().trim().min(1).max(MAX_HASH_CHARS).optional(),
+  metadata: z.record(z.string(), metadataValueSchema).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.metadata && !metadataWithinBounds(value.metadata)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['metadata'],
+      message: `artifact metadata must be bounded to depth ${MAX_METADATA_DEPTH}`,
+    });
+  }
+});
+
+export const heavyTaskSelfCheckSubmitSchema = z.object({
+  status: z.enum(['pass', 'fail', 'inconclusive']),
+  publicReason: z.string().trim().min(1).max(MAX_REASON_CHARS),
+  commandEvidence: z.array(heavyTaskCommandEvidenceSchema).max(MAX_EVIDENCE_ITEMS).optional(),
+  artifactEvidence: z.array(heavyTaskArtifactEvidenceSchema).max(MAX_EVIDENCE_ITEMS).optional(),
+}).strict().superRefine((value, ctx) => {
+  if ((value.commandEvidence?.length ?? 0) + (value.artifactEvidence?.length ?? 0) === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['commandEvidence'],
+      message: 'at least one commandEvidence or artifactEvidence item is required',
+    });
+  }
+});
+
+export type HeavyTaskSelfCheckSubmitInput = z.infer<typeof heavyTaskSelfCheckSubmitSchema>;
+
+export type HeavyTaskPublicSelfCheckValidation =
+  | { ok: true; guard: HeavyTaskSourceGuardResult & { status: 'accepted' } }
+  | { ok: false; guard: HeavyTaskSourceGuardResult & { status: 'rejected' } };
+
+export interface HeavyTaskSelfCheckRecorder {
+  recordSelfCheck(
+    input: HeavyTaskSelfCheckSubmitInput,
+    ctx: MakaToolContext,
+  ): Promise<
+    | { accepted: true; selfCheck: HeavyTaskSemanticSelfCheckState }
+    | { accepted: false; guard: HeavyTaskSourceGuardResult & { status: 'rejected' } }
+  >;
+}
+
+export function createHeavyTaskSelfCheckRecorder(input: {
+  taskRunId: string;
+  attemptId?: string;
+  store: TaskRunStore;
+  now: () => number;
+  newId: () => string;
+}): HeavyTaskSelfCheckRecorder {
+  return {
+    async recordSelfCheck(args, ctx) {
+      const ts = input.now();
+      const validation = validateHeavyTaskPublicSelfCheck(args, ts);
+      if (!validation.ok) {
+        return { accepted: false, guard: validation.guard };
+      }
+      const selfCheck: HeavyTaskSemanticSelfCheckState = {
+        schemaVersion: 1,
+        selfCheckId: input.newId(),
+        taskRunId: input.taskRunId,
+        ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+        ts,
+        status: args.status,
+        publicReason: args.publicReason,
+        commandEvidence: args.commandEvidence ?? [],
+        artifactEvidence: args.artifactEvidence ?? [],
+        guard: validation.guard,
+        source: sourceFromContext(ctx),
+      };
+      await input.store.appendEvent(input.taskRunId, {
+        type: 'heavy_task_self_check_recorded',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts,
+        selfCheck,
+      });
+      return { accepted: true, selfCheck };
+    },
+  };
+}
+
+export function buildHeavyTaskSelfCheckTools(recorder: HeavyTaskSelfCheckRecorder): MakaTool[] {
+  return [
+    {
+      name: 'self_check_submit',
+      description: 'Submit public, task-derived advisory semantic self-check evidence for this heavy-task run.',
+      parameters: heavyTaskSelfCheckSubmitSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => recorder.recordSelfCheck(heavyTaskSelfCheckSubmitSchema.parse(args), ctx),
+    },
+  ];
+}
+
+export function validateHeavyTaskPublicSelfCheck(
+  input: Pick<HeavyTaskSelfCheckSubmitInput, 'publicReason' | 'commandEvidence' | 'artifactEvidence'>,
+  now: number,
+): HeavyTaskPublicSelfCheckValidation {
+  const categories = new Set<string>();
+  for (const value of stringsFromSelfCheck(input)) {
+    for (const category of categoriesForString(value)) {
+      categories.add(category);
+    }
+  }
+  if (categories.size > 0) {
+    return {
+      ok: false,
+      guard: {
+        status: 'rejected',
+        checkedAt: now,
+        categories: [...categories].sort(),
+        publicReason: 'Rejected because submitted evidence referenced private, hidden, or evaluator-only material.',
+      },
+    };
+  }
+  return {
+    ok: true,
+    guard: {
+      status: 'accepted',
+      checkedAt: now,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+  };
+}
+
+export function isAcceptedHeavyTaskSelfCheck(
+  selfCheck: HeavyTaskSemanticSelfCheckState,
+  now = selfCheck.guard.checkedAt,
+): boolean {
+  if (selfCheck.guard.status !== 'accepted') return false;
+  return validateHeavyTaskPublicSelfCheck(selfCheck, now).ok;
+}
+
+export function renderHeavyTaskSelfCheckForPrompt(projection: {
+  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+}): string | undefined {
+  const selfCheck = projection.latestHeavyTaskSelfCheck;
+  if (!selfCheck) return undefined;
+  const lines = [
+    'Heavy-task semantic self-check state from prior task-run events:',
+    `- Latest advisory status: ${selfCheck.status}`,
+    `- Public reason: ${oneLine(selfCheck.publicReason, 240)}`,
+  ];
+  for (const command of selfCheck.commandEvidence.slice(0, 5)) {
+    lines.push(`  - command: ${oneLine(command.command, 160)} exit=${command.exitCode ?? 'unknown'}`);
+  }
+  for (const artifact of selfCheck.artifactEvidence.slice(0, 5)) {
+    lines.push(`  - artifact: ${artifact.kind} ${oneLine(artifact.path, 160)}`);
+  }
+  lines.push('Use self_check_submit to refresh advisory public semantic evidence after running public checks.');
+  return lines.join('\n');
+}
+
+function stringsFromSelfCheck(input: Pick<HeavyTaskSelfCheckSubmitInput, 'publicReason' | 'commandEvidence' | 'artifactEvidence'>): string[] {
+  const strings = [input.publicReason];
+  for (const command of input.commandEvidence ?? []) {
+    strings.push(command.command);
+    if (command.outputExcerpt) strings.push(command.outputExcerpt);
+    strings.push(...(command.artifactRefs ?? []));
+  }
+  for (const artifact of input.artifactEvidence ?? []) {
+    strings.push(artifact.path);
+    collectMetadataStrings(artifact.metadata, strings);
+  }
+  return strings.filter((value) => value.length > 0).map((value) => value.slice(0, MAX_GUARD_STRING_CHARS));
+}
+
+function collectMetadataStrings(value: unknown, output: string[], depth = 0): void {
+  if (depth > MAX_METADATA_DEPTH) return;
+  if (typeof value === 'string') {
+    output.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectMetadataStrings(item, output, depth + 1);
+    return;
+  }
+  if (recordValue(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      output.push(key);
+      collectMetadataStrings(item, output, depth + 1);
+    }
+  }
+}
+
+const THRESHOLD_EVIDENCE_PATTERN =
+  /\bhidden[ _-]?thresholds?\b|\bprivate[ _-]?thresholds?\b|\b(?:expected[ _-]?)?thresholds?[ _:=/-]*(?:0?\.\d+|\d+(?:\.\d+)?%?)\b|\b(?:pass(?:ing)?|score|similarity|accuracy)[ _-]*(?:cutoff|threshold)[ _:=/-]*(?:0?\.\d+|\d+(?:\.\d+)?%?)\b/;
+const RAW_ASSERTION_EVIDENCE_PATTERN =
+  /\bpytest[ _-]?assertions?\b|\bassertion[ _-]?derived\b|\bassertionerror\b|\bassert\s+\S+(?:\s+\S+){0,8}\s*(?:==|!=|<=|>=|<|>)\s*\S+|\bexpected\s*(?:==|!=|<=|>=|<|>|=|:)\s*\S+|\bexpected\b.{0,80}\bactual\b|\bactual\b.{0,80}\bexpected\b/;
+const EVALUATOR_FILE_PATTERN =
+  /\bevaluator[ _-]?only\b|\bnon[ _-]?public[ _-]?evaluator\b|\bevaluator[ _-]?(?:file|fixture|path|material|artifact)s?\b/;
+
+function categoriesForString(value: string): string[] {
+  const normalized = value.toLowerCase();
+  const categories: string[] = [];
+  const checks: Array<[string, RegExp]> = [
+    ['hidden_tests', /\bhidden[ _/-]?tests?\b|\bhidden\/tests?\b/],
+    ['hidden_reference_artifacts', /\bhidden[ _-]?references?\b|\bhidden[ _-]?artifacts?\b/],
+    ['hidden_thresholds', THRESHOLD_EVIDENCE_PATTERN],
+    ['private_scoring_criteria', /\bprivate[ _-]?scor(?:e|ing)[ _-]?criteria\b/],
+    ['scorer_constants', /\bscorer[ _-]?(?:specific[ _-]?)?constants?\b/],
+    ['pytest_assertions', RAW_ASSERTION_EVIDENCE_PATTERN],
+    ['official_verifier_artifacts', /\bofficial[ _-]?verifier\b|\bverifier[ _-]?output\.json\b/],
+    ['hidden_assertion_text', /\bhidden[ _-]?assertion[ _-]?text\b|\bprivate[ _-]?assertion\b/],
+    ['non_public_evaluator_files', EVALUATOR_FILE_PATTERN],
+    ['private_verifier_details', /\bprivate[ _-]?verifier\b|\bverifier[ _-]?(?:timing|order|execution[ _-]?order)\b/],
+    ['private_benchmark_identifiers', /\bprivate[ _-]?benchmark\b|\bbenchmark[ _-]?private\b/],
+  ];
+  for (const [category, pattern] of checks) {
+    if (pattern.test(normalized)) categories.push(category);
+  }
+  return categories;
+}
+
+function metadataWithinBounds(value: unknown, depth = 0): boolean {
+  if (depth > MAX_METADATA_DEPTH) return false;
+  if (typeof value === 'string') return value.length <= MAX_METADATA_STRING_CHARS;
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') return true;
+  if (Array.isArray(value)) return value.length <= MAX_METADATA_KEYS && value.every((item) => metadataWithinBounds(item, depth + 1));
+  if (!recordValue(value)) return false;
+  const entries = Object.entries(value);
+  return entries.length <= MAX_METADATA_KEYS
+    && entries.every(([key, item]) => key.length <= MAX_METADATA_STRING_CHARS && metadataWithinBounds(item, depth + 1));
+}
+
+function sourceFromContext(ctx: MakaToolContext): HeavyTaskSemanticSelfCheckState['source'] {
+  return {
+    kind: 'model_tool',
+    toolCallId: ctx.toolCallId,
+    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+  };
+}
+
+function oneLine(value: string, maxChars: number): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  return clean.length <= maxChars ? clean : `${clean.slice(0, maxChars - 3)}...`;
+}
+
+function recordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export type HeavyTaskSelfCheckEvent = Extract<TaskEvent, { type: 'heavy_task_self_check_recorded' }>;
+export type { HeavyTaskArtifactEvidence, HeavyTaskCommandEvidence, HeavyTaskSemanticSelfCheckState };

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -160,7 +160,13 @@ export type {
   HeavyTaskInventoryRecordedEvent,
   HeavyTaskInventoryState,
   HeavyTaskModeRecordedEvent,
+  HeavyTaskArtifactEvidence,
+  HeavyTaskCommandEvidence,
   HeavyTaskProgressSource,
+  HeavyTaskSelfCheckRecordedEvent,
+  HeavyTaskSelfCheckStatus,
+  HeavyTaskSemanticSelfCheckState,
+  HeavyTaskSourceGuardResult,
   HeavyTaskTodoItem,
   HeavyTaskTodoState,
   HeavyTaskTodosRecordedEvent,
@@ -306,6 +312,22 @@ export {
   HEAVY_TASK_PROGRESS_TOOL_NAMES,
   renderHeavyTaskProgressForPrompt,
 } from './heavy-task-progress.js';
+export type {
+  HeavyTaskPublicSelfCheckValidation,
+  HeavyTaskSelfCheckRecorder,
+  HeavyTaskSelfCheckSubmitInput,
+} from './heavy-task-self-check.js';
+export {
+  buildHeavyTaskSelfCheckTools,
+  createHeavyTaskSelfCheckRecorder,
+  HEAVY_TASK_SELF_CHECK_TOOL_NAMES,
+  heavyTaskArtifactEvidenceSchema,
+  heavyTaskCommandEvidenceSchema,
+  heavyTaskSelfCheckSubmitSchema,
+  isAcceptedHeavyTaskSelfCheck,
+  renderHeavyTaskSelfCheckForPrompt,
+  validateHeavyTaskPublicSelfCheck,
+} from './heavy-task-self-check.js';
 export type {
   HeadlessBackendContext,
   IsolatedCommandInput,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,6 +1,7 @@
 import type { Config, Task } from './contracts.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
 import type { HeavyTaskProgressRecorder } from './heavy-task-progress.js';
+import type { HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
 import type {
   EnvNetworkSecretPolicy,
   TaskIsolationFacts,
@@ -136,6 +137,8 @@ export interface HeadlessBackendContext {
   heavyTaskMode?: HeavyTaskModeSelection;
   /** Present only when heavy-task mode is enabled for task-run backed tooling. */
   heavyTaskProgress?: HeavyTaskProgressRecorder;
+  /** Present only when heavy-task mode is enabled for advisory public self-check tooling. */
+  heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
 }
 
 export function validateRealBackendIsolation(isolation: RealBackendIsolation | undefined): void {

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ResultRecord } from './contracts.js';
+import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import {
   isTerminalTaskRunStatus,
   type AutonomousResultTaxonomy,
@@ -60,6 +61,10 @@ export interface TaskRunExport {
     };
     todos?: {
       latest: NonNullable<TaskRunProjection['latestHeavyTaskTodos']>;
+      historyCount: number;
+    };
+    selfChecks?: {
+      latest: NonNullable<TaskRunProjection['latestHeavyTaskSelfCheck']>;
       historyCount: number;
     };
   };
@@ -295,7 +300,13 @@ function progressFromProjection(projection: TaskRunProjection): TaskRunExport['p
       historyCount: projection.heavyTaskTodoStates.length,
     };
   }
-  return progress.inventory || progress.todos ? progress : undefined;
+  if (projection.latestHeavyTaskSelfCheck) {
+    progress.selfChecks = {
+      latest: projection.latestHeavyTaskSelfCheck,
+      historyCount: projection.heavyTaskSelfChecks.length,
+    };
+  }
+  return progress.inventory || progress.todos || progress.selfChecks ? progress : undefined;
 }
 
 function runtimeEventIdsFrom(runtimeRefs: unknown): string[] {
@@ -348,8 +359,13 @@ function verifierBenchmark(verifier: VerifierResult | undefined): Record<string,
 }
 
 function eventsJsonl(events: readonly TaskEvent[]): string {
-  const body = events.map((event) => JSON.stringify(event)).join('\n');
+  const body = events.flatMap(exportableTaskEvents).map((event) => JSON.stringify(event)).join('\n');
   return body.length > 0 ? `${body}\n` : '';
+}
+
+function exportableTaskEvents(event: TaskEvent): TaskEvent[] {
+  if (event.type !== 'heavy_task_self_check_recorded') return [event];
+  return isAcceptedHeavyTaskSelfCheck(event.selfCheck) ? [event] : [];
 }
 
 export function exportContentHash(value: unknown): string {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -30,6 +30,11 @@ import {
   HEAVY_TASK_PROGRESS_TOOL_NAMES,
   renderHeavyTaskProgressForPrompt,
 } from './heavy-task-progress.js';
+import {
+  createHeavyTaskSelfCheckRecorder,
+  HEAVY_TASK_SELF_CHECK_TOOL_NAMES,
+  renderHeavyTaskSelfCheckForPrompt,
+} from './heavy-task-self-check.js';
 import type { HeadlessBackendContext } from './isolation.js';
 import {
   ISOLATED_HEADLESS_TOOL_NAMES,
@@ -136,12 +141,18 @@ export async function runTaskOnce(
   const verifier = normalizeVerifier(task);
   const heavyTaskMode = resolveHeavyTaskMode(config, task);
   const effectiveConfig = configWithHeavyTaskPolicy(config, heavyTaskMode);
-  const priorProgressPrompt = heavyTaskMode.enabled
-    ? renderHeavyTaskProgressForPrompt(await taskRunStore.project(taskRunId))
-    : undefined;
-  const instruction = withOptionalProgressPrompt(deps.instructionOverride ?? task.instruction, priorProgressPrompt);
+  const priorProjection = heavyTaskMode.enabled ? await taskRunStore.project(taskRunId) : undefined;
+  const priorProgressPrompt = priorProjection ? renderHeavyTaskProgressForPrompt(priorProjection) : undefined;
+  const priorSelfCheckPrompt = priorProjection ? renderHeavyTaskSelfCheckForPrompt(priorProjection) : undefined;
+  const instruction = withOptionalStatePrompts(deps.instructionOverride ?? task.instruction, [
+    priorProgressPrompt,
+    priorSelfCheckPrompt,
+  ]);
   const heavyTaskProgress = heavyTaskMode.enabled
     ? createHeavyTaskProgressRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
+    : undefined;
+  const heavyTaskSelfCheck = heavyTaskMode.enabled
+    ? createHeavyTaskSelfCheckRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
     : undefined;
 
   if (createTaskRun) {
@@ -236,6 +247,7 @@ export async function runTaskOnce(
       workspaceDir: workspace.dir,
       heavyTaskMode,
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
+      ...(heavyTaskSelfCheck ? { heavyTaskSelfCheck } : {}),
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),
@@ -472,16 +484,20 @@ export async function runTaskOnce(
 const DEFAULT_INTERVENTION_POLICY: TaskInterventionPolicy = { mode: 'fail_closed' };
 const DEFAULT_APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
 
-function withOptionalProgressPrompt(instruction: string, progressPrompt: string | undefined): string {
-  if (!progressPrompt || instruction.includes('Heavy-task progress state from prior task-run events:')) {
-    return instruction;
+function withOptionalStatePrompts(instruction: string, prompts: readonly (string | undefined)[]): string {
+  let next = instruction;
+  for (const prompt of prompts) {
+    if (!prompt) continue;
+    const firstLine = prompt.split('\n', 1)[0];
+    if (firstLine && next.includes(firstLine)) continue;
+    next = `${next}\n\n${prompt}`;
   }
-  return `${instruction}\n\n${progressPrompt}`;
+  return next;
 }
 
 function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: boolean): string[] {
   const names = hasIsolatedExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'];
-  if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES);
+  if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES, ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES);
   return names;
 }
 

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -327,6 +327,46 @@ export interface HeavyTaskTodoState {
   source: HeavyTaskProgressSource;
 }
 
+export type HeavyTaskSelfCheckStatus = 'pass' | 'fail' | 'inconclusive';
+
+export interface HeavyTaskCommandEvidence {
+  command: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  outputExcerpt?: string;
+  artifactRefs?: string[];
+}
+
+export interface HeavyTaskArtifactEvidence {
+  path: string;
+  kind: 'file' | 'directory' | 'log' | 'build_output' | 'generated_output' | 'other';
+  exists?: boolean;
+  sizeBytes?: number;
+  hash?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HeavyTaskSourceGuardResult {
+  status: 'accepted' | 'rejected';
+  checkedAt: number;
+  categories: string[];
+  publicReason: string;
+}
+
+export interface HeavyTaskSemanticSelfCheckState {
+  schemaVersion: 1;
+  selfCheckId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  status: HeavyTaskSelfCheckStatus;
+  publicReason: string;
+  commandEvidence: HeavyTaskCommandEvidence[];
+  artifactEvidence: HeavyTaskArtifactEvidence[];
+  guard: HeavyTaskSourceGuardResult & { status: 'accepted' };
+  source: HeavyTaskProgressSource;
+}
+
 export interface EnvNetworkSecretPolicy {
   schemaVersion: 1;
   env: 'inherit_none' | 'allowlist';
@@ -539,6 +579,11 @@ export interface HeavyTaskTodosRecordedEvent extends BaseTaskEvent {
   todos: HeavyTaskTodoState;
 }
 
+export interface HeavyTaskSelfCheckRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_self_check_recorded';
+  selfCheck: HeavyTaskSemanticSelfCheckState;
+}
+
 export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
   type: 'workspace_lease_recorded';
   lease: WorkspaceLeaseFacts;
@@ -665,6 +710,7 @@ export type TaskEvent =
   | HeavyTaskModeRecordedEvent
   | HeavyTaskInventoryRecordedEvent
   | HeavyTaskTodosRecordedEvent
+  | HeavyTaskSelfCheckRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent
   | ToolExecutorIdentityRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -1,12 +1,14 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ResultRecord } from './contracts.js';
+import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import type {
   AutonomousDecision,
   FeedbackObservation,
   HeavyTaskInventoryState,
   TaskInboxItem,
   HeavyTaskModeFacts,
+  HeavyTaskSemanticSelfCheckState,
   HeavyTaskTodoState,
   TaskIsolationFacts,
   TaskPermissionGrant,
@@ -46,6 +48,8 @@ export interface TaskRunProjection extends TaskRun {
   latestHeavyTaskInventory?: HeavyTaskInventoryState;
   heavyTaskTodoStates: HeavyTaskTodoState[];
   latestHeavyTaskTodos?: HeavyTaskTodoState;
+  heavyTaskSelfChecks: HeavyTaskSemanticSelfCheckState[];
+  latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
   isolation?: TaskIsolationFacts;
   workspaceLease?: WorkspaceLeaseFacts;
   parked?: TaskRunParkedState;
@@ -88,6 +92,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     warnings: [],
     heavyTaskInventory: [],
     heavyTaskTodoStates: [],
+    heavyTaskSelfChecks: [],
   };
   const attempts = new Map<string, TaskAttempt>();
   const inboxItems = new Map<string, TaskInboxItem>();
@@ -164,6 +169,14 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       case 'heavy_task_todos_recorded':
         projection.heavyTaskTodoStates.push(event.todos);
         projection.latestHeavyTaskTodos = event.todos;
+        break;
+      case 'heavy_task_self_check_recorded':
+        if (isAcceptedHeavyTaskSelfCheck(event.selfCheck)) {
+          projection.heavyTaskSelfChecks.push(event.selfCheck);
+          projection.latestHeavyTaskSelfCheck = event.selfCheck;
+        } else {
+          projection.warnings.push(`ignored heavy-task self-check ${event.selfCheck.selfCheckId}: source guard did not accept public evidence`);
+        }
         break;
       case 'isolation_policy_recorded':
         projection.isolation = event.facts;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -6,10 +6,12 @@ import {
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
 import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
+import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
 import type { IsolatedToolExecutor } from './isolation.js';
 
 export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskProgress?: HeavyTaskProgressRecorder;
+  heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
 }
 
 /**
@@ -32,6 +34,9 @@ export function buildIsolatedHeadlessTools(
   ];
   if (options.heavyTaskProgress) {
     tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));
+  }
+  if (options.heavyTaskSelfCheck) {
+    tools.push(...buildHeavyTaskSelfCheckTools(options.heavyTaskSelfCheck));
   }
   return tools;
 }


### PR DESCRIPTION
## Summary

Adds the P0-c heavy-task semantic self-check slice for issue #102:

- introduces enabled-heavy-task-only `self_check_submit`
- records typed public self-check state with status, public reason, command/artifact evidence, source, and accepted guard state
- rejects hidden/private/evaluator-only assertion, threshold, verifier, scorer, and benchmark-private evidence before accepted state append
- projects and exports only accepted public self-checks, including `includeEvents` export filtering
- preserves scorer/verifier authority, terminal status, finalization, and write-gate behavior

## Rive

Workflow: `maka.issue102-heavy-task-p0c`
Run: `wfrun_4122646a94d042f2a4c793c97ae2b9a7`
Root: `work_43b25b45fd6a4d74b54f6607d956ff98`
Artifacts: `/tmp/rive-maka-issue102-p0c-20260623/output/`

The reviewer returned `PATCH_REQUIRED` for raw assertion/threshold guard gaps; this PR includes the steward patch and tests for those cases.

## Verification

- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test dist/__tests__/heavy-task-self-check.test.js dist/__tests__/tools.test.js dist/__tests__/heavy-task-policy.test.js dist/__tests__/task-run-store.test.js dist/__tests__/result-export.test.js dist/__tests__/task-agent-controller.test.js`
- `npm --workspace @maka/headless test` (265 tests)
- `git diff --cached --check`

Part of #102.
