### PR TITLE
fix(runtime): preserve synthesis cache replay order

### DIFF
--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -429,14 +429,10 @@ describe('context-budget synthesis cache', () => {
       { sessionId: 'session-1', charsPerToken: 1 },
     );
 
-    const ids = result.events.map((event) => event.id);
-    assert.equal(ids.includes('prompt-alpha'), true);
-    assert.equal(ids.includes('call-beta'), true);
-    assert.equal(ids.includes('result-beta'), true);
-    assert.equal(ids.includes('recent'), true);
-    assert.equal(ids.includes('synthesis-cache:synth-key-alpha'), true);
-    assert.equal(ids.includes('call-alpha'), false);
-    assert.equal(ids.includes('result-alpha'), false);
+    assert.deepEqual(
+      result.events.map((event) => event.id),
+      ['prompt-alpha', 'synthesis-cache:synth-key-alpha', 'call-beta', 'result-beta', 'recent'],
+    );
   });
 
   test('inserts a selected synthesis block at the covered event position', () => {
@@ -473,6 +469,62 @@ describe('context-budget synthesis cache', () => {
     assert.deepEqual(
       result.events.map((event) => event.id),
       ['before', 'synthesis-cache:synth-key-alpha', 'after'],
+    );
+  });
+
+  test('inserts multiple selected synthesis blocks at their covered event positions', () => {
+    const alpha = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const beta = serializeToolResultForArchive({ text: 'raw archived key-beta payload' });
+    const events = [
+      textEvent('before', 'turn-before', 'older retained context'),
+      toolCall('call-alpha', 'turn-alpha', 'tool-alpha'),
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(alpha),
+        originalEstimatedTokens: alpha.length,
+        originalBytes: utf8Bytes(alpha),
+      }),
+      textEvent('middle', 'turn-middle', 'retained middle context'),
+      toolCall('call-beta', 'turn-beta', 'tool-beta'),
+      archivedResult('result-beta', 'turn-beta', 'tool-beta', {
+        artifactId: 'artifact-beta',
+        bodySha256: sha256(beta),
+        originalEstimatedTokens: beta.length,
+        originalBytes: utf8Bytes(beta),
+      }),
+      textEvent('after', 'turn-after', 'newer retained context'),
+    ];
+    const alphaBlock = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(alpha),
+      originalEstimatedTokens: alpha.length,
+      originalBytes: utf8Bytes(alpha),
+    });
+    const betaBlock = synthesisBlock({
+      queryKey: 'key-beta',
+      turnId: 'turn-beta',
+      runtimeEventId: 'result-beta',
+      toolCallId: 'tool-beta',
+      artifactId: 'artifact-beta',
+      bodySha256: sha256(beta),
+      originalEstimatedTokens: beta.length,
+      originalBytes: utf8Bytes(beta),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha and key-beta',
+      { enabled: true, blocks: [alphaBlock, betaBlock], maxBlocks: 2 },
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    assert.deepEqual(
+      result.events.map((event) => event.id),
+      ['before', 'synthesis-cache:synth-key-alpha', 'middle', 'synthesis-cache:synth-key-beta', 'after'],
     );
   });
 
@@ -543,6 +595,34 @@ describe('context-budget synthesis cache', () => {
     assert.equal(result.selectedBlocks.length, 0);
     assert.deepEqual(result.diagnosticPatch.synthesisCacheSkippedReasonCounts, {
       coverage_miss: 1,
+    });
+  });
+
+  test('does not append synthesis when a source event is missing', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [textEvent('recent', 'turn-recent', 'newer retained context')];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1' },
+    );
+
+    assert.equal(result.selectedBlocks.length, 0);
+    assert.deepEqual(result.events.map((event) => event.id), ['recent']);
+    assert.deepEqual(result.diagnosticPatch.synthesisCacheInvalidationReasonCounts, {
+      source_missing: 1,
     });
   });
 

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -396,6 +396,86 @@ describe('context-budget synthesis cache', () => {
     assert.match(renderSynthesisCacheBlock(block), /artifact-alpha/);
   });
 
