### PR TITLE
fix: block non-chat models from send readiness

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-readiness.test.ts
@@ -97,6 +97,20 @@ describe('chat readiness guard', () => {
       '不在连接 "Anthropic" 的启用模型列表中',
       'model_not_enabled',
     );
+
+    await assertRejectsReadiness(
+      'default model explicitly unsupported for chat',
+      () => requireReadyConnection('custom', deps({
+        connection: connection({
+          slug: 'custom',
+          defaultModel: 'gpt-image-1',
+          models: [{ id: 'gpt-image-1', capabilities: { chat: false, imageGeneration: true } }],
+        }),
+        apiKey: 'sk-test',
+      })),
+      '不能用于聊天',
+      'model_not_chat_capable',
+    );
   });
 
   test('allows none-auth local providers and real providers with secrets', async () => {
@@ -301,7 +315,7 @@ describe('chat readiness guard', () => {
   });
 
   test('classifies stale sessions that can be rebound to the current default model', () => {
-    for (const reason of ['fake_backend', 'connection_missing', 'missing_model', 'empty_model_list', 'model_not_enabled']) {
+    for (const reason of ['fake_backend', 'connection_missing', 'missing_model', 'empty_model_list', 'model_not_enabled', 'model_not_chat_capable']) {
       assert.equal(shouldRebindSessionToDefault(reason), true, reason);
     }
 

--- a/apps/desktop/src/main/chat-readiness.ts
+++ b/apps/desktop/src/main/chat-readiness.ts
@@ -150,6 +150,10 @@ function messageForReason(
       const model = requestedModel || connection.defaultModel;
       return `模型 "${model}" 不在连接 "${connection.name}" 的启用模型列表中。请到 设置 · 模型 重新选择。`;
     }
+    case 'model_not_chat_capable': {
+      const model = requestedModel || connection.defaultModel;
+      return `模型 "${model}" 不能用于聊天。请到 设置 · 模型 选择支持聊天的模型。`;
+    }
     case 'oauth_subscription_not_wired':
       return `订阅连接 "${connection.name}" 只用于账号状态查看，当前不能作为聊天模型。请先选择 API key 模型连接。`;
     case 'fake_backend':
@@ -243,5 +247,6 @@ export function shouldRebindSessionToDefault(reason: string | undefined): boolea
     reason === 'connection_missing' ||
     reason === 'missing_model' ||
     reason === 'empty_model_list' ||
-    reason === 'model_not_enabled';
+    reason === 'model_not_enabled' ||
+    reason === 'model_not_chat_capable';
 }

--- a/apps/desktop/src/renderer/chat-header-alert.ts
+++ b/apps/desktop/src/renderer/chat-header-alert.ts
@@ -44,8 +44,9 @@ export interface ChatHeaderAlertInput {
    * Computed as `(defaultConnection exists) && defaultConnection.enabled` —
    * it is NOT a send-readiness fact. The backend remains authoritative;
    * a `true` value here does NOT promise that `requireReadyConnection`
-   * will succeed (e.g. `missing_api_key` / `missing_model` / `model_not_enabled`
-   * are still gated by `isConnectionReady` at send time).
+   * will succeed (e.g. `missing_api_key` / `missing_model` /
+   * `model_not_enabled` / `model_not_chat_capable` are still gated by
+   * `isConnectionReady` at send time).
    *
    * Per PR-HEALTH-1 (xuan msg `e4887ffd`, I3 lock):
    *   - Use this only to choose the `warning` vs `destructive` tone of the

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -3552,6 +3552,8 @@ function noRealConnectionSetupDescription(reason: string | undefined): string {
       return '当前模型连接没有启用模型。请到 设置 · 模型 添加或启用模型后再发送。';
     case 'model_not_enabled':
       return '当前会话选择的模型未启用。请到 设置 · 模型 重新选择可用模型后再发送。';
+    case 'model_not_chat_capable':
+      return '当前会话选择的模型不能用于聊天。请到 设置 · 模型 重新选择支持聊天的模型后再发送。';
     case 'oauth_subscription_not_wired':
       return '这个订阅账号暂时不能作为聊天模型。请先选择可用的 API key 或已接入 OAuth 模型连接。';
     case 'fake_backend':

--- a/packages/core/src/__tests__/connection-readiness.test.ts
+++ b/packages/core/src/__tests__/connection-readiness.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isConnectionReady } from '../connection-readiness.js';
+import type { LlmConnection } from '../llm-connections.js';
+
+function connection(overrides: Partial<LlmConnection> = {}): LlmConnection {
+  return {
+    slug: 'openai-live',
+    name: 'OpenAI Live',
+    providerType: 'openai',
+    defaultModel: 'gpt-4.1',
+    enabled: true,
+    models: [{ id: 'gpt-4.1', capabilities: { chat: true, functionCalling: true } }],
+    modelSource: 'fetched',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('isConnectionReady — model capability gate', () => {
+  it('rejects an explicitly image-only default model', () => {
+    const verdict = isConnectionReady({
+      connection: connection({
+        defaultModel: 'gpt-image-1',
+        models: [{ id: 'gpt-image-1', capabilities: { imageGeneration: true, chat: false } }],
+      }),
+      hasSecret: true,
+    });
+
+    assert.deepEqual(verdict, { ready: false, reason: 'model_not_chat_capable' });
+  });
+
+  it('rejects an explicitly image-only requested model even when the default is chat-capable', () => {
+    const verdict = isConnectionReady({
+      connection: connection({
+        defaultModel: 'gpt-4.1',
+        models: [
+          { id: 'gpt-4.1', capabilities: { chat: true, functionCalling: true } },
+          { id: 'gpt-image-1', capabilities: { imageGeneration: true, chat: false } },
+        ],
+      }),
+      hasSecret: true,
+      requestedModel: 'gpt-image-1',
+    });
+
+    assert.deepEqual(verdict, { ready: false, reason: 'model_not_chat_capable' });
+  });
+
+  it('keeps explicit chat models send-ready even when they also support image generation', () => {
+    const verdict = isConnectionReady({
+      connection: connection({
+        defaultModel: 'multimodal-chat',
+        models: [{ id: 'multimodal-chat', capabilities: { chat: true, imageGeneration: true } }],
+      }),
+      hasSecret: true,
+    });
+
+    assert.deepEqual(verdict, { ready: true, model: 'multimodal-chat' });
+  });
+
+  it('does not block models with unknown capability metadata', () => {
+    const verdict = isConnectionReady({
+      connection: connection({
+        defaultModel: 'custom-chat',
+        models: [{ id: 'custom-chat' }],
+      }),
+      hasSecret: true,
+    });
+
+    assert.deepEqual(verdict, { ready: true, model: 'custom-chat' });
+  });
+});

--- a/packages/core/src/__tests__/onboarding.test.ts
+++ b/packages/core/src/__tests__/onboarding.test.ts
@@ -220,6 +220,18 @@ describe('deriveOnboardingState — 15-case matrix (@kenji + @xuan PR110a)', () 
     );
   });
 
+  it('case 13b: 1 real, has key, defaultModel unsupported_for_chat → needs_default_model', () => {
+    const conn = realConnection({
+      slug: 'anthropic-live',
+      defaultModel: 'image-only',
+      models: [{ id: 'image-only', capabilities: { chat: false, imageGeneration: true } }],
+    });
+    assert.deepEqual(
+      derive({ connections: [conn], defaultSlug: 'anthropic-live', secrets: { 'anthropic-live': true } }),
+      { kind: 'needs_default_model', connectionSlug: 'anthropic-live' },
+    );
+  });
+
   it('case 14: 1 real disabled, no ready alt → blocked: all_connections_unhealthy', () => {
     const conn = realConnection({ slug: 'anthropic-live', enabled: false });
     assert.deepEqual(

--- a/packages/core/src/connection-readiness.ts
+++ b/packages/core/src/connection-readiness.ts
@@ -24,6 +24,7 @@
  */
 
 import { PROVIDER_DEFAULTS, type LlmConnection } from './llm-connections.js';
+import { isModelExplicitlyUnsupportedForChat } from './model-catalog.js';
 
 /**
  * Canonical reasons why an LlmConnection is not ready to send.
@@ -41,6 +42,7 @@ export type ChatConfigurationReason =
   | 'missing_model'
   | 'empty_model_list'
   | 'model_not_enabled'
+  | 'model_not_chat_capable'
   | 'oauth_subscription_not_wired'
   | 'fake_backend';
 
@@ -85,6 +87,7 @@ export interface IsConnectionReadyInput {
  *   5. effective model is empty/missing → `missing_model`
  *   6. `connection.models` is enumerated but empty → `empty_model_list`
  *   7. effective model is not in `connection.models` → `model_not_enabled`
+ *   8. effective model is explicitly not chat-capable → `model_not_chat_capable`
  *
  * "Effective model" = `requestedModel ?? connection.defaultModel`.
  */
@@ -113,12 +116,16 @@ export function isConnectionReady(input: IsConnectionReadyInput): IsConnectionRe
     return { ready: false, reason: 'missing_model' };
   }
   if (connection.models) {
-    const enabled = new Set(connection.models.map((entry) => entry.id));
+    const enabled = new Map(connection.models.map((entry) => [entry.id, entry]));
     if (enabled.size === 0) {
       return { ready: false, reason: 'empty_model_list' };
     }
-    if (!enabled.has(model)) {
+    const modelEntry = enabled.get(model);
+    if (!modelEntry) {
       return { ready: false, reason: 'model_not_enabled' };
+    }
+    if (isModelExplicitlyUnsupportedForChat(modelEntry)) {
+      return { ready: false, reason: 'model_not_chat_capable' };
     }
   }
   return { ready: true, model };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -619,6 +619,7 @@ export type {
 } from './model-catalog.js';
 export {
   buildModelCatalogEntries,
+  isModelExplicitlyUnsupportedForChat,
   validateChatDefaultModel,
 } from './model-catalog.js';
 

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -188,7 +188,7 @@ function makeMissingDefaultEntry(
 function deriveUnavailableReason(input: BuildModelCatalogInput, model: ModelInfo): ModelUnavailableReason {
   if (input.providerAvailable === false) return 'provider_removed';
   if (input.authOk === false) return 'auth';
-  if (isExplicitlyUnsupportedForChat(model)) return 'unsupported_for_chat';
+  if (isModelExplicitlyUnsupportedForChat(model)) return 'unsupported_for_chat';
   if (isStale(input)) return 'stale';
   return 'none';
 }
@@ -200,7 +200,7 @@ function isStale(input: BuildModelCatalogInput): boolean {
   return now - input.modelsFetchedAt > staleAfterMs;
 }
 
-function isExplicitlyUnsupportedForChat(model: ModelInfo): boolean {
+export function isModelExplicitlyUnsupportedForChat(model: ModelInfo): boolean {
   const caps = model.capabilities;
   if (!caps) return false;
   if (caps.chat === false) return true;

--- a/packages/core/src/onboarding.ts
+++ b/packages/core/src/onboarding.ts
@@ -53,7 +53,8 @@ import type { SessionSummary } from './session.js';
  *    Fix: open the credential-entry flow for the named slug.
  *  - `needs_default_model` — the default connection has a usable
  *    secret but no valid model (no defaultModel, empty model list,
- *    or the persisted defaultModel is no longer enabled). Fix:
+ *    persisted defaultModel is no longer enabled, or the model is not
+ *    chat-capable). Fix:
  *    open the model picker for the named slug.
  *  - `ready_empty` — fully configured, no sessions yet. Show Quick
  *    Chat entry point.
@@ -161,6 +162,7 @@ export function deriveOnboardingState(input: DeriveOnboardingStateInput): Onboar
       case 'missing_model':
       case 'empty_model_list':
       case 'model_not_enabled':
+      case 'model_not_chat_capable':
         return { kind: 'needs_default_model', connectionSlug: defaultConn.slug };
       case 'connection_disabled':
       case 'fake_backend':


### PR DESCRIPTION
Issue link: N/A — implements the existing capability audit gap documented in `docs/maka-capability-audit-v1.md`.

Summary:
- Reuses the model catalog's explicit non-chat capability check in core send readiness.
- Adds `model_not_chat_capable` to onboarding, desktop send errors, renderer setup copy, and stale-session rebind classification.
- Adds focused coverage for image-only models, unknown capability metadata, onboarding routing, and desktop error copy.

Motivation:
Models that are explicitly marked as not chat-capable should not pass the chat send gate just because they appear in a connection's enabled model list. The model catalog already classifies those models as unavailable for chat defaults; the send path now enforces the same contract.

Validation:
- `npm --workspace @maka/core run test`
- `npm --workspace @maka/desktop run test -- chat-readiness`
- `npm run typecheck --workspaces --if-present`
- `git diff --check`
