### PR TITLE
docs(notes): add Maka core tech walkthrough (md + html)

### DIFF
--- a/notes/maka-core-tech-walkthrough.html
+++ b/notes/maka-core-tech-walkthrough.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Maka 核心技术解读</title>
+<style>
+  :root {
+    --bg: #0d1117;
+    --bg-soft: #161b22;
+    --bg-code: #1c2128;
+    --border: #30363d;
+    --text: #e6edf3;
+    --text-dim: #8b949e;
+    --accent: #58a6ff;
+    --accent-soft: rgba(88, 166, 255, 0.12);
+    --green: #7ee787;
+    --yellow: #e3b341;
+    --red: #ff7b72;
+    --maxw: 880px;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+      "Hiragino Sans GB", "Microsoft YaHei", Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+  }
+  /* ---------- layout ---------- */
+  .layout { display: flex; min-height: 100vh; }
+  nav.toc {
+    width: 248px;
+    flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    height: 100vh;
+    overflow-y: auto;
+    padding: 28px 18px;
+    border-right: 1px solid var(--border);
+    background: var(--bg-soft);
+    font-size: 13px;
+  }
+  nav.toc h2 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+    margin: 0 0 12px;
+  }
+  nav.toc ol { list-style: none; padding: 0; margin: 0; counter-reset: toc; }
+  nav.toc ol > li { margin: 2px 0; counter-increment: toc; }
+  nav.toc ol > li > a::before { content: counter(toc) ". "; color: var(--text-dim); }
+  nav.toc a {
+    color: var(--text-dim);
+    text-decoration: none;
+    display: block;
+    padding: 3px 8px;
+    border-radius: 6px;
+    transition: all 0.12s;
+  }
+  nav.toc a:hover { color: var(--text); background: var(--accent-soft); }
+  nav.toc ol ol { padding-left: 18px; margin: 2px 0 6px; }
+  nav.toc ol ol > li { counter-increment: none; }
+  nav.toc ol ol > li > a::before { content: ""; }
+  main { flex: 1; min-width: 0; padding: 0; }
+  .content { max-width: var(--maxw); margin: 0 auto; padding: 48px 32px 120px; }
+  /* ---------- typography ---------- */
+  h1, h2, h3, h4 { color: var(--text); line-height: 1.3; }
+  h1 {
+    font-size: 30px;
+    margin: 0 0 6px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  h2 {
+    font-size: 22px;
+    margin: 52px 0 18px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border);
+  }
+  h3 { font-size: 17px; margin: 32px 0 12px; color: var(--accent); }
+  h4 { font-size: 15px; margin: 22px 0 8px; }
+  p { margin: 0 0 14px; }
+  a { color: var(--accent); }
+  strong { color: #fff; font-weight: 600; }
+  em { color: var(--text); font-style: normal; background: var(--accent-soft); padding: 1px 5px; border-radius: 4px; }
+  ul, ol { padding-left: 22px; margin: 0 0 14px; }
+  li { margin: 4px 0; }
+  li::marker { color: var(--text-dim); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 44px 0; }
+  .lead { color: var(--text-dim); font-size: 14px; margin-bottom: 28px; }
+  /* ---------- code ---------- */
+  code {
+    font-family: "SF Mono", "Fira Code", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.88em;
+    background: var(--bg-code);
+    padding: 2px 6px;
+    border-radius: 5px;
+    border: 1px solid var(--border);
+    color: var(--green);
+  }
+  pre {
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px 20px;
+    overflow-x: auto;
+    margin: 0 0 18px;
+    line-height: 1.55;
+  }
+  pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--text);
+    font-size: 13px;
+  }
+  /* ---------- tables ---------- */
+  table { border-collapse: collapse; width: 100%; margin: 0 0 18px; font-size: 14px; }
+  th, td { border: 1px solid var(--border); padding: 8px 12px; text-align: left; }
+  th { background: var(--bg-soft); color: var(--accent); font-weight: 600; }
+  td code { background: var(--bg-soft); }
+  tbody tr:nth-child(even) { background: rgba(255,255,255,0.015); }
+  /* ---------- callouts ---------- */
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-soft);
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    margin: 0 0 18px;
+  }
+  .callout.warn { border-color: var(--yellow); background: rgba(227,179,65,0.08); }
+  .callout.danger { border-color: var(--red); background: rgba(255,123,114,0.08); }
+  /* ---------- badges ---------- */
+  .badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 20px;
+    margin: 0 2px;
+    vertical-align: middle;
+  }
+  .badge.allow { background: rgba(126,231,135,0.15); color: var(--green); }
+  .badge.prompt { background: rgba(227,179,65,0.15); color: var(--yellow); }
+  .badge.block { background: rgba(255,123,114,0.15); color: var(--red); }
+  .tag {
+    display: inline-block;
+    font-size: 12px;
+    padding: 1px 8px;
+    border-radius: 4px;
+    background: var(--bg-soft);
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    margin: 0 3px 4px 0;
+  }
+  /* ---------- footer ---------- */
+  footer { margin-top: 80px; padding-top: 20px; border-top: 1px solid var(--border); color: var(--text-dim); font-size: 13px; }
+  /* ---------- mobile ---------- */
+  @media (max-width: 860px) {
+    nav.toc { display: none; }
+    .content { padding: 32px 20px 80px; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 19px; }
+  }
+</style>
+</head>
+<body>
+<div class="layout">
+
+<nav class="toc">
+  <h2>目录</h2>
+  <ol>
+    <li><a href="#overall">整体定位</a></li>
+    <li><a href="#layers">仓库分层</a></li>
+    <li><a href="#kernel">Runtime 内核架构</a>
+      <ol>
+        <li><a href="#session-manager">SessionManager</a></li>
+        <li><a href="#agent-run">AgentRun</a></li>
+        <li><a href="#ai-sdk-backend">AiSdkBackend</a></li>
+        <li><a href="#tool-runtime">ToolRuntime</a></li>
+        <li><a href="#model-adapter">ModelAdapter</a></li>
+        <li><a href="#run-trace">RunTrace</a></li>
+      </ol>
+    </li>
+    <li><a href="#permission">权限系统</a>
+      <ol>
+        <li><a href="#modes">四档模式</a></li>
+        <li><a href="#categories">12 类工具</a></li>
+        <li><a href="#matrix">策略矩阵</a></li>
+        <li><a href="#pure">纯函数原则</a></li>
+        <li><a href="#parked">parked Promise</a></li>
+      </ol>
+    </li>
+    <li><a href="#storage">持久化与恢复</a></li>
+    <li><a href="#electron">Electron 集成</a></li>
+    <li><a href="#flow">数据流</a></li>
+    <li><a href="#summary">技术亮点</a></li>
+  </ol>
+</nav>
+
+<main>
+<div class="content">
+
+<h1>Maka 核心技术解读</h1>
+<p class="lead">面向工程师的 Maka 技术栈通读笔记 · 覆盖 runtime 内核、权限系统、持久化与恢复、Electron 集成 · 2026-06-25</p>
+
+<div class="callout">
+<strong>一句话定位</strong>：Maka 是一个本地优先（local-first）的 Electron 桌面 AI agent 工作台，让用户在自己的电脑上跑一个<strong>可观察、可控、可恢复</strong>的 agent——所有数据本地落盘，敏感值加密，工具调用走权限策略，单次对话崩溃后能从 ledger 恢复。
+</div>
+
+<h2 id="layers">仓库分层</h2>
+<p>monorepo 用 npm workspaces，分层干净，契约与实现分离：</p>
+<table>
+  <thead><tr><th>包</th><th>职责</th></tr></thead>
+  <tbody>
+    <tr><td><code>packages/core</code></td><td>纯契约层，零运行时依赖，只定义类型和纯函数</td></tr>
+    <tr><td><code>packages/storage</code></td><td>文件持久化层</td></tr>
+    <tr><td><code>packages/runtime</code></td><td>内核实现，最核心的部分</td></tr>
+    <tr><td><code>packages/ui</code></td><td>共享渲染组件</td></tr>
+    <tr><td><code>apps/desktop</code></td><td>Electron 壳子，把 runtime 装进窗口</td></tr>
+  </tbody>
+</table>
+<p>核心设计原则：契约与实现分离，runtime 内核再拆成可独立理解的边界，公共 API 保持稳定的同时内部可演化。</p>
+
+<h2 id="kernel">Runtime 内核架构</h2>
+<p>这是整个项目最值钱的部分。分层关系：</p>
+<pre><code>SessionManager            ← 对外公共 API（桌面 / bot / gateway 都走它）
+  -> AgentRun             ← 单次 turn 的生命周期 + 启动恢复
+      -> AiSdkBackend     ← 流式 + 工具循环引擎
+          -> ModelAdapter ← provider stream / usage / error 归一化
+          -> ToolRuntime  ← 工具输入校验 / 权限 / watchdog / abort / telemetry
+      -> RunTrace         ← best-effort 诊断 trace，写失败不影响对话
+      -> AgentRunStore    ← durable run ledger</code></pre>
+
+<table>
+  <thead><tr><th>模块</th><th>文件</th></tr></thead>
+  <tbody>
+    <tr><td><code>SessionManager</code> 类</td><td><code>packages/runtime/src/session-manager.ts:232</code></td></tr>
+    <tr><td><code>AgentRun.execute()</code></td><td><code>packages/runtime/src/agent-run.ts</code></td></tr>
+    <tr><td><code>send()</code> 流式泵</td><td><code>packages/runtime/src/ai-sdk-backend.ts:435</code></td></tr>
+    <tr><td><code>wrapToolExecute</code> 权限门控</td><td><code>packages/runtime/src/tool-runtime.ts:146</code></td></tr>
+    <tr><td>provider 适配</td><td><code>packages/runtime/src/model-adapter.ts</code></td></tr>
+  </tbody>
+</table>
+
+<h3 id="session-manager">SessionManager：公共 runtime API</h3>
+<p>对外（桌面 IPC、bot adapter、open-gateway 三类入口）暴露的唯一 runtime 门面。职责：session CRUD、backend registry 编排、active run 查找、恢复入口。真正干活的 turn 生命周期被委派给 <code>AgentRun</code>。</p>
+
+<h3 id="agent-run">AgentRun：单 turn 的 durable 编排</h3>
+<p>理解恢复机制的关键。一次 <code>sendMessage</code> 创建一个 <code>AgentRun</code>，负责：</p>
+<ol>
+  <li>生成 runId，写 <code>run_created</code> 事件到 ledger。</li>
+  <li>追加用户消息、写初始 turn 状态。</li>
+  <li>锁定连接快照（<code>connectionLocked</code>），防止 turn 跑到一半连接被改。</li>
+  <li>构建 prior runtime context（从历史 run 的 <code>RuntimeEvent</code> 投影成模型历史）。</li>
+  <li>驱动 backend 流事件，投影 session 状态。</li>
+  <li>写 turn 完成 / 失败 / abort / permission-wait 状态。</li>
+  <li><code>finalize()</code> 收尾：注销 active run、更新 header、写 <code>run_completed / run_failed / run_cancelled</code>。</li>
+</ol>
+<p><code>execute()</code> 是 async generator，核心结构简洁：</p>
+<pre><code>async *execute(): AsyncIterable&lt;SessionEvent&gt; {
+  try {
+    const begin = await this.begin();
+    for await (const ev of begin.backend.send(begin.backendInput)) {
+      await this.recordSessionEvent(ev);
+      yield ev;
+    }
+  } catch (error) {
+    await this.recordFailure(error);
+    throw error;
+  } finally {
+    await this.finalize();
+  }
+}</code></pre>
+<p>每个 backend 事件都会被 <code>recordSessionEvent</code> 投影成 session 状态变更（running / blocked / aborted），并记录到 run ledger。即使进程崩了，重启时也能从 ledger 重建。</p>
+
+<h3 id="ai-sdk-backend">AiSdkBackend：流式 + 多步工具循环</h3>
+<p>agent loop 的引擎。用 Vercel AI SDK 的 <code>streamText</code> 配合 <code>stopWhen: stepCountIs(N)</code> 驱动多步工具调用循环——循环本身交给 AI SDK，但所有"自己的机器"（权限、持久化、materializer、watchdog）都保留在 Maka 这边。</p>
+<p><code>send()</code> 结构（<code>ai-sdk-backend.ts:435</code>）：</p>
+<ol>
+  <li>建 <code>AsyncEventQueue&lt;SessionEvent&gt;</code>，作为后台泵和前台 yield 之间的缓冲。</li>
+  <li><code>ModelAdapter.resolveModel()</code> 解析 LanguageModel，失败立即推 error + complete。</li>
+  <li>构建 provider tools dict，<strong>每个工具的 <code>execute</code> 被权限层包了一层</strong>。</li>
+  <li>从 RuntimeEvent 历史构建模型消息。</li>
+  <li>后台泵：<code>streamText({...})</code> → <code>for await (chunk of result.fullStream)</code> → <code>ModelAdapter.handleStreamChunk</code> 归一化 → 推 queue。</li>
+  <li>前台 <code>yield* drain(queue)</code>。</li>
+</ol>
+<p>精巧点：</p>
+<ul>
+  <li><strong>StreamWatchdog</strong>：流式连接有 connect timeout 和 idle timeout，超时会 abort controller 并推 error 事件，防止挂死。</li>
+  <li><strong>step cap grace</strong>：当 <code>finishReason === 'tool-calls'</code>（撞了 step 上限）且没有 assistant 文本时，注入一条确定性提示，告诉用户已达本轮工具上限、可发"继续"。</li>
+  <li><strong>prepareStep 动态工具加载</strong>：同 turn 内可以逐步激活更多工具（deferred load），active 工具集按 step 重算。</li>
+</ul>
+
+<h3 id="tool-runtime">ToolRuntime：权限门控 seam</h3>
+<p>整个安全模型的执行点。工具的 <code>execute</code> 回调被 <code>wrapToolExecute</code> 包裹后交给 AI SDK，每次模型调用工具都经过这条链：</p>
+<ol>
+  <li><strong>loop-gate</strong>：同一个 tool + 同一组 args 连续失败 N 次，直接 block，防止 agent 死循环。block 本身不记 outcome，streak 停在阈值，后续相同调用继续被拦。</li>
+  <li><strong>PermissionEngine.evaluate()</strong> 返回三态：
+    <ul>
+      <li><span class="badge allow">allow</span> 跑真实 <code>impl</code>，写 <code>ToolResult</code>。</li>
+      <li><span class="badge block">block</span> 合成 <code>isError:true</code> 的工具结果返回给模型，不执行真实逻辑。</li>
+      <li><span class="badge prompt">prompt</span> 推 <code>PermissionRequestEvent</code> 给 UI，await 一个 parked Promise，等用户决定。allow 则跑，deny 则合成"用户拒绝"。</li>
+    </ul>
+  </li>
+  <li>工具执行期间<strong>暂停 stream watchdog</strong>（避免长任务被判超时），<code>finally</code> 里恢复。</li>
+  <li>abort signal 透传进工具，stop 按钮能中断。</li>
+  <li>记录 telemetry、artifact candidate、错误分类。</li>
+</ol>
+
+<h3 id="model-adapter">ModelAdapter：provider 归一化</h3>
+<p>把 provider / AI SDK 的细节挡在外面：stream chunk 类型、provider setup、usage 归一化、provider error mapping。</p>
+<ul>
+  <li><code>startStream</code> 统一调 <code>streamText</code>。</li>
+  <li><code>handleStreamChunk</code> 把各种 chunk 翻译成 Maka 的 <code>SessionEvent</code>（text delta、thinking delta、complete 等）。</li>
+</ul>
+<p>这样未来加 provider 不需要重复权限 / 工具 / run / session 逻辑。</p>
+
+<h3 id="run-trace">RunTrace：best-effort 诊断</h3>
+<p>记录 turn 的里程碑事件：turn started、model resolved / stream started / completed / failed、tool started / completed / failed、permission requested / decided、usage recorded、abort requested。</p>
+<div class="callout warn"><strong>关键约束</strong>：trace 写失败绝不影响用户对话。它和 session 消息 JSONL 是分开的两套持久化。</div>
+
+<h2 id="permission">权限系统</h2>
+<p>这是 Maka 区别于普通 chat demo 的核心安全设计，定义在 <code>packages/core/src/permission.ts</code>。</p>
+
+<h3 id="modes">四档 PermissionMode</h3>
+<p>
+  <span class="tag">explore</span>
+  <span class="tag">ask</span>
+  <span class="tag">execute</span>
+  <span class="tag">bypass</span>
+  ——从只读到全自动。
+</p>
+
+<h3 id="categories">12 类 ToolCategory</h3>
+<p>
+  <span class="tag">read</span>
+  <span class="tag">web_read</span>
+  <span class="tag">file_write</span>
+  <span class="tag">fs_destructive</span>
+  <span class="tag">shell_safe</span>
+  <span class="tag">shell_unsafe</span>
+  <span class="tag">git_destructive</span>
+  <span class="tag">network_send</span>
+  <span class="tag">privileged</span>
+  <span class="tag">browser</span>
+  <span class="tag">custom_tool</span>
+  <span class="tag">subagent</span>
+</p>
+
+<h3 id="matrix">mode × category 策略矩阵</h3>
+<p><code>PERMISSION_POLICY</code> 是纯函数决策表，决定每个组合是 allow / prompt / block：</p>
+<table>
+  <thead>
+    <tr><th>模式</th><th>读</th><th>写</th><th>危险操作</th><th>网络</th><th>浏览器</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>explore</code></td><td><span class="badge allow">allow</span></td><td><span class="badge block">block</span></td><td><span class="badge block">block</span></td><td><span class="badge prompt">prompt</span></td><td><span class="badge block">block</span></td></tr>
+    <tr><td><code>ask</code></td><td><span class="badge allow">allow</span></td><td><span class="badge prompt">prompt</span></td><td><span class="badge prompt">prompt</span></td><td><span class="badge prompt">prompt</span></td><td><span class="badge prompt">prompt</span></td></tr>
+    <tr><td><code>execute</code></td><td><span class="badge allow">allow</span></td><td><span class="badge allow">allow</span></td><td><span class="badge prompt">永远 prompt</span></td><td><span class="badge allow">allow</span></td><td><span class="badge prompt">永远 prompt</span></td></tr>
+    <tr><td><code>bypass</code></td><td><span class="badge allow">allow</span></td><td><span class="badge allow">allow</span></td><td><span class="badge allow">allow</span></td><td><span class="badge allow">allow</span></td><td><span class="badge allow">allow</span></td></tr>
+  </tbody>
+</table>
+<div class="callout danger"><strong>核心规则</strong>：不可逆操作（<code>fs_destructive</code>、<code>git_destructive</code>、<code>privileged</code>、<code>browser</code>）在 <code>execute</code> 模式下仍强制 prompt——浏览器操作可能发帖 / 下单，视为不可逆。<code>bypass</code> 全 allow，仅用户显式选择时进入。</div>
+<p><code>BUILTIN_TOOL_CATEGORY</code> 把 Claude SDK 风格的工具名映射到类别，<code>Bash</code> 默认 <code>shell_unsafe</code>，再由 <code>categorizeBash()</code> 根据命令前缀动态降级或升级（<code>ls</code>/<code>pwd</code> → <code>shell_safe</code>，<code>rm</code> → <code>fs_destructive</code>，<code>git push --force</code> → <code>git_destructive</code>）。</p>
+
+<h3 id="pure">纯函数原则</h3>
+<p><code>preToolUse()</code> 给定输入必然返回相同结果，不生成 UUID（requestId 由 runtime 层的 <code>PermissionEngine</code> 生成），便于测试。</p>
+
+<h3 id="parked">parked Promise 机制</h3>
+<p><code>PermissionEngine</code> 为每个 outstanding 权限请求维护一个 parked Promise，UI 的决定通过 <code>respondToPermission()</code> resolve 回等待中的 adapter。turn 结束时未回答的请求会被 reject 成 <code>user_stop</code>。</p>
+
+<h2 id="storage">持久化与恢复</h2>
+<h3>文件布局</h3>
+<p>工作数据放 Electron <code>userData</code> 下的 workspace 目录：</p>
+<pre><code>&lt;Electron userData&gt;/workspaces/default/
+  llm-connections.json
+  credentials.json
+  settings.json
+  sessions/&lt;sessionId&gt;/
+    messages.jsonl
+    runs/&lt;runId&gt;/
+      run.json          ← run header（原子写）
+      events.jsonl      ← append-only run 事件</code></pre>
+
+<h3>AgentRun ledger</h3>
+<p><code>FileAgentRunStore</code>（<code>packages/storage/src/agent-run-store.ts</code>）实现：</p>
+<ul>
+  <li><code>run.json</code> 原子写（<code>writeAtomic</code> 先写临时文件再 rename）。</li>
+  <li><code>events.jsonl</code> append-only。</li>
+  <li><strong>同 run 写串行化</strong>（<code>writeQueues</code> per sessionId+runId 的 Promise 链），避免并发写竞争。</li>
+  <li>ID 校验 <code>SAFE_ID_PATTERN</code>，防路径穿越。</li>
+  <li>读事件时容忍损坏行（<code>event_corrupt</code>）和未终止尾部。</li>
+</ul>
+<p>这套 ledger 和用户可见的 session 消息 JSONL 分开，诊断 / 恢复状态不污染对话历史。</p>
+
+<h3>启动恢复</h3>
+<p><code>recoverInterruptedSessions()</code> 优先用 run ledger：扫描持久化的 run header 和事件，分类非终态 run（<code>created</code> / <code>running</code> / <code>waiting_permission</code>），修复后收敛 session / turn 投影。覆盖场景：</p>
+<ul>
+  <li>stale 的 <code>created</code> / <code>running</code> run</li>
+  <li>停在 <code>run_started</code> / <code>model_stream_started</code> 的 run</li>
+  <li><code>tool_started</code> 后的残留</li>
+  <li><code>permission_requested</code> 后的等待</li>
+  <li>缺终态事件的 <code>model_stream_completed</code></li>
+  <li>损坏事件行</li>
+</ul>
+<p>没有 run ledger 的老 session 走旧的 message + turn-state 恢复路径。</p>
+
+<h2 id="electron">Electron 集成层</h2>
+<h3>进程边界</h3>
+<table>
+  <thead><tr><th>进程</th><th>文件</th><th>职责</th></tr></thead>
+  <tbody>
+    <tr><td>main</td><td><code>apps/desktop/src/main/main.ts</code>（4593 行）</td><td>装配 <code>SessionManager</code>、注册 IPC、管理窗口、OAuth、bot、gateway</td></tr>
+    <tr><td>preload</td><td><code>apps/desktop/src/preload/preload.ts</code></td><td><code>contextBridge</code> 暴露 <code>window.maka.*</code> 白名单 API</td></tr>
+    <tr><td>renderer</td><td><code>apps/desktop/src/renderer/</code></td><td>React UI + Settings</td></tr>
+  </tbody>
+</table>
+<p><code>main.ts:1262</code> 装配 <code>runtime = new SessionManager({...})</code>，<code>main.ts:564</code> 起 <code>OpenGatewayService</code>。IPC 用 <code>ipcMain.handle</code> 注册大量通道（memory、artifacts、settings、connection、session 等）。</p>
+
+<h3>密钥安全边界</h3>
+<ul>
+  <li>API key、OAuth token、bot token、proxy password、gateway token、Tavily key 走 Electron <code>safeStorage</code> 加密后写 <code>credentials.json</code>。</li>
+  <li>Renderer 永远拿不到明文密钥，Settings 只显示 masked 状态和测试结果。</li>
+</ul>
+
+<h3>多入口</h3>
+<p>除了桌面 UI，runtime 还服务两类外部入口：</p>
+<ul>
+  <li><strong>Bot adapter</strong>（<code>packages/runtime/src/bots/</code>）：Telegram、飞书、企业微信、微信 iLink、Discord、钉钉、QQ，都继承 <code>base-adapter.ts</code>，统一对接 SessionManager。</li>
+  <li><strong>Open Gateway</strong>（<code>open-gateway.ts</code>，1489 行）：本地 HTTP / SSE API，用 token 保护，让外部读取会话状态 / 事件 / 能力 / 健康摘要。</li>
+</ul>
+
+<h2 id="flow">数据流：一次对话的完整路径</h2>
+<ol>
+  <li>用户在 renderer 输入消息 → <code>window.maka.session.send</code> → IPC → <code>SessionManager.sendMessage</code>。</li>
+  <li>创建 <code>AgentRun</code>，写 <code>run_created</code> 到 ledger，append 用户消息到 <code>messages.jsonl</code>。</li>
+  <li>从历史 run 的 RuntimeEvent 投影模型上下文。</li>
+  <li><code>AiSdkBackend.send()</code>：构建权限包裹的工具 → <code>streamText(stepCountIs(N))</code> → 后台泵 fullStream。</li>
+  <li>每个流 chunk 经 <code>ModelAdapter.handleStreamChunk</code> 归一化成 <code>SessionEvent</code> → 推 queue → 前台 yield → IPC 流到 renderer。</li>
+  <li>模型调用工具 → <code>wrapToolExecute</code> → loop-gate → <code>PermissionEngine.evaluate</code> → allow / block / prompt → 执行或合成错误。</li>
+  <li>assistant 文本落 <code>messages.jsonl</code>，usage 记 telemetry，trace 写 run ledger。</li>
+  <li><code>finalize()</code> 收尾，写 <code>run_completed</code>，更新 session header。</li>
+</ol>
+
+<h2 id="summary">技术亮点小结</h2>
+<ul>
+  <li><strong>ledger + projection 模式</strong>：run 事件是 source of truth，session 状态是投影，崩溃可重建——整个恢复能力的根基。</li>
+  <li><strong>纯函数策略 + runtime 包装</strong>：权限决策表是纯函数好测试，requestId / parking 状态由 runtime 管，职责分得清楚。</li>
+  <li><strong>权限门控作为工具 execute 的 seam</strong>：不动 AI SDK 的循环，在 execute 回调里插入 allow / block / prompt，最小侵入。</li>
+  <li><strong>best-effort trace 不影响主路径</strong>：诊断信息尽力写，失败静默，对话绝不受拖累。</li>
+  <li><strong>同 run 写串行化 + 原子写</strong>：文件持久化的并发安全靠 Promise 链和 rename 保证。</li>
+  <li><strong>安全分层</strong>：模式 × 类别矩阵 + 命令分类器 + safeStorage 加密 + preload 白名单，多层防御。</li>
+</ul>
+
+<footer>
+  Maka 核心技术解读 · 基于 <code>maka-agent</code> 仓库源码通读生成 · 2026-06-25
+</footer>
+
+</div>
+</main>
+</div>
+</body>
+</html>

