### PR TITLE
fix(desktop): avoid orphan history compact sources

### DIFF
--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -72,6 +72,44 @@ describe('desktop history compact artifact lifecycle', () => {
     });
   });
 
+  test('does not leave source artifacts when the compact block exceeds the block token limit', async () => {
+    await withStore(async (store) => {
+      const foldedEvents = [
+        textEvent('old-1', 'turn-1', 'alpha fact'),
+        textEvent('old-2', 'turn-2', 'beta fact'),
+      ];
+      const input: HistoryCompactWriteInput = {
+        sessionId: 'session-1',
+        turnId: 'turn-write',
+        source: {
+          draftBlock: historyCompactBlock(foldedEvents, 'deterministic fallback'),
+          foldedRuntimeEvents: foldedEvents,
+        },
+        limits: {
+          maxBlocks: 1,
+          maxBlockEstimatedTokens: 1,
+          maxEstimatedTokens: 2_048,
+          charsPerToken: 4,
+        },
+      };
+
+      const createdArtifacts: string[] = [];
+      const write = await persistHistoryCompactBlocksToArtifacts(store, input, {
+        now: () => 1_800_000_000_100,
+        summarize: () => 'summary that cannot fit in one estimated token',
+        onArtifactCreated: (artifact) => {
+          createdArtifacts.push(artifact.id);
+        },
+      });
+
+      assert.equal(write.blocks.length, 0);
+      assert.equal(write.skipped, 1);
+      assert.deepEqual(write.skippedReasonCounts, { max_block_tokens: 1 });
+      assert.deepEqual(createdArtifacts, []);
+      assert.deepEqual(await store.list('session-1'), []);
+    });
+  });
+
   test('rejects deleted, wrong-source, wrong-session, malformed, wrong-version, and oversized blocks', async () => {
     await withStore(async (store) => {
       await store.create({

--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -110,6 +110,44 @@ describe('desktop history compact artifact lifecycle', () => {
     });
   });
 
+  test('does not leave source artifacts when the compact block exceeds the total token limit', async () => {
+    await withStore(async (store) => {
+      const foldedEvents = [
+        textEvent('old-1', 'turn-1', 'alpha fact'),
+        textEvent('old-2', 'turn-2', 'beta fact'),
+      ];
+      const input: HistoryCompactWriteInput = {
+        sessionId: 'session-1',
+        turnId: 'turn-write',
+        source: {
+          draftBlock: historyCompactBlock(foldedEvents, 'deterministic fallback'),
+          foldedRuntimeEvents: foldedEvents,
+        },
+        limits: {
+          maxBlocks: 1,
+          maxBlockEstimatedTokens: 1_024,
+          maxEstimatedTokens: 1,
+          charsPerToken: 4,
+        },
+      };
+
+      const createdArtifacts: string[] = [];
+      const write = await persistHistoryCompactBlocksToArtifacts(store, input, {
+        now: () => 1_800_000_000_100,
+        summarize: () => 'summary that cannot fit in one estimated token',
+        onArtifactCreated: (artifact) => {
+          createdArtifacts.push(artifact.id);
+        },
+      });
+
+      assert.equal(write.blocks.length, 0);
+      assert.equal(write.skipped, 1);
+      assert.deepEqual(write.skippedReasonCounts, { max_total_tokens: 1 });
+      assert.deepEqual(createdArtifacts, []);
+      assert.deepEqual(await store.list('session-1'), []);
+    });
+  });
+
   test('rejects deleted, wrong-source, wrong-session, malformed, wrong-version, and oversized blocks', async () => {
     await withStore(async (store) => {
       await store.create({

--- a/apps/desktop/src/main/history-compact-artifacts.ts
+++ b/apps/desktop/src/main/history-compact-artifacts.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { ArtifactRecord } from '@maka/core';
 import {
   buildHistoryCompactBlockFromSummary,
@@ -26,30 +26,20 @@ export async function persistHistoryCompactBlocksToArtifacts(
   deps: PersistHistoryCompactBlocksDeps = {},
 ): Promise<HistoryCompactWriteResult> {
   const now = deps.now?.() ?? Date.now();
-  const sourceArchiveRefs: HistoryCompactSourceArchiveRef[] = [];
-  for (const event of input.source.foldedRuntimeEvents) {
+  const sourceArchives = input.source.foldedRuntimeEvents.map((event) => {
     const serializedBody = serializeHistoryCompactSourceBody(event.content ?? {});
     const bodySha256 = sha256(serializedBody);
-    const artifact = await artifactStore.create({
-      sessionId: input.sessionId,
-      turnId: event.turnId,
-      name: `history-compact-source-${event.id}.json`,
-      kind: 'file',
-      content: JSON.stringify(event, null, 2),
-      mimeType: 'application/json',
-      source: 'history_compact_source',
-      summary: 'Archived RuntimeEvent source for history compact replay',
-      now,
-    });
-    await deps.onArtifactCreated?.(artifact);
-    sourceArchiveRefs.push({
+    const artifactId = randomUUID();
+    const ref: HistoryCompactSourceArchiveRef = {
       runtimeEventId: event.id,
-      artifactId: artifact.id,
+      artifactId,
       bodySha256,
       originalEstimatedTokens: estimateTokens(serializedBody.length, input.limits.charsPerToken),
       originalBytes: Buffer.byteLength(serializedBody, 'utf8'),
-    });
-  }
+    };
+    return { event, ref };
+  });
+  const sourceArchiveRefs = sourceArchives.map((archive) => archive.ref);
 
   const hostSummary = await Promise.resolve(deps.summarize?.(input));
   const block = buildHistoryCompactBlockFromSummary({
@@ -70,6 +60,21 @@ export async function persistHistoryCompactBlocksToArtifacts(
   }
   if ((block.estimatedTokens ?? 0) > input.limits.maxEstimatedTokens) {
     return { blocks: [], skipped: 1, skippedReasonCounts: { max_total_tokens: 1 } };
+  }
+  for (const { event, ref } of sourceArchives) {
+    const artifact = await artifactStore.create({
+      id: ref.artifactId,
+      sessionId: input.sessionId,
+      turnId: event.turnId,
+      name: `history-compact-source-${event.id}.json`,
+      kind: 'file',
+      content: JSON.stringify(event, null, 2),
+      mimeType: 'application/json',
+      source: 'history_compact_source',
+      summary: 'Archived RuntimeEvent source for history compact replay',
+      now,
+    });
+    await deps.onArtifactCreated?.(artifact);
   }
   const artifact = await artifactStore.create({
     sessionId: input.sessionId,


### PR DESCRIPTION
## Summary

- Delay `history_compact_source` artifact writes until the compact block passes token limits.
- Add regression coverage for skipped compact blocks leaving no source artifacts or artifact-created notifications.

## Why

Refs #297

History compact source artifacts were written before the compact block token checks. If the block was skipped for budget limits, those source artifacts could remain live without a replay block referencing them.

## Scope

Changed:

- Precompute source archive refs before building the compact block.
- Persist source artifacts only after `maxBlockEstimatedTokens` and `maxEstimatedTokens` checks pass.
- Cover the `max_block_tokens` skip path in the desktop artifact lifecycle test.

Not included:

- Tool-result archive timing or stable-id refactors.
- `ArtifactStore.create` API changes.

## Verification

- `npm run -w @maka/desktop test` (1547 passed)
- `git diff --check`

## User-facing impact

No UI changes. This reduces live storage artifacts left behind by skipped history compact writes.

## Reviewer notes

This is a flat, narrow slice for issue #297 focused on history compact source artifact orphans.