### PR TITLE
Centralize Claude subscription runtime headers

### DIFF
--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -33,17 +33,55 @@ describe('Claude subscription runtime wiring', () => {
     assert.match(caseRegion, /baseURL:\s*anthropicV1BaseUrl\(baseURL\)/, 'Claude OAuth must pass the AI SDK a /v1 Anthropic base URL');
     assert.match(caseRegion, /fetch,/, 'Claude OAuth must accept the desktop cloak fetch wrapper');
     assert.doesNotMatch(caseRegion, /throw new Error/, 'Claude OAuth must not remain in the experimental throw branch');
-    assert.match(caseRegion, /anthropic-beta[\s\S]*CLAUDE_SUBSCRIPTION_BETA/, 'Claude OAuth must send the Claude Code beta header set');
     assert.match(
       caseRegion,
-      /CLAUDE_SUBSCRIPTION_USER_AGENT/,
-      'Claude OAuth runtime sends must use the pinned Claude Code user-agent',
+      /headers:\s*claudeSubscriptionHeaders\(\)/,
+      'Claude OAuth must use the centralized Claude Code subscription header helper',
     );
     assert.match(
-      src,
+      caseRegion,
+      /claudeSubscriptionHeaders/,
+      'Claude OAuth runtime sends must use the pinned Claude Code user-agent',
+    );
+  });
+
+  test('Claude subscription header constants have one runtime source of truth', async () => {
+    const [authSrc, factorySrc, fetcherSrc, testConnectionSrc] = await Promise.all([
+      readFile(new URL('../../src/subscription-auth.ts', import.meta.url), 'utf8'),
+      readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8'),
+      readFile(new URL('../../src/model-fetcher.ts', import.meta.url), 'utf8'),
+      readFile(new URL('../../src/test-connection.ts', import.meta.url), 'utf8'),
+    ]);
+
+    assert.match(
+      authSrc,
       /CLAUDE_SUBSCRIPTION_USER_AGENT\s*=\s*'claude-cli\/2\.1\.153 \(external, cli\)'/,
       'Claude OAuth runtime user-agent must track the current installed Claude Code OAuth contract',
     );
+    assert.match(authSrc, /CLAUDE_SUBSCRIPTION_BETA[\s\S]*oauth-2025-04-20/);
+    assert.match(authSrc, /function claudeSubscriptionHeaders\(\)/);
+
+    for (const [name, source] of [
+      ['model-factory.ts', factorySrc],
+      ['model-fetcher.ts', fetcherSrc],
+      ['test-connection.ts', testConnectionSrc],
+    ] as const) {
+      assert.match(
+        source,
+        /claudeSubscriptionHeaders/,
+        `${name} must use the centralized Claude subscription headers helper`,
+      );
+      assert.doesNotMatch(
+        source,
+        /claude-cli\/2\.1\.153|oauth-2025-04-20/,
+        `${name} must not duplicate Claude subscription header literals`,
+      );
+      assert.doesNotMatch(
+        source,
+        /const CLAUDE_SUBSCRIPTION_(?:BETA|USER_AGENT)/,
+        `${name} must not redeclare Claude subscription header constants`,
+      );
+    }
   });
 
   test('model factory gives API-key Anthropic the /v1 SDK base without changing Kimi', async () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -4,7 +4,11 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { effectiveBaseUrl, type LlmConnection } from '@maka/core/llm-connections';
-import { anthropicV1BaseUrl, codexSubscriptionHeaders } from './subscription-auth.js';
+import {
+  anthropicV1BaseUrl,
+  claudeSubscriptionHeaders,
+  codexSubscriptionHeaders,
+} from './subscription-auth.js';
 
 export interface ModelFactoryInput {
   connection: LlmConnection;
@@ -15,10 +19,6 @@ export interface ModelFactoryInput {
 
 const ANTHROPIC_BETA =
   'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14';
-const CLAUDE_SUBSCRIPTION_BETA =
-  'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
-
 export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
   const { connection, apiKey, modelId, fetch } = input;
   const baseURL = effectiveBaseUrl(connection);
@@ -43,12 +43,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
         authToken: apiKey,
         baseURL: anthropicV1BaseUrl(baseURL),
         fetch,
-        headers: {
-          'anthropic-beta': CLAUDE_SUBSCRIPTION_BETA,
-          'User-Agent': CLAUDE_SUBSCRIPTION_USER_AGENT,
-          'anthropic-dangerous-direct-browser-access': 'true',
-          'x-app': 'cli',
-        },
+        headers: claudeSubscriptionHeaders(),
       }).chat(modelId);
 
     case 'codex-subscription':

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -6,12 +6,9 @@ import {
 } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url } from './subscription-auth.js';
