### PR TITLE
fix(ui): pre-register 4 bot brand SVGs locally so picker renders offline

### DIFF
--- a/packages/ui/src/bot-brand-icons.ts
+++ b/packages/ui/src/bot-brand-icons.ts
@@ -1,0 +1,50 @@
+/**
+ * Pre-bundled brand SVG bodies for the IM channels Maka uses for bot
+ * delivery (Telegram / WeChat / WeCom / Discord / QQ).
+ *
+ * Why local instead of `simple-icons:*` runtime CDN fetch:
+ *   The bot logos were rendering through `<IconifyIcon
+ *   icon="simple-icons:telegram">`, which Iconify lazy-fetches from
+ *   `https://api.iconify.design/...` on first render. On cold-offline
+ *   Electron launches (or when network is firewalled) the bot picker
+ *   would degrade to the `glyph` monogram fallback for the entire
+ *   session. That is wrong end-result: a desktop app's brand logos
+ *   should not depend on a third-party CDN at runtime
+ *   (@kenji audit msg `e4cfbfb0` finding round-2 #2).
+ *
+ * Each `body` is a `<path …/>` string copied verbatim from upstream
+ * Simple Icons (CC0 1.0 Universal), pinned at the upstream version
+ * where the icon was last published. The icons are then registered
+ * under the local `maka-bot:` prefix in `icons.tsx` via
+ * `addCollection`, so `<IconifyIcon icon="maka-bot:telegram">` renders
+ * synchronously without any network roundtrip.
+ *
+ * Sources (CC0 1.0 Universal — Simple Icons project, simpleicons.org):
+ *   - telegram, wechat, discord : extracted from
+ *       @iconify-json/simple-icons@1.2.87 icons.json (upstream HEAD).
+ *   - tencentqq                 : extracted from
+ *       @iconify-json/simple-icons@1.2.10 icons.json (Simple Icons
+ *       removed the bare `tencentqq` id and the QQ standalone icon
+ *       afterwards; pinning to 1.2.10 keeps the brand correct).
+ *
+ * Still on CDN (no local SVG yet — see kenji audit follow-up note):
+ *   - lark / feishu (飞书), dingtalk (钉钉). Both were never (lark /
+ *     feishu) or no longer (dingtalk) carried by Simple Icons; we will
+ *     need to source those from each brand's official kit before they
+ *     can be fully offline-stable. Until then they fall through to
+ *     the `simple-icons:*` CDN lazy fetch with the `glyph` offline
+ *     fallback, the same way as before this PR.
+ */
+
+export const MAKA_BOT_ICON_BODIES: Record<string, string> = {
+  telegram:
+    '<path fill="currentColor" d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12a12 12 0 0 0 12-12A12 12 0 0 0 12 0zm4.962 7.224c.1-.002.321.023.465.14a.5.5 0 0 1 .171.325c.016.093.036.306.02.472c-.18 1.898-.962 6.502-1.36 8.627c-.168.9-.499 1.201-.82 1.23c-.696.065-1.225-.46-1.9-.902c-1.056-.693-1.653-1.124-2.678-1.8c-1.185-.78-.417-1.21.258-1.91c.177-.184 3.247-2.977 3.307-3.23c.007-.032.014-.15-.056-.212s-.174-.041-.249-.024q-.159.037-5.061 3.345q-.72.495-1.302.48c-.428-.008-1.252-.241-1.865-.44c-.752-.245-1.349-.374-1.297-.789q.04-.324.893-.663q5.247-2.286 6.998-3.014c3.332-1.386 4.025-1.627 4.476-1.635"/>',
+  wechat:
+    '<path fill="currentColor" d="M8.691 2.188C3.891 2.188 0 5.476 0 9.53c0 2.212 1.17 4.203 3.002 5.55a.59.59 0 0 1 .213.665l-.39 1.48c-.019.07-.048.141-.048.213c0 .163.13.295.29.295a.33.33 0 0 0 .167-.054l1.903-1.114a.86.86 0 0 1 .717-.098a10.2 10.2 0 0 0 2.837.403c.276 0 .543-.027.811-.05c-.857-2.578.157-4.972 1.932-6.446c1.703-1.415 3.882-1.98 5.853-1.838c-.576-3.583-4.196-6.348-8.596-6.348M5.785 5.991c.642 0 1.162.529 1.162 1.18a1.17 1.17 0 0 1-1.162 1.178A1.17 1.17 0 0 1 4.623 7.17c0-.651.52-1.18 1.162-1.18zm5.813 0c.642 0 1.162.529 1.162 1.18a1.17 1.17 0 0 1-1.162 1.178a1.17 1.17 0 0 1-1.162-1.178c0-.651.52-1.18 1.162-1.18m5.34 2.867c-1.797-.052-3.746.512-5.28 1.786c-1.72 1.428-2.687 3.72-1.78 6.22c.942 2.453 3.666 4.229 6.884 4.229c.826 0 1.622-.12 2.361-.336a.72.72 0 0 1 .598.082l1.584.926a.3.3 0 0 0 .14.047c.134 0 .24-.111.24-.247c0-.06-.023-.12-.038-.177l-.327-1.233a.6.6 0 0 1-.023-.156a.49.49 0 0 1 .201-.398C23.024 18.48 24 16.82 24 14.98c0-3.21-2.931-5.837-6.656-6.088V8.89c-.135-.01-.27-.027-.407-.03zm-2.53 3.274c.535 0 .969.44.969.982a.976.976 0 0 1-.969.983a.976.976 0 0 1-.969-.983c0-.542.434-.982.97-.982zm4.844 0c.535 0 .969.44.969.982a.976.976 0 0 1-.969.983a.976.976 0 0 1-.969-.983c0-.542.434-.982.969-.982"/>',
+  discord:
+    '<path fill="currentColor" d="M20.317 4.37a19.8 19.8 0 0 0-4.885-1.515a.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.3 18.3 0 0 0-5.487 0a13 13 0 0 0-.617-1.25a.08.08 0 0 0-.079-.037A19.7 19.7 0 0 0 3.677 4.37a.1.1 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.08.08 0 0 0 .031.057a19.9 19.9 0 0 0 5.993 3.03a.08.08 0 0 0 .084-.028a14 14 0 0 0 1.226-1.994a.076.076 0 0 0-.041-.106a13 13 0 0 1-1.872-.892a.077.077 0 0 1-.008-.128a10 10 0 0 0 .372-.292a.07.07 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.07.07 0 0 1 .078.01q.181.149.373.292a.077.077 0 0 1-.006.127a12.3 12.3 0 0 1-1.873.892a.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.08.08 0 0 0 .084.028a19.8 19.8 0 0 0 6.002-3.03a.08.08 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.06.06 0 0 0-.031-.03M8.02 15.33c-1.182 0-2.157-1.085-2.157-2.419c0-1.333.956-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.956 2.418-2.157 2.418m7.975 0c-1.183 0-2.157-1.085-2.157-2.419c0-1.333.955-2.419 2.157-2.419c1.21 0 2.176 1.096 2.157 2.42c0 1.333-.946 2.418-2.157 2.418"/>',
+  qq:
+    '<path fill="currentColor" d="M21.395 15.035a40 40 0 0 0-.803-2.264l-1.079-2.695c.001-.032.014-.562.014-.836C19.526 4.632 17.351 0 12 0S4.474 4.632 4.474 9.241c0 .274.013.804.014.836l-1.08 2.695a39 39 0 0 0-.802 2.264c-1.021 3.283-.69 4.643-.438 4.673c.54.065 2.103-2.472 2.103-2.472c0 1.469.756 3.387 2.394 4.771c-.612.188-1.363.479-1.845.835c-.434.32-.379.646-.301.778c.343.578 5.883.369 7.482.189c1.6.18 7.14.389 7.483-.189c.078-.132.132-.458-.301-.778c-.483-.356-1.233-.646-1.846-.836c1.637-1.384 2.393-3.302 2.393-4.771c0 0 1.563 2.537 2.103 2.472c.251-.03.581-1.39-.438-4.673"/>',
+};
+
+export const MAKA_BOT_ICON_PREFIX = 'maka-bot';

