### PR TITLE
fix(workspace): add shamefully-hoist=true so pnpm build succeeds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -22,3 +22,18 @@
 # to looking up the version in the registry first.
 link-workspace-packages=true
 prefer-workspace-packages=true
+
+# Hoist all transitive deps to the root node_modules so packages can
+# resolve them even if their own package.json doesn't list every
+# transitive (matching npm's default behavior). The repo was authored
+# under npm, where transitive deps from `@maka/runtime` (`ai`, `zod`,
+# `@ai-sdk/*`, etc.) are reachable from `apps/desktop` source without
+# being declared in apps/desktop/package.json. pnpm's default strict
+# isolation breaks `apps/desktop` builds with `Cannot find module 'ai'`
+# / `'zod'` etc.
+#
+# Background: 2026-06-24 WAWQAQ's `pnpm build` failed even after the
+# workspace-resolution fix in #197. Switching to shamefully-hoist
+# unblocks pnpm without forcing a full audit of every transitive
+# import across the renderer + main process.
+shamefully-hoist=true


### PR DESCRIPTION
Follow-up to #197. WAWQAQ msg \`1620a99b\` 2026-06-24: even after the workspace resolution fix, \`pnpm build\` and \`pnpm dev\` still fail with:

\`\`\`
src/main/main.ts(1479,27): error TS2307: Cannot find module 'ai' or its corresponding type declarations.
src/main/office-document-tool.ts(4,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.
src/main/rive-workflow-tool.ts(1,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.
src/main/skills.ts(4,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.
src/main/web-search/agent-tool.ts(21,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.
\`\`\`

Root cause: pnpm's default strict isolation. Direct imports like \`import { x } from 'ai'\` in \`apps/desktop/src/main/main.ts\` work under npm because npm hoists ALL transitive deps (including \`ai\`, \`zod\` declared in \`packages/runtime/package.json\`) into the root \`node_modules\`. pnpm doesn't hoist by default — each package only sees what it explicitly declared.

Fix: add \`shamefully-hoist=true\` to \`.npmrc\`. pnpm now hoists like npm, so \`apps/desktop\` source can reach \`ai\`/\`zod\`/etc. via transitive resolution from \`@maka/runtime\`.

The "right" fix would be to audit \`apps/desktop/package.json\` and add every transitively-used dep explicitly (\`ai\`, \`zod\`, \`@ai-sdk/*\`, etc.), but that's a much larger audit + risks missing imports. \`shamefully-hoist\` unblocks pnpm now while preserving existing npm behavior.

## Verification

\`\`\`bash
$ rm -rf node_modules && pnpm install
Done in 1.3s using pnpm v10.33.1
$ pnpm build
✓ built in 2.14s
\`\`\`