### PR TITLE
[codex] Redact tool telemetry args summaries

### DIFF
--- a/packages/core/src/__tests__/redaction.test.ts
+++ b/packages/core/src/__tests__/redaction.test.ts
@@ -23,6 +23,45 @@ describe('redactSecrets', () => {
     assert.match(text, /timeout=30/);
     assert.equal(text.includes('secret-value'), false);
   });
+
+  test('masks quoted sensitive object keys in serialized JSON', () => {
+    const text = redactSecrets(JSON.stringify({
+      authorization: 'Bearer opaque-session-value',
+      apiKey: 'plain-provider-key',
+      password: 'correct-horse-battery-staple',
+      nested: {
+        accessToken: 'nested-token-value',
+      },
+      keep: 'visible',
+    }));
+
+    assert.match(text, /"authorization":"\[redacted\]"/);
+    assert.match(text, /"apiKey":"\[redacted\]"/);
+    assert.match(text, /"password":"\[redacted\]"/);
+    assert.match(text, /"accessToken":"\[redacted\]"/);
+    assert.match(text, /"keep":"visible"/);
+    assert.equal(text.includes('opaque-session-value'), false);
+    assert.equal(text.includes('plain-provider-key'), false);
+    assert.equal(text.includes('correct-horse-battery-staple'), false);
+    assert.equal(text.includes('nested-token-value'), false);
+  });
+
+  test('masks escaped and non-string sensitive JSON values structurally', () => {
+    const text = redactSecrets(JSON.stringify({
+      password: 'abc"def\\ghi',
+      token: 12345,
+      secret: { raw: 'object value should not leak' },
+      keep: 'visible',
+    }));
+
+    assert.match(text, /"password":"\[redacted\]"/);
+    assert.match(text, /"token":"\[redacted\]"/);
+    assert.match(text, /"secret":"\[redacted\]"/);
+    assert.match(text, /"keep":"visible"/);
+    assert.equal(text.includes('abc'), false);
+    assert.equal(text.includes('def'), false);
+    assert.equal(text.includes('object value should not leak'), false);
+  });
 });
 
 describe('generalizedErrorMessage', () => {

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -1,6 +1,10 @@
+const SECRET_KEY_VALUE_PATTERNS: RegExp[] = [
+  /((?:"(?:x-api-key|api-key|api_key|apiKey|access_token|accessToken|auth|authorization|token|password|secret)"\s*:\s*"))(?:\\.|[^"\\])*/gi,
+  /\b((?:x-api-key|api-key|api_key|apiKey|access_token|accessToken|token|password|secret)\s*[:=]\s*['"]?)[^\s"'&<>]+/gi,
+];
+
 const SECRET_PATTERNS: RegExp[] = [
   /\b(authorization:\s*(?:bearer|basic|token)\s+)[^\s"'<>]+/gi,
-  /\b((?:x-api-key|api-key|api_key|access_token|token|password|secret)\s*[:=]\s*)[^\s"'&<>]+/gi,
   /\b(sk-(?:ant-)?[a-z0-9_-]{8,})\b/gi,
   /\b(AIza[0-9A-Za-z_-]{20,})\b/g,
   /\b(gh[pousr]_[0-9A-Za-z_]{20,})\b/g,
@@ -9,7 +13,11 @@ const SECRET_PATTERNS: RegExp[] = [
 ];
 
 export function redactSecrets(value: string): string {
-  let next = redactUrlQuerySecrets(value);
+  let next = redactSerializedJsonSecrets(value);
+  next = redactUrlQuerySecrets(next);
+  for (const pattern of SECRET_KEY_VALUE_PATTERNS) {
+    next = next.replace(pattern, (_match, prefix: string) => `${prefix}[redacted]`);
+  }
   for (const pattern of SECRET_PATTERNS) {
     next = next.replace(pattern, (_match, prefixOrSecret: string) => {
       if (prefixOrSecret.includes(':') || prefixOrSecret.includes('=')) return `${prefixOrSecret}[redacted]`;
@@ -17,6 +25,46 @@ export function redactSecrets(value: string): string {
     });
   }
   return next;
+}
+
+function redactSerializedJsonSecrets(value: string): string {
+  const trimmed = value.trim();
+  if (!((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']')))) {
+    return value;
+  }
+  try {
+    const redacted = redactJsonValue(JSON.parse(value));
+    return redacted.changed ? JSON.stringify(redacted.value) : value;
+  } catch {
+    return value;
+  }
+}
+
+function redactJsonValue(value: unknown): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const redacted = redactJsonValue(item);
+      changed = changed || redacted.changed;
+      return redacted.value;
+    });
+    return { value: next, changed };
+  }
+  if (!value || typeof value !== 'object') return { value, changed: false };
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (isSensitiveKey(key)) {
+      next[key] = '[redacted]';
+      changed = true;
+      continue;
+    }
+    const redacted = redactJsonValue(raw);
+    next[key] = redacted.value;
+    changed = changed || redacted.changed;
+  }
+  return { value: next, changed };
 }
 
 function redactUrlQuerySecrets(value: string): string {
@@ -27,7 +75,7 @@ function redactUrlQuerySecrets(value: string): string {
 }
 
 function isSensitiveKey(key: string): boolean {
-  return /^(api[_-]?key|key|token|access[_-]?token|auth|authorization|password|secret)$/i.test(key);
+  return /^(x-api-key|api[_-]?key|key|token|access[_-]?token|auth|authorization|password|secret)$/i.test(key);
 }
 
 export function generalizedErrorMessage(error: unknown, fallback = 'Operation failed'): string {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2661,7 +2661,7 @@ describe('AiSdkBackend tool permission category hints', () => {
   test('permissionRequired=false fast path preserves tool-call/result ordering and telemetry', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];
-    const telemetry: Array<{ status: string; toolCallId?: string }> = [];
+    const telemetry: Array<{ status: string; toolCallId?: string; argsSummary?: string }> = [];
     let implCalled = false;
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
@@ -2678,7 +2678,7 @@ describe('AiSdkBackend tool permission category hints', () => {
       newId: idGenerator(),
       now: monotonicClock(),
       recordToolInvocation: (record) => {
-        telemetry.push({ status: record.status, toolCallId: record.toolCallId });
+        telemetry.push({ status: record.status, toolCallId: record.toolCallId, argsSummary: record.argsSummary });
       },
     });
     const tool: MakaTool = {
@@ -2700,7 +2700,12 @@ describe('AiSdkBackend tool permission category hints', () => {
     }).wrapToolExecute(tool, 'turn-1', { push: (event) => events.push(event) });
 
     const result = await execute(
-      { path: 'notes.md' },
+      {
+        path: 'notes.md',
+        authorization: 'Bearer opaque-session-value',
+        apiKey: 'plain-provider-key',
+        password: 'correct-horse-battery-staple',
+      },
       { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
     );
 
@@ -2720,8 +2725,15 @@ describe('AiSdkBackend tool permission category hints', () => {
     );
     assert.equal(events.some((event) => event.type === 'permission_request'), false);
     assert.deepEqual(telemetry, [
-      { status: 'success', toolCallId: 'tool-1' },
+      {
+        status: 'success',
+        toolCallId: 'tool-1',
+        argsSummary: '{"path":"notes.md","authorization":"[redacted]","apiKey":"[redacted]","password":"[redacted]"}',
+      },
     ]);
+    assert.equal(JSON.stringify(telemetry).includes('opaque-session-value'), false);
+    assert.equal(JSON.stringify(telemetry).includes('plain-provider-key'), false);
+    assert.equal(JSON.stringify(telemetry).includes('correct-horse-battery-staple'), false);
   });
 
   test('permission prompt timeout expires one request, resumes watchdog, and writes an error result', async () => {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -837,7 +837,8 @@ function deriveToolResultStatus(content: ToolResultContent): ToolInvocationRecor
 }
 
 function summarizeArgs(args: unknown): string {
-  const text = typeof args === 'string' ? args : JSON.stringify(args ?? null);
+  const raw = typeof args === 'string' ? args : JSON.stringify(args ?? null);
+  const text = redactSecrets(raw);
   return text.length <= 512 ? text : `${text.slice(0, 511)}…`;
 }
 


### PR DESCRIPTION
Closes #295.

## What changed

- Redacts tool `argsSummary` at the shared runtime summarization boundary before truncation.
- Extends shared secret redaction to serialized JSON sensitive keys such as `authorization`, `apiKey`, and `password`.
- Adds focused core and runtime regression coverage for telemetry arg summaries.

## Why

Generic tool telemetry currently records `argsSummary` by stringifying raw args. WebSearch had a special-case scrub, but sibling tools still reached telemetry through the runtime path. Redacting in the shared `summarizeArgs()` path makes success and error telemetry use the same protection.

## Validation

- `npm --workspace @maka/core run test -- --test-name-pattern redaction`
- `node --test --test-name-pattern "permissionRequired=false fast path" packages/runtime/dist/__tests__/ai-sdk-backend.test.js`

Note: `npm --workspace @maka/runtime run test -- --test-name-pattern "permissionRequired=false fast path"` still executed the broader runtime test set in this repo and hit an unrelated existing Bash timeout assertion; the target AiSdkBackend case passed directly.