### PR TITLE
refactor(desktop): 清理首次使用页死代码

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -77,7 +77,8 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     const hero = await readFile(join(process.cwd(), 'src/renderer/OnboardingHero.tsx'), 'utf8');
     const readyBlock = hero.match(/function ReadyEmptyHero[\s\S]*?interface SetupHeroProps/)?.[0] ?? '';
 
-    assert.match(readyBlock, /const visibleSuggestions = FIRST_RUN_TASK_SUGGESTIONS;/);
+    assert.match(readyBlock, /FIRST_RUN_TASK_SUGGESTIONS\.length > 0/);
+    assert.match(readyBlock, /FIRST_RUN_TASK_SUGGESTIONS\.map\(\(suggestion\) =>/);
     assert.match(readyBlock, /const nextDraft = prompt;/);
     assert.match(readyBlock, /setDraft\(nextDraft\)/);
     assert.match(readyBlock, /onClick=\{\(\) => prefillSuggestion\(suggestion\.prompt, suggestion\.mode\)\}/);

--- a/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-hero-copy.test.ts
@@ -405,7 +405,7 @@ describe('OnboardingHero Quick Chat draft lifecycle', () => {
     assert.match(readyBlock, /const readyHeroMountedRef = useRef\(true\)/);
     assert.match(
       readyBlock,
-      /useEffect\(\(\) => \{[\s\S]*readyHeroMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*readyHeroMountedRef\.current = false;[\s\S]*submitPendingRef\.current = false;[\s\S]*pendingImportActionRef\.current = null;[\s\S]*pendingSuggestionActionRef\.current = null;[\s\S]*\};[\s\S]*\}, \[\]\)/,
+      /useEffect\(\(\) => \{[\s\S]*readyHeroMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*readyHeroMountedRef\.current = false;[\s\S]*submitPendingRef\.current = false;[\s\S]*pendingImportActionRef\.current = null;[\s\S]*\};[\s\S]*\}, \[\]\)/,
       'ReadyEmptyHero must clear async pending owners on unmount and restore mounted state during StrictMode replay',
     );
     assert.match(readyBlock, /const quickChatBusy = props\.quickChatPending \|\| submitPending/);

--- a/apps/desktop/src/main/__tests__/text-file-import.test.ts
+++ b/apps/desktop/src/main/__tests__/text-file-import.test.ts
@@ -317,7 +317,7 @@ describe('text file context import', () => {
     assert.equal(folderPrompt.match(/<\/local-folder-outline>/g)?.length, 1);
   });
 
-  it('wires the import action into both Composer and first-run Quick Chat', async () => {
+  it('wires the import action into Composer and first-run drop/paste', async () => {
     const mainSource = await readFile(join(process.cwd(), 'src/renderer/main.tsx'), 'utf8');
     const mainProcessSource = await readFile(join(process.cwd(), 'src/main/main.ts'), 'utf8');
     const preloadSource = await readFile(join(process.cwd(), 'src/preload/preload.ts'), 'utf8');
@@ -333,7 +333,7 @@ describe('text file context import', () => {
     const folderPromptBlock = mainSource.match(/async function importFolderOutlinePrompt[\s\S]*?async function importFolderOutlineIntoComposer/)?.[0] ?? '';
     const folderComposerBlock = mainSource.match(/async function importFolderOutlineIntoComposer\(\)[\s\S]*?async function stop/)?.[0] ?? '';
 
-    assert.match(mainSource, /onImportTextFile=\{importTextFilePrompt\}/);
+    assert.doesNotMatch(mainSource, /onImportTextFile=\{importTextFilePrompt\}/);
     assert.match(mainSource, /onImportTextFile=\{importTextFileIntoComposer\}/);
     assert.match(mainSource, /onImportDroppedTextFiles=\{importDroppedTextFilesPrompt\}/);
     assert.match(mainSource, /onImportDroppedTextFiles=\{importDroppedTextFilesIntoComposer\}/);
@@ -384,20 +384,21 @@ describe('text file context import', () => {
     assert.match(mainProcessSource, /context:importDroppedTextFiles/);
     assert.match(preloadSource, /importDroppedTextFiles/);
     assert.match(globalSource, /importDroppedTextFiles/);
-    assert.match(mainSource, /onImportFolderOutline=\{importFolderOutlinePrompt\}/);
+    assert.doesNotMatch(mainSource, /onImportFolderOutline=\{importFolderOutlinePrompt\}/);
     assert.match(mainSource, /onImportFolderOutline=\{importFolderOutlineIntoComposer\}/);
     assert.match(mainProcessSource, /properties: \['openDirectory', 'multiSelections'\]/);
     assert.match(mainProcessSource, /title: '导入文件内容'/);
-    // PR #190 review: the inline `导入文件内容` and `导入文件夹目录`
-    // buttons were removed from the first-run composer (single-action
-    // card pattern). Drop/paste imports still go through the textarea
-    // wrapper, so `appendPromptContextDraft(current, prompt)` and the
-    // drag handlers are still wired; the visible button labels are
+    // The inline `导入文件内容` and `导入文件夹目录` buttons were removed
+    // from the first-run composer. Drop/paste imports still go through
+    // the textarea wrapper, so `appendPromptContextDraft(current, prompt)`
+    // and the drag handlers stay wired; the visible button labels are
     // no longer in the onboarding source.
     assert.match(onboardingSource, /appendPromptContextDraft\(current, prompt\)/);
     assert.match(onboardingSource, /onImportDroppedTextFiles/);
     assert.match(onboardingSource, /onDrop=\{handleDrop\}/);
     assert.match(onboardingSource, /onPaste=\{handlePaste\}/);
+    assert.doesNotMatch(onboardingSource, /onImportTextFile/);
+    assert.doesNotMatch(onboardingSource, /onImportFolderOutline/);
     assert.doesNotMatch(onboardingSource, /导入文本文件/);
     assert.doesNotMatch(uiSource, /aria-label="导入文本文件"/);
     assert.match(uiSource, /aria-label=\{pendingImportAction === 'file' \? '正在添加上下文' : '添加上下文'\}/);

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -31,6 +31,7 @@ import {
   ItemMedia,
   ItemTitle,
   Textarea,
+  appendPromptContextDraft,
   detectUiLocale,
   type UiLocale,
 } from '@maka/ui';

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -21,7 +21,7 @@
 
 import { ArrowUp, ChevronRight, Sparkles, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle } from 'lucide-react';
 import { Fragment, useCallback, useEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent } from 'react';
-import type { LlmConnection, OnboardingMilestone, OnboardingState, ProviderType, QuickChatMode, SettingsSection } from '@maka/core';
+import type { LlmConnection, OnboardingState, ProviderType, QuickChatMode, SettingsSection } from '@maka/core';
 import {
   Button,
   Item,
@@ -31,16 +31,11 @@ import {
   ItemMedia,
   ItemTitle,
   Textarea,
-  appendPromptContextDraft,
   detectUiLocale,
   type UiLocale,
 } from '@maka/ui';
 import { ProviderLogo, providerDisplay } from './settings/ProvidersPanel';
-import {
-  FIRST_RUN_TASK_SUGGESTIONS,
-  FIRST_RUN_TASK_SUGGESTION_MILESTONES,
-  type FirstRunTaskSuggestionId,
-} from './first-run-task-suggestions';
+import { FIRST_RUN_TASK_SUGGESTIONS } from './first-run-task-suggestions';
 import { getOnboardingSetupSteps, type OnboardingSetupStep } from './onboarding-hero-copy';
 
 /**
@@ -132,12 +127,7 @@ export interface OnboardingHeroProps {
    * the snapshot without restarting. Optional.
    */
   onRefreshConnections?: () => Promise<void> | void;
-  onImportTextFile?: () => Promise<string | undefined>;
   onImportDroppedTextFiles?: (files: File[]) => Promise<string | undefined>;
-  onImportFolderOutline?: () => Promise<string | undefined>;
-  onboardingMilestones?: ReadonlyArray<OnboardingMilestone>;
-  onDismissTaskSuggestion?: (id: FirstRunTaskSuggestionId) => Promise<void> | void;
-  onRestoreTaskSuggestions?: (ids: ReadonlyArray<FirstRunTaskSuggestionId>) => Promise<void> | void;
 }
 
 export function OnboardingHero(props: OnboardingHeroProps) {
@@ -208,12 +198,7 @@ export function OnboardingHero(props: OnboardingHeroProps) {
         <ReadyEmptyHero
           onQuickChatSubmit={props.onQuickChatSubmit}
           quickChatPending={props.quickChatPending === true}
-          onImportTextFile={props.onImportTextFile}
           onImportDroppedTextFiles={props.onImportDroppedTextFiles}
-          onImportFolderOutline={props.onImportFolderOutline}
-          onboardingMilestones={props.onboardingMilestones}
-          onDismissTaskSuggestion={props.onDismissTaskSuggestion}
-          onRestoreTaskSuggestions={props.onRestoreTaskSuggestions}
         />
       );
     case 'blocked':
@@ -527,24 +512,17 @@ function BlockedHero(props: {
 function ReadyEmptyHero(props: {
   onQuickChatSubmit: (prompt: string, mode?: QuickChatMode) => boolean | Promise<boolean>;
   quickChatPending: boolean;
-  onImportTextFile?: () => Promise<string | undefined>;
   onImportDroppedTextFiles?: (files: File[]) => Promise<string | undefined>;
-  onImportFolderOutline?: () => Promise<string | undefined>;
-  onboardingMilestones?: ReadonlyArray<OnboardingMilestone>;
-  onDismissTaskSuggestion?: (id: FirstRunTaskSuggestionId) => Promise<void> | void;
-  onRestoreTaskSuggestions?: (ids: ReadonlyArray<FirstRunTaskSuggestionId>) => Promise<void> | void;
 }) {
   const [draft, setDraft] = useState('');
   const [draftMode, setDraftMode] = useState<QuickChatMode | undefined>();
   const [dragActive, setDragActive] = useState(false);
   const [submitPending, setSubmitPending] = useState(false);
   const [pendingImportAction, setPendingImportAction] = useState<string | null>(null);
-  const [pendingSuggestionAction, setPendingSuggestionAction] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const readyHeroMountedRef = useRef(true);
   const submitPendingRef = useRef(false);
   const pendingImportActionRef = useRef<string | null>(null);
-  const pendingSuggestionActionRef = useRef<string | null>(null);
 
   useEffect(() => {
     readyHeroMountedRef.current = true;
@@ -552,14 +530,11 @@ function ReadyEmptyHero(props: {
       readyHeroMountedRef.current = false;
       submitPendingRef.current = false;
       pendingImportActionRef.current = null;
-      pendingSuggestionActionRef.current = null;
     };
   }, []);
 
   const copy = READY_HERO_COPY_BY_LOCALE[detectUiLocale()];
-  const visibleSuggestions = FIRST_RUN_TASK_SUGGESTIONS;
   const quickChatBusy = props.quickChatPending || submitPending;
-  const suggestionActionBusy = pendingSuggestionAction !== null;
   const importStatusText = pendingImportAction === null
     ? null
     : pendingImportAction === 'folder'
@@ -603,7 +578,7 @@ function ReadyEmptyHero(props: {
   );
 
   const prefillSuggestion = useCallback((prompt: string, mode?: QuickChatMode) => {
-    if (quickChatBusy || suggestionActionBusy) return;
+    if (quickChatBusy) return;
     const nextDraft = prompt;
     setDraft(nextDraft);
     setDraftMode(mode);
@@ -613,20 +588,6 @@ function ReadyEmptyHero(props: {
       input.focus();
       input.setSelectionRange(nextDraft.length, nextDraft.length);
     });
-  }, [quickChatBusy, suggestionActionBusy]);
-
-  const runSuggestionAction = useCallback(async (actionKey: string, action?: () => Promise<void> | void) => {
-    if (!action || quickChatBusy || pendingSuggestionActionRef.current !== null) return;
-    pendingSuggestionActionRef.current = actionKey;
-    setPendingSuggestionAction(actionKey);
-    try {
-      await action();
-    } finally {
-      if (pendingSuggestionActionRef.current === actionKey) {
-        pendingSuggestionActionRef.current = null;
-        if (readyHeroMountedRef.current) setPendingSuggestionAction(null);
-      }
-    }
   }, [quickChatBusy]);
 
   const appendImportedPrompt = useCallback((prompt: string) => {
@@ -782,30 +743,28 @@ function ReadyEmptyHero(props: {
         </Button>
       </div>
 
-      {visibleSuggestions.length > 0 && (
+      {FIRST_RUN_TASK_SUGGESTIONS.length > 0 && (
         <div className="maka-first-run-task-suggestions" aria-label="试试这些任务">
           <div className="maka-first-run-task-suggestions-inner">
             <div className="maka-first-run-task-suggestions-header">
               <strong>试试这些任务</strong>
             </div>
-            {visibleSuggestions.length > 0 && (
-              <div className="maka-first-run-task-suggestion-list">
-                {visibleSuggestions.map((suggestion) => (
-                  <span key={suggestion.id} className="maka-first-run-task-suggestion-chip">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="maka-first-run-task-suggestion"
-                      onClick={() => prefillSuggestion(suggestion.prompt, suggestion.mode)}
-                      disabled={quickChatBusy || suggestionActionBusy}
-                    >
-                      {suggestion.label}
-                    </Button>
-                  </span>
-                ))}
-              </div>
-            )}
+            <div className="maka-first-run-task-suggestion-list">
+              {FIRST_RUN_TASK_SUGGESTIONS.map((suggestion) => (
+                <div key={suggestion.id} className="maka-first-run-task-suggestion-chip">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="maka-first-run-task-suggestion"
+                    onClick={() => prefillSuggestion(suggestion.prompt, suggestion.mode)}
+                    disabled={quickChatBusy}
+                  >
+                    {suggestion.label}
+                  </Button>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -73,10 +73,6 @@ import { KeyboardHelpModal, useKeyboardHelp } from './keyboard-help';
 import { CommandPalette, buildCommandList, useCommandPalette } from './command-palette';
 import { OnboardingHero } from './OnboardingHero';
 import { FirstRunChecklist } from './FirstRunChecklist';
-import {
-  FIRST_RUN_TASK_SUGGESTION_MILESTONES,
-  type FirstRunTaskSuggestionId,
-} from './first-run-task-suggestions';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import { ProviderLogo } from './settings/ProvidersPanel';
 import { ArtifactPane } from './artifact-pane';
@@ -2423,26 +2419,6 @@ function AppShell() {
     }
   }
 
-  async function dismissFirstRunTaskSuggestion(id: FirstRunTaskSuggestionId): Promise<void> {
-    try {
-      await window.maka.onboarding.setMilestone(FIRST_RUN_TASK_SUGGESTION_MILESTONES[id], 'skipped');
-      onboarding.refresh();
-    } catch (error) {
-      toastApi.error('隐藏建议失败', generalizedErrorMessageChinese(error, '任务建议暂时无法隐藏，请稍后重试。'));
-    }
-  }
-
-  async function restoreFirstRunTaskSuggestions(ids: ReadonlyArray<FirstRunTaskSuggestionId>): Promise<void> {
-    try {
-      for (const id of ids) {
-        await window.maka.onboarding.clearMilestone(FIRST_RUN_TASK_SUGGESTION_MILESTONES[id]);
-      }
-      onboarding.refresh();
-    } catch (error) {
-      toastApi.error('恢复建议失败', generalizedErrorMessageChinese(error, '任务建议暂时无法恢复，请稍后重试。'));
-    }
-  }
-
   function showModelSetupToast(description: string, reason?: string) {
     const copy = modelSetupToastCopy(reason, description);
     toastApi.toast({
@@ -2970,12 +2946,7 @@ function AppShell() {
                         quickChatPending={quickChatPending}
                         connections={connections}
                         onRefreshConnections={refreshConnections}
-                        onImportTextFile={importTextFilePrompt}
-                        onImportFolderOutline={importFolderOutlinePrompt}
                         onImportDroppedTextFiles={importDroppedTextFilesPrompt}
-                        onboardingMilestones={onboarding.snapshot?.milestones}
-                        onDismissTaskSuggestion={dismissFirstRunTaskSuggestion}
-                        onRestoreTaskSuggestions={restoreFirstRunTaskSuggestions}
                       />
                       {onboardingState.kind === 'ready_empty' && (
                         <FirstRunChecklist


### PR DESCRIPTION
## Summary

  Follow-up to #191.

  This PR removes first-run onboarding dead code left behind after the UI changes:
  - remove unreachable dismiss / restore suggestion pipeline
  - remove unreachable inline import-file / import-folder onboarding actions
  - remove dead props and handlers passed through `OnboardingHero`
  - keep drag-and-drop / paste import behavior intact

  ## Scope

  Files changed:
  - `apps/desktop/src/renderer/OnboardingHero.tsx`
  - `apps/desktop/src/renderer/main.tsx`

  ## Verification

  - `git diff --check`