### PR TITLE
fix(settings): drop daily-review hero card pile + semantic width attr (kenji #5+#6)

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1654,34 +1654,6 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         </span>
       </header>
 
-      <div className="settingsFeatureStatusHero">
-        <span className="settingsFeatureStatusIcon" aria-hidden="true">
-          <CalendarDays size={24} strokeWidth={1.5} />
-        </span>
-        <div>
-          <div className="settingsFeatureStatusHeroHeading">
-            <h3>每日回顾</h3>
-            <span className="settingsFeatureStatusBadge">
-              {hasConfigIpc ? '本地 + LLM' : '本地汇总'}
-            </span>
-          </div>
-          <p>
-            打开右侧 Content 区里的「每日回顾」可以查看活跃会话、模型用量、工具调用，以及（开启后）LLM
-            生成的对话摘要 / 遗漏提醒等回顾内容。
-          </p>
-          {props.onOpenDailyReview && (
-            <div className="settingsFeatureStatusHeroActions">
-              <Button
-                type="button"
-                onClick={props.onOpenDailyReview}
-              >
-                打开每日回顾
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-
       {loadError ? (
         <Alert variant="error" style={{ marginTop: 12 }}>
           <AlertDescription>读取每日回顾设置失败：{loadError}</AlertDescription>
@@ -1702,7 +1674,7 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
           />
         </div>
 
-        <div className="settingsRow">
+        <div className="settingsRow" data-control-width="compact">
           <div>
             <strong>执行时间</strong>
             <small>默认 08:00 本地时间触发。</small>
@@ -1756,7 +1728,7 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
           />
         </div>
 
-        <div className="settingsRow">
+        <div className="settingsRow" data-control-width="select">
           <div>
             <strong>分析模型</strong>
             <small>
@@ -1806,17 +1778,18 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
         </div>
       </div>
 
-      {hasRunOnceIpc && (
-        <div className="settingsFeatureStatusHero" style={{ marginTop: 12 }}>
-          <span className="settingsFeatureStatusIcon" aria-hidden="true">
-            <CalendarDays size={20} strokeWidth={1.5} />
-          </span>
-          <div>
-            <div className="settingsFeatureStatusHeroHeading">
-              <h3>想先看看效果？</h3>
-            </div>
-            <p>无需开启自动执行，基于当前工作区的对话记录立即生成一份报告。</p>
-            <div className="settingsFeatureStatusHeroActions">
+      {(props.onOpenDailyReview || hasRunOnceIpc) && (
+        <div className="settingsPageFooterActions" role="toolbar" aria-label="每日回顾操作">
+          {props.onOpenDailyReview && (
+            <Button
+              type="button"
+              onClick={props.onOpenDailyReview}
+            >
+              打开每日回顾
+            </Button>
+          )}
+          {hasRunOnceIpc && (
+            <>
               <Button
                 type="button"
                 onClick={() => void triggerRun('daily')}
@@ -1831,8 +1804,8 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
               >
                 {runningMode === 'deep' ? '生成中…' : '生成深度分析'}
               </Button>
-            </div>
-          </div>
+            </>
+          )}
         </div>
       )}
     </section>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -7423,8 +7423,36 @@ button:active {
   margin-top: 10px;
 }
 
-.settingsRow > .settingsTimeInput {
+/* PR daily-review-bundled (WAWQAQ msg `afbe542d` 2026-06-25 +
+   @kenji audit finding #6): the Daily Review settings page used to
+   stack a banner + intro hero card + settings rows + "try it now"
+   hero card — too much promo chrome for a workbench settings
+   surface. The unified `.settingsPageFooterActions` is a single
+   right-aligned action row that the page renders below the rows
+   (open Daily Review · generate now · deep). Keep the action set
+   visible and uniform regardless of how many ops the page exposes. */
+.settingsPageFooterActions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+/* PR daily-review-bundled (@kenji audit finding #5): semantic width
+   bucket on the row, not a class selector keyed off the input
+   className. Different settings rows ask for different control
+   widths (time-pickers want compact, free-text selects want a 320px
+   cap); keying off the row makes the contract local and obvious. */
+.settingsRow[data-control-width="compact"] > input,
+.settingsRow[data-control-width="compact"] > .settingsTimeInput {
   max-width: 140px;
+  justify-self: end;
+}
+
+.settingsRow[data-control-width="select"] > .settingsBaseSelectTrigger {
+  max-width: 320px;
+  width: 100%;
   justify-self: end;
 }
 
@@ -7851,19 +7879,10 @@ button:active {
 .settingsField[data-orient="horizontal"] > .settingsBaseSelectTrigger {
   max-width: 320px;
 }
-/* WAWQAQ msg `0951e3b1` 2026-06-25: "每日分析里面也没办法选择分析模型。
-   选择模型的那个组件框也特别丑，特别长，完全就不对。"
-   `.settingsRow` has a 2-column grid `minmax(150px, 0.36fr) 1fr`, so the
-   right control column can be ~500px+ on a wide page. With `w-full` on
-   the Select trigger, the dropdown stretched the full right column —
-   "特别长". Cap it the same way `.settingsField[data-orient="horizontal"]`
-   does (320px) and right-align via `justify-self: end` so the trigger
-   visually matches the Switches in adjacent rows. */
-.settingsRow > .settingsBaseSelectTrigger {
-  max-width: 320px;
-  width: 100%;
-  justify-self: end;
-}
+/* WAWQAQ msg `0951e3b1` 2026-06-25 + @kenji audit #5 (msg `26a221be`):
+   moved to `.settingsRow[data-control-width="select"] >
+   .settingsBaseSelectTrigger` so the contract lives on the row, not on
+   a global class selector. See the data-control-width block above. */
 /* The horizontal row above the first one shouldn't carry a top border;
    below the last one the section footer takes over. The default
    border-bottom is fine for the inter-row hairlines. */


### PR DESCRIPTION
## Summary
Bundled response to @kenji audit findings #5 + #6 (msg \`26a221be\`) plus the structural cleanup WAWQAQ authorized in msg \`afbe542d\` (\"一次性多改，别他妈分这么多轮\").

**#6 — Daily Review hero card pile collapsed.**
Removed the intro hero card (\"每日回顾 · 本地 + LLM\" with paragraph + 「打开每日回顾」 button) and the bottom \"想先看看效果？\" hero card (paragraph + 2 generate buttons). The page now reads as:
- thin banner (1-line status)
- grouped settings rows
- single right-aligned `.settingsPageFooterActions` toolbar with **all three actions** (打开每日回顾 · 生成每日回顾 · 生成深度分析)

The `.settingsFeatureStatusHero*` CSS rules survive because the voice settings page still uses them.

**#5 — semantic width attr.**
- `.settingsRow > .settingsTimeInput` → `.settingsRow[data-control-width=\"compact\"] > input, .settingsRow[data-control-width=\"compact\"] > .settingsTimeInput`
- `.settingsRow > .settingsBaseSelectTrigger` → `.settingsRow[data-control-width=\"select\"] > .settingsBaseSelectTrigger`
- 执行时间 row gets `data-control-width=\"compact\"`, 分析模型 row gets `data-control-width=\"select\"`. The contract is now declared on the row, not implicit in the control's class name.

Verified the 4 other `SettingsSelect` call sites (proxy host, gateway host, bot domain, usage filter) are inside `.settingsField`, not `.settingsRow`, so dropping the old global rule does not affect them.

## Test plan
- [x] \`tsc --noEmit -p apps/desktop/tsconfig.renderer.json\` — clean on touched lines.
- [ ] Settings → 每日回顾 renders: banner → 9 rows → footer toolbar (right-aligned 3 buttons).
- [ ] 执行时间 input is ≤140px and right-aligned; 分析模型 trigger is ≤320px and right-aligned. Both come from `data-control-width` on their row, not from class selectors.
- [ ] 「打开每日回顾」 / 「生成每日回顾」 / 「生成深度分析」 all fire from the footer.
- [ ] No regression on Settings → 网络 (proxy), 高级 (gateway), 机器人对话 (bot domain), 使用统计 (usage filter) — those SettingsSelects sit inside `.settingsField`, not `.settingsRow`, and use the `.settingsField[data-orient=\"horizontal\"]` width contract instead.