### PR TITLE
Preserve local memory restore history

### DIFF
--- a/apps/desktop/src/main/__tests__/local-memory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/local-memory-service.test.ts
@@ -182,6 +182,73 @@ describe('LocalMemoryService', () => {
     if (restoreBackup.ok) assert.match(restoreBackup.path, /MEMORY\.md\.restore\.bak$/);
   });
 
+  it('keeps the previous restore undo when restoring twice', async () => {
+    const { service } = await makeService(1_700_000_000_000)();
+    await service.save([
+      '# Maka Memory',
+      '',
+      '## First',
+      '<!-- maka-memory: id=first origin=manual createdAt=1700000000000 -->',
+      '第一版。',
+      '',
+    ].join('\n'));
+    await service.save([
+      '# Maka Memory',
+      '',
+      '## Second',
+      '<!-- maka-memory: id=second origin=manual createdAt=1700000000001 -->',
+      '第二版。',
+      '',
+    ].join('\n'));
+
+    const firstRestore = await service.restoreBackup('save');
+    assert.equal(firstRestore.ok, true);
+    assert.match(await readFile(`${service.file}.restore.bak`, 'utf8'), /第二版/);
+
+    await service.save([
+      '# Maka Memory',
+      '',
+      '## Third',
+      '<!-- maka-memory: id=third origin=manual createdAt=1700000000002 -->',
+      '第三版。',
+      '',
+    ].join('\n'));
+    const secondRestore = await service.restoreBackup('save');
+
+    assert.equal(secondRestore.ok, true);
+    assert.match(await readFile(`${service.file}.restore.bak`, 'utf8'), /第三版/);
+    assert.match(await readFile(`${service.file}.restore.1.bak`, 'utf8'), /第二版/);
+  });
+
+  it('can restore the restore backup without overwriting the selected backup first', async () => {
+    const { service } = await makeService(1_700_000_000_000)();
+    await service.save([
+      '# Maka Memory',
+      '',
+      '## First',
+      '<!-- maka-memory: id=first origin=manual createdAt=1700000000000 -->',
+      '第一版。',
+      '',
+    ].join('\n'));
+    await service.save([
+      '# Maka Memory',
+      '',
+      '## Second',
+      '<!-- maka-memory: id=second origin=manual createdAt=1700000000001 -->',
+      '第二版。',
+      '',
+    ].join('\n'));
+    const firstRestore = await service.restoreBackup('save');
+    assert.equal(firstRestore.ok, true);
+
+    const undoRestore = await service.restoreBackup('restore');
+
+    assert.equal(undoRestore.ok, true);
+    assert.match(undoRestore.state.content, /第二版/);
+    assert.doesNotMatch(undoRestore.state.content, /第一版/);
+    assert.match(await readFile(`${service.file}.restore.1.bak`, 'utf8'), /第二版/);
+  });
+
   it('surfaces reset backup metadata so restore is visible before click', async () => {
     const { service } = await makeService(1_700_000_000_000)();
     await service.save([

--- a/apps/desktop/src/main/local-memory-service.ts
+++ b/apps/desktop/src/main/local-memory-service.ts
@@ -423,8 +423,9 @@ export class LocalMemoryService {
         if (!backupStat.isFile()) {
           throw new Error('MEMORY.md backup is not a file.');
         }
-        await this.backup('restore.bak');
-        await copyFile(backup, this.file);
+        const backupContent = await readFile(backup);
+        await this.backupRestoreUndo();
+        await writeFile(this.file, backupContent, { mode: 0o600 });
         await chmod(this.file, 0o600);
       });
       this.recordPromptUpdate('backup_restored');
@@ -721,6 +722,22 @@ export class LocalMemoryService {
     } catch {
       // No prior file to back up.
     }
+  }
+
+  private async backupRestoreUndo(): Promise<void> {
+    await this.rotateRestoreBackupHistory();
+    await this.backup('restore.bak');
+  }
+
+  private async rotateRestoreBackupHistory(): Promise<void> {
+    const maxRestoreHistory = 5;
+    for (let index = maxRestoreHistory - 1; index >= 1; index -= 1) {
+      await rename(
+        `${this.file}.restore.${index}.bak`,
+        `${this.file}.restore.${index + 1}.bak`,
+      ).catch(() => {});
+    }
+    await rename(`${this.file}.restore.bak`, `${this.file}.restore.1.bak`).catch(() => {});
   }
 
   private async enqueue<T>(task: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- Preserve the previous MEMORY.md restore undo snapshot by rotating existing `restore.bak` to numbered history before writing a new restore undo backup.
- Read the selected backup bytes before rotating restore history so restoring `restore.bak` cannot overwrite its own source.
- Add service tests for back-to-back restores and restoring the restore backup itself.

## Verification
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/local-memory-service.test.js`
- `git diff --check HEAD~1 HEAD`

Note: the machine has only ~202 MiB free (`df -h .` shows 100% capacity), so I kept verification focused to the main-process build and targeted service suite instead of a full workspace build.
