### PR TITLE
Validate WeChat send targets

### DIFF
--- a/packages/runtime/src/bots/__tests__/wechat-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/wechat-bridge.test.ts
@@ -9,6 +9,7 @@ import {
   mapWechatBridgeMessage,
   normalizeWechatBridgeUrl,
   normalizeWechatIlinkBaseUrl,
+  normalizeWechatSendTarget,
   readSseJsonObjects,
   testWechatIlinkCredentials,
 } from '../wechat-bridge.js';
@@ -29,6 +30,13 @@ describe('WechatBridge', () => {
     assert.equal(normalizeWechatIlinkBaseUrl('http://ilinkai.weixin.qq.com'), null);
     assert.equal(normalizeWechatIlinkBaseUrl('https://example.com'), null);
     assert.equal(normalizeWechatIlinkBaseUrl('http://127.0.0.1:18400'), null);
+  });
+
+  test('normalizes send targets before direct bridge and iLink sends', () => {
+    assert.equal(normalizeWechatSendTarget(' wxid_friend '), 'wxid_friend');
+    assert.equal(normalizeWechatSendTarget(' room@chatroom '), 'room@chatroom');
+    assert.equal(normalizeWechatSendTarget(''), null);
+    assert.equal(normalizeWechatSendTarget('   '), null);
   });
 
   test('bridge URL is a credential fact and a restart boundary', () => {

--- a/packages/runtime/src/bots/wechat-bridge.ts
+++ b/packages/runtime/src/bots/wechat-bridge.ts
@@ -53,6 +53,11 @@ export function normalizeWechatIlinkBaseUrl(input: string | undefined): string |
   }
 }
 
+export function normalizeWechatSendTarget(value: string): string | null {
+  const target = value.trim();
+  return target.length > 0 ? target : null;
+}
+
 export class WechatBridge extends BaseBotAdapter implements SendCapable {
   private abortController: AbortController | null = null;
 
@@ -113,13 +118,15 @@ export class WechatBridge extends BaseBotAdapter implements SendCapable {
 
   async sendMessage(chatId: string, text: string, _options?: BotSendOptions): Promise<string | null> {
     if (!this.running) return null;
+    const targetId = normalizeWechatSendTarget(chatId);
+    if (!targetId) return null;
     try {
       if (isWechatIlinkChannel(this.settings)) {
-        return await this.sendIlinkMessage(chatId, text);
+        return await this.sendIlinkMessage(targetId, text);
       }
       const response = await wechatBridgeJson(this.settings, '/send', {
         method: 'POST',
-        body: JSON.stringify({ wxid: chatId, text }),
+        body: JSON.stringify({ wxid: targetId, text }),
       });
       const status = typeof response.status === 'string' ? response.status : '';
       if (status === 'failed') {


### PR DESCRIPTION
## Summary
- trim WeChat send targets before direct bridge and iLink sends
- fail soft for empty or whitespace-only WeChat send targets
- add runtime coverage for direct bridge and room targets

## Verification
- npm --workspace @maka/runtime test -- wechat-bridge
- npm run build
- git diff --check