### PR TITLE
PR-SETTINGS-SWEEP-0: section headings on merged Settings pages + double-pad fix

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1105,8 +1105,11 @@ function SettingsPage(props: {
       );
     case 'appearance':
       // PR-SETTINGS-IA-CONSOLIDATE-0: 主题 + 个性化 → 外观.
+      // PR-SETTINGS-SWEEP-0: per-section uppercase heading so the user
+      // can see the two sub-blocks as belonging to one page.
       return (
         <div className="settingsStructuredPage">
+          <h2 className="settingsSectionHeading">主题</h2>
           <ThemeSettingsPage
             themePref={props.themePref}
             density={props.density}
@@ -1117,6 +1120,7 @@ function SettingsPage(props: {
             onDensityChange={props.onDensityChange}
             onThemePaletteChange={props.onThemePaletteChange}
           />
+          <h2 className="settingsSectionHeading">个性化</h2>
           <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />
         </div>
       );
@@ -1136,21 +1140,27 @@ function SettingsPage(props: {
       return <HealthCenterPage />;
     case 'memory-review':
       // PR-SETTINGS-IA-CONSOLIDATE-0: 记忆 + 每日回顾 → 记忆与回顾.
+      // PR-SETTINGS-SWEEP-0: section heading per sub-block.
       return (
         <div className="settingsStructuredPage">
+          <h2 className="settingsSectionHeading">本地记忆</h2>
           <MemorySettingsPage
             settings={props.settings}
             onUpdate={props.onUpdateSettings}
             onReloadSettings={props.onReloadSettings}
           />
+          <h2 className="settingsSectionHeading">每日回顾</h2>
           <DailyReviewSettingsPage onOpenDailyReview={props.onOpenDailyReview} />
         </div>
       );
     case 'voice-gateway':
       // PR-SETTINGS-IA-CONSOLIDATE-0: 语音模型 + 开放网关 → 语音与网关.
+      // PR-SETTINGS-SWEEP-0: section heading per sub-block.
       return (
         <div className="settingsStructuredPage">
+          <h2 className="settingsSectionHeading">语音模型</h2>
           <VoiceModelsSettingsPage />
+          <h2 className="settingsSectionHeading">开放网关</h2>
           <OpenGatewaySettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />
         </div>
       );

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7274,6 +7274,32 @@ button:active {
   padding: 40px 24px 64px;
 }
 
+/* PR-SETTINGS-SWEEP-0 (2026-06-23, WAWQAQ msg `59a55bdf`): when a
+   merged section stacks two sub-pages (外观 = 主题 + 个性化, etc.),
+   the inner pages each own their own `settingsStructuredPage` wrapper.
+   Without this rule, every inner wrapper would re-center and re-pad,
+   doubling the side gutters. Let the OUTER wrapper own the chrome; the
+   nested ones become visual passthroughs. */
+.settingsStructuredPage .settingsStructuredPage {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* PR-SETTINGS-SWEEP-0: section heading for merged pages. Mirrors
+   reference's small uppercase sub-section tag. */
+.settingsSectionHeading {
+  margin: 24px 20px 8px;
+  color: var(--foreground-50);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.settingsStructuredPage > .settingsSectionHeading:first-child {
+  margin-top: 0;
+}
+
 .settingsPageIntro {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

WAWQAQ msg \`59a55bdf\` asked for a systematic settings polish round. Walking the 12 pages, the loudest structural problem was on the **merged pages** (外观, 记忆与回顾, 语音与网关): two sub-pages stacked inside one \`settingsStructuredPage\` with no visual separator, and the nested wrappers double-padded the side gutters.

Two changes:

1. **Nested page wrapper fix** — each inner sub-page wraps itself in its own \`settingsStructuredPage\` (768px centered + 40/24/64 padding). The outer wrapper already owns that chrome. Added a CSS rule to make nested wrappers visual passthroughs: \`max-width: none; margin: 0; padding: 0\`.

2. **Section headings** — added \`.settingsSectionHeading\` (small caps, uppercase, tracking-wide, 11px / 600, muted) and inserted one before each sub-block on the three merged pages:
   - 外观: 主题 / 个性化
   - 记忆与回顾: 本地记忆 / 每日回顾
   - 语音与网关: 语音模型 / 开放网关

Follow-up sweep PRs will chase per-page polish (long-path display, About hero density, Bot diagnostic strip alignment, theme-card grid gaps).

## Test plan

- [x] \`npm test\` in \`apps/desktop\`: 1465 passed
- [x] Visual smoke: 记忆与回顾 page renders 本地记忆 + 每日回顾 sub-block headings; 外观 renders 主题 + 个性化 sub-block headings.