### PR TITLE
Release first-run refresh owner on close

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -182,8 +182,8 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     assert.match(source, /const statusRefreshPendingRef = useRef\(false\)/);
     assert.match(
       source,
-      /useEffect\(\(\) => \{[\s\S]*checklistMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*checklistMountedRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
-      'first-run checklist must restore mounted state during StrictMode replay',
+      /useEffect\(\(\) => \{[\s\S]*checklistMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*checklistMountedRef\.current = false;[\s\S]*statusRefreshPendingRef\.current = false;[\s\S]*\};[\s\S]*\}, \[\]\)/,
+      'first-run checklist must restore mounted state during StrictMode replay and release refresh ownership on unmount',
     );
     assert.match(source, /const isChecklistUnmounted = useCallback\(\(\) => !checklistMountedRef\.current, \[\]\)/);
     assert.match(refreshBlock, /isCancelled: \(\) => boolean = isChecklistUnmounted/);

--- a/apps/desktop/src/renderer/FirstRunChecklist.tsx
+++ b/apps/desktop/src/renderer/FirstRunChecklist.tsx
@@ -64,6 +64,7 @@ export function FirstRunChecklist(props: FirstRunChecklistProps) {
     checklistMountedRef.current = true;
     return () => {
       checklistMountedRef.current = false;
+      statusRefreshPendingRef.current = false;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- release the FirstRunChecklist status refresh owner during unmount cleanup
- extend the first-run source contract so StrictMode/unmount cleanup must clear both mounted and refresh-owner refs

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/first-run-task-suggestions.test.js
- npm --workspace @maka/desktop run build:renderer (passes with existing Vite chunk-size warning)
- git diff --check