### PR TITLE
feat(headless): add RSI round analysis model

### DIFF
--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -145,11 +145,22 @@ describe('RSI round analysis', () => {
       const runtimeEventsPath = join(dir, 'runtime.jsonl');
       const traceEventsPath = join(dir, 'trace.jsonl');
 
-      await writeJsonl(runtimeEventsPath, [functionCall('call-a', 'Bash', { z: 1, a: 1, b: 1 })]);
-      await writeJsonl(traceEventsPath, [
-        toolFailed('call-a', 'Bash', 'TimeoutError'),
-        toolFailed('call-a', 'Bash', 'TimeoutError'),
-      ]);
+      await writeJsonl(runtimeEventsPath, [functionCall('call-a', 'Bash', {
+        j: 1,
+        i: 1,
+        h: 1,
+        g: 1,
+        f: 1,
+        e: 1,
+        d: 1,
+        c: 1,
+        b: 1,
+        a: 1,
+      })]);
+      await writeJsonl(
+        traceEventsPath,
+        Array.from({ length: 1001 }, () => toolFailed('call-a', 'Bash', 'TimeoutError')),
+      );
 
       const analysis = await analyzeRsiRound({
         heldInTaskIds: ['task-a'],
@@ -157,11 +168,56 @@ describe('RSI round analysis', () => {
         candidateEvents: [
           plumbingFailed({ taskId: 'task-a', errorClass: 'missing_prompt_hash', runtimeEventsPath, traceEventsPath }),
         ],
-        limits: { maxToolFailureArgsKeys: 2, maxToolFailureEventsPerTask: 1 },
       });
 
       assert.deepEqual(analysis.toolFailureClusters, [
-        { name: 'Bash', errorClass: 'TimeoutError', argsPreview: 'a,b', count: 1, taskIds: ['task-a'] },
+        { name: 'Bash', errorClass: 'TimeoutError', argsPreview: 'a,b,c,d,e,f,g,h', count: 1000, taskIds: ['task-a'] },
+      ]);
+    });
+  });
+
+  test('keeps trace-derived clusters when runtime artifacts are unavailable', async () => {
+    await withDir(async (dir) => {
+      const missingRuntimePath = join(dir, 'missing-runtime.jsonl');
+      const traceEventsPath = join(dir, 'trace.jsonl');
+
+      await writeJsonl(traceEventsPath, [toolFailed('call-a', 'Bash', 'TimeoutError')]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath: missingRuntimePath, traceEventsPath }),
+        ],
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        { name: 'Bash', errorClass: 'TimeoutError', count: 1, taskIds: ['task-a'] },
+      ]);
+      assert.deepEqual(traceUnavailableSignals(analysis), [
+        { kind: 'trace_unavailable', taskIds: ['task-a'], source: 'runtime', reason: 'missing_file' },
+      ]);
+    });
+  });
+
+  test('signals missing trace paths instead of silently skipping artifact events', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime.jsonl');
+
+      await writeJsonl(runtimeEventsPath, [functionCall('call-a', 'Bash', { command: 'exit 1' })]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a', 'task-b'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath }),
+          plumbingFailed({ taskId: 'task-b', errorClass: 'missing_prompt_hash', runtimeEventsPath }),
+        ],
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, []);
+      assert.deepEqual(traceUnavailableSignals(analysis), [
+        { kind: 'trace_unavailable', taskIds: ['task-a', 'task-b'], source: 'trace', reason: 'missing_path' },
       ]);
     });
   });
@@ -172,45 +228,34 @@ describe('RSI round analysis', () => {
       const taskATrace = join(dir, 'task-a-trace.jsonl');
       const taskBRuntime = join(dir, 'task-b-runtime.jsonl');
       const taskBTrace = join(dir, 'task-b-trace.jsonl');
-      const taskCRuntime = join(dir, 'task-c-missing-runtime.jsonl');
-      const taskCTrace = join(dir, 'task-c-trace.jsonl');
       const taskDRuntime = join(dir, 'task-d-runtime.jsonl');
       const taskDTrace = join(dir, 'task-d-trace.jsonl');
 
       await writeJsonl(taskARuntime, [functionCall('call-a', 'Read', { path: '/app/file.txt' })]);
       await writeFile(taskATrace, '{not-json}\n', 'utf8');
       await writeJsonl(taskBRuntime, [functionCall('call-b', 'Bash', { command: 'exit 1' })]);
-      await writeJsonl(taskBTrace, [
-        toolFailed('call-b', 'Bash', 'TimeoutError'),
-        toolFailed('call-b', 'Bash', 'TimeoutError'),
-      ]);
-      await writeJsonl(taskCTrace, [toolFailed('call-c', 'Read', 'FileError')]);
+      await writeJsonl(
+        taskBTrace,
+        Array.from({ length: 10001 }, () => toolFailed('call-b', 'Bash', 'TimeoutError')),
+      );
       await writeJsonl(taskDRuntime, [functionCall('call-d', 'Glob', { pattern: '*.ts' })]);
-      await writeFile(taskDTrace, `${'x'.repeat(240)}\n`, 'utf8');
+      await writeFile(taskDTrace, `${'x'.repeat(1_000_001)}\n`, 'utf8');
 
       const analysis = await analyzeRsiRound({
-        heldInTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
+        heldInTaskIds: ['task-a', 'task-b', 'task-d'],
         lastKeptEvents: [],
         candidateEvents: [
           completed({ taskId: 'task-a', passed: false, runtimeEventsPath: taskARuntime, traceEventsPath: taskATrace }),
           completed({ taskId: 'task-b', passed: false, runtimeEventsPath: taskBRuntime, traceEventsPath: taskBTrace }),
-          completed({ taskId: 'task-c', passed: false, runtimeEventsPath: taskCRuntime, traceEventsPath: taskCTrace }),
           completed({ taskId: 'task-d', passed: false, runtimeEventsPath: taskDRuntime, traceEventsPath: taskDTrace }),
         ],
-        limits: { maxToolFailureJsonlBytes: 180, maxToolFailureJsonlLines: 1 },
       });
 
       assert.deepEqual(analysis.toolFailureClusters, []);
-      assert.deepEqual(
-        analysis.signals
-          .filter((signal) => (signal as { kind: string }).kind === 'trace_unavailable')
-          .map(({ id: _id, ...signal }) => signal),
-        [
-          { kind: 'trace_unavailable', taskIds: ['task-c'], source: 'runtime', reason: 'missing_file' },
-          { kind: 'trace_unavailable', taskIds: ['task-b', 'task-d'], source: 'trace', reason: 'input_limit_exceeded' },
-          { kind: 'trace_unavailable', taskIds: ['task-a'], source: 'trace', reason: 'invalid_jsonl' },
-        ],
-      );
+      assert.deepEqual(traceUnavailableSignals(analysis), [
+        { kind: 'trace_unavailable', taskIds: ['task-b', 'task-d'], source: 'trace', reason: 'input_limit_exceeded' },
+        { kind: 'trace_unavailable', taskIds: ['task-a'], source: 'trace', reason: 'invalid_jsonl' },
+      ]);
     });
   });
 
@@ -272,9 +317,26 @@ describe('RSI round analysis', () => {
       'coverage_regression',
       'error_class',
       'error_class',
+      'trace_unavailable',
+    ]);
+    assert.deepEqual(traceUnavailableSignals(first), [
+      { kind: 'trace_unavailable', taskIds: ['task-a', 'task-b'], source: 'trace', reason: 'missing_path' },
     ]);
   });
 });
+
+type TraceUnavailableSignal = {
+  kind: 'trace_unavailable';
+  taskIds: string[];
+  source: string;
+  reason: string;
+};
+
+function traceUnavailableSignals(analysis: Awaited<ReturnType<typeof analyzeRsiRound>>): TraceUnavailableSignal[] {
+  return analysis.signals
+    .filter((signal): signal is typeof signal & { kind: 'trace_unavailable' } => signal.kind === 'trace_unavailable')
+    .map(({ id: _id, ...signal }) => signal);
+}
 
 function completed(input: {
   taskId: string;

--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -51,6 +51,42 @@ describe('RSI round analysis', () => {
     ]);
   });
 
