### PR TITLE
Guard web search query results

### DIFF
--- a/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
@@ -146,7 +146,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /if \(!webSearchMountedRef\.current\) return;[\s\S]*if \(result\.ok\) \{[\s\S]*setLiveQueryResults\(result\.results\);[\s\S]*void persistCredentialStatus\('valid', queriedCredentialVersion\);[\s\S]*\} else \{/,
+      /if \(!isCurrentLiveQuery\(queryOwner\)\) return;[\s\S]*if \(result\.ok\) \{[\s\S]*setLiveQueryResults\(result\.results\);[\s\S]*void persistCredentialStatus\('valid', queriedCredentialVersion\);[\s\S]*\} else \{/,
       'Successful live query results must render even if credential-status persistence later fails',
     );
     assert.doesNotMatch(
@@ -165,6 +165,17 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     assert.match(page![0], /const pendingCredentialActionRef = useRef<'save' \| 'clear' \| null>\(null\)/);
     assert.match(page![0], /const testingRef = useRef\(false\)/);
     assert.match(page![0], /const liveQueryRunningRef = useRef\(false\)/);
+    assert.match(page![0], /const liveQueryInputRef = useRef\(liveQuery\)/);
+    assert.match(
+      page![0],
+      /function updateLiveQuery\(next: string\) \{[\s\S]*liveQueryInputRef\.current = next;[\s\S]*setLiveQuery\(next\);[\s\S]*setLiveQueryError\(null\);[\s\S]*setLiveQueryResults\(null\);[\s\S]*\}/,
+      'Changing the live-query input must immediately invalidate stale result/error rows.',
+    );
+    assert.match(
+      page![0],
+      /function isCurrentLiveQuery\(queryOwner: string\): boolean \{[\s\S]*return webSearchMountedRef\.current && liveQueryInputRef\.current === queryOwner;[\s\S]*\}/,
+      'Live-query continuations must be owned by the exact submitted query string.',
+    );
     assert.match(
       page![0],
       /async function runCredentialAction\([\s\S]*if \(pendingCredentialActionRef\.current !== null \|\| testingRef\.current\) return;[\s\S]*pendingCredentialActionRef\.current = action;[\s\S]*setPendingCredentialAction\(action\);[\s\S]*await run\(\);[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*setPendingCredentialAction\(null\);/,
@@ -179,7 +190,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /if \(liveQueryRunningRef\.current\) return;[\s\S]*liveQueryRunningRef\.current = true;[\s\S]*setLiveQueryRunning\(true\);[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*setLiveQueryRunning\(false\);/,
+      /if \(liveQueryRunningRef\.current\) return;[\s\S]*const queryOwner = liveQueryInputRef\.current;[\s\S]*liveQueryRunningRef\.current = true;[\s\S]*setLiveQueryRunning\(true\);[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*setLiveQueryRunning\(false\);/,
       'Live query verification must have a ref-backed duplicate-submit guard.',
     );
     assert.match(page![0], /const credentialActionBusy = pendingCredentialAction !== null \|\| testing/);
@@ -188,6 +199,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     assert.match(page![0], /pendingCredentialAction === 'save' \? '保存中…' : '保存密钥'/);
     assert.match(page![0], /disabled=\{credentialActionBusy \|\| \(draftKey\.length === 0 && !hasUsableKey\)\}/);
     assert.match(page![0], /disabled=\{credentialActionBusy\}[\s\S]*pendingCredentialAction === 'clear' \? '清空中…' : '清空密钥'/);
+    assert.match(page![0], /onChange=\{\(event\) => updateLiveQuery\(event\.currentTarget\.value\)\}/);
   });
 
   it('Settings web-search async actions stop writing component state after unmount', async () => {
@@ -227,13 +239,13 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /const result = await window\.maka\.webSearch\.query\([\s\S]*if \(!webSearchMountedRef\.current\) return;[\s\S]*if \(result\.ok\) \{[\s\S]*setLiveQueryResults\(result\.results\);/,
-      'Live-query success must not set results after unmount',
+      /const result = await window\.maka\.webSearch\.query\([\s\S]*if \(!isCurrentLiveQuery\(queryOwner\)\) return;[\s\S]*if \(result\.ok\) \{[\s\S]*setLiveQueryResults\(result\.results\);/,
+      'Live-query success must not set results after unmount or after the query input changed',
     );
     assert.match(
       page![0],
-      /if \(webSearchMountedRef\.current\) \{[\s\S]*setLiveQueryError\(settingsActionErrorMessage\(err\)\);[\s\S]*\}/,
-      'Live-query thrown errors must not set inline error state after unmount',
+      /if \(isCurrentLiveQuery\(queryOwner\)\) \{[\s\S]*setLiveQueryError\(settingsActionErrorMessage\(err\)\);[\s\S]*\}/,
+      'Live-query thrown errors must not set inline error state after unmount or after the query input changed',
     );
     assert.match(
       page![0],

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -2878,6 +2878,7 @@ function WebSearchSettingsPage(props: {
   const pendingCredentialActionRef = useRef<'save' | 'clear' | null>(null);
   const testingRef = useRef(false);
   const liveQueryRunningRef = useRef(false);
+  const liveQueryInputRef = useRef(liveQuery);
   const toast = useToast();
 
   useEffect(() => {
@@ -2889,6 +2890,17 @@ function WebSearchSettingsPage(props: {
       liveQueryRunningRef.current = false;
     };
   }, []);
+
+  function updateLiveQuery(next: string) {
+    liveQueryInputRef.current = next;
+    setLiveQuery(next);
+    setLiveQueryError(null);
+    setLiveQueryResults(null);
+  }
+
+  function isCurrentLiveQuery(queryOwner: string): boolean {
+    return webSearchMountedRef.current && liveQueryInputRef.current === queryOwner;
+  }
 
   async function runCredentialAction(action: 'save' | 'clear', run: () => Promise<void>) {
     if (pendingCredentialActionRef.current !== null || testingRef.current) return;
@@ -2993,7 +3005,8 @@ function WebSearchSettingsPage(props: {
 
   async function runLiveQuery() {
     if (liveQueryRunningRef.current) return;
-    const trimmed = liveQuery.trim();
+    const queryOwner = liveQueryInputRef.current;
+    const trimmed = queryOwner.trim();
     if (trimmed.length === 0) return;
     liveQueryRunningRef.current = true;
     setLiveQueryRunning(true);
@@ -3006,7 +3019,7 @@ function WebSearchSettingsPage(props: {
         query: trimmed,
         limit: 5,
       });
-      if (!webSearchMountedRef.current) return;
+      if (!isCurrentLiveQuery(queryOwner)) return;
       if (result.ok) {
         setLiveQueryResults(result.results);
         if (hasUsableKey) {
@@ -3019,7 +3032,7 @@ function WebSearchSettingsPage(props: {
         }
       }
     } catch (err) {
-      if (webSearchMountedRef.current) {
+      if (isCurrentLiveQuery(queryOwner)) {
         setLiveQueryError(settingsActionErrorMessage(err));
       }
     } finally {
@@ -3144,7 +3157,7 @@ function WebSearchSettingsPage(props: {
           </div>
           <Input
             value={liveQuery}
-            onChange={(event) => setLiveQuery(event.currentTarget.value)}
+            onChange={(event) => updateLiveQuery(event.currentTarget.value)}
             placeholder="例如：本周 AI 产品发布动态"
             aria-label="联网搜索真实查询"
             onKeyDown={(event) => {


### PR DESCRIPTION
## Summary
- invalidate Settings web-search live-query result/error rows as soon as the query input changes
- gate live-query async continuations by the exact submitted query string before writing results, errors, or credential status
- extend the web-search renderer boundary contract for query ownership

## Verification
- npm --workspace @maka/desktop run build:main
- (cd apps/desktop && node --test dist/main/__tests__/web-search-boundary.test.js)
- npm --workspace @maka/desktop run build:renderer
- git diff --check