### PR TITLE
fix(chrome): tokenize bare z-index sites + add allowlist contract

### DIFF
--- a/apps/desktop/src/main/__tests__/z-index-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/z-index-contract.test.ts
@@ -1,0 +1,123 @@
+/**
+ * PR-FE-BUG-HUNT-9 (kenji audit reminder 9, finding #4):
+ * lock the z-index vocabulary in styles.css so future PRs can't
+ * silently drift back to arbitrary bare digits.
+ *
+ * Rule: every `z-index: <bare integer>;` site in styles.css must
+ * either (a) be a `var(--z-*)` reference, or (b) be on the explicit
+ * `BARE_ALLOWLIST` below — meaning the bare value is intentional,
+ * local-stacking-only, and reviewers acknowledged it as part of
+ * this contract.
+ *
+ * Adding a new bare site without updating the allowlist will fail
+ * this test. That's the point.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const STYLES_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles.css');
+
+/** Sites where a bare integer z-index is intentional. Local stacking
+ *  inside a single container, no global side-effects. Each entry is
+ *  a substring of a styles.css selector that uniquely identifies the
+ *  rule containing the bare z-index. */
+const BARE_ALLOWLIST: ReadonlyArray<{ selector: string; value: number; reason: string }> = [
+  {
+    selector: '.maka-skill-featured-art span:nth-child(2)',
+    value: 2,
+    reason: 'decorative sticker stack — 3 spans inside a fixed container, no escape',
+  },
+];
+
+function stripCssComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
+  it('every bare `z-index: <integer>` in styles.css is either tokenized or explicitly allowlisted', async () => {
+    const stripped = stripCssComments(await readFile(STYLES_FILE, 'utf8'));
+
+    // Find all bare integer z-index occurrences. Skip `var(...)`.
+    const bareMatches = [...stripped.matchAll(/z-index:\s*(\d+)\s*;/g)];
+
+    // Each match: walk back to the nearest selector header `{` to
+    // identify what rule it lives in.
+    const violations: Array<{ value: number; nearby: string }> = [];
+
+    for (const match of bareMatches) {
+      const idx = match.index ?? 0;
+      const value = Number(match[1]);
+
+      // Heuristic: the nearest `{` looking backwards bounds this rule.
+      // Take ~200 chars before that `{` to capture the selector.
+      const beforeBrace = stripped.lastIndexOf('{', idx);
+      if (beforeBrace === -1) continue;
+      const selectorWindow = stripped.slice(Math.max(0, beforeBrace - 200), beforeBrace);
+      const lastSelectorStart = Math.max(
+        selectorWindow.lastIndexOf('}'),
+        selectorWindow.lastIndexOf(';'),
+        -1,
+      );
+      const selector = selectorWindow.slice(lastSelectorStart + 1).trim();
+
+      const allowed = BARE_ALLOWLIST.some(
+        (entry) => selector.includes(entry.selector) && entry.value === value,
+      );
+      if (!allowed) {
+        violations.push({ value, nearby: selector.slice(-160) });
+      }
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `Found bare z-index sites not on the allowlist. Either tokenize the value (use one of --z-* in maka-tokens.css) or add an entry to BARE_ALLOWLIST with a justification. Sites: ${JSON.stringify(violations, null, 2)}`,
+    );
+  });
+
+  it('every allowlisted bare z-index is actually present in styles.css', async () => {
+    const stripped = stripCssComments(await readFile(STYLES_FILE, 'utf8'));
+    for (const entry of BARE_ALLOWLIST) {
+      const selectorIdx = stripped.indexOf(entry.selector);
+      assert.notEqual(
+        selectorIdx,
+        -1,
+        `Allowlist entry's selector \`${entry.selector}\` is no longer in styles.css. Remove the stale entry from BARE_ALLOWLIST.`,
+      );
+      const ruleBlock = stripped.slice(selectorIdx, selectorIdx + 600);
+      assert.match(
+        ruleBlock,
+        new RegExp(`z-index:\\s*${entry.value}\\s*;`),
+        `Allowlist entry for \`${entry.selector}\` expects bare \`z-index: ${entry.value};\` but it's no longer there. Remove the stale entry from BARE_ALLOWLIST.`,
+      );
+    }
+  });
+
+  it('semantic z-* tokens stay defined in maka-tokens.css', async () => {
+    const TOKENS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/maka-tokens.css');
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    const required = [
+      '--z-base',
+      '--z-sticky',
+      '--z-titlebar',
+      '--z-panel',
+      '--z-dropdown',
+      '--z-tooltip',
+      '--z-modal',
+      '--z-overlay',
+      '--z-panel-action',
+      '--z-settings-fullpage',
+    ];
+    for (const name of required) {
+      assert.match(
+        tokens,
+        new RegExp(`${name}:\\s*\\d+\\s*;`),
+        `Token ${name} missing from maka-tokens.css. PR-FE-BUG-HUNT-9 z-index contract requires these tokens to exist.`,
+      );
+    }
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -196,6 +196,13 @@
   --z-tooltip: 150;
   --z-modal: 200;
   --z-overlay: 300;
+  /* PR-FE-BUG-HUNT-9 (kenji audit reminder 9, finding #4): named
+     micro-z tokens for the two raw z-index sites styles.css used to
+     spell as bare digits. Tokenizing preserves the previous visual
+     stacking exactly (no behavior change) while making them
+     contract-discoverable and renameable. */
+  --z-panel-action: 4;
+  --z-settings-fullpage: 35;
 
   /* === typography ===
      Primary face is Geist (variable). Falls back to system-ui so the app stays

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -404,7 +404,10 @@ button:active {
 .maka-workspace-top-actions {
   -webkit-app-region: no-drag;
   position: absolute;
-  z-index: 4;
+  /* PR-FE-BUG-HUNT-9 (kenji audit reminder 9, finding #4):
+     was bare `z-index: 4`. Tokenized to `--z-panel-action`.
+     Identical visual stacking, but referenceable + contract-locked. */
+  z-index: var(--z-panel-action);
   /* Same baseline; 17px correction = 12px half-icon + 5px detail-panel inset. */
   top: calc(var(--maka-titlebar-control-safe-top) - 17px);
   right: 24px;
@@ -3855,6 +3858,11 @@ button:active {
 .maka-skill-featured-art span:nth-child(2) {
   left: 92px;
   top: 4px;
+  /* PR-FE-BUG-HUNT-9 z-index allowlist: decorative sticker stack
+     local stacking (3 spans within `.maka-skill-featured-art`).
+     Bare 2 is intentional — these never escape the parent container,
+     so they don't need a global token. The contract test
+     `z-index-contract.test.ts` whitelists this exact site. */
   z-index: 2;
   width: 104px;
   height: 122px;
@@ -7190,7 +7198,12 @@ button:active {
   border-radius: 0;
   box-shadow: none;
   background: var(--agents-layout-bg);
-  z-index: 35;
+  /* PR-FE-BUG-HUNT-9 (kenji audit reminder 9, finding #4):
+     was bare `z-index: 35`. Tokenized to `--z-settings-fullpage`.
+     35 sits between `--z-titlebar` (40) and `--z-sticky` (20) so
+     the OS titlebar still owns top of the stack — preserved
+     visual behavior exactly. */
+  z-index: var(--z-settings-fullpage);
   overflow: hidden;
   transform: none;
   transition: opacity 160ms var(--ease-out-strong);


### PR DESCRIPTION
PR-FE-BUG-HUNT-9 picking up kenji's aesthetic-audit reminder 9 finding #4 (final remaining audit item).

## Bug

Four bare integer z-index sites in styles.css sidestep the \`--z-*\` token scale already defined in maka-tokens.css:

| Line | Selector | Value |
|---|---|---|
| 407 | \`.maka-workspace-top-actions\` | \`z-index: 4\` |
| 3858 | \`.maka-skill-featured-art span:nth-child(2)\` | \`z-index: 2\` |
| 7193 | \`.settingsModal.settingsPage\` | \`z-index: 35\` |
| ~14463 | (gradual-blur-layer, removed in PR #214) | \`z-index: 5\` |

PR #214 already removed the gradual-blur site. This PR closes the remaining three.

## Fix

1. **Two new tokens** preserving previous raw values exactly:
   - \`--z-panel-action: 4\`
   - \`--z-settings-fullpage: 35\`

2. **Tokenize** line 407 and line 7193 to reference the new tokens. Identical visual stacking.

3. **Allowlist** line 3858 — bare \`z-index: 2\` is local stacking among 3 decorative sticker spans inside a fixed-size container. They never escape the parent and don't need a global token. Added explicit allowlist comment + contract entry.

4. **New contract test** (\`z-index-contract.test.ts\`):
   - every bare \`z-index: <integer>;\` must be tokenized OR allowlisted with a justification
   - allowlist entries must still be present in styles.css (no stale entries)
   - all 10 semantic \`--z-*\` tokens stay defined in maka-tokens.css

Future PRs that re-introduce a bare z-index will fail this test unless they explicitly bump the allowlist.

## Diff

3 files: maka-tokens.css +7, styles.css +17/-2, new test +~110 lines. No visual change.

## Conflict check

Far from PR #202 (transition sweep), PR #210 (main.tsx debounce), PR #214 (footer/gradual-blur). No conflict.

## Verification

Disk still ~100%, couldn't run \`pnpm install && pnpm test\`. Contract test is greenfield — first run will validate the 4 sites here itself.