### PR TITLE
Validate cache token estimates

### DIFF
--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -133,6 +133,20 @@ describe('desktop history compact artifact lifecycle', () => {
         now: 140,
       });
       await store.create({
+        id: 'bad-estimate',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'bad-estimate.json',
+        kind: 'file',
+        content: JSON.stringify({
+          ...historyCompactBlock([textEvent('old-7', 'turn-7', 'eta')], 'bad-estimate'),
+          estimatedTokens: 'tiny',
+        }),
+        mimeType: 'application/json',
+        source: 'history_compact_block',
+        now: 145,
+      });
+      await store.create({
         id: 'oversized',
         sessionId: 'session-1',
         turnId: 'turn-1',
@@ -170,7 +184,7 @@ describe('desktop history compact artifact lifecycle', () => {
       assert.equal(loaded.skippedReasonCounts?.deleted, 1);
       assert.equal(loaded.skippedReasonCounts?.session_mismatch, 1);
       assert.equal(loaded.skippedReasonCounts?.invalid_json, 1);
-      assert.equal(loaded.skippedReasonCounts?.invalid_schema_version, 1);
+      assert.equal(loaded.skippedReasonCounts?.invalid_schema_version, 2);
       assert.equal(loaded.skippedReasonCounts?.max_total_tokens, 1);
     });
   });

--- a/apps/desktop/src/main/__tests__/synthesis-cache-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/synthesis-cache-artifacts.test.ts
@@ -134,6 +134,20 @@ describe('desktop synthesis cache artifact lifecycle', () => {
         now: 140,
       });
       await store.create({
+        id: 'bad-estimate',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        name: 'bad-estimate.json',
+        kind: 'file',
+        content: JSON.stringify({
+          ...synthesisBlock({ blockId: 'bad-estimate' }),
+          estimatedTokens: 'tiny',
+        }),
+        mimeType: 'application/json',
+        source: 'synthesis_cache_block',
+        now: 145,
+      });
+      await store.create({
         id: 'oversized',
         sessionId: 'session-1',
         turnId: 'turn-1',
@@ -168,7 +182,7 @@ describe('desktop synthesis cache artifact lifecycle', () => {
       assert.equal(loaded.skippedReasonCounts?.deleted, 1);
       assert.equal(loaded.skippedReasonCounts?.session_mismatch, 1);
       assert.equal(loaded.skippedReasonCounts?.invalid_json, 1);
-      assert.equal(loaded.skippedReasonCounts?.invalid_schema_version, 1);
+      assert.equal(loaded.skippedReasonCounts?.invalid_schema_version, 2);
       assert.equal(loaded.skippedReasonCounts?.max_total_tokens, 1);
     });
   });

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -1058,6 +1058,7 @@ export function validateHistoryCompactBlockShape(value: unknown, sessionId?: str
     && Array.isArray(block.sourceRefs)
     && block.sourceRefs.length > 0
     && block.sourceRefs.every(isValidSynthesisSourceRef)
+    && optionalNonNegativeFiniteNumber(block.estimatedTokens)
     && (
       block.sourceArchiveRefs === undefined ||
       (Array.isArray(block.sourceArchiveRefs) && block.sourceArchiveRefs.every(isValidHistoryCompactSourceArchiveRef))
@@ -1288,7 +1289,12 @@ export function validateSynthesisCacheBlockShape(value: unknown, sessionId?: str
     && Array.isArray(block.limitations)
     && Array.isArray(block.sourceRefs)
     && block.sourceRefs.length > 0
-    && block.sourceRefs.every(isValidSynthesisSourceRef);
+    && block.sourceRefs.every(isValidSynthesisSourceRef)
+    && optionalNonNegativeFiniteNumber(block.estimatedTokens);
+}
+
+function optionalNonNegativeFiniteNumber(value: unknown): boolean {
+  return value === undefined || (typeof value === 'number' && Number.isFinite(value) && value >= 0);
 }
 
 export function buildPromptSegmentEstimates(input: PromptSegmentInput): PromptSegmentEstimate[] {


### PR DESCRIPTION
## Summary
- reject persisted history compact and synthesis cache blocks when optional estimatedTokens is not a finite non-negative number
- cover malformed estimatedTokens in both desktop artifact loader regression tests

## Verification
- npm --workspace @maka/desktop test -- history-compact-artifacts synthesis-cache-artifacts
- npm --workspace @maka/runtime test -- context-budget
- npm --workspace @maka/desktop run typecheck
- npm run build
- git diff --check