### PR TITLE
refactor(ui,settings): Round D — SettingsSegmented primitive + retire 4 hand-rolled radiogroup helpers

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -67,37 +67,36 @@ describe('Settings theme page contract', () => {
 
   it('supports standard radiogroup keyboard navigation for appearance controls', async () => {
     const src = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
-    const helperBlock = src.match(/function onSettingsRadioGroupKeyDown[\s\S]*?function radioTabIndex/)?.[0] ?? '';
     const themePage = src.match(/function ThemeSettingsPage\([\s\S]*?function WebSearchSettingsPage/)?.[0] ?? '';
-    const segmentedBlock = src.match(/function Segmented[\s\S]*?function Switch/)?.[0] ?? '';
 
-    // `onSettingsRadioGroupKeyDown` + `nextRadioId` + `focusRadioValue` +
-    // `radioTabIndex` still exist because `Segmented` (the inline
-    // [value, label] pill picker) keeps native-button + manual keyboard
-    // nav — it has no card chrome to protect, so flipping it would not
-    // earn its keep here. Verify the helper logic is intact.
-    assert.match(helperBlock, /nextRadioId\(current, values, event\.key\)/);
-    assert.match(helperBlock, /event\.preventDefault\(\)/);
-    assert.match(helperBlock, /onChange\(next\)/);
-    assert.match(helperBlock, /const group = event\.currentTarget/);
-    assert.match(helperBlock, /setTimeout\(\(\) => focusRadioValue\(group, next\), 0\)/);
+    // PR round-c-choice-card-primitive + PR yuejing/settings-segmented-
+    // primitive: Theme/Palette via Base UI `RadioGroup`-backed
+    // `ChoiceCardGroup`; Segmented via Base UI `ToggleGroup`-backed
+    // `SettingsSegmented`. Both primitives provide arrow-key
+    // navigation, focus management, and roving tabindex for free, so
+    // the hand-rolled `onSettingsRadioGroupKeyDown` /
+    // `focusRadioValue` / `radioTabIndex` helpers are gone from
+    // SettingsModal.tsx. `nextRadioId` still lives in
+    // `model-table-keyboard.ts` for ProvidersPanel's model default
+    // picker.
+    assert.doesNotMatch(src, /function onSettingsRadioGroupKeyDown/);
+    assert.doesNotMatch(src, /function focusRadioValue/);
+    assert.doesNotMatch(src, /function radioTabIndex/);
+    assert.doesNotMatch(src, /import \{ nextRadioId \} from '\.\/model-table-keyboard'/);
 
-    // Theme + palette pickers now delegate keyboard navigation to the
-    // Base UI `RadioGroup` inside `ChoiceCardGroup`. Both groups must
-    // pass `value` + `onValueChange` (not `onKeyDown`) and must NOT
-    // reach back to the legacy helpers.
+    // Theme + palette pickers must use `ChoiceCardGroup` with
+    // `value` + `onValueChange` semantics, NOT the legacy keyboard
+    // helpers or `data-radio-value` attribute.
     assert.match(themePage, /<ChoiceCardGroup[\s\S]*aria-label="主题"[\s\S]*value=\{props\.themePref\}[\s\S]*onValueChange/);
     assert.match(themePage, /<ChoiceCardGroup[\s\S]*aria-label=\{group\.label\}[\s\S]*value=\{currentPalette\}[\s\S]*onValueChange/);
     assert.doesNotMatch(themePage, /onSettingsRadioGroupKeyDown|radioTabIndex|data-radio-value/);
     assert.doesNotMatch(themePage, /界面密度|props\.density|setDensity|onDensityChange/);
 
-    // `Segmented` still uses the legacy helpers. Pin them so a future
-    // sweep doesn't accidentally drop them while the Segmented call
-    // sites are still around.
-    assert.match(segmentedBlock, /if \(props\.disabled\) return;[\s\S]*onSettingsRadioGroupKeyDown\(event, values, props\.value, props\.onChange\)/);
-    assert.match(segmentedBlock, /aria-disabled=\{props\.disabled \? 'true' : undefined\}/);
-    assert.match(segmentedBlock, /disabled=\{props\.disabled\}/);
-    assert.match(segmentedBlock, /data-radio-value=\{value\}[\s\S]*tabIndex=\{radioTabIndex\(value, props\.value, values\)\}/);
+    // Segmented now comes from `@maka/ui` as `SettingsSegmented`,
+    // imported aliased as `Segmented`. The local `function Segmented`
+    // declaration must be gone.
+    assert.match(src, /SettingsSegmented as Segmented/);
+    assert.doesNotMatch(src, /^function Segmented</m);
   });
 
   it('uses the ChoiceCard primitive (not native <button> or shared <Button>) for theme + palette cards', async () => {

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -93,6 +93,7 @@ import {
   Input,
   OverlayScrollArea,
   RelativeTime,
+  SettingsSegmented as Segmented,
   SettingsSelect,
   SettingsSwitch as Switch,
   PrimitiveBadge,
@@ -121,8 +122,6 @@ import {
   NAV_GROUP_ORDER,
   type SettingsNavGroup,
 } from './nav-group-summary';
-import { nextRadioId } from './model-table-keyboard';
-
 type SettingsNavItem = {
   id: SettingsSection;
   label: string;
@@ -150,30 +149,16 @@ type AccountSecretProbeResult =
   | { slug: string; status: boolean }
   | { slug: string; status: 'error'; message: string };
 
-function focusRadioValue(container: HTMLElement, value: string) {
-  container
-    .querySelector<HTMLButtonElement>(`button[data-radio-value="${CSS.escape(value)}"]`)
-    ?.focus({ preventScroll: true });
-}
-
-function onSettingsRadioGroupKeyDown<T extends string>(
-  event: KeyboardEvent<HTMLElement>,
-  values: readonly T[],
-  current: T,
-  onChange: (next: T) => void,
-) {
-  const next = nextRadioId(current, values, event.key) as T | null;
-  if (next === null || next === current) return;
-  event.preventDefault();
-  onChange(next);
-  const group = event.currentTarget;
-  window.setTimeout(() => focusRadioValue(group, next), 0);
-}
-
-function radioTabIndex<T extends string>(value: T, current: T, values: readonly T[]): 0 | -1 {
-  if (value === current) return 0;
-  return !values.includes(current) && values[0] === value ? 0 : -1;
-}
+// `focusRadioValue`, `onSettingsRadioGroupKeyDown`, `radioTabIndex` were
+// the manual roving-tabindex / arrow-key handlers for the Theme,
+// Palette, and Segmented radiogroups. Theme + Palette migrated to the
+// Base UI `RadioGroup`-backed `ChoiceCard` primitive in PR #263;
+// Segmented migrated to the Base UI `ToggleGroup`-backed
+// `SettingsSegmented` primitive in PR yuejing/settings-segmented-primitive.
+// Both primitives now provide the same keyboard contract for free, so
+// these helpers are gone. `nextRadioId` still lives in
+// `./model-table-keyboard.ts` because ProvidersPanel.tsx's model
+// default picker keeps its hand-rolled radiogroup.
 
 // `SettingsSelect` moved to `packages/ui/src/primitives/settings-select.tsx`
 // in PR round-AB-shared-select (yuejing 2026-06-25). The Plan Reminder
@@ -6077,37 +6062,11 @@ function MetricCard(props: { title: string; value: string; detail?: string }) {
   );
 }
 
-function Segmented<T extends string>(props: { value: T; options: Array<[T, string]>; onChange(value: T): void; ariaLabel?: string; disabled?: boolean }) {
-  const values = props.options.map(([value]) => value);
-  return (
-    <div
-      className="settingsSegmented"
-      role="radiogroup"
-      aria-label={props.ariaLabel}
-      aria-disabled={props.disabled ? 'true' : undefined}
-      onKeyDown={(event) => {
-        if (props.disabled) return;
-        onSettingsRadioGroupKeyDown(event, values, props.value, props.onChange);
-      }}
-    >
-      {props.options.map(([value, label]) => (
-        <Button
-          key={value}
-          type="button"
-          role="radio"
-          aria-checked={props.value === value}
-          data-active={props.value === value}
-          data-radio-value={value}
-          tabIndex={radioTabIndex(value, props.value, values)}
-          disabled={props.disabled}
-          onClick={() => props.onChange(value)}
-        >
-          {label}
-        </Button>
-      ))}
-    </div>
-  );
-}
+// `Segmented` moved to `packages/ui/src/primitives/settings-segmented.tsx`
+// as `SettingsSegmented` (Base UI `ToggleGroup`-backed). Imported above
+// aliased as `Segmented` so the 3 call sites in this file are
+// byte-identical. PR yuejing/settings-segmented-primitive
+// (WAWQAQ msg `f1461d30` 用库的应该用库).
 
 /**
  * PR-USE-SHADCN-BASE-UI-BADGE — map the project's status-tone vocabulary

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -8874,7 +8874,7 @@ button:active {
   font-size: 11px;
 }
 
-.settingsSegmented button[data-active="true"] {
+.settingsSegmented button[data-pressed] {
   background: var(--background);
   color: var(--foreground);
   box-shadow: 0 1px 2px oklch(0 0 0 / 0.08);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -36,6 +36,7 @@ export * from './primitives/group.js';
 export * from './primitives/frame.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/preview-card.js';
+export * from './primitives/settings-segmented.js';
 export * from './primitives/settings-select.js';
 export * from './primitives/settings-switch.js';
 export * from './primitives/input-group.js';

--- a/packages/ui/src/primitives/settings-segmented.tsx
+++ b/packages/ui/src/primitives/settings-segmented.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Toggle as BaseToggle } from "@base-ui/react/toggle";
+import { ToggleGroup as BaseToggleGroup } from "@base-ui/react/toggle-group";
+import type { ReactElement } from "react";
+import { cn } from "../utils.js";
+
+/**
+ * Pill / segmented control primitive.
+ *
+ * Replaces the hand-rolled `function Segmented` in SettingsModal.tsx
+ * that wrapped a `<div role="radiogroup">` plus manual arrow-key
+ * keyboard handling via `onSettingsRadioGroupKeyDown`. Single-select
+ * is preserved by using Base UI's `ToggleGroup` with `toggleMultiple
+ * = false` (the default), which also gives us proper roving tabindex,
+ * arrow-key navigation, and `data-pressed` state for the active item
+ * for free.
+ *
+ * Caller's `className` (legacy `.settingsSegmented`) still owns the
+ * visual chrome. The primitive only contributes Base UI's behavior
+ * contract, the same way `ChoiceCard` / `SettingsSelect` are layered.
+ */
+export interface SettingsSegmentedProps<T extends string> {
+  value: T;
+  options: ReadonlyArray<readonly [T, string]>;
+  onChange(value: T): void;
+  ariaLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SettingsSegmented<T extends string>(
+  props: SettingsSegmentedProps<T>,
+): ReactElement {
+  return (
+    <BaseToggleGroup
+      // `toggleMultiple` defaults to false → single-select radio
+      // semantics. `defaultValue` is unused; we control the value.
+      value={props.value ? [props.value] : []}
+      onValueChange={(next) => {
+        const first = next[0];
+        if (typeof first === "string") props.onChange(first as T);
+      }}
+      disabled={props.disabled}
+      aria-label={props.ariaLabel}
+      className={cn("settingsSegmented", props.className)}
+    >
+      {props.options.map(([value, label]) => (
+        <BaseToggle
+          key={value}
+          value={value}
+          disabled={props.disabled}
+        >
+          {label}
+        </BaseToggle>
+      ))}
+    </BaseToggleGroup>
+  );
+}


### PR DESCRIPTION
## Summary
@WAWQAQ msg \`f1461d30\` 「用库的应该用库」: continue collapsing the hand-rolled wrappers in SettingsModal.tsx into shared @maka/ui primitives.

### Primitive
`packages/ui/src/primitives/settings-segmented.tsx` wraps Base UI's `ToggleGroup` (single-select by default). Caller's `className` (legacy `.settingsSegmented`) still owns the visual chrome — the primitive only contributes Base UI's behavior contract.

### Migration
- `function Segmented` deleted from SettingsModal. 3 call sites use the imported primitive aliased as `Segmented` so their JSX is byte-identical.
- `.settingsSegmented button[data-active=\"true\"]` → `[data-pressed]` (Base UI's Toggle state attribute).

### Helper retirement
With Theme/Palette migrated via #263 (`ChoiceCard`) and Segmented migrated here, all four hand-rolled keyboard-nav helpers in SettingsModal are dead:
- `onSettingsRadioGroupKeyDown`, `focusRadioValue`, `radioTabIndex` — deleted.
- `nextRadioId` import — deleted from SettingsModal.

`nextRadioId` itself stays in `model-table-keyboard.ts` because ProvidersPanel's model default picker keeps its hand-rolled radiogroup.

### Contract test pivot
Keyboard-nav assertion in `settings-theme-contract.test.ts` flips: was 'Segmented uses the legacy helpers' → 'Segmented imports SettingsSegmented; the local function Segmented declaration is gone; the 4 hand-rolled helpers are gone'.

## Test plan
- [x] `pnpm -F @maka/ui build` — clean.
- [x] `tsc --noEmit -p apps/desktop/tsconfig.renderer.json` — only the pre-existing unrelated TS2366.
- [x] `settings-theme-contract.test.ts` — 6/6 pass.
- [x] `renderer-style-pruning-contract.test.ts` — 2/2 pass.
- [ ] Visual smoke: Settings → 模型 / 通用 pages with Segmented pills still toggle correctly; arrow keys cycle between options; active pill has the white background + light shadow chrome.