### PR TITLE
PR-SETTINGS-REVIEW-0: rapid-iteration Settings polish (8 fixes)

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -183,11 +183,10 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     assert.match(source, /workspaceInstructions\.getState\(\)/);
     assert.match(source, /创建项目指令文件/);
     assert.match(source, /workspaceInstructionCount > 0/);
-    // PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23): 记忆 + 每日回顾 merged
-    // into the new `memory-review` section. The "create project
-    // instruction" checklist item still points at the same workspace
-    // instructions settings; the section id just renamed.
-    assert.match(source, /onOpenSettingsSection\('memory-review'\)/);
+    // PR-SETTINGS-REVIEW-0: memory section is on its own again
+    // (the merged memory-review page was too dense). Workspace
+    // instructions live there.
+    assert.match(source, /onOpenSettingsSection\('memory'\)/);
   });
 
   it('fails soft when first-run checklist status probes reject', async () => {

--- a/apps/desktop/src/main/__tests__/maka-uri.test.ts
+++ b/apps/desktop/src/main/__tests__/maka-uri.test.ts
@@ -71,16 +71,13 @@ describe('parseMakaUri — settings', () => {
   it('accepts every known SettingsSection', () => {
     // The full SettingsSection enum, locked here so a section
     // removal in core trips this test.
-    // PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23, WAWQAQ msg `d93fe001`):
-    // 16 → 12 sections. Mapping:
-    //   network                       → general (proxy folded in)
-    //   personalization + theme       → appearance
-    //   memory + daily-review         → memory-review
-    //   voice-models + open-gateway   → voice-gateway
+    // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: 13 sections
+    // total. memory and daily-review split back apart.
     const sections = [
       'general',
       'appearance',
-      'memory-review',
+      'memory',
+      'daily-review',
       'models',
       'usage',
       'voice-gateway',

--- a/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/visual-smoke-fixture.test.ts
@@ -393,7 +393,8 @@ describe('visual smoke fixture mode', () => {
       { scenario: 'settings-bots', expectedSection: 'bot-chat' },
       { scenario: 'settings-about', expectedSection: 'about' },
       { scenario: 'settings-general', expectedSection: 'general' },
-      { scenario: 'settings-memory-review', expectedSection: 'memory-review' },
+      { scenario: 'settings-memory', expectedSection: 'memory' },
+      { scenario: 'settings-daily-review', expectedSection: 'daily-review' },
     ] as const;
 
     for (const { scenario, expectedSection } of cases) {

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -35,14 +35,14 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // assistantTone, network proxy, etc. — already comes from the
   // default settings.json seed.)
   'settings-data',
-  // PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23, WAWQAQ msg `d93fe001`):
-  // settings nav consolidation. `personalization + theme` → appearance;
-  // `daily-review + memory` → memory-review; `network` (proxy) → general.
+  // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: memory and
+  // daily-review split back apart per WAWQAQ msg `886f6406`.
   'settings-appearance',
   'settings-bots',
   'settings-about',
   'settings-general',
-  'settings-memory-review',
+  'settings-memory',
+  'settings-daily-review',
   'module-skills',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
@@ -339,8 +339,10 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       // PR-SETTINGS-IA-CONSOLIDATE-0: 通用 now also hosts the proxy
       // block that used to live on its own 网络 page.
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'general' };
-    case 'settings-memory-review':
-      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'memory-review' };
+    case 'settings-memory':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'memory' };
+    case 'settings-daily-review':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'daily-review' };
     case 'module-skills':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'skills', sidebarCollapsed: false };
     case 'module-daily-review':
@@ -506,7 +508,7 @@ export async function seedVisualSmokeFixture(input: {
   if (input.fixture.scenario === 'plan-reminders') {
     await writePlanReminders(input.workspaceRoot, now);
   }
-  if (input.fixture.scenario === 'module-daily-review' || input.fixture.scenario === 'settings-memory-review') {
+  if (input.fixture.scenario === 'module-daily-review' || input.fixture.scenario === 'settings-daily-review') {
     await writeDailyReviewArchives(input.workspaceRoot, now);
   }
 }

--- a/apps/desktop/src/renderer/FirstRunChecklist.tsx
+++ b/apps/desktop/src/renderer/FirstRunChecklist.tsx
@@ -190,7 +190,7 @@ export function FirstRunChecklist(props: FirstRunChecklistProps) {
           : '项目指令状态暂时没刷新成功，打开记忆设置可查看。',
         done: workspaceInstructionStatusKnown && workspaceInstructionCount > 0,
         trackCompletion: workspaceInstructionStatusKnown,
-        onClick: () => props.onOpenSettingsSection('memory-review'),
+        onClick: () => props.onOpenSettingsSection('memory'),
       },
       {
         // xuan c06e13f transparent MEMORY.md MVP + my
@@ -205,7 +205,7 @@ export function FirstRunChecklist(props: FirstRunChecklistProps) {
         done:
           settings.localMemory.enabled
           && settings.localMemory.agentReadEnabled,
-        onClick: () => props.onOpenSettingsSection('memory-review'),
+        onClick: () => props.onOpenSettingsSection('memory'),
       },
       {
         // xuan d91422d PR-VOICE-CAPTURE-SMOKE-0: Settings → 语音模型

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -2902,7 +2902,7 @@ function AppShell() {
                 onModelChange={(input) => setSessionModel(input)}
                 userLabel={userLabel}
                 memoryActive={memoryActive}
-                onOpenMemorySettings={() => openSettingsSection('memory-review')}
+                onOpenMemorySettings={() => openSettingsSection('memory')}
                 mode={navSelection.section}
                 connectionAlert={chatConnectionAlert}
                 eventStreamAlert={chatEventStreamAlert}

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -7,6 +7,7 @@ import {
   Bot,
   Brain,
   CalendarDays,
+  ChevronLeft,
   Cpu,
   Database,
   Info,
@@ -201,19 +202,18 @@ function SettingsSelect<T extends string>(props: {
 // node:test without a DOM / React.
 export type { SettingsNavGroup };
 
-// PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23, WAWQAQ msg `d93fe001`):
-// 16 → 12 visible sections. Single-purpose pages folded back into
-// broader containers to mirror reference's nav shape (one big
-// Preferences + a small set of narrow tabs). See
-// `notes/reference-settings.md` §7 for the mapping.
+// PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: WAWQAQ msg
+// `886f6406` rolled back the 记忆+回顾 merge — the combined page was
+// too dense. 记忆 and 每日回顾 are separate nav items again.
 export const SETTINGS_NAV: SettingsNavItem[] = [
-  // Group 1: 基础 — 通用 (kitchen sink) + 外观 (theme + personalization merged)
+  // Group 1: 基础 — 通用 (kitchen sink) + 外观 (personalization + theme merged)
   { id: 'general', label: '通用', Icon: SettingsIcon, enabled: true, group: '基础' },
   { id: 'appearance', label: '外观', Icon: Palette, enabled: true, group: '基础' },
-  // Group 2: AI — models, usage, memory+review, voice+gateway merged
+  // Group 2: AI — models, usage, memory, daily-review, voice+gateway
   { id: 'models', label: '模型', Icon: Cpu, enabled: true, group: 'AI' },
   { id: 'usage', label: '使用统计', Icon: BarChart3, enabled: true, group: 'AI' },
-  { id: 'memory-review', label: '记忆与回顾', Icon: Brain, enabled: true, group: 'AI' },
+  { id: 'memory', label: '记忆', Icon: Brain, enabled: true, group: 'AI' },
+  { id: 'daily-review', label: '每日回顾', Icon: CalendarDays, enabled: true, group: 'AI' },
   { id: 'voice-gateway', label: '语音与网关', Icon: Volume2, enabled: true, group: 'AI' },
   // Group 3: 集成 — bot、搜索 (network/proxy now lives inside 通用)
   { id: 'bot-chat', label: '机器人对话', Icon: Bot, enabled: true, group: '集成' },
@@ -957,6 +957,20 @@ function SettingsSurface(props: {
     <main className="settingsSurface agents-layout-body" data-modal="true" aria-label="设置内容">
       <aside className="settingsSidebar agents-sidebar" data-settings-nav-column aria-label="设置侧栏">
         <div className="settingsSidebarInner">
+          {/* PR-SETTINGS-REVIEW-0 (WAWQAQ msg `e1194266`): the
+              right-side X close button was visually orphaned at the
+              page-top. Replace with a `← 返回` link at the top of the
+              sidebar, matching reference's `返回应用` affordance. */}
+          <Button
+            className="settingsBackButton"
+            variant="quiet"
+            type="button"
+            aria-label="返回应用"
+            onClick={props.onClose}
+          >
+            <ChevronLeft size={14} strokeWidth={1.75} aria-hidden="true" />
+            <span>返回应用</span>
+          </Button>
           <header>
             <span>设置</span>
           </header>
@@ -990,9 +1004,6 @@ function SettingsSurface(props: {
       <section className="settingsMainPane agents-content-area" data-agents-view="settings">
         <header className="settingsPageHeader">
           <h2>{activeItem.label}</h2>
-          <Button className="settingsCloseButton" variant="quiet" size="icon-sm" type="button" aria-label="关闭设置" onClick={props.onClose}>
-            <X strokeWidth={1.75} aria-hidden="true" />
-          </Button>
         </header>
 
         <OverlayScrollArea
@@ -1104,11 +1115,14 @@ function SettingsPage(props: {
         </div>
       );
     case 'appearance':
-      // PR-SETTINGS-IA-CONSOLIDATE-0: 主题 + 个性化 → 外观.
-      // PR-SETTINGS-SWEEP-0: per-section uppercase heading so the user
-      // can see the two sub-blocks as belonging to one page.
+      // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0 (WAWQAQ msg
+      // `6759cd0f`): 个性化 first, 主题 after. Personalization is the
+      // identity / display-name block; theme is presentation. Reading
+      // top→down the user picks "who am I" then "how does it look".
       return (
         <div className="settingsStructuredPage">
+          <h2 className="settingsSectionHeading">个性化</h2>
+          <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />
           <h2 className="settingsSectionHeading">主题</h2>
           <ThemeSettingsPage
             themePref={props.themePref}
@@ -1120,8 +1134,6 @@ function SettingsPage(props: {
             onDensityChange={props.onDensityChange}
             onThemePaletteChange={props.onThemePaletteChange}
           />
-          <h2 className="settingsSectionHeading">个性化</h2>
-          <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />
         </div>
       );
     case 'data':
@@ -1138,21 +1150,18 @@ function SettingsPage(props: {
       return <PermissionCenterPage />;
     case 'health':
       return <HealthCenterPage />;
-    case 'memory-review':
-      // PR-SETTINGS-IA-CONSOLIDATE-0: 记忆 + 每日回顾 → 记忆与回顾.
-      // PR-SETTINGS-SWEEP-0: section heading per sub-block.
+    case 'memory':
+      // PR-SETTINGS-REVIEW-0 (WAWQAQ msg `886f6406`): the merged
+      // memory-review page was too dense; 记忆 is its own page again.
       return (
-        <div className="settingsStructuredPage">
-          <h2 className="settingsSectionHeading">本地记忆</h2>
-          <MemorySettingsPage
-            settings={props.settings}
-            onUpdate={props.onUpdateSettings}
-            onReloadSettings={props.onReloadSettings}
-          />
-          <h2 className="settingsSectionHeading">每日回顾</h2>
-          <DailyReviewSettingsPage onOpenDailyReview={props.onOpenDailyReview} />
-        </div>
+        <MemorySettingsPage
+          settings={props.settings}
+          onUpdate={props.onUpdateSettings}
+          onReloadSettings={props.onReloadSettings}
+        />
       );
+    case 'daily-review':
+      return <DailyReviewSettingsPage onOpenDailyReview={props.onOpenDailyReview} />;
     case 'voice-gateway':
       // PR-SETTINGS-IA-CONSOLIDATE-0: 语音模型 + 开放网关 → 语音与网关.
       // PR-SETTINGS-SWEEP-0: section heading per sub-block.

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -6912,8 +6912,33 @@ button:active {
   min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  padding: 22px 10px 12px 14px;
+  /* PR-SETTINGS-REVIEW-0 (2026-06-23, WAWQAQ msg `1b2d4e83`): traffic
+     light row sits at y=14–28 on macOS; 22px sidebar top padding put
+     the 设置 brand right against it. Bump to 52px so the brand label
+     starts well below the traffic lights, matching reference. */
+  padding: 52px 10px 12px 14px;
   background: transparent;
+}
+
+/* PR-SETTINGS-REVIEW-0 (WAWQAQ msg `e1194266`): left-aligned `返回应用`
+   in place of the right-side X. Sits above the 设置 brand. */
+.settingsBackButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+  margin: 0 0 10px 4px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--foreground-60);
+  font-size: 13px;
+  font-weight: 500;
+  -webkit-app-region: no-drag;
+}
+.settingsBackButton:hover {
+  background: oklch(from var(--foreground) l c h / 0.05);
+  color: var(--foreground);
 }
 
 .settingsSidebar header {
@@ -7213,6 +7238,14 @@ button:active {
   gap: 10px;
 }
 
+/* PR-SETTINGS-REVIEW-0 (2026-06-23, WAWQAQ msgs `f97ed407` + `8577326c`):
+   pull the page header into the same centered max-w-3xl column as the
+   content. Before this, the header sat in `.settingsMainPane` padding
+   (~34px from pane edge), while the row cards lived in the centered
+   768px column (~152px from pane edge at 1280 viewport) — the title
+   and content were visibly misaligned. Drop the mainpane padding to
+   thin top/bottom so the header + content can both share the centered
+   column. */
 .settingsMainPane {
   position: relative;
   min-width: 0;
@@ -7225,14 +7258,24 @@ button:active {
   background: var(--agents-content-area-bg);
   box-shadow: none;
   overflow: hidden;
-  padding: 26px 34px 30px;
+  /* PR-SETTINGS-REVIEW-0: traffic-light-aligned top padding so the
+     page title sits at the same Y baseline as the sidebar brand. */
+  padding: 52px 0 0;
 }
 
+/* PR-SETTINGS-REVIEW-0 fix-2: max-width centering on a grid child
+   didn't actually align the H2 with the centered column underneath.
+   Use the same edge math the content column uses
+   (`calc((100% - 768px) / 2 + 24px)`) so the header content lines up
+   with row cards regardless of viewport width. */
 .settingsPageHeader {
   min-height: 36px;
+  padding: 0 max(24px, calc((100% - 768px) / 2 + 24px));
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  /* X close button moved to the sidebar `返回应用` — header hosts the
+     page title only, left-aligned. */
+  justify-content: flex-start;
   gap: 18px;
 }
 
@@ -7286,13 +7329,17 @@ button:active {
 }
 
 /* PR-SETTINGS-SWEEP-0: section heading for merged pages. Mirrors
-   reference's small uppercase sub-section tag. */
+   reference's small uppercase sub-section tag.
+   PR-SETTINGS-REVIEW-0 alignment fix: flush-left with the card stack
+   (cards carry their own L padding internally), and bump the heading
+   to 12/2px tracking so it reads as a real sub-section break rather
+   than a hairline. */
 .settingsSectionHeading {
-  margin: 24px 4px 8px;
-  color: var(--foreground-50);
-  font-size: 11px;
+  margin: 24px 2px 10px;
+  color: var(--foreground-55);
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 .settingsStructuredPage > .settingsSectionHeading:first-child {
@@ -7320,9 +7367,12 @@ button:active {
   font-size: 13px;
 }
 
-/* PR-SETTINGS-SHELL-OWNS-LAYOUT-0 correction (WAWQAQ msg `eafc18a1`):
-   reference rows have 1px borders + 8px radius + light bg, not flat
-   rows. Reverting the PR-SETTINGS-PAGE-BODY-0 flatness. */
+/* PR-SETTINGS-SHELL-OWNS-LAYOUT-0 (WAWQAQ msg `eafc18a1`) +
+   PR-SETTINGS-REVIEW-0 (WAWQAQ msg `f97ed407`): rows are bordered
+   cards, but the border must be a low-alpha tint so it doesn't
+   double up with the surrounding surface chrome. `var(--border)` was
+   too hard; switch to a 6% foreground overlay so the card edge is
+   suggestive, not declarative. */
 .settingsFormRow {
   min-height: 56px;
   display: flex;
@@ -7330,14 +7380,15 @@ button:active {
   justify-content: space-between;
   gap: 16px;
   padding: 16px 20px;
-  border: 1px solid var(--border);
+  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
   border-radius: 8px;
-  background: var(--background, var(--foreground-2));
+  background: transparent;
   transition: background 150ms var(--ease-out-strong), border-color 150ms var(--ease-out-strong);
 }
 
 .settingsFormRow:hover {
-  border-color: oklch(from var(--foreground) l c h / 0.18);
+  border-color: oklch(from var(--foreground) l c h / 0.14);
+  background: oklch(from var(--foreground) l c h / 0.02);
 }
 
 .settingsFormRow strong,
@@ -9007,24 +9058,25 @@ button:active {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
 }
 
-/* PR-SETTINGS-SHELL-OWNS-LAYOUT-0 correction (WAWQAQ msg `eafc18a1`):
-   reference rows are bordered cards (1px border, 8px radius), so put
-   back the per-row chrome — but flat-tinted, NOT the heavy lifted
-   provider-card chrome. */
+/* PR-SETTINGS-SHELL-OWNS-LAYOUT-0 (WAWQAQ msg `eafc18a1`) +
+   PR-SETTINGS-REVIEW-0 (WAWQAQ msg `f97ed407`): bordered cards with
+   a 6% foreground tint border so they don't compete with the outer
+   pane chrome. */
 .settingsRow {
   display: grid;
   grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
   align-items: center;
   gap: 16px;
   padding: 16px 20px;
-  border: 1px solid var(--border);
+  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
   border-radius: 8px;
-  background: var(--background, var(--foreground-2));
+  background: transparent;
   transition: background 150ms var(--ease-out-strong), border-color 150ms var(--ease-out-strong);
 }
 
 .settingsRow:hover {
-  border-color: oklch(from var(--foreground) l c h / 0.18);
+  border-color: oklch(from var(--foreground) l c h / 0.14);
+  background: oklch(from var(--foreground) l c h / 0.02);
 }
 
 .settingsRow > div {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -17,22 +17,25 @@ import {
 import { defaultLocalMemorySettings, normalizeLocalMemorySettings } from './local-memory.js';
 
 /**
- * PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23, WAWQAQ msg `d93fe001`):
- * 4 single-purpose pages merged into broader containers to mirror the
- * reference Settings shape (one big Preferences page + a small set of
- * narrow tabs). Mapping from the old set:
+ * PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0 (WAWQAQ msg
+ * `886f6406`): the memory+review merge had too much density and got
+ * split back out. Other merges (network→general, personalization+
+ * theme→appearance, voice-models+open-gateway→voice-gateway) held.
  *
- *   - `network`                       → `general` (proxy block lives at the bottom)
+ * Final mapping:
+ *   - `network`                       → `general`
  *   - `personalization` + `theme`     → `appearance`
- *   - `memory` + `daily-review`       → `memory-review`
  *   - `voice-models` + `open-gateway` → `voice-gateway`
+ *   - `daily-review` is its own section again
+ *   - `memory` is its own section again
  *
- * 16 visible sections → 12. See notes/reference-settings.md §7.
+ * 13 visible sections. See notes/reference-settings.md §7.
  */
 export type SettingsSection =
   | 'general'
   | 'appearance'
-  | 'memory-review'
+  | 'memory'
+  | 'daily-review'
   | 'models'
   | 'usage'
   | 'voice-gateway'

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -15,14 +15,15 @@ export type VisualSmokeScenario =
   | 'permission-destructive'
   | 'stale-sessions'
   | 'settings-data'
-  // PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23): personalization + theme
-  // merged into 'appearance', daily-review + memory merged into
-  // 'memory-review', network (proxy) folded back into general.
+  // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: memory and
+  // daily-review split back apart; appearance + voice-gateway stay
+  // merged; network folded into general.
   | 'settings-appearance'
   | 'settings-bots'
   | 'settings-about'
   | 'settings-general'
-  | 'settings-memory-review'
+  | 'settings-memory'
+  | 'settings-daily-review'
   | 'module-skills'
   | 'module-daily-review'
   | 'workstation-statuses'

--- a/packages/ui/src/maka-uri.ts
+++ b/packages/ui/src/maka-uri.ts
@@ -55,7 +55,8 @@ import type { SettingsSection } from '@maka/core';
 const ALLOWED_SETTINGS_SECTIONS = new Set<SettingsSection>([
   'general',
   'appearance',
-  'memory-review',
+  'memory',
+  'daily-review',
   'models',
   'usage',
   'voice-gateway',

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -69,12 +69,13 @@ const ALL_SCENARIOS = [
   'permission-destructive',
   'stale-sessions',
   'settings-data',
-  // PR-SETTINGS-IA-CONSOLIDATE-0 (2026-06-23): consolidated nav.
+  // PR-SETTINGS-IA-CONSOLIDATE-0 + PR-SETTINGS-REVIEW-0: memory split out.
   'settings-appearance',
   'settings-bots',
   'settings-about',
   'settings-general',
-  'settings-memory-review',
+  'settings-memory',
+  'settings-daily-review',
   'module-skills',
   'module-daily-review',
   'workstation-statuses',


### PR DESCRIPTION
## Summary

WAWQAQ ran a rapid review pass and flagged ~8 issues across a series of messages. Bundled into one PR per project preference for larger PRs.

1. **Sidebar + traffic light spacing** — 22px → 52px top padding so 设置 brand clears macOS traffic light.
2. **Row borders too hard** — switched from \`var(--border)\` to 8% foreground tint so card edges are suggestive, not declarative. Transparent bg; hover amplifies border + adds 2% bg lift.
3. **Page title misaligned with content** — header padding now uses \`max(24px, calc((100% - 768px) / 2 + 24px))\` so the title sits directly above the first row card regardless of viewport.
4. **\`返回应用\` replaces right-side X close** — left-aligned chevron link at the top of the sidebar, matching reference's "back to app" affordance.
5. **记忆 + 每日回顾 split back apart** — the merged \`memory-review\` page was too dense. They are separate nav items again. SettingsSection type, ALLOWED_SETTINGS_SECTIONS, render switch, visual-smoke scenarios, deeplinks, contract tests all moved together.
6. **外观: 个性化 before 主题** — identity ("who am I") then presentation ("how does it look") top→down.
7. **Section heading L margin fix** — flush with the card edge.
8. **Row hover state polish** — 2% bg lift on top of border tone amplification.

## Test plan

- [x] \`npm test\` in \`apps/desktop\`: 1466 passed
- [x] Visual smoke: settings-general now shows the proper title alignment, return-to-app link, subtle row borders.