### PR TITLE
fix(ui,styles): Plan Reminder trigger logo + 100vh→100dvh sweep (kenji round 3 #2, #6)

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -757,7 +757,7 @@
   .maka-shell {
     display: grid;
     grid-template-columns: var(--w-sidebar) 1fr;
-    height: 100vh;
+    height: 100dvh;
     background: var(--background);
     color: var(--foreground);
     font-size: var(--font-size-base);
@@ -1938,7 +1938,7 @@
     border-radius: var(--radius-modal);
     box-shadow: var(--shadow-modal);
     width: min(520px, calc(100vw - 48px));
-    max-height: calc(100vh - 80px);
+    max-height: calc(100dvh - 80px);
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -5025,7 +5025,7 @@ button:active {
 
 .maka-help-modal {
   width: min(560px, calc(100vw - 48px));
-  max-height: calc(100vh - 96px);
+  max-height: calc(100dvh - 96px);
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.05);
@@ -13118,7 +13118,7 @@ button:active {
   align-content: start;
   justify-items: center;
   width: 100%;
-  min-height: calc(100vh - 84px);
+  min-height: calc(100dvh - 84px);
   padding: clamp(40px, 7vh, 76px) 28px 48px;
 }
 

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -2007,6 +2007,30 @@ function PlanReminderSelect<T extends string>(props: {
   ariaLabel: string;
   disabled?: boolean;
 }) {
+  // PR audit3 (@kenji msg `232aec0f` finding #2): the dropdown items
+  // already render the brand icon, but the collapsed `<SelectValue />`
+  // was falling back to the plain label string — open dropdown showed
+  // a logo, but the picked value collapsed back to text. Build a
+  // value→{label,icon} lookup and have `SelectValue`'s function child
+  // render the icon + label together so the selected state matches the
+  // option state.
+  const optionByValue = new Map<T, { label: string; icon: ReactNode | null }>();
+  for (const option of props.options) {
+    const [value, label] = option;
+    optionByValue.set(value, {
+      label,
+      icon: option.length === 3 ? option[2] : null,
+    });
+  }
+  const renderOptionRow = (label: string, icon: ReactNode | null, className = 'maka-plan-select-option') =>
+    icon ? (
+      <span className={className}>
+        <span className="maka-plan-select-option-icon" aria-hidden="true">{icon}</span>
+        <span>{label}</span>
+      </span>
+    ) : (
+      <>{label}</>
+    );
   return (
     <SelectRoot
       value={props.value}
@@ -2017,7 +2041,13 @@ function PlanReminderSelect<T extends string>(props: {
       }}
     >
       <SelectTrigger className="maka-plan-select w-full" aria-label={props.ariaLabel}>
-        <SelectValue />
+        <SelectValue>
+          {(value: T) => {
+            const entry = optionByValue.get(value);
+            if (!entry) return null;
+            return renderOptionRow(entry.label, entry.icon);
+          }}
+        </SelectValue>
       </SelectTrigger>
       <SelectPortal>
         <SelectPositioner alignItemWithTrigger={false} sideOffset={6}>
@@ -2027,14 +2057,7 @@ function PlanReminderSelect<T extends string>(props: {
               const icon = option.length === 3 ? option[2] : null;
               return (
                 <SelectItem key={value} value={value}>
-                  {icon ? (
-                    <span className="maka-plan-select-option">
-                      <span className="maka-plan-select-option-icon" aria-hidden="true">{icon}</span>
-                      <span>{label}</span>
-                    </span>
-                  ) : (
-                    label
-                  )}
+                  {renderOptionRow(label, icon)}
                 </SelectItem>
               );
             })}


### PR DESCRIPTION
## Summary
Acts on @kenji audit thread `#my-ai:c28a6293` msg `232aec0f`. Round 3 against `af66ebb7` post-#249.

**#2 — Plan Reminder select collapsed state was text-only.** PR #247 added the brand icon to each `<SelectItem>`, but `<SelectValue />` defaulted to rendering just the label string, so opening the dropdown showed logos and selecting one collapsed back to plain text. Build a `value → {label, icon}` lookup inside `PlanReminderSelect` and feed `SelectValue` a function-child so the trigger renders the same icon + label row as the items.

**#6 — `100vh` residue in renderer CSS.** Four sites swapped to `100dvh`:
- `maka-tokens.css:760` — `.maka-shell` `height`
- `maka-tokens.css:1941` — `.maka-modal` `max-height: calc(… - 80px)`
- `styles.css:5028` — `.maka-help-modal` `max-height: calc(… - 96px)`
- `styles.css:13121` — `.maka-onboarding-stack` `min-height: calc(… - 84px)`

Other renderer surfaces already use `100dvh`; this brings the legacy four into line.

**Deferred** (per kenji's own scope):
- **#1** Feishu / DingTalk official-brand-kit sourcing — separate PR.
- **#3 / #4** `SettingsSelect` / `Segmented` / `ChoiceCard` primitive unification — design-system refactor with no end-result delta in isolation.
- **#5** layout-property transitions — kenji gated on visual-smoke harness.

## Test plan
- [x] `pnpm -F @maka/ui build` — clean.
- [ ] Plan Reminder: open `平台` select, pick an option — the closed trigger now shows the brand logo + label (not plain text).
- [ ] `grep -n "100vh" apps/desktop/src/renderer/{maka-tokens,styles}.css` returns nothing.
- [ ] On a tall Electron window resize: `.maka-shell` and `.maka-modal` don't overshoot the visible viewport.