### PR TITLE
feat(headless): add RSI R2 safety primitives

### DIFF
--- a/packages/headless/src/__tests__/rsi-r2-safety.test.ts
+++ b/packages/headless/src/__tests__/rsi-r2-safety.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  canonicalRsiTokenList,
+  hashRsiHeldInTaskSet,
+  isRsiR2FailurePattern,
+  promptSafeToken,
+  validateRsiPromptText,
+} from '../rsi-r2-safety.js';
+
+describe('RSI R2 safety primitives', () => {
+  test('recognizes only the R2 failure patterns that candidate rationales may cite', () => {
+    assert.equal(isRsiR2FailurePattern('coverage_regression'), true);
+    assert.equal(isRsiR2FailurePattern('tool_failed'), true);
+    assert.equal(isRsiR2FailurePattern('held_out_regressed'), false);
+    assert.equal(isRsiR2FailurePattern('verification_failed\nheld_out_regressed'), false);
+  });
+
+  test('sanitizes trace-derived prompt tokens with a safe fallback', () => {
+    assert.equal(promptSafeToken('Bash.exec-1:ok', 'fallback'), 'Bash.exec-1:ok');
+    assert.equal(promptSafeToken('tool with spaces', 'fallback'), 'fallback');
+    assert.equal(promptSafeToken('x'.repeat(65), 'fallback'), 'fallback');
+    assert.equal(promptSafeToken('工具', 'fallback'), 'fallback');
+  });
+
+  test('validates bounded prompt text before it can become durable feedback', () => {
+    assert.equal(
+      validateRsiPromptText('  investigate repeated Bash timeouts  ', {
+        fieldName: 'hypothesis',
+        maxChars: 80,
+      }),
+      'investigate repeated Bash timeouts',
+    );
+
+    assert.throws(
+      () => validateRsiPromptText('held_out_regressed on hidden task', {
+        fieldName: 'hypothesis',
+        maxChars: 80,
+      }),
+      /hypothesis contains forbidden held_out/i,
+    );
+    assert.throws(
+      () => validateRsiPromptText('```raw trace```', {
+        fieldName: 'hypothesis',
+        maxChars: 80,
+      }),
+      /hypothesis contains forbidden code_fence/i,
+    );
+    assert.throws(
+      () => validateRsiPromptText('line one\nline two', {
+        fieldName: 'hypothesis',
+        maxChars: 80,
+      }),
+      /hypothesis must be single-line/i,
+    );
+    assert.throws(
+      () => validateRsiPromptText('x'.repeat(81), {
+        fieldName: 'hypothesis',
+        maxChars: 80,
+      }),
+      /hypothesis exceeds 80 chars/i,
+    );
+  });
+
+  test('canonicalizes bounded token lists for evidence refs and task ids', () => {
+    assert.deepEqual(
+      canonicalRsiTokenList(['task-b', 'task-a', 'task-b'], {
+        fieldName: 'predictedFixes',
+        maxItems: 4,
+      }),
+      ['task-a', 'task-b'],
+    );
+
+    assert.throws(
+      () => canonicalRsiTokenList(['task-a', 'task-b', 'task-c'], {
+        fieldName: 'riskTasks',
+        maxItems: 2,
+      }),
+      /riskTasks exceeds 2 items/i,
+    );
+    assert.throws(
+      () => canonicalRsiTokenList(['task a'], {
+        fieldName: 'evidenceRefs',
+        maxItems: 4,
+      }),
+      /evidenceRefs\[0\] must be prompt-safe/i,
+    );
+  });
+
+  test('hashes held-in task sets independent of order while rejecting unsafe ids', () => {
+    assert.equal(
+      hashRsiHeldInTaskSet(['task-b', 'task-a']),
+      hashRsiHeldInTaskSet(['task-a', 'task-b']),
+    );
+    assert.notEqual(
+      hashRsiHeldInTaskSet(['task-a', 'task-b']),
+      hashRsiHeldInTaskSet(['task-a', 'task-c']),
+    );
+    assert.match(hashRsiHeldInTaskSet(['task-a']), /^sha256:[a-f0-9]{16}$/);
+    assert.throws(
+      () => hashRsiHeldInTaskSet(['held out task']),
+      /heldInTaskIds\[0\] must be prompt-safe/i,
+    );
+  });
+});

