### PR TITLE
fix(frontend): 5 bugs from parallel hunt — IME / search-race / palette-race / IPC catch / transition-all

### DIFF
--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -85,6 +85,41 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     }
   });
 
+  it('Tailwind `transition-all` is banned in @maka/ui primitives', async () => {
+    // PR-FE-BUG-HUNT-0 (kenji bug-hunt 2026-06-24): the previous
+    // checks only scanned renderer CSS files. shadcn primitives use
+    // Tailwind class strings that don't show up there. Three sites
+    // were caught (command/sheet overlays + sidebar rail) where
+    // `transition-all` animates every changing property — including
+    // layout-trigger ones like width/transform/etc. — instead of
+    // just the `opacity` / `transform` that actually animates.
+    // Enumerate the moving properties: `transition-opacity`,
+    // `transition-[transform,opacity]`, etc.
+    const { readdir } = await import('node:fs/promises');
+    const offenders: string[] = [];
+    async function walk(dir: string): Promise<void> {
+      const entries = await readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.isFile() && /\.(tsx|ts)$/.test(entry.name)) {
+          const src = await readFile(full, 'utf8');
+          if (/\btransition-all\b/.test(src)) {
+            offenders.push(full.replace(REPO_ROOT + '/', ''));
+          }
+        }
+      }
+    }
+    await walk(resolve(REPO_ROOT, 'packages/ui/src/primitives'));
+    await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+    assert.deepEqual(
+      offenders,
+      [],
+      `\`transition-all\` is banned. Enumerate the moving properties (e.g. \`transition-opacity\` or \`transition-[transform,opacity]\`):\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
   it('--duration-{quick,base,emphasized,large} tokens are defined in maka-tokens.css', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
     assert.match(tokens, /--duration-quick:\s*120ms/, '--duration-quick must be 120ms');

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -563,6 +563,14 @@ function ReadyEmptyHero(props: {
 
   const handleKey = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      // PR-FE-BUG-HUNT-0 (kenji bug-hunt 2026-06-24): mirror the main
+      // Composer's IME composition guard. Without this, a Chinese /
+      // Japanese / Korean user committing an IME composition with
+      // Enter immediately fires `submit()` and sends the unfinished
+      // draft. The same guard at packages/ui/src/components.tsx:5640
+      // already covers the main chat input; the onboarding-hero clone
+      // had drifted.
+      if (event.nativeEvent.isComposing || event.key === 'Process') return;
       // Enter (without modifier) → submit. Shift+Enter inserts newline.
       if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
         event.preventDefault();

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -775,6 +775,29 @@ function AppShell() {
     }
   }
 
+  /* PR-FE-BUG-HUNT-0 (kenji bug-hunt 2026-06-24): SearchModal +
+     CommandPalette callbacks used to be inline arrows in JSX, so
+     their identity churned on every App re-render. SearchModal's
+     debounce effect lists `searchThread` in its dep array; during a
+     turn stream `App` re-renders many times per second and the
+     180ms timeout was torn down + restarted on every render, so it
+     never reached its `setTimeout` fire — search was effectively
+     dead while a stream was active. Same root cause for the palette
+     selection effect that resets keyboard highlight on every deps
+     change. Stable refs + memos keep the timers alive. */
+  const openSessionInChatRef = useRef(openSessionInChat);
+  openSessionInChatRef.current = openSessionInChat;
+  const searchModalDeps = useMemo(
+    () => ({ searchThread: (request: Parameters<typeof window.maka.search.thread>[0]) => window.maka.search.thread(request) }),
+    [],
+  );
+  const searchModalOnNavigate = useCallback((sessionId: string, turnId?: string) => {
+    openSessionInChatRef.current(sessionId, turnId);
+  }, []);
+  const paletteOnSelectSession = useCallback((sessionId: string, turnId?: string) => {
+    openSessionInChatRef.current(sessionId, turnId);
+  }, []);
+
   async function handleTurnFooterAction(
     turnId: string,
     actionId: TurnFooterActionMeta['id'],
@@ -3083,18 +3106,24 @@ function AppShell() {
       {searchModalOpen && (
         <SearchModal
           onClose={closeSearchModal}
-          deps={{ searchThread: (request) => window.maka.search.thread(request) }}
-          onNavigateToSession={(sessionId, turnId) => {
-            openSessionInChat(sessionId, turnId);
-          }}
+          /* PR-FE-BUG-HUNT-0 (kenji bug-hunt 2026-06-24): `deps` and
+             `onNavigateToSession` used to be created inline on every
+             App re-render. SearchModal's debounce effect lists
+             `searchThread` in its dep array, so the 180ms timeout was
+             torn down + restarted on every parent render. During an
+             active stream `App` re-renders many times per second, and
+             the timer never reached its setTimeout fire — search was
+             effectively dead while a turn was streaming. Stable refs
+             keep the timer alive. Same root cause for the palette
+             below. */
+          deps={searchModalDeps}
+          onNavigateToSession={searchModalOnNavigate}
         />
       )}
       {paletteOpen && (
         <CommandPalette
           onClose={closePalette}
-          onSelectSession={(sessionId, turnId) => {
-            openSessionInChat(sessionId, turnId);
-          }}
+          onSelectSession={paletteOnSelectSession}
           commands={buildCommandList({
             sessions: visibleSessions,
             activeSessionId: activeId,

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1083,6 +1083,13 @@ function SettingsPage(props: {
   onOpenDailyReview?(): void;
   onOpenSession?(sessionId: string): void;
 }) {
+  // PR-FE-BUG-HUNT-0 (kenji bug-hunt 2026-06-24): the inline `void
+  // props.onUpdateSettings(...)` at the privacy toggle below
+  // discarded rejection promises, so an IPC failure became an
+  // Unhandled Promise Rejection at the renderer level with no user
+  // feedback. Toast surface mirrors the rest of the file's catch
+  // pattern (PR-STOP-ERROR-SURFACE-0 / PR-BOT-RESTART-RACE-0).
+  const toast = useToast();
   switch (props.section) {
     case 'models':
       return (
@@ -1127,7 +1134,11 @@ function SettingsPage(props: {
               <Switch
                 ariaLabel="启用隐身模式"
                 checked={props.settings.privacy.incognitoActive}
-                onChange={(incognitoActive) => void props.onUpdateSettings({ privacy: { incognitoActive } })}
+                onChange={(incognitoActive) => {
+                  props.onUpdateSettings({ privacy: { incognitoActive } }).catch((error: unknown) => {
+                    toast.error('隐身模式切换失败', generalizedErrorMessageChinese(error, '设置未生效，请稍后重试'));
+                  });
+                }}
               />
             </div>
           </SettingsRows>

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -43,7 +43,7 @@ export function CommandDialogBackdrop({
   return (
     <CommandDialogPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
         className,
       )}
       data-slot="command-dialog-backdrop"

--- a/packages/ui/src/primitives/sheet.tsx
+++ b/packages/ui/src/primitives/sheet.tsx
@@ -32,7 +32,7 @@ export function SheetBackdrop({
   return (
     <SheetPrimitive.Backdrop
       className={cn(
-        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-opacity duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
         className,
       )}
       data-slot="sheet-backdrop"

--- a/packages/ui/src/primitives/sidebar.tsx
+++ b/packages/ui/src/primitives/sidebar.tsx
@@ -315,7 +315,7 @@ export function SidebarRail({
     <button
       aria-label="切换侧边栏"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-[transform,opacity] ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",


### PR DESCRIPTION
WAWQAQ msg \`c4e6e61c\` 2026-06-24: yuejing = frontend engineer (solve kenji's finds + hunt FE/animation/chain bugs). Spawned 3 parallel deep-review agents (animation/motion, execution-chain, React logic); this PR fixes the 5 HIGH-confidence bugs they converged on.

## Fixes

**H1. IME composition mis-fires Quick Chat send** — \`OnboardingHero.tsx:564\`. CN/JP/KR users committing an IME composition with Enter immediately sent their unfinished draft. Mirrored the main Composer's \`event.nativeEvent.isComposing\` guard.

**H2 + H3. Search + palette die during streaming** — \`main.tsx\`. \`SearchModal deps={{...}}\` + \`CommandPalette onSelectSession={(s) => ...}\` were inline. App re-renders many times per second during streams; the debounce + highlight-reset effects keyed on these props were torn down every render, so search never fired and palette navigation reset constantly. Fix: \`useMemo\` deps + \`useCallback\` over a \`useRef\` of \`openSessionInChat\`.

**H4. Privacy IPC error unhandled** — \`SettingsModal.tsx:1130\`. \`void onUpdateSettings(...)\` discarded rejection → Unhandled Promise Rejection with no user feedback. Added \`.catch\` + toast surface mirroring PR-STOP-ERROR-SURFACE-0 / PR-BOT-RESTART-RACE-0.

**H5. Tailwind \`transition-all\` slipped through motion contract** — 3 sites in \`packages/ui/src/primitives/{command,sheet,sidebar}.tsx\`. The PR-MOTION-TOKEN-CONVERGE-0 contract only scanned CSS files. Replaced with \`transition-opacity\` (overlays) / \`transition-[transform,opacity]\` (sidebar rail). Extended the contract test with a 4th case that walks \`packages/ui/src/primitives\` + \`apps/desktop/src/renderer\` for any \`\\btransition-all\\b\` token.

## Out of scope (follow-ups)

- MEDIUM findings: ClaudeSubscriptionCard mountedRef, rapid-resize localStorage spam, WechatQrLoginModal interval churn, ReadyEmptyHero \`[props]\` deps — not user-visible HIGH.
- Bare easing / duration token migration across maka-tokens.css — kenji's aesthetic lane.

## Verification

Local disk is currently at 100% (system-level, not repo-side) so I could not run \`pnpm install && pnpm test && pnpm build\` end-to-end before pushing. The diff is small and the fixes are static-analysis-clean. **Please review the diff carefully + run the test suite yourself before merging.** I'll rerun the gate once disk space frees up.

Branch: \`yuejing/fe-bug-hunt-0\`