### PR TITLE
PR-PERMISSIONS-UNIFIED-CARD-0: unify OS permission rows + horizontal actions

### DIFF
--- a/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { readRendererContractCss } from './contract-css-helpers.js';
+
+const repoRoot = process.cwd().endsWith('apps/desktop')
+  ? join(process.cwd(), '..', '..')
+  : process.cwd();
+
+async function readRepo(path: string): Promise<string> {
+  return readFile(join(repoRoot, path), 'utf8');
+}
+
+function ruleBody(css: string, selector: string): string {
+  // Match the rule body for an exact selector. Anchored via `\n` so e.g.
+  // `.settingsOsPermissionRow` does not also match `.settingsOsPermissionRowFoo`.
+  const escaped = selector.replace(/[.[\]/+*]/g, (ch) => `\\${ch}`);
+  const re = new RegExp(`(?:^|\\n)\\s*${escaped}\\s*\\{([^}]*)\\}`, 'm');
+  const match = css.match(re);
+  return match ? match[1]! : '';
+}
+
+describe('PR-PERMISSIONS-UNIFIED-CARD-0 contract (#309)', () => {
+  it('.settingsOsPermissionList renders as a single grouped card', async () => {
+    const css = await readRendererContractCss();
+    const body = ruleBody(css, '.settingsOsPermissionList');
+    assert.ok(body, '.settingsOsPermissionList rule must exist');
+
+    // Grouped card chrome lives on the outer container.
+    assert.match(body, /\bborder:\s*1px\s+solid\s+var\(--border\)/, 'list must own the outer border');
+    assert.match(body, /\bborder-radius:\s*12px\b/, 'list must own the 12px outer radius');
+    assert.match(body, /\bbackground:\s*var\(--background\)/, 'list must own the outer background');
+    assert.match(body, /\boverflow:\s*hidden\b/, 'list must clip rows so divider corners stay clean');
+
+    // It must be a vertical stack (not a grid with gap that re-introduces
+    // the floating-card look).
+    assert.match(body, /\bdisplay:\s*flex\b/, 'list must use flex layout');
+    assert.match(body, /\bflex-direction:\s*column\b/, 'list must stack rows vertically');
+    assert.doesNotMatch(body, /\bgap:\s*[1-9]/, 'list must not put a gap between rows (use hairline divider instead)');
+  });
+
+  it('.settingsOsPermissionRow drops per-row card chrome in favor of a hairline divider', async () => {
+    const css = await readRendererContractCss();
+    const body = ruleBody(css, '.settingsOsPermissionRow');
+    assert.ok(body, '.settingsOsPermissionRow rule must exist');
+
+    // The grouped card pattern owns its chrome on the outer list. Each
+    // row must not re-introduce its own border / radius / shadow.
+    assert.doesNotMatch(body, /\bborder:\s*1px\b/, 'row must not own a per-row border');
+    assert.doesNotMatch(body, /\bborder-radius:\s*[0-9]/, 'row must not own a per-row border-radius');
+    assert.doesNotMatch(body, /\bbox-shadow:\s*[^;]+;/, 'row must not own a per-row box-shadow');
+
+    // Adjacency selector provides a 6% foreground hairline between rows.
+    assert.match(
+      css,
+      /\.settingsOsPermissionRow\s*\+\s*\.settingsOsPermissionRow\s*\{[^}]*border-top:\s*1px solid oklch\(from var\(--foreground\) l c h \/ 0\.06\)/,
+      'adjacent rows must share a 6% foreground hairline divider',
+    );
+  });
+
+  it('.settingsOsPermissionActions lays out buttons horizontally + right-aligned', async () => {
+    const css = await readRendererContractCss();
+    const body = ruleBody(css, '.settingsOsPermissionActions');
+    assert.ok(body, '.settingsOsPermissionActions rule must exist');
+
+    assert.match(body, /\bdisplay:\s*flex\b/, 'actions must use flex layout');
+    assert.match(body, /\bflex-direction:\s*row\b/, 'actions must be a row, not a column');
+    assert.match(body, /\bjustify-content:\s*flex-end\b/, 'actions must be right-aligned');
+    assert.doesNotMatch(body, /\bflex-direction:\s*column\b/, 'actions must not stack vertically');
+  });
+
+  it('OsPermissionRow JSX renders open-settings before request, ghost when both, primary when alone', async () => {
+    const src = await readRepo('apps/desktop/src/renderer/settings/SettingsModal.tsx');
+    // Scope to the actions block (delimited by `<div className="settingsOsPermissionActions">` …
+    // `</div>`). The non-greedy `[\s\S]*?` plus the `</div>` close avoid
+    // accidentally swallowing the surrounding `</li>` boundary.
+    const actionsBlock = src.match(
+      /className="settingsOsPermissionActions"[\s\S]*?<\/div>/,
+    )?.[0] ?? '';
+    assert.ok(actionsBlock, 'settingsOsPermissionActions JSX block must exist');
+
+    const showOpenIdx = actionsBlock.indexOf('showOpenSettings');
+    const showRequestIdx = actionsBlock.indexOf('showRequest');
+    assert.ok(showOpenIdx > -1 && showRequestIdx > -1, 'both gates must exist in the actions block');
+    assert.ok(
+      showOpenIdx < showRequestIdx,
+      'open-settings button must render before request button so primary anchors the right edge',
+    );
+
+    // When both are shown, open-settings collapses to variant=ghost; when
+    // alone (no `请求授权`) it returns to variant=default so the row
+    // still has a primary CTA.
+    assert.match(
+      actionsBlock,
+      /variant=\{showRequest \? 'ghost' : 'default'\}/,
+      'open-settings button must be ghost when paired with request, default when alone',
+    );
+
+    // Request button does not pass a `variant` prop — it defaults to the
+    // primary `default` variant. Make sure no future edit silently
+    // demotes it to ghost.
+    const requestButton = actionsBlock.match(/showRequest && \(\s*<Button[\s\S]*?<\/Button>\s*\)/)?.[0] ?? '';
+    assert.ok(requestButton, 'showRequest && Button JSX must be findable');
+    assert.doesNotMatch(
+      requestButton,
+      /variant=("|\{')(ghost|secondary|outline|link)/,
+      'request-permission button must remain the primary CTA',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -6654,7 +6654,27 @@ function OsPermissionRow(props: {
           <small className="settingsOsPermissionReason">{snapshot.reason}</small>
         ) : null}
       </div>
+      {/* PR-PERMISSIONS-UNIFIED-CARD-0 (WAWQAQ msg `d3ea9a33`
+          2026-06-26): the action buttons used to stack vertically with
+          two competing button styles (primary + secondary). Order so
+          the primary "请求授权" anchors the right edge, with the
+          system-settings link as a quieter ghost variant on the left.
+          When only one button is shown (e.g. the OS doesn't expose a
+          request flow for the permission), it still falls under the
+          primary slot — no awkward "lonely secondary" state. */}
       <div className="settingsOsPermissionActions">
+        {showOpenSettings && (
+          <Button
+            type="button"
+            variant={showRequest ? 'ghost' : 'default'}
+            size="sm"
+            onClick={props.onOpenSettings}
+            disabled={busy}
+            aria-busy={pendingKey === 'openSettings' ? 'true' : undefined}
+          >
+            {pendingKey === 'openSettings' ? '打开中…' : '前往系统设置'}
+          </Button>
+        )}
         {showRequest && (
           <Button
             type="button"
@@ -6664,18 +6684,6 @@ function OsPermissionRow(props: {
             aria-busy={pendingKey === 'request' ? 'true' : undefined}
           >
             {pendingKey === 'request' ? '请求中…' : '请求授权'}
-          </Button>
-        )}
-        {showOpenSettings && (
-          <Button
-            type="button"
-            variant={showRequest ? 'secondary' : 'default'}
-            size="sm"
-            onClick={props.onOpenSettings}
-            disabled={busy}
-            aria-busy={pendingKey === 'openSettings' ? 'true' : undefined}
-          >
-            {pendingKey === 'openSettings' ? '打开中…' : '前往系统设置'}
           </Button>
         )}
       </div>

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -333,34 +333,47 @@
     color: var(--foreground-70);
   }
 
+  /* PR-PERMISSIONS-UNIFIED-CARD-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
+     "权限与能力，里面的权限部分都是应该并在一块的，现在不是一个单独
+     的权限组件，和其他的组件不一样". The OS-permission rows used to
+     each render as their own bordered card with a 12px gap between
+     them, so the section read as 4 floating chips instead of one
+     grouped settings card. Wrap them in a single outer card (border +
+     radius + background) and have each row contribute just a bottom
+     hairline divider — same shape as `.settingsRows` on the General /
+     Bot Chat / Daily Review pages. */
   .settingsOsPermissionList {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: grid;
-    /* PR-SETTINGS-PERMISSION-POLISH-0 (WAWQAQ msg `6a04b077` reference
-       comparison): cards looked cramped at 6px gap; reference has ~12px
-       between cards so each row breathes. */
-    gap: 12px;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--background);
+    overflow: hidden;
   }
 
-  /* PR-PERMISSION-PAGE-REDESIGN: card layout with icon + body + actions.
-     PR-SETTINGS-PERMISSION-POLISH-0 (round 16): bumped padding 12/14 → 16/18,
-     icon track 32 → 36, label 14 → 15, purpose 12.5 → 13 + 1.5 line-height.
-     Status-tinted icon bg so reference's pastel chip-icon feel survives. */
+  /* Per-row hairline divider — last child drops it so the outer card
+     border closes cleanly. */
+  .settingsOsPermissionRow + .settingsOsPermissionRow {
+    border-top: 1px solid oklch(from var(--foreground) l c h / 0.06);
+  }
+
+  /* PR-PERMISSION-PAGE-REDESIGN: icon + body + actions row layout.
+     PR-PERMISSIONS-UNIFIED-CARD-0: dropped the per-row border + radius
+     + shadow that ran against the outer grouped card. The status-tinted
+     border now lives as a left-edge accent stripe (see status rules
+     below) so denied / granted / not_determined still read at a glance. */
   .settingsOsPermissionRow {
+    position: relative;
     display: grid;
     grid-template-columns: 36px minmax(0, 1fr) auto;
     align-items: flex-start;
     gap: 14px;
     padding: 16px 18px;
-    border: 1px solid var(--card-border-color, var(--border));
-    border-radius: var(--card-radius, 10px);
-    background: var(--card-bg, var(--background));
-    box-shadow:
-      var(--card-shadow, none),
-      var(--card-highlight, none);
-    transition: border-color 160ms var(--ease-out-strong), box-shadow 160ms var(--ease-out-strong);
+    background: var(--background);
+    transition: background 160ms var(--ease-out-strong);
   }
 
   .settingsOsPermissionIcon {
@@ -434,22 +447,47 @@
     font-style: italic;
   }
 
+  /* PR-PERMISSIONS-UNIFIED-CARD-0: action buttons used to stack
+     vertically (column / align-items: flex-end / 6px gap), which read
+     as "two separate options" rather than a primary + secondary pair.
+     Lay them out horizontally with the primary "请求授权" on the right
+     so the eye-tracking matches `.settingsPageFooterActions` and the
+     reference Settings rows elsewhere. The two buttons share size="sm"
+     so the row height stays flush; the secondary "前往系统设置" uses
+     `variant="ghost"` (less competing chrome) so the primary visibly
+     anchors the row. */
   .settingsOsPermissionActions {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
-    align-items: flex-end;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
     flex-shrink: 0;
   }
 
-  .settingsOsPermissionRow[data-state="denied"] {
-    border-color: oklch(from var(--destructive) l c h / 0.30);
+  /* PR-PERMISSIONS-UNIFIED-CARD-0: status accents live as left-edge
+     stripes on the outer grouped card so denied / not_determined /
+     granted are visible at a glance without re-introducing per-row
+     borders that fight the unified card. */
+  .settingsOsPermissionRow[data-state="denied"]::before,
+  .settingsOsPermissionRow[data-state="not_determined"]::before,
+  .settingsOsPermissionRow[data-state="granted"]::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
   }
-  .settingsOsPermissionRow[data-state="not_determined"] {
-    border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
+  .settingsOsPermissionRow[data-state="denied"]::before {
+    background: oklch(from var(--destructive) l c h / 0.55);
   }
-  .settingsOsPermissionRow[data-state="granted"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
+  .settingsOsPermissionRow[data-state="not_determined"]::before {
+    background: oklch(from var(--warning, var(--info)) l c h / 0.55);
+  }
+  .settingsOsPermissionRow[data-state="granted"]::before {
+    background: oklch(from var(--success) l c h / 0.45);
   }
   .settingsOsPermissionRow[data-state="granted"] .settingsOsPermissionIcon {
     background: oklch(from var(--success) l c h / 0.08);


### PR DESCRIPTION
## Summary

WAWQAQ msg \`d3ea9a33\` 2026-06-26 (two halves of one issue):

> 权限与能力，里面的权限部分都是应该并在一块的，现在不是一个单独的权限组件，和其他的组件不一样。其他的模式，这里面相关的东西都是并在一块的，而不是中间有间隔和空白。

> 现在权限与能力里面，权限的部分有些地方有两个按钮，这个按钮的设置太不美观了。一个是请求授权，一个是前往系统设置，它们的颜色感觉配置不美观，位置也配置的不美观，需要重新设置。

## Unify the rows

- The OS-permission list used to render each row as its own bordered card with a 12px gap — 4 floating chips instead of one grouped card like \`.settingsRows\` elsewhere.
- Now: \`.settingsOsPermissionList\` is the single outer card (border + 12px radius + background). Each row drops its own border and just gets a top hairline divider via \`.settingsOsPermissionRow + .settingsOsPermissionRow\`.
- Status accent (denied / not_determined / granted) lives as a 3px left-edge stripe so the at-a-glance read stays intact.

## Fix the two buttons

- Used to stack vertically with two competing button styles (primary + secondary).
- Now horizontal flex with primary "请求授权" on the right (LTR eye-tracking, matches the rest of Settings) and the system-settings link as quieter \`variant="ghost"\` on the left.
- If request is hidden (some permissions don't expose a programmatic request flow), open-settings stays \`default\` primary so the row still has one clear CTA.

## Test plan

- [x] \`npx tsx --test src/main/__tests__/*-contract.test.ts\` → 439/440 pass (1 pre-existing flaky)
- [ ] Visual: open Settings → 权限与能力, verify the OS permission section reads as one grouped card with horizontal actions, and that denied / pending / granted rows still show their status color via the left-edge stripe.