### PR TITLE
test(desktop): refresh stale contract checks

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
@@ -15,10 +15,11 @@ describe('Bot settings UI contract', () => {
   it('keeps platform rows scannable with brand badges and status dots', async () => {
     const settings = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
     const styles = await readRepo('apps/desktop/src/renderer/styles.css');
+    const brand = await readRepo('packages/ui/src/bot-brand.ts');
 
-    assert.match(settings, /const BOT_BRAND\b/, 'Bot settings must keep per-platform brand presentation metadata');
+    assert.match(settings, /BOT_BRAND,\n\s+Button,/, 'Bot settings must import shared per-platform brand presentation metadata');
     for (const provider of ['telegram', 'feishu', 'wecom', 'wechat', 'discord', 'dingtalk', 'qq']) {
-      assert.match(settings, new RegExp(`${provider}:\\s*\\{[\\s\\S]*?configDocUrl:`), `${provider} needs a visible configuration-document link target`);
+      assert.match(brand, new RegExp(`${provider}:\\s*\\{[\\s\\S]*?configDocUrl:`), `${provider} needs a visible configuration-document link target`);
       assert.match(styles, new RegExp(`\\.settingsBotHero\\[data-provider="${provider}"\\]`), `${provider} hero must export a brand color CSS variable`);
     }
     assert.match(settings, /function BotBrandLogo\b/, 'Bot settings must use the shared brand-logo component');

--- a/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/local-memory-ui-contract.test.ts
@@ -575,8 +575,10 @@ describe('local MEMORY.md Settings UI contract', () => {
 
     assert.match(service, /async restoreLatestBackup/);
     assert.match(service, /\`\$\{this\.file\}\.reset\.bak\`/);
-    assert.match(service, /await this\.backup\('restore\.bak'\)/);
-    assert.match(service, /copyFile\(backup, this\.file\)/);
+    assert.match(service, /await this\.backupRestoreUndo\(\)/);
+    assert.match(service, /const backupContent = await readFile\(backup\)/);
+    assert.match(service, /await writeFile\(this\.file, backupContent, \{ mode: 0o600 \}\)/);
+    assert.match(service, /await chmod\(this\.file, 0o600\)/);
     assert.match(service, /没有找到上一版 MEMORY\.md 备份/);
     assert.match(main, /ipcMain\.handle\('memory:restoreLatestBackup'/);
     assert.match(preload, /restoreLatestBackup\(\)/);

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -481,7 +481,7 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       refreshUntilTurn,
-      /readMessages\(sessionId\)[\s\S]*hasSentUserTurn = next\.some\(\(message\) => message\.type === 'user' && message\.turnId === turnId\)[\s\S]*hasSentUserTurn && activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)/,
+      /readMessages\(sessionId\)[\s\S]*if \(activeIdRef\.current !== sessionId\) return;[\s\S]*hasSentUserTurn = next\.some\(\(message\) => message\.type === 'user' && message\.turnId === turnId\)[\s\S]*if \(hasSentUserTurn\) \{[\s\S]*setMessages\(next\)/,
       'the visible-message wait must be tied to the exact turnId sent by the Composer',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -113,11 +113,7 @@ describe('project context workspace picker', () => {
     // alone — no more "选择工作目录 ai ▾" doubled string.
     assert.match(ui, /\? <span className="maka-composer-workspace-current">\{props\.workspacePicker\.label\}<\/span>[\s\S]*?: <span>选择工作目录<\/span>/);
     assert.match(ui, /当前分支 \$\{props\.workspacePicker\.branch\}/);
-    // PR #190 review: composer card measure narrowed from 680 → 620
-    // to match the first-run hero composer width; the workspace-row
-    // pill tracks the new measure so it stays aligned with the card
-    // left edge. (Was 750→680 in PR-PARCHMENT-HOME-2, now 680→620.)
-    assert.match(styles, /\.maka-composer-workspace-row\s*\{[\s\S]*?width:\s*min\(620px,\s*80vw\)/);
+    assert.match(styles, /\.maka-composer-workspace-row\s*\{[\s\S]*?width:\s*min\(var\(--maka-chat-measure,\s*680px\),\s*100%\)/);
     assert.match(styles, /\.maka-composer-workspace-picker\s*\{/);
     assert.match(styles, /-webkit-app-region:\s*no-drag/);
     assert.match(renderer, /basenameFromPath\(appInfo\.projectPath\)/);

--- a/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
@@ -14,7 +14,7 @@ import {
   type RiveWorkflowToolResult,
 } from '../rive-workflow-tool.js';
 
-describe('RiveWorkflow tool and CLI bridge', () => {
+describe('RiveWorkflow tool and CLI bridge', { concurrency: false }, () => {
   it('registers as a permission-gated custom MakaTool', () => {
     const tool = buildRiveWorkflowTool();
     assert.equal(tool.name, RIVE_WORKFLOW_TOOL_NAME);

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -105,10 +105,12 @@ describe('Settings form accessibility labels', () => {
 
   it('keeps migrated Settings text fields and action buttons on shared UI primitives', async () => {
     const settings = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
+    const settingsSelect = await readRepo('packages/ui/src/primitives/settings-select.tsx');
     const passwordInput = await readRepo('apps/desktop/src/renderer/settings/password-input.tsx');
     const providersPanel = await readRepo('apps/desktop/src/renderer/settings/ProvidersPanel.tsx');
 
-    assert.match(settings, /SelectItem,[\s\S]*SelectPopup,[\s\S]*SelectPortal,[\s\S]*SelectPositioner,[\s\S]*SelectRoot,[\s\S]*SelectTrigger,[\s\S]*SelectValue,/);
+    assert.match(settings, /SettingsSelect,/);
+    assert.match(settingsSelect, /SelectItem,[\s\S]*SelectPopup,[\s\S]*SelectPortal,[\s\S]*SelectPositioner,[\s\S]*SelectRoot,[\s\S]*SelectTrigger,[\s\S]*SelectValue,/);
     assert.match(passwordInput, /import \{ Button, Input, useToast \} from '@maka\/ui';/);
     // ProvidersPanel sources its UI from the shared @maka/ui primitives;
     // tolerant of single- vs multi-line import formatting.
@@ -116,8 +118,8 @@ describe('Settings form accessibility labels', () => {
     for (const name of ['Button', 'PrimitiveTabs', 'PrimitiveTabsList', 'PrimitiveTabsTrigger', 'Input', 'RelativeTime', 'Textarea', 'useToast', 'useModalA11y']) {
       assert.ok(providersPanelUiImport.includes(name), `ProvidersPanel should import ${name} from @maka/ui`);
     }
-    assert.match(settings, /function SettingsSelect<T extends string>/);
-    assert.match(settings, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{6\}>/);
+    assert.match(settingsSelect, /export function SettingsSelect<T extends string>/);
+    assert.match(settingsSelect, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{6\}>/);
 
     // ThemeSettingsPage uses native <button> on purpose for the radio-card
     // pickers (mode / palette): the cards are a custom grid with a preview

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -52,10 +52,10 @@ describe('Settings coming-soon cleanup contract', () => {
     assert.doesNotMatch(settings, /V0\.1|V0\.2|capture smoke|之后会加|后续版本开放|阶段开放/, 'feature status pages must not read like demo-stage roadmap copy');
     // PR-DAILY-REVIEW-FULL-0: Settings → 每日回顾 became a real config form
     // (enable toggle, execute time, section toggles, deep analysis, manual
-    // trigger). The page still keeps a status badge ("本地汇总" or "本地 + LLM"
-    // depending on whether the backend pipeline is wired), but the body is
-    // no longer a static "shipped features" list.
-    assert.match(settings, /本地汇总/, 'Daily Review status badge should still describe the shipped local aggregate mode when the pipeline is not yet wired');
+    // trigger). The page status now describes the wired automatic analysis
+    // path and keeps the local-only fallback copy in the same branch.
+    assert.match(settings, /每天自动分析本机对话，生成摘要、遗漏提醒和建议。模型按需消耗。/, 'Daily Review status should describe the shipped automatic analysis mode');
+    assert.match(settings, /当前版本仅本地数字聚合，定时生成 \/ LLM 摘要尚未连接到后端。/, 'Daily Review fallback should still describe the local aggregate mode when the pipeline is not wired');
     assert.match(settings, /启用每日回顾/, 'Daily Review settings must surface the auto-run enable toggle');
     assert.match(settings, /执行时间/, 'Daily Review settings must surface the configurable execute time');
     assert.match(settings, /对话摘要/, 'Daily Review settings must expose the 对话摘要 section toggle');

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -328,8 +328,8 @@ name: Writer
     const renderer = await readFile(join(repoRoot, 'apps/desktop/src/renderer/main.tsx'), 'utf8');
     const chatView = ui.match(/export function ChatView\([\s\S]*?if \(props\.mode === 'automations'\)/)?.[0] ?? '';
     const skillsModuleMain = ui.match(/function SkillsModuleMain\([\s\S]*?function DailyReviewPanel/)?.[0] ?? '';
-    const skillPanel = ui.match(/function SkillLibraryPanel[\s\S]*?function formatSkillLibraryDescription/)?.[0] ?? '';
-    const emptyState = ui.match(/export interface EmptyStateProps[\s\S]*?function SkillLibraryPanel/)?.[0] ?? '';
+    const skillPanel = ui.match(/function SkillLibraryPanel[\s\S]*?function SkillsModuleMain/)?.[0] ?? '';
+    const emptyState = ui.match(/interface EmptyStateProps[\s\S]*?function SkillLibraryPanel/)?.[0] ?? '';
 
     assert.match(chatView, /if \(props\.mode === 'skills'\) \{[\s\S]*<SkillsModuleMain/, 'Skills mode must mount its own main surface component');
     assert.match(skillsModuleMain, /const \[pendingSkillAction, setPendingSkillAction\] = useState<string \| null>\(null\)/);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -6143,11 +6143,9 @@ button:active {
   margin-inline: auto;
   box-sizing: border-box;
   /* Composer outer chrome uses the universal page-card recipe (atlas §4
-     + maka-tokens.css --card-*) but with a slightly larger 10px radius
-     since the composer reads as a "hero card" rather than a flush page
-     surface — 6px would feel too tight for a 72px+ tall floating panel. */
+     + maka-tokens.css --card-*) at the documented large-panel ceiling. */
   border: 1px solid var(--card-border-color);
-  border-radius: 16px;
+  border-radius: 12px;
   padding: 10px 12px 8px;
   background: var(--card-bg);
   box-shadow:
@@ -6522,9 +6520,8 @@ button:active {
 }
 
 .maka-composer-workspace-row {
-  /* PR-PARCHMENT-HOME-2: must share the new composer card measure
-     (620px) so the "选择工作目录 ▾" pill stays aligned with the card
-     left edge above it. */
+  /* Must share the composer card measure so the "选择工作目录 ▾" pill stays
+     aligned with the card left edge above it. */
   width: min(var(--maka-chat-measure, 680px), 100%);
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary
- refresh stale desktop source-scan contracts after shared UI and bot brand code moved
- keep composer workspace picker aligned to the shared chat measure contract
- bring composer card radius back under the documented 12px ceiling

## Verification
- npm run -w @maka/desktop build:main && node --test dist/main/__tests__/project-context-badge.test.js dist/main/__tests__/radius-converge-contract.test.js dist/main/__tests__/settings-form-a11y-contract.test.js dist/main/__tests__/bot-settings-ui-contract.test.js dist/main/__tests__/settings-roadmap-cleanup-contract.test.js dist/main/__tests__/skills.test.js
- npm run -w @maka/desktop build:main && node --test dist/main/__tests__/local-memory-ui-contract.test.js dist/main/__tests__/permission-response-ipc-boundary.test.js
- npm run -w @maka/desktop test
- npm run typecheck