### PR TITLE
chore(css): finish dead-class cleanup — drop .maka-composer-role-chip arm (round 6, final)

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -6328,7 +6328,6 @@ button:active {
   text-align: center;
 }
 
-.maka-composer-role-chip,
 .maka-composer-mode-chip,
 .maka-composer-model-chip {
   height: 26px;
@@ -6343,18 +6342,12 @@ button:active {
   font-size: 10.5px;
   font-weight: 500;
   white-space: nowrap;
-}
-
-.maka-composer-role-chip,
-.maka-composer-mode-chip,
-.maka-composer-model-chip {
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
     color var(--duration-base) var(--ease-out-strong),
     border-color var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-composer-role-chip:hover,
 .maka-composer-mode-chip:hover,
 .maka-composer-model-chip:hover {
   background: var(--foreground-3);


### PR DESCRIPTION
Final round of the dead-CSS sweep. Continues PR #230 / #231 / #232 / #233 / #234.

## What

\`.maka-composer-role-chip\` was the last dead \`.maka-*\` class still lingering after round 1. Deferred then because it appeared in three multi-class selector lists with the live \`.maka-composer-mode-chip\` + \`.maka-composer-model-chip\`.

This PR drops the \`.maka-composer-role-chip\` arm from each selector list **and** merges two adjacent rule blocks that had the same selectors (13-declaration block + 1-declaration transition block) into one. The :hover rule also drops the role-chip arm. Behavior unchanged for the two live chip variants; one fewer rule for readers to mentally combine.

After this PR my full styles.css sweep returns ZERO remaining dead classes.

## Diff

\`1 file, -9 lines\`. CSS-only. Zero visual change.

## Sweep totals (final)

| PR | Lines removed | Theme |
|---|---|---|
| #230 | -174 | \`.maka-skeleton-*\`, \`.maka-mode-switcher\`, 9 singletons |
| #231 | -38 | \`.connectionForm\`, \`.credentialField\` core |
| #232 | -79 | \`.providers*\` old layout |
| #233 | -36 | \`.chatToolbar\`, \`.emptyChat\`, \`.eyebrow\`, \`.credentialField\` residual |
| #234 | -156 | \`.settingsBotDomainSelect\`, settings modal codepath, \`.catalogCustom\`, \`.providerModelRow/Source\` |
| #235 (this) | -9 | \`.maka-composer-role-chip\` arm + rule merge |
| **Total** | **-492** | |

styles.css ~14150 → ~13658 lines (~3.5% drop). Zero visual change across the whole sweep — every removed selector was verified to have zero JSX consumers via \`grep -rE \"\\\\b<name>\\\\b\" --include=\"*.tsx\" --include=\"*.ts\" apps packages\`.