### PR TITLE
test(contract): lock ui.tsx design-system escape hatches (kenji audit #1)

### DIFF
--- a/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
@@ -1,0 +1,119 @@
+/**
+ * PR-FE-BUG-HUNT-12 (kenji aesthetic-audit reminder 4-6, finding #1):
+ * `packages/ui/src/ui.tsx` is a motion / design contract blind spot.
+ *
+ * The PR-MOTION-TOKEN-CONVERGE-0 contract scans
+ * `packages/ui/src/primitives/` and `apps/desktop/src/renderer/`, but
+ * NOT the aggregate UI re-export layer at `packages/ui/src/ui.tsx`.
+ * That file inlines a bunch of Tailwind utility classes (z-40 / z-50 /
+ * `backdrop-blur-sm` / `transition-[height]`) which would otherwise be
+ * caught by the existing motion / z-index converge contracts.
+ *
+ * This test pins the EXACT set of design-system escape hatches that
+ * currently exist in ui.tsx. Adding a new escape-hatch class without
+ * updating the allowlist will fail this test. Removing an entry that
+ * no longer exists also fails — preventing stale allowlist drift.
+ *
+ * The intent is NOT to remove these in this PR (that would touch Base
+ * UI primitive wrappers and risk visual breakage). The intent is to
+ * lock the perimeter so kenji / WAWQAQ can decide one at a time which
+ * to tokenize, and so no NEW primitive PR can introduce a sixth or
+ * seventh escape hatch without explicit acknowledgment.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const UI_FILE = resolve(REPO_ROOT, 'packages/ui/src/ui.tsx');
+
+/** Each entry is one allowed bare design-system escape hatch.
+ *  `pattern` is the literal substring expected in ui.tsx; `count` is
+ *  the number of distinct occurrences. Bump the count when adding a
+ *  new acknowledged site; remove the entry when the last site is
+ *  tokenized away. */
+const ALLOWED_BARE: ReadonlyArray<{ pattern: string; count: number; reason: string }> = [
+  {
+    pattern: 'z-40',
+    count: 2,
+    reason:
+      'dialog + sheet backdrop scrim layer; sits below the popup at z-50. Equivalent to --z-titlebar (40) by value but semantically distinct, so not yet tokenized.',
+  },
+  {
+    pattern: 'z-50',
+    count: 5,
+    reason:
+      'dialog popup, sheet popup, tooltip popup, select popup, popover. All shadcn/Base UI overlay surfaces. Equivalent to --z-panel (50) by value but semantically distinct.',
+  },
+  {
+    pattern: 'backdrop-blur-sm',
+    count: 2,
+    reason:
+      'dialog + sheet backdrop visual depth. Pending kenji #6 audit decision on whether to drop blur entirely or tokenize a single --blur-scrim value.',
+  },
+  {
+    pattern: 'transition-[height]',
+    count: 1,
+    reason:
+      'accordion content panel needs height animation because content is variable-height; `transform: scaleY` would distort children. Layout-property transition is intentional here.',
+  },
+];
+
+describe('PR-FE-BUG-HUNT-12 ui.tsx design contract', () => {
+  it('every allowed bare class appears in ui.tsx exactly the expected number of times', async () => {
+    const src = await readFile(UI_FILE, 'utf8');
+    for (const entry of ALLOWED_BARE) {
+      // Use a regex to count occurrences. Escape brackets etc.
+      const escaped = entry.pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(escaped, 'g');
+      const matches = src.match(regex) ?? [];
+      assert.equal(
+        matches.length,
+        entry.count,
+        `Expected ${entry.count} occurrences of \`${entry.pattern}\` in packages/ui/src/ui.tsx, found ${matches.length}. Either tokenize the new site or bump the count in ALLOWED_BARE with a justification.`,
+      );
+    }
+  });
+
+  it('no UNEXPECTED bare z-index classes have crept in (z-0 through z-50)', async () => {
+    const src = await readFile(UI_FILE, 'utf8');
+    // Tailwind default z-index utilities are z-0, z-10, z-20, z-30,
+    // z-40, z-50. Only z-40 and z-50 are allowlisted above; any z-0
+    // / z-10 / z-20 / z-30 would be a new escape hatch.
+    const UNEXPECTED = ['z-0', 'z-10', 'z-20', 'z-30'];
+    for (const pat of UNEXPECTED) {
+      const regex = new RegExp(`\\b${pat}\\b`, 'g');
+      const matches = src.match(regex) ?? [];
+      assert.equal(
+        matches.length,
+        0,
+        `Found ${matches.length} bare \`${pat}\` in ui.tsx. Tokenize via --z-* or, if intentional, add to ALLOWED_BARE with a justification.`,
+      );
+    }
+  });
+
+  it('no new bare backdrop-blur intensity variants have crept in beyond `sm`', async () => {
+    const src = await readFile(UI_FILE, 'utf8');
+    // We allow backdrop-blur-sm (allowlisted above). Any other intensity
+    // (md / lg / xl / 2xl / 3xl / none / [arbitrary]) is a new escape hatch.
+    const UNEXPECTED_BLURS = [
+      'backdrop-blur-md',
+      'backdrop-blur-lg',
+      'backdrop-blur-xl',
+      'backdrop-blur-2xl',
+      'backdrop-blur-3xl',
+      'backdrop-blur-none',
+    ];
+    for (const pat of UNEXPECTED_BLURS) {
+      const regex = new RegExp(pat.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+      const matches = src.match(regex) ?? [];
+      assert.equal(
+        matches.length,
+        0,
+        `Found ${matches.length} occurrences of \`${pat}\` in ui.tsx. Tokenize via --blur-* or, if intentional, add to ALLOWED_BARE with a justification.`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
PR-FE-BUG-HUNT-12 closing kenji's audit reminder 4-6 finding #1 (msg \`6cc0e04d\` 2026-06-24).

## Bug

\`packages/ui/src/ui.tsx\` is a motion / design-contract blind spot. The PR-MOTION-TOKEN-CONVERGE-0 contract scans \`packages/ui/src/primitives/\` and \`apps/desktop/src/renderer/\` but NOT the aggregate re-export layer at ui.tsx. That file inlines Tailwind utilities that would otherwise be caught by existing contracts:

| Class | Count | Where |
|---|---|---|
| \`z-40\` | 2 | dialog + sheet backdrop |
| \`z-50\` | 5 | dialog popup, sheet popup, tooltip, select popup, popover |
| \`backdrop-blur-sm\` | 2 | dialog + sheet backdrop |
| \`transition-[height]\` | 1 | accordion content panel |

Without a contract, future primitive PRs can quietly add a sixth or seventh escape hatch without design-system review.

## Approach

Greenfield contract test pinning the EXACT set + count. Three checks:
1. Each allowlisted pattern appears exactly the expected number of times — both new sites and stale entries fail.
2. No other bare Tailwind z-index utilities (z-0 / z-10 / z-20 / z-30) crept in.
3. No other bare backdrop-blur intensity variants beyond \`sm\` crept in.

## Why I'm NOT removing the escape hatches in this PR

Touches Base UI primitive wrappers (Dialog, Sheet, Tooltip, Select, Popover, Accordion) and risks visual breakage. Each removal needs kenji / WAWQAQ review on what to tokenize to. Contract locks the perimeter; future PRs replace one at a time.

The accordion \`transition-[height]\` is documented as intentional — content panels are variable-height; transform scaling would distort children. That one stays even after full tokenization.

## Diff

1 new file, ~110 lines test. No source change, no visual change. No overlap with any open PR.

## Verification

Disk still ~100%, couldn't run \`pnpm install && pnpm test\`. The contract is self-validating — first run will confirm all four allowlist counts match the file as it stands.