### PR TITLE
fix(css): revert #257 @layer wrapping — sidebar content was centered

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(process.cwd(), '..', '..');
+const STYLES_PATH = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
+
+/**
+ * Returns the number of `@layer` blocks enclosing the first occurrence of
+ * `selectorLine` in `styles`. 0 means the rule is unlayered.
+ *
+ * Author rules placed inside `@layer base`/`@layer components` sit BELOW
+ * Tailwind v4's `utilities` layer in the cascade, so they lose to any
+ * utility class on the same element regardless of specificity.
+ */
+function enclosingLayerCount(styles: string, selectorLine: string): number {
+  const lines = styles.split('\n');
+  let depth = 0;
+  const layerOpenDepths: number[] = [];
+  for (const line of lines) {
+    if (line.trim() === selectorLine) return layerOpenDepths.length;
+    if (/^\s*@layer\s+[\w, ]+\{/.test(line)) {
+      layerOpenDepths.push(depth);
+      depth += (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
+      continue;
+    }
+    for (const ch of line) {
+      if (ch === '{') depth += 1;
+      else if (ch === '}') {
+        depth -= 1;
+        if (layerOpenDepths.length > 0 && depth === layerOpenDepths[layerOpenDepths.length - 1]) {
+          layerOpenDepths.pop();
+        }
+      }
+    }
+  }
+  return -1; // selector not found
+}
+
+describe('renderer style layer cascade contract', () => {
+  /**
+   * Regression guard for #257 / #253 Round A.
+   *
+   * The sidebar nav rows render as `<UiButton size="nav" className="maka-nav-row">`
+   * (packages/ui/src/components.tsx). The cva button base always carries the
+   * Tailwind utilities `inline-flex items-center justify-center`, and the
+   * `nav` size variant deliberately contributes NO layout utilities so that
+   * `.maka-nav-row` (display: grid + grid-template-columns + text-align: left)
+   * is the layout source of truth.
+   *
+   * That only holds while `.maka-nav-row` outranks the utilities. #257 wrapped
+   * styles.css into `@layer base`/`@layer components`; because Tailwind v4
+   * orders `base, components, utilities`, the layered `.maka-nav-row` lost to
+   * `inline-flex justify-center`, collapsing every sidebar button (nav rows,
+   * session rows, settings) to flex-centered content. Keep these override
+   * rules unlayered (or in a layer declared AFTER utilities) so they win.
+   */
+  it('keeps .maka-nav-row out of any @layer so it beats Tailwind button utilities', async () => {
+    const styles = await readFile(STYLES_PATH, 'utf8');
+    const layers = enclosingLayerCount(styles, '.maka-nav-row {');
+    assert.notEqual(layers, -1, '.maka-nav-row { rule not found in styles.css');
+    assert.equal(
+      layers,
+      0,
+      `.maka-nav-row is nested in ${layers} @layer block(s); it must stay unlayered to ` +
+        'override the cva button base utilities (inline-flex/justify-center). See #257 regression.',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -61,7 +61,6 @@
      rewritten to point at the canonical token. */
 }
 
-@layer base {
 :root {
   /* PR-REFERENCE-PIXEL-3 (WAWQAQ msg `f79de85f` round 3): match
      reference implementation's `[data-agents-page] { --sidebar-width: 240px }`
@@ -192,9 +191,7 @@ button:active {
   transition-duration: 0.01ms !important;
   caret-color: transparent !important;
 }
-}
 
-@layer components {
 .appFrame {
   height: 100dvh;
   padding: 0;
@@ -13929,5 +13926,3 @@ html[data-theme="dark-parchment"] [data-banner-logo] :is(path, circle)[stroke*="
    eliminates the escape hatch + the raw z-index. If a future scroll
    edge needs a fade we'll add a named class with an explicit
    contract instead. */
-
-}


### PR DESCRIPTION
## Symptom

The sidebar nav rows (新任务 / 每日回顾 / 技能 / 定时任务), session-list rows, and the settings button all rendered with their content centered when they should be left-aligned. It's subtle in a narrow sidebar and increasingly obvious the wider the sidebar is dragged.

## Root cause

#257 (`cbdf1088`) wrapped `styles.css` component rules into `@layer base` / `@layer components`, described as "pure structural wrapping." But Tailwind v4 orders the cascade `base → components → utilities`, so **utilities have the highest priority**.

The sidebar nav rows render as `<UiButton size="nav" className="maka-nav-row">`: the cva button base always carries the Tailwind utilities `inline-flex items-center justify-center`, and `.maka-nav-row` (`display: grid` + `text-align: left`) only overrode them **while it stayed unlayered**. Once moved into `@layer components`, it lost to the utilities → content centered. The compensating `!important` cleanup was deferred to "Round H," so the override has nothing to lean on today.

## Evidence (CDP toggle)

Injecting a rule into the live renderer with the **same selector and specificity as `.maka-nav-row`, differing only in being unlayered**:

| State | `.maka-nav-row` computed `display` |
|---|---|
| Layered (#257 as-is) | `flex` (the `inline-flex` utility wins) |
| Unlayered injection | `grid` (`.maka-nav-row` wins, layout restored) |
| Injection removed | `flex` (centered again) |

Same rule, one variable (layer membership) → the cause is the cascade layer, not specificity.

## Change

- **Revert #257** (removes the 5 lines of `@layer` wrapping), restoring the unlayered cascade the whole stylesheet's override pattern depends on. Fixes every affected element at once (nav rows, session rows, settings button).
- **Adds a regression contract test** `renderer-style-layer-cascade-contract.test.ts`: asserts `.maka-nav-row` is not nested in any `@layer`. Red on `cbdf1088`, green after the revert.

## Verification

- Real window: all four nav labels share a uniform `42px` left offset (if centered, different label lengths would start at different offsets), `display: grid`, and session rows are left-aligned too.
- `npm run -w @maka/desktop test`: **this PR adds zero new failures.** The 16 failures already present in the suite are pre-existing on `origin/main` — stale contracts introduced by ancestors of #257 (e.g. `BOT_BRAND` moved to `@maka/ui`, a changed `copyFile` signature, a radius value) — and are out of scope here.

## Known trade-off (reviewed)

A full revert also returns the global form/button resets (`button/input/textarea/select { font: inherit }`, the global `button { transition }`) to unlayered, so they again outrank Tailwind text utilities. Measured impact vs #257: ~85 controls go from `font-weight: 500` back to `400`, and ~48 controls go from `13.125px` (`text-sm`) back to the inherited `15px`. This is **not a new regression** — it is the exact control typography the app shipped for months before #257; #257 incidentally flipped it one day ago alongside the sidebar break. Restoring it wholesale is the intended behavior of this revert. Whether controls *should* let `text-sm` / `font-medium` win is a deliberate design decision deferred to the sidebar-redesign / CSS-layering-governance follow-up, not this hotfix.

## Follow-up (not in this PR)

- If Round A (#253) re-lands, component-override rules must sit in a layer declared **after** utilities (or stay unlayered) — not in `@layer components`.
- Sidebar redesign + governance of the shadcn-primitive vs bespoke-CSS styling authority is tracked separately.
