### PR TITLE
Invalidate short thread searches immediately

### DIFF
--- a/apps/desktop/src/main/__tests__/use-thread-search.test.ts
+++ b/apps/desktop/src/main/__tests__/use-thread-search.test.ts
@@ -15,6 +15,8 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import type {
   SearchErrorReason,
@@ -25,10 +27,13 @@ import type {
 import {
   THREAD_SEARCH_MIN_QUERY_CODE_POINTS,
   createThreadSearchPoller,
+  isThreadSearchQueryDispatchable,
   normalizeHits,
   type ThreadSearchState,
 } from '../../renderer/use-thread-search.js';
 import { buildContentSearchCommands } from '../../renderer/command-palette-content-search.js';
+
+const repoRoot = join(process.cwd(), '..', '..');
 
 // ---------------------------------------------------------------------------
 // normalizeHits — pure
@@ -148,6 +153,14 @@ describe('createThreadSearchPoller — race + lifecycle (xuan 6e7372c5)', () => 
 
   it('MIN constant is at least 2 (avoid one-char churn)', () => {
     assert.ok(THREAD_SEARCH_MIN_QUERY_CODE_POINTS >= 2);
+  });
+
+  it('isThreadSearchQueryDispatchable mirrors the min-length code-point threshold', () => {
+    assert.equal(isThreadSearchQueryDispatchable(''), false);
+    assert.equal(isThreadSearchQueryDispatchable(' a '), false);
+    assert.equal(isThreadSearchQueryDispatchable('你'), false);
+    assert.equal(isThreadSearchQueryDispatchable('ab'), true);
+    assert.equal(isThreadSearchQueryDispatchable('你好'), true);
   });
 
   it('valid query → loading → results', async () => {
@@ -355,6 +368,17 @@ describe('createThreadSearchPoller — race + lifecycle (xuan 6e7372c5)', () => 
       // ticket. So `postDisposeCalls` must be empty.
       assert.fail('unexpected state after dispose: ' + s.kind);
     }
+  });
+});
+
+describe('useThreadSearchImpl debounce boundary', () => {
+  it('invalidates below-threshold queries before scheduling the debounce timer', async () => {
+    const source = await readFile(join(repoRoot, 'apps/desktop/src/renderer/use-thread-search.ts'), 'utf8');
+    assert.match(
+      source,
+      /useEffect\(\(\) => \{\s*const poller = pollerRef\.current!;\s*if \(!isThreadSearchQueryDispatchable\(query\)\) \{\s*poller\.setQuery\(query\);\s*return;\s*\}\s*const timer = setTimeout/s,
+      'short or empty queries must synchronously invalidate stale in-flight content-search results before debounce',
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/use-thread-search.ts
+++ b/apps/desktop/src/renderer/use-thread-search.ts
@@ -96,6 +96,10 @@ export interface UseThreadSearchResult {
   state: ThreadSearchState;
 }
 
+export function isThreadSearchQueryDispatchable(query: string): boolean {
+  return Array.from(query.trim()).length >= THREAD_SEARCH_MIN_QUERY_CODE_POINTS;
+}
+
 /**
  * React-less poller. Owns the ticket counter + unmount flag so the
  * stale-response defense and lifecycle gating are testable without a
@@ -132,9 +136,7 @@ export function createThreadSearchPoller(
 
   return {
     setQuery(query: string): void {
-      const trimmed = query.trim();
-      const codePointCount = Array.from(trimmed).length;
-      if (codePointCount < THREAD_SEARCH_MIN_QUERY_CODE_POINTS) {
+      if (!isThreadSearchQueryDispatchable(query)) {
         // Every keystroke below threshold invalidates any inflight
         // ticket so a previously-dispatched result cannot land on top.
         inflightTicket += 1;
@@ -142,6 +144,7 @@ export function createThreadSearchPoller(
         return;
       }
 
+      const trimmed = query.trim();
       const ticket = ++inflightTicket;
       emit({ kind: 'loading', query: trimmed });
 
@@ -207,6 +210,10 @@ export function useThreadSearchImpl(query: string, deps: UseThreadSearchDeps): U
   // Debounce keystrokes before dispatching.
   useEffect(() => {
     const poller = pollerRef.current!;
+    if (!isThreadSearchQueryDispatchable(query)) {
+      poller.setQuery(query);
+      return;
+    }
     const timer = setTimeout(() => {
       poller.setQuery(query);
     }, THREAD_SEARCH_DEBOUNCE_MS);


### PR DESCRIPTION
## Summary
- share the thread-search min-length check between the poller and React hook
- immediately invalidate empty/one-character Command Palette content searches instead of waiting for the debounce timer
- add coverage so below-threshold queries cannot leave stale in-flight search results visible

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/use-thread-search.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check