### PR TITLE
Show browser address validation errors

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-logic.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-logic.test.ts
@@ -14,10 +14,12 @@ describe('browser logic', () => {
   it('parseNavigable accepts only http(s) and normalizes', () => {
     assert.equal(parseNavigable('https://example.com'), 'https://example.com/');
     assert.equal(parseNavigable('http://a.test/x?y=1'), 'http://a.test/x?y=1');
+    assert.equal(parseNavigable('example.com'), 'https://example.com/');
     assert.equal(parseNavigable('file:///etc/passwd'), null);
     assert.equal(parseNavigable('javascript:alert(1)'), null);
     assert.equal(parseNavigable('about:blank'), null);
     assert.equal(parseNavigable('not a url'), null);
+    assert.equal(parseNavigable('http://'), null);
   });
 
   it('safeExternalUrl passes only mailto/tel', () => {

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -9,9 +9,18 @@ describe('renderer utility surfaces use shared UI primitives', () => {
   it('keeps browser chrome on Button/Input instead of raw form controls', async () => {
     const source = await readFile(join(process.cwd(), 'src/renderer/browser-panel.tsx'), 'utf8');
 
-    assert.match(source, /import \{[^}]*\bButton\b[^}]*\bInput\b[^}]*\} from '@maka\/ui';/);
+    assert.match(source, /import \{ normalizeBrowserAddressInput, type BrowserState \} from '@maka\/core';/);
+    assert.match(source, /import \{[^}]*\bButton\b[^}]*\bInput\b[^}]*\buseToast\b[^}]*\} from '@maka\/ui';/);
     assert.doesNotMatch(source, /<button\b/, 'BrowserPanel nav controls must use shared Button');
     assert.doesNotMatch(source, /<input\b/, 'BrowserPanel address bar must use shared Input');
+    assert.doesNotMatch(source, /const full = \/\^\[a-z\]\+/, 'BrowserPanel must not keep renderer-only address prefix regex');
+    assert.match(
+      source,
+      /const result = normalizeBrowserAddressInput\(address\);[\s\S]*if \(!result\.ok\) \{[\s\S]*toast\.error\('无法打开地址', browserAddressFailureCopy\(result\.reason\)\);[\s\S]*return;[\s\S]*window\.maka\.browser\.navigate\(sessionId, result\.url\)/,
+      'BrowserPanel must validate addresses with the shared helper before invoking browser navigation',
+    );
+    assert.match(source, /嵌入式浏览器只支持打开 HTTP\/HTTPS 网页地址。/);
+    assert.match(source, /这个地址无法识别，请检查网址后重试。/);
     for (const label of [
       '浏览器后退',
       '浏览器前进',

--- a/apps/desktop/src/main/browser/logic.ts
+++ b/apps/desktop/src/main/browser/logic.ts
@@ -3,7 +3,7 @@
  * by plain unit tests. The electron-bound view lives in controller.ts.
  */
 
-import type { BrowserState, BrowserViewRect } from '@maka/core';
+import { normalizeBrowserAddressInput, type BrowserState, type BrowserViewRect } from '@maka/core';
 
 export type { BrowserState, BrowserViewRect };
 
@@ -14,14 +14,8 @@ export type { BrowserState, BrowserViewRect };
  * surfaces. Returns the parsed (normalized) URL string, or null if not allowed.
  */
 export function parseNavigable(input: string): string | null {
-  let url: URL;
-  try {
-    url = new URL(input);
-  } catch {
-    return null;
-  }
-  if (url.protocol === 'http:' || url.protocol === 'https:') return url.toString();
-  return null;
+  const result = normalizeBrowserAddressInput(input);
+  return result.ok ? result.url : null;
 }
 
 // Page-provided non-web links are handed to the OS only for this tight set of

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -15,7 +15,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, ChevronRight, Globe, RotateCw, X } from '@maka/ui/icons';
-import type { BrowserState } from '@maka/core';
+import { normalizeBrowserAddressInput, type BrowserState } from '@maka/core';
 import {
   Button,
   Empty,
@@ -24,6 +24,7 @@ import {
   EmptyMedia,
   EmptyTitle,
   Input,
+  useToast,
 } from '@maka/ui';
 
 const EMPTY_STATE: BrowserState = {
@@ -37,8 +38,18 @@ const EMPTY_STATE: BrowserState = {
   hasPage: false,
 };
 
+function browserAddressFailureCopy(reason: 'unsupported_scheme' | 'invalid_url'): string {
+  switch (reason) {
+    case 'unsupported_scheme':
+      return '嵌入式浏览器只支持打开 HTTP/HTTPS 网页地址。';
+    case 'invalid_url':
+      return '这个地址无法识别，请检查网址后重试。';
+  }
+}
+
 export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   const { sessionId, hidden } = props;
+  const toast = useToast();
   const stripRef = useRef<HTMLDivElement>(null);
   const [state, setState] = useState<BrowserState>(EMPTY_STATE);
   // The address input is editable; it only snaps to the live URL when the user
@@ -108,13 +119,17 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   }, [sessionId, showView]);
 
   const go = useCallback(() => {
-    const url = address.trim();
-    if (!url) return;
-    // Bare hostnames get https://; anything already schemed passes through and
-    // main rejects non-web schemes.
-    const full = /^[a-z]+:\/\//i.test(url) ? url : `https://${url}`;
-    void window.maka.browser.navigate(sessionId, full);
-  }, [address, sessionId]);
+    const result = normalizeBrowserAddressInput(address);
+    if (!result.ok) {
+      if (result.reason !== 'empty') {
+        toast.error('无法打开地址', browserAddressFailureCopy(result.reason));
+      }
+      return;
+    }
+    void window.maka.browser.navigate(sessionId, result.url).catch(() => {
+      toast.error('浏览器导航失败', '页面暂时无法打开，请稍后重试。');
+    });
+  }, [address, sessionId, toast]);
 
   return (
     <div className="maka-browser-panel" aria-label="嵌入式浏览器">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "./events": "./dist/events.js",
     "./session": "./dist/session.js",
     "./agent-run": "./dist/agent-run.js",
+    "./browser": "./dist/browser.js",
     "./session-event-health": "./dist/session-event-health.js",
     "./permission": "./dist/permission.js",
     "./permission-request-health": "./dist/permission-request-health.js",

--- a/packages/core/src/__tests__/browser.test.ts
+++ b/packages/core/src/__tests__/browser.test.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { normalizeBrowserAddressInput } from '../browser.js';
+
+describe('browser address input normalization', () => {
+  it('normalizes http(s) addresses and bare hostnames', () => {
+    assert.deepEqual(normalizeBrowserAddressInput('https://example.com'), { ok: true, url: 'https://example.com/' });
+    assert.deepEqual(normalizeBrowserAddressInput(' http://a.test/x?y=1 '), { ok: true, url: 'http://a.test/x?y=1' });
+    assert.deepEqual(normalizeBrowserAddressInput('example.com'), { ok: true, url: 'https://example.com/' });
+  });
+
+  it('returns stable rejection reasons for non-navigable input', () => {
+    assert.deepEqual(normalizeBrowserAddressInput('   '), { ok: false, reason: 'empty' });
+    assert.deepEqual(normalizeBrowserAddressInput('file:///etc/passwd'), { ok: false, reason: 'unsupported_scheme' });
+    assert.deepEqual(normalizeBrowserAddressInput('javascript:alert(1)'), { ok: false, reason: 'unsupported_scheme' });
+    assert.deepEqual(normalizeBrowserAddressInput('about:blank'), { ok: false, reason: 'unsupported_scheme' });
+    assert.deepEqual(normalizeBrowserAddressInput('http://'), { ok: false, reason: 'invalid_url' });
+  });
+});

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -25,3 +25,35 @@ export interface BrowserViewRect {
   width: number;
   height: number;
 }
+
+export type BrowserAddressInputFailureReason = 'empty' | 'unsupported_scheme' | 'invalid_url';
+
+export type BrowserAddressInputResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: BrowserAddressInputFailureReason };
+
+/**
+ * Normalize a user-entered browser address before it crosses the IPC boundary.
+ * Bare hostnames are treated as HTTPS, while explicit non-web schemes are
+ * rejected with a visible reason for the renderer.
+ */
+export function normalizeBrowserAddressInput(input: string): BrowserAddressInputResult {
+  const trimmed = input.trim();
+  if (!trimmed) return { ok: false, reason: 'empty' };
+
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(trimmed);
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return { ok: false, reason: 'invalid_url' };
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, reason: 'unsupported_scheme' };
+  }
+
+  return { ok: true, url: url.toString() };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,7 +121,13 @@ export type {
 export { AGENT_RUN_STATUSES } from './agent-run.js';
 
 // browser.ts
-export type { BrowserState, BrowserViewRect } from './browser.js';
+export type {
+  BrowserAddressInputFailureReason,
+  BrowserAddressInputResult,
+  BrowserState,
+  BrowserViewRect,
+} from './browser.js';
+export { normalizeBrowserAddressInput } from './browser.js';
 
 // session-event-health.ts
 export type {


### PR DESCRIPTION
## Summary
- add a shared @maka/core browser address normalizer with stable rejection reasons
- use the shared normalizer from both main browser navigation and BrowserPanel
- show a toast when the address bar rejects unsupported schemes or malformed URLs instead of silently no-oping

## Verification
- npm --workspace @maka/core run build
- node --test packages/core/dist/__tests__/browser.test.js
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/browser-logic.test.js dist/main/__tests__/renderer-utility-primitives-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check