### PR TITLE
Add heavy-task compact evidence envelopes

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -64,6 +64,7 @@ class PromptCapturingProgressBackend implements AgentBackend {
   constructor(
     sessionId: string,
     private readonly progress: HeadlessBackendContext['heavyTaskProgress'],
+    private readonly evidence: HeadlessBackendContext['heavyTaskEvidence'],
     private readonly prompts: string[],
   ) {
     this.sessionId = sessionId;
@@ -87,6 +88,11 @@ class PromptCapturingProgressBackend implements AgentBackend {
       await this.progress.recordTodos({
         items: [{ id: 'fix', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
       }, toolCtx);
+      await this.evidence?.recordToolEvidence({
+        name: 'Bash',
+        input: { command: 'npm test', cwd: '/workspace', timeoutMs: 120_000 },
+        result: { exitCode: 1, stdout: `public failure summary\n${'x'.repeat(5_000)}`, stderr: 'short stderr\n' },
+      }, toolCtx);
     }
     const ts = Date.now();
     yield { type: 'complete', id: `progress-complete-${this.prompts.length}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
@@ -98,7 +104,7 @@ class PromptCapturingProgressBackend implements AgentBackend {
 }
 
 const registerPromptCapturingProgressBackend = (prompts: string[]) => (registry: BackendRegistry, context: HeadlessBackendContext): void => {
-  registry.register('fake', (ctx) => new PromptCapturingProgressBackend(ctx.sessionId, context.heavyTaskProgress, prompts));
+  registry.register('fake', (ctx) => new PromptCapturingProgressBackend(ctx.sessionId, context.heavyTaskProgress, context.heavyTaskEvidence, prompts));
 };
 
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
@@ -241,7 +247,12 @@ describe('runAutonomousTask', () => {
       assert.match(prompts[1] ?? '', /Heavy-task progress state from prior task-run events/);
       assert.match(prompts[1] ?? '', /Inventory summary: Inspected public task files/);
       assert.match(prompts[1] ?? '', /Active todo: fix/);
+      assert.match(prompts[1] ?? '', /Heavy-task compact evidence from prior public tool\/check\/artifact observations/);
+      assert.match(prompts[1] ?? '', /tool:Bash exit=1/);
+      assert.match(prompts[1] ?? '', /truncated=true/);
+      assert.doesNotMatch(prompts[1] ?? '', new RegExp(`x{${3_000}}`));
       assert.equal((prompts[1]?.match(/Heavy-task progress state/g) ?? []).length, 1);
+      assert.equal((prompts[1]?.match(/Heavy-task compact evidence/g) ?? []).length, 1);
     });
   });
 

--- a/packages/headless/src/__tests__/heavy-task-evidence.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-evidence.test.ts
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  compactArtifactEvidence,
+  compactSelfCheckEvidence,
+  compactTextEvidence,
+  compactToolEvidence,
+  renderHeavyTaskEvidenceForPrompt,
+} from '../heavy-task-evidence.js';
+import type { HeavyTaskCompactEvidenceEnvelope, HeavyTaskSemanticSelfCheckState } from '../task-contracts.js';
+
+const base = {
+  evidenceId: 'evidence-1',
+  taskRunId: 'run-1',
+  attemptId: 'attempt-1',
+  ts: 10,
+  source: { kind: 'model_tool' as const, toolCallId: 'tool-call-1', sessionId: 'session-1', turnId: 'turn-1' },
+};
+
+describe('heavy-task compact evidence', () => {
+  test('compactTextEvidence bounds excerpts and records truncation metadata', () => {
+    const large = `start\n${'x'.repeat(5_000)}`;
+    const summary = compactTextEvidence(large, {
+      stream: 'stdout',
+      limitChars: 100,
+      ref: 'runtime-event-1',
+      refKind: 'runtime_event',
+    });
+
+    assert.equal(summary.stream, 'stdout');
+    assert.equal(summary.truncated, true);
+    assert.ok((summary.excerpt?.length ?? 0) <= 100);
+    assert.equal(summary.truncationRef?.ref, 'runtime-event-1');
+    assert.equal(summary.truncationRef?.refKind, 'runtime_event');
+    assert.equal(summary.truncationRef?.originalBytes, Buffer.byteLength(large, 'utf8'));
+    assert.ok((summary.truncationRef?.omittedBytes ?? 0) > 0);
+    assert.notEqual(summary.excerpt, large);
+  });
+
+  test('Bash normalization records command, exit code, timeout, and bounded streams', () => {
+    const largeStdout = `public output\n${'a'.repeat(5_000)}`;
+    const evidence = compactToolEvidence({
+      ...base,
+      name: 'Bash',
+      input: { command: 'npm test -- --runInBand', cwd: '/workspace', timeoutMs: 12_000 },
+      result: { exitCode: 124, stdout: largeStdout, stderr: 'timeout\n', timedOut: true },
+    });
+
+    assert.equal(evidence.kind, 'tool');
+    assert.equal(evidence.public, true);
+    assert.equal(evidence.tool?.name, 'Bash');
+    assert.equal(evidence.tool?.exitCode, 124);
+    assert.equal(evidence.tool?.timedOut, true);
+    assert.equal(evidence.tool?.ok, false);
+    assert.equal(evidence.tool?.inputSummary.command, 'npm test -- --runInBand');
+    assert.equal(evidence.tool?.outputs[0]?.stream, 'stdout');
+    assert.equal(evidence.tool?.outputs[0]?.truncated, true);
+    assert.notEqual(evidence.tool?.outputs[0]?.excerpt, largeStdout);
+  });
+
+  test('Read and Grep normalization records path/query and bounded excerpts', () => {
+    const readEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'read-evidence',
+      name: 'Read',
+      input: { cwd: '/workspace', path: 'src/file.ts', offset: 10, limit: 25 },
+      result: { content: `line one\n${'b'.repeat(5_000)}` },
+    });
+    const grepEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'grep-evidence',
+      name: 'Grep',
+      input: { cwd: '/workspace', pattern: 'needle', path: 'src', glob: '*.ts' },
+      result: { matches: Array.from({ length: 200 }, (_, i) => `src/file.ts:${i + 1}:needle ${'c'.repeat(50)}`) },
+    });
+
+    assert.equal(readEvidence.tool?.inputSummary.path, 'src/file.ts');
+    assert.equal(readEvidence.tool?.inputSummary.offset, 10);
+    assert.equal(readEvidence.tool?.outputs[0]?.stream, 'content');
+    assert.equal(readEvidence.tool?.outputs[0]?.truncated, true);
+    assert.equal(grepEvidence.tool?.inputSummary.pattern, 'needle');
+    assert.equal(grepEvidence.tool?.inputSummary.matchCount, 200);
+    assert.equal(grepEvidence.tool?.outputs[0]?.stream, 'matches');
+    assert.equal(grepEvidence.tool?.outputs[0]?.truncated, true);
+    assert.ok((grepEvidence.tool?.outputs[0]?.excerpt?.length ?? 0) < grepEvidence.tool?.outputs[0]?.byteCount!);
+  });
+
+  test('Write and Edit normalization omits mutation payloads and uses diff placeholders', () => {
+    const writeContent = 'secret write body should not appear';
+    const writeEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'write-evidence',
+      name: 'Write',
+      input: { cwd: '/workspace', path: 'src/out.txt', content: writeContent },
+      result: { ok: true, path: 'src/out.txt', bytes: Buffer.byteLength(writeContent, 'utf8') },
+    });
+    const editEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'edit-evidence',
+      name: 'Edit',
+      input: {
+        cwd: '/workspace',
+        path: 'src/out.txt',
+        oldString: 'old private body',
+        newString: 'new private body',
+      },
+      result: { ok: true, path: 'src/out.txt', replacements: 1 },
+    });
+    const serialized = JSON.stringify([writeEvidence, editEvidence]);
+
+    assert.equal(writeEvidence.tool?.inputSummary.contentOmitted, true);
+    assert.equal(writeEvidence.tool?.diff?.status, 'not_captured');
+    assert.equal(editEvidence.tool?.inputSummary.oldStringOmitted, true);
+    assert.equal(editEvidence.tool?.inputSummary.newStringOmitted, true);
+    assert.equal(editEvidence.tool?.inputSummary.replacements, 1);
+    assert.equal(editEvidence.tool?.diff?.status, 'not_captured');
+    assert.doesNotMatch(serialized, /secret write body|old private body|new private body/);
+  });
+
+  test('artifact normalization preserves metadata without artifact body content', () => {
+    const evidence = compactArtifactEvidence({
+      ...base,
+      artifact: {
+        schemaVersion: 1,
+        artifactId: 'artifact-1',
+        taskRunId: 'run-1',
+        ts: 12,
+        kind: 'generated_output',
+        authority: { source: 'runtime', authoritative: false, label: 'public runtime capture' },
+        path: '/tmp/out.log',
+        workspacePath: 'out.log',
+        artifactRef: 'file:/tmp/out.log',
+        hash: 'sha256:abc',
+        mimeType: 'text/plain',
+        metadata: { sizeBytes: 123, content: 'raw artifact body', nested: { output: 'raw output', label: 'public label' } },
+      },
+    });
+
+    assert.equal(evidence.kind, 'artifact');
+    assert.equal(evidence.artifact?.artifactId, 'artifact-1');
+    assert.equal(evidence.artifact?.path, '/tmp/out.log');
+    assert.equal(evidence.artifact?.artifactRef, 'file:/tmp/out.log');
+    assert.equal(evidence.artifact?.hash, 'sha256:abc');
+    assert.deepEqual(evidence.artifact?.authority, { source: 'runtime', authoritative: false, label: 'public runtime capture' });
+    assert.deepEqual(evidence.artifact?.metadata, { sizeBytes: 123, nested: { label: 'public label' } });
+    assert.doesNotMatch(JSON.stringify(evidence), /raw artifact body|raw output/);
+  });
+
+  test('tool and artifact compaction omits non-public benchmark evidence patterns', () => {
+    const bashEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'guarded-bash',
+      name: 'Bash',
+      input: { command: 'cat hidden/tests/private_case.txt', cwd: '/workspace' },
+      result: {
+        exitCode: 1,
+        stdout: 'hidden/tests/private_case.py expected == actual',
+        stderr: 'official verifier output.json threshold 0.95',
+      },
+    });
+    const readEvidence = compactToolEvidence({
+      ...base,
+      evidenceId: 'guarded-read',
+      name: 'Read',
+      input: { cwd: '/workspace', path: 'hidden/tests/private_case.py' },
+      result: { content: 'private benchmark assertion text should stay out' },
+    });
+    const artifactEvidence = compactArtifactEvidence({
+      ...base,
+      evidenceId: 'guarded-artifact',
+      artifact: {
+        path: 'hidden/tests/reference.jpg',
+        kind: 'generated_output',
+        metadata: {
+          safe: 'public label',
+          nested: { verdict: 'private verifier timing order' },
+        },
+      },
+    });
+    const serialized = JSON.stringify([bashEvidence, readEvidence, artifactEvidence]);
+
+    assert.match(serialized, /\[omitted: non-public benchmark evidence pattern\]/);
+    assert.doesNotMatch(serialized, /hidden\/tests|private_case|expected == actual|official verifier output\.json|threshold 0\.95|private benchmark|private verifier timing order/);
+    assert.equal(artifactEvidence.artifact?.metadata?.safe, 'public label');
+  });
+
+  test('prompt renderer includes compact evidence and omits raw large output', () => {
+    const large = 'z'.repeat(5_000);
+    const evidence = compactToolEvidence({
+      ...base,
+      name: 'Bash',
+      input: { command: 'npm test', cwd: '/workspace' },
+      result: { exitCode: 1, stdout: `failed\n${large}`, stderr: '' },
+    });
+    const prompt = renderHeavyTaskEvidenceForPrompt({ heavyTaskEvidence: [evidence] });
+
+    assert.match(prompt ?? '', /Heavy-task compact evidence/);
+    assert.match(prompt ?? '', /tool:Bash exit=1/);
+    assert.match(prompt ?? '', /truncated=true/);
+    assert.doesNotMatch(prompt ?? '', new RegExp(`z{${3_000}}`));
+    assert.equal(renderHeavyTaskEvidenceForPrompt({ heavyTaskEvidence: [] }), undefined);
+  });
+
+  test('accepted self-check evidence compacts and private rejected evidence is ignored', () => {
+    const accepted = selfCheck('self-check-1', 'npm test passed on public files.');
+    const privatePayload = selfCheck('self-check-private', 'hidden/tests/private_case.py revealed a failure.');
+    const ids = idFactory();
+    const acceptedEvidence = compactSelfCheckEvidence({ selfCheck: accepted, newId: ids });
+    const rejectedEvidence = compactSelfCheckEvidence({ selfCheck: privatePayload, newId: ids });
+
+    assert.equal(acceptedEvidence[0]?.kind, 'check');
+    assert.equal(acceptedEvidence[0]?.check?.linkedSelfCheckId, 'self-check-1');
+    assert.ok(acceptedEvidence.some((item) => item.tool?.name === 'self_check_submit'));
+    const artifactEvidence = acceptedEvidence.find((item) => item.artifact?.path === 'build-output.log');
+    assert.equal(artifactEvidence?.artifact?.authority?.source, 'self_check');
+    assert.equal(artifactEvidence?.artifact?.authority?.authoritative, false);
+    assert.deepEqual(rejectedEvidence, []);
+  });
+});
+
+function selfCheck(selfCheckId: string, publicReason: string): HeavyTaskSemanticSelfCheckState {
+  return {
+    schemaVersion: 1,
+    selfCheckId,
+    taskRunId: 'run-1',
+    ts: 10,
+    status: 'pass',
+    publicReason,
+    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+    artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
+    guard: {
+      status: 'accepted',
+      checkedAt: 10,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'tool-call-1' },
+  };
+}
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `evidence-${++i}`;
+}

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -231,6 +231,44 @@ describe('task run export', () => {
         },
       },
       {
+        type: 'heavy_task_evidence_recorded',
+        id: 'e4a',
+        taskRunId: 'run-progress',
+        ts: 4,
+        evidence: {
+          schemaVersion: 1,
+          evidenceId: 'evidence-bash-1',
+          taskRunId: 'run-progress',
+          ts: 4,
+          kind: 'tool',
+          public: true,
+          source: { kind: 'model_tool', toolCallId: 'tool-5', toolName: 'Bash' },
+          tool: {
+            name: 'Bash',
+            inputSummary: { command: 'npm test' },
+            exitCode: 1,
+            ok: false,
+            outputs: [{
+              stream: 'stdout',
+              excerpt: 'public failure summary',
+              byteCount: 5_500,
+              lineCount: 20,
+              truncated: true,
+              truncationRef: {
+                truncated: true,
+                originalBytes: 5_500,
+                visibleBytes: 22,
+                omittedBytes: 5_478,
+                ref: 'runtime-event-1',
+                refKind: 'runtime_event',
+              },
+            }],
+            diff: { status: 'not_applicable' },
+          },
+          links: { runtimeEventIds: ['runtime-event-1'] },
+        },
+      },
+      {
         type: 'heavy_task_self_check_recorded',
         id: 'e5',
         taskRunId: 'run-progress',
@@ -262,6 +300,12 @@ describe('task run export', () => {
     assert.equal(exported.progress?.todos?.historyCount, 1);
     assert.equal(exported.progress?.selfChecks?.latest.selfCheckId, 'self-check-1');
     assert.equal(exported.progress?.selfChecks?.historyCount, 1);
+    assert.equal(exported.progress?.evidence?.latest.evidenceId, 'evidence-bash-1');
+    assert.equal(exported.progress?.evidence?.historyCount, 4);
+    assert.ok(exported.progress?.evidence?.recent.some((item) => item.check?.linkedSelfCheckId === 'self-check-1'));
+    assert.ok(exported.progress?.evidence?.recent.some((item) => item.artifact?.path === 'build-output.log'));
+    const bashEvidence = exported.progress?.evidence?.recent.find((item) => item.evidenceId === 'evidence-bash-1');
+    assert.equal(bashEvidence?.tool?.outputs[0]?.truncationRef?.ref, 'runtime-event-1');
 
     const outDir = await mkdtemp(join(tmpdir(), 'maka-progress-export-'));
     try {
@@ -277,7 +321,11 @@ describe('task run export', () => {
       assert.doesNotMatch(taskRunJson, /private_case|official-verifier-output/);
       assert.doesNotMatch(compactJson, /private_case|official-verifier-output/);
       assert.doesNotMatch(eventsJsonl, /private_case|official-verifier-output/);
+      assert.doesNotMatch(taskRunJson, /x{3000}|raw large stdout|old edit string|new edit string/);
+      assert.match(compactJson, /evidence-bash-1/);
+      assert.match(compactJson, /runtime-event-1/);
       assert.match(eventsJsonl, /self-check-1/);
+      assert.match(eventsJsonl, /evidence-bash-1/);
     } finally {
       await rm(outDir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/scorer.test.ts
+++ b/packages/headless/src/__tests__/scorer.test.ts
@@ -69,4 +69,46 @@ describe('defaultFinalScorer', () => {
     assert.equal(score.taxonomy, 'verification_failed');
     assert.equal(score.errorClass, 'verification_failed');
   });
+
+  test('does not treat compact evidence as verifier authority', () => {
+    const verifierResult: VerifierResult = {
+      id: 'verifier',
+      taskRunId: 'run',
+      ts: 1,
+      kind: 'command',
+      passed: false,
+      exitCode: 1,
+      errorClass: 'verification_failed',
+      authority: { source: 'official_harbor_verifier', authoritative: true },
+      details: {
+        compactEvidence: {
+          latest: {
+            schemaVersion: 1,
+            evidenceId: 'evidence-pass-like',
+            taskRunId: 'run',
+            ts: 1,
+            kind: 'check',
+            public: true,
+            source: { kind: 'model_tool', toolCallId: 'tool-1' },
+            check: { status: 'pass', linkedSelfCheckId: 'self-check-1' },
+          },
+        },
+      },
+    };
+
+    const score = defaultFinalScorer({
+      config,
+      task,
+      runnerCompleted: true,
+      runnerStatus: 'completed',
+      submittedSnapshot,
+      verifierResult,
+    });
+
+    assert.equal(score.passed, false);
+    assert.equal(score.scored, true);
+    assert.equal(score.eligible, true);
+    assert.equal(score.taxonomy, 'verification_failed');
+    assert.equal(score.errorClass, 'verification_failed');
+  });
 });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -284,6 +284,7 @@ const registerProgressToolBackend = (seen: HeadlessBackendContext[]) => (registr
     sessionId: ctx.sessionId,
     header: ctx.header,
     tools: buildIsolatedHeadlessTools(context.toolExecutor!, {
+      ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
       ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
       ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
     }),
@@ -414,6 +415,7 @@ describe('runTaskOnce', () => {
       });
 
       assert.equal(seenContexts[0]?.heavyTaskMode?.enabled, true);
+      assert.ok(seenContexts[0]?.heavyTaskEvidence);
       assert.ok(seenContexts[0]?.heavyTaskProgress);
       assert.ok(seenContexts[0]?.heavyTaskSelfCheck);
       assert.ok(result.projection.toolExecutors[0]?.toolNames.includes('inventory_submit'));

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -57,6 +57,45 @@ function completedEvents(taskRunId = 'tr-1'): TaskEvent[] {
   ];
 }
 
+function heavyTaskEvidenceEvent(
+  taskRunId: string,
+  id: string,
+  evidenceId: string,
+  name: 'Bash' | 'Read',
+  ts: number,
+): TaskEvent {
+  return {
+    type: 'heavy_task_evidence_recorded',
+    id,
+    taskRunId,
+    ts,
+    evidence: {
+      schemaVersion: 1,
+      evidenceId,
+      taskRunId,
+      ts,
+      kind: 'tool',
+      public: true,
+      source: { kind: 'model_tool', toolCallId: `tool-${ts}`, toolName: name },
+      tool: {
+        name,
+        inputSummary: name === 'Bash' ? { command: 'npm test' } : { path: 'README.md' },
+        ...(name === 'Bash' ? { exitCode: 0 } : {}),
+        ok: true,
+        outputs: [{
+          stream: name === 'Bash' ? 'stdout' : 'content',
+          excerpt: 'bounded public summary',
+          byteCount: 22,
+          lineCount: 1,
+          truncated: false,
+          truncationRef: { truncated: false, originalBytes: 22, visibleBytes: 22, omittedBytes: 0 },
+        }],
+        diff: { status: 'not_applicable' },
+      },
+    },
+  };
+}
+
 describe('TaskRunStore', () => {
   test('appends and replays events in order', async () => {
     const store = createInMemoryTaskRunStore();
@@ -113,6 +152,65 @@ describe('TaskRunStore', () => {
     assert.equal(projection.artifacts.length, 1);
     assert.equal(projection.artifacts[0]?.workspacePath, '/app');
     assert.equal(projection.artifacts[0]?.authority.source, 'container_capture');
+    assert.equal(projection.heavyTaskEvidence.length, 0);
+  });
+
+  test('projects compact evidence for heavy-task runtime artifacts and skips official artifacts', () => {
+    const taskRunId = 'tr-artifact-evidence';
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'heavy_task_mode_recorded',
+        id: 'e-2',
+        taskRunId,
+        ts: 2,
+        facts: {
+          schemaVersion: 1,
+          enabled: true,
+          triggerSource: 'config',
+          triggerReason: 'long public task',
+          policyVersion: 'maka-heavy-task-policy.v1',
+        },
+      },
+      {
+        type: 'task_run_artifact_recorded',
+        id: 'e-3',
+        taskRunId,
+        ts: 3,
+        artifact: {
+          schemaVersion: 1,
+          artifactId: 'artifact-runtime',
+          taskRunId,
+          ts: 3,
+          kind: 'generated_output',
+          path: 'build-output.log',
+          authority: { source: 'runtime', authoritative: false, label: 'public runtime artifact' },
+          metadata: { label: 'public label', body: 'raw artifact body' },
+        },
+      },
+      {
+        type: 'task_run_artifact_recorded',
+        id: 'e-4',
+        taskRunId,
+        ts: 4,
+        artifact: {
+          schemaVersion: 1,
+          artifactId: 'artifact-official',
+          taskRunId,
+          ts: 4,
+          kind: 'benchmark_manifest',
+          path: 'official-verifier-output.json',
+          authority: { source: 'official_harbor_verifier', authoritative: true },
+        },
+      },
+    ], taskRunId);
+
+    assert.equal(projection.artifacts.length, 2);
+    assert.equal(projection.heavyTaskEvidence.length, 1);
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.artifactId, 'artifact-runtime');
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.authority?.source, 'runtime');
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.metadata?.label, 'public label');
+    assert.doesNotMatch(JSON.stringify(projection.heavyTaskEvidence), /raw artifact body|official-verifier-output/);
   });
 
   test('projects heavy-task mode facts', () => {
@@ -214,6 +312,20 @@ describe('TaskRunStore', () => {
     assert.equal(projection.latestHeavyTaskTodos?.items[0]?.id, 'edit');
   });
 
+  test('projects heavy-task compact evidence from replay order', () => {
+    const taskRunId = 'tr-evidence';
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e-1', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      heavyTaskEvidenceEvent(taskRunId, 'e-2', 'evidence-1', 'Bash', 2),
+      heavyTaskEvidenceEvent(taskRunId, 'e-3', 'evidence-2', 'Read', 3),
+    ], taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence.length, 2);
+    assert.equal(projection.heavyTaskEvidence[0]?.evidenceId, 'evidence-1');
+    assert.equal(projection.latestHeavyTaskEvidence?.evidenceId, 'evidence-2');
+    assert.equal(projection.latestHeavyTaskEvidence?.tool?.name, 'Read');
+  });
+
   test('projects only accepted public heavy-task self-checks from replay', () => {
     const taskRunId = 'tr-self-check';
     const accepted = acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed on public files.');
@@ -236,6 +348,9 @@ describe('TaskRunStore', () => {
 
     assert.equal(projection.heavyTaskSelfChecks.length, 1);
     assert.equal(projection.latestHeavyTaskSelfCheck?.selfCheckId, 'self-check-1');
+    assert.deepEqual(projection.heavyTaskEvidence.map((item) => item.kind), ['check', 'tool', 'artifact']);
+    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.path, 'build-output.log');
+    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.authority?.source, 'self_check');
     assert.equal(projection.warnings.length, 2);
     assert.match(projection.warnings.join('\n'), /source guard did not accept/);
   });

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -10,6 +10,8 @@ import {
   LOAD_TOOLS_NAME,
   ToolAvailabilityRuntime,
 } from '@maka/runtime';
+import { createHeavyTaskEvidenceRecorder } from '../heavy-task-evidence.js';
+import { createInMemoryTaskRunStore } from '../task-run-store.js';
 import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
 
 const execAsync = promisify(childExec);
@@ -227,6 +229,49 @@ describe('isolated headless tools', () => {
     );
     assert.equal(await readFile(file, 'utf8'), 'function f() {\n    return 2;\n}\n');
     assert.deepEqual(nativeCalls, []);
+  });
+
+  test('enabled heavy-task evidence recorder captures Bash, Read, Grep, Write, and Edit results', async () => {
+    const store = createInMemoryTaskRunStore();
+    let id = 0;
+    const recorder = createHeavyTaskEvidenceRecorder({
+      taskRunId: 'run-evidence',
+      attemptId: 'attempt-1',
+      store,
+      now: () => 100 + id,
+      newId: () => `id-${++id}`,
+    });
+    const tools = buildIsolatedHeadlessTools({
+      async exec(input) {
+        if (input.command.startsWith("node -e '")) {
+          return { exitCode: 0, stdout: '{"matchedVia":"exact","startLine":1,"endLine":1}', stderr: '' };
+        }
+        return { exitCode: 2, stdout: `large stdout\n${'x'.repeat(5_000)}`, stderr: 'short stderr\n' };
+      },
+      async readFile(input) {
+        return { content: `read ${input.path}\n${'r'.repeat(5_000)}` };
+      },
+      async writeFile(input) {
+        return { ok: true, path: input.path, bytes: Buffer.byteLength(input.content, 'utf8') };
+      },
+      async grepFiles() {
+        return { matches: ['src/file.ts:1:needle'] };
+      },
+    }, { heavyTaskEvidence: recorder });
+    const ctx = toolCtx('/workspace');
+
+    await tool(tools, 'Bash').impl({ command: 'npm test' }, ctx);
+    await tool(tools, 'Read').impl({ path: 'src/file.ts', limit: 10 }, ctx);
+    await tool(tools, 'Grep').impl({ pattern: 'needle', path: 'src' }, ctx);
+    await tool(tools, 'Write').impl({ path: 'src/out.txt', content: 'write payload must be omitted' }, ctx);
+    await tool(tools, 'Edit').impl({ path: 'src/out.txt', old_string: 'old payload', new_string: 'new payload' }, ctx);
+
+    const projection = await store.project('run-evidence');
+    assert.deepEqual(projection.heavyTaskEvidence.map((item) => item.tool?.name), ['Bash', 'Read', 'Grep', 'Write', 'Edit']);
+    assert.equal(projection.latestHeavyTaskEvidence?.tool?.name, 'Edit');
+    assert.equal(projection.heavyTaskEvidence[0]?.tool?.outputs[0]?.truncated, true);
+    const serialized = JSON.stringify(projection.heavyTaskEvidence);
+    assert.doesNotMatch(serialized, /write payload must be omitted|old payload|new payload/);
   });
 
   test('sh-backed file tools fall back to command-backed isolated operations', async () => {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -33,7 +33,7 @@ import type { HeadlessBackendContext, IsolatedToolExecutor, RealBackendIsolation
 import { ISOLATED_HEADLESS_TOOL_NAMES, validateRealBackendIsolation } from './isolation.js';
 import { PiCliJsonTransport } from './pi-cli-json-transport.js';
 import { backendNeedsIsolation } from './runner.js';
-import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from './tools.js';
+import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools, type BuildIsolatedHeadlessToolsOptions } from './tools.js';
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
@@ -305,7 +305,11 @@ export function buildAiSdkCellBackendRegistration(input: {
         modelId: input.model,
         permissionEngine,
         modelFactory: getAIModel,
-        tools: buildHarborCellAiSdkTools(context.toolExecutor!),
+        tools: buildHarborCellAiSdkTools(context.toolExecutor!, {
+          ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
+          ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+          ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+        }),
         toolAvailability: buildIsolatedHeadlessToolAvailability(),
         providerOptions: buildProviderOptions(connection, input.model),
         systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
@@ -318,9 +322,12 @@ export function buildAiSdkCellBackendRegistration(input: {
   };
 }
 
-export function buildHarborCellAiSdkTools(executor: IsolatedToolExecutor): MakaTool[] {
+export function buildHarborCellAiSdkTools(
+  executor: IsolatedToolExecutor,
+  options: BuildIsolatedHeadlessToolsOptions = {},
+): MakaTool[] {
   const nonInteractiveToolNames = new Set<string>(ISOLATED_HEADLESS_TOOL_NAMES);
-  return buildIsolatedHeadlessTools(executor).map((tool) => (
+  return buildIsolatedHeadlessTools(executor, options).map((tool) => (
     nonInteractiveToolNames.has(tool.name)
       ? { ...tool, permissionRequired: false }
       : tool

--- a/packages/headless/src/heavy-task-evidence.ts
+++ b/packages/headless/src/heavy-task-evidence.ts
@@ -1,0 +1,560 @@
+import type { MakaToolContext } from '@maka/runtime';
+import { isAcceptedHeavyTaskSelfCheck, validateHeavyTaskPublicSelfCheck } from './heavy-task-self-check.js';
+import type {
+  HeavyTaskArtifactEvidence,
+  HeavyTaskCommandEvidence,
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskDiffSummary,
+  HeavyTaskOutputSummary,
+  HeavyTaskProgressSource,
+  HeavyTaskSemanticSelfCheckState,
+  HeavyTaskToolEvidenceName,
+  HeavyTaskTruncationRef,
+  TaskRunArtifact,
+} from './task-contracts.js';
+import type { TaskRunStore } from './task-run-store.js';
+import type {
+  IsolatedCommandInput,
+  IsolatedCommandResult,
+  IsolatedEditFileInput,
+  IsolatedEditFileResult,
+  IsolatedGlobInput,
+  IsolatedGlobResult,
+  IsolatedGrepInput,
+  IsolatedGrepResult,
+  IsolatedReadFileInput,
+  IsolatedReadFileResult,
+  IsolatedWriteFileInput,
+  IsolatedWriteFileResult,
+} from './isolation.js';
+
+export const HEAVY_TASK_EVIDENCE_SCHEMA_VERSION = 1;
+export const DEFAULT_TEXT_EVIDENCE_LIMIT_CHARS = 2_000;
+export const DEFAULT_PROMPT_EVIDENCE_LIMIT = 8;
+export const DEFAULT_EXPORT_EVIDENCE_LIMIT = 25;
+const NON_PUBLIC_EVIDENCE_PLACEHOLDER = '[omitted: non-public benchmark evidence pattern]';
+
+export interface CompactTextEvidenceOptions {
+  stream: HeavyTaskOutputSummary['stream'];
+  limitChars?: number;
+  ref?: string;
+  refKind?: HeavyTaskTruncationRef['refKind'];
+  forceTruncated?: boolean;
+}
+
+export interface HeavyTaskCompactEvidenceInput {
+  evidenceId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  source: HeavyTaskCompactEvidenceEnvelope['source'];
+}
+
+export type HeavyTaskToolEvidenceInput =
+  | {
+      name: 'Bash';
+      input: IsolatedCommandInput;
+      result: IsolatedCommandResult & { timedOut?: boolean };
+      error?: unknown;
+    }
+  | {
+      name: 'Read';
+      input: IsolatedReadFileInput;
+      result: IsolatedReadFileResult;
+    }
+  | {
+      name: 'Grep';
+      input: IsolatedGrepInput;
+      result: IsolatedGrepResult;
+    }
+  | {
+      name: 'Write';
+      input: IsolatedWriteFileInput;
+      result: IsolatedWriteFileResult;
+    }
+  | {
+      name: 'Edit';
+      input: IsolatedEditFileInput;
+      result: IsolatedEditFileResult;
+    }
+  | {
+      name: 'Glob';
+      input: IsolatedGlobInput;
+      result: IsolatedGlobResult;
+    };
+
+export interface HeavyTaskEvidenceRecorder {
+  recordToolEvidence(input: HeavyTaskToolEvidenceInput, ctx: MakaToolContext): Promise<HeavyTaskCompactEvidenceEnvelope>;
+  recordArtifactEvidence(artifact: TaskRunArtifact, ctx?: Partial<MakaToolContext>): Promise<HeavyTaskCompactEvidenceEnvelope>;
+}
+
+export function compactTextEvidence(value: string, options: CompactTextEvidenceOptions): HeavyTaskOutputSummary {
+  const limitChars = options.limitChars ?? DEFAULT_TEXT_EVIDENCE_LIMIT_CHARS;
+  const originalBytes = Buffer.byteLength(value, 'utf8');
+  const lineCount = value.length === 0 ? 0 : value.split(/\r?\n/).length;
+  const truncatedByLength = value.length > limitChars;
+  const rawExcerpt = value.length === 0 ? undefined : oneLine(value.slice(0, limitChars), limitChars);
+  const redactedBySourceGuard = rawExcerpt !== undefined && !isPublicEvidenceString(rawExcerpt);
+  const truncated = Boolean(options.forceTruncated || truncatedByLength || redactedBySourceGuard);
+  const excerpt = redactedBySourceGuard ? NON_PUBLIC_EVIDENCE_PLACEHOLDER : rawExcerpt;
+  const visibleBytes = redactedBySourceGuard || !excerpt ? 0 : Buffer.byteLength(excerpt, 'utf8');
+  const truncationRef: HeavyTaskTruncationRef = {
+    truncated,
+    originalBytes,
+    visibleBytes,
+    omittedBytes: Math.max(0, originalBytes - visibleBytes),
+    ...(options.ref ? { ref: options.ref } : {}),
+    ...(options.refKind ? { refKind: options.refKind } : {}),
+  };
+  return {
+    stream: options.stream,
+    ...(excerpt ? { excerpt } : {}),
+    lineCount,
+    byteCount: originalBytes,
+    truncated,
+    truncationRef,
+  };
+}
+
+export function compactToolEvidence(
+  input: HeavyTaskCompactEvidenceInput & HeavyTaskToolEvidenceInput,
+): HeavyTaskCompactEvidenceEnvelope {
+  const base = envelopeBase(input, 'tool', { ...input.source, toolName: input.name });
+  switch (input.name) {
+    case 'Bash':
+      return {
+        ...base,
+        tool: {
+          name: 'Bash',
+          inputSummary: {
+            command: compactPublicString(input.input.command, 500),
+            cwd: compactPublicString(input.input.cwd, 500),
+            timeoutMs: input.input.timeoutMs,
+          },
+          exitCode: input.result.exitCode,
+          timedOut: input.result.timedOut ?? false,
+          ok: input.result.exitCode === 0,
+          outputs: [
+            compactTextEvidence(input.result.stdout, { stream: 'stdout', refKind: 'future_storage' }),
+            compactTextEvidence(input.result.stderr, { stream: 'stderr', refKind: 'future_storage' }),
+          ],
+          diff: { status: 'not_applicable' },
+        },
+      };
+    case 'Read':
+      return {
+        ...base,
+        tool: {
+          name: 'Read',
+          inputSummary: {
+            path: compactPublicString(input.input.path, 500),
+            offset: input.input.offset,
+            limit: input.input.limit,
+          },
+          ok: true,
+          outputs: [
+            compactTextEvidence(input.result.content, {
+              stream: 'content',
+              refKind: 'future_storage',
+              forceTruncated: input.input.limit !== undefined,
+            }),
+          ],
+          diff: { status: 'not_applicable' },
+        },
+      };
+    case 'Grep': {
+      const matches = input.result.matches.join('\n');
+      return {
+        ...base,
+        tool: {
+          name: 'Grep',
+          inputSummary: {
+            pattern: compactPublicString(input.input.pattern, 240),
+            path: input.input.path ? compactPublicString(input.input.path, 500) : undefined,
+            glob: input.input.glob ? compactPublicString(input.input.glob, 240) : undefined,
+            matchCount: input.result.matches.length,
+          },
+          ok: true,
+          outputs: [
+            compactTextEvidence(matches, {
+              stream: 'matches',
+              refKind: 'future_storage',
+              forceTruncated: input.result.matches.length >= 200,
+            }),
+          ],
+          diff: { status: 'not_applicable' },
+        },
+      };
+    }
+    case 'Write':
+      return {
+        ...base,
+        tool: {
+          name: 'Write',
+          inputSummary: {
+            path: compactPublicString(input.input.path, 500),
+            contentBytes: Buffer.byteLength(input.input.content, 'utf8'),
+            contentOmitted: true,
+          },
+          ok: input.result.ok,
+          outputs: [omittedOutput('content', Buffer.byteLength(input.input.content, 'utf8'))],
+          diff: notCapturedDiff(input.result.path),
+        },
+      };
+    case 'Edit':
+      return {
+        ...base,
+        tool: {
+          name: 'Edit',
+          inputSummary: {
+            path: compactPublicString(input.input.path, 500),
+            oldStringBytes: Buffer.byteLength(input.input.oldString, 'utf8'),
+            newStringBytes: Buffer.byteLength(input.input.newString, 'utf8'),
+            oldStringOmitted: true,
+            newStringOmitted: true,
+            replacements: input.result.replacements,
+          },
+          ok: input.result.ok,
+          outputs: [omittedOutput('diff')],
+          diff: notCapturedDiff(input.result.path),
+        },
+      };
+    case 'Glob':
+      return {
+        ...base,
+        tool: {
+          name: 'Glob',
+          inputSummary: {
+            pattern: compactPublicString(input.input.pattern, 240),
+            searchCwd: input.input.searchCwd ? compactPublicString(input.input.searchCwd, 500) : undefined,
+            fileCount: input.result.files.length,
+          },
+          ok: true,
+          outputs: [
+            compactTextEvidence(input.result.files.join('\n'), {
+              stream: 'output',
+              refKind: 'future_storage',
+              forceTruncated: input.result.files.length >= 200,
+            }),
+          ],
+          diff: { status: 'not_applicable' },
+        },
+      };
+  }
+}
+
+export function compactArtifactEvidence(
+  input: HeavyTaskCompactEvidenceInput & { artifact: TaskRunArtifact | HeavyTaskArtifactEvidence; source?: HeavyTaskProgressSource },
+): HeavyTaskCompactEvidenceEnvelope {
+  const artifact = input.artifact;
+  const isTaskRunArtifact = 'schemaVersion' in artifact && 'artifactId' in artifact;
+  const source = input.source;
+  return {
+    ...envelopeBase(input, 'artifact', source),
+    artifact: {
+      ...(isTaskRunArtifact ? { artifactId: compactPublicString(artifact.artifactId, 500) } : {}),
+      ...(artifact.path ? { path: compactPublicString(artifact.path, 500) } : {}),
+      ...('workspacePath' in artifact && artifact.workspacePath ? { workspacePath: compactPublicString(artifact.workspacePath, 500) } : {}),
+      ...('artifactRef' in artifact && artifact.artifactRef ? { artifactRef: compactPublicString(artifact.artifactRef, 500) } : {}),
+      kind: compactPublicString(artifact.kind, 200),
+      ...('exists' in artifact && artifact.exists !== undefined ? { exists: artifact.exists } : {}),
+      ...('sizeBytes' in artifact && artifact.sizeBytes !== undefined ? { sizeBytes: artifact.sizeBytes } : {}),
+      ...(artifact.hash ? { hash: compactPublicString(artifact.hash, 200) } : {}),
+      ...('mimeType' in artifact && artifact.mimeType ? { mimeType: compactPublicString(artifact.mimeType, 200) } : {}),
+      ...(artifact.metadata ? { metadata: sanitizeMetadata(artifact.metadata) } : {}),
+      ...(isTaskRunArtifact ? { authority: compactAuthority(artifact.authority) } : compactAuthorityFromSource(source)),
+    },
+    links: isTaskRunArtifact ? { artifactIds: [compactPublicString(artifact.artifactId, 500)] } : undefined,
+  };
+}
+
+export function compactSelfCheckEvidence(input: {
+  selfCheck: HeavyTaskSemanticSelfCheckState;
+  newId: () => string;
+}): HeavyTaskCompactEvidenceEnvelope[] {
+  const selfCheck = input.selfCheck;
+  if (!isAcceptedHeavyTaskSelfCheck(selfCheck)) return [];
+  const base = {
+    taskRunId: selfCheck.taskRunId,
+    attemptId: selfCheck.attemptId,
+    ts: selfCheck.ts,
+    source: selfCheck.source,
+  };
+  const checkEnvelope: HeavyTaskCompactEvidenceEnvelope = {
+    ...envelopeBase({ ...base, evidenceId: input.newId(), source: selfCheck.source }, 'check', selfCheck.source),
+    check: {
+      status: selfCheck.status,
+      linkedSelfCheckId: selfCheck.selfCheckId,
+    },
+  };
+  const commands = selfCheck.commandEvidence.map((command) =>
+    compactSelfCheckCommandEvidence({
+      ...base,
+      evidenceId: input.newId(),
+      source: { ...selfCheck.source, toolName: 'self_check_submit' },
+      command,
+      selfCheckId: selfCheck.selfCheckId,
+    }),
+  );
+  const artifacts = selfCheck.artifactEvidence.map((artifact) => ({
+    ...compactArtifactEvidence({
+      ...base,
+      evidenceId: input.newId(),
+      source: { ...selfCheck.source, toolName: 'self_check_submit' },
+      artifact,
+    }),
+    links: { checkIds: [selfCheck.selfCheckId] },
+  }));
+  return [checkEnvelope, ...commands, ...artifacts];
+}
+
+export function createHeavyTaskEvidenceRecorder(input: {
+  taskRunId: string;
+  attemptId?: string;
+  store: TaskRunStore;
+  now: () => number;
+  newId: () => string;
+}): HeavyTaskEvidenceRecorder {
+  return {
+    async recordToolEvidence(toolInput, ctx) {
+      const ts = input.now();
+      const evidence = compactToolEvidence({
+        ...toolInput,
+        evidenceId: input.newId(),
+        taskRunId: input.taskRunId,
+        ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+        ts,
+        source: sourceFromContext(ctx, toolInput.name),
+      } as HeavyTaskCompactEvidenceInput & HeavyTaskToolEvidenceInput);
+      await input.store.appendEvent(input.taskRunId, {
+        type: 'heavy_task_evidence_recorded',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts,
+        evidence,
+      });
+      return evidence;
+    },
+    async recordArtifactEvidence(artifact, ctx) {
+      const ts = input.now();
+      const evidence = compactArtifactEvidence({
+        evidenceId: input.newId(),
+        taskRunId: input.taskRunId,
+        ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+        ts,
+        source: sourceFromPartialContext(ctx),
+        artifact,
+      });
+      await input.store.appendEvent(input.taskRunId, {
+        type: 'heavy_task_evidence_recorded',
+        id: input.newId(),
+        taskRunId: input.taskRunId,
+        ts,
+        evidence,
+      });
+      return evidence;
+    },
+  };
+}
+
+export function renderHeavyTaskEvidenceForPrompt(projection: {
+  heavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope[];
+}): string | undefined {
+  const evidence = projection.heavyTaskEvidence ?? [];
+  if (evidence.length === 0) return undefined;
+  const recent = evidence.slice(-DEFAULT_PROMPT_EVIDENCE_LIMIT);
+  const lines = ['Heavy-task compact evidence from prior public tool/check/artifact observations:'];
+  for (const item of recent) {
+    if (item.tool) {
+      const status = toolStatus(item.tool);
+      lines.push(`- ${item.evidenceId} tool:${item.tool.name} ${status} ${inputSummary(item.tool.inputSummary)}`);
+      for (const output of item.tool.outputs.slice(0, 2)) {
+        lines.push(`  - ${output.stream}: ${output.excerpt ? oneLine(output.excerpt, 180) : '[omitted]'}${truncationSuffix(output)}`);
+      }
+      if (item.tool.diff && item.tool.diff.status !== 'not_applicable') {
+        lines.push(`  - diff: ${item.tool.diff.status}${item.tool.diff.truncationRef?.ref ? ` ref=${item.tool.diff.truncationRef.ref}` : ''}`);
+      }
+    } else if (item.artifact) {
+      lines.push(`- ${item.evidenceId} artifact:${item.artifact.kind ?? 'unknown'} ${oneLine(item.artifact.path ?? item.artifact.workspacePath ?? item.artifact.artifactRef ?? item.artifact.artifactId ?? 'unknown', 180)}`);
+    } else if (item.check) {
+      lines.push(`- ${item.evidenceId} check:${item.check.status ?? 'unknown'} selfCheck=${item.check.linkedSelfCheckId ?? 'none'}`);
+    }
+  }
+  if (evidence.length > recent.length) {
+    lines.push(`- ${evidence.length - recent.length} older compact evidence item(s) omitted`);
+  }
+  lines.push('Use these summaries and refs only; do not assume omitted raw stdout, stderr, file content, or diffs are available.');
+  return lines.join('\n');
+}
+
+function compactSelfCheckCommandEvidence(input: HeavyTaskCompactEvidenceInput & {
+  command: HeavyTaskCommandEvidence;
+  selfCheckId: string;
+}): HeavyTaskCompactEvidenceEnvelope {
+  return {
+    ...envelopeBase(input, 'tool', input.source),
+    tool: {
+      name: 'self_check_submit',
+      inputSummary: {
+        command: compactPublicString(input.command.command, 500),
+        artifactRefs: (input.command.artifactRefs ?? []).map((ref) => compactPublicString(ref, 500)),
+      },
+      exitCode: input.command.exitCode,
+      ...(input.command.timedOut !== undefined ? { timedOut: input.command.timedOut } : {}),
+      ...(input.command.exitCode === undefined || input.command.exitCode === null ? {} : { ok: input.command.exitCode === 0 }),
+      outputs: input.command.outputExcerpt
+        ? [compactTextEvidence(input.command.outputExcerpt, { stream: 'output', refKind: 'future_storage' })]
+        : [],
+      diff: { status: 'not_applicable' },
+    },
+    links: { checkIds: [input.selfCheckId], artifactIds: (input.command.artifactRefs ?? []).map((ref) => compactPublicString(ref, 500)) },
+  };
+}
+
+function envelopeBase(
+  input: HeavyTaskCompactEvidenceInput,
+  kind: HeavyTaskCompactEvidenceEnvelope['kind'],
+  source: HeavyTaskCompactEvidenceEnvelope['source'],
+): Omit<HeavyTaskCompactEvidenceEnvelope, 'tool' | 'artifact' | 'check' | 'links'> {
+  return {
+    schemaVersion: HEAVY_TASK_EVIDENCE_SCHEMA_VERSION,
+    evidenceId: input.evidenceId,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    ts: input.ts,
+    kind,
+    public: true,
+    source,
+  };
+}
+
+function sourceFromContext(ctx: MakaToolContext, toolName: HeavyTaskToolEvidenceName): HeavyTaskCompactEvidenceEnvelope['source'] {
+  return {
+    kind: 'model_tool',
+    toolCallId: ctx.toolCallId,
+    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx.turnId ? { turnId: ctx.turnId } : {}),
+    toolName,
+  };
+}
+
+function sourceFromPartialContext(ctx: Partial<MakaToolContext> | undefined): HeavyTaskCompactEvidenceEnvelope['source'] {
+  return {
+    kind: 'model_tool',
+    toolCallId: ctx?.toolCallId ?? 'system-artifact',
+    ...(ctx?.sessionId ? { sessionId: ctx.sessionId } : {}),
+    ...(ctx?.turnId ? { turnId: ctx.turnId } : {}),
+  };
+}
+
+function omittedOutput(stream: HeavyTaskOutputSummary['stream'], byteCount = 0): HeavyTaskOutputSummary {
+  return {
+    stream,
+    byteCount,
+    lineCount: 0,
+    truncated: true,
+    truncationRef: {
+      truncated: true,
+      originalBytes: byteCount,
+      visibleBytes: 0,
+      omittedBytes: byteCount,
+      refKind: 'future_storage',
+    },
+  };
+}
+
+function notCapturedDiff(path: string): HeavyTaskDiffSummary {
+  return {
+    status: 'not_captured',
+    files: [{ path: compactPublicString(path, 500) }],
+    truncationRef: { truncated: true, refKind: 'future_storage' },
+  };
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata).slice(0, 30)) {
+    if (/^(?:body|content|stdout|stderr|output|diff|old_string|new_string)$/i.test(key)) continue;
+    if (!isPublicEvidenceString(key)) continue;
+    const next = sanitizeMetadataValue(value, 0);
+    if (next !== undefined) out[key] = next;
+  }
+  return out;
+}
+
+function sanitizeMetadataValue(value: unknown, depth: number): unknown {
+  if (depth > 3) return undefined;
+  if (typeof value === 'string') {
+    const clean = oneLine(value, 500);
+    return isPublicEvidenceString(clean) ? clean : undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'boolean' || value === null) return value;
+  if (Array.isArray(value)) return value.slice(0, 30).map((item) => sanitizeMetadataValue(item, depth + 1)).filter((item) => item !== undefined);
+  if (recordValue(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value).slice(0, 30)) {
+      if (/^(?:body|content|stdout|stderr|output|diff|old_string|new_string)$/i.test(key)) continue;
+      if (!isPublicEvidenceString(key)) continue;
+      const next = sanitizeMetadataValue(item, depth + 1);
+      if (next !== undefined) out[key] = next;
+    }
+    return out;
+  }
+  return undefined;
+}
+
+function toolStatus(item: NonNullable<HeavyTaskCompactEvidenceEnvelope['tool']>): string {
+  if (item.exitCode !== undefined) return `exit=${item.exitCode ?? 'unknown'}`;
+  if (item.ok !== undefined) return `ok=${item.ok ? 'true' : 'false'}`;
+  return 'status=unknown';
+}
+
+function inputSummary(input: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(input).slice(0, 4)) {
+    if (value === undefined) continue;
+    parts.push(`${key}=${oneLine(String(value), 80)}`);
+  }
+  return parts.join(' ');
+}
+
+function truncationSuffix(output: HeavyTaskOutputSummary): string {
+  const ref = output.truncationRef?.ref ? ` ref=${output.truncationRef.ref}` : '';
+  const omitted = output.truncationRef?.omittedBytes ? ` omittedBytes=${output.truncationRef.omittedBytes}` : '';
+  return output.truncated || ref || omitted ? ` [truncated=${output.truncated}${omitted}${ref}]` : '';
+}
+
+function oneLine(value: string, maxChars: number): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  return clean.length <= maxChars ? clean : `${clean.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function compactPublicString(value: string, maxChars: number): string {
+  const clean = oneLine(value, maxChars);
+  return isPublicEvidenceString(clean) ? clean : NON_PUBLIC_EVIDENCE_PLACEHOLDER;
+}
+
+function compactAuthority(authority: TaskRunArtifact['authority']): NonNullable<HeavyTaskCompactEvidenceEnvelope['artifact']>['authority'] {
+  return {
+    source: compactPublicString(authority.source, 200),
+    authoritative: authority.authoritative,
+    ...(authority.label ? { label: compactPublicString(authority.label, 500) } : {}),
+  };
+}
+
+function compactAuthorityFromSource(
+  source: HeavyTaskCompactEvidenceEnvelope['source'],
+): Pick<NonNullable<HeavyTaskCompactEvidenceEnvelope['artifact']>, 'authority'> {
+  if (source.toolName !== 'self_check_submit') return {};
+  return { authority: { source: 'self_check', authoritative: false } };
+}
+
+function isPublicEvidenceString(value: string): boolean {
+  if (value.length === 0) return true;
+  return validateHeavyTaskPublicSelfCheck({ publicReason: value }, 0).ok;
+}
+
+function recordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -156,6 +156,11 @@ export type {
   AutonomousResultTaxonomy,
   EnvNetworkSecretPolicy,
   FeedbackObservation,
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskDiffSummary,
+  HeavyTaskEvidenceKind,
+  HeavyTaskEvidenceRecordedEvent,
+  HeavyTaskOutputSummary,
   HeavyTaskInventoryItem,
   HeavyTaskInventoryRecordedEvent,
   HeavyTaskInventoryState,
@@ -167,9 +172,11 @@ export type {
   HeavyTaskSelfCheckStatus,
   HeavyTaskSemanticSelfCheckState,
   HeavyTaskSourceGuardResult,
+  HeavyTaskToolEvidenceName,
   HeavyTaskTodoItem,
   HeavyTaskTodoState,
   HeavyTaskTodosRecordedEvent,
+  HeavyTaskTruncationRef,
   HeadlessInterventionMode,
   IsolationPolicyRecordedEvent,
   PermissionDecision,
@@ -328,6 +335,24 @@ export {
   renderHeavyTaskSelfCheckForPrompt,
   validateHeavyTaskPublicSelfCheck,
 } from './heavy-task-self-check.js';
+export type {
+  CompactTextEvidenceOptions,
+  HeavyTaskCompactEvidenceInput,
+  HeavyTaskEvidenceRecorder,
+  HeavyTaskToolEvidenceInput,
+} from './heavy-task-evidence.js';
+export {
+  compactArtifactEvidence,
+  compactSelfCheckEvidence,
+  compactTextEvidence,
+  compactToolEvidence,
+  createHeavyTaskEvidenceRecorder,
+  DEFAULT_EXPORT_EVIDENCE_LIMIT,
+  DEFAULT_PROMPT_EVIDENCE_LIMIT,
+  DEFAULT_TEXT_EVIDENCE_LIMIT_CHARS,
+  HEAVY_TASK_EVIDENCE_SCHEMA_VERSION,
+  renderHeavyTaskEvidenceForPrompt,
+} from './heavy-task-evidence.js';
 export type {
   HeavyTaskCompletionInput,
   HeavyTaskCompletionStatus,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,4 +1,5 @@
 import type { Config, Task } from './contracts.js';
+import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
 import type { HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import type { HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
@@ -41,6 +42,22 @@ export interface IsolatedWriteFileResult {
   ok: boolean;
   path: string;
   bytes: number;
+}
+
+export interface IsolatedEditFileInput {
+  cwd: string;
+  path: string;
+  oldString: string;
+  newString: string;
+}
+
+export interface IsolatedEditFileResult {
+  ok: boolean;
+  path: string;
+  replacements: number;
+  matchedVia?: string;
+  startLine?: number;
+  endLine?: number;
 }
 
 export interface IsolatedGlobInput {
@@ -130,6 +147,8 @@ export interface HeadlessBackendContext {
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   /** Present only when heavy-task mode is enabled for advisory public self-check tooling. */
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
+  /** Present only when heavy-task mode is enabled for compact public evidence capture. */
+  heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
 }
 
 export function validateRealBackendIsolation(isolation: RealBackendIsolation | undefined): void {

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -71,6 +71,11 @@ export interface TaskRunExport {
       latest: NonNullable<TaskRunProjection['latestHeavyTaskSelfCheck']>;
       historyCount: number;
     };
+    evidence?: {
+      latest: NonNullable<TaskRunProjection['latestHeavyTaskEvidence']>;
+      recent: TaskRunProjection['heavyTaskEvidence'];
+      historyCount: number;
+    };
   };
   isolation: {
     policy?: TaskRunProjection['isolation'];
@@ -315,7 +320,14 @@ function progressFromProjection(projection: TaskRunProjection): TaskRunExport['p
       historyCount: projection.heavyTaskSelfChecks.length,
     };
   }
-  return progress.inventory || progress.todos || progress.selfChecks ? progress : undefined;
+  if (projection.latestHeavyTaskEvidence) {
+    progress.evidence = {
+      latest: projection.latestHeavyTaskEvidence,
+      recent: projection.heavyTaskEvidence.slice(-25),
+      historyCount: projection.heavyTaskEvidence.length,
+    };
+  }
+  return progress.inventory || progress.todos || progress.selfChecks || progress.evidence ? progress : undefined;
 }
 
 function runtimeEventIdsFrom(runtimeRefs: unknown): string[] {
@@ -373,8 +385,13 @@ function eventsJsonl(events: readonly TaskEvent[]): string {
 }
 
 function exportableTaskEvents(event: TaskEvent): TaskEvent[] {
-  if (event.type !== 'heavy_task_self_check_recorded') return [event];
-  return isAcceptedHeavyTaskSelfCheck(event.selfCheck) ? [event] : [];
+  if (event.type === 'heavy_task_self_check_recorded') {
+    return isAcceptedHeavyTaskSelfCheck(event.selfCheck) ? [event] : [];
+  }
+  if (event.type === 'heavy_task_evidence_recorded') {
+    return event.evidence.public === true ? [event] : [];
+  }
+  return [event];
 }
 
 export function exportContentHash(value: unknown): string {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -24,6 +24,10 @@ import {
 } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
+import {
+  createHeavyTaskEvidenceRecorder,
+  renderHeavyTaskEvidenceForPrompt,
+} from './heavy-task-evidence.js';
 import { configWithHeavyTaskPolicy, resolveHeavyTaskMode } from './heavy-task-policy.js';
 import {
   createHeavyTaskProgressRecorder,
@@ -144,15 +148,20 @@ export async function runTaskOnce(
   const priorProjection = heavyTaskMode.enabled ? await taskRunStore.project(taskRunId) : undefined;
   const priorProgressPrompt = priorProjection ? renderHeavyTaskProgressForPrompt(priorProjection) : undefined;
   const priorSelfCheckPrompt = priorProjection ? renderHeavyTaskSelfCheckForPrompt(priorProjection) : undefined;
+  const priorEvidencePrompt = priorProjection ? renderHeavyTaskEvidenceForPrompt(priorProjection) : undefined;
   const instruction = withOptionalStatePrompts(deps.instructionOverride ?? task.instruction, [
     priorProgressPrompt,
     priorSelfCheckPrompt,
+    priorEvidencePrompt,
   ]);
   const heavyTaskProgress = heavyTaskMode.enabled
     ? createHeavyTaskProgressRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
     : undefined;
   const heavyTaskSelfCheck = heavyTaskMode.enabled
     ? createHeavyTaskSelfCheckRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
+    : undefined;
+  const heavyTaskEvidence = heavyTaskMode.enabled
+    ? createHeavyTaskEvidenceRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
     : undefined;
 
   if (createTaskRun) {
@@ -248,6 +257,7 @@ export async function runTaskOnce(
       heavyTaskMode,
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
       ...(heavyTaskSelfCheck ? { heavyTaskSelfCheck } : {}),
+      ...(heavyTaskEvidence ? { heavyTaskEvidence } : {}),
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -367,6 +367,85 @@ export interface HeavyTaskSemanticSelfCheckState {
   source: HeavyTaskProgressSource;
 }
 
+export type HeavyTaskEvidenceKind = 'tool' | 'check' | 'artifact';
+export type HeavyTaskToolEvidenceName = 'Bash' | 'Read' | 'Grep' | 'Write' | 'Edit' | 'Glob' | string;
+
+export interface HeavyTaskTruncationRef {
+  truncated: boolean;
+  originalBytes?: number;
+  visibleBytes?: number;
+  omittedBytes?: number;
+  ref?: string;
+  refKind?: 'runtime_event' | 'artifact' | 'external' | 'future_storage';
+}
+
+export interface HeavyTaskOutputSummary {
+  stream: 'stdout' | 'stderr' | 'output' | 'content' | 'matches' | 'diff';
+  excerpt?: string;
+  lineCount?: number;
+  byteCount?: number;
+  truncated: boolean;
+  truncationRef?: HeavyTaskTruncationRef;
+}
+
+export interface HeavyTaskDiffSummary {
+  status: 'not_applicable' | 'not_captured' | 'present';
+  files?: Array<{ path: string; additions?: number; deletions?: number }>;
+  excerpt?: string;
+  truncationRef?: HeavyTaskTruncationRef;
+}
+
+export interface HeavyTaskCompactEvidenceEnvelope {
+  schemaVersion: 1;
+  evidenceId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  kind: HeavyTaskEvidenceKind;
+  public: true;
+  source: HeavyTaskProgressSource & {
+    runtimeEventId?: string;
+    toolName?: HeavyTaskToolEvidenceName;
+  };
+  tool?: {
+    name: HeavyTaskToolEvidenceName;
+    inputSummary: Record<string, unknown>;
+    exitCode?: number | null;
+    timedOut?: boolean;
+    ok?: boolean;
+    outputs: HeavyTaskOutputSummary[];
+    diff?: HeavyTaskDiffSummary;
+  };
+  artifact?: {
+    artifactId?: string;
+    path?: string;
+    workspacePath?: string;
+    artifactRef?: string;
+    kind?: string;
+    exists?: boolean;
+    sizeBytes?: number;
+    hash?: string;
+    mimeType?: string;
+    metadata?: Record<string, unknown>;
+    authority?: {
+      source: string;
+      authoritative: boolean;
+      label?: string;
+    };
+  };
+  check?: {
+    checkId?: string;
+    status?: 'pass' | 'fail' | 'inconclusive' | 'unknown';
+    linkedSelfCheckId?: string;
+  };
+  links?: {
+    todoIds?: string[];
+    checkIds?: string[];
+    artifactIds?: string[];
+    runtimeEventIds?: string[];
+  };
+}
+
 export interface EnvNetworkSecretPolicy {
   schemaVersion: 1;
   env: 'inherit_none' | 'allowlist';
@@ -584,6 +663,11 @@ export interface HeavyTaskSelfCheckRecordedEvent extends BaseTaskEvent {
   selfCheck: HeavyTaskSemanticSelfCheckState;
 }
 
+export interface HeavyTaskEvidenceRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_evidence_recorded';
+  evidence: HeavyTaskCompactEvidenceEnvelope;
+}
+
 export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
   type: 'workspace_lease_recorded';
   lease: WorkspaceLeaseFacts;
@@ -711,6 +795,7 @@ export type TaskEvent =
   | HeavyTaskInventoryRecordedEvent
   | HeavyTaskTodosRecordedEvent
   | HeavyTaskSelfCheckRecordedEvent
+  | HeavyTaskEvidenceRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent
   | ToolExecutorIdentityRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -1,11 +1,13 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ResultRecord } from './contracts.js';
+import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
 import { evaluateHeavyTaskCompletionStatus, type HeavyTaskCompletionStatus } from './heavy-task-finalization.js';
 import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import type {
   AutonomousDecision,
   FeedbackObservation,
+  HeavyTaskCompactEvidenceEnvelope,
   HeavyTaskInventoryState,
   TaskInboxItem,
   HeavyTaskModeFacts,
@@ -51,6 +53,8 @@ export interface TaskRunProjection extends TaskRun {
   latestHeavyTaskTodos?: HeavyTaskTodoState;
   heavyTaskSelfChecks: HeavyTaskSemanticSelfCheckState[];
   latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+  heavyTaskEvidence: HeavyTaskCompactEvidenceEnvelope[];
+  latestHeavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope;
   heavyTaskCompletion?: HeavyTaskCompletionStatus;
   isolation?: TaskIsolationFacts;
   workspaceLease?: WorkspaceLeaseFacts;
@@ -95,6 +99,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     heavyTaskInventory: [],
     heavyTaskTodoStates: [],
     heavyTaskSelfChecks: [],
+    heavyTaskEvidence: [],
   };
   const attempts = new Map<string, TaskAttempt>();
   const inboxItems = new Map<string, TaskInboxItem>();
@@ -155,6 +160,16 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         break;
       case 'task_run_artifact_recorded':
         projection.artifacts.push(event.artifact);
+        if (projection.heavyTaskMode?.enabled === true && isCompactEvidenceEligibleArtifact(event.artifact)) {
+          appendCompactEvidence(projection, compactArtifactEvidence({
+            evidenceId: `${event.id}:compact-artifact`,
+            taskRunId: projection.taskRunId,
+            ...(event.artifact.attemptId ? { attemptId: event.artifact.attemptId } : {}),
+            ts: event.ts,
+            source: { kind: 'model_tool', toolCallId: `task-run-artifact:${event.id}`, toolName: 'artifact' },
+            artifact: event.artifact,
+          }));
+        }
         break;
       case 'score_result_recorded':
         projection.scoreResults.push(event.result);
@@ -176,8 +191,20 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
         if (isAcceptedHeavyTaskSelfCheck(event.selfCheck)) {
           projection.heavyTaskSelfChecks.push(event.selfCheck);
           projection.latestHeavyTaskSelfCheck = event.selfCheck;
+          appendCompactEvidence(
+            projection,
+            ...compactSelfCheckEvidence({
+              selfCheck: event.selfCheck,
+              newId: selfCheckEvidenceIdFactory(event.selfCheck.selfCheckId),
+            }),
+          );
         } else {
           projection.warnings.push(`ignored heavy-task self-check ${event.selfCheck.selfCheckId}: source guard did not accept public evidence`);
+        }
+        break;
+      case 'heavy_task_evidence_recorded':
+        if (!appendCompactEvidence(projection, event.evidence)) {
+          projection.warnings.push(`ignored heavy-task evidence ${event.evidence.evidenceId}: evidence must be public and match taskRunId`);
         }
         break;
       case 'isolation_policy_recorded':
@@ -467,11 +494,35 @@ function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: numbe
   return terminalEvents + 1;
 }
 
+function appendCompactEvidence(projection: TaskRunProjection, ...evidence: HeavyTaskCompactEvidenceEnvelope[]): boolean {
+  let ok = true;
+  for (const item of evidence) {
+    if (item.public !== true || item.taskRunId !== projection.taskRunId) {
+      ok = false;
+      continue;
+    }
+    projection.heavyTaskEvidence.push(item);
+    projection.latestHeavyTaskEvidence = item;
+  }
+  return ok;
+}
+
+function selfCheckEvidenceIdFactory(selfCheckId: string): () => string {
+  let index = 0;
+  return () => `${selfCheckId}:compact-${++index}`;
+}
+
+function isCompactEvidenceEligibleArtifact(artifact: TaskRunArtifact): boolean {
+  return (artifact.authority.source === 'runtime' || artifact.authority.source === 'self_check')
+    && artifact.authority.authoritative !== true;
+}
+
 function hasHeavyTaskCompletionState(projection: TaskRunProjection): boolean {
   return projection.heavyTaskMode?.enabled === true
     || projection.heavyTaskInventory.length > 0
     || projection.heavyTaskTodoStates.length > 0
-    || projection.heavyTaskSelfChecks.length > 0;
+    || projection.heavyTaskSelfChecks.length > 0
+    || projection.heavyTaskEvidence.length > 0;
 }
 
 function safeFileId(id: string): string {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -6,11 +6,13 @@ import {
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
+import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
 import type { IsolatedToolExecutor } from './isolation.js';
 
 export interface BuildIsolatedHeadlessToolsOptions {
+  heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
 }
@@ -24,12 +26,12 @@ export function buildIsolatedHeadlessTools(
   options: BuildIsolatedHeadlessToolsOptions = {},
 ): MakaTool[] {
   const tools = [
-    buildIsolatedBashTool(executor),
-    buildIsolatedReadTool(executor),
-    buildIsolatedWriteTool(executor),
-    buildIsolatedEditTool(executor),
-    buildIsolatedGlobTool(executor),
-    buildIsolatedGrepTool(executor),
+    buildIsolatedBashTool(executor, options),
+    buildIsolatedReadTool(executor, options),
+    buildIsolatedWriteTool(executor, options),
+    buildIsolatedEditTool(executor, options),
+    buildIsolatedGlobTool(executor, options),
+    buildIsolatedGrepTool(executor, options),
     buildSubagentSpawnTool(),
     ...buildSubagentProjectionTools(),
   ];
@@ -54,7 +56,10 @@ export function buildIsolatedHeadlessToolAvailability(): ToolAvailabilityConfig 
   };
 }
 
-export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedBashTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Bash',
     description: 'Run a shell command in the isolated headless task workspace.',
@@ -63,14 +68,21 @@ export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool 
       timeout_ms: z.number().int().positive().max(600_000).optional(),
     }),
     permissionRequired: true,
-    impl: async ({ command, timeout_ms }, { cwd, emitOutput }) => {
-      const result = await executor.exec({
+    impl: async ({ command, timeout_ms }, ctx) => {
+      const { cwd, emitOutput } = ctx;
+      const input = {
         command,
         cwd,
         timeoutMs: timeout_ms ?? 120_000,
+      };
+      const result = await executor.exec({
+        command: input.command,
+        cwd: input.cwd,
+        timeoutMs: input.timeoutMs,
       });
       if (result.stdout) emitOutput('stdout', result.stdout);
       if (result.stderr) emitOutput('stderr', result.stderr);
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Bash', input, result }, ctx);
       return {
         kind: 'terminal',
         cwd,
@@ -83,7 +95,10 @@ export function buildIsolatedBashTool(executor: IsolatedToolExecutor): MakaTool 
   };
 }
 
-export function buildIsolatedReadTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedReadTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Read',
     description: 'Read a file from the isolated headless task workspace.',
@@ -93,38 +108,60 @@ export function buildIsolatedReadTool(executor: IsolatedToolExecutor): MakaTool 
       limit: z.number().int().positive().optional(),
     }),
     permissionRequired: false,
-    impl: async ({ path, offset, limit }, { cwd }) => {
+    impl: async ({ path, offset, limit }, ctx) => {
+      const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Read path');
-      if (executor.readFile) return await executor.readFile({ cwd, path: normalizedPath, offset, limit });
+      const input = { cwd, path: normalizedPath, offset, limit };
+      if (executor.readFile) {
+        const result = await executor.readFile(input);
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Read', input, result }, ctx);
+        return result;
+      }
       const stdout = await execFileCommand(executor, cwd, shellFileCommand(READ_SCRIPT, [
         normalizedPath,
         numberArg(offset),
         numberArg(limit),
       ]));
-      return { content: stdout };
+      const result = { content: stdout };
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Read', input, result }, ctx);
+      return result;
     },
   };
 }
 
-export function buildIsolatedWriteTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedWriteTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Write',
     description: 'Write content to a file in the isolated headless task workspace.',
     parameters: z.object({ path: z.string(), content: z.string() }),
     permissionRequired: true,
-    impl: async ({ path, content }, { cwd }) => {
+    impl: async ({ path, content }, ctx) => {
+      const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Write path');
-      if (executor.writeFile) return await executor.writeFile({ cwd, path: normalizedPath, content });
+      const input = { cwd, path: normalizedPath, content };
+      if (executor.writeFile) {
+        const result = await executor.writeFile(input);
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
+        return result;
+      }
       await execFileCommand(executor, cwd, shellFileCommand(WRITE_SCRIPT, [
         normalizedPath,
         content,
       ]));
-      return { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
+      const result = { ok: true, path: normalizedPath, bytes: Buffer.byteLength(content, 'utf8') };
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Write', input, result }, ctx);
+      return result;
     },
   };
 }
 
-export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedEditTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Edit',
     description:
@@ -139,8 +176,10 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
       new_string: z.string(),
     }),
     permissionRequired: true,
-    impl: async ({ path, old_string, new_string }, { cwd }) => {
+    impl: async ({ path, old_string, new_string }, ctx) => {
+      const { cwd } = ctx;
       const normalizedPath = normalizeWorkspacePath(path, cwd, 'Edit path');
+      const input = { cwd, path: normalizedPath, oldString: old_string, newString: new_string };
       // Edit ALWAYS runs the shared computeEditedSource — unlike Read/Write/Glob/
       // Grep it has NO native-executor fast path, because its matching logic is
       // non-trivial and must stay the single source of truth with the in-process
@@ -152,12 +191,17 @@ export function buildIsolatedEditTool(executor: IsolatedToolExecutor): MakaTool 
         Buffer.from(old_string, 'utf8').toString('base64'),
         Buffer.from(new_string, 'utf8').toString('base64'),
       ]));
-      return { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
+      const result = { ok: true, path: normalizedPath, replacements: 1, ...parseEditMeta(editStdout) };
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Edit', input, result }, ctx);
+      return result;
     },
   };
 }
 
-export function buildIsolatedGlobTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedGlobTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Glob',
     description: 'Find files in the isolated headless task workspace matching a glob pattern.',
@@ -166,21 +210,32 @@ export function buildIsolatedGlobTool(executor: IsolatedToolExecutor): MakaTool 
       cwd: z.string().optional(),
     }),
     permissionRequired: false,
-    impl: async ({ pattern, cwd: relCwd }, { cwd }) => {
+    impl: async ({ pattern, cwd: relCwd }, ctx) => {
+      const { cwd } = ctx;
       const normalizedPattern = normalizeWorkspaceGlobPattern(pattern, cwd, 'Glob pattern');
       const normalizedRelCwd = relCwd === undefined ? undefined : normalizeWorkspacePath(relCwd, cwd, 'Glob cwd');
-      if (executor.globFiles) return await executor.globFiles({ cwd, pattern: normalizedPattern, searchCwd: normalizedRelCwd });
+      const input = { cwd, pattern: normalizedPattern, searchCwd: normalizedRelCwd };
+      if (executor.globFiles) {
+        const result = await executor.globFiles(input);
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Glob', input, result }, ctx);
+        return result;
+      }
       const stdout = await execFileCommand(executor, cwd, shellFileCommand(GLOB_SCRIPT, [
         normalizedPattern,
         globPatternToEre(normalizedPattern),
         normalizedRelCwd ?? '',
       ]));
-      return { files: parseLineArray(stdout) };
+      const result = { files: parseLineArray(stdout) };
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Glob', input, result }, ctx);
+      return result;
     },
   };
 }
 
-export function buildIsolatedGrepTool(executor: IsolatedToolExecutor): MakaTool {
+export function buildIsolatedGrepTool(
+  executor: IsolatedToolExecutor,
+  options: Pick<BuildIsolatedHeadlessToolsOptions, 'heavyTaskEvidence'> = {},
+): MakaTool {
   return {
     name: 'Grep',
     description: 'Search file contents with a regex in the isolated headless task workspace.',
@@ -190,22 +245,30 @@ export function buildIsolatedGrepTool(executor: IsolatedToolExecutor): MakaTool 
       glob: z.string().optional(),
     }),
     permissionRequired: false,
-    impl: async ({ pattern, path, glob }, { cwd }) => {
+    impl: async ({ pattern, path, glob }, ctx) => {
+      const { cwd } = ctx;
       const normalizedPath = path === undefined ? undefined : normalizeWorkspacePath(path, cwd, 'Grep path');
       const normalizedGlob = glob === undefined ? undefined : normalizeWorkspaceGlobPattern(glob, cwd, 'Grep glob');
-      if (executor.grepFiles) return await executor.grepFiles({
+      const input = {
         cwd,
         pattern,
         path: normalizedPath,
         glob: normalizedGlob,
-      });
+      };
+      if (executor.grepFiles) {
+        const result = await executor.grepFiles(input);
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Grep', input, result }, ctx);
+        return result;
+      }
       const stdout = await execFileCommand(executor, cwd, shellFileCommand(GREP_SCRIPT, [
         pattern,
         normalizedPath ?? '',
         normalizedGlob ?? '',
         normalizedGlob === undefined ? '' : globPatternToEre(normalizedGlob),
       ]));
-      return { matches: parseLineArray(stdout) };
+      const result = { matches: parseLineArray(stdout) };
+      await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Grep', input, result }, ctx);
+      return result;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add schema-versioned compact evidence envelopes for heavy-task tool, check, and artifact observations.
- Capture Bash/Read/Grep/Write/Edit/Glob tool evidence with bounded output summaries, truncation refs, exit/timeout metadata, omitted mutation payloads, and diff placeholders.
- Project/export/resume compact evidence through task-run replay, bounded result exports, and continuation prompts while preserving default-off behavior and verifier/scorer authority.
- Preserve artifact authority in compact metadata, derive accepted self-check/runtime artifact compact evidence, and filter non-public benchmark/evaluator patterns from compact excerpts and summaries.

## Rive
- Workflow: maka.issue102-heavy-task-p1a
- Run: wfrun_ac7a46ccdcae4b808623f30c61dd1190
- Reviewer returned PATCH_REQUIRED on artifact authority/path coverage; steward patch applied and verified.

## Verification
- npm --workspace @maka/headless run typecheck
- npm --workspace @maka/headless run build
- node --test dist/__tests__/heavy-task-evidence.test.js dist/__tests__/tools.test.js dist/__tests__/task-run-store.test.js dist/__tests__/result-export.test.js dist/__tests__/autonomous-agent-loop.test.js dist/__tests__/task-agent-controller.test.js dist/__tests__/scorer.test.js (71 tests / 7 suites)
- npm --workspace @maka/headless test (286 tests / 38 suites)
- git diff --check
- git diff --cached --check