### PR TITLE
feat: shared fault-tolerant Edit replacer (re-land #107, Option A)

### DIFF
--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -134,7 +134,7 @@ describe('isolated headless tools', () => {
     assert.ok(names.includes('self_check_submit'));
   });
 
-  test('Read, Write, Edit, Glob, and Grep delegate to native isolated executor methods', async () => {
+  test('Read, Write, Glob, and Grep delegate to native isolated executor methods', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-host-'));
     await writeFile(join(cwd, 'target.txt'), 'host\n', 'utf8');
     const calls: Array<{ name: string; input: unknown }> = [];
@@ -149,10 +149,6 @@ describe('isolated headless tools', () => {
       async writeFile(input) {
         calls.push({ name: 'Write', input });
         return { ok: true, path: input.path, bytes: Buffer.byteLength(input.content, 'utf8') };
-      },
-      async editFile(input) {
-        calls.push({ name: 'Edit', input });
-        return { ok: true, path: input.path, replacements: 1 };
       },
       async globFiles(input) {
         calls.push({ name: 'Glob', input });
@@ -172,14 +168,6 @@ describe('isolated headless tools', () => {
       path: 'target.txt',
       bytes: 9,
     });
-    assert.deepEqual(
-      await tool(tools, 'Edit').impl({
-        path: join(cwd, 'target.txt'),
-        old_string: 'host',
-        new_string: 'external',
-      }, toolCtx(cwd)),
-      { ok: true, path: 'target.txt', replacements: 1 },
-    );
     assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: `${cwd}/*.txt`, cwd: join(cwd, 'src') }, toolCtx(cwd)), {
       files: ['container.txt'],
     });
@@ -195,10 +183,50 @@ describe('isolated headless tools', () => {
     assert.deepEqual(calls, [
       { name: 'Read', input: { cwd, path: 'target.txt', offset: 1, limit: 2 } },
       { name: 'Write', input: { cwd, path: 'target.txt', content: 'external\n' } },
-      { name: 'Edit', input: { cwd, path: 'target.txt', oldString: 'host', newString: 'external' } },
       { name: 'Glob', input: { cwd, pattern: '*.txt', searchCwd: 'src' } },
       { name: 'Grep', input: { cwd, pattern: 'needle', path: 'src', glob: '*.txt' } },
     ]);
+  });
+
+  test('Edit ignores native file ops and always runs the shared replacer', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-native-'));
+    await mkdir(join(cwd, 'src'));
+    const file = join(cwd, 'src', 'f.ts');
+    await writeFile(file, 'function f() {\n    return 1;\n}\n', 'utf8');
+    const nativeCalls: string[] = [];
+    // A fully native-capable executor: Edit must STILL bypass these and run the
+    // shared computeEditedSource via node -e (there is no native Edit hook).
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+      async readFile() { nativeCalls.push('readFile'); return { content: '' }; },
+      async writeFile(input) { nativeCalls.push('writeFile'); return { ok: true, path: input.path, bytes: 0 }; },
+      async globFiles() { nativeCalls.push('globFiles'); return { files: [] }; },
+      async grepFiles() { nativeCalls.push('grepFiles'); return { matches: [] }; },
+    });
+
+    // The fuzzy match works and returns the shared-replacer metadata
+    // (matchedVia/startLine/endLine) — proof it went through computeEditedSource,
+    // not a native shortcut — and no native file op was consulted for Edit.
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl(
+        { path: 'src/f.ts', old_string: 'function f() {\n  return 1;\n}', new_string: 'function f() {\n    return 2;\n}' },
+        toolCtx(cwd),
+      ),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'line-trimmed', startLine: 1, endLine: 3 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 2;\n}\n');
+    assert.deepEqual(nativeCalls, []);
   });
 
   test('sh-backed file tools fall back to command-backed isolated operations', async () => {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { exec as childExec } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -201,7 +201,7 @@ describe('isolated headless tools', () => {
     ]);
   });
 
