### PR TITLE
fix(workspace): enable pnpm workspace resolution via .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ node_modules
 dist
 .DS_Store
 *.log
+# pnpm-lock.yaml is generated locally — the repo tracks package-lock.json
+# (npm-first). pnpm users get correct workspace resolution via the .npmrc
+# `link-workspace-packages` setting.
+pnpm-lock.yaml
 *.tsbuildinfo
 __pycache__/
 *.pyc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,24 @@
+# Workspace resolution settings.
+#
+# `link-workspace-packages=true` tells pnpm to resolve `@maka/*`
+# dependencies declared with literal version "0.1.0" (in
+# packages/headless, packages/runtime, packages/storage, packages/ui,
+# apps/desktop) from the local workspace tree instead of trying to
+# fetch them from the npm registry (where they don't exist — they're
+# private).
+#
+# `prefer-workspace-packages=true` makes pnpm pick the workspace
+# version even when the registry has a matching one, so a future
+# version bump doesn't accidentally pull in a published copy.
+#
+# npm doesn't need either flag — it walks workspace packages
+# automatically based on the root `workspaces` field. But because
+# the team has both npm and pnpm users, we set these here so
+# `pnpm install` works without each user having to configure their
+# own global ~/.npmrc.
+#
+# Background: 2026-06-24 WAWQAQ's `pnpm install` failed with
+# `ERR_PNPM_FETCH_404 GET .../@maka/runtime` because pnpm defaults
+# to looking up the version in the registry first.
+link-workspace-packages=true
+prefer-workspace-packages=true


### PR DESCRIPTION
WAWQAQ msg \`4e620fe8\` 2026-06-24: \`pnpm install\` fails on the team's pnpm-based checkout with:

\`\`\`
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@maka%2Fruntime: Not Found - 404
This error happened while installing a direct dependency of packages/headless
\`\`\`

Root cause: the internal \`@maka/*\` packages are declared in dependent package.json files with literal version \`"0.1.0"\` (instead of \`workspace:*\`). pnpm defaults to looking up that version in the npm registry first; the private workspace packages don't exist there, so it 404s.

Fix: add \`.npmrc\` with \`link-workspace-packages=true\` + \`prefer-workspace-packages=true\`. pnpm reads these and resolves \`@maka/*\` from the local workspace tree.

## Why not switch \`"0.1.0"\` → \`"workspace:*"\`?

That would be the canonical fix, but I tried it locally and npm 11.9 still treats the \`workspace:\` protocol as \`EUNSUPPORTEDPROTOCOL\` for nested workspace deps in this repo's layout. Changing the version strings would break the existing npm path. The \`.npmrc\` flags are pnpm-specific (npm just warns on unknown keys and continues working via the root \`workspaces\` field), so this fix unblocks pnpm without breaking npm.

## Also

- gitignore \`pnpm-lock.yaml\` — the repo tracks \`package-lock.json\` (npm-first); pnpm users generate their own lockfile locally.

## Verification

- \`pnpm install\` succeeds
- \`node_modules/@maka/runtime\` is a symlink to \`../../packages/runtime\` (workspace resolution, not registry fetch)
- npm install still works (with harmless warnings about the unknown config keys)