### PR TITLE
fix(workspace): approve electron/esbuild postinstall under pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,12 @@
   "devDependencies": {
     "@types/node": "^25.0.0",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@jackwener/opencli",
+      "electron",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
Follow-up to #197 and #198. WAWQAQ msg \`92265b89\` 2026-06-24: \`pnpm dev\` still fails:

\`\`\`
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
    at getElectronPath (node_modules/.pnpm/electron@39.8.10/node_modules/electron/index.js:17:11)
\`\`\`

Root cause: pnpm defaults to BLOCKING postinstall scripts for security. \`pnpm install\` warned us:

\`\`\`
Ignored build scripts: @jackwener/opencli@1.8.4, electron@39.8.10, esbuild@0.27.7.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
\`\`\`

Electron's postinstall downloads the actual binary to \`node_modules/electron/dist\`. Without it, \`electron .\` finds the wrapper but no binary and crashes.

Fix: add \`pnpm.onlyBuiltDependencies\` to root package.json with the three packages that need their postinstall to actually run:
- \`electron\` — downloads the Electron binary
- \`esbuild\` — drops the platform-specific native binary
- \`@jackwener/opencli\` — drops its own native binary

npm always runs postinstall scripts, so this only affects pnpm users.

## Verification

\`pnpm install && pnpm dev\` boots Electron and stays alive past 25s (no ELIFECYCLE error, no "Electron failed to install" crash). Build chain runs cleanly through all 6 workspaces.