### PR TITLE
[codex] fix kimi coding plan urls

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -14,6 +14,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
+  PROVIDER_DEFAULTS,
   normalizeConnectionBaseUrl,
   validateConnectionBaseUrl,
 } from '../llm-connections.js';
@@ -44,6 +45,7 @@ describe('validateConnectionBaseUrl (PR-UI-IPC-1, @kenji msg 35260e29)', () => {
         'https://generativelanguage.googleapis.com',
         'https://api.deepseek.com',
         'https://api.z.ai/api/coding/paas/v4',
+        'https://api.kimi.com/coding/v1',
         'https://api.moonshot.cn/v1',
       ];
       for (const url of canonical) {
@@ -179,6 +181,15 @@ describe('validateConnectionBaseUrl (PR-UI-IPC-1, @kenji msg 35260e29)', () => {
       assert.equal(validateConnectionBaseUrl('HTTPS://api.example.com'), null);
       assert.equal(validateConnectionBaseUrl('Http://localhost:8000'), null);
     });
+  });
+});
+
+describe('provider URL defaults', () => {
+  it('keeps Kimi Coding Plan separate from Moonshot API key access', () => {
+    assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].baseUrl, 'https://api.kimi.com/coding/v1');
+    assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].signupUrl, 'https://www.kimi.com/code/console');
+    assert.equal(PROVIDER_DEFAULTS.moonshot.baseUrl, 'https://api.moonshot.cn/v1');
+    assert.equal(PROVIDER_DEFAULTS.moonshot.signupUrl, 'https://platform.kimi.com/console/api-keys');
   });
 });
 

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -132,7 +132,7 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
   'kimi-coding-plan': {
     label: 'Kimi Coding Plan',
     description: 'Kimi for Coding over Anthropic-compatible protocol.',
-    baseUrl: 'https://api.moonshot.cn/anthropic',
+    baseUrl: 'https://api.kimi.com/coding/v1',
     authKind: 'api_key',
     backendKind: 'ai-sdk',
     fallbackModels: ['kimi-for-coding'],
@@ -140,7 +140,7 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
     protocol: 'anthropic',
     category: 'domestic',
     catalogBadge: 'Coding',
-    signupUrl: 'https://platform.moonshot.cn/console/api-keys',
+    signupUrl: 'https://www.kimi.com/code/console',
   },
   openai: {
     label: 'OpenAI',
@@ -192,7 +192,7 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
     protocol: 'openai',
     category: 'domestic',
     catalogBadge: 'API',
-    signupUrl: 'https://platform.moonshot.cn/console/api-keys',
+    signupUrl: 'https://platform.kimi.com/console/api-keys',
   },
   'zai-coding-plan': {
     label: 'Z.AI Coding Plan',


### PR DESCRIPTION
## Why
- Kimi Coding Plan was still using an old Moonshot Anthropic-compatible URL.
- The regular Moonshot/Kimi API-key provider should stay on the OpenAI-compatible Moonshot API URL.

## How
- Point Kimi Coding Plan to `https://api.kimi.com/coding/v1`.
- Update Kimi Coding Plan and Moonshot account links to the current Kimi pages.
- Add a provider-default test that keeps Coding Plan separate from regular Moonshot API access.

## Tests
- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/core run build`
- `node --test packages/core/dist/__tests__/llm-connections.test.js`