### PR TITLE
Fix prompt optimization gateway model routing

### DIFF
--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -10,6 +10,7 @@ import {
   extractRewardHackVerifierPatterns,
   partitionPromptTasks,
   resolvePromptOptimizationRunRoot,
+  resolvePromptOptimizationModelId,
   runPromptOptimizationRun,
 } from '../prompt-optimization-run.js';
 
@@ -133,6 +134,20 @@ describe('resolvePromptOptimizationRunRoot', () => {
         /MAKA_PROMPT_RUN_ID must contain only/,
       );
     }
+  });
+});
+
+describe('resolvePromptOptimizationModelId', () => {
+  test('strips only the prefix owned by the selected native provider', () => {
+    assert.equal(resolvePromptOptimizationModelId('deepseek/deepseek-v4-flash', 'deepseek'), 'deepseek-v4-flash');
+    assert.equal(resolvePromptOptimizationModelId('openai/gpt-4.1', 'openai'), 'gpt-4.1');
+  });
+
+  test('keeps slashful gateway-routed model ids when the prefix is not the provider', () => {
+    assert.equal(
+      resolvePromptOptimizationModelId('anthropic/claude-sonnet-4-5', 'openai-compatible'),
+      'anthropic/claude-sonnet-4-5',
+    );
   });
 });
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -358,7 +358,7 @@ const defaultHarborProcessRunner: HarborProcessRunner = async (request) => {
  * ("openai-compatible" routing "anthropic/claude-sonnet-4-5"). The cell's
  * parseModelSpec preserves whatever it receives when a provider is set, so the
  * stripping must happen here. */
-function modelIdForProvider(model: string, provider: string): string {
+export function modelIdForProvider(model: string, provider: string): string {
   const prefix = `${provider}/`;
   return model.startsWith(prefix) ? model.slice(prefix.length) : model;
 }

--- a/packages/headless/src/prompt-optimization-run.ts
+++ b/packages/headless/src/prompt-optimization-run.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 import type { LlmConnection } from '@maka/core';
 import type { Config } from './contracts.js';
 import type { FixedPromptTask, HarborTaskRunner } from './fixed-prompt-controller.js';
-import { createHarborTaskRunner, type HarborTaskPricing } from './harbor-task-runner.js';
+import { createHarborTaskRunner, modelIdForProvider, type HarborTaskPricing } from './harbor-task-runner.js';
 import { createAiSdkMetaAgent } from './meta-agent-completion.js';
 import { createCliPromptCandidateGit, type MetaAgent } from './prompt-candidate-loop.js';
 import {
@@ -214,9 +214,7 @@ export async function runPromptOptimizationRun(
 ): Promise<PromptOptimizationRunResult> {
   assertValidPromptTaskPartitions(input.heldInTasks, input.heldOutTasks);
 
-  const modelId = input.model.includes('/')
-    ? input.model.slice(input.model.indexOf('/') + 1)
-    : input.model;
+  const modelId = resolvePromptOptimizationModelId(input.model, input.provider);
 
   const harborRunner = input.harborRunner ?? createHarborTaskRunner({
     makaRepoPath: input.makaRepoPath,
@@ -276,6 +274,10 @@ export async function runPromptOptimizationRun(
     ...(input.now ? { now: input.now } : {}),
     ...(input.newId ? { newId: input.newId } : {}),
   });
+}
+
+export function resolvePromptOptimizationModelId(model: string, provider: string): string {
+  return modelIdForProvider(model, provider);
 }
 
 function assertValidPromptTaskPartitions(


### PR DESCRIPTION
## Summary
- Share the provider-aware model-id normalization used by Harbor with the real prompt-optimization run wiring
- Preserve slashful gateway-routed model ids such as `anthropic/claude-sonnet-4-5` when provider is `openai-compatible`
- Add a prompt-run boundary test for native-provider stripping vs gateway preservation

## Root cause
`buildHarborJobConfig` already stripped only provider-owned prefixes, but `runPromptOptimizationRun` stripped everything before the first slash before constructing the meta-agent/config. Gateway-routed models could therefore be sent as `claude-sonnet-4-5` instead of `anthropic/claude-sonnet-4-5`.

## Verification
- `npm --workspace @maka/headless test -- prompt-optimization-run harbor-task-runner` (403/403)
- `npm --workspace @maka/headless run build`
- `git diff --check`
- `npm run build`
