### PR TITLE
Permission Center compact — drop KPI band, inline status, single CTA

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -6343,17 +6343,22 @@ function PermissionCenterPage() {
         </div>
       </header>
 
-      <section className="settingsPermissionSummary" aria-label="权限概览">
-        <PermissionSummaryTile label="已授权" value={counts.granted} tone="success" />
-        <PermissionSummaryTile label="等待授权" value={counts.pending} tone="warning" />
-        <PermissionSummaryTile label="已拒绝" value={counts.denied} tone="destructive" />
-        <PermissionSummaryTile label="未知 / 不支持" value={counts.other} tone="neutral" />
-      </section>
-
+      {/* PR-PERMISSION-COMPACT (WAWQAQ msg 56f997b1 2026-06-23): the
+          4-tile KPI summary band was removed. Reference Settings put
+          the status badge inline on each permission row, so the band
+          repeated information the rows already carry — busier without
+          being more useful. Counts are still derived for an inline
+          subtitle below the section title. */}
       <section aria-label="系统权限" className="settingsPermissionSection">
         <header>
           <h4>系统权限</h4>
-          <small>Maka 读到的 OS 级权限状态。点击右侧按钮可以直接前往「系统设置 → 隐私与安全性」对应分区。</small>
+          <small>
+            {counts.granted}/{OS_PERMISSION_IDS.length} 已授权
+            {counts.pending > 0 ? ` · ${counts.pending} 待授权` : ''}
+            {counts.denied > 0 ? ` · ${counts.denied} 已拒绝` : ''}
+            <span className="settingsPermissionSubdivider"> · </span>
+            点击右侧按钮直接前往「系统设置 → 隐私与安全性」对应分区。
+          </small>
         </header>
         <ul className="settingsOsPermissionList" aria-label="系统权限列表">
           {OS_PERMISSION_IDS.map((id) => (
@@ -6397,19 +6402,6 @@ function PermissionCenterPage() {
         高风险自动化能力必须保持逐项审批、可审计、可撤销。
         这里只读取系统权限与功能能力的当前快照，授权变更仍需在「系统设置 → 隐私与安全性」完成。
       </p>
-    </div>
-  );
-}
-
-function PermissionSummaryTile(props: {
-  label: string;
-  value: number;
-  tone: 'success' | 'warning' | 'destructive' | 'neutral';
-}) {
-  return (
-    <div className="settingsPermissionSummaryTile" data-tone={props.tone}>
-      <span className="settingsPermissionSummaryValue">{props.value}</span>
-      <span className="settingsPermissionSummaryLabel">{props.label}</span>
     </div>
   );
 }
@@ -6624,6 +6616,20 @@ function OsPermissionRow(props: {
 
   const showRequest = snapshot.canRequest && snapshot.status !== 'granted';
   const showOpenSettings = snapshot.canOpenSettings && snapshot.status !== 'granted';
+  // PR-PERMISSION-COMPACT (WAWQAQ msg 56f997b1 2026-06-23): when both
+  // "request access" and "open system settings" are available, only
+  // show "request" — it's the more direct action. The deep-link to
+  // System Settings stays available via the system-level shortcut in
+  // the section header. Two stacked CTAs on the same row read as a
+  // form, not a settings item.
+  const primaryAction = showRequest
+    ? { key: 'request' as const, label: pendingKey === 'request' ? '请求中…' : '请求授权', onClick: props.onRequest }
+    : showOpenSettings
+      ? { key: 'openSettings' as const, label: pendingKey === 'openSettings' ? '打开中…' : '去授权', onClick: props.onOpenSettings }
+      : null;
+  const combinedDescription = impact
+    ? `${purpose}  ·  影响功能：${impact}`
+    : purpose;
 
   return (
     <li className="settingsOsPermissionRow" data-state={snapshot.status}>
@@ -6633,41 +6639,28 @@ function OsPermissionRow(props: {
       <div className="settingsOsPermissionBody">
         <div className="settingsOsPermissionHeading">
           <strong>{label}</strong>
-          <PrimitiveBadge variant={statusBadgeVariant(stateCopy.tone)}>{stateCopy.label}</PrimitiveBadge>
+          <span className="settingsOsPermissionInlineStatus" data-tone={stateCopy.tone}>
+            {stateCopy.label}
+          </span>
         </div>
-        <small className="settingsOsPermissionPurpose">{purpose}</small>
-        {impact ? (
-          <small className="settingsOsPermissionImpact">
-            <span className="settingsOsPermissionImpactLabel">影响功能</span>
-            <span>{impact}</span>
-          </small>
+        {combinedDescription ? (
+          <small className="settingsOsPermissionPurpose">{combinedDescription}</small>
         ) : null}
         {snapshot.reason ? (
           <small className="settingsOsPermissionReason">{snapshot.reason}</small>
         ) : null}
       </div>
       <div className="settingsOsPermissionActions">
-        {showRequest && (
+        {primaryAction && (
           <Button
             type="button"
+            variant="secondary"
             size="sm"
-            onClick={props.onRequest}
+            onClick={primaryAction.onClick}
             disabled={busy}
-            aria-busy={pendingKey === 'request' ? 'true' : undefined}
+            aria-busy={pendingKey === primaryAction.key ? 'true' : undefined}
           >
-            {pendingKey === 'request' ? '请求中…' : '请求授权'}
-          </Button>
-        )}
-        {showOpenSettings && (
-          <Button
-            type="button"
-            variant={showRequest ? 'secondary' : 'default'}
-            size="sm"
-            onClick={props.onOpenSettings}
-            disabled={busy}
-            aria-busy={pendingKey === 'openSettings' ? 'true' : undefined}
-          >
-            {pendingKey === 'openSettings' ? '打开中…' : '前往系统设置'}
+            {primaryAction.label}
           </Button>
         )}
       </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -11585,24 +11585,31 @@ button:active {
   line-height: 1.5;
 }
 
-.settingsOsPermissionImpact {
+/* PR-PERMISSION-COMPACT (WAWQAQ msg 56f997b1): the impact chip was
+   merged into the row description ("用途  ·  影响功能：X") so each
+   permission row stays a single line of meta text. The old
+   `.settingsOsPermissionImpact*` rules came out with it. */
+
+/* Inline status text next to the row title — replaces the standalone
+   PrimitiveBadge column. Tone-tinted text without a background pill
+   reads closer to the reference Settings voice and frees the right
+   side of the row for the single CTA. */
+.settingsOsPermissionInlineStatus {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.74rem;
-  color: var(--foreground-65);
-  line-height: 1.45;
-}
-.settingsOsPermissionImpactLabel {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: oklch(from var(--foreground) l c h / 0.05);
+  font-size: 0.72rem;
+  font-weight: 500;
   color: var(--foreground-55);
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.005em;
+}
+.settingsOsPermissionInlineStatus[data-tone="success"] {
+  color: oklch(from var(--success) l c h);
+}
+.settingsOsPermissionInlineStatus[data-tone="warning"] {
+  color: oklch(from var(--warning, var(--info)) l c h);
+}
+.settingsOsPermissionInlineStatus[data-tone="destructive"] {
+  color: oklch(from var(--destructive) l c h);
 }
 
 .settingsOsPermissionReason {
@@ -11633,46 +11640,14 @@ button:active {
   color: oklch(from var(--success) l c h);
 }
 
-/* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
-   Quick read of overall posture (X granted / Y waiting / Z denied /
-   W other) so users see what's configured at a glance. */
-.settingsPermissionSummary {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-}
-.settingsPermissionSummaryTile {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 12px 14px;
-  border: 1px solid var(--card-border-color, var(--border));
-  border-radius: var(--card-radius, 8px);
-  background: var(--card-bg, var(--background));
-  box-shadow:
-    var(--card-shadow, none),
-    var(--card-highlight, none);
-}
-.settingsPermissionSummaryValue {
-  font-size: 1.5rem;
-  font-weight: 600;
-  line-height: 1.1;
-  font-variant-numeric: tabular-nums;
-  color: var(--foreground);
-}
-.settingsPermissionSummaryLabel {
-  font-size: 0.72rem;
-  color: var(--foreground-60);
-  letter-spacing: 0.02em;
-}
-.settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {
-  color: oklch(from var(--success) l c h);
-}
-.settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
-  color: oklch(from var(--warning, var(--info)) l c h);
-}
-.settingsPermissionSummaryTile[data-tone="destructive"] .settingsPermissionSummaryValue {
-  color: oklch(from var(--destructive) l c h);
+/* PR-PERMISSION-COMPACT (WAWQAQ msg 56f997b1): the 4-tile KPI summary
+   band was removed. The counts now sit in the section subtitle, and
+   the per-row inline status already shows posture row by row. */
+
+.settingsPermissionSubdivider {
+  display: inline-block;
+  margin: 0 4px;
+  color: var(--foreground-35);
 }
 
 /* Diagnostic 5-column capability detail collapsed by default so the


### PR DESCRIPTION
Per WAWQAQ msg `56f997b1` (2026-06-23) + reference Settings screenshots: the previous Permission Center read busier than the reference even though it shipped the same information.

## Three deltas closed

1. **4-tile KPI band removed.** Summary tiles (已授权 / 等待授权 / 已拒绝 / 未知不支持) duplicated the inline status badge each permission row already carries. The counts now sit in the section subtitle: `X/5 已授权 · Y 待授权 · Z 已拒绝 · 点击右侧按钮直接前往…`.

2. **Status badge inline, not a separate column.** Was a `<PrimitiveBadge variant>` chip after the title; now a small tone-tinted span sitting in the heading row. The chip silhouette read as a tag, not a status read-out.

3. **Single CTA per row, not two stacked buttons.** When both `canRequest` and `canOpenSettings` are available, only "请求授权" shows. When only `canOpenSettings`, the label collapses to "去授权" (reference voice — direct, action-led).

Plus: the 影响功能 chip was merged into the purpose copy as `"用途  ·  影响功能：X"`, so each permission row stays a single line of meta text instead of three stacked small-text fragments.

## Net diff

67 insertions / 99 deletions across 2 files. `PermissionSummaryTile` + `.settingsPermissionSummary*` + `.settingsOsPermissionImpact*` deleted; `.settingsOsPermissionInlineStatus` added.

## Test plan

- [x] `apps/desktop` test suite: 1465 / 1465 pass
- [x] Renderer + main typecheck clean
- [x] `@maka/ui` build clean