### PR TITLE
Update Maka product tagline

### DIFF
--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -175,6 +175,12 @@ const FORBIDDEN_VISIBLE_COPY: ForbiddenCopy[] = [
       "shared empty-state titles should frame empty product surfaces as actionable waiting states (`等待开始对话` / `等待添加 Skill` / `等待创建计划提醒`), not unfinished setup copy.",
   },
   {
+    label: 'old generic Maka tagline',
+    needle: /本地运行、自主规划、安全可控的\s*AI\s*工作搭子/,
+    reason:
+      "Maka's product tagline is `自主规划，陪你把事做完的智能个人助手。`; the older generic `AI 工作搭子` line under-states the product promise.",
+  },
+  {
     label: 'workspace instruction missing-state toast sounds unfinished',
     needle: /当前项目还没有项目指引/,
     reason:
@@ -244,6 +250,17 @@ describe('visible-copy hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2)', 
       );
     });
   }
+
+  it('pins the zh empty-chat hero product tagline', async () => {
+    const heroPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'components.tsx');
+    const src = stripComments(await readFile(heroPath, 'utf8'));
+
+    assert.match(
+      src,
+      /intro:\s*'自主规划，陪你把事做完的智能个人助手。'/,
+      'The default zh chat empty hero should carry Maka’s exact product tagline.',
+    );
+  });
 });
 
 describe('terminal truncation handoff contract', () => {

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -278,8 +278,8 @@ function NeedsConnectionHero(props: {
           再开始第一条对话。" worked as an instruction but read more
           like documentation than a product promise. reference implementation's home
           hero is a single short imperative ("不止聊天，搞定一切")
-          plus a one-line product positioning ("本地运行、自主规划、
-          安全可控的 AI 工作搭子"). Same shape, Maka-honest wording.
+          plus a one-line product positioning ("自主规划，陪你把事做完的智能个人助手。").
+          Same shape, Maka-honest wording.
         */}
         <h1>不只是聊天，搞定真事。</h1>
         <p>

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5069,7 +5069,7 @@ const EMPTY_HERO_COPY_BY_LOCALE: Record<PromptSuggestionLocale, {
     },
     headlineWithLabel: (greeting, label) => `${greeting} ${label}，今天想做点什么？`,
     headlineFallback: (greeting, tail) => `${greeting}，${tail}。`,
-    intro: '本地运行、自主规划、安全可控的 AI 工作搭子。',
+    intro: '自主规划，陪你把事做完的智能个人助手。',
   },
   en: {
     ariaLabel: 'Start a conversation',


### PR DESCRIPTION
## Summary
- update the zh empty-chat hero tagline to `自主规划，陪你把事做完的智能个人助手。`
- update the stale onboarding source comment so the old tagline no longer survives in code search
- extend visible-copy hygiene coverage to ban the old generic tagline and pin the exact new one

## Verification
- `npm --workspace @maka/desktop test -- visible-copy-hygiene-contract` (actual full desktop suite 1469/1469, console/a11y clean)
- `npm --workspace @maka/desktop run typecheck`
- `npm run build` (existing Vite chunk-size warning)
- `git diff --check`