### PR TITLE
Validate Discord channel route targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
@@ -8,6 +8,7 @@ const {
   reconnectBackoffMs,
   buildDiscordSendBody,
   normalizeDiscordReplyToMessageId,
+  normalizeDiscordChannelId,
   classifyDiscordSendResponse,
   discordMessageToEvent,
   splitDiscordContent,
@@ -104,6 +105,18 @@ describe('normalizeDiscordReplyToMessageId', () => {
     assert.equal(normalizeDiscordReplyToMessageId('0'), undefined);
     assert.equal(normalizeDiscordReplyToMessageId('-1'), undefined);
     assert.equal(normalizeDiscordReplyToMessageId('1.5'), undefined);
+  });
+});
+
+describe('normalizeDiscordChannelId', () => {
+  it('trims and accepts positive decimal snowflake strings', () => {
+    assert.equal(normalizeDiscordChannelId(' 123456789012345678 '), '123456789012345678');
+  });
+
+  it('rejects empty, non-decimal, zero, and negative values', () => {
+    for (const value of ['', '   ', 'abc', '0', '-1', '1.5']) {
+      assert.equal(normalizeDiscordChannelId(value), undefined, value);
+    }
   });
 });
 

--- a/packages/runtime/src/bots/discord-bridge.ts
+++ b/packages/runtime/src/bots/discord-bridge.ts
@@ -132,6 +132,12 @@ function normalizeDiscordReplyToMessageId(value: string | undefined): string | u
   return trimmed;
 }
 
+function normalizeDiscordChannelId(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
 /**
  * Pure helper: classify a Discord HTTP send response so the caller
  * can route between done / retry / fatal. Discord's 429 returns a
@@ -263,15 +269,17 @@ export class DiscordBotBridge extends BaseBotAdapter implements SendCapable {
    */
   async sendMessage(chatId: string, text: string, options?: BotSendOptions): Promise<string | null> {
     if (this.platform !== 'discord' || !this.running) return null;
+    const channelId = normalizeDiscordChannelId(chatId);
+    if (!channelId) return null;
     const chunks = splitDiscordContent(text);
     let lastMessageId: string | null = null;
     for (let i = 0; i < chunks.length; i++) {
       const body = buildDiscordSendBody(chunks[i], options, i);
-      const first = await this.performSend(chatId, body);
+      const first = await this.performSend(channelId, body);
       let classification = first;
       if (first.kind === 'retry') {
         await sleep(first.delayMs);
-        classification = await this.performSend(chatId, body);
+        classification = await this.performSend(channelId, body);
       }
       if (classification.kind !== 'ok') {
         this.readiness = this.readiness === 'operational' ? 'degraded' : 'credentials_valid';
@@ -291,8 +299,10 @@ export class DiscordBotBridge extends BaseBotAdapter implements SendCapable {
 
   async sendTypingIndicator(chatId: string): Promise<boolean> {
     if (this.platform !== 'discord' || !this.running) return false;
+    const channelId = normalizeDiscordChannelId(chatId);
+    if (!channelId) return false;
     try {
-      const response = await proxiedFetch(`${DISCORD_API}/channels/${chatId}/typing`, {
+      const response = await proxiedFetch(`${DISCORD_API}/channels/${channelId}/typing`, {
         method: 'POST',
         headers: { Authorization: `Bot ${this.settings.token}` },
         timeoutMs: 5_000,
@@ -600,6 +610,7 @@ export const __TEST__ = {
   reconnectBackoffMs,
   buildDiscordSendBody,
   normalizeDiscordReplyToMessageId,
+  normalizeDiscordChannelId,
   classifyDiscordSendResponse,
   discordMessageToEvent,
   splitDiscordContent,


### PR DESCRIPTION
## Summary
- normalize Discord channel ids before building send/typing REST paths
- fail soft for empty, whitespace-only, or non-decimal channel ids instead of constructing malformed /channels/... endpoints
- add runtime tests for channel id normalization

## Verification
- npm --workspace @maka/runtime test -- discord-bridge
- npm run build
- git diff --check