### PR TITLE
Validate Telegram reply targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/telegram-reply-to.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-reply-to.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { __TEST__ } from '../simple-bridge.js';
 
-const { buildTelegramSendBody } = __TEST__;
+const { buildTelegramSendBody, normalizeTelegramReplyToMessageId } = __TEST__;
 
 describe('buildTelegramSendBody (PR-BOT-REPLY-TO-MESSAGE-0)', () => {
   it('emits only chat_id + text when no reply target is provided', () => {
@@ -35,12 +35,47 @@ describe('buildTelegramSendBody (PR-BOT-REPLY-TO-MESSAGE-0)', () => {
     assert.equal('allow_sending_without_reply' in withoutField, false);
   });
 
-  it('coerces the message id to Number — Telegram requires an integer', () => {
+  it('coerces a decimal message id string to Number — Telegram requires an integer', () => {
     // BotMessageEvent.sourceMessageId is typed as `string` so the call site
-    // forwards whatever the platform handler captured; coercion happens here
-    // so the API call uses the integer the wire protocol expects.
+    // forwards the platform handler capture; safe decimal coercion happens
+    // here so the API call uses the integer the wire protocol expects.
     const body = buildTelegramSendBody('chat-1', 'hello', { replyToMessageId: '1234567890' }, 0);
     assert.equal(body.reply_to_message_id, 1234567890);
     assert.equal(typeof body.reply_to_message_id, 'number');
+  });
+
+  it('omits invalid reply ids rather than sending NaN or zero to Telegram', () => {
+    for (const replyToMessageId of ['abc', '  ', '0', '-1', '1.5']) {
+      const body = buildTelegramSendBody('chat-1', 'hello', { replyToMessageId }, 0);
+      assert.equal('reply_to_message_id' in body, false, replyToMessageId);
+      assert.equal('allow_sending_without_reply' in body, false, replyToMessageId);
+    }
+  });
+
+  it('rejects reply ids outside JavaScript safe integer range', () => {
+    const body = buildTelegramSendBody(
+      'chat-1',
+      'hello',
+      { replyToMessageId: '9007199254740992' },
+      0,
+    );
+
+    assert.equal('reply_to_message_id' in body, false);
+    assert.equal('allow_sending_without_reply' in body, false);
+  });
+});
+
+describe('normalizeTelegramReplyToMessageId', () => {
+  it('trims and accepts positive safe integer strings', () => {
+    assert.equal(normalizeTelegramReplyToMessageId(' 42 '), 42);
+  });
+
+  it('rejects missing, non-decimal, zero, and unsafe values', () => {
+    assert.equal(normalizeTelegramReplyToMessageId(undefined), undefined);
+    assert.equal(normalizeTelegramReplyToMessageId(''), undefined);
+    assert.equal(normalizeTelegramReplyToMessageId('abc'), undefined);
+    assert.equal(normalizeTelegramReplyToMessageId('0'), undefined);
+    assert.equal(normalizeTelegramReplyToMessageId('1.5'), undefined);
+    assert.equal(normalizeTelegramReplyToMessageId('9007199254740992'), undefined);
   });
 });

--- a/packages/runtime/src/bots/simple-bridge.ts
+++ b/packages/runtime/src/bots/simple-bridge.ts
@@ -95,11 +95,20 @@ function buildTelegramSendBody(
     chat_id: chatId,
     text: chunk,
   };
-  if (chunkIndex === 0 && options?.replyToMessageId) {
-    body.reply_to_message_id = Number(options.replyToMessageId);
+  const replyToMessageId = normalizeTelegramReplyToMessageId(options?.replyToMessageId);
+  if (chunkIndex === 0 && replyToMessageId !== undefined) {
+    body.reply_to_message_id = replyToMessageId;
     body.allow_sending_without_reply = true;
   }
   return body;
+}
+
+function normalizeTelegramReplyToMessageId(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+  const numeric = Number(trimmed);
+  return Number.isSafeInteger(numeric) ? numeric : undefined;
 }
 
 /**
@@ -221,6 +230,7 @@ export const __TEST__ = {
   prefixWithinUtf16,
   splitForTelegram,
   buildTelegramSendBody,
+  normalizeTelegramReplyToMessageId,
   isAllowedUser,
   classifyTelegramSendResponse,
   TELEGRAM_RETRY_MIN_MS,


### PR DESCRIPTION
## Summary
- omit Telegram reply threading fields when the source message id is malformed
- add a small normalizer for positive safe integer reply ids
- cover invalid, zero, decimal, whitespace, and unsafe reply id cases

## Verification
- npm --workspace @maka/runtime test -- telegram-reply-to (actual runtime suite: 657 pass / 1 skipped)
- npm run build (passes; existing Vite chunk-size warning)
- git diff --check