### PR TITLE
feat(desktop): headless visual-smoke capture, no foreground window

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -245,15 +245,31 @@ import type { BrowserViewRect } from './browser/logic.js';
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 
-const visualSmokeFixture = resolveVisualSmokeFixture(
-  process.env.MAKA_VISUAL_SMOKE_FIXTURE,
-  app.isPackaged,
-  process.env.MAKA_VISUAL_SMOKE_REDUCED_MOTION,
-  process.env.MAKA_VISUAL_SMOKE_AUTO_CAPTURE,
-  process.env.MAKA_VISUAL_SMOKE_THEME,
-  process.env.MAKA_VISUAL_SMOKE_LOCALE,
-  process.env.MAKA_VISUAL_SMOKE_TIMEZONE,
-);
+// PR-VISUAL-SMOKE-HEADLESS: resolve the fixture defensively. An unknown
+// scenario (e.g. the capture script's list got ahead of a stale build, or
+// a typo'd MAKA_VISUAL_SMOKE_FIXTURE) throws here during top-level module
+// evaluation. Left uncaught it surfaces a blocking native error dialog and
+// the capture driver waits out its full marker timeout (~60s). In capture
+// mode we instead log a parseable line and exit fast so the run fails in
+// milliseconds with no dialog. Outside capture mode the throw is rethrown.
+let visualSmokeFixture: ReturnType<typeof resolveVisualSmokeFixture>;
+try {
+  visualSmokeFixture = resolveVisualSmokeFixture(
+    process.env.MAKA_VISUAL_SMOKE_FIXTURE,
+    app.isPackaged,
+    process.env.MAKA_VISUAL_SMOKE_REDUCED_MOTION,
+    process.env.MAKA_VISUAL_SMOKE_AUTO_CAPTURE,
+    process.env.MAKA_VISUAL_SMOKE_THEME,
+    process.env.MAKA_VISUAL_SMOKE_LOCALE,
+    process.env.MAKA_VISUAL_SMOKE_TIMEZONE,
+  );
+} catch (error) {
+  if (process.env.MAKA_VISUAL_SMOKE_FIXTURE) {
+    console.error(`[visual-smoke] fatal: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+  throw error;
+}
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', visualSmokeFixture?.workspaceName ?? 'default');
 const store = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
@@ -1708,6 +1724,13 @@ async function createWindow(): Promise<void> {
     // renderer side of the same gate.
     resizable: true,
     backgroundColor: initialBg,
+    // PR-VISUAL-SMOKE-HEADLESS: under visual-smoke capture, never show the
+    // window or let the app take foreground — captures run while the
+    // developer keeps working in another app. `webContents.capturePage()`
+    // still returns a painted frame on a hidden window because
+    // `paintWhenInitiallyHidden` defaults to true. Real runs keep the
+    // default `show: true`.
+    ...(process.env.MAKA_VISUAL_SMOKE_FIXTURE ? { show: false } : {}),
     // Glass material — reference-atlas §1 + §12.1 documents the upstream
     // reference layout's `light-glass` / `dark-glass` themes that paint
     // the sidebar against native macOS vibrancy material. Enabling
@@ -4509,11 +4532,19 @@ app.whenReady().then(async () => {
   // builds get the icon via .app bundle Info.plist; this covers the
   // dev path.
   if (process.platform === 'darwin' && app.dock) {
-    try {
-      const iconPath = join(import.meta.dirname, '..', '..', 'assets', 'icon.png');
-      app.dock.setIcon(nativeImage.createFromPath(iconPath));
-    } catch (error) {
-      console.error('[icon] failed to set dock icon:', error);
+    if (process.env.MAKA_VISUAL_SMOKE_FIXTURE) {
+      // PR-VISUAL-SMOKE-HEADLESS: hide the dock icon so the spawned
+      // Electron runs as an accessory app — no dock bounce, and it
+      // never becomes frontmost / steals focus from the developer's
+      // active window during a capture run.
+      app.dock.hide();
+    } else {
+      try {
+        const iconPath = join(import.meta.dirname, '..', '..', 'assets', 'icon.png');
+        app.dock.setIcon(nativeImage.createFromPath(iconPath));
+      } catch (error) {
+        console.error('[icon] failed to set dock icon:', error);
+      }
     }
   }
 

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -299,23 +299,22 @@ async function captureSingle(scenario, variant) {
 }
 
 async function resolveElectronBin() {
-  // Use the locally-resolved electron binary so we don't depend on a
-  // global install.
-  const electronModule = join(REPO_ROOT, 'node_modules', 'electron');
-  if (!existsSync(electronModule)) {
-    console.error('[capture-screenshots] electron not installed; run `npm install` first.');
-    process.exit(2);
-  }
-  // Node's `require.resolve('electron')` returns a string with the path
-  // to the binary; we read package.json + use main field.
+  // Resolve the electron binary via Node's module resolution, which walks
+  // up the directory tree from this script. A git worktree's node_modules
+  // holds only the workspace's own @maka/* packages, so electron lives in
+  // the parent checkout's node_modules — the upward walk finds it there.
+  // We intentionally do NOT hard-require `REPO_ROOT/node_modules/electron`,
+  // which a worktree legitimately lacks; `import('electron')` returns the
+  // resolved binary path string regardless of which ancestor provides it.
   try {
     const exportPath = (await import('electron')).default;
     if (typeof exportPath === 'string') return exportPath;
+    console.error('[capture-screenshots] electron resolved but exposed no binary path; run `npm install`.');
+    process.exit(2);
   } catch (err) {
-    console.error('[capture-screenshots] failed to resolve electron:', err);
+    console.error('[capture-screenshots] electron not resolvable (run `npm install` in the repo root):', err);
     process.exit(2);
   }
-  return null;
 }
 
 async function main() {


### PR DESCRIPTION
## What

Make the visual-smoke screenshot harness headless, worktree-runnable, and crash-fast.

## Why

Captures launched a real Electron window that grabbed foreground focus on every (scenario × variant), so the harness was intrusive to run during interactive work — and it could not run from a git worktree at all. A stale build also crashed each capture with a blocking native error dialog and a ~60s marker timeout.

## Changes

- **Headless capture** (`apps/desktop/src/main/main.ts`): under `MAKA_VISUAL_SMOKE_FIXTURE`, the window is created with `show: false` and the macOS dock icon is hidden, so the capture process never shows a window or steals focus. `capturePage()` still returns a painted frame on a hidden window (`paintWhenInitiallyHidden` defaults to true).
- **Crash-fast** (`main.ts`): an unknown scenario (stale build whose scenario set lags the capture script, or a typo'd env) now logs `[visual-smoke] fatal: …` and exits immediately, instead of throwing during top-level module evaluation → blocking native error dialog → ~60s marker timeout.
- **Worktree-runnable** (`scripts/capture-screenshots.mjs`): resolve the electron binary via Node's upward module resolution instead of hard-requiring `REPO_ROOT/node_modules/electron`, so a git worktree (whose node_modules holds only the workspace's own `@maka/*` packages) finds electron in the parent checkout.

All branches are gated behind `MAKA_VISUAL_SMOKE_FIXTURE`; real (non-capture) runs are unchanged.

## Verification

- Headless capture across empty / modal (command palette, permission) / settings scenarios — all render correctly, no foreground window, no dock bounce, ~1.0–1.3s each.
- Capture runs from a git worktree with no electron symlink (upward resolution).
- Bogus scenario exits in <1s with `[visual-smoke] fatal …` and no dialog (previously 60s + native dialog).
- `npm -w @maka/desktop run typecheck` clean; desktop suite 1466 pass / 0 fail.
