### PR TITLE
fix(ui): smooth assistant completion handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/assistant-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/assistant-stream.test.ts
@@ -340,6 +340,12 @@ describe('applyAssistantDelta — monotonic truncated propagation', () => {
 });
 
 describe('applyAssistantComplete — final payload replace path', () => {
+  it('returns an empty result for an empty complete payload', () => {
+    const result = applyAssistantComplete('');
+
+    assert.deepEqual(result, { text: '', redacted: false, truncated: false });
+  });
+
   it('does not apply the per-delta cap to a complete payload under the total cap', () => {
     const finalText = 'word '.repeat(Math.ceil(ASSISTANT_MAX_DELTA_CHARS / 5) + 20);
     assert.ok(finalText.length > ASSISTANT_MAX_DELTA_CHARS);

--- a/apps/desktop/src/main/__tests__/assistant-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/assistant-stream.test.ts
@@ -19,6 +19,7 @@ import { describe, it } from 'node:test';
 import {
   ASSISTANT_MAX_DELTA_CHARS,
   ASSISTANT_MAX_TOTAL_CHARS,
+  applyAssistantComplete,
   applyAssistantDelta,
 } from '@maka/ui/assistant-stream';
 
@@ -335,5 +336,28 @@ describe('applyAssistantDelta — monotonic truncated propagation', () => {
   it('reports truncated=false for a small delta that fits comfortably', () => {
     const result = applyAssistantDelta('hello', ' there');
     assert.equal(result.truncated, false);
+  });
+});
+
+describe('applyAssistantComplete — final payload replace path', () => {
+  it('does not apply the per-delta cap to a complete payload under the total cap', () => {
+    const finalText = 'word '.repeat(Math.ceil(ASSISTANT_MAX_DELTA_CHARS / 5) + 20);
+    assert.ok(finalText.length > ASSISTANT_MAX_DELTA_CHARS);
+    assert.ok(finalText.length < ASSISTANT_MAX_TOTAL_CHARS);
+
+    const result = applyAssistantComplete(finalText);
+
+    assert.equal(result.text, finalText);
+    assert.equal(result.truncated, false);
+  });
+
+  it('redacts and total-caps the final complete payload before it reaches state', () => {
+    const secret = 'sk-abcdef1234567890abcdef1234567890';
+    const result = applyAssistantComplete(`token ${secret} tail that is too long`, { maxTotalChars: 24 });
+
+    assert.ok(!result.text.includes(secret), 'raw secret must not survive complete payload handling');
+    assert.ok(result.text.endsWith('\n\n[…后续已截断]'));
+    assert.equal(result.redacted, true);
+    assert.equal(result.truncated, true);
   });
 });

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -20,7 +20,7 @@ describe('active session message lifecycle contract', () => {
     const ui = await readFile(join(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'components.tsx'), 'utf8');
     const activeSessionEffect = src.match(/useEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
     const activeReadCatch = activeSessionEffect.match(/readMessages\(activeId\)[\s\S]*?\.catch\(\(error\) => \{[\s\S]*?\n      \}\);/)?.[0] ?? '';
-    const refreshMessages = src.match(/async function refreshMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const refreshMessages = src.match(/async function refreshMessages\(sessionId: string\)(?:: Promise<boolean>)? \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const retryMessages = src.match(/async function retryMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(

--- a/apps/desktop/src/main/__tests__/smooth-stream.test.ts
+++ b/apps/desktop/src/main/__tests__/smooth-stream.test.ts
@@ -29,6 +29,7 @@ import { describe, it } from 'node:test';
 import {
   computeFrameAdvance,
   prepareSmoothStreamText,
+  resolveCompletionMaxCps,
   resolveInitialDisplayedCount,
   segmentGraphemes,
   shouldSnapForBacklog,
@@ -270,8 +271,21 @@ describe('shouldSnapForBacklog', () => {
         rawGraphemeCount: 5_200,
         displayedGraphemeCount: 200,
         maxBacklogGraphemes: 800,
+        streaming: true,
       }),
       true,
+    );
+  });
+
+  it('does not snap a completion-drain backlog just because the final text arrived at once', () => {
+    assert.equal(
+      shouldSnapForBacklog({
+        rawGraphemeCount: 5_200,
+        displayedGraphemeCount: 200,
+        maxBacklogGraphemes: 800,
+        streaming: false,
+      }),
+      false,
     );
   });
 });
@@ -293,6 +307,34 @@ describe('updateEma', () => {
   it('ignores non-finite observed (stalled arrival → dt 0 → cps Infinity)', () => {
     assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: Infinity }), 50);
     assert.equal(updateEma({ prevEma: 50, alpha: 0.3, observedCps: NaN }), 50);
+  });
+});
+
+describe('resolveCompletionMaxCps', () => {
+  it('raises the completion ceiling so a large final tail can drain inside the budget', () => {
+    assert.equal(
+      resolveCompletionMaxCps({
+        rawGraphemeCount: 5_200,
+        displayedGraphemeCount: 200,
+        elapsedMs: 0,
+        budgetMs: 500,
+        maxCps: 400,
+      }),
+      10_000,
+    );
+  });
+
+  it('keeps the normal max when the final tail already fits the budget', () => {
+    assert.equal(
+      resolveCompletionMaxCps({
+        rawGraphemeCount: 260,
+        displayedGraphemeCount: 200,
+        elapsedMs: 0,
+        budgetMs: 500,
+        maxCps: 400,
+      }),
+      400,
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -6,6 +6,12 @@ import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ChatView } from '@maka/ui';
+import {
+  drainAssistantStreamSlot,
+  markAssistantStreamSlotDraining,
+  settleAssistantStreamSlot,
+  type AssistantStreamSlots,
+} from '@maka/ui/assistant-stream';
 
 describe('assistant streaming handoff', () => {
   it('keeps a draining assistant answer as the single visible owner before committed handoff', () => {
@@ -58,25 +64,6 @@ describe('assistant streaming handoff', () => {
     );
   });
 
-  it('refreshes committed messages before clearing the drained streaming bubble', async () => {
-    const rendererPath = sourcePath('src/renderer/main.tsx');
-    const source = await readFile(rendererPath, 'utf8');
-    const start = source.indexOf('function settleAssistantStreaming');
-    const end = source.indexOf('\n\n  function handleEvent', start);
-    const body = start >= 0 && end > start ? source.slice(start, end) : '';
-
-    assert.ok(body, 'settleAssistantStreaming should be present');
-    const refreshIndex = body.indexOf('await refreshMessages(sessionId)');
-    const clearIndex = body.indexOf('setStreamingBySession');
-
-    assert.ok(refreshIndex >= 0, 'handoff should await the committed message refresh');
-    assert.ok(clearIndex >= 0, 'handoff should still clear streaming after refresh');
-    assert.ok(
-      refreshIndex < clearIndex,
-      'handoff must not blank the streaming bubble before committed history is ready',
-    );
-  });
-
   it('complete uses the live streaming slot ref instead of the subscription-time closure', async () => {
     const rendererPath = sourcePath('src/renderer/main.tsx');
     const source = await readFile(rendererPath, 'utf8');
@@ -93,6 +80,127 @@ describe('assistant streaming handoff', () => {
       /const slot = streamingBySession\[sessionId\]/,
       'complete must not read streamingBySession from the stale subscription closure',
     );
+  });
+
+  it('text_complete replaces the live slot with the final draining text', () => {
+    const current: AssistantStreamSlots = {
+      'session-1': { text: 'part', truncated: true, phase: 'streaming', messageId: 'assistant-1' },
+    };
+
+    const next = drainAssistantStreamSlot(current, 'session-1', 'final answer', 'assistant-1');
+
+    assert.equal(next['session-1']?.text, 'final answer');
+    assert.equal(next['session-1']?.truncated, false);
+    assert.equal(next['session-1']?.phase, 'draining');
+    assert.equal(next['session-1']?.messageId, 'assistant-1');
+  });
+
+  it('complete marks the current streamed text as draining without replacing it', () => {
+    const current: AssistantStreamSlots = {
+      'session-1': { text: 'delta accumulated text', truncated: false, phase: 'streaming', messageId: 'assistant-1' },
+    };
+
+    const next = markAssistantStreamSlotDraining(current, 'session-1');
+
+    assert.equal(next['session-1']?.text, 'delta accumulated text');
+    assert.equal(next['session-1']?.phase, 'draining');
+    assert.equal(next['session-1']?.messageId, 'assistant-1');
+  });
+
+  it('clears the settled stream slot even when the committed-message refresh fails once', async () => {
+    let slots: AssistantStreamSlots = {
+      'session-1': { text: 'final answer', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+    };
+
+    await settleAssistantStreamSlot({
+      sessionId: 'session-1',
+      messageId: 'assistant-1',
+      getCurrent: () => slots,
+      refreshMessages: async () => false,
+      setCurrent: (updater) => {
+        slots = updater(slots);
+      },
+    });
+
+    assert.deepEqual(slots['session-1'], { text: '', truncated: false, phase: 'streaming' });
+  });
+
+  it('refreshes committed messages before clearing the settled stream slot when refresh succeeds', async () => {
+    const order: string[] = [];
+    let slots: AssistantStreamSlots = {
+      'session-1': { text: 'final answer', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+    };
+
+    await settleAssistantStreamSlot({
+      sessionId: 'session-1',
+      messageId: 'assistant-1',
+      getCurrent: () => slots,
+      refreshMessages: async () => {
+        order.push('refresh');
+        return true;
+      },
+      setCurrent: (updater) => {
+        order.push('clear');
+        slots = updater(slots);
+      },
+    });
+
+    assert.deepEqual(order, ['refresh', 'clear']);
+    assert.deepEqual(slots['session-1'], { text: '', truncated: false, phase: 'streaming' });
+  });
+
+  it('does not clear a newer stream slot that replaces the settled one during refresh', async () => {
+    const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-old' };
+    let slots: AssistantStreamSlots = { 'session-1': settledSlot };
+
+    await settleAssistantStreamSlot({
+      sessionId: 'session-1',
+      messageId: 'assistant-old',
+      getCurrent: () => slots,
+      refreshMessages: async () => {
+        slots = {
+          'session-1': { text: 'new answer', truncated: false, phase: 'streaming', messageId: 'assistant-new' },
+        };
+        return true;
+      },
+      setCurrent: (updater) => {
+        slots = updater(slots);
+      },
+    });
+
+    assert.deepEqual(slots['session-1'], {
+      text: 'new answer',
+      truncated: false,
+      phase: 'streaming',
+      messageId: 'assistant-new',
+    });
+  });
+
+  it('does not clear a replaced draining slot only because the message id still matches', async () => {
+    const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-1' };
+    let slots: AssistantStreamSlots = { 'session-1': settledSlot };
+
+    await settleAssistantStreamSlot({
+      sessionId: 'session-1',
+      messageId: 'assistant-1',
+      getCurrent: () => slots,
+      refreshMessages: async () => {
+        slots = {
+          'session-1': { text: 'replacement final', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+        };
+        return true;
+      },
+      setCurrent: (updater) => {
+        slots = updater(slots);
+      },
+    });
+
+    assert.deepEqual(slots['session-1'], {
+      text: 'replacement final',
+      truncated: false,
+      phase: 'draining',
+      messageId: 'assistant-1',
+    });
   });
 });
 

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -1,15 +1,13 @@
 import { strict as assert } from 'node:assert';
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ChatView } from '@maka/ui';
 import {
+  applyAssistantComplete,
+  clearSettledAssistantStreamSlot,
   drainAssistantStreamSlot,
   markAssistantStreamSlotDraining,
-  settleAssistantStreamSlot,
   type AssistantStreamSlots,
 } from '@maka/ui/assistant-stream';
 
@@ -51,43 +49,12 @@ describe('assistant streaming handoff', () => {
     );
   });
 
-  it('does not clear the live assistant buffer directly on text_complete', async () => {
-    const rendererPath = sourcePath('src/renderer/main.tsx');
-    const source = await readFile(rendererPath, 'utf8');
-    const branch = source.match(/case 'text_complete':[\s\S]*?case 'thinking_delta':/)?.[0] ?? '';
-
-    assert.ok(branch, 'text_complete branch should be present');
-    assert.doesNotMatch(
-      branch,
-      /clearStreaming\(sessionId\)/,
-      'text_complete should drain the smoother before clearing the streaming bubble',
-    );
-  });
-
-  it('complete uses the live streaming slot ref instead of the subscription-time closure', async () => {
-    const rendererPath = sourcePath('src/renderer/main.tsx');
-    const source = await readFile(rendererPath, 'utf8');
-    const branch = source.match(/case 'complete':[\s\S]*?default:/)?.[0] ?? '';
-
-    assert.ok(branch, 'complete branch should be present');
-    assert.match(
-      branch,
-      /streamingBySessionRef\.current\[sessionId\]/,
-      'complete events arrive through an activeId-only subscription, so the handler must read the latest streaming slot from a ref',
-    );
-    assert.doesNotMatch(
-      branch,
-      /const slot = streamingBySession\[sessionId\]/,
-      'complete must not read streamingBySession from the stale subscription closure',
-    );
-  });
-
   it('text_complete replaces the live slot with the final draining text', () => {
     const current: AssistantStreamSlots = {
       'session-1': { text: 'part', truncated: true, phase: 'streaming', messageId: 'assistant-1' },
     };
 
-    const next = drainAssistantStreamSlot(current, 'session-1', 'final answer', 'assistant-1');
+    const next = drainAssistantStreamSlot(current, 'session-1', applyAssistantComplete('final answer'), 'assistant-1');
 
     assert.equal(next['session-1']?.text, 'final answer');
     assert.equal(next['session-1']?.truncated, false);
@@ -107,68 +74,48 @@ describe('assistant streaming handoff', () => {
     assert.equal(next['session-1']?.messageId, 'assistant-1');
   });
 
-  it('clears the settled stream slot even when the committed-message refresh fails once', async () => {
-    let slots: AssistantStreamSlots = {
-      'session-1': { text: 'final answer', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+  it('settled slot reducer clears after refresh failure because the clear no longer depends on refresh success', () => {
+    const settledSlot = { text: 'final answer', truncated: false, phase: 'draining' as const, messageId: 'assistant-1' };
+    const slots: AssistantStreamSlots = {
+      'session-1': settledSlot,
     };
 
-    await settleAssistantStreamSlot({
-      sessionId: 'session-1',
-      messageId: 'assistant-1',
-      getCurrent: () => slots,
-      refreshMessages: async () => false,
-      setCurrent: (updater) => {
-        slots = updater(slots);
-      },
-    });
+    const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-1');
 
-    assert.deepEqual(slots['session-1'], { text: '', truncated: false, phase: 'streaming' });
+    assert.deepEqual(next['session-1'], { text: '', truncated: false, phase: 'streaming' });
   });
 
-  it('refreshes committed messages before clearing the settled stream slot when refresh succeeds', async () => {
-    const order: string[] = [];
-    let slots: AssistantStreamSlots = {
-      'session-1': { text: 'final answer', truncated: false, phase: 'draining', messageId: 'assistant-1' },
-    };
-
-    await settleAssistantStreamSlot({
-      sessionId: 'session-1',
-      messageId: 'assistant-1',
-      getCurrent: () => slots,
-      refreshMessages: async () => {
-        order.push('refresh');
-        return true;
-      },
-      setCurrent: (updater) => {
-        order.push('clear');
-        slots = updater(slots);
-      },
-    });
-
-    assert.deepEqual(order, ['refresh', 'clear']);
-    assert.deepEqual(slots['session-1'], { text: '', truncated: false, phase: 'streaming' });
-  });
-
-  it('does not clear a newer stream slot that replaces the settled one during refresh', async () => {
+  it('settled slot reducer keeps refresh-before-clear callers race-safe for a newer stream slot', () => {
     const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-old' };
-    let slots: AssistantStreamSlots = { 'session-1': settledSlot };
+    const slots: AssistantStreamSlots = {
+      'session-1': { text: 'new answer', truncated: false, phase: 'streaming', messageId: 'assistant-new' },
+    };
 
-    await settleAssistantStreamSlot({
-      sessionId: 'session-1',
-      messageId: 'assistant-old',
-      getCurrent: () => slots,
-      refreshMessages: async () => {
-        slots = {
-          'session-1': { text: 'new answer', truncated: false, phase: 'streaming', messageId: 'assistant-new' },
-        };
-        return true;
-      },
-      setCurrent: (updater) => {
-        slots = updater(slots);
-      },
-    });
+    const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-old');
 
-    assert.deepEqual(slots['session-1'], {
+    assert.equal(next, slots);
+  });
+
+  it('settled slot reducer clears a replayed equivalent draining slot after refresh', () => {
+    const settledSlot = { text: 'final answer', truncated: false, phase: 'draining' as const, messageId: 'assistant-1' };
+    const slots: AssistantStreamSlots = {
+      'session-1': { text: 'final answer', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+    };
+
+    const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-1');
+
+    assert.deepEqual(next['session-1'], { text: '', truncated: false, phase: 'streaming' });
+  });
+
+  it('settled slot reducer does not clear a newer stream slot that replaces the settled one during refresh', () => {
+    const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-old' };
+    const slots: AssistantStreamSlots = {
+      'session-1': { text: 'new answer', truncated: false, phase: 'streaming', messageId: 'assistant-new' },
+    };
+
+    const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-old');
+
+    assert.deepEqual(next['session-1'], {
       text: 'new answer',
       truncated: false,
       phase: 'streaming',
@@ -176,26 +123,15 @@ describe('assistant streaming handoff', () => {
     });
   });
 
-  it('does not clear a replaced draining slot only because the message id still matches', async () => {
+  it('settled slot reducer does not clear a replaced draining slot only because the message id still matches', () => {
     const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-1' };
-    let slots: AssistantStreamSlots = { 'session-1': settledSlot };
+    const slots: AssistantStreamSlots = {
+      'session-1': { text: 'replacement final', truncated: false, phase: 'draining', messageId: 'assistant-1' },
+    };
 
-    await settleAssistantStreamSlot({
-      sessionId: 'session-1',
-      messageId: 'assistant-1',
-      getCurrent: () => slots,
-      refreshMessages: async () => {
-        slots = {
-          'session-1': { text: 'replacement final', truncated: false, phase: 'draining', messageId: 'assistant-1' },
-        };
-        return true;
-      },
-      setCurrent: (updater) => {
-        slots = updater(slots);
-      },
-    });
+    const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-1');
 
-    assert.deepEqual(slots['session-1'], {
+    assert.deepEqual(next['session-1'], {
       text: 'replacement final',
       truncated: false,
       phase: 'draining',
@@ -206,10 +142,4 @@ describe('assistant streaming handoff', () => {
 
 function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
-}
-
-function sourcePath(relativeFromDesktop: string): string {
-  const fromDesktop = join(process.cwd(), relativeFromDesktop);
-  if (existsSync(fromDesktop)) return fromDesktop;
-  return join(process.cwd(), 'apps/desktop', relativeFromDesktop);
 }

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -57,6 +57,43 @@ describe('assistant streaming handoff', () => {
       'text_complete should drain the smoother before clearing the streaming bubble',
     );
   });
+
+  it('refreshes committed messages before clearing the drained streaming bubble', async () => {
+    const rendererPath = sourcePath('src/renderer/main.tsx');
+    const source = await readFile(rendererPath, 'utf8');
+    const start = source.indexOf('function settleAssistantStreaming');
+    const end = source.indexOf('\n\n  function handleEvent', start);
+    const body = start >= 0 && end > start ? source.slice(start, end) : '';
+
+    assert.ok(body, 'settleAssistantStreaming should be present');
+    const refreshIndex = body.indexOf('await refreshMessages(sessionId)');
+    const clearIndex = body.indexOf('setStreamingBySession');
+
+    assert.ok(refreshIndex >= 0, 'handoff should await the committed message refresh');
+    assert.ok(clearIndex >= 0, 'handoff should still clear streaming after refresh');
+    assert.ok(
+      refreshIndex < clearIndex,
+      'handoff must not blank the streaming bubble before committed history is ready',
+    );
+  });
+
+  it('complete uses the live streaming slot ref instead of the subscription-time closure', async () => {
+    const rendererPath = sourcePath('src/renderer/main.tsx');
+    const source = await readFile(rendererPath, 'utf8');
+    const branch = source.match(/case 'complete':[\s\S]*?default:/)?.[0] ?? '';
+
+    assert.ok(branch, 'complete branch should be present');
+    assert.match(
+      branch,
+      /streamingBySessionRef\.current\[sessionId\]/,
+      'complete events arrive through an activeId-only subscription, so the handler must read the latest streaming slot from a ref',
+    );
+    assert.doesNotMatch(
+      branch,
+      /const slot = streamingBySession\[sessionId\]/,
+      'complete must not read streamingBySession from the stale subscription closure',
+    );
+  });
 });
 
 function countOccurrences(haystack: string, needle: string): number {

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -1,0 +1,70 @@
+import { strict as assert } from 'node:assert';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ChatView } from '@maka/ui';
+
+describe('assistant streaming handoff', () => {
+  it('keeps a draining assistant answer as the single visible owner before committed handoff', () => {
+    const finalText = '12345678';
+    const markup = renderToStaticMarkup(createElement(ChatView, {
+      activeSession: {
+        id: 'session-1',
+        name: 'handoff',
+        lastMessageAt: 1,
+        status: 'active',
+        backend: 'ai-sdk',
+        labels: [],
+        isFlagged: false,
+        isArchived: false,
+        hasUnread: false,
+        llmConnectionSlug: 'conn',
+        model: 'model',
+        permissionMode: 'ask',
+      },
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: finalText, modelId: 'model' },
+      ],
+      streamingText: finalText,
+      streamingComplete: true,
+      streamingMessageId: 'assistant-1',
+      tools: [],
+      mode: 'sessions',
+      onNew() {},
+    } satisfies Parameters<typeof ChatView>[0]));
+
+    assert.match(markup, /maka-bubble-streaming/, 'draining output should remain in the streaming bubble');
+    assert.equal(
+      countOccurrences(markup, finalText),
+      1,
+      'draining output must not render both the committed message and the streaming bubble',
+    );
+  });
+
+  it('does not clear the live assistant buffer directly on text_complete', async () => {
+    const rendererPath = sourcePath('src/renderer/main.tsx');
+    const source = await readFile(rendererPath, 'utf8');
+    const branch = source.match(/case 'text_complete':[\s\S]*?case 'thinking_delta':/)?.[0] ?? '';
+
+    assert.ok(branch, 'text_complete branch should be present');
+    assert.doesNotMatch(
+      branch,
+      /clearStreaming\(sessionId\)/,
+      'text_complete should drain the smoother before clearing the streaming bubble',
+    );
+  });
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+function sourcePath(relativeFromDesktop: string): string {
+  const fromDesktop = join(process.cwd(), relativeFromDesktop);
+  if (existsSync(fromDesktop)) return fromDesktop;
+  return join(process.cwd(), 'apps/desktop', relativeFromDesktop);
+}

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -299,7 +299,18 @@ function AppShell() {
     phase: 'streaming' | 'draining';
     messageId?: string;
   };
-  const [streamingBySession, setStreamingBySession] = useState<Record<string, AssistantStreamSlot>>({});
+  const [streamingBySession, setStreamingBySessionState] = useState<Record<string, AssistantStreamSlot>>({});
+  // Session event handlers are subscribed per activeId; read live stream slots from this ref to avoid stale render closures.
+  const streamingBySessionRef = useRef<Record<string, AssistantStreamSlot>>({});
+  function setStreamingBySession(
+    updater: (current: Record<string, AssistantStreamSlot>) => Record<string, AssistantStreamSlot>,
+  ) {
+    const current = streamingBySessionRef.current;
+    const next = updater(current);
+    if (next === current) return;
+    streamingBySessionRef.current = next;
+    setStreamingBySessionState(next);
+  }
   /**
    * PR-UI-LAYOUT-42 (@kenji reference renderer audit, external docs/12-renderer.md §15.3):
    * The reference design displays Anthropic-style `reasoning_content`
@@ -2142,7 +2153,7 @@ function AppShell() {
     }
   }
 
-  async function refreshMessages(sessionId: string) {
+  async function refreshMessages(sessionId: string): Promise<boolean> {
     try {
       const next = await window.maka.sessions.readMessages(sessionId);
       if (activeIdRef.current === sessionId) {
@@ -2155,12 +2166,14 @@ function AppShell() {
           return updated;
         });
       }
+      return true;
     } catch (error) {
       if (activeIdRef.current === sessionId) {
         const message = generalizedErrorMessageChinese(error, '对话内容暂时无法刷新，请稍后重试。');
         setMessageLoadErrorBySession((current) => ({ ...current, [sessionId]: message }));
         toastApi.error('刷新对话失败', message);
       }
+      return false;
     }
   }
   async function retryMessages(sessionId: string) {
@@ -2263,17 +2276,18 @@ function AppShell() {
     clearThinking(sessionId);
   }
 
-  function settleAssistantStreaming(sessionId: string, messageId?: string) {
-    const currentSlot = streamingBySession[sessionId];
+  async function settleAssistantStreaming(sessionId: string, messageId?: string) {
+    const currentSlot = streamingBySessionRef.current[sessionId];
     if (!currentSlot || currentSlot.phase !== 'draining') return;
     if (messageId && currentSlot.messageId && currentSlot.messageId !== messageId) return;
+    const refreshed = await refreshMessages(sessionId);
+    if (!refreshed) return;
     setStreamingBySession((current) => {
       const prev = current[sessionId];
       if (!prev || prev.phase !== 'draining') return current;
       if (messageId && prev.messageId && prev.messageId !== messageId) return current;
       return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
     });
-    void refreshMessages(sessionId);
   }
 
   function handleEvent(sessionId: string, event: SessionEvent) {
@@ -2464,7 +2478,7 @@ function AppShell() {
       case 'complete':
         let deferMessageRefresh = false;
         if (event.stopReason !== 'permission_handoff') {
-          const slot = streamingBySession[sessionId];
+          const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
             markAssistantStreamingComplete(sessionId);
             deferMessageRefresh = true;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -35,9 +35,9 @@ import { PROVIDER_DEFAULTS } from '@maka/core';
 import {
   applyAssistantComplete,
   applyAssistantDelta,
+  clearSettledAssistantStreamSlot,
   drainAssistantStreamSlot,
   markAssistantStreamSlotDraining,
-  settleAssistantStreamSlot,
   type AssistantStreamSlot,
   applyThinkingComplete,
   applyThinkingDelta,
@@ -2250,23 +2250,16 @@ function AppShell() {
       void refreshMessages(sessionId);
       return;
     }
-    setStreamingBySession((current) => drainAssistantStreamSlot(current, sessionId, text, messageId));
-    clearThinking(sessionId);
-  }
-
-  function markAssistantStreamingComplete(sessionId: string) {
-    setStreamingBySession((current) => markAssistantStreamSlotDraining(current, sessionId));
+    setStreamingBySession((current) => drainAssistantStreamSlot(current, sessionId, applied, messageId));
     clearThinking(sessionId);
   }
 
   async function settleAssistantStreaming(sessionId: string, messageId?: string) {
-    await settleAssistantStreamSlot({
-      sessionId,
-      messageId,
-      getCurrent: () => streamingBySessionRef.current,
-      refreshMessages: () => refreshMessages(sessionId),
-      setCurrent: setStreamingBySession,
-    });
+    const settledSlot = streamingBySessionRef.current[sessionId];
+    if (!settledSlot || settledSlot.phase !== 'draining') return;
+    if (messageId && settledSlot.messageId && settledSlot.messageId !== messageId) return;
+    await refreshMessages(sessionId).catch(() => false);
+    setStreamingBySession((current) => clearSettledAssistantStreamSlot(current, sessionId, settledSlot, messageId));
   }
 
   function handleEvent(sessionId: string, event: SessionEvent) {
@@ -2459,7 +2452,8 @@ function AppShell() {
         if (event.stopReason !== 'permission_handoff') {
           const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
-            markAssistantStreamingComplete(sessionId);
+            setStreamingBySession((current) => markAssistantStreamSlotDraining(current, sessionId));
+            clearThinking(sessionId);
             deferMessageRefresh = true;
           } else {
             clearStreaming(sessionId);

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -35,6 +35,10 @@ import { PROVIDER_DEFAULTS } from '@maka/core';
 import {
   applyAssistantComplete,
   applyAssistantDelta,
+  drainAssistantStreamSlot,
+  markAssistantStreamSlotDraining,
+  settleAssistantStreamSlot,
+  type AssistantStreamSlot,
   applyThinkingComplete,
   applyThinkingDelta,
   applyToolOutputChunk,
@@ -293,12 +297,6 @@ function AppShell() {
   // `truncated` is monotonic while deltas are streaming; `text_complete`
   // replaces the slot with the final payload, so the flag then reflects the
   // final visible text until `clearStreaming` resets the slot.
-  type AssistantStreamSlot = {
-    text: string;
-    truncated: boolean;
-    phase: 'streaming' | 'draining';
-    messageId?: string;
-  };
   const [streamingBySession, setStreamingBySessionState] = useState<Record<string, AssistantStreamSlot>>({});
   // Session event handlers are subscribed per activeId; read live stream slots from this ref to avoid stale render closures.
   const streamingBySessionRef = useRef<Record<string, AssistantStreamSlot>>({});
@@ -2252,41 +2250,22 @@ function AppShell() {
       void refreshMessages(sessionId);
       return;
     }
-    setStreamingBySession((current) => ({
-      ...current,
-      [sessionId]: {
-        text: applied.text,
-        truncated: applied.truncated,
-        phase: 'draining',
-        ...(messageId ? { messageId } : {}),
-      },
-    }));
+    setStreamingBySession((current) => drainAssistantStreamSlot(current, sessionId, text, messageId));
     clearThinking(sessionId);
   }
 
   function markAssistantStreamingComplete(sessionId: string) {
-    setStreamingBySession((current) => {
-      const prev = current[sessionId];
-      if (!prev?.text || prev.phase === 'draining') return current;
-      return {
-        ...current,
-        [sessionId]: { ...prev, phase: 'draining' },
-      };
-    });
+    setStreamingBySession((current) => markAssistantStreamSlotDraining(current, sessionId));
     clearThinking(sessionId);
   }
 
   async function settleAssistantStreaming(sessionId: string, messageId?: string) {
-    const currentSlot = streamingBySessionRef.current[sessionId];
-    if (!currentSlot || currentSlot.phase !== 'draining') return;
-    if (messageId && currentSlot.messageId && currentSlot.messageId !== messageId) return;
-    const refreshed = await refreshMessages(sessionId);
-    if (!refreshed) return;
-    setStreamingBySession((current) => {
-      const prev = current[sessionId];
-      if (!prev || prev.phase !== 'draining') return current;
-      if (messageId && prev.messageId && prev.messageId !== messageId) return current;
-      return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
+    await settleAssistantStreamSlot({
+      sessionId,
+      messageId,
+      getCurrent: () => streamingBySessionRef.current,
+      refreshMessages: () => refreshMessages(sessionId),
+      setCurrent: setStreamingBySession,
     });
   }
 

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -33,6 +33,7 @@ import {
 } from '@maka/core';
 import { PROVIDER_DEFAULTS } from '@maka/core';
 import {
+  applyAssistantComplete,
   applyAssistantDelta,
   applyThinkingComplete,
   applyThinkingDelta,
@@ -289,10 +290,15 @@ function AppShell() {
   // pair lives in a SINGLE useState so the `text_delta` handler can
   // produce both fields from one functional updater — no
   // cross-mutation between updaters, no closure-variable hack.
-  // `truncated` is monotonic per-session: once flipped to `true`
-  // within a streaming turn, stays true until `clearStreaming`
-  // resets the slot.
-  type AssistantStreamSlot = { text: string; truncated: boolean };
+  // `truncated` is monotonic while deltas are streaming; `text_complete`
+  // replaces the slot with the final payload, so the flag then reflects the
+  // final visible text until `clearStreaming` resets the slot.
+  type AssistantStreamSlot = {
+    text: string;
+    truncated: boolean;
+    phase: 'streaming' | 'draining';
+    messageId?: string;
+  };
   const [streamingBySession, setStreamingBySession] = useState<Record<string, AssistantStreamSlot>>({});
   /**
    * PR-UI-LAYOUT-42 (@kenji reference renderer audit, external docs/12-renderer.md §15.3):
@@ -379,6 +385,8 @@ function AppShell() {
   const activeStreamingSlot = activeId ? streamingBySession[activeId] : undefined;
   const activeStreaming = activeStreamingSlot?.text ?? '';
   const activeStreamingTruncated = activeStreamingSlot?.truncated === true;
+  const activeStreamingComplete = activeStreamingSlot?.phase === 'draining';
+  const activeStreamingMessageId = activeStreamingComplete ? activeStreamingSlot?.messageId : undefined;
   const activeThinking = activeId ? thinkingBySession[activeId] ?? '' : '';
   const activeThinkingTruncated = activeId ? thinkingTruncatedBySession[activeId] === true : false;
   // Set of session ids with a live streaming delta — drives the sidebar
@@ -1364,7 +1372,7 @@ function AppShell() {
       setStreamingBySession((current) => {
         const next = { ...current };
         for (const [sid, text] of Object.entries(seed)) {
-          next[sid] = { text, truncated: false };
+          next[sid] = { text, truncated: false, phase: 'streaming' };
         }
         return next;
       });
@@ -2202,8 +2210,12 @@ function AppShell() {
     setStreamingBySession((current) => {
       const prev = current[sessionId];
       if (!prev || (prev.text === '' && prev.truncated === false)) return current;
-      return { ...current, [sessionId]: { text: '', truncated: false } };
+      return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
     });
+    clearThinking(sessionId);
+  }
+
+  function clearThinking(sessionId: string) {
     // PR-UI-LAYOUT-42: thinking is part of the same streaming turn —
     // any clearStreaming caller (abort / error / complete) means the
     // turn is done, so the Reasoning panel should also collapse.
@@ -2218,6 +2230,50 @@ function AppShell() {
       delete next[sessionId];
       return next;
     });
+  }
+
+  function drainAssistantStreaming(sessionId: string, text: string, messageId?: string) {
+    const applied = applyAssistantComplete(text);
+    if (!applied.text) {
+      clearStreaming(sessionId);
+      void refreshMessages(sessionId);
+      return;
+    }
+    setStreamingBySession((current) => ({
+      ...current,
+      [sessionId]: {
+        text: applied.text,
+        truncated: applied.truncated,
+        phase: 'draining',
+        ...(messageId ? { messageId } : {}),
+      },
+    }));
+    clearThinking(sessionId);
+  }
+
+  function markAssistantStreamingComplete(sessionId: string) {
+    setStreamingBySession((current) => {
+      const prev = current[sessionId];
+      if (!prev?.text || prev.phase === 'draining') return current;
+      return {
+        ...current,
+        [sessionId]: { ...prev, phase: 'draining' },
+      };
+    });
+    clearThinking(sessionId);
+  }
+
+  function settleAssistantStreaming(sessionId: string, messageId?: string) {
+    const currentSlot = streamingBySession[sessionId];
+    if (!currentSlot || currentSlot.phase !== 'draining') return;
+    if (messageId && currentSlot.messageId && currentSlot.messageId !== messageId) return;
+    setStreamingBySession((current) => {
+      const prev = current[sessionId];
+      if (!prev || prev.phase !== 'draining') return current;
+      if (messageId && prev.messageId && prev.messageId !== messageId) return current;
+      return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
+    });
+    void refreshMessages(sessionId);
   }
 
   function handleEvent(sessionId: string, event: SessionEvent) {
@@ -2239,12 +2295,10 @@ function AppShell() {
         // raw `event.text` only flows through the helper input; it
         // never enters state un-redacted or un-capped.
         //
-        // Combined state shape (fixup v2): a single
-        // `AssistantStreamSlot = { text, truncated }` lets us
-        // produce both fields from one functional updater without
-        // cross-mutating outer locals or chaining setStates. The
-        // `truncated` flag is monotonic per-session — once true,
-        // stays true until `clearStreaming`.
+        // Combined state shape: one functional updater owns visible
+        // text, truncation, phase, and message identity, so the final
+        // `text_complete` handoff can drain the same bubble instead of
+        // racing a committed-message refresh.
         setStreamingBySession((current) => {
           const prevSlot = current[sessionId];
           const prevText = prevSlot?.text ?? '';
@@ -2262,14 +2316,18 @@ function AppShell() {
           }
           return {
             ...current,
-            [sessionId]: { text: applied.text, truncated: nextTruncated },
+            [sessionId]: {
+              text: applied.text,
+              truncated: nextTruncated,
+              phase: 'streaming',
+              messageId: event.messageId,
+            },
           };
         });
         break;
       }
       case 'text_complete':
-        clearStreaming(sessionId);
-        void refreshMessages(sessionId);
+        drainAssistantStreaming(sessionId, event.text, event.messageId);
         break;
       case 'thinking_delta':
         // PR-UI-LAYOUT-42 / C0 review fixup (@kenji msg 7885a347):
@@ -2303,9 +2361,8 @@ function AppShell() {
         // ProviderEvent's `text` is the FULL final reasoning string,
         // so we replace rather than append (still through the
         // redaction + cap chokepoint via `applyThinkingComplete`).
-        // Keep visible until `text_complete` collapses the panel via
-        // `clearStreaming`; this avoids the flicker between "thinking
-        // done" and "answer streaming".
+        // Keep visible until `text_complete` collapses the panel; this
+        // avoids the flicker between "thinking done" and "answer streaming".
         setThinkingBySession((current) => {
           const applied = applyThinkingComplete(event.text);
           // PR-UI-C0 review nit #1 (@kenji msg 68ca6bc7): `complete`
@@ -2405,8 +2462,15 @@ function AppShell() {
         void refreshMessages(sessionId);
         break;
       case 'complete':
+        let deferMessageRefresh = false;
         if (event.stopReason !== 'permission_handoff') {
-          clearStreaming(sessionId);
+          const slot = streamingBySession[sessionId];
+          if (slot?.text) {
+            markAssistantStreamingComplete(sessionId);
+            deferMessageRefresh = true;
+          } else {
+            clearStreaming(sessionId);
+          }
           // PR-PERMISSION-UI-CLEANUP-0: parallel the `abort` branch
           // above — drop any stranded permission request for this
           // session when it completes for non-permission-handoff
@@ -2416,7 +2480,9 @@ function AppShell() {
           setPermissionBySession((current) => clearPermissions(current, sessionId));
         }
         void refreshSessions();
-        void refreshMessages(sessionId);
+        if (!deferMessageRefresh) {
+          void refreshMessages(sessionId);
+        }
         break;
       default:
         break;
@@ -2998,6 +3064,9 @@ function AppShell() {
               <ChatView
                 messages={messages}
                 streamingText={activeStreaming}
+                streamingComplete={activeStreamingComplete}
+                streamingMessageId={activeStreamingMessageId}
+                onStreamingSettled={activeId ? () => settleAssistantStreaming(activeId, activeStreamingMessageId) : undefined}
                 streamingTruncated={activeStreamingTruncated}
                 thinkingText={activeThinking}
                 thinkingTruncated={activeThinkingTruncated}

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -321,11 +321,13 @@ describe('SessionManager permission mode updates', () => {
     const iterator = manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })[Symbol.asyncIterator]();
 
     expect((await iterator.next()).value?.type).toBe('text_delta');
-    expect((await iterator.next()).value?.type).toBe('text_complete');
+    const textComplete = (await iterator.next()).value;
+    expect(textComplete?.type).toBe('text_complete');
     expect((await iterator.next()).value?.type).toBe('complete');
 
     const messages = await manager.getMessages(session.id);
     expect(messages.map((message) => message.type)).toEqual(['user', 'assistant', 'turn_state']);
+    expect(messages[1]?.id).toBe(textComplete?.type === 'text_complete' ? textComplete.messageId : undefined);
 
     await iterator.next();
   });

--- a/packages/ui/src/assistant-stream.ts
+++ b/packages/ui/src/assistant-stream.ts
@@ -75,6 +75,15 @@ export interface ApplyAssistantResult {
   truncated: boolean;
 }
 
+export interface AssistantStreamSlot {
+  text: string;
+  truncated: boolean;
+  phase: 'streaming' | 'draining';
+  messageId?: string;
+}
+
+export type AssistantStreamSlots = Record<string, AssistantStreamSlot>;
+
 /**
  * Apply a single `text_delta` to the prior accumulated assistant
  * text. Pure: no React state, no DOM, no IPC.
@@ -214,4 +223,56 @@ export function applyAssistantComplete(
     redacted: redactionHappened,
     truncated: totalTruncated,
   };
+}
+
+export function drainAssistantStreamSlot(
+  current: AssistantStreamSlots,
+  sessionId: string,
+  text: string,
+  messageId?: string,
+): AssistantStreamSlots {
+  const applied = applyAssistantComplete(text);
+  return {
+    ...current,
+    [sessionId]: {
+      text: applied.text,
+      truncated: applied.truncated,
+      phase: 'draining',
+      ...(messageId ? { messageId } : {}),
+    },
+  };
+}
+
+export function markAssistantStreamSlotDraining(
+  current: AssistantStreamSlots,
+  sessionId: string,
+): AssistantStreamSlots {
+  const prev = current[sessionId];
+  if (!prev?.text || prev.phase === 'draining') return current;
+  return {
+    ...current,
+    [sessionId]: { ...prev, phase: 'draining' },
+  };
+}
+
+export async function settleAssistantStreamSlot(input: {
+  sessionId: string;
+  messageId?: string;
+  getCurrent: () => AssistantStreamSlots;
+  refreshMessages: () => Promise<boolean>;
+  setCurrent: (updater: (current: AssistantStreamSlots) => AssistantStreamSlots) => void;
+}): Promise<void> {
+  const currentSlot = input.getCurrent()[input.sessionId];
+  if (!isMatchingDrainingSlot(currentSlot, input.messageId)) return;
+  await input.refreshMessages().catch(() => false);
+  input.setCurrent((current) => {
+    const prev = current[input.sessionId];
+    if (prev !== currentSlot) return current;
+    return { ...current, [input.sessionId]: { text: '', truncated: false, phase: 'streaming' } };
+  });
+}
+
+function isMatchingDrainingSlot(slot: AssistantStreamSlot | undefined, messageId?: string): slot is AssistantStreamSlot {
+  if (!slot || slot.phase !== 'draining') return false;
+  return !(messageId && slot.messageId && slot.messageId !== messageId);
 }

--- a/packages/ui/src/assistant-stream.ts
+++ b/packages/ui/src/assistant-stream.ts
@@ -228,10 +228,9 @@ export function applyAssistantComplete(
 export function drainAssistantStreamSlot(
   current: AssistantStreamSlots,
   sessionId: string,
-  text: string,
+  applied: ApplyAssistantResult,
   messageId?: string,
 ): AssistantStreamSlots {
-  const applied = applyAssistantComplete(text);
   return {
     ...current,
     [sessionId]: {
@@ -255,24 +254,30 @@ export function markAssistantStreamSlotDraining(
   };
 }
 
-export async function settleAssistantStreamSlot(input: {
-  sessionId: string;
-  messageId?: string;
-  getCurrent: () => AssistantStreamSlots;
-  refreshMessages: () => Promise<boolean>;
-  setCurrent: (updater: (current: AssistantStreamSlots) => AssistantStreamSlots) => void;
-}): Promise<void> {
-  const currentSlot = input.getCurrent()[input.sessionId];
-  if (!isMatchingDrainingSlot(currentSlot, input.messageId)) return;
-  await input.refreshMessages().catch(() => false);
-  input.setCurrent((current) => {
-    const prev = current[input.sessionId];
-    if (prev !== currentSlot) return current;
-    return { ...current, [input.sessionId]: { text: '', truncated: false, phase: 'streaming' } };
-  });
+export function clearSettledAssistantStreamSlot(
+  current: AssistantStreamSlots,
+  sessionId: string,
+  settledSlot: AssistantStreamSlot,
+  messageId?: string,
+): AssistantStreamSlots {
+  const currentSlot = current[sessionId];
+  if (!isEquivalentSettledSlot(currentSlot, settledSlot, messageId)) return current;
+  return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
 }
 
-function isMatchingDrainingSlot(slot: AssistantStreamSlot | undefined, messageId?: string): slot is AssistantStreamSlot {
-  if (!slot || slot.phase !== 'draining') return false;
-  return !(messageId && slot.messageId && slot.messageId !== messageId);
+function isEquivalentSettledSlot(
+  slot: AssistantStreamSlot | undefined,
+  settledSlot: AssistantStreamSlot,
+  messageId?: string,
+): slot is AssistantStreamSlot {
+  if (!slot || slot.phase !== 'draining' || settledSlot.phase !== 'draining') return false;
+  if (slot === settledSlot) return true;
+
+  const expectedMessageId = messageId ?? settledSlot.messageId;
+  if (!expectedMessageId) return false;
+
+  return slot.messageId === expectedMessageId &&
+    settledSlot.messageId === expectedMessageId &&
+    slot.text === settledSlot.text &&
+    slot.truncated === settledSlot.truncated;
 }

--- a/packages/ui/src/assistant-stream.ts
+++ b/packages/ui/src/assistant-stream.ts
@@ -182,3 +182,36 @@ export function applyAssistantDelta(
     truncated: deltaTruncated || totalTruncated,
   };
 }
+
+/**
+ * Apply a `text_complete` final payload. The complete event carries the FULL
+ * final assistant text, so this is a replace path: redact and apply only the
+ * per-session total cap, not the per-delta cap used for incremental chunks.
+ */
+export function applyAssistantComplete(
+  rawText: string,
+  options: Pick<ApplyAssistantOptions, 'maxTotalChars'> = {},
+): ApplyAssistantResult {
+  const maxTotal = options.maxTotalChars ?? ASSISTANT_MAX_TOTAL_CHARS;
+
+  if (typeof rawText !== 'string') {
+    return { text: '', redacted: false, truncated: false };
+  }
+
+  const redacted = redactSecrets(rawText);
+  const redactionHappened = redacted !== rawText;
+
+  let result = redacted;
+  let totalTruncated = false;
+  if (result.length > maxTotal) {
+    const keep = maxTotal - TRUNCATED_TAIL_MARKER.length;
+    result = redacted.slice(0, keep) + TRUNCATED_TAIL_MARKER;
+    totalTruncated = true;
+  }
+
+  return {
+    text: result,
+    redacted: redactionHappened,
+    truncated: totalTruncated,
+  };
+}

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -3914,6 +3914,12 @@ export interface ChatHeaderAlert {
 export function ChatView(props: {
   messages: StoredMessage[];
   streamingText: string;
+  /** True after upstream emitted the final assistant text, while the UI is draining the smoother. */
+  streamingComplete?: boolean;
+  /** Assistant message id hidden while the matching streaming bubble drains. */
+  streamingMessageId?: string;
+  /** Called once the streaming bubble has displayed the final text and can hand off to history. */
+  onStreamingSettled?(): void;
   /**
    * PR-UI-LAYOUT-42: Anthropic extended-thinking stream from
    * `ThinkingDeltaEvent` (`@maka/core/events`). When non-empty, a
@@ -4070,10 +4076,13 @@ export function ChatView(props: {
   // chat + storedTools survive for the empty-state and streaming-bubble
   // paths; the main message log is now driven by `turns` (per @kenji UI-04
   // turn-grouping projection).
-  const chat = materializeChat(props.messages);
-  const storedTools = materializeTools(props.messages);
+  const visibleMessages = props.streamingComplete && props.streamingMessageId
+    ? props.messages.filter((message) => !(message.type === 'assistant' && message.id === props.streamingMessageId))
+    : props.messages;
+  const chat = materializeChat(visibleMessages);
+  const storedTools = materializeTools(visibleMessages);
   const tools = mergeTools(storedTools, props.tools);
-  const turns = materializeTurns(props.messages, props.tools);
+  const turns = materializeTurns(visibleMessages, props.tools);
   const capabilityAuditReport = useMemo(
     () => deriveCapabilityAuditReport({
       skills: props.skills ?? [],
@@ -4395,7 +4404,9 @@ export function ChatView(props: {
                 {props.streamingText && (
                   <StreamingAssistantBubble
                     text={props.streamingText}
+                    live={props.streamingComplete !== true}
                     truncated={props.streamingTruncated === true}
+                    onSettled={props.onStreamingSettled}
                   />
                 )}
               </article>
@@ -5327,15 +5338,15 @@ const STATUS_FOOTER_PRIORITY: Record<TurnFooterActionMeta['id'], 'primary' | 'se
  *
  * Wraps the live `streamingText` in `useSmoothStreamContent` so the
  * visible text grows at the EMA-tracked arrival CPS instead of
- * lurching with each network chunk. The bubble itself unmounts on
- * `text_complete` / abort / error (parent clears `streamingText`), so
- * the smoother only has to handle the live phase — settled history
- * messages render via the regular Markdown path with no smoothing.
+ * lurching with each network chunk. On `text_complete`, the parent keeps
+ * the bubble mounted with `live=false` so the smoother can drain the final
+ * tail before settled history takes over. Abort / error still unmount
+ * immediately.
  *
- * `streaming=true` while this component is mounted: by construction
- * the parent only renders it when the stream is in progress.
+ * `live=false` after `text_complete`: keep the bubble mounted until
+ * the smoother catches up, then notify the parent to hand off to history.
  */
-function StreamingAssistantBubble(props: { text: string; truncated?: boolean }) {
+function StreamingAssistantBubble(props: { text: string; live: boolean; truncated?: boolean; onSettled?: () => void }) {
   // PR-UI-C1 review fixup (@kenji msg fbb8f119): the smoother
   // typewriters PREFIXES of its input string. If the raw text
   // contains a mid-delta secret like `Authorization: Bearer sk-...`,
@@ -5355,10 +5366,22 @@ function StreamingAssistantBubble(props: { text: string; truncated?: boolean }) 
   // contract holds even if a future caller forgets the chokepoint.
   const snap = useStreamSnap();
   const safeText = prepareSmoothStreamText(props.text);
-  const { displayed } = useSmoothStreamContent(safeText, {
-    streaming: true,
+  const { displayed, catchingUp } = useSmoothStreamContent(safeText, {
+    streaming: props.live,
     snap,
   });
+  const settledRef = useRef(false);
+
+  useEffect(() => {
+    settledRef.current = false;
+  }, [safeText, props.live]);
+
+  useEffect(() => {
+    if (props.live || catchingUp || settledRef.current) return;
+    settledRef.current = true;
+    props.onSettled?.();
+  }, [props.live, catchingUp, props.onSettled]);
+
   return (
     <div className="maka-bubble-assistant maka-bubble-streaming">
       <Markdown text={displayed} />

--- a/packages/ui/src/smooth-stream.ts
+++ b/packages/ui/src/smooth-stream.ts
@@ -25,9 +25,8 @@
  *     hydration (initial mount with non-empty raw) and "the network
  *     dumped 5KB in one chunk" without infinite catch-up.
  *   - **Complete flush budget**: when `streaming` flips to false,
- *     allow at most `completeFlushBudgetMs` of typewriter time to
- *     finish; then snap. This guarantees the user never waits more
- *     than ~600ms after the response actually completes.
+ *     raise the catch-up speed so the remaining tail drains within
+ *     `completeFlushBudgetMs` instead of snapping to the final text.
  *   - **Reduced-motion bypass**: callers pass `snap: true` (typically
  *     derived from `prefers-reduced-motion: reduce` or the
  *     visual-smoke fixture attribute) to skip all smoothing.
@@ -94,8 +93,9 @@ export interface SmoothStreamOptions {
   maxCps?: number;
   /**
    * After `streaming` flips to `false`, the hook allows at most this
-   * many ms to finish flushing the remaining backlog at the smoothed
-   * CPS. Past the budget it snaps. Default 600.
+   * many ms to finish flushing the remaining backlog. The hook may exceed
+   * `maxCps` during this drain so completion stays smooth without waiting
+   * indefinitely. Default 600.
    */
   completeFlushBudgetMs?: number;
 }
@@ -163,6 +163,8 @@ export interface BacklogSnapInputs {
   rawGraphemeCount: number;
   displayedGraphemeCount: number;
   maxBacklogGraphemes: number;
+  /** Backlog snap is only for live network bursts, not completion drain. */
+  streaming?: boolean;
 }
 
 /**
@@ -170,7 +172,28 @@ export interface BacklogSnapInputs {
  * True when (raw - displayed) > threshold.
  */
 export function shouldSnapForBacklog(inputs: BacklogSnapInputs): boolean {
+  if (inputs.streaming === false) return false;
   return inputs.rawGraphemeCount - inputs.displayedGraphemeCount > inputs.maxBacklogGraphemes;
+}
+
+export interface CompletionMaxCpsInputs {
+  rawGraphemeCount: number;
+  displayedGraphemeCount: number;
+  elapsedMs: number;
+  budgetMs: number;
+  maxCps: number;
+}
+
+/**
+ * Pure: while a stream is completing, raise the frame speed enough to drain
+ * the remaining tail inside the completion budget. This keeps the completion
+ * handoff fast without a visible end-of-budget snap.
+ */
+export function resolveCompletionMaxCps(inputs: CompletionMaxCpsInputs): number {
+  const backlog = inputs.rawGraphemeCount - inputs.displayedGraphemeCount;
+  if (backlog <= 0) return inputs.maxCps;
+  const remainingMs = Math.max(1, inputs.budgetMs - inputs.elapsedMs);
+  return Math.max(inputs.maxCps, Math.ceil((backlog * 1000) / remainingMs));
 }
 
 export interface EmaUpdateInputs {
@@ -318,6 +341,7 @@ export function useSmoothStreamContent(
           rawGraphemeCount: rawLength,
           displayedGraphemeCount: displayedCount,
           maxBacklogGraphemes: maxBacklog,
+          streaming: options.streaming,
         })
       ) {
         setDisplayedCount(rawLength);
@@ -325,14 +349,19 @@ export function useSmoothStreamContent(
       }
 
       // Stream-end bounded flush. Once streaming flips false and we
-      // still have backlog, allow at most completeBudget ms to drain.
+      // still have backlog, raise the speed enough to drain inside
+      // completeBudget instead of snapping the tail all at once.
+      let frameMaxCps = maxCps;
       if (!options.streaming) {
         const s = refs.current;
         if (s.completeStartedAt === 0) s.completeStartedAt = now;
-        if (now - s.completeStartedAt > completeBudget) {
-          setDisplayedCount(rawLength);
-          return;
-        }
+        frameMaxCps = resolveCompletionMaxCps({
+          rawGraphemeCount: rawLength,
+          displayedGraphemeCount: displayedCount,
+          elapsedMs: now - s.completeStartedAt,
+          budgetMs: completeBudget,
+          maxCps,
+        });
       }
 
       const dtMs = Math.max(0, now - frameStartedAt);
@@ -342,7 +371,7 @@ export function useSmoothStreamContent(
         emaCps: refs.current.emaCps,
         dtMs,
         minCps,
-        maxCps,
+        maxCps: frameMaxCps,
       });
       if (advance > 0) {
         setDisplayedCount((cur) => Math.min(cur + advance, rawLength));


### PR DESCRIPTION
## Summary

Smooth the transition from assistant streaming output to the committed final message, including terminal `complete` handoff, refresh-failure recovery, and replay-safe settle cleanup.

## Why

The `complete` event handler is subscribed per `activeId`, so it could read a stale `streamingBySession` closure from subscription time. When that happened, the renderer missed the visible streaming bubble, cleared/refreshed immediately, and the UI could briefly show no assistant stream or an older committed state before jumping to the full persisted answer.

A follow-up review found two edge cases: a one-time committed-message refresh failure could leave the stream slot in `draining`, and replaying the same final `text_complete` while settle refresh was in flight could replace the slot object without changing its semantic content.

## Scope

Changed:

- Keep live assistant stream slots in a ref so terminal event handlers read current streaming state without resubscribing on every delta.
- Keep assistant stream helpers in `@maka/ui/assistant-stream` as pure reducers only.
- Apply final `text_complete` payload redaction/capping once, then pass the applied result into the draining-slot reducer.
- On settle, renderer best-effort refreshes committed messages, then clears the captured/equivalent draining slot; equivalent replay means same `messageId`, text, and truncation state.
- Keep refresh-before-clear ordering while avoiding stale-object and same-terminal replay stuck bubbles.
- Hide the matching committed assistant message during drain to avoid duplicate visible answers.
- Replace fragile source-shape handoff tests with executable reducer behavior tests.
- Add runtime contract coverage for `text_complete.messageId === persisted assistant.id`.

Not included:

- No broader turn lifecycle rewrite.
- No changes to runtime provider event contracts.

## Verification

- `node --test "apps/desktop/src/main/__tests__/assistant-stream.test.ts" "apps/desktop/src/main/__tests__/smooth-stream.test.ts" "apps/desktop/src/main/__tests__/streaming-handoff.test.ts"`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test`
- `npm run build && npm run check:stale`
- `node --test "packages/runtime/dist/__tests__/session-manager.test.js"`
- Manual Electron verification from the worktree build with `--remote-debugging-port=9230`.

## User-facing impact

Assistant responses should no longer jump from a partial streamed prefix directly to the full completed answer. The final tail drains through the existing smoother, committed history is refreshed when possible, then the streaming bubble is cleared without getting stuck if refresh fails once or the same terminal event is replayed.

No migrations, docs, or changelog changes.

## Reviewer notes

The renderer owns async refresh orchestration in `apps/desktop/src/renderer/main.tsx`; `packages/ui/src/assistant-stream.ts` now only exposes pure slot reducers and final-payload helpers.