--- a/notes/maka-core-tech-walkthrough.md
+++ b/notes/maka-core-tech-walkthrough.md
@@ -1,0 +1,301 @@
+# Maka 核心技术解读
+
+> 一份面向工程师的 Maka 技术栈通读笔记。覆盖 runtime 内核、权限系统、持久化与恢复、Electron 集成。
+> 生成日期：2026-06-25
+
+## 目录
+
+- [整体定位](#整体定位)
+- [仓库分层](#仓库分层)
+- [Runtime 内核架构](#runtime-内核架构)
+  - [SessionManager：公共 runtime API](#sessionmanager公共-runtime-api)
+  - [AgentRun：单 turn 的 durable 编排](#agentrun单-turn-的-durable-编排)
+  - [AiSdkBackend：流式 + 多步工具循环](#aisdkbackend流式--多步工具循环)
+  - [ToolRuntime：权限门控 seam](#toolruntime权限门控-seam)
+  - [ModelAdapter：provider 归一化](#modeladapterprovider-归一化)
+  - [RunTrace：best-effort 诊断](#runtracebest-effort-诊断)
+- [权限系统](#权限系统)
+  - [四档 PermissionMode](#四档-permissionmode)
+  - [12 类 ToolCategory](#12-类-toolcategory)
+  - [mode × category 策略矩阵](#mode--category-策略矩阵)
+  - [纯函数原则](#纯函数原则)
+  - [parked Promise 机制](#parked-promise-机制)
+- [持久化与恢复](#持久化与恢复)
+  - [文件布局](#文件布局)
+  - [AgentRun ledger](#agentrun-ledger)
+  - [启动恢复](#启动恢复)
+- [Electron 集成层](#electron-集成层)
+  - [进程边界](#进程边界)
+  - [密钥安全边界](#密钥安全边界)
+  - [多入口](#多入口)
+- [数据流：一次对话的完整路径](#数据流一次对话的完整路径)
+- [技术亮点小结](#技术亮点小结)
+
+---
+
+## 整体定位
+
+Maka 是一个**本地优先（local-first）的 Electron 桌面 AI agent 工作台**。一句话概括它的技术追求：让用户在自己的电脑上跑一个**可观察、可控、可恢复**的 agent——所有数据本地落盘，敏感值加密，工具调用走权限策略，单次对话崩溃后能从 ledger 恢复。
+
+## 仓库分层
+
+monorepo 用 npm workspaces，分层干净：
+
+- `packages/core`：纯契约层，零运行时依赖，只定义类型和纯函数。
+- `packages/storage`：文件持久化层。
+- `packages/runtime`：内核实现，最核心的部分。
+- `packages/ui`：共享渲染组件。
+- `apps/desktop`：Electron 壳子，把 runtime 装进窗口。
+
+**核心设计原则**：契约与实现分离，runtime 内核再拆成可独立理解的边界，公共 API 保持稳定的同时内部可演化。
+
+---
+
+## Runtime 内核架构
+
+这是整个项目最值钱的部分。分层关系：
+
+```
+SessionManager            ← 对外公共 API（桌面 / bot / gateway 都走它）
+  -> AgentRun             ← 单次 turn 的生命周期 + 启动恢复
+      -> AiSdkBackend     ← 流式 + 工具循环引擎
+          -> ModelAdapter ← provider stream / usage / error 归一化
+          -> ToolRuntime  ← 工具输入校验 / 权限 / watchdog / abort / telemetry
+      -> RunTrace         ← best-effort 诊断 trace，写失败不影响对话
+      -> AgentRunStore    ← durable run ledger
+```
+
+关键代码入口：
+
+| 模块 | 文件 |
+| --- | --- |
+| `SessionManager` 类 | `packages/runtime/src/session-manager.ts:232` |
+| `AgentRun.execute()` | `packages/runtime/src/agent-run.ts` |
+| `send()` 流式泵 | `packages/runtime/src/ai-sdk-backend.ts:435` |
+| `wrapToolExecute` 权限门控 | `packages/runtime/src/tool-runtime.ts:146` |
+| provider 适配 | `packages/runtime/src/model-adapter.ts` |
+
+### SessionManager：公共 runtime API
+
+对外（桌面 IPC、bot adapter、open-gateway 三类入口）暴露的唯一 runtime 门面。职责：
+
+- session CRUD
+- backend registry 编排
+- active run 查找
+- 恢复入口
+
+真正干活的 turn 生命周期被委派给 `AgentRun`。
+
+### AgentRun：单 turn 的 durable 编排
+
+理解恢复机制的关键。一次 `sendMessage` 会创建一个 `AgentRun`，它负责：
+
+1. 生成 runId，写 `run_created` 事件到 ledger。
+2. 追加用户消息、写初始 turn 状态。
+3. 锁定连接快照（`connectionLocked`），防止 turn 跑到一半连接被改。
+4. 构建 prior runtime context（从历史 run 的 `RuntimeEvent` 投影成模型历史）。
+5. 驱动 backend 流事件，投影 session 状态。
+6. 写 turn 完成 / 失败 / abort / permission-wait 状态。
+7. `finalize()` 收尾：注销 active run、更新 header、写 `run_completed / run_failed / run_cancelled`。
+
+`execute()` 是 async generator，核心结构简洁：
+
+```ts
+async *execute(): AsyncIterable<SessionEvent> {
+  try {
+    const begin = await this.begin();
+    for await (const ev of begin.backend.send(begin.backendInput)) {
+      await this.recordSessionEvent(ev);
+      yield ev;
+    }
+  } catch (error) {
+    await this.recordFailure(error);
+    throw error;
+  } finally {
+    await this.finalize();
+  }
+}
+```
+
+每个 backend 事件都会被 `recordSessionEvent` 投影成 session 状态变更（running / blocked / aborted），并记录到 run ledger。即使进程崩了，重启时也能从 ledger 重建。
+
+### AiSdkBackend：流式 + 多步工具循环
+
+agent loop 的引擎。用 Vercel AI SDK 的 `streamText` 配合 `stopWhen: stepCountIs(N)` 驱动多步工具调用循环——循环本身交给 AI SDK，但所有"自己的机器"（权限、持久化、materializer、watchdog）都保留在 Maka 这边。
+
+`send()` 结构（`ai-sdk-backend.ts:435`）：
+
+1. 建 `AsyncEventQueue<SessionEvent>`，作为后台泵和前台 yield 之间的缓冲。
+2. `ModelAdapter.resolveModel()` 解析 LanguageModel，失败立即推 error + complete。
+3. 构建 provider tools dict，**每个工具的 `execute` 被权限层包了一层**。
+4. 从 RuntimeEvent 历史构建模型消息。
+5. 后台泵：`streamText({...})` → `for await (chunk of result.fullStream)` → `ModelAdapter.handleStreamChunk` 归一化 → 推 queue。
+6. 前台 `yield* drain(queue)`。
+
+精巧点：
+
+- **StreamWatchdog**：流式连接有 connect timeout 和 idle timeout，超时会 abort controller 并推 error 事件，防止挂死。
+- **step cap grace**：当 `finishReason === 'tool-calls'`（撞了 step 上限）且没有 assistant 文本时，注入一条确定性提示，告诉用户已达本轮工具上限、可发"继续"。
+- **prepareStep 动态工具加载**：同 turn 内可以逐步激活更多工具（deferred load），active 工具集按 step 重算。
+
+### ToolRuntime：权限门控 seam
+
+整个安全模型的执行点。工具的 `execute` 回调被 `wrapToolExecute` 包裹后交给 AI SDK，每次模型调用工具都经过这条链：
+
+1. **loop-gate**：同一个 tool + 同一组 args 连续失败 N 次，直接 block，防止 agent 死循环。block 本身不记 outcome，streak 停在阈值，后续相同调用继续被拦。
+2. **PermissionEngine.evaluate()** 返回三态：
+   - `allow` → 跑真实 `impl`，写 `ToolResult`。
+   - `block` → 合成 `isError:true` 的工具结果返回给模型，不执行真实逻辑。
+   - `prompt` → 推 `PermissionRequestEvent` 给 UI，await 一个 parked Promise，等用户决定。allow 则跑，deny 则合成"用户拒绝"。
+3. 工具执行期间**暂停 stream watchdog**（避免长任务被判超时），`finally` 里恢复。
+4. abort signal 透传进工具，stop 按钮能中断。
+5. 记录 telemetry、artifact candidate、错误分类。
+
+### ModelAdapter：provider 归一化
+
+把 provider / AI SDK 的细节挡在外面：stream chunk 类型、provider setup、usage 归一化、provider error mapping。
+
+- `startStream` 统一调 `streamText`。
+- `handleStreamChunk` 把各种 chunk 翻译成 Maka 的 `SessionEvent`（text delta、thinking delta、complete 等）。
+
+这样未来加 provider 不需要重复权限 / 工具 / run / session 逻辑。
+
+### RunTrace：best-effort 诊断
+
+记录 turn 的里程碑事件：turn started、model resolved / stream started / completed / failed、tool started / completed / failed、permission requested / decided、usage recorded、abort requested。
+
+**关键约束：trace 写失败绝不影响用户对话**。它和 session 消息 JSONL 是分开的两套持久化。
+
+---
+
+## 权限系统
+
+这是 Maka 区别于普通 chat demo 的核心安全设计，定义在 `packages/core/src/permission.ts`。
+
+### 四档 PermissionMode
+
+`explore` / `ask` / `execute` / `bypass`，从只读到全自动。
+
+### 12 类 ToolCategory
+
+`read`、`web_read`、`file_write`、`fs_destructive`、`shell_safe`、`shell_unsafe`、`git_destructive`、`network_send`、`privileged`、`browser`、`custom_tool`、`subagent`。
+
+### mode × category 策略矩阵
+
+`PERMISSION_POLICY` 是纯函数决策表，决定每个组合是 `allow` / `prompt` / `block`。设计很克制：
+
+| 模式 | 读 | 写 | 危险操作 | 网络 | 浏览器 |
+| --- | --- | --- | --- | --- | --- |
+| `explore` | allow | block | block | web_read=prompt | block |
+| `ask` | allow | prompt | prompt | prompt | prompt |
+| `execute` | allow | allow | **永远 prompt** | allow | **永远 prompt** |
+| `bypass` | allow | allow | allow | allow | allow |
+
+核心规则：**不可逆操作（`fs_destructive`、`git_destructive`、`privileged`、`browser`）在 `execute` 模式下仍强制 prompt**——浏览器操作可能发帖 / 下单，视为不可逆。`bypass` 全 allow，仅用户显式选择时进入。
+
+`BUILTIN_TOOL_CATEGORY` 把 Claude SDK 风格的工具名映射到类别，`Bash` 默认 `shell_unsafe`，再由 `categorizeBash()` 根据命令前缀动态降级或升级（`ls`/`pwd` → `shell_safe`，`rm` → `fs_destructive`，`git push --force` → `git_destructive`）。
+
+### 纯函数原则
+
+`preToolUse()` 给定输入必然返回相同结果，不生成 UUID（requestId 由 runtime 层的 `PermissionEngine` 生成），便于测试。
+
+### parked Promise 机制
+
+`PermissionEngine` 为每个 outstanding 权限请求维护一个 parked Promise，UI 的决定通过 `respondToPermission()` resolve 回等待中的 adapter。turn 结束时未回答的请求会被 reject 成 `user_stop`。
+
+---
+
+## 持久化与恢复
+
+### 文件布局
+
+工作数据放 Electron `userData` 下的 workspace 目录：
+
+```
+<Electron userData>/workspaces/default/
+  llm-connections.json
+  credentials.json
+  settings.json
+  sessions/<sessionId>/
+    messages.jsonl
+    runs/<runId>/
+      run.json          ← run header（原子写）
+      events.jsonl      ← append-only run 事件
+```
+
+### AgentRun ledger
+
+`FileAgentRunStore`（`packages/storage/src/agent-run-store.ts`）实现：
+
+- `run.json` 原子写（`writeAtomic` 先写临时文件再 rename）。
+- `events.jsonl` append-only。
+- **同 run 写串行化**（`writeQueues` per sessionId+runId 的 Promise 链），避免并发写竞争。
+- ID 校验 `SAFE_ID_PATTERN`，防路径穿越。
+- 读事件时容忍损坏行（`event_corrupt`）和未终止尾部。
+
+这套 ledger 和用户可见的 session 消息 JSONL 分开，诊断 / 恢复状态不污染对话历史。
+
+### 启动恢复
+
+`recoverInterruptedSessions()` 优先用 run ledger：扫描持久化的 run header 和事件，分类非终态 run（`created` / `running` / `waiting_permission`），修复后收敛 session / turn 投影。
+
+覆盖的恢复场景：
+
+- stale 的 `created` / `running` run
+- 停在 `run_started` / `model_stream_started` 的 run
+- `tool_started` 后的残留
+- `permission_requested` 后的等待
+- 缺终态事件的 `model_stream_completed`
+- 损坏事件行
+
+没有 run ledger 的老 session 走旧的 message + turn-state 恢复路径。
+
+---
+
+## Electron 集成层
+
+### 进程边界
+
+| 进程 | 文件 | 职责 |
+| --- | --- | --- |
+| main | `apps/desktop/src/main/main.ts`（4593 行） | 装配 `SessionManager`、注册 IPC、管理窗口、OAuth、bot、gateway |
+| preload | `apps/desktop/src/preload/preload.ts` | `contextBridge` 暴露 `window.maka.*` 白名单 API |
+| renderer | `apps/desktop/src/renderer/` | React UI + Settings |
+
+`main.ts:1262` 装配 `runtime = new SessionManager({...})`，`main.ts:564` 起 `OpenGatewayService`。IPC 用 `ipcMain.handle` 注册大量通道（memory、artifacts、settings、connection、session 等）。
+
+### 密钥安全边界
+
+- API key、OAuth token、bot token、proxy password、gateway token、Tavily key 走 Electron `safeStorage` 加密后写 `credentials.json`。
+- Renderer 永远拿不到明文密钥，Settings 只显示 masked 状态和测试结果。
+
+### 多入口
+
+除了桌面 UI，runtime 还服务两类外部入口：
+
+- **Bot adapter**（`packages/runtime/src/bots/`）：Telegram、飞书、企业微信、微信 iLink、Discord、钉钉、QQ，都继承 `base-adapter.ts`，统一对接 SessionManager。
+- **Open Gateway**（`open-gateway.ts`，1489 行）：本地 HTTP / SSE API，用 token 保护，让外部读取会话状态 / 事件 / 能力 / 健康摘要。
+
+---
+
+## 数据流：一次对话的完整路径
+
+1. 用户在 renderer 输入消息 → `window.maka.session.send` → IPC → `SessionManager.sendMessage`。
+2. 创建 `AgentRun`，写 `run_created` 到 ledger，append 用户消息到 `messages.jsonl`。
+3. 从历史 run 的 RuntimeEvent 投影模型上下文。
+4. `AiSdkBackend.send()`：构建权限包裹的工具 → `streamText(stepCountIs(N))` → 后台泵 fullStream。
+5. 每个流 chunk 经 `ModelAdapter.handleStreamChunk` 归一化成 `SessionEvent` → 推 queue → 前台 yield → IPC 流到 renderer。
+6. 模型调用工具 → `wrapToolExecute` → loop-gate → `PermissionEngine.evaluate` → allow / block / prompt → 执行或合成错误。
+7. assistant 文本落 `messages.jsonl`，usage 记 telemetry，trace 写 run ledger。
+8. `finalize()` 收尾，写 `run_completed`，更新 session header。
+
+---
+
+## 技术亮点小结
+
+- **ledger + projection 模式**：run 事件是 source of truth，session 状态是投影，崩溃可重建——整个恢复能力的根基。
+- **纯函数策略 + runtime 包装**：权限决策表是纯函数好测试，requestId / parking 状态由 runtime 管，职责分得清楚。
+- **权限门控作为工具 execute 的 seam**：不动 AI SDK 的循环，在 execute 回调里插入 allow / block / prompt，最小侵入。
+- **best-effort trace 不影响主路径**：诊断信息尽力写，失败静默，对话绝不受拖累。
+- **同 run 写串行化 + 原子写**：文件持久化的并发安全靠 Promise 链和 rename 保证。
+- **安全分层**：模式 × 类别矩阵 + 命令分类器 + safeStorage 加密 + preload 白名单，多层防御。


### PR DESCRIPTION
- 整理 runtime 内核架构（SessionManager/AgentRun/AiSdkBackend/ToolRuntime/ModelAdapter/RunTrace）
- 权限系统（四档模式 × 12 类工具策略矩阵）
- 持久化与启动恢复（AgentRun ledger + projection）
- Electron 集成层与一次对话完整数据流
- Markdown 与带样式 HTML 双格式