### PR TITLE
fix(runtime): search archived tool result bodies for gated retrieval

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -420,232 +420,43 @@ describe('AiSdkBackend model history', () => {
   });
 
   test('gates archive hydration to RuntimeEvent turns selected by history search', async () => {
-    const model = completionModel();
-    const events: SessionEvent[] = [];
-    const archivedBodies = new Map<string, string>();
-    const readRuntimeEventIds: string[] = [];
     const selectedResult = { body: 'PHASE7_SELECTED_SENTINEL'.repeat(20) };
     const unselectedResult = { body: 'PHASE7_UNSELECTED_SENTINEL'.repeat(20) };
-    const backend = new AiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: connection(),
-      apiKey: 'sk-test',
-      modelId: 'mock-model-id',
-      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
-      modelFactory: () => model,
-      tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
-      contextBudget: {
-        name: 'archive-retrieval-gated-test',
-        maxHistoryTurns: 1,
-        minRecentTurns: 0,
-        staleToolResultPrune: {
-          enabled: true,
-          maxResultEstimatedTokens: 1,
-          minRecentTurnsFull: 0,
-        },
-        archiveRetrieval: {
-          enabled: true,
-          mode: 'history_search_gated',
-          maxResults: 2,
-          maxEstimatedTokens: 4096,
-          maxBytes: 4096,
-        },
-        historySearch: {
-          enabled: true,
-          maxResults: 1,
-          around: 1,
-          maxEstimatedTokens: 4096,
-        },
-        charsPerToken: 1,
-      },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        readRuntimeEventIds.push(event.runtimeEventId);
-        const body = archivedBodies.get(event.runtimeEventId);
-        assert.ok(body);
-        return event.bodySha256 === sha256(body)
-          ? { ok: true, serializedResult: body }
-          : { ok: false, reason: 'corrupt' };
-      },
+    const result = await runArchiveGatedReplay({
+      query: 'Find needle-a and recover its archived result',
+      selectedResult,
+      unselectedResult,
+      selectedPath: 'needle-a.txt',
+      unselectedPath: 'needle-b.txt',
     });
 
-    for await (const event of backend.send({
-      turnId: 'turn-current',
-      text: 'Find needle-a and recover its archived result',
-      context: [],
-      runtimeContext: [
-        runtimeEvent({
-          id: 'rt-call-a',
-          turnId: 'turn-a',
-          role: 'model',
-          author: 'agent',
-          content: { kind: 'function_call', id: 'tool-a', name: 'Read', args: { path: 'needle-a.txt' } },
-        }),
-        runtimeEvent({
-          id: 'rt-result-a',
-          turnId: 'turn-a',
-          role: 'tool',
-          author: 'tool',
-          content: { kind: 'function_response', id: 'tool-a', name: 'Read', result: selectedResult, isError: false },
-        }),
-        runtimeEvent({
-          id: 'rt-call-b',
-          turnId: 'turn-b',
-          role: 'model',
-          author: 'agent',
-          content: { kind: 'function_call', id: 'tool-b', name: 'Read', args: { path: 'needle-b.txt' } },
-        }),
-        runtimeEvent({
-          id: 'rt-result-b',
-          turnId: 'turn-b',
-          role: 'tool',
-          author: 'tool',
-          content: { kind: 'function_response', id: 'tool-b', name: 'Read', result: unselectedResult, isError: false },
-        }),
-        runtimeTextEvent({
-          id: 'rt-new',
-          turnId: 'turn-new',
-          role: 'user',
-          author: 'user',
-          text: 'newer retained context',
-        }),
-      ],
-    })) {
-      events.push(event);
-    }
-
-    assert.deepEqual(readRuntimeEventIds, ['rt-result-a']);
-    const prompt = JSON.stringify(compactPrompt(model));
-    assert.match(prompt, /PHASE7_SELECTED_SENTINEL/);
-    assert.equal(prompt.includes('PHASE7_UNSELECTED_SENTINEL'), false);
-    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
-      event.type === 'token_usage'
-    );
-    assert.equal(usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
-    assert.equal(usage?.contextBudget?.archiveRetrievalEligibleTurns, 1);
-    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
-    assert.equal(usage?.contextBudget?.historySearchMatches, 1);
+    assert.deepEqual(result.readRuntimeEventIds, ['rt-result-a']);
+    assert.match(result.prompt, /PHASE7_SELECTED_SENTINEL/);
+    assert.equal(result.prompt.includes('PHASE7_UNSELECTED_SENTINEL'), false);
+    assert.equal(result.usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
+    assert.equal(result.usage?.contextBudget?.archiveRetrievalEligibleTurns, 1);
+    assert.equal(result.usage?.contextBudget?.retrievedArchiveToolResults, 1);
+    assert.equal(result.usage?.contextBudget?.historySearchMatches, 1);
   });
 
   test('gates archive hydration using searchable original tool result content', async () => {
-    const model = completionModel();
-    const events: SessionEvent[] = [];
-    const archivedBodies = new Map<string, string>();
-    const readRuntimeEventIds: string[] = [];
     const selectedResult = { body: 'zzztokenbodyonly777'.repeat(20) };
     const unselectedResult = { body: 'other_payload'.repeat(20) };
-    const backend = new AiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: connection(),
-      apiKey: 'sk-test',
-      modelId: 'mock-model-id',
-      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
-      modelFactory: () => model,
-      tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
-      contextBudget: {
-        name: 'archive-retrieval-body-search-test',
-        maxHistoryTurns: 1,
-        minRecentTurns: 0,
-        staleToolResultPrune: {
-          enabled: true,
-          maxResultEstimatedTokens: 1,
-          minRecentTurnsFull: 0,
-        },
-        archiveRetrieval: {
-          enabled: true,
-          mode: 'history_search_gated',
-          maxResults: 2,
-          maxEstimatedTokens: 4096,
-          maxBytes: 4096,
-        },
-        historySearch: {
-          enabled: true,
-          maxResults: 1,
-          around: 1,
-          maxEstimatedTokens: 4096,
-        },
-        charsPerToken: 1,
-      },
-      archiveToolResult: async (event) => {
-        archivedBodies.set(event.runtimeEventId, event.serializedResult);
-        return { artifactId: `artifact-${event.runtimeEventId}` };
-      },
-      readToolResultArchive: async (event) => {
-        readRuntimeEventIds.push(event.runtimeEventId);
-        const body = archivedBodies.get(event.runtimeEventId);
-        assert.ok(body);
-        return event.bodySha256 === sha256(body)
-          ? { ok: true, serializedResult: body }
-          : { ok: false, reason: 'corrupt' };
-      },
+    const result = await runArchiveGatedReplay({
+      query: 'zzztokenbodyonly777',
+      selectedResult,
+      unselectedResult,
+      selectedPath: 'selected.txt',
+      unselectedPath: 'unselected.txt',
+      selectedAfterUnselected: true,
     });
 
-    for await (const event of backend.send({
-      turnId: 'turn-current',
-      text: 'zzztokenbodyonly777',
-      context: [],
-      runtimeContext: [
-        runtimeEvent({
-          id: 'rt-call-b',
-          turnId: 'turn-b',
-          role: 'model',
-          author: 'agent',
-          content: { kind: 'function_call', id: 'tool-b', name: 'Read', args: { path: 'unselected.txt' } },
-        }),
-        runtimeEvent({
-          id: 'rt-result-b',
-          turnId: 'turn-b',
-          role: 'tool',
-          author: 'tool',
-          content: { kind: 'function_response', id: 'tool-b', name: 'Read', result: unselectedResult, isError: false },
-        }),
-        runtimeEvent({
-          id: 'rt-call-a',
-          turnId: 'turn-a',
-          role: 'model',
-          author: 'agent',
-          content: { kind: 'function_call', id: 'tool-a', name: 'Read', args: { path: 'selected.txt' } },
-        }),
-        runtimeEvent({
-          id: 'rt-result-a',
-          turnId: 'turn-a',
-          role: 'tool',
-          author: 'tool',
-          content: { kind: 'function_response', id: 'tool-a', name: 'Read', result: selectedResult, isError: false },
-        }),
-        runtimeTextEvent({
-          id: 'rt-new',
-          turnId: 'turn-new',
-          role: 'user',
-          author: 'user',
-          text: 'newer retained context',
-        }),
-      ],
-    })) {
-      events.push(event);
-    }
-
-    assert.deepEqual(readRuntimeEventIds, ['rt-result-a']);
-    const prompt = JSON.stringify(compactPrompt(model));
-    assert.match(prompt, /zzztokenbodyonly777/);
-    assert.equal(prompt.includes('other_payload'), false);
-    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
-      event.type === 'token_usage'
-    );
-    assert.equal(usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
-    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
-    assert.equal(usage?.contextBudget?.historySearchMatches, 1);
+    assert.deepEqual(result.readRuntimeEventIds, ['rt-result-a']);
+    assert.match(result.prompt, /zzztokenbodyonly777/);
+    assert.equal(result.prompt.includes('other_payload'), false);
+    assert.equal(result.usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
+    assert.equal(result.usage?.contextBudget?.retrievedArchiveToolResults, 1);
+    assert.equal(result.usage?.contextBudget?.historySearchMatches, 1);
   });
 
   test('uses selected synthesis block instead of hydrating covered archived payload', async () => {
@@ -3687,6 +3498,125 @@ describe('AiSdkBackend loop-gate turn wiring', () => {
     assert.equal(resets, 2, 'resetTurnState runs at turn start and at cleanup');
   });
 });
+
+async function runArchiveGatedReplay(input: {
+  query: string;
+  selectedResult: unknown;
+  unselectedResult: unknown;
+  selectedPath: string;
+  unselectedPath: string;
+  selectedAfterUnselected?: boolean;
+}): Promise<{
+  prompt: string;
+  readRuntimeEventIds: string[];
+  usage: Extract<SessionEvent, { type: 'token_usage' }> | undefined;
+}> {
+  const model = completionModel();
+  const events: SessionEvent[] = [];
+  const archivedBodies = new Map<string, string>();
+  const readRuntimeEventIds: string[] = [];
+  const backend = new AiSdkBackend({
+    sessionId: 'session-1',
+    header: header(),
+    appendMessage: async () => {},
+    connection: connection(),
+    apiKey: 'sk-test',
+    modelId: 'mock-model-id',
+    permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+    modelFactory: () => model,
+    tools: [],
+    newId: idGenerator(),
+    now: monotonicClock(),
+    contextBudget: {
+      name: 'archive-retrieval-gated-test',
+      maxHistoryTurns: 1,
+      minRecentTurns: 0,
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 0,
+      },
+      archiveRetrieval: {
+        enabled: true,
+        mode: 'history_search_gated',
+        maxResults: 2,
+        maxEstimatedTokens: 4096,
+        maxBytes: 4096,
+      },
+      historySearch: {
+        enabled: true,
+        maxResults: 1,
+        around: 1,
+        maxEstimatedTokens: 4096,
+      },
+      charsPerToken: 1,
+    },
+    archiveToolResult: async (event) => {
+      archivedBodies.set(event.runtimeEventId, event.serializedResult);
+      return { artifactId: `artifact-${event.runtimeEventId}` };
+    },
+    readToolResultArchive: async (event) => {
+      readRuntimeEventIds.push(event.runtimeEventId);
+      const body = archivedBodies.get(event.runtimeEventId);
+      assert.ok(body);
+      return event.bodySha256 === sha256(body)
+        ? { ok: true, serializedResult: body }
+        : { ok: false, reason: 'corrupt' };
+    },
+  });
+  const selectedEvents = archiveGatedTurnEvents('a', input.selectedPath, input.selectedResult);
+  const unselectedEvents = archiveGatedTurnEvents('b', input.unselectedPath, input.unselectedResult);
+  const runtimeContext = [
+    ...(input.selectedAfterUnselected ? unselectedEvents : selectedEvents),
+    ...(input.selectedAfterUnselected ? selectedEvents : unselectedEvents),
+    runtimeTextEvent({
+      id: 'rt-new',
+      turnId: 'turn-new',
+      role: 'user',
+      author: 'user',
+      text: 'newer retained context',
+    }),
+  ];
+
+  for await (const event of backend.send({
+    turnId: 'turn-current',
+    text: input.query,
+    context: [],
+    runtimeContext,
+  })) {
+    events.push(event);
+  }
+
+  const prompt = JSON.stringify(compactPrompt(model));
+  if (typeof prompt !== 'string') assert.fail('model prompt was not captured');
+  const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+    event.type === 'token_usage'
+  );
+  return { prompt, readRuntimeEventIds, usage };
+}
+
+function archiveGatedTurnEvents(
+  suffix: 'a' | 'b',
+  path: string,
+  result: unknown,
+): RuntimeEvent[] {
+  return [
+    runtimeEvent({
+      id: `rt-call-${suffix}`,
+      turnId: `turn-${suffix}`,
+      role: 'model',
+      author: 'agent',
+      content: { kind: 'function_call', id: `tool-${suffix}`, name: 'Read', args: { path } },
+    }),
+    runtimeEvent({
+      id: `rt-result-${suffix}`,
+      turnId: `turn-${suffix}`,
+      role: 'tool',
+      author: 'tool',
+      content: { kind: 'function_response', id: `tool-${suffix}`, name: 'Read', result, isError: false },
+    }),
+  ];
+}
 
 function completionModel(): MockLanguageModelV3 {
   const chunks: LanguageModelV3StreamPart[] = [

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -534,6 +534,120 @@ describe('AiSdkBackend model history', () => {
     assert.equal(usage?.contextBudget?.historySearchMatches, 1);
   });
 
+  test('gates archive hydration using searchable original tool result content', async () => {
+    const model = completionModel();
+    const events: SessionEvent[] = [];
+    const archivedBodies = new Map<string, string>();
+    const readRuntimeEventIds: string[] = [];
+    const selectedResult = { body: 'zzztokenbodyonly777'.repeat(20) };
+    const unselectedResult = { body: 'other_payload'.repeat(20) };
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'archive-retrieval-body-search-test',
+        maxHistoryTurns: 1,
+        minRecentTurns: 0,
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+        },
+        archiveRetrieval: {
+          enabled: true,
+          mode: 'history_search_gated',
+          maxResults: 2,
+          maxEstimatedTokens: 4096,
+          maxBytes: 4096,
+        },
+        historySearch: {
+          enabled: true,
+          maxResults: 1,
+          around: 1,
+          maxEstimatedTokens: 4096,
+        },
+        charsPerToken: 1,
+      },
+      archiveToolResult: async (event) => {
+        archivedBodies.set(event.runtimeEventId, event.serializedResult);
+        return { artifactId: `artifact-${event.runtimeEventId}` };
+      },
+      readToolResultArchive: async (event) => {
+        readRuntimeEventIds.push(event.runtimeEventId);
+        const body = archivedBodies.get(event.runtimeEventId);
+        assert.ok(body);
+        return event.bodySha256 === sha256(body)
+          ? { ok: true, serializedResult: body }
+          : { ok: false, reason: 'corrupt' };
+      },
+    });
+
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'zzztokenbodyonly777',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call-b',
+          turnId: 'turn-b',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-b', name: 'Read', args: { path: 'unselected.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-b',
+          turnId: 'turn-b',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-b', name: 'Read', result: unselectedResult, isError: false },
+        }),
+        runtimeEvent({
+          id: 'rt-call-a',
+          turnId: 'turn-a',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-a', name: 'Read', args: { path: 'selected.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result-a',
+          turnId: 'turn-a',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-a', name: 'Read', result: selectedResult, isError: false },
+        }),
+        runtimeTextEvent({
+          id: 'rt-new',
+          turnId: 'turn-new',
+          role: 'user',
+          author: 'user',
+          text: 'newer retained context',
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    assert.deepEqual(readRuntimeEventIds, ['rt-result-a']);
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /zzztokenbodyonly777/);
+    assert.equal(prompt.includes('other_payload'), false);
+    const usage = events.find((event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+      event.type === 'token_usage'
+    );
+    assert.equal(usage?.contextBudget?.archiveRetrievalMode, 'history_search_gated');
+    assert.equal(usage?.contextBudget?.retrievedArchiveToolResults, 1);
+    assert.equal(usage?.contextBudget?.historySearchMatches, 1);
+  });
+
   test('uses selected synthesis block instead of hydrating covered archived payload', async () => {
     const model = completionModel();
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1026,7 +1026,14 @@ export class AiSdkBackend implements AgentBackend {
       historySearchSource,
       input.text,
       contextBudget?.historySearch,
-      { charsPerToken: contextBudget?.charsPerToken },
+      {
+        charsPerToken: contextBudget?.charsPerToken,
+        // Match archived-result body text for gated retrieval without making
+        // the full pre-prune result model-visible through history replay.
+        ...(contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
+          ? { searchEvents: priorRuntimeContext }
+          : {}),
+      },
     );
     const archiveRetrievalAllowedTurnIds = contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
       ? new Set(historyAround.events.map((event) => runtimeEventTurnKey(event)))

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -116,9 +116,12 @@ import {
   rawEvidenceRequestReason,
   retrieveArchivedToolResultsForReplay,
   retrieveRuntimeEventHistoryAround,
+  searchRuntimeEventHistory,
   selectSynthesisCacheForReplay,
   type ContextBudgetPolicy,
   type HistoryCompactBlock,
+  type RuntimeEventHistoryAroundResult,
+  type RuntimeEventHistorySearchPolicy,
   type StaleToolResultArchiveCandidate,
   type SynthesisCacheBlock,
   type SynthesisSourceRef,
@@ -1022,19 +1025,20 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     const historySearchSource = buildHistorySearchSource(priorRuntimeContext, contextBudget);
-    const historyAround = retrieveRuntimeEventHistoryAround(
-      historySearchSource,
-      input.text,
-      contextBudget?.historySearch,
-      {
-        charsPerToken: contextBudget?.charsPerToken,
-        // Match archived-result body text for gated retrieval without making
-        // the full pre-prune result model-visible through history replay.
-        ...(contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
-          ? { searchEvents: priorRuntimeContext }
-          : {}),
-      },
-    );
+    const historyAround = contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
+      ? retrieveReplayHistoryAroundSearchSource(
+          historySearchSource,
+          priorRuntimeContext,
+          input.text,
+          contextBudget?.historySearch,
+          { charsPerToken: contextBudget?.charsPerToken },
+        )
+      : retrieveRuntimeEventHistoryAround(
+          historySearchSource,
+          input.text,
+          contextBudget?.historySearch,
+          { charsPerToken: contextBudget?.charsPerToken },
+        );
     const archiveRetrievalAllowedTurnIds = contextBudget?.archiveRetrieval?.mode === 'history_search_gated'
       ? new Set(historyAround.events.map((event) => runtimeEventTurnKey(event)))
       : undefined;
@@ -1721,6 +1725,63 @@ function buildContextBudgetDiagnosticShell(
 
 function runtimeEventTurnKey(event: RuntimeEvent): string {
   return event.turnId || '<unknown-turn>';
+}
+
+function retrieveReplayHistoryAroundSearchSource(
+  replayEvents: readonly RuntimeEvent[],
+  searchEvents: readonly RuntimeEvent[],
+  query: string,
+  policy: RuntimeEventHistorySearchPolicy | undefined,
+  options: { charsPerToken?: number } = {},
+): RuntimeEventHistoryAroundResult {
+  if (policy?.enabled !== true) {
+    return { events: [], hits: [], diagnosticPatch: {} };
+  }
+  const charsPerToken = options.charsPerToken ?? 4;
+  const around = Math.max(0, Math.floor(policy.around ?? 1));
+  const maxEstimatedTokens = typeof policy.maxEstimatedTokens === 'number'
+    && Number.isFinite(policy.maxEstimatedTokens)
+    && policy.maxEstimatedTokens > 0
+    ? Math.floor(policy.maxEstimatedTokens)
+    : 4_096;
+  const hits = searchRuntimeEventHistory(searchEvents, policy.query ?? query, policy);
+  const selectedIndexes = new Set<number>();
+  const indexesByEventId = new Map(replayEvents.map((event, index) => [event.id, index]));
+  let skipped = 0;
+  for (const hit of hits) {
+    const index = indexesByEventId.get(hit.eventId);
+    if (index === undefined) {
+      skipped += 1;
+      continue;
+    }
+    for (let cursor = Math.max(0, index - around); cursor <= Math.min(replayEvents.length - 1, index + around); cursor += 1) {
+      selectedIndexes.add(cursor);
+    }
+  }
+
+  const selectedEvents: RuntimeEvent[] = [];
+  let selectedTokens = 0;
+  for (const index of [...selectedIndexes].sort((a, b) => a - b)) {
+    const event = replayEvents[index]!;
+    const estimate = estimateRuntimeEventsTokens([event], charsPerToken);
+    if (selectedTokens + estimate > maxEstimatedTokens) {
+      skipped += 1;
+      continue;
+    }
+    selectedEvents.push(event);
+    selectedTokens += estimate;
+  }
+
+  return {
+    events: selectedEvents,
+    hits,
+    diagnosticPatch: {
+      historySearchMatches: hits.length,
+      historyAroundRetrievedEvents: selectedEvents.length,
+      historyAroundEstimatedTokens: selectedTokens,
+      ...(skipped > 0 ? { historyAroundSkippedEvents: skipped } : {}),
+    },
+  };
 }
 
 function buildHistorySearchSource(

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -839,7 +839,7 @@ export function retrieveRuntimeEventHistoryAround(
   events: readonly RuntimeEvent[],
   query: string,
   policy: RuntimeEventHistorySearchPolicy | undefined,
-  options: { charsPerToken?: number; searchEvents?: readonly RuntimeEvent[] } = {},
+  options: { charsPerToken?: number } = {},
 ): RuntimeEventHistoryAroundResult {
   if (policy?.enabled !== true) {
     return { events: [], hits: [], diagnosticPatch: {} };
@@ -847,7 +847,7 @@ export function retrieveRuntimeEventHistoryAround(
   const charsPerToken = options.charsPerToken ?? 4;
   const around = Math.max(0, Math.floor(policy.around ?? 1));
   const maxEstimatedTokens = finitePositive(policy.maxEstimatedTokens) ?? 4_096;
-  const hits = searchRuntimeEventHistory(options.searchEvents ?? events, policy.query ?? query, policy);
+  const hits = searchRuntimeEventHistory(events, policy.query ?? query, policy);
   const selectedIndexes = new Set<number>();
   const indexesByEventId = new Map(events.map((event, index) => [event.id, index]));
   for (const hit of hits) {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -839,7 +839,7 @@ export function retrieveRuntimeEventHistoryAround(
   events: readonly RuntimeEvent[],
   query: string,
   policy: RuntimeEventHistorySearchPolicy | undefined,
-  options: { charsPerToken?: number } = {},
+  options: { charsPerToken?: number; searchEvents?: readonly RuntimeEvent[] } = {},
 ): RuntimeEventHistoryAroundResult {
   if (policy?.enabled !== true) {
     return { events: [], hits: [], diagnosticPatch: {} };
@@ -847,7 +847,7 @@ export function retrieveRuntimeEventHistoryAround(
   const charsPerToken = options.charsPerToken ?? 4;
   const around = Math.max(0, Math.floor(policy.around ?? 1));
   const maxEstimatedTokens = finitePositive(policy.maxEstimatedTokens) ?? 4_096;
-  const hits = searchRuntimeEventHistory(events, policy.query ?? query, policy);
+  const hits = searchRuntimeEventHistory(options.searchEvents ?? events, policy.query ?? query, policy);
   const selectedIndexes = new Set<number>();
   const indexesByEventId = new Map(events.map((event, index) => [event.id, index]));
   for (const hit of hits) {


### PR DESCRIPTION
## Summary

Let `history_search_gated` match archived tool-result body text using the original runtime events as a search-only source, while keeping replay sourced from the pruned context unless archive retrieval hydrates the selected turn.

## Why

Part of #297. Queries that only matched the original large tool-result body could fail to select the archived turn, so gated archive retrieval had no eligible turn to hydrate.

## Scope

Changed:

- Keep `retrieveRuntimeEventHistoryAround` on its original single-source API.
- Add a private `AiSdkBackend` branch that searches original prior runtime events, maps hits by event ID onto the pruned replay source, and estimates tokens from replay events.
- Add a regression test for body-only archive search hits.
- Extract the archive-gated backend test fixture so the behavior assertions stay focused.

Not included:

- Archive id stability changes.
- Desktop archive persistence changes.
- Synthesis replay ordering changes.

## Verification

- `npm run -w @maka/runtime test`

## User-facing impact

History search can now recover archived tool results when the user query matches only the archived body content. No docs, changelog, migrations, or breaking changes.

## Reviewer notes

The original full tool result is used only for deterministic internal search selection inside `AiSdkBackend`; replay still uses the pruned event source so large stale results are not model-visible unless the archive reader hydrates the selected result.