### PR TITLE
Gate project directory picker

### DIFF
--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -82,8 +82,21 @@ describe('project context workspace picker', () => {
     assert.match(globalTypes, /selectProjectDirectory\(\): Promise</);
     assert.match(renderer, /async function selectProjectDirectory\(\)/);
     assert.match(renderer, /window\.maka\.app\.selectProjectDirectory\(\)/);
+    assert.match(renderer, /const \[projectPickerPending, setProjectPickerPending\] = useState\(false\)/);
+    assert.match(renderer, /const projectPickerPendingRef = useRef\(false\)/);
+    assert.match(
+      renderer,
+      /async function selectProjectDirectory\(\) \{[\s\S]*if \(projectPickerPendingRef\.current\) return;[\s\S]*projectPickerPendingRef\.current = true;[\s\S]*setProjectPickerPending\(true\);[\s\S]*window\.maka\.app\.selectProjectDirectory\(\)/,
+      'project picker must synchronously reject duplicate native dialog requests before React commits disabled state',
+    );
+    assert.match(
+      renderer,
+      /finally \{[\s\S]*projectPickerPendingRef\.current = false;[\s\S]*setProjectPickerPending\(false\);/,
+      'project picker must release its pending owner after the native dialog resolves or fails',
+    );
     assert.match(renderer, /setAppInfo\(\{ projectPath: result\.projectPath, projectGit: result\.projectGit \}\)/);
     assert.match(renderer, /toastApi\.success\('已切换工作目录', basenameFromPath\(result\.projectPath\)\)/);
+    assert.match(workspacePickerBlock, /pending:\s*projectPickerPending/);
     assert.match(workspacePickerBlock, /void selectProjectDirectory\(\)/);
     assert.doesNotMatch(workspacePickerBlock, /openProjectFolder\(\)|openWorkspaceFolder\(\)|openPath\(/);
   });
@@ -107,6 +120,9 @@ describe('project context workspace picker', () => {
     assert.match(ui, /workspacePicker\?:\s*\{/);
     assert.match(ui, /className="maka-composer-workspace-picker"/);
     assert.match(ui, /branch\?: string \| null;/);
+    assert.match(ui, /pending\?: boolean;/);
+    assert.match(ui, /disabled=\{props\.workspacePicker\.pending === true\}/);
+    assert.match(ui, /aria-busy=\{props\.workspacePicker\.pending === true \? 'true' : undefined\}/);
     // WAWQAQ msg `28128c9e` (2026-06-20): the "选择工作目录" placeholder
     // is only rendered when no directory has been selected yet. Once
     // a label is set, the picker renders `.maka-composer-workspace-current`

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -333,6 +333,7 @@ function AppShell() {
   const [skills, setSkills] = useState<SkillEntry[]>([]);
   const [planReminders, setPlanReminders] = useState<PlanReminder[]>([]);
   const [appInfo, setAppInfo] = useState<RendererAppInfo | null>(null);
+  const [projectPickerPending, setProjectPickerPending] = useState(false);
   const [helpOpen, closeHelp, openHelp] = useKeyboardHelp();
   const [paletteOpen, openPalette, closePalette] = useCommandPalette();
   // Search modal state. Sidebar `搜索` opens the real thread-search
@@ -355,6 +356,7 @@ function AppShell() {
   }
   const composerRef = useRef<ComposerHandle>(null);
   const activeIdRef = useRef<string | undefined>(undefined);
+  const projectPickerPendingRef = useRef(false);
   const activeStreamingSlot = activeId ? streamingBySession[activeId] : undefined;
   const activeStreaming = activeStreamingSlot?.text ?? '';
   const activeStreamingTruncated = activeStreamingSlot?.truncated === true;
@@ -1632,6 +1634,9 @@ function AppShell() {
   }
 
   async function selectProjectDirectory() {
+    if (projectPickerPendingRef.current) return;
+    projectPickerPendingRef.current = true;
+    setProjectPickerPending(true);
     try {
       const result = await window.maka.app.selectProjectDirectory();
       if (!result.ok) {
@@ -1644,6 +1649,9 @@ function AppShell() {
       toastApi.success('已切换工作目录', basenameFromPath(result.projectPath));
     } catch (error) {
       toastApi.error('选择工作目录失败', generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。'));
+    } finally {
+      projectPickerPendingRef.current = false;
+      setProjectPickerPending(false);
     }
   }
 
@@ -3076,6 +3084,7 @@ function AppShell() {
                 workspacePicker={{
                   label: appInfo ? basenameFromPath(appInfo.projectPath) : undefined,
                   branch: appInfo?.projectGit.branch,
+                  pending: projectPickerPending,
                   onOpen: () => {
                     void selectProjectDirectory();
                   },

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5578,6 +5578,7 @@ export const Composer = forwardRef<
     workspacePicker?: {
       label?: string;
       branch?: string | null;
+      pending?: boolean;
       onOpen(): void;
     };
     /**
@@ -6163,6 +6164,8 @@ export const Composer = forwardRef<
             type="button"
             variant="quiet"
             className="maka-composer-workspace-picker"
+            disabled={props.workspacePicker.pending === true}
+            aria-busy={props.workspacePicker.pending === true ? 'true' : undefined}
             onClick={props.workspacePicker.onOpen}
             title={props.workspacePicker.branch ? `选择工作目录 · ${props.workspacePicker.branch}` : '选择工作目录'}
             aria-label={props.workspacePicker.branch


### PR DESCRIPTION
## Summary
- add a ref-backed pending owner around the project directory picker native dialog
- surface the pending state through the shared Composer workspace picker button
- extend the project-context contract so duplicate picker requests stay blocked

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/project-context-badge.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check