### PR TITLE
Guard Daily Review archive body loads

### DIFF
--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -96,7 +96,7 @@ describe('Daily Review copy feedback contract', () => {
     assert.match(panelBlock, /const pendingDailyReviewActionRef = useRef<string \| null>\(null\)/);
     assert.match(
       panelBlock,
-      /useEffect\(\(\) => \{\s*dailyReviewMountedRef\.current = true;[\s\S]*?return \(\) => \{\s*dailyReviewMountedRef\.current = false;\s*pendingDailyReviewActionRef\.current = null;\s*\};\s*\}, \[\]\)/,
+      /useEffect\(\(\) => \{\s*dailyReviewMountedRef\.current = true;[\s\S]*?return \(\) => \{\s*dailyReviewMountedRef\.current = false;\s*pendingDailyReviewActionRef\.current = null;\s*(?:archiveLoadRequestRef\.current \+= 1;\s*)?\};\s*\}, \[\]\)/,
       'Daily Review export pending ownership must be released when the main panel unmounts or StrictMode replays cleanup',
     );
     assert.match(panelBlock, /const dailyReviewActionBusy = pendingDailyReviewAction !== null/);
@@ -123,6 +123,46 @@ describe('Daily Review copy feedback contract', () => {
       main,
       /onSaveDailyReviewMarkdown=\{\(input\) => saveDailyReviewMarkdown\(input, \{ shouldShowFeedback: isDailyReviewSurfaceActive \}\)\}/,
       'Daily Review save feedback must be gated to the active Daily Review surface',
+    );
+  });
+
+  it('guards Daily Review archive body loads against stale async responses', async () => {
+    const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/components.tsx'), 'utf8');
+    const panelBlock = ui.match(/function DailyReviewPanel[\s\S]*?function PlanReminderPanel/)?.[0] ?? '';
+    const archiveLoadBlock = panelBlock.match(/useEffect\(\(\) => \{\s*const getArchive = props\.bridge\.getArchive;[\s\S]*?\}, \[archiveReloadToken, selectedArchiveId, props\.bridge\]\);/)?.[0] ?? '';
+
+    assert.match(panelBlock, /const archiveLoadRequestRef = useRef\(0\)/);
+    assert.match(
+      panelBlock,
+      /return \(\) => \{\s*dailyReviewMountedRef\.current = false;\s*pendingDailyReviewActionRef\.current = null;\s*archiveLoadRequestRef\.current \+= 1;\s*\};/,
+      'Daily Review archive loads must be invalidated when the panel unmounts',
+    );
+    assert.match(
+      panelBlock,
+      /function chooseDailyReviewArchive\(archiveId: string\) \{\s*archiveLoadRequestRef\.current \+= 1;\s*setSelectedArchiveId\(archiveId\);\s*setSelectedArchive\(null\);\s*setArchiveLoading\(Boolean\(props\.bridge\.getArchive\)\);\s*setArchiveError\(null\);\s*\}/,
+      'Archive row selection must synchronously invalidate the previous body request before React effect cleanup runs',
+    );
+    assert.match(panelBlock, /onClick=\{\(\) => chooseDailyReviewArchive\(archive\.id\)\}/);
+    assert.match(panelBlock, /chooseDailyReviewArchive\(result\.archiveId\);/);
+    assert.match(
+      archiveLoadBlock,
+      /if \(!getArchive \|\| !selectedArchiveId\) \{\s*archiveLoadRequestRef\.current \+= 1;\s*setSelectedArchive\(null\);/,
+      'Disabling or clearing the archive selection must invalidate any pending body load',
+    );
+    assert.match(
+      archiveLoadBlock,
+      /const archiveId = selectedArchiveId;\s*const archiveRequestId = \+\+archiveLoadRequestRef\.current;[\s\S]*getArchive\(archiveId\)/,
+      'Each archive body load must capture both the selected id and a request token',
+    );
+    assert.match(
+      archiveLoadBlock,
+      /\.then\(\(next\) => \{\s*if \(cancelled\) return;\s*if \(archiveLoadRequestRef\.current !== archiveRequestId\) return;\s*setSelectedArchive\(next\);/,
+      'Older successful archive body loads must not overwrite the current selection',
+    );
+    assert.match(
+      archiveLoadBlock,
+      /\.catch\(\(err: unknown\) => \{\s*if \(cancelled\) return;\s*if \(archiveLoadRequestRef\.current !== archiveRequestId\) return;\s*setSelectedArchive\(null\);/,
+      'Older failed archive body loads must not clear or error the current selection',
     );
   });
 

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -1435,6 +1435,7 @@ function DailyReviewPanel(props: {
   const dailyReviewMountedRef = useRef(true);
   const summaryScopeKeyRef = useRef<string | null>(null);
   const pendingDailyReviewActionRef = useRef<string | null>(null);
+  const archiveLoadRequestRef = useRef(0);
   const currentSummaryScopeKey = dailyReviewScopeKey(offsetDays, range);
   const visibleSummary = summaryScopeKey === currentSummaryScopeKey ? summary : null;
   const canLoadArchives = Boolean(props.bridge.listArchives && props.bridge.getArchive);
@@ -1444,8 +1445,17 @@ function DailyReviewPanel(props: {
     return () => {
       dailyReviewMountedRef.current = false;
       pendingDailyReviewActionRef.current = null;
+      archiveLoadRequestRef.current += 1;
     };
   }, []);
+
+  function chooseDailyReviewArchive(archiveId: string) {
+    archiveLoadRequestRef.current += 1;
+    setSelectedArchiveId(archiveId);
+    setSelectedArchive(null);
+    setArchiveLoading(Boolean(props.bridge.getArchive));
+    setArchiveError(null);
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -1507,21 +1517,27 @@ function DailyReviewPanel(props: {
   useEffect(() => {
     const getArchive = props.bridge.getArchive;
     if (!getArchive || !selectedArchiveId) {
+      archiveLoadRequestRef.current += 1;
       setSelectedArchive(null);
       setArchiveLoading(false);
       return;
     }
     let cancelled = false;
+    const archiveId = selectedArchiveId;
+    const archiveRequestId = ++archiveLoadRequestRef.current;
+    setSelectedArchive(null);
     setArchiveLoading(true);
     setArchiveError(null);
-    getArchive(selectedArchiveId)
+    getArchive(archiveId)
       .then((next) => {
         if (cancelled) return;
+        if (archiveLoadRequestRef.current !== archiveRequestId) return;
         setSelectedArchive(next);
         setArchiveLoading(false);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
+        if (archiveLoadRequestRef.current !== archiveRequestId) return;
         setSelectedArchive(null);
         setArchiveError(dailyReviewPanelErrorMessage(err));
         setArchiveLoading(false);
@@ -1576,7 +1592,7 @@ function DailyReviewPanel(props: {
     await runDailyReviewAction(`run:${mode}`, async () => {
       try {
         const result = await runOnce({ mode });
-        setSelectedArchiveId(result.archiveId);
+        chooseDailyReviewArchive(result.archiveId);
         setArchiveReloadToken((n) => n + 1);
         setReloadToken((n) => n + 1);
       } catch (err) {
@@ -1697,7 +1713,7 @@ function DailyReviewPanel(props: {
                       variant="quiet"
                       className="maka-daily-review-archive-row"
                       data-active={selectedArchiveId === archive.id ? 'true' : undefined}
-                      onClick={() => setSelectedArchiveId(archive.id)}
+                      onClick={() => chooseDailyReviewArchive(archive.id)}
                     >
                       <span className="maka-daily-review-archive-row-title">
                         {formatDailyReviewArchiveTitle(archive)}


### PR DESCRIPTION
## Summary
- Guard Daily Review archive body loads with a request token so stale `getArchive()` responses cannot overwrite a newer selected report.
- Clear the old archive body immediately when selecting or generating a report, and invalidate pending loads on panel unmount.
- Add a source contract for the archive load ownership rule.

## Root cause
Daily Review archive bodies are loaded asynchronously through `bridge.getArchive(selectedArchiveId)`. The effect used a local cleanup boolean, which protects after React commits the next effect cleanup, but explicit archive selection did not synchronously invalidate the already-running body request. A slow previous report load could still race with a newer selection before cleanup ran, leaving stale body/error state visible for the selected row.

## Verification
- `npm --workspace @maka/desktop run build:main`
- `cd apps/desktop && node --test dist/main/__tests__/daily-review-copy-feedback-contract.test.js`
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`

Renderer build still reports the existing Vite large chunk warning.
