### PR TITLE
fix(settings): address kenji daily-review audit findings 1-4

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1476,13 +1476,10 @@ function buildDailyReviewModelOptions(
     ? connections.find((connection) => connection.slug === defaultConnectionSlug)
     : null;
   const options: Array<readonly [string, string]> = [
-    [
-      DAILY_REVIEW_DEFAULT_MODEL_VALUE,
-      defaultConnection?.defaultModel
-        ? `对话默认（${defaultConnection.defaultModel}）`
-        : '对话默认',
-    ],
+    [DAILY_REVIEW_DEFAULT_MODEL_VALUE, '跟随对话默认'],
   ];
+  type Entry = { key: string; model: string; connectionName: string };
+  const entries: Entry[] = [];
   const seenKeys = new Set<string>();
   for (const connection of connections) {
     if (!connection.enabled) continue;
@@ -1501,8 +1498,23 @@ function buildDailyReviewModelOptions(
       const key = `${connection.slug}::${model}`;
       if (seenKeys.has(key)) continue;
       seenKeys.add(key);
-      options.push([key, model]);
+      entries.push({ key, model, connectionName: connection.name });
     }
+  }
+  // Finding #4 (kenji audit 2026-06-25): when two connections both expose
+  // the same model id, the flat-label list becomes "gpt-5.5 / gpt-5.5" and
+  // looks unselectable. Only disambiguate the entries that actually collide;
+  // the common case (unique model ids) stays terse per WAWQAQ's
+  // 「只用模型名就行了」 directive.
+  const modelCounts = new Map<string, number>();
+  for (const entry of entries) {
+    modelCounts.set(entry.model, (modelCounts.get(entry.model) ?? 0) + 1);
+  }
+  for (const entry of entries) {
+    const label = (modelCounts.get(entry.model) ?? 0) > 1
+      ? `${entry.model} · ${entry.connectionName}`
+      : entry.model;
+    options.push([entry.key, label]);
   }
   const trimmedCurrent = currentModelKey.trim();
   if (
@@ -1700,7 +1712,7 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
             aria-label="每日回顾执行时间"
             className="settingsTimeInput"
             value={effectiveConfig?.executeTime ?? '08:00'}
-            disabled={formDisabled || savingKey === 'executeTime' || !(effectiveConfig?.enabled ?? false)}
+            disabled={formDisabled || savingKey === 'executeTime'}
             onChange={(event) => {
               const value = event.target.value;
               if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return;
@@ -1804,7 +1816,7 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
               <h3>想先看看效果？</h3>
             </div>
             <p>无需开启自动执行，基于当前工作区的对话记录立即生成一份报告。</p>
-            <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <div className="settingsFeatureStatusHeroActions">
               <Button
                 type="button"
                 onClick={() => void triggerRun('daily')}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7419,6 +7419,7 @@ button:active {
 .settingsFeatureStatusHeroActions {
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
## Summary
Acts on @kenji's daily-review audit (thread msg \`26a221be\`) against #237 main \`4e0247f6\`. Verified each finding against current source before fixing.

**Fixed:**
1. **Bottom 「想先看看效果？」 buttons left-aligned** — routed through the same `.settingsFeatureStatusHeroActions` flex+right-align class as the top button; added `gap: 8px` to support multi-button clusters.
2. **执行时间 disabled when master switch off** — dropped `!(effectiveConfig?.enabled ?? false)` from the disable condition. Pick a time first, then enable — common flow no longer blocked.
3. **分析模型 default-row label** — `对话默认（gpt-5.5）` → `跟随对话默认`. Per WAWQAQ \"只用模型名\": the default-row doesn't pick a model, it follows the conversation default; model id only appears on explicit-pick rows.
4. **Duplicate model ids across connections** — only the colliding entries get `· ${connection.name}` disambiguation; unique model ids stay terse.

**Deferred** (with kenji concurrence):
- **#5** `data-control-width` semantic API to replace CSS selector width patches — pure refactor, no end-result change.
- **#6** collapse the Daily Review hero card pile into one grouped settings surface — bigger visual restructure; needs WAWQAQ sign-off before swinging.

## Test plan
- [x] \`tsc --noEmit -p apps/desktop/tsconfig.renderer.json\` — clean on touched lines.
- [ ] With master switch OFF, edit 执行时间 → value persists; flipping switch ON inherits the time.
- [ ] With single ai-sdk connection, 分析模型 dropdown shows 「跟随对话默认」 + model ids only.
- [ ] With two connections exposing the same model id, the colliding rows get the \` · connection name\` suffix.
- [ ] Click 生成每日回顾 / 生成深度分析 — buttons sit at the right edge of the hero card with proper gap.