### PR TITLE
Fix chat model switcher choices

### DIFF
--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -96,6 +96,11 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.doesNotMatch(renderer, /onModelChange=\{\(input\) => void setSessionModel\(input\)\}/);
     assert.match(renderer, /modelChangePending=\{activeId \? pendingSessionModelBySession\[activeId\] === true : false\}/);
     assert.match(renderer, /PROVIDER_DEFAULTS\[connection\.providerType\]/);
+    assert.match(
+      renderer,
+      /const rawModels = connection\.models !== undefined[\s\S]*\? connection\.models\.map\(\(model\) => model\.id\)[\s\S]*: connection\.defaultModel[\s\S]*\? \[connection\.defaultModel\][\s\S]*: defaults\.fallbackModels;/,
+      'chat model choices must fall back to provider defaults only when the connection has no explicit model list/default yet',
+    );
     assert.match(renderer, /CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS\.has\(model\.trim\(\)\)/);
     assert.match(ui, /function ChatModelSwitcher/);
     assert.match(ui, /modelChangePending\?: boolean/);

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -192,11 +192,11 @@ function buildChatModelChoices(connections: readonly LlmConnection[]): ChatModel
       continue;
     }
     const seen = new Set<string>();
-    const rawModels = connection.models?.length
+    const rawModels = connection.models !== undefined
       ? connection.models.map((model) => model.id)
       : connection.defaultModel
         ? [connection.defaultModel]
-        : [];
+        : defaults.fallbackModels;
     const safeModels = connection.providerType === 'codex-subscription'
       ? rawModels.filter((model) => !CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS.has(model.trim()))
       : rawModels;


### PR DESCRIPTION
## Summary
- make chat model choices fall back to provider fallback models when a valid AI-SDK connection has no explicit model list/default yet
- preserve the fail-closed behavior for explicitly fetched empty model lists by treating `models: []` as empty, not as a fallback trigger
- extend the sticky-session model contract so the chat switcher stays selectable for fallback-backed providers

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop test -- session-sticky-model-contract (runs full desktop test suite: 1465/1465 pass, check-console/check-a11y clean)
- npm run build (passes; existing Vite chunk-size warning)
- git diff --check
