### PR TITLE
PR-SETTINGS-NO-PANE-BORDER-0: pane seam removed + cards regrouped + 设置 brand dropped

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -5,9 +5,9 @@ import {
   BarChart3,
   Bell,
   Bot,
+  ArrowLeft,
   Brain,
   CalendarDays,
-  ChevronLeft,
   Cpu,
   Database,
   Info,
@@ -957,10 +957,9 @@ function SettingsSurface(props: {
     <main className="settingsSurface agents-layout-body" data-modal="true" aria-label="设置内容">
       <aside className="settingsSidebar agents-sidebar" data-settings-nav-column aria-label="设置侧栏">
         <div className="settingsSidebarInner">
-          {/* PR-SETTINGS-REVIEW-0 (WAWQAQ msg `e1194266`): the
-              right-side X close button was visually orphaned at the
-              page-top. Replace with a `← 返回` link at the top of the
-              sidebar, matching reference's `返回应用` affordance. */}
+          {/* PR-SETTINGS-NO-PANE-BORDER-0 (WAWQAQ msg `8effe691`):
+              reference sidebar has just `← 返回应用` then straight
+              into the nav — no big "设置" brand label. Match it. */}
           <Button
             className="settingsBackButton"
             variant="quiet"
@@ -968,12 +967,9 @@ function SettingsSurface(props: {
             aria-label="返回应用"
             onClick={props.onClose}
           >
-            <ChevronLeft size={14} strokeWidth={1.75} aria-hidden="true" />
+            <ArrowLeft size={16} strokeWidth={1.85} aria-hidden="true" />
             <span>返回应用</span>
           </Button>
-          <header>
-            <span>设置</span>
-          </header>
           <nav aria-label="设置分组">
             {groupedNav().map(({ group, items }) => (
               <div key={group} className="settingsNavGroup" role="group" aria-label={group}>
@@ -1091,27 +1087,34 @@ function SettingsPage(props: {
     case 'about':
       return <AboutSettingsPage />;
     case 'general':
-      // PR-SETTINGS-IA-CONSOLIDATE-0: 通用 now also hosts the proxy
-      // block that used to live on its own 网络 page.
+      // PR-SETTINGS-NO-PANE-BORDER-0 (WAWQAQ msg `d0e7dfb3`):
+      // multiple grouped cards stacked vertically, each one its own
+      // `<SettingsRows>` card. 隐身模式 alone, system defaults
+      // together, proxy alone — same shape as the reference layout
+      // (which has separate cards per logical group).
       return (
         <div className="settingsStructuredPage">
-          <div className="settingsFormRow">
-            <div>
-              <strong>隐身模式</strong>
-              <small>开启后暂停本地记忆读写、联网搜索和计划提醒触发；关闭后恢复正常工作区状态。</small>
+          <SettingsRows>
+            <div className="settingsFormRow">
+              <div>
+                <strong>隐身模式</strong>
+                <small>开启后暂停本地记忆读写、联网搜索和计划提醒触发；关闭后恢复正常工作区状态。</small>
+              </div>
+              <Switch
+                ariaLabel="启用隐身模式"
+                checked={props.settings.privacy.incognitoActive}
+                onChange={(incognitoActive) => void props.onUpdateSettings({ privacy: { incognitoActive } })}
+              />
             </div>
-            <Switch
-              ariaLabel="启用隐身模式"
-              checked={props.settings.privacy.incognitoActive}
-              onChange={(incognitoActive) => void props.onUpdateSettings({ privacy: { incognitoActive } })}
-            />
-          </div>
+          </SettingsRows>
           <SettingsRows>
             <SettingRow title="启动" detail="打开应用后回到最近一次对话。" value="已启用" />
             <SettingRow title="新对话模式" detail="新对话默认从确认模式开始。" value="确认" />
             <SettingRow title="默认模型" detail="新对话默认使用的模型连接。" value={props.defaultSlug ?? '未设置'} />
           </SettingsRows>
-          <NetworkProxySection settings={props.settings} onUpdate={props.onUpdateSettings} />
+          <SettingsRows>
+            <NetworkProxySection settings={props.settings} onUpdate={props.onUpdateSettings} />
+          </SettingsRows>
         </div>
       );
     case 'appearance':

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7246,20 +7246,27 @@ button:active {
    and content were visibly misaligned. Drop the mainpane padding to
    thin top/bottom so the header + content can both share the centered
    column. */
+/* PR-SETTINGS-NO-PANE-BORDER-0 (2026-06-23, WAWQAQ msg `aabfa2b8`):
+   the right pane was rendering as a separate floating plate (border +
+   tinted bg + corner radius + margin gap from sidebar). Reference's
+   Settings has NO seam between the sidebar and the content surface —
+   they share one continuous canvas. Drop the pane border, radius,
+   margin, and explicit background so the right pane visually flows
+   into the same surface as the nav. */
 .settingsMainPane {
   position: relative;
   min-width: 0;
   min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  margin: var(--agents-content-area-gap) var(--agents-content-area-gap) var(--agents-content-area-gap) 0;
-  border: 1px solid var(--color-border-tertiary);
-  border-radius: var(--agents-content-area-radius);
-  background: var(--agents-content-area-bg);
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   box-shadow: none;
   overflow: hidden;
-  /* PR-SETTINGS-REVIEW-0: traffic-light-aligned top padding so the
-     page title sits at the same Y baseline as the sidebar brand. */
+  /* Traffic-light-aligned top padding so the page title sits at the
+     same Y baseline as the sidebar brand. */
   padding: 52px 0 0;
 }
 
@@ -7315,27 +7322,25 @@ button:active {
   padding: 40px 24px 64px;
 }
 
-/* PR-SETTINGS-GROUPED-CARD-0 (2026-06-23, WAWQAQ msg `1abecd66`):
-   reference packs settings rows tightly inside ONE outer card and
-   separates them with hairline dividers — NOT per-row standalone
-   cards with gaps. Switch to that pattern: the page container is the
-   card; rows are flush, with `border-bottom` between adjacent rows. */
+/* PR-SETTINGS-NO-PANE-BORDER-0 (WAWQAQ msg `d0e7dfb3`): nested
+   card-in-card was the previous problem — `.settingsStructuredPage`
+   was a card AND it contained `<SettingsRows>` cards AND orphan
+   `.settingsFormRow` direct children. Reference shows multiple
+   GROUPED cards stacked vertically. So `.settingsStructuredPage` is
+   no longer a card — it's just the vertical container with gap, and
+   `.settingsRows` is the ONLY card primitive. */
 .settingsStructuredPage {
   display: grid;
   align-content: start;
-  gap: 0;
-  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
-  border-radius: 12px;
-  overflow: hidden;
+  gap: 16px;
   background: transparent;
 }
 
-/* Merged sub-pages (外观, 通用 has proxy block at bottom): both
-   surfaces flow into the same outer card — strip nested chrome. */
+/* Nested `.settingsStructuredPage` (merged pages like 外观 stack two
+   sub-pages, each wrapping in their own `.settingsStructuredPage`):
+   the inner one just passes through. */
 .settingsStructuredPage .settingsStructuredPage {
-  border: 0;
-  border-radius: 0;
-  overflow: visible;
+  gap: 16px;
 }
 
 /* PR-SETTINGS-SWEEP-0: section heading for merged pages. Mirrors


### PR DESCRIPTION
## Summary

Three reference-alignment fixes batched into one PR:

1. **Pane seam removed** (WAWQAQ msg \`aabfa2b8\`) — \`.settingsMainPane\` was rendering as a separate floating plate (border + tinted bg + corner radius). Reference has no seam between sidebar and content. Dropped pane chrome; surfaces share one canvas.

2. **设置 brand dropped + back button restyled** (\`8effe691\`) — reference sidebar starts with \`← 返回应用\` then straight into the nav. Removed the "设置" header. Switched icon \`ChevronLeft\` → \`ArrowLeft\` size 16.

3. **Card-in-card fix** (\`d0e7dfb3\`) — \`.settingsStructuredPage\` was both a card AND a container of nested cards + orphan rows. Visually broken: rows like 隐身模式 floated chromeless, while 启动/新对话/默认 sat in a card, then 代理服务器 floated again. New shape: \`.settingsStructuredPage\` is just a grid with 16px gap, \`.settingsRows\` is the only card primitive. Each logical group wraps in \`<SettingsRows>\`. Now three grouped cards stack vertically per reference.

## Test plan

- [x] \`npm test\` in \`apps/desktop\`: 1466 passed
- [x] Visual smoke: 通用 shows three discrete grouped cards; no seam between sidebar and content.