### PR TITLE
fix(settings): tighten daily-review settings UX (button align, time input width, model labels)

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1476,22 +1476,15 @@ function buildDailyReviewModelOptions(
   const options: Array<readonly [string, string]> = [
     [
       DAILY_REVIEW_DEFAULT_MODEL_VALUE,
-      defaultConnection
-        ? `使用对话默认模型（${defaultConnection.name} · ${defaultConnection.defaultModel || '默认模型'}）`
-        : '使用对话默认模型',
+      defaultConnection?.defaultModel
+        ? `对话默认（${defaultConnection.defaultModel}）`
+        : '对话默认',
     ],
   ];
   const seenKeys = new Set<string>();
   for (const connection of connections) {
+    if (!connection.enabled) continue;
     const defaults = PROVIDER_DEFAULTS[connection.providerType];
-    if (!connection.enabled || defaults.backendKind !== 'ai-sdk') continue;
-    if (
-      defaults.authKind === 'oauth_token' &&
-      connection.providerType !== 'claude-subscription' &&
-      connection.providerType !== 'codex-subscription'
-    ) {
-      continue;
-    }
     const rawModels = connection.models?.length
       ? connection.models.map((model) => model.id)
       : connection.defaultModel
@@ -1506,7 +1499,7 @@ function buildDailyReviewModelOptions(
       const key = `${connection.slug}::${model}`;
       if (seenKeys.has(key)) continue;
       seenKeys.add(key);
-      options.push([key, `${connection.name} · ${model}`]);
+      options.push([key, model]);
     }
   }
   const trimmedCurrent = currentModelKey.trim();
@@ -1515,7 +1508,8 @@ function buildDailyReviewModelOptions(
     trimmedCurrent !== DAILY_REVIEW_DEFAULT_MODEL_VALUE &&
     !options.some(([value]) => value === trimmedCurrent)
   ) {
-    options.push([trimmedCurrent, `当前自定义模型：${trimmedCurrent}`]);
+    const tail = trimmedCurrent.split('::').pop() || trimmedCurrent;
+    options.push([trimmedCurrent, tail]);
   }
   return options;
 }
@@ -1662,13 +1656,14 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
             生成的对话摘要 / 遗漏提醒等回顾内容。
           </p>
           {props.onOpenDailyReview && (
-            <Button
-              type="button"
-              onClick={props.onOpenDailyReview}
-              style={{ marginTop: 8 }}
-            >
-              打开每日回顾
-            </Button>
+            <div className="settingsFeatureStatusHeroActions">
+              <Button
+                type="button"
+                onClick={props.onOpenDailyReview}
+              >
+                打开每日回顾
+              </Button>
+            </div>
           )}
         </div>
       </div>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7429,6 +7429,17 @@ button:active {
   margin: 0;
 }
 
+.settingsFeatureStatusHeroActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.settingsRow > .settingsTimeInput {
+  max-width: 140px;
+  justify-self: end;
+}
+
 .settingsFeatureStatusBadge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Address 3 visual / interaction issues WAWQAQ reported on the Daily Review settings page:

1. **Button alignment.** 「打开每日回顾」 was glued to the paragraph margin (left-aligned). Wrap it in a `.settingsFeatureStatusHeroActions` flex container that pushes it to the right edge of the hero card, matching the rest of the settings page right-side convention.
2. **Time input width.** The `<Input type="time">` was rendering full-width so it read as a plain text field rather than an adjustable time-picker. Cap it at `max-width: 140px` and `justify-self: end` to look like the other compact value-side controls.
3. **Model select labels + 「无法选择」.**
   - Drop the verbose `connection.name · model` prefix in every option; show just the model id (and `对话默认（model）` for the default pseudo-row).
   - Drop the `backendKind !== 'ai-sdk'` and OAuth filter so the user's default OAuth connection (e.g. Codex OAuth) shows up as an explicit option. Previously a Codex-OAuth-only setup left the dropdown with only the default pseudo-row — visually unselectable.

No backend changes: `resolveDailyReviewModelContext` already routes through `getAIModel` for any enabled connection, so loosening the filter on the picker side is safe.

## Test plan
- [ ] Open Settings → 每日回顾 with Codex OAuth as default. Confirm 「打开每日回顾」 sits on the right edge of the hero card.
- [ ] Confirm 执行时间 renders as a narrow time-picker (≤140px), not a full-width text field, and the native time picker still opens.
- [ ] Confirm 分析模型 dropdown shows `对话默认（gpt-5.5）` for the default row and just `gpt-5.5` (etc.) for explicit options.
- [ ] Confirm explicit model selection persists and that picking a Codex OAuth model runs Daily Review successfully.