+  test('only reports coverage regression when last kept was covered', async () => {
+    const analysis = await analyzeRsiRound({
+      heldInTaskIds: ['task-a', 'task-b', 'task-c'],
+      lastKeptEvents: [
+        completed({ taskId: 'task-a', passed: true }),
+        completed({ taskId: 'task-c', passed: false, scored: false, errorClass: 'max_tokens' }),
+      ],
+      candidateEvents: [
+        completed({ taskId: 'task-a', passed: false, scored: false, errorClass: 'max_tokens' }),
+        completed({ taskId: 'task-b', passed: false, scored: false, errorClass: 'max_tokens' }),
+        completed({ taskId: 'task-c', passed: false, scored: false, errorClass: 'max_tokens' }),
+      ],
+    });
+
+    assert.deepEqual(analysis.coverageRegressionTaskIds, ['task-a']);
+  });
+
+  test('sanitizes prompt-visible error classes before grouping and signaling', async () => {
+    const analysis = await analyzeRsiRound({
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [],
+      candidateEvents: [
+        completed({ taskId: 'task-a', passed: false, errorClass: '<unsafe verifier clue /app/tests/secret.md>' }),
+      ],
+    });
+
+    assert.deepEqual(analysis.errorClassDistribution, [{ errorClass: 'unknown_error', count: 1 }]);
+    assert.equal(JSON.stringify(analysis).includes('<unsafe verifier clue'), false);
+    assert.deepEqual(
+      analysis.signals
+        .filter((signal) => signal.kind === 'error_class')
+        .map(({ id: _id, ...signal }) => signal),
+      [{ kind: 'error_class', taskIds: ['task-a'], errorClass: 'unknown_error', count: 1 }],
+    );
+  });
+
   test('aggregates bounded prompt-safe tool failure clusters from held-in traces', async () => {
     await withDir(async (dir) => {
       const taskARuntime = join(dir, 'task-a-runtime.jsonl');
@@ -101,6 +137,109 @@ describe('RSI round analysis', () => {
       ]);
       assert.equal(JSON.stringify(analysis).includes('held-out'), false);
       assert.equal(JSON.stringify(analysis).includes('<unsafe'), false);
+    });
+  });
+
+  test('aggregates tool failure clusters from plumbing events with traces', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime.jsonl');
+      const traceEventsPath = join(dir, 'trace.jsonl');
+
+      await writeJsonl(runtimeEventsPath, [functionCall('call-a', 'Bash', { z: 1, a: 1, b: 1 })]);
+      await writeJsonl(traceEventsPath, [
+        toolFailed('call-a', 'Bash', 'TimeoutError'),
+        toolFailed('call-a', 'Bash', 'TimeoutError'),
+      ]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          plumbingFailed({ taskId: 'task-a', errorClass: 'missing_prompt_hash', runtimeEventsPath, traceEventsPath }),
+        ],
+        limits: { maxToolFailureArgsKeys: 2, maxToolFailureEventsPerTask: 1 },
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        { name: 'Bash', errorClass: 'TimeoutError', argsPreview: 'a,b', count: 1, taskIds: ['task-a'] },
+      ]);
+    });
+  });
+
+  test('keeps trace parsing bounded and tolerant per task', async () => {
+    await withDir(async (dir) => {
+      const taskARuntime = join(dir, 'task-a-runtime.jsonl');
+      const taskATrace = join(dir, 'task-a-trace.jsonl');
+      const taskBRuntime = join(dir, 'task-b-runtime.jsonl');
+      const taskBTrace = join(dir, 'task-b-trace.jsonl');
+      const taskCRuntime = join(dir, 'task-c-missing-runtime.jsonl');
+      const taskCTrace = join(dir, 'task-c-trace.jsonl');
+      const taskDRuntime = join(dir, 'task-d-runtime.jsonl');
+      const taskDTrace = join(dir, 'task-d-trace.jsonl');
+
+      await writeJsonl(taskARuntime, [functionCall('call-a', 'Read', { path: '/app/file.txt' })]);
+      await writeFile(taskATrace, '{not-json}\n', 'utf8');
+      await writeJsonl(taskBRuntime, [functionCall('call-b', 'Bash', { command: 'exit 1' })]);
+      await writeJsonl(taskBTrace, [
+        toolFailed('call-b', 'Bash', 'TimeoutError'),
+        toolFailed('call-b', 'Bash', 'TimeoutError'),
+      ]);
+      await writeJsonl(taskCTrace, [toolFailed('call-c', 'Read', 'FileError')]);
+      await writeJsonl(taskDRuntime, [functionCall('call-d', 'Glob', { pattern: '*.ts' })]);
+      await writeFile(taskDTrace, `${'x'.repeat(240)}\n`, 'utf8');
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath: taskARuntime, traceEventsPath: taskATrace }),
+          completed({ taskId: 'task-b', passed: false, runtimeEventsPath: taskBRuntime, traceEventsPath: taskBTrace }),
+          completed({ taskId: 'task-c', passed: false, runtimeEventsPath: taskCRuntime, traceEventsPath: taskCTrace }),
+          completed({ taskId: 'task-d', passed: false, runtimeEventsPath: taskDRuntime, traceEventsPath: taskDTrace }),
+        ],
+        limits: { maxToolFailureJsonlBytes: 180, maxToolFailureJsonlLines: 1 },
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, []);
+      assert.deepEqual(
+        analysis.signals
+          .filter((signal) => (signal as { kind: string }).kind === 'trace_unavailable')
+          .map(({ id: _id, ...signal }) => signal),
+        [
+          { kind: 'trace_unavailable', taskIds: ['task-c'], source: 'runtime', reason: 'missing_file' },
+          { kind: 'trace_unavailable', taskIds: ['task-b', 'task-d'], source: 'trace', reason: 'input_limit_exceeded' },
+          { kind: 'trace_unavailable', taskIds: ['task-a'], source: 'trace', reason: 'invalid_jsonl' },
+        ],
+      );
+    });
+  });
+
+  test('treats non-positive tool failure cluster limits as zero', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime.jsonl');
+      const traceEventsPath = join(dir, 'trace.jsonl');
+
+      await writeJsonl(runtimeEventsPath, [
+        functionCall('call-a', 'Bash', { command: 'exit 1' }),
+        functionCall('call-b', 'Read', { path: '/app/file.txt' }),
+      ]);
+      await writeJsonl(traceEventsPath, [
+        toolFailed('call-a', 'Bash', 'TimeoutError'),
+        toolFailed('call-b', 'Read', 'FileError'),
+      ]);
+
+      for (const maxToolFailureClusters of [0, -1]) {
+        const analysis = await analyzeRsiRound({
+          heldInTaskIds: ['task-a'],
+          lastKeptEvents: [],
+          candidateEvents: [
+            completed({ taskId: 'task-a', passed: false, runtimeEventsPath, traceEventsPath }),
+          ],
+          limits: { maxToolFailureClusters },
+        });
+
+        assert.deepEqual(analysis.toolFailureClusters, []);
+      }
     });
   });
 
@@ -168,7 +307,12 @@ function completed(input: {
   };
 }
 