-  test('file tools fall back to command-backed isolated operations', async () => {
+  test('sh-backed file tools fall back to command-backed isolated operations', async () => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-fallback-'));
     await mkdir(join(cwd, 'src'));
     const absoluteFile = join(cwd, 'src', 'file.txt');
@@ -236,20 +236,115 @@ describe('isolated headless tools', () => {
     assert.deepEqual(await tool(tools, 'Read').impl({ path: absoluteFile, offset: 1, limit: 1 }, toolCtx(cwd)), {
       content: 'needle',
     });
-    assert.deepEqual(
-      await tool(tools, 'Edit').impl({ path: absoluteFile, old_string: 'hello', new_string: 'hi' }, toolCtx(cwd)),
-      { ok: true, path: 'src/file.txt', replacements: 1 },
-    );
     assert.deepEqual(await tool(tools, 'Glob').impl({ pattern: absoluteGlob }, toolCtx(cwd)), {
       files: ['src/file.txt'],
     });
     assert.deepEqual(await tool(tools, 'Grep').impl({ pattern: 'needle', path: absoluteSrc, glob: absoluteGlob }, toolCtx(cwd)), {
       matches: ['src/file.txt:2:needle'],
     });
-    assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hi\nneedle\n');
-    assert.ok(calls.length >= 5);
+    assert.equal(await readFile(join(cwd, 'src/file.txt'), 'utf8'), 'hello\nneedle\n');
+    // Edit is intentionally excluded here: it runs via `node -e` (covered by the
+    // dedicated Edit test below) while Read/Write/Glob/Grep stay POSIX-sh scripts
+    // that must work with only base coreutils on PATH (here pinned to /usr/bin:/bin).
+    assert.ok(calls.length >= 4);
     assert.ok(calls.every((command) => command.startsWith("sh -c '")));
     assert.ok(calls.every((command) => !command.includes('node -e')));
+  });
+
+  test('command-backed Edit runs the shared fuzzy matcher via node -e', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-'));
+    await mkdir(join(cwd, 'src'));
+    const file = join(cwd, 'src', 'f.ts');
+    // 4-space indented body on disk; the model's old_string uses 2-space indent.
+    await writeFile(file, 'function f() {\n    return 1;\n}\n', 'utf8');
+    await chmod(file, 0o600); // editing must preserve the original mode, not widen it
+    const calls: string[] = [];
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        calls.push(input.command);
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    // Fuzzy: indentation drift is forgiven, and the matched span/strategy is reported.
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl(
+        { path: 'src/f.ts', old_string: 'function f() {\n  return 1;\n}', new_string: 'function f() {\n    return 2;\n}' },
+        toolCtx(cwd),
+      ),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'line-trimmed', startLine: 1, endLine: 3 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 2;\n}\n');
+
+    // Exact match still works and reports matchedVia: 'exact'.
+    assert.deepEqual(
+      await tool(tools, 'Edit').impl({ path: 'src/f.ts', old_string: 'return 2;', new_string: 'return 3;' }, toolCtx(cwd)),
+      { ok: true, path: 'src/f.ts', replacements: 1, matchedVia: 'exact', startLine: 2, endLine: 2 },
+    );
+    assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 3;\n}\n');
+    assert.equal((await stat(file)).mode & 0o777, 0o600); // mode preserved across the tmp+rename
+
+    // Edit refuses to follow a symlink out of the workspace (mirrors existing_target()).
+    const outside = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-outside-'));
+    await writeFile(join(outside, 'secret.txt'), 'secret\n', 'utf8');
+    await symlink(join(outside, 'secret.txt'), join(cwd, 'src', 'link.txt'));
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl({ path: 'src/link.txt', old_string: 'secret', new_string: 'edited' }, toolCtx(cwd)),
+      /inside workspace/,
+    );
+    assert.equal(await readFile(join(outside, 'secret.txt'), 'utf8'), 'secret\n');
+
+    // Every Edit ran through node -e (the shared computeEditedSource), not sh.
+    assert.ok(calls.length >= 3);
+    assert.ok(calls.every((command) => command.startsWith("node -e '")));
+  });
+
+  test('command-backed Edit edits a binary file byte-exactly without corrupting non-UTF-8 bytes', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-headless-tools-edit-bin-'));
+    await mkdir(join(cwd, 'src'));
+    const file = join(cwd, 'src', 'b.bin');
+    // Lone 0xff / 0xfe are invalid UTF-8; decoding as utf8 would replace them with
+    // U+FFFD and corrupt the file. The edit path must keep them byte-for-byte.
+    await writeFile(file, Buffer.concat([Buffer.from([0xff]), Buffer.from('ABC', 'utf8'), Buffer.from([0xfe])]));
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        try {
+          const { stdout, stderr } = await execAsync(input.command, { cwd: input.cwd, maxBuffer: 1024 * 1024 });
+          return { exitCode: 0, stdout, stderr };
+        } catch (error: any) {
+          return {
+            exitCode: typeof error?.code === 'number' ? error.code : 1,
+            stdout: typeof error?.stdout === 'string' ? error.stdout : '',
+            stderr: typeof error?.stderr === 'string' ? error.stderr : String(error),
+          };
+        }
+      },
+    });
+
+    // Exact byte-level replacement: the surrounding non-UTF-8 bytes are preserved.
+    const result = await tool(tools, 'Edit').impl(
+      { path: 'src/b.bin', old_string: 'ABC', new_string: 'XYZ' },
+      toolCtx(cwd),
+    );
+    assert.equal((result as { matchedVia?: string }).matchedVia, 'exact');
+    assert.deepEqual([...(await readFile(file))], [0xff, 0x58, 0x59, 0x5a, 0xfe]);
+
+    // A non-exact (fuzzy) edit on a binary file is refused, not guessed — and the
+    // file is left untouched.
+    await assert.rejects(
+      async () => await tool(tools, 'Edit').impl({ path: 'src/b.bin', old_string: 'X Y Z', new_string: 'Q' }, toolCtx(cwd)),
+      /looks binary/,
+    );
+    assert.deepEqual([...(await readFile(file))], [0xff, 0x58, 0x59, 0x5a, 0xfe]);
   });
 
   test('command-backed file tools do not follow symlinks outside the isolated workspace', async () => {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -332,8 +332,6 @@ export type {
   HeadlessBackendContext,
   IsolatedCommandInput,
   IsolatedCommandResult,
-  IsolatedEditFileInput,
-  IsolatedEditFileResult,
   IsolatedGlobInput,
   IsolatedGlobResult,
   IsolatedGrepInput,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -43,19 +43,6 @@ export interface IsolatedWriteFileResult {
   bytes: number;
 }
 
-export interface IsolatedEditFileInput {
-  cwd: string;
-  path: string;
-  oldString: string;
-  newString: string;
-}
-
-export interface IsolatedEditFileResult {
-  ok: boolean;
-  path: string;
-  replacements: number;
-}
-
 export interface IsolatedGlobInput {
   cwd: string;
   pattern: string;
@@ -95,10 +82,14 @@ export interface IsolatedToolExecutor {
    * external workspace without shelling through exec. If omitted,
    * buildIsolatedHeadlessTools falls back to command-backed operations inside
    * the isolated boundary.
+   *
+   * Edit deliberately has NO native hook: its matching logic is non-trivial and
+   * must stay the single source of truth with the in-process builtin Edit, so it
+   * always runs the shared computeEditedSource via `node -e` (see
+   * buildIsolatedEditTool) regardless of which native ops an executor provides.
    */
   readFile?(input: IsolatedReadFileInput): Promise<IsolatedReadFileResult>;
   writeFile?(input: IsolatedWriteFileInput): Promise<IsolatedWriteFileResult>;
-  editFile?(input: IsolatedEditFileInput): Promise<IsolatedEditFileResult>;
   globFiles?(input: IsolatedGlobInput): Promise<IsolatedGlobResult>;
   grepFiles?(input: IsolatedGrepInput): Promise<IsolatedGrepResult>;
 }

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -141,15 +141,12 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
     permissionRequired: true,
     impl: async ({ path, old_string, new_string }, { cwd }) => {
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Edit path');
-      if (executor.editFile) {
-        return await executor.editFile({ cwd, path: normalizedPath, oldString: old_string, newString: new_string });
-      }
-      // Edit is the one file tool whose matching logic is non-trivial and must
-      // stay byte-identical to the in-process builtin Edit. Rather than keep a
-      // second (perl) matcher, it runs the SHARED computeEditedSource via
-      // `node -e` (node is guaranteed in the headless/Harbor environment); the
-      // other file tools stay on the POSIX-sh scripts. old/new are base64-encoded
-      // so arbitrary content survives argv transport unchanged.
+      // Edit ALWAYS runs the shared computeEditedSource — unlike Read/Write/Glob/
+      // Grep it has NO native-executor fast path, because its matching logic is
+      // non-trivial and must stay the single source of truth with the in-process
+      // builtin Edit. It runs via `node -e` (node is guaranteed in the headless/
+      // Harbor environment); the other file tools stay on the POSIX-sh scripts.
+      // old/new are base64-encoded so arbitrary content survives argv transport.
       const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
         normalizedPath,
         Buffer.from(old_string, 'utf8').toString('base64'),

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -2,6 +2,7 @@ import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
 import {
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
+  COMPUTE_EDITED_SOURCE_FN_SOURCE,
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
@@ -126,7 +127,12 @@ export function buildIsolatedWriteTool(executor: IsolatedToolExecutor): MakaTool
 export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool {
   return {
     name: 'Edit',
-    description: 'Replace an exact string in a file in the isolated headless task workspace.',
+    description:
+      'Replace old_string with new_string in a file in the isolated headless task workspace. '
+      + 'Prefers an exact, unique match; if exact fails it tolerates limited whitespace/indentation/escape '
+      + 'drift in old_string, but only when the match is unambiguous (otherwise it errors — re-read and retry '
+      + 'with exact text). new_string is written verbatim, so provide the exact final text/indentation you want. '
+      + 'Errors if old_string is not found or not unique.',
     parameters: z.object({
       path: z.string(),
       old_string: z.string(),
@@ -138,12 +144,18 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
       if (executor.editFile) {
         return await executor.editFile({ cwd, path: normalizedPath, oldString: old_string, newString: new_string });
       }
-      await execFileCommand(executor, cwd, shellFileCommand(EDIT_SCRIPT, [
+      // Edit is the one file tool whose matching logic is non-trivial and must
+      // stay byte-identical to the in-process builtin Edit. Rather than keep a
+      // second (perl) matcher, it runs the SHARED computeEditedSource via
+      // `node -e` (node is guaranteed in the headless/Harbor environment); the
+      // other file tools stay on the POSIX-sh scripts. old/new are base64-encoded
+      // so arbitrary content survives argv transport unchanged.
+      const editStdout = await execFileCommand(executor, cwd, nodeFileCommand(EDIT_SCRIPT, [
         normalizedPath,
-        old_string,
-        new_string,
+        Buffer.from(old_string, 'utf8').toString('base64'),
+        Buffer.from(new_string, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path: normalizedPath, replacements: 1 };
+      return { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
     },
   };
 }
@@ -213,6 +225,14 @@ function shellFileCommand(script: string, args: string[]): string {
   return ['sh', '-c', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
 }
 
+// Like shellFileCommand but runs the script with `node -e`. Used only by Edit,
+// whose matcher (computeEditedSource) is shared TypeScript that cannot be
+// expressed in POSIX sh. shellQuote escapes the embedded script (including its
+// single quotes) so the serialized function survives transport intact.
+function nodeFileCommand(script: string, args: string[]): string {
+  return ['node', '-e', shellQuote(script), '--', ...args.map(shellQuote)].join(' ');
+}
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
@@ -224,6 +244,26 @@ function numberArg(value: number | undefined): string {
 function parseLineArray(stdout: string): string[] {
   if (!stdout) return [];
   return stdout.replace(/\n$/, '').split('\n').filter((line) => line.length > 0);
+}
+
+// EDIT_SCRIPT applies the edit and THEN prints this metadata, so the file is
+// already changed by the time we parse. matchedVia / line range are best-effort
+// observability; a malformed payload must not turn a successful edit into a
+// reported failure, so this fails open to {} (a protocol regression is caught by
+// tests, which assert the metadata is present on success).
+function parseEditMeta(stdout: string): { matchedVia?: string; startLine?: number; endLine?: number } {
+  try {
+    const parsed: unknown = JSON.parse(stdout || '{}');
+    if (!parsed || typeof parsed !== 'object') return {};
+    const { matchedVia, startLine, endLine } = parsed as Record<string, unknown>;
+    return {
+      matchedVia: typeof matchedVia === 'string' ? matchedVia : undefined,
+      startLine: typeof startLine === 'number' ? startLine : undefined,
+      endLine: typeof endLine === 'number' ? endLine : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function globPatternToEre(pattern: string): string {
@@ -367,33 +407,111 @@ target=$(writable_target "$1" 'Write path') || exit 1
 printf '%s' "$2" > "$target"
 `;
 
-const EDIT_SCRIPT = `${COMMON_SHELL_HELPERS}
-root=$(pwd -P) || exit 1
-target=$(existing_target "$1" 'Edit path') || exit 1
-tmp=$(mktemp "$target.maka-edit.XXXXXX") || exit 1
-perl -0 -e '
-  use strict;
-  use warnings;
-  my ($old, $new, $target, $tmp) = @ARGV;
-  die "old_string must not be empty\n" if $old eq "";
-  open my $in, "<:raw", $target or die "$target: $!\n";
-  local $/;
-  my $content = <$in>;
-  close $in;
-  my $count = () = $content =~ /\\Q$old\\E/g;
-  die "old_string not found in $target\n" if $count == 0;
-  die "old_string is not unique in $target ($count matches)\n" if $count > 1;
-  $content =~ s/\\Q$old\\E/$new/;
-  open my $out, ">:raw", $tmp or die "$tmp: $!\n";
-  print {$out} $content;
-  close $out;
-' "$2" "$3" "$target" "$tmp"
-rc=$?
-if [ "$rc" -ne 0 ]; then
-  rm -f "$tmp"
-  exit "$rc"
-fi
-mv "$tmp" "$target"
+// Edit runs as a `node -e` script (not sh) so it can embed the shared
+// computeEditedSource matcher verbatim — keeping a single source of truth with
+// the in-process builtin Edit instead of a divergent perl reimplementation.
+// Path containment mirrors COMMON_SHELL_HELPERS' existing_target(): reject a
+// symlinked target outright and require the resolved path to stay inside the
+// workspace root. Keep this policy in lockstep with existing_target().
+//
+// The file is read as raw BYTES. A valid-UTF-8 file goes through the shared
+// computeEditedSource (exact + fuzzy) because its utf8 round-trip is lossless; a
+// binary / invalid-UTF-8 file is NEVER decoded (that would replace stray bytes
+// with U+FFFD and corrupt it) — it only permits a unique, exact, byte-level
+// replacement, preserving the prior perl ':raw' guarantee that an exact edit can
+// never corrupt a binary file.
+const EDIT_SCRIPT = `const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const computeEditedSource = ${COMPUTE_EDITED_SOURCE_FN_SOURCE};
+function inside(root, target) {
+  const rel = path.relative(root, target);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+function editTarget(root, inputPath, label) {
+  const target = path.join(root, inputPath);
+  let stat;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') throw new Error(label + ' does not exist: ' + inputPath);
+    throw error;
+  }
+  if (stat.isSymbolicLink()) throw new Error(label + ' must stay inside workspace');
+  const real = stat.isDirectory()
+    ? fs.realpathSync(target)
+    : path.join(fs.realpathSync(path.dirname(target)), path.basename(target));
+  if (!inside(root, real)) throw new Error(label + ' must stay inside workspace');
+  return real;
+}
+function countNewlines(buf, end) {
+  let n = 0;
+  for (let i = 0; i < end; i++) if (buf[i] === 10) n += 1;
+  return n;
+}
+function writeAtomic(target, data) {
+  // Atomic write (tmp + rename), matching the prior perl EDIT_SCRIPT, so a crash
+  // mid-write can never leave a torn file — only the old or the new content. The
+  // temp name is unpredictable (crypto) and created with 'wx' (O_CREAT|O_EXCL) at
+  // the target's OWN permission bits, so a pre-planted symlink at the temp path
+  // can neither be guessed nor followed, and the temp is never briefly wider than
+  // the target. A chmod after creation still applies any bits umask stripped. On
+  // a later failure we unlink ONLY the temp we created (guarded by 'created'), so
+  // a partial/looser-mode file is never left and a foreign file at an EEXIST temp
+  // path is never deleted.
+  const mode = fs.statSync(target).mode & 0o777;
+  const tmp = target + '.maka-edit.' + crypto.randomBytes(8).toString('hex');
+  let created = false;
+  try {
+    fs.writeFileSync(tmp, data, { flag: 'wx', mode: mode });
+    created = true;
+    fs.chmodSync(tmp, mode);
+    fs.renameSync(tmp, target);
+  } catch (error) {
+    if (created) { try { fs.unlinkSync(tmp); } catch (_) {} }
+    throw error;
+  }
+}
+try {
+  const [inputPath, oldBase64, newBase64] = process.argv.slice(1);
+  const root = fs.realpathSync(process.cwd());
+  const target = editTarget(root, inputPath, 'Edit path');
+  const raw = fs.readFileSync(target);
+  const source = raw.toString('utf8');
+  if (Buffer.compare(Buffer.from(source, 'utf8'), raw) === 0) {
+    // Valid UTF-8: the decode is lossless, so the shared matcher (exact + fuzzy)
+    // runs on the decoded text with no risk of byte corruption.
+    const oldString = Buffer.from(oldBase64, 'base64').toString('utf8');
+    const newString = Buffer.from(newBase64, 'base64').toString('utf8');
+    const result = computeEditedSource(source, oldString, newString, inputPath);
+    writeAtomic(target, Buffer.from(result.content, 'utf8'));
+    process.stdout.write(JSON.stringify({ matchedVia: result.matchedVia, startLine: result.startLine, endLine: result.endLine }));
+  } else {
+    // Binary / invalid UTF-8: never decode. Allow only a unique, exact, byte-level
+    // replacement so an exact edit can never corrupt the file; fuzzy is impossible
+    // here by construction (it needs text).
+    const oldBuf = Buffer.from(oldBase64, 'base64');
+    const newBuf = Buffer.from(newBase64, 'base64');
+    if (oldBuf.length === 0) throw new Error('old_string must not be empty in ' + inputPath);
+    const first = raw.indexOf(oldBuf);
+    if (first === -1) {
+      throw new Error('Refusing a non-exact match in ' + inputPath + ': the file is not valid UTF-8 (looks binary). Re-read it and pass the exact bytes to replace.');
+    }
+    if (raw.indexOf(oldBuf, first + oldBuf.length) !== -1) {
+      throw new Error('old_string is not unique in ' + inputPath + ' (binary file: the exact bytes match more than once)');
+    }
+    writeAtomic(target, Buffer.concat([raw.slice(0, first), newBuf, raw.slice(first + oldBuf.length)]));
+    const startLine = countNewlines(raw, first) + 1;
+    const endsWithNewline = oldBuf[oldBuf.length - 1] === 10;
+    const spanLineCount = Math.max(countNewlines(oldBuf, oldBuf.length) + 1 - (endsWithNewline ? 1 : 0), 1);
+    process.stdout.write(JSON.stringify({ matchedVia: 'exact', startLine: startLine, endLine: startLine + spanLineCount - 1 }));
+  }
+} catch (error) {
+  // Surface a clean message (matching the prior perl die behavior) instead of a
+  // node [eval] stack trace; execFileCommand propagates stderr to the model.
+  process.stderr.write(error && error.message ? error.message : String(error));
+  process.exit(1);
+}
 `;
 
 const GLOB_SCRIPT = `${COMMON_SHELL_HELPERS}

--- a/packages/runtime/src/__tests__/edit-replace.test.ts
+++ b/packages/runtime/src/__tests__/edit-replace.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from '../edit-replace.js';
+
+describe('computeEditedSource — exact match', () => {
+  test('replaces the single occurrence and reports an exact match + line range', () => {
+    assert.deepEqual(computeEditedSource('hello world', 'world', 'Maka', 'a.txt'), {
+      content: 'hello Maka',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+
+  test('reports the matched multi-line range (1-based, inclusive)', () => {
+    const content = 'a\nb\nTARGET1\nTARGET2\nc\n';
+    const result = computeEditedSource(content, 'TARGET1\nTARGET2', 'X', 'a.txt');
+    assert.equal(result.content, 'a\nb\nX\nc\n');
+    assert.equal(result.startLine, 3);
+    assert.equal(result.endLine, 4);
+  });
+
+  test('inserts new_string literally (no $-pattern interpretation)', () => {
+    const result = computeEditedSource('const x = old;', 'old', '$&value', 'a.txt');
+    assert.equal(result.content, 'const x = $&value;');
+  });
+
+  test('throws with the where label when old_string is absent', () => {
+    assert.throws(() => computeEditedSource('hello', 'absent', 'x', 'src/a.txt'), /old_string not found in src\/a\.txt/);
+  });
+
+  test('throws with the match count when old_string is not unique', () => {
+    assert.throws(() => computeEditedSource('a a a', 'a', 'b', 'b.txt'), /old_string is not unique in b\.txt \(3 matches\)/);
+  });
+
+  test('rejects identical old_string and new_string', () => {
+    assert.throws(() => computeEditedSource('abc', 'abc', 'abc', 'b.txt'), /identical/);
+  });
+
+  test('rejects an empty old_string', () => {
+    assert.throws(() => computeEditedSource('abc', '', 'x', 'b.txt'), /must not be empty/);
+  });
+});
+
+describe('computeEditedSource — fuzzy cascade', () => {
+  test('line-trimmed: tolerates indentation drift on a multi-line block', () => {
+    const content = 'function f() {\n    return 1;\n}\n'; // 4-space body
+    const oldString = 'function f() {\n  return 1;\n}'; // model used 2-space body
+    const result = computeEditedSource(content, oldString, 'function f() {\n    return 2;\n}', 'f.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 3);
+  });
+
+  test('whitespace: tolerates collapsed internal whitespace', () => {
+    const content = 'const  x   =   1;';
+    const result = computeEditedSource(content, 'const x = 1;', 'const x = 2;', 'w.ts');
+    assert.equal(result.matchedVia, 'whitespace');
+    assert.equal(result.content, 'const x = 2;');
+  });
+
+  test('escape: tolerates literal backslash escapes in old_string', () => {
+    const content = 'line1\nline2';
+    const result = computeEditedSource(content, 'line1\\nline2', 'X', 'e.ts');
+    assert.equal(result.matchedVia, 'escape');
+    assert.equal(result.content, 'X');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test('line-trimmed: preserves a trailing newline in old_string (no extra blank line)', () => {
+    const content = '  abcde\n  fghij\n';
+    const result = computeEditedSource(content, 'abcde\nfghij\n', 'xxxxx\nyyyyy\n', 'n.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'xxxxx\nyyyyy\n');
+    assert.equal(result.startLine, 1);
+    assert.equal(result.endLine, 2);
+  });
+
+  test("a span's trailing newline is a terminator, not an extra line, for endLine", () => {
+    assert.deepEqual(computeEditedSource('abc\n', 'abc\n', 'def\n', 'r.ts'), {
+      content: 'def\n',
+      matchedVia: 'exact',
+      startLine: 1,
+      endLine: 1,
+    });
+  });
+});
+
+describe('computeEditedSource — anti-corruption guards', () => {
+  test('rejects multiple distinct fuzzy candidates instead of guessing', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n   x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}'; // matches both blocks by trimmed lines
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /different line-trimmed candidates/);
+  });
+
+  test('rejects a fuzzy span that occurs more than once', () => {
+    const content = 'function a() {\n  x;\n}\nfunction a() {\n  x;\n}\n';
+    const oldString = 'function a() {\n    x;\n}';
+    assert.throws(() => computeEditedSource(content, oldString, 'Y', 'a.ts'), /occurs more than once/);
+  });
+
+  test('rejects a too-short old_string for a non-exact match', () => {
+    const content = 'a   b';
+    assert.throws(() => computeEditedSource(content, 'a b', 'c', 's.ts'), /too short/);
+  });
+
+  test('a multi-line old_string never collapses onto a single line (whitespace)', () => {
+    const content = 'header\nalpha beta\nfooter\n';
+    assert.throws(() => computeEditedSource(content, 'alpha\nbeta', 'X', 'w.ts'), /not found/);
+  });
+});
+
+describe('computeEditedSource — verbatim replacement (no indentation migration)', () => {
+  test('fuzzy match writes new_string verbatim; the file indentation is NOT migrated', () => {
+    const content = 'def f():\n        return 1\n'; // 8-space body on disk
+    const oldString = 'def f():\n    return 1'; // model used a 4-space body
+    const newString = 'def f():\n    return 2'; // model's new_string is also 4-space
+    const result = computeEditedSource(content, oldString, newString, 'p.py');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    // new_string is inserted exactly as given (4-space), deliberately NOT
+    // re-indented to the file's 8-space — callers own the final formatting.
+    assert.equal(result.content, 'def f():\n    return 2\n');
+  });
+});
+
+describe('computeEditedSource — oversized / binary fuzzy guards', () => {
+  test('binary (NUL) file: exact still edits, fuzzy is refused', () => {
+    const nul = String.fromCharCode(0);
+    const content = 'alpha' + nul + 'needle here';
+    assert.equal(
+      computeEditedSource(content, 'needle here', 'replaced', 'b.bin').content,
+      'alpha' + nul + 'replaced',
+    );
+    assert.throws(() => computeEditedSource(content, 'needle  here', 'x', 'b.bin'), /looks binary/);
+  });
+
+  test('oversized file: exact still edits, fuzzy is refused', () => {
+    const content = 'x'.repeat(1_000_001) + '\nunique anchor line\n'; // > MAX_FUZZY_SOURCE_BYTES
+    assert.equal(
+      computeEditedSource(content, 'unique anchor line', 'edited anchor', 'big.txt').matchedVia,
+      'exact',
+    );
+    assert.throws(
+      () => computeEditedSource(content, '  unique anchor line  ', 'x', 'big.txt'),
+      /too large to fuzzy-match/,
+    );
+  });
+});
+
+describe('computeEditedSource — serialized embedding', () => {
+  test('serialized source is standalone and reproduces the full cascade', () => {
+    assert.equal(typeof COMPUTE_EDITED_SOURCE_FN_SOURCE, 'string');
+    const embedded = new Function(`return (${COMPUTE_EDITED_SOURCE_FN_SOURCE})`)() as typeof computeEditedSource;
+    // exercise a fuzzy path to prove nested helpers survive serialization
+    const result = embedded('function f() {\n    return 1;\n}\n', 'function f() {\n  return 1;\n}', 'function f() {\n    return 2;\n}', 'x.ts');
+    assert.equal(result.matchedVia, 'line-trimmed');
+    assert.equal(result.content, 'function f() {\n    return 2;\n}\n');
+  });
+});

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -11,6 +11,7 @@ import { exec, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { computeEditedSource } from './edit-replace.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
@@ -81,7 +82,11 @@ export function buildBuiltinTools(): MakaTool[] {
     {
       name: 'Edit',
       description:
-        'Replace an exact string in a file. Errors if old_string is not unique or not found.',
+        'Replace old_string with new_string in a file. Prefers an exact, unique match; '
+        + 'if exact fails it tolerates limited whitespace/indentation/escape drift in old_string, '
+        + 'but only when the match is unambiguous (otherwise it errors — re-read and retry with exact text). '
+        + 'new_string is written verbatim, so provide the exact final text/indentation you want. '
+        + 'Errors if old_string is not found or not unique.',
       parameters: z.object({
         path: z.string(),
         old_string: z.string(),
@@ -91,14 +96,16 @@ export function buildBuiltinTools(): MakaTool[] {
       impl: async ({ path, old_string, new_string }, { cwd }) => {
         const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
         const current = await fs.readFile(abs, 'utf8');
-        const count = current.split(old_string).length - 1;
-        if (count === 0) throw new Error(`old_string not found in ${path}`);
-        if (count > 1) {
-          throw new Error(`old_string is not unique in ${path} (${count} matches)`);
-        }
-        const next = current.replace(old_string, new_string);
-        await fs.writeFile(abs, next, 'utf8');
-        return { ok: true, path: abs, replacements: 1 };
+        const result = computeEditedSource(current, old_string, new_string, path);
+        await fs.writeFile(abs, result.content, 'utf8');
+        return {
+          ok: true,
+          path: abs,
+          replacements: 1,
+          matchedVia: result.matchedVia,
+          startLine: result.startLine,
+          endLine: result.endLine,
+        };
       },
     },
     {

--- a/packages/runtime/src/edit-replace.ts
+++ b/packages/runtime/src/edit-replace.ts
@@ -1,0 +1,301 @@
+// packages/runtime/src/edit-replace.ts
+//
+// Shared, fault-tolerant string-edit logic used by BOTH Edit tool
+// implementations:
+//   - the in-process builtin Edit tool (packages/runtime/src/builtin-tools.ts),
+//     which imports and calls computeEditedSource directly, and
+//   - the isolated headless Edit tool (packages/headless/src/tools.ts), which
+//     embeds COMPUTE_EDITED_SOURCE_FN_SOURCE into a `node -e` script that runs
+//     inside the isolated executor process (the actual benchmark path).
+//
+// CONSTRAINT: computeEditedSource must stay fully self-contained — no imports,
+// no references to module-scope bindings, every helper a nested *function
+// declaration* (hoisted, so order-independent), no generators — so that
+// `.toString()` yields a standalone definition that runs unchanged inside the
+// isolated process. This keeps a single source of truth for both call sites.
+//
+// SAFETY MODEL (the point of this module): exact-match drift (whitespace,
+// indentation, escaping) is forgiven, but a fuzzy match must never silently
+// land in the wrong place. Every fuzzy strategy here verifies the FULL span is
+// structurally equivalent to old_string (not just anchors), and a strategy is
+// only accepted when it produces exactly ONE candidate occurring exactly ONCE.
+// Any ambiguity throws instead of guessing.
+//
+// new_string is written VERBATIM at the matched location: the fuzzy strategies
+// only LOCATE the unique span, they never re-indent or rewrite the replacement.
+// This matches opencode's replacers (none migrate indentation), so callers must
+// supply new_string with the exact final formatting they want. Fuzzy matching is
+// additionally gated to text-sized, non-binary source; exact matching is never
+// gated, so a very large source is still edited with an exact snippet. This
+// function operates on a string — binary-*file* byte safety is the caller's I/O
+// concern (the headless isolated Edit reads/writes bytes and only allows an exact
+// byte-level replacement on non-UTF-8 files; see EDIT_SCRIPT).
+//
+// Strategies are adapted from opencode's edit.ts (sourced from cline diff-apply
+// + gemini-cli editCorrector). We keep the three distinctly-reachable full-span
+// matchers (line-trimmed, whitespace-normalized, escape-normalized) and omit:
+//   - indentation-flexible and trimmed-boundary, which are strictly shadowed by
+//     line-trimmed / whitespace-normalized here (they add no reachable match);
+//   - block-anchor and context-aware, which match on partial signal (first/last
+//     line + similarity) and need a tuned similarity threshold — deliberately
+//     deferred to keep wrong-location risk out.
+
+export type EditMatchStrategy =
+  | 'exact'
+  | 'line-trimmed'
+  | 'whitespace'
+  | 'escape';
+
+export interface EditMatch {
+  /** The full new file content after the replacement. */
+  content: string;
+  /** Which strategy located old_string ('exact' or a fuzzy strategy name). */
+  matchedVia: EditMatchStrategy;
+  /** 1-based first line of the matched span in the original source. */
+  startLine: number;
+  /** 1-based last line (inclusive) of the matched span in the original source. */
+  endLine: number;
+}
+
+/**
+ * Apply a single, unambiguous replacement of `oldString` with `newString` in
+ * `source`, tolerating whitespace/indentation/escape drift via a guarded fuzzy
+ * cascade. `where` is the caller's relative path, embedded in error messages.
+ *
+ * @returns the new content plus which strategy matched and the matched line
+ *   range (so the caller can show the model where the edit landed).
+ * @throws when old_string is absent, ambiguous, identical to new_string, too
+ *   short to fuzzy-match safely, or matches a disproportionately large span.
+ */
+export function computeEditedSource(
+  source: string,
+  oldString: string,
+  newString: string,
+  where: string,
+): EditMatch {
+  // Declared inside the function (not module scope) so .toString() carries it
+  // into the isolated EDIT_SCRIPT — module-scope references do not survive
+  // serialization. Minimum trimmed old_string length for a non-exact match.
+  const MIN_FUZZY_OLD_STRING_LENGTH = 5;
+  // Fuzzy scanning walks the whole source repeatedly, so it is restricted to
+  // text-sized inputs. The cap is in UTF-16 code units (String#length) — the
+  // actual cost metric for the indexOf/split/substring scans below, not file
+  // bytes. Exact matching above is NEVER gated by these, so a very large source
+  // is still edited with an exact snippet.
+  const MAX_FUZZY_SOURCE_CHARS = 1_000_000;
+  const MAX_FUZZY_SOURCE_LINES = 50_000;
+
+  if (oldString === newString) {
+    throw new Error(`No changes to apply in ${where}: old_string and new_string are identical`);
+  }
+  if (oldString === '') {
+    throw new Error(`old_string must not be empty in ${where}`);
+  }
+
+  // Exact match first — counted via indexOf so a large file is not split into an
+  // array of substrings just to count. Short-circuits before any fuzzy work.
+  const exactCount = countOccurrences(source, oldString);
+  if (exactCount === 1) {
+    return finish(source, oldString, newString, 'exact');
+  }
+  if (exactCount > 1) {
+    throw new Error(`old_string is not unique in ${where} (${exactCount} matches)`);
+  }
+
+  // Exact failed — entering fuzzy territory. Apply fuzzy-only guards up front so
+  // a too-short, binary, or oversized input is rejected before any scanning.
+  if (oldString.trim().length < MIN_FUZZY_OLD_STRING_LENGTH) {
+    throw new Error(
+      `old_string is too short for a non-exact match in ${where}; provide a longer, exact snippet`,
+    );
+  }
+  if (source.indexOf(String.fromCharCode(0)) !== -1) {
+    throw new Error(
+      `Refusing a non-exact match in ${where}: the file looks binary (contains a NUL byte). Re-read it and pass exact text.`,
+    );
+  }
+  if (source.length > MAX_FUZZY_SOURCE_CHARS || countOccurrences(source, '\n') + 1 > MAX_FUZZY_SOURCE_LINES) {
+    throw new Error(
+      `Refusing a non-exact match in ${where}: the file is too large to fuzzy-match safely. Re-read it and pass exact text.`,
+    );
+  }
+
+  // Fuzzy strategies, increasing tolerance. Each returns FULL-span candidates
+  // structurally equivalent to old_string; the loop below requires exactly one.
+  const strategies: Array<[EditMatchStrategy, (content: string, find: string) => string[]]> = [
+    ['line-trimmed', lineTrimmedSpans],
+    ['whitespace', whitespaceNormalizedSpans],
+    ['escape', escapeNormalizedSpans],
+  ];
+
+  for (const [name, finder] of strategies) {
+    const spans = dedupeInContent(source, finder(source, oldString));
+    if (spans.length === 0) continue;
+    if (spans.length > 1) {
+      throw new Error(
+        `old_string matched ${spans.length} different ${name} candidates in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    const span = spans[0];
+    if (source.indexOf(span) !== source.lastIndexOf(span)) {
+      throw new Error(
+        `old_string matched a ${name} span that occurs more than once in ${where}; provide more exact context to disambiguate`,
+      );
+    }
+    if (isDisproportionate(span, oldString)) {
+      throw new Error(
+        `Refusing ${name} match in ${where}: the matched span is much larger than old_string. Re-read the file and pass the exact text to replace.`,
+      );
+    }
+    return finish(source, span, newString, name);
+  }
+
+  throw new Error(
+    `old_string not found in ${where}; it must match the file's text including whitespace and indentation`,
+  );
+
+  // ---- nested helpers (kept inside for self-contained .toString() embedding) ----
+
+  function finish(
+    content: string,
+    span: string,
+    replacement: string,
+    matchedVia: EditMatchStrategy,
+  ): EditMatch {
+    const index = content.indexOf(span);
+    const before = content.slice(0, index);
+    const startLine = before.split('\n').length;
+    // A trailing newline in the span is the last line's terminator, not an
+    // extra line, so it must not bump endLine.
+    const spanLineCount = span.split('\n').length - (span.endsWith('\n') ? 1 : 0);
+    const endLine = startLine + Math.max(spanLineCount, 1) - 1;
+    // slice-join (not String.replace) so `$&`/`$1` in newString are literal.
+    const next = before + replacement + content.slice(index + span.length);
+    return { content: next, matchedVia, startLine, endLine };
+  }
+
+  function countOccurrences(haystack: string, needle: string): number {
+    if (needle === '') return 0;
+    let count = 0;
+    let index = haystack.indexOf(needle);
+    while (index !== -1) {
+      count += 1;
+      index = haystack.indexOf(needle, index + needle.length);
+    }
+    return count;
+  }
+
+  function dedupeInContent(content: string, candidates: string[]): string[] {
+    const out: string[] = [];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      if (content.indexOf(candidate) === -1) continue;
+      if (out.indexOf(candidate) === -1) out.push(candidate);
+    }
+    return out;
+  }
+
+  function lineTrimmedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const originalLines = content.split('\n');
+    const findEndsWithNewline = find.endsWith('\n');
+    const searchLines = find.split('\n');
+    if (searchLines.length > 0 && searchLines[searchLines.length - 1] === '') {
+      searchLines.pop();
+    }
+    if (searchLines.length === 0) return out;
+    for (let i = 0; i <= originalLines.length - searchLines.length; i++) {
+      let matches = true;
+      for (let j = 0; j < searchLines.length; j++) {
+        if (originalLines[i + j].trim() !== searchLines[j].trim()) {
+          matches = false;
+          break;
+        }
+      }
+      if (!matches) continue;
+      let startIndex = 0;
+      for (let k = 0; k < i; k++) startIndex += originalLines[k].length + 1;
+      let endIndex = startIndex;
+      for (let k = 0; k < searchLines.length; k++) {
+        endIndex += originalLines[i + k].length;
+        if (k < searchLines.length - 1) endIndex += 1;
+      }
+      // If old_string ended with a newline, the matched span must include the
+      // file's newline after the last matched line; otherwise the replacement
+      // would drop or duplicate a line break. When there is no such newline
+      // (EOF with no trailing newline) this is not a faithful match — skip it.
+      if (findEndsWithNewline) {
+        const lastLine = i + searchLines.length - 1;
+        if (lastLine >= originalLines.length - 1) continue;
+        endIndex += 1;
+      }
+      out.push(content.substring(startIndex, endIndex));
+    }
+    return out;
+  }
+
+  function whitespaceNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const normalize = (text: string) => text.replace(/\s+/g, ' ').trim();
+    const normalizedFind = normalize(find);
+    if (normalizedFind === '') return out;
+    const lines = content.split('\n');
+    const findLines = find.split('\n');
+    if (findLines.length === 1) {
+      // Single-line old_string: match individual lines only. A multi-line
+      // old_string must never collapse onto one physical line — normalize()
+      // turns newlines into spaces, so an unguarded single-line scan would let
+      // `a\nb` match the line `a b`, which is a wrong-location edit.
+      for (let i = 0; i < lines.length; i++) {
+        if (normalize(lines[i]) === normalizedFind) out.push(lines[i]);
+      }
+    } else {
+      for (let i = 0; i <= lines.length - findLines.length; i++) {
+        const block = lines.slice(i, i + findLines.length).join('\n');
+        if (normalize(block) === normalizedFind) out.push(block);
+      }
+    }
+    return out;
+  }
+
+  function escapeNormalizedSpans(content: string, find: string): string[] {
+    const out: string[] = [];
+    const unescape = (str: string) =>
+      str.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (match: string, ch: string) => {
+        if (ch === 'n') return '\n';
+        if (ch === 't') return '\t';
+        if (ch === 'r') return '\r';
+        if (ch === "'") return "'";
+        if (ch === '"') return '"';
+        if (ch === '`') return '`';
+        if (ch === '\\') return '\\';
+        if (ch === '\n') return '\n';
+        if (ch === '$') return '$';
+        return match;
+      });
+    const unescapedFind = unescape(find);
+    if (content.includes(unescapedFind)) out.push(unescapedFind);
+    const lines = content.split('\n');
+    const findLines = unescapedFind.split('\n');
+    for (let i = 0; i <= lines.length - findLines.length; i++) {
+      const block = lines.slice(i, i + findLines.length).join('\n');
+      if (unescape(block) === unescapedFind) out.push(block);
+    }
+    return out;
+  }
+
+  function isDisproportionate(span: string, find: string): boolean {
+    const oldLines = find.split('\n').length;
+    const spanLines = span.split('\n').length;
+    if (spanLines >= Math.max(oldLines + 3, oldLines * 2)) return true;
+    if (oldLines === 1) return false;
+    return span.trim().length > Math.max(find.trim().length + 500, find.trim().length * 4);
+  }
+}
+
+/**
+ * Serialized source of computeEditedSource, captured once at module load for
+ * embedding into the isolated headless EDIT_SCRIPT. Using the live function's
+ * own source avoids drift between the in-process and serialized forms.
+ */
+export const COMPUTE_EDITED_SOURCE_FN_SOURCE: string = computeEditedSource.toString();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,6 +66,8 @@ export type {
 
 export { buildBuiltinTools } from './builtin-tools.js';
 export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
+export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
+export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export {
   AGENT_CONTEXT_ISOLATED,
   AGENT_INVOCATION_FOREGROUND,


### PR DESCRIPTION
## What

Re-lands the shared fault-tolerant Edit replacer that was reverted from main (#107 → revert #127), redone as **Option A**: match opencode's replacer behavior exactly and add orthogonal safety guards. This is the keystone of the issue #92 tool-fidelity work — the boundary all later PRs build on.

A single self-contained `computeEditedSource(source, oldString, newString, where)` is the one matcher for both Edit surfaces:
- **builtin Edit** (`packages/runtime/src/builtin-tools.ts`) imports and calls it directly.
- **isolated headless Edit** (`packages/headless/src/tools.ts`, the benchmark/Harbor path) embeds its `.toString()` into a `node -e` script (node is guaranteed in that env). Read/Write/Glob/Grep stay on the POSIX-sh scripts — Edit is the only tool whose matcher is non-trivial shared logic.

## Matching behavior

Guarded fuzzy cascade: `exact → line-trimmed → whitespace → escape`. It forgives whitespace/indentation/escape drift in `old_string`, but never lands in the wrong place — each fuzzy strategy verifies the **full span**, accepts only a **unique single** match, and rejects too-short or disproportionate spans; any ambiguity throws instead of guessing.

`new_string` is written **verbatim** — fuzzy strategies only *locate* the span, they never re-indent the replacement. This matches opencode's replacers (none migrate indentation); callers own the final formatting. (The earlier "indentation migration" idea was dropped as over-engineering and off-thesis.)

## Safety guards

- **Fuzzy is gated to text-sized, non-binary source** (reject NUL / oversized / over-long before scanning); **exact is never gated**, so a large source can still be edited with exact text. Size cap is in UTF-16 code units — the scans' real cost metric.
- **Binary-safe I/O on the headless path:** the file is read as raw bytes. Valid-UTF-8 files run through the shared matcher (lossless round-trip); binary / invalid-UTF-8 files are never decoded and allow only a unique, exact, **byte-level** replacement — preserving the prior perl `:raw` guarantee that an exact edit never corrupts a binary file.
- **Atomic write** (tmp + rename) with an unpredictable `O_EXCL` temp created at the target's own mode (no brief world-wider window), and cleanup that removes only the temp it created.
- **Path containment** mirrors `existing_target()` (reject symlinks, contain in workspace).

## Tests

`packages/runtime/src/__tests__/edit-replace.test.ts` (exact, fuzzy cascade, anti-corruption guards, verbatim-no-migration, oversized/binary guards, serialized embedding) and `packages/headless/src/__tests__/tools.test.ts` (node-`-e` fuzzy + exact + mode preservation + symlink reject + binary byte-exact non-corruption).

- runtime: 611 pass · headless: 267 pass · typecheck: clean across all workspaces.

## Review

Gated with an independent reviewer (xhigh): the first pass flagged binary utf8-corruption (P1), a size-metric naming issue (P2), and temp-file mode/cleanup (P2) — all addressed here. The re-gate found no P0/P1.