### PR TITLE
chore(ui): demote 4 more unused-export interfaces to file-private

### DIFF
--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -338,7 +338,7 @@ function Count(props: { value: number }) {
   return <small>{props.value}</small>;
 }
 
-export interface SkillEntry {
+interface SkillEntry {
   id: string;
   name: string;
   description: string;
@@ -796,7 +796,7 @@ export function SessionListPanel(props: {
  * `.maka-button.maka-empty-state-cta` so we never grow a competing
  * pile of "empty-state action variants".
  */
-export interface EmptyStateProps {
+interface EmptyStateProps {
   Icon: typeof Search;
   title: string;
   body: ReactNode;
@@ -808,7 +808,7 @@ export interface EmptyStateProps {
   dataEmptyView?: string;
 }
 
-export function EmptyState(props: EmptyStateProps) {
+function EmptyState(props: EmptyStateProps) {
   const className = cn(
     'maka-empty-state rounded-xl border-border bg-card/70 p-8 text-card-foreground shadow-maka-panel',
     props.extraClassName,
@@ -2801,7 +2801,7 @@ function searchModalThrownErrorMessage(error: unknown): string {
   return generalizedErrorMessageChinese(error, '搜索服务需要刷新，请重试。');
 }
 
-export interface SearchModalCloseOptions {
+interface SearchModalCloseOptions {
   restoreFocus?: boolean;
 }
 


### PR DESCRIPTION
Follow-up to PR #224. After scanning a wider set of \`components.tsx\` exports, 4 more had zero external consumers:

| Symbol | Line | Internal use |
|---|---|---|
| \`SkillEntry\` | 341 | skill catalog row shape (5x in file) |
| \`EmptyStateProps\` | 799 | empty-state component props |
| \`EmptyState\` | 811 | shared empty-state component (10x in file) |
| \`SearchModalCloseOptions\` | 2804 | internal close-event payload |

\`EmptyState\` is the largest demotion: PR-EMPTY-STATE-COMPONENT-0 (task #8, 2026-05-19) extracted it anticipating multi-file reuse. Three months later still only used inside components.tsx — every surface that wanted an empty state ended up using it via that file's internal call sites, not via the public barrel. Demote until a real external consumer materializes; re-adding \`export\` is one line.

Verified zero external imports via:
\`\`\`bash
grep -rE \"^import.*\\\\b<name>\\\\b\" --include=\"*.tsx\" --include=\"*.ts\" \\\\
  apps/desktop/src packages/ui/src
\`\`\`

## Diff

\`1 file, 4 insertions(+), 4 deletions(-)\`. Zero runtime impact (TS type elision). Zero visual change.