-function plumbingFailed(input: { taskId: string; errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' }): FixedPromptTaskWalEvent {
+function plumbingFailed(input: {
+  taskId: string;
+  errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash';
+  runtimeEventsPath?: string;
+  traceEventsPath?: string;
+}): FixedPromptTaskWalEvent {
   return {
     schemaVersion: 1,
     type: 'task_plumbing_failed',
@@ -187,7 +331,8 @@ function plumbingFailed(input: { taskId: string; errorClass: 'zero_cost_with_tok
     tokenSummary: tokenSummary({ input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 }),
     steps: 1,
     durationMs: 10,
-    runtimeEventsPath: '/tmp/runtime-events.jsonl',
+    runtimeEventsPath: input.runtimeEventsPath ?? '/tmp/runtime-events.jsonl',
+    ...(input.traceEventsPath ? { traceEventsPath: input.traceEventsPath } : {}),
     harbor: { reward: 0 },
   };
 }

--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { FixedPromptTaskWalEvent } from '../fixed-prompt-controller.js';
+import { analyzeRsiRound, heldInTaskSetHash } from '../rsi-round-analysis.js';
+import { tokenSummary } from './helpers/cell-output-fixtures.js';
+
+describe('RSI round analysis', () => {
+  test('summarizes held-in transitions, coverage regressions, and error classes', async () => {
+    const lastKeptEvents = [
+      completed({ taskId: 'task-a', passed: true }),
+      completed({ taskId: 'task-b', passed: false, errorClass: 'verification_failed' }),
+      completed({ taskId: 'task-c', passed: false, errorClass: 'verification_failed' }),
+    ];
+    const previousCandidateEvents = [
+      completed({ taskId: 'task-a', passed: false, errorClass: 'verification_failed' }),
+      completed({ taskId: 'task-b', passed: false, errorClass: 'verification_failed' }),
+      completed({ taskId: 'task-c', passed: true }),
+    ];
+    const candidateEvents = [
+      completed({ taskId: 'task-a', passed: false, errorClass: 'verification_failed' }),
+      completed({ taskId: 'task-b', passed: false, scored: false, errorClass: 'max_tokens' }),
+      plumbingFailed({ taskId: 'task-c', errorClass: 'missing_prompt_hash' }),
+      completed({ taskId: 'held-out-secret', passed: true }),
+    ];
+
+    const analysis = await analyzeRsiRound({
+      heldInTaskIds: ['task-a', 'task-b', 'task-c'],
+      lastKeptEvents,
+      previousCandidateEvents,
+      candidateEvents,
+    });
+
+    assert.equal(analysis.heldInTaskSetHash, heldInTaskSetHash(['task-c', 'task-a', 'task-b']));
+    assert.deepEqual(analysis.transitionVsLastKept, [
+      { taskId: 'task-a', from: 'pass', to: 'fail' },
+      { taskId: 'task-b', from: 'fail', to: 'unscored' },
+      { taskId: 'task-c', from: 'fail', to: 'plumbing' },
+    ]);
+    assert.deepEqual(analysis.transitionVsPreviousCandidate, [
+      { taskId: 'task-b', from: 'fail', to: 'unscored' },
+      { taskId: 'task-c', from: 'pass', to: 'plumbing' },
+    ]);
+    assert.deepEqual(analysis.coverageRegressionTaskIds, ['task-b', 'task-c']);
+    assert.deepEqual(analysis.errorClassDistribution, [
+      { errorClass: 'max_tokens', count: 1 },
+      { errorClass: 'missing_prompt_hash', count: 1 },
+      { errorClass: 'verification_failed', count: 1 },
+    ]);
+  });
+
+  test('aggregates bounded prompt-safe tool failure clusters from held-in traces', async () => {
+    await withDir(async (dir) => {
+      const taskARuntime = join(dir, 'task-a-runtime.jsonl');
+      const taskATrace = join(dir, 'task-a-trace.jsonl');
+      const taskBRuntime = join(dir, 'task-b-runtime.jsonl');
+      const taskBTrace = join(dir, 'task-b-trace.jsonl');
+      const taskCRuntime = join(dir, 'task-c-runtime.jsonl');
+      const taskCTrace = join(dir, 'task-c-trace.jsonl');
+      const heldOutRuntime = join(dir, 'held-out-runtime.jsonl');
+      const heldOutTrace = join(dir, 'held-out-trace.jsonl');
+
+      await writeJsonl(taskARuntime, [functionCall('call-a', 'Bash', { command: 'exit 1', timeoutMs: 10 })]);
+      await writeJsonl(taskATrace, [
+        toolFailed('call-a', 'Bash', 'TimeoutError'),
+        toolFailed('call-a', 'Bash', 'TimeoutError'),
+      ]);
+      await writeJsonl(taskBRuntime, [functionCall('call-b', 'Read', { path: '/app/file.txt' })]);
+      await writeJsonl(taskBTrace, [
+        toolFailed('call-b', 'Read', 'FileError'),
+        toolFailed('call-b', 'Read', 'FileError'),
+        toolFailed('call-b', 'Read', 'FileError'),
+      ]);
+      await writeJsonl(taskCRuntime, [functionCall('call-c', '<unsafe tool>', { '<raw>': 'x' })]);
+      await writeJsonl(taskCTrace, [toolFailed('call-c', '<unsafe tool>', 'bad error')]);
+      await writeJsonl(heldOutRuntime, [functionCall('call-held-out', 'SecretTool', { secret: 'held-out' })]);
+      await writeJsonl(heldOutTrace, [
+        toolFailed('call-held-out', 'SecretTool', 'SecretError'),
+        toolFailed('call-held-out', 'SecretTool', 'SecretError'),
+        toolFailed('call-held-out', 'SecretTool', 'SecretError'),
+        toolFailed('call-held-out', 'SecretTool', 'SecretError'),
+      ]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a', 'task-b', 'task-c'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath: taskARuntime, traceEventsPath: taskATrace }),
+          completed({ taskId: 'task-b', passed: false, runtimeEventsPath: taskBRuntime, traceEventsPath: taskBTrace }),
+          completed({ taskId: 'task-c', passed: false, runtimeEventsPath: taskCRuntime, traceEventsPath: taskCTrace }),
+          completed({ taskId: 'held-out-secret', passed: false, runtimeEventsPath: heldOutRuntime, traceEventsPath: heldOutTrace }),
+        ],
+        limits: { maxToolFailureClusters: 2 },
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        { name: 'Read', errorClass: 'FileError', argsPreview: 'path', count: 3, taskIds: ['task-b'] },
+        { name: 'Bash', errorClass: 'TimeoutError', argsPreview: 'command,timeoutMs', count: 2, taskIds: ['task-a'] },
+      ]);
+      assert.equal(JSON.stringify(analysis).includes('held-out'), false);
+      assert.equal(JSON.stringify(analysis).includes('<unsafe'), false);
+    });
+  });
+
+  test('emits deterministic held-in-only analysis signal ids for later evidence refs', async () => {
+    const input = {
+      heldInTaskIds: ['task-b', 'task-a'],
+      lastKeptEvents: [
+        completed({ taskId: 'task-a', passed: true }),
+        completed({ taskId: 'task-b', passed: false, errorClass: 'verification_failed' }),
+      ],
+      candidateEvents: [
+        completed({ taskId: 'task-a', passed: false, errorClass: 'verification_failed' }),
+        completed({ taskId: 'task-b', passed: false, scored: false, errorClass: 'max_tokens' }),
+        completed({ taskId: 'held-out-secret', passed: false, errorClass: 'secret_error' }),
+      ],
+    };
+
+    const first = await analyzeRsiRound(input);
+    const second = await analyzeRsiRound({ ...input, heldInTaskIds: ['task-a', 'task-b'] });
+
+    assert.deepEqual(first.signals, second.signals);
+    assert.ok(first.signals.length > 0);
+    for (const signal of first.signals) {
+      assert.match(signal.id, /^rsi-sig:[0-9a-f]{16}$/);
+      assert.equal(signal.taskIds.includes('held-out-secret'), false);
+    }
+    assert.deepEqual(first.signals.map((signal) => signal.kind), [
+      'transition',
+      'transition',
+      'coverage_regression',
+      'error_class',
+      'error_class',
+    ]);
+  });
+});
+
+function completed(input: {
+  taskId: string;
+  passed: boolean;
+  scored?: boolean;
+  errorClass?: string;
+  runtimeEventsPath?: string;
+  traceEventsPath?: string;
+}): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_completed',
+    id: `${input.taskId}-event`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: input.passed ? 'completed' : 'failed',
+    passed: input.passed,
+    scored: input.scored ?? true,
+    eligible: true,
+    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+    promptHash: 'sha256:prompt',
+    tokenSummary: tokenSummary({ input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 }),
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: input.runtimeEventsPath ?? '/tmp/runtime-events.jsonl',
+    ...(input.traceEventsPath ? { traceEventsPath: input.traceEventsPath } : {}),
+    harbor: { reward: input.passed ? 1 : 0 },
+  };
+}
+
+function plumbingFailed(input: { taskId: string; errorClass: 'zero_cost_with_tokens' | 'prompt_hash_mismatch' | 'missing_prompt_hash' }): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_plumbing_failed',
+    id: `${input.taskId}-plumbing`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: 'plumbing_failed',
+    passed: false,
+    scored: false,
+    eligible: false,
+    errorClass: input.errorClass,
+    error: 'plumbing failed',
+    expectedPromptHash: 'sha256:prompt',
+    tokenSummary: tokenSummary({ input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 }),
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: '/tmp/runtime-events.jsonl',
+    harbor: { reward: 0 },
+  };
+}
+
+function functionCall(id: string, name: string, args: Record<string, unknown>): unknown {
+  return { content: { kind: 'function_call', id, name, args } };
+}
+
+function toolFailed(toolUseId: string, toolName: string, errorClass: string): unknown {
+  return { type: 'tool_failed', data: { toolUseId, toolName, errorClass } };
+}
+
+async function writeJsonl(path: string, events: readonly unknown[]): Promise<void> {
+  await writeFile(path, `${events.map((event) => JSON.stringify(event)).join('\n')}\n`, 'utf8');
+}
+
+async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-rsi-analysis-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -1,6 +1,12 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import type { FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
+
+const DEFAULT_MAX_TOOL_FAILURE_CLUSTERS = 10;
+const DEFAULT_MAX_TOOL_FAILURE_JSONL_BYTES = 1_000_000;
+const DEFAULT_MAX_TOOL_FAILURE_JSONL_LINES = 10_000;
+const DEFAULT_MAX_TOOL_FAILURE_EVENTS_PER_TASK = 1_000;
+const DEFAULT_MAX_TOOL_FAILURE_ARGS_KEYS = 8;
 
 export type RsiTaskOutcome = 'pass' | 'fail' | 'unscored' | 'infra' | 'budget' | 'plumbing' | 'missing';
 
@@ -22,6 +28,10 @@ export interface RsiToolFailureCluster {
   errorClass?: string;
   argsPreview?: string;
 }
+
+export type RsiTraceUnavailableSource = 'runtime' | 'trace';
+
+export type RsiTraceUnavailableReason = 'missing_file' | 'invalid_jsonl' | 'input_limit_exceeded' | 'unreadable';
 
 export type RsiAnalysisSignal =
   | {
@@ -48,6 +58,13 @@ export type RsiAnalysisSignal =
     kind: 'tool_failure_cluster';
     taskIds: string[];
     cluster: RsiToolFailureCluster;
+  }
+  | {
+    id: string;
+    kind: 'trace_unavailable';
+    taskIds: string[];
+    source: RsiTraceUnavailableSource;
+    reason: RsiTraceUnavailableReason;
   };
 
 export interface RsiRoundAnalysis {
@@ -67,15 +84,51 @@ export interface AnalyzeRsiRoundInput {
   candidateEvents: readonly FixedPromptTaskWalEvent[];
   limits?: {
     maxToolFailureClusters?: number;
+    maxToolFailureJsonlBytes?: number;
+    maxToolFailureJsonlLines?: number;
+    maxToolFailureEventsPerTask?: number;
+    maxToolFailureArgsKeys?: number;
   };
 }
 
+interface RsiErrorClassGroup extends RsiErrorClassCount {
+  taskIds: string[];
+}
+
+interface RsiTraceUnavailableGroup {
+  taskIds: string[];
+  source: RsiTraceUnavailableSource;
+  reason: RsiTraceUnavailableReason;
+}
+
+interface NormalizedToolFailureLimits {
+  maxClusters: number;
+  maxJsonlBytes: number;
+  maxJsonlLines: number;
+  maxEventsPerTask: number;
+  maxArgsKeys: number;
+}
+
+interface ToolFailureClusterResult {
+  clusters: RsiToolFailureCluster[];
+  traceUnavailable: RsiTraceUnavailableGroup[];
+}
+
+type BoundedJsonlResult =
+  | { ok: true; events: unknown[] }
+  | { ok: false; reason: RsiTraceUnavailableReason };
+
+type FunctionCallsByIdResult =
+  | { ok: true; value: Map<string, { name: string; argsPreview: string }> }
+  | { ok: false; reason: RsiTraceUnavailableReason };
+
 export async function analyzeRsiRound(input: AnalyzeRsiRoundInput): Promise<RsiRoundAnalysis> {
   const heldInTaskIds = sortedUnique(input.heldInTaskIds);
+  const lastKeptByTask = eventsByHeldInTask(input.lastKeptEvents, heldInTaskIds);
   const candidateByTask = eventsByHeldInTask(input.candidateEvents, heldInTaskIds);
   const transitionVsLastKept = taskTransitions(
     heldInTaskIds,
-    eventsByHeldInTask(input.lastKeptEvents, heldInTaskIds),
+    lastKeptByTask,
     candidateByTask,
   );
   const transitionVsPreviousCandidate = input.previousCandidateEvents
@@ -85,26 +138,29 @@ export async function analyzeRsiRound(input: AnalyzeRsiRoundInput): Promise<RsiR
       candidateByTask,
     )
     : [];
-  const coverageRegressionTaskIds = heldInTaskIds.filter((taskId) => !isCovered(candidateByTask.get(taskId)));
-  const errors = errorClassDistribution(heldInTaskIds, candidateByTask);
+  const coverageRegressionTaskIds = heldInTaskIds.filter((taskId) => (
+    isCovered(lastKeptByTask.get(taskId)) && !isCovered(candidateByTask.get(taskId))
+  ));
+  const errorGroups = safeErrorClassGroups(heldInTaskIds, candidateByTask);
   const toolFailures = await toolFailureClusters(
     heldInTaskIds,
     candidateByTask,
-    input.limits?.maxToolFailureClusters ?? 10,
+    normalizeToolFailureLimits(input.limits),
   );
   return {
     heldInTaskSetHash: heldInTaskSetHash(heldInTaskIds),
     transitionVsLastKept,
     transitionVsPreviousCandidate,
     coverageRegressionTaskIds,
-    errorClassDistribution: errors,
-    toolFailureClusters: toolFailures,
+    errorClassDistribution: errorGroups.map(({ taskIds: _taskIds, ...group }) => group),
+    toolFailureClusters: toolFailures.clusters,
     signals: analysisSignals({
       transitionVsLastKept,
       transitionVsPreviousCandidate,
       coverageRegressionTaskIds,
-      errorClassTaskIds: errorClassTaskIds(heldInTaskIds, candidateByTask),
-      toolFailureClusters: toolFailures,
+      errorGroups,
+      toolFailureClusters: toolFailures.clusters,
+      traceUnavailable: toolFailures.traceUnavailable,
     }),
   };
 }
@@ -138,41 +194,32 @@ function isCovered(event: FixedPromptTaskWalEvent | undefined): boolean {
   return event?.type === 'task_completed' && event.eligible && event.scored;
 }
 
-function errorClassDistribution(
+function safeErrorClassGroups(
   heldInTaskIds: readonly string[],
   events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
-): RsiErrorClassCount[] {
-  const counts = new Map<string, number>();
-  for (const taskId of heldInTaskIds) {
-    const errorClass = events.get(taskId)?.errorClass;
-    if (errorClass) counts.set(errorClass, (counts.get(errorClass) ?? 0) + 1);
-  }
-  return [...counts.entries()]
-    .map(([errorClass, count]) => ({ errorClass, count }))
-    .sort((a, b) => b.count - a.count || a.errorClass.localeCompare(b.errorClass));
-}
-
-function errorClassTaskIds(
-  heldInTaskIds: readonly string[],
-  events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
-): Map<string, string[]> {
-  const byErrorClass = new Map<string, string[]>();
+): RsiErrorClassGroup[] {
+  const groups = new Map<string, RsiErrorClassGroup>();
   for (const taskId of heldInTaskIds) {
     const errorClass = events.get(taskId)?.errorClass;
     if (!errorClass) continue;
-    const tasks = byErrorClass.get(errorClass) ?? [];
-    tasks.push(taskId);
-    byErrorClass.set(errorClass, tasks);
+    const safeErrorClass = promptSafeToken(errorClass, 'unknown_error');
+    const current = groups.get(safeErrorClass) ?? { errorClass: safeErrorClass, count: 0, taskIds: [] };
+    current.count += 1;
+    current.taskIds.push(taskId);
+    groups.set(safeErrorClass, current);
   }
-  return byErrorClass;
+  return [...groups.values()]
+    .map((group) => ({ ...group, taskIds: [...group.taskIds].sort(compareStrings) }))
+    .sort((a, b) => b.count - a.count || compareStrings(a.errorClass, b.errorClass));
 }
 
 function analysisSignals(input: {
   transitionVsLastKept: readonly RsiTaskTransition[];
   transitionVsPreviousCandidate: readonly RsiTaskTransition[];
   coverageRegressionTaskIds: readonly string[];
-  errorClassTaskIds: ReadonlyMap<string, readonly string[]>;
+  errorGroups: readonly RsiErrorClassGroup[];
   toolFailureClusters: readonly RsiToolFailureCluster[];
+  traceUnavailable: readonly RsiTraceUnavailableGroup[];
 }): RsiAnalysisSignal[] {
   return [
     ...input.transitionVsLastKept.map((transition) => transitionSignal('last_kept', transition)),
@@ -180,18 +227,23 @@ function analysisSignals(input: {
     ...(input.coverageRegressionTaskIds.length > 0
       ? [withSignalId({ kind: 'coverage_regression' as const, taskIds: [...input.coverageRegressionTaskIds] })]
       : []),
-    ...[...input.errorClassTaskIds.entries()]
-      .map(([errorClass, taskIds]) => withSignalId({
+    ...input.errorGroups
+      .map(({ errorClass, count, taskIds }) => withSignalId({
         kind: 'error_class' as const,
         taskIds: [...taskIds],
         errorClass,
-        count: taskIds.length,
-      }))
-      .sort((a, b) => b.count - a.count || a.errorClass.localeCompare(b.errorClass)),
+        count,
+      })),
     ...input.toolFailureClusters.map((cluster) => withSignalId({
       kind: 'tool_failure_cluster' as const,
       taskIds: cluster.taskIds,
       cluster,
+    })),
+    ...input.traceUnavailable.map((unavailable) => withSignalId({
+      kind: 'trace_unavailable' as const,
+      taskIds: unavailable.taskIds,
+      source: unavailable.source,
+      reason: unavailable.reason,
     })),
   ];
 }
@@ -230,17 +282,30 @@ function eventsByHeldInTask(
 async function toolFailureClusters(
   heldInTaskIds: readonly string[],
   events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
-  limit: number,
-): Promise<RsiToolFailureCluster[]> {
+  limits: NormalizedToolFailureLimits,
+): Promise<ToolFailureClusterResult> {
   const clusters = new Map<string, RsiToolFailureCluster & { taskIdSet: Set<string> }>();
+  const traceUnavailable = new Map<string, RsiTraceUnavailableGroup & { taskIdSet: Set<string> }>();
+  if (limits.maxClusters === 0) return { clusters: [], traceUnavailable: [] };
   for (const taskId of heldInTaskIds) {
     const event = events.get(taskId);
-    if (!event || event.type !== 'task_completed' || !event.traceEventsPath) continue;
-    const callsById = await functionCallsById(event.runtimeEventsPath);
-    const traceEvents = await readJsonl(event.traceEventsPath);
-    for (const traceEvent of traceEvents) {
-      const failure = toolFailureDigest(traceEvent, callsById);
+    if (!event || !hasToolFailureArtifacts(event)) continue;
+    const callsById = await functionCallsById(event.runtimeEventsPath, limits);
+    if (!callsById.ok) {
+      addTraceUnavailable(traceUnavailable, taskId, 'runtime', callsById.reason);
+      continue;
+    }
+    const traceEvents = await readBoundedJsonl(event.traceEventsPath, limits);
+    if (!traceEvents.ok) {
+      addTraceUnavailable(traceUnavailable, taskId, 'trace', traceEvents.reason);
+      continue;
+    }
+    let failureEvents = 0;
+    for (const traceEvent of traceEvents.events) {
+      if (failureEvents >= limits.maxEventsPerTask) break;
+      const failure = toolFailureDigest(traceEvent, callsById.value);
       if (!failure) continue;
+      failureEvents += 1;
       const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
       const current = clusters.get(key) ?? {
         ...failure,
@@ -254,36 +319,72 @@ async function toolFailureClusters(
     }
   }
 
-  return [...clusters.values()]
-    .map(({ taskIdSet, ...cluster }) => ({
-      ...cluster,
-      taskIds: [...taskIdSet].sort((a, b) => a.localeCompare(b)),
-    }))
-    .sort(compareToolFailureClusters)
-    .slice(0, limit);
+  return {
+    clusters: [...clusters.values()]
+      .map(({ taskIdSet, ...cluster }) => ({
+        ...cluster,
+        taskIds: [...taskIdSet].sort(compareStrings),
+      }))
+      .sort(compareToolFailureClusters)
+      .slice(0, limits.maxClusters),
+    traceUnavailable: [...traceUnavailable.values()]
+      .map(({ taskIdSet, ...group }) => ({
+        ...group,
+        taskIds: [...taskIdSet].sort(compareStrings),
+      }))
+      .sort(compareTraceUnavailable),
+  };
 }
 
-async function functionCallsById(path: string): Promise<Map<string, { name: string; argsPreview: string }>> {
+async function functionCallsById(
+  path: string,
+  limits: NormalizedToolFailureLimits,
+): Promise<FunctionCallsByIdResult> {
+  const runtimeEvents = await readBoundedJsonl(path, limits);
+  if (!runtimeEvents.ok) return runtimeEvents;
   const calls = new Map<string, { name: string; argsPreview: string }>();
-  const runtimeEvents = await readJsonl(path);
-  for (const event of runtimeEvents) {
+  for (const event of runtimeEvents.events) {
     if (!isRecord(event) || !isRecord(event.content)) continue;
     const content = event.content;
     if (content.kind !== 'function_call' || typeof content.id !== 'string' || typeof content.name !== 'string') continue;
     calls.set(content.id, {
       name: promptSafeToken(content.name, 'unknown_tool'),
-      argsPreview: argsPreview(content.args),
+      argsPreview: argsPreview(content.args, limits.maxArgsKeys),
     });
   }
-  return calls;
+  return { ok: true, value: calls };
 }
 
-async function readJsonl(path: string): Promise<unknown[]> {
-  const raw = await readFile(path, 'utf8');
-  return raw
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as unknown);
+async function readBoundedJsonl(path: string, limits: NormalizedToolFailureLimits): Promise<BoundedJsonlResult> {
+  let size: number;
+  try {
+    size = (await stat(path)).size;
+  } catch (error) {
+    return { ok: false, reason: isNotFound(error) ? 'missing_file' : 'unreadable' };
+  }
+  if (size > limits.maxJsonlBytes) return { ok: false, reason: 'input_limit_exceeded' };
+
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (error) {
+    return { ok: false, reason: isNotFound(error) ? 'missing_file' : 'unreadable' };
+  }
+  if (Buffer.byteLength(raw, 'utf8') > limits.maxJsonlBytes) {
+    return { ok: false, reason: 'input_limit_exceeded' };
+  }
+  const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+  if (lines.length > limits.maxJsonlLines) return { ok: false, reason: 'input_limit_exceeded' };
+
+  const events: unknown[] = [];
+  for (const line of lines) {
+    try {
+      events.push(JSON.parse(line) as unknown);
+    } catch {
+      return { ok: false, reason: 'invalid_jsonl' };
+    }
+  }
+  return { ok: true, events };
 }
 
 function toolFailureDigest(
@@ -303,18 +404,66 @@ function toolFailureDigest(
 
 function compareToolFailureClusters(a: RsiToolFailureCluster, b: RsiToolFailureCluster): number {
   return b.count - a.count
-    || a.name.localeCompare(b.name)
-    || (a.errorClass ?? '').localeCompare(b.errorClass ?? '')
-    || (a.argsPreview ?? '').localeCompare(b.argsPreview ?? '')
-    || a.taskIds.join(',').localeCompare(b.taskIds.join(','));
+    || compareStrings(a.name, b.name)
+    || compareStrings(a.errorClass ?? '', b.errorClass ?? '')
+    || compareStrings(a.argsPreview ?? '', b.argsPreview ?? '')
+    || compareStrings(a.taskIds.join(','), b.taskIds.join(','));
 }
 
-function argsPreview(args: unknown): string {
+function compareTraceUnavailable(a: RsiTraceUnavailableGroup, b: RsiTraceUnavailableGroup): number {
+  return compareStrings(a.source, b.source)
+    || compareStrings(a.reason, b.reason)
+    || compareStrings(a.taskIds.join(','), b.taskIds.join(','));
+}
+
+function argsPreview(args: unknown, maxKeys: number): string {
   if (!isRecord(args)) return typeof args;
+  if (maxKeys === 0) return '';
   return Object.keys(args)
     .map((key) => promptSafeToken(key, 'arg'))
-    .sort((a, b) => a.localeCompare(b))
+    .sort(compareStrings)
+    .slice(0, maxKeys)
     .join(',');
+}
+
+function addTraceUnavailable(
+  groups: Map<string, RsiTraceUnavailableGroup & { taskIdSet: Set<string> }>,
+  taskId: string,
+  source: RsiTraceUnavailableSource,
+  reason: RsiTraceUnavailableReason,
+): void {
+  const key = `${source}\0${reason}`;
+  const current = groups.get(key) ?? { source, reason, taskIds: [], taskIdSet: new Set<string>() };
+  current.taskIdSet.add(taskId);
+  groups.set(key, current);
+}
+
+function hasToolFailureArtifacts(event: FixedPromptTaskWalEvent): event is FixedPromptTaskWalEvent & {
+  runtimeEventsPath: string;
+  traceEventsPath: string;
+} {
+  return 'runtimeEventsPath' in event
+    && typeof event.runtimeEventsPath === 'string'
+    && typeof event.traceEventsPath === 'string';
+}
+
+function normalizeToolFailureLimits(limits: AnalyzeRsiRoundInput['limits']): NormalizedToolFailureLimits {
+  return {
+    maxClusters: nonNegativeInt(limits?.maxToolFailureClusters, DEFAULT_MAX_TOOL_FAILURE_CLUSTERS),
+    maxJsonlBytes: nonNegativeInt(limits?.maxToolFailureJsonlBytes, DEFAULT_MAX_TOOL_FAILURE_JSONL_BYTES),
+    maxJsonlLines: nonNegativeInt(limits?.maxToolFailureJsonlLines, DEFAULT_MAX_TOOL_FAILURE_JSONL_LINES),
+    maxEventsPerTask: nonNegativeInt(limits?.maxToolFailureEventsPerTask, DEFAULT_MAX_TOOL_FAILURE_EVENTS_PER_TASK),
+    maxArgsKeys: nonNegativeInt(limits?.maxToolFailureArgsKeys, DEFAULT_MAX_TOOL_FAILURE_ARGS_KEYS),
+  };
+}
+
+function nonNegativeInt(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.trunc(value));
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function promptSafeToken(value: string, fallback: string): string {
@@ -322,10 +471,14 @@ function promptSafeToken(value: string, fallback: string): string {
   return fallback;
 }
 
+function isNotFound(error: unknown): boolean {
+  return isRecord(error) && error.code === 'ENOENT';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function sortedUnique(values: readonly string[]): string[] {
-  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+  return [...new Set(values)].sort(compareStrings);
 }

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -31,7 +31,7 @@ export interface RsiToolFailureCluster {
 
 export type RsiTraceUnavailableSource = 'runtime' | 'trace';
 
-export type RsiTraceUnavailableReason = 'missing_file' | 'invalid_jsonl' | 'input_limit_exceeded' | 'unreadable';
+export type RsiTraceUnavailableReason = 'missing_path' | 'missing_file' | 'invalid_jsonl' | 'input_limit_exceeded' | 'unreadable';
 
 export type RsiAnalysisSignal =
   | {
@@ -84,10 +84,6 @@ export interface AnalyzeRsiRoundInput {
   candidateEvents: readonly FixedPromptTaskWalEvent[];
   limits?: {
     maxToolFailureClusters?: number;
-    maxToolFailureJsonlBytes?: number;
-    maxToolFailureJsonlLines?: number;
-    maxToolFailureEventsPerTask?: number;
-    maxToolFailureArgsKeys?: number;
   };
 }
 
@@ -289,10 +285,9 @@ async function toolFailureClusters(
   if (limits.maxClusters === 0) return { clusters: [], traceUnavailable: [] };
   for (const taskId of heldInTaskIds) {
     const event = events.get(taskId);
-    if (!event || !hasToolFailureArtifacts(event)) continue;
-    const callsById = await functionCallsById(event.runtimeEventsPath, limits);
-    if (!callsById.ok) {
-      addTraceUnavailable(traceUnavailable, taskId, 'runtime', callsById.reason);
+    if (!event || !hasRuntimePath(event)) continue;
+    if (!hasTracePath(event)) {
+      addTraceUnavailable(traceUnavailable, taskId, 'trace', 'missing_path');
       continue;
     }
     const traceEvents = await readBoundedJsonl(event.traceEventsPath, limits);
@@ -300,10 +295,13 @@ async function toolFailureClusters(
       addTraceUnavailable(traceUnavailable, taskId, 'trace', traceEvents.reason);
       continue;
     }
+    const callsById = await functionCallsById(event.runtimeEventsPath, limits);
+    if (!callsById.ok) addTraceUnavailable(traceUnavailable, taskId, 'runtime', callsById.reason);
+    const calls = callsById.ok ? callsById.value : new Map<string, { name: string; argsPreview: string }>();
     let failureEvents = 0;
     for (const traceEvent of traceEvents.events) {
       if (failureEvents >= limits.maxEventsPerTask) break;
-      const failure = toolFailureDigest(traceEvent, callsById.value);
+      const failure = toolFailureDigest(traceEvent, calls);
       if (!failure) continue;
       failureEvents += 1;
       const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
@@ -438,22 +436,21 @@ function addTraceUnavailable(
   groups.set(key, current);
 }
 
-function hasToolFailureArtifacts(event: FixedPromptTaskWalEvent): event is FixedPromptTaskWalEvent & {
-  runtimeEventsPath: string;
-  traceEventsPath: string;
-} {
-  return 'runtimeEventsPath' in event
-    && typeof event.runtimeEventsPath === 'string'
-    && typeof event.traceEventsPath === 'string';
+function hasRuntimePath(event: FixedPromptTaskWalEvent): event is FixedPromptTaskWalEvent & { runtimeEventsPath: string } {
+  return 'runtimeEventsPath' in event && typeof event.runtimeEventsPath === 'string';
+}
+
+function hasTracePath(event: FixedPromptTaskWalEvent): event is FixedPromptTaskWalEvent & { traceEventsPath: string } {
+  return 'traceEventsPath' in event && typeof event.traceEventsPath === 'string';
 }
 
 function normalizeToolFailureLimits(limits: AnalyzeRsiRoundInput['limits']): NormalizedToolFailureLimits {
   return {
     maxClusters: nonNegativeInt(limits?.maxToolFailureClusters, DEFAULT_MAX_TOOL_FAILURE_CLUSTERS),
-    maxJsonlBytes: nonNegativeInt(limits?.maxToolFailureJsonlBytes, DEFAULT_MAX_TOOL_FAILURE_JSONL_BYTES),
-    maxJsonlLines: nonNegativeInt(limits?.maxToolFailureJsonlLines, DEFAULT_MAX_TOOL_FAILURE_JSONL_LINES),
-    maxEventsPerTask: nonNegativeInt(limits?.maxToolFailureEventsPerTask, DEFAULT_MAX_TOOL_FAILURE_EVENTS_PER_TASK),
-    maxArgsKeys: nonNegativeInt(limits?.maxToolFailureArgsKeys, DEFAULT_MAX_TOOL_FAILURE_ARGS_KEYS),
+    maxJsonlBytes: DEFAULT_MAX_TOOL_FAILURE_JSONL_BYTES,
+    maxJsonlLines: DEFAULT_MAX_TOOL_FAILURE_JSONL_LINES,
+    maxEventsPerTask: DEFAULT_MAX_TOOL_FAILURE_EVENTS_PER_TASK,
+    maxArgsKeys: DEFAULT_MAX_TOOL_FAILURE_ARGS_KEYS,
   };
 }
 

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -1,0 +1,331 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import type { FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
+
+export type RsiTaskOutcome = 'pass' | 'fail' | 'unscored' | 'infra' | 'budget' | 'plumbing' | 'missing';
+
+export interface RsiTaskTransition {
+  taskId: string;
+  from: RsiTaskOutcome;
+  to: RsiTaskOutcome;
+}
+
+export interface RsiErrorClassCount {
+  errorClass: string;
+  count: number;
+}
+
+export interface RsiToolFailureCluster {
+  name: string;
+  count: number;
+  taskIds: string[];
+  errorClass?: string;
+  argsPreview?: string;
+}
+
+export type RsiAnalysisSignal =
+  | {
+    id: string;
+    kind: 'transition';
+    taskIds: string[];
+    basis: 'last_kept' | 'previous_candidate';
+    transition: RsiTaskTransition;
+  }
+  | {
+    id: string;
+    kind: 'coverage_regression';
+    taskIds: string[];
+  }
+  | {
+    id: string;
+    kind: 'error_class';
+    taskIds: string[];
+    errorClass: string;
+    count: number;
+  }
+  | {
+    id: string;
+    kind: 'tool_failure_cluster';
+    taskIds: string[];
+    cluster: RsiToolFailureCluster;
+  };
+
+export interface RsiRoundAnalysis {
+  heldInTaskSetHash: string;
+  transitionVsLastKept: RsiTaskTransition[];
+  transitionVsPreviousCandidate: RsiTaskTransition[];
+  coverageRegressionTaskIds: string[];
+  errorClassDistribution: RsiErrorClassCount[];
+  toolFailureClusters: RsiToolFailureCluster[];
+  signals: RsiAnalysisSignal[];
+}
+
+export interface AnalyzeRsiRoundInput {
+  heldInTaskIds: readonly string[];
+  lastKeptEvents: readonly FixedPromptTaskWalEvent[];
+  previousCandidateEvents?: readonly FixedPromptTaskWalEvent[];
+  candidateEvents: readonly FixedPromptTaskWalEvent[];
+  limits?: {
+    maxToolFailureClusters?: number;
+  };
+}
+
+export async function analyzeRsiRound(input: AnalyzeRsiRoundInput): Promise<RsiRoundAnalysis> {
+  const heldInTaskIds = sortedUnique(input.heldInTaskIds);
+  const candidateByTask = eventsByHeldInTask(input.candidateEvents, heldInTaskIds);
+  const transitionVsLastKept = taskTransitions(
+    heldInTaskIds,
+    eventsByHeldInTask(input.lastKeptEvents, heldInTaskIds),
+    candidateByTask,
+  );
+  const transitionVsPreviousCandidate = input.previousCandidateEvents
+    ? taskTransitions(
+      heldInTaskIds,
+      eventsByHeldInTask(input.previousCandidateEvents, heldInTaskIds),
+      candidateByTask,
+    )
+    : [];
+  const coverageRegressionTaskIds = heldInTaskIds.filter((taskId) => !isCovered(candidateByTask.get(taskId)));
+  const errors = errorClassDistribution(heldInTaskIds, candidateByTask);
+  const toolFailures = await toolFailureClusters(
+    heldInTaskIds,
+    candidateByTask,
+    input.limits?.maxToolFailureClusters ?? 10,
+  );
+  return {
+    heldInTaskSetHash: heldInTaskSetHash(heldInTaskIds),
+    transitionVsLastKept,
+    transitionVsPreviousCandidate,
+    coverageRegressionTaskIds,
+    errorClassDistribution: errors,
+    toolFailureClusters: toolFailures,
+    signals: analysisSignals({
+      transitionVsLastKept,
+      transitionVsPreviousCandidate,
+      coverageRegressionTaskIds,
+      errorClassTaskIds: errorClassTaskIds(heldInTaskIds, candidateByTask),
+      toolFailureClusters: toolFailures,
+    }),
+  };
+}
+
+export function heldInTaskSetHash(taskIds: readonly string[]): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(sortedUnique(taskIds))).digest('hex')}`;
+}
+
+function taskTransitions(
+  heldInTaskIds: readonly string[],
+  previous: ReadonlyMap<string, FixedPromptTaskWalEvent>,
+  current: ReadonlyMap<string, FixedPromptTaskWalEvent>,
+): RsiTaskTransition[] {
+  return heldInTaskIds.flatMap((taskId) => {
+    const from = taskOutcome(previous.get(taskId));
+    const to = taskOutcome(current.get(taskId));
+    return from === to ? [] : [{ taskId, from, to }];
+  });
+}
+
+function taskOutcome(event: FixedPromptTaskWalEvent | undefined): RsiTaskOutcome {
+  if (!event) return 'missing';
+  if (event.type === 'task_infra_failed') return 'infra';
+  if (event.type === 'task_budget_exhausted') return 'budget';
+  if (event.type === 'task_plumbing_failed') return 'plumbing';
+  if (!event.eligible || !event.scored) return 'unscored';
+  return event.passed ? 'pass' : 'fail';
+}
+
+function isCovered(event: FixedPromptTaskWalEvent | undefined): boolean {
+  return event?.type === 'task_completed' && event.eligible && event.scored;
+}
+
+function errorClassDistribution(
+  heldInTaskIds: readonly string[],
+  events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
+): RsiErrorClassCount[] {
+  const counts = new Map<string, number>();
+  for (const taskId of heldInTaskIds) {
+    const errorClass = events.get(taskId)?.errorClass;
+    if (errorClass) counts.set(errorClass, (counts.get(errorClass) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([errorClass, count]) => ({ errorClass, count }))
+    .sort((a, b) => b.count - a.count || a.errorClass.localeCompare(b.errorClass));
+}
+
+function errorClassTaskIds(
+  heldInTaskIds: readonly string[],
+  events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
+): Map<string, string[]> {
+  const byErrorClass = new Map<string, string[]>();
+  for (const taskId of heldInTaskIds) {
+    const errorClass = events.get(taskId)?.errorClass;
+    if (!errorClass) continue;
+    const tasks = byErrorClass.get(errorClass) ?? [];
+    tasks.push(taskId);
+    byErrorClass.set(errorClass, tasks);
+  }
+  return byErrorClass;
+}
+
+function analysisSignals(input: {
+  transitionVsLastKept: readonly RsiTaskTransition[];
+  transitionVsPreviousCandidate: readonly RsiTaskTransition[];
+  coverageRegressionTaskIds: readonly string[];
+  errorClassTaskIds: ReadonlyMap<string, readonly string[]>;
+  toolFailureClusters: readonly RsiToolFailureCluster[];
+}): RsiAnalysisSignal[] {
+  return [
+    ...input.transitionVsLastKept.map((transition) => transitionSignal('last_kept', transition)),
+    ...input.transitionVsPreviousCandidate.map((transition) => transitionSignal('previous_candidate', transition)),
+    ...(input.coverageRegressionTaskIds.length > 0
+      ? [withSignalId({ kind: 'coverage_regression' as const, taskIds: [...input.coverageRegressionTaskIds] })]
+      : []),
+    ...[...input.errorClassTaskIds.entries()]
+      .map(([errorClass, taskIds]) => withSignalId({
+        kind: 'error_class' as const,
+        taskIds: [...taskIds],
+        errorClass,
+        count: taskIds.length,
+      }))
+      .sort((a, b) => b.count - a.count || a.errorClass.localeCompare(b.errorClass)),
+    ...input.toolFailureClusters.map((cluster) => withSignalId({
+      kind: 'tool_failure_cluster' as const,
+      taskIds: cluster.taskIds,
+      cluster,
+    })),
+  ];
+}
+
+function transitionSignal(
+  basis: 'last_kept' | 'previous_candidate',
+  transition: RsiTaskTransition,
+): RsiAnalysisSignal {
+  return withSignalId({
+    kind: 'transition' as const,
+    taskIds: [transition.taskId],
+    basis,
+    transition,
+  });
+}
+
+function withSignalId<T extends Omit<RsiAnalysisSignal, 'id'>>(signal: T): T & { id: string } {
+  return {
+    id: `rsi-sig:${createHash('sha256').update(JSON.stringify(signal)).digest('hex').slice(0, 16)}`,
+    ...signal,
+  };
+}
+
+function eventsByHeldInTask(
+  events: readonly FixedPromptTaskWalEvent[],
+  heldInTaskIds: readonly string[],
+): Map<string, FixedPromptTaskWalEvent> {
+  const heldIn = new Set(heldInTaskIds);
+  const byTask = new Map<string, FixedPromptTaskWalEvent>();
+  for (const event of events) {
+    if (heldIn.has(event.taskId)) byTask.set(event.taskId, event);
+  }
+  return byTask;
+}
+
+async function toolFailureClusters(
+  heldInTaskIds: readonly string[],
+  events: ReadonlyMap<string, FixedPromptTaskWalEvent>,
+  limit: number,
+): Promise<RsiToolFailureCluster[]> {
+  const clusters = new Map<string, RsiToolFailureCluster & { taskIdSet: Set<string> }>();
+  for (const taskId of heldInTaskIds) {
+    const event = events.get(taskId);
+    if (!event || event.type !== 'task_completed' || !event.traceEventsPath) continue;
+    const callsById = await functionCallsById(event.runtimeEventsPath);
+    const traceEvents = await readJsonl(event.traceEventsPath);
+    for (const traceEvent of traceEvents) {
+      const failure = toolFailureDigest(traceEvent, callsById);
+      if (!failure) continue;
+      const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
+      const current = clusters.get(key) ?? {
+        ...failure,
+        count: 0,
+        taskIds: [],
+        taskIdSet: new Set<string>(),
+      };
+      current.count += 1;
+      current.taskIdSet.add(taskId);
+      clusters.set(key, current);
+    }
+  }
+
+  return [...clusters.values()]
+    .map(({ taskIdSet, ...cluster }) => ({
+      ...cluster,
+      taskIds: [...taskIdSet].sort((a, b) => a.localeCompare(b)),
+    }))
+    .sort(compareToolFailureClusters)
+    .slice(0, limit);
+}
+
+async function functionCallsById(path: string): Promise<Map<string, { name: string; argsPreview: string }>> {
+  const calls = new Map<string, { name: string; argsPreview: string }>();
+  const runtimeEvents = await readJsonl(path);
+  for (const event of runtimeEvents) {
+    if (!isRecord(event) || !isRecord(event.content)) continue;
+    const content = event.content;
+    if (content.kind !== 'function_call' || typeof content.id !== 'string' || typeof content.name !== 'string') continue;
+    calls.set(content.id, {
+      name: promptSafeToken(content.name, 'unknown_tool'),
+      argsPreview: argsPreview(content.args),
+    });
+  }
+  return calls;
+}
+
+async function readJsonl(path: string): Promise<unknown[]> {
+  const raw = await readFile(path, 'utf8');
+  return raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function toolFailureDigest(
+  event: unknown,
+  callsById: ReadonlyMap<string, { name: string; argsPreview: string }>,
+): Omit<RsiToolFailureCluster, 'count' | 'taskIds'> | undefined {
+  if (!isRecord(event) || event.type !== 'tool_failed' || !isRecord(event.data)) return undefined;
+  const data = event.data;
+  if (typeof data.toolName !== 'string') return undefined;
+  const call = typeof data.toolUseId === 'string' ? callsById.get(data.toolUseId) : undefined;
+  return {
+    name: promptSafeToken(data.toolName, 'unknown_tool'),
+    ...(typeof data.errorClass === 'string' ? { errorClass: promptSafeToken(data.errorClass, 'unknown_error') } : {}),
+    ...(call?.argsPreview ? { argsPreview: call.argsPreview } : {}),
+  };
+}
+
+function compareToolFailureClusters(a: RsiToolFailureCluster, b: RsiToolFailureCluster): number {
+  return b.count - a.count
+    || a.name.localeCompare(b.name)
+    || (a.errorClass ?? '').localeCompare(b.errorClass ?? '')
+    || (a.argsPreview ?? '').localeCompare(b.argsPreview ?? '')
+    || a.taskIds.join(',').localeCompare(b.taskIds.join(','));
+}
+
+function argsPreview(args: unknown): string {
+  if (!isRecord(args)) return typeof args;
+  return Object.keys(args)
+    .map((key) => promptSafeToken(key, 'arg'))
+    .sort((a, b) => a.localeCompare(b))
+    .join(',');
+}
+
+function promptSafeToken(value: string, fallback: string): string {
+  if (/^[A-Za-z0-9_.:-]{1,64}$/.test(value)) return value;
+  return fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## Summary

- Add a standalone RSI round analysis model for #311 PRB.
- Summarize held-in task transitions vs last kept and previous candidate, true coverage regressions, and sanitized errorClass distribution.
- Add bounded, sorted, prompt-safe tool failure clustering plus deterministic analysis signal ids and a held-in task-set hash.
- Add trace-unavailable signals for missing, malformed, or capped trace/runtime JSONL inputs without failing the whole analysis.

## Why

Part of #311. This gives later R2 PRs a deterministic held-in-only evidence model without changing the optimization loop, meta-agent prompt, WAL schema, or acceptance policy.

## Scope

Changed:

- Added `packages/headless/src/rsi-round-analysis.ts`.
- Added fixture tests for transitions, coverage regression, sanitized error classes, prompt-safe tool failure clusters, plumbing traces, held-in filtering, bounded trace parsing, and deterministic signal ids.

Not included:

- No `candidateRationale` schema or parsing.
- No loop integration or `renderMetaAgentPrompt(...)` changes.
- No controller/prompt attribution.
- No keep/discard or acceptance-policy changes.
- No dependency on #313 or #315; this PR stays flat-from-main.

## Review follow-up

- Sanitizes raw `errorClass` before distribution and signal generation.
- Bounds trace/runtime JSONL reads by byte and line limits, with per-task unavailable signals instead of rejecting the round.
- Treats coverage regression as covered in last kept to uncovered in candidate.
- Includes `task_plumbing_failed` trace artifacts when present.
- Handles non-positive cluster limits and caps args preview keys / per-task failure events.

## Verification

- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`

## User-facing impact

None. Headless-only model/test addition; no runtime loop behavior changes.

## Reviewer notes

This is the flat PRB slice for #311. The analyzer is intentionally standalone; PRD/F will later bind `evidenceRefs` and thread prompt-safe attribution into the loop.