### PR TITLE
Fix prompt smoke cost threshold

### DIFF
--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -293,6 +293,33 @@ describe('runPromptOptimizationLoop', () => {
     });
   });
 
+  test('reports a cost-ceiling smoke failure when the loop stops exactly at budget', async () => {
+    await withHarness(async (harness) => {
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 8);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        const index = taskIndex(taskId);
+        if (taskId.startsWith('hout-')) return index < 4 ? 1 : 0;
+        if (roundId.startsWith('baseline-')) return index < 10 ? 1 : 0;
+        return 1;
+      };
+
+      const result = await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 3,
+        baselineRuns: 2,
+        costCeilingUsd: 1.68,
+      });
+
+      assert.equal(result.stopReason, 'cost_ceiling_exceeded');
+      assert.equal(result.decisions.length, 1);
+      assert.equal(result.smoke.totalCostUsd, 1.68);
+      assert.ok(result.smoke.failures.includes('cost_ceiling_exceeded'));
+    });
+  });
+
   test('drops a held-in task that never completes in baseline and calibrates on the rest', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 3);

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -74,6 +74,26 @@ describe('prompt structural smoke report', () => {
     assert.match(markdown, /- cost_ceiling_exceeded/);
   });
 
+  test('fails when task cost reaches the configured ceiling exactly', () => {
+    const events: FixedPromptWalEvent[] = [];
+    for (let index = 1; index <= 10; index += 1) {
+      const roundId = `round-${index}`;
+      events.push(committedEvent(roundId));
+      events.push(completedEvent(roundId, `task-${index}`, 0.1));
+      events.push(decisionEvent(roundId, 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }));
+    }
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 10,
+      costCeilingUsd: 1,
+    });
+
+    assert.equal(report.totalCostUsd, 1);
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['cost_ceiling_exceeded']);
+  });
+
   test('fails when decision rounds have no task evidence', () => {
     const events: FixedPromptWalEvent[] = [];
     for (let index = 1; index <= 10; index += 1) {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -57,7 +57,7 @@ export function promptStructuralSmokeReport(
   if (observedRounds < minimumRounds) failures.push('minimum_rounds_not_met');
   if (observedRunCount > 1) failures.push('multiple_runs_present');
   if (roundsWithoutTaskEvidence.length > 0) failures.push('task_evidence_missing');
-  if (input.costCeilingUsd !== undefined && totalCostUsd > input.costCeilingUsd) {
+  if (input.costCeilingUsd !== undefined && totalCostUsd >= input.costCeilingUsd) {
     failures.push('cost_ceiling_exceeded');
   }
   if (taskEvents.some((event) => event.type === 'task_plumbing_failed')) {


### PR DESCRIPTION
## Summary
- Align prompt structural smoke with the controller's cost guard by treating cost equal to the configured ceiling as `cost_ceiling_exceeded`.
- Add structural-smoke and loop-level regressions for exact-budget stops.

## Verification
- `npm --workspace @maka/headless test`
- `git diff --check`
- `npm run build`

Note: branch is based on `github/main` (`0cbb7664`) and intentionally excludes the shared-only UI/CSS commit `a7a54422`.
