### PR TITLE
Guard password copy feedback timer

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -177,8 +177,23 @@ describe('Settings form accessibility labels', () => {
 
     assert.match(passwordInput, /const toast = useToast\(\)/);
     assert.match(passwordInput, /const copyingRef = useRef\(false\)/);
+    assert.match(passwordInput, /const mountedRef = useRef\(true\)/);
+    assert.match(passwordInput, /const copyFeedbackTimerRef = useRef<number \| null>\(null\)/);
+    assert.match(
+      passwordInput,
+      /return \(\) => \{[\s\S]*mountedRef\.current = false;[\s\S]*copyingRef\.current = false;[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);/,
+      'PasswordInput must clear pending copy-feedback timers and invalidate clipboard state when it unmounts',
+    );
+    assert.match(
+      passwordInput,
+      /function showCopiedFeedback\(\) \{[\s\S]*window\.clearTimeout\(copyFeedbackTimerRef\.current\);[\s\S]*setJustCopied\(true\);[\s\S]*copyFeedbackTimerRef\.current = window\.setTimeout\(\(\) => \{[\s\S]*if \(mountedRef\.current\) setJustCopied\(false\);/,
+      'PasswordInput must replace stale success timers so repeated copies do not clear fresh success feedback early',
+    );
     assert.match(passwordInput, /if \(copyingRef\.current\) return;/);
     assert.match(passwordInput, /setCopying\(true\)/);
+    assert.match(passwordInput, /if \(mountedRef\.current\) showCopiedFeedback\(\)/);
+    assert.match(passwordInput, /if \(mountedRef\.current\) toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\)/);
+    assert.match(passwordInput, /if \(mountedRef\.current\) setCopying\(false\)/);
     assert.match(passwordInput, /disabled=\{copying\}/);
     assert.match(passwordInput, /aria-label=\{copying \? '复制中' : justCopied \? '已复制' : '复制'\}/);
     assert.match(passwordInput, /toast\.error\('复制失败', '剪贴板不可用或被系统拒绝。'\)/);

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Check, Copy, Eye, EyeOff } from '@maka/ui/icons';
 import { Button, Input, useToast } from '@maka/ui';
 
@@ -30,6 +30,32 @@ export function PasswordInput(props: {
   const [justCopied, setJustCopied] = useState(false);
   const [copying, setCopying] = useState(false);
   const copyingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const copyFeedbackTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      copyingRef.current = false;
+      if (copyFeedbackTimerRef.current !== null) {
+        window.clearTimeout(copyFeedbackTimerRef.current);
+        copyFeedbackTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  function showCopiedFeedback() {
+    if (copyFeedbackTimerRef.current !== null) {
+      window.clearTimeout(copyFeedbackTimerRef.current);
+    }
+    setJustCopied(true);
+    copyFeedbackTimerRef.current = window.setTimeout(() => {
+      copyFeedbackTimerRef.current = null;
+      if (mountedRef.current) setJustCopied(false);
+    }, 1200);
+  }
+
   async function copyValue() {
     if (!props.value) return;
     if (copyingRef.current) return;
@@ -37,13 +63,12 @@ export function PasswordInput(props: {
     setCopying(true);
     try {
       await navigator.clipboard.writeText(props.value);
-      setJustCopied(true);
-      window.setTimeout(() => setJustCopied(false), 1200);
+      if (mountedRef.current) showCopiedFeedback();
     } catch {
-      toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
+      if (mountedRef.current) toast.error('复制失败', '剪贴板不可用或被系统拒绝。');
     } finally {
       copyingRef.current = false;
-      setCopying(false);
+      if (mountedRef.current) setCopying(false);
     }
   }
   return (


### PR DESCRIPTION
## Summary
- guard shared Settings PasswordInput clipboard continuations behind a mounted ref
- clear/reuse the copy success timer so unmounts and repeated copies do not trigger stale state updates
- extend the Settings form contract around password copy lifecycle behavior

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/settings-form-a11y-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check