+  test('retains same-turn events not covered by a selected synthesis block', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      textEvent('prompt-alpha', 'turn-alpha', 'please inspect key-alpha'),
+      toolCall('call-alpha', 'turn-alpha', 'tool-alpha'),
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+      toolCall('call-beta', 'turn-alpha', 'tool-beta'),
+      toolResult('result-beta', 'turn-alpha', 'tool-beta', { text: 'unrelated same-turn payload' }),
+      textEvent('recent', 'turn-recent', 'newer retained context'),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    const ids = result.events.map((event) => event.id);
+    assert.equal(ids.includes('prompt-alpha'), true);
+    assert.equal(ids.includes('call-beta'), true);
+    assert.equal(ids.includes('result-beta'), true);
+    assert.equal(ids.includes('recent'), true);
+    assert.equal(ids.includes('synthesis-cache:synth-key-alpha'), true);
+    assert.equal(ids.includes('call-alpha'), false);
+    assert.equal(ids.includes('result-alpha'), false);
+  });
+
+  test('inserts a selected synthesis block at the covered event position', () => {
+    const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
+    const events = [
+      textEvent('before', 'turn-before', 'older retained context'),
+      toolCall('call-alpha', 'turn-alpha', 'tool-alpha'),
+      archivedResult('result-alpha', 'turn-alpha', 'tool-alpha', {
+        artifactId: 'artifact-alpha',
+        bodySha256: sha256(serialized),
+        originalEstimatedTokens: serialized.length,
+        originalBytes: utf8Bytes(serialized),
+      }),
+      textEvent('after', 'turn-after', 'newer retained context'),
+    ];
+    const block = synthesisBlock({
+      queryKey: 'key-alpha',
+      turnId: 'turn-alpha',
+      runtimeEventId: 'result-alpha',
+      toolCallId: 'tool-alpha',
+      artifactId: 'artifact-alpha',
+      bodySha256: sha256(serialized),
+      originalEstimatedTokens: serialized.length,
+      originalBytes: utf8Bytes(serialized),
+    });
+
+    const result = selectSynthesisCacheForReplay(
+      events,
+      'Recover key-alpha',
+      { enabled: true, blocks: [block] },
+      { sessionId: 'session-1', charsPerToken: 1 },
+    );
+
+    assert.deepEqual(
+      result.events.map((event) => event.id),
+      ['before', 'synthesis-cache:synth-key-alpha', 'after'],
+    );
+  });
+
   test('does not select synthesis when raw evidence is requested', () => {
     const serialized = serializeToolResultForArchive({ text: 'raw archived key-alpha payload' });
     const events = [

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -979,24 +979,53 @@ export function selectSynthesisCacheForReplay(
     return { events: [...events], selectedBlocks, diagnosticPatch };
   }
 
-  const coveredTurns = new Set<string>();
   const coveredEventIds = new Set<string>();
+  const coveredToolCallIds = new Set<string>();
+  const insertions = new Map<number, RuntimeEvent[]>();
+  const trailingInsertions: RuntimeEvent[] = [];
   for (const block of selectedBlocks) {
-    for (const turnId of block.coverage.turnIds) coveredTurns.add(turnId);
+    const blockEventIds = new Set(block.coverage.runtimeEventIds);
+    const blockToolCallIds = new Set(block.coverage.toolCallIds);
     for (const eventId of block.coverage.runtimeEventIds) coveredEventIds.add(eventId);
+    for (const toolCallId of block.coverage.toolCallIds) coveredToolCallIds.add(toolCallId);
     for (const ref of block.sourceRefs) {
-      if ('turnId' in ref) coveredTurns.add(ref.turnId);
-      if ('runtimeEventId' in ref) coveredEventIds.add(ref.runtimeEventId);
+      if ('runtimeEventId' in ref) {
+        coveredEventIds.add(ref.runtimeEventId);
+        blockEventIds.add(ref.runtimeEventId);
+      }
+      if ('toolCallId' in ref) {
+        coveredToolCallIds.add(ref.toolCallId);
+        blockToolCallIds.add(ref.toolCallId);
+      }
+    }
+    const insertionIndex = events.findIndex((event) =>
+      blockEventIds.has(event.id) ||
+      (event.content?.kind === 'function_call' && blockToolCallIds.has(event.content.id))
+    );
+    const synthetic = synthesisBlockRuntimeEvent(block, options.sessionId);
+    if (insertionIndex >= 0) {
+      const existing = insertions.get(insertionIndex);
+      if (existing) existing.push(synthetic);
+      else insertions.set(insertionIndex, [synthetic]);
+    } else {
+      trailingInsertions.push(synthetic);
     }
   }
-  const retained = events.filter((event) =>
-    !coveredEventIds.has(event.id) && !coveredTurns.has(turnKey(event))
-  );
+  const replayEvents: RuntimeEvent[] = [];
+  for (const [index, event] of events.entries()) {
+    const synthetic = insertions.get(index);
+    if (synthetic) replayEvents.push(...synthetic);
+    if (
+      coveredEventIds.has(event.id) ||
+      (event.content?.kind === 'function_call' && coveredToolCallIds.has(event.content.id))
+    ) {
+      continue;
+    }
+    replayEvents.push(event);
+  }
+  replayEvents.push(...trailingInsertions);
   return {
-    events: [
-      ...retained,
-      ...selectedBlocks.map((block) => synthesisBlockRuntimeEvent(block, options.sessionId)),
-    ],
+    events: replayEvents,
     selectedBlocks,
     diagnosticPatch,
   };

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -982,7 +982,6 @@ export function selectSynthesisCacheForReplay(
   const coveredEventIds = new Set<string>();
   const coveredToolCallIds = new Set<string>();
   const insertions = new Map<number, RuntimeEvent[]>();
-  const trailingInsertions: RuntimeEvent[] = [];
   for (const block of selectedBlocks) {
     const blockEventIds = new Set(block.coverage.runtimeEventIds);
     const blockToolCallIds = new Set(block.coverage.toolCallIds);
@@ -1002,14 +1001,13 @@ export function selectSynthesisCacheForReplay(
       blockEventIds.has(event.id) ||
       (event.content?.kind === 'function_call' && blockToolCallIds.has(event.content.id))
     );
-    const synthetic = synthesisBlockRuntimeEvent(block, options.sessionId);
-    if (insertionIndex >= 0) {
-      const existing = insertions.get(insertionIndex);
-      if (existing) existing.push(synthetic);
-      else insertions.set(insertionIndex, [synthetic]);
-    } else {
-      trailingInsertions.push(synthetic);
+    if (insertionIndex < 0) {
+      throw new Error('validated synthesis cache block has no covered replay event');
     }
+    const synthetic = synthesisBlockRuntimeEvent(block, options.sessionId);
+    const existing = insertions.get(insertionIndex);
+    if (existing) existing.push(synthetic);
+    else insertions.set(insertionIndex, [synthetic]);
   }
   const replayEvents: RuntimeEvent[] = [];
   for (const [index, event] of events.entries()) {
@@ -1023,7 +1021,6 @@ export function selectSynthesisCacheForReplay(
     }
     replayEvents.push(event);
   }
-  replayEvents.push(...trailingInsertions);
   return {
     events: replayEvents,
     selectedBlocks,


### PR DESCRIPTION
## Summary

Fix synthesis cache replay so selected cache blocks replace only the covered evidence and stay in chronological history order.

## Why

Refs #297. The previous replay path removed every event from a covered turn and appended the synthetic synthesis event at the end, which could drop unrelated same-turn context and invert older/newer history order.

## Scope

Changed:
- retain same-turn runtime events that are not covered by the selected synthesis block
- remove the covered tool call together with its covered tool result so replay does not contain a dangling tool call
- insert the synthetic synthesis cache event at the earliest covered evidence position
- add regression tests for same-turn retention and replay ordering

Not included:
- archive placeholder shape changes
- desktop archive persistence changes
- broad synthesis cache redesign

## Verification

- npm run -w @maka/runtime test

## User-facing impact

Model replay keeps the intended chronological prior context when a synthesis cache block is selected. No migrations, docs, or breaking changes.

## Reviewer notes

This PR is intentionally flat against main and limited to synthesis replay semantics for the issue #297 split.