### PR TITLE
Release WeChat scan confirmation owner

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
@@ -271,8 +271,13 @@ describe('Bot settings UI contract', () => {
     );
     assert.match(
       settings,
-      /if \(cancelled \|\| !scanLoginMountedRef\.current\) return;[\s\S]*if \(result\.data\.status === 'confirmed'\) \{[\s\S]*scanLoginConfirmingRef\.current = true;[\s\S]*setStatus\('confirmed'\);[\s\S]*await props\.onConfirmed\(result\.data\.credentials\);/,
+      /if \(cancelled \|\| !scanLoginMountedRef\.current\) return;[\s\S]*if \(result\.data\.status === 'confirmed'\) \{[\s\S]*scanLoginConfirmingRef\.current = true;[\s\S]*setStatus\('confirmed'\);[\s\S]*await props\.onConfirmed\(result\.data\.credentials\);[\s\S]*scanLoginConfirmingRef\.current = false;/,
       'Direct WeChat scan-login confirmation must be owned and must not continue from a stale poll',
+    );
+    assert.match(
+      settings,
+      /catch \(error\) \{[\s\S]*if \(cancelled \|\| !scanLoginMountedRef\.current\) return;[\s\S]*scanLoginConfirmingRef\.current = false;[\s\S]*setStatus\('error'\);[\s\S]*setErrorMessage\(settingsActionErrorMessage\(error\)\);/,
+      'Direct WeChat scan-login confirmation failures must release confirmation ownership so refreshed QR polling can resume',
     );
     assert.match(
       settings,

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -524,11 +524,13 @@ function WeChatScanLoginModal(props: {
           scanLoginConfirmingRef.current = true;
           setStatus('confirmed');
           await props.onConfirmed(result.data.credentials);
+          scanLoginConfirmingRef.current = false;
         } else if (result.data.status === 'expired') {
           setStatus('expired');
         }
       } catch (error) {
         if (cancelled || !scanLoginMountedRef.current) return;
+        scanLoginConfirmingRef.current = false;
         setStatus('error');
         setErrorMessage(settingsActionErrorMessage(error));
       } finally {


### PR DESCRIPTION
## Summary
- Release the direct WeChat scan-login confirmation owner after a confirmed credential handoff succeeds.
- Release that owner on confirmation/save failures so the error-state “refresh QR” path can poll again.
- Extend the existing bot Settings UI contract to pin the recovery path.

## Root Cause
The WeChat direct scan login modal set `scanLoginConfirmingRef` when iLink reported the QR code as confirmed, then awaited the parent `onConfirmed` save/reload path. If that parent path rejected, the modal rendered an error but never cleared `scanLoginConfirmingRef`. A later QR refresh returned to `waiting`, but the interval saw the stale confirmation guard and skipped every poll forever.

## Verification
- `npm --workspace @maka/desktop run build:main`
- `node --test dist/main/__tests__/bot-settings-ui-contract.test.js` (7/7)
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`
