### PR TITLE
fix(chat-header): unify top-right cluster + soften blocked status tone

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -58,8 +58,8 @@ describe('presentSessionStatus', () => {
     }
   });
 
-  it('blocked is destructive', () => {
-    assert.equal(presentSessionStatus('blocked').tone, 'destructive');
+  it('blocked is warning (recoverable, not a hard failure)', () => {
+    assert.equal(presentSessionStatus('blocked').tone, 'warning');
   });
 
   it('done is success', () => {

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -2847,15 +2847,15 @@ function AppShell() {
           )}
           <div className="maka-workspace-top-actions" role="toolbar" aria-label="工作区辅助操作">
             <UiButton
-              className="maka-workspace-feedback-action"
+              className="maka-workspace-icon-action"
               variant="quiet"
-              size="sm"
+              size="icon-sm"
               type="button"
               onClick={() => openSettingsSection('about')}
+              aria-label="问题反馈"
               title="问题反馈 · 打开关于与环境信息"
             >
               <MessageCircleQuestion size={15} strokeWidth={1.7} aria-hidden="true" />
-              <span>问题反馈</span>
             </UiButton>
             <UiButton
               className="maka-workspace-icon-action"

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -49,7 +49,15 @@ const STATUS_PRESENTATION: Record<SessionStatus, SessionStatusPresentation> = {
   active: { label: '可继续', tone: 'neutral', interactive: true },
   running: { label: '进行中', tone: 'accent', interactive: true },
   waiting_for_user: { label: '等你确认', tone: 'warning', interactive: true },
-  blocked: { label: '已阻塞', tone: 'destructive', interactive: true },
+  // `blocked` was destructive (red) but most blocked states are
+  // recoverable (permission_required, auth retry, missing connection
+  // selection) — the chat header pill ended up sitting beside monochrome
+  // quiet-icon utility buttons, where the bright red read as a hard
+  // error in a row that did not deserve one. 'warning' (warm yellow)
+  // honestly conveys "you need to do something" without screaming
+  // failure. Real hard failures surface through ChatHeaderAlertBadge,
+  // which still uses destructive.
+  blocked: { label: '已阻塞', tone: 'warning', interactive: true },
   review: { label: '待审核', tone: 'info', interactive: true },
   done: { label: '已完成', tone: 'success', interactive: true },
   archived: { label: '已归档', tone: 'muted', interactive: false },

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -424,26 +424,13 @@ button:active {
   display: none;
 }
 
-.maka-workspace-feedback-action,
 .maka-workspace-icon-action {
+  width: 24px;
   height: 24px;
   border-radius: 6px;
   color: var(--foreground-65);
 }
 
-.maka-workspace-feedback-action {
-  gap: 4px;
-  padding-inline: 6px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--foreground-55);
-}
-
-.maka-workspace-icon-action {
-  width: 24px;
-}
-
-.maka-workspace-feedback-action:hover,
 .maka-workspace-icon-action:hover {
   color: var(--foreground);
   background: var(--foreground-5);

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -338,7 +338,7 @@ function Count(props: { value: number }) {
   return <small>{props.value}</small>;
 }
 
-interface SkillEntry {
+export interface SkillEntry {
   id: string;
   name: string;
   description: string;
@@ -3452,10 +3452,19 @@ const STATUS_LABEL_BY_STATUS = {
   aborted: '已中止',
 } as const;
 
+// `blocked` was 'destructive' (red), which read as a hard error in the
+// chat header even when the session was just waiting on permission or a
+// connection retry. The chat top-right cluster sits visually alongside
+// monochrome quiet-icon buttons, so the bright red pill clashed. Most
+// blocked sessions are recoverable (permission_required, auth retry,
+// missing connection), so 'warning' (warm yellow) is the honest tone —
+// "you need to do something" rather than "this failed". The destructive
+// red is reserved for hard failures (e.g. permanent connection / auth
+// rejection), which surface through ChatHeaderAlertBadge instead.
 const STATUS_TONE_BY_STATUS = {
   running: 'accent',
   waiting_for_user: 'warning',
-  blocked: 'destructive',
+  blocked: 'warning',
   review: 'info',
   done: 'success',
   archived: 'muted',


### PR DESCRIPTION
## Summary
WAWQAQ flagged the chat top-right area as visually broken: the 「问题反馈」 button carried a text label while the other 3 top-bar actions (command palette / help / health) were icon-only, and the 「已阻塞」 status pill rendered next to that row in a bright destructive-red tone that clashed with the monochrome quiet-icons.

This PR fixes both in one shot:

1. **Top-right row unification** — 「问题反馈」 routed through the same `.maka-workspace-icon-action` (size=icon-sm) bucket as the other three. Icon kept (`MessageCircleQuestion`), label moves to tooltip + aria-label. CSS shared block collapsed.
2. **`blocked` tone destructive → warning** — Most blocked sessions are recoverable (permission_required, auth retry, missing connection). The destructive red read as a hard failure in a row of monochrome quiet-icons. `warning` (warm yellow) honestly says "you need to do something" without overpromising hard failure. Real hard failures still surface through `ChatHeaderAlertBadge` in destructive.
3. **Re-export `SkillEntry`** — PR #229 demoted it but `apps/desktop/src/renderer/main.tsx` still imports it as a type — pre-existing build-break on upstream main. One-line export so the renderer's typecheck stays green.

## Test plan
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — clean
- [x] `node --test dist/main/__tests__/session-status-presentation.test.js` — 36/36 pass; renamed contract test confirms `blocked → warning`
- [ ] Visually verify top-right cluster: 4 evenly-spaced 24×24 icon buttons.
- [ ] Visually verify 「已阻塞」 pill renders in the warm-yellow warning tone, not bright red.
- [ ] Verify `OnboardingHero` blocked hero still renders destructive tone (different code path — `getOnboardingHeroCopy` keeps its own `tone: 'destructive'` for `all_connections_unhealthy`).