### PR TITLE
fix(sidebar): session-row Escape during rename silently commits typed value

### DIFF
--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -3498,6 +3498,12 @@ function SessionRow(props: {
   const rowMountedRef = useRef(true);
   const pendingActionRef = useRef<SessionRowActionId | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  // PR-FE-BUG-HUNT-11: Escape on the rename input has to suppress the
+  // blur-fires-on-unmount commit. Without this ref, the sequence
+  //   type → Escape → setEditing(false) → input unmounts → blur fires
+  //   with the typed value → commitRename(typed) → rename happens
+  // would silently commit the user's typed value despite the cancel.
+  const escapeCancelledRef = useRef(false);
   const actionBusy = pendingAction !== null;
   const actionTabIndex = actionsVisible ? 0 : -1;
 
@@ -3590,13 +3596,23 @@ function SessionRow(props: {
               defaultValue={session.name}
               maxLength={80}
               aria-label="重命名对话"
-              onBlur={(event) => commitRename(event.currentTarget.value)}
+              onBlur={(event) => {
+                // PR-FE-BUG-HUNT-11: skip the commit when the blur was
+                // caused by Escape cancelling edit mode (input unmounts
+                // → blur fires with the typed value otherwise).
+                if (escapeCancelledRef.current) {
+                  escapeCancelledRef.current = false;
+                  return;
+                }
+                commitRename(event.currentTarget.value);
+              }}
               onKeyDown={(event) => {
                 // IME guard so committing CJK characters with Enter doesn't
                 // submit the rename before the user is done.
                 if (event.nativeEvent.isComposing || event.key === 'Process') return;
                 if (event.key === 'Escape') {
                   event.preventDefault();
+                  escapeCancelledRef.current = true;
                   setEditing(false);
                 }
               }}


### PR DESCRIPTION
PR-FE-BUG-HUNT-11 — a real correctness bug found via parallel structural hunt.

## Bug

Pressing Escape on the inline rename input in a session row does NOT cancel the rename — the typed value gets committed silently.

## Reproduce

1. Hover any session row in the sidebar → click rename action
2. Type a new name in the inline input
3. Press Escape (intending to cancel)

**Expected:** original session name preserved.
**Actual:** typed value is committed; session is renamed.

## Root cause

\`packages/ui/src/components.tsx:3593-3605\` — the Escape handler calls \`setEditing(false)\`, which unmounts the \`<input>\`. React fires a final \`blur\` event on the unmounting input, and the \`onBlur\` handler unconditionally calls \`commitRename(event.currentTarget.value)\`. Because \`defaultValue={session.name}\` only sets the INITIAL value, \`currentTarget.value\` at unmount time is whatever the user typed, which \`commitRename\` then sees as non-original non-empty and commits.

## Fix

Add \`escapeCancelledRef\` flag. Escape branch sets it to true before \`setEditing(false)\`. Blur handler checks it first, short-circuits when set, resets to false. Matches the existing \`pendingActionRef\` / \`rowMountedRef\` cleanup-ref scheme already used in this component (lines 3498-3499).

## Diff

\`1 file changed, 17 insertions(+), 1 deletion(-)\`. Touches only the rename input's onBlur + onKeyDown and adds one ref. No overlap with any open PR.

## Hunt context

Found via parallel Explore-agent scan on session-row + artifact-pane layers. The artifact-pane finding (\`artifact-preview.tsx:85\` diff line key instability) was a false positive on verify — the \`\${index}:\${prefix}\` key is index-anchored so duplicate prefixes don't collide across positions. Reporting transparently.

## Verification

Disk still ~100%, couldn't run \`pnpm install && pnpm test\`. Manual trace through keydown → setEditing → unmount → blur sequence confirms the bug exists and the ref gates it cleanly.