### PR TITLE
Gate plan reminder form actions

### DIFF
--- a/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/plan-reminder-panel-contract.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+function blockBetween(source: string, start: string, end: string): string {
+  return source.match(new RegExp(`${start}[\\s\\S]*?${end}`))?.[0] ?? '';
+}
+
+describe('Plan Reminder panel async action contract', () => {
+  it('gates form submit and refresh before React commits disabled state', async () => {
+    const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/components.tsx'), 'utf8');
+    const panelBlock = blockBetween(ui, 'function PlanReminderPanel', '\\/\\*\\*');
+    const submitBlock = blockBetween(panelBlock, 'async function submit', 'async function runPlanReminderAction');
+    const refreshBlock = blockBetween(panelBlock, 'async function refreshFromPanel', 'return \\(');
+
+    assert.match(panelBlock, /const \[submitPending, setSubmitPending\] = useState\(false\)/);
+    assert.match(panelBlock, /const \[refreshPending, setRefreshPending\] = useState\(false\)/);
+    assert.match(panelBlock, /const submitPendingRef = useRef\(false\)/);
+    assert.match(panelBlock, /const refreshPendingRef = useRef\(false\)/);
+    assert.match(
+      panelBlock,
+      /return \(\) => \{\s*planReminderMountedRef\.current = false;\s*submitPendingRef\.current = false;\s*refreshPendingRef\.current = false;\s*pendingActionKeysRef\.current = new Set\(\);/,
+      'Plan Reminder pending form/refresh owners must be released when the panel unmounts',
+    );
+
+    assert.match(
+      panelBlock,
+      /function closeReminderDialog\(\) \{\s*if \(submitPendingRef\.current\) return;\s*setFormDialogOpen\(false\);/,
+      'The form dialog must not close while a submit is still owned by the panel',
+    );
+    assert.match(
+      submitBlock,
+      /event\.preventDefault\(\);\s*if \(submitDisabled \|\| submitPendingRef\.current\) return;\s*submitPendingRef\.current = true;/,
+      'Plan Reminder submit must synchronously reject duplicate submits before React disables the submit button',
+    );
+    assert.match(submitBlock, /setSubmitPending\(true\);/);
+    assert.match(
+      submitBlock,
+      /finally \{\s*submitPendingRef\.current = false;\s*if \(planReminderMountedRef\.current\) setSubmitPending\(false\);/,
+      'Plan Reminder submit owner must release without writing React state after unmount',
+    );
+    assert.match(panelBlock, /const submitDisabled = !canCreate \|\| submitPending;/);
+    assert.match(panelBlock, /<form className="maka-plan-form" onSubmit=\{submit\} aria-busy=\{submitPending \? 'true' : undefined\}>/);
+    assert.match(panelBlock, /<UiButton className="maka-button maka-plan-submit" type="submit" disabled=\{submitDisabled\}>/);
+
+    assert.match(
+      refreshBlock,
+      /if \(!props\.onRefresh \|\| refreshPendingRef\.current\) return;\s*refreshPendingRef\.current = true;\s*setRefreshPending\(true\);/,
+      'Plan Reminder refresh must synchronously reject duplicate refresh clicks before React disables the icon button',
+    );
+    assert.match(
+      refreshBlock,
+      /finally \{\s*refreshPendingRef\.current = false;\s*if \(planReminderMountedRef\.current\) setRefreshPending\(false\);/,
+      'Plan Reminder refresh owner must release without writing React state after unmount',
+    );
+    assert.match(panelBlock, /disabled=\{!props\.onRefresh \|\| refreshPending\}/);
+    assert.match(panelBlock, /aria-busy=\{refreshPending \? 'true' : undefined\}/);
+  });
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -2060,6 +2060,8 @@ function PlanReminderPanel(props: {
   const [submitPending, setSubmitPending] = useState(false);
   const [pendingActionKeys, setPendingActionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const planReminderMountedRef = useRef(true);
+  const submitPendingRef = useRef(false);
+  const refreshPendingRef = useRef(false);
   const pendingActionKeysRef = useRef<Set<string>>(new Set());
   const [formDialogOpen, setFormDialogOpen] = useState(false);
   const [planView, setPlanView] = useState<PlanReminderView>('tasks');
@@ -2109,6 +2111,8 @@ function PlanReminderPanel(props: {
     planReminderMountedRef.current = true;
     return () => {
       planReminderMountedRef.current = false;
+      submitPendingRef.current = false;
+      refreshPendingRef.current = false;
       pendingActionKeysRef.current = new Set();
     };
   }, []);
@@ -2148,7 +2152,7 @@ function PlanReminderPanel(props: {
   }
 
   function closeReminderDialog() {
-    if (submitPending) return;
+    if (submitPendingRef.current) return;
     setFormDialogOpen(false);
     resetForm();
   }
@@ -2195,7 +2199,8 @@ function PlanReminderPanel(props: {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (submitDisabled) return;
+    if (submitDisabled || submitPendingRef.current) return;
+    submitPendingRef.current = true;
     const input = {
       title: title.trim(),
       note: note.trim(),
@@ -2217,6 +2222,7 @@ function PlanReminderPanel(props: {
         setFormDialogOpen(false);
       }
     } finally {
+      submitPendingRef.current = false;
       if (planReminderMountedRef.current) setSubmitPending(false);
     }
   }
@@ -2241,11 +2247,13 @@ function PlanReminderPanel(props: {
   }
 
   async function refreshFromPanel() {
-    if (!props.onRefresh || refreshPending) return;
+    if (!props.onRefresh || refreshPendingRef.current) return;
+    refreshPendingRef.current = true;
     setRefreshPending(true);
     try {
       await props.onRefresh();
     } finally {
+      refreshPendingRef.current = false;
       if (planReminderMountedRef.current) setRefreshPending(false);
     }
   }


### PR DESCRIPTION
## Summary
- add ref-backed pending owners for Plan Reminder form submit and panel refresh actions
- prevent same-frame duplicate create/update submits and overlapping refreshes before React disabled state commits
- add a Plan Reminder panel contract for submit/refresh ownership and unmount release

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/plan-reminder-panel-contract.test.js
- npm --workspace @maka/desktop run build:renderer
- git diff --check