### PR TITLE
fix(chat): debounce sidebar-width localStorage write during pointer drag

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1150,8 +1150,18 @@ function AppShell() {
     };
   }, [activeId, activeSession?.status, activeStreaming.length, hasInFlightLiveTools, activePermission?.requestId]);
 
+  // PR-FE-BUG-HUNT-5 (kenji bug-hunt 2026-06-24 LOW): pointer drag on
+  // the sidebar resizer fires `setSessionListWidth` on every move
+  // event — at ~60Hz over a long drag, that's a couple hundred
+  // localStorage writes for a single resize gesture. The setting
+  // converges to the user's final width at rest; intermediate
+  // values aren't load-bearing. 200ms trailing debounce keeps the
+  // last-render value in storage without flushing every pixel.
   useEffect(() => {
-    safeLocalStorageSet('maka-chat-list-width-v1', String(sessionListWidth));
+    const handle = window.setTimeout(() => {
+      safeLocalStorageSet('maka-chat-list-width-v1', String(sessionListWidth));
+    }, 200);
+    return () => window.clearTimeout(handle);
   }, [sessionListWidth]);
 
   useEffect(() => {


### PR DESCRIPTION
PR-FE-BUG-HUNT-5 (LOW from kenji-led bug-hunt 2026-06-24 round 1).

## Bug

The sidebar-list resizer drag fires \`setSessionListWidth\` on every pointermove event — at ~60Hz over a long drag, that's a couple hundred localStorage writes for a single resize gesture. The setting converges to the user's final width at rest; intermediate values aren't load-bearing.

## Fix

200ms trailing debounce on the \`useEffect\` that flushes to localStorage. Cleanup clears the pending timeout on each fresh width change, so only the last-render value gets written. Drag finished → 200ms idle → one localStorage write.

Behavior invisible — the user's final width persists exactly as before, just without the per-frame I/O. Especially noticeable on spinning disks and on Electron's IPC-backed safeLocalStorage path.

## Diff

\`1 file changed, 11 insertions(+), 1 deletion(-)\` — \`apps/desktop/src/renderer/main.tsx:1153\`. Same-file as PR #202 but in a different region (line 1153 vs PR #202's edits at lines 768 + 3083), so trivial merge resolution if both land.

## Verification

Local disk still at 100%, couldn't run \`pnpm install && pnpm test\` end-to-end. Mechanical pattern.