### PR TITLE
fix: surface deleted artifact tombstones

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
@@ -48,7 +48,7 @@ describe('ArtifactPane async lifecycle contract', () => {
     );
     assert.match(
       refreshBlock,
-      /const next = await window\.maka\.artifacts\.list\(sessionId\)[\s\S]*if \(artifactPaneMountedRef\.current && requestSeq === artifactListRequestSeqRef\.current\) \{[\s\S]*recordsSessionIdRef\.current = sessionId[\s\S]*setRecordsSessionId\(sessionId\)[\s\S]*setRecords\(next\)/,
+      /const next = await window\.maka\.artifacts\.list\(sessionId, \{ includeDeleted: true \}\)[\s\S]*if \(artifactPaneMountedRef\.current && requestSeq === artifactListRequestSeqRef\.current\) \{[\s\S]*recordsSessionIdRef\.current = sessionId[\s\S]*setRecordsSessionId\(sessionId\)[\s\S]*setRecords\(next\)/,
       'artifact list responses may set records only if the pane is still mounted and they are still the latest request',
     );
     assert.match(
@@ -68,8 +68,18 @@ describe('ArtifactPane async lifecycle contract', () => {
     );
     assert.match(
       src,
-      /const listRef = useRef<HTMLUListElement>\(null\);[\s\S]*const previewRef = useRef<HTMLDivElement>\(null\);[\s\S]*const activeListError = listError && listError\.sessionId === sessionId \? listError\.message : null;[\s\S]*if \(!sessionId \|\| \(activeRecords\.length === 0 && !activeListError\)\) \{[\s\S]*return null;/,
-      'all hooks must run before the ArtifactPane early return',
+      /const listRef = useRef<HTMLUListElement>\(null\);[\s\S]*const previewRef = useRef<HTMLDivElement>\(null\);[\s\S]*const activeListError = listError && listError\.sessionId === sessionId \? listError\.message : null;[\s\S]*const hasLiveArtifact = activeRecords\.some\(\(record\) => record\.status !== 'deleted'\);[\s\S]*if \(!sessionId \|\| \(!hasLiveArtifact && !activeListError\)\) \{[\s\S]*return null;/,
+      'all hooks must run before the ArtifactPane early return, and deleted-only lists must not mount the pane',
+    );
+    assert.match(
+      src,
+      /setSelectedId\(preferredArtifactSelectionId\(activeRecords\)\)/,
+      'artifact selection fallback must route through the live-first helper',
+    );
+    assert.match(
+      src,
+      /function preferredArtifactSelectionId\(records: readonly ArtifactRecord\[\]\): string \| null \{[\s\S]*records\.find\(\(record\) => record\.status !== 'deleted'\) \?\? records\[0\]/,
+      'selection fallback must prefer a live artifact while keeping deleted tombstones selectable when explicitly chosen',
     );
     assert.match(
       src,

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -115,7 +115,7 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
       return;
     }
     try {
-      const next = await window.maka.artifacts.list(sessionId);
+      const next = await window.maka.artifacts.list(sessionId, { includeDeleted: true });
       if (artifactPaneMountedRef.current && requestSeq === artifactListRequestSeqRef.current) {
         recordsSessionIdRef.current = sessionId;
         setRecordsSessionId(sessionId);
@@ -164,16 +164,14 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
     [records, recordsSessionId, sessionId],
   );
 
-  // Keep selection valid as the list churns. When the selected artifact is
-  // deleted/purged we fall back to the newest live record so the preview
-  // pane doesn't show stale failure copy on an empty list.
+  // 已删除墓碑记录保持可选，用于展示明确失败态；只有选中 id 彻底消失时才回退到最新 live artifact。
   useEffect(() => {
     if (activeRecords.length === 0) {
       if (selectedId !== null) setSelectedId(null);
       return;
     }
     if (!selectedId || !activeRecords.some((record) => record.id === selectedId)) {
-      setSelectedId(activeRecords[0]!.id);
+      setSelectedId(preferredArtifactSelectionId(activeRecords));
     }
   }, [activeRecords, selectedId]);
 
@@ -184,13 +182,14 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
   const listRef = useRef<HTMLUListElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const activeListError = listError && listError.sessionId === sessionId ? listError.message : null;
+  const hasLiveArtifact = activeRecords.some((record) => record.status !== 'deleted');
   const artifactActionBusy = pendingArtifactAction !== null;
 
   // §9.1.3: "默认隐藏；当 session 内至少 1 个 live artifact 时显示". Returning
   // `null` keeps the chat surface flush with the right window edge until
   // the runtime actually produces an artifact. A current-session list error is
   // also visible; otherwise "list failed" is indistinguishable from "no files".
-  if (!sessionId || (activeRecords.length === 0 && !activeListError)) {
+  if (!sessionId || (!hasLiveArtifact && !activeListError)) {
     return null;
   }
 
@@ -609,6 +608,10 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function preferredArtifactSelectionId(records: readonly ArtifactRecord[]): string | null {
+  return (records.find((record) => record.status !== 'deleted') ?? records[0])?.id ?? null;
 }
 
 const relativeTimeFormat: Intl.RelativeTimeFormat =


### PR DESCRIPTION
Issue link:
- docs/full-product-test-plan.md §1 Artifact Workbench completion
- docs/design-system.md §9.1 Artifact failure states

Summary:
- Request deleted artifact tombstones in the ArtifactPane list so the artifact-errors fixture can render the deleted preview failure state.
- Keep the pane hidden when a session has only deleted artifacts, preserving the existing live-artifact visibility contract.
- Prefer a live artifact for automatic selection fallback while leaving explicitly selected deleted tombstones previewable.

Motivation:
- The artifact-errors fixture seeds deleted.md, and the smoke path expects deleted / missing / unsupported failure states to be visible.
- The renderer previously called artifacts.list(sessionId) without includeDeleted, so deleted tombstones were filtered before the pane could render the explicit deleted-state copy.

Validation:
- npm --workspace @maka/desktop run build:main
- cd apps/desktop && node --test dist/main/__tests__/artifact-pane-lifecycle-contract.test.js
- npm --workspace @maka/desktop run typecheck
- npm run typecheck --workspaces --if-present
- git diff --check