### PR TITLE
Fix filtered model radio tab order

### DIFF
--- a/apps/desktop/src/main/__tests__/model-table-keyboard.test.ts
+++ b/apps/desktop/src/main/__tests__/model-table-keyboard.test.ts
@@ -18,6 +18,7 @@ import { describe, it } from 'node:test';
 import {
   isRadioGroupNavKey,
   nextRadioId,
+  tabbableRadioId,
 } from '../../renderer/settings/model-table-keyboard.js';
 
 const FIVE = ['glm-4.5', 'glm-4.5-air', 'glm-4.6', 'glm-4.7', 'glm-5'];
@@ -96,5 +97,23 @@ describe('nextRadioId — non-nav keys / edge cases', () => {
     // Default model `glm-4.5` is filtered out; user presses ArrowDown.
     // Should land on the first visible item.
     assert.equal(nextRadioId('glm-4.5', ['glm-5', 'glm-4.6'], 'ArrowDown'), 'glm-5');
+  });
+});
+
+describe('tabbableRadioId', () => {
+  it('keeps the selected visible radio in the tab order', () => {
+    assert.equal(tabbableRadioId('glm-4.6', FIVE), 'glm-4.6');
+  });
+
+  it('falls back to the first visible radio when the selected model is filtered out', () => {
+    assert.equal(tabbableRadioId('glm-4.5', ['glm-4.7', 'glm-5']), 'glm-4.7');
+  });
+
+  it('falls back to the first visible radio when no default model exists yet', () => {
+    assert.equal(tabbableRadioId(undefined, ['glm-4.7', 'glm-5']), 'glm-4.7');
+  });
+
+  it('returns null for an empty filtered result set', () => {
+    assert.equal(tabbableRadioId('glm-4.5', []), null);
   });
 });

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -154,6 +154,16 @@ describe('Settings form accessibility labels', () => {
     assert.doesNotMatch(providersPanel, /<textarea\b/, 'ProvidersPanel must use the shared Textarea primitive for Settings text areas');
     assert.doesNotMatch(providersPanel, /<select\b/, 'ProvidersPanel must use the Base UI Select primitive for Settings selects');
     assert.doesNotMatch(providersPanel, /className="maka-button/, 'ProvidersPanel governed Buttons must not layer the legacy maka-button class (inert under the @maka/ui Button utilities, so it is dead weight)');
+    assert.match(
+      providersPanel,
+      /const tabbableModelId = tabbableRadioId\(props\.defaultModel \|\| undefined, visibleModelIds\);/,
+      'ModelTable must keep one visible model row tabbable when the selected default is filtered out',
+    );
+    assert.doesNotMatch(
+      providersPanel,
+      /tabIndex=\{isDefault \|\| \(!props\.defaultModel && filtered\[0\]\?\.id === model\.id\) \? 0 : -1\}/,
+      'ModelTable must not regress to zero tabbable radios when search hides the selected default model',
+    );
     // `Item` rows become real buttons through Base UI's polymorphic
     // `render={<button .../>}` prop, which is a primitive render target rather
     // than a hand-rolled control. Strip those before asserting no raw <button>

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type RefObject } from 'react';
 import { ChevronRight, X } from '@maka/ui/icons';
-import { nextRadioId } from './model-table-keyboard';
+import { nextRadioId, tabbableRadioId } from './model-table-keyboard';
 import {
   CATALOG_PROVIDER_TYPES,
   PROVIDER_DEFAULTS,
@@ -1822,6 +1822,8 @@ function ModelTable(props: {
     if (!q) return props.modelChoices;
     return props.modelChoices.filter((m) => m.id.toLowerCase().includes(q));
   }, [props.modelChoices, query]);
+  const visibleModelIds = useMemo(() => filtered.map((m) => m.id), [filtered]);
+  const tabbableModelId = tabbableRadioId(props.defaultModel || undefined, visibleModelIds);
 
   const headerLine =
     props.modelSource === 'fetched'
@@ -1840,14 +1842,12 @@ function ModelTable(props: {
     if (!list) return;
     const radios = Array.from(list.querySelectorAll<HTMLButtonElement>('button[role="radio"]'));
     if (radios.length === 0) return;
-    const visibleIds = filtered.map((m) => m.id);
-    const currentId = (document.activeElement as HTMLElement | null)?.closest('button[role="radio"]')
-      ? radios[radios.indexOf(document.activeElement as HTMLButtonElement)]?.dataset.modelId
-      : undefined;
-    const nextId = nextRadioId(currentId, visibleIds, event.key);
+    const focusedRadio = (document.activeElement as HTMLElement | null)?.closest<HTMLButtonElement>('button[role="radio"]');
+    const currentId = focusedRadio?.dataset.modelId;
+    const nextId = nextRadioId(currentId, visibleModelIds, event.key);
     if (nextId === null || nextId === currentId) return;
     event.preventDefault();
-    const nextIndex = visibleIds.indexOf(nextId);
+    const nextIndex = visibleModelIds.indexOf(nextId);
     const next = radios[nextIndex];
     next?.focus({ preventScroll: false });
     next?.scrollIntoView({ block: 'nearest' });
@@ -1941,7 +1941,7 @@ function ModelTable(props: {
                   disabled={props.disabled}
                   // Only the active radio is in the tab order; arrow keys
                   // move focus inside the group. Standard ARIA radiogroup.
-                  tabIndex={isDefault || (!props.defaultModel && filtered[0]?.id === model.id) ? 0 : -1}
+                  tabIndex={tabbableModelId === model.id ? 0 : -1}
                   onClick={() => props.onPickDefault(model.id)}
                 >
                   <span className="modelTableRowRadio" aria-hidden="true" />

--- a/apps/desktop/src/renderer/settings/model-table-keyboard.ts
+++ b/apps/desktop/src/renderer/settings/model-table-keyboard.ts
@@ -25,6 +25,21 @@ export function isRadioGroupNavKey(key: string): boolean {
 }
 
 /**
+ * Resolve the single radio that should stay in the tab order for the current
+ * filtered view. ARIA radiogroups need one tabbable item even when the selected
+ * value is currently filtered out of the DOM; otherwise keyboard users cannot
+ * tab into the visible results to choose a replacement.
+ */
+export function tabbableRadioId(
+  selectedId: string | undefined,
+  visibleIds: readonly string[],
+): string | null {
+  if (visibleIds.length === 0) return null;
+  if (selectedId !== undefined && visibleIds.includes(selectedId)) return selectedId;
+  return visibleIds[0] ?? null;
+}
+
+/**
  * Resolve the next radio id from the radio-group keyboard event. Returns
  * `null` for non-nav keys or empty groups; the caller should bail without
  * intercepting the key in either case.


### PR DESCRIPTION
## Summary
- Fix Settings -> 模型 default-model picker so a filtered result list still has one tabbable radio when the current default model is hidden by search.
- Extract the tab-order rule into the pure model-table keyboard helper and lock it with tests/contracts.
- Tighten the keyboard handler to read the actual closest focused radio instead of assuming document.activeElement is always the button.

## Root cause
When the selected default model was filtered out, the old tabIndex expression only made a row tabbable if it was the selected model or there was no default model. With a hidden selected default, every visible row became tabIndex=-1, so keyboard users could not tab into the visible results to choose a replacement.

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/model-table-keyboard.test.js dist/main/__tests__/settings-form-a11y-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check