### PR TITLE
fix(chat): bail refreshMessagesUntilTurn poll on session switch

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -2048,20 +2048,30 @@ function AppShell() {
   async function refreshMessagesUntilTurn(sessionId: string, turnId: string): Promise<void> {
     const deadline = Date.now() + USER_MESSAGE_VISIBLE_TIMEOUT_MS;
     while (Date.now() <= deadline) {
+      // PR-FE-BUG-HUNT-4 (kenji bug-hunt 2026-06-24 LOW): bail if the
+      // user navigated away from the session this poll was started for.
+      // Previously the loop kept burning IPC bandwidth for the full
+      // 1200ms after a session switch (the setState was gated, but the
+      // readMessages call still fired every 40ms). Now we stop the
+      // polling cycle itself.
+      if (activeIdRef.current !== sessionId) return;
       try {
         const next = await window.maka.sessions.readMessages(sessionId);
+        if (activeIdRef.current !== sessionId) return;
         const hasSentUserTurn = next.some((message) => message.type === 'user' && message.turnId === turnId);
-        if (hasSentUserTurn && activeIdRef.current === sessionId) {
+        if (hasSentUserTurn) {
           setMessages(next);
+          return;
         }
-        if (hasSentUserTurn) return;
       } catch {
         // Keep the current visible messages while the bounded retry loop
         // waits for the async send path to persist the first user message.
       }
       await new Promise((resolve) => window.setTimeout(resolve, USER_MESSAGE_VISIBLE_POLL_MS));
     }
-    await refreshMessages(sessionId);
+    if (activeIdRef.current === sessionId) {
+      await refreshMessages(sessionId);
+    }
   }
 
   function clearStreaming(sessionId: string) {


### PR DESCRIPTION
PR-FE-BUG-HUNT-4 (LOW from kenji-led bug-hunt 2026-06-24 round 1).

## Bug

\`refreshMessagesUntilTurn\` polls \`readMessages\` every 40ms for up to 1200ms while waiting for a freshly-sent user turn to land in the session journal. The setState was already gated on \`activeIdRef.current === sessionId\`, but the IPC call itself kept firing until the deadline — burning up to 30 IPC roundtrips on a session the user no longer cared about.

## Fix

Check \`activeIdRef.current !== sessionId\` at the top of each loop iteration AND immediately after the \`await\`. Bail early so the polling cycle stops, not just the setState. Same guard on the deadline-fallthrough \`refreshMessages(sessionId)\`.

Invisible when the user stays on the session (common case). Saves bandwidth + CPU on fast session-switch scenarios.

## Diff

\`1 file changed, 13 insertions(+), 3 deletions(-)\` — \`apps/desktop/src/renderer/main.tsx:2048-2065\`. No conflict with the other in-flight PRs.

## Verification

Local disk still at 100%, couldn't run \`pnpm install && pnpm test\` end-to-end. Static logic change, mechanical pattern.