### PR TITLE
Reset browser panel state on session switch

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -28,6 +28,16 @@ describe('renderer utility surfaces use shared UI primitives', () => {
       /aria-label=\{state\.loading \? '停止加载页面' : '刷新页面'\}/,
       'BrowserPanel reload/stop icon-only action must expose a state-specific accessible name',
     );
+    assert.match(
+      source,
+      /disabled=\{!state\.hasPage && !state\.loading\}[\s\S]*state\.loading \? void window\.maka\.browser\.stop\(sessionId\) : void window\.maka\.browser\.reload\(sessionId\)/,
+      'BrowserPanel reload action must not stay clickable in the empty no-page state',
+    );
+    assert.match(
+      source,
+      /useEffect\(\(\) => \{[\s\S]*editingRef\.current = false;[\s\S]*setState\(EMPTY_STATE\);[\s\S]*setAddress\(''\);[\s\S]*window\.maka\.browser[\s\S]*\.getState\(sessionId\)[\s\S]*\.catch\(\(\) => apply\(EMPTY_STATE\)\);[\s\S]*\}, \[sessionId\]\)/,
+      'BrowserPanel must clear stale browser chrome synchronously when switching sessions and fail-soft on state-read errors',
+    );
   });
 
   it('keeps unsupported artifact preview CTA on Button without legacy classes', async () => {

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -50,12 +50,18 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   // Subscribe to this session's state pushes + seed the initial state.
   useEffect(() => {
     let alive = true;
+    editingRef.current = false;
+    setState(EMPTY_STATE);
+    setAddress('');
     const apply = (next: BrowserState) => {
       if (!alive) return;
       setState(next);
       if (!editingRef.current) setAddress(next.url);
     };
-    void window.maka.browser.getState(sessionId).then((s) => apply(s ?? EMPTY_STATE));
+    void window.maka.browser
+      .getState(sessionId)
+      .then((s) => apply(s ?? EMPTY_STATE))
+      .catch(() => apply(EMPTY_STATE));
     const off = window.maka.browser.onState((payload) => {
       if (payload.sessionId === sessionId) apply(payload.state);
     });
@@ -144,6 +150,7 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
           className="maka-browser-navbtn"
           aria-label={state.loading ? '停止加载页面' : '刷新页面'}
           title={state.loading ? '停止' : '刷新'}
+          disabled={!state.hasPage && !state.loading}
           onClick={() =>
             state.loading ? void window.maka.browser.stop(sessionId) : void window.maka.browser.reload(sessionId)
           }


### PR DESCRIPTION
## Summary
- reset BrowserPanel local browser state/address synchronously when sessionId changes
- fail-soft initial browser state reads to EMPTY_STATE instead of keeping stale chrome
- disable reload in the empty no-page state while preserving stop during loading
- add renderer utility contract coverage for the session-switch/reset behavior

## Verification
- npm --workspace @maka/desktop test -- renderer-utility-primitives-contract (1511/1511, console/a11y gates clean)
- npm run build (passes; existing Vite chunk-size warning only)
- git diff --check maka-agent/main..HEAD

## Notes
This PR is intentionally narrow. I compared shared origin/main against maka-agent/main and did not apply the whole diff because it would regress newer GitHub-side radius/motion/icon contract work and delete docs/deepseek-reasonix-cost-runtime-design.md from #195.