### PR TITLE
Validate Discord reply targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
@@ -7,6 +7,7 @@ const {
   decideDiscordClose,
   reconnectBackoffMs,
   buildDiscordSendBody,
+  normalizeDiscordReplyToMessageId,
   classifyDiscordSendResponse,
   discordMessageToEvent,
   splitDiscordContent,
@@ -73,6 +74,36 @@ describe('buildDiscordSendBody', () => {
   it('does NOT thread continuation chunks (chunkIndex > 0)', () => {
     const body = buildDiscordSendBody('tail', { replyToMessageId: '123' }, 1);
     assert.deepEqual(body, { content: 'tail' });
+  });
+
+  it('trims valid reply ids before threading the first chunk', () => {
+    const body = buildDiscordSendBody('hello', { replyToMessageId: ' 123 ' }, 0);
+    assert.deepEqual(body.message_reference, {
+      message_id: '123',
+      fail_if_not_exists: false,
+    });
+  });
+
+  it('omits invalid reply ids rather than sending malformed message_reference', () => {
+    for (const replyToMessageId of ['abc', '  ', '0', '-1', '1.5']) {
+      const body = buildDiscordSendBody('hello', { replyToMessageId }, 0);
+      assert.deepEqual(body, { content: 'hello' }, replyToMessageId);
+    }
+  });
+});
+
+describe('normalizeDiscordReplyToMessageId', () => {
+  it('trims and accepts positive decimal snowflake strings', () => {
+    assert.equal(normalizeDiscordReplyToMessageId(' 123456789012345678 '), '123456789012345678');
+  });
+
+  it('rejects missing, non-decimal, zero, and negative values', () => {
+    assert.equal(normalizeDiscordReplyToMessageId(undefined), undefined);
+    assert.equal(normalizeDiscordReplyToMessageId(''), undefined);
+    assert.equal(normalizeDiscordReplyToMessageId('abc'), undefined);
+    assert.equal(normalizeDiscordReplyToMessageId('0'), undefined);
+    assert.equal(normalizeDiscordReplyToMessageId('-1'), undefined);
+    assert.equal(normalizeDiscordReplyToMessageId('1.5'), undefined);
   });
 });
 

--- a/packages/runtime/src/bots/discord-bridge.ts
+++ b/packages/runtime/src/bots/discord-bridge.ts
@@ -115,13 +115,21 @@ export function buildDiscordSendBody(
   chunkIndex: number,
 ): Record<string, unknown> {
   const body: Record<string, unknown> = { content: text };
-  if (chunkIndex === 0 && options?.replyToMessageId) {
+  const replyToMessageId = normalizeDiscordReplyToMessageId(options?.replyToMessageId);
+  if (chunkIndex === 0 && replyToMessageId !== undefined) {
     body.message_reference = {
-      message_id: options.replyToMessageId,
+      message_id: replyToMessageId,
       fail_if_not_exists: false,
     };
   }
   return body;
+}
+
+function normalizeDiscordReplyToMessageId(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+  return trimmed;
 }
 
 /**
@@ -591,6 +599,7 @@ export const __TEST__ = {
   decideDiscordClose,
   reconnectBackoffMs,
   buildDiscordSendBody,
+  normalizeDiscordReplyToMessageId,
   classifyDiscordSendResponse,
   discordMessageToEvent,
   splitDiscordContent,


### PR DESCRIPTION
## Summary
- trim Discord reply target ids before threading bot replies
- omit malformed, zero, decimal, or negative reply ids so normal message delivery still succeeds
- add regression coverage for Discord send-body reply references

## Verification
- npm --workspace @maka/runtime test -- discord-bridge
- npm run build
- git diff --check