### PR TITLE
PR-SETTINGS-PAGE-BODY-0: settings body to reference recipe

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7258,10 +7258,20 @@ button:active {
   padding-bottom: 8px;
 }
 
+/* PR-SETTINGS-PAGE-BODY-0 (2026-06-23, WAWQAQ msg `2c810f2d`): bring
+   Settings page body to reference's recipe. Two visible problems before:
+   (a) content surface had no left/right whitespace — rows stretched
+   edge-to-edge of the right pane. Reference uses a `max-w-3xl` (768px)
+   centered column with generous side padding. (b) per-row chrome was
+   bordered + tinted plates with shadows; reference uses flat rows with
+   spacing-only separation. */
 .settingsStructuredPage {
   display: grid;
   align-content: start;
-  gap: 16px;
+  gap: 0;
+  max-width: 768px;
+  margin: 0 auto;
+  padding: 40px 24px 64px;
 }
 
 .settingsPageIntro {
@@ -7285,14 +7295,23 @@ button:active {
   font-size: 13px;
 }
 
+/* PR-SETTINGS-PAGE-BODY-0: reference rows are flat — no border-bottom
+   between rows, spacing-only separation. Padding tightens vertically to
+   16/20 (was 6/0). Label / sub-text bumped to 14/12 from 12/11 to match
+   reference's `text-sm font-medium` + `text-xs text-text-quaternary`. */
 .settingsFormRow {
-  min-height: 40px;
+  min-height: 56px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  border-bottom: 1px solid var(--border);
-  padding: 6px 0;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  transition: background 150ms var(--ease-out-strong);
+}
+
+.settingsFormRow:hover {
+  background: oklch(from var(--foreground) l c h / 0.03);
 }
 
 .settingsFormRow strong,
@@ -7300,17 +7319,17 @@ button:active {
 .settingsFormGrid label span {
   display: block;
   color: var(--foreground);
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
 }
 
 .settingsFormRow small,
 .settingsField small {
   display: block;
-  margin-top: 2px;
+  margin-top: 4px;
   color: var(--foreground-50);
-  font-size: 11px;
-  line-height: 1.35;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .settingsFieldWarning {
@@ -8951,8 +8970,7 @@ button:active {
 }
 
 .providerEmpty,
-.providerCard,
-.settingsRow {
+.providerCard {
   border-radius: 8px;
   border: 1px solid var(--border);
   background: var(--foreground-2);
@@ -8960,11 +8978,22 @@ button:active {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
 }
 
+/* PR-SETTINGS-PAGE-BODY-0 (2026-06-23): `.settingsRow` was sharing the
+   bordered/tinted-plate chrome with `.providerCard`; reference uses
+   flat rows with no border or background plate. Provider cards keep
+   their chrome (they ARE cards) — only `.settingsRow` flattens. */
 .settingsRow {
   display: grid;
   grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
   align-items: center;
-  gap: 12px;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  transition: background 150ms var(--ease-out-strong);
+}
+
+.settingsRow:hover {
+  background: oklch(from var(--foreground) l c h / 0.03);
 }
 
 .settingsRow > div {
@@ -8975,10 +9004,10 @@ button:active {
 .providerEmpty span,
 .settingsRow small {
   display: block;
-  margin-top: 2px;
+  margin-top: 4px;
   color: var(--foreground-55);
   font-size: 12px;
-  line-height: 1.45;
+  line-height: 1.4;
 }
 
 .connectionForm label {
@@ -9631,17 +9660,20 @@ button:active {
   color: var(--destructive-text);
 }
 
+/* PR-SETTINGS-PAGE-BODY-0: label / value typography aligned with the
+   reference recipe (text-sm font-medium for label; quaternary tone for
+   the right-side value text). */
 .settingsRow strong {
   color: var(--foreground);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
   white-space: nowrap;
 }
 
 .settingsRow > span {
   min-width: 0;
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: 13px;
   overflow-wrap: anywhere;
   text-align: right;
 }

--- a/notes/reference-settings.md
+++ b/notes/reference-settings.md
@@ -222,6 +222,28 @@ Reference does NOT use bordered card containers around groups of
 controls. The default presentation is a **flat row list inside the
 `max-w-3xl` column**.
 
+### 4.0 Content-column padding — WAWQAQ msg `2c810f2d` 2026-06-23
+
+WAWQAQ called out the left/right whitespace as visibly wider in
+reference than in Maka. Concrete numbers from a second RE pass:
+
+- The content column is `mx-auto max-w-3xl pt-10 pb-16` (= 768px wide,
+  40px top, 64px bottom). No explicit `px-N` is applied inside the
+  column — the side whitespace comes from the column NOT filling the
+  right pane.
+- At the typical desktop window width (~1280px viewport, 256px nav
+  rail), the right pane is ~1024px. A 768px centered column leaves
+  ~128px of whitespace on each side. That's the "wider padding" effect.
+- Inside each row, padding is `px-5 py-4` (20px / 16px). Rows do NOT
+  carry their own border, background plate, or shadow — separation is
+  pure spacing.
+
+**Maka delta found 2026-06-23**:
+- `.settingsStructuredPage` had `gap: 16px` but NO `max-width` / `margin: 0 auto` — rows stretched to fill the right pane. Fixed to `max-width: 768px; margin: 0 auto; padding: 40px 24px 64px`.
+- `.settingsFormRow` had `border-bottom: 1px solid var(--border)` and `padding: 6px 0` — both wrong. Reference uses spacing-only and `px-5 py-4`. Fixed to `padding: 16px 20px`, no border-bottom.
+- `.settingsRow` was sharing `.providerCard` chrome (bordered, tinted, lifted). Provider cards keep their chrome (they ARE cards); `.settingsRow` flattened to a flex row.
+- Label was 12px / 600 weight; bumped to 14px / 500. Sub-text 11px → 12px. Matches reference `text-sm font-medium` + `text-xs text-text-quaternary`.
+
 ### 4.1 Row
 
 ```


### PR DESCRIPTION
## Summary

WAWQAQ msg `2c810f2d` flagged that the IA-consolidation PR moved the nav but left the page body looking nothing like reference. Specifically: "Content Surface 左右的 padding 显然比我们的宽". Second-pass pixel RE confirmed two structural deltas:

1. **Content column wasn't constrained.** Reference uses `mx-auto max-w-3xl pt-10 pb-16` (768px centered). Maka's `.settingsStructuredPage` had `gap: 16px` and no max-width — rows ran edge-to-edge of the right pane. At a 1280px viewport with the 256px nav rail, a 768px centered column leaves ~128px whitespace on each side. That's the "wider padding" WAWQAQ saw.

2. **Rows had card chrome.** Reference uses flat rows (no border, no plate, no shadow) — separation is pure spacing. Maka was rendering every `.settingsRow` with the bordered + tinted + shadowed `.providerCard` chrome.

### Changes

- `.settingsStructuredPage`: `max-width: 768px; margin: 0 auto; padding: 40px 24px 64px`. Gap removed (rows own their padding).
- `.settingsFormRow`: drop `border-bottom`, padding `16px 20px`, `min-height: 56px`, subtle hover bg.
- `.settingsRow`: split out of the `.providerCard` chrome block; redefined as a flat grid row with `16px 20px` padding, transparent bg.
- Label typography 12px / 600 → 14px / 500 (reference `text-sm font-medium`).
- Sub-text typography 11px → 12px (reference `text-xs`).

`notes/reference-settings.md` §4.0 captures the measurements + maka delta as recorded spec.

## Test plan

- [x] `npm test` in `apps/desktop`: 1465 passed
- [x] Visual smoke: `settings-general/light-1280-motion` — content column centered with ~128px whitespace each side, rows flat with spacing-only separation, 代理服务器 row at the bottom sits in the same rhythm.