### PR TITLE
Fail closed on invalid connection files

### DIFF
--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -247,6 +247,55 @@ describe('FileConnectionStore', () => {
       assert.equal(await store.getDefault(), null);
       await store.setDefault('enabled-openai');
       assert.equal(await store.getDefault(), 'enabled-openai');
+    });
+  });
+
+  test('rejects wrong top-level connection files instead of overwriting them as empty', async () => {
+    await withConnectionStore(async (store, dir) => {
+      const filePath = join(dir, 'llm-connections.json');
+      const invalid = JSON.stringify({ defaultSlug: null }, null, 2) + '\n';
+      await writeFile(filePath, invalid, 'utf8');
+
+      await assert.rejects(
+        () => store.list(),
+        /connections must be an array/,
+      );
+      await assert.rejects(
+        () => store.create({
+          slug: 'openai-main',
+          name: 'OpenAI',
+          providerType: 'openai',
+          defaultModel: 'gpt-4o-mini',
+        }),
+        /connections must be an array/,
+      );
+      assert.equal(await readFile(filePath, 'utf8'), invalid);
+    });
+  });
+
+  test('rejects invalid defaultSlug types without overwriting connection bytes', async () => {
+    await withConnectionStore(async (store, dir) => {
+      const filePath = join(dir, 'llm-connections.json');
+      const invalid = JSON.stringify({ defaultSlug: 42, connections: [] }, null, 2) + '\n';
+      await writeFile(filePath, invalid, 'utf8');
+
+      await assert.rejects(
+        () => store.getDefault(),
+        /defaultSlug must be a string or null/,
+      );
+      await assert.rejects(
+        () => store.save({
+          slug: 'anthropic-main',
+          name: 'Claude',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-5-20250929',
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        }),
+        /defaultSlug must be a string or null/,
+      );
+      assert.equal(await readFile(filePath, 'utf8'), invalid);
     });
   });
 });

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -191,10 +191,11 @@ class FileConnectionStore implements ConnectionStore {
 
   private async readUnlocked(): Promise<ConnectionsFile> {
     try {
-      const raw = JSON.parse(await readFile(this.path, 'utf8')) as ConnectionsFile;
-      const connections = (raw.connections ?? []).map((connection) => migrateConnectionV1ToV2(connection));
+      const raw = JSON.parse(await readFile(this.path, 'utf8')) as unknown;
+      const parsed = normalizeConnectionsFile(raw);
+      const connections = parsed.connections.map((connection) => migrateConnectionV1ToV2(connection));
       return {
-        defaultSlug: normalizeDefaultSlug(raw.defaultSlug, connections),
+        defaultSlug: normalizeDefaultSlug(parsed.defaultSlug, connections),
         connections,
       };
     } catch (error) {
@@ -215,6 +216,27 @@ class FileConnectionStore implements ConnectionStore {
     this.queue = next.catch(() => {});
     return next;
   }
+}
+
+function normalizeConnectionsFile(value: unknown): ConnectionsFile {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid connection file: expected an object');
+  }
+  const record = value as Partial<ConnectionsFile>;
+  if (!Array.isArray(record.connections)) {
+    throw new Error('Invalid connection file: connections must be an array');
+  }
+  if (
+    record.defaultSlug !== undefined &&
+    record.defaultSlug !== null &&
+    typeof record.defaultSlug !== 'string'
+  ) {
+    throw new Error('Invalid connection file: defaultSlug must be a string or null');
+  }
+  return {
+    defaultSlug: record.defaultSlug ?? null,
+    connections: record.connections,
+  };
 }
 
 function normalizeDefaultSlug(defaultSlug: string | null | undefined, connections: LlmConnection[]): string | null {


### PR DESCRIPTION
## Summary
- reject existing llm-connections.json files whose top-level value is not a connection object with a connections array
- reject invalid defaultSlug types instead of normalizing them away
- add regressions that verify list/create/save failures leave invalid file bytes untouched

## Verification
- npm --workspace @maka/storage test
- npm run build
- git diff --check