### PR TITLE
fix(chat): center the streaming answer in the turn column

### DIFF
--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -25,6 +25,10 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'artifact-pane',
   'artifact-errors',
   'streaming-sidebar',
+  // PR-STREAM-TURN-CENTER: active session renders the live answer bubble in
+  // the main panel (below a committed turn) so the screenshot locks
+  // streaming-vs-committed horizontal alignment.
+  'streaming-answer',
   'permission-destructive',
   'stale-sessions',
   // PR108j: per-Settings-section fixtures so the screenshot pipeline
@@ -310,6 +314,16 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
         streamingBySession: streamingState(),
         liveToolsBySession: streamingTools(),
       };
+    case 'streaming-answer':
+      // Active session = the committed turn-narrative session, PLUS a live
+      // answer streaming into it. The main panel then shows a settled turn
+      // and the in-flight bubble together, so the screenshot proves they
+      // share the same centered column (the streaming-turn-center fix).
+      return {
+        ...state,
+        activeSessionId: TURN_SESSION_ID,
+        streamingBySession: { [TURN_SESSION_ID]: STREAMING_ANSWER_MARKDOWN },
+      };
     case 'permission-destructive':
       return {
         ...state,
@@ -542,6 +556,21 @@ const TURN_CONTROL_SCENARIOS = new Set<VisualSmokeScenario>([
 
 const TURN_SESSION_ID = 'visual-smoke-turn';
 const STREAMING_SESSION_ID = 'visual-smoke-streaming';
+// PR-STREAM-TURN-CENTER: realistic multi-block markdown (heading + paragraph +
+// list) for the `streaming-answer` scenario, so the captured streaming bubble
+// exercises the same prose layout a real answer does and its left edge is
+// unambiguous to compare against the committed turn above it.
+const STREAMING_ANSWER_MARKDOWN = [
+  '## Maka Desktop 项目概况',
+  '',
+  '这里是当前项目的快速概览：',
+  '',
+  '- 框架：Electron + React 19 + Vite 7',
+  '- 语言：TypeScript',
+  '- 构建：tsc（main / preload）+ Vite（renderer）',
+  '',
+  '正在整理目录结构，稍等……',
+].join('\n');
 const PERMISSION_SESSION_ID = 'visual-smoke-permission';
 const WORKSTATION_RUNNING_SESSION_ID = 'visual-smoke-ws-running';
 const WORKSTATION_WAITING_SESSION_ID = 'visual-smoke-ws-waiting';

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -12,6 +12,12 @@ export type VisualSmokeScenario =
   | 'artifact-pane'
   | 'artifact-errors'
   | 'streaming-sidebar'
+  // PR-STREAM-TURN-CENTER: streaming-sidebar only shows the SIDEBAR dot (its
+  // active session is a committed one). This seeds an ACTIVE session whose
+  // main panel renders the live answer bubble below a committed turn, so the
+  // screenshot locks streaming-vs-committed horizontal alignment — the gap
+  // that let the "streaming markdown sits ~110px too far left" bug ship.
+  | 'streaming-answer'
   | 'permission-destructive'
   | 'stale-sessions'
   | 'settings-data'

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4329,29 +4329,40 @@ export function ChatView(props: {
             );
           })}
           {(props.streamingText || props.thinkingText) && (
-            <article className="maka-message-row maka-turn-streaming message assistant streaming">
-              {/* PR-UI-LAYOUT-42: Reasoning panel for Anthropic-style
-               * extended thinking. Renders ABOVE the streaming
-               * answer because thinking always precedes the
-               * answer. Default-open during streaming so the user
-               * sees the model reasoning; users can collapse it
-               * if too verbose. The panel disappears entirely on
-               * text_complete / abort / error (parent clears the
-               * thinkingBySession entry). */}
-              {props.thinkingText && (
-                <ReasoningPanel
-                  text={props.thinkingText}
-                  live={!props.streamingText}
-                  truncated={props.thinkingTruncated === true}
-                />
-              )}
-              {props.streamingText && (
-                <StreamingAssistantBubble
-                  text={props.streamingText}
-                  truncated={props.streamingTruncated === true}
-                />
-              )}
-            </article>
+            // PR-STREAM-TURN-CENTER: the in-flight answer must use the SAME
+            // `.maka-turn` shell a committed turn uses. `.maka-turn` owns the
+            // centered 680px reading column (max-width + margin:0 auto). A bare
+            // `.message.assistant` instead left-aligns — its unlayered
+            // margin-right:auto outranks `.maka-message-row`'s margin:0 auto —
+            // so without this wrapper the streaming answer rendered ~110px left
+            // of where it lands once committed, a visible horizontal jump on
+            // text_complete. Wrapping here makes streaming structurally
+            // identical to TurnView's committed turn.
+            <section className="maka-turn maka-turn-streaming">
+              <article className="maka-message-row message assistant streaming">
+                {/* PR-UI-LAYOUT-42: Reasoning panel for Anthropic-style
+                 * extended thinking. Renders ABOVE the streaming
+                 * answer because thinking always precedes the
+                 * answer. Default-open during streaming so the user
+                 * sees the model reasoning; users can collapse it
+                 * if too verbose. The panel disappears entirely on
+                 * text_complete / abort / error (parent clears the
+                 * thinkingBySession entry). */}
+                {props.thinkingText && (
+                  <ReasoningPanel
+                    text={props.thinkingText}
+                    live={!props.streamingText}
+                    truncated={props.thinkingTruncated === true}
+                  />
+                )}
+                {props.streamingText && (
+                  <StreamingAssistantBubble
+                    text={props.streamingText}
+                    truncated={props.streamingTruncated === true}
+                  />
+                )}
+              </article>
+            </section>
           )}
           {/* Defensive: if any tool ended up outside a turn (e.g. legacy
               sessions without turnId), render those at the very end so they

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -66,6 +66,7 @@ const ALL_SCENARIOS = [
   'artifact-pane',
   'artifact-errors',
   'streaming-sidebar',
+  'streaming-answer',
   'permission-destructive',
   'stale-sessions',
   'settings-data',


### PR DESCRIPTION
## Summary
While streaming, the in-flight assistant answer rendered as a **bare** `<article class="maka-message-row maka-turn-streaming message assistant streaming">` appended straight to `.maka-chat`, skipping the `.maka-turn` wrapper every committed turn uses.

`.maka-turn` owns the centered 680px reading column (`max-width` + `margin:0 auto`). On the bare article the **unlayered** `.message.assistant { margin-right:auto }` (styles.css) outranks the layered `.maka-message-row { margin:0 auto }` (maka-tokens.css `@layer components`), so the article **left-aligned** instead of centering. The answer therefore sat well left of where it lands once the turn commits and re-renders inside `.maka-turn` — a visible horizontal jump on `text_complete`.

1. **Fix** — wrap the streaming block in `.maka-turn` so it is structurally identical to a committed turn. Centering now comes from the wrapper; the jump is gone. One spot, pure structure, no shared-rule / contract-test changes.
2. **Coverage** — add a `streaming-answer` visual-smoke scenario (active session with a live markdown answer streaming in **below a committed turn**) so the streaming main-panel surface finally has a screenshot. That gap is why this shipped: `streaming-sidebar` only exercises the sidebar dot, never the main-panel bubble.

## Screenshots (Before / After)
<img width="2560" height="3472" alt="image" src="https://github.com/user-attachments/assets/64334b48-1dbc-40a3-b498-02cdc9a95950" />
红色虚线 = 正确的列左缘。流式 markdown 左边缘 **69px → 313px**（已提交文本 = 313px），即 delta **244px → 0**，与已提交答案完全同列。

## Test plan
- [x] `@maka/core` / `@maka/ui` / `@maka/desktop` build — clean.
- [x] Touched files typecheck clean (`tsc --noEmit`).
- [x] Full desktop test suite — no new failures vs base (`794132ad` adds 0 reds).
- [x] A/B capture on the new `streaming-answer` fixture: streaming-vs-committed left edge **69px → 313px** (delta **244px → 0**).
- [ ] Live: send a message, watch a markdown answer stream — renders in the centered column, no horizontal jump on completion.
