### PR TITLE
Guard artifact actions by session

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-lifecycle-contract.test.ts
@@ -33,6 +33,11 @@ describe('ArtifactPane async lifecycle contract', () => {
     );
     assert.match(
       src,
+      /const artifactPaneSessionIdRef = useRef<string \| undefined>\(sessionId\);[\s\S]*artifactPaneSessionIdRef\.current = sessionId;/,
+      'ArtifactPane must track the latest active session so async action continuations cannot update a stale chat surface',
+    );
+    assert.match(
+      src,
       /useEffect\(\(\) => \{[\s\S]*artifactPaneMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*artifactPaneMountedRef\.current = false;[\s\S]*artifactListRequestSeqRef\.current \+= 1;[\s\S]*pendingArtifactListRetryRef\.current = false;[\s\S]*pendingArtifactActionRef\.current = null;[\s\S]*\};[\s\S]*\}, \[\]\)/,
       'ArtifactPane unmount must invalidate list responses, release pending owners, and be StrictMode replay safe',
     );
@@ -142,13 +147,29 @@ describe('ArtifactPane async lifecycle contract', () => {
       'artifact action failure helper must not directly echo raw Error.message',
     );
     assert.match(openBlock, /catch \(error\) \{[\s\S]*toast\.error\('无法在 Finder 中打开生成文件', artifactActionErrorMessage\(error\)\)/);
-    assert.match(openBlock, /const result = await window\.maka\.app\.openArtifactPath\(artifactId\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;/);
+    assert.match(openBlock, /const actionSessionId = sessionId;[\s\S]*const result = await window\.maka\.app\.openArtifactPath\(artifactId\);[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;/);
     assert.match(copyBlock, /catch \(error\) \{[\s\S]*toast\.error\('复制失败', artifactActionErrorMessage\(error\)\)/);
-    assert.match(copyBlock, /const result = await window\.maka\.artifacts\.readText\(artifactId\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;[\s\S]*await navigator\.clipboard\.writeText\(result\.text\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;/);
+    assert.match(copyBlock, /const actionSessionId = sessionId;[\s\S]*const result = await window\.maka\.artifacts\.readText\(artifactId\);[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;[\s\S]*await navigator\.clipboard\.writeText\(result\.text\);[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;/);
     assert.match(saveBlock, /catch \(error\) \{[\s\S]*toast\.error\('另存失败', artifactActionErrorMessage\(error\)\)/);
-    assert.match(saveBlock, /const result = await window\.maka\.app\.saveArtifactAs\(artifactId\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;/);
+    assert.match(saveBlock, /const actionSessionId = sessionId;[\s\S]*const result = await window\.maka\.app\.saveArtifactAs\(artifactId\);[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;/);
     assert.match(deleteBlock, /catch \(error\) \{[\s\S]*toast\.error\(`删除 \$\{name\} 失败`, artifactActionErrorMessage\(error\)\)/);
-    assert.match(deleteBlock, /if \(!artifactPaneMountedRef\.current\) return;[\s\S]*await window\.maka\.artifacts\.delete\(artifactId\);[\s\S]*await refresh\(\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;/);
+    assert.match(deleteBlock, /const actionSessionId = sessionId;[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;[\s\S]*await window\.maka\.artifacts\.delete\(artifactId\);[\s\S]*await refresh\(\);[\s\S]*if \(!isArtifactActionSurfaceActive\(actionSessionId\)\) return;/);
+  });
+
+  it('drops stale artifact action continuations after switching sessions', async () => {
+    const src = await readFile(ARTIFACT_PANE_SOURCE, 'utf8');
+    const actionOwnerBlock = src.match(/function isArtifactActionSurfaceActive[\s\S]*?async function openInFinder/)?.[0] ?? '';
+
+    assert.match(
+      actionOwnerBlock,
+      /function isArtifactActionSurfaceActive\(actionSessionId: string \| undefined\): boolean \{[\s\S]*actionSessionId &&[\s\S]*artifactPaneMountedRef\.current &&[\s\S]*artifactPaneSessionIdRef\.current === actionSessionId &&[\s\S]*recordsSessionIdRef\.current === actionSessionId/,
+      'artifact actions must verify both the mounted surface and the active records session before post-await side effects',
+    );
+    assert.doesNotMatch(
+      src,
+      /await navigator\.clipboard\.writeText\(result\.text\);[\s\S]*if \(!artifactPaneMountedRef\.current\) return;/,
+      'copy must not write stale artifact text just because the pane component remains mounted',
+    );
   });
 
   it('gates artifact toolbar actions while async work is pending', async () => {

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -91,9 +91,12 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
   const [pendingArtifactAction, setPendingArtifactAction] = useState<string | null>(null);
   const artifactListRequestSeqRef = useRef(0);
   const artifactPaneMountedRef = useRef(true);
+  const artifactPaneSessionIdRef = useRef<string | undefined>(sessionId);
   const recordsSessionIdRef = useRef<string | undefined>(undefined);
   const pendingArtifactListRetryRef = useRef(false);
   const pendingArtifactActionRef = useRef<string | null>(null);
+
+  artifactPaneSessionIdRef.current = sessionId;
 
   // ---- live data ---------------------------------------------------------
 
@@ -211,6 +214,15 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
     }
   }
 
+  function isArtifactActionSurfaceActive(actionSessionId: string | undefined): boolean {
+    return Boolean(
+      actionSessionId &&
+        artifactPaneMountedRef.current &&
+        artifactPaneSessionIdRef.current === actionSessionId &&
+        recordsSessionIdRef.current === actionSessionId,
+    );
+  }
+
   async function retryArtifactListRefresh() {
     if (pendingArtifactListRetryRef.current) return;
     pendingArtifactListRetryRef.current = true;
@@ -224,14 +236,15 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
   }
 
   async function openInFinder(artifactId: string) {
+    const actionSessionId = sessionId;
     try {
       const result = await window.maka.app.openArtifactPath(artifactId);
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       if (!result.ok) {
         toast.error('无法在 Finder 中打开生成文件', openPathFailureCopy(result.reason));
       }
     } catch (error) {
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.error('无法在 Finder 中打开生成文件', artifactActionErrorMessage(error));
     }
   }
@@ -242,26 +255,28 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
     // call doesn't leak base64 into the clipboard.
     const record = activeRecords.find((entry) => entry.id === artifactId);
     if (!record || !isTextKind(record.kind)) return;
+    const actionSessionId = sessionId;
     try {
       const result = await window.maka.artifacts.readText(artifactId);
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       if (!result.ok) {
         toast.error('复制失败', '无法读取生成文件文本内容。');
         return;
       }
       await navigator.clipboard.writeText(result.text);
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.success('已复制生成文件文本', `${record.name} · ${formatBytes(record.sizeBytes)}`);
     } catch (error) {
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.error('复制失败', artifactActionErrorMessage(error));
     }
   }
 
   async function saveAs(artifactId: string) {
+    const actionSessionId = sessionId;
     try {
       const result = await window.maka.app.saveArtifactAs(artifactId);
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       if (result.ok) {
         const record = activeRecords.find((entry) => entry.id === artifactId);
         toast.success('已另存生成文件', record?.name ?? result.saved);
@@ -270,12 +285,13 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
       if (result.reason === 'canceled') return;
       toast.error('另存失败', saveArtifactFailureCopy(result.reason));
     } catch (error) {
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.error('另存失败', artifactActionErrorMessage(error));
     }
   }
 
   async function deleteArtifact(artifactId: string) {
+    const actionSessionId = sessionId;
     const record = activeRecords.find((entry) => entry.id === artifactId);
     const name = record?.name ?? '生成文件';
     const ok = await toast.confirm({
@@ -286,14 +302,14 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
       destructive: true,
     });
     if (!ok) return;
-    if (!artifactPaneMountedRef.current) return;
+    if (!isArtifactActionSurfaceActive(actionSessionId)) return;
     try {
       await window.maka.artifacts.delete(artifactId);
       await refresh();
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.success(`已删除 ${name}`);
     } catch (error) {
-      if (!artifactPaneMountedRef.current) return;
+      if (!isArtifactActionSurfaceActive(actionSessionId)) return;
       toast.error(`删除 ${name} 失败`, artifactActionErrorMessage(error));
     }
   }


### PR DESCRIPTION
## Summary
- add an active-session owner guard for ArtifactPane async toolbar actions
- prevent stale artifact copy/save/delete/open continuations from writing clipboard, deleting, refreshing, or toasting after the user switches sessions
- extend the artifact pane lifecycle contract to require session-owner checks, not just mounted checks

## Verification
- npm --workspace @maka/desktop run build:main
- cd apps/desktop && node --test dist/main/__tests__/artifact-pane-lifecycle-contract.test.js
- npm --workspace @maka/desktop run build:renderer
- git diff --check