### PR TITLE
PR-SETTINGS-CHAT-PANE-NO-BORDER-0: drop residual chat right-pane border (round 13/15)

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -242,9 +242,15 @@ button:active {
      sidebar stays flat. Keep this at the shell boundary so chat,
      modules, and artifact panes share one workspace surface.
      gap/radius match reference layout-derived values (4px/6px)
-  per WAWQAQ ef6b2852. */
+  per WAWQAQ ef6b2852.
+     PR-SETTINGS-CHAT-PANE-NO-BORDER-0 (WAWQAQ msg `ab6240fc`, round
+     13/15): the previous round dropped the border on the more-specific
+     `.agents-content-area` overlay, but this BASE rule still carried
+     it. Some view states (cron / skills modules) don't add the
+     `agents-content-area` class so the base border leaked through and
+     WAWQAQ saw a seam in chat. Drop the border here too. */
   margin: 4px 4px 4px 0;
-  border: 1px solid var(--border);
+  border: 0;
   border-radius: 6px;
   background: var(--background);
   box-shadow: none;


### PR DESCRIPTION
Round 13/15. WAWQAQ ab6240fc — chat right pane still showed a border. The previous PR dropped it only on the .agents-content-area overlay; the base .maka-panel-detail.maka-floating-panel rule still had border:1px which leaked through in cron/skills views. Set border:0 on the base. Composer keeps its border via more-specific .maka-composer-inner selector. 1466 tests pass.