### PR TITLE
Guard provider create sheet lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -85,7 +85,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.ok(reloadMatch, 'ProvidersPanel reload() must exist');
     assert.match(
       panel,
-      /const providersPanelMountedRef = useRef\(false\);[\s\S]*const providersReloadTicketRef = useRef\(0\);/,
+      /const providersPanelMountedRef = useRef\(false\);[\s\S]*const providersReloadTicketRef = useRef\(0\);[\s\S]*const providerSheetLifecycleRef = useRef\(0\);/,
       'ProvidersPanel reloads must track mounted state and latest request ownership',
     );
     assert.match(
@@ -110,8 +110,13 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       src,
-      /onCreated=\{async \(slug\) => \{[\s\S]*const reloaded = await reload\(\);[\s\S]*if \(!reloaded \|\| !providersPanelMountedRef\.current\) return;[\s\S]*setSelectedSlug\(slug\);[\s\S]*setAddingType\(null\);/,
-      'AddProviderForm completion must not select/close a stale sheet after ProvidersPanel unmounts',
+      /function closeProviderConfigSheet\(\) \{[\s\S]*providerSheetLifecycleRef\.current \+= 1;[\s\S]*setAddingType\(null\);[\s\S]*setSelectedSlug\(null\);[\s\S]*\}/,
+      'closing a provider config sheet must invalidate pending sheet-scoped continuations',
+    );
+    assert.match(
+      src,
+      /onCreated=\{async \(slug\) => \{[\s\S]*const providerSheetLifecycle = providerSheetLifecycleRef\.current;[\s\S]*const reloaded = await reload\(\);[\s\S]*providerSheetLifecycleRef\.current !== providerSheetLifecycle[\s\S]*\) return;[\s\S]*setSelectedSlug\(slug\);[\s\S]*setAddingType\(null\);/,
+      'AddProviderForm completion must not select/close a stale sheet after ProvidersPanel unmounts or sheet close',
     );
     assert.match(
       src,
@@ -238,13 +243,23 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       addForm,
+      /const addProviderMountedRef = useRef\(false\)[\s\S]*useEffect\(\(\) => \{[\s\S]*addProviderMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*addProviderMountedRef\.current = false;[\s\S]*busyRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\);/,
+      'AddProviderForm must track its own sheet lifetime so pending create continuations cannot write after overlay close',
+    );
+    assert.match(
+      addForm,
       /async function submit\(\) \{[\s\S]*if \(busyRef\.current\) return;[\s\S]*busyRef\.current = true;[\s\S]*setBusy\(true\);[\s\S]*props\.bridge\.create\(/,
       'AddProviderForm create must set the duplicate-submit guard before awaiting bridge.create()',
     );
     assert.match(
       addForm,
-      /finally \{[\s\S]*busyRef\.current = false;[\s\S]*setBusy\(false\);[\s\S]*\}/,
-      'AddProviderForm create guard must always release after success or failure',
+      /const connection = await props\.bridge\.create\([\s\S]*\);[\s\S]*if \(!addProviderMountedRef\.current\) return;[\s\S]*await props\.onCreated\(connection\.slug\);/,
+      'AddProviderForm create completion must not re-open/select provider detail after the sheet was closed mid-save',
+    );
+    assert.match(
+      addForm,
+      /catch \(err\) \{[\s\S]*if \(addProviderMountedRef\.current\) setError\(providerPanelActionErrorMessage\(err\)\);[\s\S]*\} finally \{[\s\S]*busyRef\.current = false;[\s\S]*if \(addProviderMountedRef\.current\) setBusy\(false\);[\s\S]*\}/,
+      'AddProviderForm create guard must release without setting React state after sheet unmount',
     );
     assert.match(
       addForm,

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -99,6 +99,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const providersPanelMountedRef = useRef(false);
   const providersReloadTicketRef = useRef(0);
+  const providerSheetLifecycleRef = useRef(0);
   const toast = useToast();
 
   async function reload(): Promise<boolean> {
@@ -199,7 +200,14 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
   );
 
   function startAdd(type: ProviderType) {
+    providerSheetLifecycleRef.current += 1;
     setAddingType(type);
+    setSelectedSlug(null);
+  }
+
+  function closeProviderConfigSheet() {
+    providerSheetLifecycleRef.current += 1;
+    setAddingType(null);
     setSelectedSlug(null);
   }
 
@@ -292,6 +300,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
                                 <button
                                   type="button"
                                   onClick={() => {
+                                    providerSheetLifecycleRef.current += 1;
                                     setSelectedSlug(connection.slug);
                                     setAddingType(null);
                                   }}
@@ -384,10 +393,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
 
       {(addingType || selected) && (
         <ProviderConfigSheetOverlay
-          onClose={() => {
-            setAddingType(null);
-            setSelectedSlug(null);
-          }}
+          onClose={closeProviderConfigSheet}
         >
             {addingType ? (
               <AddProviderForm
@@ -397,8 +403,13 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
                 existingSlugs={connections.map((connection) => connection.slug)}
                 onCancel={() => setAddingType(null)}
                 onCreated={async (slug) => {
+                  const providerSheetLifecycle = providerSheetLifecycleRef.current;
                   const reloaded = await reload();
-                  if (!reloaded || !providersPanelMountedRef.current) return;
+                  if (
+                    !reloaded ||
+                    !providersPanelMountedRef.current ||
+                    providerSheetLifecycleRef.current !== providerSheetLifecycle
+                  ) return;
                   setSelectedSlug(slug);
                   setAddingType(null);
                 }}
@@ -1224,10 +1235,19 @@ function AddProviderForm(props: {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
+  const addProviderMountedRef = useRef(false);
 
   const requiresBaseUrl = !defaults.baseUrl;
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
+
+  useEffect(() => {
+    addProviderMountedRef.current = true;
+    return () => {
+      addProviderMountedRef.current = false;
+      busyRef.current = false;
+    };
+  }, []);
 
   async function submit() {
     if (busyRef.current) return;
@@ -1251,12 +1271,13 @@ function AddProviderForm(props: {
         baseUrl: baseUrl || undefined,
         defaultModel,
       });
+      if (!addProviderMountedRef.current) return;
       await props.onCreated(connection.slug);
     } catch (err) {
-      setError(providerPanelActionErrorMessage(err));
+      if (addProviderMountedRef.current) setError(providerPanelActionErrorMessage(err));
     } finally {
       busyRef.current = false;
-      setBusy(false);
+      if (addProviderMountedRef.current) setBusy(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard AddProviderForm create continuations with a form-mounted ref so closing the provider sheet mid-save cannot write local form state after unmount.
- Add provider-sheet lifecycle invalidation in ProvidersPanel so an in-flight create reload cannot reselect/reopen the newly-created provider after the user already closed the sheet.
- Extend the model OAuth/source contract to pin both guards.

## Root Cause
The provider add form disabled the visible Cancel button while `bridge.create()` was pending, but the config sheet overlay remained closable. If the user clicked the overlay while create/reload was in flight, `onCreated` could resume later and set `selectedSlug`, reopening the provider detail sheet even though the user had closed it. The form also released pending/error state without its own mounted guard.

## Verification
- `npm --workspace @maka/desktop run build:main`
- `node --test dist/main/__tests__/model-oauth-section-contract.test.js` (34/34)
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`
