### PR TITLE
Cancel Claude OAuth requests on modal close

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -1165,8 +1165,38 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       claudeCard,
+      /const claudeAuthRequestIdRef = useRef<string \| null>\(null\)/,
+      'Claude OAuth must keep the active auth request in a ref so unmount cleanup can cancel it',
+    );
+    assert.match(
+      claudeCard,
+      /return \(\) => \{[\s\S]*claudeCardMountedRef\.current = false;[\s\S]*const pendingAuthRequestId = claudeAuthRequestIdRef\.current;[\s\S]*claudeAuthRequestIdRef\.current = null;[\s\S]*if \(pendingAuthRequestId\) void window\.maka\.claudeSubscription\.cancelAuthorization\(pendingAuthRequestId\);[\s\S]*\};/,
+      'closing the Claude OAuth modal mid-login must cancel the pending auth request',
+    );
+    assert.match(
+      claudeCard,
       /function beginPendingAction\(action: ClaudeSubscriptionPendingAction\): boolean \{[\s\S]*if \(pendingActionRef\.current !== null\) return false;[\s\S]*pendingActionRef\.current = action;[\s\S]*setPendingAction\(action\);[\s\S]*return true;/,
       'Claude OAuth duplicate clicks must be rejected before React re-renders disabled buttons',
+    );
+    assert.match(
+      claudeCard,
+      /claudeAuthRequestIdRef\.current = payload\.authRequestId;[\s\S]*if \(!claudeCardMountedRef\.current\) \{[\s\S]*claudeAuthRequestIdRef\.current = null;[\s\S]*void window\.maka\.claudeSubscription\.cancelAuthorization\(payload\.authRequestId\);[\s\S]*return;[\s\S]*\}/,
+      'Claude OAuth must cancel auth requests created after the component was already closed',
+    );
+    assert.match(
+      claudeCard,
+      /if \(!opened\.ok\) \{[\s\S]*claudeAuthRequestIdRef\.current = null;[\s\S]*void window\.maka\.claudeSubscription\.cancelAuthorization\(payload\.authRequestId\);[\s\S]*setAuthRequestId\(null\);/,
+      'Claude OAuth must cancel a pending request when opening the browser fails',
+    );
+    assert.match(
+      claudeCard,
+      /if \(result\.ok\) \{[\s\S]*claudeAuthRequestIdRef\.current = null;[\s\S]*setAuthRequestId\(null\);/,
+      'successful Claude paste-code completion must clear the pending auth request ref',
+    );
+    assert.match(
+      claudeCard,
+      /await window\.maka\.claudeSubscription\.cancelAuthorization\(authRequestId\);[\s\S]*claudeAuthRequestIdRef\.current = null;[\s\S]*setAuthRequestId\(null\);/,
+      'explicit Claude OAuth cancellation must clear the pending auth request ref',
     );
     assert.match(claudeCard, /if \(!beginPendingAction\('login'\)\) return;/, 'starting login must use the ref-backed action guard');
     assert.match(claudeCard, /if \(!beginPendingAction\('submit'\)\) return;/, 'submitting an authorization code must use the ref-backed action guard');

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -2051,6 +2051,7 @@ function ClaudeSubscriptionCard() {
   const [pendingAction, setPendingAction] = useState<ClaudeSubscriptionPendingAction | null>(null);
   const pendingActionRef = useRef<ClaudeSubscriptionPendingAction | null>(null);
   const [authRequestId, setAuthRequestId] = useState<string | null>(null);
+  const claudeAuthRequestIdRef = useRef<string | null>(null);
   const [stateHint, setStateHint] = useState<string | null>(null);
   const [pasteValue, setPasteValue] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
@@ -2067,6 +2068,9 @@ function ClaudeSubscriptionCard() {
     claudeCardMountedRef.current = true;
     return () => {
       claudeCardMountedRef.current = false;
+      const pendingAuthRequestId = claudeAuthRequestIdRef.current;
+      claudeAuthRequestIdRef.current = null;
+      if (pendingAuthRequestId) void window.maka.claudeSubscription.cancelAuthorization(pendingAuthRequestId);
     };
   }, []);
 
@@ -2180,12 +2184,18 @@ function ClaudeSubscriptionCard() {
       // mounted). Discriminate by checking for the `ok` field; the
       // envelope variant has it, the success payload does not.
       const payload = await window.maka.claudeSubscription.getAuthUrl();
-      if (!claudeCardMountedRef.current) return;
       if ('ok' in payload) {
+        if (!claudeCardMountedRef.current) return;
         // Envelope variant. `ok: true` shouldn't happen for
         // getAuthUrl (success returns the payload, not an envelope),
         // so this branch is the failure case in practice.
         toast.error('无法开始登录', payload.ok ? '请稍后再试。' : subscriptionResultMessage(payload.message, '无法开始登录，请稍后再试。'));
+        return;
+      }
+      claudeAuthRequestIdRef.current = payload.authRequestId;
+      if (!claudeCardMountedRef.current) {
+        claudeAuthRequestIdRef.current = null;
+        void window.maka.claudeSubscription.cancelAuthorization(payload.authRequestId);
         return;
       }
       setAuthRequestId(payload.authRequestId);
@@ -2198,13 +2208,20 @@ function ClaudeSubscriptionCard() {
       if (!claudeCardMountedRef.current) return;
       if (!opened.ok) {
         toast.error('无法打开浏览器', subscriptionResultMessage(opened.message, '无法打开浏览器，请稍后重试。'));
+        claudeAuthRequestIdRef.current = null;
+        void window.maka.claudeSubscription.cancelAuthorization(payload.authRequestId);
         setAuthRequestId(null);
         setStateHint(null);
       }
       await refresh();
     } catch (error) {
+      const pendingAuthRequestId = claudeAuthRequestIdRef.current;
+      claudeAuthRequestIdRef.current = null;
+      if (pendingAuthRequestId) void window.maka.claudeSubscription.cancelAuthorization(pendingAuthRequestId);
       const message = subscriptionActionErrorMessage(error);
       if (!claudeCardMountedRef.current) return;
+      setAuthRequestId(null);
+      setStateHint(null);
       toast.error('无法开始登录', message);
       setPasteError(message);
     } finally {
@@ -2224,6 +2241,7 @@ function ClaudeSubscriptionCard() {
       if (!claudeCardMountedRef.current) return;
       if (result.ok) {
         toast.success('登录成功', '已绑定 Claude 订阅。');
+        claudeAuthRequestIdRef.current = null;
         setAuthRequestId(null);
         setStateHint(null);
         setPasteValue('');
@@ -2247,6 +2265,7 @@ function ClaudeSubscriptionCard() {
     try {
       await window.maka.claudeSubscription.cancelAuthorization(authRequestId);
       if (!claudeCardMountedRef.current) return;
+      claudeAuthRequestIdRef.current = null;
       setAuthRequestId(null);
       setStateHint(null);
       setPasteValue('');


### PR DESCRIPTION
## Summary
- Cancel the active Claude OAuth authorization request when the Claude subscription modal/card unmounts.
- Keep the current Claude auth request id in a ref so cleanup can see it even before React state catches up.
- Clear the ref on browser-open failure, startup failure, successful paste-code completion, and explicit cancel.

## Root cause
The generic browser OAuth modal already cancels a pending auth request on unmount, but the Claude paste-code card only tracked authRequestId in React state. Closing the modal mid-login could leave a stale pending authorization request in the main process until a later explicit cancel or timeout.

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/model-oauth-section-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check