### PR TITLE
fix(settings): use Alert primitive for daily-review load-error

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -82,6 +82,8 @@ import {
 import { BOT_PROVIDERS, MAX_ALLOWED_USER_IDS, createDefaultSettings, parseAllowedUserIdsFromText } from '@maka/core/settings';
 import { CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS, PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import {
+  Alert,
+  AlertDescription,
   Button,
   DialogContent,
   DialogRoot,
@@ -1669,9 +1671,9 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
       </div>
 
       {loadError ? (
-        <div className="settingsAlert" role="alert" style={{ marginTop: 12 }}>
-          读取每日回顾设置失败：{loadError}
-        </div>
+        <Alert variant="error" style={{ marginTop: 12 }}>
+          <AlertDescription>读取每日回顾设置失败：{loadError}</AlertDescription>
+        </Alert>
       ) : null}
 
       <div className="settingsRows">


### PR DESCRIPTION
## Summary
Tiny but honest 'use the library more' win: the `读取每日回顾设置失败` error branch in Settings → 每日回顾 was rendering through a bare `<div className=\"settingsAlert\">` — and there is **no** `.settingsAlert` CSS rule in `styles.css`, so when the rare error path fired (`dailyReviewIpc.getConfig()` rejected) the user got an unstyled paragraph.

Replace with the shadcn-style `Alert` primitive (variant=\"error\"), which already ships the proper destructive-tinted border + background + icon slot.

Scope is intentionally small. The bigger `.settingsFeatureStatusHero` / `.settingsFeatureStatusBanner` migrations to shadcn `Card` composition look identical visually because the bespoke CSS already does Card's job — invisible refactor, no end-result win, so skipped per WAWQAQ's '只看最后的结果' directive (msg `d13074c7`).

## Test plan
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — clean on touched lines.
- [ ] Force `dailyReviewIpc.getConfig()` to throw and confirm the Alert renders with the proper destructive border/background.