--- a/packages/ui/src/bot-brand.ts
+++ b/packages/ui/src/bot-brand.ts
@@ -5,7 +5,13 @@ export interface BotBrand {
   color: string;
   /** Single-character offline fallback while the remote icon loads. */
   glyph: string;
-  /** Iconify Simple Icons id, lazy-fetched from the Iconify CDN. */
+  /**
+   * Iconify icon id. When the prefix is `maka-bot:*` the icon is
+   * pre-registered locally (`bot-brand-icons.ts`) and renders
+   * synchronously with no CDN roundtrip; when the prefix is
+   * `simple-icons:*` the icon is lazy-fetched from the Iconify CDN at
+   * runtime — the `glyph` field is the offline fallback for that case.
+   */
   iconifyId: string;
   /** Optional product-side help link for credential provisioning docs. */
   configDocUrl?: string;
@@ -15,12 +21,19 @@ export interface BotBrand {
 // Plan Reminder delivery picker need real brand logos here so the same
 // channel reads as the same channel everywhere in the product (kenji
 // audit 2026-06-25 msg `e4cfbfb0` finding #2).
+//
+// `maka-bot:*` ids are pre-bundled SVG bodies that render offline.
+// `simple-icons:*` ids still rely on Iconify's CDN — Simple Icons
+// dropped (or never carried) Feishu/Lark and DingTalk standalone
+// icons, so until we source them from each brand's official kit they
+// fall back to the colored-tile-with-glyph state when offline. Track
+// the gap on @kenji audit follow-up.
 export const BOT_BRAND: Record<BotProvider, BotBrand> = {
-  telegram: { color: '#229ED9', glyph: 'T', iconifyId: 'simple-icons:telegram', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
+  telegram: { color: '#229ED9', glyph: 'T', iconifyId: 'maka-bot:telegram', configDocUrl: 'https://core.telegram.org/bots/tutorial' },
   feishu:   { color: '#00C6B7', glyph: '飞', iconifyId: 'simple-icons:lark', configDocUrl: 'https://open.feishu.cn/document/server-docs/bot-v3' },
-  wecom:    { color: '#0089FF', glyph: '企', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
-  wechat:   { color: '#07C160', glyph: '微', iconifyId: 'simple-icons:wechat', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
-  discord:  { color: '#5865F2', glyph: 'D', iconifyId: 'simple-icons:discord', configDocUrl: 'https://discord.com/developers/docs/intro' },
+  wecom:    { color: '#0089FF', glyph: '企', iconifyId: 'maka-bot:wechat', configDocUrl: 'https://developer.work.weixin.qq.com/document/' },
+  wechat:   { color: '#07C160', glyph: '微', iconifyId: 'maka-bot:wechat', configDocUrl: 'https://developers.weixin.qq.com/doc/offiaccount/Getting_Started/Overview.html' },
+  discord:  { color: '#5865F2', glyph: 'D', iconifyId: 'maka-bot:discord', configDocUrl: 'https://discord.com/developers/docs/intro' },
   dingtalk: { color: '#1372FB', glyph: '钉', iconifyId: 'simple-icons:dingtalk', configDocUrl: 'https://open.dingtalk.com/document/' },
-  qq:       { color: '#EB1923', glyph: 'Q', iconifyId: 'simple-icons:tencentqq', configDocUrl: 'https://bot.q.qq.com/wiki/' },
+  qq:       { color: '#EB1923', glyph: 'Q', iconifyId: 'maka-bot:qq', configDocUrl: 'https://bot.q.qq.com/wiki/' },
 };

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -33,11 +33,29 @@
 
 import { Icon, addCollection } from '@iconify/react';
 import { icons as phData } from '@iconify-json/ph';
+import {
+  MAKA_BOT_ICON_BODIES,
+  MAKA_BOT_ICON_PREFIX,
+} from './bot-brand-icons.js';
 import type { ComponentType } from 'react';
 
 // Register the Phosphor icon collection once at module load so every
 // `<Icon icon="ph:…">` renders synchronously without a CDN fetch.
 addCollection(phData);
+
+// Register the local bot brand SVG collection so
+// `<IconifyIcon icon="maka-bot:telegram">` etc. resolve synchronously,
+// without hitting `api.iconify.design` at runtime. See
+// `bot-brand-icons.ts` for the source provenance and why only 4 of the
+// 6 bot brands are local today (kenji audit msg `e4cfbfb0` round-2 #2).
+addCollection({
+  prefix: MAKA_BOT_ICON_PREFIX,
+  width: 24,
+  height: 24,
+  icons: Object.fromEntries(
+    Object.entries(MAKA_BOT_ICON_BODIES).map(([name, body]) => [name, { body }]),
+  ),
+});
 
 /**
  * Re-export of `@iconify/react`'s `<Icon>` for cases where a caller


### PR DESCRIPTION
## Summary
Acts on @kenji audit msg \`e4cfbfb0\` round-2 #2 (\`#my-ai:c28a6293\` thread).

The bot logo picker used \`<IconifyIcon icon=\"simple-icons:telegram\">\` etc., which lazy-fetches from \`api.iconify.design\` at runtime. On cold-offline Electron launches or firewalled networks the logos degraded to the monogram fallback. Desktop brand logos shouldn't depend on a third-party CDN.

**Partial offline fix landing 4 of 6 brands today:**
- `packages/ui/src/bot-brand-icons.ts` ships the SVG `<path>` bodies for **telegram / wechat / discord / qq**, copied verbatim from upstream Simple Icons (CC0). Provenance + pinned upstream version documented inline.
- `icons.tsx` registers them as a local Iconify collection under the `maka-bot:*` prefix at module load.
- `BOT_BRAND` updated: telegram, wechat, wecom, discord, qq now point at `maka-bot:*`.

**Honest gap (documented inline):** feishu/lark and dingtalk are not (and never were) carried by Simple Icons under those names. They still use `simple-icons:*` CDN lazy fetch with the colored-tile + glyph offline fallback. Sourcing those two from each brand's official kit is a separate follow-up so this PR's SVG provenance stays auditable. kenji's contract goal (zero `simple-icons:*` ids) is partially met.

No new runtime deps. `@iconify-json/simple-icons` was used only as a local one-shot extraction source.

## Test plan
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — clean on touched files.
- [x] `pnpm -F @maka/ui build` — clean.
- [ ] Pull network cable, restart Maka, open Settings → 机器人对话: Telegram / WeChat / WeCom / Discord / QQ render real logos. Feishu / DingTalk show colored tile + glyph (documented gap).
- [ ] Same offline, open Plan Reminder → 平台 select: same 4 brands show real logos in trigger + items.