### PR TITLE
Add heavy-task finalization eligibility v2

### DIFF
--- a/packages/headless/src/__tests__/heavy-task-finalization.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-finalization.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { evaluateHeavyTaskCompletionStatus } from '../heavy-task-finalization.js';
 import type {
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskEngineeringRecord,
   HeavyTaskModeFacts,
   HeavyTaskSemanticSelfCheckState,
   HeavyTaskSelfCheckStatus,
@@ -19,7 +21,47 @@ const heavyTaskMode: HeavyTaskModeFacts = {
 };
 
 describe('heavy-task finalization status', () => {
-  test('marks semantic complete with accepted pass self-check and completed todos', () => {
+  test('marks semantic complete only when the advisory evidence chain is complete', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [
+        toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] }),
+        toolEvidence('e-write', { todoIds: ['edit'], toolName: 'Write', diff: true }),
+      ],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+        patchRecord('record-patch', 'patch-1', { todoIds: ['edit'], evidenceIds: ['e-write'], changedFiles: ['src/app.js'] }),
+      ],
+    });
+
+    assert.equal(status.runtime.capLike, true);
+    assert.equal(status.runtime.capKind, 'budget_exhausted');
+    assert.equal(status.semantic.status, 'complete');
+    assert.equal(status.semantic.evidenceChain.outcome, 'complete');
+    assert.deepEqual(status.semantic.unresolvedTodoIds, []);
+    assert.equal(status.finalization.eligible, true);
+    assert.equal(status.finalization.boundedTurnImplemented, false);
+
+    const nonCapStatus = evaluateHeavyTaskCompletionStatus({
+      status: 'completed',
+      taxonomy: 'passed',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] })],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+      ],
+    });
+    assert.equal(nonCapStatus.semantic.evidenceChain.outcome, 'complete');
+    assert.equal(nonCapStatus.finalization.eligible, false);
+  });
+
+  test('requires completed todos to have linked P1-a or P1-b support beyond self-check alone', () => {
     const status = evaluateHeavyTaskCompletionStatus({
       status: 'budget_exhausted',
       taxonomy: 'budget_exhausted',
@@ -28,16 +70,139 @@ describe('heavy-task finalization status', () => {
       latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
     });
 
-    assert.equal(status.runtime.capLike, true);
-    assert.equal(status.runtime.capKind, 'budget_exhausted');
-    assert.equal(status.semantic.status, 'complete');
-    assert.equal(status.semantic.advisory, true);
-    assert.deepEqual(status.semantic.unresolvedTodoIds, []);
-    assert.equal(status.finalization.eligible, true);
-    assert.equal(status.finalization.boundedTurnImplemented, false);
+    assert.equal(status.semantic.status, 'incomplete');
+    assert.equal(status.semantic.evidenceChain.outcome, 'missing');
+    assert.deepEqual(status.semantic.evidenceChain.missingItemIds, ['todo:edit']);
+    assert.equal(status.finalization.eligible, false);
   });
 
-  test('treats cancelled todos with evidence as nonblocking', () => {
+  test('standalone artifact compact evidence does not satisfy required completed todos', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [artifactEvidence('e-artifact-only', { todoIds: ['edit'], artifactId: 'artifact-frame' })],
+    });
+
+    assert.equal(status.semantic.status, 'incomplete');
+    assert.equal(status.semantic.evidenceChain.outcome, 'missing');
+    assert.deepEqual(status.semantic.evidenceChain.missingItemIds, ['todo:edit']);
+    assert.equal(status.finalization.eligible, false);
+  });
+
+  test('official verifier artifact compact evidence is ignored for advisory finalization support', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [artifactEvidence('e-official-artifact', {
+        todoIds: ['edit'],
+        artifactId: 'artifact-official',
+        authority: { source: 'official_harbor_verifier', authoritative: true },
+      })],
+    });
+
+    assert.equal(status.semantic.status, 'incomplete');
+    assert.equal(status.semantic.evidenceChain.outcome, 'missing');
+    assert.deepEqual(status.semantic.evidenceChain.missingItemIds, ['todo:edit']);
+    assert.equal(status.finalization.eligible, false);
+  });
+
+  test('failed targeted check linked to a required todo blocks eligibility', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [toolEvidence('e-check-fail', { todoIds: ['edit'], checkIds: ['check-fail'], ok: false })],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-fail', 'check-fail', 'fail', {
+          todoIds: ['edit'],
+          evidenceIds: ['e-check-fail'],
+          status: 'failed',
+        }),
+      ],
+    });
+
+    assert.equal(status.semantic.evidenceChain.outcome, 'failed');
+    assert.deepEqual(status.semantic.evidenceChain.failedItemIds, ['targeted_check:check-fail']);
+    assert.equal(status.finalization.eligible, false);
+  });
+
+  test('failed targeted check repaired by later repair and passing check becomes complete', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass', { ts: 8 }),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [
+        toolEvidence('e-check-fail', { todoIds: ['edit'], checkIds: ['check-fail'], ok: false }),
+        toolEvidence('e-repair', { todoIds: ['edit'], checkIds: ['check-pass'] }),
+      ],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-fail', 'check-fail', 'fail', {
+          todoIds: ['edit'],
+          evidenceIds: ['e-check-fail'],
+          status: 'failed',
+          ts: 3,
+        }),
+        repairRecord('record-repair', ['check-fail'], {
+          todoIds: ['edit'],
+          evidenceIds: ['e-repair'],
+          changedFiles: ['src/app.js'],
+          ts: 4,
+        }),
+        checkRecord('record-check-pass', 'check-pass', 'pass', {
+          todoIds: ['edit'],
+          evidenceIds: ['e-repair'],
+          ts: 5,
+        }),
+      ],
+    });
+
+    assert.equal(status.semantic.evidenceChain.outcome, 'complete');
+    assert.equal(status.semantic.status, 'complete');
+    assert.equal(status.finalization.eligible, true);
+  });
+
+  test('inconclusive targeted checks and self-checks block required completion', () => {
+    const targeted = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [toolEvidence('e-check', { todoIds: ['edit'], checkIds: ['check-inconclusive'] })],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check', 'check-inconclusive', 'inconclusive', { todoIds: ['edit'], evidenceIds: ['e-check'] }),
+      ],
+    });
+    assert.equal(targeted.semantic.evidenceChain.outcome, 'inconclusive');
+    assert.deepEqual(targeted.semantic.evidenceChain.inconclusiveItemIds, ['targeted_check:check-inconclusive']);
+    assert.equal(targeted.finalization.eligible, false);
+
+    const selfCheckOnly = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('inconclusive'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] })],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+      ],
+    });
+    assert.equal(selfCheckOnly.semantic.evidenceChain.outcome, 'inconclusive');
+    assert.equal(selfCheckOnly.finalization.eligible, false);
+  });
+
+  test('cancelled todo requires public rationale plus durable nonblocking support', () => {
     const status = evaluateHeavyTaskCompletionStatus({
       status: 'incomplete',
       taxonomy: 'agent_incomplete',
@@ -45,14 +210,60 @@ describe('heavy-task finalization status', () => {
       latestHeavyTaskSelfCheck: selfCheck('pass'),
       latestHeavyTaskTodos: todos([
         { id: 'implemented', status: 'completed' },
-        { id: 'optional-polish', status: 'cancelled', evidence: 'Out of scope after public README review.' },
+        { id: 'optional-polish', status: 'cancelled', evidence: 'Not required by public task.' },
       ]),
+      heavyTaskEvidence: [
+        toolEvidence('e-check-pass', { todoIds: ['implemented'], checkIds: ['check-pass'] }),
+        toolEvidence('e-optional', { todoIds: ['optional-polish'] }),
+      ],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['implemented'], evidenceIds: ['e-check-pass'] }),
+        engineeringRecord('record-optional', 'patch', {
+          todoIds: ['optional-polish'],
+          evidenceIds: ['e-optional'],
+          status: 'abandoned',
+        }),
+      ],
     });
 
     assert.equal(status.semantic.status, 'complete');
+    assert.equal(status.semantic.evidenceChain.outcome, 'complete');
     assert.deepEqual(status.semantic.nonblockingTodoIds, ['optional-polish']);
-    assert.deepEqual(status.semantic.unresolvedTodoIds, []);
+    assert.deepEqual(status.semantic.evidenceChain.nonblockingItemIds, ['todo:optional-polish']);
     assert.equal(status.finalization.eligible, true);
+
+    const missing = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'optional-polish', status: 'cancelled', evidence: 'Not required by public task.' }]),
+    });
+    assert.equal(missing.semantic.evidenceChain.outcome, 'missing');
+    assert.equal(missing.finalization.eligible, false);
+  });
+
+  test('dangling engineering record links are missing evidence-chain items', () => {
+    const status = evaluateHeavyTaskCompletionStatus({
+      status: 'budget_exhausted',
+      taxonomy: 'budget_exhausted',
+      heavyTaskMode,
+      latestHeavyTaskSelfCheck: selfCheck('pass'),
+      latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-dangling', 'check-dangling', 'pass', {
+          todoIds: ['edit'],
+          evidenceIds: ['e-missing'],
+          completeness: 'incomplete',
+          incompleteReason: 'referenced links were not found',
+        }),
+      ],
+    });
+
+    assert.equal(status.semantic.evidenceChain.outcome, 'missing');
+    assert.ok(status.semantic.evidenceChain.missingItemIds.includes('targeted_check:check-dangling'));
+    assert.ok(status.semantic.evidenceChain.missingItemIds.includes('compact_evidence:record-dangling:e-missing'));
+    assert.equal(status.finalization.eligible, false);
   });
 
   test('requires accepted public pass self-check evidence', () => {
@@ -74,6 +285,10 @@ describe('heavy-task finalization status', () => {
         heavyTaskMode,
         latestHeavyTaskSelfCheck: item.selfCheck,
         latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+        heavyTaskEvidence: [toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] })],
+        heavyTaskEngineeringRecords: [
+          checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+        ],
       });
 
       assert.equal(status.semantic.status, 'incomplete', item.name);
