### PR TITLE
PR-SETTINGS-RESTORE-SURFACE-0: restore content plate, drop seam border (round 5/15)

### DIFF
--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -84,17 +84,26 @@
   transition: margin-left 150ms ease-out;
 }
 
+/* PR-SETTINGS-RESTORE-SURFACE-0 (WAWQAQ msg `c8dc03e4`): main chat
+   pane was rendering with a 1px border that read as a seam between
+   sidebar and content. Drop the border on the floating panel
+   variant; keep the surface plate (bg + radius + margin) so content
+   still reads as its own canvas. */
 .maka-panel-detail.maka-floating-panel.agents-content-area {
   position: relative;
   margin: var(--agents-content-area-gap) var(--agents-content-area-gap) var(--agents-content-area-gap) 0;
-  border: 1px solid var(--color-border-tertiary);
+  border: 0;
   border-radius: var(--agents-content-area-radius);
   background: var(--agents-content-area-bg);
   box-shadow: none;
 }
 
+/* `.agents-parchment-paper-surface` is reused by the composer body —
+   composer keeps its border (overridden below). The bare class on the
+   content area drops its border so we don't double up with the
+   floating-panel rule above. */
 .agents-parchment-paper-surface {
-  border: 1px solid var(--color-border-tertiary);
+  border: 0;
   background-color: var(--agents-content-area-bg);
   box-shadow: none;
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7251,23 +7251,23 @@ button:active {
    and content were visibly misaligned. Drop the mainpane padding to
    thin top/bottom so the header + content can both share the centered
    column. */
-/* PR-SETTINGS-NO-PANE-BORDER-0 (2026-06-23, WAWQAQ msg `aabfa2b8`):
-   the right pane was rendering as a separate floating plate (border +
-   tinted bg + corner radius + margin gap from sidebar). Reference's
-   Settings has NO seam between the sidebar and the content surface —
-   they share one continuous canvas. Drop the pane border, radius,
-   margin, and explicit background so the right pane visually flows
-   into the same surface as the nav. */
+/* PR-SETTINGS-RESTORE-SURFACE-0 (WAWQAQ msg `32ed9490` correction):
+   previous PR over-corrected — I read "no seam" as "no plate", but
+   reference's content surface is still a lighter-bg plate vs the
+   sidebar. The seam-between rule is: no visible BORDER line between
+   sidebar and content, but the content does have its own background
+   plate + rounded corners + small floating margin. Restore the
+   surface; just no border. */
 .settingsMainPane {
   position: relative;
   min-width: 0;
   min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  margin: 0;
+  margin: var(--agents-content-area-gap) var(--agents-content-area-gap) var(--agents-content-area-gap) 0;
   border: 0;
-  border-radius: 0;
-  background: transparent;
+  border-radius: var(--agents-content-area-radius);
+  background: var(--agents-content-area-bg);
   box-shadow: none;
   overflow: hidden;
   /* Traffic-light-aligned top padding so the page title sits at the


### PR DESCRIPTION
Correction round. PR-NO-PANE-BORDER-0 over-corrected — I read WAWQAQ's "no seam" as "no plate". Restored: content surface bg + radius + floating margin on both settings (`.settingsMainPane`) and main app chat pane (`.maka-panel-detail.maka-floating-panel.agents-content-area` + `.agents-parchment-paper-surface`). Border stays at 0 so no seam line between sidebar and content. Composer keeps its border via more-specific rule.