### PR TITLE
Validate DingTalk send route targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
@@ -8,6 +8,7 @@ const {
   dingTalkReconnectBackoffMs,
   buildDingTalkGroupSendBody,
   buildDingTalkSingleSendBody,
+  pickDingTalkSendRoute,
   classifyDingTalkSendResponse,
   dingTalkPayloadToEvent,
   buildDingTalkAckFrame,
@@ -56,6 +57,28 @@ describe('buildDingTalkSingleSendBody', () => {
     assert.deepEqual(body.userIds, ['user-99']);
     assert.equal(body.msgKey, 'sampleText');
     assert.equal(body.msgParam, '{"content":"hi"}');
+  });
+});
+
+describe('pickDingTalkSendRoute', () => {
+  it('routes cid-prefixed chat ids to group send with trimmed target ids', () => {
+    const route = pickDingTalkSendRoute(' cidp-abc ', 'app-key-1', 'hello');
+    assert.ok(route);
+    assert.equal(route.path, '/v1.0/robot/groupMessages/send');
+    assert.equal(route.body.openConversationId, 'cidp-abc');
+    assert.equal(route.body.robotCode, 'app-key-1');
+  });
+
+  it('routes non-cid chat ids to single send with trimmed user ids', () => {
+    const route = pickDingTalkSendRoute(' user-99 ', 'app-key-1', 'hi');
+    assert.ok(route);
+    assert.equal(route.path, '/v1.0/robot/oToMessages/batchSend');
+    assert.deepEqual(route.body.userIds, ['user-99']);
+  });
+
+  it('returns null for empty route target ids', () => {
+    assert.equal(pickDingTalkSendRoute('', 'app-key-1', 'hi'), null);
+    assert.equal(pickDingTalkSendRoute('   ', 'app-key-1', 'hi'), null);
   });
 });
 

--- a/packages/runtime/src/bots/dingtalk-bridge.ts
+++ b/packages/runtime/src/bots/dingtalk-bridge.ts
@@ -115,6 +115,27 @@ export function buildDingTalkSingleSendBody(
   };
 }
 
+export function pickDingTalkSendRoute(
+  chatId: string,
+  robotCode: string,
+  text: string,
+): {
+  path: string;
+  body: Record<string, unknown>;
+} | null {
+  const targetId = chatId.trim();
+  if (!targetId) return null;
+  const isGroup = targetId.startsWith('cid');
+  return {
+    path: isGroup
+      ? '/v1.0/robot/groupMessages/send'
+      : '/v1.0/robot/oToMessages/batchSend',
+    body: isGroup
+      ? buildDingTalkGroupSendBody(targetId, robotCode, text)
+      : buildDingTalkSingleSendBody(targetId, robotCode, text),
+  };
+}
+
 /**
  * Pure helper: classify DingTalk's HTTP send response so we can route
  * between done / retry / fatal. DingTalk uses `errcode` style (0 = ok)
@@ -274,21 +295,16 @@ export class DingTalkBotBridge extends BaseBotAdapter implements SendCapable {
    */
   async sendMessage(chatId: string, text: string, _options?: BotSendOptions): Promise<string | null> {
     if (this.platform !== 'dingtalk' || !this.running) return null;
+    const robotCode = this.settings.appId?.trim() ?? '';
+    const route = pickDingTalkSendRoute(chatId, robotCode, text);
+    if (!route) return null;
     const token = await this.refreshTokenIfNeeded();
     if (!token) return null;
-    const robotCode = this.settings.appId?.trim() ?? '';
-    const isGroup = chatId.startsWith('cid');
-    const body = isGroup
-      ? buildDingTalkGroupSendBody(chatId, robotCode, text)
-      : buildDingTalkSingleSendBody(chatId, robotCode, text);
-    const path = isGroup
-      ? '/v1.0/robot/groupMessages/send'
-      : '/v1.0/robot/oToMessages/batchSend';
-    const first = await this.performSend(path, body, token);
+    const first = await this.performSend(route.path, route.body, token);
     let classification = first;
     if (first.kind === 'retry') {
       await sleep(first.delayMs);
-      classification = await this.performSend(path, body, token);
+      classification = await this.performSend(route.path, route.body, token);
     }
     if (classification.kind !== 'ok') {
       this.readiness = this.readiness === 'operational' ? 'degraded' : 'credentials_valid';
@@ -521,6 +537,7 @@ export const __TEST__ = {
   dingTalkReconnectBackoffMs,
   buildDingTalkGroupSendBody,
   buildDingTalkSingleSendBody,
+  pickDingTalkSendRoute,
   classifyDingTalkSendResponse,
   dingTalkPayloadToEvent,
   buildDingTalkAckFrame,


### PR DESCRIPTION
## Summary
- route DingTalk sends through a pure picker that trims chat ids before choosing group vs single endpoints
- fail soft for empty DingTalk route targets before refreshing tokens or building malformed send bodies
- add runtime tests for trimmed group/single routing and empty target rejection

## Verification
- npm --workspace @maka/runtime test -- dingtalk-bridge
- npm run build
- git diff --check