@@ -138,6 +353,10 @@ describe('heavy-task finalization status', () => {
         heavyTaskMode,
         latestHeavyTaskSelfCheck: selfCheck('pass'),
         latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+        heavyTaskEvidence: [toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] })],
+        heavyTaskEngineeringRecords: [
+          checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+        ],
       });
 
       assert.equal(status.runtime.capLike, true, item.name);
@@ -151,6 +370,10 @@ describe('heavy-task finalization status', () => {
       heavyTaskMode,
       latestHeavyTaskSelfCheck: selfCheck('pass'),
       latestHeavyTaskTodos: todos([{ id: 'edit', status: 'completed' }]),
+      heavyTaskEvidence: [toolEvidence('e-check-pass', { todoIds: ['edit'], checkIds: ['check-pass'] })],
+      heavyTaskEngineeringRecords: [
+        checkRecord('record-check-pass', 'check-pass', 'pass', { todoIds: ['edit'], evidenceIds: ['e-check-pass'] }),
+      ],
     });
     assert.equal(verifierFailure.runtime.capLike, false);
     assert.equal(verifierFailure.runtime.capKind, 'none');
@@ -161,20 +384,20 @@ describe('heavy-task finalization status', () => {
 
 function selfCheck(
   status: HeavyTaskSelfCheckStatus,
-  options: { guardStatus?: 'accepted' | 'rejected'; publicReason?: string } = {},
+  options: { guardStatus?: 'accepted' | 'rejected'; publicReason?: string; ts?: number } = {},
 ): HeavyTaskSemanticSelfCheckState {
   return {
     schemaVersion: 1,
     selfCheckId: `self-check-${status}-${options.guardStatus ?? 'accepted'}`,
     taskRunId: 'run-1',
-    ts: 2,
+    ts: options.ts ?? 2,
     status,
     publicReason: options.publicReason ?? 'npm test passed against public files.',
     commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
     artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
     guard: {
       status: options.guardStatus ?? 'accepted',
-      checkedAt: 2,
+      checkedAt: options.ts ?? 2,
       categories: options.guardStatus === 'rejected' ? ['official_verifier_artifacts'] : [],
       publicReason: options.guardStatus === 'rejected'
         ? 'Rejected because submitted evidence referenced private, hidden, or evaluator-only material.'
@@ -198,5 +421,207 @@ function todos(items: Array<{ id: string; status: HeavyTaskTodoItem['status']; e
       ...(item.evidence ? { evidence: item.evidence } : {}),
     })),
     source: { kind: 'model_tool', toolCallId: 'tool-todos' },
+  };
+}
+
+function toolEvidence(
+  evidenceId: string,
+  options: {
+    todoIds?: string[];
+    checkIds?: string[];
+    artifactIds?: string[];
+    toolName?: string;
+    ok?: boolean;
+    diff?: boolean;
+  } = {},
+): HeavyTaskCompactEvidenceEnvelope {
+  return {
+    schemaVersion: 1,
+    evidenceId,
+    taskRunId: 'run-1',
+    ts: 4,
+    kind: 'tool',
+    public: true,
+    source: { kind: 'model_tool', toolCallId: `tool-${evidenceId}`, toolName: options.toolName ?? 'Bash' },
+    tool: {
+      name: options.toolName ?? 'Bash',
+      inputSummary: options.toolName === 'Write' ? { filePath: 'src/app.js' } : { command: 'npm test' },
+      exitCode: options.ok === false ? 1 : 0,
+      ok: options.ok !== false,
+      outputs: [{
+        stream: options.diff ? 'diff' : 'stdout',
+        excerpt: options.diff ? 'src/app.js changed' : 'public check output',
+        lineCount: 1,
+        byteCount: 19,
+        truncated: false,
+      }],
+      diff: options.diff ? { status: 'present', files: [{ path: 'src/app.js', additions: 1, deletions: 0 }] } : { status: 'not_applicable' },
+    },
+    links: {
+      ...(options.todoIds ? { todoIds: options.todoIds } : {}),
+      ...(options.checkIds ? { checkIds: options.checkIds } : {}),
+      ...(options.artifactIds ? { artifactIds: options.artifactIds } : {}),
+    },
+  };
+}
+
+function artifactEvidence(
+  evidenceId: string,
+  options: {
+    todoIds?: string[];
+    artifactId: string;
+    authority?: NonNullable<NonNullable<HeavyTaskCompactEvidenceEnvelope['artifact']>['authority']>;
+  },
+): HeavyTaskCompactEvidenceEnvelope {
+  return {
+    schemaVersion: 1,
+    evidenceId,
+    taskRunId: 'run-1',
+    ts: 4,
+    kind: 'artifact',
+    public: true,
+    source: { kind: 'model_tool', toolCallId: `tool-${evidenceId}`, toolName: 'artifact' },
+    artifact: {
+      artifactId: options.artifactId,
+      path: `${options.artifactId}.log`,
+      kind: 'generated_output',
+      exists: true,
+      ...(options.authority ? { authority: options.authority } : {}),
+    },
+    links: {
+      ...(options.todoIds ? { todoIds: options.todoIds } : {}),
+      artifactIds: [options.artifactId],
+    },
+  };
+}
+
+function checkRecord(
+  recordId: string,
+  checkId: string,
+  result: NonNullable<HeavyTaskEngineeringRecord['targetedCheck']>['result'],
+  options: {
+    todoIds: string[];
+    evidenceIds?: string[];
+    status?: HeavyTaskEngineeringRecord['status'];
+    completeness?: HeavyTaskEngineeringRecord['completeness'];
+    incompleteReason?: string;
+    ts?: number;
+  },
+): HeavyTaskEngineeringRecord {
+  return engineeringRecord(recordId, 'targeted_check', {
+    todoIds: options.todoIds,
+    evidenceIds: options.evidenceIds ?? [],
+    checkIds: [checkId],
+    status: options.status ?? (result === 'pass' ? 'passed' : result === 'fail' ? 'failed' : 'running'),
+    completeness: options.completeness,
+    incompleteReason: options.incompleteReason,
+    ts: options.ts,
+    targetedCheck: {
+      checkId,
+      command: 'npm test',
+      expectedSignal: 'public tests pass',
+      observedSignal: result === 'pass' ? 'public tests passed' : 'public tests did not pass',
+      result,
+    },
+  });
+}
+
+function patchRecord(
+  recordId: string,
+  patchId: string,
+  options: {
+    todoIds: string[];
+    evidenceIds?: string[];
+    artifactIds?: string[];
+    changedFiles?: string[];
+    status?: HeavyTaskEngineeringRecord['status'];
+    ts?: number;
+  },
+): HeavyTaskEngineeringRecord {
+  return engineeringRecord(recordId, 'patch', {
+    todoIds: options.todoIds,
+    evidenceIds: options.evidenceIds ?? [],
+    artifactIds: options.artifactIds ?? [],
+    changedFiles: options.changedFiles ?? [],
+    status: options.status ?? 'passed',
+    ts: options.ts,
+    patch: {
+      patchId,
+      changedFiles: options.changedFiles ?? [],
+      changeSummary: 'Changed public source file.',
+      mutationEvidenceIds: options.evidenceIds ?? [],
+    },
+  });
+}
+
+function repairRecord(
+  recordId: string,
+  failedCheckIds: string[],
+  options: {
+    todoIds: string[];
+    evidenceIds?: string[];
+    changedFiles?: string[];
+    ts?: number;
+  },
+): HeavyTaskEngineeringRecord {
+  return engineeringRecord(recordId, 'repair', {
+    todoIds: options.todoIds,
+    evidenceIds: options.evidenceIds ?? [],
+    checkIds: failedCheckIds,
+    changedFiles: options.changedFiles ?? [],
+    status: 'repaired',
+    ts: options.ts,
+    repair: {
+      failedCheckIds,
+      repairStrategy: 'Adjust public source and rerun check.',
+      outcome: 'check_passed',
+    },
+  });
+}
+
+function engineeringRecord(
+  recordId: string,
+  kind: HeavyTaskEngineeringRecord['kind'],
+  options: {
+    todoIds: string[];
+    evidenceIds?: string[];
+    checkIds?: string[];
+    artifactIds?: string[];
+    changedFiles?: string[];
+    status?: HeavyTaskEngineeringRecord['status'];
+    completeness?: HeavyTaskEngineeringRecord['completeness'];
+    incompleteReason?: string;
+    ts?: number;
+    targetedCheck?: HeavyTaskEngineeringRecord['targetedCheck'];
+    repair?: HeavyTaskEngineeringRecord['repair'];
+    patch?: HeavyTaskEngineeringRecord['patch'];
+  },
+): HeavyTaskEngineeringRecord {
+  return {
+    schemaVersion: 1,
+    recordId,
+    taskRunId: 'run-1',
+    ts: options.ts ?? 4,
+    kind,
+    title: `${kind} record`,
+    summary: `${kind} public summary`,
+    status: options.status ?? 'passed',
+    completeness: options.completeness ?? 'complete',
+    ...(options.incompleteReason ? { incompleteReason: options.incompleteReason } : {}),
+    source: { kind: 'model_tool', toolCallId: `tool-${recordId}`, toolName: kind === 'targeted_check' ? 'check_record' : 'engineering_record' },
+    links: {
+      todoIds: options.todoIds,
+      evidenceIds: options.evidenceIds ?? [],
+      toolCallIds: [`tool-${recordId}`],
+      checkIds: options.checkIds ?? [],
+      artifactIds: options.artifactIds ?? [],
+      changedFiles: options.changedFiles ?? [],
+      patchIds: options.patch?.patchId ? [options.patch.patchId] : [],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    ...(options.targetedCheck ? { targetedCheck: options.targetedCheck } : {}),
+    ...(options.repair ? { repair: options.repair } : {}),
+    ...(options.patch ? { patch: options.patch } : {}),
   };
 }

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -398,6 +398,9 @@ describe('task run export', () => {
     assert.equal(exported.heavyTask?.completion.runtime.capLike, true);
     assert.equal(exported.heavyTask?.completion.semantic.status, 'complete');
     assert.equal(exported.heavyTask?.completion.semantic.advisory, true);
+    assert.equal(exported.heavyTask?.completion.semantic.evidenceChain.outcome, 'complete');
+    assert.ok(exported.heavyTask?.completion.semantic.evidenceChain.completeItemIds.includes('targeted_check:check-edit'));
+    assert.deepEqual(exported.heavyTask?.completion.semantic.evidenceChain.nonblockingItemIds, ['todo:optional-polish']);
     assert.deepEqual(exported.heavyTask?.completion.semantic.unresolvedTodoIds, []);
     assert.deepEqual(exported.heavyTask?.completion.semantic.nonblockingTodoIds, ['optional-polish']);
     assert.equal(exported.heavyTask?.completion.finalization.eligible, true);
@@ -765,6 +768,23 @@ function heavyTaskCompletionEvents(todos: HeavyTaskTodoItem[] = [
         source: { kind: 'model_tool', toolCallId: 'tool-self-check' },
       },
     },
+    completionEvidenceEvent(taskRunId, 'hc4a', 'e-check-edit', { todoIds: ['edit'], checkIds: ['check-edit'], ts: 4.1 }),
+    completionEvidenceEvent(taskRunId, 'hc4b', 'e-optional-polish', { todoIds: ['optional-polish'], ts: 4.2, toolName: 'Read' }),
+    completionEngineeringEvent(taskRunId, 'hc4c', completionCheckRecord(taskRunId, {
+      recordId: 'record-check-edit',
+      checkId: 'check-edit',
+      todoIds: ['edit'],
+      evidenceIds: ['e-check-edit'],
+      ts: 4.3,
+    })),
+    completionEngineeringEvent(taskRunId, 'hc4d', completionPatchRecord(taskRunId, {
+      recordId: 'record-optional-polish',
+      todoIds: ['optional-polish'],
+      evidenceIds: ['e-optional-polish'],
+      changedFiles: ['README.md'],
+      status: 'abandoned',
+      ts: 4.4,
+    })),
     {
       type: 'verifier_result_recorded',
       id: 'hc5',
@@ -806,6 +826,134 @@ function heavyTaskCompletionEvents(todos: HeavyTaskTodoItem[] = [
       error: { message: 'runtime step cap reached', class: 'max_steps' },
     },
   ];
+}
+
+function completionEvidenceEvent(
+  taskRunId: string,
+  id: string,
+  evidenceId: string,
+  options: { todoIds?: string[]; checkIds?: string[]; ts: number; toolName?: 'Bash' | 'Read' },
+): TaskEvent {
+  return {
+    type: 'heavy_task_evidence_recorded',
+    id,
+    taskRunId,
+    ts: options.ts,
+    evidence: {
+      schemaVersion: 1,
+      evidenceId,
+      taskRunId,
+      ts: options.ts,
+      kind: 'tool',
+      public: true,
+      source: { kind: 'model_tool', toolCallId: `tool-${evidenceId}`, toolName: options.toolName ?? 'Bash' },
+      tool: {
+        name: options.toolName ?? 'Bash',
+        inputSummary: options.toolName === 'Read' ? { path: 'README.md' } : { command: 'npm test' },
+        exitCode: options.toolName === 'Read' ? undefined : 0,
+        ok: true,
+        outputs: [{
+          stream: options.toolName === 'Read' ? 'content' : 'stdout',
+          excerpt: 'bounded public summary',
+          truncated: false,
+        }],
+        diff: { status: 'not_applicable' },
+      },
+      links: {
+        ...(options.todoIds ? { todoIds: options.todoIds } : {}),
+        ...(options.checkIds ? { checkIds: options.checkIds } : {}),
+      },
+    },
+  };
+}
+
+function completionEngineeringEvent(taskRunId: string, id: string, record: HeavyTaskEngineeringRecord): TaskEvent {
+  return {
+    type: 'heavy_task_engineering_recorded',
+    id,
+    taskRunId,
+    ts: record.ts,
+    record,
+  };
+}
+
+function completionCheckRecord(taskRunId: string, input: {
+  recordId: string;
+  checkId: string;
+  todoIds: string[];
+  evidenceIds: string[];
+  ts: number;
+}): HeavyTaskEngineeringRecord {
+  return {
+    schemaVersion: 1,
+    recordId: input.recordId,
+    taskRunId,
+    ts: input.ts,
+    kind: 'targeted_check',
+    title: 'Run public targeted check',
+    summary: 'Public targeted check passed.',
+    status: 'passed',
+    completeness: 'complete',
+    source: { kind: 'model_tool', toolCallId: `tool-${input.recordId}`, toolName: 'check_record' },
+    links: {
+      todoIds: input.todoIds,
+      evidenceIds: input.evidenceIds,
+      toolCallIds: [`tool-${input.recordId}`],
+      checkIds: [input.checkId],
+      artifactIds: [],
+      changedFiles: [],
+      patchIds: [],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    targetedCheck: {
+      checkId: input.checkId,
+      command: 'npm test',
+      expectedSignal: 'public tests pass',
+      observedSignal: 'public tests passed',
+      result: 'pass',
+    },
+  };
+}
+
+function completionPatchRecord(taskRunId: string, input: {
+  recordId: string;
+  todoIds: string[];
+  evidenceIds: string[];
+  changedFiles: string[];
+  status?: HeavyTaskEngineeringRecord['status'];
+  ts: number;
+}): HeavyTaskEngineeringRecord {
+  const patchId = `patch-${input.recordId}`;
+  return {
+    schemaVersion: 1,
+    recordId: input.recordId,
+    taskRunId,
+    ts: input.ts,
+    kind: 'patch',
+    title: 'Record public patch decision',
+    summary: 'Public patch record with compact evidence links.',
+    status: input.status ?? 'passed',
+    completeness: 'complete',
+    source: { kind: 'model_tool', toolCallId: `tool-${input.recordId}`, toolName: 'engineering_record' },
+    links: {
+      todoIds: input.todoIds,
+      evidenceIds: input.evidenceIds,
+      toolCallIds: [`tool-${input.recordId}`],
+      checkIds: [],
+      artifactIds: [],
+      changedFiles: input.changedFiles,
+      patchIds: [patchId],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    patch: {
+      patchId,
+      changedFiles: input.changedFiles,
+      changeSummary: 'Changed public source file.',
+      mutationEvidenceIds: input.evidenceIds,
+    },
+  };
 }
 
 function engineeringRecord(

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -3,7 +3,7 @@ import { appendFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
+import type { HeavyTaskEngineeringRecord, HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
 import { createInMemoryTaskRunStore, createTaskRunStore, projectTaskRun } from '../task-run-store.js';
 
 function eventIdFactory(): () => string {
@@ -63,6 +63,7 @@ function heavyTaskEvidenceEvent(
   evidenceId: string,
   name: 'Bash' | 'Read',
   ts: number,
+  links: { todoIds?: string[]; checkIds?: string[]; artifactIds?: string[] } = {},
 ): TaskEvent {
   return {
     type: 'heavy_task_evidence_recorded',
@@ -92,6 +93,100 @@ function heavyTaskEvidenceEvent(
         }],
         diff: { status: 'not_applicable' },
       },
+      ...(Object.keys(links).length > 0 ? { links } : {}),
+    },
+  };
+}
+
+function heavyTaskEngineeringRecordEvent(
+  taskRunId: string,
+  id: string,
+  record: HeavyTaskEngineeringRecord,
+): TaskEvent {
+  return {
+    type: 'heavy_task_engineering_recorded',
+    id,
+    taskRunId,
+    ts: record.ts,
+    record,
+  };
+}
+
+function targetedCheckRecord(taskRunId: string, input: {
+  recordId: string;
+  checkId: string;
+  todoIds: string[];
+  evidenceIds: string[];
+  ts: number;
+}): HeavyTaskEngineeringRecord {
+  return {
+    schemaVersion: 1,
+    recordId: input.recordId,
+    taskRunId,
+    ts: input.ts,
+    kind: 'targeted_check',
+    title: 'Run public targeted check',
+    summary: 'Public check passed.',
+    status: 'passed',
+    completeness: 'complete',
+    source: { kind: 'model_tool', toolCallId: `tool-${input.recordId}`, toolName: 'check_record' },
+    links: {
+      todoIds: input.todoIds,
+      evidenceIds: input.evidenceIds,
+      toolCallIds: [`tool-${input.recordId}`],
+      checkIds: [input.checkId],
+      artifactIds: [],
+      changedFiles: [],
+      patchIds: [],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    targetedCheck: {
+      checkId: input.checkId,
+      command: 'npm test',
+      expectedSignal: 'public checks pass',
+      observedSignal: 'public checks passed',
+      result: 'pass',
+    },
+  };
+}
+
+function patchRecord(taskRunId: string, input: {
+  recordId: string;
+  todoIds: string[];
+  evidenceIds: string[];
+  changedFiles: string[];
+  status?: HeavyTaskEngineeringRecord['status'];
+  ts: number;
+}): HeavyTaskEngineeringRecord {
+  const patchId = `patch-${input.recordId}`;
+  return {
+    schemaVersion: 1,
+    recordId: input.recordId,
+    taskRunId,
+    ts: input.ts,
+    kind: 'patch',
+    title: 'Record public patch decision',
+    summary: 'Public patch record with compact evidence links.',
+    status: input.status ?? 'passed',
+    completeness: 'complete',
+    source: { kind: 'model_tool', toolCallId: `tool-${input.recordId}`, toolName: 'engineering_record' },
+    links: {
+      todoIds: input.todoIds,
+      evidenceIds: input.evidenceIds,
+      toolCallIds: [`tool-${input.recordId}`],
+      checkIds: [],
+      artifactIds: [],
+      changedFiles: input.changedFiles,
+      patchIds: [patchId],
+      hypothesisIds: [],
+      repairIds: [],
+    },
+    patch: {
+      patchId,
+      changedFiles: input.changedFiles,
+      changeSummary: 'Changed public source file.',
+      mutationEvidenceIds: input.evidenceIds,
     },
   };
 }
@@ -396,6 +491,23 @@ describe('TaskRunStore', () => {
         ts: 4,
         selfCheck: acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed against public files.'),
       },
+      heavyTaskEvidenceEvent(taskRunId, 'e-4a', 'e-check-edit', 'Bash', 4.1, { todoIds: ['edit'], checkIds: ['check-edit'] }),
+      heavyTaskEvidenceEvent(taskRunId, 'e-4b', 'e-optional', 'Read', 4.2, { todoIds: ['optional'] }),
+      heavyTaskEngineeringRecordEvent(taskRunId, 'e-4c', targetedCheckRecord(taskRunId, {
+        recordId: 'record-check-edit',
+        checkId: 'check-edit',
+        todoIds: ['edit'],
+        evidenceIds: ['e-check-edit'],
+        ts: 4.3,
+      })),
+      heavyTaskEngineeringRecordEvent(taskRunId, 'e-4d', patchRecord(taskRunId, {
+        recordId: 'record-optional',
+        todoIds: ['optional'],
+        evidenceIds: ['e-optional'],
+        changedFiles: ['README.md'],
+        status: 'abandoned',
+        ts: 4.4,
+      })),
       {
         type: 'score_result_recorded',
         id: 'e-5',
@@ -425,6 +537,8 @@ describe('TaskRunStore', () => {
     assert.equal(projection.heavyTaskCompletion?.runtime.taxonomy, 'verification_failed');
     assert.equal(projection.heavyTaskCompletion?.runtime.capKind, 'runtime_step_cap');
     assert.equal(projection.heavyTaskCompletion?.semantic.status, 'complete');
+    assert.equal(projection.heavyTaskCompletion?.semantic.evidenceChain.outcome, 'complete');
+    assert.deepEqual(projection.heavyTaskCompletion?.semantic.evidenceChain.nonblockingItemIds, ['todo:optional']);
     assert.deepEqual(projection.heavyTaskCompletion?.semantic.nonblockingTodoIds, ['optional']);
     assert.equal(projection.heavyTaskCompletion?.finalization.eligible, true);
     assert.equal(projection.result?.taxonomy, 'verification_failed');

--- a/packages/headless/src/heavy-task-finalization.ts
+++ b/packages/headless/src/heavy-task-finalization.ts
@@ -2,6 +2,8 @@ import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
 import type {
   AutonomousDecision,
   AutonomousResultTaxonomy,
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskEngineeringRecord,
   HeavyTaskModeFacts,
   HeavyTaskSelfCheckStatus,
   HeavyTaskSemanticSelfCheckState,
@@ -24,6 +26,45 @@ export type HeavyTaskRuntimeCapKind =
 
 export type HeavyTaskSemanticStatus = 'complete' | 'incomplete';
 
+export type HeavyTaskEvidenceChainOutcome =
+  | 'complete'
+  | 'nonblocking'
+  | 'failed'
+  | 'missing'
+  | 'inconclusive';
+
+export interface HeavyTaskEvidenceChainItem {
+  id: string;
+  kind:
+    | 'todo'
+    | 'self_check'
+    | 'targeted_check'
+    | 'patch'
+    | 'repair'
+    | 'artifact'
+    | 'compact_evidence'
+    | 'nonblocking_rationale';
+  required: boolean;
+  outcome: HeavyTaskEvidenceChainOutcome;
+  reason: string;
+  todoIds: string[];
+  evidenceIds: string[];
+  checkIds: string[];
+  artifactIds: string[];
+  recordIds: string[];
+}
+
+export interface HeavyTaskEvidenceChainSummary {
+  schemaVersion: 1;
+  outcome: HeavyTaskEvidenceChainOutcome;
+  completeItemIds: string[];
+  nonblockingItemIds: string[];
+  failedItemIds: string[];
+  missingItemIds: string[];
+  inconclusiveItemIds: string[];
+  items: HeavyTaskEvidenceChainItem[];
+}
+
 export interface HeavyTaskCompletionStatus {
   schemaVersion: 1;
   runtime: {
@@ -43,6 +84,7 @@ export interface HeavyTaskCompletionStatus {
     todoSetId?: string;
     unresolvedTodoIds: string[];
     nonblockingTodoIds: string[];
+    evidenceChain: HeavyTaskEvidenceChainSummary;
   };
   finalization: {
     eligible: boolean;
@@ -58,6 +100,8 @@ export interface HeavyTaskCompletionInput {
   heavyTaskMode?: HeavyTaskModeFacts;
   latestHeavyTaskTodos?: HeavyTaskTodoState;
   latestHeavyTaskSelfCheck?: HeavyTaskSemanticSelfCheckState;
+  heavyTaskEvidence?: readonly HeavyTaskCompactEvidenceEnvelope[];
+  heavyTaskEngineeringRecords?: readonly HeavyTaskEngineeringRecord[];
   decisions?: readonly AutonomousDecision[];
 }
 
@@ -98,40 +142,303 @@ function semanticStatusFromInput(input: HeavyTaskCompletionInput): HeavyTaskComp
   const todos = input.latestHeavyTaskTodos;
   const unresolvedTodoIds = unresolvedTodoIdsFrom(todos);
   const nonblockingTodoIds = nonblockingTodoIdsFrom(todos);
+  const evidenceChain = evaluateEvidenceChain(input);
   const base = {
     advisory: true as const,
     ...(selfCheck ? { selfCheckId: selfCheck.selfCheckId, selfCheckStatus: selfCheck.status } : {}),
     ...(todos ? { todoSetId: todos.todoSetId } : {}),
     unresolvedTodoIds,
     nonblockingTodoIds,
+    evidenceChain,
   };
 
   if (input.heavyTaskMode?.enabled !== true) {
     return { ...base, status: 'incomplete', reason: 'heavy-task mode is not enabled' };
   }
-  if (!selfCheck) {
-    return { ...base, status: 'incomplete', reason: 'missing accepted public self-check evidence' };
-  }
-  if (!isAcceptedHeavyTaskSelfCheck(selfCheck)) {
-    return { ...base, status: 'incomplete', reason: 'latest self-check evidence was not accepted as public' };
-  }
-  if (selfCheck.status !== 'pass') {
-    return { ...base, status: 'incomplete', reason: `latest self-check status is ${selfCheck.status}` };
-  }
-  if (!todos) {
-    return { ...base, status: 'incomplete', reason: 'missing latest heavy-task todos' };
-  }
-  if (todos.items.length === 0) {
-    return { ...base, status: 'incomplete', reason: 'latest heavy-task todos are empty' };
-  }
-  if (unresolvedTodoIds.length > 0) {
-    return { ...base, status: 'incomplete', reason: 'latest heavy-task todos contain unresolved work' };
+  if (evidenceChain.outcome !== 'complete') {
+    return { ...base, status: 'incomplete', reason: semanticReasonForEvidenceChain(evidenceChain.outcome) };
   }
   return {
     ...base,
     status: 'complete',
-    reason: 'accepted public self-check passed and latest todos are resolved/nonblocking',
+    reason: 'accepted public self-check passed and required evidence chain is complete',
   };
+}
+
+function evaluateEvidenceChain(input: HeavyTaskCompletionInput): HeavyTaskEvidenceChainSummary {
+  const index = buildEvidenceIndex(input);
+  const items: HeavyTaskEvidenceChainItem[] = [];
+
+  items.push(evaluateSelfCheckItem(input, index));
+
+  const todos = input.latestHeavyTaskTodos;
+  if (!todos) {
+    items.push(chainItem({
+      id: 'todo:latest',
+      kind: 'todo',
+      required: true,
+      outcome: 'missing',
+      reason: 'missing latest heavy-task todos',
+    }));
+  } else if (todos.items.length === 0) {
+    items.push(chainItem({
+      id: `todo_set:${todos.todoSetId}`,
+      kind: 'todo',
+      required: true,
+      outcome: 'missing',
+      reason: 'latest heavy-task todos are empty',
+    }));
+  } else {
+    for (const todo of todos.items) items.push(evaluateTodoItem(todo, index));
+  }
+
+  for (const record of input.heavyTaskEngineeringRecords ?? []) {
+    const item = evaluateEngineeringRecordItem(record, input, index);
+    if (item) items.push(item);
+    items.push(...missingRecordLinkItems(record, input, index));
+  }
+
+  return summarizeEvidenceChain(dedupeChainItems(items));
+}
+
+function evaluateSelfCheckItem(
+  input: HeavyTaskCompletionInput,
+  index: EvidenceIndex,
+): HeavyTaskEvidenceChainItem {
+  const selfCheck = input.latestHeavyTaskSelfCheck;
+  if (!selfCheck) {
+    return chainItem({
+      id: 'self_check:latest',
+      kind: 'self_check',
+      required: true,
+      outcome: 'missing',
+      reason: 'missing accepted public self-check evidence',
+    });
+  }
+  const evidenceIds = index.evidenceIdsByCheckId.get(selfCheck.selfCheckId) ?? [];
+  if (!isAcceptedHeavyTaskSelfCheck(selfCheck)) {
+    return chainItem({
+      id: `self_check:${selfCheck.selfCheckId}`,
+      kind: 'self_check',
+      required: true,
+      outcome: 'missing',
+      reason: 'latest self-check evidence was not accepted as public',
+      evidenceIds,
+      checkIds: [selfCheck.selfCheckId],
+    });
+  }
+  if (selfCheck.status === 'fail') {
+    return chainItem({
+      id: `self_check:${selfCheck.selfCheckId}`,
+      kind: 'self_check',
+      required: true,
+      outcome: 'failed',
+      reason: 'latest accepted public self-check failed',
+      evidenceIds,
+      checkIds: [selfCheck.selfCheckId],
+    });
+  }
+  if (selfCheck.status === 'inconclusive') {
+    return chainItem({
+      id: `self_check:${selfCheck.selfCheckId}`,
+      kind: 'self_check',
+      required: true,
+      outcome: 'inconclusive',
+      reason: 'latest accepted public self-check was inconclusive',
+      evidenceIds,
+      checkIds: [selfCheck.selfCheckId],
+    });
+  }
+  return chainItem({
+    id: `self_check:${selfCheck.selfCheckId}`,
+    kind: 'self_check',
+    required: true,
+    outcome: 'complete',
+    reason: 'latest accepted public self-check passed',
+    evidenceIds,
+    checkIds: [selfCheck.selfCheckId],
+  });
+}
+
+function evaluateTodoItem(todo: HeavyTaskTodoItem, index: EvidenceIndex): HeavyTaskEvidenceChainItem {
+  const support = supportForTodo(todo.id, index);
+  if (todo.status === 'completed') {
+    if (support.evidenceIds.length === 0 && support.recordIds.length === 0 && support.checkIds.length === 0 && support.artifactIds.length === 0) {
+      return chainItem({
+        id: `todo:${todo.id}`,
+        kind: 'todo',
+        required: true,
+        outcome: 'missing',
+        reason: 'completed todo has no linked compact evidence, patch, targeted check, or engineering record support',
+        todoIds: [todo.id],
+      });
+    }
+    return chainItem({
+      id: `todo:${todo.id}`,
+      kind: 'todo',
+      required: true,
+      outcome: 'complete',
+      reason: 'completed todo has linked public evidence-chain support',
+      todoIds: [todo.id],
+      evidenceIds: support.evidenceIds,
+      checkIds: support.checkIds,
+      artifactIds: support.artifactIds,
+      recordIds: support.recordIds,
+    });
+  }
+  if (todo.status === 'cancelled') {
+    if (hasNonblockingTodoEvidence(todo, index)) {
+      return chainItem({
+        id: `todo:${todo.id}`,
+        kind: 'todo',
+        required: false,
+        outcome: 'nonblocking',
+        reason: 'cancelled todo has public rationale and durable nonblocking support',
+        todoIds: [todo.id],
+        evidenceIds: support.evidenceIds,
+        checkIds: support.checkIds,
+        artifactIds: support.artifactIds,
+        recordIds: support.recordIds,
+      });
+    }
+    return chainItem({
+      id: `todo:${todo.id}`,
+      kind: 'todo',
+      required: true,
+      outcome: 'missing',
+      reason: 'cancelled todo is missing public rationale or durable nonblocking support',
+      todoIds: [todo.id],
+      evidenceIds: support.evidenceIds,
+      checkIds: support.checkIds,
+      artifactIds: support.artifactIds,
+      recordIds: support.recordIds,
+    });
+  }
+  return chainItem({
+    id: `todo:${todo.id}`,
+    kind: 'todo',
+    required: true,
+    outcome: 'missing',
+    reason: `todo status ${todo.status} is unresolved`,
+    todoIds: [todo.id],
+    evidenceIds: support.evidenceIds,
+    checkIds: support.checkIds,
+    artifactIds: support.artifactIds,
+    recordIds: support.recordIds,
+  });
+}
+
+function evaluateEngineeringRecordItem(
+  record: HeavyTaskEngineeringRecord,
+  input: HeavyTaskCompletionInput,
+  index: EvidenceIndex,
+): HeavyTaskEvidenceChainItem | undefined {
+  const required = recordRequired(record, input.latestHeavyTaskTodos, index);
+  if (record.kind === 'targeted_check') return evaluateTargetedCheckItem(record, input, index, required);
+  if (record.kind === 'patch') return evaluatePatchItem(record, required);
+  if (record.kind === 'repair') return evaluateRepairItem(record, required);
+  return undefined;
+}
+
+function evaluateTargetedCheckItem(
+  record: HeavyTaskEngineeringRecord,
+  input: HeavyTaskCompletionInput,
+  index: EvidenceIndex,
+  required: boolean,
+): HeavyTaskEvidenceChainItem {
+  const checkId = record.targetedCheck?.checkId;
+  const base = recordChainRefs(record, index);
+  const id = `targeted_check:${checkId ?? record.recordId}`;
+  if (record.completeness !== 'complete') {
+    return chainItem({
+      id,
+      kind: 'targeted_check',
+      required,
+      outcome: required ? 'missing' : 'nonblocking',
+      reason: record.incompleteReason ?? 'targeted check record is incomplete',
+      ...base,
+    });
+  }
+  if (record.status === 'failed' || record.targetedCheck?.result === 'fail') {
+    if (isFailedCheckRepaired(record, input)) {
+      return chainItem({
+        id,
+        kind: 'targeted_check',
+        required,
+        outcome: 'complete',
+        reason: 'failed targeted check was followed by complete repair and later passing evidence',
+        ...base,
+      });
+    }
+    return chainItem({
+      id,
+      kind: 'targeted_check',
+      required,
+      outcome: required ? 'failed' : 'nonblocking',
+      reason: 'targeted check failed',
+      ...base,
+    });
+  }
+  if (record.targetedCheck?.result === 'inconclusive') {
+    return chainItem({
+      id,
+      kind: 'targeted_check',
+      required,
+      outcome: required ? 'inconclusive' : 'nonblocking',
+      reason: 'targeted check was inconclusive',
+      ...base,
+    });
+  }
+  return chainItem({
+    id,
+    kind: 'targeted_check',
+    required,
+    outcome: 'complete',
+    reason: 'targeted check passed',
+    ...base,
+  });
+}
+
+function evaluatePatchItem(record: HeavyTaskEngineeringRecord, required: boolean): HeavyTaskEvidenceChainItem {
+  const hasMutationSupport = record.links.evidenceIds.length > 0
+    || record.links.artifactIds.length > 0
+    || record.links.changedFiles.length > 0
+    || (record.patch?.mutationEvidenceIds.length ?? 0) > 0
+    || (record.patch?.changedFiles.length ?? 0) > 0;
+  const outcome: HeavyTaskEvidenceChainOutcome = record.completeness !== 'complete' || !hasMutationSupport
+    ? (required ? 'missing' : 'nonblocking')
+    : record.status === 'failed'
+      ? (required ? 'failed' : 'nonblocking')
+      : 'complete';
+  return chainItem({
+    id: `patch:${record.patch?.patchId ?? record.recordId}`,
+    kind: 'patch',
+    required,
+    outcome,
+    reason: outcome === 'complete'
+      ? 'patch record has mutation evidence'
+      : record.incompleteReason ?? 'patch record is missing mutation evidence',
+    ...recordChainRefs(record),
+  });
+}
+
+function evaluateRepairItem(record: HeavyTaskEngineeringRecord, required: boolean): HeavyTaskEvidenceChainItem {
+  const repairOutcome = record.repair?.outcome;
+  const outcome: HeavyTaskEvidenceChainOutcome = record.completeness !== 'complete'
+    ? (required ? 'missing' : 'nonblocking')
+    : repairOutcome === 'check_passed' || record.status === 'repaired'
+      ? 'complete'
+      : repairOutcome === 'check_failed'
+        ? (required ? 'failed' : 'nonblocking')
+        : (required ? 'inconclusive' : 'nonblocking');
+  return chainItem({
+    id: `repair:${record.recordId}`,
+    kind: 'repair',
+    required,
+    outcome,
+    reason: outcome === 'complete' ? 'repair record links a passing follow-up check' : record.incompleteReason ?? 'repair record lacks passing follow-up evidence',
+    ...recordChainRefs(record),
+  });
 }
 
 function unresolvedTodoIdsFrom(todos: HeavyTaskTodoState | undefined): string[] {
@@ -150,6 +457,321 @@ function isResolvedOrNonblockingTodo(item: HeavyTaskTodoItem): boolean {
 
 function isNonblockingTodo(item: HeavyTaskTodoItem): boolean {
   return item.status === 'cancelled' && typeof item.evidence === 'string' && item.evidence.trim().length > 0;
+}
+
+interface EvidenceIndex {
+  evidenceById: Map<string, HeavyTaskCompactEvidenceEnvelope>;
+  evidenceIdsByTodoId: Map<string, string[]>;
+  evidenceIdsByCheckId: Map<string, string[]>;
+  evidenceIdsByArtifactId: Map<string, string[]>;
+  recordsByTodoId: Map<string, HeavyTaskEngineeringRecord[]>;
+  recordsByCheckId: Map<string, HeavyTaskEngineeringRecord[]>;
+  compactArtifactIds: Set<string>;
+}
+
+function buildEvidenceIndex(input: HeavyTaskCompletionInput): EvidenceIndex {
+  const index: EvidenceIndex = {
+    evidenceById: new Map(),
+    evidenceIdsByTodoId: new Map(),
+    evidenceIdsByCheckId: new Map(),
+    evidenceIdsByArtifactId: new Map(),
+    recordsByTodoId: new Map(),
+    recordsByCheckId: new Map(),
+    compactArtifactIds: new Set(),
+  };
+  for (const evidence of input.heavyTaskEvidence ?? []) {
+    if (isOfficialVerifierArtifactEvidence(evidence)) continue;
+    index.evidenceById.set(evidence.evidenceId, evidence);
+    if (isDirectTodoSupportEvidence(evidence)) {
+      for (const todoId of evidence.links?.todoIds ?? []) addToMapList(index.evidenceIdsByTodoId, todoId, evidence.evidenceId);
+    }
+    for (const checkId of compactEvidenceCheckIds(evidence)) addToMapList(index.evidenceIdsByCheckId, checkId, evidence.evidenceId);
+    for (const artifactId of compactEvidenceArtifactIds(evidence)) {
+      addToMapList(index.evidenceIdsByArtifactId, artifactId, evidence.evidenceId);
+      index.compactArtifactIds.add(artifactId);
+    }
+  }
+  for (const record of input.heavyTaskEngineeringRecords ?? []) {
+    for (const todoId of record.links.todoIds) addToMapList(index.recordsByTodoId, todoId, record);
+    for (const checkId of recordCheckIds(record)) addToMapList(index.recordsByCheckId, checkId, record);
+  }
+  return index;
+}
+
+function isDirectTodoSupportEvidence(evidence: HeavyTaskCompactEvidenceEnvelope): boolean {
+  return evidence.kind !== 'artifact';
+}
+
+function isOfficialVerifierArtifactEvidence(evidence: HeavyTaskCompactEvidenceEnvelope): boolean {
+  if (evidence.artifact?.authority?.authoritative === true) return true;
+  const source = evidence.artifact?.authority?.source.toLowerCase();
+  return source === 'official_harbor_verifier'
+    || source === 'official_verifier'
+    || source === 'verifier'
+    || source === 'scorer';
+}
+
+function supportForTodo(todoId: string, index: EvidenceIndex): {
+  evidenceIds: string[];
+  checkIds: string[];
+  artifactIds: string[];
+  recordIds: string[];
+} {
+  const records = index.recordsByTodoId.get(todoId) ?? [];
+  const evidenceIds = new Set(index.evidenceIdsByTodoId.get(todoId) ?? []);
+  const checkIds = new Set<string>();
+  const artifactIds = new Set<string>();
+  const recordIds = new Set<string>();
+  for (const record of records) {
+    if (!recordSupportsTodo(record)) continue;
+    recordIds.add(record.recordId);
+    for (const evidenceId of record.links.evidenceIds) evidenceIds.add(evidenceId);
+    for (const artifactId of record.links.artifactIds) artifactIds.add(artifactId);
+    for (const checkId of recordCheckIds(record)) checkIds.add(checkId);
+    for (const evidenceId of record.patch?.mutationEvidenceIds ?? []) evidenceIds.add(evidenceId);
+  }
+  for (const artifactId of artifactIds) {
+    for (const evidenceId of index.evidenceIdsByArtifactId.get(artifactId) ?? []) evidenceIds.add(evidenceId);
+  }
+  for (const checkId of checkIds) {
+    for (const evidenceId of index.evidenceIdsByCheckId.get(checkId) ?? []) evidenceIds.add(evidenceId);
+  }
+  return {
+    evidenceIds: sorted([...evidenceIds].filter((id) => index.evidenceById.has(id))),
+    checkIds: sorted([...checkIds]),
+    artifactIds: sorted([...artifactIds]),
+    recordIds: sorted([...recordIds]),
+  };
+}
+
+function hasNonblockingTodoEvidence(todo: HeavyTaskTodoItem, index: EvidenceIndex): boolean {
+  if (!isNonblockingTodo(todo)) return false;
+  const support = supportForTodo(todo.id, index);
+  if (support.evidenceIds.length > 0 || support.artifactIds.length > 0) return true;
+  const records = index.recordsByTodoId.get(todo.id) ?? [];
+  return records.some((record) => {
+    if (record.completeness !== 'complete') return false;
+    if (record.status === 'abandoned' || record.status === 'superseded') return true;
+    if (record.kind === 'targeted_check' && (record.targetedCheck?.result === 'fail' || record.targetedCheck?.result === 'inconclusive')) return true;
+    return false;
+  });
+}
+
+function recordSupportsTodo(record: HeavyTaskEngineeringRecord): boolean {
+  if (record.completeness !== 'complete') return false;
+  if (record.status === 'failed' || record.status === 'running' || record.status === 'proposed' || record.status === 'abandoned') return false;
+  if (record.kind === 'targeted_check') return record.targetedCheck?.result === 'pass';
+  if (record.kind === 'repair') return record.repair?.outcome === 'check_passed' || record.status === 'repaired';
+  if (record.kind === 'patch') {
+    return record.links.evidenceIds.length > 0
+      || record.links.artifactIds.length > 0
+      || record.links.changedFiles.length > 0
+      || (record.patch?.mutationEvidenceIds.length ?? 0) > 0
+      || (record.patch?.changedFiles.length ?? 0) > 0;
+  }
+  return record.links.evidenceIds.length > 0;
+}
+
+function recordRequired(
+  record: HeavyTaskEngineeringRecord,
+  todos: HeavyTaskTodoState | undefined,
+  index: EvidenceIndex,
+): boolean {
+  if (record.links.todoIds.length === 0) return false;
+  const todoById = new Map((todos?.items ?? []).map((todo) => [todo.id, todo]));
+  return record.links.todoIds.some((todoId) => {
+    const todo = todoById.get(todoId);
+    return !todo || todo.status !== 'cancelled' || !hasNonblockingTodoEvidence(todo, index);
+  });
+}
+
+function isFailedCheckRepaired(record: HeavyTaskEngineeringRecord, input: HeavyTaskCompletionInput): boolean {
+  const checkId = record.targetedCheck?.checkId;
+  if (!checkId) return false;
+  const records = [...(input.heavyTaskEngineeringRecords ?? [])].sort((a, b) => a.ts - b.ts);
+  const repair = records.find((candidate) =>
+    candidate.ts > record.ts
+    && candidate.kind === 'repair'
+    && candidate.completeness === 'complete'
+    && candidate.repair?.outcome === 'check_passed'
+    && candidate.repair.failedCheckIds.includes(checkId)
+  );
+  if (!repair) return false;
+  const repairedTodoIds = new Set(record.links.todoIds);
+  const laterPassingCheck = records.some((candidate) =>
+    candidate.ts > repair.ts
+    && candidate.kind === 'targeted_check'
+    && candidate.completeness === 'complete'
+    && candidate.targetedCheck?.result === 'pass'
+    && candidate.links.todoIds.some((todoId) => repairedTodoIds.has(todoId))
+  );
+  const laterSelfCheck = input.latestHeavyTaskSelfCheck
+    && isAcceptedHeavyTaskSelfCheck(input.latestHeavyTaskSelfCheck)
+    && input.latestHeavyTaskSelfCheck.status === 'pass'
+    && input.latestHeavyTaskSelfCheck.ts > repair.ts;
+  return Boolean(laterPassingCheck || laterSelfCheck);
+}
+
+function missingRecordLinkItems(
+  record: HeavyTaskEngineeringRecord,
+  input: HeavyTaskCompletionInput,
+  index: EvidenceIndex,
+): HeavyTaskEvidenceChainItem[] {
+  const items: HeavyTaskEvidenceChainItem[] = [];
+  const required = recordRequired(record, input.latestHeavyTaskTodos, index);
+  for (const evidenceId of record.links.evidenceIds) {
+    if (index.evidenceById.has(evidenceId)) continue;
+    items.push(chainItem({
+      id: `compact_evidence:${record.recordId}:${evidenceId}`,
+      kind: 'compact_evidence',
+      required,
+      outcome: required ? 'missing' : 'nonblocking',
+      reason: 'engineering record references compact evidence that is not present in projection',
+      todoIds: record.links.todoIds,
+      evidenceIds: [evidenceId],
+      checkIds: recordCheckIds(record),
+      recordIds: [record.recordId],
+    }));
+  }
+  for (const artifactId of record.links.artifactIds) {
+    if (index.compactArtifactIds.has(artifactId)) continue;
+    items.push(chainItem({
+      id: `artifact:${record.recordId}:${artifactId}`,
+      kind: 'artifact',
+      required,
+      outcome: required ? 'missing' : 'nonblocking',
+      reason: 'engineering record references artifact evidence that is not present in projection',
+      todoIds: record.links.todoIds,
+      artifactIds: [artifactId],
+      checkIds: recordCheckIds(record),
+      recordIds: [record.recordId],
+    }));
+  }
+  return items;
+}
+
+function recordChainRefs(record: HeavyTaskEngineeringRecord, index?: EvidenceIndex): Pick<HeavyTaskEvidenceChainItem, 'todoIds' | 'evidenceIds' | 'checkIds' | 'artifactIds' | 'recordIds'> {
+  const evidenceIds = new Set(record.links.evidenceIds);
+  for (const evidenceId of record.patch?.mutationEvidenceIds ?? []) evidenceIds.add(evidenceId);
+  for (const checkId of recordCheckIds(record)) {
+    for (const evidenceId of index?.evidenceIdsByCheckId.get(checkId) ?? []) evidenceIds.add(evidenceId);
+  }
+  return {
+    todoIds: sorted(record.links.todoIds),
+    evidenceIds: sorted([...evidenceIds].filter((id) => !index || index.evidenceById.has(id))),
+    checkIds: sorted(recordCheckIds(record)),
+    artifactIds: sorted(record.links.artifactIds),
+    recordIds: [record.recordId],
+  };
+}
+
+function recordCheckIds(record: HeavyTaskEngineeringRecord): string[] {
+  return sorted([
+    ...record.links.checkIds,
+    ...(record.targetedCheck?.checkId ? [record.targetedCheck.checkId] : []),
+    ...(record.repair?.failedCheckIds ?? []),
+  ]);
+}
+
+function compactEvidenceCheckIds(evidence: HeavyTaskCompactEvidenceEnvelope): string[] {
+  return sorted([
+    ...(evidence.links?.checkIds ?? []),
+    ...(evidence.check?.checkId ? [evidence.check.checkId] : []),
+    ...(evidence.check?.linkedSelfCheckId ? [evidence.check.linkedSelfCheckId] : []),
+  ]);
+}
+
+function compactEvidenceArtifactIds(evidence: HeavyTaskCompactEvidenceEnvelope): string[] {
+  return sorted([
+    ...(evidence.links?.artifactIds ?? []),
+    ...(evidence.artifact?.artifactId ? [evidence.artifact.artifactId] : []),
+    ...(evidence.artifact?.path ? [evidence.artifact.path] : []),
+    ...(evidence.artifact?.workspacePath ? [evidence.artifact.workspacePath] : []),
+  ]);
+}
+
+function summarizeEvidenceChain(items: HeavyTaskEvidenceChainItem[]): HeavyTaskEvidenceChainSummary {
+  const failedItemIds = itemIdsByOutcome(items, 'failed');
+  const missingItemIds = itemIdsByOutcome(items, 'missing');
+  const inconclusiveItemIds = itemIdsByOutcome(items, 'inconclusive');
+  const requiredFailed = items.some((item) => item.required && item.outcome === 'failed');
+  const requiredMissing = items.some((item) => item.required && item.outcome === 'missing');
+  const requiredInconclusive = items.some((item) => item.required && item.outcome === 'inconclusive');
+  const outcome: HeavyTaskEvidenceChainOutcome = requiredFailed
+    ? 'failed'
+    : requiredMissing
+      ? 'missing'
+      : requiredInconclusive
+        ? 'inconclusive'
+        : 'complete';
+  return {
+    schemaVersion: 1,
+    outcome,
+    completeItemIds: itemIdsByOutcome(items, 'complete'),
+    nonblockingItemIds: itemIdsByOutcome(items, 'nonblocking'),
+    failedItemIds,
+    missingItemIds,
+    inconclusiveItemIds,
+    items,
+  };
+}
+
+function itemIdsByOutcome(items: readonly HeavyTaskEvidenceChainItem[], outcome: HeavyTaskEvidenceChainOutcome): string[] {
+  return items.filter((item) => item.outcome === outcome).map((item) => item.id);
+}
+
+function semanticReasonForEvidenceChain(outcome: HeavyTaskEvidenceChainOutcome): string {
+  if (outcome === 'failed') return 'required evidence chain contains failed evidence';
+  if (outcome === 'missing') return 'required evidence chain is missing evidence';
+  if (outcome === 'inconclusive') return 'required evidence chain is inconclusive';
+  return 'required evidence chain is incomplete';
+}
+
+function chainItem(input: {
+  id: string;
+  kind: HeavyTaskEvidenceChainItem['kind'];
+  required: boolean;
+  outcome: HeavyTaskEvidenceChainOutcome;
+  reason: string;
+  todoIds?: string[];
+  evidenceIds?: string[];
+  checkIds?: string[];
+  artifactIds?: string[];
+  recordIds?: string[];
+}): HeavyTaskEvidenceChainItem {
+  return {
+    id: input.id,
+    kind: input.kind,
+    required: input.required,
+    outcome: input.outcome,
+    reason: input.reason,
+    todoIds: sorted(input.todoIds ?? []),
+    evidenceIds: sorted(input.evidenceIds ?? []),
+    checkIds: sorted(input.checkIds ?? []),
+    artifactIds: sorted(input.artifactIds ?? []),
+    recordIds: sorted(input.recordIds ?? []),
+  };
+}
+
+function dedupeChainItems(items: HeavyTaskEvidenceChainItem[]): HeavyTaskEvidenceChainItem[] {
+  const seen = new Set<string>();
+  const deduped: HeavyTaskEvidenceChainItem[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function addToMapList<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const values = map.get(key) ?? [];
+  values.push(value);
+  map.set(key, values);
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
 }
 
 function classifyCapKind(input: HeavyTaskCompletionInput, reason: string | undefined): HeavyTaskRuntimeCapKind {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -383,6 +383,9 @@ export {
 export type {
   HeavyTaskCompletionInput,
   HeavyTaskCompletionStatus,
+  HeavyTaskEvidenceChainItem,
+  HeavyTaskEvidenceChainOutcome,
+  HeavyTaskEvidenceChainSummary,
   HeavyTaskRuntimeCapKind,
   HeavyTaskSemanticStatus,
 } from './heavy-task-finalization.js';

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -351,6 +351,8 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       heavyTaskMode: projection.heavyTaskMode,
       latestHeavyTaskTodos: projection.latestHeavyTaskTodos,
       latestHeavyTaskSelfCheck: projection.latestHeavyTaskSelfCheck,
+      heavyTaskEvidence: projection.heavyTaskEvidence,
+      heavyTaskEngineeringRecords: projection.heavyTaskEngineeringRecords,
       decisions: projection.decisions,
     });
   }


### PR DESCRIPTION
## Summary
- upgrade advisory `heavyTaskCompletion.semantic` from self-check + todo resolution to a required evidence-chain projection
- include required todo support, targeted check results, patch/repair records, nonblocking cancelled-todo rationale, and compact artifact/evidence references in the exportable chain
- keep official verifier/scorer authority unchanged; official verifier artifacts are ignored for advisory support, and artifact-only compact evidence cannot satisfy a required todo
- preserve semantic/runtime dual status and expose bounded `evidenceChain` outcome details while keeping `semantic.status` compatibility

## Rive
- workflow: `maka.issue102-heavy-task-p1c`
- run: `wfrun_92c48b3124ab43fc9839e9b70993bb6c`
- root: `work_e7fc3e7429bc46ef8e4c0576a5b7e4bf`
- scheduler: `sched_9aebbb9d5ef44f89a119b18bd3d2929f`
- artifacts: `/tmp/rive-maka-issue102-p1c-20260623/output/`

## Verification
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/heavy-task-finalization.test.js packages/headless/dist/__tests__/task-run-store.test.js packages/headless/dist/__tests__/result-export.test.js packages/headless/dist/__tests__/scorer.test.js`
- `npm --workspace @maka/headless test`
- `git diff --check`
- `git diff --cached --check`
