### PR TITLE
Stop voice smoke capture on close

### DIFF
--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -87,8 +87,13 @@ describe('voice capture smoke Settings contract', () => {
     assert.ok(voicePage, 'voice settings page source must be discoverable');
     assert.match(
       voicePage!,
-      /const voicePageMountedRef = useRef\(false\);[\s\S]*voicePageMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*voicePageMountedRef\.current = false;[\s\S]*captureSmokeBusyRef\.current = false;/,
+      /const voicePageMountedRef = useRef\(false\);[\s\S]*const activeVoiceCaptureStreamRef = useRef<MediaStream \| null>\(null\);[\s\S]*voicePageMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*voicePageMountedRef\.current = false;[\s\S]*activeVoiceCaptureStreamRef\.current\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*activeVoiceCaptureStreamRef\.current = null;[\s\S]*captureSmokeBusyRef\.current = false;/,
       'voice capture smoke must track page ownership and release the pending owner when Settings closes',
+    );
+    assert.match(
+      voicePage!,
+      /stream = await navigator\.mediaDevices\.getUserMedia[\s\S]*activeVoiceCaptureStreamRef\.current = stream;[\s\S]*if \(!voicePageMountedRef\.current\) return;/,
+      'voice capture smoke must remember the active MediaStream before the mounted check so unmount cleanup can stop it immediately',
     );
     assert.match(
       voicePage!,
@@ -107,8 +112,8 @@ describe('voice capture smoke Settings contract', () => {
     );
     assert.match(
       voicePage!,
-      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*captureSmokeBusyRef\.current = false;[\s\S]*if \(voicePageMountedRef\.current\) \{[\s\S]*setIsBusy\(false\);/,
-      'voice capture cleanup must stop microphone tracks even after unmount but only write React state while mounted',
+      /finally \{[\s\S]*stream\?\.getTracks\(\)\.forEach\(\(track\) => track\.stop\(\)\);[\s\S]*if \(activeVoiceCaptureStreamRef\.current === stream\) \{[\s\S]*activeVoiceCaptureStreamRef\.current = null;[\s\S]*\}[\s\S]*captureSmokeBusyRef\.current = false;[\s\S]*if \(voicePageMountedRef\.current\) \{[\s\S]*setIsBusy\(false\);/,
+      'voice capture cleanup must stop microphone tracks, clear the active stream owner, and only write React state while mounted',
     );
   });
 

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1775,6 +1775,7 @@ function VoiceModelsSettingsPage() {
   const [isBusy, setIsBusy] = useState(false);
   const captureSmokeBusyRef = useRef(false);
   const voicePageMountedRef = useRef(false);
+  const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
   const toast = useToast();
   const caps = defaultVoiceCaptureCaps();
   const smokeStatusId = useId();
@@ -1783,6 +1784,8 @@ function VoiceModelsSettingsPage() {
     voicePageMountedRef.current = true;
     return () => {
       voicePageMountedRef.current = false;
+      activeVoiceCaptureStreamRef.current?.getTracks().forEach((track) => track.stop());
+      activeVoiceCaptureStreamRef.current = null;
       captureSmokeBusyRef.current = false;
     };
   }, []);
@@ -1821,6 +1824,7 @@ function VoiceModelsSettingsPage() {
           sampleRate: caps.maxSampleRate,
         },
       });
+      activeVoiceCaptureStreamRef.current = stream;
       if (!voicePageMountedRef.current) return;
       setPermission('granted');
       setSmoke({ status: 'recording', message: '正在录制 2 秒本地样本；样本只在内存里计算大小，结束后立即丢弃。' });
@@ -1871,6 +1875,9 @@ function VoiceModelsSettingsPage() {
       }
     } finally {
       stream?.getTracks().forEach((track) => track.stop());
+      if (activeVoiceCaptureStreamRef.current === stream) {
+        activeVoiceCaptureStreamRef.current = null;
+      }
       captureSmokeBusyRef.current = false;
       if (voicePageMountedRef.current) {
         setIsBusy(false);


### PR DESCRIPTION
## Summary
- keep the active voice smoke MediaStream in a ref while the Settings voice page is mounted
- stop microphone tracks immediately when the page unmounts, instead of waiting for the async smoke test to finish
- keep the existing finally cleanup as a fallback and clear the active stream owner

## Verification
- npm --workspace @maka/desktop run build:main
- (cd apps/desktop && node --test dist/main/__tests__/voice-capture-smoke-contract.test.js)
- npm --workspace @maka/desktop run build:renderer
- git diff --check