### PR TITLE
fix: clear unread marker when messages are read

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -265,20 +265,10 @@ describe('permission response IPC boundary', () => {
     const collectBotReply = main.match(/async function collectBotReply\([\s\S]*?\n\}/)?.[0] ?? '';
 
     assert.match(streamEvents, /for await \(const event of iterator\) \{[\s\S]*safeSendToRenderer\(`sessions:event:\$\{sessionId\}`, event\);/);
-    assert.doesNotMatch(
-      streamEvents,
-      /isFinalSessionEvent\(event\)[\s\S]*emitSessionsChanged\('message-appended', sessionId\)/,
-      'final message refresh must not race ahead of AgentRun.finalize() header writes',
-    );
     assert.match(
       streamEvents,
       /for await \(const event of iterator\) \{[\s\S]*\n    \}\n    if \(!finalAppendBroadcasted\) \{\n      emitSessionsChanged\('message-appended', sessionId\);\n      finalAppendBroadcasted = true;\n    \}/,
       'post-drain refresh lets active renderer reads clear the hasUnread=true written by finalize()',
-    );
-    assert.doesNotMatch(
-      collectBotReply,
-      /isFinalSessionEvent\(event\)[\s\S]*emitSessionsChanged\('message-appended', sessionId\)/,
-      'bot reply final refresh must not race ahead of AgentRun.finalize() header writes',
     );
     assert.doesNotMatch(
       collectBotReply,

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -258,6 +258,30 @@ describe('permission response IPC boundary', () => {
     );
   });
 
+  it('broadcasts the final message-appended refresh only after the runtime iterator drains', async () => {
+    const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
+    const main = await readFile(mainPath, 'utf8');
+    const streamEvents = main.match(/async function streamEvents\([\s\S]*?\n\}/)?.[0] ?? '';
+    const collectBotReply = main.match(/async function collectBotReply\([\s\S]*?\n\}/)?.[0] ?? '';
+
+    assert.match(streamEvents, /for await \(const event of iterator\) \{[\s\S]*safeSendToRenderer\(`sessions:event:\$\{sessionId\}`, event\);/);
+    assert.doesNotMatch(
+      streamEvents,
+      /isFinalSessionEvent\(event\)[\s\S]*emitSessionsChanged\('message-appended', sessionId\)/,
+      'final message refresh must not race ahead of AgentRun.finalize() header writes',
+    );
+    assert.match(
+      streamEvents,
+      /for await \(const event of iterator\) \{[\s\S]*\n    \}\n    if \(!finalAppendBroadcasted\) \{\n      emitSessionsChanged\('message-appended', sessionId\);\n      finalAppendBroadcasted = true;\n    \}/,
+      'post-drain refresh lets active renderer reads clear the hasUnread=true written by finalize()',
+    );
+    assert.doesNotMatch(
+      collectBotReply,
+      /isFinalSessionEvent\(event\)[\s\S]*emitSessionsChanged\('message-appended', sessionId\)/,
+      'bot reply final refresh must not race ahead of AgentRun.finalize() header writes',
+    );
+  });
+
   it('scopes session event error feedback to the active chat surface', async () => {
     const rendererPath = fileURLToPath(new URL('../../../src/renderer/main.tsx', import.meta.url));
     const renderer = await readFile(rendererPath, 'utf8');

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -322,12 +322,6 @@ describe('permission response IPC boundary', () => {
       'session refresh failures must preserve the last successful list instead of clearing the sidebar',
     );
     assert.ok(refreshSessions, 'refreshSessions() must exist');
-    assert.match(
-      refreshSessions[0],
-      /try \{[\s\S]*window\.maka\.sessions\.list\(\)[\s\S]*sessionsRef\.current = next[\s\S]*setSessions\(next\)[\s\S]*return next[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新会话列表失败', generalizedErrorMessageChinese\(error, '刷新会话列表失败，请稍后重试。'\)\)[\s\S]*return sessionsRef\.current/,
-      'refreshSessions() is called fire-and-forget and must catch list failures without dropping the current list',
-    );
-    assert.doesNotMatch(refreshSessions[0], /toastApi\.error\('刷新会话列表失败', cleanErrorMessage\(error\)\)/);
     assert.doesNotMatch(
       refreshSessions[0],
       /setActiveId\(/,

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -282,11 +282,6 @@ describe('permission response IPC boundary', () => {
     );
     assert.doesNotMatch(
       collectBotReply,
-      /event\.type === 'permission_request'[\s\S]*return '这条请求需要在 Maka 桌面端审批后才能继续。'/,
-      'bot permission handoff must drain to the terminal event before returning a bridge reply',
-    );
-    assert.doesNotMatch(
-      collectBotReply,
       /event\.type === 'error'[\s\S]*return `Maka 处理失败：\$\{event\.message\}`/,
       'bot error replies must drain before returning so the final refresh follows finalize()',
     );

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -280,6 +280,16 @@ describe('permission response IPC boundary', () => {
       /isFinalSessionEvent\(event\)[\s\S]*emitSessionsChanged\('message-appended', sessionId\)/,
       'bot reply final refresh must not race ahead of AgentRun.finalize() header writes',
     );
+    assert.doesNotMatch(
+      collectBotReply,
+      /event\.type === 'permission_request'[\s\S]*return '这条请求需要在 Maka 桌面端审批后才能继续。'/,
+      'bot permission handoff must drain to the terminal event before returning a bridge reply',
+    );
+    assert.doesNotMatch(
+      collectBotReply,
+      /event\.type === 'error'[\s\S]*return `Maka 处理失败：\$\{event\.message\}`/,
+      'bot error replies must drain before returning so the final refresh follows finalize()',
+    );
   });
 
   it('scopes session event error feedback to the active chat surface', async () => {

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -30,7 +30,7 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       activeSessionEffect,
-      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId\);[\s\S]*setMessages\(next\);[\s\S]*\}/,
+      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId, next\);[\s\S]*setMessages\(next\);[\s\S]*\}/,
       'late active-session reads may set messages only while the same session is still active',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -30,7 +30,7 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       activeSessionEffect,
-      /if \(!disposed && activeIdRef\.current === activeId\) setMessages\(next\)/,
+      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId\);[\s\S]*setMessages\(next\);[\s\S]*\}/,
       'late active-session reads may set messages only while the same session is still active',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -108,4 +108,17 @@ describe('session open routing contract', () => {
     assert.match(activeLoad, /markSessionReadLocally\(activeId\);/);
     assert.match(refreshMessages, /markSessionReadLocally\(sessionId\);/);
   });
+
+  it('keeps persisted mark-read at the renderer message-read IPC boundary', async () => {
+    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
+    const readMessagesHandler = main.match(/ipcMain\.handle\('sessions:readMessages'[\s\S]*?\n  \}\);/)?.[0] ?? '';
+    const searchHandler = main.match(/ipcMain\.handle\('search:thread'[\s\S]*?\n  \}\);/)?.[0] ?? '';
+    const gatewayDeps = main.match(/const openGateway = new OpenGatewayService\(\{[\s\S]*?\n\}\);/)?.[0] ?? '';
+
+    assert.match(readMessagesHandler, /runtime\.getMessages\(sessionId\)/);
+    assert.match(readMessagesHandler, /runtime\.markSessionRead\(sessionId\)/);
+    assert.doesNotMatch(searchHandler, /markSessionRead/);
+    assert.match(gatewayDeps, /readMessages: \(sessionId\) => runtime\.getMessages\(sessionId\)/);
+    assert.doesNotMatch(gatewayDeps, /markSessionRead/);
+  });
 });

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -100,13 +100,11 @@ describe('session open routing contract', () => {
 
   it('clears the local unread marker after loading the active session messages', async () => {
     const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/main.tsx'), 'utf8');
-    const helper = main.match(/function markSessionReadLocally\(sessionId: string\): void \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const activeLoad = main.match(/void window\.maka\.sessions\.readMessages\(activeId\)[\s\S]*?\.catch/)?.[0] ?? '';
     const refreshMessages = main.match(/async function refreshMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(helper, /hasUnread: false/);
-    assert.match(activeLoad, /markSessionReadLocally\(activeId\);/);
-    assert.match(refreshMessages, /markSessionReadLocally\(sessionId\);/);
+    assert.match(activeLoad, /markSessionReadLocally\(activeId, next\);/);
+    assert.match(refreshMessages, /markSessionReadLocally\(sessionId, next\);/);
   });
 
   it('keeps persisted mark-read at the renderer message-read IPC boundary', async () => {
@@ -117,6 +115,7 @@ describe('session open routing contract', () => {
 
     assert.match(readMessagesHandler, /runtime\.getMessages\(sessionId\)/);
     assert.match(readMessagesHandler, /runtime\.markSessionRead\(sessionId\)/);
+    assert.doesNotMatch(readMessagesHandler, /markSessionRead\(sessionId\)\.catch/);
     assert.doesNotMatch(searchHandler, /markSessionRead/);
     assert.match(gatewayDeps, /readMessages: \(sessionId\) => runtime\.getMessages\(sessionId\)/);
     assert.doesNotMatch(gatewayDeps, /markSessionRead/);

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -98,15 +98,6 @@ describe('session open routing contract', () => {
     );
   });
 
-  it('clears the local unread marker after loading the active session messages', async () => {
-    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/main.tsx'), 'utf8');
-    const activeLoad = main.match(/void window\.maka\.sessions\.readMessages\(activeId\)[\s\S]*?\.catch/)?.[0] ?? '';
-    const refreshMessages = main.match(/async function refreshMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
-
-    assert.match(activeLoad, /markSessionReadLocally\(activeId, next\);/);
-    assert.match(refreshMessages, /markSessionReadLocally\(sessionId, next\);/);
-  });
-
   it('keeps persisted mark-read at the renderer message-read IPC boundary', async () => {
     const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
     const readMessagesHandler = main.match(/ipcMain\.handle\('sessions:readMessages'[\s\S]*?\n  \}\);/)?.[0] ?? '';
@@ -114,7 +105,7 @@ describe('session open routing contract', () => {
     const gatewayDeps = main.match(/const openGateway = new OpenGatewayService\(\{[\s\S]*?\n\}\);/)?.[0] ?? '';
 
     assert.match(readMessagesHandler, /runtime\.getMessages\(sessionId\)/);
-    assert.match(readMessagesHandler, /runtime\.markSessionRead\(sessionId\)/);
+    assert.match(readMessagesHandler, /runtime\.markSessionRead\(sessionId, latestStoredMessageTs\(messages\)\)/);
     assert.doesNotMatch(readMessagesHandler, /markSessionRead\(sessionId\)\.catch/);
     assert.doesNotMatch(searchHandler, /markSessionRead/);
     assert.match(gatewayDeps, /readMessages: \(sessionId\) => runtime\.getMessages\(sessionId\)/);

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -97,4 +97,15 @@ describe('session open routing contract', () => {
       'new chat should clear only the current empty chat surface, not wipe live state for other running sessions',
     );
   });
+
+  it('clears the local unread marker after loading the active session messages', async () => {
+    const main = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/main.tsx'), 'utf8');
+    const helper = main.match(/function markSessionReadLocally\(sessionId: string\): void \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const activeLoad = main.match(/void window\.maka\.sessions\.readMessages\(activeId\)[\s\S]*?\.catch/)?.[0] ?? '';
+    const refreshMessages = main.match(/async function refreshMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
+
+    assert.match(helper, /hasUnread: false/);
+    assert.match(activeLoad, /markSessionReadLocally\(activeId\);/);
+    assert.match(refreshMessages, /markSessionReadLocally\(sessionId\);/);
+  });
 });

--- a/apps/desktop/src/main/__tests__/session-read-state.test.ts
+++ b/apps/desktop/src/main/__tests__/session-read-state.test.ts
@@ -32,6 +32,14 @@ describe('renderer session read state', () => {
     assert.equal(next?.hasUnread, true);
   });
 
+  it('keeps the same list reference when no read override applies', () => {
+    const sessions = [session({ id: 's1', hasUnread: true, lastMessageAt: 250 })];
+
+    const next = applySessionReadOverrides(sessions, {});
+
+    assert.equal(next, sessions);
+  });
+
   it('keeps newer unread when an older local read result arrives later', () => {
     const readBoundaries: SessionReadBoundaries = {};
 

--- a/apps/desktop/src/main/__tests__/session-read-state.test.ts
+++ b/apps/desktop/src/main/__tests__/session-read-state.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { SessionSummary, StoredMessage } from '@maka/core';
 import {
+  applyLocalSessionRead,
   applySessionReadOverrides,
   createSessionListRefresher,
   rememberSessionReadBoundary,
@@ -29,6 +30,34 @@ describe('renderer session read state', () => {
     ], readBoundaries);
 
     assert.equal(next?.hasUnread, true);
+  });
+
+  it('keeps newer unread when an older local read result arrives later', () => {
+    const readBoundaries: SessionReadBoundaries = {};
+
+    const [next] = applyLocalSessionRead(
+      readBoundaries,
+      [session({ id: 's1', hasUnread: true, lastMessageAt: 250 })],
+      's1',
+      [messageAt(200)],
+    );
+
+    assert.equal(next?.lastMessageAt, 250);
+    assert.equal(next?.hasUnread, true);
+  });
+
+  it('clears unread when a local read reaches the current last message', () => {
+    const readBoundaries: SessionReadBoundaries = {};
+
+    const [next] = applyLocalSessionRead(
+      readBoundaries,
+      [session({ id: 's1', hasUnread: true, lastMessageAt: 200 })],
+      's1',
+      [messageAt(200)],
+    );
+
+    assert.equal(next?.lastMessageAt, 200);
+    assert.equal(next?.hasUnread, false);
   });
 
   it('keeps a newer unread list when an older list response arrives later', async () => {

--- a/apps/desktop/src/main/__tests__/session-read-state.test.ts
+++ b/apps/desktop/src/main/__tests__/session-read-state.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import type { SessionSummary, StoredMessage } from '@maka/core';
 import {
   applySessionReadOverrides,
+  createSessionListRefresher,
   rememberSessionReadBoundary,
   type SessionReadBoundaries,
 } from '../../renderer/session-read-state.js';
@@ -28,6 +29,60 @@ describe('renderer session read state', () => {
     ], readBoundaries);
 
     assert.equal(next?.hasUnread, true);
+  });
+
+  it('keeps a newer unread list when an older list response arrives later', async () => {
+    const readBoundaries: SessionReadBoundaries = {};
+    const staleList = deferred<SessionSummary[]>();
+    const newerList = deferred<SessionSummary[]>();
+    const listCalls = [staleList.promise, newerList.promise];
+    let currentSessions: SessionSummary[] = [];
+    const refresher = createSessionListRefresher({
+      listSessions: async () => listCalls.shift() ?? [],
+      readBoundaries: () => readBoundaries,
+      currentSessions: () => currentSessions,
+      commitSessions: (next) => {
+        currentSessions = next;
+      },
+      onError: () => {},
+    });
+
+    rememberSessionReadBoundary(readBoundaries, 's1', [messageAt(200)]);
+    const staleRefresh = refresher.refresh();
+    const newerRefresh = refresher.refresh();
+    newerList.resolve([session({ id: 's1', hasUnread: true, lastMessageAt: 250 })]);
+    await newerRefresh;
+    staleList.resolve([session({ id: 's1', hasUnread: true, lastMessageAt: 200 })]);
+    await staleRefresh;
+
+    assert.equal(currentSessions[0]?.lastMessageAt, 250);
+    assert.equal(currentSessions[0]?.hasUnread, true);
+  });
+
+  it('keeps the current list when the latest list refresh fails', async () => {
+    const readBoundaries: SessionReadBoundaries = {};
+    const original = [session({ id: 's1', hasUnread: true, lastMessageAt: 250 })];
+    const errors: unknown[] = [];
+    let currentSessions = original;
+    const refresher = createSessionListRefresher({
+      listSessions: async () => {
+        throw new Error('list failed');
+      },
+      readBoundaries: () => readBoundaries,
+      currentSessions: () => currentSessions,
+      commitSessions: (next) => {
+        currentSessions = next;
+      },
+      onError: (error) => {
+        errors.push(error);
+      },
+    });
+
+    const result = await refresher.refresh();
+
+    assert.equal(result, original);
+    assert.equal(currentSessions, original);
+    assert.equal(errors.length, 1);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/session-read-state.test.ts
+++ b/apps/desktop/src/main/__tests__/session-read-state.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { SessionSummary, StoredMessage } from '@maka/core';
+import {
+  applySessionReadOverrides,
+  rememberSessionReadBoundary,
+  type SessionReadBoundaries,
+} from '../../renderer/session-read-state.js';
+
+describe('renderer session read state', () => {
+  it('keeps a late stale list response from restoring unread on a locally read session', async () => {
+    const readBoundaries: SessionReadBoundaries = {};
+    const staleList = deferred<SessionSummary[]>();
+
+    const listAfterLocalRead = staleList.promise.then((sessions) => applySessionReadOverrides(sessions, readBoundaries));
+    rememberSessionReadBoundary(readBoundaries, 's1', [messageAt(200)]);
+    staleList.resolve([session({ id: 's1', hasUnread: true, lastMessageAt: 200 })]);
+
+    assert.equal((await listAfterLocalRead)[0]?.hasUnread, false);
+  });
+
+  it('allows a newer message to restore unread after the local read boundary', () => {
+    const readBoundaries: SessionReadBoundaries = {};
+    rememberSessionReadBoundary(readBoundaries, 's1', [messageAt(200)]);
+
+    const [next] = applySessionReadOverrides([
+      session({ id: 's1', hasUnread: true, lastMessageAt: 250 }),
+    ], readBoundaries);
+
+    assert.equal(next?.hasUnread, true);
+  });
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? 'Session',
+    isFlagged: overrides.isFlagged ?? false,
+    isArchived: overrides.isArchived ?? false,
+    labels: overrides.labels ?? [],
+    hasUnread: overrides.hasUnread ?? false,
+    lastMessageAt: overrides.lastMessageAt,
+    lastMessagePreview: overrides.lastMessagePreview,
+    status: overrides.status ?? 'active',
+    blockedReason: overrides.blockedReason,
+    statusUpdatedAt: overrides.statusUpdatedAt,
+    parentSessionId: overrides.parentSessionId,
+    branchOfTurnId: overrides.branchOfTurnId,
+    backend: overrides.backend ?? 'ai-sdk',
+    llmConnectionSlug: overrides.llmConnectionSlug ?? 'default',
+    model: overrides.model ?? 'default',
+    permissionMode: overrides.permissionMode ?? 'ask',
+  };
+}
+
+function messageAt(ts: number): StoredMessage {
+  return {
+    type: 'assistant',
+    id: `m-${ts}`,
+    turnId: `t-${ts}`,
+    ts,
+    text: 'ok',
+    modelId: 'test-model',
+  };
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -3677,10 +3677,10 @@ async function streamEvents(
       if (isTurnStatusChangingSessionEvent(event)) {
         emitSessionsChanged('turn-status-change', sessionId);
       }
-      if (!finalAppendBroadcasted && isFinalSessionEvent(event)) {
-        emitSessionsChanged('message-appended', sessionId);
-        finalAppendBroadcasted = true;
-      }
+    }
+    if (!finalAppendBroadcasted) {
+      emitSessionsChanged('message-appended', sessionId);
+      finalAppendBroadcasted = true;
     }
   } catch (error) {
     const event = {
@@ -3699,6 +3699,7 @@ async function streamEvents(
     emitSessionsChanged('turn-status-change', sessionId);
     if (!finalAppendBroadcasted) {
       emitSessionsChanged('message-appended', sessionId);
+      finalAppendBroadcasted = true;
     }
   }
 }
@@ -4020,10 +4021,10 @@ async function collectBotReply(
       if (isTurnStatusChangingSessionEvent(event)) {
         emitSessionsChanged('turn-status-change', sessionId);
       }
-      if (!finalAppendBroadcasted && isFinalSessionEvent(event)) {
-        emitSessionsChanged('message-appended', sessionId);
-        finalAppendBroadcasted = true;
-      }
+    }
+    if (!finalAppendBroadcasted) {
+      emitSessionsChanged('message-appended', sessionId);
+      finalAppendBroadcasted = true;
     }
   } catch (error) {
     safeSendToRenderer(`sessions:event:${sessionId}`, {
@@ -4038,7 +4039,10 @@ async function collectBotReply(
     } satisfies SessionEvent);
     emitSessionsChanged('status-change', sessionId);
     emitSessionsChanged('turn-status-change', sessionId);
-    if (!finalAppendBroadcasted) emitSessionsChanged('message-appended', sessionId);
+    if (!finalAppendBroadcasted) {
+      emitSessionsChanged('message-appended', sessionId);
+      finalAppendBroadcasted = true;
+    }
     return `Maka 处理失败：${errorMessage(error)}`;
   }
   return latestText;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2622,8 +2622,12 @@ function registerIpc(): void {
     emitSessionsChanged('created', session.id);
     return session;
   });
-  ipcMain.handle('sessions:readMessages', (_event, sessionId: string) =>
-    visualSmokeFixture ? store.readMessages(sessionId) : runtime.getMessages(sessionId));
+  ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
+    if (visualSmokeFixture) return store.readMessages(sessionId);
+    const messages = await runtime.getMessages(sessionId);
+    await runtime.markSessionRead(sessionId).catch(() => {});
+    return messages;
+  });
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
   // PR-SEARCH-2: local thread search. Renderer-facing channel; the pure
   // helper in `./search/thread-search.ts` enforces all gates (G1 snippet

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -52,6 +52,7 @@ import type {
   SessionEvent,
   SessionHeader,
   SessionListFilter,
+  StoredMessage,
   SettingsTestResult,
   UpdateAppSettingsResult,
   UpdateConnectionInput,
@@ -2625,7 +2626,7 @@ function registerIpc(): void {
   ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
     if (visualSmokeFixture) return store.readMessages(sessionId);
     const messages = await runtime.getMessages(sessionId);
-    await runtime.markSessionRead(sessionId);
+    await runtime.markSessionRead(sessionId, latestStoredMessageTs(messages));
     return messages;
   });
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
@@ -4055,6 +4056,14 @@ function isStatusChangingSessionEvent(event: SessionEvent): boolean {
     event.type === 'complete' ||
     event.type === 'abort' ||
     event.type === 'error';
+}
+
+function latestStoredMessageTs(messages: readonly StoredMessage[]): number | undefined {
+  let latest: number | undefined;
+  for (const message of messages) {
+    if (Number.isFinite(message.ts)) latest = latest === undefined ? message.ts : Math.max(latest, message.ts);
+  }
+  return latest;
 }
 
 function isTurnStatusChangingSessionEvent(event: SessionEvent): boolean {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -4001,6 +4001,7 @@ async function collectBotReply(
   let userAppendBroadcasted = false;
   let finalAppendBroadcasted = false;
   let latestText = '';
+  let earlyReply: string | undefined;
   try {
     for await (const event of iterator) {
       if (!userAppendBroadcasted) {
@@ -4010,10 +4011,10 @@ async function collectBotReply(
       safeSendToRenderer(`sessions:event:${sessionId}`, event);
       if (event.type === 'text_complete') latestText = event.text;
       if (event.type === 'permission_request') {
-        return '这条请求需要在 Maka 桌面端审批后才能继续。';
+        earlyReply ??= '这条请求需要在 Maka 桌面端审批后才能继续。';
       }
       if (event.type === 'error') {
-        return `Maka 处理失败：${event.message}`;
+        earlyReply = `Maka 处理失败：${event.message}`;
       }
       if (isStatusChangingSessionEvent(event)) {
         emitSessionsChanged('status-change', sessionId);
@@ -4045,7 +4046,7 @@ async function collectBotReply(
     }
     return `Maka 处理失败：${errorMessage(error)}`;
   }
-  return latestText;
+  return earlyReply ?? latestText;
 }
 
 function isFinalSessionEvent(event: SessionEvent): boolean {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -4011,7 +4011,7 @@ async function collectBotReply(
       safeSendToRenderer(`sessions:event:${sessionId}`, event);
       if (event.type === 'text_complete') latestText = event.text;
       if (event.type === 'permission_request') {
-        earlyReply ??= '这条请求需要在 Maka 桌面端审批后才能继续。';
+        return '这条请求需要在 Maka 桌面端审批后才能继续。';
       }
       if (event.type === 'error') {
         earlyReply = `Maka 处理失败：${event.message}`;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2625,7 +2625,7 @@ function registerIpc(): void {
   ipcMain.handle('sessions:readMessages', async (_event, sessionId: string) => {
     if (visualSmokeFixture) return store.readMessages(sessionId);
     const messages = await runtime.getMessages(sessionId);
-    await runtime.markSessionRead(sessionId).catch(() => {});
+    await runtime.markSessionRead(sessionId);
     return messages;
   });
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
@@ -4047,10 +4047,6 @@ async function collectBotReply(
     return `Maka 处理失败：${errorMessage(error)}`;
   }
   return earlyReply ?? latestText;
-}
-
-function isFinalSessionEvent(event: SessionEvent): boolean {
-  return event.type === 'text_complete' || event.type === 'complete' || event.type === 'abort' || event.type === 'error';
 }
 
 function isStatusChangingSessionEvent(event: SessionEvent): boolean {

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1145,7 +1145,10 @@ function AppShell() {
     }));
     void window.maka.sessions.readMessages(activeId)
       .then((next) => {
-        if (!disposed && activeIdRef.current === activeId) setMessages(next);
+        if (!disposed && activeIdRef.current === activeId) {
+          markSessionReadLocally(activeId);
+          setMessages(next);
+        }
       })
       .catch((error) => {
         if (!disposed && activeIdRef.current === activeId) {
@@ -1277,6 +1280,20 @@ function AppShell() {
   function upsertSessionSummary(session: SessionSummary): void {
     setSessions((current) => {
       const next = [session, ...current.filter((entry) => entry.id !== session.id)];
+      sessionsRef.current = next;
+      return next;
+    });
+  }
+
+  function markSessionReadLocally(sessionId: string): void {
+    setSessions((current) => {
+      let changed = false;
+      const next = current.map((session) => {
+        if (session.id !== sessionId || !session.hasUnread) return session;
+        changed = true;
+        return { ...session, hasUnread: false };
+      });
+      if (!changed) return current;
       sessionsRef.current = next;
       return next;
     });
@@ -2118,6 +2135,7 @@ function AppShell() {
     try {
       const next = await window.maka.sessions.readMessages(sessionId);
       if (activeIdRef.current === sessionId) {
+        markSessionReadLocally(sessionId);
         setMessages(next);
         setMessageLoadErrorBySession((current) => {
           if (!current[sessionId]) return current;
@@ -2158,6 +2176,7 @@ function AppShell() {
         if (activeIdRef.current !== sessionId) return;
         const hasSentUserTurn = next.some((message) => message.type === 'user' && message.turnId === turnId);
         if (hasSentUserTurn) {
+          markSessionReadLocally(sessionId);
           setMessages(next);
           return;
         }

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -99,7 +99,7 @@ import {
   recordSessionEventStreamEvent,
 } from './session-event-health';
 import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
-import { applySessionReadOverrides, rememberSessionReadBoundary, type SessionReadBoundaries } from './session-read-state';
+import { createSessionListRefresher, rememberSessionReadBoundary, type SessionListRefresher, type SessionReadBoundaries } from './session-read-state';
 import './styles.css';
 
 const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
@@ -257,6 +257,21 @@ function AppShell() {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const sessionsRef = useRef<SessionSummary[]>([]);
   const sessionReadBoundariesRef = useRef<SessionReadBoundaries>({});
+  const sessionListRefresherRef = useRef<SessionListRefresher | null>(null);
+  if (!sessionListRefresherRef.current) {
+    sessionListRefresherRef.current = createSessionListRefresher({
+      listSessions: () => window.maka.sessions.list(),
+      readBoundaries: () => sessionReadBoundariesRef.current,
+      currentSessions: () => sessionsRef.current,
+      commitSessions: (next) => {
+        sessionsRef.current = next;
+        setSessions(next);
+      },
+      onError: (error) => {
+        toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
+      },
+    });
+  }
   const [activeId, setActiveIdState] = useState<string | undefined>();
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
@@ -1245,16 +1260,7 @@ function AppShell() {
   }, [navSelection]);
 
   async function refreshSessions(): Promise<SessionSummary[]> {
-    try {
-      const listed = await window.maka.sessions.list();
-      const next = applySessionReadOverrides(listed, sessionReadBoundariesRef.current);
-      sessionsRef.current = next;
-      setSessions(next);
-      return next;
-    } catch (error) {
-      toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
-      return sessionsRef.current;
-    }
+    return sessionListRefresherRef.current!.refresh();
   }
 
   async function refreshShellSettings() {

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -99,7 +99,7 @@ import {
   recordSessionEventStreamEvent,
 } from './session-event-health';
 import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
-import { createSessionListRefresher, rememberSessionReadBoundary, type SessionListRefresher, type SessionReadBoundaries } from './session-read-state';
+import { applyLocalSessionRead, createSessionListRefresher, type SessionListRefresher, type SessionReadBoundaries } from './session-read-state';
 import './styles.css';
 
 const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
@@ -1295,20 +1295,8 @@ function AppShell() {
   }
 
   function markSessionReadLocally(sessionId: string, readMessages: readonly StoredMessage[]): void {
-    rememberSessionReadBoundary(
-      sessionReadBoundariesRef.current,
-      sessionId,
-      readMessages,
-      sessionsRef.current.find((session) => session.id === sessionId)?.lastMessageAt,
-    );
     setSessions((current) => {
-      let changed = false;
-      const next = current.map((session) => {
-        if (session.id !== sessionId || !session.hasUnread) return session;
-        changed = true;
-        return { ...session, hasUnread: false };
-      });
-      if (!changed) return current;
+      const next = applyLocalSessionRead(sessionReadBoundariesRef.current, current, sessionId, readMessages);
       sessionsRef.current = next;
       return next;
     });

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -99,6 +99,7 @@ import {
   recordSessionEventStreamEvent,
 } from './session-event-health';
 import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
+import { applySessionReadOverrides, rememberSessionReadBoundary, type SessionReadBoundaries } from './session-read-state';
 import './styles.css';
 
 const NO_REAL_CONNECTION_CODE = 'NO_REAL_CONNECTION';
@@ -255,6 +256,7 @@ function AppShell() {
   const toastApi = useToast();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const sessionsRef = useRef<SessionSummary[]>([]);
+  const sessionReadBoundariesRef = useRef<SessionReadBoundaries>({});
   const [activeId, setActiveIdState] = useState<string | undefined>();
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
@@ -1146,7 +1148,7 @@ function AppShell() {
     void window.maka.sessions.readMessages(activeId)
       .then((next) => {
         if (!disposed && activeIdRef.current === activeId) {
-          markSessionReadLocally(activeId);
+          markSessionReadLocally(activeId, next);
           setMessages(next);
         }
       })
@@ -1244,7 +1246,8 @@ function AppShell() {
 
   async function refreshSessions(): Promise<SessionSummary[]> {
     try {
-      const next = await window.maka.sessions.list();
+      const listed = await window.maka.sessions.list();
+      const next = applySessionReadOverrides(listed, sessionReadBoundariesRef.current);
       sessionsRef.current = next;
       setSessions(next);
       return next;
@@ -1285,7 +1288,13 @@ function AppShell() {
     });
   }
 
-  function markSessionReadLocally(sessionId: string): void {
+  function markSessionReadLocally(sessionId: string, readMessages: readonly StoredMessage[]): void {
+    rememberSessionReadBoundary(
+      sessionReadBoundariesRef.current,
+      sessionId,
+      readMessages,
+      sessionsRef.current.find((session) => session.id === sessionId)?.lastMessageAt,
+    );
     setSessions((current) => {
       let changed = false;
       const next = current.map((session) => {
@@ -2135,7 +2144,7 @@ function AppShell() {
     try {
       const next = await window.maka.sessions.readMessages(sessionId);
       if (activeIdRef.current === sessionId) {
-        markSessionReadLocally(sessionId);
+        markSessionReadLocally(sessionId, next);
         setMessages(next);
         setMessageLoadErrorBySession((current) => {
           if (!current[sessionId]) return current;
@@ -2176,7 +2185,7 @@ function AppShell() {
         if (activeIdRef.current !== sessionId) return;
         const hasSentUserTurn = next.some((message) => message.type === 'user' && message.turnId === turnId);
         if (hasSentUserTurn) {
-          markSessionReadLocally(sessionId);
+          markSessionReadLocally(sessionId, next);
           setMessages(next);
           return;
         }

--- a/apps/desktop/src/renderer/session-read-state.ts
+++ b/apps/desktop/src/renderer/session-read-state.ts
@@ -7,7 +7,7 @@ export interface SessionListRefresher {
 }
 
 export interface SessionListRefresherOptions {
-  listSessions: () => Promise<readonly SessionSummary[]>;
+  listSessions: () => Promise<SessionSummary[]>;
   readBoundaries: () => Readonly<SessionReadBoundaries>;
   currentSessions: () => SessionSummary[];
   commitSessions: (sessions: SessionSummary[]) => void;
@@ -25,7 +25,7 @@ export function rememberSessionReadBoundary(
 }
 
 export function applySessionReadOverrides(
-  sessions: readonly SessionSummary[],
+  sessions: SessionSummary[],
   boundaries: Readonly<SessionReadBoundaries>,
 ): SessionSummary[] {
   let changed = false;
@@ -36,12 +36,12 @@ export function applySessionReadOverrides(
     changed = true;
     return { ...session, hasUnread: false };
   });
-  return changed ? next : [...sessions];
+  return changed ? next : sessions;
 }
 
 export function applyLocalSessionRead(
   boundaries: SessionReadBoundaries,
-  sessions: readonly SessionSummary[],
+  sessions: SessionSummary[],
   sessionId: string,
   readMessages: readonly StoredMessage[],
 ): SessionSummary[] {

--- a/apps/desktop/src/renderer/session-read-state.ts
+++ b/apps/desktop/src/renderer/session-read-state.ts
@@ -2,6 +2,18 @@ import type { SessionSummary, StoredMessage } from '@maka/core';
 
 export type SessionReadBoundaries = Record<string, number>;
 
+export interface SessionListRefresher {
+  refresh(): Promise<SessionSummary[]>;
+}
+
+export interface SessionListRefresherOptions {
+  listSessions: () => Promise<readonly SessionSummary[]>;
+  readBoundaries: () => Readonly<SessionReadBoundaries>;
+  currentSessions: () => SessionSummary[];
+  commitSessions: (sessions: SessionSummary[]) => void;
+  onError: (error: unknown) => void;
+}
+
 export function rememberSessionReadBoundary(
   boundaries: SessionReadBoundaries,
   sessionId: string,
@@ -26,6 +38,25 @@ export function applySessionReadOverrides(
     return { ...session, hasUnread: false };
   });
   return changed ? next : [...sessions];
+}
+
+export function createSessionListRefresher(options: SessionListRefresherOptions): SessionListRefresher {
+  let latestRequestId = 0;
+  return {
+    async refresh(): Promise<SessionSummary[]> {
+      const requestId = ++latestRequestId;
+      try {
+        const listed = await options.listSessions();
+        if (requestId !== latestRequestId) return options.currentSessions();
+        const next = applySessionReadOverrides(listed, options.readBoundaries());
+        options.commitSessions(next);
+        return next;
+      } catch (error) {
+        if (requestId === latestRequestId) options.onError(error);
+        return options.currentSessions();
+      }
+    },
+  };
 }
 
 function latestMessageTs(messages: readonly StoredMessage[]): number | undefined {

--- a/apps/desktop/src/renderer/session-read-state.ts
+++ b/apps/desktop/src/renderer/session-read-state.ts
@@ -1,0 +1,38 @@
+import type { SessionSummary, StoredMessage } from '@maka/core';
+
+export type SessionReadBoundaries = Record<string, number>;
+
+export function rememberSessionReadBoundary(
+  boundaries: SessionReadBoundaries,
+  sessionId: string,
+  messages: readonly StoredMessage[],
+  fallbackLastMessageAt?: number,
+): void {
+  const boundary = latestMessageTs(messages) ?? fallbackLastMessageAt;
+  if (boundary === undefined) return;
+  boundaries[sessionId] = Math.max(boundaries[sessionId] ?? 0, boundary);
+}
+
+export function applySessionReadOverrides(
+  sessions: readonly SessionSummary[],
+  boundaries: Readonly<SessionReadBoundaries>,
+): SessionSummary[] {
+  let changed = false;
+  const next = sessions.map((session) => {
+    const boundary = boundaries[session.id];
+    if (boundary === undefined || !session.hasUnread) return session;
+    if ((session.lastMessageAt ?? 0) > boundary) return session;
+    changed = true;
+    return { ...session, hasUnread: false };
+  });
+  return changed ? next : [...sessions];
+}
+
+function latestMessageTs(messages: readonly StoredMessage[]): number | undefined {
+  let latest: number | undefined;
+  for (const message of messages) {
+    if (!Number.isFinite(message.ts)) continue;
+    latest = latest === undefined ? message.ts : Math.max(latest, message.ts);
+  }
+  return latest;
+}

--- a/apps/desktop/src/renderer/session-read-state.ts
+++ b/apps/desktop/src/renderer/session-read-state.ts
@@ -18,9 +18,8 @@ export function rememberSessionReadBoundary(
   boundaries: SessionReadBoundaries,
   sessionId: string,
   messages: readonly StoredMessage[],
-  fallbackLastMessageAt?: number,
 ): void {
-  const boundary = latestMessageTs(messages) ?? fallbackLastMessageAt;
+  const boundary = latestMessageTs(messages);
   if (boundary === undefined) return;
   boundaries[sessionId] = Math.max(boundaries[sessionId] ?? 0, boundary);
 }
@@ -38,6 +37,16 @@ export function applySessionReadOverrides(
     return { ...session, hasUnread: false };
   });
   return changed ? next : [...sessions];
+}
+
+export function applyLocalSessionRead(
+  boundaries: SessionReadBoundaries,
+  sessions: readonly SessionSummary[],
+  sessionId: string,
+  readMessages: readonly StoredMessage[],
+): SessionSummary[] {
+  rememberSessionReadBoundary(boundaries, sessionId, readMessages);
+  return applySessionReadOverrides(sessions, boundaries);
 }
 
 export function createSessionListRefresher(options: SessionListRefresherOptions): SessionListRefresher {

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -676,6 +676,12 @@ class ReadOnlyStore implements SessionStore {
     return { ...makeHeader(id), ...patch };
   }
 
+  async markSessionReadThrough(id: string, readThroughTs: number): Promise<SessionHeader> {
+    const header = makeHeader(id);
+    if (!Number.isFinite(readThroughTs) || !header.hasUnread || (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs)) return header;
+    return { ...header, hasUnread: false };
+  }
+
   async archive(_sessionId: string): Promise<void> {}
   async unarchive(_sessionId: string): Promise<void> {}
   async setFlagged(_sessionId: string, _isFlagged: boolean): Promise<void> {}

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -365,6 +365,21 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).hasUnread).toBe(false);
   });
 
+  test('markSessionRead rejects when the unread header write fails', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_632) });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { hasUnread: true });
+    store.failUpdateHeaderFor.add(session.id);
+
+    await expectRejects(manager.markSessionRead(session.id), /Cannot update header/);
+
+    store.failUpdateHeaderFor.delete(session.id);
+    expect((await store.readHeader(session.id)).hasUnread).toBe(true);
+  });
+
   test('runtime event ledger write failure does not fail sendMessage', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -3016,6 +3031,7 @@ class MemorySessionStore implements SessionStore {
   readonly failReadMessagesFor = new Set<string>();
   readonly failNextReadMessagesFor = new Map<string, number>();
   readonly failListTurnsFor = new Set<string>();
+  readonly failUpdateHeaderFor = new Set<string>();
   disposeCount = 0;
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {
@@ -3082,6 +3098,7 @@ class MemorySessionStore implements SessionStore {
   }
 
   async updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader> {
+    if (this.failUpdateHeaderFor.has(sessionId)) throw new Error(`Cannot update header for ${sessionId}`);
     const current = await this.readHeader(sessionId);
     const next = { ...current, ...patch };
     this.headers.set(sessionId, next);

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -330,7 +330,7 @@ describe('SessionManager permission mode updates', () => {
     await iterator.next();
   });
 
-  test('reading messages clears the session unread marker', async () => {
+  test('reading messages keeps the session unread marker as a pure query', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -348,6 +348,19 @@ describe('SessionManager permission mode updates', () => {
     await store.updateHeader(session.id, { hasUnread: true });
 
     await manager.getMessages(session.id);
+
+    expect((await store.readHeader(session.id)).hasUnread).toBe(true);
+  });
+
+  test('markSessionRead clears the session unread marker', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_631) });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { hasUnread: true });
+
+    await manager.markSessionRead(session.id);
 
     expect((await store.readHeader(session.id)).hasUnread).toBe(false);
   });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -358,23 +358,36 @@ describe('SessionManager permission mode updates', () => {
     backends.register('fake', (ctx) => new TestBackend(ctx));
     const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_631) });
     const session = await manager.createSession(makeInput());
-    await store.updateHeader(session.id, { hasUnread: true });
+    await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 200 });
 
-    await manager.markSessionRead(session.id);
+    await manager.markSessionRead(session.id, 200);
 
     expect((await store.readHeader(session.id)).hasUnread).toBe(false);
+  });
+
+  test('markSessionRead keeps unread when a newer message arrives after the read boundary', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_632) });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 250 });
+
+    await manager.markSessionRead(session.id, 200);
+
+    expect((await store.readHeader(session.id)).hasUnread).toBe(true);
   });
 
   test('markSessionRead rejects when the unread header write fails', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
-    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_632) });
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_633) });
     const session = await manager.createSession(makeInput());
-    await store.updateHeader(session.id, { hasUnread: true });
+    await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 200 });
     store.failUpdateHeaderFor.add(session.id);
 
-    await expectRejects(manager.markSessionRead(session.id), /Cannot update header/);
+    await expectRejects(manager.markSessionRead(session.id, 200), /Cannot update header/);
 
     store.failUpdateHeaderFor.delete(session.id);
     expect((await store.readHeader(session.id)).hasUnread).toBe(true);

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -378,11 +378,29 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).hasUnread).toBe(true);
   });
 
-  test('markSessionRead rejects when the unread header write fails', async () => {
+  test('markSessionRead keeps unread when a newer message finalizes between the read check and write', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
     backends.register('fake', (ctx) => new TestBackend(ctx));
     const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_633) });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 200 });
+    store.interleaveBeforeMarkSessionReadWriteFor.set(session.id, async () => {
+      await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 250 });
+    });
+
+    await manager.markSessionRead(session.id, 200);
+
+    const header = await store.readHeader(session.id);
+    expect(header.lastMessageAt).toBe(250);
+    expect(header.hasUnread).toBe(true);
+  });
+
+  test('markSessionRead rejects when the unread header write fails', async () => {
+    const store = new MemorySessionStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({ store, backends, newId: nextId(), now: nextNow(6_634) });
     const session = await manager.createSession(makeInput());
     await store.updateHeader(session.id, { hasUnread: true, lastMessageAt: 200 });
     store.failUpdateHeaderFor.add(session.id);
@@ -3045,6 +3063,7 @@ class MemorySessionStore implements SessionStore {
   readonly failNextReadMessagesFor = new Map<string, number>();
   readonly failListTurnsFor = new Set<string>();
   readonly failUpdateHeaderFor = new Set<string>();
+  readonly interleaveBeforeMarkSessionReadWriteFor = new Map<string, () => Promise<void> | void>();
   disposeCount = 0;
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {
@@ -3083,6 +3102,7 @@ class MemorySessionStore implements SessionStore {
   async readHeader(sessionId: string): Promise<SessionHeader> {
     const header = this.headers.get(sessionId);
     if (!header) throw new Error(`Unknown session ${sessionId}`);
+    await this.runMarkSessionReadInterleave(sessionId);
     return header;
   }
 
@@ -3116,6 +3136,24 @@ class MemorySessionStore implements SessionStore {
     const next = { ...current, ...patch };
     this.headers.set(sessionId, next);
     return next;
+  }
+
+  async markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader> {
+    await this.runMarkSessionReadInterleave(sessionId);
+    if (this.failUpdateHeaderFor.has(sessionId)) throw new Error(`Cannot update header for ${sessionId}`);
+    const current = await this.readHeader(sessionId);
+    if (!current.hasUnread) return current;
+    if (current.lastMessageAt !== undefined && current.lastMessageAt > readThroughTs) return current;
+    const next = { ...current, hasUnread: false };
+    this.headers.set(sessionId, next);
+    return next;
+  }
+
+  private async runMarkSessionReadInterleave(sessionId: string): Promise<void> {
+    const hook = this.interleaveBeforeMarkSessionReadWriteFor.get(sessionId);
+    if (!hook) return;
+    this.interleaveBeforeMarkSessionReadWriteFor.delete(sessionId);
+    await hook();
   }
 
   async archive(sessionId: string): Promise<void> {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -330,6 +330,28 @@ describe('SessionManager permission mode updates', () => {
     await iterator.next();
   });
 
+  test('reading messages clears the session unread marker', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_630),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { hasUnread: true });
+
+    await manager.getMessages(session.id);
+
+    expect((await store.readHeader(session.id)).hasUnread).toBe(false);
+  });
+
   test('runtime event ledger write failure does not fail sendMessage', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -354,9 +354,11 @@ export class SessionManager {
     if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
   }
 
-  async markSessionRead(sessionId: string): Promise<void> {
+  async markSessionRead(sessionId: string, readThroughTs: number | undefined): Promise<void> {
+    if (readThroughTs === undefined || !Number.isFinite(readThroughTs)) return;
     const header = await this.deps.store.readHeader(sessionId);
     if (!header.hasUnread) return;
+    if (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs) return;
     const next = await this.deps.store.updateHeader(sessionId, { hasUnread: false });
     this.runtimeKernel.updateCachedHeader(sessionId, next);
   }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -250,7 +250,9 @@ export class SessionManager {
   }
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {
-    return (await this.readModel().getSessionView(sessionId)).messages;
+    const view = await this.readModel().getSessionView(sessionId);
+    await this.markSessionRead(sessionId).catch(() => {});
+    return view.messages;
   }
 
   async listTurns(sessionId: string): Promise<TurnRecord[]> {
@@ -352,6 +354,13 @@ export class SessionManager {
     await this.deps.store.setFlagged(sessionId, isFlagged);
     const header = await this.deps.store.readHeader(sessionId).catch(() => undefined);
     if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
+  }
+
+  private async markSessionRead(sessionId: string): Promise<void> {
+    const header = await this.deps.store.readHeader(sessionId);
+    if (!header.hasUnread) return;
+    const next = await this.deps.store.updateHeader(sessionId, { hasUnread: false });
+    this.runtimeKernel.updateCachedHeader(sessionId, next);
   }
 
   async renameSession(sessionId: string, name: string): Promise<void> {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -250,9 +250,7 @@ export class SessionManager {
   }
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {
-    const view = await this.readModel().getSessionView(sessionId);
-    await this.markSessionRead(sessionId).catch(() => {});
-    return view.messages;
+    return (await this.readModel().getSessionView(sessionId)).messages;
   }
 
   async listTurns(sessionId: string): Promise<TurnRecord[]> {
@@ -356,7 +354,7 @@ export class SessionManager {
     if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
   }
 
-  private async markSessionRead(sessionId: string): Promise<void> {
+  async markSessionRead(sessionId: string): Promise<void> {
     const header = await this.deps.store.readHeader(sessionId);
     if (!header.hasUnread) return;
     const next = await this.deps.store.updateHeader(sessionId, { hasUnread: false });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -160,6 +160,7 @@ export interface SessionStore {
   appendMessage(sessionId: string, m: StoredMessage): Promise<void>;
   appendMessages(sessionId: string, ms: StoredMessage[]): Promise<void>;
   updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader>;
+  markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader>;
   archive(sessionId: string): Promise<void>;
   unarchive(sessionId: string): Promise<void>;
   setFlagged(sessionId: string, isFlagged: boolean): Promise<void>;
@@ -356,10 +357,7 @@ export class SessionManager {
 
   async markSessionRead(sessionId: string, readThroughTs: number | undefined): Promise<void> {
     if (readThroughTs === undefined || !Number.isFinite(readThroughTs)) return;
-    const header = await this.deps.store.readHeader(sessionId);
-    if (!header.hasUnread) return;
-    if (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs) return;
-    const next = await this.deps.store.updateHeader(sessionId, { hasUnread: false });
+    const next = await this.deps.store.markSessionReadThrough(sessionId, readThroughTs);
     this.runtimeKernel.updateCachedHeader(sessionId, next);
   }
 

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -69,6 +69,23 @@ describe('FileSessionStore CRUD', () => {
     });
   });
 
+  test('markSessionReadThrough clears unread only through the current last message', async () => {
+    await withStore(async (store) => {
+      const header = await store.create(makeInput({ name: 'Unread' }));
+      await store.updateHeader(header.id, { hasUnread: true, lastMessageAt: 250 });
+
+      const unchanged = await store.markSessionReadThrough(header.id, 200);
+      assert.equal(unchanged.lastMessageAt, 250);
+      assert.equal(unchanged.hasUnread, true);
+      assert.equal((await store.readHeader(header.id)).hasUnread, true);
+
+      const cleared = await store.markSessionReadThrough(header.id, 250);
+      assert.equal(cleared.lastMessageAt, 250);
+      assert.equal(cleared.hasUnread, false);
+      assert.equal((await store.readHeader(header.id)).hasUnread, false);
+    });
+  });
+
   test('rename trims whitespace, rejects empty strings, and caps absurd lengths', async () => {
     await withStore(async (store) => {
       const header = await store.create(makeInput({ name: 'Old' }));

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput, SessionHeader } from '@maka/core';
+import type { CreateSessionInput, SessionHeader, StoredMessage } from '@maka/core';
 import { createSessionStore } from '../session-store.js';
 
 describe('FileSessionStore CRUD', () => {
@@ -84,6 +84,25 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(cleared.hasUnread, false);
       assert.equal((await store.readHeader(header.id)).hasUnread, false);
     });
+  });
+
+  test('markSessionReadThrough uses visible message timestamps when header lastMessageAt is stale', async () => {
+    for (const headerLastMessageAt of [100, undefined]) {
+      await withStore(async (store) => {
+        const header = await store.create(makeInput({ name: 'Stale unread' }));
+        await store.appendMessage(header.id, assistantMessageAt(250));
+        await store.updateHeader(header.id, { hasUnread: true, lastMessageAt: headerLastMessageAt });
+
+        const unchanged = await store.markSessionReadThrough(header.id, 200);
+        assert.equal(unchanged.hasUnread, true);
+        assert.equal((await store.list())[0]?.lastMessageAt, 250);
+        assert.equal((await store.readHeader(header.id)).hasUnread, true);
+
+        const cleared = await store.markSessionReadThrough(header.id, 250);
+        assert.equal(cleared.hasUnread, false);
+        assert.equal((await store.readHeader(header.id)).hasUnread, false);
+      });
+    }
   });
 
   test('rename trims whitespace, rejects empty strings, and caps absurd lengths', async () => {
@@ -718,6 +737,17 @@ function makeRawHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
     permissionMode: 'ask',
     schemaVersion: 1,
     ...overrides,
+  };
+}
+
+function assistantMessageAt(ts: number): StoredMessage {
+  return {
+    type: 'assistant',
+    id: `assistant-${ts}`,
+    turnId: `turn-${ts}`,
+    ts,
+    text: 'ok',
+    modelId: 'fake-model',
   };
 }
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -175,7 +175,8 @@ class FileSessionStore implements SessionStore {
     let nextHeader: SessionHeader | undefined;
     await this.withQueue(sessionId, async () => {
       const { header, messages } = await this.readFilePartsUnlocked(sessionId);
-      if (!Number.isFinite(readThroughTs) || !header.hasUnread || (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs)) {
+      const effectiveLastMessageAt = maxTimestamp(header.lastMessageAt, latestVisibleMessageAt(messages));
+      if (!Number.isFinite(readThroughTs) || !header.hasUnread || (effectiveLastMessageAt !== undefined && effectiveLastMessageAt > readThroughTs)) {
         nextHeader = header;
         return;
       }

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -23,6 +23,7 @@ export interface SessionStore {
   appendMessage(sessionId: string, message: StoredMessage): Promise<void>;
   appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void>;
   updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader>;
+  markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader>;
   archive(sessionId: string): Promise<void>;
   unarchive(sessionId: string): Promise<void>;
   setFlagged(sessionId: string, isFlagged: boolean): Promise<void>;
@@ -163,6 +164,22 @@ class FileSessionStore implements SessionStore {
     await this.withQueue(sessionId, async () => {
       const { header, messages } = await this.readFilePartsUnlocked(sessionId);
       nextHeader = { ...header, ...patch };
+      const lines = [JSON.stringify(nextHeader), ...messages.map((message) => JSON.stringify(message))];
+      await this.writeAtomic(this.sessionPath(sessionId), lines.join('\n') + '\n');
+    });
+    if (!nextHeader) throw new Error(`Failed to update session ${sessionId}`);
+    return nextHeader;
+  }
+
+  async markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader> {
+    let nextHeader: SessionHeader | undefined;
+    await this.withQueue(sessionId, async () => {
+      const { header, messages } = await this.readFilePartsUnlocked(sessionId);
+      if (!Number.isFinite(readThroughTs) || !header.hasUnread || (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs)) {
+        nextHeader = header;
+        return;
+      }
+      nextHeader = { ...header, hasUnread: false };
       const lines = [JSON.stringify(nextHeader), ...messages.map((message) => JSON.stringify(message))];
       await this.writeAtomic(this.sessionPath(sessionId), lines.join('\n') + '\n');
     });


### PR DESCRIPTION
## Summary

- Clear a session unread marker persistently when the renderer reads that session messages.
- Keep `SessionManager.getMessages()` as a pure query so thread search and the open gateway do not mark sessions read.
- Optimistically clear the renderer sidebar row after active-session message loads so the unread dot disappears immediately.
- Preserve local read state across stale `sessions:list` responses and stale local read results while allowing newer messages to become unread again.
- Apply latest-wins ordering to concurrent session-list refreshes so older list responses cannot hide newer unread output.
- Mark sessions read atomically only through the effective message timestamp actually read, so output appended before or during mark-read remains unread.
- Delay final message refresh broadcasts until after runtime iterator drain/finalize, so active sessions can clear the final `hasUnread: true` write.

## Why

Unread dots should mean there is agent output the user has not viewed yet. Opening a session is the read boundary; background reads from search or the open gateway must not mutate persisted unread state. Final refreshes must happen after runtime finalization, and older list/read responses or non-atomic persisted writes must not overwrite newer unread state.

## Scope

Changed:

- Added store-level `markSessionReadThrough(sessionId, readThroughTs)` so the latest header and visible message timestamps are read and conditionally written inside one queued storage operation.
- Added `SessionManager.markSessionRead(sessionId, readThroughTs)` for the explicit persisted read boundary.
- Wired `sessions:readMessages` IPC to mark the session read after a successful message read, using the max `ts` returned by that read and without swallowing persistence failures.
- Updated renderer local session state after active-session message reads.
- Added renderer read-boundary tracking so late stale list responses and late stale read results cannot clear unread for newer messages.
- Added latest-wins ordering for concurrent session-list refreshes.
- Kept shared `getMessages()` pure for thread search/open gateway reads.
- Moved final `message-appended` refresh broadcasts in the normal stream path to after iterator drain.
- Kept bot permission handoff replies immediate, while terminal bot errors drain before returning.
- Removed the unused `isFinalSessionEvent()` helper and narrowed brittle renderer source-shape assertions.
- Avoided unnecessary session-list array copies when read overrides do not change anything.
- Added runtime, storage, and desktop behavior coverage for mark-read behavior, atomic persisted read-through, stale header timestamp handling, read-boundary isolation, stale-list ordering, stale local-read ordering, latest-wins list refreshes, and final-refresh ordering.

Not included:

- No CSS/sidebar restyling, to avoid overlapping PR #269 renderer style split.
- No schema migration or bulk cleanup of historical unread markers.

## Verification

- `apps/desktop$ npx tsx --test src/main/__tests__/permission-response-ipc-boundary.test.ts`
- `apps/desktop$ npx tsx --test src/main/__tests__/session-message-lifecycle-contract.test.ts`
- `apps/desktop$ npx tsx --test src/main/__tests__/session-read-state.test.ts`
- `npx tsx --test apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts`
- `npx tsx --test packages/runtime/src/__tests__/session-manager.test.ts`
- `npx tsx --test packages/runtime/src/__tests__/runtime-event-read-model.test.ts`
- `npx tsx --test packages/storage/src/__tests__/session-store.test.ts`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/storage run build`
- `npm run typecheck --workspaces --if-present`
- `git diff --check`

## User-facing impact

Opening a session now clears its unread marker and persists that state across restarts only for messages actually read. Background search and open-gateway reads keep unread state intact. Active sessions should not show stale unread markers, and background/newer output should not be hidden by stale header timestamps, older session-list, local-read, or persisted mark-read races. No `CHANGELOG.md`, docs, breaking changes, or migrations.

## Reviewer notes

- Claude review found one P1 boundary issue in the initial implementation: `getMessages()` was clearing unread for shared read paths. Fixed by moving persisted mark-read to `sessions:readMessages` IPC.
- Claude re-review found no P0/P1/P2 issues.
- Fresh-eye subagent review found a finalization race where active sessions could be written back to unread after an early final refresh. Fixed by broadcasting final `message-appended` after iterator drain/finalize.
- Fresh-eye subagent follow-up found bot permission handoff would regress if it waited for drain. Fixed by preserving immediate permission handoff replies while still draining terminal bot errors before returning.
- Fresh-eye final gate review found no P0/P1/P2 issues.
- Review follow-up fixed a stale-list read-boundary race, stopped swallowing mark-read persistence failures, and removed a dead final-event helper.
- Follow-up fixed concurrent `sessions.list()` latest-wins ordering, added mark-read read-through protection, and replaced brittle renderer source-shape assertions with behavior tests for the list refresh race.
- Follow-up fixed the renderer local-read race where an older `readMessages()` result could clear unread for newer output.
- Follow-up fixed the persisted mark-read race by moving read-through comparison into the storage queued write, and handled the P3 no-op list copy.
- Latest review follow-up aligned storage mark-read with sidebar summary timestamp derivation for stale headers.
- GitHub reports no checks for this branch.
