### PR TITLE
fix(desktop): remove Settings nav active accent rail

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -247,4 +247,17 @@ describe('Settings form accessibility labels', () => {
       'Settings sidebar navigation groups must not regress to anonymous visual-only labels',
     );
   });
+
+  it('keeps the Settings active nav row neutral without a leading accent rail', async () => {
+    const styles = await readRepo('apps/desktop/src/renderer/styles.css');
+    const activeRule = styles.match(/\.settingsNavItem\[data-active="true"\]\s*\{[\s\S]*?\n\}/)?.[0] ?? '';
+
+    assert.match(activeRule, /background:\s*oklch\(from var\(--foreground\) l c h \/ 0\.065\);/);
+    assert.match(activeRule, /box-shadow:\s*none;/);
+    assert.doesNotMatch(
+      activeRule,
+      /inset\s+\d+px\s+0\s+0\s+var\(--accent\)|border-left|border-inline-start/,
+      'Settings active nav item must not draw the left green accent rail',
+    );
+  });
 });

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7398,14 +7398,12 @@ button:active {
   /* PR-SETTINGS-NAV-FOCUS-0 (round 14/15): bump the active state from
      the muted `--settings-nav-row-selected-bg` token to a slightly
      more visible 6.5% foreground overlay + 500 weight.
-     PR-SETTINGS-MOTION-TYPO-TOKENS-0 (round 15/15): add 3px inset
-     accent bar on the LEFT edge — Redesign-Skill recipe. Carries
-     brand into the most-used surface without recoloring the fill.
-     Inset shadow (not actual border) so the 38px row geometry stays. */
+     WAWQAQ msg 49bd00e1: keep the selected row neutral. A leading
+     accent rail reads like a stray status marker in the Settings nav. */
   background: oklch(from var(--foreground) l c h / 0.065);
   color: var(--foreground);
   font-weight: 500;
-  box-shadow: inset 3px 0 0 var(--accent);
+  box-shadow: none;
 }
 
 .settingsNavItem:focus-visible {


### PR DESCRIPTION
## Summary\n- Remove the green leading accent rail from the active Settings sidebar nav row\n- Keep the selected row as a neutral foreground overlay\n- Add a contract test preventing the active nav row from reintroducing a left accent rail\n\n## Verification\n- npm -w @maka/desktop run test -- settings-form-a11y-contract (1512/1512 pass)\n- npm run typecheck --workspaces --if-present\n- npm run build\n- pnpm build\n- git diff --check