### PR TITLE
refactor(ui,settings): move SettingsSwitch adapter to @maka/ui primitive

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -94,8 +94,8 @@ import {
   OverlayScrollArea,
   RelativeTime,
   SettingsSelect,
+  SettingsSwitch as Switch,
   PrimitiveBadge,
-  Switch as BaseUiSwitch,
   Textarea,
   redactSecrets,
   useModalA11y,
@@ -6126,37 +6126,11 @@ function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'destruct
   }
 }
 
-/**
- * PR-USE-SHADCN-BASE-UI-SWITCH — internal adapter that maps the existing
- * `{ ariaLabel, checked, onChange, disabled, ariaDescribedBy }` callsite
- * shape onto the shared `BaseUiSwitch` (Base UI `Switch.Root` +
- * `Switch.Thumb` styled with the project's semantic Tailwind tokens).
- *
- * Why an adapter, not a callsite rewrite: 15+ Switch usages across this
- * 6900-line settings module all use `ariaLabel` / `onChange`. Renaming
- * every callsite at the same time would conflict with the parallel
- * Settings polish lanes; the adapter lets us swap the implementation
- * (now real `[role="switch"]` semantics, real Base UI keyboard/focus
- * handling, proper data-checked attribute) without touching the
- * callers.
- */
-function Switch(props: {
-  ariaLabel: string;
-  checked: boolean;
-  onChange(checked: boolean): void;
-  disabled?: boolean;
-  ariaDescribedBy?: string;
-}) {
-  return (
-    <BaseUiSwitch
-      aria-label={props.ariaLabel}
-      aria-describedby={props.ariaDescribedBy}
-      checked={props.checked}
-      disabled={props.disabled}
-      onCheckedChange={(next) => props.onChange(next)}
-    />
-  );
-}
+// `Switch` adapter (15+ settings toggle callsites use `ariaLabel /
+// onChange`) was moved to `packages/ui/src/primitives/settings-switch.tsx`
+// as `SettingsSwitch`. Imported above as `Switch` so the call sites
+// don't need touching. PR yuejing/switch-primitive-and-css-cleanup
+// (WAWQAQ msg `f1461d30`).
 
 /**
  * PR-UI-8 — Permission Center read-only page. Consumes `window.maka.permissions.getSnapshot()`

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -37,6 +37,7 @@ export * from './primitives/frame.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/preview-card.js';
 export * from './primitives/settings-select.js';
+export * from './primitives/settings-switch.js';
 export * from './primitives/input-group.js';
 export * from './primitives/pagination.js';
 export * from './primitives/sidebar.js';

--- a/packages/ui/src/primitives/settings-switch.tsx
+++ b/packages/ui/src/primitives/settings-switch.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { Switch as BaseUiSwitch } from "../ui.js";
+
+/**
+ * Settings-flavored Switch adapter.
+ *
+ * Reshapes Base UI's `{ checked, onCheckedChange, aria-label }` API
+ * into `{ checked, onChange, ariaLabel, ariaDescribedBy, disabled }` —
+ * the shape the 15+ settings toggle call sites have been using since
+ * before the Base UI migration. Lives in `@maka/ui` so a single
+ * primitive change (e.g. swapping the underlying control) propagates
+ * to every settings page automatically, instead of duplicating the
+ * adapter inside SettingsModal.tsx.
+ *
+ * Use this in any settings/preferences row where the row description
+ * already supplies the label. For chat / composer / chat-header
+ * toggles that pass Base UI props directly (e.g. `checked={false}
+ * disabled aria-label="..."`), use the underlying `Switch` /
+ * `BaseUiSwitch` re-export instead.
+ */
+export interface SettingsSwitchProps {
+  ariaLabel: string;
+  checked: boolean;
+  onChange(checked: boolean): void;
+  disabled?: boolean;
+  ariaDescribedBy?: string;
+}
+
+export function SettingsSwitch(props: SettingsSwitchProps): ReactElement {
+  return (
+    <BaseUiSwitch
+      aria-label={props.ariaLabel}
+      aria-describedby={props.ariaDescribedBy}
+      checked={props.checked}
+      disabled={props.disabled}
+      onCheckedChange={(next) => props.onChange(next)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
@WAWQAQ msg `f1461d30` 「用库的应该用库」: keep collapsing local hand-rolled wrappers into shared `@maka/ui` primitives.

The 17-line `Switch` adapter inside `SettingsModal.tsx` that reshapes Base UI's `{ checked, onCheckedChange, aria-label }` API into the settings-toggle `{ ariaLabel, checked, onChange, disabled, ariaDescribedBy }` shape moves to `packages/ui/src/primitives/settings-switch.tsx` as `SettingsSwitch`.

`SettingsModal.tsx` imports it aliased as `Switch` so all 15+ call sites stay byte-identical:
```tsx
import { SettingsSwitch as Switch, … } from '@maka/ui';
```

The other `<Switch>` consumer in `packages/ui/src/components.tsx:2290` already uses Base UI's direct API (`<Switch checked={false} disabled aria-label=\"…\" />`) and stays untouched — it's not a settings-row toggle.

## Test plan
- [x] `pnpm -F @maka/ui build` — clean.
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — only pre-existing unrelated TS2366.
- [x] `renderer-style-pruning-contract.test.ts` — 2/2 pass (kenji's selector inventory guard found no new orphan CSS).