### PR TITLE
PR-GENERAL-DEFAULTS-CONFIGURABLE-0: real General-page default-model control

### DIFF
--- a/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
@@ -1,0 +1,99 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import { join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(process.cwd(), '..', '..');
+const SETTINGS_MODAL = join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'settings', 'SettingsModal.tsx');
+
+/**
+ * PR-GENERAL-DEFAULTS-CONFIGURABLE-0 (WAWQAQ msg `d3ea9a33` 2026-06-26).
+ *
+ * The General page used to ship three read-only `<SettingRow>` lines —
+ * "启动" / "新对话模式" / "默认模型" — that read like settings but had
+ * no configurable backing. The fix dropped the two without persisted
+ * storage and replaced the third with a real `<SettingsSelect>` wired
+ * to `connections.setDefault`. This contract pins both halves so the
+ * regression can't drift back in.
+ */
+describe('General settings configurable contract', () => {
+  it('does not ship the three retired read-only SettingRow lines on General', async () => {
+    const src = await readFile(SETTINGS_MODAL, 'utf8');
+    // Each retired line was: `<SettingRow title="启动" detail="…" value="已启用" />`
+    // etc. Test the trio of (title, hardcoded value) pairs.
+    assert.doesNotMatch(
+      src,
+      /<SettingRow\s+title="启动"[\s\S]*?value="已启用"/,
+      'General page must not re-introduce the read-only 启动 row — make it real (with a backing AppSettings field + IPC) or leave it out.',
+    );
+    assert.doesNotMatch(
+      src,
+      /<SettingRow\s+title="新对话模式"[\s\S]*?value="询问权限"/,
+      'General page must not re-introduce the read-only 新对话模式 row — permission mode is per-session in the composer.',
+    );
+    // The 默认模型 row was: `<SettingRow ... value={props.defaultSlug ?? '未设置'} />`.
+    // Block the SettingRow shape specifically; the new real control is a
+    // `<SettingsSelect>` inside `<GeneralDefaultsCard>`.
+    assert.doesNotMatch(
+      src,
+      /<SettingRow\s+title="默认模型"[\s\S]*?value=\{props\.defaultSlug/,
+      'General page 默认模型 row must use the real <SettingsSelect> inside <GeneralDefaultsCard>, not a read-only <SettingRow>.',
+    );
+  });
+
+  it('renders a real <GeneralDefaultsCard> that persists the default model via connections.setDefault', async () => {
+    const src = await readFile(SETTINGS_MODAL, 'utf8');
+    // The card must be defined and used.
+    assert.match(
+      src,
+      /function GeneralDefaultsCard\(props: \{[\s\S]*connections:\s*readonly LlmConnection\[\];/,
+      '<GeneralDefaultsCard> must accept a readonly LlmConnection[] so the General page can render every enabled connection',
+    );
+    assert.match(
+      src,
+      /<GeneralDefaultsCard\s+connections=\{props\.connections\}\s+defaultSlug=\{props\.defaultSlug\}\s+onRefresh=\{props\.onRefreshConnections\}/,
+      '<GeneralDefaultsCard> must be mounted by the General-page render branch with connections / defaultSlug / onRefresh wired through',
+    );
+    // The actual select + persistence must use the shared SettingsSelect
+    // and the existing connections.setDefault IPC.
+    assert.match(
+      src,
+      /<SettingsSelect[\s\S]*ariaLabel="默认模型连接"[\s\S]*onChange=/,
+      'GeneralDefaultsCard must use the shared <SettingsSelect> primitive (not a custom dropdown) so the popup layering, keyboard nav, and chrome match the rest of Settings',
+    );
+    assert.match(
+      src,
+      /window\.maka\.connections\.setDefault\(/,
+      'GeneralDefaultsCard must persist the choice through the existing connections.setDefault IPC; no new app-settings field needed',
+    );
+  });
+
+  it('guards GeneralDefaultsCard with the same mounted-ref + savingRef ownership pattern used elsewhere in SettingsModal', async () => {
+    const src = await readFile(SETTINGS_MODAL, 'utf8');
+    // Capture the function's body up to the next top-level `function`
+    // declaration so per-card guards are checked inside the component.
+    const cardBlock =
+      src.match(/function GeneralDefaultsCard\(props:[\s\S]*?\n(?=function\s)/)?.[0] ?? '';
+    assert.ok(cardBlock.length > 0, 'GeneralDefaultsCard source must be discoverable');
+    assert.match(
+      cardBlock,
+      /const mountedRef = useRef\(true\);/,
+      'GeneralDefaultsCard must track page-mounted ownership so a slow IPC write does not call setSaving(false) after Settings closes',
+    );
+    assert.match(
+      cardBlock,
+      /const savingRef = useRef\(false\);/,
+      'GeneralDefaultsCard must use a synchronous savingRef so rapid duplicate selects do not race a previous in-flight save',
+    );
+    assert.match(
+      cardBlock,
+      /if \(savingRef\.current\) return;[\s\S]*savingRef\.current = true;[\s\S]*setSaving\(true\);[\s\S]*await window\.maka\.connections\.setDefault/,
+      'GeneralDefaultsCard must take the synchronous savingRef lock before awaiting the IPC; React state alone is not enough to block double-clicks',
+    );
+    assert.match(
+      cardBlock,
+      /catch \(error\)[\s\S]*if \(mountedRef\.current\) \{[\s\S]*toast\.error\('保存默认模型失败'/,
+      'GeneralDefaultsCard failures must surface a localized toast and only while still mounted — silent unhandled rejection regressed the page before',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1058,6 +1058,86 @@ function SettingsSurface(props: {
   );
 }
 
+/**
+ * PR-GENERAL-DEFAULTS-CONFIGURABLE-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
+ * the General page used to ship three read-only `<SettingRow>` lines
+ * (启动 / 新对话模式 / 默认模型) that read like settings but had no
+ * configurable backing — the static text was the entire UI. Drop the
+ * two without backing storage; replace the third with a real
+ * `<SettingsSelect>` that lets the user pick the default LLM
+ * connection inline. The `connections.setDefault(slug)` IPC already
+ * exists; this just wires it up.
+ */
+function GeneralDefaultsCard(props: {
+  connections: readonly LlmConnection[];
+  defaultSlug: string | null;
+  onRefresh(): Promise<void>;
+}) {
+  const toast = useToast();
+  const mountedRef = useRef(true);
+  const savingRef = useRef(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      savingRef.current = false;
+    };
+  }, []);
+
+  const options = useMemo<ReadonlyArray<readonly [string, string]>>(() => {
+    const opts: Array<readonly [string, string]> = [['', '未设置']];
+    for (const connection of props.connections) {
+      if (!connection.enabled) continue;
+      opts.push([connection.slug, connection.name]);
+    }
+    return opts;
+  }, [props.connections]);
+
+  const selectedValue = props.defaultSlug ?? '';
+
+  async function persistDefault(nextSlug: string) {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setSaving(true);
+    try {
+      await window.maka.connections.setDefault(nextSlug || null);
+      if (!mountedRef.current) return;
+      await props.onRefresh();
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error('保存默认模型失败', settingsActionErrorMessage(error));
+      }
+    } finally {
+      if (savingRef.current) {
+        savingRef.current = false;
+      }
+      if (mountedRef.current) setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsRows>
+      <div className="settingsRow" data-control-width="select">
+        <div>
+          <strong>默认模型</strong>
+          <small>新对话默认使用的模型连接；可在「模型」页里管理具体连接。</small>
+        </div>
+        <SettingsSelect
+          value={selectedValue}
+          ariaLabel="默认模型连接"
+          options={options}
+          disabled={saving}
+          onChange={(value) => {
+            void persistDefault(value);
+          }}
+        />
+      </div>
+    </SettingsRows>
+  );
+}
+
 function SettingsPage(props: {
   section: SettingsSection;
   settings: AppSettings;
@@ -1134,11 +1214,11 @@ function SettingsPage(props: {
               />
             </div>
           </SettingsRows>
-          <SettingsRows>
-            <SettingRow title="启动" detail="打开应用后回到最近一次对话。" value="已启用" />
-            <SettingRow title="新对话模式" detail="新对话默认从询问权限开始。" value="询问权限" />
-            <SettingRow title="默认模型" detail="新对话默认使用的模型连接。" value={props.defaultSlug ?? '未设置'} />
-          </SettingsRows>
+          <GeneralDefaultsCard
+            connections={props.connections}
+            defaultSlug={props.defaultSlug}
+            onRefresh={props.onRefreshConnections}
+          />
           <SettingsRows>
             <NetworkProxySection settings={props.settings} onUpdate={props.onUpdateSettings} />
           </SettingsRows>


### PR DESCRIPTION
## Summary

WAWQAQ msg \`d3ea9a33\` 2026-06-26: \"通用里面的很多选项现在都完全无法配置\". The General page used to ship 3 read-only \`<SettingRow>\` lines (启动 / 新对话模式 / 默认模型) that read like settings but had no configurable backing.

## Fix

- 启动 (resume last session): hardcoded renderer behavior, no \`AppSettings\` field. **Drop the row**; making it a real choice needs new persisted state across composer + session restore.
- 新对话模式 (default permission mode): permission mode is already configurable per-session in the composer. Adding a persisted \"default\" cuts across composer + chat session subsystems. **Drop the row**.
- 默认模型 (default model connection): \`connections.setDefault(slug)\` IPC already exists. **Replace with a real \`<SettingsSelect>\`** — new \`<GeneralDefaultsCard>\` component lists every enabled connection, persists via the existing IPC, refreshes parent on success, toasts on failure.

The new component uses the same mounted-ref + savingRef synchronous ownership pattern as the rest of SettingsModal (PR-STOP-ERROR-SURFACE-0 / PR-BOT-RESTART-RACE-0 lineage) so duplicate selects don't race and in-flight saves can't write React state after Settings closes.

## Test plan

- [x] \`npx tsx --test src/main/__tests__/*-contract.test.ts\` → 439/440 pass (1 pre-existing flaky)
- [ ] Visual: open Settings → 通用, change default model from the dropdown, verify the choice persists across Settings close/reopen and reflects in chat header.