### PR TITLE
Validate QQ send route targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
@@ -197,6 +197,21 @@ describe('pickQQSendRoute', () => {
     assert.equal(route!.body.msg_type, 0);
   });
 
+  it('trims accidental whitespace around route target ids', () => {
+    assert.equal(
+      pickQQSendRoute('channel: chan-1 ', 'hi')?.path,
+      '/channels/chan-1/messages',
+    );
+    assert.equal(
+      pickQQSendRoute('group: g-1 ', 'hi')?.path,
+      '/v2/groups/g-1/messages',
+    );
+    assert.equal(
+      pickQQSendRoute('c2c: uo-1 ', 'hi')?.path,
+      '/v2/users/uo-1/messages',
+    );
+  });
+
   it('routes group: chatIds to /v2/groups/{id}/messages', () => {
     const route = pickQQSendRoute('group:g-1', 'hi');
     assert.ok(route);
@@ -217,6 +232,15 @@ describe('pickQQSendRoute', () => {
   it('returns null for unknown chatId prefix (defensive)', () => {
     assert.equal(pickQQSendRoute('unknown:foo', 'hi'), null);
     assert.equal(pickQQSendRoute('', 'hi'), null);
+  });
+
+  it('returns null for known prefixes with no route target id', () => {
+    assert.equal(pickQQSendRoute('channel:', 'hi'), null);
+    assert.equal(pickQQSendRoute('channel:   ', 'hi'), null);
+    assert.equal(pickQQSendRoute('group:', 'hi'), null);
+    assert.equal(pickQQSendRoute('group:   ', 'hi'), null);
+    assert.equal(pickQQSendRoute('c2c:', 'hi'), null);
+    assert.equal(pickQQSendRoute('c2c:   ', 'hi'), null);
   });
 });
 

--- a/packages/runtime/src/bots/qq-bridge.ts
+++ b/packages/runtime/src/bots/qq-bridge.ts
@@ -236,8 +236,10 @@ export function pickQQSendRoute(chatId: string, text: string, options?: BotSendO
 } | null {
   const replyId = options?.replyToMessageId;
   if (chatId.startsWith('channel:')) {
+    const targetId = chatId.slice('channel:'.length).trim();
+    if (!targetId) return null;
     return {
-      path: `/channels/${chatId.slice('channel:'.length)}/messages`,
+      path: `/channels/${targetId}/messages`,
       body: {
         content: text,
         msg_type: 0,
@@ -246,8 +248,10 @@ export function pickQQSendRoute(chatId: string, text: string, options?: BotSendO
     };
   }
   if (chatId.startsWith('group:')) {
+    const targetId = chatId.slice('group:'.length).trim();
+    if (!targetId) return null;
     return {
-      path: `/v2/groups/${chatId.slice('group:'.length)}/messages`,
+      path: `/v2/groups/${targetId}/messages`,
       body: {
         content: text,
         msg_type: 0,
@@ -256,8 +260,10 @@ export function pickQQSendRoute(chatId: string, text: string, options?: BotSendO
     };
   }
   if (chatId.startsWith('c2c:')) {
+    const targetId = chatId.slice('c2c:'.length).trim();
+    if (!targetId) return null;
     return {
-      path: `/v2/users/${chatId.slice('c2c:'.length)}/messages`,
+      path: `/v2/users/${targetId}/messages`,
       body: {
         content: text,
         msg_type: 0,


### PR DESCRIPTION
## Summary
- reject QQ send chatIds with known prefixes but empty route target ids
- trim accidental whitespace around QQ channel/group/c2c target ids before building REST paths
- add regressions for blank known-prefix chatIds and trimmed route ids

## Verification
- npm --workspace @maka/runtime test -- qq-bridge (actual runtime suite: 659 pass / 1 skipped)
- npm run build (passes; existing Vite chunk-size warning)
- git diff --check