### PR TITLE
Fail closed on invalid plan reminder entries

### DIFF
--- a/packages/storage/src/__tests__/plan-reminder-store.test.ts
+++ b/packages/storage/src/__tests__/plan-reminder-store.test.ts
@@ -345,6 +345,87 @@ describe('PlanReminderStore', () => {
     assert.equal(await readFile(filePath, 'utf8'), invalid);
   });
 
+  it('rejects malformed reminder entries instead of filtering them out on write', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-plan-reminders-'));
+    const filePath = join(root, 'plan-reminders.json');
+    const runAt = Date.now() + 60_000;
+    const invalid = JSON.stringify([
+      {
+        id: 'valid',
+        title: '保留提醒',
+        note: '',
+        schedule: { kind: 'once', runAt },
+        delivery: { channel: 'local' },
+        status: 'scheduled',
+        enabled: true,
+        createdAt: runAt - 1000,
+        updatedAt: runAt - 1000,
+        nextRunAt: runAt,
+        runs: [],
+        runCount: 0,
+      },
+      {
+        id: 'corrupt',
+        title: '坏提醒',
+        note: '',
+        schedule: { kind: 'once', runAt },
+        delivery: { channel: 'local' },
+        status: 'scheduled',
+        enabled: true,
+        createdAt: runAt - 1000,
+        updatedAt: runAt - 1000,
+        nextRunAt: runAt,
+      },
+    ], null, 2) + '\n';
+    await writeFile(filePath, invalid, 'utf8');
+
+    const store = createPlanReminderStore(root);
+    await assert.rejects(
+      () => store.list(),
+      /entry 2 is malformed/,
+    );
+    await assert.rejects(
+      () => store.create({ title: '新提醒', runAt: runAt + 60_000 }),
+      /entry 2 is malformed/,
+    );
+    assert.equal(await readFile(filePath, 'utf8'), invalid);
+  });
+
+  it('rejects malformed reminder run history instead of dropping bad run records', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-plan-reminders-'));
+    const filePath = join(root, 'plan-reminders.json');
+    const runAt = Date.now() + 60_000;
+    const invalid = JSON.stringify([{
+      id: 'run-history',
+      title: '历史提醒',
+      note: '',
+      schedule: { kind: 'recurring', startAt: runAt, recurrence: 'daily' },
+      delivery: { channel: 'local' },
+      status: 'scheduled',
+      enabled: true,
+      createdAt: runAt - 1000,
+      updatedAt: runAt - 1000,
+      nextRunAt: runAt,
+      runs: [
+        { id: 'run-1', at: runAt - 1000, status: 'triggered', message: '已触发' },
+        { id: 'run-2', at: runAt, status: 'unknown', message: '坏历史' },
+      ],
+      runCount: 2,
+    }], null, 2) + '\n';
+    await writeFile(filePath, invalid, 'utf8');
+
+    const store = createPlanReminderStore(root);
+    await assert.rejects(
+      () => store.list(),
+      /entry 1 has malformed run record 2/,
+    );
+    await assert.rejects(
+      () => store.update('run-history', { title: '改名' }),
+      /entry 1 has malformed run record 2/,
+    );
+    assert.equal(await readFile(filePath, 'utf8'), invalid);
+  });
+
   it('rejects invalid creates before writing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-plan-reminders-'));
     const store = createPlanReminderStore(root);

--- a/packages/storage/src/plan-reminder-store.ts
+++ b/packages/storage/src/plan-reminder-store.ts
@@ -236,9 +236,7 @@ class FilePlanReminderStore implements PlanReminderStore {
       if (!Array.isArray(parsed)) {
         throw new Error('Invalid plan reminders file: expected an array');
       }
-      return parsed
-        .map(normalizePersistedPlanReminder)
-        .filter((reminder): reminder is PlanReminder => Boolean(reminder));
+      return parsed.map((value, index) => normalizePersistedPlanReminder(value, index));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
       throw error;
@@ -291,8 +289,13 @@ function nextPlanReminderResumeRunAt(schedule: PlanReminder['schedule'], now: nu
   return undefined;
 }
 
-function normalizePersistedPlanReminder(value: unknown): PlanReminder | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+function normalizePersistedPlanReminder(value: unknown, index: number): PlanReminder {
+  const invalid = (reason: string): never => {
+    throw new Error(`Invalid plan reminders file: entry ${index + 1} ${reason}`);
+  };
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    invalid('is not an object');
+  }
   const record = value as Partial<PlanReminder>;
   const valid = typeof record.id === 'string' &&
     typeof record.title === 'string' &&
@@ -303,19 +306,29 @@ function normalizePersistedPlanReminder(value: unknown): PlanReminder | null {
     typeof record.createdAt === 'number' &&
     typeof record.updatedAt === 'number' &&
     typeof record.runCount === 'number';
-  if (!valid) return null;
+  if (!valid) invalid('is malformed');
   const delivery = normalizePlanReminderDeliveryTarget((record as { delivery?: unknown }).delivery);
-  if (!delivery.ok) return null;
-  const runs = Array.isArray(record.runs)
-    ? record.runs.filter(isPersistedPlanReminderRunRecord)
-    : [];
-  if (runs.length === 0 && isPersistedPlanReminderRunRecord(record.lastRun)) {
+  const deliveryValue = delivery.ok ? delivery.value : invalid('has invalid delivery');
+  const runs: PlanReminderRunRecord[] = [];
+  if (record.runs !== undefined) {
+    if (!Array.isArray(record.runs)) invalid('has malformed runs');
+    for (const [runIndex, run] of record.runs.entries()) {
+      if (!isPersistedPlanReminderRunRecord(run)) {
+        invalid(`has malformed run record ${runIndex + 1}`);
+      }
+      runs.push(run);
+    }
+  }
+  if (record.lastRun !== undefined && !isPersistedPlanReminderRunRecord(record.lastRun)) {
+    invalid('has malformed lastRun');
+  }
+  if (runs.length === 0 && record.lastRun !== undefined) {
     runs.push(record.lastRun);
   }
   return {
     ...record,
     schedule: record.schedule,
-    delivery: delivery.value,
+    delivery: deliveryValue,
     runs,
     ...(isPersistedPlanReminderRunRecord(record.lastRun)
       ? { lastRun: record.lastRun }


### PR DESCRIPTION
## Summary
- reject malformed entries inside plan-reminders.json instead of filtering them out
- reject malformed persisted run history instead of dropping bad run records
- cover read and write paths so invalid files remain byte-for-byte untouched

## Verification
- npm --workspace @maka/storage test -- plan-reminder-store
- npm run build
- git diff --check