### PR TITLE
Guard new chat send ownership

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -93,4 +93,31 @@ describe('home composer new-chat model picker', () => {
       'send() must forward the validated picked model to sessions.create when one was chosen',
     );
   });
+
+  it('does not let stale new-chat send creation steal the active session after navigation', async () => {
+    const renderer = await readRepo('apps/desktop/src/renderer/main.tsx');
+    const sendBlock = renderer.match(/async function send\(text: string\): Promise<boolean> \{[\s\S]*?\n  async function importTextFilePrompt/)?.[0] ?? '';
+
+    assert.match(
+      renderer,
+      /function isNewChatSendSurfaceActive\(owner: ComposerImportOwner\): boolean \{[\s\S]*owner\.sessionId === undefined[\s\S]*navSelectionRef\.current\.section === 'sessions'[\s\S]*activeIdRef\.current === undefined[\s\S]*\}/,
+      'new-chat sends must capture the empty-chat surface before async session creation',
+    );
+    assert.match(
+      sendBlock,
+      /const newChatOwner = initialSessionId \? null : captureComposerImportOwner\(\);/,
+      'send() must capture the no-active-session composer owner before sessions.create()',
+    );
+    assert.match(sendBlock, /upsertSessionSummary\(session\);/);
+    assert.match(
+      sendBlock,
+      /if \(newChatOwner && isNewChatSendSurfaceActive\(newChatOwner\)\) \{[\s\S]*setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\);[\s\S]*setActiveId\(session\.id\);[\s\S]*showOptimisticUserMessage\(session\.id, turnId, text, \{ replaceCurrentMessages: true \}\);[\s\S]*\}/,
+      'newly-created sessions may only become active if the user is still on the original empty new-chat surface',
+    );
+    assert.match(
+      sendBlock,
+      /await window\.maka\.sessions\.send\(session\.id, \{ type: 'send', turnId, text \}\);[\s\S]*if \(activeIdRef\.current === session\.id\) \{[\s\S]*await refreshMessagesUntilTurn\(session\.id, turnId\);[\s\S]*\}[\s\S]*await refreshSessions\(\);/,
+      'background new-chat sends should continue and refresh the list, but must not poll messages unless the created session is active',
+    );
+  });
 });

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -965,6 +965,13 @@ function AppShell() {
       && activeIdRef.current === owner.sessionId;
   }
 
+  function isNewChatSendSurfaceActive(owner: ComposerImportOwner): boolean {
+    return owner.navSection === 'sessions'
+      && owner.sessionId === undefined
+      && navSelectionRef.current.section === 'sessions'
+      && activeIdRef.current === undefined;
+  }
+
   useEffect(() => {
     activeIdRef.current = activeId;
   }, [activeId]);
@@ -1902,6 +1909,7 @@ function AppShell() {
 
   async function send(text: string): Promise<boolean> {
     const initialSessionId = activeIdRef.current;
+    const newChatOwner = initialSessionId ? null : captureComposerImportOwner();
     let optimisticSessionId: string | undefined;
     let optimisticTurnId: string | undefined;
     try {
@@ -1914,14 +1922,18 @@ function AppShell() {
             ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }
             : {}),
         });
-        setNavSelection({ section: 'sessions', filter: 'chats' });
-        setActiveId(session.id);
         upsertSessionSummary(session);
         optimisticSessionId = session.id;
         optimisticTurnId = turnId;
-        showOptimisticUserMessage(session.id, turnId, text, { replaceCurrentMessages: true });
+        if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
+          setNavSelection({ section: 'sessions', filter: 'chats' });
+          setActiveId(session.id);
+          showOptimisticUserMessage(session.id, turnId, text, { replaceCurrentMessages: true });
+        }
         await window.maka.sessions.send(session.id, { type: 'send', turnId, text });
-        await refreshMessagesUntilTurn(session.id, turnId);
+        if (activeIdRef.current === session.id) {
+          await refreshMessagesUntilTurn(session.id, turnId);
+        }
         await refreshSessions();
         return true;
       }
@@ -1939,7 +1951,9 @@ function AppShell() {
       const feedbackSessionId = optimisticSessionId ?? initialSessionId;
       const sendStillOwnsCurrentSurface = feedbackSessionId
         ? activeIdRef.current === feedbackSessionId
-        : activeIdRef.current === initialSessionId;
+        : newChatOwner
+          ? isNewChatSendSurfaceActive(newChatOwner)
+          : activeIdRef.current === initialSessionId;
       if (!sendStillOwnsCurrentSurface) return false;
       if (isNoRealConnectionError(error)) {
         const reason = noRealConnectionReasonFromError(error);


### PR DESCRIPTION
## Summary
- capture the empty new-chat composer surface before async session creation
- only activate the newly created session and insert optimistic text if the user is still on that same empty-chat surface
- keep background new-chat sends completing and refreshing the sidebar without stealing the current active session

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/composer-new-chat-model-picker-contract.test.js (from apps/desktop)
- npm --workspace @maka/desktop run build:renderer
- git diff --check