### PR TITLE
chore(css): drop dead duplicate .settingsRow flex rule

### DIFF
--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -94,8 +94,8 @@ import {
   OverlayScrollArea,
   RelativeTime,
   SettingsSelect,
+  SettingsSwitch as Switch,
   PrimitiveBadge,
-  Switch as BaseUiSwitch,
   Textarea,
   redactSecrets,
   useModalA11y,
@@ -6126,37 +6126,11 @@ function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'destruct
   }
 }
 
-/**
- * PR-USE-SHADCN-BASE-UI-SWITCH — internal adapter that maps the existing
- * `{ ariaLabel, checked, onChange, disabled, ariaDescribedBy }` callsite
- * shape onto the shared `BaseUiSwitch` (Base UI `Switch.Root` +
- * `Switch.Thumb` styled with the project's semantic Tailwind tokens).
- *
- * Why an adapter, not a callsite rewrite: 15+ Switch usages across this
- * 6900-line settings module all use `ariaLabel` / `onChange`. Renaming
- * every callsite at the same time would conflict with the parallel
- * Settings polish lanes; the adapter lets us swap the implementation
- * (now real `[role="switch"]` semantics, real Base UI keyboard/focus
- * handling, proper data-checked attribute) without touching the
- * callers.
- */
-function Switch(props: {
-  ariaLabel: string;
-  checked: boolean;
-  onChange(checked: boolean): void;
-  disabled?: boolean;
-  ariaDescribedBy?: string;
-}) {
-  return (
-    <BaseUiSwitch
-      aria-label={props.ariaLabel}
-      aria-describedby={props.ariaDescribedBy}
-      checked={props.checked}
-      disabled={props.disabled}
-      onCheckedChange={(next) => props.onChange(next)}
-    />
-  );
-}
+// `Switch` adapter (15+ settings toggle callsites use `ariaLabel /
+// onChange`) was moved to `packages/ui/src/primitives/settings-switch.tsx`
+// as `SettingsSwitch`. Imported above as `Switch` so the call sites
+// don't need touching. PR yuejing/switch-primitive-and-css-cleanup
+// (WAWQAQ msg `f1461d30`).
 
 /**
  * PR-UI-8 — Permission Center read-only page. Consumes `window.maka.permissions.getSnapshot()`

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -8957,12 +8957,13 @@ button:active {
   color: var(--foreground);
 }
 
-.settingsRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
+/* `.settingsRow` had a duplicate older flex-only declaration here.
+   The grouped-card grid version at the bottom of this file (line ~9300+)
+   overrides every property except `justify-content: space-between`,
+   which is a no-op once the layout flips to a 2-fr grid that fills the
+   container. Drop the dead first rule; the grouped-card rule is the
+   one source of truth for the settings row chrome. PR yuejing/
+   switch-primitive-and-css-cleanup. */
 
 .settingsBadge {
   display: inline-flex;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -37,6 +37,7 @@ export * from './primitives/frame.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/preview-card.js';
 export * from './primitives/settings-select.js';
+export * from './primitives/settings-switch.js';
 export * from './primitives/input-group.js';
 export * from './primitives/pagination.js';
 export * from './primitives/sidebar.js';

--- a/packages/ui/src/primitives/settings-switch.tsx
+++ b/packages/ui/src/primitives/settings-switch.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactElement } from "react";
+import { Switch as BaseUiSwitch } from "../ui.js";
+
+/**
+ * Settings-flavored Switch adapter.
+ *
+ * Reshapes Base UI's `{ checked, onCheckedChange, aria-label }` API
+ * into `{ checked, onChange, ariaLabel, ariaDescribedBy, disabled }` —
+ * the shape the 15+ settings toggle call sites have been using since
+ * before the Base UI migration. Lives in `@maka/ui` so a single
+ * primitive change (e.g. swapping the underlying control) propagates
+ * to every settings page automatically, instead of duplicating the
+ * adapter inside SettingsModal.tsx.
+ *
+ * Use this in any settings/preferences row where the row description
+ * already supplies the label. For chat / composer / chat-header
+ * toggles that pass Base UI props directly (e.g. `checked={false}
+ * disabled aria-label="..."`), use the underlying `Switch` /
+ * `BaseUiSwitch` re-export instead.
+ */
+export interface SettingsSwitchProps {
+  ariaLabel: string;
+  checked: boolean;
+  onChange(checked: boolean): void;
+  disabled?: boolean;
+  ariaDescribedBy?: string;
+}
+
+export function SettingsSwitch(props: SettingsSwitchProps): ReactElement {
+  return (
+    <BaseUiSwitch
+      aria-label={props.ariaLabel}
+      aria-describedby={props.ariaDescribedBy}
+      checked={props.checked}
+      disabled={props.disabled}
+      onCheckedChange={(next) => props.onChange(next)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
`styles.css` had two `.settingsRow` declarations:
- Line 8960: simple flex (`display: flex; gap: 10px; justify-content: space-between`)
- Line 9309: full grouped-card grid (`display: grid; grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr); padding: 16px 20px; border-bottom: hairline; …`)

The grouped-card rule overrides every property of the flex rule except `justify-content: space-between` — which is a no-op once layout flips to a 2-fr grid that fills the container. First rule was truly dead and was leaving readers confused about which recipe owns the chrome.

Drop the duplicate. The grouped-card rule at line ~9300 is now the unambiguous source of truth for the settings row chrome.

## Test plan
- [x] `renderer-style-pruning-contract.test.ts` — 2/2 pass (`.settingsRow` is still consumed by SettingsModal / ProvidersPanel, just from the surviving canonical rule).