### PR TITLE
fix(settings): align 返回应用 back button to settings nav row recipe

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7254,18 +7254,32 @@ button:active {
 /* PR-SETTINGS-REVIEW-0 (WAWQAQ msg `e1194266`): left-aligned `返回应用`
    in place of the right-side X. Sits above the 设置 brand. */
 .settingsBackButton {
-  display: inline-flex;
+  /* WAWQAQ msg `dd21e793` 2026-06-25: the "返回应用" link previously
+     used 4px 8px padding + 13px / weight 500 + 6px radius + 4px gap +
+     `align-self: flex-start` — none of which matched `.settingsNavItem`
+     below it (38px height, 12px h-pad, 7px radius, 14px / weight 500,
+     12px gap). Combined with `inline-flex` + no width, the back link
+     looked intrinsically sized and visually centered, while every nav
+     row below was full-width, left-aligned with the same glyph + label
+     rhythm. Match `.settingsNavItem` exactly so the row reads as part
+     of the same vertical list. */
+  width: calc(100% - 8px);
+  height: 38px;
+  min-height: 38px;
+  display: flex;
   align-items: center;
-  gap: 4px;
-  align-self: flex-start;
-  margin: 0 0 10px 4px;
-  padding: 4px 8px;
-  border-radius: 6px;
+  gap: 12px;
+  margin: 0 4px 4px;
+  padding: 6px 12px;
+  border-radius: 7px;
   background: transparent;
-  color: var(--foreground-60);
-  font-size: 13px;
+  color: var(--foreground-70);
+  font-size: 14px;
   font-weight: 500;
+  text-align: left;
+  justify-content: initial;
   -webkit-app-region: no-drag;
+  transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
 }
 .settingsBackButton:hover {
   background: oklch(from var(--foreground) l c h / 0.05);


### PR DESCRIPTION
WAWQAQ msg \`dd21e793\` 2026-06-25 #5/5:

> \"返回应用 的样式和其他的侧边栏的样式不是一样的，这样子也不美观。就它一个居中，然后它的样式和其他的 通用 外观 这些的样式都不一样。\"

## Bug

\`.settingsBackButton\` and \`.settingsNavItem\` were styled completely differently — back link inline-flex / 13px / 4-8px padding / 6px radius / 4px gap, nav items flex full-width / 14px / 6-12px padding / 7px radius / 12px gap. The back link looked intrinsically sized + visually centered, mismatching the full-width left-aligned 通用 / 外观 / etc. rows below it.

## Fix

Rewrite \`.settingsBackButton\` to inherit the \`.settingsNavItem\` recipe verbatim (width, height, padding, radius, gap, font, color tokens). Tighten the bottom margin from 10px to 4px so the back row joins the nav stack rhythm.

## Diff

\`1 file, 22 insertions(+), 8 deletions(-)\`. CSS-only.