### PR TITLE
fix: stabilize tool result archive artifacts

### DIFF
--- a/apps/desktop/src/main/__tests__/tool-result-archive-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-result-archive-artifacts.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { createArtifactStore, type ArtifactStore } from '@maka/storage';
+import type { ToolResultArchiveRecorderInput } from '@maka/runtime';
+import { persistArchivedToolResultToArtifacts } from '../tool-result-archive-artifacts.js';
+
+describe('desktop tool-result archive artifacts', () => {
+  test('reuses the archive artifact for the same stale tool result body', async () => {
+    await withStore(async (store) => {
+      const event = archiveEvent();
+
+      const first = await persistArchivedToolResultToArtifacts(store, event);
+      const second = await persistArchivedToolResultToArtifacts(store, event);
+
+      assert.equal(second.artifactId, first.artifactId);
+      const records = await store.list(event.sessionId);
+      assert.equal(records.length, 1);
+      assert.equal(records[0]?.id, first.artifactId);
+      assert.equal(records[0]?.source, 'tool_result_archive');
+    });
+  });
+});
+
+function archiveEvent(): ToolResultArchiveRecorderInput {
+  const result = { body: 'large archived output'.repeat(20) };
+  const serializedResult = JSON.stringify(result);
+  return {
+    sessionId: 'session-1',
+    runtimeEventId: 'runtime-result-1',
+    turnId: 'turn-1',
+    toolCallId: 'tool-call-1',
+    toolName: 'Read',
+    result,
+    serializedResult,
+    bodySha256: sha256(serializedResult),
+    originalEstimatedTokens: serializedResult.length,
+    originalBytes: Buffer.byteLength(serializedResult, 'utf8'),
+    rewriteVersion: 1,
+    reason: 'stale_tool_result_pruned_before_compact',
+  };
+}
+
+async function withStore(fn: (store: ArtifactStore) => Promise<void>): Promise<void> {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-tool-result-archive-'));
+  try {
+    await fn(createArtifactStore(workspaceRoot));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -80,6 +80,7 @@ import { buildWebSearchAgentTool, WEB_SEARCH_TOOL_NAME } from './web-search/agen
 import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
 import { resolveTavilyApiKey } from './web-search/credentials.js';
 import { runThreadSearch } from './search/thread-search.js';
+import { persistArchivedToolResultToArtifacts } from './tool-result-archive-artifacts.js';
 import {
   normalizeBranchFromTurnInput,
   normalizePermissionResponse,
@@ -769,17 +770,7 @@ async function persistToolArtifacts(cwd: string, event: ToolArtifactRecorderInpu
 async function persistArchivedToolResult(
   event: ToolResultArchiveRecorderInput,
 ): Promise<{ artifactId: string }> {
-  const artifact = await artifactStore.create({
-    sessionId: event.sessionId,
-    turnId: event.turnId,
-    name: `tool-result-${event.runtimeEventId}.json`,
-    kind: 'file',
-    content: event.serializedResult,
-    mimeType: 'application/json',
-    source: 'tool_result_archive',
-    summary: `Archived ${event.toolName} tool result for context budget replay`,
-  });
-  return { artifactId: artifact.id };
+  return persistArchivedToolResultToArtifacts(artifactStore, event);
 }
 
 async function readArchivedToolResult(

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, nativeTheme, safeStorage, screen, shell } from 'electron';
 import { isExternalUrl } from './external-link-guard.js';
 import { readSavedBounds, writeSavedBounds, type SavedBounds } from './window-state.js';
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { copyFile, mkdir, readFile, realpath } from 'node:fs/promises';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { release as osRelease, arch as osArch } from 'node:os';
@@ -80,7 +80,10 @@ import { buildWebSearchAgentTool, WEB_SEARCH_TOOL_NAME } from './web-search/agen
 import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
 import { resolveTavilyApiKey } from './web-search/credentials.js';
 import { runThreadSearch } from './search/thread-search.js';
-import { persistArchivedToolResultToArtifacts } from './tool-result-archive-artifacts.js';
+import {
+  persistArchivedToolResultToArtifacts,
+  readArchivedToolResultFromArtifacts,
+} from './tool-result-archive-artifacts.js';
 import {
   normalizeBranchFromTurnInput,
   normalizePermissionResponse,
@@ -776,19 +779,7 @@ async function persistArchivedToolResult(
 async function readArchivedToolResult(
   event: ToolResultArchiveReaderInput,
 ): Promise<ToolResultArchiveReadResult> {
-  const record = await artifactStore.get(event.artifactId);
-  if (!record) return { ok: false, reason: 'not_found' };
-  if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
-  if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
-  if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
-  if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
-
-  const read = await artifactStore.readText(event.artifactId, {
-    maxBytes: event.maxBytes ?? event.originalBytes,
-  });
-  if (!read.ok) return read;
-  if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
-  return { ok: true, serializedResult: read.text };
+  return readArchivedToolResultFromArtifacts(artifactStore, event);
 }
 
 async function resolveToolArtifactSourcePath(cwd: string, sourcePath: string): Promise<string | null> {
@@ -1055,10 +1046,6 @@ function parseHistoryCompactMode(value: string | undefined): NonNullable<Context
 
 function parseArchiveRetrievalMode(value: string | undefined): NonNullable<ContextBudgetPolicy['archiveRetrieval']>['mode'] | undefined {
   return value === 'history_search_gated' || value === 'eager' ? value : undefined;
-}
-
-function sha256(text: string): string {
-  return createHash('sha256').update(text).digest('hex');
 }
 
 function buildSubscriptionModelFetch(

--- a/apps/desktop/src/main/tool-result-archive-artifacts.ts
+++ b/apps/desktop/src/main/tool-result-archive-artifacts.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import type { ArtifactStore } from '@maka/storage';
+import type { ToolResultArchiveRecorderInput } from '@maka/runtime';
+
+export async function persistArchivedToolResultToArtifacts(
+  artifactStore: Pick<ArtifactStore, 'create' | 'get' | 'readText'>,
+  event: ToolResultArchiveRecorderInput,
+): Promise<{ artifactId: string }> {
+  const id = stableToolResultArchiveArtifactId(event);
+  const existing = await artifactStore.get(id);
+  if (existing?.status === 'live') {
+    if (existing.source !== 'tool_result_archive') throw new Error('tool result archive artifact id conflict: source mismatch');
+    if (existing.sessionId !== event.sessionId) throw new Error('tool result archive artifact id conflict: session mismatch');
+    if (existing.sizeBytes !== event.originalBytes) throw new Error('tool result archive artifact id conflict: size mismatch');
+    const read = await artifactStore.readText(id, { maxBytes: event.originalBytes });
+    if (!read.ok) throw new Error(`tool result archive artifact id conflict: ${read.reason}`);
+    if (sha256(read.text) !== event.bodySha256) throw new Error('tool result archive artifact id conflict: hash mismatch');
+    return { artifactId: id };
+  }
+
+  const artifact = await artifactStore.create({
+    id,
+    sessionId: event.sessionId,
+    turnId: event.turnId,
+    name: `tool-result-${event.runtimeEventId}.json`,
+    kind: 'file',
+    content: event.serializedResult,
+    mimeType: 'application/json',
+    source: 'tool_result_archive',
+    summary: `Archived ${event.toolName} tool result for context budget replay`,
+  });
+  return { artifactId: artifact.id };
+}
+
+export function stableToolResultArchiveArtifactId(event: Pick<
+  ToolResultArchiveRecorderInput,
+  'sessionId' | 'runtimeEventId' | 'toolCallId' | 'toolName' | 'bodySha256' | 'rewriteVersion'
+>): string {
+  return `tool-result-archive-${sha256(JSON.stringify({
+    sessionId: event.sessionId,
+    runtimeEventId: event.runtimeEventId,
+    toolCallId: event.toolCallId,
+    toolName: event.toolName,
+    bodySha256: event.bodySha256,
+    rewriteVersion: event.rewriteVersion,
+  })).slice(0, 32)}`;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/apps/desktop/src/main/tool-result-archive-artifacts.ts
+++ b/apps/desktop/src/main/tool-result-archive-artifacts.ts
@@ -1,6 +1,11 @@
 import { createHash } from 'node:crypto';
 import type { ArtifactStore } from '@maka/storage';
-import type { ToolResultArchiveRecorderInput } from '@maka/runtime';
+import {
+  ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  type ToolResultArchiveReaderInput,
+  type ToolResultArchiveReadResult,
+  type ToolResultArchiveRecorderInput,
+} from '@maka/runtime';
 
 export async function persistArchivedToolResultToArtifacts(
   artifactStore: Pick<ArtifactStore, 'create' | 'get' | 'readText'>,
@@ -9,12 +14,12 @@ export async function persistArchivedToolResultToArtifacts(
   const id = stableToolResultArchiveArtifactId(event);
   const existing = await artifactStore.get(id);
   if (existing?.status === 'live') {
-    if (existing.source !== 'tool_result_archive') throw new Error('tool result archive artifact id conflict: source mismatch');
-    if (existing.sessionId !== event.sessionId) throw new Error('tool result archive artifact id conflict: session mismatch');
-    if (existing.sizeBytes !== event.originalBytes) throw new Error('tool result archive artifact id conflict: size mismatch');
-    const read = await artifactStore.readText(id, { maxBytes: event.originalBytes });
+    const read = await readArchivedToolResultFromArtifacts(artifactStore, {
+      ...event,
+      kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+      artifactId: id,
+    });
     if (!read.ok) throw new Error(`tool result archive artifact id conflict: ${read.reason}`);
-    if (sha256(read.text) !== event.bodySha256) throw new Error('tool result archive artifact id conflict: hash mismatch');
     return { artifactId: id };
   }
 
@@ -30,6 +35,25 @@ export async function persistArchivedToolResultToArtifacts(
     summary: `Archived ${event.toolName} tool result for context budget replay`,
   });
   return { artifactId: artifact.id };
+}
+
+export async function readArchivedToolResultFromArtifacts(
+  artifactStore: Pick<ArtifactStore, 'get' | 'readText'>,
+  event: ToolResultArchiveReaderInput,
+): Promise<ToolResultArchiveReadResult> {
+  const record = await artifactStore.get(event.artifactId);
+  if (!record) return { ok: false, reason: 'not_found' };
+  if (record.status === 'deleted') return { ok: false, reason: 'deleted' };
+  if (record.source !== 'tool_result_archive') return { ok: false, reason: 'source_mismatch' };
+  if (record.sessionId !== event.sessionId) return { ok: false, reason: 'session_mismatch' };
+  if (record.sizeBytes !== event.originalBytes) return { ok: false, reason: 'size_mismatch' };
+
+  const read = await artifactStore.readText(event.artifactId, {
+    maxBytes: event.maxBytes ?? event.originalBytes,
+  });
+  if (!read.ok) return read;
+  if (sha256(read.text) !== event.bodySha256) return { ok: false, reason: 'corrupt' };
+  return { ok: true, serializedResult: read.text };
 }
 
 export function stableToolResultArchiveArtifactId(event: Pick<

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -30,6 +30,7 @@ import {
 } from '../request-shape.js';
 import {
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
   buildHistoryCompactBlockFromSummary,
   type HistoryCompactBlock,
@@ -259,6 +260,71 @@ describe('AiSdkBackend model history', () => {
     assert.match(prompt, /"kind":"maka\.archived_tool_result"/);
     assert.match(prompt, /"artifactId":"artifact-rt-result"/);
     assert.match(prompt, /"runtimeEventId":"rt-result"/);
+    assert.equal(prompt.includes(oldResult.body), false);
+  });
+
+  test('preserves existing archive refs when preparing stale tool-result pruning', async () => {
+    const model = completionModel();
+    const oldResult = { body: 'EXISTING_ARCHIVE_REF_PAYLOAD'.repeat(20) };
+    const oldSerialized = JSON.stringify(oldResult);
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        name: 'existing-archive-ref-test',
+        staleToolResultPrune: {
+          enabled: true,
+          maxResultEstimatedTokens: 1,
+          minRecentTurnsFull: 0,
+          archiveRefs: [{
+            runtimeEventId: 'rt-result',
+            toolCallId: 'tool-1',
+            toolName: 'Read',
+            artifactId: 'artifact-existing-rt-result',
+            bodySha256: sha256(oldSerialized),
+            originalEstimatedTokens: oldSerialized.length,
+            originalBytes: utf8Bytes(oldSerialized),
+            rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+            reason: 'stale_tool_result_pruned_before_compact',
+          }],
+        },
+        charsPerToken: 1,
+      },
+    });
+
+    await drain(backend.send({
+      turnId: 'turn-current',
+      text: 'current user',
+      context: [],
+      runtimeContext: [
+        runtimeEvent({
+          id: 'rt-call',
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-1', name: 'Read', args: { path: 'package.json' } },
+        }),
+        runtimeEvent({
+          id: 'rt-result',
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: oldResult, isError: false },
+        }),
+      ],
+    }));
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.match(prompt, /"artifactId":"artifact-existing-rt-result"/);
     assert.equal(prompt.includes(oldResult.body), false);
   });
 
@@ -2190,6 +2256,7 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
   test('stale tool-result pruning replaces old payloads before budgeting and preserves replay pairing', () => {
     const oldResult = { body: 'x'.repeat(500) };
     const newResult = { body: 'y'.repeat(500) };
+    const oldSerialized = JSON.stringify(oldResult);
     const events = [
       runtimeEvent({
         id: 'old-call',
@@ -2259,9 +2326,9 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
           toolCallId: 'tool-old',
           toolName: 'Read',
           artifactId: 'artifact-old-result',
-          bodySha256: 'sha256-old-result',
-          originalEstimatedTokens: JSON.stringify(oldResult).length,
-          originalBytes: utf8Bytes(JSON.stringify(oldResult)),
+          bodySha256: sha256(oldSerialized),
+          originalEstimatedTokens: oldSerialized.length,
+          originalBytes: utf8Bytes(oldSerialized),
           rewriteVersion: 1,
           reason: 'stale_tool_result_pruned_before_compact',
         }],
@@ -2298,7 +2365,7 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
     assert.equal(placeholder?.runtimeEventId, 'old-result');
     assert.equal(placeholder?.toolCallId, 'tool-old');
     assert.equal(placeholder?.toolName, 'Read');
-    assert.equal(placeholder?.bodySha256, 'sha256-old-result');
+    assert.equal(placeholder?.bodySha256, sha256(oldSerialized));
 
     const newResponse = budgeted.events.find((event) => event.id === 'new-result');
     assert.equal(newResponse?.content?.kind, 'function_response');

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -263,10 +263,11 @@ describe('AiSdkBackend model history', () => {
     assert.equal(prompt.includes(oldResult.body), false);
   });
 
-  test('preserves existing archive refs when preparing stale tool-result pruning', async () => {
+  test('preserves existing archive refs while adding newly archived refs', async () => {
     const model = completionModel();
-    const oldResult = { body: 'EXISTING_ARCHIVE_REF_PAYLOAD'.repeat(20) };
-    const oldSerialized = JSON.stringify(oldResult);
+    const existingResult = { body: 'EXISTING_ARCHIVE_REF_PAYLOAD'.repeat(20) };
+    const newResult = { body: 'NEW_ARCHIVE_REF_PAYLOAD'.repeat(20) };
+    const existingSerialized = JSON.stringify(existingResult);
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
@@ -290,15 +291,19 @@ describe('AiSdkBackend model history', () => {
             toolCallId: 'tool-1',
             toolName: 'Read',
             artifactId: 'artifact-existing-rt-result',
-            bodySha256: sha256(oldSerialized),
-            originalEstimatedTokens: oldSerialized.length,
-            originalBytes: utf8Bytes(oldSerialized),
+            bodySha256: sha256(existingSerialized),
+            originalEstimatedTokens: existingSerialized.length,
+            originalBytes: utf8Bytes(existingSerialized),
             rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
             reason: 'stale_tool_result_pruned_before_compact',
           }],
         },
         charsPerToken: 1,
       },
+      archiveToolResult: async (event) =>
+        event.runtimeEventId === 'rt-new-result'
+          ? { artifactId: 'artifact-new-rt-result' }
+          : undefined,
     });
 
     await drain(backend.send({
@@ -318,14 +323,30 @@ describe('AiSdkBackend model history', () => {
           turnId: 'turn-prev',
           role: 'tool',
           author: 'tool',
-          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: oldResult, isError: false },
+          content: { kind: 'function_response', id: 'tool-1', name: 'Read', result: existingResult, isError: false },
+        }),
+        runtimeEvent({
+          id: 'rt-new-call',
+          turnId: 'turn-new',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'tool-2', name: 'Read', args: { path: 'new.txt' } },
+        }),
+        runtimeEvent({
+          id: 'rt-new-result',
+          turnId: 'turn-new',
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'tool-2', name: 'Read', result: newResult, isError: false },
         }),
       ],
     }));
 
     const prompt = JSON.stringify(compactPrompt(model));
     assert.match(prompt, /"artifactId":"artifact-existing-rt-result"/);
-    assert.equal(prompt.includes(oldResult.body), false);
+    assert.match(prompt, /"artifactId":"artifact-new-rt-result"/);
+    assert.equal(prompt.includes(existingResult.body), false);
+    assert.equal(prompt.includes(newResult.body), false);
   });
 
   test('history search does not re-add stale full tool results after archive pruning', async () => {

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -150,6 +150,51 @@ describe('context-budget archive retrieval', () => {
     assert.equal(retrieval.diagnosticPatch.archiveRetrievalFailures, 0);
   });
 
+  test('rejects archive refs whose body hash does not match the current result', () => {
+    const currentResult = { kind: 'text', text: 'alpha payload sentinel' };
+    const staleResult = { kind: 'text', text: 'bravo payload sentinel' };
+    const currentSerialized = serializeToolResultForArchive(currentResult);
+    const staleSerialized = serializeToolResultForArchive(staleResult);
+    assert.equal(currentSerialized.length, staleSerialized.length);
+    assert.equal(utf8Bytes(currentSerialized), utf8Bytes(staleSerialized));
+    const events = [
+      toolCall('call-old', 'turn-old', 'tool-old'),
+      toolResult('result-old', 'turn-old', 'tool-old', currentResult),
+      toolCall('call-new', 'turn-new', 'tool-new'),
+      toolResult('result-new', 'turn-new', 'tool-new', { kind: 'text', text: 'new full payload' }),
+    ];
+
+    const budgeted = applyRuntimeEventContextBudget(events, {
+      staleToolResultPrune: {
+        enabled: true,
+        maxResultEstimatedTokens: 1,
+        minRecentTurnsFull: 1,
+        archiveRefs: [{
+          runtimeEventId: 'result-old',
+          toolCallId: 'tool-old',
+          toolName: 'Read',
+          artifactId: 'artifact-stale',
+          bodySha256: sha256(staleSerialized),
+          originalEstimatedTokens: currentSerialized.length,
+          originalBytes: utf8Bytes(currentSerialized),
+          rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+          reason: 'stale_tool_result_pruned_before_compact',
+        }],
+      },
+      minRecentTurns: 1,
+      charsPerToken: 1,
+    });
+
+    assert.ok(budgeted);
+    assert.equal(budgeted.diagnostic.prunedToolResults ?? 0, 0);
+    assert.equal(budgeted.diagnostic.archiveWriteFailures, 1);
+    const result = budgeted.events.find((event) => event.id === 'result-old');
+    assert.deepEqual(
+      result?.content?.kind === 'function_response' ? result.content.result : undefined,
+      currentResult,
+    );
+  });
+
   test('keeps placeholders and records corrupt/missing archive diagnostics', async () => {
     const serialized = serializeToolResultForArchive({ kind: 'text', text: 'body' });
     const events = [toolCall('call-1', 'turn-1', 'tool-1'), archivedResult('result-1', 'turn-1', 'tool-1', {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1187,7 +1187,13 @@ export class AiSdkBackend implements AgentBackend {
     if (policy.staleToolResultPrune?.enabled === true) {
       const candidates = collectStaleToolResultArchiveCandidates(runtimeContext, policy);
       if (candidates.length > 0) {
-        const archiveRefs: ToolResultArchiveRef[] = [];
+        const archiveRefs = new Map<string, ToolResultArchiveRef>();
+        const existingArchiveRefs = nextPolicy.staleToolResultPrune?.archiveRefs;
+        if (Array.isArray(existingArchiveRefs)) {
+          for (const ref of existingArchiveRefs) archiveRefs.set(ref.runtimeEventId, ref);
+        } else if (existingArchiveRefs) {
+          for (const ref of Object.values(existingArchiveRefs)) archiveRefs.set(ref.runtimeEventId, ref);
+        }
         for (const candidate of candidates) {
           const bodySha256 = sha256(candidate.serializedResult);
           const archived = await Promise.resolve(this.input.archiveToolResult?.({
@@ -1196,7 +1202,7 @@ export class AiSdkBackend implements AgentBackend {
             bodySha256,
           })).catch(() => undefined);
           if (!archived?.artifactId) continue;
-          archiveRefs.push({
+          archiveRefs.set(candidate.runtimeEventId, {
             runtimeEventId: candidate.runtimeEventId,
             toolCallId: candidate.toolCallId,
             toolName: candidate.toolName,
@@ -1213,7 +1219,7 @@ export class AiSdkBackend implements AgentBackend {
           ...nextPolicy,
           staleToolResultPrune: {
             ...nextPolicy.staleToolResultPrune!,
-            archiveRefs,
+            archiveRefs: [...archiveRefs.values()],
           },
         };
       }

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -1634,6 +1634,7 @@ function pruneStaleToolResultsBeforeCompact(
       runtimeEventId: event.id,
       toolCallId: content.id,
       toolName: content.name,
+      bodySha256: sha256(serializedResult),
       originalBytes: resultBytes,
       originalEstimatedTokens: resultEstimatedTokens,
     })) {
@@ -1775,6 +1776,7 @@ function archiveRefMatches(
     runtimeEventId: string;
     toolCallId: string;
     toolName: string;
+    bodySha256: string;
     originalEstimatedTokens: number;
     originalBytes: number;
   },
@@ -1788,6 +1790,7 @@ function archiveRefMatches(
     && ref.artifactId.length > 0
     && typeof ref.bodySha256 === 'string'
     && ref.bodySha256.length > 0
+    && ref.bodySha256 === candidate.bodySha256
     && ref.originalEstimatedTokens === candidate.originalEstimatedTokens
     && ref.originalBytes === candidate.originalBytes;
 }


### PR DESCRIPTION
## Summary

Make stale tool-result archive artifacts deterministic, validate archive refs against the current result body, and preserve existing archive refs while preparing context-budget policy.

## Why

Part of #297. Desktop archive writes used random artifact ids, so the same stale tool result could be archived again on later turns. Because the model-visible placeholder includes `artifactId`, that caused prompt churn and made archive-backed replay/synthesis cache references unstable.

## Scope

Changed:

- Generate stable desktop `tool_result_archive` artifact ids from the archive identity and reuse an existing live matching artifact.
- Reuse one desktop archive read/validation helper for both archive persistence reuse and runtime archive reads, covering source, session, size, and `bodySha256`.
- Require `archiveRefMatches` to compare the current serialized result hash, not just ids and sizes.
- Merge existing `archiveRefs` with newly written refs in `AiSdkBackend.prepareContextBudgetPolicy`.
- Add regression coverage for artifact reuse, hash mismatch rejection, and preserving an existing ref while adding a newly archived ref.

Not included:

- Removing `artifactId` from model-visible archive placeholders.
- Synthesis cache replay ordering changes.
- History-search gated archive body matching changes.
- History compact source orphan cleanup.

## Verification

- `npm run -w @maka/runtime test`
- `npm run -w @maka/desktop test -- --test-name-pattern "reuses the archive artifact"`
- `git diff --check`

## User-facing impact

No UI changes. Repeated turns should stop creating duplicate archive artifacts for the same stale tool result body, and archive placeholders should remain stable across replays.

## Reviewer notes

Flat, narrow slice for #297. This is intended to land before the synthesis replay, gated history search, and artifact-orphan follow-ups because it stabilizes the archive identity they build on.

Review follow-up: the desktop archive validation rules are now shared by persist-time reuse and runtime archive reads. The backend regression now covers one existing archive ref plus one newly archived ref in the same policy preparation.