### PR TITLE
fix(settings,ui): kenji audit round 2 findings 1, 2(prev), 5 — Memory wrap, Plan Reminder bot logos, marginTop classes

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -84,6 +84,7 @@ import { CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS, PROVIDER_DEFAULTS } from
 import {
   Alert,
   AlertDescription,
+  BOT_BRAND,
   Button,
   DialogContent,
   DialogRoot,
@@ -292,18 +293,9 @@ function groupedNav(): Array<{ group: SettingsNavGroup; items: SettingsNavItem[]
  * `configDocUrl` is the official developer doc surfaced inline as a
  * "查看配置文档 →" link.
  */
-const BOT_BRAND: Record<
-  BotProvider,
-  { color: string; glyph: string; iconifyId: string; configDocUrl?: string }
-> = {
-  telegram: { color: '#229ED9', glyph: 'T', iconifyId: 'simple-icons:telegram', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
-  feishu:   { color: '#00C6B7', glyph: '飞', iconifyId: 'simple-icons:lark', configDocUrl: 'https://open.feishu.cn/document/server-docs/bot-v3' },
-  wecom:    { color: '#0089FF', glyph: '企', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
-  wechat:   { color: '#07C160', glyph: '微', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
-  discord:  { color: '#5865F2', glyph: 'D', iconifyId: 'simple-icons:discord', configDocUrl: 'https://discord.com/developers/docs/intro' },
-  dingtalk: { color: '#1372FB', glyph: '钉', iconifyId: 'simple-icons:dingtalk', configDocUrl: 'https://open.dingtalk.com/document/' },
-  qq:       { color: '#EB1923', glyph: 'Q', iconifyId: 'simple-icons:tencentqq', configDocUrl: 'https://bot.q.qq.com/wiki/' },
-};
+// BOT_BRAND moved to `packages/ui/src/bot-brand.ts` so the Plan Reminder
+// delivery picker can use the same brand metadata as Settings here (@kenji
+// audit 2026-06-25 msg `e4cfbfb0` finding #2). Imported via `@maka/ui`.
 
 // PR-BOT-WECHAT-SCAN-LOGIN-0 (WAWQAQ msg `2fa6ada6`): help copy
 // rewritten per reference screenshots — short product sentence pointing
@@ -1655,7 +1647,7 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
       </header>
 
       {loadError ? (
-        <Alert variant="error" style={{ marginTop: 12 }}>
+        <Alert variant="error" className="settingsSurfaceAlert">
           <AlertDescription>读取每日回顾设置失败：{loadError}</AlertDescription>
         </Alert>
       ) : null}
@@ -3921,46 +3913,48 @@ function MemorySettingsPage(props: {
 
   return (
     <div className="settingsStructuredPage">
-      <div className="settingsFormRow">
-        <div>
-          <strong>本地 MEMORY.md</strong>
-          <small>透明 Markdown 文件，保存在当前本机工作区。这里的内容不会自动从聊天里抽取。</small>
+      <div className="settingsRows">
+        <div className="settingsFormRow">
+          <div>
+            <strong>本地 MEMORY.md</strong>
+            <small>透明 Markdown 文件，保存在当前本机工作区。这里的内容不会自动从聊天里抽取。</small>
+          </div>
+          <span className="settingsConnectionBadge" data-tone={memoryStatusTone(effective.status)}>
+            {memoryStatusLabel(effective.status)}
+          </span>
+          <Switch
+            ariaLabel="启用本地 MEMORY.md"
+            checked={effective.enabled}
+            disabled={memoryControlsDisabled}
+            onChange={(enabled) => void setEnabled(enabled)}
+          />
         </div>
-        <span className="settingsConnectionBadge" data-tone={memoryStatusTone(effective.status)}>
-          {memoryStatusLabel(effective.status)}
-        </span>
-        <Switch
-          ariaLabel="启用本地 MEMORY.md"
-          checked={effective.enabled}
-          disabled={memoryControlsDisabled}
-          onChange={(enabled) => void setEnabled(enabled)}
-        />
-      </div>
 
-      <div className="settingsFormRow">
-        <div>
-          <strong>模型上下文可读取</strong>
-          <small>默认关闭。开启后才允许发送消息时把本地记忆加入 prompt；隐身模式下仍会禁用。</small>
+        <div className="settingsFormRow">
+          <div>
+            <strong>模型上下文可读取</strong>
+            <small>默认关闭。开启后才允许发送消息时把本地记忆加入 prompt；隐身模式下仍会禁用。</small>
+          </div>
+          <Switch
+            ariaLabel="允许模型上下文读取本地记忆"
+            checked={effective.agentReadEnabled}
+            disabled={memoryControlsDisabled || !effective.enabled}
+            onChange={(enabled) => void setAgentReadEnabled(enabled)}
+          />
         </div>
-        <Switch
-          ariaLabel="允许模型上下文读取本地记忆"
-          checked={effective.agentReadEnabled}
-          disabled={memoryControlsDisabled || !effective.enabled}
-          onChange={(enabled) => void setAgentReadEnabled(enabled)}
-        />
-      </div>
 
-      <div className="settingsFormRow">
-        <div>
-          <strong>项目指令文件</strong>
-          <small>读取当前工作区的 AGENTS.md / CLAUDE.md / GEMINI.md；按低优先级指令注入，可随时关闭。</small>
+        <div className="settingsFormRow">
+          <div>
+            <strong>项目指令文件</strong>
+            <small>读取当前工作区的 AGENTS.md / CLAUDE.md / GEMINI.md；按低优先级指令注入，可随时关闭。</small>
+          </div>
+          <Switch
+            ariaLabel="启用项目指令文件"
+            checked={props.settings.workspaceInstructions.enabled}
+            disabled={memoryControlsDisabled}
+            onChange={(enabled) => void setWorkspaceInstructionsEnabled(enabled)}
+          />
         </div>
-        <Switch
-          ariaLabel="启用项目指令文件"
-          checked={props.settings.workspaceInstructions.enabled}
-          disabled={memoryControlsDisabled}
-          onChange={(enabled) => void setWorkspaceInstructionsEnabled(enabled)}
-        />
       </div>
 
       {workspaceInstructionState && (
@@ -6037,7 +6031,7 @@ function UsageSettingsPage(props: {
       {usageDraft.activeTab === 'requests' && !usageDraft.showDetails ? (
         <div className="settingsNotice">
           当前仅显示汇总指标。打开详情记录后，可以查看逐条模型请求和工具调用，按模型、工具或状态筛选，并用于排查费用与失败请求。
-          <div className="settingsActionRow" style={{ marginTop: 8 }}>
+          <div className="settingsActionRow settingsNoticeAction">
             <Button type="button" variant="ghost" size="sm" onClick={() => void updateUsage({ showDetails: true })}>
               显示明细
             </Button>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -3305,6 +3305,28 @@ button:active {
   min-width: var(--anchor-width);
 }
 
+/* PR audit2-bundled (@kenji audit msg `e4cfbfb0` finding #2): the Plan
+   Reminder delivery picker now carries real IM brand logos so it reads
+   the same as Settings → 机器人对话. The icon slot lines up with the
+   text via inline-flex; the icon tile is a fixed 16x16 to absorb
+   Iconify's size: '100%' rendering of the lazy-loaded simple-icons
+   svg without pushing the option row height around. */
+.maka-plan-select-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.maka-plan-select-option-icon {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .maka-plan-search-summary {
   display: flex;
   min-width: 0;
@@ -7437,6 +7459,18 @@ button:active {
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 16px;
+}
+
+/* PR audit2-bundled (@kenji audit #5 msg `e4cfbfb0`): names for the
+   inline `style={{ marginTop: N }}` patches that were sprinkled around
+   settings surfaces. Keeps the spacing decision discoverable + locked
+   in the design token surface instead of buried in JSX. */
+.settingsSurfaceAlert {
+  margin-top: 12px;
+}
+
+.settingsNoticeAction {
+  margin-top: 8px;
 }
 
 /* PR daily-review-bundled (@kenji audit finding #5): semantic width

--- a/packages/ui/src/bot-brand.ts
+++ b/packages/ui/src/bot-brand.ts
@@ -1,0 +1,26 @@
+import type { BotProvider } from '@maka/core';
+
+export interface BotBrand {
+  /** Hex color used as the brand tint behind the logo tile. */
+  color: string;
+  /** Single-character offline fallback while the remote icon loads. */
+  glyph: string;
+  /** Iconify Simple Icons id, lazy-fetched from the Iconify CDN. */
+  iconifyId: string;
+  /** Optional product-side help link for credential provisioning docs. */
+  configDocUrl?: string;
+}
+
+// Shared bot brand metadata. Both Settings → 机器人对话 and the chat-side
+// Plan Reminder delivery picker need real brand logos here so the same
+// channel reads as the same channel everywhere in the product (kenji
+// audit 2026-06-25 msg `e4cfbfb0` finding #2).
+export const BOT_BRAND: Record<BotProvider, BotBrand> = {
+  telegram: { color: '#229ED9', glyph: 'T', iconifyId: 'simple-icons:telegram', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
+  feishu:   { color: '#00C6B7', glyph: '飞', iconifyId: 'simple-icons:lark', configDocUrl: 'https://open.feishu.cn/document/server-docs/bot-v3' },
+  wecom:    { color: '#0089FF', glyph: '企', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
+  wechat:   { color: '#07C160', glyph: '微', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
+  discord:  { color: '#5865F2', glyph: 'D', iconifyId: 'simple-icons:discord', configDocUrl: 'https://discord.com/developers/docs/intro' },
+  dingtalk: { color: '#1372FB', glyph: '钉', iconifyId: 'simple-icons:dingtalk', configDocUrl: 'https://open.dingtalk.com/document/' },
+  qq:       { color: '#EB1923', glyph: 'Q', iconifyId: 'simple-icons:tencentqq', configDocUrl: 'https://bot.q.qq.com/wiki/' },
+};

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -47,7 +47,9 @@ import {
   Trash2,
   Wifi,
   X,
+  IconifyIcon,
 } from './icons.js';
+import { BOT_BRAND } from './bot-brand.js';
 import { redactSecrets } from './redact.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import {
@@ -1990,9 +1992,17 @@ function DailyReviewTopList(props: { title: string; entries: ReadonlyArray<Daily
   );
 }
 
+// PR audit2-bundled (@kenji msg `e4cfbfb0` finding #2): the third
+// tuple slot lets callers pass a leading icon (e.g. the real IM brand
+// logo) so the Plan Reminder delivery picker reads identically to
+// Settings → 机器人对话, instead of falling back to plain Chinese text.
+type PlanReminderOption<T extends string> =
+  | readonly [T, string]
+  | readonly [T, string, ReactNode];
+
 function PlanReminderSelect<T extends string>(props: {
   value: T;
-  options: ReadonlyArray<readonly [T, string]>;
+  options: ReadonlyArray<PlanReminderOption<T>>;
   onChange(value: T): void;
   ariaLabel: string;
   disabled?: boolean;
@@ -2012,11 +2022,22 @@ function PlanReminderSelect<T extends string>(props: {
       <SelectPortal>
         <SelectPositioner alignItemWithTrigger={false} sideOffset={6}>
           <SelectPopup className="maka-plan-select-popup">
-            {props.options.map(([value, label]) => (
-              <SelectItem key={value} value={value}>
-                {label}
-              </SelectItem>
-            ))}
+            {props.options.map((option) => {
+              const [value, label] = option;
+              const icon = option.length === 3 ? option[2] : null;
+              return (
+                <SelectItem key={value} value={value}>
+                  {icon ? (
+                    <span className="maka-plan-select-option">
+                      <span className="maka-plan-select-option-icon" aria-hidden="true">{icon}</span>
+                      <span>{label}</span>
+                    </span>
+                  ) : (
+                    label
+                  )}
+                </SelectItem>
+              );
+            })}
           </SelectPopup>
         </SelectPositioner>
       </SelectPortal>
@@ -2694,7 +2715,19 @@ function PlanReminderPanel(props: {
                       onChange={(value) => setDeliveryPlatform(value)}
                       disabled={formInteractionDisabled}
                       ariaLabel="平台"
-                      options={BOT_DELIVERY_PROVIDERS.map((provider) => [provider, botDisplayLabel(provider)] as const)}
+                      options={BOT_DELIVERY_PROVIDERS.map((provider) => {
+                        const brand = BOT_BRAND[provider];
+                        const icon = (
+                          <IconifyIcon
+                            icon={brand.iconifyId}
+                            width="100%"
+                            height="100%"
+                            aria-hidden="true"
+                            fallback={<>{brand.glyph}</>}
+                          />
+                        );
+                        return [provider, botDisplayLabel(provider), icon] as const;
+                      })}
                     />
                   </label>
                   <label className="maka-plan-field">

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -25,6 +25,7 @@ export * from './utils.js';
 // local helper. Net-new components that aren't already covered
 // by our shared component-style wrappers in `./ui.js` re-export here so
 // consumers can `import { Alert, Empty, Sidebar, ... } from '@maka/ui'`.
+export * from './bot-brand.js';
 export * from './primitives/alert.js';
 export * from './primitives/empty.js';
 export * from './primitives/item.js';


### PR DESCRIPTION
## Summary
Acts on @kenji audit thread `#my-ai:c28a6293` msg `e4cfbfb0`. Bundled per WAWQAQ's directive (\"一次性多改\").

**#1 — Memory page top control rows lacked a card surface.** Wrap the 3 `.settingsFormRow` blocks in `<div className=\"settingsRows\">` so they inherit the grouped-card outer border + 12px radius + overflow:hidden treatment used elsewhere in settings.

**#2 (kenji round-1 #2 / round-2 #3) — Plan Reminder bot picker is now text-only.**
- Move `BOT_BRAND` to `packages/ui/src/bot-brand.ts` so both Settings and Plan Reminder share one brand-metadata source.
- Extend `PlanReminderSelect` to accept an optional `ReactNode` icon as the 3rd tuple slot.
- Render `<IconifyIcon icon={brand.iconifyId} fallback={brand.glyph}>` per provider in the Plan Reminder delivery picker.

**#5 — Two inline `style={{ marginTop }}` patches.** `Alert variant=\"error\" style={{ marginTop: 12 }}` → `className=\"settingsSurfaceAlert\"`; `<div className=\"settingsActionRow\" style={{ marginTop: 8 }}>` → `className=\"settingsActionRow settingsNoticeAction\"`. New classes live in `styles.css`.

**Deferred** (per kenji's own scope + WAWQAQ 「只看最后的结果」):
- **kenji round-2 #2** (CDN-dependent bot logos → local Iconify collection registration) — real visible win when offline / CDN blocked, but needs SVG inlining for 7 simple-icons; will land as a focused follow-up PR so this one stays reviewable.
- **#3 / round-2 #4** (RadioCard / ChoiceCard primitive for theme/palette picker) — pure design-system refactor, no visible delta.
- **#4 / round-2 #5** (`SettingsSelect` / `Segmented` / `ChoiceCard` unification) — bigger cross-cutting; current fix covers the immediate model-name and Plan-Reminder-icon issues.
- **#6** (layout-property transitions in sidebar/tabs/accordion) — kenji explicitly flagged these as visual-smoke-gated.

## Test plan
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — clean on touched lines.
- [x] `pnpm -F @maka/ui build` + `pnpm -F @maka/core build` — clean.
- [ ] Settings → 记忆: 3 top toggles render inside a single grouped card with hairline dividers, no floating-row appearance.
- [ ] Plan Reminder: 平台 select trigger + each option shows the IM brand logo + label.
- [ ] Settings → 每日回顾 loadError branch still renders the Alert with proper top spacing (now via `.settingsSurfaceAlert`).
- [ ] Settings → 使用统计 \"显示明细\" action row still has 8px top spacing (now via `.settingsNoticeAction`).