### PR TITLE
Gate permission center actions

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -235,6 +235,31 @@ describe('Settings coming-soon cleanup contract', () => {
     assert.doesNotMatch(settings, /case\s+'missing':\s*return\s+'缺少必要配置'/, 'configuration missing must not use raw missing-field copy');
   });
 
+  it('gates Permission Center OS permission actions with one synchronous owner', async () => {
+    const settings = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
+    const permissionPage = settings.match(/function PermissionCenterPage\(\)[\s\S]*?function CapabilityRow/)?.[0] ?? '';
+
+    assert.match(permissionPage, /const \[pendingPermAction, setPendingPermAction\] = useState<string \| null>\(null\)/);
+    assert.match(permissionPage, /const pendingPermActionRef = useRef<string \| null>\(null\)/);
+    assert.match(
+      permissionPage,
+      /return \(\) => \{[\s\S]*mountedRef\.current = false;[\s\S]*pendingPermActionRef\.current = null;/,
+      'Permission Center must release the pending action owner when Settings closes',
+    );
+    assert.match(
+      permissionPage,
+      /const actionKey = `\$\{permId\}:\$\{kind\}`;[\s\S]*if \(pendingPermActionRef\.current\) return;[\s\S]*pendingPermActionRef\.current = actionKey;[\s\S]*setPendingPermAction\(actionKey\);/,
+      'Permission Center must synchronously reject same-frame duplicate permission actions before React commits disabled state',
+    );
+    assert.match(
+      permissionPage,
+      /finally \{[\s\S]*if \(pendingPermActionRef\.current === actionKey\) \{[\s\S]*pendingPermActionRef\.current = null;[\s\S]*\}[\s\S]*if \(mountedRef\.current\) setPendingPermAction\(null\);/,
+      'Permission Center must release only the action it owns and avoid state writes after unmount',
+    );
+    assert.match(permissionPage, /busy=\{pendingPermAction !== null\}/);
+    assert.match(permissionPage, /pendingKey=\{pendingPermAction === `\$\{id\}:request` \? 'request'/);
+  });
+
   it('keeps bot readiness waiting states action-oriented', async () => {
     const settings = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
 

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -6178,11 +6178,13 @@ function PermissionCenterPage() {
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const toast = useToast();
   const mountedRef = useRef(true);
+  const pendingPermActionRef = useRef<string | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      pendingPermActionRef.current = null;
     };
   }, []);
 
@@ -6215,6 +6217,8 @@ function PermissionCenterPage() {
     kind: 'request' | 'openSettings',
   ) {
     const actionKey = `${permId}:${kind}`;
+    if (pendingPermActionRef.current) return;
+    pendingPermActionRef.current = actionKey;
     setPendingPermAction(actionKey);
     try {
       const result =
@@ -6231,6 +6235,9 @@ function PermissionCenterPage() {
     } catch (err) {
       if (mountedRef.current) toast.error('权限操作失败', settingsActionErrorMessage(err));
     } finally {
+      if (pendingPermActionRef.current === actionKey) {
+        pendingPermActionRef.current = null;
+      }
       if (mountedRef.current) setPendingPermAction(null);
     }
   }


### PR DESCRIPTION
## Summary
- add a synchronous pending owner for Permission Center OS permission actions
- prevent same-frame duplicate request/open-settings IPC calls before React commits disabled state
- extend the Settings cleanup contract to lock the owner lifecycle and busy display

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/settings-roadmap-cleanup-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check