### PR TITLE
chore(ui): demote 5 unused-export interfaces to file-private

### DIFF
--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -215,7 +215,7 @@ export type NavSelection =
   | { section: 'skills' }
   | { section: 'daily-review' };
 
-export type SessionFilter = 'chats' | 'flagged' | 'archived';
+type SessionFilter = 'chats' | 'flagged' | 'archived';
 
 /**
  * Sidebar module ids. "sessions" is still the lower history region label,
@@ -372,7 +372,7 @@ type PlanReminderUpdatePatch = {
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 
-export interface SessionRowActions {
+interface SessionRowActions {
   /** Flag (pin) state toggle. */
   onToggleFlag(sessionId: string, next: boolean): void | Promise<void>;
   /** Move to / out of the archive bucket. */
@@ -1354,7 +1354,7 @@ function SkillsModuleMain(props: {
  * UI layer is reusable in fixtures / visual smoke / future surfaces
  * (e.g. a desktop notification renderer).
  */
-export interface DailyReviewBridge {
+interface DailyReviewBridge {
   fetchDay(offsetDays: number, daySpan?: number): Promise<DailyReviewSummary>;
   /**
    * PR-DAILY-REVIEW-FULL-0 — optional pipeline methods. Renderer checks
@@ -2790,7 +2790,7 @@ function PlanReminderPanel(props: {
  * fail-closed paths return the error envelope and the modal renders
  * them as user-facing copy.
  */
-export interface SearchModalDeps {
+interface SearchModalDeps {
   searchThread(request: SearchRequest): Promise<
     | SearchResult[]
     | { ok: false; reason: SearchErrorReason; message: string }
@@ -6068,7 +6068,7 @@ export function loadToolDisplayName(locale: UiLocale): string {
   return locale === 'en' ? 'Load tools' : '加载工具组';
 }
 
-export interface LoadToolResultDescription {
+interface LoadToolResultDescription {
   title: string;
   countLabel: string;
   toolsText: string;


### PR DESCRIPTION
Lane 3 (simplification), reminder fire #1 of WAWQAQ's new mandate.

## Bug

5 \`export interface\` / \`export type\` declarations in \`packages/ui/src/components.tsx\` have **zero** external consumers but were still being re-exported through the \`@maka/ui\` barrel (\`index.ts: export * from './components.js'\`):

| Symbol | Line | Internal use |
|---|---|---|
| \`SessionFilter\` | 218 | sidebar filter union |
| \`SessionRowActions\` | 375 | row action callbacks |
| \`DailyReviewBridge\` | 1357 | daily-review IPC bridge type |
| \`SearchModalDeps\` | 2793 | search modal IPC bridge type |
| \`LoadToolResultDescription\` | 6071 | internal helper return type |

## Verification

\`\`\`bash
grep -rE \"^import.*\\\\b<name>\\\\b\" --include=\"*.tsx\" --include=\"*.ts\" \\\\
  apps/desktop/src packages/ui/src
\`\`\`

Returns zero matches for each — none of them are imported anywhere outside \`components.tsx\` itself.

## Fix

Drop the \`export\` keyword. They're still defined in the file and TypeScript resolves them locally just fine for the internal call sites.

## Why

1. Stops leaking internal-shape types as if they were public API.
2. Makes future \"what's actually public\" review easier.
3. Removes 5 names from IDE auto-import suggestions.

If a future consumer legitimately needs one of these, re-adding \`export\` is a one-line follow-up.

## Diff

\`1 file changed, 5 insertions(+), 5 deletions(-)\` — pure metadata change. Zero runtime impact (TS type elision means these don't exist in emitted JS). Zero visual change. No other open PR touches these specific lines.