### PR TITLE
Add explicit bypass permission mode

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -173,11 +173,11 @@ describe('permission mode transition guard copy', () => {
   it('composer mode menu offers the user-facing permission modes via base-ui Menu', async () => {
     const ui = await readFile(join(REPO_ROOT, 'packages/ui/src/components.tsx'), 'utf8');
 
-    // Two-mode picker: explore is retired from the picker entirely
+    // Three-mode picker: explore is retired from the picker entirely
     // (read-only mode has no useful runtime toggle for normal chat —
     // Deep-Research sessions set it internally). The picker shows
-    // 'ask' (询问权限) and 'execute' (自动执行).
-    assert.match(ui, /const PERMISSION_MODE_ORDER: PermissionMode\[\] = \['ask', 'execute'\];/);
+    // 'ask' (询问权限), 'execute' (自动执行), and 'bypass' (Bypass permissions).
+    assert.match(ui, /const PERMISSION_MODE_ORDER: PermissionMode\[\] = \['ask', 'execute', 'bypass'\];/);
 
     // Mode chip uses base-ui Menu (not a custom radiogroup) — keyboard
     // arrow / Home / End navigation is delegated to the primitive.

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -29,7 +29,7 @@ import {
   Wifi,
   type LucideIcon,
 } from 'lucide-react';
-import type { LlmConnection, SessionSummary, SettingsSection, ThemePreference } from '@maka/core';
+import type { LlmConnection, PermissionMode, SessionSummary, SettingsSection, ThemePreference } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
 import {
   Button,
@@ -137,8 +137,8 @@ export function buildCommandList(args: {
    * composer's permission-mode dropdown (PR-MOVE-PERMISSION-MODE
    * relocated the picker out of the chat header).
    */
-  onSetPermissionMode?(mode: 'explore' | 'ask' | 'execute'): Promise<void> | void;
-  activePermissionMode?: 'explore' | 'ask' | 'execute';
+  onSetPermissionMode?(mode: PermissionMode): Promise<void> | void;
+  activePermissionMode?: PermissionMode;
   /**
    * PR-CMD-PALETTE-PASTE-DAILY-REVIEW-0: fetch today's review and
    * paste the Markdown into the composer instead of the clipboard.
@@ -470,10 +470,11 @@ export function buildCommandList(args: {
   if (args.onSetPermissionMode && args.activeSessionId) {
     const setMode = args.onSetPermissionMode;
     const current = args.activePermissionMode;
-    const modes: Array<{ id: 'explore' | 'ask' | 'execute'; label: string; hintCopy: string }> = [
+    const modes: Array<{ id: PermissionMode; label: string; hintCopy: string }> = [
       { id: 'explore', label: '权限 · 只读', hintCopy: '读取和搜索直通，写入仍确认' },
-      { id: 'ask', label: '权限 · 确认', hintCopy: '每条敏感工具都先确认（默认）' },
-      { id: 'execute', label: '权限 · 执行', hintCopy: '可信工具直通，不可逆仍提示' },
+      { id: 'ask', label: '权限 · 询问权限', hintCopy: '每条敏感工具都先确认（默认）' },
+      { id: 'execute', label: '权限 · 自动执行', hintCopy: '常见工具直通，破坏性操作仍确认' },
+      { id: 'bypass', label: '权限 · Bypass permissions', hintCopy: '全部工具直通，不再弹权限确认' },
     ];
     for (const entry of modes) {
       cmds.push({

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1479,8 +1479,9 @@ function AppShell() {
       }
       const labels: Record<PermissionMode, string> = {
         explore: '只读模式',
-        ask: '确认模式',
-        execute: '执行模式',
+        ask: '询问权限',
+        execute: '自动执行',
+        bypass: 'Bypass permissions',
       };
       if (activeIdRef.current === sessionId) toastApi.success(`已切到 ${labels[mode]}`, modeDescriptions[mode]);
       await refreshSessions();
@@ -3393,7 +3394,8 @@ function AppShell() {
 const modeDescriptions: Record<PermissionMode, string> = {
   explore: '只读工具直通，写入或网络仍需确认。',
   ask: '所有敏感工具调用前都会停下来征求允许或拒绝。',
-  execute: '常见工具直通；只有破坏性操作仍然拦截。',
+  execute: '常见工具直通；破坏性操作、特权操作和浏览器操作仍然确认。',
+  bypass: '跳过全部工具确认，包括破坏性操作、特权操作和浏览器操作。',
 };
 
 /**

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1137,7 +1137,7 @@ function SettingsPage(props: {
           </SettingsRows>
           <SettingsRows>
             <SettingRow title="启动" detail="打开应用后回到最近一次对话。" value="已启用" />
-            <SettingRow title="新对话模式" detail="新对话默认从确认模式开始。" value="确认" />
+            <SettingRow title="新对话模式" detail="新对话默认从询问权限开始。" value="询问权限" />
             <SettingRow title="默认模型" detail="新对话默认使用的模型连接。" value={props.defaultSlug ?? '未设置'} />
           </SettingsRows>
           <SettingsRows>
@@ -2173,8 +2173,8 @@ function AccountSettingsPage(props: {
       <SettingsRows>
         <SettingRow
           title="默认权限模式"
-          detail="新会话默认从确认模式开始；可在对话顶部切到只读或执行。"
-          value="需要确认"
+          detail="新会话默认从询问权限开始；可在输入框左下角切到自动执行或 Bypass permissions。"
+          value="询问权限"
         />
         <SettingRow
           title="凭据保护"

--- a/packages/core/src/__tests__/permission.test.ts
+++ b/packages/core/src/__tests__/permission.test.ts
@@ -240,6 +240,36 @@ describe('preToolUse — execute mode', () => {
   });
 });
 
+describe('preToolUse — bypass mode', () => {
+  test('rm → allow without prompting', () => {
+    const r = evaluate('Bash', { command: 'rm important.txt' }, 'bypass');
+    expect(r.proceed).toBe(true);
+    expect(r.needsPrompt).toBe(false);
+    expect(r.category).toBe('fs_destructive');
+  });
+
+  test('git reset --hard → allow without prompting', () => {
+    const r = evaluate('Bash', { command: 'git reset --hard HEAD~5' }, 'bypass');
+    expect(r.proceed).toBe(true);
+    expect(r.needsPrompt).toBe(false);
+    expect(r.category).toBe('git_destructive');
+  });
+
+  test('sudo → allow without prompting', () => {
+    const r = evaluate('Bash', { command: 'sudo systemctl stop foo' }, 'bypass');
+    expect(r.proceed).toBe(true);
+    expect(r.needsPrompt).toBe(false);
+    expect(r.category).toBe('privileged');
+  });
+
+  test('browser actions → allow without prompting', () => {
+    const r = evaluate('browser_click', { ref: '[12]' }, 'bypass', [], 'browser');
+    expect(r.proceed).toBe(true);
+    expect(r.needsPrompt).toBe(false);
+    expect(r.category).toBe('browser');
+  });
+});
+
 describe('preToolUse — turnRemembered', () => {
   test('remembered scope → allow the same tool intent when policy says prompt', () => {
     const args = { path: '/x' };
@@ -316,7 +346,7 @@ describe('PERMISSION_POLICY matrix invariants', () => {
     'custom_tool',
     'subagent',
   ];
-  const modes: PermissionMode[] = ['explore', 'ask', 'execute'];
+  const modes: PermissionMode[] = ['explore', 'ask', 'execute', 'bypass'];
 
   test('every (mode, category) pair has a decision', () => {
     for (const mode of modes) {
@@ -343,6 +373,7 @@ describe('PERMISSION_POLICY matrix invariants', () => {
     expect(PERMISSION_POLICY.ask.browser).toBe('prompt');
     // The key contrast with network_send: not silently allowed in execute.
     expect(PERMISSION_POLICY.execute.browser).toBe('prompt');
+    expect(PERMISSION_POLICY.bypass.browser).toBe('allow');
   });
 
   test('explore mode allows local reads + safe shell (web_read prompts post PR-AGENT-WEB-SEARCH-TOOL-0)', () => {
@@ -367,5 +398,12 @@ describe('PERMISSION_POLICY matrix invariants', () => {
     expect(PERMISSION_POLICY.explore.web_read).toBe('prompt');
     expect(PERMISSION_POLICY.ask.web_read).toBe('prompt');
     expect(PERMISSION_POLICY.execute.web_read).toBe('allow');
+    expect(PERMISSION_POLICY.bypass.web_read).toBe('allow');
+  });
+
+  test('bypass mode allows every category without prompting', () => {
+    for (const cat of categories) {
+      expect(PERMISSION_POLICY.bypass[cat]).toBe('allow');
+    }
   });
 });

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -13,7 +13,7 @@
 // Mode + Tool categories
 // ============================================================================
 
-export const PERMISSION_MODES = ['explore', 'ask', 'execute'] as const;
+export const PERMISSION_MODES = ['explore', 'ask', 'execute', 'bypass'] as const;
 export type PermissionMode = typeof PERMISSION_MODES[number];
 
 export function isPermissionMode(value: unknown): value is PermissionMode {
@@ -115,6 +115,20 @@ export const PERMISSION_POLICY: Record<PermissionMode, Record<ToolCategory, Poli
     // user's "allow for this turn" then carries the observe→act loop.
     browser: 'prompt',
   },
+  bypass: {
+    read: 'allow',
+    web_read: 'allow',
+    shell_safe: 'allow',
+    file_write: 'allow',
+    fs_destructive: 'allow',
+    shell_unsafe: 'allow',
+    git_destructive: 'allow',
+    network_send: 'allow',
+    privileged: 'allow',
+    browser: 'allow',
+    custom_tool: 'allow',
+    subagent: 'allow',
+  },
 };
 
 // ============================================================================
@@ -191,7 +205,7 @@ export const PRIVILEGED_SHELL_PREFIXES: readonly string[] = [
 ];
 
 /** Irreversible filesystem operations. `rm` in any form (incl. single-file
- *  `rm foo.txt`) lands here so execute mode still prompts. */
+ *  `rm foo.txt`) lands here so auto/execute mode still prompts. */
 export const FS_DESTRUCTIVE_PATTERNS: readonly RegExp[] = [
   /^rm\b/, //                                       all rm (single-file, -r, -rf, etc.)
   /^rmdir\b/,

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -186,6 +186,7 @@ const modeRank: Record<PermissionMode, number> = {
   explore: 0,
   ask: 1,
   execute: 2,
+  bypass: 3,
 };
 
 export function listBuiltinAgentDefinitions(options: AgentDefinitionListOptions = {}): AgentDefinitionListItem[] {

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4003,7 +4003,7 @@ interface PermissionModeMeta {
 /**
  * PR-MOVE-PERMISSION-MODE (WAWQAQ msgs 47fe0d0e / 21993dcc / a667cf6c
  * 2026-06-23): the user-facing permission-mode picker is now a
- * two-option dropdown sitting in the composer left-controls instead
+ * three-option dropdown sitting in the composer left-controls instead
  * of a 3-chip switcher at the chat header. The `explore` (read-only)
  * mode was retired from the picker — for an agent that can't write
  * or run anything, the mode is "not useful". Internally `explore`
@@ -4028,12 +4028,17 @@ const PERMISSION_MODE_META: Record<PermissionMode, PermissionModeMeta> = {
   },
   execute: {
     label: '自动执行',
-    hint: 'Agent 自跑全部工具，不打断你。等价于 reference 的 Bypass permissions — 适合让 agent 长时间独立完成任务。',
+    hint: '常见工具直通，破坏性操作、特权操作和浏览器操作仍会停下来确认。',
+    tone: 'caution',
+  },
+  bypass: {
+    label: 'Bypass permissions',
+    hint: '跳过全部工具确认，包括破坏性操作、特权操作和浏览器操作。只在完全信任本轮任务时使用。',
     tone: 'caution',
   },
 };
 
-const PERMISSION_MODE_ORDER: PermissionMode[] = ['ask', 'execute'];
+const PERMISSION_MODE_ORDER: PermissionMode[] = ['ask', 'execute', 'bypass'];
 
 export interface ChatHeaderAlert {
   /** Visual tone — drives badge color in the chat header. */
@@ -6273,10 +6278,11 @@ export const Composer = forwardRef<
      * PR-MOVE-PERMISSION-MODE (WAWQAQ 47fe0d0e + a667cf6c): the
      * permission mode picker lives inside the composer left-controls
      * instead of the chat header. Composer renders a dropdown labelled
-     * by the current mode (询问权限 / 自动执行); selecting an option
-     * fires `onPermissionModeChange`. When the active session is in
-     * the legacy `explore` mode the picker collapses to display
-     * 询问权限 — explore is internal-only now and won't surface here.
+     * by the current mode (询问权限 / 自动执行 / Bypass permissions);
+     * selecting an option fires `onPermissionModeChange`. When the
+     * active session is in the legacy `explore` mode the picker
+     * collapses to display 询问权限 — explore is internal-only now and
+     * won't surface here.
      */
     permissionMode?: PermissionMode;
     permissionModePending?: boolean;
@@ -6648,9 +6654,9 @@ export const Composer = forwardRef<
             {/* PR-MOVE-PERMISSION-MODE: the static "通用" role chip
                 was replaced by the permission-mode dropdown — that
                 spot is where the reference Settings expects users to
-                pick "Ask permissions" / "Auto mode" / etc. Maka
-                exposes the two user-facing modes only (`ask` /
-                `execute`); `explore` collapses to `ask` in the
+                pick "Ask permissions" / "Auto mode" / "Bypass
+                permissions". Maka exposes the user-facing modes
+                `ask` / `execute` / `bypass`; `explore` collapses to `ask` in the
                 display because Deep Research sessions use it
                 internally but it's not a useful runtime toggle for
                 normal chat. */}


### PR DESCRIPTION
## Summary
- add a distinct `bypass` permission mode that allows every tool category without prompting
- keep `execute` as Auto mode, where destructive, privileged, and browser actions still prompt
- expose Ask permissions / Auto mode / Bypass permissions in the composer and command palette, and fix Settings copy

## Verification
- `npm --workspace @maka/core test -- permission`
- `npm --workspace @maka/desktop test -- session-status-presentation`
- `npm --workspace @maka/runtime test -- subagent-tools session-manager`
- `npm --workspace @maka/desktop run typecheck`
- `npm run build`
- `git diff --check`