### PR TITLE
PR-DAILY-REVIEW-BUGS-0: fix 4 Daily Review settings bugs + Select popup z-index

### DIFF
--- a/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
@@ -43,9 +43,9 @@ const ALLOWED_BARE: ReadonlyArray<{ pattern: string; count: number; reason: stri
   },
   {
     pattern: 'z-50',
-    count: 5,
+    count: 2,
     reason:
-      'dialog popup, sheet popup, tooltip popup, select popup, popover. All shadcn/Base UI overlay surfaces. Equivalent to --z-panel (50) by value but semantically distinct.',
+      'dialog popup (DialogContent) + sheet popup. The previously z-50 floating-overlay surfaces (TooltipPopup, SelectPopup, PopoverPopup) were tokenized to `z-[var(--z-overlay)]` so a Select opened from inside a Settings modal floats above the modal (WAWQAQ msg `d3ea9a33` 2026-06-26).',
   },
   {
     pattern: 'backdrop-blur-sm',

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1656,9 +1656,12 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
             value={effectiveConfig?.executeTime ?? '08:00'}
             disabled={formDisabled || savingKey === 'executeTime'}
             onChange={(event) => {
-              const value = event.target.value;
-              if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return;
-              void patchConfig('executeTime', { executeTime: value });
+              // Native time-pickers only fire `change` once the value
+              // is a complete HH:MM (or cleared); the earlier hand-
+              // rolled regex would silently drop any intermediate
+              // state the user typed (e.g. `08:0`), making the picker
+              // feel stuck. Trust the browser.
+              void patchConfig('executeTime', { executeTime: event.target.value });
             }}
           />
         </div>
@@ -1750,6 +1753,26 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
 
       {(props.onOpenDailyReview || hasRunOnceIpc) && (
         <div className="settingsPageFooterActions" role="toolbar" aria-label="每日回顾操作">
+          {hasRunOnceIpc && (
+            <>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => void triggerRun('deep')}
+                disabled={runningMode !== null}
+              >
+                {runningMode === 'deep' ? '生成中…' : '生成深度分析'}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => void triggerRun('daily')}
+                disabled={runningMode !== null}
+              >
+                {runningMode === 'daily' ? '生成中…' : '生成每日回顾'}
+              </Button>
+            </>
+          )}
           {props.onOpenDailyReview && (
             <Button
               type="button"
@@ -1757,24 +1780,6 @@ function DailyReviewSettingsPage(props: { onOpenDailyReview?: () => void }) {
             >
               打开每日回顾
             </Button>
-          )}
-          {hasRunOnceIpc && (
-            <>
-              <Button
-                type="button"
-                onClick={() => void triggerRun('daily')}
-                disabled={runningMode !== null}
-              >
-                {runningMode === 'daily' ? '生成中…' : '生成每日回顾'}
-              </Button>
-              <Button
-                type="button"
-                onClick={() => void triggerRun('deep')}
-                disabled={runningMode !== null}
-              >
-                {runningMode === 'deep' ? '生成中…' : '生成深度分析'}
-              </Button>
-            </>
           )}
         </div>
       )}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -333,7 +333,7 @@ export const TooltipPopup = forwardRef<HTMLDivElement, React.ComponentPropsWitho
   return (
     <BaseTooltip.Popup
       ref={ref}
-      className={cn('z-50 rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel', className)}
+      className={cn('z-[var(--z-overlay)] rounded-md border border-border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel', className)}
       {...props}
     />
   );
@@ -371,7 +371,14 @@ export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithou
   { className, ...props },
   ref,
 ) {
-  return <BaseSelect.Popup ref={ref} className={cn('z-50 min-w-40 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
+  // The Settings modal uses `--z-modal` (200) — the previous bare
+  // popup layer (Tailwind utility worth 50) was below it, so any
+  // `<SettingsSelect>` opened inside a modal (e.g. Daily Review
+  // → 分析模型) rendered its popup beneath the modal content and
+  // read as "can't select". Pin the popup to `--z-overlay` (300)
+  // so it always floats above the modal it was triggered from
+  // (WAWQAQ msg `d3ea9a33` 2026-06-26).
+  return <BaseSelect.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
 });
 export const SelectGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Group>>(function SelectGroup(
   { className, ...props },
@@ -784,7 +791,7 @@ export const PopoverPopup = forwardRef<
   return (
     <BasePopover.Popup
       ref={ref}
-      className={cn('z-50 rounded-lg border border-border bg-popover p-3 text-sm text-popover-foreground shadow-maka-panel', className)}
+      className={cn('z-[var(--z-overlay)] rounded-lg border border-border bg-popover p-3 text-sm text-popover-foreground shadow-maka-panel', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

WAWQAQ msg \`d3ea9a33\` 2026-06-26 — Daily Review settings page bugs:
1. **Buttons left-aligned** (visually): CSS was already \`flex-end\`, but 3 same-color primary buttons read as a flat row. Fix → split into 2 secondary + 1 primary so the primary action anchors the right.
2. **执行时间 can't be adjusted**: hand-rolled regex was silently dropping incomplete values. Native time-pickers only fire \`change\` on complete HH:MM (or empty). Remove the regex; trust the browser.
3. **Button styles look off in disabled state**: same fix as (1); once variants differ, disabled states match the rest of Settings.
4. **分析模型 can't be selected** (real bug): \`SelectPopup\` in \`packages/ui/src/ui.tsx\` was using \`z-50\` (= 50). Settings modal sits at \`--z-modal\` (200), so the popup rendered BELOW the modal backdrop and reads as "doesn't open". Tokenize → \`z-[var(--z-overlay)]\` (300). Same fix applied to \`TooltipPopup\` + \`PopoverPopup\` since they had the same bug.

Plus contract follow-up: \`ui-tsx-design-contract\` z-50 allowlist count 5 → 2 (only \`DialogContent\` + \`SheetPopup\` keep the bare class).

## Test plan

- [x] \`apps/desktop$ npx tsx --test src/main/__tests__/*-contract.test.ts\` → 438/439 pass (1 pre-existing flaky subagent SSR test unchanged on main)
- [x] \`npx tsc --noEmit -p packages/ui/tsconfig.json\` → ✓
- [ ] Visual verification in Settings → 每日回顾 (next dev-run)