### PR TITLE
fix(chat): refine message chrome follow-up to #212

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2622,7 +2622,8 @@ function registerIpc(): void {
     emitSessionsChanged('created', session.id);
     return session;
   });
-  ipcMain.handle('sessions:readMessages', (_event, sessionId: string) => runtime.getMessages(sessionId));
+  ipcMain.handle('sessions:readMessages', (_event, sessionId: string) =>
+    visualSmokeFixture ? store.readMessages(sessionId) : runtime.getMessages(sessionId));
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
   // PR-SEARCH-2: local thread search. Renderer-facing channel; the pure
   // helper in `./search/thread-search.ts` enforces all gates (G1 snippet

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1181,7 +1181,8 @@ function AppShell() {
   async function refreshShellSettings() {
     try {
       const next = await window.maka.settings.get();
-      const pref = next.appearance?.theme ?? 'auto';
+      const smoke = await window.maka.visualSmoke.getState();
+      const pref = smoke?.theme ?? next.appearance?.theme ?? 'auto';
       const palette = next.appearance?.palette ?? 'default';
       const name = next.personalization?.displayName ?? '';
       // PR-LANG-PREF-0: apply persisted UI locale preference to

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -850,7 +850,9 @@
     padding: 24px 0 16px 0;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    /* PR-CHAT-CHROME-FOLLOWUP-0: looser separation BETWEEN turns so each
+       Q+A unit reads as its own block (the within-turn gap stays tight). */
+    gap: 24px;
   }
   .maka-message-row {
     max-width: var(--maka-chat-measure, 680px);
@@ -874,7 +876,11 @@
   .maka-turn {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    /* PR-CHAT-CHROME-FOLLOWUP-0: 4px → 8px. The parts of one turn (user
+       block, summary, tools, answer) were cramped; 8px gives a calmer
+       internal rhythm while still reading as one unit against the 24px
+       between-turn gap. */
+    gap: 8px;
     max-width: var(--maka-chat-measure, 680px);
     margin: 0 auto;
     width: 100%;
@@ -888,40 +894,51 @@
   /* Compact turn summary chips between the user message and the rest of
    * the turn. Surfaces "用了哪个模型，跑了几个工具，耗时多少，token 多少"
    * inline so each turn answers @kenji's UI-04 follow-up questions. */
+  /* PR-CHAT-CHROME-FOLLOWUP-0: the summary reads as ONE quiet caption
+     line (model · tools · duration · tokens) at the shared 12px chrome
+     size, not a cluster of 9-10px pills. Middot separators carry the
+     rhythm; the chips themselves drop their pill chrome. */
   .maka-turn-summary {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
-    padding: 0 0 0 0;
-    margin-top: 0;
+    align-items: center;
+    gap: 6px;
     margin-bottom: 2px;
-    opacity: 0.86;
+    color: var(--foreground-50);
+    font-variant-numeric: tabular-nums;
   }
 
   .maka-turn-summary-chip {
     display: inline-flex;
     align-items: center;
-    gap: 3px;
-    padding: 0;
-    border-radius: 999px;
-    background: transparent;
-    color: var(--foreground-42);
-    font-size: 9.5px;
+    gap: 4px;
+    color: var(--foreground-50);
+    font-size: 12px;
     font-weight: 500;
-    line-height: 1.25;
-    letter-spacing: 0;
+    line-height: 1.4;
+  }
+
+  .maka-turn-summary-chip:not(:first-child)::before {
+    content: "·";
+    margin-right: 4px;
+    color: var(--foreground-40);
+    font-weight: 400;
   }
 
   .maka-turn-summary-chip code {
     background: transparent;
     color: inherit;
     font-family: var(--font-mono);
-    font-size: 9.5px;
+    font-size: 12px;
+  }
+
+  .maka-turn-summary-chip[data-kind="model"] code {
+    color: var(--foreground-60);
+    font-weight: 600;
   }
 
   .maka-turn-summary-chip[data-kind="tools"] {
-    color: var(--foreground-42);
-    background: transparent;
+    color: var(--foreground-50);
   }
 
   .maka-turn-summary-chip[data-kind="duration"] {
@@ -931,33 +948,30 @@
   .maka-turn-summary-chip[data-kind="tokens"] {
     font-variant-numeric: tabular-nums;
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 12px;
   }
 
   .maka-turn-summary-chip[data-state="in-progress"] {
-    background: transparent;
     color: var(--accent);
     font-weight: 600;
   }
 
   /* PR-CHAT-NON-DEFAULT-MODEL-CHIP-0: emphasize a per-turn model
-     switch. The chip itself gets a warning border + the "切换"
-     pill renders inside the chip in warning tone so the user
-     notices that this turn departed from the sticky session model
-     (kenji 3-way decision lock). */
-  .maka-turn-summary-chip[data-kind="model"][data-switched="true"] {
-    color: var(--foreground-55);
+     switch — the "切换" pill renders inside the chip in a muted tone
+     so the user notices that this turn departed from the sticky
+     session model (kenji 3-way decision lock). */
+  .maka-turn-summary-chip[data-kind="model"][data-switched="true"] code {
+    color: var(--foreground-60);
   }
 
   .maka-turn-summary-chip-switched {
-    margin-left: 2px;
-    padding: 0 4px;
+    margin-left: 4px;
+    padding: 1px 6px;
     border-radius: 999px;
     background: oklch(from var(--foreground) l c h / 0.06);
-    color: var(--foreground-45);
-    font-size: 8.5px;
+    color: var(--foreground-60);
+    font-size: 11px;
     font-weight: 600;
-    letter-spacing: 0;
   }
 
   /* Optional reasoning block — collapsed by default, expandable to inspect
@@ -1118,21 +1132,24 @@
        previous turn while it lands. */
     box-sizing: border-box;
   }
-  /* User message: plain text block aligned to the right, matching the
-     assistant's no-bubble body treatment while preserving the dialogue
-     structure via row alignment + metadata placement. */
+  /* User message: a tinted, width-capped block anchored to the right.
+     PR-CHAT-CHROME-FOLLOWUP-0: the previous treatment was transparent
+     right-aligned text — for a long message it filled most of the
+     column, so the right-anchor was imperceptible. Re-tinting with the
+     existing `--chat-user-bg` token + a width cap makes "what the human
+     said" read clearly on the right at any length. The block shrink-
+     wraps to its content because `.message.user` aligns items to
+     flex-end (so short messages stay compact). Radius 10px matches the
+     code-block family and stays under the sharp-identity ceiling. */
   .maka-bubble-user {
-    background: transparent;
-    border-radius: 0;
-    padding: 2px 0 0;
-    line-height: 1.68;
-    color: var(--foreground);
-    max-width: min(100%, 640px);
-    margin-left: auto;
-    margin-right: 0;
+    background: var(--chat-user-bg);
+    color: var(--chat-user-foreground, var(--foreground));
+    border-radius: 10px;
+    padding: 10px 14px;
+    line-height: 1.6;
+    max-width: min(100%, 78%);
     white-space: pre-wrap;
     word-wrap: break-word;
-    text-align: left;
   }
   /* Assistant: no bubble — just text on background, like an editor.
      The bubble itself flows naturally; child markdown elements (h*, p, ul,

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1487,6 +1487,21 @@
     opacity: 1;
     background: transparent;
   }
+  /* User-turn meta-row copy. The meta row is NOT a
+     `.maka-bubble-with-actions` wrapper, so the absolute hover-reveal
+     above never matches it — without this the affordance is
+     permanently invisible and absolute-positioned to the wrong box.
+     Render it inline + always visible at the quiet caption weight, so
+     "copy what I said" reads without a hover and on touch. */
+  .maka-message-meta .maka-message-copy {
+    position: static;
+    width: 22px;
+    height: 22px;
+    opacity: 1;
+    transform: none;
+    background: transparent;
+    color: var(--foreground-40);
+  }
   .maka-bubble-with-actions:hover .maka-message-copy,
   .maka-bubble-with-actions:focus-within .maka-message-copy,
   .maka-message-copy:focus-visible {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1487,21 +1487,9 @@
     opacity: 1;
     background: transparent;
   }
-  /* User-turn meta-row copy. The meta row is NOT a
-     `.maka-bubble-with-actions` wrapper, so the absolute hover-reveal
-     above never matches it — without this the affordance is
-     permanently invisible and absolute-positioned to the wrong box.
-     Render it inline + always visible at the quiet caption weight, so
-     "copy what I said" reads without a hover and on touch. */
-  .maka-message-meta .maka-message-copy {
-    position: static;
-    width: 22px;
-    height: 22px;
-    opacity: 1;
-    transform: none;
-    background: transparent;
-    color: var(--foreground-40);
-  }
+  /* (The user-turn meta-row copy renders via MessageCopyButton's
+     `footerStyle`, so it reuses `.maka-turn-footer-action` directly and
+     needs no bespoke override here.) */
   .maka-bubble-with-actions:hover .maka-message-copy,
   .maka-bubble-with-actions:focus-within .maka-message-copy,
   .maka-message-copy:focus-visible {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -5701,6 +5701,10 @@ button:active {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  /* Separate the meta row from the bubble. Kept below the 8px turn
+     rhythm so the time + copy still read as belonging to the bubble
+     (proximity) rather than floating between turns. */
+  gap: 6px;
 }
 
 .maka-turn > .maka-turn-summary,

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -5674,31 +5674,27 @@ button:active {
 .message.assistant > span { color: var(--accent); }
 .message.system > span { color: var(--info-text); }
 
+/* PR-CHAT-CHROME-FOLLOWUP-0: the relative time is always visible now
+   (it was `opacity: 0` until hover, which hid it on touch + from
+   assistive tech). It stays quiet — 12px at the shared chrome size,
+   muted — and rides in the user turn's meta row beneath the block. */
 .maka-message-time-inline {
   display: inline-block;
-  color: var(--foreground-35);
-  font-size: 10px;
+  color: var(--foreground-40);
+  font-size: 12px;
   font-weight: 500;
   line-height: 1;
   font-variant-numeric: tabular-nums;
-  opacity: 0;
-  transform: translateY(-1px);
-  transition: opacity 120ms ease;
-  pointer-events: none;
   white-space: nowrap;
 }
 
-.maka-message-time-inline-after {
-  margin-left: 8px;
-}
-
-.maka-message-time-inline-before {
-  margin-right: 8px;
-}
-
-.message:hover .maka-message-time-inline,
-.message:focus-within .maka-message-time-inline {
-  opacity: 1;
+/* User turn meta row: quiet time + a copy affordance, right-aligned
+   beneath the message block (the parent `.message.user` aligns items
+   to flex-end, so this row shrink-wraps and hugs the right edge). */
+.maka-message-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .message.user {
@@ -11363,13 +11359,14 @@ button:active {
 .maka-turn-footer-action {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 5px;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 8px;
   border-radius: 8px;
   border: 0;
   background: transparent;
-  color: var(--foreground-42);
-  font-size: 10px;
+  color: var(--foreground-50);
+  font-size: 12px;
   transition: background 120ms ease, color 120ms ease, opacity 120ms ease;
 }
 .maka-turn-footer:hover,
@@ -11400,49 +11397,15 @@ button:active {
   color: var(--destructive);
 }
 
-/* PR-UI-17 (audit §3.4): footer action density.
- *
- * Secondary actions (branch / copy) render icon-only by default to
- * reduce noise when the turn already shows lineage badges + status
- * pills. Hovering or focusing into the toolbar expands all actions
- * to full icon+label so the affordance is still discoverable. The
- * label stays in the DOM as visually-hidden text so screen readers
- * read it identically regardless of presentation state. Pending
- * actions explicitly opt back to full layout via data-pending so
- * the user sees "正在重试…" not just a spinner icon.
- *
- * `prefers-reduced-motion` users still get the same final state, just
- * with the width transition collapsed.
- */
-.maka-turn-footer-action[data-priority="secondary"] {
-  padding-right: 6px;
-  /* Smooth width transition between collapsed (icon-only) and expanded
-   * (icon + label). The label is the natural child; we just hide its
-   * occupied space via max-width + overflow. */
-}
-.maka-turn-footer-action[data-priority="secondary"] > span {
-  display: inline-block;
-  max-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  opacity: 0;
-  margin-left: 0;
-  transition: max-width 160ms ease, opacity 120ms ease, margin-left 160ms ease;
-}
-.maka-turn-footer:hover .maka-turn-footer-action[data-priority="secondary"] > span,
-.maka-turn-footer:focus-within .maka-turn-footer-action[data-priority="secondary"] > span,
-.maka-turn-footer-action[data-priority="secondary"]:focus-visible > span,
-.maka-turn-footer-action[data-priority="secondary"][data-pending] > span {
-  max-width: 120px;
-  opacity: 1;
-  margin-left: 4px;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .maka-turn-footer-action[data-priority="secondary"] > span {
-    transition: none;
-  }
-}
+/* PR-CHAT-CHROME-FOLLOWUP-0: footer actions render uniformly — icon +
+ * label, always visible, at the shared 12px chrome size. This supersedes
+ * the PR-UI-17 primary/secondary collapse, which hid branch/copy (and,
+ * after #212, retry/regenerate too) behind a hover-to-expand width
+ * animation. That left an unclear, undeclared priority split and made
+ * the most common action — copy — hard to find. The strip stays quiet at
+ * rest via the toolbar's 0.72 opacity and lifts to full on hover/focus;
+ * the label is no longer width-collapsed. `data-priority` is retained on
+ * the element for downstream styling but no longer drives visibility. */
 
 
 /* PR109e-d: Failed turn banner. Lives above the assistant message body

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -1,8 +1,7 @@
 /**
  * Small pure helpers backing the chat surface (TurnView,
  * RelativeTime, StreamingAssistantBubble, etc.) —
- * time formatters, role/avatar label derivation, turn duration +
- * abort marker copy.
+ * time formatters, turn duration + abort marker copy.
  *
  * PR-UI-LIB-EXTRACT-4 (round 5/10) introduced this module with a
  * deliberate ESM circular import on `./components.js` for
@@ -10,13 +9,16 @@
  * cycle by lifting `detectUiLocale` into a new `locale-helpers`
  * leaf module; this file now depends on that leaf instead.
  *
- * Why this seam: avatar/initial derivation has Unicode codepoint
- * subtleties (emoji vs CJK vs Latin), duration formatting has
- * ms→s→m bucket rules, and the abort-marker label is i18n-able
- * copy. Each rule was previously buried between TurnView's 200-
- * line JSX block and StreamingAssistantBubble's stream-snap
- * hookup; the bundle now sits as 6 short pure functions easy to
- * unit-test in isolation.
+ * Why this seam: duration formatting has ms→s→m bucket rules, and
+ * the abort-marker label is i18n-able copy. Each rule was
+ * previously buried between TurnView's 200-line JSX block and
+ * StreamingAssistantBubble's stream-snap hookup; the bundle now
+ * sits as short pure functions easy to unit-test in isolation.
+ *
+ * PR-CHAT-CHROME-FOLLOWUP-0: `messageRoleLabel` / `avatarInitial`
+ * were removed — the chat surface dropped per-message avatars and
+ * name labels (MessageMeta), leaving both helpers with zero call
+ * sites.
  */
 
 import { detectUiLocale } from './locale-helpers.js';
@@ -33,28 +35,6 @@ export function createAbsoluteTimeFormat(): Intl.DateTimeFormat {
 
 export function formatAbsoluteTimestamp(ts: number): string {
   return createAbsoluteTimeFormat().format(new Date(ts));
-}
-
-export function messageRoleLabel(role: string, userLabel?: string): string {
-  if (role === 'user') {
-    const trimmed = userLabel?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : '你';
-  }
-  if (role === 'assistant') return 'Maka';
-  return role;
-}
-
-/**
- * Initial-glyph derivation for the message avatar. Uses the first non-ASCII
- * codepoint or first ASCII letter so a userLabel like "JK" → "J", a Chinese
- * userLabel like "用户" → "用", an emoji name like "🦊 fox" → "🦊".
- */
-export function avatarInitial(label: string): string {
-  const trimmed = label.trim();
-  if (trimmed.length === 0) return '你';
-  // Pull the first codepoint so we don't slice an emoji surrogate pair.
-  const [first] = trimmed;
-  return first ?? '?';
 }
 
 export function formatTurnDuration(ms: number): string {

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4529,28 +4529,33 @@ function ChatModelSwitcher(props: {
  */
 const MessageBody = memo(function MessageBody(props: { role: string; text: string; ts?: number }) {
   if (props.role === 'user') {
+    // User turn: the message sits in a tinted, width-capped block aligned to
+    // the right (so the right-anchor reads even for long messages), with a
+    // quiet always-visible time + a copy affordance in a meta row beneath it.
+    // The time is no longer hover-gated (was `opacity: 0` until hover, which
+    // hid it from touch + assistive tech); copy reuses MessageCopyButton.
     return (
-      <div className="maka-bubble-user">
-        <MessageTimeInline ts={props.ts} position="before" />
-        <span>{props.text}</span>
-      </div>
+      <>
+        <div className="maka-bubble-user">
+          <span>{props.text}</span>
+        </div>
+        <div className="maka-message-meta">
+          {props.ts !== undefined && (
+            <RelativeTime ts={props.ts} className="maka-message-time-inline" />
+          )}
+          <MessageCopyButton text={props.text} />
+        </div>
+      </>
     );
   }
+  // Assistant / system body: open prose, no bubble. Per-turn timing lives in
+  // the turn summary; copy + the other actions live in the turn footer.
   return (
     <div className="maka-bubble-assistant maka-bubble-with-actions">
       <Markdown text={props.text} />
-      <MessageTimeInline ts={props.ts} />
     </div>
   );
 });
-
-function MessageTimeInline(props: { ts?: number; position?: 'before' | 'after' }) {
-  if (props.ts === undefined) return null;
-  const positionClass = props.position === 'before'
-    ? 'maka-message-time-inline-before'
-    : 'maka-message-time-inline-after';
-  return <RelativeTime ts={props.ts} className={`maka-message-time-inline ${positionClass}`} />;
-}
 
 function MessageCopyButton(props: { text: string; label?: string }) {
   const copyFeedback = useClipboardCopyFeedback(1400, { redact: false });
@@ -4843,6 +4848,7 @@ function TurnView(props: {
       {turn.user && (
         <article
           className="maka-message-row message user"
+          aria-label="你发送的消息"
           title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts) : undefined}
         >
           <MessageBody role="user" text={turn.user.text} ts={turn.user.ts} />
@@ -4868,6 +4874,7 @@ function TurnView(props: {
         <article
           className="maka-message-row message assistant"
           data-turn-status={turn.status}
+          aria-label="Maka 的回答"
           title={turn.assistant.ts ? formatAbsoluteTimestamp(turn.assistant.ts) : undefined}
         >
           <div className="maka-bubble-assistant-stack">

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4533,7 +4533,9 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
     // the right (so the right-anchor reads even for long messages), with a
     // quiet always-visible time + a copy affordance in a meta row beneath it.
     // The time is no longer hover-gated (was `opacity: 0` until hover, which
-    // hid it from touch + assistive tech); copy reuses MessageCopyButton.
+    // hid it from touch + assistive tech). Copy reuses MessageCopyButton in
+    // `footerStyle`, so it's the same quiet ghost action as the assistant
+    // turn footer's copy (same primitive + `.maka-turn-footer-action`).
     return (
       <>
         <div className="maka-bubble-user">
@@ -4543,7 +4545,7 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
           {props.ts !== undefined && (
             <RelativeTime ts={props.ts} className="maka-message-time-inline" />
           )}
-          <MessageCopyButton text={props.text} />
+          <MessageCopyButton text={props.text} footerStyle />
         </div>
       </>
     );
@@ -4557,7 +4559,7 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
   );
 });
 
-function MessageCopyButton(props: { text: string; label?: string }) {
+function MessageCopyButton(props: { text: string; label?: string; footerStyle?: boolean }) {
   const copyFeedback = useClipboardCopyFeedback(1400, { redact: false });
   const copyPhase = copyFeedback.phaseFor('message');
   const copyPending = copyPhase === 'pending';
@@ -4567,7 +4569,17 @@ function MessageCopyButton(props: { text: string; label?: string }) {
     await copyFeedback.copy('message', props.text);
   }
 
-  const baseLabel = props.label ?? '复制消息';
+  // `footerStyle` renders this copy as the SAME quiet ghost action the
+  // assistant turn footer uses (`.maka-turn-footer-action`, also a UiButton
+  // variant="quiet" size="sm" with icon + "复制"). The user-message copy and
+  // the assistant copy then read as one button by construction — same
+  // primitive, same class, same icon metrics — instead of a look-alike
+  // bespoke treatment.
+  const footer = props.footerStyle === true;
+  const visibleLabel = footer ? (props.label ?? '复制') : props.label;
+  const iconSize = footer ? 12 : 14;
+
+  const baseLabel = props.label ?? (footer ? '复制' : '复制消息');
   const actionLabel = copyPhase === 'pending'
     ? '复制中'
     : copyPhase === 'copied'
@@ -4578,9 +4590,9 @@ function MessageCopyButton(props: { text: string; label?: string }) {
   return (
     <UiButton
       type="button"
-      className="maka-message-copy"
+      className={footer ? 'maka-turn-footer-action' : 'maka-message-copy'}
       variant="quiet"
-      size="icon-sm"
+      size={footer ? 'sm' : 'icon-sm'}
       onClick={() => void copy()}
       aria-label={copyPhase ? `${actionLabel} · ${baseLabel}` : baseLabel}
       aria-busy={copyPending ? 'true' : undefined}
@@ -4588,10 +4600,10 @@ function MessageCopyButton(props: { text: string; label?: string }) {
       data-copied={copied}
       data-copy-feedback={copyPhase ?? undefined}
       data-pending={copyPending ? 'true' : undefined}
-      data-labelled={props.label ? 'true' : undefined}
+      data-labelled={(!footer && props.label) ? 'true' : undefined}
     >
-      {copied ? <Check size={14} strokeWidth={2} aria-hidden="true" /> : <Copy size={14} strokeWidth={1.75} aria-hidden="true" />}
-      {props.label && <span>{copyPhase === 'pending' ? '复制中…' : copyPhase === 'failed' ? '复制失败' : copied ? '已复制' : props.label}</span>}
+      {copied ? <Check size={iconSize} strokeWidth={2} aria-hidden="true" /> : <Copy size={iconSize} strokeWidth={footer ? 2 : 1.75} aria-hidden="true" />}
+      {visibleLabel && <span>{copyPhase === 'pending' ? '复制中…' : copyPhase === 'failed' ? '复制失败' : copied ? '已复制' : visibleLabel}</span>}
     </UiButton>
   );
 }


### PR DESCRIPTION
## Background

#212 (`fix: refine chat message chrome`, a fork PR) is merged. This is the agreed follow-up: it clears the non-blocking notes from that review and lands the message-chrome design the owner approved in-session. The design was first prototyped as a mock built on the real design tokens and iterated to taste (clean and elegant, a strict two-step type scale, one icon language, a 4pt spacing rhythm). This PR lands that mock into the real components / CSS, reusing existing components rather than hand-rolling new ones.

## Changes

### User messages (the review's main complaint: "not right-aligned")
- The user message is re-tinted into a width-capped block (`--chat-user-bg`, 10px radius) anchored to the right, so the right alignment reads even for long messages. The previous treatment was transparent right-aligned text, which filled most of the column on long messages and made the alignment imperceptible. The block shrink-wraps to its content via `align-items: flex-end` on `.message.user`, so short messages stay compact on the right.
- A meta row beneath the block adds an always-visible time plus a copy affordance. Copy **reuses the existing `MessageCopyButton`** (not a new feature or a new component), answering the "add a copy button under the user message" request. The meta row sits 6px below the block (under the 8px turn rhythm), so the caption reads as belonging to the bubble rather than floating between turns.
- The user copy renders in `footerStyle`, so it is the **same control** as the assistant turn-footer copy by construction: same `UiButton` primitive, same `.maka-turn-footer-action` class, same 12px icon + "复制" label. The two copies no longer drift into different shapes (the earlier icon-only circle vs the labeled footer ghost).

### Readability + accessibility
- Timestamps are no longer hover-gated (they were `opacity: 0` until hover, hidden on touch and from assistive tech). They now render quietly and always-on at the 12px chrome size.
- The chrome type scale is unified: summary, footer, and time all sit at 12px (previously a mix of 9-10px), body stays 15px, monospace 13px. The turn summary collapses from a cluster of tiny pills into one quiet caption line (`model · tools · duration · tokens`, middot-separated).
- Footer actions render uniformly (icon + label, always visible, 28px minimum touch target). This supersedes the PR-UI-17 primary/secondary label-collapse, which after #212 had also reclassified retry/regenerate to secondary (undeclared) and made the most common action, copy, hard to find. `data-priority` is retained on the element for downstream styling but no longer drives visibility.
- The user / assistant message containers get `aria-label`s.
- Spacing rhythm: 24px between turns, 8px within a turn.

### Cleanup
- Removed the dead helpers `avatarInitial` / `messageRoleLabel` (zero call sites after MessageMeta was dropped) and the now-unused `MessageTimeInline`.

## Commits

1. `fix(chat): refine message chrome follow-up to #212` — the chrome changes above (CSS + `MessageBody` / helpers in `@maka/ui`).
2. `test(visual-smoke): render seeded chat fixtures + honor theme override` — a **separate, self-contained harness concern**: under visual-smoke capture the seeded fixture conversation did not project into the turn list (the renderer showed the empty hero) and the theme raced to dark. Two visual-smoke-guarded fixes (IPC `sessions:readMessages` reads the fixture store under capture; `refreshShellSettings` prefers the smoke theme override) make the chat surface actually render for screenshots. Zero real-user impact — both paths are gated on the visual-smoke fixture. Can be split into its own PR if preferred.
3. `fix(chat): reveal user-message copy + space the meta row` — fixes two regressions the AFTER screenshot surfaced: the user-message copy button never rendered (`.maka-message-copy` is absolute + `opacity:0`, revealed only inside a hovered `.maka-bubble-with-actions`, which the meta row is not), and the time hugged the bubble (no gap on the `.message.user` flex column).
4. `fix(chat): unify user-message copy with the assistant footer copy` — the user copy and the assistant footer copy had drifted into two control families (icon-only circle vs labeled ghost). Render the user copy via `MessageCopyButton`'s new `footerStyle`, reusing the same `UiButton` primitive + `.maka-turn-footer-action` class so they are identical by construction. Drops the bespoke meta-row CSS from commit 3.

## Verification
- `npm run typecheck`: passes across all workspaces.
- `npm run -w @maka/ui build`: passes.
- CSS contract suite (radius-converge, motion-token-converge, chat-chrome-no-gradient, visible-copy-hygiene, icon-system, icon-set): 51 tests, 50 pass. The single failure is a `border-radius: 16px` on the composer (`styles.css` ~line 6339), **pre-existing on main and untouched by this branch** (`git diff origin/main` shows no `16px` change). Every contract this PR touches passes.

## Screenshots
<img width="2280" height="791" alt="image" src="https://github.com/user-attachments/assets/91d123c3-b97f-41c0-9a97-5549d9b92b43" />
<img width="2280" height="791" alt="image" src="https://github.com/user-attachments/assets/acfc44f4-845d-448f-ab19-6eab66329bbd" />

Reproduce:

```sh
npm run -w @maka/desktop build:renderer
node scripts/capture-screenshots.mjs --scenario turn-narrative
# → apps/desktop/tests/screenshots/turn-narrative/{light,dark}-1280-motion.png
```
