### PR TITLE
PR-PALETTE-SWATCH-VISIBLE-0: fix Appearance palette swatches showing as empty grey circles

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-style-pruning-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-pruning-contract.test.ts
@@ -74,6 +74,25 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'shadow-modal',
   'smooth-corners',
   'task-list-item',
+  // PR-PALETTE-SWATCH-VISIBLE-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
+  // ThemeSettingsPage composes the palette swatch class with a template
+  // string — `settingsPaletteSwatch settingsPaletteSwatch-${palette}` —
+  // so the literal `.settingsPaletteSwatch-{name}` selector for each
+  // palette never appears verbatim in the renderer source. The CSS
+  // rules in `styles/settings/theme-preview.css` are real and consumed
+  // at runtime; allowlist them so the orphan-selector guard doesn't
+  // delete the colored backgrounds again.
+  'settingsPaletteSwatch-default',
+  'settingsPaletteSwatch-onedark',
+  'settingsPaletteSwatch-catppuccin-mocha',
+  'settingsPaletteSwatch-tokyo-night',
+  'settingsPaletteSwatch-nord',
+  'settingsPaletteSwatch-coral',
+  'settingsPaletteSwatch-azure',
+  'settingsPaletteSwatch-forest',
+  'settingsPaletteSwatch-dusk',
+  'settingsPaletteSwatch-sand',
+  'settingsPaletteSwatch-mono',
 ]);
 
 async function readSourceFiles(dir: string): Promise<string[]> {

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -317,7 +317,32 @@
   border-radius: 50%;
   border: 2px solid var(--border);
   box-shadow: inset 0 0 0 2px oklch(1 0 0 / 0.25);
+  /* Fallback in case a swatch name has no per-palette rule below
+     (e.g. a new palette landed in `THEME_PALETTES` but its swatch
+     color wasn't added yet) — show the active accent so the missing
+     row at least previews something instead of going invisible. */
+  background: var(--accent);
 }
+
+/* PR-PALETTE-SWATCH-VISIBLE-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
+   each palette's swatch needs its own background-color or every
+   `.settingsPaletteSwatch-*` falls through to no fill and reads as
+   an empty grey circle on the Appearance page. The accent values are
+   copied verbatim from the light-mode block of each `[data-maka-
+   theme="…"]` rule in `maka-tokens.css` so the picker previews the
+   palette's brand identity even when the current page is on a
+   different palette. */
+.settingsPaletteSwatch-default          { background: oklch(0.70 0.135 152); }
+.settingsPaletteSwatch-onedark          { background: oklch(0.60 0.14 250); }
+.settingsPaletteSwatch-catppuccin-mocha { background: oklch(0.65 0.18 330); }
+.settingsPaletteSwatch-tokyo-night      { background: oklch(0.55 0.16 215); }
+.settingsPaletteSwatch-nord             { background: oklch(0.62 0.12 215); }
+.settingsPaletteSwatch-coral            { background: oklch(0.68 0.18 25); }
+.settingsPaletteSwatch-azure            { background: oklch(0.58 0.18 252); }
+.settingsPaletteSwatch-forest           { background: oklch(0.50 0.12 152); }
+.settingsPaletteSwatch-dusk             { background: oklch(0.55 0.18 305); }
+.settingsPaletteSwatch-sand             { background: oklch(0.62 0.14 55); }
+.settingsPaletteSwatch-mono             { background: oklch(0.30 0 0); }
 /* PR-PALETTE-PICKER-GROUPS-0: subgroup container that gathers a small
    heading (编辑器主题 / 产品色调) above its own grid. Spacing matches
    the existing settingsSubheading rhythm so the page reads as one


### PR DESCRIPTION
## Summary

WAWQAQ msg \`d3ea9a33\` 2026-06-26: "现在外观里面的颜色都没有显示出来". The Appearance palette picker composes each swatch class with a template string (\`settingsPaletteSwatch settingsPaletteSwatch-\${palette}\`) but \`styles/settings/theme-preview.css\` only carried the base size/border recipe — no per-palette \`background-color\` for any of the 11 \`THEME_PALETTES\`. Every swatch fell through to transparent and read as an empty grey circle.

## Fix

- Add a \`.settingsPaletteSwatch-{name}\` rule for each entry in \`THEME_PALETTES\` (default / onedark / catppuccin-mocha / tokyo-night / nord / coral / azure / forest / dusk / sand / mono). The accent values are copied verbatim from each palette's light-mode \`[data-maka-theme="…"]\` block in \`maka-tokens.css\` so the picker previews the brand identity regardless of the user's current theme.
- Safety net on the base \`.settingsPaletteSwatch\` rule: \`background: var(--accent)\`. If a future palette ships in \`THEME_PALETTES\` without a matching swatch rule, it falls through to the active accent instead of going invisible.
- Contract follow-up: allowlist the 11 \`settingsPaletteSwatch-*\` selectors as dynamic style hooks since they're composed via template string and never appear verbatim in source.

## Test plan

- [x] \`npx tsx --test src/main/__tests__/*-contract.test.ts\` → 439/440 pass (1 pre-existing flaky)
- [ ] Visual: open Settings → 外观, scroll to palette picker, verify each swatch shows its real accent color (coral pink, azure blue, forest green, etc.) instead of empty grey circles.