### PR TITLE
PR-NAV-NEW-TASK-WEIGHT-0: unbold 新任务 + harmonize nav row size

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -874,8 +874,12 @@ button:active {
   -webkit-app-region: no-drag;
   padding: 3px 6px;
   text-align: left;
-  font-size: 13px;
-  line-height: 1.25;
+  /* PR-NAV-NEW-TASK-WEIGHT-0 (2026-06-23): reference-atlas §2 type
+     scale uses text-sm (14px / 20px line-height) for sidebar nav
+     rows. Maka was sitting at 13px / 1.25 (≈16.25px line-height),
+     a half-step smaller that read tighter than the reference. */
+  font-size: 14px;
+  line-height: 1.43;
   transition:
     background 150ms var(--ease-out-strong),
     color 150ms var(--ease-out-strong);
@@ -906,8 +910,13 @@ button:active {
 }
 
 .maka-nav-new-task {
+  /* PR-NAV-NEW-TASK-WEIGHT-0 (2026-06-23): "新任务" should not render
+     bold by default — the active-state already carries weight: 600,
+     and a permanently-bold idle entry reads as "this is the active
+     page" even when nothing is selected. Reference nav rows are all
+     normal weight at rest; the create-action stays a normal-weight
+     row with the SquarePen glyph carrying the affordance. */
   color: var(--foreground);
-  font-weight: 600;
 }
 
 .maka-nav-new-task .maka-nav-icon {


### PR DESCRIPTION
## Summary

WAWQAQ flagged two sidebar nav typography issues:

- **`新任务` was permanently bold** (`font-weight: 600` on `.maka-nav-new-task`). It read as if it were the active page even when nothing was selected. The active state already carries weight 600, and reference nav rows are all normal-weight at rest. The SquarePen glyph already signals "create" — the label doesn't need to also shout. Dropped the explicit weight.
- **`.maka-nav-row` was at 13px / 1.25 line-height** (≈16.25px). Reference-atlas §2 text-sm token is 14px / 20px, which is what the reference sidebar uses. Bumped to 14px / 1.43.

## Test plan

- [x] `npm test` in `apps/desktop`: 1466 passed
- [x] Visual smoke: `sidebar-long-sessions/light-1280-motion` shows 新任务 / 每日回顾 / 技能 at uniform weight, with 定时任务 (active) the only weight-600 row.