### PR TITLE
Gate web search enable toggles

### DIFF
--- a/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
@@ -161,6 +161,8 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     const page = settings.match(/function WebSearchSettingsPage[\s\S]*?function webSearchQueryDisabledReason/);
 
     assert.ok(page, 'Web search settings page block must exist');
+    assert.match(page![0], /const \[pendingWebSearchEnabled, setPendingWebSearchEnabled\] = useState\(false\)/);
+    assert.match(page![0], /const pendingWebSearchEnabledRef = useRef\(false\)/);
     assert.match(page![0], /const \[pendingCredentialAction, setPendingCredentialAction\] = useState<'save' \| 'clear' \| null>\(null\)/);
     assert.match(page![0], /const pendingCredentialActionRef = useRef<'save' \| 'clear' \| null>\(null\)/);
     assert.match(page![0], /const testingRef = useRef\(false\)/);
@@ -181,6 +183,11 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
       /async function runCredentialAction\([\s\S]*if \(pendingCredentialActionRef\.current !== null \|\| testingRef\.current\) return;[\s\S]*pendingCredentialActionRef\.current = action;[\s\S]*setPendingCredentialAction\(action\);[\s\S]*await run\(\);[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*setPendingCredentialAction\(null\);/,
       'Saving or clearing Tavily credentials must reject duplicate clicks synchronously and expose pending state.',
     );
+    assert.match(
+      page![0],
+      /async function setEnabled\(enabled: boolean\) \{[\s\S]*if \(pendingWebSearchEnabledRef\.current\) return;[\s\S]*pendingWebSearchEnabledRef\.current = true;[\s\S]*setPendingWebSearchEnabled\(true\);[\s\S]*await updateWebSearch\(\{ enabled \}\);[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*setPendingWebSearchEnabled\(false\);/,
+      'The web-search enable switch must reject duplicate same-frame toggles and expose local pending state.',
+    );
     assert.match(page![0], /runCredentialAction\('save', async \(\) => \{/);
     assert.match(page![0], /runCredentialAction\('clear', async \(\) => \{/);
     assert.match(
@@ -200,6 +207,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     assert.match(page![0], /disabled=\{credentialActionBusy \|\| \(draftKey\.length === 0 && !hasUsableKey\)\}/);
     assert.match(page![0], /disabled=\{credentialActionBusy\}[\s\S]*pendingCredentialAction === 'clear' \? '清空中…' : '清空密钥'/);
     assert.match(page![0], /onChange=\{\(event\) => updateLiveQuery\(event\.currentTarget\.value\)\}/);
+    assert.match(page![0], /disabled=\{!hasUsableKey \|\| pendingWebSearchEnabled\}/);
   });
 
   it('Settings web-search async actions stop writing component state after unmount', async () => {
@@ -214,8 +222,13 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(
       page![0],
-      /useEffect\(\(\) => \{[\s\S]*webSearchMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*webSearchMountedRef\.current = false;[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*testingRef\.current = false;[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
+      /useEffect\(\(\) => \{[\s\S]*webSearchMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*webSearchMountedRef\.current = false;[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*pendingCredentialActionRef\.current = null;[\s\S]*testingRef\.current = false;[\s\S]*liveQueryRunningRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
       'Unmount must mark the page inactive and release synchronous pending owners',
+    );
+    assert.match(
+      page![0],
+      /finally \{[\s\S]*pendingWebSearchEnabledRef\.current = false;[\s\S]*if \(webSearchMountedRef\.current\) \{[\s\S]*setPendingWebSearchEnabled\(false\);[\s\S]*\}/,
+      'Web-search enable completion must not set pending switch state after unmount',
     );
     assert.match(
       page![0],

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -2875,6 +2875,7 @@ function WebSearchSettingsPage(props: {
   const credentialSource = tavily.credentialSource;
   const usingEnvKey = credentialSource === 'env';
   const [draftKey, setDraftKey] = useState('');
+  const [pendingWebSearchEnabled, setPendingWebSearchEnabled] = useState(false);
   const [pendingCredentialAction, setPendingCredentialAction] = useState<'save' | 'clear' | null>(null);
   const [testing, setTesting] = useState(false);
   const [liveQuery, setLiveQuery] = useState('');
@@ -2882,6 +2883,7 @@ function WebSearchSettingsPage(props: {
   const [liveQueryResults, setLiveQueryResults] = useState<readonly { title: string; url: string; snippet: string; source: string }[] | null>(null);
   const [liveQueryError, setLiveQueryError] = useState<string | null>(null);
   const webSearchMountedRef = useRef(true);
+  const pendingWebSearchEnabledRef = useRef(false);
   const pendingCredentialActionRef = useRef<'save' | 'clear' | null>(null);
   const testingRef = useRef(false);
   const liveQueryRunningRef = useRef(false);
@@ -2892,6 +2894,7 @@ function WebSearchSettingsPage(props: {
     webSearchMountedRef.current = true;
     return () => {
       webSearchMountedRef.current = false;
+      pendingWebSearchEnabledRef.current = false;
       pendingCredentialActionRef.current = null;
       testingRef.current = false;
       liveQueryRunningRef.current = false;
@@ -2939,7 +2942,17 @@ function WebSearchSettingsPage(props: {
   }
 
   async function setEnabled(enabled: boolean) {
-    await updateWebSearch({ enabled });
+    if (pendingWebSearchEnabledRef.current) return;
+    pendingWebSearchEnabledRef.current = true;
+    setPendingWebSearchEnabled(true);
+    try {
+      await updateWebSearch({ enabled });
+    } finally {
+      pendingWebSearchEnabledRef.current = false;
+      if (webSearchMountedRef.current) {
+        setPendingWebSearchEnabled(false);
+      }
+    }
   }
 
   async function persistCredentialStatus(status: WebSearchCredentialStatus, credentialVersion: number): Promise<boolean> {
@@ -3091,7 +3104,7 @@ function WebSearchSettingsPage(props: {
             <Switch
               ariaLabel="启用联网搜索"
               checked={webSearch.enabled}
-              disabled={!hasUsableKey}
+              disabled={!hasUsableKey || pendingWebSearchEnabled}
               onChange={(enabled) => void setEnabled(enabled)}
             />
           </div>


### PR DESCRIPTION
## Summary
- add a ref-backed pending owner for the Settings web-search enable switch
- disable the switch while the settings update is in flight and release ownership on unmount/finally
- extend the web-search boundary contract for duplicate-toggle and unmount behavior

## Verification
- npm --workspace @maka/desktop run build:main
- (cd apps/desktop && node --test dist/main/__tests__/web-search-boundary.test.js)
- npm --workspace @maka/desktop run build:renderer
- git diff --check