### PR TITLE
fix(settings): Switch thumb escapes track (WAWQAQ "白点跑到框外")

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7911,12 +7911,22 @@ button:active {
 .settingsField [role="switch"] > span {
   height: 22px;
   width: 22px;
-  transform: translateX(2px);
+  /* WAWQAQ msg `b45dc33d` 2026-06-25: Settings Switch thumbs ("白点")
+     were escaping the track to the right. Root cause: Tailwind v4's
+     `translate-x-0.5` / `translate-x-[1.125rem]` utilities applied on
+     <BaseSwitch.Thumb> in `packages/ui/src/ui.tsx:464` emit the
+     `translate:` CSS property, not `transform:`. The previous overrides
+     here set `transform: translateX(...)`, which is an INDEPENDENT
+     property — both stacked additively, pushing the thumb 2-18px past
+     the right edge of the 46px track at h-6.5 settings scale.
+     Fix: override the same `translate:` property so the value wins by
+     specificity instead of compounding. */
+  translate: 2px 0;
 }
 
 .settingsFormRow [role="switch"][data-checked] > span,
 .settingsField [role="switch"][data-checked] > span {
-  transform: translateX(22px);
+  translate: 22px 0;
 }
 
 .settingsFormRow strong,


### PR DESCRIPTION
WAWQAQ msg \`b45dc33d\` 2026-06-25: \"按钮的现在都是坏的。按钮里面的样式错了。里面的白点都移到框外面去了。\"

## Root cause

Tailwind v4 changed the \`translate-x-*\` utilities to emit the \`translate:\` CSS property (modern individual transform shorthand), NOT \`transform:\`. The Switch primitive at \`packages/ui/src/ui.tsx:464\` uses Tailwind v4's \`translate-x-0.5 ... data-[checked]:translate-x-[1.125rem]\`.

The settings-row overrides at \`styles.css:7910-7920\` used the OLD CSS property name (\`transform: translateX(2px)\` / \`transform: translateX(22px)\`).

\`translate:\` and \`transform:\` are **independent properties** in modern CSS — when both apply, the browser stacks BOTH translations additively. In settings, the thumb was being translated by:

- 0.5rem (8px) + 2px = 10px when unchecked
- 1.125rem (18px) + 22px = 40px when checked

On a 46px-wide track with a 22px thumb, the checked position pushed the thumb 16px past the right edge. That's the \"白点跑到框外\".

## Fix

Override the same \`translate:\` property Tailwind writes. \`translate: 22px 0\` wins by selector specificity over the utility class. No more property-mismatch stacking.

Outside settings (chat/sidebar usage of Switch) is unaffected — that path still gets Tailwind's defaults on a 36px-wide track.

## Diff

\`1 file changed, 4 lines changed\` (transform → translate, ×2). CSS-only.