### PR TITLE
Remove UI density setting

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -41,14 +41,14 @@ describe('renderer startup fail-soft contract', () => {
     assert.match(mountEffect, /void refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
-      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyDensity\(den\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
+      /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,
       'startup shell settings load failures must surface visibly without exposing raw storage/system details',
     );
     assert.doesNotMatch(refreshShellSettings, /toastApi\.error\('载入外观设置失败', cleanErrorMessage\(error\)\)/);
     assert.doesNotMatch(
       refreshShellSettings,
-      /catch \(error\) \{[\s\S]*applyUiLocale\('auto'\)|catch \(error\) \{[\s\S]*applyTheme\('auto'\)|catch \(error\) \{[\s\S]*applyDensity\('comfortable'\)|catch \(error\) \{[\s\S]*applyThemePalette\('default'\)/,
-      'startup shell settings failures must not force default language/theme/density/palette over unknown persisted settings',
+      /catch \(error\) \{[\s\S]*applyUiLocale\('auto'\)|catch \(error\) \{[\s\S]*applyTheme\('auto'\)|catch \(error\) \{[\s\S]*applyThemePalette\('default'\)/,
+      'startup shell settings failures must not force default language/theme/palette over unknown persisted settings',
     );
     assert.match(
       refreshConnections,

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -111,9 +111,9 @@ describe('Settings form accessibility labels', () => {
     assert.match(settings, /function SettingsSelect<T extends string>/);
     assert.match(settings, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{6\}>/);
 
-    // ThemeSettingsPage uses native <button> on purpose for the 3 radio-card
-    // pickers (mode / palette / density): the cards are a custom grid with a
-    // preview tile + label, and the shared <Button>'s baked-in Tailwind
+    // ThemeSettingsPage uses native <button> on purpose for the radio-card
+    // pickers (mode / palette): the cards are a custom grid with a preview
+    // tile + label, and the shared <Button>'s baked-in Tailwind
     // utilities (`h-9 inline-flex bg-primary text-primary-foreground`) collapse
     // the card to a 36px-tall black pill. See `settings-theme-contract.test.ts`
     // which pins the inverse direction (radio cards must stay native).

--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -34,17 +34,12 @@ describe('Settings theme page contract', () => {
     );
     assert.match(
       themePage![0],
-      /props\.onDensityChange\(next\);[\s\S]*await persistAppearance\(\{ density: next \}\)/,
-      'Density changes must keep instant preview before persisting',
-    );
-    assert.match(
-      themePage![0],
       /props\.onThemePaletteChange\(next\);[\s\S]*await persistAppearance\(\{ palette: next \}\)/,
       'Palette changes must keep instant preview before persisting',
     );
     assert.doesNotMatch(
       themePage![0],
-      /await props\.onUpdate\(\{ appearance: \{ (theme|density|palette): next \} \}\)/,
+      /await props\.onUpdate\(\{ appearance: \{ (theme|palette): next \} \}\)/,
       'Appearance controls must not call raw settings update without the fail-soft helper',
     );
   });
@@ -83,17 +78,16 @@ describe('Settings theme page contract', () => {
     assert.match(helperBlock, /setTimeout\(\(\) => focusRadioValue\(group, next\), 0\)/);
     assert.match(themePage, /aria-label="主题"[\s\S]*onKeyDown=\{\(event\) => onSettingsRadioGroupKeyDown/);
     assert.match(themePage, /aria-label=\{group\.label\}[\s\S]*onKeyDown=\{\(event\) => onSettingsRadioGroupKeyDown/);
-    assert.match(themePage, /aria-label="界面密度"[\s\S]*onKeyDown=\{\(event\) => onSettingsRadioGroupKeyDown/);
     assert.match(themePage, /data-radio-value=\{option\.value\}[\s\S]*tabIndex=\{radioTabIndex\(option\.value, props\.themePref/);
     assert.match(themePage, /data-radio-value=\{palette\}[\s\S]*tabIndex=\{radioTabIndex\(palette, currentPalette, group\.palettes\)\}/);
-    assert.match(themePage, /data-radio-value=\{option\.value\}[\s\S]*tabIndex=\{radioTabIndex\(option\.value, props\.density/);
+    assert.doesNotMatch(themePage, /界面密度|props\.density|setDensity|onDensityChange/);
     assert.match(segmentedBlock, /if \(props\.disabled\) return;[\s\S]*onSettingsRadioGroupKeyDown\(event, values, props\.value, props\.onChange\)/);
     assert.match(segmentedBlock, /aria-disabled=\{props\.disabled \? 'true' : undefined\}/);
     assert.match(segmentedBlock, /disabled=\{props\.disabled\}/);
     assert.match(segmentedBlock, /data-radio-value=\{value\}[\s\S]*tabIndex=\{radioTabIndex\(value, props\.value, values\)\}/);
   });
 
-  it('keeps theme/palette/density radio cards on native <button>, not <Button>', async () => {
+  it('keeps theme and palette radio cards on native <button>, not <Button>', async () => {
     // Regression guard for WAWQAQ msg 5f75daf6 — commit b40d097 swapped
     // these cards onto packages/ui's <Button>, which bakes in
     // `h-9 inline-flex bg-primary text-primary-foreground` Tailwind
@@ -115,16 +109,16 @@ describe('Settings theme page contract', () => {
     assert.equal(
       ucButtonCount,
       0,
-      `Theme/palette/density radio cards must use native <button>, not <Button> from packages/ui (found ${ucButtonCount} <Button> occurrences in the page)`,
+      `Theme/palette radio cards must use native <button>, not <Button> from packages/ui (found ${ucButtonCount} <Button> occurrences in the page)`,
     );
     assert.equal(
       lcButtonCount,
-      3,
-      `Expected exactly 3 native <button> elements (mode picker, palette picker, density picker), found ${lcButtonCount}`,
+      2,
+      `Expected exactly 2 native <button> elements (mode picker, palette picker), found ${lcButtonCount}`,
     );
     assert.match(themePage, /className="settingsThemeOption settingsThemeOptionPreview"/);
     assert.match(themePage, /className="settingsThemeOption settingsPaletteOption"/);
-    assert.match(themePage, /className="settingsThemeOption"\s*\n\s*onClick=\{\(\) => void setDensity/);
+    assert.doesNotMatch(themePage, /界面密度|settingsDensitySwatch|setDensity/);
   });
 
   it('keeps theme page copy Chinese-first and user-facing', async () => {
@@ -132,13 +126,11 @@ describe('Settings theme page contract', () => {
     const themePage = src.match(/function ThemeSettingsPage\([\s\S]*?function WebSearchSettingsPage/)?.[0] ?? '';
     const themeCopy = [
       src.match(/const THEME_OPTIONS[\s\S]*?\];/)?.[0] ?? '',
-      src.match(/const DENSITY_OPTIONS[\s\S]*?\];/)?.[0] ?? '',
       src.match(/const PALETTE_HELP[\s\S]*?\};/)?.[0] ?? '',
       themePage.match(/<p className="settingsHelpText">[\s\S]*?<\/p>/)?.[0] ?? '',
     ].join('\n');
 
     assert.match(themeCopy, /匹配 macOS 当前浅色或深色偏好。/);
-    assert.match(themeCopy, /专业编辑器风格。/);
     assert.match(themeCopy, /Maka 原本的紫色强调色/);
     assert.match(themeCopy, /湖蓝强调色，干净冷静/);
     assert.match(themeCopy, /保存在本地外观设置里下次启动延续/);

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -24,7 +24,6 @@ import type {
   TextFileImportPreflightFailureReason,
   ThemePalette,
   ThemePreference,
-  UiDensity,
 } from '@maka/core';
 import {
   CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS,
@@ -94,7 +93,7 @@ import {
 import { deriveTurnFooterActions } from './turn-footer-actions';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
-import { applyDensity, applyTheme, applyThemePalette, applyUiLocale } from './theme';
+import { applyTheme, applyThemePalette, applyUiLocale } from './theme';
 import { openPathActionLabel, openPathFailureCopy } from './open-path';
 import {
   createSessionEventStreamSubscription,
@@ -330,7 +329,6 @@ function AppShell() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsRequestedSection, setSettingsRequestedSection] = useState<SettingsSection | undefined>(undefined);
   const [themePref, setThemePref] = useState<ThemePreference>('auto');
-  const [density, setDensity] = useState<UiDensity>('comfortable');
   const [themePalette, setThemePalette] = useState<ThemePalette>('default');
   const [userLabel, setUserLabel] = useState<string>('');
   const [skills, setSkills] = useState<SkillEntry[]>([]);
@@ -1059,10 +1057,6 @@ function AppShell() {
     return unsubscribe;
   }, [themePref]);
 
-  useEffect(() => {
-    applyDensity(density);
-  }, [density]);
-
   // PR-THEME-APPLY-AND-DONE-POLISH-0 (WAWQAQ msg `dec85e5b`): re-apply the
   // palette data attribute whenever the persisted setting changes, so
   // switching themes in Settings is immediately visible. Previously the
@@ -1189,7 +1183,6 @@ function AppShell() {
     try {
       const next = await window.maka.settings.get();
       const pref = next.appearance?.theme ?? 'auto';
-      const den = next.appearance?.density ?? 'comfortable';
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
       // PR-LANG-PREF-0: apply persisted UI locale preference to
@@ -1199,11 +1192,9 @@ function AppShell() {
       const uiLocale = next.personalization?.uiLocale ?? 'auto';
       applyUiLocale(uiLocale);
       setThemePref(pref);
-      setDensity(den);
       setThemePalette(palette);
       setUserLabel(name);
       applyTheme(pref);
-      applyDensity(den);
       applyThemePalette(palette);
     } catch (error) {
       toastApi.error('载入外观设置失败', generalizedErrorMessageChinese(error, '外观设置暂时无法载入，请稍后重试。'));
@@ -3080,8 +3071,6 @@ function AppShell() {
           onClose={closeSettings}
           themePref={themePref}
           onThemeChange={setThemePref}
-          density={density}
-          onDensityChange={setDensity}
           themePalette={themePalette}
           onThemePaletteChange={setThemePalette}
           onUserLabelChange={setUserLabel}

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -257,33 +257,6 @@
   --h-toolbar: 40px;
   --h-composer-min: 56px;
 
-  /* === UI density ===
-     Three profiles map to the same set of tokens; see the `[data-ui-density]`
-     selectors below maka-tokens.css for the active values. Components read
-     these instead of hardcoded paddings so a single switch retunes the whole
-     surface (external design reference-deep §7). */
-  --ui-density-message-gap: 18px;
-  --ui-density-message-pad-x: 24px;
-  --ui-density-message-pad-y: 10px;
-  --ui-density-composer-pad-y: 18px;
-  --ui-density-row-pad-y: 10px;
-}
-
-/* Comfortable is the default; selectors below tune only the deltas. */
-:root[data-ui-density="compact"] {
-  --ui-density-message-gap: 12px;
-  --ui-density-message-pad-x: 20px;
-  --ui-density-message-pad-y: 6px;
-  --ui-density-composer-pad-y: 12px;
-  --ui-density-row-pad-y: 7px;
-}
-
-:root[data-ui-density="spacious"] {
-  --ui-density-message-gap: 26px;
-  --ui-density-message-pad-x: 32px;
-  --ui-density-message-pad-y: 14px;
-  --ui-density-composer-pad-y: 24px;
-  --ui-density-row-pad-y: 14px;
 }
 
 /* =============================================================================
@@ -857,13 +830,13 @@
     padding: 24px 0 16px 0;
     display: flex;
     flex-direction: column;
-    gap: var(--ui-density-message-gap, 16px);
+    gap: 18px;
   }
   .maka-message-row {
     max-width: 760px;
     margin: 0 auto;
     width: 100%;
-    padding: 0 var(--ui-density-message-pad-x, 24px);
+    padding: 0 24px;
     /* Subtle fade on first paint — uses @starting-style instead of a
        keyframe so the transition is interruptible and stays smooth even
        when messages are streaming in rapidly (emil-design-eng "Use CSS
@@ -882,14 +855,14 @@
   .maka-turn {
     display: flex;
     flex-direction: column;
-    gap: var(--ui-density-turn-inner-gap, 8px);
+    gap: 8px;
     max-width: 760px;
     margin: 0 auto;
     width: 100%;
   }
 
   .maka-turn-tools {
-    padding: 0 var(--ui-density-message-pad-x, 24px);
+    padding: 0 24px;
   }
 
   /* Compact turn summary chips between the user message and the rest of
@@ -899,7 +872,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
-    padding: 0 var(--ui-density-message-pad-x, 24px);
+    padding: 0 24px;
     margin-top: -2px;
   }
 
@@ -1599,7 +1572,7 @@
      * a strong horizontal line slicing the panel. The composer's
      * own border + rounded chrome below is sufficient visual
      * separation; no extra line needed. */
-    padding: var(--ui-density-composer-pad-y, 16px) 24px var(--ui-density-composer-pad-y, 18px) 24px;
+    padding: 18px 24px;
     background: var(--background);
   }
   .maka-composer-inner {

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -52,7 +52,6 @@ import type {
   SettingsSection,
   ThemePalette,
   ThemePreference,
-  UiDensity,
   UpdateAppSettingsResult,
   UsageRange,
   UsageStats,
@@ -753,8 +752,6 @@ export function SettingsModal(props: {
   onClose(): void;
   themePref: ThemePreference;
   onThemeChange(pref: ThemePreference): void;
-  density: UiDensity;
-  onDensityChange(density: UiDensity): void;
   /**
    * PR-THEME-APPLY-AND-DONE-POLISH-0 (WAWQAQ msg `dec85e5b`): current
    * palette + live setter. Click handler calls `onThemePaletteChange(next)`
@@ -809,8 +806,6 @@ export function SettingsModal(props: {
         onClose={props.onClose}
         themePref={props.themePref}
         onThemeChange={props.onThemeChange}
-        density={props.density}
-        onDensityChange={props.onDensityChange}
         themePalette={props.themePalette}
         onThemePaletteChange={props.onThemePaletteChange}
         onUserLabelChange={props.onUserLabelChange}
@@ -830,8 +825,6 @@ function SettingsSurface(props: {
   onClose(): void;
   themePref: ThemePreference;
   onThemeChange(pref: ThemePreference): void;
-  density: UiDensity;
-  onDensityChange(density: UiDensity): void;
   themePalette: ThemePalette;
   onThemePaletteChange(palette: ThemePalette): void;
   onUserLabelChange?(label: string): void;
@@ -1017,14 +1010,12 @@ function SettingsSurface(props: {
               connections={props.connections}
               defaultSlug={props.defaultSlug}
               themePref={props.themePref}
-              density={props.density}
               themePalette={props.themePalette}
               onRefreshConnections={props.onRefresh}
               onUpdateSettings={updateSettings}
               onReloadSettings={reloadSettings}
               onReloadUsage={reloadUsage}
               onThemeChange={props.onThemeChange}
-              onDensityChange={props.onDensityChange}
               onThemePaletteChange={props.onThemePaletteChange}
               onOpenDailyReview={props.onOpenDailyReview}
               onOpenSession={props.onOpenSession}
@@ -1043,14 +1034,12 @@ function SettingsPage(props: {
   connections: LlmConnection[];
   defaultSlug: string | null;
   themePref: ThemePreference;
-  density: UiDensity;
   themePalette: ThemePalette;
   onRefreshConnections(): Promise<void>;
   onUpdateSettings(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
   onReloadSettings(): Promise<void>;
   onReloadUsage(range?: UsageRange): Promise<void>;
   onThemeChange(pref: ThemePreference): void;
-  onDensityChange(density: UiDensity): void;
   onThemePaletteChange(palette: ThemePalette): void;
   onOpenDailyReview?(): void;
   onOpenSession?(sessionId: string): void;
@@ -1129,12 +1118,10 @@ function SettingsPage(props: {
           <h2 className="settingsSectionHeading">主题</h2>
           <ThemeSettingsPage
             themePref={props.themePref}
-            density={props.density}
             themePalette={props.themePalette}
             settings={props.settings}
             onUpdate={props.onUpdateSettings}
             onThemeChange={props.onThemeChange}
-            onDensityChange={props.onDensityChange}
             onThemePaletteChange={props.onThemePaletteChange}
           />
         </div>
@@ -2634,12 +2621,6 @@ function collectPersonalizationWarningCopy(warnings: PersonalizationSettingsWarn
   return warnings.map((warning) => copy[warning]).join('\n');
 }
 
-const DENSITY_OPTIONS: Array<{ value: UiDensity; label: string; help: string }> = [
-  { value: 'compact', label: '紧凑', help: '减小行间距与控件高度，更接近专业编辑器风格。' },
-  { value: 'comfortable', label: '舒适', help: '默认。平衡阅读和密度。' },
-  { value: 'spacious', label: '宽松', help: '更大留白，适合长会话沉浸阅读。' },
-];
-
 /**
  * Mini chat-surface mockup rendered inside each theme radio tile. Replaces
  * the generic gradient swatch with a representative preview so the user
@@ -2726,12 +2707,10 @@ const PALETTE_GROUPS: ReadonlyArray<{ id: string; label: string; palettes: Reado
 
 function ThemeSettingsPage(props: {
   themePref: ThemePreference;
-  density: UiDensity;
   themePalette: ThemePalette;
   settings: AppSettings;
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
   onThemeChange(pref: ThemePreference): void;
-  onDensityChange(density: UiDensity): void;
   onThemePaletteChange(palette: ThemePalette): void;
 }) {
   const toast = useToast();
@@ -2765,15 +2744,10 @@ function ThemeSettingsPage(props: {
     await persistAppearance({ theme: next });
   }
 
-  async function setDensity(next: UiDensity) {
-    props.onDensityChange(next);
-    await persistAppearance({ density: next });
-  }
-
   // PR-THEME-PRODUCT-PALETTES-0 (WAWQAQ msg `4472ee95`) + PR-THEME-APPLY-
   // AND-DONE-POLISH-0 (WAWQAQ msg `dec85e5b`): apply the palette
   // synchronously on click for instant feedback, then persist. Same
-  // pattern as setTheme/setDensity above. The original comment claimed
+  // pattern as setTheme above. The original comment claimed
   // the IPC round-trip would re-apply on its own, but main.tsx had no
   // listener for palette changes — only ran applyThemePalette once at
   // mount — so switches were invisible until the next app start.
@@ -2869,42 +2843,6 @@ function ThemeSettingsPage(props: {
           </div>
         </div>
       ))}
-
-      <h3 className="settingsSubheading">界面密度</h3>
-      <div
-        className="settingsThemeOptions settingsDensityOptions"
-        role="radiogroup"
-        aria-label="界面密度"
-        onKeyDown={(event) => onSettingsRadioGroupKeyDown(
-          event,
-          DENSITY_OPTIONS.map((option) => option.value),
-          props.density,
-          (next) => void setDensity(next),
-        )}
-      >
-        {DENSITY_OPTIONS.map((option) => (
-          // Native <button>: same reason as the theme/palette pickers above.
-          <button
-            key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={props.density === option.value}
-            data-active={props.density === option.value}
-            data-radio-value={option.value}
-            tabIndex={radioTabIndex(option.value, props.density, DENSITY_OPTIONS.map((item) => item.value))}
-            className="settingsThemeOption"
-            onClick={() => void setDensity(option.value)}
-          >
-            <span className={`settingsDensitySwatch settingsDensitySwatch-${option.value}`} aria-hidden="true">
-              <span /><span /><span />
-            </span>
-            <span className="settingsThemeLabel">
-              <strong>{option.label}</strong>
-              <small>{option.help}</small>
-            </span>
-          </button>
-        ))}
-      </div>
 
       <p className="settingsHelpText">
         切换会立即生效，并保存在本地外观设置里下次启动延续。通知统一显示在屏幕右下角。

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -8242,31 +8242,6 @@ button:active {
   margin-top: -6px;
 }
 
-/* Density swatch: three rows of stacked lines that visualize the spacing
-   without needing real chat content. Each variant grows the gap. */
-.settingsDensitySwatch {
-  width: 56px;
-  height: 40px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 4px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--background);
-}
-
-.settingsDensitySwatch span {
-  display: block;
-  height: 3px;
-  width: 70%;
-  border-radius: 2px;
-  background: var(--foreground-40);
-}
-
-.settingsDensitySwatch-spacious span { width: 78%; }
-
 .settingsBotLayout {
   min-height: 470px;
   display: grid;

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -5,10 +5,7 @@
 // is `auto`, the helper subscribes to the system `prefers-color-scheme` media
 // query so the app follows OS-level Light/Dark switches in real time.
 //
-// Also exposes `applyDensity()` which sets `data-ui-density` on <html>; CSS
-// reads the attribute to swap a coherent set of `--ui-density-*` tokens.
-
-import type { ThemePalette, ThemePreference, UiDensity } from '@maka/core';
+import type { ThemePalette, ThemePreference } from '@maka/core';
 import { safeLocalStorageSet } from './browser-storage';
 
 const DARK_CLASS = 'dark';
@@ -65,10 +62,6 @@ function setDarkClass(isDark: boolean): void {
   // Lets native form controls and scrollbars pick up the right base colors per
   // the Vercel Web Interface Guidelines dark-mode rule.
   root.style.colorScheme = isDark ? 'dark' : 'light';
-}
-
-export function applyDensity(density: UiDensity): void {
-  document.documentElement.setAttribute('data-ui-density', density);
 }
 
 /**

--- a/apps/desktop/tests/smoke.md
+++ b/apps/desktop/tests/smoke.md
@@ -1160,7 +1160,7 @@ lines):
 - `normalizeSettings()` falls `appearance.palette` closed to
   `'default'` on any miss (missing / unknown / non-string). The
   same normalize pass must NOT silently reset unrelated fields
-  (theme / density / palette ↔ toastPosition / personalization /
+  (theme / palette ↔ toastPosition / personalization /
   network).
 - `createDefaultSettings()` seeds `appearance.palette: 'default'`.
 - Renderer path: `applyThemePalette(palette)` writes
@@ -1244,7 +1244,7 @@ contract case):
 
 **Residual / non-blocking.**
 - `setToastPosition` keeps optimistic React state if `onUpdate(...)`
-  throws; matches existing theme/density semantics. A stricter
+  throws; matches existing theme/palette semantics. A stricter
   catch-revert path can land in a follow-up if needed; not gated
   by D2.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -165,19 +165,17 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 > 这是有意的反规范：Maka 整体 0px 直角 + 关键交互组件 6/8/10px。新 PR 不要引
 > 入 "更柔和" 的 12/14/16px，那会破坏 sharp 视觉。
 
-### 1.5 间距（Spacing）+ 密度 token
+### 1.5 间距（Spacing）
 
-| Token | 值（comfortable） | compact / spacious | 用法 |
-|---|---|---|---|
-| `--spacing` | 0.25rem (4px) | 不变 | 基础步距 |
-| `--ui-density-message-gap` | 18px | 12 / 26 | 每条 turn 之间 |
-| `--ui-density-message-pad-x` | 24px | 20 / 32 | 消息行水平 padding |
-| `--ui-density-message-pad-y` | 10px | 6 / 14 | 消息行垂直 padding |
-| `--ui-density-composer-pad-y` | 18px | 12 / 24 | 输入区上下 padding |
-| `--ui-density-row-pad-y` | 10px | 7 / 14 | 列表行 padding |
-| `--ui-density-turn-inner-gap` | 8px（默认） | — | turn 内三段（user / tools / assistant）间隙 |
+| Token / 值 | 用法 |
+|---|---|
+| `--spacing` = 0.25rem (4px) | 基础步距 |
+| chat gap = 18px | 每条 turn 之间 |
+| message pad-x = 24px | 消息行水平 padding |
+| composer pad-y = 18px | 输入区上下 padding |
+| turn inner gap = 8px | turn 内三段（user / tools / assistant）间隙 |
 
-详细规则见 §2 密度契约。
+Maka 不提供用户可配置的界面密度。新增布局应按具体 surface 的信息量定间距，不要新增全局 density switch。
 
 ### 1.6 动效（Motion）
 
@@ -234,32 +232,15 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 
 ---
 
-## 2. 密度契约（Density contract）
-
-三档密度对应 `:root[data-ui-density="..."]`：
-
-| 模式 | 触发 | message-gap | message-pad-x | message-pad-y | composer-pad-y | row-pad-y |
-|---|---|---|---|---|---|---|
-| `compact` | 显式选择 | 12px | 20 | 6 | 12 | 7 |
-| `comfortable` | 默认 | 18px | 24 | 10 | 18 | 10 |
-| `spacious` | 显式选择 | 26px | 32 | 14 | 24 | 14 |
+## 2. 间距契约（Spacing contract）
 
 **规则**：
 
-1. **新组件必须消费 token，不能硬编码 padding/gap**。例如：
-   ```css
-   .maka-chat { gap: var(--ui-density-message-gap, 16px); }
-   .maka-message-row { padding: 0 var(--ui-density-message-pad-x, 24px); }
-   ```
-   `, 16px` 的兜底值仅是字符串失败时的 fallback，正常路径必须经由 token。
+1. **新组件按 surface 明确写出稳定间距**。聊天主 surface 当前使用 18px turn gap、24px horizontal message padding、18px composer vertical padding。
 
-2. **不要在密度切换里改 typography**。字号、行高保持稳定；只调间距、padding、
-   行间 gap。否则文本 reflow 会让用户每次切换密度都"找内容找半天"。
+2. **不要用全局密度切换改 typography**。字号、行高保持稳定；具体页面需要更紧或更松时，在该页面局部调整。
 
-3. **密度切换是 `<html>` 级别**：CSS attribute selector `:root[data-ui-density=…]`
-   只在根节点生效。组件不要在自己内部 override 密度属性。
-
-4. **新增密度 token** 须同 PR 在本节登记新行 + 同步三档值。
+3. **不要新增 `<html data-ui-density>` 或 Settings 里的密度配置**。界面密度不是产品设置项。
 
 ---
 

--- a/docs/full-product-test-plan.md
+++ b/docs/full-product-test-plan.md
@@ -79,7 +79,7 @@ Required deliverables:
 - Redacted diagnostics copy.
 - First-run stepper: provider preset, paste key, test/fetch models, choose default, send smoke prompt.
 - Quick Chat MVP: global shortcut and panel window; no accessibility-tree capture in MVP unless separately approved and gated.
-- Settings panels for UI density/font/sidebar, chat tuning, editable keybindings, and advanced flags.
+- Settings panels for font/sidebar, chat tuning, editable keybindings, and advanced flags.
 
 Done means:
 

--- a/docs/ui-quality-plan.md
+++ b/docs/ui-quality-plan.md
@@ -17,7 +17,7 @@ invariant or skips a §5 testing layer for its surface does not merge.
 **UI = everything inside `apps/desktop/src/renderer/` and
 `packages/ui/`.** This covers:
 
-- Visual composition (layout, tokens, light/dark/density themes)
+- Visual composition (layout, tokens, light/dark themes)
 - Interaction (mouse, keyboard, touch later)
 - Motion (durations, easings, reduced-motion)
 - Accessibility (ARIA, focus management, screen reader)
@@ -121,11 +121,10 @@ prose because they're judgement calls.
 - Use `@starting-style` for entrance animations where supported.
 - Animate `transform` and `opacity` only; never `width / height / top`.
 
-### 3.4 Density + theme
+### 3.4 Spacing + theme
 
-- Every component MUST render correctly under all three densities
-  (`compact / comfortable / spacious`) — verified via density toggle in
-  Settings.
+- Every component MUST use stable spacing that matches its local
+  information density; Maka does not expose a global UI density toggle.
 - Every component MUST render correctly under light + dark theme via
   `.dark` class.
 - Tokens MUST come from `maka-tokens.css`; **no hardcoded color** in
@@ -457,7 +456,7 @@ pattern is:
    the matching App-level mount point). Pass IPC handles via
    `window.maka.*`.
 6. **Add** styles to `apps/desktop/src/renderer/styles.css` using tokens
-   only. Include light / dark / density / motion variants.
+   only. Include light / dark / motion variants.
 7. **Add** ARIA roles + keyboard navigation per §3.
 8. **Add** fixture scenario in `visual-smoke-fixture.ts` with realistic
    data including the failure / empty state.

--- a/notes/reference-settings.md
+++ b/notes/reference-settings.md
@@ -372,7 +372,7 @@ section. Concrete proposal:
 | Group       | Item        | Holds                                                      |
 |-------------|-------------|------------------------------------------------------------|
 | 基础         | 通用         | Aggregator: 隐身模式, 启动行为, 新对话模式, 默认模型, 通知, 网络代理, 保持唤醒, 自动更新, 关闭窗口行为 |
-| 基础         | 外观         | Theme + density + palette + font (merge 主题 + 个性化)        |
+| 基础         | 外观         | 个性化 + theme + palette + font (merge 主题 + 个性化)          |
 | AI          | 模型         | Provider connections + OAuth + per-model config            |
 | AI          | 记忆与回顾    | Merge `记忆` + `每日回顾`                                     |
 | AI          | 语音与网关    | Merge `语音模型` + `开放网关`                                  |

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -246,25 +246,23 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
   test('migration: settings.json without `palette` field loads with palette=default', () => {
     // Older settings.json that pre-dates PR-UI-D1 will not have
     // `appearance.palette`. normalizeSettings must seed `default`
-    // without touching theme/density.
+    // without touching theme.
     const legacy = {
       appearance: {
         theme: 'dark' as const,
-        density: 'compact' as const,
         // no palette field
       },
     };
     const normalized = normalizeSettings(legacy);
     expect(normalized.appearance.palette).toBe('default');
     expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.density).toBe('compact');
+    expect('density' in normalized.appearance).toBe(false);
   });
 
   test('fail-closed: unknown palette string falls back to default', () => {
     const malformed = {
       appearance: {
         theme: 'auto' as const,
-        density: 'comfortable' as const,
         palette: 'evil-unknown',
       },
     };
@@ -277,7 +275,6 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
       const malformed = {
         appearance: {
           theme: 'auto' as const,
-          density: 'comfortable' as const,
           palette: bad,
         },
       };
@@ -291,7 +288,6 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
       const input = {
         appearance: {
           theme: 'auto' as const,
-          density: 'comfortable' as const,
           palette,
         },
       };
@@ -302,12 +298,11 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
 
   test('palette validation does NOT silently reset unrelated settings fields', () => {
     // @kenji gate: "no silent reset of unrelated settings". Even with
-    // a malformed palette, all other fields (theme, density,
+    // a malformed palette, all other current fields (theme,
     // personalization, network, bot channels) must keep their values.
     const input = {
       appearance: {
         theme: 'dark' as const,
-        density: 'spacious' as const,
         palette: 'evil-unknown',
       },
       personalization: {
@@ -331,7 +326,7 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
     const normalized = normalizeSettings(input);
     expect(normalized.appearance.palette).toBe('default');
     expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.density).toBe('spacious');
+    expect('density' in normalized.appearance).toBe(false);
     expect(normalized.personalization.displayName).toBe('Yuejing');
     expect(normalized.personalization.assistantTone).toBe('concise');
     expect(normalized.network.proxy.enabled).toBe(true);
@@ -344,7 +339,6 @@ describe('theme palette settings contract (PR-UI-D1, @kenji msg 68bf2b13)', () =
     const patched = mergeSettings(current, { appearance: { palette: 'onedark' } });
     expect(patched.appearance.palette).toBe('onedark');
     expect(patched.appearance.theme).toBe('auto'); // unchanged
-    expect(patched.appearance.density).toBe('comfortable'); // unchanged
   });
 
   test('mergeSettings + normalizeSettings: patching with unknown palette ends up at default', () => {
@@ -369,7 +363,6 @@ describe('fixed toast position settings contract', () => {
     const legacy = {
       appearance: {
         theme: 'dark' as const,
-        density: 'compact' as const,
         palette: 'onedark' as const,
         toastPosition: 'top-left',
       },
@@ -377,7 +370,6 @@ describe('fixed toast position settings contract', () => {
     const normalized = normalizeSettings(legacy);
     expect('toastPosition' in normalized.appearance).toBe(false);
     expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.density).toBe('compact');
     expect(normalized.appearance.palette).toBe('onedark');
   });
 
@@ -385,7 +377,6 @@ describe('fixed toast position settings contract', () => {
     const input = {
       appearance: {
         theme: 'dark' as const,
-        density: 'spacious' as const,
         palette: 'tokyo-night' as const,
         toastPosition: 'evil-corner',
       },
@@ -397,7 +388,6 @@ describe('fixed toast position settings contract', () => {
     const normalized = normalizeSettings(input);
     expect('toastPosition' in normalized.appearance).toBe(false);
     expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.density).toBe('spacious');
     expect(normalized.appearance.palette).toBe('tokyo-night');
     expect(normalized.personalization.displayName).toBe('Yuejing');
     expect(normalized.personalization.assistantTone).toBe('concise');
@@ -417,7 +407,6 @@ describe('fixed toast position settings contract', () => {
     const input = {
       appearance: {
         theme: 'auto' as const,
-        density: 'comfortable' as const,
         palette: 'evil-unknown',
         toastPosition: 'evil-corner',
       },
@@ -425,6 +414,38 @@ describe('fixed toast position settings contract', () => {
     const normalized = normalizeSettings(input);
     expect(normalized.appearance.palette).toBe('default');
     expect('toastPosition' in normalized.appearance).toBe(false);
+  });
+});
+
+describe('removed UI density settings contract', () => {
+  test('createDefaultSettings does not persist a density setting', () => {
+    const defaults = createDefaultSettings();
+    expect('density' in defaults.appearance).toBe(false);
+  });
+
+  test('migration: legacy settings.json with density drops that field', () => {
+    const normalized = normalizeSettings({
+      appearance: {
+        theme: 'dark' as const,
+        density: 'compact',
+        palette: 'onedark' as const,
+      },
+    });
+
+    expect('density' in normalized.appearance).toBe(false);
+    expect(normalized.appearance.theme).toBe('dark');
+    expect(normalized.appearance.palette).toBe('onedark');
+  });
+
+  test('mergeSettings + normalizeSettings strips density patch input', () => {
+    const current = createDefaultSettings();
+    const patched = mergeSettings(current, { appearance: { density: 'spacious' } as never });
+    const normalized = normalizeSettings(patched);
+
+    expect('density' in patched.appearance).toBe(true);
+    expect('density' in normalized.appearance).toBe(false);
+    expect(normalized.appearance.theme).toBe('auto');
+    expect(normalized.appearance.palette).toBe('default');
   });
 });
 
@@ -458,7 +479,6 @@ describe('open gateway settings contract', () => {
     const normalized = normalizeSettings({
       appearance: {
         theme: 'dark',
-        density: 'compact',
       },
       openGateway: {
         enabled: true,
@@ -469,7 +489,7 @@ describe('open gateway settings contract', () => {
     });
 
     expect(normalized.appearance.theme).toBe('dark');
-    expect(normalized.appearance.density).toBe('compact');
+    expect('density' in normalized.appearance).toBe(false);
     expect(normalized.openGateway.enabled).toBe(true);
     expect(normalized.openGateway.host).toBe('0.0.0.0');
     expect(normalized.openGateway.port).toBe(4939);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -642,7 +642,6 @@ export type {
   PersonalizationSettingsWarning,
   ThemePalette,
   ThemePreference,
-  UiDensity,
   UpdateAppSettingsInput,
   UpdateAppSettingsResult,
   UpdateAppSettingsWarnings,

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -140,7 +140,6 @@ export interface UsageSettings {
 }
 
 export type ThemePreference = 'light' | 'dark' | 'auto';
-export type UiDensity = 'compact' | 'comfortable' | 'spacious';
 
 /**
  * PR-UI-2 (@yuejing 2026-05-22): base46 palette catalog. Each value
@@ -177,7 +176,6 @@ export function isThemePalette(value: unknown): value is ThemePalette {
 
 export interface AppearanceSettings {
   theme: ThemePreference;
-  density: UiDensity;
   /**
    * PR-UI-2: optional base46 palette override. When omitted or `default`,
    * Maka renders the original purple-accent palette. Older settings.json
@@ -435,7 +433,6 @@ export function createDefaultSettings(): AppSettings {
     },
     appearance: {
       theme: 'auto',
-      density: 'comfortable',
       palette: 'default',
     },
     personalization: {
@@ -620,7 +617,11 @@ export function normalizeSettings(input: unknown): AppSettings {
     rawOnboarding && typeof rawOnboarding === 'object'
       ? (rawOnboarding as { milestones?: unknown }).milestones
       : undefined;
-  const { toastPosition: _legacyToastPosition, ...appearanceWithoutLegacyToastPosition } =
+  const {
+    toastPosition: _legacyToastPosition,
+    density: _legacyDensity,
+    ...appearanceWithoutLegacyFields
+  } =
     base.appearance as AppearanceSettings & Record<string, unknown>;
   return {
     ...base,
@@ -634,14 +635,13 @@ export function normalizeSettings(input: unknown): AppSettings {
     // non-string, unknown string).
     //
     // Critical: this MUST NOT silently reset other appearance fields
-    // (theme / density). We only override palette when it fails the
-    // type guard; everything else keeps mergeSettings's behavior.
-    // Legacy `appearance.toastPosition` is intentionally stripped here.
-    // Toasts are fixed to one app-wide position; keeping the old
-    // persisted setting would make the removed picker a hidden behavior
-    // surface.
+    // (theme). We only override palette when it fails the type guard;
+    // everything else keeps mergeSettings's behavior.
+    // Legacy `appearance.toastPosition` and `appearance.density` are
+    // intentionally stripped here. Toasts are fixed to one app-wide
+    // position; UI density is no longer a product setting.
     appearance: {
-      ...appearanceWithoutLegacyToastPosition,
+      ...appearanceWithoutLegacyFields,
       palette: isThemePalette(base.appearance.palette) ? base.appearance.palette : 'default',
     },
     // PR-LANG-PREF-0: closed-enum fail-closed for the new


### PR DESCRIPTION
## Summary
- remove the persisted UI density setting from core settings and strip legacy appearance.density during normalization
- delete the renderer density state, applyDensity helper, Settings density picker, CSS density token switch, and dead density swatch styles
- keep Appearance order as personalization before theme and update docs/contracts to say density is not a product setting

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/core test
- npm --workspace @maka/desktop test -- settings-theme-contract renderer-startup-fail-soft-contract settings-form-a11y-contract (actual full desktop 1466/1466; check-console/check-a11y clean)
- npm run build (passes; existing Vite chunk-size warning)
- git diff --check