### PR TITLE
refactor(css): wrap styles.css rules into @layer base + components (Round A, #253)

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -61,6 +61,7 @@
      rewritten to point at the canonical token. */
 }
 
+@layer base {
 :root {
   /* PR-REFERENCE-PIXEL-3 (WAWQAQ msg `f79de85f` round 3): match
      reference implementation's `[data-agents-page] { --sidebar-width: 240px }`
@@ -191,7 +192,9 @@ button:active {
   transition-duration: 0.01ms !important;
   caret-color: transparent !important;
 }
+}
 
+@layer components {
 .appFrame {
   height: 100dvh;
   padding: 0;
@@ -13926,3 +13929,5 @@ html[data-theme="dark-parchment"] [data-banner-logo] :is(path, circle)[stroke*="
    eliminates the escape hatch + the raw z-index. If a future scroll
    edge needs a fade we'll add a named class with an explicit
    contract instead. */
+
+}


### PR DESCRIPTION
Wrap global resets (body, scrollbars, button reset, sr-only, reduced-motion, visual-smoke) into @layer base, and all component rules into @layer components, aligning with maka-tokens.css which already declares the same three layers (base / utilities / components).

This is the prerequisite for later rounds: unlayered styles.css had higher priority than any @layer, so 47 !important declarations were cascade hacks. With components-layered rules, tailwind utilities now override components by layer order, removing the need for most of those hacks (actual !important removal is Round H).

No rule, selector, property, or !important is changed — pure structural wrapping. Verified: comment balance 300/300, brace balance 1901/1901, lightningcss parse VALID.

Part of issue #253 Round A.