+import { anthropicV1Url, claudeSubscriptionHeaders } from './subscription-auth.js';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
-const CLAUDE_SUBSCRIPTION_BETA =
-  'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
 
 export async function fetchProviderModels(
   connection: LlmConnection,
@@ -80,11 +77,8 @@ async function fetchProviderModelsStrict(
 function anthropicModelHeaders(connection: LlmConnection, apiKey: string): Record<string, string> {
   if (connection.providerType === 'claude-subscription') {
     return {
+      ...claudeSubscriptionHeaders(),
       Authorization: `Bearer ${apiKey}`,
-      'User-Agent': CLAUDE_SUBSCRIPTION_USER_AGENT,
-      'anthropic-beta': CLAUDE_SUBSCRIPTION_BETA,
-      'anthropic-dangerous-direct-browser-access': 'true',
-      'x-app': 'cli',
       'anthropic-version': '2023-06-01',
     };
   }

--- a/packages/runtime/src/subscription-auth.ts
+++ b/packages/runtime/src/subscription-auth.ts
@@ -1,4 +1,16 @@
 export const CODEX_SUBSCRIPTION_USER_AGENT = 'codex_cli_rs/0.0.0 (Maka)';
+export const CLAUDE_SUBSCRIPTION_BETA =
+  'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
+export const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
+
+export function claudeSubscriptionHeaders(): Record<string, string> {
+  return {
+    'User-Agent': CLAUDE_SUBSCRIPTION_USER_AGENT,
+    'anthropic-beta': CLAUDE_SUBSCRIPTION_BETA,
+    'anthropic-dangerous-direct-browser-access': 'true',
+    'x-app': 'cli',
+  };
+}
 
 /**
  * The Anthropic AI SDK expects a versioned API prefix and appends

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -5,12 +5,9 @@ import {
   type LlmConnection,
 } from '@maka/core/llm-connections';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url } from './subscription-auth.js';
+import { anthropicV1Url, claudeSubscriptionHeaders } from './subscription-auth.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
-const CLAUDE_SUBSCRIPTION_BETA =
-  'oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219';
-const CLAUDE_SUBSCRIPTION_USER_AGENT = 'claude-cli/2.1.153 (external, cli)';
 
 export async function testConnection(
   connection: LlmConnection,
@@ -59,11 +56,8 @@ async function probeAnthropic(
 ): Promise<ConnectionTestResult> {
   const headers: Record<string, string> = connection.providerType === 'claude-subscription'
     ? {
+        ...claudeSubscriptionHeaders(),
         Authorization: `Bearer ${secret}`,
-        'User-Agent': CLAUDE_SUBSCRIPTION_USER_AGENT,
-        'anthropic-beta': CLAUDE_SUBSCRIPTION_BETA,
-        'anthropic-dangerous-direct-browser-access': 'true',
-        'x-app': 'cli',
         'anthropic-version': '2023-06-01',
         'content-type': 'application/json',
       }


### PR DESCRIPTION
## Summary
- move Claude subscription runtime beta/user-agent/app headers into `subscription-auth.ts`
- route model sends, model fetches, and connection probes through one helper
- add a runtime contract that forbids duplicate Claude subscription header literals in those call sites

## Why
PR #243 had to update the same Claude Code OAuth header constants in several runtime files. Keeping those values duplicated makes future Claude Code drift easy to miss. This keeps one runtime source of truth next to the existing subscription auth helpers.

## Verification
- npm --workspace @maka/runtime run build
- node --test packages/runtime/dist/__tests__/claude-subscription-runtime.test.js packages/runtime/dist/__tests__/model-fetcher.test.js
- git diff --check
