### PR TITLE
Reset command palette highlight on result changes

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -149,6 +149,22 @@ describe('Command palette accessibility and visible copy', () => {
     assert.match(rowBlock, /data-pending=\{commandCommitPending \? 'true' : undefined\}/);
   });
 
+  it('resets active command to the first result when the result set changes', async () => {
+    const src = await readRepo('apps/desktop/src/renderer/command-palette.tsx');
+    const highlightEffect = src.match(/useEffect\(\(\) => \{[\s\S]*?Reset highlight whenever the result set changes\.[\s\S]*?\}, \[combined\]\);/)?.[0] ?? '';
+
+    assert.match(
+      highlightEffect,
+      /setHighlight\(0\);/,
+      'CommandPalette must reset highlight to the first new result after filtering/search results change',
+    );
+    assert.doesNotMatch(
+      highlightEffect,
+      /Math\.min\(current,\s*Math\.max\(0,\s*combined\.length - 1\)\)/,
+      'CommandPalette must not preserve a stale lower-row highlight across a new result set',
+    );
+  });
+
   it('scrubs thrown command action failures before toast', async () => {
     const main = await readRepo('apps/desktop/src/renderer/main.tsx');
     const commandPaletteBlock = main.match(/commands=\{buildCommandList\(\{[\s\S]*?\n\s*\}\)\}/)?.[0] ?? '';

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -628,7 +628,7 @@ export function CommandPalette(props: {
 
   useEffect(() => {
     // Reset highlight whenever the result set changes.
-    setHighlight((current) => Math.min(current, Math.max(0, combined.length - 1)));
+    setHighlight(0);
   }, [combined]);
 
   const grouped = useMemo(() => groupCommands(combined), [combined]);


### PR DESCRIPTION
## Summary
- Reset CommandPalette highlight to the first command whenever the filtered/content result set changes.
- Add a contract that forbids preserving a stale lower-row highlight across new result sets.

## Root cause
The code comment said the palette resets highlight whenever the result set changes, but the implementation only clamped the old index. If a user navigated down the palette, typed a new query, then pressed Enter, the palette could activate the same index in the new result set instead of the first/new best match.

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/command-palette-a11y-copy-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check