### PR TITLE
Fail closed on invalid plan reminder files

### DIFF
--- a/packages/storage/src/__tests__/plan-reminder-store.test.ts
+++ b/packages/storage/src/__tests__/plan-reminder-store.test.ts
@@ -327,6 +327,24 @@ describe('PlanReminderStore', () => {
     assert.equal((await store.list()).find((entry) => entry.id === reminder.id)?.lastRun?.id, 'run-1');
   });
 
+  it('rejects wrong top-level reminder files instead of overwriting them as empty', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-plan-reminders-'));
+    const filePath = join(root, 'plan-reminders.json');
+    const invalid = JSON.stringify({ reminders: [] }, null, 2) + '\n';
+    await writeFile(filePath, invalid, 'utf8');
+
+    const store = createPlanReminderStore(root);
+    await assert.rejects(
+      () => store.list(),
+      /expected an array/,
+    );
+    await assert.rejects(
+      () => store.create({ title: '新提醒', runAt: Date.now() + 60_000 }),
+      /expected an array/,
+    );
+    assert.equal(await readFile(filePath, 'utf8'), invalid);
+  });
+
   it('rejects invalid creates before writing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-plan-reminders-'));
     const store = createPlanReminderStore(root);

--- a/packages/storage/src/plan-reminder-store.ts
+++ b/packages/storage/src/plan-reminder-store.ts
@@ -233,7 +233,9 @@ class FilePlanReminderStore implements PlanReminderStore {
     try {
       const text = await readFile(this.filePath, 'utf8');
       const parsed = JSON.parse(text) as unknown;
-      if (!Array.isArray(parsed)) return [];
+      if (!Array.isArray(parsed)) {
+        throw new Error('Invalid plan reminders file: expected an array');
+      }
       return parsed
         .map(normalizePersistedPlanReminder)
         .filter((reminder): reminder is PlanReminder => Boolean(reminder));


### PR DESCRIPTION
## Summary
- reject persisted plan reminder files whose top-level JSON is not an array
- prevent create/update flows from treating a wrong-shape file as empty and overwriting it
- add a regression that verifies the invalid file bytes remain untouched after list/create failures

## Verification
- npm --workspace @maka/storage test
- npm run build
- git diff --check