### PR TITLE
Guard project picker lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -83,16 +83,28 @@ describe('project context workspace picker', () => {
     assert.match(renderer, /async function selectProjectDirectory\(\)/);
     assert.match(renderer, /window\.maka\.app\.selectProjectDirectory\(\)/);
     assert.match(renderer, /const \[projectPickerPending, setProjectPickerPending\] = useState\(false\)/);
+    assert.match(renderer, /const rendererMountedRef = useRef\(true\)/);
     assert.match(renderer, /const projectPickerPendingRef = useRef\(false\)/);
+    assert.match(renderer, /const projectPickerRequestRef = useRef\(0\)/);
     assert.match(
       renderer,
-      /async function selectProjectDirectory\(\) \{[\s\S]*if \(projectPickerPendingRef\.current\) return;[\s\S]*projectPickerPendingRef\.current = true;[\s\S]*setProjectPickerPending\(true\);[\s\S]*window\.maka\.app\.selectProjectDirectory\(\)/,
+      /return \(\) => \{[\s\S]*rendererMountedRef\.current = false;[\s\S]*projectPickerRequestRef\.current \+= 1;[\s\S]*projectPickerPendingRef\.current = false;/,
+      'project picker must invalidate native-dialog owners when the renderer shell unmounts',
+    );
+    assert.match(
+      renderer,
+      /async function selectProjectDirectory\(\) \{[\s\S]*if \(projectPickerPendingRef\.current\) return;[\s\S]*const requestId = projectPickerRequestRef\.current \+ 1;[\s\S]*projectPickerRequestRef\.current = requestId;[\s\S]*projectPickerPendingRef\.current = true;[\s\S]*setProjectPickerPending\(true\);[\s\S]*const isCurrentProjectPickerRequest = \(\) => rendererMountedRef\.current && projectPickerRequestRef\.current === requestId;[\s\S]*window\.maka\.app\.selectProjectDirectory\(\)[\s\S]*if \(!isCurrentProjectPickerRequest\(\)\) return;/,
       'project picker must synchronously reject duplicate native dialog requests before React commits disabled state',
     );
     assert.match(
       renderer,
-      /finally \{[\s\S]*projectPickerPendingRef\.current = false;[\s\S]*setProjectPickerPending\(false\);/,
-      'project picker must release its pending owner after the native dialog resolves or fails',
+      /catch \(error\) \{[\s\S]*if \(isCurrentProjectPickerRequest\(\)\) \{[\s\S]*toastApi\.error\('选择工作目录失败'/,
+      'project picker failure feedback must stay scoped to the current mounted picker request',
+    );
+    assert.match(
+      renderer,
+      /finally \{[\s\S]*if \(projectPickerRequestRef\.current === requestId\) \{[\s\S]*projectPickerPendingRef\.current = false;[\s\S]*if \(rendererMountedRef\.current\) setProjectPickerPending\(false\);/,
+      'project picker must release only the matching pending owner after the native dialog resolves or fails',
     );
     assert.match(renderer, /setAppInfo\(\{ projectPath: result\.projectPath, projectGit: result\.projectGit \}\)/);
     assert.match(renderer, /toastApi\.success\('已切换工作目录', basenameFromPath\(result\.projectPath\)\)/);

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -356,7 +356,9 @@ function AppShell() {
   }
   const composerRef = useRef<ComposerHandle>(null);
   const activeIdRef = useRef<string | undefined>(undefined);
+  const rendererMountedRef = useRef(true);
   const projectPickerPendingRef = useRef(false);
+  const projectPickerRequestRef = useRef(0);
   const activeStreamingSlot = activeId ? streamingBySession[activeId] : undefined;
   const activeStreaming = activeStreamingSlot?.text ?? '';
   const activeStreamingTruncated = activeStreamingSlot?.truncated === true;
@@ -1087,8 +1089,12 @@ function AppShell() {
         openSettings();
       }
     }
+    rendererMountedRef.current = true;
     window.addEventListener('keydown', onKeyDown);
     return () => {
+      rendererMountedRef.current = false;
+      projectPickerRequestRef.current += 1;
+      projectPickerPendingRef.current = false;
       unsubscribeConnections();
       unsubscribeSessionChanges();
       unsubscribeOpenSettings();
@@ -1647,10 +1653,14 @@ function AppShell() {
 
   async function selectProjectDirectory() {
     if (projectPickerPendingRef.current) return;
+    const requestId = projectPickerRequestRef.current + 1;
+    projectPickerRequestRef.current = requestId;
     projectPickerPendingRef.current = true;
     setProjectPickerPending(true);
+    const isCurrentProjectPickerRequest = () => rendererMountedRef.current && projectPickerRequestRef.current === requestId;
     try {
       const result = await window.maka.app.selectProjectDirectory();
+      if (!isCurrentProjectPickerRequest()) return;
       if (!result.ok) {
         if (result.reason !== 'cancelled') {
           toastApi.error('选择工作目录失败', selectProjectDirectoryFailureCopy(result.reason));
@@ -1660,10 +1670,14 @@ function AppShell() {
       setAppInfo({ projectPath: result.projectPath, projectGit: result.projectGit });
       toastApi.success('已切换工作目录', basenameFromPath(result.projectPath));
     } catch (error) {
-      toastApi.error('选择工作目录失败', generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。'));
+      if (isCurrentProjectPickerRequest()) {
+        toastApi.error('选择工作目录失败', generalizedErrorMessageChinese(error, '项目路径暂时无法读取，请稍后重试。'));
+      }
     } finally {
-      projectPickerPendingRef.current = false;
-      setProjectPickerPending(false);
+      if (projectPickerRequestRef.current === requestId) {
+        projectPickerPendingRef.current = false;
+        if (rendererMountedRef.current) setProjectPickerPending(false);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add a mounted/request owner to the composer project directory picker
- invalidate pending native-dialog owners on renderer shell unmount
- scope project-picker success/failure feedback and pending release to the current request

## Verification
- npm --workspace @maka/desktop run build:main
- node --test dist/main/__tests__/project-context-badge.test.js
- npm --workspace @maka/desktop run build:renderer (passes with existing Vite chunk-size warning)
- git diff --check