### PR TITLE
Update Claude subscription OAuth endpoints

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
@@ -62,6 +62,11 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
     // actually built here.
     const src = await readFile(CLOAK_SOURCE, 'utf8');
     assert.match(src, /claude-cli\//, 'cloak module must build the Claude Code UA');
+    assert.match(
+      src,
+      /CLAUDE_CODE_PRODUCT_VERSION\s*=\s*'2\.1\.153'/,
+      'cloak module must track the current Claude Code product version',
+    );
     assert.match(src, /X-Stainless-/, 'cloak module must build Stainless headers');
     assert.match(src, /You are Claude Code/, 'cloak module must inject the Claude Code system prefix');
     // PR-CLAUDE-OAUTH-RUNTIME-VERSION-PIN-0: pin the Runtime-Version
@@ -171,6 +176,35 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
     );
   });
 
+  it('OAuth authorize flow tracks current Claude Code subscription endpoints and scopes', async () => {
+    const src = await readFile(SERVICE_SOURCE, 'utf8');
+    assert.match(
+      src,
+      /CLAUDE_AUTHORIZE_ENDPOINT\s*=\s*'https:\/\/claude\.com\/cai\/oauth\/authorize'/,
+      'Claude subscription auth must use Claude Code subscription authorize route, not the stale claude.ai endpoint',
+    );
+    assert.match(
+      src,
+      /CLAUDE_REDIRECT_URI\s*=\s*'https:\/\/platform\.claude\.com\/oauth\/code\/callback'/,
+      'Claude subscription auth must use the current platform callback route',
+    );
+    assert.match(
+      src,
+      /CLAUDE_TOKEN_ENDPOINT\s*=\s*'https:\/\/platform\.claude\.com\/v1\/oauth\/token'/,
+      'Claude subscription token exchange must use the current platform token endpoint',
+    );
+    assert.match(
+      src,
+      /CLAUDE_SCOPE\s*=\s*'user:sessions:claude_code user:mcp_servers user:file_upload'/,
+      'Claude subscription auth must request the current Claude Code account scopes',
+    );
+    assert.doesNotMatch(
+      src,
+      /https:\/\/console\.anthropic\.com\/(?:oauth\/code\/callback|v1\/oauth\/token)|org:create_api_key user:profile user:inference/,
+      'Claude subscription auth must not regress to the stale console Anthropic OAuth route',
+    );
+  });
+
   it('token exchange failures do not consume pending authorization or collapse into generic auth copy', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     const completeStart = src.indexOf('async completeAuthorization(');
@@ -194,7 +228,7 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
   it('OAuth token endpoint UA matches the claude-cli/X.Y.Z shape Anthropic accepts (PR-CLAUDE-CARD-MOVE-0)', async () => {
     // WAWQAQ msg a62a4c1c reported "Authorization failed / Invalid
     // request format" after login. Root cause was that the OAuth
-    // token endpoint (https://console.anthropic.com/v1/oauth/token)
+    // token endpoint (https://platform.claude.com/v1/oauth/token)
     // rejected our `maka-desktop/0.1.0 (oauth-subscription)` UA. The
     // The upstream Claude Code OAuth path sends
     // `claude-cli/X.Y.Z (external, cli)`. This is distinct from the
@@ -205,6 +239,11 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
       src,
       /OAUTH_USER_AGENT\s*=\s*`claude-cli\/\$\{CLAUDE_SUBSCRIPTION_PRODUCT_VERSION\}\s+\(external,\s*cli\)`/,
       'OAuth UA constant must match claude-cli/X.Y.Z (external, cli) shape',
+    );
+    assert.match(
+      src,
+      /CLAUDE_SUBSCRIPTION_PRODUCT_VERSION\s*=\s*'2\.1\.153'/,
+      'OAuth UA product version should track the current installed Claude Code OAuth contract',
     );
     assert.doesNotMatch(
       src,

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -45,21 +45,23 @@ import {
 } from '@maka/core';
 
 // =============================================================
-// Endpoints + client id — reverse-engineered from the upstream
-// Claude.ai web client. Verified against the external reference at
-// main.js:15913-15919.
+// Endpoints + client id — mirror Claude Code's current OAuth
+// login flow. Verified against the installed Claude Code 2.1.153
+// binary constants (`CLAUDE_AI_AUTHORIZE_URL`, `TOKEN_URL`) after
+// the older Claude.ai / console.anthropic.com OAuth route started
+// rejecting new auth attempts.
 // =============================================================
 const CLAUDE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
-const CLAUDE_AUTHORIZE_ENDPOINT = 'https://claude.ai/oauth/authorize';
-const CLAUDE_REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
-const CLAUDE_TOKEN_ENDPOINT = 'https://console.anthropic.com/v1/oauth/token';
+const CLAUDE_AUTHORIZE_ENDPOINT = 'https://claude.com/cai/oauth/authorize';
+const CLAUDE_REDIRECT_URI = 'https://platform.claude.com/oauth/code/callback';
+const CLAUDE_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
 const CLAUDE_USAGE_ENDPOINT = 'https://api.anthropic.com/api/oauth/usage';
 const CLAUDE_PROFILE_ENDPOINT = 'https://api.anthropic.com/api/oauth/profile';
-const CLAUDE_SCOPE = 'org:create_api_key user:profile user:inference';
+const CLAUDE_SCOPE = 'user:sessions:claude_code user:mcp_servers user:file_upload';
 
 // Anthropic's OAuth token endpoint rejects requests whose
 // User-Agent does not match the `claude-cli/X.Y.Z (external, cli)`
-// shape (verified against the external reference at main.js:15919).
+// shape (verified against Claude Code 2.1.153).
 // WAWQAQ msg a62a4c1c reported "Invalid request format" after
 // login; the symptom was the OAuth endpoint rejecting our previous
 // `maka-desktop/0.1.0 (oauth-subscription)` UA. The cloak path is a
@@ -67,7 +69,7 @@ const CLAUDE_SCOPE = 'org:create_api_key user:profile user:inference';
 // now defaults on for the visible OAuth model path. WAWQAQ
 // already accepted the ToS implication of the OAuth flow at all
 // (msg `fd421634`, baked into `isSubscriptionExperimentalEnabled`).
-export const CLAUDE_SUBSCRIPTION_PRODUCT_VERSION = '2.1.88';
+export const CLAUDE_SUBSCRIPTION_PRODUCT_VERSION = '2.1.153';
 const OAUTH_USER_AGENT = `claude-cli/${CLAUDE_SUBSCRIPTION_PRODUCT_VERSION} (external, cli)`;
 
 // =============================================================

--- a/apps/desktop/src/main/oauth/cloaked-request.ts
+++ b/apps/desktop/src/main/oauth/cloaked-request.ts
@@ -38,7 +38,7 @@
 
 import { randomUUID } from 'node:crypto';
 
-const CLAUDE_CODE_PRODUCT_VERSION = '2.1.88';
+const CLAUDE_CODE_PRODUCT_VERSION = '2.1.153';
 const CLAUDE_CODE_UA = `claude-cli/${CLAUDE_CODE_PRODUCT_VERSION} (external, cli)`;
 const CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude.";
 

--- a/packages/core/src/__tests__/oauth-subscription.test.ts
+++ b/packages/core/src/__tests__/oauth-subscription.test.ts
@@ -82,9 +82,9 @@ describe('pkceCodeChallenge (RFC 7636 §4.2)', () => {
 describe('buildClaudeAuthorizationUrl', () => {
   const config: ClaudeAuthorizationConfig = {
     clientId: 'test-client-id',
-    authorizeEndpoint: 'https://claude.ai/oauth/authorize',
-    redirectUri: 'https://console.anthropic.com/oauth/code/callback',
-    scope: 'org:create_api_key user:profile user:inference',
+    authorizeEndpoint: 'https://claude.com/cai/oauth/authorize',
+    redirectUri: 'https://platform.claude.com/oauth/code/callback',
+    scope: 'user:sessions:claude_code user:mcp_servers user:file_upload',
   };
 
   it('emits all required PKCE + OAuth params', () => {

--- a/packages/core/src/oauth-subscription.ts
+++ b/packages/core/src/oauth-subscription.ts
@@ -233,7 +233,7 @@ export function pkceCodeChallenge(verifier: string, sha256: Sha256Digest): strin
 export interface ClaudeAuthorizationConfig {
   /** Anthropic-registered OAuth client_id. */
   clientId: string;
-  /** Authorization endpoint (e.g. https://claude.ai/oauth/authorize). */
+  /** Authorization endpoint (e.g. https://claude.com/cai/oauth/authorize). */
   authorizeEndpoint: string;
   /** Redirect URI registered with the client_id. */
   redirectUri: string;

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -34,6 +34,16 @@ describe('Claude subscription runtime wiring', () => {
     assert.match(caseRegion, /fetch,/, 'Claude OAuth must accept the desktop cloak fetch wrapper');
     assert.doesNotMatch(caseRegion, /throw new Error/, 'Claude OAuth must not remain in the experimental throw branch');
     assert.match(caseRegion, /anthropic-beta[\s\S]*CLAUDE_SUBSCRIPTION_BETA/, 'Claude OAuth must send the Claude Code beta header set');
+    assert.match(
+      caseRegion,
+      /CLAUDE_SUBSCRIPTION_USER_AGENT/,
+      'Claude OAuth runtime sends must use the pinned Claude Code user-agent',
+    );
+    assert.match(
+      src,
+      /CLAUDE_SUBSCRIPTION_USER_AGENT\s*=\s*'claude-cli\/2\.1\.153 \(external, cli\)'/,
+      'Claude OAuth runtime user-agent must track the current installed Claude Code OAuth contract',
+    );
   });
 
   test('model factory gives API-key Anthropic the /v1 SDK base without changing Kimi', async () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -17,7 +17,7 @@ const ANTHROPIC_BETA =
   'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14';
 const CLAUDE_SUBSCRIPTION_BETA =
   'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.88 (external, cli)';
+const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
 
 export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
   const { connection, apiKey, modelId, fetch } = input;

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -11,7 +11,7 @@ import { anthropicV1Url } from './subscription-auth.js';
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 const CLAUDE_SUBSCRIPTION_BETA =
   'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.88 (external, cli)';
+const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
 
 export async function fetchProviderModels(
   connection: LlmConnection,

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -10,7 +10,7 @@ import { anthropicV1Url } from './subscription-auth.js';
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 const CLAUDE_SUBSCRIPTION_BETA =
   'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.88 (external, cli)';
+const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
 
 export async function testConnection(
   connection: LlmConnection,


### PR DESCRIPTION
## Summary
- move Claude subscription auth from the stale claude.ai / console.anthropic.com OAuth route to the current Claude Code subscription route and platform token callback
- update Claude Code UA/version pins from 2.1.88 to 2.1.153 across main-process OAuth, cloak requests, and runtime subscription headers
- add static contracts so the OAuth endpoints, scopes, and version pins do not silently drift back

## Evidence
- yetone/alma-plugins current HEAD has no Claude OAuth plugin; only Cursor and OpenAI/Codex auth plugins are present
- local Claude Code is 2.1.153 and its binary exposes current OAuth constants: claude.com/cai/oauth/authorize, platform.claude.com/oauth/code/callback, platform.claude.com/v1/oauth/token, and scopes user:sessions:claude_code user:mcp_servers user:file_upload

## Verification
- npm --workspace @maka/core run build
- npm --workspace @maka/runtime run build
- npm --workspace @maka/desktop run build:main
- node --test packages/core/dist/__tests__/oauth-subscription.test.js
- node --test packages/runtime/dist/__tests__/claude-subscription-runtime.test.js packages/runtime/dist/__tests__/model-fetcher.test.js
- node --test dist/main/__tests__/claude-subscription-cloak-flag.test.js (from apps/desktop)
- git diff --check

Note: the first build:main attempt failed with ENOSPC while disk had ~103 MiB free. I removed a stale node_modules directory from an old detached worktree in my agent workspace, then reran the focused builds/tests successfully.