### PR TITLE
fix(composer): let the home composer pick the new-chat model

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -77,12 +77,20 @@ describe('home composer new-chat model picker', () => {
       /onPickNewChatModel=\{\(input\) => setPendingNewChatModel\(input\)\}/,
       'main.tsx must wire the composer pick to setPendingNewChatModel',
     );
-    // send() forwards the explicit pick to sessions.create; absence keeps the
-    // backend default behavior unchanged.
+    // A pick only stays in effect while it is still an offered choice; once the
+    // connection/model is removed the picker must fall back to the default so it
+    // never shows — nor sends — a model sessions.create would reject.
     assert.match(
       renderer,
-      /\.\.\.\(pendingNewChatModel\s*\?\s*\{ llmConnectionSlug: pendingNewChatModel\.llmConnectionSlug, model: pendingNewChatModel\.model \}/,
-      'send() must forward the picked model to sessions.create when one was chosen',
+      /const validPendingNewChatModel\s*=[\s\S]*?chatModelChoices\.some\(/,
+      'main.tsx must drop a stale pendingNewChatModel that is no longer an offered choice',
+    );
+    // send() forwards only the *validated* pick to sessions.create; absence
+    // keeps the backend default behavior unchanged.
+    assert.match(
+      renderer,
+      /\.\.\.\(validPendingNewChatModel\s*\?\s*\{ llmConnectionSlug: validPendingNewChatModel\.llmConnectionSlug, model: validPendingNewChatModel\.model \}/,
+      'send() must forward the validated picked model to sessions.create when one was chosen',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Home / empty-state composer model picker.
+ *
+ * Regression guard for the bug where the model chip below the home composer
+ * showed a chevron (and a "选择模型" label) but was a dead `<span>` — clicking
+ * it did nothing because the interactive `ChatModelSwitcher` is bound to a live
+ * session and the no-session branch fell back to a static chip. The fix routes
+ * the no-session branch to an interactive `NewChatModelPicker` whose pick is
+ * forwarded to `sessions.create`, so the next new chat starts on the chosen
+ * model. This locks:
+ *   - the no-session branch renders the interactive picker (not a dead chip);
+ *   - the picker does NOT hand-add a second chevron (SelectTrigger owns it);
+ *   - both pickers share one `ModelChoiceOptions` list (no duplicated JSX);
+ *   - main.tsx wires the pick and forwards it to sessions.create.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd().endsWith('apps/desktop')
+  ? join(process.cwd(), '..', '..')
+  : process.cwd();
+
+async function readRepo(path: string): Promise<string> {
+  return readFile(join(repoRoot, path), 'utf8');
+}
+
+describe('home composer new-chat model picker', () => {
+  it('renders an interactive picker (not a dead chip) on the no-session branch', async () => {
+    const ui = await readRepo('packages/ui/src/components.tsx');
+
+    // The no-session branch must route to the interactive picker when a pick
+    // handler and choices exist, keeping the static chip only as the
+    // no-choices fallback.
+    assert.match(
+      ui,
+      /\) : props\.onPickNewChatModel && \(props\.modelChoices\?\.length \?\? 0\) > 0 \? \(\s*<NewChatModelPicker/,
+      'composer no-session branch must render <NewChatModelPicker> when a pick handler + choices are present',
+    );
+
+    const picker = ui.match(/function NewChatModelPicker\(props: \{[\s\S]*?\}\) \{[\s\S]*?\n\}/)?.[0] ?? '';
+    assert.notEqual(picker, '', 'NewChatModelPicker component must exist');
+    // Interactive: built on SelectRoot, fires the pick on value change.
+    assert.match(picker, /<SelectRoot<string>/, 'NewChatModelPicker must be a real SelectRoot dropdown');
+    assert.match(picker, /props\.onPick\(next\)/, 'NewChatModelPicker must call onPick with the chosen model');
+    // No hand-added chevron — SelectTrigger renders its own BaseSelect.Icon.
+    assert.doesNotMatch(
+      picker,
+      /<ChevronDown/,
+      'NewChatModelPicker must not hand-add a chevron (SelectTrigger already renders one) — guards the double-chevron regression',
+    );
+  });
+
+  it('shares one ModelChoiceOptions list between both model pickers', async () => {
+    const ui = await readRepo('packages/ui/src/components.tsx');
+    assert.match(ui, /function ModelChoiceOptions\(\{ groups \}/, 'shared ModelChoiceOptions list component must exist');
+    const usages = ui.match(/<ModelChoiceOptions groups=\{grouped\} \/>/g) ?? [];
+    assert.equal(
+      usages.length,
+      2,
+      'both ChatModelSwitcher and NewChatModelPicker must render the shared <ModelChoiceOptions> (no duplicated grouped list)',
+    );
+  });
+
+  it('wires the pick and forwards the chosen model to sessions.create', async () => {
+    const renderer = await readRepo('apps/desktop/src/renderer/main.tsx');
+
+    assert.match(
+      renderer,
+      /const \[pendingNewChatModel, setPendingNewChatModel\] = useState</,
+      'main.tsx must hold the picked new-chat model in state',
+    );
+    assert.match(
+      renderer,
+      /onPickNewChatModel=\{\(input\) => setPendingNewChatModel\(input\)\}/,
+      'main.tsx must wire the composer pick to setPendingNewChatModel',
+    );
+    // send() forwards the explicit pick to sessions.create; absence keeps the
+    // backend default behavior unchanged.
+    assert.match(
+      renderer,
+      /\.\.\.\(pendingNewChatModel\s*\?\s*\{ llmConnectionSlug: pendingNewChatModel\.llmConnectionSlug, model: pendingNewChatModel\.model \}/,
+      'send() must forward the picked model to sessions.create when one was chosen',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -484,8 +484,18 @@ function AppShell() {
   // changed) and is forwarded to sessions.create in `send()`. Renderer-only —
   // it never mutates the persisted Settings · 模型 default.
   const [pendingNewChatModel, setPendingNewChatModel] = useState<{ llmConnectionSlug: string; model: string } | null>(null);
+  // A pick only stays in effect while it is still an offered choice. If the user
+  // later disables/removes that connection or model, fall back to the default so
+  // the home chip never shows — nor sends — a model that no longer exists.
+  const validPendingNewChatModel =
+    pendingNewChatModel &&
+    chatModelChoices.some(
+      (c) => c.connectionSlug === pendingNewChatModel.llmConnectionSlug && c.model === pendingNewChatModel.model,
+    )
+      ? pendingNewChatModel
+      : null;
   const defaultConnModel = defaultConnectionEntry?.defaultModel || defaultConnectionEntry?.models?.[0]?.id;
-  const newChatModel = pendingNewChatModel
+  const newChatModel = validPendingNewChatModel
     ?? (defaultConnectionEntry && defaultConnModel
       ? { llmConnectionSlug: defaultConnectionEntry.slug, model: defaultConnModel }
       : undefined);
@@ -1892,8 +1902,8 @@ function AppShell() {
         const session = await window.maka.sessions.create({
           permissionMode: 'ask',
           name: text.slice(0, 42) || '新建对话',
-          ...(pendingNewChatModel
-            ? { llmConnectionSlug: pendingNewChatModel.llmConnectionSlug, model: pendingNewChatModel.model }
+          ...(validPendingNewChatModel
+            ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }
             : {}),
         });
         setNavSelection({ section: 'sessions', filter: 'chats' });
@@ -3048,7 +3058,7 @@ function AppShell() {
                 onImportFolderOutline={importFolderOutlineIntoComposer}
                 modelLabel={
                   activeModelLabel
-                  ?? pendingNewChatModel?.model
+                  ?? validPendingNewChatModel?.model
                   ?? activeConnection?.defaultModel
                   ?? activeConnection?.models?.[0]?.id
                   ?? defaultConnectionEntry?.defaultModel

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -479,6 +479,16 @@ function AppShell() {
     () => buildChatModelChoices(connections),
     [connections],
   );
+  // Home / empty-state composer: which model the next NEW chat starts with.
+  // Null = follow the default connection; a pick overrides it (sticky until
+  // changed) and is forwarded to sessions.create in `send()`. Renderer-only —
+  // it never mutates the persisted Settings · 模型 default.
+  const [pendingNewChatModel, setPendingNewChatModel] = useState<{ llmConnectionSlug: string; model: string } | null>(null);
+  const defaultConnModel = defaultConnectionEntry?.defaultModel || defaultConnectionEntry?.models?.[0]?.id;
+  const newChatModel = pendingNewChatModel
+    ?? (defaultConnectionEntry && defaultConnModel
+      ? { llmConnectionSlug: defaultConnectionEntry.slug, model: defaultConnModel }
+      : undefined);
   const activeConnectionLabel = activeSession?.backend === 'fake'
     ? '本地模拟连接'
     : activeConnection?.name ?? activeSession?.llmConnectionSlug;
@@ -1882,6 +1892,9 @@ function AppShell() {
         const session = await window.maka.sessions.create({
           permissionMode: 'ask',
           name: text.slice(0, 42) || '新建对话',
+          ...(pendingNewChatModel
+            ? { llmConnectionSlug: pendingNewChatModel.llmConnectionSlug, model: pendingNewChatModel.model }
+            : {}),
         });
         setNavSelection({ section: 'sessions', filter: 'chats' });
         setActiveId(session.id);
@@ -3035,6 +3048,7 @@ function AppShell() {
                 onImportFolderOutline={importFolderOutlineIntoComposer}
                 modelLabel={
                   activeModelLabel
+                  ?? pendingNewChatModel?.model
                   ?? activeConnection?.defaultModel
                   ?? activeConnection?.models?.[0]?.id
                   ?? defaultConnectionEntry?.defaultModel
@@ -3047,6 +3061,8 @@ function AppShell() {
                 modelChoices={chatModelChoices}
                 modelChangePending={activeId ? pendingSessionModelBySession[activeId] === true : false}
                 onModelChange={(input) => setSessionModel(input)}
+                newChatModel={newChatModel}
+                onPickNewChatModel={(input) => setPendingNewChatModel(input)}
                 workspacePicker={{
                   label: appInfo ? basenameFromPath(appInfo.projectPath) : undefined,
                   branch: appInfo?.projectGit.branch,

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4396,6 +4396,32 @@ export function ChatView(props: {
   );
 }
 
+/**
+ * Shared grouped option rows for both model pickers: one `<SelectItem>` per
+ * model, connections separated by a divider. Only the list is shared — the
+ * in-session `ChatModelSwitcher` and the home `NewChatModelPicker` keep their
+ * own trigger and selection behavior.
+ */
+function ModelChoiceOptions({ groups }: { groups: ReturnType<typeof groupModelChoices> }) {
+  return (
+    <>
+      {groups.map((group, groupIdx) => (
+        <SelectGroup key={group.connectionSlug}>
+          {groupIdx > 0 && <SelectSeparator />}
+          {group.choices.map((choice) => (
+            <SelectItem
+              key={modelChoiceValue(choice.connectionSlug, choice.model)}
+              value={modelChoiceValue(choice.connectionSlug, choice.model)}
+            >
+              <span className="maka-model-switcher-item-main">{choice.model}</span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      ))}
+    </>
+  );
+}
+
 function ChatModelSwitcher(props: {
   activeSession: SessionSummary;
   activeModel?: string;
@@ -4527,25 +4553,61 @@ function ChatModelSwitcher(props: {
                     {grouped.length > 0 && <SelectSeparator />}
                   </>
                 )}
-                {grouped.map((group, groupIdx) => (
-                  <SelectGroup key={group.connectionSlug}>
-                    {groupIdx > 0 && <SelectSeparator />}
-                    {group.choices.map((choice) => (
-                      <SelectItem
-                        key={modelChoiceValue(choice.connectionSlug, choice.model)}
-                        value={modelChoiceValue(choice.connectionSlug, choice.model)}
-                      >
-                        <span className="maka-model-switcher-item-main">{choice.model}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                ))}
+                <ModelChoiceOptions groups={grouped} />
               </SelectList>
             </SelectPopup>
           </SelectPositioner>
         </SelectPortal>
       </SelectRoot>
     </div>
+  );
+}
+
+/**
+ * Home / empty-state model picker (no active session yet). Unlike
+ * `ChatModelSwitcher` — which is bound to a live session and switches THAT
+ * session's model — this one just records which model the next new chat should
+ * start with. Reuses the model chip's look so the only visible change is that
+ * the chevron now actually opens a menu.
+ */
+function NewChatModelPicker(props: {
+  label: string;
+  choices: ChatModelChoice[];
+  currentValue?: string;
+  onPick(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
+}) {
+  const grouped = groupModelChoices(props.choices);
+  return (
+    <SelectRoot<string>
+      items={props.choices.map((choice) => ({
+        value: modelChoiceValue(choice.connectionSlug, choice.model),
+        label: choice.model,
+      }))}
+      value={props.currentValue}
+      onValueChange={(value) => {
+        const next = typeof value === 'string' ? parseModelChoiceValue(value) : undefined;
+        if (next) void props.onPick(next);
+      }}
+    >
+      <SelectTrigger
+        className="maka-composer-model-chip"
+        aria-label={`选择新对话模型，当前 ${props.label}`}
+        title={`新对话使用的模型：${props.label}`}
+      >
+        <span className="maka-composer-model-chip-text">{props.label}</span>
+        <span className="maka-composer-model-status" aria-hidden="true" />
+        {/* SelectTrigger already renders a BaseSelect.Icon chevron — no manual one. */}
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="maka-model-switcher-positioner">
+          <SelectPopup className="maka-model-switcher-popup">
+            <SelectList>
+              <ModelChoiceOptions groups={grouped} />
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
   );
 }
 
@@ -5491,6 +5553,14 @@ export const Composer = forwardRef<
     modelChoices?: ChatModelChoice[];
     modelChangePending?: boolean;
     onModelChange?(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
+    /**
+     * Home / empty-state composer only (no active session yet): the model
+     * the next new chat will start with, and the picker callback. When set,
+     * the otherwise-static model chip becomes a real dropdown so the user can
+     * choose the new-chat model inline instead of only via Settings · 模型.
+     */
+    newChatModel?: { llmConnectionSlug: string; model: string };
+    onPickNewChatModel?(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
     workspacePicker?: {
       label?: string;
       branch?: string | null;
@@ -6002,6 +6072,17 @@ export const Composer = forwardRef<
                     pending={props.modelChangePending}
                     disabledReason={modelSwitcherDisabledReason}
                     onChange={props.onModelChange}
+                  />
+                ) : props.onPickNewChatModel && (props.modelChoices?.length ?? 0) > 0 ? (
+                  <NewChatModelPicker
+                    label={modelChipLabel}
+                    choices={props.modelChoices ?? []}
+                    currentValue={
+                      props.newChatModel
+                        ? modelChoiceValue(props.newChatModel.llmConnectionSlug, props.newChatModel.model)
+                        : undefined
+                    }
+                    onPick={props.onPickNewChatModel}
                   />
                 ) : (
                   <span className="maka-composer-model-chip" aria-label={`当前模型：${modelChipLabel}`} title={modelChipLabel}>


### PR DESCRIPTION
## Summary
The model chip under the home / empty-state composer showed a chevron (and a "选择模型" label when unset) and even had a hover style, but it was a dead `<span>` — clicking it did nothing. The interactive `ChatModelSwitcher` is bound to a live session, so the no-session branch fell back to a static chip. Users could only change the new-chat model via Settings · 模型.

1. **Fix** — add `NewChatModelPicker`, a session-independent `SelectRoot` dropdown over the model choices already passed to the composer. Picking records `pendingNewChatModel` in the renderer and `send()` forwards it to `sessions.create`, so the next new chat starts on the chosen model. Renderer-only — it never mutates the persisted Settings · 模型 default, and omitting a pick keeps the existing backend-default behavior unchanged.
2. **Double-chevron fix** — `SelectTrigger` already renders its own `BaseSelect.Icon` chevron; dropped the manually-added one so the chip shows a single chevron.
3. **Cleanup** — extract the duplicated grouped option list into a shared `ModelChoiceOptions`, used by both `ChatModelSwitcher` (in-session) and `NewChatModelPicker` (home). They keep their own trigger + selection behavior; only the list is shared (no full merge — the in-session one carries per-session pending/optimistic logic the home one doesn't need).

## Screenshots (After)
<img width="358" height="390" alt="截屏2026-06-25 17 46 01" src="https://github.com/user-attachments/assets/8abcc1d8-0589-4664-adf7-7a4d513092c4" />


## Test plan
- [x] `@maka/ui` build + `@maka/desktop` typecheck — clean.
- [x] New contract test `composer-new-chat-model-picker-contract` — 3/3 pass (interactive picker on the no-session branch, no double chevron, both pickers share `ModelChoiceOptions`, `send()` → `sessions.create` wiring).
- [x] Full desktop test suite — 0 new failures vs base; the 6 remaining reds are pre-existing drift unrelated to this change, and the in-session model-switcher tests stay green.
- [x] Live (confirmed): home composer → model chip opens a grouped dropdown; picking sets the new-chat model. Chevron fix applied after that confirmation.
