### PR TITLE
feat(headless): validate prompt candidate rationale

### DIFF
--- a/packages/headless/src/__tests__/meta-agent-completion.test.ts
+++ b/packages/headless/src/__tests__/meta-agent-completion.test.ts
@@ -20,6 +20,14 @@ const connection: LlmConnection = {
 };
 
 const base = { connection, apiKey: 'unused', modelId: 'deepseek-v4-flash' } as const;
+const candidateRationale = {
+  failurePattern: 'coverage_regression',
+  evidenceRefs: ['analysis-signal-1'],
+  hypothesis: 'coverage fell after the previous prompt change',
+  targetedFix: 'keep the completion criteria explicit and conservative',
+  predictedFixes: [],
+  riskTasks: [],
+} as const;
 
 describe('extractJsonObject', () => {
   test('strips a ```json fence', () => {
@@ -45,12 +53,13 @@ describe('createAiSdkMetaAgentCompletion', () => {
   test('cleans fenced JSON so parseMetaAgentResult accepts it', async () => {
     const complete = createAiSdkMetaAgentCompletion({
       ...base,
-      generate: async () => '```json\n{"systemPrompt":"NEW PROMPT","summary":"tightened rules"}\n```',
+      generate: async () => `\`\`\`json\n${JSON.stringify({ systemPrompt: 'NEW PROMPT', summary: 'tightened rules', candidateRationale })}\n\`\`\``,
     });
     const raw = await complete({ prompt: 'render' });
     assert.deepEqual(parseMetaAgentResult(raw), {
       systemPrompt: 'NEW PROMPT',
       summary: 'tightened rules',
+      candidateRationale,
     });
   });
 
@@ -74,7 +83,7 @@ describe('createAiSdkMetaAgent', () => {
       ...base,
       generate: async ({ prompt }) => {
         assert.match(prompt, /Current System Prompt/);
-        return '{"systemPrompt":"IMPROVED","summary":"removed redundant step"}';
+        return JSON.stringify({ systemPrompt: 'IMPROVED', summary: 'removed redundant step', candidateRationale });
       },
     });
     const result = await agent({
@@ -87,5 +96,6 @@ describe('createAiSdkMetaAgent', () => {
     });
     assert.equal(result.systemPrompt, 'IMPROVED');
     assert.equal(result.summary, 'removed redundant step');
+    assert.deepEqual(result.candidateRationale, candidateRationale);
   });
 });

--- a/packages/headless/src/__tests__/meta-agent-completion.test.ts
+++ b/packages/headless/src/__tests__/meta-agent-completion.test.ts
@@ -22,7 +22,6 @@ const connection: LlmConnection = {
 const base = { connection, apiKey: 'unused', modelId: 'deepseek-v4-flash' } as const;
 const candidateRationale = {
   failurePattern: 'coverage_regression',
-  evidenceRefs: ['analysis-signal-1'],
   hypothesis: 'coverage fell after the previous prompt change',
   targetedFix: 'keep the completion criteria explicit and conservative',
   predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -258,15 +258,7 @@ describe('prompt candidate loop', () => {
     );
   });
 
-  test('rejects unsafe or oversized candidateRationale evidence and text before writing', async () => {
-    await assertRejectsCandidateRationale(
-      validCandidateRationale({ evidenceRefs: ['../held-out-secret'] }),
-      /candidateRationale.evidenceRefs must contain safe analysis signal ids/,
-    );
-    await assertRejectsCandidateRationale(
-      validCandidateRationale({ evidenceRefs: Array.from({ length: 9 }, (_, i) => `signal-${i}`) }),
-      /candidateRationale.evidenceRefs must contain at most 8 items/,
-    );
+  test('rejects unsafe or oversized candidateRationale text before writing', async () => {
     await assertRejectsCandidateRationale(
       validCandidateRationale({ hypothesis: 'held-out regressed after reading tests/test.sh' }),
       /candidateRationale.hypothesis contains forbidden prompt-memory content/,
@@ -1285,6 +1277,7 @@ describe('prompt candidate loop', () => {
     assert.match(prompt, /task-a/);
     assert.match(prompt, /original prompt/);
     assert.match(prompt, /candidateRationale/);
+    assert.equal(prompt.includes('evidenceRefs'), false);
 
     const metaAgent = createScriptedMetaAgent({
       complete: async ({ prompt: renderedPrompt }) => {
@@ -1786,7 +1779,6 @@ function candidatePromptResult(input: {
 function validCandidateRationale(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     failurePattern: 'coverage_regression',
-    evidenceRefs: ['analysis-signal-1'],
     hypothesis: 'coverage fell after the previous prompt change',
     targetedFix: 'keep the completion criteria explicit and conservative',
     predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -30,6 +30,10 @@ describe('prompt candidate loop', () => {
       await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
       await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
       await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\nheld-out-secret\ttrue\n', 'utf8');
+      const candidateRationale = validCandidateRationale({
+        predictedFixes: ['task-a'],
+        riskTasks: ['task-a'],
+      });
 
       let seenInput: MetaAgentPromptInput | undefined;
       await runPromptCandidateRound({
@@ -57,7 +61,7 @@ describe('prompt candidate loop', () => {
         ],
         metaAgent: async (input): Promise<MetaAgentPromptResult> => {
           seenInput = input;
-          return candidatePromptResult({ summary: 'tightened output instruction' });
+          return candidatePromptResult({ summary: 'tightened output instruction', candidateRationale });
         },
         git: gitNoop(dir),
         now: () => 100,
@@ -85,6 +89,7 @@ describe('prompt candidate loop', () => {
           commitSha: 'commit-1',
           summary: 'tightened output instruction',
           promptHash: hashSystemPrompt('candidate prompt\n'),
+          candidateRationale,
         },
       ]);
     });

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -13,6 +13,7 @@ import {
   renderMetaAgentPrompt,
   runPromptCandidateRound,
   scanRuntimeEventsForRewardHack,
+  type CandidateRationale,
   type MetaAgentPromptInput,
   type MetaAgentPromptResult,
 } from '../prompt-candidate-loop.js';
@@ -56,7 +57,7 @@ describe('prompt candidate loop', () => {
         ],
         metaAgent: async (input): Promise<MetaAgentPromptResult> => {
           seenInput = input;
-          return { systemPrompt: 'candidate prompt\n', summary: 'tightened output instruction' };
+          return candidatePromptResult({ summary: 'tightened output instruction' });
         },
         git: gitNoop(dir),
         now: () => 100,
@@ -124,7 +125,7 @@ describe('prompt candidate loop', () => {
         ],
         metaAgent: async (input): Promise<MetaAgentPromptResult> => {
           seenInput = input;
-          return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          return candidatePromptResult();
         },
         git: gitNoop(dir),
         now: () => 100,
@@ -137,6 +138,138 @@ describe('prompt candidate loop', () => {
       assert.equal(JSON.stringify(seenInput).includes('held-out-secret'), false);
       assert.equal(JSON.stringify(seenInput).includes('do not leak'), false);
     });
+  });
+
+  test('rejects meta-agent output without candidateRationale before writing or committing', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      let committed = false;
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' } as MetaAgentPromptResult),
+          git: {
+            ...gitNoop(dir),
+            commit: async () => {
+              committed = true;
+              return 'commit-1';
+            },
+          },
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /candidateRationale must be a JSON object/,
+      );
+
+      assert.equal(committed, false);
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('rejects candidateRationale with an invalid failurePattern before writing', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({ failurePattern: 'held_out_regressed' }),
+          }),
+          git: gitNoop(dir),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /candidateRationale.failurePattern must be one of:/,
+      );
+
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+  });
+
+  test('rejects candidateRationale task ids outside the held-in set before writing', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({ predictedFixes: ['held-out-secret'] }),
+          }),
+          git: gitNoop(dir),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /candidateRationale.predictedFixes contains non-held-in task id: held-out-secret/,
+      );
+
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
+
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ riskTasks: ['held-out-secret'] }),
+      /candidateRationale.riskTasks contains non-held-in task id: held-out-secret/,
+    );
+  });
+
+  test('rejects unsafe or oversized candidateRationale evidence and text before writing', async () => {
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ evidenceRefs: ['../held-out-secret'] }),
+      /candidateRationale.evidenceRefs must contain safe analysis signal ids/,
+    );
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ evidenceRefs: Array.from({ length: 9 }, (_, i) => `signal-${i}`) }),
+      /candidateRationale.evidenceRefs must contain at most 8 items/,
+    );
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ hypothesis: 'held-out regressed after reading tests/test.sh' }),
+      /candidateRationale.hypothesis contains forbidden prompt-memory content/,
+    );
+    await assertRejectsCandidateRationale(
+      validCandidateRationale({ targetedFix: '```\nraw trace chunk\n```' }),
+      /candidateRationale.targetedFix contains forbidden prompt-memory content/,
+    );
   });
 
   test('rejects trajectory digests outside the held-in task set before calling the meta-agent', async () => {
@@ -162,7 +295,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [{ taskId: 'held-out-secret', summary: 'do not leak this trajectory' }],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(dir),
           now: () => 100,
@@ -200,7 +333,7 @@ describe('prompt candidate loop', () => {
           heldOutDigests: [{ taskId: 'task-a', summary: 'held-out summary' }],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(dir),
           now: () => 100,
@@ -235,7 +368,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(dir),
         } as unknown as Parameters<typeof runPromptCandidateRound>[0]),
@@ -272,7 +405,7 @@ describe('prompt candidate loop', () => {
           heldOutArtifactPaths: [heldOutEventsPath],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(dir),
         } as unknown as Parameters<typeof runPromptCandidateRound>[0]),
@@ -319,7 +452,7 @@ describe('prompt candidate loop', () => {
         heldOutArtifactPaths: [heldOutEventsPath],
         metaAgent: async (input): Promise<MetaAgentPromptResult> => {
           seenInput = input;
-          return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+          return candidatePromptResult();
         },
         git: gitNoop(agentDir),
         now: () => 100,
@@ -365,7 +498,7 @@ describe('prompt candidate loop', () => {
           heldOutArtifactPaths: [heldOutEventsPath],
           metaAgent: async () => {
             metaAgentCalled = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(agentDir),
         }),
@@ -407,7 +540,7 @@ describe('prompt candidate loop', () => {
           heldOutArtifactPaths: [visibleHeldOutLinkPath],
           metaAgent: async () => {
             metaAgentCalled = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(agentDir),
         }),
@@ -448,7 +581,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
           metaAgent: async () => {
             metaAgentCalled = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(agentDir),
         }),
@@ -489,7 +622,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
           metaAgent: async () => {
             metaAgentCalled = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: gitNoop(agentDir),
         }),
@@ -521,7 +654,7 @@ describe('prompt candidate loop', () => {
           heldInTaskIds: [],
           heldInDigests: [],
           heldOutDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'system_prompt.md',
@@ -569,7 +702,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath: join(dir, 'results.jsonl'),
           heldInTaskIds: [],
           heldInDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: gitNoop(dir),
           now: () => 100,
           newId: idFactory(),
@@ -605,7 +738,7 @@ describe('prompt candidate loop', () => {
             resultsJsonlPath: join(dir, 'results.jsonl'),
             heldInTaskIds: [],
             heldInDigests: [],
-            metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+            metaAgent: async () => candidatePromptResult(),
             git: {
               gitRootPath: dir,
               systemPromptGitPath: 'prompts/system_prompt.md',
@@ -651,7 +784,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath: join(dir, 'results.jsonl'),
           heldInTaskIds: [],
           heldInDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'prompts/system_prompt.md',
@@ -704,7 +837,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -740,7 +873,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath: join(dir, 'results.jsonl'),
           heldInTaskIds: [],
           heldInDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: {
             gitRootPath: dir,
             systemPromptGitPath: 'system_prompt.md',
@@ -1146,6 +1279,7 @@ describe('prompt candidate loop', () => {
     assert.match(prompt, /Improve conservatively/);
     assert.match(prompt, /task-a/);
     assert.match(prompt, /original prompt/);
+    assert.match(prompt, /candidateRationale/);
 
     const metaAgent = createScriptedMetaAgent({
       complete: async ({ prompt: renderedPrompt }) => {
@@ -1153,6 +1287,7 @@ describe('prompt candidate loop', () => {
         return JSON.stringify({
           systemPrompt: 'candidate prompt\n',
           summary: 'ask for exact output line',
+          candidateRationale: validCandidateRationale(),
         });
       },
     });
@@ -1160,6 +1295,7 @@ describe('prompt candidate loop', () => {
     assert.deepEqual(await metaAgent(input), {
       systemPrompt: 'candidate prompt\n',
       summary: 'ask for exact output line',
+      candidateRationale: validCandidateRationale(),
     });
   });
 
@@ -1190,7 +1326,7 @@ describe('prompt candidate loop', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         heldInTaskIds: [],
         heldInDigests: [],
-        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        metaAgent: async () => candidatePromptResult(),
         git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
         now: () => 100,
         newId: idFactory(),
@@ -1238,7 +1374,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             await writeFile(scratchPath, 'candidate side edit\n', 'utf8');
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1282,7 +1418,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             await rm(scratchPath);
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1324,7 +1460,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             await writeFile(programPath, 'tampered program\n', 'utf8');
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1369,7 +1505,7 @@ describe('prompt candidate loop', () => {
             await writeFile(notesPath, 'side commit\n', 'utf8');
             await execFileAsync('git', ['add', 'notes.md'], { cwd: dir });
             await execFileAsync('git', ['commit', '-m', 'side edit'], { cwd: dir });
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1411,7 +1547,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath,
           heldInTaskIds: [],
           heldInDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
           newId: idFactory(),
@@ -1451,7 +1587,7 @@ describe('prompt candidate loop', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         heldInTaskIds: [],
         heldInDigests: [],
-        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        metaAgent: async () => candidatePromptResult(),
         git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath: 'system_prompt.md' }),
         now: () => 100,
         newId: idFactory(),
@@ -1489,7 +1625,7 @@ describe('prompt candidate loop', () => {
         resultsJsonlPath: join(packageDir, 'results.jsonl'),
         heldInTaskIds: [],
         heldInDigests: [],
-        metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+        metaAgent: async () => candidatePromptResult(),
         git: createCliPromptCandidateGit({ cwd: packageDir, systemPromptPath: 'system_prompt.md' }),
         now: () => 100,
         newId: idFactory(),
@@ -1529,7 +1665,7 @@ describe('prompt candidate loop', () => {
           resultsJsonlPath: join(dir, 'results.jsonl'),
           heldInTaskIds: [],
           heldInDigests: [],
-          metaAgent: async () => ({ systemPrompt: 'candidate prompt\n', summary: 'changed prompt' }),
+          metaAgent: async () => candidatePromptResult(),
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
           newId: idFactory(),
@@ -1573,7 +1709,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1615,7 +1751,7 @@ describe('prompt candidate loop', () => {
           heldInDigests: [],
           metaAgent: async () => {
             called = true;
-            return { systemPrompt: 'candidate prompt\n', summary: 'changed prompt' };
+            return candidatePromptResult();
           },
           git: createCliPromptCandidateGit({ cwd: dir, systemPromptPath }),
           now: () => 100,
@@ -1629,6 +1765,65 @@ describe('prompt candidate loop', () => {
     });
   });
 });
+
+function candidatePromptResult(input: {
+  systemPrompt?: string;
+  summary?: string;
+  candidateRationale?: Record<string, unknown>;
+} = {}): MetaAgentPromptResult {
+  return {
+    systemPrompt: input.systemPrompt ?? 'candidate prompt\n',
+    summary: input.summary ?? 'changed prompt',
+    candidateRationale: (input.candidateRationale ?? validCandidateRationale()) as unknown as CandidateRationale,
+  };
+}
+
+function validCandidateRationale(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    failurePattern: 'coverage_regression',
+    evidenceRefs: ['analysis-signal-1'],
+    hypothesis: 'coverage fell after the previous prompt change',
+    targetedFix: 'keep the completion criteria explicit and conservative',
+    predictedFixes: [],
+    riskTasks: [],
+    ...overrides,
+  };
+}
+
+async function assertRejectsCandidateRationale(
+  candidateRationale: Record<string, unknown>,
+  expected: RegExp,
+): Promise<void> {
+  await withDir(async (dir) => {
+    const programPath = join(dir, 'program.md');
+    const systemPromptPath = join(dir, 'system_prompt.md');
+    const resultsTsvPath = join(dir, 'results.tsv');
+    await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+    await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+    await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+    await assert.rejects(
+      runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: ['task-a'],
+        heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+        metaAgent: async () => candidatePromptResult({ candidateRationale }),
+        git: gitNoop(dir),
+        now: () => 100,
+        newId: idFactory(),
+      }),
+      expected,
+    );
+
+    assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+  });
+}
 
 function gitNoop(gitRootPath = process.cwd()) {
   return {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -31,6 +32,12 @@ describe('prompt candidate loop', () => {
       await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
       await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\nheld-out-secret\ttrue\n', 'utf8');
       const candidateRationale = validCandidateRationale({
+        predictedFixes: ['task-a'],
+        riskTasks: ['task-a'],
+        heldInTaskSetHash: 'sha256:model-supplied-held-in',
+        candidateRationaleHash: 'sha256:model-supplied-rationale',
+      });
+      const committedCandidateRationale = validCandidateRationale({
         predictedFixes: ['task-a'],
         riskTasks: ['task-a'],
       });
@@ -89,10 +96,22 @@ describe('prompt candidate loop', () => {
           commitSha: 'commit-1',
           summary: 'tightened output instruction',
           promptHash: hashSystemPrompt('candidate prompt\n'),
-          candidateRationale,
+          heldInTaskSetHash: expectedHeldInTaskSetHash(['task-a']),
+          candidateRationaleHash: expectedCandidateRationaleHash(committedCandidateRationale),
+          candidateRationale: committedCandidateRationale,
         },
       ]);
     });
+  });
+
+  test('hashes the held-in task set independent of input order', async () => {
+    const firstHash = await runCandidateRoundHeldInTaskSetHash(['task-b', 'task-a']);
+    const secondHash = await runCandidateRoundHeldInTaskSetHash(['task-a', 'task-b']);
+    const differentHash = await runCandidateRoundHeldInTaskSetHash(['task-a']);
+
+    assert.equal(firstHash, secondHash);
+    assert.notEqual(firstHash, differentHash);
+    assert.equal(firstHash, expectedHeldInTaskSetHash(['task-a', 'task-b']));
   });
 
   test('filters results TSV by held-in tasks independently from trajectory digests', async () => {
@@ -1820,6 +1839,51 @@ async function assertRejectsCandidateRationale(
 
     assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
   });
+}
+
+async function runCandidateRoundHeldInTaskSetHash(heldInTaskIds: readonly string[]): Promise<string> {
+  let heldInTaskSetHash = '';
+  await withDir(async (dir) => {
+    const programPath = join(dir, 'program.md');
+    const systemPromptPath = join(dir, 'system_prompt.md');
+    const resultsTsvPath = join(dir, 'results.tsv');
+    const resultsJsonlPath = join(dir, 'results.jsonl');
+    await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+    await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+    await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\ntask-b\tfalse\n', 'utf8');
+
+    await runPromptCandidateRound({
+      runId: 'run-1',
+      roundId: 'round-1',
+      agentCwdPath: await testAgentCwd(dir),
+      programPath,
+      systemPromptPath,
+      resultsTsvPath,
+      resultsJsonlPath,
+      heldInTaskIds,
+      heldInDigests: heldInTaskIds.map((taskId) => ({ taskId, summary: 'failed held-in task' })),
+      metaAgent: async () => candidatePromptResult(),
+      git: gitNoop(dir),
+      now: () => 100,
+      newId: idFactory(),
+    });
+
+    const [event] = (await readFile(resultsJsonlPath, 'utf8')).trimEnd().split('\n').map((line) => JSON.parse(line));
+    heldInTaskSetHash = event.heldInTaskSetHash;
+  });
+  return heldInTaskSetHash;
+}
+
+function expectedHeldInTaskSetHash(heldInTaskIds: readonly string[]): string {
+  return sha256Json([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)));
+}
+
+function expectedCandidateRationaleHash(candidateRationale: Record<string, unknown>): string {
+  return sha256Json(candidateRationale);
+}
+
+function sha256Json(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
 }
 
 function gitNoop(gitRootPath = process.cwd()) {

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -491,6 +491,14 @@ function fakeMetaAgent(): MetaAgent {
   return async (promptInput) => ({
     systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
     summary: `tuned for ${promptInput.roundId}`,
+    candidateRationale: {
+      failurePattern: 'coverage_regression',
+      evidenceRefs: [],
+      hypothesis: 'stable held-in coverage can improve with a clearer prompt',
+      targetedFix: 'make the success criteria explicit without adding task-specific answers',
+      predictedFixes: [],
+      riskTasks: [],
+    },
   });
 }
 

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -493,7 +493,6 @@ function fakeMetaAgent(): MetaAgent {
     summary: `tuned for ${promptInput.roundId}`,
     candidateRationale: {
       failurePattern: 'coverage_regression',
-      evidenceRefs: [],
       hypothesis: 'stable held-in coverage can improve with a clearer prompt',
       targetedFix: 'make the success criteria explicit without adding task-specific answers',
       predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -442,6 +442,18 @@ function committedEvent(
     commitSha: `candidate-${roundId}`,
     summary: `candidate ${roundId}`,
     promptHash,
+    candidateRationale: candidateRationale(),
+  };
+}
+
+function candidateRationale() {
+  return {
+    failurePattern: 'coverage_regression' as const,
+    evidenceRefs: [],
+    hypothesis: 'held-in coverage can improve with a clearer prompt',
+    targetedFix: 'make success criteria explicit without task-specific answers',
+    predictedFixes: [],
+    riskTasks: [],
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -449,7 +449,6 @@ function committedEvent(
 function candidateRationale() {
   return {
     failurePattern: 'coverage_regression' as const,
-    evidenceRefs: [],
     hypothesis: 'held-in coverage can improve with a clearer prompt',
     targetedFix: 'make success criteria explicit without task-specific answers',
     predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -442,6 +442,8 @@ function committedEvent(
     commitSha: `candidate-${roundId}`,
     summary: `candidate ${roundId}`,
     promptHash,
+    heldInTaskSetHash: 'sha256:held-in-task-set',
+    candidateRationaleHash: 'sha256:candidate-rationale',
     candidateRationale: candidateRationale(),
   };
 }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -150,6 +150,24 @@ export interface PromptCandidateCommittedEvent {
   commitSha: string;
   summary: string;
   promptHash: string;
+  candidateRationale: PromptCandidateRationale;
+}
+
+export type PromptCandidateFailurePattern =
+  | 'coverage_regression'
+  | 'tool_failed'
+  | 'max_tokens'
+  | 'runtime_error'
+  | 'verification_failed'
+  | 'other';
+
+export interface PromptCandidateRationale {
+  failurePattern: PromptCandidateFailurePattern;
+  evidenceRefs: readonly string[];
+  hypothesis: string;
+  targetedFix: string;
+  predictedFixes: readonly string[];
+  riskTasks: readonly string[];
 }
 
 export type PromptCandidateRewardHackScan =

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -153,17 +153,19 @@ export interface PromptCandidateCommittedEvent {
   candidateRationale: PromptCandidateRationale;
 }
 
-export type PromptCandidateFailurePattern =
-  | 'coverage_regression'
-  | 'tool_failed'
-  | 'max_tokens'
-  | 'runtime_error'
-  | 'verification_failed'
-  | 'other';
+export const PROMPT_CANDIDATE_FAILURE_PATTERNS = [
+  'coverage_regression',
+  'tool_failed',
+  'max_tokens',
+  'runtime_error',
+  'verification_failed',
+  'other',
+] as const;
+
+export type PromptCandidateFailurePattern = typeof PROMPT_CANDIDATE_FAILURE_PATTERNS[number];
 
 export interface PromptCandidateRationale {
   failurePattern: PromptCandidateFailurePattern;
-  evidenceRefs: readonly string[];
   hypothesis: string;
   targetedFix: string;
   predictedFixes: readonly string[];

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -150,6 +150,8 @@ export interface PromptCandidateCommittedEvent {
   commitSha: string;
   summary: string;
   promptHash: string;
+  heldInTaskSetHash: string;
+  candidateRationaleHash: string;
   candidateRationale: PromptCandidateRationale;
 }
 

--- a/packages/headless/src/meta-agent-completion.ts
+++ b/packages/headless/src/meta-agent-completion.ts
@@ -4,7 +4,8 @@ import { runOneShotCompletion } from './one-shot-completion.js';
 
 const META_AGENT_SYSTEM =
   'You optimize a single benchmark system prompt. Reply with exactly one JSON object '
-  + '{"systemPrompt": "...", "summary": "..."} and nothing else — no markdown fences, no prose.';
+  + '{"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["safe-analysis-signal-id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}} '
+  + 'and nothing else - no markdown fences, no prose.';
 
 export interface CreateAiSdkMetaAgentInput {
   connection: LlmConnection;

--- a/packages/headless/src/meta-agent-completion.ts
+++ b/packages/headless/src/meta-agent-completion.ts
@@ -4,7 +4,7 @@ import { runOneShotCompletion } from './one-shot-completion.js';
 
 const META_AGENT_SYSTEM =
   'You optimize a single benchmark system prompt. Reply with exactly one JSON object '
-  + '{"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["safe-analysis-signal-id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}} '
+  + '{"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}} '
   + 'and nothing else - no markdown fences, no prose.';
 
 export interface CreateAiSdkMetaAgentInput {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -13,6 +13,21 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+const CANDIDATE_FAILURE_PATTERNS = [
+  'coverage_regression',
+  'tool_failed',
+  'max_tokens',
+  'runtime_error',
+  'verification_failed',
+  'other',
+] as const;
+const CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS = 8;
+const CANDIDATE_RATIONALE_MAX_TASK_IDS = 16;
+const CANDIDATE_RATIONALE_MAX_TEXT_CHARS = 280;
+const CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS = 2000;
+const SAFE_RATIONALE_ID_RE = /^[A-Za-z0-9_.:-]{1,128}$/;
+const FORBIDDEN_RATIONALE_TEXT_RE = /```|\r|\n|held[-_]out|verifier|expected[- ]output|\/app\/|tests\/|test\.sh|canary|runtime-events|events\.jsonl|raw trace/i;
+
 export interface TrajectoryDigest {
   taskId: string;
   errorClass?: string;
@@ -54,6 +69,17 @@ export type RewardHackScanResult =
   | { decision: 'quarantine'; reason: 'no_model_visible_events' }
   | { decision: 'quarantine'; reason: 'verifier_pattern'; matchedPatterns: readonly string[] };
 
+export type CandidateFailurePattern = typeof CANDIDATE_FAILURE_PATTERNS[number];
+
+export interface CandidateRationale {
+  failurePattern: CandidateFailurePattern;
+  evidenceRefs: readonly string[];
+  hypothesis: string;
+  targetedFix: string;
+  predictedFixes: readonly string[];
+  riskTasks: readonly string[];
+}
+
 export interface MetaAgentPromptInput {
   runId: string;
   roundId: string;
@@ -66,6 +92,7 @@ export interface MetaAgentPromptInput {
 export interface MetaAgentPromptResult {
   systemPrompt: string;
   summary: string;
+  candidateRationale: CandidateRationale;
 }
 
 export type MetaAgent = (input: MetaAgentPromptInput) => Promise<MetaAgentPromptResult>;
@@ -156,6 +183,7 @@ export async function runPromptCandidateRound(
     resultsTsv,
     heldInDigests: input.heldInDigests,
   });
+  validateCandidateRationale(result.candidateRationale, input.heldInTaskIds);
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
   let commitSha: string;
@@ -360,7 +388,9 @@ export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): Me
 export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
   return [
     'You are improving one system prompt for benchmark tasks.',
-    'Return JSON only: {"systemPrompt":"...","summary":"..."}.',
+    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["safe-analysis-signal-id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
+    'candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
+    'Do not include held-out tasks, verifier internals, expected outputs, raw traces, file paths, code fences, or multiline text in candidateRationale.',
     '',
     '# Program',
     input.program,
@@ -406,13 +436,99 @@ export function parseMetaAgentResult(raw: string): MetaAgentPromptResult {
   if (!isRecord(parsed)) throw new Error('meta-agent output must be a JSON object');
   const systemPrompt = parsed.systemPrompt;
   const summary = parsed.summary;
+  const candidateRationale = parseCandidateRationaleShape(parsed.candidateRationale);
   if (typeof systemPrompt !== 'string' || systemPrompt.length === 0) {
     throw new Error('meta-agent output systemPrompt must be a non-empty string');
   }
   if (typeof summary !== 'string' || summary.length === 0) {
     throw new Error('meta-agent output summary must be a non-empty string');
   }
-  return { systemPrompt, summary };
+  return { systemPrompt, summary, candidateRationale };
+}
+
+function validateCandidateRationale(value: unknown, heldInTaskIds: readonly string[]): void {
+  const candidateRationale = parseCandidateRationaleShape(value);
+  validateHeldInTaskIds(candidateRationale.predictedFixes, 'predictedFixes', heldInTaskIds);
+  validateHeldInTaskIds(candidateRationale.riskTasks, 'riskTasks', heldInTaskIds);
+}
+
+function parseCandidateRationaleShape(value: unknown): CandidateRationale {
+  if (!isRecord(value)) {
+    throw new Error('candidateRationale must be a JSON object');
+  }
+  const serialized = JSON.stringify(value);
+  if (serialized.length > CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS) {
+    throw new Error(`candidateRationale must serialize to at most ${CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS} characters`);
+  }
+  if (!CANDIDATE_FAILURE_PATTERNS.includes(value.failurePattern as typeof CANDIDATE_FAILURE_PATTERNS[number])) {
+    throw new Error(`candidateRationale.failurePattern must be one of: ${CANDIDATE_FAILURE_PATTERNS.join(', ')}`);
+  }
+  const evidenceRefs = parseEvidenceRefsShape(value.evidenceRefs);
+  const hypothesis = parseRationaleTextShape(value.hypothesis, 'hypothesis');
+  const targetedFix = parseRationaleTextShape(value.targetedFix, 'targetedFix');
+  const predictedFixes = parseTaskIdArrayShape(value.predictedFixes, 'predictedFixes');
+  const riskTasks = parseTaskIdArrayShape(value.riskTasks, 'riskTasks');
+  return {
+    failurePattern: value.failurePattern as CandidateFailurePattern,
+    evidenceRefs,
+    hypothesis,
+    targetedFix,
+    predictedFixes,
+    riskTasks,
+  };
+}
+
+function parseEvidenceRefsShape(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new Error('candidateRationale.evidenceRefs must be an array');
+  }
+  if (value.length > CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS) {
+    throw new Error(`candidateRationale.evidenceRefs must contain at most ${CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS} items`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || !SAFE_RATIONALE_ID_RE.test(item)) {
+      throw new Error('candidateRationale.evidenceRefs must contain safe analysis signal ids');
+    }
+  }
+  return value;
+}
+
+function parseRationaleTextShape(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`candidateRationale.${field} must be a non-empty string`);
+  }
+  if (value.length > CANDIDATE_RATIONALE_MAX_TEXT_CHARS) {
+    throw new Error(`candidateRationale.${field} must be at most ${CANDIDATE_RATIONALE_MAX_TEXT_CHARS} characters`);
+  }
+  if (FORBIDDEN_RATIONALE_TEXT_RE.test(value)) {
+    throw new Error(`candidateRationale.${field} contains forbidden prompt-memory content`);
+  }
+  return value;
+}
+
+function validateHeldInTaskIds(value: unknown, field: string, heldInTaskIds: readonly string[]): void {
+  const taskIds = parseTaskIdArrayShape(value, field);
+  const heldIn = new Set(heldInTaskIds);
+  for (const item of taskIds) {
+    if (!heldIn.has(item)) {
+      throw new Error(`candidateRationale.${field} contains non-held-in task id: ${item}`);
+    }
+  }
+}
+
+function parseTaskIdArrayShape(value: unknown, field: string): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`candidateRationale.${field} must be an array`);
+  }
+  if (value.length > CANDIDATE_RATIONALE_MAX_TASK_IDS) {
+    throw new Error(`candidateRationale.${field} must contain at most ${CANDIDATE_RATIONALE_MAX_TASK_IDS} items`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || item.length === 0) {
+      throw new Error(`candidateRationale.${field} must contain non-empty task id strings`);
+    }
+  }
+  return value;
 }
 
 function promptCandidateCommittedEvent(input: {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -8,25 +8,17 @@ import {
   appendFixedPromptWalEvent,
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   hashSystemPrompt,
+  PROMPT_CANDIDATE_FAILURE_PATTERNS,
   type PromptCandidateCommittedEvent,
+  type PromptCandidateFailurePattern,
   type PromptCandidateRationale,
 } from './fixed-prompt-controller.js';
 
 const execFileAsync = promisify(execFile);
 
-const CANDIDATE_FAILURE_PATTERNS = [
-  'coverage_regression',
-  'tool_failed',
-  'max_tokens',
-  'runtime_error',
-  'verification_failed',
-  'other',
-] as const;
-const CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS = 8;
 const CANDIDATE_RATIONALE_MAX_TASK_IDS = 16;
 const CANDIDATE_RATIONALE_MAX_TEXT_CHARS = 280;
 const CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS = 2000;
-const SAFE_RATIONALE_ID_RE = /^[A-Za-z0-9_.:-]{1,128}$/;
 const FORBIDDEN_RATIONALE_TEXT_RE = /```|\r|\n|held[-_]out|verifier|expected[- ]output|\/app\/|tests\/|test\.sh|canary|runtime-events|events\.jsonl|raw trace/i;
 
 export interface TrajectoryDigest {
@@ -70,7 +62,7 @@ export type RewardHackScanResult =
   | { decision: 'quarantine'; reason: 'no_model_visible_events' }
   | { decision: 'quarantine'; reason: 'verifier_pattern'; matchedPatterns: readonly string[] };
 
-export type CandidateFailurePattern = typeof CANDIDATE_FAILURE_PATTERNS[number];
+export type CandidateFailurePattern = PromptCandidateFailurePattern;
 
 export type CandidateRationale = PromptCandidateRationale;
 
@@ -383,7 +375,7 @@ export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): Me
 export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
   return [
     'You are improving one system prompt for benchmark tasks.',
-    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["safe-analysis-signal-id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
+    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
     'candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
     'Do not include held-out tasks, verifier internals, expected outputs, raw traces, file paths, code fences, or multiline text in candidateRationale.',
     '',
@@ -456,37 +448,20 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   if (serialized.length > CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS) {
     throw new Error(`candidateRationale must serialize to at most ${CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS} characters`);
   }
-  if (!CANDIDATE_FAILURE_PATTERNS.includes(value.failurePattern as typeof CANDIDATE_FAILURE_PATTERNS[number])) {
-    throw new Error(`candidateRationale.failurePattern must be one of: ${CANDIDATE_FAILURE_PATTERNS.join(', ')}`);
+  if (!PROMPT_CANDIDATE_FAILURE_PATTERNS.includes(value.failurePattern as PromptCandidateFailurePattern)) {
+    throw new Error(`candidateRationale.failurePattern must be one of: ${PROMPT_CANDIDATE_FAILURE_PATTERNS.join(', ')}`);
   }
-  const evidenceRefs = parseEvidenceRefsShape(value.evidenceRefs);
   const hypothesis = parseRationaleTextShape(value.hypothesis, 'hypothesis');
   const targetedFix = parseRationaleTextShape(value.targetedFix, 'targetedFix');
   const predictedFixes = parseTaskIdArrayShape(value.predictedFixes, 'predictedFixes');
   const riskTasks = parseTaskIdArrayShape(value.riskTasks, 'riskTasks');
   return {
     failurePattern: value.failurePattern as CandidateFailurePattern,
-    evidenceRefs,
     hypothesis,
     targetedFix,
     predictedFixes,
     riskTasks,
   };
-}
-
-function parseEvidenceRefsShape(value: unknown): readonly string[] {
-  if (!Array.isArray(value)) {
-    throw new Error('candidateRationale.evidenceRefs must be an array');
-  }
-  if (value.length > CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS) {
-    throw new Error(`candidateRationale.evidenceRefs must contain at most ${CANDIDATE_RATIONALE_MAX_EVIDENCE_REFS} items`);
-  }
-  for (const item of value) {
-    if (typeof item !== 'string' || !SAFE_RATIONALE_ID_RE.test(item)) {
-      throw new Error('candidateRationale.evidenceRefs must contain safe analysis signal ids');
-    }
-  }
-  return value;
 }
 
 function parseRationaleTextShape(value: unknown, field: string): string {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -9,6 +9,7 @@ import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   hashSystemPrompt,
   type PromptCandidateCommittedEvent,
+  type PromptCandidateRationale,
 } from './fixed-prompt-controller.js';
 
 const execFileAsync = promisify(execFile);
@@ -71,14 +72,7 @@ export type RewardHackScanResult =
 
 export type CandidateFailurePattern = typeof CANDIDATE_FAILURE_PATTERNS[number];
 
-export interface CandidateRationale {
-  failurePattern: CandidateFailurePattern;
-  evidenceRefs: readonly string[];
-  hypothesis: string;
-  targetedFix: string;
-  predictedFixes: readonly string[];
-  riskTasks: readonly string[];
-}
+export type CandidateRationale = PromptCandidateRationale;
 
 export interface MetaAgentPromptInput {
   runId: string;
@@ -183,7 +177,7 @@ export async function runPromptCandidateRound(
     resultsTsv,
     heldInDigests: input.heldInDigests,
   });
-  validateCandidateRationale(result.candidateRationale, input.heldInTaskIds);
+  const candidateRationale = validateCandidateRationale(result.candidateRationale, input.heldInTaskIds);
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
   let commitSha: string;
@@ -203,6 +197,7 @@ export async function runPromptCandidateRound(
       commitSha,
       summary: result.summary,
       systemPrompt: result.systemPrompt,
+      candidateRationale,
     }));
   } catch (error) {
     await input.git.rollbackCommit(commitSha);
@@ -446,10 +441,11 @@ export function parseMetaAgentResult(raw: string): MetaAgentPromptResult {
   return { systemPrompt, summary, candidateRationale };
 }
 
-function validateCandidateRationale(value: unknown, heldInTaskIds: readonly string[]): void {
+function validateCandidateRationale(value: unknown, heldInTaskIds: readonly string[]): CandidateRationale {
   const candidateRationale = parseCandidateRationaleShape(value);
   validateHeldInTaskIds(candidateRationale.predictedFixes, 'predictedFixes', heldInTaskIds);
   validateHeldInTaskIds(candidateRationale.riskTasks, 'riskTasks', heldInTaskIds);
+  return candidateRationale;
 }
 
 function parseCandidateRationaleShape(value: unknown): CandidateRationale {
@@ -539,6 +535,7 @@ function promptCandidateCommittedEvent(input: {
   commitSha: string;
   summary: string;
   systemPrompt: string;
+  candidateRationale: CandidateRationale;
 }): PromptCandidateCommittedEvent {
   return {
     schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
@@ -550,6 +547,7 @@ function promptCandidateCommittedEvent(input: {
     commitSha: input.commitSha,
     summary: input.summary,
     promptHash: hashSystemPrompt(input.systemPrompt),
+    candidateRationale: input.candidateRationale,
   };
 }
 

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -189,6 +189,7 @@ export async function runPromptCandidateRound(
       commitSha,
       summary: result.summary,
       systemPrompt: result.systemPrompt,
+      heldInTaskIds: input.heldInTaskIds,
       candidateRationale,
     }));
   } catch (error) {
@@ -510,6 +511,7 @@ function promptCandidateCommittedEvent(input: {
   commitSha: string;
   summary: string;
   systemPrompt: string;
+  heldInTaskIds: readonly string[];
   candidateRationale: CandidateRationale;
 }): PromptCandidateCommittedEvent {
   return {
@@ -522,8 +524,22 @@ function promptCandidateCommittedEvent(input: {
     commitSha: input.commitSha,
     summary: input.summary,
     promptHash: hashSystemPrompt(input.systemPrompt),
+    heldInTaskSetHash: hashHeldInTaskSet(input.heldInTaskIds),
+    candidateRationaleHash: hashCandidateRationale(input.candidateRationale),
     candidateRationale: input.candidateRationale,
   };
+}
+
+function hashHeldInTaskSet(heldInTaskIds: readonly string[]): string {
+  return sha256Json([...new Set(heldInTaskIds)].sort((a, b) => a.localeCompare(b)));
+}
+
+function hashCandidateRationale(candidateRationale: CandidateRationale): string {
+  return sha256Json(candidateRationale);
+}
+
+function sha256Json(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
 }
 
 export function assertOnlySystemPromptChanged(


### PR DESCRIPTION
## Summary
- Add a typed `candidateRationale` contract to prompt candidate results.
- Validate rationale shape, bounds, safe evidence refs, and held-in task references before writing `system_prompt.md` or committing.
- Update meta-agent JSON instructions and test fixtures to require the rationale object.

## Why
R2 needs a structured, bounded prompt-memory channel before candidate prompt writes become durable.

Refs #311

## Scope
Changed:
- `packages/headless/src/prompt-candidate-loop.ts` rationale parsing and pre-write validation.
- `packages/headless/src/meta-agent-completion.ts` JSON contract instruction.
- Headless tests for valid and invalid rationale paths.

Not included:
- Deterministic analysis signal generation.
- Analysis-id existence binding.
- Controller/prompt attribution.
- Structural smoke integration.
- Keep/discard semantics or LLM repair loops.

## Verification
- `npm run -w @maka/headless test`
- `npm run -w @maka/headless typecheck`

## User-facing impact
No desktop UI impact. Headless prompt optimization meta-agents must now return `candidateRationale`.

## Reviewer notes
`evidenceRefs` are validated as opaque safe ids only; binding them to future analysis signals is intentionally deferred.