### PR TITLE
fix(bot-settings): swap monogram glyphs for real brand icons

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   CalendarDays,
   Cpu,
   Database,
+  IconifyIcon,
   Info,
   Mic,
   Monitor,
@@ -268,21 +269,38 @@ function groupedNav(): Array<{ group: SettingsNavGroup; items: SettingsNavItem[]
 }
 
 /**
- * PR-BOT-SETTINGS-UI-0 (WAWQAQ msg `51c7b4ff`): per-platform brand
- * presentation. The glyph is a single-character monogram tinted with
- * the brand color so the platform is recognizable at a glance without
- * embedding upstream platform logo SVGs (license/asset hygiene).
+ * Per-platform brand presentation.
+ *
+ * History:
+ * - PR-BOT-SETTINGS-UI-0 (WAWQAQ msg `51c7b4ff`) shipped single-char
+ *   monograms (T / 飞 / 企 / 微 / D / 钉 / Q) tinted with the brand color
+ *   as a license/asset-hygiene compromise.
+ * - WAWQAQ msg `c8a9fc6f` 2026-06-25 reversed this: "IM 的渠道，这一些
+ *   显然应该用真实的图标，而不是用字。就像现在模型的这一些图标都是
+ *   用的真实对应公司的图标。" → swap the monogram for the real brand
+ *   icon, the same way model providers already use their actual logos.
+ *
+ * Implementation: `iconifyId` references a Simple Icons entry on the
+ * Iconify CDN. `@iconify/react` lazy-fetches on first render and caches
+ * thereafter; no new bundled collection needed (we don't ship
+ * `@iconify-json/simple-icons` because it would balloon the dep tree
+ * for 7 used icons). `glyph` stays as the offline fallback while the
+ * icon is in flight.
+ *
  * `configDocUrl` is the official developer doc surfaced inline as a
  * "查看配置文档 →" link.
  */
-const BOT_BRAND: Record<BotProvider, { color: string; glyph: string; configDocUrl?: string }> = {
-  telegram: { color: '#229ED9', glyph: 'T', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
-  feishu:   { color: '#00C6B7', glyph: '飞', configDocUrl: 'https://open.feishu.cn/document/server-docs/bot-v3' },
-  wecom:    { color: '#0089FF', glyph: '企', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
-  wechat:   { color: '#07C160', glyph: '微', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
-  discord:  { color: '#5865F2', glyph: 'D', configDocUrl: 'https://discord.com/developers/docs/intro' },
-  dingtalk: { color: '#1372FB', glyph: '钉', configDocUrl: 'https://open.dingtalk.com/document/' },
-  qq:       { color: '#EB1923', glyph: 'Q', configDocUrl: 'https://bot.q.qq.com/wiki/' },
+const BOT_BRAND: Record<
+  BotProvider,
+  { color: string; glyph: string; iconifyId: string; configDocUrl?: string }
+> = {
+  telegram: { color: '#229ED9', glyph: 'T', iconifyId: 'simple-icons:telegram', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
+  feishu:   { color: '#00C6B7', glyph: '飞', iconifyId: 'simple-icons:lark', configDocUrl: 'https://open.feishu.cn/document/server-docs/bot-v3' },
+  wecom:    { color: '#0089FF', glyph: '企', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
+  wechat:   { color: '#07C160', glyph: '微', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
+  discord:  { color: '#5865F2', glyph: 'D', iconifyId: 'simple-icons:discord', configDocUrl: 'https://discord.com/developers/docs/intro' },
+  dingtalk: { color: '#1372FB', glyph: '钉', iconifyId: 'simple-icons:dingtalk', configDocUrl: 'https://open.dingtalk.com/document/' },
+  qq:       { color: '#EB1923', glyph: 'Q', iconifyId: 'simple-icons:tencentqq', configDocUrl: 'https://bot.q.qq.com/wiki/' },
 };
 
 // PR-BOT-WECHAT-SCAN-LOGIN-0 (WAWQAQ msg `2fa6ada6`): help copy
@@ -372,7 +390,18 @@ function BotBrandLogo(props: {
       aria-hidden="true"
       style={{ ['--bot-brand-color' as string]: brand.color }}
     >
-      {brand.glyph}
+      {/* WAWQAQ msg `c8a9fc6f` 2026-06-25: real brand icon (Iconify
+          `simple-icons` set, lazy-loaded from the Iconify CDN). The
+          monogram (`brand.glyph`) stays as the `IconifyIcon` `fallback`
+          so the tile isn't blank during the first paint while the
+          remote SVG is in flight. */}
+      <IconifyIcon
+        icon={brand.iconifyId}
+        width="60%"
+        height="60%"
+        aria-hidden="true"
+        fallback={<>{brand.glyph}</>}
+      />
       {props.support !== 'planned' && (
         <span className="settingsBotLogoStatusDot" data-tone={copy.tone} aria-hidden="true" />
       )}

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -39,6 +39,20 @@ import type { ComponentType } from 'react';
 // `<Icon icon="ph:…">` renders synchronously without a CDN fetch.
 addCollection(phData);
 
+/**
+ * Re-export of `@iconify/react`'s `<Icon>` for cases where a caller
+ * needs to render an arbitrary Iconify id (e.g. `simple-icons:wechat`
+ * for the bot-settings brand logos) without taking a direct dependency
+ * on `@iconify/react` from the consuming workspace.
+ *
+ * Icons NOT pre-registered above (everything outside `ph:*`) are
+ * lazy-fetched from the Iconify CDN on first render and then cached by
+ * the Iconify runtime. Use this sparingly — pin a real brand icon
+ * collection (`@iconify-json/simple-icons` etc.) if a surface ends up
+ * needing many or needs offline rendering.
+ */
+export { Icon as IconifyIcon } from '@iconify/react';
+
 /** Phosphor weight options.
  *   `'thin'`    — `ph:gear-thin` (very light strokes)
  *   `'light'`   — `ph:gear-light` (matches old Lucide stroke ~1.5)


### PR DESCRIPTION
WAWQAQ msg \`c8a9fc6f\` 2026-06-25:

> \"现在 im 的渠道，这一些显然应该用真实的图标，而不是用字。就像现在模型的这一些图标都是用的真实对应公司的图标。\"

## Bug

PR-BOT-SETTINGS-UI-0 originally shipped colored single-char monograms (T / 飞 / 企 / 微 / D / 钉 / Q) for the 7 bot channels. WAWQAQ reversed the license/asset-hygiene argument — model providers already use real brand logos, channels should match.

## Fix

\`packages/ui/src/icons.tsx\` re-exports \`@iconify/react\`'s \`Icon\` as \`IconifyIcon\` so consumers can render arbitrary Iconify ids without taking a direct \`@iconify/react\` dep.

\`SettingsModal.tsx\`:
- \`BOT_BRAND\` map gains an \`iconifyId\` field referencing the matching Simple Icons entry (e.g. \`simple-icons:telegram\`, \`simple-icons:wechat\`).
- \`BotBrandLogo\` renders \`<IconifyIcon icon={brand.iconifyId} fallback={brand.glyph} />\` — the monogram stays as fallback during the lazy-fetch + offline states.

## Notes on dep cost

No new bundled dep. \`@iconify/react\` is already a \`@maka/ui\` dependency. The bigger \`@iconify-json/simple-icons\` collection (~8MB) is intentionally NOT bundled — 7 icons fetched on-demand from the Iconify CDN keeps the bundle small. Tradeoff: a brief monogram fallback flash on cold first paint.

## Diff

\`2 files, +56 / -13\`. No CSS changes (the \`.settingsBotLogo\` tile already centers via flex).