### PR TITLE
Validate QQ typing route targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
@@ -11,6 +11,7 @@ const {
   qqGroupMessageToEvent,
   qqC2CMessageToEvent,
   pickQQSendRoute,
+  pickQQTypingRoute,
   QQ_INTENTS,
 } = __TEST__;
 
@@ -259,14 +260,16 @@ describe('QQ_INTENTS', () => {
 // messaging stack with no typing endpoint).
 describe('QQ sendTypingIndicator routing (PR-BOT-QQ-TYPING-INDICATOR-0)', () => {
   it('only routes channel: chatIds to the typing endpoint', () => {
-    // Re-check the same routing rule the bridge applies inline.
-    function shouldSendTyping(chatId: string): boolean {
-      return chatId.startsWith('channel:');
-    }
-    assert.equal(shouldSendTyping('channel:c-1'), true);
-    assert.equal(shouldSendTyping('group:g-1'), false);
-    assert.equal(shouldSendTyping('c2c:u-1'), false);
-    assert.equal(shouldSendTyping('dm:dm-1'), false);
-    assert.equal(shouldSendTyping(''), false);
+    assert.equal(pickQQTypingRoute('channel:c-1'), '/channels/c-1/typing');
+    assert.equal(pickQQTypingRoute('group:g-1'), null);
+    assert.equal(pickQQTypingRoute('c2c:u-1'), null);
+    assert.equal(pickQQTypingRoute('dm:dm-1'), null);
+    assert.equal(pickQQTypingRoute(''), null);
+  });
+
+  it('trims channel ids and skips empty typing targets', () => {
+    assert.equal(pickQQTypingRoute('channel: c-1 '), '/channels/c-1/typing');
+    assert.equal(pickQQTypingRoute('channel:'), null);
+    assert.equal(pickQQTypingRoute('channel:   '), null);
   });
 });

--- a/packages/runtime/src/bots/qq-bridge.ts
+++ b/packages/runtime/src/bots/qq-bridge.ts
@@ -274,6 +274,13 @@ export function pickQQSendRoute(chatId: string, text: string, options?: BotSendO
   return null;
 }
 
+export function pickQQTypingRoute(chatId: string): string | null {
+  if (!chatId.startsWith('channel:')) return null;
+  const channelId = chatId.slice('channel:'.length).trim();
+  if (!channelId) return null;
+  return `/channels/${channelId}/typing`;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -365,12 +372,12 @@ export class QQBotBridge extends BaseBotAdapter implements SendCapable {
    */
   async sendTypingIndicator(chatId: string): Promise<boolean> {
     if (this.platform !== 'qq' || !this.running) return false;
-    if (!chatId.startsWith('channel:')) return false;
+    const route = pickQQTypingRoute(chatId);
+    if (!route) return false;
     const token = await this.refreshTokenIfNeeded();
     if (!token) return false;
-    const channelId = chatId.slice('channel:'.length);
     try {
-      const response = await proxiedFetch(`${QQ_API}/channels/${channelId}/typing`, {
+      const response = await proxiedFetch(`${QQ_API}${route}`, {
         method: 'POST',
         headers: { Authorization: `QQBot ${token}` },
         timeoutMs: 5_000,
@@ -716,5 +723,6 @@ export const __TEST__ = {
   qqGroupMessageToEvent,
   qqC2CMessageToEvent,
   pickQQSendRoute,
+  pickQQTypingRoute,
   QQ_INTENTS,
 };


### PR DESCRIPTION
## Summary
- route QQ typing indicators through a real helper instead of inline prefix checks
- trim channel ids and skip empty channel targets before building /typing endpoints
- extend QQ bridge tests to cover malformed typing targets

## Verification
- npm --workspace @maka/runtime test -- qq-bridge
- npm run build
- git diff --check