### PR TITLE
fix(motion): unify live-indicator pulse amplitude across streaming dots

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -11642,7 +11642,14 @@ button:active {
 
 @keyframes maka-reasoning-panel-pulse {
   0%, 100% { opacity: 0.6; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.15); }
+  /* PR-FE-BUG-HUNT-6 (kenji aesthetic audit reminder 9, finding #5):
+     standardize live-dot pulse amplitude across the three streaming
+     indicators. The semantic is identical ("live work happening")
+     but the amplitudes drifted: list-row dot 10%, reasoning-panel
+     dot 15%, tool-output dot 18%. Settled on scale(1.1) — the
+     calmest of the three — because the dots run continuously while
+     a turn is streaming and the larger pulses read as agitated. */
+  50% { opacity: 1; transform: scale(1.1); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -12631,7 +12638,8 @@ button:active {
 
 @keyframes maka-tool-output-stream-pulse {
   0%, 100% { opacity: 0.55; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.18); }
+  /* PR-FE-BUG-HUNT-6: see reasoning-dot block — unified to 1.1. */
+  50% { opacity: 1; transform: scale(1.1); }
 }
 
 /* PR-UI-12 fixup (@xuan review): the visual-smoke fixture attr collapsed


### PR DESCRIPTION
PR-FE-BUG-HUNT-6 picking up kenji's aesthetic-audit reminder 9 finding #5.

## Bug

Three streaming-state indicator dots share the same semantic (\"live work happening\") but their pulse amplitudes drifted:

- \`.maka-list-row-streaming-dot\` keyframe at styles.css:2231 — \`scale(1.1)\`
- \`.maka-reasoning-panel-dot\` keyframe at styles.css:11645 — \`scale(1.15)\`
- \`.maka-tool-output-stream-pulse\` keyframe at styles.css:12634 — \`scale(1.18)\`

When more than one is visible at the same time (e.g. user in a turn that's streaming text AND a tool call is in flight) the amplitudes pile up and the screen reads as agitated.

## Fix

Settle all three to \`scale(1.1)\` — the calmest of the three. These dots pulse continuously while a turn is streaming, and the larger amplitudes are visually loud at that cadence. The list-row dot was already at 1.1 so this is a unification at the existing low end, not a raise.

## Diff

\`1 file changed, 10 insertions(+), 2 deletions(-)\` — two keyframes in styles.css. No overlap with PR #202's styles.css edits (those touch onboarding rules + the cubic-bezier sweep, not @keyframes scale values).

## Verification

Local disk still ~100%, couldn't run \`pnpm install && pnpm test\` end-to-end. CSS-only value change.