### PR TITLE
Add heavy-task engineering records

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -65,6 +65,7 @@ class PromptCapturingProgressBackend implements AgentBackend {
     sessionId: string,
     private readonly progress: HeadlessBackendContext['heavyTaskProgress'],
     private readonly evidence: HeadlessBackendContext['heavyTaskEvidence'],
+    private readonly engineering: HeadlessBackendContext['heavyTaskEngineering'],
     private readonly prompts: string[],
   ) {
     this.sessionId = sessionId;
@@ -88,11 +89,27 @@ class PromptCapturingProgressBackend implements AgentBackend {
       await this.progress.recordTodos({
         items: [{ id: 'fix', content: 'Patch implementation', status: 'in_progress', priority: 'high' }],
       }, toolCtx);
-      await this.evidence?.recordToolEvidence({
+      const compactEvidence = await this.evidence?.recordToolEvidence({
         name: 'Bash',
         input: { command: 'npm test', cwd: '/workspace', timeoutMs: 120_000 },
         result: { exitCode: 1, stdout: `public failure summary\n${'x'.repeat(5_000)}`, stderr: 'short stderr\n' },
       }, toolCtx);
+      if (compactEvidence) {
+        await this.engineering?.recordCheck({
+          title: 'Public test check',
+          summary: 'The public test command failed and should guide the next repair.',
+          status: 'failed',
+          links: {
+            todoIds: ['fix'],
+            toolCallIds: ['progress-tool-call'],
+            evidenceIds: [compactEvidence.evidenceId],
+          },
+          command: 'npm test',
+          expectedSignal: 'public tests pass',
+          observedSignal: 'public tests failed',
+          result: 'fail',
+        }, toolCtx);
+      }
     }
     const ts = Date.now();
     yield { type: 'complete', id: `progress-complete-${this.prompts.length}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
@@ -104,7 +121,13 @@ class PromptCapturingProgressBackend implements AgentBackend {
 }
 
 const registerPromptCapturingProgressBackend = (prompts: string[]) => (registry: BackendRegistry, context: HeadlessBackendContext): void => {
-  registry.register('fake', (ctx) => new PromptCapturingProgressBackend(ctx.sessionId, context.heavyTaskProgress, context.heavyTaskEvidence, prompts));
+  registry.register('fake', (ctx) => new PromptCapturingProgressBackend(
+    ctx.sessionId,
+    context.heavyTaskProgress,
+    context.heavyTaskEvidence,
+    context.heavyTaskEngineering,
+    prompts,
+  ));
 };
 
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
@@ -250,9 +273,13 @@ describe('runAutonomousTask', () => {
       assert.match(prompts[1] ?? '', /Heavy-task compact evidence from prior public tool\/check\/artifact observations/);
       assert.match(prompts[1] ?? '', /tool:Bash exit=1/);
       assert.match(prompts[1] ?? '', /truncated=true/);
+      assert.match(prompts[1] ?? '', /Heavy-task structured engineering loop records from prior task-run events/);
+      assert.match(prompts[1] ?? '', /targeted_check status=failed completeness=complete/);
+      assert.match(prompts[1] ?? '', /todos=fix/);
       assert.doesNotMatch(prompts[1] ?? '', new RegExp(`x{${3_000}}`));
       assert.equal((prompts[1]?.match(/Heavy-task progress state/g) ?? []).length, 1);
       assert.equal((prompts[1]?.match(/Heavy-task compact evidence/g) ?? []).length, 1);
+      assert.equal((prompts[1]?.match(/Heavy-task structured engineering loop/g) ?? []).length, 1);
     });
   });
 

--- a/packages/headless/src/__tests__/heavy-task-engineering.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-engineering.test.ts
@@ -1,0 +1,346 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  createHeavyTaskEngineeringRecorder,
+  renderHeavyTaskEngineeringForPrompt,
+} from '../heavy-task-engineering.js';
+import type {
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskEngineeringRecord,
+  TaskEvent,
+} from '../task-contracts.js';
+import { createInMemoryTaskRunStore, projectTaskRun } from '../task-run-store.js';
+
+describe('heavy-task engineering records', () => {
+  test('records valid hypothesis, targeted check, repair, and patch submissions', async () => {
+    const store = createInMemoryTaskRunStore(seedEvents('run-engineering'));
+    let id = 0;
+    const recorder = createHeavyTaskEngineeringRecorder({
+      taskRunId: 'run-engineering',
+      attemptId: 'attempt-1',
+      store,
+      now: () => 100 + id,
+      newId: () => `gen-${++id}`,
+    });
+
+    const hypothesis = await recorder.recordEngineering({
+      kind: 'hypothesis',
+      title: 'Build check should reveal missing import',
+      summary: 'The current todo likely fails because the public build cannot resolve a local import.',
+      status: 'proposed',
+      links: { todoIds: ['todo-build'] },
+      hypothesis: {
+        expectedSignal: 'npm test reports a missing local import',
+        rationaleEvidenceIds: ['evidence-bash-1'],
+      },
+    }, toolCtx('tool-record-1'));
+
+    assert.equal(hypothesis.accepted, true);
+    assert.equal(hypothesis.record.kind, 'hypothesis');
+    assert.equal(hypothesis.record.completeness, 'complete');
+    assert.deepEqual(hypothesis.missingLinks, []);
+
+    const check = await recorder.recordCheck({
+      title: 'Run unit tests',
+      summary: 'The public test command exercises the build path.',
+      status: 'failed',
+      links: {
+        todoIds: ['todo-build'],
+        toolCallIds: ['tool-bash-1'],
+        evidenceIds: ['evidence-bash-1'],
+      },
+      command: 'npm test',
+      expectedSignal: 'test command completes successfully',
+      observedSignal: 'test command failed before the repair',
+      result: 'fail',
+    }, toolCtx('tool-record-2'));
+
+    assert.equal(check.accepted, true);
+    assert.equal(check.checkId, check.record.targetedCheck?.checkId);
+
+    const repair = await recorder.recordEngineering({
+      kind: 'repair',
+      title: 'Repair import path',
+      summary: 'Update the local import path used by the public build.',
+      status: 'repaired',
+      links: { todoIds: ['todo-build'], changedFiles: ['src/app.js'] },
+      repair: {
+        failedCheckIds: [check.checkId],
+        hypothesisId: hypothesis.record.recordId,
+        repairStrategy: 'Adjust the local import to match the public source tree.',
+        outcome: 'check_passed',
+      },
+    }, toolCtx('tool-record-3'));
+
+    assert.equal(repair.accepted, true);
+    assert.equal(repair.record.repair?.failedCheckIds[0], check.checkId);
+
+    const patch = await recorder.recordEngineering({
+      kind: 'patch',
+      title: 'Patch app import',
+      summary: 'The implementation change is limited to one public source file.',
+      status: 'passed',
+      links: { todoIds: ['todo-build'] },
+      patch: {
+        changedFiles: ['src/app.js'],
+        changeSummary: 'Updated the import path and reran public tests.',
+        mutationEvidenceIds: ['evidence-edit-1'],
+      },
+    }, toolCtx('tool-record-4'));
+
+    assert.equal(patch.accepted, true);
+    assert.equal(patch.record.patch?.changedFiles[0], 'src/app.js');
+
+    const projection = await store.project('run-engineering');
+    assert.equal(projection.heavyTaskEngineeringRecords.length, 4);
+    assert.equal(projection.latestHeavyTaskEngineeringRecord?.kind, 'patch');
+  });
+
+  test('rejects complete check records that miss required links', async () => {
+    const recorder = createHeavyTaskEngineeringRecorder({
+      taskRunId: 'run-reject',
+      store: createInMemoryTaskRunStore(seedEvents('run-reject')),
+      now: () => 1,
+      newId: () => 'id',
+    });
+
+    await assert.rejects(
+      recorder.recordCheck({
+        title: 'Run tests',
+        summary: 'Missing evidence links should not be accepted as complete.',
+        status: 'failed',
+        links: { todoIds: ['todo-build'] },
+        command: 'npm test',
+        expectedSignal: 'tests pass',
+        observedSignal: 'tests fail',
+        result: 'fail',
+      }, toolCtx('tool-record')),
+      /complete targeted_check record requires toolCallIds/,
+    );
+  });
+
+  test('accepts explicitly incomplete records with incompleteReason', async () => {
+    const recorder = createHeavyTaskEngineeringRecorder({
+      taskRunId: 'run-incomplete',
+      store: createInMemoryTaskRunStore(seedEvents('run-incomplete')),
+      now: () => 1,
+      newId: (() => {
+        let id = 0;
+        return () => `id-${++id}`;
+      })(),
+    });
+
+    const result = await recorder.recordEngineering({
+      kind: 'hypothesis',
+      title: 'Need more evidence',
+      summary: 'The hypothesis is recorded before a public check exists.',
+      status: 'proposed',
+      completeness: 'incomplete',
+      incompleteReason: 'No compact public evidence envelope exists for this hypothesis yet.',
+      links: { todoIds: ['todo-build'] },
+      hypothesis: {
+        expectedSignal: 'a later public check identifies the failing area',
+      },
+    }, toolCtx('tool-record'));
+
+    assert.equal(result.accepted, true);
+    assert.equal(result.record.completeness, 'incomplete');
+    assert.match(result.record.incompleteReason ?? '', /No compact public evidence/);
+  });
+
+  test('rejects private or evaluator-only material through the source guard', async () => {
+    const recorder = createHeavyTaskEngineeringRecorder({
+      taskRunId: 'run-private',
+      store: createInMemoryTaskRunStore(seedEvents('run-private')),
+      now: () => 1,
+      newId: () => 'id',
+    });
+
+    const result = await recorder.recordEngineering({
+      kind: 'hypothesis',
+      title: 'Avoid official verifier artifacts',
+      summary: 'This mentions official verifier artifacts and must be rejected.',
+      status: 'proposed',
+      links: { todoIds: ['todo-build'] },
+      hypothesis: {
+        expectedSignal: 'public tests show the issue',
+        rationaleEvidenceIds: ['evidence-bash-1'],
+      },
+    }, toolCtx('tool-record'));
+
+    assert.equal(result.accepted, false);
+    assert.ok(result.guard.categories.includes('official_verifier_artifacts'));
+  });
+
+  test('replay downgrades dangling links and prompt rendering stays compact', () => {
+    const dangling = engineeringRecord('run-dangling', {
+      links: {
+        todoIds: ['todo-missing'],
+        evidenceIds: ['evidence-missing'],
+        toolCallIds: [],
+        checkIds: ['check-missing'],
+        artifactIds: ['artifact-missing'],
+        changedFiles: [],
+        patchIds: [],
+        hypothesisIds: [],
+        repairIds: [],
+      },
+    });
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-dangling', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      { type: 'heavy_task_engineering_recorded', id: 'e2', taskRunId: 'run-dangling', ts: 2, record: dangling },
+    ], 'run-dangling');
+
+    assert.equal(projection.heavyTaskEngineeringRecords[0]?.completeness, 'incomplete');
+    assert.deepEqual(projection.heavyTaskEngineeringRecords[0]?.projection?.missingTodoIds, ['todo-missing']);
+    assert.deepEqual(projection.heavyTaskEngineeringRecords[0]?.projection?.missingEvidenceIds, ['evidence-missing']);
+    assert.deepEqual(projection.heavyTaskEngineeringRecords[0]?.projection?.missingArtifactIds, ['artifact-missing']);
+    assert.deepEqual(projection.heavyTaskEngineeringRecords[0]?.projection?.missingCheckIds, ['check-missing']);
+    assert.match(renderHeavyTaskEngineeringForPrompt(projection) ?? '', /missingTodos=todo-missing/);
+  });
+
+  test('replay downgrades complete records that omit required links', () => {
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-missing-required', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+      {
+        type: 'heavy_task_engineering_recorded',
+        id: 'e2',
+        taskRunId: 'run-missing-required',
+        ts: 2,
+        record: engineeringRecord('run-missing-required', {
+          kind: 'patch',
+          patch: {
+            patchId: 'patch-without-required-links',
+            changedFiles: ['src/app.js'],
+            changeSummary: 'Missing todo and mutation evidence links should downgrade this replayed event.',
+            mutationEvidenceIds: [],
+          },
+          links: {
+            todoIds: [],
+            evidenceIds: [],
+            toolCallIds: [],
+            checkIds: [],
+            artifactIds: [],
+            changedFiles: ['src/app.js'],
+            patchIds: ['patch-without-required-links'],
+            hypothesisIds: [],
+            repairIds: [],
+          },
+        }),
+      },
+    ], 'run-missing-required');
+
+    const record = projection.heavyTaskEngineeringRecords[0];
+    assert.equal(record?.completeness, 'incomplete');
+    assert.match(record?.incompleteReason ?? '', /Required links are missing/);
+    assert.match(record?.incompleteReason ?? '', /todoIds/);
+    assert.match(record?.incompleteReason ?? '', /mutationEvidenceIds/);
+  });
+});
+
+function seedEvents(taskRunId: string): TaskEvent[] {
+  return [
+    { type: 'task_run_created', id: 'e-create', taskRunId, ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+    {
+      type: 'heavy_task_todos_recorded',
+      id: 'e-todos',
+      taskRunId,
+      ts: 2,
+      todos: {
+        schemaVersion: 1,
+        todoSetId: 'todos-1',
+        taskRunId,
+        ts: 2,
+        items: [{ id: 'todo-build', content: 'Fix the public build', status: 'in_progress', priority: 'high' }],
+        source: { kind: 'model_tool', toolCallId: 'tool-todos' },
+      },
+    },
+    evidenceEvent(taskRunId, 'evidence-bash-1', 'Bash'),
+    evidenceEvent(taskRunId, 'evidence-edit-1', 'Edit'),
+    {
+      type: 'task_run_artifact_recorded',
+      id: 'e-artifact',
+      taskRunId,
+      ts: 4,
+      artifact: {
+        schemaVersion: 1,
+        artifactId: 'artifact-build-output',
+        taskRunId,
+        ts: 4,
+        kind: 'generated_output',
+        path: 'build-output.log',
+        authority: { source: 'runtime', authoritative: false },
+      },
+    },
+  ];
+}
+
+function evidenceEvent(taskRunId: string, evidenceId: string, toolName: string): TaskEvent {
+  const evidence: HeavyTaskCompactEvidenceEnvelope = {
+    schemaVersion: 1,
+    evidenceId,
+    taskRunId,
+    ts: 3,
+    kind: 'tool',
+    public: true,
+    source: { kind: 'model_tool', toolCallId: `tool-${toolName.toLowerCase()}`, toolName },
+    tool: {
+      name: toolName,
+      inputSummary: toolName === 'Bash' ? { command: 'npm test' } : { path: 'src/app.js' },
+      ok: toolName !== 'Bash',
+      ...(toolName === 'Bash' ? { exitCode: 1 } : {}),
+      outputs: [{
+        stream: toolName === 'Bash' ? 'stdout' : 'diff',
+        excerpt: 'bounded public output summary',
+        truncated: false,
+      }],
+      diff: toolName === 'Edit' ? { status: 'not_captured', files: [{ path: 'src/app.js' }] } : { status: 'not_applicable' },
+    },
+  };
+  return { type: 'heavy_task_evidence_recorded', id: `event-${evidenceId}`, taskRunId, ts: 3, evidence };
+}
+
+function engineeringRecord(taskRunId: string, partial: Partial<HeavyTaskEngineeringRecord>): HeavyTaskEngineeringRecord {
+  return {
+    schemaVersion: 1,
+    recordId: 'record-1',
+    taskRunId,
+    ts: 2,
+    kind: 'targeted_check',
+    title: 'Dangling public check',
+    summary: 'A hand-written event references missing public ids.',
+    status: 'failed',
+    completeness: 'complete',
+    source: { kind: 'model_tool', toolCallId: 'tool-record', toolName: 'check_record' },
+    links: {
+      todoIds: ['todo-build'],
+      evidenceIds: [],
+      toolCallIds: ['tool-bash'],
+      checkIds: ['check-unit-1'],
+      artifactIds: [],
+      changedFiles: [],
+      patchIds: [],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    targetedCheck: {
+      checkId: 'check-unit-1',
+      command: 'npm test',
+      expectedSignal: 'tests pass',
+      observedSignal: 'tests fail',
+      result: 'fail',
+    },
+    ...partial,
+  };
+}
+
+function toolCtx(toolCallId: string) {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    cwd: '/workspace',
+    toolCallId,
+    abortSignal: new AbortController().signal,
+    emitOutput: () => undefined,
+  };
+}

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { renderTaskRunMarkdown, taskRunExportFromProjection, writeTaskRunExport } from '../result-export.js';
-import type { HeavyTaskTodoItem, TaskEvent } from '../task-contracts.js';
+import type { HeavyTaskCompactEvidenceEnvelope, HeavyTaskEngineeringRecord, HeavyTaskTodoItem, TaskEvent } from '../task-contracts.js';
 import { projectTaskRun } from '../task-run-store.js';
 
 describe('task run export', () => {
@@ -173,6 +173,59 @@ describe('task run export', () => {
 
     assert.equal(exported.policy, undefined);
     assert.equal(exported.progress, undefined);
+  });
+
+  test('exports bounded heavy-task engineering state in full and compact result views', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-engineering-export-'));
+    try {
+      const projection = projectTaskRun([
+        { type: 'task_run_created', id: 'e1', taskRunId: 'run-engineering-export', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+        {
+          type: 'heavy_task_todos_recorded',
+          id: 'e-todos',
+          taskRunId: 'run-engineering-export',
+          ts: 1.5,
+          todos: {
+            schemaVersion: 1,
+            todoSetId: 'todos-1',
+            taskRunId: 'run-engineering-export',
+            ts: 1.5,
+            items: [{ id: 'todo-export', content: 'Export engineering records', status: 'in_progress', priority: 'high' }],
+            source: { kind: 'model_tool', toolCallId: 'tool-todos' },
+          },
+        },
+        engineeringEvidenceEvent('run-engineering-export'),
+        {
+          type: 'heavy_task_engineering_recorded',
+          id: 'e2',
+          taskRunId: 'run-engineering-export',
+          ts: 2,
+          record: engineeringRecord('run-engineering-export', 'record-1', 'complete'),
+        },
+        {
+          type: 'heavy_task_engineering_recorded',
+          id: 'e3',
+          taskRunId: 'run-engineering-export',
+          ts: 3,
+          record: engineeringRecord('run-engineering-export', 'record-2', 'incomplete'),
+        },
+      ], 'run-engineering-export');
+
+      const exported = taskRunExportFromProjection(projection, { exportedAt: '2026-06-23T00:00:00.000Z' });
+      assert.equal(exported.progress?.engineering?.historyCount, 2);
+      assert.equal(exported.progress?.engineering?.incompleteCount, 1);
+      assert.equal(exported.progress?.engineering?.latest.recordId, 'record-2');
+      assert.equal(exported.progress?.engineering?.recent.length, 2);
+
+      const written = await writeTaskRunExport(dir, projection, { exportedAt: '2026-06-23T00:00:00.000Z' });
+      const full = JSON.parse(await readFile(written.files.taskRunJson, 'utf8'));
+      const compact = JSON.parse(await readFile(written.files.resultJson, 'utf8'));
+      assert.equal(full.progress.engineering.historyCount, 2);
+      assert.equal(compact.progress.engineering.incompleteCount, 1);
+      assert.equal(compact.progress.engineering.latest.summary.includes('raw stdout'), false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   test('exports heavy-task progress snapshots and compact result progress', async () => {
@@ -753,4 +806,63 @@ function heavyTaskCompletionEvents(todos: HeavyTaskTodoItem[] = [
       error: { message: 'runtime step cap reached', class: 'max_steps' },
     },
   ];
+}
+
+function engineeringRecord(
+  taskRunId: string,
+  recordId: string,
+  completeness: HeavyTaskEngineeringRecord['completeness'],
+): HeavyTaskEngineeringRecord {
+  return {
+    schemaVersion: 1,
+    recordId,
+    taskRunId,
+    ts: recordId === 'record-1' ? 2 : 3,
+    kind: 'patch',
+    title: 'Patch public source',
+    summary: completeness === 'complete'
+      ? 'Changed src/app.js and linked compact mutation evidence.'
+      : 'Patch summary is intentionally incomplete until the next public check.',
+    status: completeness === 'complete' ? 'passed' : 'running',
+    completeness,
+    ...(completeness === 'incomplete' ? { incompleteReason: 'Follow-up public check has not been recorded yet.' } : {}),
+    source: { kind: 'model_tool', toolCallId: `tool-${recordId}`, toolName: 'engineering_record' },
+    links: {
+      todoIds: completeness === 'complete' ? ['todo-export'] : [],
+      evidenceIds: completeness === 'complete' ? ['evidence-export'] : [],
+      toolCallIds: [],
+      checkIds: [],
+      artifactIds: [],
+      changedFiles: ['src/app.js'],
+      patchIds: [`patch-${recordId}`],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    patch: {
+      patchId: `patch-${recordId}`,
+      changedFiles: ['src/app.js'],
+      changeSummary: 'Changed a public source file without embedding raw stdout or diff output.',
+      mutationEvidenceIds: completeness === 'complete' ? ['evidence-export'] : [],
+    },
+  };
+}
+
+function engineeringEvidenceEvent(taskRunId: string): TaskEvent {
+  const evidence: HeavyTaskCompactEvidenceEnvelope = {
+    schemaVersion: 1,
+    evidenceId: 'evidence-export',
+    taskRunId,
+    ts: 1.75,
+    kind: 'tool',
+    public: true,
+    source: { kind: 'model_tool', toolCallId: 'tool-edit', toolName: 'Edit' },
+    tool: {
+      name: 'Edit',
+      inputSummary: { path: 'src/app.js' },
+      ok: true,
+      outputs: [{ stream: 'diff', excerpt: 'bounded public edit summary', truncated: false }],
+      diff: { status: 'not_captured', files: [{ path: 'src/app.js' }] },
+    },
+  };
+  return { type: 'heavy_task_evidence_recorded', id: 'e-evidence', taskRunId, ts: 1.75, evidence };
 }

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -70,12 +70,14 @@ describe('isolated headless tools', () => {
     assert.ok(!names.includes('inventory_submit'));
     assert.ok(!names.includes('todo_update'));
     assert.ok(!names.includes('self_check_submit'));
+    assert.ok(!names.includes('engineering_record'));
+    assert.ok(!names.includes('check_record'));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
   });
 
-  test('progress and self-check tools are included only when heavy-task recorders are enabled', () => {
+  test('progress, self-check, and engineering tools are included only when heavy-task recorders are enabled', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -128,12 +130,88 @@ describe('isolated headless tools', () => {
           };
         },
       },
+      heavyTaskEngineering: {
+        async recordEngineering() {
+          return {
+            accepted: true,
+            complete: true,
+            missingLinks: [],
+            record: {
+              schemaVersion: 1,
+              recordId: 'record-1',
+              taskRunId: 'run-1',
+              ts: 1,
+              kind: 'hypothesis',
+              title: 'Hypothesis',
+              summary: 'A public hypothesis',
+              status: 'proposed',
+              completeness: 'complete',
+              source: { kind: 'model_tool', toolCallId: 'tool-1', toolName: 'engineering_record' },
+              links: {
+                todoIds: ['todo-1'],
+                evidenceIds: ['evidence-1'],
+                toolCallIds: [],
+                checkIds: [],
+                artifactIds: [],
+                changedFiles: [],
+                patchIds: [],
+                hypothesisIds: [],
+                repairIds: [],
+              },
+              hypothesis: {
+                expectedSignal: 'public check identifies the problem',
+                rationaleEvidenceIds: ['evidence-1'],
+              },
+            },
+          };
+        },
+        async recordCheck() {
+          return {
+            accepted: true,
+            complete: true,
+            missingLinks: [],
+            checkId: 'check-1',
+            record: {
+              schemaVersion: 1,
+              recordId: 'record-2',
+              taskRunId: 'run-1',
+              ts: 1,
+              kind: 'targeted_check',
+              title: 'Check',
+              summary: 'A public check',
+              status: 'passed',
+              completeness: 'complete',
+              source: { kind: 'model_tool', toolCallId: 'tool-1', toolName: 'check_record' },
+              links: {
+                todoIds: ['todo-1'],
+                evidenceIds: ['evidence-1'],
+                toolCallIds: ['tool-1'],
+                checkIds: ['check-1'],
+                artifactIds: [],
+                changedFiles: [],
+                patchIds: [],
+                hypothesisIds: [],
+                repairIds: [],
+              },
+              targetedCheck: {
+                checkId: 'check-1',
+                command: 'npm test',
+                expectedSignal: 'pass',
+                observedSignal: 'pass',
+                result: 'pass',
+              },
+            },
+          };
+        },
+      },
     });
 
     const names = tools.map((tool) => tool.name);
     assert.ok(names.includes('inventory_submit'));
     assert.ok(names.includes('todo_update'));
     assert.ok(names.includes('self_check_submit'));
+    assert.ok(names.includes('engineering_record'));
+    assert.ok(names.includes('check_record'));
   });
 
   test('Read, Write, Glob, and Grep delegate to native isolated executor methods', async () => {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -309,6 +309,7 @@ export function buildAiSdkCellBackendRegistration(input: {
           ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
           ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
           ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+          ...(context.heavyTaskEngineering ? { heavyTaskEngineering: context.heavyTaskEngineering } : {}),
         }),
         toolAvailability: buildIsolatedHeadlessToolAvailability(),
         providerOptions: buildProviderOptions(connection, input.model),

--- a/packages/headless/src/heavy-task-engineering.ts
+++ b/packages/headless/src/heavy-task-engineering.ts
@@ -1,0 +1,582 @@
+import type { MakaTool, MakaToolContext } from '@maka/runtime';
+import { z } from 'zod';
+import { validateHeavyTaskPublicSelfCheck } from './heavy-task-self-check.js';
+import type {
+  HeavyTaskEngineeringCompleteness,
+  HeavyTaskEngineeringLinks,
+  HeavyTaskEngineeringRecord,
+  HeavyTaskEngineeringRecordKind,
+  HeavyTaskSourceGuardResult,
+  TaskEvent,
+  TaskRunArtifact,
+} from './task-contracts.js';
+import type { TaskRunProjection, TaskRunStore } from './task-run-store.js';
+
+export const HEAVY_TASK_ENGINEERING_SCHEMA_VERSION = 1;
+export const HEAVY_TASK_ENGINEERING_TOOL_NAMES = ['engineering_record', 'check_record'] as const;
+export const DEFAULT_PROMPT_ENGINEERING_LIMIT = 8;
+export const DEFAULT_EXPORT_ENGINEERING_LIMIT = 25;
+
+const MAX_TEXT_CHARS = 2_000;
+const MAX_SHORT_TEXT_CHARS = 500;
+const MAX_COMMAND_CHARS = 1_000;
+const MAX_ITEMS = 50;
+const ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+
+const stableIdSchema = z.string().trim().min(1).max(120).regex(ID_PATTERN);
+const textSchema = z.string().trim().min(1).max(MAX_TEXT_CHARS);
+const shortTextSchema = z.string().trim().min(1).max(MAX_SHORT_TEXT_CHARS);
+const idArraySchema = z.array(stableIdSchema).max(MAX_ITEMS).optional();
+const fileArraySchema = z.array(shortTextSchema).max(MAX_ITEMS).optional();
+const completenessSchema = z.enum(['complete', 'incomplete']).optional();
+const recordStatusSchema = z.enum(['proposed', 'running', 'passed', 'failed', 'repaired', 'superseded', 'abandoned']);
+
+const linksSchema = z.object({
+  todoIds: idArraySchema,
+  evidenceIds: idArraySchema,
+  toolCallIds: idArraySchema,
+  checkIds: idArraySchema,
+  artifactIds: idArraySchema,
+  changedFiles: fileArraySchema,
+  patchIds: idArraySchema,
+  hypothesisIds: idArraySchema,
+  repairIds: idArraySchema,
+}).strict().optional();
+
+type EngineeringInputLinks = Partial<HeavyTaskEngineeringLinks>;
+type RefinableRecordInput = {
+  completeness?: string;
+  incompleteReason?: string;
+  links?: EngineeringInputLinks;
+  kind?: string;
+  hypothesis?: { rationaleEvidenceIds?: string[] };
+  repair?: { failedCheckIds?: string[] };
+  patch?: { changedFiles?: string[]; mutationEvidenceIds?: string[] };
+};
+
+const baseRecordSchema = z.object({
+  title: textSchema,
+  summary: textSchema,
+  status: recordStatusSchema,
+  completeness: completenessSchema,
+  incompleteReason: textSchema.optional(),
+  links: linksSchema,
+}).strict();
+
+export const engineeringRecordSubmitSchema = baseRecordSchema.extend({
+  kind: z.enum(['hypothesis', 'repair', 'patch']),
+  hypothesis: z.object({
+    expectedSignal: textSchema,
+    rationaleEvidenceIds: z.array(stableIdSchema).max(MAX_ITEMS).optional(),
+  }).strict().optional(),
+  repair: z.object({
+    failedCheckIds: z.array(stableIdSchema).max(MAX_ITEMS).optional(),
+    hypothesisId: stableIdSchema.optional(),
+    repairStrategy: textSchema,
+    outcome: z.enum(['not_checked', 'check_passed', 'check_failed', 'inconclusive']),
+  }).strict().optional(),
+  patch: z.object({
+    changedFiles: z.array(shortTextSchema).max(MAX_ITEMS).optional(),
+    changeSummary: textSchema,
+    mutationEvidenceIds: z.array(stableIdSchema).max(MAX_ITEMS).optional(),
+  }).strict().optional(),
+}).superRefine((value, ctx) => {
+  refineCommonRecord(value, ctx);
+  if (value.kind === 'hypothesis' && !value.hypothesis) {
+    issue(ctx, ['hypothesis'], 'hypothesis payload is required');
+  }
+  if (value.kind === 'repair' && !value.repair) {
+    issue(ctx, ['repair'], 'repair payload is required');
+  }
+  if (value.kind === 'patch' && !value.patch) {
+    issue(ctx, ['patch'], 'patch payload is required');
+  }
+});
+
+export const checkRecordSubmitSchema = baseRecordSchema.extend({
+  command: z.string().trim().min(1).max(MAX_COMMAND_CHARS).optional(),
+  expectedSignal: textSchema,
+  observedSignal: textSchema,
+  result: z.enum(['pass', 'fail', 'inconclusive']),
+}).superRefine(refineCommonRecord);
+
+export type EngineeringRecordSubmitInput = z.infer<typeof engineeringRecordSubmitSchema>;
+export type CheckRecordSubmitInput = z.infer<typeof checkRecordSubmitSchema>;
+
+export interface HeavyTaskEngineeringRecorder {
+  recordEngineering(
+    input: EngineeringRecordSubmitInput,
+    ctx: MakaToolContext,
+  ): Promise<HeavyTaskEngineeringRecordResult>;
+  recordCheck(
+    input: CheckRecordSubmitInput,
+    ctx: MakaToolContext,
+  ): Promise<HeavyTaskEngineeringRecordResult & { checkId: string }>;
+}
+
+export type HeavyTaskEngineeringRecordResult =
+  | {
+      accepted: true;
+      record: HeavyTaskEngineeringRecord;
+      missingLinks: string[];
+      complete: boolean;
+    }
+  | {
+      accepted: false;
+      guard: HeavyTaskSourceGuardResult & { status: 'rejected' };
+    };
+
+export function createHeavyTaskEngineeringRecorder(input: {
+  taskRunId: string;
+  attemptId?: string;
+  store: TaskRunStore;
+  now: () => number;
+  newId: () => string;
+}): HeavyTaskEngineeringRecorder {
+  return {
+    async recordEngineering(rawArgs, ctx) {
+      const args = engineeringRecordSubmitSchema.parse(rawArgs);
+      const ts = input.now();
+      const guard = validateEngineeringStrings(args, ts);
+      if (!guard.ok) return { accepted: false, guard: guard.guard };
+      const record = buildEngineeringRecord({ args, ctx, ts, taskRunId: input.taskRunId, attemptId: input.attemptId, newId: input.newId });
+      await rejectDuplicateRecordRefs(record, input.store, input.taskRunId);
+      const projected = resolveHeavyTaskEngineeringRecordLinks(record, await input.store.project(input.taskRunId));
+      await appendRecord(input.store, input.taskRunId, projected, ts, input.newId);
+      return recordResult(projected);
+    },
+    async recordCheck(rawArgs, ctx) {
+      const args = checkRecordSubmitSchema.parse(rawArgs);
+      const ts = input.now();
+      const guard = validateEngineeringStrings({ kind: 'targeted_check', ...args }, ts);
+      if (!guard.ok) return { accepted: false, guard: guard.guard, checkId: '' };
+      const record = buildCheckRecord({ args, ctx, ts, taskRunId: input.taskRunId, attemptId: input.attemptId, newId: input.newId });
+      await rejectDuplicateRecordRefs(record, input.store, input.taskRunId);
+      const projected = resolveHeavyTaskEngineeringRecordLinks(record, await input.store.project(input.taskRunId));
+      await appendRecord(input.store, input.taskRunId, projected, ts, input.newId);
+      return { ...recordResult(projected), checkId: projected.targetedCheck!.checkId };
+    },
+  };
+}
+
+export function buildHeavyTaskEngineeringTools(recorder: HeavyTaskEngineeringRecorder): MakaTool[] {
+  return [
+    {
+      name: 'engineering_record',
+      description: 'Record a structured heavy-task hypothesis, repair, or patch summary linked to todos, checks, files, artifacts, and compact evidence ids.',
+      parameters: engineeringRecordSubmitSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => recorder.recordEngineering(engineeringRecordSubmitSchema.parse(args), ctx),
+    },
+    {
+      name: 'check_record',
+      description: 'Record a structured targeted check linked to todo ids, tool call ids, and compact evidence envelope ids.',
+      parameters: checkRecordSubmitSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => recorder.recordCheck(checkRecordSubmitSchema.parse(args), ctx),
+    },
+  ];
+}
+
+export function resolveHeavyTaskEngineeringRecordLinks(
+  record: HeavyTaskEngineeringRecord,
+  projection: Pick<TaskRunProjection, 'latestHeavyTaskTodos' | 'heavyTaskEvidence' | 'artifacts' | 'heavyTaskEngineeringRecords'>,
+): HeavyTaskEngineeringRecord {
+  const todoIds = new Set(projection.latestHeavyTaskTodos?.items.map((item) => item.id) ?? []);
+  const evidenceIds = new Set(projection.heavyTaskEvidence.map((item) => item.evidenceId));
+  const artifactIds = new Set(projection.artifacts.map((item) => item.artifactId));
+  const checkIds = new Set<string>();
+  for (const check of projection.heavyTaskEvidence.flatMap((item) => [item.check?.checkId, item.check?.linkedSelfCheckId, ...(item.links?.checkIds ?? [])])) {
+    if (check) checkIds.add(check);
+  }
+  for (const item of projection.heavyTaskEngineeringRecords) {
+    if (item.targetedCheck?.checkId) checkIds.add(item.targetedCheck.checkId);
+  }
+  if (record.targetedCheck?.checkId) {
+    checkIds.add(record.targetedCheck.checkId);
+  }
+
+  const missingTodoIds = missing(record.links.todoIds, todoIds);
+  const missingEvidenceIds = missing(record.links.evidenceIds, evidenceIds);
+  const missingArtifactIds = missing(record.links.artifactIds, artifactIds);
+  const missingCheckIds = missing(record.links.checkIds, checkIds);
+  const projectionState = { missingTodoIds, missingEvidenceIds, missingArtifactIds, missingCheckIds };
+  const missingRequired = missingRequiredLinksForRecord(record);
+  const hasMissing = missingTodoIds.length
+    + missingEvidenceIds.length
+    + missingArtifactIds.length
+    + missingCheckIds.length
+    + missingRequired.length > 0;
+  if (!hasMissing) return { ...record, projection: projectionState };
+  return {
+    ...record,
+    completeness: 'incomplete',
+    incompleteReason: record.incompleteReason ?? (
+      missingRequired.length > 0
+        ? `Required links are missing for a complete ${record.kind} record: ${missingRequired.join(', ')}.`
+        : 'Referenced todo, evidence, artifact, or check links were not found during task-run replay.'
+    ),
+    projection: projectionState,
+  };
+}
+
+export function isPublicHeavyTaskEngineeringRecord(record: HeavyTaskEngineeringRecord, now = record.ts): boolean {
+  return validateEngineeringStrings(record, now).ok;
+}
+
+export function renderHeavyTaskEngineeringForPrompt(projection: {
+  heavyTaskEngineeringRecords?: HeavyTaskEngineeringRecord[];
+}): string | undefined {
+  const records = projection.heavyTaskEngineeringRecords ?? [];
+  if (records.length === 0) return undefined;
+  const recent = records.slice(-DEFAULT_PROMPT_ENGINEERING_LIMIT);
+  const lines = ['Heavy-task structured engineering loop records from prior task-run events:'];
+  for (const record of recent) {
+    const missing = missingSummary(record);
+    lines.push(`- ${record.recordId} ${record.kind} status=${record.status} completeness=${record.completeness}${missing}`);
+    lines.push(`  - todos=${joinOrNone(record.links.todoIds)} checks=${joinOrNone(record.links.checkIds)} evidence=${joinOrNone(record.links.evidenceIds)}`);
+    if (record.links.changedFiles.length > 0) lines.push(`  - changedFiles=${record.links.changedFiles.slice(0, 6).map((file) => oneLine(file, 80)).join(', ')}`);
+    lines.push(`  - ${oneLine(record.title, 120)}: ${oneLine(record.summary, 180)}`);
+  }
+  if (records.length > recent.length) {
+    lines.push(`- ${records.length - recent.length} older engineering record(s) omitted`);
+  }
+  lines.push('Continue linking engineering_record/check_record submissions to current todo ids, check ids, compact evidence ids, tool call ids, and changed files/artifacts.');
+  return lines.join('\n');
+}
+
+export function compactHeavyTaskEngineeringState(records: readonly HeavyTaskEngineeringRecord[]): {
+  latest: HeavyTaskEngineeringRecord;
+  recent: HeavyTaskEngineeringRecord[];
+  historyCount: number;
+  incompleteCount: number;
+} | undefined {
+  if (records.length === 0) return undefined;
+  return {
+    latest: records[records.length - 1],
+    recent: records.slice(-DEFAULT_EXPORT_ENGINEERING_LIMIT),
+    historyCount: records.length,
+    incompleteCount: records.filter((record) => record.completeness === 'incomplete').length,
+  };
+}
+
+function buildEngineeringRecord(input: {
+  args: EngineeringRecordSubmitInput;
+  ctx: MakaToolContext;
+  ts: number;
+  taskRunId: string;
+  attemptId?: string;
+  newId: () => string;
+}): HeavyTaskEngineeringRecord {
+  const id = input.newId();
+  const links = normalizeLinks(input.args.links);
+  const completeness = completenessFor(input.args);
+  const base = baseRecord(input, id, input.args.kind, completeness, links, 'engineering_record');
+  if (input.args.kind === 'hypothesis') {
+    const hypothesis = input.args.hypothesis!;
+    const rationaleEvidenceIds = unique(hypothesis.rationaleEvidenceIds ?? []);
+    return {
+      ...base,
+      links: { ...links, evidenceIds: unique([...links.evidenceIds, ...rationaleEvidenceIds]) },
+      hypothesis: { expectedSignal: hypothesis.expectedSignal, rationaleEvidenceIds },
+    };
+  }
+  if (input.args.kind === 'repair') {
+    const repair = input.args.repair!;
+    const failedCheckIds = unique(repair.failedCheckIds ?? input.args.links?.checkIds ?? []);
+    return {
+      ...base,
+      links: { ...links, checkIds: unique([...links.checkIds, ...failedCheckIds]), hypothesisIds: unique([...links.hypothesisIds, repair.hypothesisId].filter(isString)) },
+      repair: {
+        failedCheckIds,
+        ...(repair.hypothesisId ? { hypothesisId: repair.hypothesisId } : {}),
+        repairStrategy: repair.repairStrategy,
+        outcome: repair.outcome,
+      },
+    };
+  }
+  const patch = input.args.patch!;
+  const patchId = input.newId();
+  const changedFiles = unique(patch.changedFiles ?? links.changedFiles);
+  const mutationEvidenceIds = unique(patch.mutationEvidenceIds ?? []);
+  return {
+    ...base,
+    links: {
+      ...links,
+      evidenceIds: unique([...links.evidenceIds, ...mutationEvidenceIds]),
+      changedFiles,
+      patchIds: unique([...links.patchIds, patchId]),
+    },
+    patch: {
+      patchId,
+      changedFiles,
+      changeSummary: patch.changeSummary,
+      mutationEvidenceIds,
+    },
+  };
+}
+
+function buildCheckRecord(input: {
+  args: CheckRecordSubmitInput;
+  ctx: MakaToolContext;
+  ts: number;
+  taskRunId: string;
+  attemptId?: string;
+  newId: () => string;
+}): HeavyTaskEngineeringRecord {
+  const checkId = input.newId();
+  const links = normalizeLinks(input.args.links);
+  const toolCallIds = unique([...links.toolCallIds, input.ctx.toolCallId]);
+  return {
+    ...baseRecord(input, input.newId(), 'targeted_check', completenessFor(input.args), {
+      ...links,
+      toolCallIds,
+      checkIds: unique([...links.checkIds, checkId]),
+    }, 'check_record'),
+    targetedCheck: {
+      checkId,
+      ...(input.args.command ? { command: input.args.command } : {}),
+      expectedSignal: input.args.expectedSignal,
+      observedSignal: input.args.observedSignal,
+      result: input.args.result,
+    },
+  };
+}
+
+function baseRecord(
+  input: { args: EngineeringRecordSubmitInput | CheckRecordSubmitInput; ctx: MakaToolContext; ts: number; taskRunId: string; attemptId?: string },
+  recordId: string,
+  kind: HeavyTaskEngineeringRecordKind,
+  completeness: HeavyTaskEngineeringCompleteness,
+  links: HeavyTaskEngineeringLinks,
+  toolName: 'engineering_record' | 'check_record',
+): Omit<HeavyTaskEngineeringRecord, 'hypothesis' | 'targetedCheck' | 'repair' | 'patch'> {
+  return {
+    schemaVersion: HEAVY_TASK_ENGINEERING_SCHEMA_VERSION,
+    recordId,
+    taskRunId: input.taskRunId,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    ts: input.ts,
+    kind,
+    title: input.args.title,
+    summary: input.args.summary,
+    status: input.args.status,
+    completeness,
+    ...(input.args.incompleteReason ? { incompleteReason: input.args.incompleteReason } : {}),
+    source: {
+      kind: 'model_tool',
+      toolCallId: input.ctx.toolCallId,
+      ...(input.ctx.sessionId ? { sessionId: input.ctx.sessionId } : {}),
+      ...(input.ctx.turnId ? { turnId: input.ctx.turnId } : {}),
+      toolName,
+    },
+    links,
+  };
+}
+
+function completenessFor(input: EngineeringRecordSubmitInput | CheckRecordSubmitInput): HeavyTaskEngineeringCompleteness {
+  return input.completeness ?? 'complete';
+}
+
+function normalizeLinks(input: EngineeringInputLinks | undefined): HeavyTaskEngineeringLinks {
+  return {
+    todoIds: unique(input?.todoIds ?? []),
+    evidenceIds: unique(input?.evidenceIds ?? []),
+    toolCallIds: unique(input?.toolCallIds ?? []),
+    checkIds: unique(input?.checkIds ?? []),
+    artifactIds: unique(input?.artifactIds ?? []),
+    changedFiles: unique(input?.changedFiles ?? []),
+    patchIds: unique(input?.patchIds ?? []),
+    hypothesisIds: unique(input?.hypothesisIds ?? []),
+    repairIds: unique(input?.repairIds ?? []),
+  };
+}
+
+function refineCommonRecord(value: RefinableRecordInput, ctx: z.RefinementCtx): void {
+  const completeness = value.completeness ?? 'complete';
+  if (completeness === 'incomplete' && !value.incompleteReason) {
+    issue(ctx, ['incompleteReason'], 'incomplete records require incompleteReason');
+  }
+  if (completeness === 'complete') {
+    const missing = requiredMissing(value);
+    for (const item of missing) issue(ctx, [item], `complete ${value.kind ?? 'targeted_check'} record requires ${item}`);
+  }
+  for (const [name, values] of Object.entries(value.links ?? {})) {
+    if (Array.isArray(values) && values.length !== new Set(values).size) {
+      issue(ctx, ['links', name], `duplicate ids in ${name}`);
+    }
+  }
+}
+
+function requiredMissing(value: RefinableRecordInput): string[] {
+  const links = normalizeLinks(value.links);
+  if (value.kind === 'hypothesis') {
+    return [
+      links.todoIds.length === 0 ? 'todoIds' : '',
+      (value.hypothesis?.rationaleEvidenceIds?.length ?? 0) === 0 ? 'rationaleEvidenceIds' : '',
+    ].filter(Boolean);
+  }
+  if (value.kind === 'repair') {
+    return [
+      links.todoIds.length === 0 ? 'todoIds' : '',
+      (value.repair?.failedCheckIds?.length ?? links.checkIds.length) === 0 ? 'failedCheckIds' : '',
+      links.changedFiles.length === 0 && links.artifactIds.length === 0 ? 'changedFiles or artifactIds' : '',
+    ].filter(Boolean);
+  }
+  if (value.kind === 'patch') {
+    return [
+      links.todoIds.length === 0 ? 'todoIds' : '',
+      (value.patch?.changedFiles?.length ?? links.changedFiles.length) === 0 && links.artifactIds.length === 0 ? 'changedFiles or artifactIds' : '',
+      (value.patch?.mutationEvidenceIds?.length ?? 0) === 0 ? 'mutationEvidenceIds' : '',
+    ].filter(Boolean);
+  }
+  return [
+    links.todoIds.length === 0 ? 'todoIds' : '',
+    links.toolCallIds.length === 0 ? 'toolCallIds' : '',
+    links.evidenceIds.length === 0 ? 'evidenceIds' : '',
+  ].filter(Boolean);
+}
+
+function missingRequiredLinksForRecord(record: HeavyTaskEngineeringRecord): string[] {
+  if (record.completeness === 'incomplete') return [];
+  if (record.kind === 'hypothesis') {
+    return [
+      record.links.todoIds.length === 0 ? 'todoIds' : '',
+      !record.hypothesis ? 'hypothesis' : '',
+      ((record.hypothesis?.rationaleEvidenceIds.length ?? 0) + record.links.evidenceIds.length) === 0 ? 'rationaleEvidenceIds' : '',
+    ].filter(Boolean);
+  }
+  if (record.kind === 'targeted_check') {
+    return [
+      record.links.todoIds.length === 0 ? 'todoIds' : '',
+      record.links.toolCallIds.length === 0 ? 'toolCallIds' : '',
+      record.links.evidenceIds.length === 0 ? 'evidenceIds' : '',
+      !record.targetedCheck?.checkId ? 'checkId' : '',
+    ].filter(Boolean);
+  }
+  if (record.kind === 'repair') {
+    return [
+      record.links.todoIds.length === 0 ? 'todoIds' : '',
+      !record.repair ? 'repair' : '',
+      ((record.repair?.failedCheckIds.length ?? 0) + record.links.checkIds.length) === 0 ? 'failedCheckIds' : '',
+      record.links.changedFiles.length === 0 && record.links.artifactIds.length === 0 ? 'changedFiles or artifactIds' : '',
+    ].filter(Boolean);
+  }
+  return [
+    record.links.todoIds.length === 0 ? 'todoIds' : '',
+    !record.patch?.patchId ? 'patchId' : '',
+    record.links.changedFiles.length === 0 && record.links.artifactIds.length === 0 ? 'changedFiles or artifactIds' : '',
+    ((record.patch?.mutationEvidenceIds.length ?? 0) + record.links.evidenceIds.length) === 0 ? 'mutationEvidenceIds' : '',
+  ].filter(Boolean);
+}
+
+function validateEngineeringStrings(value: unknown, now: number): { ok: true } | { ok: false; guard: HeavyTaskSourceGuardResult & { status: 'rejected' } } {
+  const categories = new Set<string>();
+  for (const text of stringsFrom(value)) {
+    const validation = validateHeavyTaskPublicSelfCheck({ publicReason: text.slice(0, MAX_TEXT_CHARS) }, now);
+    if (!validation.ok) validation.guard.categories.forEach((category) => categories.add(category));
+  }
+  if (categories.size === 0) return { ok: true };
+  return {
+    ok: false,
+    guard: {
+      status: 'rejected',
+      checkedAt: now,
+      categories: [...categories].sort(),
+      publicReason: 'Rejected because submitted engineering record referenced private, hidden, or evaluator-only material.',
+    },
+  };
+}
+
+function stringsFrom(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(stringsFrom);
+  if (!value || typeof value !== 'object') return [];
+  const out: string[] = [];
+  for (const [key, item] of Object.entries(value)) {
+    if (['title', 'summary', 'incompleteReason', 'expectedSignal', 'observedSignal', 'command', 'changeSummary', 'repairStrategy', 'changedFiles'].includes(key)) {
+      out.push(...stringsFrom(item));
+    } else if (typeof item === 'object') {
+      out.push(...stringsFrom(item));
+    }
+  }
+  return out.filter((item) => item.trim().length > 0);
+}
+
+async function rejectDuplicateRecordRefs(record: HeavyTaskEngineeringRecord, store: TaskRunStore, taskRunId: string): Promise<void> {
+  const projection = await store.project(taskRunId);
+  const recordIds = new Set(projection.heavyTaskEngineeringRecords.map((item) => item.recordId));
+  const checkIds = new Set(projection.heavyTaskEngineeringRecords.map((item) => item.targetedCheck?.checkId).filter(isString));
+  const patchIds = new Set(projection.heavyTaskEngineeringRecords.map((item) => item.patch?.patchId).filter(isString));
+  if (recordIds.has(record.recordId)) throw new Error(`duplicate engineering record id: ${record.recordId}`);
+  if (record.targetedCheck && checkIds.has(record.targetedCheck.checkId)) throw new Error(`duplicate check id: ${record.targetedCheck.checkId}`);
+  if (record.patch && patchIds.has(record.patch.patchId)) throw new Error(`duplicate patch id: ${record.patch.patchId}`);
+}
+
+async function appendRecord(
+  store: TaskRunStore,
+  taskRunId: string,
+  record: HeavyTaskEngineeringRecord,
+  ts: number,
+  newId: () => string,
+): Promise<void> {
+  await store.appendEvent(taskRunId, {
+    type: 'heavy_task_engineering_recorded',
+    id: newId(),
+    taskRunId,
+    ts,
+    record,
+  });
+}
+
+function recordResult(record: HeavyTaskEngineeringRecord): Extract<HeavyTaskEngineeringRecordResult, { accepted: true }> {
+  const missingLinks = [
+    ...record.projection?.missingTodoIds ?? [],
+    ...record.projection?.missingEvidenceIds ?? [],
+    ...record.projection?.missingArtifactIds ?? [],
+    ...record.projection?.missingCheckIds ?? [],
+  ];
+  return {
+    accepted: true,
+    record,
+    missingLinks,
+    complete: record.completeness === 'complete',
+  };
+}
+
+function missing(values: readonly string[], known: Set<string>): string[] {
+  return values.filter((value) => !known.has(value));
+}
+
+function missingSummary(record: HeavyTaskEngineeringRecord): string {
+  const parts: string[] = [];
+  if (record.projection?.missingTodoIds.length) parts.push(`missingTodos=${record.projection.missingTodoIds.join(',')}`);
+  if (record.projection?.missingEvidenceIds.length) parts.push(`missingEvidence=${record.projection.missingEvidenceIds.join(',')}`);
+  if (record.projection?.missingArtifactIds.length) parts.push(`missingArtifacts=${record.projection.missingArtifactIds.join(',')}`);
+  if (record.projection?.missingCheckIds.length) parts.push(`missingChecks=${record.projection.missingCheckIds.join(',')}`);
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function joinOrNone(values: readonly string[]): string {
+  return values.length > 0 ? values.slice(0, 8).join(',') : 'none';
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function oneLine(value: string, maxChars: number): string {
+  const clean = value.replace(/\s+/g, ' ').trim();
+  return clean.length <= maxChars ? clean : `${clean.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function issue(ctx: z.RefinementCtx, path: (string | number)[], message: string): void {
+  ctx.addIssue({ code: z.ZodIssueCode.custom, path, message });
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export type HeavyTaskEngineeringEvent = Extract<TaskEvent, { type: 'heavy_task_engineering_recorded' }>;
+export type HeavyTaskEngineeringArtifactLink = Pick<TaskRunArtifact, 'artifactId'>;

--- a/packages/headless/src/heavy-task-policy.ts
+++ b/packages/headless/src/heavy-task-policy.ts
@@ -85,6 +85,8 @@ export function buildHeavyTaskSystemPromptPolicy(
     '- Use inventory_submit to submit a structured inventory snapshot after initial public inspection and whenever the important workspace/artifact inventory changes.',
     '- Use todo_update to submit the full current todo/progress snapshot as work advances. Keep at most one item in_progress, and treat todo completion as advisory progress rather than benchmark success.',
     '- Use self_check_submit to submit public, task-derived semantic self-check evidence from visible tests, builds, sample commands, or artifact inspections. Include public command/artifact evidence only.',
+    '- Use engineering_record for structured hypotheses, repairs, and patch/change summaries. Link records to todo ids, compact evidence ids, check ids, tool call ids, changed files, and artifact ids where those links apply.',
+    '- Use check_record for targeted checks. Complete check records require todo ids, tool call ids, and compact evidence ids; incomplete records require an explicit incomplete reason.',
     '- The self_check_submit source guard rejects hidden, private, or evaluator-only material before it can become accepted task-run state. Treat accepted checks as advisory engineering feedback.',
     '- Official benchmark scoring remains external and authoritative. Do not claim success solely from your own checks, and do not replace verifier results with self-checks.',
     `- Do not seek, infer, read, or rely on forbidden evaluator material: ${FORBIDDEN_HEAVY_TASK_POLICY_TERMS.join(', ')}.`,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -158,6 +158,11 @@ export type {
   FeedbackObservation,
   HeavyTaskCompactEvidenceEnvelope,
   HeavyTaskDiffSummary,
+  HeavyTaskEngineeringCompleteness,
+  HeavyTaskEngineeringLinks,
+  HeavyTaskEngineeringRecord,
+  HeavyTaskEngineeringRecordKind,
+  HeavyTaskEngineeringRecordRecordedEvent,
   HeavyTaskEvidenceKind,
   HeavyTaskEvidenceRecordedEvent,
   HeavyTaskOutputSummary,
@@ -335,6 +340,28 @@ export {
   renderHeavyTaskSelfCheckForPrompt,
   validateHeavyTaskPublicSelfCheck,
 } from './heavy-task-self-check.js';
+export type {
+  CheckRecordSubmitInput,
+  EngineeringRecordSubmitInput,
+  HeavyTaskEngineeringArtifactLink,
+  HeavyTaskEngineeringEvent,
+  HeavyTaskEngineeringRecorder,
+  HeavyTaskEngineeringRecordResult,
+} from './heavy-task-engineering.js';
+export {
+  buildHeavyTaskEngineeringTools,
+  checkRecordSubmitSchema,
+  compactHeavyTaskEngineeringState,
+  createHeavyTaskEngineeringRecorder,
+  DEFAULT_EXPORT_ENGINEERING_LIMIT,
+  DEFAULT_PROMPT_ENGINEERING_LIMIT,
+  engineeringRecordSubmitSchema,
+  HEAVY_TASK_ENGINEERING_SCHEMA_VERSION,
+  HEAVY_TASK_ENGINEERING_TOOL_NAMES,
+  isPublicHeavyTaskEngineeringRecord,
+  renderHeavyTaskEngineeringForPrompt,
+  resolveHeavyTaskEngineeringRecordLinks,
+} from './heavy-task-engineering.js';
 export type {
   CompactTextEvidenceOptions,
   HeavyTaskCompactEvidenceInput,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,4 +1,5 @@
 import type { Config, Task } from './contracts.js';
+import type { HeavyTaskEngineeringRecorder } from './heavy-task-engineering.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
 import type { HeavyTaskProgressRecorder } from './heavy-task-progress.js';
@@ -149,6 +150,8 @@ export interface HeadlessBackendContext {
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
   /** Present only when heavy-task mode is enabled for compact public evidence capture. */
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
+  /** Present only when heavy-task mode is enabled for structured engineering loop records. */
+  heavyTaskEngineering?: HeavyTaskEngineeringRecorder;
 }
 
 export function validateRealBackendIsolation(isolation: RealBackendIsolation | undefined): void {

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ResultRecord } from './contracts.js';
+import { compactHeavyTaskEngineeringState, isPublicHeavyTaskEngineeringRecord } from './heavy-task-engineering.js';
 import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import {
   isTerminalTaskRunStatus,
@@ -75,6 +76,12 @@ export interface TaskRunExport {
       latest: NonNullable<TaskRunProjection['latestHeavyTaskEvidence']>;
       recent: TaskRunProjection['heavyTaskEvidence'];
       historyCount: number;
+    };
+    engineering?: {
+      latest: NonNullable<TaskRunProjection['latestHeavyTaskEngineeringRecord']>;
+      recent: TaskRunProjection['heavyTaskEngineeringRecords'];
+      historyCount: number;
+      incompleteCount: number;
     };
   };
   isolation: {
@@ -327,7 +334,11 @@ function progressFromProjection(projection: TaskRunProjection): TaskRunExport['p
       historyCount: projection.heavyTaskEvidence.length,
     };
   }
-  return progress.inventory || progress.todos || progress.selfChecks || progress.evidence ? progress : undefined;
+  const engineering = compactHeavyTaskEngineeringState(projection.heavyTaskEngineeringRecords);
+  if (engineering) {
+    progress.engineering = engineering;
+  }
+  return progress.inventory || progress.todos || progress.selfChecks || progress.evidence || progress.engineering ? progress : undefined;
 }
 
 function runtimeEventIdsFrom(runtimeRefs: unknown): string[] {
@@ -390,6 +401,9 @@ function exportableTaskEvents(event: TaskEvent): TaskEvent[] {
   }
   if (event.type === 'heavy_task_evidence_recorded') {
     return event.evidence.public === true ? [event] : [];
+  }
+  if (event.type === 'heavy_task_engineering_recorded') {
+    return isPublicHeavyTaskEngineeringRecord(event.record) ? [event] : [];
   }
   return [event];
 }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -25,6 +25,11 @@ import {
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import {
+  createHeavyTaskEngineeringRecorder,
+  HEAVY_TASK_ENGINEERING_TOOL_NAMES,
+  renderHeavyTaskEngineeringForPrompt,
+} from './heavy-task-engineering.js';
+import {
   createHeavyTaskEvidenceRecorder,
   renderHeavyTaskEvidenceForPrompt,
 } from './heavy-task-evidence.js';
@@ -149,10 +154,12 @@ export async function runTaskOnce(
   const priorProgressPrompt = priorProjection ? renderHeavyTaskProgressForPrompt(priorProjection) : undefined;
   const priorSelfCheckPrompt = priorProjection ? renderHeavyTaskSelfCheckForPrompt(priorProjection) : undefined;
   const priorEvidencePrompt = priorProjection ? renderHeavyTaskEvidenceForPrompt(priorProjection) : undefined;
+  const priorEngineeringPrompt = priorProjection ? renderHeavyTaskEngineeringForPrompt(priorProjection) : undefined;
   const instruction = withOptionalStatePrompts(deps.instructionOverride ?? task.instruction, [
     priorProgressPrompt,
     priorSelfCheckPrompt,
     priorEvidencePrompt,
+    priorEngineeringPrompt,
   ]);
   const heavyTaskProgress = heavyTaskMode.enabled
     ? createHeavyTaskProgressRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
@@ -162,6 +169,9 @@ export async function runTaskOnce(
     : undefined;
   const heavyTaskEvidence = heavyTaskMode.enabled
     ? createHeavyTaskEvidenceRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
+    : undefined;
+  const heavyTaskEngineering = heavyTaskMode.enabled
+    ? createHeavyTaskEngineeringRecorder({ taskRunId, attemptId, store: taskRunStore, now, newId })
     : undefined;
 
   if (createTaskRun) {
@@ -258,6 +268,7 @@ export async function runTaskOnce(
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
       ...(heavyTaskSelfCheck ? { heavyTaskSelfCheck } : {}),
       ...(heavyTaskEvidence ? { heavyTaskEvidence } : {}),
+      ...(heavyTaskEngineering ? { heavyTaskEngineering } : {}),
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),
@@ -507,7 +518,7 @@ function withOptionalStatePrompts(instruction: string, prompts: readonly (string
 
 function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: boolean): string[] {
   const names = hasIsolatedExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'];
-  if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES, ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES);
+  if (heavyTaskEnabled && hasIsolatedExecutor) names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES, ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES, ...HEAVY_TASK_ENGINEERING_TOOL_NAMES);
   return names;
 }
 

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -446,6 +446,71 @@ export interface HeavyTaskCompactEvidenceEnvelope {
   };
 }
 
+export type HeavyTaskEngineeringRecordKind =
+  | 'hypothesis'
+  | 'targeted_check'
+  | 'repair'
+  | 'patch';
+
+export type HeavyTaskEngineeringCompleteness = 'complete' | 'incomplete';
+
+export interface HeavyTaskEngineeringLinks {
+  todoIds: string[];
+  evidenceIds: string[];
+  toolCallIds: string[];
+  checkIds: string[];
+  artifactIds: string[];
+  changedFiles: string[];
+  patchIds: string[];
+  hypothesisIds: string[];
+  repairIds: string[];
+}
+
+export interface HeavyTaskEngineeringRecord {
+  schemaVersion: 1;
+  recordId: string;
+  taskRunId: string;
+  attemptId?: string;
+  ts: number;
+  kind: HeavyTaskEngineeringRecordKind;
+  title: string;
+  summary: string;
+  status: 'proposed' | 'running' | 'passed' | 'failed' | 'repaired' | 'superseded' | 'abandoned';
+  completeness: HeavyTaskEngineeringCompleteness;
+  incompleteReason?: string;
+  source: HeavyTaskProgressSource & { toolName: 'engineering_record' | 'check_record' };
+  links: HeavyTaskEngineeringLinks;
+  hypothesis?: {
+    expectedSignal: string;
+    rationaleEvidenceIds: string[];
+  };
+  targetedCheck?: {
+    checkId: string;
+    command?: string;
+    expectedSignal: string;
+    observedSignal: string;
+    result: 'pass' | 'fail' | 'inconclusive';
+  };
+  repair?: {
+    failedCheckIds: string[];
+    hypothesisId?: string;
+    repairStrategy: string;
+    outcome: 'not_checked' | 'check_passed' | 'check_failed' | 'inconclusive';
+  };
+  patch?: {
+    patchId: string;
+    changedFiles: string[];
+    changeSummary: string;
+    mutationEvidenceIds: string[];
+  };
+  projection?: {
+    missingTodoIds: string[];
+    missingEvidenceIds: string[];
+    missingArtifactIds: string[];
+    missingCheckIds: string[];
+  };
+}
+
 export interface EnvNetworkSecretPolicy {
   schemaVersion: 1;
   env: 'inherit_none' | 'allowlist';
@@ -668,6 +733,11 @@ export interface HeavyTaskEvidenceRecordedEvent extends BaseTaskEvent {
   evidence: HeavyTaskCompactEvidenceEnvelope;
 }
 
+export interface HeavyTaskEngineeringRecordRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_engineering_recorded';
+  record: HeavyTaskEngineeringRecord;
+}
+
 export interface WorkspaceLeaseRecordedEvent extends BaseTaskEvent {
   type: 'workspace_lease_recorded';
   lease: WorkspaceLeaseFacts;
@@ -796,6 +866,7 @@ export type TaskEvent =
   | HeavyTaskTodosRecordedEvent
   | HeavyTaskSelfCheckRecordedEvent
   | HeavyTaskEvidenceRecordedEvent
+  | HeavyTaskEngineeringRecordRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent
   | ToolExecutorIdentityRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -2,12 +2,17 @@ import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ResultRecord } from './contracts.js';
 import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
+import {
+  isPublicHeavyTaskEngineeringRecord,
+  resolveHeavyTaskEngineeringRecordLinks,
+} from './heavy-task-engineering.js';
 import { evaluateHeavyTaskCompletionStatus, type HeavyTaskCompletionStatus } from './heavy-task-finalization.js';
 import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import type {
   AutonomousDecision,
   FeedbackObservation,
   HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskEngineeringRecord,
   HeavyTaskInventoryState,
   TaskInboxItem,
   HeavyTaskModeFacts,
@@ -55,6 +60,8 @@ export interface TaskRunProjection extends TaskRun {
   latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
   heavyTaskEvidence: HeavyTaskCompactEvidenceEnvelope[];
   latestHeavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope;
+  heavyTaskEngineeringRecords: HeavyTaskEngineeringRecord[];
+  latestHeavyTaskEngineeringRecord?: HeavyTaskEngineeringRecord;
   heavyTaskCompletion?: HeavyTaskCompletionStatus;
   isolation?: TaskIsolationFacts;
   workspaceLease?: WorkspaceLeaseFacts;
@@ -100,6 +107,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     heavyTaskTodoStates: [],
     heavyTaskSelfChecks: [],
     heavyTaskEvidence: [],
+    heavyTaskEngineeringRecords: [],
   };
   const attempts = new Map<string, TaskAttempt>();
   const inboxItems = new Map<string, TaskInboxItem>();
@@ -205,6 +213,11 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       case 'heavy_task_evidence_recorded':
         if (!appendCompactEvidence(projection, event.evidence)) {
           projection.warnings.push(`ignored heavy-task evidence ${event.evidence.evidenceId}: evidence must be public and match taskRunId`);
+        }
+        break;
+      case 'heavy_task_engineering_recorded':
+        if (!appendHeavyTaskEngineeringRecord(projection, event.record)) {
+          projection.warnings.push(`ignored heavy-task engineering record ${event.record.recordId}: record must be public and match taskRunId`);
         }
         break;
       case 'isolation_policy_recorded':
@@ -507,6 +520,19 @@ function appendCompactEvidence(projection: TaskRunProjection, ...evidence: Heavy
   return ok;
 }
 
+function appendHeavyTaskEngineeringRecord(projection: TaskRunProjection, record: HeavyTaskEngineeringRecord): boolean {
+  if (record.taskRunId !== projection.taskRunId || !isPublicHeavyTaskEngineeringRecord(record)) {
+    return false;
+  }
+  const resolved = resolveHeavyTaskEngineeringRecordLinks(record, projection);
+  projection.heavyTaskEngineeringRecords.push(resolved);
+  projection.latestHeavyTaskEngineeringRecord = resolved;
+  if (record.completeness === 'complete' && resolved.completeness === 'incomplete') {
+    projection.warnings.push(`downgraded heavy-task engineering record ${record.recordId}: referenced links were not found`);
+  }
+  return true;
+}
+
 function selfCheckEvidenceIdFactory(selfCheckId: string): () => string {
   let index = 0;
   return () => `${selfCheckId}:compact-${++index}`;
@@ -522,7 +548,8 @@ function hasHeavyTaskCompletionState(projection: TaskRunProjection): boolean {
     || projection.heavyTaskInventory.length > 0
     || projection.heavyTaskTodoStates.length > 0
     || projection.heavyTaskSelfChecks.length > 0
-    || projection.heavyTaskEvidence.length > 0;
+    || projection.heavyTaskEvidence.length > 0
+    || projection.heavyTaskEngineeringRecords.length > 0;
 }
 
 function safeFileId(id: string): string {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -6,6 +6,7 @@ import {
 } from '@maka/runtime';
 import { posix as pathPosix } from 'node:path';
 import { z } from 'zod';
+import { buildHeavyTaskEngineeringTools, type HeavyTaskEngineeringRecorder } from './heavy-task-engineering.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
@@ -15,6 +16,7 @@ export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
+  heavyTaskEngineering?: HeavyTaskEngineeringRecorder;
 }
 
 /**
@@ -40,6 +42,9 @@ export function buildIsolatedHeadlessTools(
   }
   if (options.heavyTaskSelfCheck) {
     tools.push(...buildHeavyTaskSelfCheckTools(options.heavyTaskSelfCheck));
+  }
+  if (options.heavyTaskEngineering) {
+    tools.push(...buildHeavyTaskEngineeringTools(options.heavyTaskEngineering));
   }
   return tools;
 }


### PR DESCRIPTION
## Summary
- add opt-in heavy-task structured engineering records via model-visible engineering_record and check_record tools
- persist/replay/export/resume compact hypothesis, targeted check, repair, and patch/change records linked to todos, compact evidence, checks, tool calls, files, and artifacts
- preserve scorer/verifier authority and default non-heavy-task behavior

Depends on PR #132 (P1-a compact evidence envelopes). This branch is stacked on top of issue102-heavy-task-p1a until that PR lands.

## Verification
- npm --workspace @maka/headless run typecheck
- npm --workspace @maka/headless run build
- focused affected suite: 55 tests / 6 suites passed
- npm --workspace @maka/headless test: 296 tests / 39 suites passed
- git diff --check
- git diff --cached --check