### PR TITLE
Fix artifact metadata read failures

### DIFF
--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -146,6 +146,19 @@ describe('FileArtifactStore', () => {
     });
   });
 
+  test('fails loud on metadata read I/O errors instead of treating the index as empty', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const metadataPath = join(workspaceRoot, 'artifacts', 'metadata.jsonl');
+      await mkdir(metadataPath, { recursive: true });
+
+      const store = createArtifactStore(workspaceRoot);
+      await assert.rejects(
+        () => store.list('session-1'),
+        { code: 'EISDIR' },
+      );
+    });
+  });
+
   test('guards first metadata load with one shared in-flight promise', async () => {
     const source = await readFile(join(process.cwd(), 'src/artifact-store.ts'), 'utf8');
     assert.match(source, /private loadPromise: Promise<void> \| null = null;/);

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -175,10 +175,9 @@ class FileArtifactStore implements ArtifactStore {
         const text = await readFile(this.metadataPath, 'utf8');
         this.records = parseArtifactMetadata(text);
       } catch (error) {
+        if (!isNotFound(error)) throw error;
         this.records = [];
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-          await this.writeMetadataUnlocked();
-        }
+        await this.writeMetadataUnlocked();
       }
       this.loaded = true;
     })();
@@ -283,6 +282,13 @@ function isInsideOrSamePath(root: string, target: string): boolean {
   if (target === root) return true;
   const rel = relative(root, target);
   return rel !== '' && !rel.startsWith('..') && rel !== '..' && !rel.includes(`..${sep}`) && !rel.startsWith(sep);
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && error.code === 'ENOENT';
 }
 
 function sniffAllowedBinaryMime(bytes: Uint8Array): string | null {


### PR DESCRIPTION
## Summary
- fail loud when artifact metadata exists but cannot be read
- keep empty-index initialization only for missing metadata.jsonl
- add a regression test using a directory at metadata.jsonl to cover real read failure handling

## Verification
- npm --workspace @maka/storage test
- npm run build
- git diff --check