### PR TITLE
fix(ui): drop layout-trigger properties from Tooltip transitions

### DIFF
--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -39,14 +39,14 @@ export function TooltipPopup({
       <TooltipPrimitive.Positioner
         align={align}
         anchor={anchor}
-        className="z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom,transform] data-instant:transition-none"
+        className="z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-transform data-instant:transition-none"
         data-slot="tooltip-positioner"
         side={side}
         sideOffset={sideOffset}
       >
         <TooltipPrimitive.Popup
           className={cn(
-            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) text-balance rounded-md border bg-popover not-dark:bg-clip-padding text-popover-foreground text-xs shadow-md/5 transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) text-balance rounded-md border bg-popover not-dark:bg-clip-padding text-popover-foreground text-xs shadow-md/5 transition-[scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
             className,
           )}
           data-slot="tooltip-popup"


### PR DESCRIPTION
Kenji aesthetic-audit reminder 4/6 (msg \`6cc0e04d\` 2026-06-24, finding #2): Tooltip is a high-frequency hover/focus surface and should use instant positioning + compositor-only popup transitions.

Two sites violated:

1. **Positioner**: \`transition-[top,left,right,bottom,transform]\` — \`top\` / \`left\` / \`right\` / \`bottom\` are layout-trigger properties. Every reposition (anchor scrolled, side flipped on collision) ran through layout + paint instead of compositor. Reduced to \`transition-transform\` so the transform-based reposition still tweens smoothly; the layout positioning happens instantly off-frame.
2. **Popup**: \`transition-[width,height,scale,opacity]\` — \`width\` / \`height\` are layout-trigger. Reduced to \`transition-[scale,opacity]\` (which is what the data-starting-style / data-ending-style \`scale-98\` + \`opacity-0\` actually animate). The popup-width / popup-height CSS vars still set the size; just no longer transitioned.

## Out of scope (deferred)

- Drawer's \`transition-[transform,box-shadow,height,background-color]\` and 450ms raw cubic-bezier (kenji's finding #3)
- Tabs' \`transition-[width,translate]\` indicator (kenji's finding #4)

Both interact with swipe gesture / tab sizing logic and need a focused PR with visual smoke verification.

## Diff

\`1 file changed, 2 insertions(+), 2 deletions(-)\` — \`packages/ui/src/primitives/tooltip.tsx\`. No conflict with #202 / #204 / #206.

## Verification

Local disk still ~100% so couldn't run \`pnpm install && pnpm test\` end-to-end. Static class-string change.