### PR TITLE
feat(desktop): polish first-run home composer and sidebar header

### DIFF
--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -19,7 +19,7 @@
 //     `connectionName` promise) until sanitized display data is
 //     wired in a later PR.
 
-import { ChevronRight, RotateCcw, Sparkles, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle, FolderOpen, Paperclip, X } from 'lucide-react';
+import { ArrowUp, ChevronRight, Sparkles, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle } from 'lucide-react';
 import { Fragment, useCallback, useEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent } from 'react';
 import type { LlmConnection, OnboardingMilestone, OnboardingState, ProviderType, QuickChatMode, SettingsSection } from '@maka/core';
 import {
@@ -68,7 +68,7 @@ const READY_HERO_COPY_BY_LOCALE: Record<UiLocale, {
     // dropped the all-caps English prefix to match the Chinese-
     // first surface; en-locale entry below stays all-English.
     eyebrow: '准备就绪 · 开始对话',
-    headline: '你已经配置好了 —— 直接说说你想做什么。',
+    headline: '今天想让 Maka 帮你做什么？',
     intro: '下面这个输入框会用默认模型开新会话；空提交也会打开一个空会话，方便你之后再输入。',
     quickChatPlaceholder: '给 Maka 发消息…',
     quickChatAria: '快速对话输入框',
@@ -79,7 +79,7 @@ const READY_HERO_COPY_BY_LOCALE: Record<UiLocale, {
   en: {
     ariaLabel: 'Start a conversation',
     eyebrow: 'READY · Start a conversation',
-    headline: 'You\'re all set — just say what you want to do.',
+    headline: 'What should Maka help with today?',
     intro: 'The box below opens a new session with your default model; empty submit also opens a session so you can type later.',
     quickChatPlaceholder: 'Message Maka…',
     quickChatAria: 'Quick Chat input',
@@ -557,17 +557,7 @@ function ReadyEmptyHero(props: {
   }, []);
 
   const copy = READY_HERO_COPY_BY_LOCALE[detectUiLocale()];
-  const hiddenSuggestionIds = new Set(
-    (props.onboardingMilestones ?? [])
-      .filter((milestone) => milestone.skippedAt !== undefined)
-      .map((milestone) => milestone.id),
-  );
-  const visibleSuggestions = FIRST_RUN_TASK_SUGGESTIONS.filter(
-    (suggestion) => !hiddenSuggestionIds.has(FIRST_RUN_TASK_SUGGESTION_MILESTONES[suggestion.id]),
-  );
-  const hiddenSuggestions = FIRST_RUN_TASK_SUGGESTIONS.filter(
-    (suggestion) => hiddenSuggestionIds.has(FIRST_RUN_TASK_SUGGESTION_MILESTONES[suggestion.id]),
-  );
+  const visibleSuggestions = FIRST_RUN_TASK_SUGGESTIONS;
   const quickChatBusy = props.quickChatPending || submitPending;
   const suggestionActionBusy = pendingSuggestionAction !== null;
   const importStatusText = pendingImportAction === null
@@ -614,7 +604,7 @@ function ReadyEmptyHero(props: {
 
   const prefillSuggestion = useCallback((prompt: string, mode?: QuickChatMode) => {
     if (quickChatBusy || suggestionActionBusy) return;
-    const nextDraft = appendPromptContextDraft(draft, prompt);
+    const nextDraft = prompt;
     setDraft(nextDraft);
     setDraftMode(mode);
     window.requestAnimationFrame(() => {
@@ -623,7 +613,7 @@ function ReadyEmptyHero(props: {
       input.focus();
       input.setSelectionRange(nextDraft.length, nextDraft.length);
     });
-  }, [draft, quickChatBusy, suggestionActionBusy]);
+  }, [quickChatBusy, suggestionActionBusy]);
 
   const runSuggestionAction = useCallback(async (actionKey: string, action?: () => Promise<void> | void) => {
     if (!action || quickChatBusy || pendingSuggestionActionRef.current !== null) return;
@@ -672,16 +662,6 @@ function ReadyEmptyHero(props: {
       }
     }
   }, [appendImportedPrompt, quickChatBusy]);
-
-  const importTextFile = useCallback(async () => {
-    if (!props.onImportTextFile || quickChatBusy) return;
-    await runImportAction('file', props.onImportTextFile);
-  }, [props.onImportTextFile, quickChatBusy, runImportAction]);
-
-  const importFolderOutline = useCallback(async () => {
-    if (!props.onImportFolderOutline || quickChatBusy) return;
-    await runImportAction('folder', props.onImportFolderOutline);
-  }, [props.onImportFolderOutline, quickChatBusy, runImportAction]);
 
   const importActionBusy = pendingImportAction !== null;
 
@@ -759,133 +739,74 @@ function ReadyEmptyHero(props: {
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        <Textarea
-          ref={inputRef}
-          className="maka-onboarding-quickchat-input"
-          placeholder={copy.quickChatPlaceholder}
-          rows={3}
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          onKeyDown={handleKey}
-          onPaste={handlePaste}
-          disabled={quickChatBusy}
-          aria-label={copy.quickChatAria}
-        />
+        <div className="maka-onboarding-quickchat-field">
+          <Textarea
+            ref={inputRef}
+            className="maka-onboarding-quickchat-input"
+            placeholder={copy.quickChatPlaceholder}
+            rows={3}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={handleKey}
+            onPaste={handlePaste}
+            disabled={quickChatBusy}
+            aria-label={copy.quickChatAria}
+          />
+          <small
+            className="maka-onboarding-quickchat-example"
+            data-pending={importStatusText ? 'true' : undefined}
+            aria-hidden={importStatusText ? undefined : 'true'}
+            aria-live={importStatusText ? 'polite' : undefined}
+          >
+            {importStatusText ?? copy.quickChatExample}
+          </small>
+        </div>
         {dragActive && (
           <span className="maka-visually-hidden" role="status" aria-live="polite">
             松开以导入文件内容
           </span>
         )}
-        <small
-          className="maka-onboarding-quickchat-example"
-          data-pending={importStatusText ? 'true' : undefined}
-          aria-hidden={importStatusText ? undefined : 'true'}
-          aria-live={importStatusText ? 'polite' : undefined}
-        >
-          {importStatusText ?? copy.quickChatExample}
-        </small>
         {draftMode === 'deep_research' && (
           <span className="maka-onboarding-quickchat-mode">深度研究 · 只读分析</span>
         )}
-        <div className="maka-onboarding-quickchat-actions">
-          {props.onImportTextFile && (
-            <Button
-              type="button"
-              variant="ghost"
-              className="maka-onboarding-quickchat-action"
-              onClick={() => void importTextFile()}
-              disabled={quickChatBusy || importActionBusy}
-              data-pending={pendingImportAction === 'file' ? 'true' : undefined}
-              aria-busy={pendingImportAction === 'file' ? 'true' : undefined}
-            >
-              <Paperclip size={14} strokeWidth={1.75} aria-hidden="true" />
-              <span>{pendingImportAction === 'file' ? '导入中…' : '导入文件内容'}</span>
-            </Button>
-          )}
-          {props.onImportFolderOutline && (
-            <Button
-              type="button"
-              variant="ghost"
-              className="maka-onboarding-quickchat-action"
-              onClick={() => void importFolderOutline()}
-              disabled={quickChatBusy || importActionBusy}
-              data-pending={pendingImportAction === 'folder' ? 'true' : undefined}
-              aria-busy={pendingImportAction === 'folder' ? 'true' : undefined}
-            >
-              <FolderOpen size={14} strokeWidth={1.75} aria-hidden="true" />
-              <span>{pendingImportAction === 'folder' ? '导入中…' : '导入文件夹目录'}</span>
-            </Button>
-          )}
-          <Button
-            type="button"
-            className="maka-onboarding-quickchat-submit"
-            onClick={submit}
-            disabled={quickChatBusy}
-            aria-busy={quickChatBusy ? 'true' : undefined}
-          >
-            {quickChatBusy ? copy.submitPendingLabel : copy.submitIdleLabel}
-          </Button>
-        </div>
+        <Button
+          type="button"
+          className="maka-onboarding-quickchat-submit"
+          onClick={submit}
+          disabled={quickChatBusy}
+          aria-busy={quickChatBusy ? 'true' : undefined}
+          aria-label={quickChatBusy ? copy.submitPendingLabel : copy.submitIdleLabel}
+          title={quickChatBusy ? copy.submitPendingLabel : copy.submitIdleLabel}
+        >
+          <ArrowUp size={18} strokeWidth={2.2} aria-hidden="true" />
+        </Button>
       </div>
 
-      {(visibleSuggestions.length > 0 || hiddenSuggestions.length > 0) && (
+      {visibleSuggestions.length > 0 && (
         <div className="maka-first-run-task-suggestions" aria-label="试试这些任务">
-          <div className="maka-first-run-task-suggestions-header">
-            <strong>试试这些任务</strong>
-            {hiddenSuggestions.length > 0 && (
-              <Button
-                type="button"
-                variant="quiet"
-                size="sm"
-                className="maka-first-run-task-suggestions-restore"
-                onClick={() => void runSuggestionAction(
-                  'restore',
-                  () => props.onRestoreTaskSuggestions?.(hiddenSuggestions.map((item) => item.id)),
-                )}
-                disabled={quickChatBusy || suggestionActionBusy || !props.onRestoreTaskSuggestions}
-                aria-busy={pendingSuggestionAction === 'restore' ? 'true' : undefined}
-              >
-                <RotateCcw size={12} strokeWidth={1.75} aria-hidden="true" />
-                <span>{pendingSuggestionAction === 'restore' ? '恢复中…' : `恢复 ${hiddenSuggestions.length} 项`}</span>
-              </Button>
-            )}
-          </div>
-          {visibleSuggestions.length > 0 && (
-            <div className="maka-first-run-task-suggestion-list">
-              {visibleSuggestions.map((suggestion) => (
-                <span key={suggestion.id} className="maka-first-run-task-suggestion-chip">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="maka-first-run-task-suggestion"
-                    onClick={() => prefillSuggestion(suggestion.prompt, suggestion.mode)}
-                    disabled={quickChatBusy || suggestionActionBusy}
-                  >
-                    {suggestion.label}
-                  </Button>
-                  {props.onDismissTaskSuggestion && (
+          <div className="maka-first-run-task-suggestions-inner">
+            <div className="maka-first-run-task-suggestions-header">
+              <strong>试试这些任务</strong>
+            </div>
+            {visibleSuggestions.length > 0 && (
+              <div className="maka-first-run-task-suggestion-list">
+                {visibleSuggestions.map((suggestion) => (
+                  <span key={suggestion.id} className="maka-first-run-task-suggestion-chip">
                     <Button
                       type="button"
-                      variant="quiet"
-                      size="icon-sm"
-                      className="maka-first-run-task-suggestion-dismiss"
-                      onClick={() => void runSuggestionAction(
-                        `dismiss:${suggestion.id}`,
-                        () => props.onDismissTaskSuggestion?.(suggestion.id),
-                      )}
+                      variant="ghost"
+                      size="sm"
+                      className="maka-first-run-task-suggestion"
+                      onClick={() => prefillSuggestion(suggestion.prompt, suggestion.mode)}
                       disabled={quickChatBusy || suggestionActionBusy}
-                      aria-busy={pendingSuggestionAction === `dismiss:${suggestion.id}` ? 'true' : undefined}
-                      aria-label={`隐藏任务建议：${suggestion.label}`}
-                      title="隐藏"
                     >
-                      <X size={12} strokeWidth={1.75} aria-hidden="true" />
+                      {suggestion.label}
                     </Button>
-                  )}
-                </span>
-              ))}
-            </div>
-          )}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </section>

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -2785,39 +2785,41 @@ function AppShell() {
         >
           {sessionListCollapsed && (
             <div className="maka-collapsed-drag-strip" aria-label="侧边栏已收起">
-              <UiButton
-                className="maka-collapsed-topbar-button"
-                variant="quiet"
-                size="icon-sm"
-                type="button"
-                onClick={() => setSessionListCollapsed(false)}
-                aria-label="展开侧边栏"
-                title="展开侧边栏"
-              >
-                <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
-              </UiButton>
-              <UiButton
-                className="maka-collapsed-topbar-button"
-                variant="quiet"
-                size="icon-sm"
-                type="button"
-                onClick={() => setSearchModalOpen(true)}
-                aria-label="搜索对话"
-                title="搜索对话"
-              >
-                <Search size={16} strokeWidth={1.65} aria-hidden="true" />
-              </UiButton>
-              <UiButton
-                className="maka-collapsed-topbar-button"
-                variant="quiet"
-                size="icon-sm"
-                type="button"
-                onClick={createSession}
-                aria-label="新任务"
-                title="新任务"
-              >
-                <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
-              </UiButton>
+              <div className="maka-collapsed-topbar-actions">
+                <UiButton
+                  className="maka-collapsed-topbar-button"
+                  variant="quiet"
+                  size="icon-sm"
+                  type="button"
+                  onClick={() => setSearchModalOpen(true)}
+                  aria-label="搜索对话"
+                  title="搜索对话"
+                >
+                  <Search size={16} strokeWidth={1.65} aria-hidden="true" />
+                </UiButton>
+                <UiButton
+                  className="maka-collapsed-topbar-button"
+                  variant="quiet"
+                  size="icon-sm"
+                  type="button"
+                  onClick={() => setSessionListCollapsed(false)}
+                  aria-label="展开侧边栏"
+                  title="展开侧边栏"
+                >
+                  <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
+                </UiButton>
+                <UiButton
+                  className="maka-collapsed-topbar-button"
+                  variant="quiet"
+                  size="icon-sm"
+                  type="button"
+                  onClick={createSession}
+                  aria-label="新任务"
+                  title="新任务"
+                >
+                  <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
+                </UiButton>
+              </div>
             </div>
           )}
           <div className="maka-workspace-top-actions" role="toolbar" aria-label="工作区辅助操作">

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -266,11 +266,18 @@ button:active {
 .maka-collapsed-drag-strip {
   min-height: 38px;
   display: flex;
-  align-items: flex-start;
-  gap: 6px;
+  align-items: center;
+  gap: 0;
   /* 17px correction = 12px half-icon + 5px detail-panel inset. */
   padding: calc(var(--maka-titlebar-control-safe-top) - 17px) 12px 0 var(--maka-titlebar-control-safe-left);
   -webkit-app-region: drag;
+}
+
+.maka-collapsed-topbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  -webkit-app-region: no-drag;
 }
 
 .maka-collapsed-topbar-button {
@@ -664,14 +671,26 @@ button:active {
 .maka-sidebar-drag-strip {
   min-height: 34px;
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 6px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
   box-sizing: border-box;
   /* Same baseline; 18px correction = 12px half-icon + 6px sidebar-header pad. */
   padding-top: calc(var(--maka-titlebar-control-safe-top) - 18px);
   padding-left: calc(var(--maka-titlebar-control-safe-left) - 10px);
   -webkit-app-region: drag;
+}
+
+.maka-sidebar-brand {
+  margin-right: auto;
+  color: var(--foreground);
+  font-family: Georgia, "Times New Roman", Times, serif;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 24px;
+  letter-spacing: 0;
+  -webkit-app-region: no-drag;
+  user-select: none;
 }
 
 .maka-sidebar-search-button,
@@ -705,9 +724,11 @@ button:active {
 }
 
 .maka-session-panel[data-collapsed="true"] .maka-sidebar-drag-strip {
-  display: grid;
-  justify-content: center;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
   gap: 4px;
+  padding-left: 8px;
 }
 
 .maka-session-panel[data-collapsed="true"] .maka-session-panel-footer {
@@ -1872,18 +1893,16 @@ button:active {
    main composer but lives inside the hero card so the first-run
    surface stays self-contained. */
 .maka-onboarding-ready header h1 {
-  /* Heavier display weight to balance the 56px brand mark above
-     and match reference implementation's "不止聊天，搞定一切" hero scale. clamp
-     keeps it from blowing out on narrow windows where the hero
-     competes with the composer below for vertical space. */
-  font-size: 28px;
-  font-weight: 600;
+  font-family: Georgia, "Times New Roman", Times, serif;
+  font-size: 29px;
+  font-weight: 680;
   letter-spacing: 0;
-  line-height: 1.12;
+  line-height: 1.18;
 }
 .maka-onboarding-ready header p {
   /* Slightly larger subtitle so it carries the meaning without
      reading like fine print under the now-heavier h1. */
+  margin-top: 6px;
   font-size: 14px;
   line-height: 1.5;
   max-width: 56ch;
@@ -1892,29 +1911,51 @@ button:active {
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin-top: 8px;
-  border-radius: 10px;
-  border: 0;
-  background: var(--background);
-  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.06);
+  margin-top: 24px;
+  width: min(100%, 620px);
+  margin-inline: auto;
+  position: relative;
+  border-radius: 20px;
+  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
+  background: var(--background-elevated, var(--background));
+  box-shadow:
+    0 18px 42px oklch(from var(--foreground) l c h / 0.07),
+    0 1px 0 oklch(from var(--foreground) 1 0 h / 0.72) inset;
   transition:
-    box-shadow 160ms ease;
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
+
+.maka-onboarding-quickchat-field {
+  display: grid;
+  gap: 8px;
+  padding: 20px 150px 20px 22px;
+}
+
 .maka-onboarding-quickchat:focus-within {
-  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.16);
+  border-color: oklch(from var(--accent) l c h / 0.34);
+  box-shadow:
+    0 20px 52px oklch(from var(--foreground) l c h / 0.10),
+    0 0 0 4px oklch(from var(--accent) l c h / 0.08),
+    0 1px 0 oklch(from var(--foreground) 1 0 h / 0.75) inset;
 }
 .maka-onboarding-quickchat-input {
+  appearance: none;
+  box-sizing: border-box;
   width: 100%;
-  resize: vertical;
-  min-height: 64px;
-  padding: 10px 12px;
-  border-radius: 10px 10px 0 0;
-  border: 0;
-  background: transparent;
+  resize: none;
+  min-height: 90px;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
   color: var(--foreground);
   font: inherit;
-  font-size: 13px;
+  font-size: 15px;
   line-height: 1.5;
+  box-shadow: none !important;
+  outline: none;
 }
 .maka-onboarding-quickchat[data-drag-active="true"] .maka-onboarding-quickchat-input {
   border-color: oklch(from var(--accent) l c h / 0.46);
@@ -1929,6 +1970,7 @@ button:active {
      textarea reads as part of one card instead of having a
      second nested focus rectangle. */
   outline: none;
+  box-shadow: none !important;
 }
 .maka-onboarding-quickchat-input:disabled {
   opacity: 0.6;
@@ -1938,10 +1980,11 @@ button:active {
  * quickChat textarea so first-run users still see an example of what
  * to type after we shortened the placeholder to "Message Maka…". */
 .maka-onboarding-quickchat-example {
-  margin-top: -2px;
-  padding-inline: 12px;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-inline: 0;
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.4;
   font-style: italic;
 }
@@ -1952,8 +1995,8 @@ button:active {
 }
 .maka-onboarding-quickchat-mode {
   width: fit-content;
-  max-width: calc(100% - 32px);
-  margin: 6px 16px 0;
+  max-width: calc(100% - 190px);
+  margin: -10px 150px 18px 22px;
   border: 1px solid var(--border);
   border-radius: 999px;
   padding: 4px 8px;
@@ -1962,32 +2005,61 @@ button:active {
   font-size: 0.78rem;
   line-height: 1;
 }
-.maka-onboarding-quickchat-action,
 .maka-onboarding-quickchat-submit {
-  min-width: 120px;
+  min-width: auto;
 }
 
-.maka-onboarding-quickchat-actions {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding: 6px 8px;
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.05);
-}
-
-.maka-onboarding-quickchat-action,
 .maka-onboarding-quickchat-submit {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
+  min-width: 40px;
+  padding: 0;
+  border-radius: 14px;
+  background: var(--accent);
+  color: var(--accent-foreground, oklch(0.985 0.003 250));
+  box-shadow:
+    inset 0 1px 0 oklch(1 0 0 / 0.16),
+    0 10px 20px oklch(from var(--accent) l c h / 0.22);
+}
+
+.maka-onboarding-quickchat-submit {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+}
+
+.maka-onboarding-quickchat-submit:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 88%, black);
+  color: var(--accent-foreground, oklch(0.985 0.003 250));
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 oklch(1 0 0 / 0.18),
+    0 12px 24px oklch(from var(--accent) l c h / 0.26);
+}
+
+.maka-onboarding-quickchat-submit:disabled {
+  background: color-mix(in srgb, var(--accent) 58%, white);
+  color: var(--accent-foreground, oklch(0.985 0.003 250));
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .maka-first-run-task-suggestions {
   display: grid;
-  gap: 8px;
-  margin-top: 16px;
+  justify-items: center;
+  gap: 0;
+  margin-top: 22px;
+  width: min(760px, 100%);
+}
+
+.maka-first-run-task-suggestions-inner {
+  width: min(100%, 760px);
+  display: grid;
+  gap: 10px;
 }
 
 .maka-first-run-task-suggestions-header {
@@ -1999,59 +2071,46 @@ button:active {
 
 .maka-first-run-task-suggestions-header > strong {
   font-size: 12px;
-  color: var(--foreground-60);
+  color: var(--foreground-50);
   font-weight: 600;
-}
-
-.maka-first-run-task-suggestions-restore {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--foreground-55);
-  height: auto;
-  min-height: 24px;
-  padding: 2px 4px;
-  font-size: 12px;
-  line-height: 1.2;
-}
-
-.maka-first-run-task-suggestions-restore:hover {
-  color: var(--foreground);
-}
-
-.maka-first-run-task-suggestions-restore:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: 6px;
 }
 
 .maka-first-run-task-suggestion-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  justify-content: center;
+  gap: 10px;
 }
 
 .maka-first-run-task-suggestion-chip {
+  position: relative;
   display: inline-flex;
-  align-items: stretch;
-  min-height: 32px;
+  align-items: center;
+  flex: 0 0 auto;
 }
 
 .maka-first-run-task-suggestion {
-  border: 1px solid var(--foreground-10);
-  border-radius: 8px 0 0 8px;
-  background: var(--foreground-3);
-  color: var(--foreground-80);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  flex: 0 0 auto;
+  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
+  border-radius: 999px;
+  background: oklch(from var(--background-elevated, var(--background)) l c h / 0.78);
+  color: var(--foreground-75);
   height: auto;
-  min-height: 32px;
-  padding: 6px 10px;
-  font-size: 12px;
-  line-height: 1.35;
+  min-height: 38px;
+  padding: 9px 18px;
+  font-size: 12.5px;
+  line-height: 1.2;
+  text-align: center;
+  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.04);
 }
 
 .maka-first-run-task-suggestion:hover {
-  background: var(--foreground-5);
-  border-color: var(--foreground-20);
+  background: var(--background-elevated, var(--background));
+  border-color: oklch(from var(--foreground) l c h / 0.16);
   color: var(--foreground);
 }
 
@@ -2063,33 +2122,6 @@ button:active {
 .maka-first-run-task-suggestion:disabled {
   opacity: 0.55;
   cursor: not-allowed;
-}
-
-.maka-first-run-task-suggestion-dismiss {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: auto;
-  width: 28px;
-  border: 1px solid var(--foreground-10);
-  border-left: 0;
-  border-radius: 0 8px 8px 0;
-  background: var(--foreground-3);
-  color: var(--foreground-45);
-}
-
-.maka-first-run-task-suggestion-dismiss:hover {
-  background: var(--foreground-5);
-  color: var(--foreground-80);
-}
-
-.maka-first-run-task-suggestion-dismiss:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.maka-first-run-task-suggestion-chip:has(.maka-first-run-task-suggestion:only-child) .maka-first-run-task-suggestion {
-  border-radius: 8px;
 }
 
 /* @kenji PR110c review: loading slot rendered while the first
@@ -6177,8 +6209,8 @@ button:active {
 .composer .maka-composer-inner {
   --h-composer-min: 72px;
   position: relative;
-  width: min(680px, 80vw);
-  max-width: 680px;
+  width: min(620px, 80vw);
+  max-width: 620px;
   margin-inline: auto;
   box-sizing: border-box;
   /* Composer outer chrome uses the universal page-card recipe (atlas §4
@@ -6550,9 +6582,9 @@ button:active {
 
 .maka-composer-workspace-row {
   /* PR-PARCHMENT-HOME-2: must share the new composer card measure
-     (680px) so the "选择工作目录 ▾" pill stays aligned with the card
+     (620px) so the "选择工作目录 ▾" pill stays aligned with the card
      left edge above it. */
-  width: min(680px, 80vw);
+  width: min(620px, 80vw);
   display: flex;
   justify-content: flex-start;
   box-sizing: border-box;
@@ -13178,28 +13210,55 @@ button:active {
    ──────────────────────────────────────────────────────────────── */
 .maka-onboarding-stack {
   display: grid;
-  gap: 18px;
+  gap: 28px;
   align-content: start;
+  justify-items: center;
+  width: 100%;
+  min-height: calc(100vh - 84px);
+  padding: clamp(40px, 7vh, 76px) 28px 48px;
+}
+
+.maka-onboarding-stack > .maka-onboarding-ready {
+  margin: 0;
+}
+
+.maka-onboarding-ready {
+  width: min(760px, 100%);
+  padding: 0;
+  gap: 0;
+}
+
+.maka-onboarding-ready header {
+  justify-items: center;
+  text-align: center;
+}
+
+.maka-onboarding-ready .maka-onboarding-eyebrow {
+  display: none;
 }
 
 .maka-first-run-checklist {
-  border: 1px solid var(--foreground-10);
-  border-radius: 10px;
-  padding: 14px 16px;
-  background: var(--foreground-3);
+  width: min(760px, 100%);
+  border: 1px solid oklch(from var(--foreground) l c h / 0.07);
+  border-radius: 14px;
+  padding: 14px;
+  background: oklch(from var(--background-elevated, var(--background)) l c h / 0.58);
   display: grid;
-  gap: 10px;
+  gap: 12px;
+  box-shadow: 0 10px 30px oklch(from var(--foreground) l c h / 0.04);
 }
 
 .maka-first-run-checklist-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--foreground);
+  color: var(--foreground-65);
+  padding: 0 4px 2px;
 }
 
 .maka-first-run-checklist-header strong {
-  font-size: 14px;
+  color: var(--foreground);
+  font-size: 13px;
 }
 
 .maka-first-run-checklist-count {
@@ -13256,28 +13315,33 @@ button:active {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
 }
 
 .maka-first-run-checklist-row > button {
   height: auto;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 8px 10px;
-  display: grid;
-  grid-template-columns: 22px 1fr auto;
+  min-height: 38px;
+  background: var(--background);
+  border: 1px solid oklch(from var(--foreground) l c h / 0.07);
+  border-radius: 10px;
+  padding: 7px 10px 7px 8px;
+  display: inline-grid;
+  grid-template-columns: 20px max-content 0;
   align-items: center;
-  gap: 10px;
-  width: 100%;
+  gap: 7px;
+  width: auto;
   text-align: left;
-  color: var(--foreground);
+  color: var(--foreground-75);
+  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.03);
 }
 
 .maka-first-run-checklist-row > button:hover {
-  background: var(--foreground-5);
-  border-color: var(--foreground-10);
+  background: var(--background-elevated, var(--background));
+  border-color: oklch(from var(--foreground) l c h / 0.14);
+  color: var(--foreground);
 }
 
 .maka-first-run-checklist-row[data-done="true"] > button {
@@ -13286,15 +13350,15 @@ button:active {
 }
 
 .maka-first-run-checklist-row[data-done="true"] > button:hover {
-  background: var(--foreground-3);
+  background: var(--background);
   border-color: transparent;
 }
 
 .maka-first-run-checklist-status {
   display: inline-grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   background: var(--foreground-5);
   color: var(--foreground-70);
@@ -13306,28 +13370,80 @@ button:active {
 }
 
 .maka-first-run-checklist-copy {
-  display: grid;
-  gap: 2px;
+  display: block;
   min-width: 0;
 }
 
 .maka-first-run-checklist-copy strong {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .maka-first-run-checklist-copy small {
+  display: none;
   font-size: 12px;
   color: var(--foreground-50);
   line-height: 1.45;
 }
 
 .maka-first-run-checklist-arrow {
+  display: none;
   color: var(--foreground-40);
 }
 
 .maka-first-run-checklist-row[data-done="true"] .maka-first-run-checklist-arrow {
   display: none;
+}
+
+@media (max-width: 760px) {
+  .maka-onboarding-stack {
+    gap: 22px;
+    padding: 28px 16px 32px;
+  }
+
+  .maka-onboarding-ready header h1 {
+    font-size: 24px;
+    line-height: 1.2;
+  }
+
+  .maka-onboarding-ready header p {
+    margin-top: 8px;
+  }
+
+  .maka-onboarding-quickchat-input {
+    min-height: 88px;
+    padding: 0;
+  }
+
+  .maka-onboarding-quickchat-field {
+    padding: 16px 16px 72px;
+  }
+
+  .maka-onboarding-quickchat-example {
+    padding-inline: 0;
+    margin-bottom: 0;
+  }
+
+  .maka-onboarding-quickchat-submit {
+    right: 16px;
+    bottom: 16px;
+    width: calc(100% - 32px);
+    justify-content: center;
+  }
+
+  .maka-first-run-task-suggestions-header {
+    justify-content: center;
+  }
+
+  .maka-first-run-task-suggestion-list,
+  .maka-first-run-checklist-list {
+    justify-content: center;
+  }
+
+  .maka-first-run-checklist {
+    padding: 12px;
+  }
 }
 
 /* ────────────────────────────────────────────────────────────────

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -497,6 +497,9 @@ export function SessionListPanel(props: {
     >
       <header className="maka-session-panel-header">
         <div className="maka-sidebar-drag-strip">
+          {!props.sidebarCollapsed && (
+            <span className="maka-sidebar-brand" aria-hidden="true">Maka</span>
+          )}
           {props.onOpenSearchModal && (
             <button
               className="maka-sidebar-search-button"


### PR DESCRIPTION
## Summary

  Polish the desktop first-run home experience to feel closer to the Claude-style layout while keeping Maka’s existing interaction model.

  This PR updates the onboarding home screen, quick-start task buttons, send button styling, and sidebar header behavior.

  ## What changed

  ### First-run home composer

  - Redesigned the ready_empty quick chat input into a cleaner single-card composer.
  - Removed the old bottom attachment action row from the first-run input.
  - Removed the native textarea resize handle by disabling manual resize.
  - Narrowed and centered the home composer to a more compact measure.
  - Changed the send button from a large CTA pill to a smaller icon-only action.
  - Updated the send button styling to use the app theme accent color.
  - Kept drag-and-drop / paste import behavior for text files.

  ### Task suggestion buttons

  - Kept the four fixed task suggestions always visible:
      - 读一下这个项目
      - 深度研究一个项目
      - 整理一个文件夹
      - 联网研究一个主题

  - Removed the hide / restore suggestion flow entirely.
  - Made suggestion buttons size to fit their text instead of forcing equal widths.
  - Centered suggestion text visually within each button.
  - Changed suggestion click behavior to replace the current composer content instead of appending to it.

  ### First-run layout alignment

  - Unified the first-run layout so the composer, task suggestions, and “接下来可以探索” module align on the same centered axis.
  - Refined spacing, card width, and button layout for a more balanced home screen.

  ### Sidebar header behavior

  - Restored Maka branding in the expanded sidebar header.
  - Styled the expanded sidebar brand with a serif wordmark treatment inspired by the Claude reference.
  - Reduced the Maka wordmark size so it sits at the same visual level as the adjacent header controls.
  - Kept the collapsed sidebar state icon-only.
  - Adjusted collapsed-state controls so the buttons sit flush to the left instead of centered.
  - Tightened the relationship between search and sidebar toggle controls.

  ### Typography

  - Updated the first-run headline 今天想让 Maka 帮你做什么？ to use the same serif family as the Maka brand wordmark.

  ## Files changed

  - apps/desktop/src/renderer/OnboardingHero.tsx
  - apps/desktop/src/renderer/main.tsx
  - apps/desktop/src/renderer/styles.css
  - packages/ui/src/components.tsx

  ## Validation

  - npm --workspace @maka/desktop run typecheck
  - npm --workspace @maka/desktop run build