### PR TITLE
feat: surface capability audit records

### DIFF
--- a/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { deriveCapabilityAuditReport } from '@maka/core';
+import { CapabilityAuditStrip } from '@maka/ui';
+
+const repoRoot = process.cwd().endsWith('apps/desktop')
+  ? join(process.cwd(), '..', '..')
+  : process.cwd();
+
+describe('capability audit visible system contract', () => {
+  it('renders sources, skills, and automations status without widening skill permissions', () => {
+    const report = deriveCapabilityAuditReport({
+      now: 1_700_000_000_000,
+      skills: [
+        {
+          id: 'writer',
+          name: 'Writer',
+          description: 'Drafts release notes.',
+          declaredTools: ['Read', 'Write', 'Bash'],
+        },
+      ],
+      planReminders: [
+        {
+          id: 'plan-1',
+          title: '每日复盘',
+          note: '',
+          schedule: { kind: 'recurring', startAt: 1_700_000_000_000, recurrence: 'daily' },
+          delivery: { channel: 'local' },
+          status: 'scheduled',
+          enabled: true,
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+          nextRunAt: 1_700_003_600_000,
+          lastRun: { id: 'run-1', at: 1_700_001_000_000, status: 'failed', message: 'failed' },
+          runs: [],
+          runCount: 1,
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(createElement(CapabilityAuditStrip, { report, focus: 'skills' }));
+
+    assert.match(markup, /aria-label="能力审计摘要"/);
+    assert.match(markup, /能力审计/);
+    assert.match(markup, /3 类声明工具/);
+    assert.match(markup, /1\/1 来源就绪/);
+    assert.match(markup, /1\/1 技能启用/);
+    assert.match(markup, /1\/1 自动化启用/);
+    assert.match(markup, /1 个自动化上次失败/);
+    assert.equal(report.skills[0].permissionMode, 'ask');
+    assert.notEqual(report.skills[0].permissionMode, 'execute');
+  });
+
+  it('wires ChatView through a single derived audit report for Skills and Automations', async () => {
+    const components = await readFile(join(repoRoot, 'packages', 'ui', 'src', 'components.tsx'), 'utf8');
+
+    assert.match(
+      components,
+      /const capabilityAuditReport = useMemo\([\s\S]*deriveCapabilityAuditReport\(\{[\s\S]*skills: props\.skills \?\? \[\],[\s\S]*planReminders: props\.planReminders \?\? \[\],[\s\S]*\}\)/,
+      'ChatView must derive the capability audit report from the same skills and plan-reminder snapshots',
+    );
+    assert.match(
+      components,
+      /<SkillsModuleMain[\s\S]*auditReport=\{capabilityAuditReport\}/,
+      'Skills module must receive the shared capability audit report',
+    );
+    assert.match(
+      components,
+      /<PlanReminderPanel[\s\S]*auditReport=\{capabilityAuditReport\}/,
+      'Automations module must receive the shared capability audit report',
+    );
+  });
+
+  it('keeps the audit strip as a full-width band with responsive metrics', async () => {
+    const styles = await readFile(join(repoRoot, 'apps', 'desktop', 'src', 'renderer', 'styles.css'), 'utf8');
+
+    assert.match(styles, /\.maka-capability-audit-strip\s*\{[\s\S]*display:\s*flex/);
+    assert.match(styles, /\.maka-capability-audit-metrics\s*\{[\s\S]*grid-template-columns:\s*repeat\(3, minmax\(92px, 1fr\)\)/);
+    assert.match(styles, /@media \(max-width: 1100px\)[\s\S]*\.maka-capability-audit-strip\s*\{[\s\S]*display:\s*grid/);
+    assert.match(styles, /@media \(max-width: 1100px\)[\s\S]*\.maka-capability-audit-metrics\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\)/);
+  });
+});

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2810,6 +2810,80 @@ button:active {
   color: oklch(0.84 0.07 245);
 }
 
+.maka-capability-audit-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px solid var(--foreground-8);
+  border-radius: 6px;
+  background:
+    linear-gradient(90deg, oklch(from var(--accent) l c h / 0.06), transparent 42%),
+    var(--background);
+  padding: 12px 14px;
+}
+
+.maka-capability-audit-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.maka-capability-audit-kicker {
+  color: var(--foreground-50);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.maka-capability-audit-copy strong {
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.maka-capability-audit-copy small {
+  color: var(--foreground-60);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.maka-capability-audit-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(92px, 1fr));
+  gap: 6px;
+  min-width: min(420px, 48%);
+  margin: 0;
+}
+
+.maka-capability-audit-metrics div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  border-left: 1px solid var(--foreground-8);
+  padding-left: 10px;
+}
+
+.maka-capability-audit-metrics dt {
+  color: var(--foreground-45);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.maka-capability-audit-metrics dd {
+  margin: 0;
+  color: var(--foreground-80);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
 .maka-plan-tabs {
   display: grid;
   gap: 8px;
@@ -3369,6 +3443,15 @@ button:active {
 
   .maka-plan-system-alert {
     display: grid;
+  }
+
+  .maka-capability-audit-strip {
+    display: grid;
+  }
+
+  .maka-capability-audit-metrics {
+    grid-template-columns: minmax(0, 1fr);
+    min-width: 0;
   }
 
   .maka-plan-template-strip {

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1355,27 +1355,42 @@ via `deriveTurnLineageMap()`（PR109d）。
 
 ### 9.10 Sources / Skills / Automations 可见系统（@kenji item 5）
 
-Maka 当前 skills 是文件系统扫描结果（`window.maka.skills.list()`），无 source、
-无 automation；reference implementation 把这三类做成可审计 + 可禁用的一等公民。
+Maka 当前第一步实现为 core contract + existing module surface：skills 仍来自
+文件系统扫描结果（`window.maka.skills.list()`），automations 复用 Plan Reminder。
+`@maka/core/capability-audit` 把这两类现有快照派生成一个可测试的
+`CapabilityAuditReport`，并在 Skills / Automations 页面顶部显示同一份
+审计摘要。后续接入真实 MCP/API source 时，应填充同一个 `SourceRecord`
+输入，而不是新增平行 UI contract。
 
 **Contract**：
 
 | 实体 | 字段 | UI 表面 |
 |---|---|---|
-| `Source` | `id / name / auth / scope / lastSyncAt / status` | Settings · 来源（新 panel） |
-| `Skill` | `id / name / declaredTools[] / requestedTools[] / installedAt / source` | Settings · 技能（已有，需扩 `requestedTools`） |
-| `Automation` | `id / name / trigger / lastRunAt / status / lastError` | Settings · 自动化（新 panel） |
+| `SourceRecord` | `slug / name / type / enabled / authType / scopeSummary[] / status / lastTestAt / lastErrorReason` | Skills / Automations 顶部审计摘要；未来可扩 Settings · 来源 |
+| `SkillAuditRecord` | `id / name / description / declaredTools[] / enabled / sourceSlug / permissionMode` | Skills 顶部审计摘要 + 已安装技能列表 |
+| `AutomationRecord` | `id / name / enabled / trigger / permissionMode / lastRunAt / lastRunStatus` | Automations 顶部审计摘要 + 计划提醒列表 / 执行记录 |
 
 **关键不变量**：
 - **skill 不等于 permission widening**：skill 声明 `allowed-tools` 仅是 *请求*，
   实际能用的工具仍受 PermissionEngine 检查；UI 表现要让用户看到 "声明" vs
-  "实际授权" 的差异（参考 PR51 的 "declared / requested" 区分）
+  "实际授权" 的差异。`SkillAuditRecord.permissionMode` 只能是 `explore | ask`，
+  不允许因为 `declaredTools` 升级到 `execute`。
 - **source 凭据不渲染原文**：与 connection apiKey 一致，masked + safeStorage
 - **automation last-run 失败 → 自动禁用**？ 决策点：弱协议（仅显示 error），还是
   连续 N 次失败自动 disable？后者需要新的 backend 状态机
 
-**Gate**：smoke path `sources-skills-automations`：seed 3 个 source、5 个 skill、
-2 个 automation，验各自 panel 渲染 + 禁用切换 + last-run/sync 时间显示。
+**当前 Gate**：
+- `packages/core/src/__tests__/capability-audit.test.ts`：锁定 source /
+  skill / automation enum、workspace skills source 派生、Skill 不放大权限、
+  Plan Reminder → Automation last-run 映射。
+- `apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts`：
+  server-render 审计摘要条，确认 Skills / Automations 共享同一份
+  `CapabilityAuditReport`，并锁定窄屏指标布局。
+- 现有 visual fixture 覆盖入口：`skills` 打开 Skills module；
+  `plan-reminders` 打开 Automations module。未来如果新增独立
+  Sources 面板或禁用切换，必须新增 `sources-skills-automations`
+  smoke path：seed 3 个 source、5 个 skill、2 个 automation，验各自 panel
+  渲染 + 禁用切换 + last-run/sync 时间显示。
 
 ### 9.11 Health Center 表面契约（@kenji item 7 — 扩 9.3）
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "./runtime-inputs": "./dist/runtime-inputs.js",
     "./visual-smoke": "./dist/visual-smoke.js",
     "./capabilities": "./dist/capabilities.js",
+    "./capability-audit": "./dist/capability-audit.js",
     "./health": "./dist/health.js",
     "./search": "./dist/search.js",
     "./bot-events": "./dist/bot-events.js",

--- a/packages/core/src/__tests__/capability-audit.test.ts
+++ b/packages/core/src/__tests__/capability-audit.test.ts
@@ -1,0 +1,154 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AUTOMATION_LAST_RUN_STATUSES,
+  AUTOMATION_RECORD_TRIGGERS,
+  CAPABILITY_AUDIT_PERMISSION_MODES,
+  LOCAL_SKILL_SOURCE_SLUG,
+  SOURCE_AUTH_TYPES,
+  SOURCE_RECORD_STATUSES,
+  SOURCE_RECORD_TYPES,
+  deriveCapabilityAuditReport,
+  type CapabilityAuditSkillInput,
+} from '../capability-audit.js';
+import type { PlanReminder } from '../plan-reminders.js';
+
+describe('capability audit contract', () => {
+  it('locks the visible source and automation enums', () => {
+    assert.deepEqual(SOURCE_RECORD_TYPES, ['mcp', 'api', 'local']);
+    assert.deepEqual(SOURCE_AUTH_TYPES, ['oauth', 'bearer', 'none']);
+    assert.deepEqual(SOURCE_RECORD_STATUSES, ['ready', 'needs_auth', 'error', 'disabled']);
+    assert.deepEqual(CAPABILITY_AUDIT_PERMISSION_MODES, ['explore', 'ask', 'execute']);
+    assert.deepEqual(AUTOMATION_RECORD_TRIGGERS, ['manual', 'schedule', 'event']);
+    assert.deepEqual(AUTOMATION_LAST_RUN_STATUSES, ['ok', 'error', 'skipped']);
+  });
+
+  it('synthesizes a local skills source and keeps skill permission mode read-first', () => {
+    const skills: CapabilityAuditSkillInput[] = [
+      {
+        id: 'research',
+        name: 'Research',
+        description: 'Drafts research notes.',
+        declaredTools: ['Read', 'Bash', 'Write'],
+      },
+      {
+        id: 'notes',
+        name: 'Notes',
+        description: '',
+      },
+    ];
+
+    const report = deriveCapabilityAuditReport({ now: 1_700_000_000_000, skills });
+
+    assert.equal(report.checkedAt, 1_700_000_000_000);
+    assert.equal(report.sources.length, 1);
+    assert.equal(report.sources[0].slug, LOCAL_SKILL_SOURCE_SLUG);
+    assert.equal(report.sources[0].type, 'local');
+    assert.equal(report.sources[0].status, 'ready');
+    assert.deepEqual(report.sources[0].scopeSummary, ['2 个本地 Skill', '3 类声明工具']);
+    assert.equal(report.summary.sourceCount, 1);
+    assert.equal(report.summary.readySourceCount, 1);
+    assert.equal(report.summary.skillCount, 2);
+    assert.equal(report.summary.enabledSkillCount, 2);
+    assert.equal(report.summary.skillsWithDeclaredTools, 1);
+    assert.equal(report.summary.declaredToolKindCount, 3);
+    assert.equal(report.skills[0].sourceSlug, LOCAL_SKILL_SOURCE_SLUG);
+    assert.equal(report.skills[0].permissionMode, 'ask');
+    assert.notEqual(report.skills[0].permissionMode, 'execute');
+    assert.equal(report.skills[1].permissionMode, 'explore');
+  });
+
+  it('maps plan reminders into automation records without losing run state', () => {
+    const reminders: PlanReminder[] = [
+      {
+        id: 'auto-1',
+        title: '每日复盘',
+        note: '',
+        schedule: { kind: 'recurring', startAt: 1_700_000_000_000, recurrence: 'daily' },
+        delivery: { channel: 'local' },
+        status: 'scheduled',
+        enabled: true,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+        nextRunAt: 1_700_003_600_000,
+        lastRun: { id: 'run-1', at: 1_700_001_000_000, status: 'triggered', message: 'ok' },
+        runs: [],
+        runCount: 1,
+      },
+      {
+        id: 'auto-2',
+        title: '周会提醒',
+        note: '',
+        schedule: { kind: 'once', runAt: 1_700_000_100_000 },
+        delivery: { channel: 'local' },
+        status: 'paused',
+        enabled: false,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+        runs: [],
+        runCount: 0,
+        lastRun: { id: 'run-2', at: 1_700_001_500_000, status: 'blocked', message: 'skip' },
+      },
+      {
+        id: 'auto-3',
+        title: '月末归档',
+        note: '',
+        schedule: { kind: 'once', runAt: 1_700_000_200_000 },
+        delivery: { channel: 'local' },
+        status: 'completed',
+        enabled: false,
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+        runs: [],
+        runCount: 0,
+        lastRun: { id: 'run-3', at: 1_700_001_900_000, status: 'failed', message: 'fail' },
+      },
+    ];
+
+    const report = deriveCapabilityAuditReport({ planReminders: reminders });
+
+    assert.equal(report.automations.length, 3);
+    assert.equal(report.automations[0].trigger, 'schedule');
+    assert.equal(report.automations[0].permissionMode, 'execute');
+    assert.equal(report.automations[0].lastRunStatus, 'ok');
+    assert.equal(report.automations[1].permissionMode, 'ask');
+    assert.equal(report.automations[1].lastRunStatus, 'skipped');
+    assert.equal(report.automations[2].permissionMode, 'explore');
+    assert.equal(report.automations[2].lastRunStatus, 'error');
+    assert.equal(report.summary.automationCount, 3);
+    assert.equal(report.summary.enabledAutomationCount, 1);
+    assert.equal(report.summary.executableAutomationCount, 1);
+    assert.equal(report.summary.failedAutomationCount, 1);
+    assert.equal(report.summary.skippedAutomationCount, 1);
+  });
+
+  it('keeps explicit remote sources visible without forcing a local duplicate', () => {
+    const report = deriveCapabilityAuditReport({
+      sources: [
+        {
+          slug: 'mcp-github',
+          name: 'GitHub MCP',
+          type: 'mcp',
+          enabled: true,
+          authType: 'oauth',
+          scopeSummary: ['issues', 'pull requests'],
+          status: 'ready',
+          lastTestAt: 1_700_000_000_000,
+        },
+      ],
+      skills: [
+        {
+          id: 'github-review',
+          name: 'GitHub Review',
+          description: 'Reviews PRs.',
+          declaredTools: ['Read'],
+          sourceSlug: 'mcp-github',
+        },
+      ],
+    });
+
+    assert.equal(report.sources.length, 1);
+    assert.equal(report.sources[0].slug, 'mcp-github');
+    assert.equal(report.skills[0].sourceSlug, 'mcp-github');
+  });
+});

--- a/packages/core/src/capability-audit.ts
+++ b/packages/core/src/capability-audit.ts
@@ -1,0 +1,232 @@
+import type { PlanReminder, PlanReminderRunStatus } from './plan-reminders.js';
+
+export const SOURCE_RECORD_TYPES = ['mcp', 'api', 'local'] as const;
+export type SourceRecordType = typeof SOURCE_RECORD_TYPES[number];
+
+export const SOURCE_AUTH_TYPES = ['oauth', 'bearer', 'none'] as const;
+export type SourceAuthType = typeof SOURCE_AUTH_TYPES[number];
+
+export const SOURCE_RECORD_STATUSES = ['ready', 'needs_auth', 'error', 'disabled'] as const;
+export type SourceRecordStatus = typeof SOURCE_RECORD_STATUSES[number];
+
+export const CAPABILITY_AUDIT_PERMISSION_MODES = ['explore', 'ask', 'execute'] as const;
+export type CapabilityAuditPermissionMode = typeof CAPABILITY_AUDIT_PERMISSION_MODES[number];
+
+export const AUTOMATION_RECORD_TRIGGERS = ['manual', 'schedule', 'event'] as const;
+export type AutomationRecordTrigger = typeof AUTOMATION_RECORD_TRIGGERS[number];
+
+export const AUTOMATION_LAST_RUN_STATUSES = ['ok', 'error', 'skipped'] as const;
+export type AutomationLastRunStatus = typeof AUTOMATION_LAST_RUN_STATUSES[number];
+
+export const LOCAL_SKILL_SOURCE_SLUG = 'workspace-skills';
+
+export interface SourceRecord {
+  slug: string;
+  name: string;
+  type: SourceRecordType;
+  enabled: boolean;
+  authType: SourceAuthType;
+  scopeSummary: string[];
+  status: SourceRecordStatus;
+  lastTestAt?: number;
+  lastErrorReason?: string;
+}
+
+export interface CapabilityAuditSkillInput {
+  id: string;
+  name: string;
+  description?: string;
+  declaredTools?: readonly string[];
+  enabled?: boolean;
+  sourceSlug?: string;
+}
+
+export interface SkillAuditRecord {
+  id: string;
+  name: string;
+  description: string;
+  declaredTools: string[];
+  enabled: boolean;
+  sourceSlug: string;
+  permissionMode: Exclude<CapabilityAuditPermissionMode, 'execute'>;
+}
+
+export interface AutomationRecord {
+  id: string;
+  name: string;
+  enabled: boolean;
+  trigger: AutomationRecordTrigger;
+  permissionMode: CapabilityAuditPermissionMode;
+  lastRunAt?: number;
+  lastRunStatus?: AutomationLastRunStatus;
+}
+
+export interface CapabilityAuditSummary {
+  sourceCount: number;
+  readySourceCount: number;
+  needsAuthSourceCount: number;
+  errorSourceCount: number;
+  disabledSourceCount: number;
+  skillCount: number;
+  enabledSkillCount: number;
+  skillsWithDeclaredTools: number;
+  declaredToolKindCount: number;
+  automationCount: number;
+  enabledAutomationCount: number;
+  executableAutomationCount: number;
+  failedAutomationCount: number;
+  skippedAutomationCount: number;
+}
+
+export interface CapabilityAuditReport {
+  checkedAt: number;
+  sources: SourceRecord[];
+  skills: SkillAuditRecord[];
+  automations: AutomationRecord[];
+  summary: CapabilityAuditSummary;
+}
+
+export interface DeriveCapabilityAuditReportInput {
+  now?: number;
+  sources?: readonly SourceRecord[];
+  skills?: readonly CapabilityAuditSkillInput[];
+  planReminders?: readonly PlanReminder[];
+}
+
+export function deriveCapabilityAuditReport(input: DeriveCapabilityAuditReportInput = {}): CapabilityAuditReport {
+  const now = Math.trunc(input.now ?? Date.now());
+  const skills = normalizeSkillInputs(input.skills ?? []);
+  const declaredToolKindCount = distinctDeclaredToolKinds(skills).length;
+  const sources = normalizeSourceRecords(input.sources ?? []);
+  const needsLocalSkillSource = sources.length === 0 || skills.some((skill) => skill.sourceSlug === LOCAL_SKILL_SOURCE_SLUG);
+  const allSources = needsLocalSkillSource && !sources.some((source) => source.slug === LOCAL_SKILL_SOURCE_SLUG)
+    ? [localSkillSource(skills.length, declaredToolKindCount, now), ...sources]
+    : sources;
+  const automations = (input.planReminders ?? []).map(planReminderToAutomationRecord);
+
+  return {
+    checkedAt: now,
+    sources: allSources,
+    skills,
+    automations,
+    summary: summarizeCapabilityAudit(allSources, skills, automations),
+  };
+}
+
+function normalizeSkillInputs(skills: readonly CapabilityAuditSkillInput[]): SkillAuditRecord[] {
+  return skills.map((skill, index) => {
+    const id = normalizeNonEmptyString(skill.id) ?? `skill-${index + 1}`;
+    const declaredTools = uniqueNonEmptyStrings(skill.declaredTools ?? []);
+    return {
+      id,
+      name: normalizeNonEmptyString(skill.name) ?? id,
+      description: normalizeNonEmptyString(skill.description) ?? '',
+      declaredTools,
+      enabled: skill.enabled ?? true,
+      sourceSlug: normalizeNonEmptyString(skill.sourceSlug) ?? LOCAL_SKILL_SOURCE_SLUG,
+      permissionMode: declaredTools.length > 0 ? 'ask' : 'explore',
+    };
+  });
+}
+
+function normalizeSourceRecords(sources: readonly SourceRecord[]): SourceRecord[] {
+  return sources.map((source, index) => {
+    const slug = normalizeNonEmptyString(source.slug) ?? `source-${index + 1}`;
+    return {
+      slug,
+      name: normalizeNonEmptyString(source.name) ?? slug,
+      type: source.type,
+      enabled: source.enabled,
+      authType: source.authType,
+      scopeSummary: uniqueNonEmptyStrings(source.scopeSummary),
+      status: source.status,
+      ...(typeof source.lastTestAt === 'number' ? { lastTestAt: Math.trunc(source.lastTestAt) } : {}),
+      ...(source.lastErrorReason ? { lastErrorReason: source.lastErrorReason } : {}),
+    };
+  });
+}
+
+function localSkillSource(skillCount: number, declaredToolKindCount: number, now: number): SourceRecord {
+  const hasSkills = skillCount > 0;
+  return {
+    slug: LOCAL_SKILL_SOURCE_SLUG,
+    name: '工作区 skills 目录',
+    type: 'local',
+    enabled: hasSkills,
+    authType: 'none',
+    scopeSummary: hasSkills
+      ? [`${skillCount} 个本地 Skill`, `${declaredToolKindCount} 类声明工具`]
+      : ['等待添加本地 Skill'],
+    status: hasSkills ? 'ready' : 'disabled',
+    ...(hasSkills ? { lastTestAt: now } : { lastErrorReason: '未检测到已安装 Skill' }),
+  };
+}
+
+function planReminderToAutomationRecord(reminder: PlanReminder): AutomationRecord {
+  return {
+    id: reminder.id,
+    name: reminder.title,
+    enabled: reminder.enabled && reminder.status === 'scheduled',
+    trigger: 'schedule',
+    permissionMode: planReminderPermissionMode(reminder),
+    ...(typeof reminder.lastRun?.at === 'number' ? { lastRunAt: reminder.lastRun.at } : {}),
+    ...(reminder.lastRun ? { lastRunStatus: mapPlanReminderRunStatus(reminder.lastRun.status) } : {}),
+  };
+}
+
+function planReminderPermissionMode(reminder: PlanReminder): CapabilityAuditPermissionMode {
+  if (reminder.status === 'completed') return 'explore';
+  if (!reminder.enabled || reminder.status === 'paused') return 'ask';
+  return 'execute';
+}
+
+function mapPlanReminderRunStatus(status: PlanReminderRunStatus): AutomationLastRunStatus {
+  if (status === 'triggered') return 'ok';
+  if (status === 'blocked') return 'skipped';
+  return 'error';
+}
+
+function summarizeCapabilityAudit(
+  sources: readonly SourceRecord[],
+  skills: readonly SkillAuditRecord[],
+  automations: readonly AutomationRecord[],
+): CapabilityAuditSummary {
+  return {
+    sourceCount: sources.length,
+    readySourceCount: sources.filter((source) => source.status === 'ready').length,
+    needsAuthSourceCount: sources.filter((source) => source.status === 'needs_auth').length,
+    errorSourceCount: sources.filter((source) => source.status === 'error').length,
+    disabledSourceCount: sources.filter((source) => source.status === 'disabled').length,
+    skillCount: skills.length,
+    enabledSkillCount: skills.filter((skill) => skill.enabled).length,
+    skillsWithDeclaredTools: skills.filter((skill) => skill.declaredTools.length > 0).length,
+    declaredToolKindCount: distinctDeclaredToolKinds(skills).length,
+    automationCount: automations.length,
+    enabledAutomationCount: automations.filter((automation) => automation.enabled).length,
+    executableAutomationCount: automations.filter((automation) => automation.permissionMode === 'execute').length,
+    failedAutomationCount: automations.filter((automation) => automation.lastRunStatus === 'error').length,
+    skippedAutomationCount: automations.filter((automation) => automation.lastRunStatus === 'skipped').length,
+  };
+}
+
+function distinctDeclaredToolKinds(skills: readonly Pick<SkillAuditRecord, 'declaredTools'>[]): string[] {
+  return uniqueNonEmptyStrings(skills.flatMap((skill) => skill.declaredTools));
+}
+
+function uniqueNonEmptyStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = normalizeNonEmptyString(value);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function normalizeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.normalize('NFC').replace(/\s+/g, ' ').trim();
+  return normalized.length > 0 ? normalized : undefined;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -263,6 +263,33 @@ export {
   runtimeProbeFromBotReadiness,
 } from './capabilities.js';
 
+// capability-audit.ts
+export type {
+  AutomationLastRunStatus,
+  AutomationRecord,
+  AutomationRecordTrigger,
+  CapabilityAuditPermissionMode,
+  CapabilityAuditReport,
+  CapabilityAuditSkillInput,
+  CapabilityAuditSummary,
+  DeriveCapabilityAuditReportInput,
+  SkillAuditRecord,
+  SourceAuthType,
+  SourceRecord,
+  SourceRecordStatus,
+  SourceRecordType,
+} from './capability-audit.js';
+export {
+  AUTOMATION_LAST_RUN_STATUSES,
+  AUTOMATION_RECORD_TRIGGERS,
+  CAPABILITY_AUDIT_PERMISSION_MODES,
+  LOCAL_SKILL_SOURCE_SLUG,
+  SOURCE_AUTH_TYPES,
+  SOURCE_RECORD_STATUSES,
+  SOURCE_RECORD_TYPES,
+  deriveCapabilityAuditReport,
+} from './capability-audit.js';
+
 // health.ts
 export type {
   HealthSignal,

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -65,6 +65,7 @@ import type {
   PermissionMode,
   PermissionRequestEvent,
   PermissionResponse,
+  CapabilityAuditReport,
   BotProvider,
   PlanReminder,
   PlanReminderDeliveryTarget,
@@ -82,6 +83,7 @@ import {
   derivePermissionRequestHealth,
   BOT_DELIVERY_PROVIDERS,
   botDisplayLabel,
+  deriveCapabilityAuditReport,
   formatPlanReminderDeliveryTarget,
   formatPermissionRequestWait,
   formatRelativeTimestamp,
@@ -1091,8 +1093,56 @@ function formatSkillLibraryDescription(skill: SkillEntry): string | undefined {
   return '打开技能文件查看适用场景。';
 }
 
+export function CapabilityAuditStrip(props: { report: CapabilityAuditReport; focus: 'skills' | 'automations' }) {
+  const report = props.report;
+  const sourceCopy = report.summary.sourceCount === 0
+    ? '0 个来源'
+    : `${report.summary.readySourceCount}/${report.summary.sourceCount} 来源就绪`;
+  const skillCopy = `${report.summary.enabledSkillCount}/${report.summary.skillCount} 技能启用`;
+  const automationCopy = `${report.summary.enabledAutomationCount}/${report.summary.automationCount} 自动化启用`;
+  const riskCopy = capabilityAuditRiskCopy(report);
+  const primaryCopy = props.focus === 'skills'
+    ? `${report.summary.declaredToolKindCount} 类声明工具`
+    : `${report.summary.executableAutomationCount} 个可执行自动化`;
+
+  return (
+    <section className="maka-capability-audit-strip" aria-label="能力审计摘要">
+      <div className="maka-capability-audit-copy">
+        <span className="maka-capability-audit-kicker">能力审计</span>
+        <strong>{primaryCopy}</strong>
+        <small>{riskCopy}</small>
+      </div>
+      <dl className="maka-capability-audit-metrics" aria-label="来源、技能、自动化状态">
+        <div>
+          <dt>来源</dt>
+          <dd>{sourceCopy}</dd>
+        </div>
+        <div>
+          <dt>技能</dt>
+          <dd>{skillCopy}</dd>
+        </div>
+        <div>
+          <dt>自动化</dt>
+          <dd>{automationCopy}</dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+
+function capabilityAuditRiskCopy(report: CapabilityAuditReport): string {
+  const issues: string[] = [];
+  if (report.summary.needsAuthSourceCount > 0) issues.push(`${report.summary.needsAuthSourceCount} 个来源等待授权`);
+  if (report.summary.errorSourceCount > 0) issues.push(`${report.summary.errorSourceCount} 个来源异常`);
+  if (report.summary.failedAutomationCount > 0) issues.push(`${report.summary.failedAutomationCount} 个自动化上次失败`);
+  if (report.summary.skippedAutomationCount > 0) issues.push(`${report.summary.skippedAutomationCount} 个自动化上次跳过`);
+  if (issues.length === 0) return 'Skill 声明工具只作为权限请求展示；不会放大当前会话权限。';
+  return issues.join(' · ');
+}
+
 function SkillsModuleMain(props: {
   skills?: SkillEntry[];
+  auditReport?: CapabilityAuditReport;
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
@@ -1130,6 +1180,7 @@ function SkillsModuleMain(props: {
 
   const skillActionBusy = pendingSkillAction !== null;
   const skillCreateLegacyLabel = pendingSkillAction === 'create' ? '创建中…' : '创建示例';
+  const auditReport = props.auditReport ?? deriveCapabilityAuditReport({ skills: props.skills ?? [] });
   return (
     <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="技能">
       <header className="maka-module-main-header">
@@ -1178,6 +1229,7 @@ function SkillsModuleMain(props: {
           </UiButton>
         </div>
       </header>
+      <CapabilityAuditStrip report={auditReport} focus="skills" />
       <SkillLibraryPanel
         skills={props.skills}
         onRefreshSkills={props.onRefreshSkills ? () => runSkillAction('refresh', props.onRefreshSkills) : undefined}
@@ -1970,6 +2022,7 @@ const PLAN_REMINDER_EXAMPLE_TEMPLATES: readonly PlanReminderExampleTemplate[] = 
 
 function PlanReminderPanel(props: {
   reminders: PlanReminder[];
+  auditReport?: CapabilityAuditReport;
   onRefresh?(): void | Promise<void>;
   onCreate?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
   onUpdate?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
@@ -2038,6 +2091,7 @@ function PlanReminderPanel(props: {
   const submitDisabled = !canCreate || submitPending;
   const formInteractionDisabled = submitPending;
   const isEditing = editingId !== null;
+  const auditReport = props.auditReport ?? deriveCapabilityAuditReport({ planReminders: props.reminders });
 
   useEffect(() => {
     planReminderMountedRef.current = true;
@@ -2246,6 +2300,8 @@ function PlanReminderPanel(props: {
             <Switch checked={false} disabled aria-label="保持系统唤醒暂未启用" />
           </div>
         </Alert>
+
+        <CapabilityAuditStrip report={auditReport} focus="automations" />
 
         <TabsRoot
           className="maka-plan-tabs"
@@ -4227,6 +4283,13 @@ export function ChatView(props: {
   const storedTools = materializeTools(props.messages);
   const tools = mergeTools(storedTools, props.tools);
   const turns = materializeTurns(props.messages, props.tools);
+  const capabilityAuditReport = useMemo(
+    () => deriveCapabilityAuditReport({
+      skills: props.skills ?? [],
+      planReminders: props.planReminders ?? [],
+    }),
+    [props.skills, props.planReminders],
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const [pinnedToBottom, setPinnedToBottom] = useState(true);
   const [highlightedTurnId, setHighlightedTurnId] = useState<string | null>(null);
@@ -4293,6 +4356,7 @@ export function ChatView(props: {
     return (
       <SkillsModuleMain
         skills={props.skills}
+        auditReport={capabilityAuditReport}
         onRefreshSkills={props.onRefreshSkills}
         onCreateSkillTemplate={props.onCreateSkillTemplate}
         onOpenSkill={props.onOpenSkill}
@@ -4306,6 +4370,7 @@ export function ChatView(props: {
       <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="定时任务">
         <PlanReminderPanel
           reminders={props.planReminders ?? []}
+          auditReport={capabilityAuditReport}
           onRefresh={props.onRefreshPlanReminders}
           onCreate={props.onCreatePlanReminder}
           onUpdate={props.onUpdatePlanReminder}


### PR DESCRIPTION
Issue link:
- docs/maka-capability-audit-v1.md §7 Sources / Skills / Automations visible system

Summary:
- Add @maka/core capability audit records for Sources, Skills, and Automations.
- Derive local workspace skill source state, read-first skill permission modes, and plan-reminder automation status from existing snapshots.
- Surface a shared capability audit strip on the Skills and Automations module pages.
- Align docs/design-system.md §9.10 with the implemented audit contract and current test gates.

Motivation:
- Maka already lists local skills and scheduled reminders, but users could not audit source readiness, declared skill tools, or automation run state in one visible contract.
- Skill declared tools remain permission requests only; this PR keeps them from widening execution permission.

Validation:
- npm --workspace @maka/core run test
- npm --workspace @maka/ui run typecheck
- npm --workspace @maka/desktop run test -- capability-audit-ui-contract
- npm run typecheck --workspaces --if-present
- git diff --check