### PR TITLE
fix(settings): stop re-arming WeChat QR poll interval on every refresh

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -684,13 +684,22 @@ function WechatQrLoginModal(props: {
     };
   }, [reloadNonce]);
 
+  // PR-FE-BUG-HUNT-2 (kenji bug-hunt 2026-06-24 MEDIUM): the previous
+  // dep `[result]` re-armed the 3-second polling interval every time
+  // the QR refresh produced a new `result` object reference — even
+  // when the meaningful state (`ok` / `loggedIn` / `expired`) was
+  // unchanged. The interval clock drifted on every refresh,
+  // sometimes pushing the next poll 2.9s past the intended cadence.
+  // Depend on the gating booleans directly so the interval stays
+  // armed continuously while the user is actively scanning.
+  const shouldPollQr = !!result?.ok && !result.loggedIn && !result.expired;
   useEffect(() => {
-    if (!result?.ok || result.loggedIn || result.expired) return undefined;
+    if (!shouldPollQr) return undefined;
     const interval = window.setInterval(() => {
       reloadQrCode();
     }, 3_000);
     return () => window.clearInterval(interval);
-  }, [result]);
+  }, [shouldPollQr]);
 
   const qrDataUrl = result?.ok ? result.qrcode : null;
   const expired = result?.ok ? result.expired : false;


### PR DESCRIPTION
PR-FE-BUG-HUNT-2 (MEDIUM from kenji-led bug-hunt 2026-06-24).

## Bug

\`WechatQrLoginModal\`'s 3-second polling effect listed the whole \`result\` object in its dep array:

\`\`\`tsx
useEffect(() => {
  if (!result?.ok || result.loggedIn || result.expired) return undefined;
  const interval = window.setInterval(() => { reloadQrCode(); }, 3_000);
  return () => window.clearInterval(interval);
}, [result]);
\`\`\`

Every successful QR refresh produces a new \`result\` reference → effect cleanup tears down the interval → effect re-arms → the 3-second clock restarts from zero.

The polling cadence drifts: each refresh pushes the next poll up to ~5.9 s after the previous poll instead of the intended 3 s. Over a long scan, the modal notices \`loggedIn: true\` from the bridge later than it should.

## Fix

Derive a boolean \`shouldPollQr = !!result?.ok && !result.loggedIn && !result.expired\` and depend on \`[shouldPollQr]\`. Interval armed once when scanning starts, torn down once when the gating state flips (logged in / expired / error). \`reloadQrCode\` only touches stable refs + state setters, so the captured closure is safe.

## Diff

\`1 file changed, 11 insertions(+), 2 deletions(-)\` — single function, lines 687-693. No conflict with #202 / #204.

## Verification

Local disk still ~100% so I couldn't run \`pnpm install && pnpm test\` end-to-end. Static change, mechanical pattern. **Please review the diff + run the suite before merging.**