--- a/packages/headless/src/__tests__/rsi-r2-safety.test.ts
+++ b/packages/headless/src/__tests__/rsi-r2-safety.test.ts
@@ -21,6 +21,10 @@ describe('RSI R2 safety primitives', () => {
     assert.equal(promptSafeToken('tool with spaces', 'fallback'), 'fallback');
     assert.equal(promptSafeToken('x'.repeat(65), 'fallback'), 'fallback');
     assert.equal(promptSafeToken('工具', 'fallback'), 'fallback');
+    assert.throws(
+      () => promptSafeToken('tool with spaces', 'bad fallback'),
+      /fallback must be prompt-safe/i,
+    );
   });
 
   test('validates bounded prompt text before it can become durable feedback', () => {
@@ -46,6 +50,15 @@ describe('RSI R2 safety primitives', () => {
       }),
       /hypothesis contains forbidden code_fence/i,
     );
+    for (const unsafe of ['/app/tests/test.sh', 'runtime-events.jsonl', 'resultsJsonlPath', 'results.tsv']) {
+      assert.throws(
+        () => validateRsiPromptText(unsafe, {
+          fieldName: 'hypothesis',
+          maxChars: 80,
+        }),
+        /hypothesis contains forbidden/i,
+      );
+    }
     assert.throws(
       () => validateRsiPromptText('line one\nline two', {
         fieldName: 'hypothesis',
@@ -70,9 +83,23 @@ describe('RSI R2 safety primitives', () => {
       }),
       ['task-a', 'task-b'],
     );
+    assert.deepEqual(
+      canonicalRsiTokenList(['task_a', 'task-a', 'task.A', 'task:a', 'Task-a', 'task-A'], {
+        fieldName: 'evidenceRefs',
+        maxItems: 6,
+      }),
+      ['Task-a', 'task-A', 'task-a', 'task.A', 'task:a', 'task_a'],
+    );
 
     assert.throws(
       () => canonicalRsiTokenList(['task-a', 'task-b', 'task-c'], {
+        fieldName: 'riskTasks',
+        maxItems: 2,
+      }),
+      /riskTasks exceeds 2 items/i,
+    );
+    assert.throws(
+      () => canonicalRsiTokenList(Array(100).fill('task-a'), {
         fieldName: 'riskTasks',
         maxItems: 2,
       }),
@@ -96,7 +123,11 @@ describe('RSI R2 safety primitives', () => {
       hashRsiHeldInTaskSet(['task-a', 'task-b']),
       hashRsiHeldInTaskSet(['task-a', 'task-c']),
     );
-    assert.match(hashRsiHeldInTaskSet(['task-a']), /^sha256:[a-f0-9]{16}$/);
+    assert.equal(
+      hashRsiHeldInTaskSet(['task_a', 'task-a', 'task.A', 'task:a', 'Task-a', 'task-A']),
+      'sha256:afb9a3f239bb32247e4d013a0249f11cca97d3ba192710080ed43a7dce9089d0',
+    );
+    assert.match(hashRsiHeldInTaskSet(['task-a']), /^sha256:[a-f0-9]{64}$/);
     assert.throws(
       () => hashRsiHeldInTaskSet(['held out task']),
       /heldInTaskIds\[0\] must be prompt-safe/i,

--- a/packages/headless/src/__tests__/rsi-r2-safety.test.ts
+++ b/packages/headless/src/__tests__/rsi-r2-safety.test.ts
@@ -25,6 +25,14 @@ describe('RSI R2 safety primitives', () => {
       () => promptSafeToken('tool with spaces', 'bad fallback'),
       /fallback must be prompt-safe/i,
     );
+    assert.throws(
+      () => promptSafeToken(123 as unknown as string, 'fallback'),
+      /value must be prompt-safe/i,
+    );
+    assert.throws(
+      () => promptSafeToken('tool with spaces', 123 as unknown as string),
+      /fallback must be prompt-safe/i,
+    );
   });
 
   test('validates bounded prompt text before it can become durable feedback', () => {
@@ -112,6 +120,15 @@ describe('RSI R2 safety primitives', () => {
       }),
       /evidenceRefs\[0\] must be prompt-safe/i,
     );
+    for (const unsafe of [123, true, {}]) {
+      assert.throws(
+        () => canonicalRsiTokenList([unsafe as unknown as string], {
+          fieldName: 'evidenceRefs',
+          maxItems: 4,
+        }),
+        /evidenceRefs\[0\] must be prompt-safe/i,
+      );
+    }
   });
 
   test('hashes held-in task sets independent of order while rejecting unsafe ids', () => {

--- a/packages/headless/src/rsi-r2-safety.ts
+++ b/packages/headless/src/rsi-r2-safety.ts
@@ -1,0 +1,85 @@
+import { createHash } from 'node:crypto';
+
+export const RSI_R2_FAILURE_PATTERNS = [
+  'coverage_regression',
+  'tool_failed',
+  'max_tokens',
+  'runtime_error',
+  'verification_failed',
+  'other',
+] as const;
+
+export type RsiR2FailurePattern = typeof RSI_R2_FAILURE_PATTERNS[number];
+
+export interface ValidateRsiPromptTextOptions {
+  fieldName: string;
+  maxChars: number;
+}
+
+export interface CanonicalRsiTokenListOptions {
+  fieldName: string;
+  maxItems: number;
+}
+
+const PROMPT_SAFE_TOKEN_RE = /^[A-Za-z0-9_.:-]{1,64}$/;
+
+const FORBIDDEN_TEXT_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: 'code_fence', pattern: /```/ },
+  { name: 'held_out', pattern: /held[-_ ]?out/i },
+  { name: 'expected_output', pattern: /expected[-_ ]?output/i },
+  { name: 'verifier', pattern: /\bverifier\b/i },
+  { name: 'test_path', pattern: /(?:^|[\s"'`])(?:\.\/)?tests\//i },
+];
+
+export function isRsiR2FailurePattern(value: unknown): value is RsiR2FailurePattern {
+  return typeof value === 'string'
+    && (RSI_R2_FAILURE_PATTERNS as readonly string[]).includes(value);
+}
+
+export function promptSafeToken(value: string, fallback: string): string {
+  return PROMPT_SAFE_TOKEN_RE.test(value) ? value : fallback;
+}
+
+export function validateRsiPromptText(value: string, options: ValidateRsiPromptTextOptions): string {
+  const text = value.trim();
+  if (text.length === 0) throw new Error(`${options.fieldName} must be non-empty`);
+  if (text.length > options.maxChars) {
+    throw new Error(`${options.fieldName} exceeds ${options.maxChars} chars`);
+  }
+  if (/\r|\n/.test(text)) throw new Error(`${options.fieldName} must be single-line`);
+  for (const forbidden of FORBIDDEN_TEXT_PATTERNS) {
+    if (forbidden.pattern.test(text)) {
+      throw new Error(`${options.fieldName} contains forbidden ${forbidden.name}`);
+    }
+  }
+  return text;
+}
+
+export function canonicalRsiTokenList(
+  values: readonly string[],
+  options: CanonicalRsiTokenListOptions,
+): string[] {
+  const canonical = values.map((value, index) => {
+    if (!PROMPT_SAFE_TOKEN_RE.test(value)) {
+      throw new Error(`${options.fieldName}[${index}] must be prompt-safe`);
+    }
+    return value;
+  });
+  const deduped = [...new Set(canonical)].sort((a, b) => a.localeCompare(b));
+  if (deduped.length > options.maxItems) {
+    throw new Error(`${options.fieldName} exceeds ${options.maxItems} items`);
+  }
+  return deduped;
+}
+
+export function hashRsiHeldInTaskSet(taskIds: readonly string[]): string {
+  const canonical = canonicalRsiTokenList(taskIds, {
+    fieldName: 'heldInTaskIds',
+    maxItems: Number.MAX_SAFE_INTEGER,
+  });
+  const digest = createHash('sha256')
+    .update(JSON.stringify(canonical))
+    .digest('hex')
+    .slice(0, 16);
+  return `sha256:${digest}`;
+}

--- a/packages/headless/src/rsi-r2-safety.ts
+++ b/packages/headless/src/rsi-r2-safety.ts
@@ -28,7 +28,8 @@ const FORBIDDEN_TEXT_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
   { name: 'held_out', pattern: /held[-_ ]?out/i },
   { name: 'expected_output', pattern: /expected[-_ ]?output/i },
   { name: 'verifier', pattern: /\bverifier\b/i },
-  { name: 'test_path', pattern: /(?:^|[\s"'`])(?:\.\/)?tests\//i },
+  { name: 'test_path', pattern: /(?:^|[\s"'`])(?:\.\/|\/app\/)?tests\//i },
+  { name: 'controller_artifact', pattern: /\b(?:runtime-events|results)\.(?:jsonl|tsv)\b|\bresultsJsonlPath\b/i },
 ];
 
 export function isRsiR2FailurePattern(value: unknown): value is RsiR2FailurePattern {
@@ -37,6 +38,9 @@ export function isRsiR2FailurePattern(value: unknown): value is RsiR2FailurePatt
 }
 
 export function promptSafeToken(value: string, fallback: string): string {
+  if (!PROMPT_SAFE_TOKEN_RE.test(fallback)) {
+    throw new Error('fallback must be prompt-safe');
+  }
   return PROMPT_SAFE_TOKEN_RE.test(value) ? value : fallback;
 }
 
@@ -59,17 +63,21 @@ export function canonicalRsiTokenList(
   values: readonly string[],
   options: CanonicalRsiTokenListOptions,
 ): string[] {
+  if (values.length > options.maxItems) {
+    throw new Error(`${options.fieldName} exceeds ${options.maxItems} items`);
+  }
   const canonical = values.map((value, index) => {
     if (!PROMPT_SAFE_TOKEN_RE.test(value)) {
       throw new Error(`${options.fieldName}[${index}] must be prompt-safe`);
     }
     return value;
   });
-  const deduped = [...new Set(canonical)].sort((a, b) => a.localeCompare(b));
-  if (deduped.length > options.maxItems) {
-    throw new Error(`${options.fieldName} exceeds ${options.maxItems} items`);
-  }
+  const deduped = [...new Set(canonical)].sort(comparePromptSafeTokens);
   return deduped;
+}
+
+function comparePromptSafeTokens(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export function hashRsiHeldInTaskSet(taskIds: readonly string[]): string {
@@ -79,7 +87,6 @@ export function hashRsiHeldInTaskSet(taskIds: readonly string[]): string {
   });
   const digest = createHash('sha256')
     .update(JSON.stringify(canonical))
-    .digest('hex')
-    .slice(0, 16);
+    .digest('hex');
   return `sha256:${digest}`;
 }

--- a/packages/headless/src/rsi-r2-safety.ts
+++ b/packages/headless/src/rsi-r2-safety.ts
@@ -38,8 +38,11 @@ export function isRsiR2FailurePattern(value: unknown): value is RsiR2FailurePatt
 }
 
 export function promptSafeToken(value: string, fallback: string): string {
-  if (!PROMPT_SAFE_TOKEN_RE.test(fallback)) {
+  if (typeof fallback !== 'string' || !PROMPT_SAFE_TOKEN_RE.test(fallback)) {
     throw new Error('fallback must be prompt-safe');
+  }
+  if (typeof value !== 'string') {
+    throw new Error('value must be prompt-safe');
   }
   return PROMPT_SAFE_TOKEN_RE.test(value) ? value : fallback;
 }
@@ -67,7 +70,7 @@ export function canonicalRsiTokenList(
     throw new Error(`${options.fieldName} exceeds ${options.maxItems} items`);
   }
   const canonical = values.map((value, index) => {
-    if (!PROMPT_SAFE_TOKEN_RE.test(value)) {
+    if (typeof value !== 'string' || !PROMPT_SAFE_TOKEN_RE.test(value)) {
       throw new Error(`${options.fieldName}[${index}] must be prompt-safe`);
     }
     return value;


### PR DESCRIPTION
## Summary

Adds the first flat PR for #311: small reusable RSI R2 safety primitives for later analysis/rationale PRs.

## Why

R2 needs shared guardrails before PR B/C wire richer observability into the loop: prompt-safe tokens, bounded durable feedback text, canonical token lists, allowed failure-pattern names, and a stable held-in task-set hash.

Part of #311.

## Scope

Changed:
- adds `packages/headless/src/rsi-r2-safety.ts`
- adds unit coverage for failure-pattern allowlisting, prompt-safe token fallback, bounded text validation, canonical token lists, and held-in task-set hashing

Not included:
- no deterministic round analysis model
- no `candidateRationale` schema or WAL persistence
- no attribution/projection work
- no loop integration or acceptance-policy behavior changes

## Verification

- `node ../../worktree-bootstrap.mjs`
- `npm run -w @maka/headless build && node --test "packages/headless/dist/__tests__/rsi-r2-safety.test.js"`
- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`

## User-facing impact

None. Package-internal primitives only; no runtime behavior changes.

## Reviewer notes

This PR intentionally keeps the helpers package-local and unintegrated. PR D/F can decide which pieces become shared callers once PR B/C land.