### PR TITLE
feat(headless): add heavy-task benchmark evidence tools

### DIFF
--- a/packages/headless/src/__tests__/heavy-task-policy.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-policy.test.ts
@@ -126,7 +126,10 @@ describe('heavy-task policy', () => {
     assert.match(prompt, /inspect public task files/);
     assert.match(prompt, /inventory_submit/);
     assert.match(prompt, /todo_update/);
+    assert.match(prompt, /engineering_record/);
+    assert.match(prompt, /check_record/);
     assert.match(prompt, /self_check_submit/);
+    assert.match(prompt, /inventory -> hypothesize -> patch -> targeted_check -> repair -> semantic_self_check -> finish_or_continue/);
     assert.match(prompt, /public, task-derived semantic self-check evidence/);
     assert.match(prompt, /agent-owned public self-check plan before broad implementation/);
     assert.match(prompt, /Derive the plan only from visible task\/workspace evidence/);
@@ -171,6 +174,17 @@ describe('heavy-task policy', () => {
     assert.doesNotMatch(policy, /(?:from|using|based on|derived from) hidden/i);
     assert.doesNotMatch(policy, /(?:from|using|based on|derived from) private/i);
     assert.doesNotMatch(policy, /(?:from|using|based on|derived from) evaluator/i);
+  });
+
+  test('benchmark complexity signals can enable heavy-task mode when config is silent', () => {
+    const selection = resolveHeavyTaskMode(baseConfig, {
+      ...baseTask,
+      benchmark: { metadata: { taskComplexity: 'heavy' } },
+    });
+
+    assert.equal(selection.enabled, true);
+    assert.equal(selection.triggerSource, 'task_metadata');
+    assert.match(selection.triggerReason, /task complexity signal: heavy/);
   });
 });
 

--- a/packages/headless/src/heavy-task-policy.ts
+++ b/packages/headless/src/heavy-task-policy.ts
@@ -65,6 +65,16 @@ export function resolveHeavyTaskMode(config: Config, task?: Task): HeavyTaskMode
       policyVersion: taskMode.policyVersion ?? HEAVY_TASK_POLICY_VERSION,
     };
   }
+  const signalMode = normalizeTaskSignalMode(task);
+  if (signalMode?.enabled === true) {
+    return {
+      schemaVersion: 1,
+      enabled: true,
+      triggerSource: 'task_metadata',
+      triggerReason: signalMode.reason ?? 'heavy-task mode enabled by benchmark task complexity signal',
+      policyVersion: signalMode.policyVersion ?? HEAVY_TASK_POLICY_VERSION,
+    };
+  }
 
   return {
     schemaVersion: 1,
@@ -82,6 +92,7 @@ export function buildHeavyTaskSystemPromptPolicy(
     `Heavy-task benchmark policy (${selection.policyVersion})`,
     '',
     '- Work like a persistent engineer on a long-running task: inspect public task files and workspace state before editing, keep compact evidence that helps continue the work, and avoid relying on assistant prose as durable state.',
+    '- Follow this work loop until the task is done or a real cap is reached: inventory -> hypothesize -> patch -> targeted_check -> repair -> semantic_self_check -> finish_or_continue.',
     '- Use inventory_submit to submit a structured inventory snapshot after initial public inspection and whenever the important workspace/artifact inventory changes.',
     '- Use todo_update to submit the full current todo/progress snapshot as work advances. Keep at most one item in_progress, and treat todo completion as advisory progress rather than benchmark success.',
     '- After initial public inspection and inventory, define an agent-owned public self-check plan before broad implementation, expensive builds, or long-running commands. Derive the plan only from visible task/workspace evidence such as public instructions, files, build metadata, sample commands, or generated public artifacts.',
@@ -117,6 +128,24 @@ function normalizeTaskMetadataMode(metadata: Record<string, unknown> | undefined
   const mode = normalizeModeConfig(metadata.heavyTaskMode);
   if (mode) return mode;
   return normalizeModeConfig(metadata.heavyTask);
+}
+
+function normalizeTaskSignalMode(task: Task | undefined): HeavyTaskModeConfig | undefined {
+  const metadata = task?.benchmark?.metadata;
+  if (!metadata) return undefined;
+  const taskComplexity = cleanString(metadata.taskComplexity);
+  if (taskComplexity && ['heavy', 'long', 'complex'].includes(taskComplexity.toLowerCase())) {
+    return { enabled: true, reason: `benchmark task complexity signal: ${taskComplexity}` };
+  }
+  const runtimeSignal = cleanString(metadata.runtimeSignal);
+  if (runtimeSignal && ['heavy_task', 'long_running', 'complex_engineering'].includes(runtimeSignal.toLowerCase())) {
+    return { enabled: true, reason: `benchmark runtime signal: ${runtimeSignal}` };
+  }
+  const instructionSignal = cleanString(metadata.instructionSignal);
+  if (instructionSignal && ['heavy_task', 'long_running', 'complex_engineering'].includes(instructionSignal.toLowerCase())) {
+    return { enabled: true, reason: `benchmark instruction signal: ${instructionSignal}` };
+  }
+  return undefined;
 }
 
 function normalizeModeConfig(value: unknown): HeavyTaskModeConfig | undefined {


### PR DESCRIPTION
## Summary

  Adds heavy-task benchmark policy refinements for issue #102:

  - explicit persistent engineering loop in the heavy-task prompt
  - metadata-driven activation from task complexity/runtime/instruction signals
  - config disable remains authoritative over task metadata
  - policy tests covering the new prompt requirements and trigger behavior

  ## Verification

  - `npm --workspace @maka/runtime run build`
  - `npm --workspace @maka/headless test`