### PR TITLE
Group web search settings rows

### DIFF
--- a/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
@@ -281,6 +281,44 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
   });
 
+  it('Settings web-search simple controls use grouped Settings row cards instead of naked form blocks', async () => {
+    const settings = await readFile(join(REPO_ROOT, 'apps/desktop/src/renderer/settings/SettingsModal.tsx'), 'utf8');
+    const styles = await readFile(join(REPO_ROOT, 'apps/desktop/src/renderer/styles.css'), 'utf8');
+    const page = settings.match(/function WebSearchSettingsPage[\s\S]*?function webSearchQueryDisabledReason/);
+
+    assert.ok(page, 'Web search settings page block must exist');
+    assert.match(
+      page![0],
+      /<div className="settingsRows settingsWebSearchCredentialCard">/,
+      'Web search credential controls should sit in the shared grouped Settings card primitive',
+    );
+    assert.match(
+      page![0],
+      /<div className="settingsRows settingsWebSearchQueryCard">/,
+      'Web search live-query controls should sit in the shared grouped Settings card primitive',
+    );
+    for (const rowClass of [
+      'settingsRow settingsWebSearchEnableRow',
+      'settingsRow settingsWebSearchKeyRow',
+      'settingsRow settingsWebSearchCredentialActionRow',
+      'settingsRow settingsWebSearchQueryIntroRow',
+      'settingsRow settingsWebSearchQueryInputRow',
+      'settingsRow settingsWebSearchSearchRow',
+    ]) {
+      assert.match(page![0], new RegExp(`className="${rowClass}"`), `Web search Settings must keep ${rowClass} inside grouped rows`);
+    }
+    assert.match(page![0], /className="settingsWebSearchDisabledReason"/);
+    assert.match(page![0], /<ul className="settingsWebSearchResults" aria-label="联网搜索真实查询结果">/);
+    assert.doesNotMatch(
+      page![0],
+      /settingsFormRow|settingsFormGrid|style=\{\{/,
+      'Web search Settings must not regress to naked form rows/grids or inline layout styles',
+    );
+    assert.match(styles, /\.settingsWebSearchKeyRow > \.settingsPasswordField/);
+    assert.match(styles, /\.settingsWebSearchQueryIntroRow\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\);/);
+    assert.match(styles, /\.settingsWebSearchDisabledReason\s*\{[\s\S]*?color:\s*var\(--foreground-50\);/);
+  });
+
   it('Settings credential badge uses waiting-state copy instead of raw missing configuration copy', async () => {
     const settings = await readFile(join(REPO_ROOT, 'apps/desktop/src/renderer/settings/SettingsModal.tsx'), 'utf8');
     const page = settings.match(/function WebSearchSettingsPage[\s\S]*?function webSearchQueryDisabledReason/);

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -3095,33 +3095,42 @@ function WebSearchSettingsPage(props: {
 
   return (
     <div className="settingsStructuredPage">
-      <div className="settingsFormRow">
-        <div>
-          <strong>启用联网搜索</strong>
-          <small>开关启用后，界面里显式触发的查询才会真的请求 Tavily。模型不会自动调用。</small>
+      <div className="settingsRows settingsWebSearchCredentialCard">
+        <div className="settingsRow settingsWebSearchEnableRow">
+          <div>
+            <strong>启用联网搜索</strong>
+            <small>开关启用后，界面里显式触发的查询才会真的请求 Tavily。模型不会自动调用。</small>
+          </div>
+          <div className="settingsWebSearchControlCluster">
+            <div className="settingsWebSearchStatusCluster" role="group" aria-label="联网搜索凭据状态">
+              <span className="settingsConnectionBadge" data-tone={statusCopy.tone}>
+                {statusCopy.label}
+              </span>
+              {hasCheckedAt && (
+                <small>
+                  最近测试 <RelativeTime ts={checkedAtMs} />
+                </small>
+              )}
+              <small>{presentWebSearchCredentialSource(credentialSource, hasStoredKey)}</small>
+            </div>
+            <Switch
+              ariaLabel="启用联网搜索"
+              checked={webSearch.enabled}
+              disabled={!hasUsableKey}
+              onChange={(enabled) => void setEnabled(enabled)}
+            />
+          </div>
         </div>
-        <div className="settingsWebSearchStatusCluster" role="group" aria-label="联网搜索凭据状态">
-          <span className="settingsConnectionBadge" data-tone={statusCopy.tone}>
-            {statusCopy.label}
-          </span>
-          {hasCheckedAt && (
-            <small>
-              最近测试 <RelativeTime ts={checkedAtMs} />
-            </small>
-          )}
-          <small>{presentWebSearchCredentialSource(credentialSource, hasStoredKey)}</small>
-        </div>
-        <Switch
-          ariaLabel="启用联网搜索"
-          checked={webSearch.enabled}
-          disabled={!hasUsableKey}
-          onChange={(enabled) => void setEnabled(enabled)}
-        />
-      </div>
 
-      <div className="settingsFormGrid">
-        <label>
-          <span>Tavily 密钥</span>
+        <div className="settingsRow settingsWebSearchKeyRow">
+          <div>
+            <strong>Tavily 密钥</strong>
+            <small>
+              {usingEnvKey
+                ? '当前使用环境变量 TAVILY_API_KEY / MAKA_TAVILY_API_KEY；如需改用保存的密钥，请移除环境变量后重启。'
+                : <>保存在主进程设置中，渲染器永远看不到明文。在 <a href="https://tavily.com" target="_blank" rel="noreferrer">tavily.com</a> 申请。</>}
+            </small>
+          </div>
           <PasswordInput
             value={draftKey}
             onChange={setDraftKey}
@@ -3129,51 +3138,55 @@ function WebSearchSettingsPage(props: {
             placeholder={usingEnvKey ? '由环境变量提供' : hasStoredKey ? '已保存（输入新密钥可替换）' : 'tvly-xxxxxxxx'}
             ariaLabel="Tavily 密钥"
           />
-          <small>
-            {usingEnvKey
-              ? '当前使用环境变量 TAVILY_API_KEY / MAKA_TAVILY_API_KEY；如需改用保存的密钥，请移除环境变量后重启。'
-              : <>保存在主进程设置中，渲染器永远看不到明文。在 <a href="https://tavily.com" target="_blank" rel="noreferrer">tavily.com</a> 申请。</>}
-          </small>
-        </label>
-      </div>
+        </div>
 
-      <div className="settingsFormRow" style={{ gap: 8, flexWrap: 'wrap' }}>
-        <Button
-          type="button"
-          disabled={credentialActionBusy || usingEnvKey || draftKey.length === 0}
-          onClick={() => void saveDraftKey()}
-        >
-          {pendingCredentialAction === 'save' ? '保存中…' : '保存密钥'}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={credentialActionBusy || (draftKey.length === 0 && !hasUsableKey)}
-          onClick={() => void runTest()}
-        >
-          {testing ? '测试中…' : '测试凭据'}
-        </Button>
-        {hasStoredKey && (
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={credentialActionBusy}
-            onClick={() => void clearKey()}
-          >
-            {pendingCredentialAction === 'clear' ? '清空中…' : '清空密钥'}
-          </Button>
-        )}
-      </div>
-
-      <div className="settingsFormRow">
-        <div style={{ flex: 1 }}>
-          <strong>真实查询验证</strong>
-          <small>直接发一条真实查询，看到 Tavily 返回的标题 / 摘要 / 来源域名。结果只显示在此页面，不写入会话也不写入遥测。</small>
+        <div className="settingsRow settingsWebSearchCredentialActionRow">
+          <div>
+            <strong>凭据操作</strong>
+            <small>保存后可以测试一次真实请求；清空凭据会同步关闭联网搜索。</small>
+          </div>
+          <div className="settingsActionRow settingsWebSearchActionButtons">
+            <Button
+              type="button"
+              disabled={credentialActionBusy || usingEnvKey || draftKey.length === 0}
+              onClick={() => void saveDraftKey()}
+            >
+              {pendingCredentialAction === 'save' ? '保存中…' : '保存密钥'}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={credentialActionBusy || (draftKey.length === 0 && !hasUsableKey)}
+              onClick={() => void runTest()}
+            >
+              {testing ? '测试中…' : '测试凭据'}
+            </Button>
+            {hasStoredKey && (
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={credentialActionBusy}
+                onClick={() => void clearKey()}
+              >
+                {pendingCredentialAction === 'clear' ? '清空中…' : '清空密钥'}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
-      <div className="settingsFormGrid">
-        <label>
-          <span>查询</span>
+
+      <div className="settingsRows settingsWebSearchQueryCard">
+        <div className="settingsRow settingsWebSearchQueryIntroRow">
+          <div>
+            <strong>真实查询验证</strong>
+            <small>直接发一条真实查询，看到 Tavily 返回的标题 / 摘要 / 来源域名。结果只显示在此页面，不写入会话也不写入遥测。</small>
+          </div>
+        </div>
+        <div className="settingsRow settingsWebSearchQueryInputRow">
+          <div>
+            <strong>查询</strong>
+            <small>输入一条用于验证联网搜索配置的真实请求。</small>
+          </div>
           <Input
             value={liveQuery}
             onChange={(event) => setLiveQuery(event.currentTarget.value)}
@@ -3186,21 +3199,27 @@ function WebSearchSettingsPage(props: {
               }
             }}
           />
-        </label>
-      </div>
-      <div>
-        <Button
-          type="button"
-          disabled={liveQueryRunning || queryDisabledReason !== null}
-          onClick={() => void runLiveQuery()}
-        >
-          {liveQueryRunning ? '搜索中…' : '搜索'}
-        </Button>
-        {!liveQueryRunning && queryDisabledReason && (
-          <small style={{ marginLeft: 12, color: 'var(--foreground-50)' }}>
-            {queryDisabledReason}
-          </small>
-        )}
+        </div>
+        <div className="settingsRow settingsWebSearchSearchRow">
+          <div>
+            <strong>执行查询</strong>
+            <small>按钮可用时会走主进程 Tavily 请求并刷新下方结果。</small>
+          </div>
+          <div className="settingsWebSearchSearchControls">
+            <Button
+              type="button"
+              disabled={liveQueryRunning || queryDisabledReason !== null}
+              onClick={() => void runLiveQuery()}
+            >
+              {liveQueryRunning ? '搜索中…' : '搜索'}
+            </Button>
+            {!liveQueryRunning && queryDisabledReason && (
+              <small className="settingsWebSearchDisabledReason">
+                {queryDisabledReason}
+              </small>
+            )}
+          </div>
+        </div>
       </div>
 
       {liveQueryError && (

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -12612,6 +12612,16 @@ button:active {
   gap: 10px;
 }
 
+.settingsWebSearchControlCluster,
+.settingsWebSearchSearchControls {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .settingsWebSearchStatusCluster {
   display: inline-flex;
   flex-wrap: wrap;
@@ -12623,9 +12633,30 @@ button:active {
 
 .settingsWebSearchStatusCluster small {
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: 12px;
   font-family: var(--font-mono);
   white-space: nowrap;
+}
+
+.settingsWebSearchKeyRow > .settingsPasswordField,
+.settingsWebSearchQueryInputRow > input {
+  width: min(100%, 360px);
+  justify-self: end;
+}
+
+.settingsWebSearchActionButtons {
+  justify-content: flex-end;
+}
+
+.settingsWebSearchQueryIntroRow {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.settingsWebSearchDisabledReason {
+  color: var(--foreground-50);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: right;
 }
 
 .settingsWebSearchResult {
@@ -12661,6 +12692,37 @@ button:active {
   line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+@media (max-width: 720px) {
+  .settingsWebSearchEnableRow,
+  .settingsWebSearchKeyRow,
+  .settingsWebSearchCredentialActionRow,
+  .settingsWebSearchQueryInputRow,
+  .settingsWebSearchSearchRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settingsWebSearchControlCluster,
+  .settingsWebSearchSearchControls,
+  .settingsWebSearchActionButtons {
+    justify-content: flex-start;
+  }
+
+  .settingsWebSearchStatusCluster {
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .settingsWebSearchKeyRow > .settingsPasswordField,
+  .settingsWebSearchQueryInputRow > input {
+    width: 100%;
+    justify-self: stretch;
+  }
+
+  .settingsWebSearchDisabledReason {
+    text-align: left;
+  }
 }
 
 /* ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Move Settings -> 联网搜索 simple controls into two grouped Settings row cards: credentials and live-query verification
- Remove naked settingsFormRow/settingsFormGrid blocks and inline layout styles from the web-search page
- Add a web-search boundary contract that locks the grouped-card structure and keeps query results as independent result cards

## Verification
- npm --workspace @maka/desktop run typecheck
- npm --workspace @maka/desktop test -- web-search-boundary settings-form-a11y-contract (1467/1467, check-console/check-a11y clean)
- git diff --check
- npm run build