### PR TITLE
fix(chat): add missing useCallback import to main.tsx (hotfix PR #202)

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from 'react';
+import { StrictMode, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent, type PointerEvent } from 'react';
 import { createRoot } from 'react-dom/client';
 import { CircleGauge, Grid3X3, HelpCircle, MessageCircleQuestion, PanelLeftOpen, Search, SquarePen } from '@maka/ui/icons';
 import type {


### PR DESCRIPTION
🚨 **hotfix — renderer crashes at startup**

WAWQAQ reports a runtime crash:

\`\`\`
ReferenceError: useCallback is not defined
at q80 (dist/renderer/assets/index-D4LgUpob.js:128:31343)
\`\`\`

## Root cause

PR #202 added two \`useCallback\`-wrapped callbacks in \`apps/desktop/src/renderer/main.tsx\` (lines 794 + 797 — \`searchModalOnNavigate\` and \`paletteOnSelectSession\`), but the React named imports on line 1 were not updated:

\`\`\`tsx
import { StrictMode, useEffect, useMemo, useRef, useState, ... } from 'react';
                                                              // ↑ no useCallback
\`\`\`

esbuild / Vite don't fail on undeclared identifiers in source code — they only break at runtime when the call site is hit. \`useCallback\` is referenced inside a function body, so the bundle built successfully but crashed on first render.

Same root cause as PR #221 (paste IME \`isComposing\`): I didn't run \`tsc --noEmit\` against the affected package before pushing. Saved memory \`feedback_tsc_before_ship.md\` after #221; doubling down on it after this.

## Fix

Add \`useCallback\` to the named imports on line 1.

## Verification

Local disk still ~96%; couldn't run a full build. Single-line import fix; reading the change confirms it.