### PR TITLE
Guard browser navigation failure feedback

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -16,8 +16,21 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.doesNotMatch(source, /const full = \/\^\[a-z\]\+/, 'BrowserPanel must not keep renderer-only address prefix regex');
     assert.match(
       source,
-      /const result = normalizeBrowserAddressInput\(address\);[\s\S]*if \(!result\.ok\) \{[\s\S]*toast\.error\('无法打开地址', browserAddressFailureCopy\(result\.reason\)\);[\s\S]*return;[\s\S]*window\.maka\.browser\.navigate\(sessionId, result\.url\)/,
+      /const result = normalizeBrowserAddressInput\(address\);[\s\S]*if \(!result\.ok\) \{[\s\S]*toast\.error\('无法打开地址', browserAddressFailureCopy\(result\.reason\)\);[\s\S]*return;[\s\S]*const ownerSessionId = sessionId;[\s\S]*window\.maka\.browser\.navigate\(ownerSessionId, result\.url\)/,
       'BrowserPanel must validate addresses with the shared helper before invoking browser navigation',
+    );
+    assert.match(source, /const browserPanelMountedRef = useRef\(false\)/);
+    assert.match(source, /const browserPanelSessionIdRef = useRef\(sessionId\)/);
+    assert.match(source, /browserPanelSessionIdRef\.current = sessionId/);
+    assert.match(
+      source,
+      /const isBrowserPanelSessionCurrent = useCallback\(\(ownerSessionId: string\): boolean => \{[\s\S]*return browserPanelMountedRef\.current && browserPanelSessionIdRef\.current === ownerSessionId;[\s\S]*\}, \[\]\);/,
+      'BrowserPanel async continuations must be owned by the active mounted session.',
+    );
+    assert.match(
+      source,
+      /window\.maka\.browser\.navigate\(ownerSessionId, result\.url\)\.catch\(\(\) => \{[\s\S]*if \(isBrowserPanelSessionCurrent\(ownerSessionId\)\) \{[\s\S]*toast\.error\('浏览器导航失败', '页面暂时无法打开，请稍后重试。'\);[\s\S]*\}/,
+      'BrowserPanel must not toast a stale navigation failure after switching sessions or unmounting.',
     );
     assert.match(source, /嵌入式浏览器只支持打开 HTTP\/HTTPS 网页地址。/);
     assert.match(source, /这个地址无法识别，请检查网址后重试。/);

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -57,6 +57,21 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   // did-navigate state push.
   const [address, setAddress] = useState('');
   const editingRef = useRef(false);
+  const browserPanelMountedRef = useRef(false);
+  const browserPanelSessionIdRef = useRef(sessionId);
+
+  browserPanelSessionIdRef.current = sessionId;
+
+  useEffect(() => {
+    browserPanelMountedRef.current = true;
+    return () => {
+      browserPanelMountedRef.current = false;
+    };
+  }, []);
+
+  const isBrowserPanelSessionCurrent = useCallback((ownerSessionId: string): boolean => {
+    return browserPanelMountedRef.current && browserPanelSessionIdRef.current === ownerSessionId;
+  }, []);
 
   // Subscribe to this session's state pushes + seed the initial state.
   useEffect(() => {
@@ -126,10 +141,13 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
       }
       return;
     }
-    void window.maka.browser.navigate(sessionId, result.url).catch(() => {
-      toast.error('浏览器导航失败', '页面暂时无法打开，请稍后重试。');
+    const ownerSessionId = sessionId;
+    void window.maka.browser.navigate(ownerSessionId, result.url).catch(() => {
+      if (isBrowserPanelSessionCurrent(ownerSessionId)) {
+        toast.error('浏览器导航失败', '页面暂时无法打开，请稍后重试。');
+      }
     });
-  }, [address, sessionId, toast]);
+  }, [address, isBrowserPanelSessionCurrent, sessionId, toast]);
 
   return (
     <div className="maka-browser-panel" aria-label="嵌入式浏览器">


### PR DESCRIPTION
## Summary
- track BrowserPanel mounted/session ownership for async browser navigation continuations
- only show navigation failure toast while the same browser session still owns the panel
- extend renderer utility contract to prevent stale browser navigation failure feedback

## Verification
- npm --workspace @maka/desktop run build:main
- (cd apps/desktop && node --test dist/main/__tests__/renderer-utility-primitives-contract.test.js)
- npm --workspace @maka/desktop run build:renderer
- git diff --check