### PR TITLE
Add active tool result pruning

### DIFF
--- a/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
+++ b/packages/headless/src/__tests__/autonomous-agent-loop.test.ts
@@ -57,6 +57,32 @@ const registerPermissionRequestBackend = (registry: BackendRegistry): void => {
   registry.register('fake', (ctx) => new PermissionRequestBackend(ctx.sessionId));
 };
 
+class RuntimeContextCapturingBackend implements AgentBackend {
+  readonly kind: BackendKind = 'fake';
+  readonly sessionId: string;
+
+  constructor(
+    sessionId: string,
+    private readonly runtimeContextCounts: number[],
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.runtimeContextCounts.push(input.runtimeContext?.length ?? 0);
+    const ts = Date.now();
+    yield { type: 'complete', id: `context-complete-${this.runtimeContextCounts.length}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerRuntimeContextCapturingBackend = (runtimeContextCounts: number[]) => (registry: BackendRegistry): void => {
+  registry.register('fake', (ctx) => new RuntimeContextCapturingBackend(ctx.sessionId, runtimeContextCounts));
+};
+
 class PromptCapturingProgressBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
   readonly sessionId: string;
@@ -220,6 +246,30 @@ describe('runAutonomousTask', () => {
         result.projection.events.filter((event) => event.type === 'task_run_budget_exhausted').length,
         1,
       );
+    });
+  });
+
+  test('can replay prior attempt runtime events into the next autonomous attempt', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const runtimeContextCounts: number[] = [];
+      const task: Task = {
+        id: 'replay-prior-runtime-context',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'test -f missing.txt', protectedPaths: [] },
+      };
+
+      const result = await runAutonomousTask(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerRuntimeContextCapturingBackend(runtimeContextCounts),
+        replayPriorAttemptRuntimeContext: true,
+        budget: { maxAttempts: 2 },
+        newId: idFactory(),
+      });
+
+      assert.equal(result.attempts.length, 2);
+      assert.equal(runtimeContextCounts[0], 0);
+      assert.ok((runtimeContextCounts[1] ?? 0) > 0, 'expected second attempt to receive prior runtime events');
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -17,7 +17,7 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /^#!\/usr\/bin\/env node/);
     assert.match(source, /runHarborCellFromEnv/);
     assert.match(source, /process\.env/);
-    assert.match(cellSource, /env\.MAKA_WORKDIR \?\? process\.cwd\(\)/);
+    assert.match(cellSource, /resolvedEnv\.MAKA_WORKDIR \?\? process\.cwd\(\)/);
   });
 
   test('maka_agent.py invokes run-cell with the shared artifact contract', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -18,6 +19,7 @@ import type { Config } from '../contracts.js';
 import type { HeadlessBackendContext, IsolatedToolExecutor } from '../isolation.js';
 import {
   buildAiSdkCellBackendRegistration,
+  buildHarborCellContextBudgetBackendOptions,
   buildHarborCellAiSdkTools,
   createHarborCellLocalToolExecutor,
   HARBOR_CELL_OUTPUT_FILENAME,
@@ -390,6 +392,96 @@ describe('runHarborCell', () => {
         outputUsdPer1M: 0.29,
         cacheReadUsdPer1M: 0.0029,
       });
+    });
+  });
+
+  test('Harbor ai-sdk backend wires env-driven tool-result archive pruning', async () => {
+    await withDirs(async ({ workspaceDir, outputDir }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on',
+          MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: '1',
+          MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: '0',
+          MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
+          MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS: '2',
+          MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER: '1',
+          MAKA_CONTEXT_ARCHIVE_RETRIEVAL: 'on',
+          MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS: '1',
+        },
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (backend as unknown as {
+        input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions>;
+      }).input;
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.enabled, true);
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.maxResultEstimatedTokens, 1);
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 0);
+      assert.equal(backendInput.contextBudget?.activeToolResultPrune?.enabled, true);
+      assert.equal(backendInput.contextBudget?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 2);
+      assert.equal(backendInput.contextBudget?.activeToolResultPrune?.minStepNumber, 1);
+      assert.equal(backendInput.contextBudget?.archiveRetrieval?.enabled, true);
+      assert.equal(backendInput.contextBudget?.archiveRetrieval?.maxResults, 1);
+      assert.ok(backendInput.archiveToolResult, 'expected archive writer');
+      assert.ok(backendInput.readToolResultArchive, 'expected archive reader');
+
+      const serializedResult = JSON.stringify({ body: 'large tool result' });
+      const bodySha256 = createHash('sha256').update(serializedResult).digest('hex');
+      const originalBytes = Buffer.byteLength(serializedResult, 'utf8');
+      const archived = await backendInput.archiveToolResult({
+        sessionId: 'session-1',
+        runtimeEventId: 'rt-result',
+        turnId: 'turn-old',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        result: { body: 'large tool result' },
+        serializedResult,
+        originalEstimatedTokens: 99,
+        originalBytes,
+        rewriteVersion: 1,
+        reason: 'stale_tool_result_pruned_before_compact',
+        bodySha256,
+      });
+      assert.ok(archived?.artifactId);
+      assert.match(
+        await readFile(join(outputDir, 'tool-result-archives', archived.artifactId), 'utf8'),
+        /"runtimeEventId":"rt-result"/,
+      );
+
+      const read = await backendInput.readToolResultArchive({
+        kind: 'maka.archived_tool_result',
+        rewriteVersion: 1,
+        artifactId: archived.artifactId,
+        runtimeEventId: 'rt-result',
+        toolCallId: 'tool-1',
+        toolName: 'Read',
+        bodySha256,
+        originalEstimatedTokens: 99,
+        originalBytes,
+        reason: 'stale_tool_result_pruned_before_compact',
+        sessionId: 'session-1',
+      });
+      assert.deepEqual(read, { ok: true, serializedResult });
     });
   });
 

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -92,6 +92,7 @@ export type AutonomousDecisionPolicy = (
 
 export interface RunAutonomousTaskOptions extends RunTaskOnceDeps {
   budget: AutonomousLoopBudget;
+  replayPriorAttemptRuntimeContext?: boolean;
   selfCheck?: false | SelfCheckPolicy;
   feedbackPrompt?: (input: FeedbackPromptInput) => string;
   decision?: AutonomousDecisionPolicy;
@@ -180,6 +181,7 @@ export async function runAutonomousTask(
   let instructionOverride: string | undefined = options.instructionOverride;
   let runtimeStepsUsed = 0;
   let latestResultRecord: ResultRecord | undefined;
+  let priorRuntimeContext = options.priorRuntimeContext ? [...options.priorRuntimeContext] : [];
 
   while (attempts.length < options.budget.maxAttempts) {
     const beforeAttemptBudget = budgetSnapshot(options.budget, attempts.length, runtimeStepsUsed, startedAt, now());
@@ -225,10 +227,14 @@ export async function runAutonomousTask(
       createTaskRun: false,
       closeTaskRun: false,
       ...(instructionOverride ? { instructionOverride } : {}),
+      ...(priorRuntimeContext.length > 0 ? { priorRuntimeContext } : {}),
     });
     attempts.push(attempt);
     latestResultRecord = attempt.resultRecord;
     runtimeStepsUsed += attempt.resultRecord.steps;
+    if (options.replayPriorAttemptRuntimeContext) {
+      priorRuntimeContext = [...priorRuntimeContext, ...attempt.invocation.events];
+    }
 
     const afterAttemptBudget = budgetSnapshot(options.budget, attempts.length, runtimeStepsUsed, startedAt, now());
     const selfCheck = isWallTimeExhausted(afterAttemptBudget)

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
 import { exec as nodeExec } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import type {
@@ -22,6 +23,9 @@ import {
   runShellWithBoundedTail,
   type MakaTool,
   type InvocationResult,
+  type ContextBudgetPolicy,
+  type ToolResultArchiveReader,
+  type ToolResultArchiveRecorder,
 } from '@maka/runtime';
 import {
   createAgentRunStore,
@@ -76,6 +80,24 @@ export interface RunHarborCellFromEnvOptions {
 export interface ResolvedHarborCellAiSdkEnv {
   connection: LlmConnection;
   apiKey: string;
+}
+
+export interface HarborCellContextBudgetBackendOptions {
+  contextBudget?: ContextBudgetPolicy;
+  archiveToolResult?: ToolResultArchiveRecorder;
+  readToolResultArchive?: ToolResultArchiveReader;
+}
+
+interface HarborCellToolResultArchiveRecord {
+  version: 1;
+  sessionId: string;
+  runtimeEventId: string;
+  toolCallId: string;
+  toolName: string;
+  bodySha256: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  serializedResult: string;
 }
 
 const PI_BASE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'TMPDIR', 'TMP', 'TEMP', 'SHELL', 'SystemRoot', 'COMSPEC'];
@@ -194,42 +216,47 @@ export async function runHarborCellFromEnv(
   const now = options.now ?? Date.now;
   const newId = options.newId ?? randomId;
   const outputDir = env.MAKA_OUTPUT_DIR ?? '/logs/agent';
-  const backend = backendFromEnv(env.MAKA_BACKEND);
+  const storageRoot = env.MAKA_STORAGE_ROOT ?? join(outputDir, 'maka-storage');
+  const resolvedEnv: RunHarborCellEnv = { ...env, MAKA_OUTPUT_DIR: outputDir, MAKA_STORAGE_ROOT: storageRoot };
+  const backend = backendFromEnv(resolvedEnv.MAKA_BACKEND);
   const baseConfig = {
-    id: env.MAKA_CONFIG_ID ?? 'harbor-cell',
+    id: resolvedEnv.MAKA_CONFIG_ID ?? 'harbor-cell',
     backend,
-    ...(env.MAKA_SYSTEM_PROMPT !== undefined ? { systemPrompt: env.MAKA_SYSTEM_PROMPT } : {}),
+    ...(resolvedEnv.MAKA_SYSTEM_PROMPT !== undefined ? { systemPrompt: resolvedEnv.MAKA_SYSTEM_PROMPT } : {}),
   };
   let config: Config;
   let registerBackends = options.registerBackends;
 
   switch (backend) {
     case 'ai-sdk': {
-      const modelSpec = parseModelSpec(env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash', env.MAKA_PROVIDER);
+      const modelSpec = parseModelSpec(
+        resolvedEnv.MAKA_MODEL ?? resolvedEnv.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash',
+        resolvedEnv.MAKA_PROVIDER,
+      );
       config = {
         ...baseConfig,
-        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
+        llmConnectionSlug: resolvedEnv.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
         model: modelSpec.model,
       };
       registerBackends ??= buildAiSdkCellBackendRegistration({
         provider: modelSpec.provider,
         model: modelSpec.model,
-        env,
+        env: resolvedEnv,
         now,
         newId,
       });
       break;
     }
     case 'pi-agent': {
-      const model = env.MAKA_PI_MODEL ?? env.MAKA_MODEL ?? env.HARBOR_MODEL;
+      const model = resolvedEnv.MAKA_PI_MODEL ?? resolvedEnv.MAKA_MODEL ?? resolvedEnv.HARBOR_MODEL;
       if (!model) throw new Error('MAKA_PI_MODEL, MAKA_MODEL, or HARBOR_MODEL must include a model id');
-      const piProvider = env.MAKA_PI_PROVIDER;
+      const piProvider = resolvedEnv.MAKA_PI_PROVIDER;
       if (!registerBackends && !piProvider) {
         throw new Error('MAKA_PI_PROVIDER is required when using the default Pi CLI transport');
       }
       config = {
         ...baseConfig,
-        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? piProvider ?? 'pi-agent',
+        llmConnectionSlug: resolvedEnv.MAKA_LLM_CONNECTION_SLUG ?? piProvider ?? 'pi-agent',
         model,
       };
       registerBackends ??= (registry) => {
@@ -240,10 +267,10 @@ export async function runHarborCellFromEnv(
             appendMessage: ctx.appendMessage ?? ((message) => ctx.store.appendMessage(ctx.sessionId, message)),
             permissionEngine: new PermissionEngine({ newId, now }),
             transport: new PiCliJsonTransport({
-              command: env.MAKA_PI_COMMAND ?? 'pi',
+              command: resolvedEnv.MAKA_PI_COMMAND ?? 'pi',
               ...(piProvider ? { provider: piProvider } : {}),
               model,
-              env: buildPiCliEnv(env, piProvider),
+              env: buildPiCliEnv(resolvedEnv, piProvider),
             }),
           }),
         );
@@ -253,25 +280,25 @@ export async function runHarborCellFromEnv(
     case 'fake':
       config = {
         ...baseConfig,
-        llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
-        model: env.MAKA_MODEL ?? env.HARBOR_MODEL ?? 'fake',
+        llmConnectionSlug: resolvedEnv.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
+        model: resolvedEnv.MAKA_MODEL ?? resolvedEnv.HARBOR_MODEL ?? 'fake',
       };
       break;
   }
 
   return await runHarborCell({
     config,
-    instruction: await instructionFromEnv(env),
-    cwd: env.MAKA_WORKDIR ?? process.cwd(),
+    instruction: await instructionFromEnv(resolvedEnv),
+    cwd: resolvedEnv.MAKA_WORKDIR ?? process.cwd(),
     outputDir,
-    storageRoot: env.MAKA_STORAGE_ROOT ?? join(outputDir, 'maka-storage'),
+    storageRoot,
     ...(registerBackends ? { registerBackends } : {}),
     ...(backendNeedsIsolation(backend)
       ? {
           realBackendIsolation: {
             kind: 'external',
             label: 'Harbor task container',
-            toolExecutor: createHarborCellLocalToolExecutor(env),
+            toolExecutor: createHarborCellLocalToolExecutor(resolvedEnv),
           },
         }
       : {}),
@@ -299,6 +326,7 @@ export function buildAiSdkCellBackendRegistration(input: {
     ? (key: string): PricingConfig | null => (key === modelKey ? pricingOverride : getBuiltinPricing(key))
     : getBuiltinPricing;
   const permissionEngine = new PermissionEngine({ newId: input.newId, now: input.now });
+  const contextBudgetBackendOptions = buildHarborCellContextBudgetBackendOptions(input.env);
   return (registry, context) => {
     if (!context.toolExecutor) {
       throw new Error('Harbor ai-sdk backend requires an isolated tool executor');
@@ -322,6 +350,7 @@ export function buildAiSdkCellBackendRegistration(input: {
         providerOptions: buildProviderOptions(connection, input.model),
         systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
         lookupPricing,
+        ...contextBudgetBackendOptions,
         newId: input.newId,
         now: input.now,
         recordRunTrace: ctx.recordRunTrace,
@@ -340,6 +369,134 @@ export function buildHarborCellAiSdkTools(
       ? { ...tool, permissionRequired: false }
       : tool
   ));
+}
+
+export function buildHarborCellContextBudgetBackendOptions(
+  env: RunHarborCellEnv = process.env,
+): HarborCellContextBudgetBackendOptions {
+  const pruneEnabled = booleanEnv(
+    env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE ??
+    env.MAKA_HARBOR_CONTEXT_STALE_TOOL_RESULT_PRUNE ??
+    env.MAKA_TOOL_RESULT_PRUNE,
+  );
+  const activePruneEnabled = booleanEnv(
+    env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE ??
+    env.MAKA_HARBOR_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE ??
+    env.MAKA_ACTIVE_TOOL_RESULT_PRUNE,
+  );
+  const archiveRetrievalEnabled = booleanEnv(
+    env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL ??
+    env.MAKA_HARBOR_CONTEXT_ARCHIVE_RETRIEVAL,
+  );
+  if (!pruneEnabled && !activePruneEnabled && !archiveRetrievalEnabled) return {};
+
+  const contextBudget: ContextBudgetPolicy = {
+    name: env.MAKA_CONTEXT_BUDGET_NAME ?? 'harbor-context-budget',
+  };
+  const charsPerToken = numericEnv(env.MAKA_CONTEXT_CHARS_PER_TOKEN);
+  const maxHistoryEstimatedTokens = numericEnv(env.MAKA_CONTEXT_MAX_HISTORY_ESTIMATED_TOKENS);
+  const maxHistoryTurns = numericEnv(env.MAKA_CONTEXT_MAX_HISTORY_TURNS);
+  const minRecentTurns = numericEnv(env.MAKA_CONTEXT_MIN_RECENT_TURNS);
+  if (charsPerToken !== undefined) contextBudget.charsPerToken = charsPerToken;
+  if (maxHistoryEstimatedTokens !== undefined) contextBudget.maxHistoryEstimatedTokens = maxHistoryEstimatedTokens;
+  if (maxHistoryTurns !== undefined) contextBudget.maxHistoryTurns = maxHistoryTurns;
+  if (minRecentTurns !== undefined) contextBudget.minRecentTurns = minRecentTurns;
+
+  if (pruneEnabled) {
+    const maxResultEstimatedTokens = numericEnv(
+      env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS ??
+      env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS,
+    );
+    const minRecentTurnsFull = numericEnv(env.MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL);
+    contextBudget.staleToolResultPrune = {
+      enabled: true,
+      ...(maxResultEstimatedTokens !== undefined ? { maxResultEstimatedTokens } : {}),
+      ...(minRecentTurnsFull !== undefined ? { minRecentTurnsFull } : {}),
+    };
+  }
+
+  if (activePruneEnabled) {
+    const maxCurrentResultEstimatedTokens = numericEnv(
+      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS ??
+      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS,
+    );
+    const minStepNumber = numericEnv(env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER);
+    const archiveRequiredRaw =
+      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_ARCHIVE_REQUIRED ??
+      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_ARCHIVE_REQUIRED;
+    contextBudget.activeToolResultPrune = {
+      enabled: true,
+      ...(maxCurrentResultEstimatedTokens !== undefined ? { maxCurrentResultEstimatedTokens } : {}),
+      ...(minStepNumber !== undefined ? { minStepNumber } : {}),
+      ...(archiveRequiredRaw !== undefined ? { archiveRequired: booleanEnv(archiveRequiredRaw) } : {}),
+    };
+  }
+
+  if (archiveRetrievalEnabled) {
+    const maxResults = numericEnv(env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS);
+    const maxEstimatedTokens = numericEnv(env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_ESTIMATED_TOKENS);
+    const maxBytes = numericEnv(env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES);
+    contextBudget.archiveRetrieval = {
+      enabled: true,
+      ...(env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MODE === 'history_search_gated'
+        ? { mode: 'history_search_gated' as const }
+        : {}),
+      ...(maxResults !== undefined ? { maxResults } : {}),
+      ...(maxEstimatedTokens !== undefined ? { maxEstimatedTokens } : {}),
+      ...(maxBytes !== undefined ? { maxBytes } : {}),
+    };
+  }
+
+  const archiveDir = harborCellToolResultArchiveDir(env);
+  if (!archiveDir) return { contextBudget };
+  return {
+    contextBudget,
+    archiveToolResult: async (input) => {
+      await mkdir(archiveDir, { recursive: true });
+      const artifactId = harborCellToolResultArchiveArtifactId(input);
+      const record: HarborCellToolResultArchiveRecord = {
+        version: 1,
+        sessionId: input.sessionId,
+        runtimeEventId: input.runtimeEventId,
+        toolCallId: input.toolCallId,
+        toolName: input.toolName,
+        bodySha256: input.bodySha256,
+        originalEstimatedTokens: input.originalEstimatedTokens,
+        originalBytes: input.originalBytes,
+        serializedResult: input.serializedResult,
+      };
+      await writeFile(join(archiveDir, artifactId), `${JSON.stringify(record)}\n`, 'utf8');
+      return { artifactId };
+    },
+    readToolResultArchive: async (input) => {
+      if (!isSafeHarborCellArchiveArtifactId(input.artifactId)) return { ok: false, reason: 'not_allowed' };
+      let raw: string;
+      try {
+        raw = await readFile(join(archiveDir, input.artifactId), 'utf8');
+      } catch {
+        return { ok: false, reason: 'not_found' };
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return { ok: false, reason: 'corrupt' };
+      }
+      if (!isHarborCellToolResultArchiveRecord(parsed)) return { ok: false, reason: 'corrupt' };
+      if (parsed.sessionId !== input.sessionId) return { ok: false, reason: 'session_mismatch' };
+      if (parsed.runtimeEventId !== input.runtimeEventId || parsed.toolCallId !== input.toolCallId) {
+        return { ok: false, reason: 'source_mismatch' };
+      }
+      if (parsed.originalBytes !== input.originalBytes) return { ok: false, reason: 'size_mismatch' };
+      if (parsed.bodySha256 !== input.bodySha256) return { ok: false, reason: 'source_mismatch' };
+      const actualSha = createHash('sha256').update(parsed.serializedResult).digest('hex');
+      if (actualSha !== input.bodySha256) return { ok: false, reason: 'corrupt' };
+      if (Buffer.byteLength(parsed.serializedResult, 'utf8') !== input.originalBytes) {
+        return { ok: false, reason: 'size_mismatch' };
+      }
+      return { ok: true, serializedResult: parsed.serializedResult };
+    },
+  };
 }
 
 export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
@@ -441,6 +598,65 @@ function numericEnv(raw: string | undefined): number | undefined {
   if (raw === undefined || raw.trim() === '') return undefined;
   const value = Number(raw);
   return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function booleanEnv(raw: string | undefined): boolean {
+  if (raw === undefined) return false;
+  switch (raw.trim().toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+    case 'enabled':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function harborCellToolResultArchiveDir(env: RunHarborCellEnv): string | undefined {
+  return (
+    env.MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR ??
+    env.MAKA_TOOL_RESULT_ARCHIVE_DIR ??
+    env.MAKA_HARBOR_TOOL_RESULT_ARCHIVE_DIR ??
+    (env.MAKA_OUTPUT_DIR ? join(env.MAKA_OUTPUT_DIR, 'tool-result-archives') : undefined)
+  );
+}
+
+function harborCellToolResultArchiveArtifactId(input: {
+  sessionId: string;
+  runtimeEventId: string;
+  bodySha256: string;
+}): string {
+  return [
+    safeArtifactIdPart(input.sessionId),
+    safeArtifactIdPart(input.runtimeEventId),
+    safeArtifactIdPart(input.bodySha256.slice(0, 16)),
+  ].join('--') + '.json';
+}
+
+function safeArtifactIdPart(value: string): string {
+  const safe = value.replace(/[^A-Za-z0-9_.=-]/g, '_').slice(0, 96);
+  return safe || 'unknown';
+}
+
+function isSafeHarborCellArchiveArtifactId(value: string): boolean {
+  return /^[A-Za-z0-9_.=-]+\.json$/.test(value);
+}
+
+function isHarborCellToolResultArchiveRecord(value: unknown): value is HarborCellToolResultArchiveRecord {
+  return (
+    isRecord(value) &&
+    value.version === 1 &&
+    typeof value.sessionId === 'string' &&
+    typeof value.runtimeEventId === 'string' &&
+    typeof value.toolCallId === 'string' &&
+    typeof value.toolName === 'string' &&
+    typeof value.bodySha256 === 'string' &&
+    typeof value.originalEstimatedTokens === 'number' &&
+    typeof value.originalBytes === 'number' &&
+    typeof value.serializedResult === 'string'
+  );
 }
 
 /** Provider secrets the LLM backend already captured; task tool subprocesses must

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -93,6 +93,7 @@ export interface RunTaskOnceDeps extends RunExperimentDeps {
   createTaskRun?: boolean;
   closeTaskRun?: boolean;
   instructionOverride?: string;
+  priorRuntimeContext?: readonly RuntimeEvent[];
   permissionMode?: 'execute';
   interventionPolicy?: TaskInterventionPolicy;
   permissionGrants?: readonly TaskPermissionGrant[];
@@ -312,6 +313,7 @@ export async function runTaskOnce(
         run,
         header,
         instruction,
+        ...(deps.priorRuntimeContext ? { priorRuntimeContext: deps.priorRuntimeContext } : {}),
         now,
         newId,
       });
@@ -719,6 +721,7 @@ interface RunRuntimeAttemptInput {
   run: AgentRun;
   header: SessionHeader;
   instruction: string;
+  priorRuntimeContext?: readonly RuntimeEvent[];
   now: () => number;
   newId: () => string;
 }
@@ -753,6 +756,10 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<Invocat
     onInitialRuntimeEvent: (event) => input.run.recordRuntimeEvents([event]),
     stopOnTerminal: false,
   });
+  const runtimeContext = [
+    ...(input.priorRuntimeContext ?? []),
+    ...(begin.backendInput.runtimeContext ?? []),
+  ];
 
   const invocation = await runner.run({
     sessionId: input.header.id,
@@ -760,7 +767,7 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<Invocat
     turnId: input.run.turnId,
     text: input.instruction,
     context: begin.backendInput.context,
-    ...(begin.backendInput.runtimeContext !== undefined ? { runtimeContext: begin.backendInput.runtimeContext } : {}),
+    ...(runtimeContext.length > 0 ? { runtimeContext } : {}),
     ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
     source: 'test',
     lineage: input.run.lineage,

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -1,0 +1,273 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import { MockLanguageModelV3, convertArrayToReadableStream } from 'ai/test';
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from '@ai-sdk/provider';
+import type { ModelMessage } from 'ai';
+
+import { rewriteActiveToolResultsInMessages } from '../active-tool-result-prune.js';
+import { composePrepareStep } from '../ai-sdk-backend.js';
+import { ModelAdapter } from '../model-adapter.js';
+import { ToolAvailabilityRuntime, LOAD_TOOLS_NAME } from '../tool-availability.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+const ZERO_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
+
+describe('active current-turn tool-result pruning', () => {
+  test('prepareStep composition returns both activeTools and rewritten messages', async () => {
+    const originalMessages = [largeToolMessage('Read', 'tool-1', 'SECRET'.repeat(20))];
+    const activePrune = async () => {
+      const rewritten = await rewriteActiveToolResultsInMessages({
+        messages: originalMessages,
+        policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+        stepNumber: 1,
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        charsPerToken: 1,
+        archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
+      });
+      return rewritten.rewritten > 0 ? { messages: rewritten.messages } : undefined;
+    };
+    const composed = composePrepareStep(
+      () => ({ activeTools: ['Read', LOAD_TOOLS_NAME] }),
+      activePrune,
+    );
+
+    assert.ok(composed);
+    const result = await composed({
+      steps: [],
+      stepNumber: 1,
+      model: {},
+      messages: originalMessages,
+      experimental_context: undefined,
+    });
+
+    assert.deepEqual(result?.activeTools, ['Read', LOAD_TOOLS_NAME]);
+    assert.ok(result?.messages);
+    assert.match(JSON.stringify(result.messages), /maka\.active_archived_tool_result/);
+  });
+
+  test('oversized current-turn tool result is archived and replaced before next step', async () => {
+    const largeBody = 'SECRET_PAYLOAD_SHOULD_BE_ARCHIVED'.repeat(20);
+    const archiveRequests: Array<{ serializedResult: string; bodySha256: string; toolCallId: string }> = [];
+    const prompts: unknown[] = [];
+    let step = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async ({ prompt }) => {
+        step += 1;
+        prompts.push(prompt);
+        const parts: LanguageModelV3StreamPart[] = step === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'tool-1', toolName: 'Read', input: JSON.stringify({}) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+            ];
+        return { stream: convertArrayToReadableStream(parts) };
+      },
+    });
+
+    const archivedPlaceholders = new Map();
+    const result = await newAdapter().startStream({
+      model,
+      messages: [{ role: 'user', content: 'read it' }],
+      tools: {
+        Read: {
+          description: 'Read',
+          inputSchema: z.object({}),
+          execute: () => ({ body: largeBody }),
+        },
+      },
+      activeTools: ['Read'],
+      prepareStep: async (options) => {
+        const rewritten = await rewriteActiveToolResultsInMessages({
+          messages: options.messages,
+          policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+          stepNumber: options.stepNumber,
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          charsPerToken: 1,
+          archivedPlaceholders,
+          archiveToolResult: (candidate) => {
+            archiveRequests.push({
+              serializedResult: candidate.serializedResult,
+              bodySha256: candidate.bodySha256,
+              toolCallId: candidate.toolCallId,
+            });
+            return { artifactId: 'artifact-tool-1' };
+          },
+        });
+        return rewritten.rewritten > 0 ? { messages: rewritten.messages } : undefined;
+      },
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    await drain(result.fullStream);
+
+    assert.equal(prompts.length, 2, 'expected a tool step and a follow-up step');
+    assert.equal(archiveRequests.length, 1);
+    assert.match(archiveRequests[0]?.bodySha256 ?? '', /^[a-f0-9]{64}$/);
+    assert.equal(archiveRequests[0]?.toolCallId, 'tool-1');
+    const secondPrompt = JSON.stringify(prompts[1]);
+    assert.match(secondPrompt, /maka\.active_archived_tool_result/);
+    assert.match(secondPrompt, /artifact-tool-1/);
+    assert.equal(secondPrompt.includes(largeBody), false);
+  });
+
+  test('archive failure keeps the original tool result', async () => {
+    const messages = [largeToolMessage('Read', 'tool-1', 'KEEP_ME'.repeat(20))];
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => {
+        throw new Error('archive unavailable');
+      },
+    });
+
+    assert.equal(rewritten.rewritten, 0);
+    assert.equal(rewritten.archiveFailures, 1);
+    assert.deepEqual(rewritten.messages, messages);
+    assert.match(JSON.stringify(rewritten.messages), /KEEP_ME/);
+    assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
+  });
+
+  test('eligible tool-call ids keep prior replay tool results untouched', async () => {
+    const priorBody = 'PRIOR_REPLAY_RESULT_SHOULD_STAY_FULL'.repeat(20);
+    const currentBody = 'CURRENT_STEP_RESULT_SHOULD_BE_ARCHIVED'.repeat(20);
+    const archiveRequests: string[] = [];
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages: [
+        largeToolMessage('Read', 'prior-tool-call', priorBody),
+        largeToolMessage('Read', 'current-tool-call', currentBody),
+      ],
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      eligibleToolCallIds: new Set(['current-tool-call']),
+      archiveToolResult: (candidate) => {
+        archiveRequests.push(candidate.toolCallId);
+        return { artifactId: `artifact-${candidate.toolCallId}` };
+      },
+    });
+
+    assert.equal(rewritten.rewritten, 1);
+    assert.deepEqual(archiveRequests, ['current-tool-call']);
+    const nextPrompt = JSON.stringify(rewritten.messages);
+    assert.match(nextPrompt, /PRIOR_REPLAY_RESULT_SHOULD_STAY_FULL/);
+    assert.doesNotMatch(nextPrompt, /CURRENT_STEP_RESULT_SHOULD_BE_ARCHIVED/);
+    assert.match(nextPrompt, /artifact-current-tool-call/);
+  });
+
+  test('tool availability same-turn activation still works when active prune hook is composed', async () => {
+    const runtime = new ToolAvailabilityRuntime(
+      [makaTool('Read'), makaTool('RiveWorkflow')],
+      { economy: true, groups: [{ id: 'rive', toolNames: ['RiveWorkflow'] }] },
+      makaTool('invalid'),
+    );
+    const plan = runtime.prepare([]);
+    const toolsPerStep: string[][] = [];
+    const model = new MockLanguageModelV3({
+      doStream: async ({ tools }) => {
+        toolsPerStep.push((tools ?? []).map((tool) => tool.name));
+        const parts: LanguageModelV3StreamPart[] = toolsPerStep.length === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'tool-call', toolCallId: 'load-1', toolName: LOAD_TOOLS_NAME, input: JSON.stringify({ group: 'rive' }) },
+              { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: ZERO_USAGE },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: ZERO_USAGE },
+            ];
+        return { stream: convertArrayToReadableStream(parts) };
+      },
+    });
+
+    const aiSdkTools: Record<string, unknown> = {};
+    for (const tool of plan.providerTools) {
+      aiSdkTools[tool.name] = {
+        description: tool.description,
+        inputSchema: tool.parameters,
+        execute: tool.name === LOAD_TOOLS_NAME ? () => ({ loaded: ['RiveWorkflow'] }) : () => ({ ok: true }),
+      };
+    }
+
+    const activePrune = async (options: Parameters<NonNullable<typeof plan.prepareStep>>[0] & { messages: ModelMessage[]; stepNumber: number }) => {
+      const rewritten = await rewriteActiveToolResultsInMessages({
+        messages: options.messages,
+        policy: { enabled: true, maxCurrentResultEstimatedTokens: 1024 },
+        stepNumber: options.stepNumber,
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        archiveToolResult: () => ({ artifactId: 'unused' }),
+      });
+      return rewritten.rewritten > 0 ? { messages: rewritten.messages } : undefined;
+    };
+
+    const result = await newAdapter().startStream({
+      model,
+      messages: [{ role: 'user', content: 'load rive' }],
+      tools: aiSdkTools,
+      activeTools: plan.activeTools,
+      prepareStep: composePrepareStep(plan.prepareStep, activePrune),
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    await drain(result.fullStream);
+
+    assert.ok(!toolsPerStep[0]?.includes('RiveWorkflow'), 'step 0 hides the group tool');
+    assert.ok(toolsPerStep[1]?.includes('RiveWorkflow'), 'step 1 advertises the loaded group tool');
+  });
+});
+
+function largeToolMessage(toolName: string, toolCallId: string, body: string): ModelMessage {
+  return {
+    role: 'tool',
+    content: [{
+      type: 'tool-result',
+      toolCallId,
+      toolName,
+      output: { type: 'json', value: { body } },
+    }],
+  };
+}
+
+function makaTool(name: string): MakaTool {
+  return {
+    name,
+    description: `${name} tool`,
+    parameters: z.object({}),
+    impl: () => ({ ok: true }),
+  };
+}
+
+function newAdapter(): ModelAdapter {
+  return new ModelAdapter({
+    connection: { providerType: 'openai' } as never,
+    apiKey: 'test',
+    modelId: 'mock',
+    modelFactory: () => ({}),
+    providerOptions: {},
+    maxSteps: 4,
+    newId: () => 'id',
+    now: () => 0,
+  });
+}
+
+async function drain(iterable: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ of iterable) {
+    void _;
+  }
+}

--- a/packages/runtime/src/active-tool-result-prune.ts
+++ b/packages/runtime/src/active-tool-result-prune.ts
@@ -1,0 +1,293 @@
+import { createHash } from 'node:crypto';
+import type { JSONValue, ModelMessage } from 'ai';
+
+import {
+  ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+  estimateTokens,
+  serializeToolResultForArchive,
+  type ActiveArchivedToolResultPlaceholder,
+  type ActiveToolResultArchiveCandidate,
+  type ActiveToolResultPrunePolicy,
+} from './context-budget.js';
+
+const DEFAULT_MAX_CURRENT_RESULT_ESTIMATED_TOKENS = 8192;
+const DEFAULT_CHARS_PER_TOKEN = 4;
+
+export interface ActiveToolResultPruneArchiveInput extends ActiveToolResultArchiveCandidate {
+  bodySha256: string;
+}
+
+export interface ActiveToolResultPruneInput {
+  messages: readonly ModelMessage[];
+  policy: ActiveToolResultPrunePolicy | undefined;
+  stepNumber: number;
+  sessionId: string;
+  turnId: string;
+  charsPerToken?: number;
+  eligibleToolCallIds?: ReadonlySet<string>;
+  archiveToolResult?: (
+    input: ActiveToolResultPruneArchiveInput,
+  ) => Promise<{ artifactId: string } | void> | { artifactId: string } | void;
+  archivedPlaceholders?: Map<string, ActiveArchivedToolResultPlaceholder>;
+}
+
+export interface ActiveToolResultPruneResult {
+  messages: ModelMessage[];
+  rewritten: number;
+  archiveFailures: number;
+}
+
+type ToolResultPartish = {
+  type?: unknown;
+  toolCallId?: unknown;
+  toolName?: unknown;
+  output?: unknown;
+  result?: unknown;
+  [key: string]: unknown;
+};
+
+type Replacement =
+  | { changed: false; archiveFailure?: boolean }
+  | { changed: true; part: ToolResultPartish };
+
+export async function rewriteActiveToolResultsInMessages(
+  input: ActiveToolResultPruneInput,
+): Promise<ActiveToolResultPruneResult> {
+  const policy = input.policy;
+  const minStepNumber = Math.max(0, Math.floor(policy?.minStepNumber ?? 1));
+  if (policy?.enabled !== true || input.stepNumber < minStepNumber) {
+    return { messages: [...input.messages], rewritten: 0, archiveFailures: 0 };
+  }
+
+  const maxResultEstimatedTokens =
+    finitePositive(policy.maxCurrentResultEstimatedTokens)
+    ?? DEFAULT_MAX_CURRENT_RESULT_ESTIMATED_TOKENS;
+  const archiveRequired = policy.archiveRequired !== false;
+  const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  const archivedPlaceholders = input.archivedPlaceholders ?? new Map<string, ActiveArchivedToolResultPlaceholder>();
+
+  let rewritten = 0;
+  let archiveFailures = 0;
+  let anyChanged = false;
+  const nextMessages: ModelMessage[] = [];
+
+  for (const message of input.messages) {
+    if (message.role !== 'tool' || !Array.isArray(message.content)) {
+      nextMessages.push(message);
+      continue;
+    }
+
+    let nextContent: unknown[] | undefined;
+    const originalContent = message.content as unknown[];
+    for (let index = 0; index < originalContent.length; index += 1) {
+      const part = originalContent[index];
+      if (!isToolResultPartish(part)) {
+        if (nextContent) nextContent.push(part);
+        continue;
+      }
+
+      const replacement = await rewriteToolResultPart({
+        part,
+        policy,
+        turnId: input.turnId,
+        charsPerToken,
+        maxResultEstimatedTokens,
+        archiveRequired,
+        eligibleToolCallIds: input.eligibleToolCallIds,
+        archiveToolResult: input.archiveToolResult,
+        archivedPlaceholders,
+      });
+
+      if (replacement.changed) {
+        rewritten += 1;
+        anyChanged = true;
+        if (!nextContent) nextContent = originalContent.slice(0, index);
+        nextContent.push(replacement.part);
+      } else {
+        if (replacement.archiveFailure) archiveFailures += 1;
+        if (nextContent) nextContent.push(part);
+      }
+    }
+
+    if (nextContent) {
+      nextMessages.push({ ...message, content: nextContent } as ModelMessage);
+    } else {
+      nextMessages.push(message);
+    }
+  }
+
+  return {
+    messages: anyChanged ? nextMessages : [...input.messages],
+    rewritten,
+    archiveFailures,
+  };
+}
+
+async function rewriteToolResultPart(input: {
+  part: ToolResultPartish;
+  policy: ActiveToolResultPrunePolicy;
+  turnId: string;
+  charsPerToken: number;
+  maxResultEstimatedTokens: number;
+  archiveRequired: boolean;
+  eligibleToolCallIds?: ReadonlySet<string>;
+  archiveToolResult?: ActiveToolResultPruneInput['archiveToolResult'];
+  archivedPlaceholders: Map<string, ActiveArchivedToolResultPlaceholder>;
+}): Promise<Replacement> {
+  if (typeof input.part.toolCallId !== 'string' || typeof input.part.toolName !== 'string') {
+    return { changed: false };
+  }
+  if (input.eligibleToolCallIds && !input.eligibleToolCallIds.has(input.part.toolCallId)) {
+    return { changed: false };
+  }
+
+  const payload = extractPayload(input.part);
+  if (!payload) return { changed: false };
+  if (isActiveArchivedToolResultPlaceholder(payload.value)) return { changed: false };
+
+  const serializedResult = serializeToolResultForArchive(payload.value);
+  const originalEstimatedTokens = estimateTokens(serializedResult.length, input.charsPerToken);
+  if (originalEstimatedTokens <= input.maxResultEstimatedTokens) return { changed: false };
+
+  const originalBytes = utf8ByteLength(serializedResult);
+  const bodySha256 = sha256(serializedResult);
+  const cacheKey = `${input.part.toolCallId}:${bodySha256}`;
+  let placeholder = input.archivedPlaceholders.get(cacheKey);
+
+  if (!placeholder) {
+    const candidate: ActiveToolResultPruneArchiveInput = {
+      turnId: input.turnId,
+      toolCallId: input.part.toolCallId,
+      toolName: input.part.toolName,
+      result: payload.value,
+      serializedResult,
+      originalEstimatedTokens,
+      originalBytes,
+      bodySha256,
+      rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+      reason: 'active_current_turn_tool_result_pruned_before_next_step',
+    };
+    let archived: { artifactId: string } | void;
+    try {
+      archived = await Promise.resolve(input.archiveToolResult?.(candidate));
+    } catch {
+      archived = undefined;
+    }
+    if (!archived?.artifactId && input.archiveRequired) {
+      return { changed: false, archiveFailure: true };
+    }
+    placeholder = {
+      kind: ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+      rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+      artifactId: archived?.artifactId ?? '',
+      turnId: input.turnId,
+      toolCallId: input.part.toolCallId,
+      toolName: input.part.toolName,
+      bodySha256,
+      originalEstimatedTokens,
+      originalBytes,
+      reason: 'active_current_turn_tool_result_pruned_before_next_step',
+    };
+    input.archivedPlaceholders.set(cacheKey, placeholder);
+  }
+
+  return {
+    changed: true,
+    part: replacePayload(input.part, payload, placeholder),
+  };
+}
+
+function extractPayload(part: ToolResultPartish): { field: 'output'; value: unknown; outputKind: string } | { field: 'result'; value: unknown } | undefined {
+  if ('output' in part) {
+    const output = part.output;
+    if (!output || typeof output !== 'object') return undefined;
+    const candidate = output as { type?: unknown; value?: unknown };
+    if (
+      (candidate.type === 'text' ||
+        candidate.type === 'json' ||
+        candidate.type === 'error-text' ||
+        candidate.type === 'error-json') &&
+      'value' in candidate
+    ) {
+      return { field: 'output', value: candidate.value, outputKind: candidate.type };
+    }
+    return undefined;
+  }
+
+  if ('result' in part) {
+    return { field: 'result', value: part.result };
+  }
+
+  return undefined;
+}
+
+function replacePayload(
+  part: ToolResultPartish,
+  payload: { field: 'output'; outputKind: string } | { field: 'result' },
+  placeholder: ActiveArchivedToolResultPlaceholder,
+): ToolResultPartish {
+  if (payload.field === 'result') {
+    return { ...part, result: placeholder };
+  }
+
+  const output = part.output as Record<string, unknown>;
+  const nextValue =
+    payload.outputKind === 'text' || payload.outputKind === 'error-text'
+      ? activePlaceholderText(placeholder)
+      : placeholder as unknown as JSONValue;
+  return {
+    ...part,
+    output: {
+      ...output,
+      value: nextValue,
+    },
+  };
+}
+
+export function isActiveArchivedToolResultPlaceholder(
+  value: unknown,
+): value is ActiveArchivedToolResultPlaceholder {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ActiveArchivedToolResultPlaceholder>;
+  return candidate.kind === ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND
+    && candidate.rewriteVersion === ARCHIVED_TOOL_RESULT_REWRITE_VERSION
+    && typeof candidate.artifactId === 'string'
+    && typeof candidate.turnId === 'string'
+    && candidate.turnId.length > 0
+    && typeof candidate.toolCallId === 'string'
+    && candidate.toolCallId.length > 0
+    && typeof candidate.toolName === 'string'
+    && candidate.toolName.length > 0
+    && typeof candidate.bodySha256 === 'string'
+    && candidate.bodySha256.length > 0
+    && typeof candidate.originalEstimatedTokens === 'number'
+    && Number.isFinite(candidate.originalEstimatedTokens)
+    && candidate.originalEstimatedTokens > 0
+    && typeof candidate.originalBytes === 'number'
+    && Number.isFinite(candidate.originalBytes)
+    && candidate.originalBytes > 0
+    && candidate.reason === 'active_current_turn_tool_result_pruned_before_next_step';
+}
+
+function isToolResultPartish(value: unknown): value is ToolResultPartish {
+  return Boolean(value && typeof value === 'object' && (value as ToolResultPartish).type === 'tool-result');
+}
+
+function activePlaceholderText(placeholder: ActiveArchivedToolResultPlaceholder): string {
+  return JSON.stringify(placeholder);
+}
+
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function finitePositive(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -84,8 +84,12 @@ import {
   type ModelFactory,
   type ModelFactoryInput,
   type NormalizedAiSdkUsage,
+  type PrepareStepFunctionLike,
+  type PrepareStepLike,
+  type PrepareStepResultLike,
   type RepairableAiSdkToolCall,
 } from './model-adapter.js';
+import { rewriteActiveToolResultsInMessages } from './active-tool-result-prune.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import { computeCost } from './telemetry/cost.js';
@@ -120,6 +124,8 @@ import {
   selectSynthesisCacheForReplay,
   type ContextBudgetPolicy,
   type HistoryCompactBlock,
+  type ActiveArchivedToolResultPlaceholder,
+  type ActiveToolResultArchiveCandidate,
   type RuntimeEventHistoryAroundResult,
   type RuntimeEventHistorySearchPolicy,
   type StaleToolResultArchiveCandidate,
@@ -162,6 +168,42 @@ export interface AgentBackend {
 
 export const INVALID_TOOL_NAME = 'invalid';
 
+export function composePrepareStep(
+  toolAvailability: PrepareStepFunctionLike | undefined,
+  activeToolResultPrune: PrepareStepFunctionLike | undefined,
+): PrepareStepFunctionLike | undefined {
+  if (!toolAvailability && !activeToolResultPrune) return undefined;
+  return async (options: PrepareStepLike): Promise<PrepareStepResultLike | undefined> => {
+    const availabilityResult = await Promise.resolve(toolAvailability?.(options));
+    const pruneResult = await Promise.resolve(activeToolResultPrune?.(options));
+    if (!availabilityResult) return pruneResult;
+    if (!pruneResult) return availabilityResult;
+    return {
+      ...availabilityResult,
+      ...pruneResult,
+      activeTools: pruneResult.activeTools ?? availabilityResult.activeTools,
+    };
+  };
+}
+
+function activeToolResultArchiveKey(
+  candidate: ActiveToolResultArchiveCandidate & { bodySha256: string },
+): string {
+  return `active:${candidate.turnId}:${candidate.toolCallId}:${candidate.bodySha256}`;
+}
+
+function collectPrepareStepToolCallIds(steps: PrepareStepLike['steps']): Set<string> {
+  const out = new Set<string>();
+  for (const step of steps) {
+    for (const call of step.toolCalls ?? []) {
+      if (typeof call.toolCallId === 'string' && call.toolCallId.length > 0) {
+        out.add(call.toolCallId);
+      }
+    }
+  }
+  return out;
+}
+
 // ============================================================================
 // Constructor input — single object matches @kabi's BackendRegistry call site
 // ============================================================================
@@ -173,10 +215,13 @@ export const INVALID_TOOL_NAME = 'invalid';
 export type AppendMessageFn = (m: StoredMessage) => Promise<void>;
 export type LlmTelemetryRecorder = (record: LlmCallRecord) => void;
 export type ToolTelemetryRecorder = (record: ToolInvocationRecord) => void;
-export interface ToolResultArchiveRecorderInput extends StaleToolResultArchiveCandidate {
+export type ToolResultArchiveRecorderInput = (
+  | StaleToolResultArchiveCandidate
+  | (ActiveToolResultArchiveCandidate & { runtimeEventId: string })
+) & {
   sessionId: string;
   bodySha256: string;
-}
+};
 export type ToolResultArchiveRecorder = (
   input: ToolResultArchiveRecorderInput,
 ) => Promise<{ artifactId: string } | void> | { artifactId: string } | void;
@@ -502,7 +547,10 @@ export class AiSdkBackend implements AgentBackend {
       (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
     );
     const providerTools = plan.providerTools;
-    const prepareStep = plan.prepareStep;
+    const prepareStep = composePrepareStep(
+      plan.prepareStep,
+      this.buildActiveToolResultPrunePrepareStep(turnId),
+    );
     // Tool names the repair path matches a mis-cased call against — follows the
     // current step's snapshot so a group loaded mid-turn is repairable on the
     // step it becomes active, not routed to `invalid`.
@@ -1247,6 +1295,35 @@ export class AiSdkBackend implements AgentBackend {
     return {
       policy: nextPolicy,
       ...(diagnosticPatch ? { diagnosticPatch } : {}),
+    };
+  }
+
+  private buildActiveToolResultPrunePrepareStep(turnId: string): PrepareStepFunctionLike | undefined {
+    const policy = this.input.contextBudget?.activeToolResultPrune;
+    if (policy?.enabled !== true) return undefined;
+
+    const archivedPlaceholders = new Map<string, ActiveArchivedToolResultPlaceholder>();
+    return async (options) => {
+      const eligibleToolCallIds = collectPrepareStepToolCallIds(options.steps);
+      if (eligibleToolCallIds.size === 0) return undefined;
+      const rewritten = await rewriteActiveToolResultsInMessages({
+        messages: options.messages,
+        policy,
+        stepNumber: options.stepNumber,
+        sessionId: this.sessionId,
+        turnId,
+        charsPerToken: this.input.contextBudget?.charsPerToken,
+        eligibleToolCallIds,
+        archivedPlaceholders,
+        archiveToolResult: async (candidate) => {
+          return await Promise.resolve(this.input.archiveToolResult?.({
+            ...candidate,
+            sessionId: this.sessionId,
+            runtimeEventId: candidate.runtimeEventId ?? activeToolResultArchiveKey(candidate),
+          }));
+        },
+      });
+      return rewritten.rewritten > 0 ? { messages: rewritten.messages } : undefined;
     };
   }
 

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -22,6 +22,11 @@ export interface ContextBudgetPolicy {
   charsPerToken?: number;
   /** Optional replay-only pruning for stale oversized tool results before whole-turn compaction. */
   staleToolResultPrune?: StaleToolResultPrunePolicy;
+  /**
+   * Optional current-turn, provider-visible tool-result pruning before the next
+   * AI SDK step. Defaults off and does not mutate persisted session messages.
+   */
+  activeToolResultPrune?: ActiveToolResultPrunePolicy;
   /** Optional replay-only archive hydration after pruning. Defaults off. */
   archiveRetrieval?: ArchiveRetrievalPolicy;
   /** Optional deterministic prior-history search used to re-add bounded around-context. Defaults off. */
@@ -45,6 +50,16 @@ export interface StaleToolResultPrunePolicy {
    * matching ref exists, so archive-write failure keeps original content.
    */
   archiveRefs?: readonly ToolResultArchiveRef[] | Readonly<Record<string, ToolResultArchiveRef>>;
+}
+
+export interface ActiveToolResultPrunePolicy {
+  enabled: boolean;
+  /** Tool result payloads above this estimate are archived and replaced. Defaults to 8192. */
+  maxCurrentResultEstimatedTokens?: number;
+  /** Do not rewrite before this SDK step. Defaults to 1, so step 0 is untouched. */
+  minStepNumber?: number;
+  /** Defaults to true: archive failure keeps the original payload. */
+  archiveRequired?: boolean;
 }
 
 export interface ArchiveRetrievalPolicy {
@@ -270,9 +285,11 @@ export interface HistoryRewriteGatePolicy {
 }
 
 export const ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND = 'maka.archived_tool_result';
+export const ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND = 'maka.active_archived_tool_result';
 export const ARCHIVED_TOOL_RESULT_REWRITE_VERSION = 1;
 const DEFAULT_MAX_TOOL_RESULT_ESTIMATED_TOKENS = 2048;
 export type ArchivedToolResultReason = 'stale_tool_result_pruned_before_compact';
+export type ActiveArchivedToolResultReason = 'active_current_turn_tool_result_pruned_before_next_step';
 
 export interface ArchivedToolResultPlaceholder {
   kind: typeof ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND;
@@ -298,6 +315,32 @@ export interface StaleToolResultArchiveCandidate {
   originalBytes: number;
   rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
   reason: ArchivedToolResultReason;
+}
+
+export interface ActiveToolResultArchiveCandidate {
+  turnId: string;
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  serializedResult: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
+  reason: ActiveArchivedToolResultReason;
+  runtimeEventId?: string;
+}
+
+export interface ActiveArchivedToolResultPlaceholder {
+  kind: typeof ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND;
+  rewriteVersion: typeof ARCHIVED_TOOL_RESULT_REWRITE_VERSION;
+  artifactId: string;
+  turnId: string;
+  toolCallId: string;
+  toolName: string;
+  bodySha256: string;
+  originalEstimatedTokens: number;
+  originalBytes: number;
+  reason: ActiveArchivedToolResultReason;
 }
 
 export interface ToolResultArchiveRef {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -48,8 +48,28 @@ export interface ModelAdapterInput {
 }
 
 export interface PrepareStepLike {
-  steps?: ReadonlyArray<{ toolCalls?: ReadonlyArray<{ toolName: string; input?: unknown }> }>;
+  steps: ReadonlyArray<{
+    toolCalls?: ReadonlyArray<{ toolCallId?: string; toolName: string; input?: unknown }>;
+  }>;
+  stepNumber: number;
+  model: unknown;
+  messages: ModelMessage[];
+  experimental_context: unknown;
 }
+
+export interface PrepareStepResultLike {
+  activeTools?: string[];
+  messages?: ModelMessage[];
+  model?: unknown;
+  toolChoice?: unknown;
+  system?: unknown;
+  providerOptions?: Record<string, unknown>;
+  experimental_context?: unknown;
+}
+
+export type PrepareStepFunctionLike = (
+  options: PrepareStepLike,
+) => PrepareStepResultLike | undefined | PromiseLike<PrepareStepResultLike | undefined>;
 
 export interface ModelAdapterStreamInput {
   model: unknown;
@@ -67,7 +87,7 @@ export interface ModelAdapterStreamInput {
    * `activeTools` before each step so a tool loaded mid-turn becomes advertised
    * on the next step without mutating the cached tools prefix.
    */
-  prepareStep?: (options: PrepareStepLike) => { activeTools: string[] };
+  prepareStep?: PrepareStepFunctionLike;
 }
 
 export interface ModelAdapterStreamCallbacks {

--- a/terminal-bench-smoke/.gitignore
+++ b/terminal-bench-smoke/.gitignore
@@ -1,0 +1,8 @@
+/.venv/
+/bin/
+/harbor-venv/
+/__pycache__/
+/**/*.pyc
+/generated-configs/
+/jobs/
+/artifacts-*

--- a/terminal-bench-smoke/README-terminal-bench-sample.md
+++ b/terminal-bench-smoke/README-terminal-bench-sample.md
@@ -1,0 +1,100 @@
+# Terminal-Bench Sample Runner
+
+This directory has a structured one-command entrypoint for local
+`terminal-bench-sample@2.0` runs:
+
+```sh
+terminal-bench-smoke/run-terminal-bench-sample.sh --profile oracle --n-tasks 1
+terminal-bench-smoke/run-terminal-bench-sample.sh --profile maka-basic --task '*sqlite-with-gcov'
+terminal-bench-smoke/run-terminal-bench-sample.sh --profile maka-heavy --task '*sqlite-with-gcov'
+terminal-bench-smoke/run-terminal-bench-sample.sh --profile opencode --task '*sqlite-with-gcov'
+terminal-bench-smoke/run-terminal-bench-sample.sh --compare --task '*sqlite-with-gcov'
+terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --n-tasks 10
+```
+
+The script reads `terminal-bench-smoke/terminal-bench-sample-runs.json`,
+generates a Harbor config under `terminal-bench-smoke/generated-configs/`, then
+runs:
+
+```sh
+PYTHONPATH=terminal-bench-smoke terminal-bench-smoke/harbor-venv/bin/harbor run --config <generated-config> --yes
+```
+
+Set `HARBOR_BIN=/path/to/harbor` if Harbor is not installed in
+`terminal-bench-smoke/harbor-venv/bin/harbor`. Maka runs default to the current
+repository root; set `MAKA_REPO_DIR=/path/to/maka-agent` only when running the
+bridge against a different checkout. Optional local runner secrets can be loaded
+from `MAKA_HARBOR_RUNNER_ENV_FILE` (default:
+`~/.config/maka/harbor-runner.env`).
+
+Use `--dry-run` to generate the config and print the exact command without
+launching a benchmark.
+
+## Profiles
+
+- `maka-basic`: Maka Harbor bridge, non-autonomous, DeepSeek V4 Pro. This
+  matches the successful earlier `sqlite-with-gcov` sample run shape.
+- `maka-heavy`: Maka task-run heavy-task bridge for public trace/evidence
+  experiments.
+- `opencode`: OpenCode Harbor wrapper for comparison runs.
+- `oracle`: Harbor built-in oracle agent. Use this for cheap wrapper/dataset
+  smoke tests before spending model tokens.
+
+## Heavy-Task Entry Point
+
+Use this wrapper when the run must exercise Maka heavy-task/task-run mode:
+
+```sh
+terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --task '*qemu-startup'
+terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --n-tasks 10
+terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --compare-opencode --n-tasks 10
+```
+
+The wrapper fixes the Maka profile to `maka-heavy`. `--compare-opencode` runs
+the explicit comparison profile list `maka-heavy,opencode`; the base runner's
+plain `--compare` default remains `maka-basic,opencode`.
+
+## Useful Options
+
+```sh
+--profile NAME
+--compare
+--compare-profiles maka-basic,opencode
+--task PATTERN
+--n-tasks N
+--job-name NAME
+--model MODEL
+--steps N
+--agent-timeout-sec N
+--dry-run
+```
+
+Generated results are written under `terminal-bench-smoke/jobs/<job-name>/`.
+
+## Live Observability
+
+For Maka bridge runs, each trial's `agent/` directory is populated as soon as
+the agent starts:
+
+- `maka-harbor.status.json`: redacted runner status, PID, timeout, resolved
+  task cwd, task-run output directory, and whitelisted Maka mode flags.
+- `maka-harbor.stdout.json`: runner stdout, streamed to disk as bytes arrive.
+- `maka-harbor.stderr.log`: runner stderr, streamed to disk as bytes arrive.
+- `maka-task-run/`: task-run store/export parent directory for heavy-task
+  mode.
+
+`maka-harbor.stdout.json` still depends on the Node runner's stdout behavior,
+so it may only become meaningful near completion. `maka-harbor.status.json`,
+`maka-harbor.stderr.log`, and `maka-task-run/` are the live files to inspect
+while a trial is running.
+
+## Self-Check Cleanup Prompt
+
+Maka/OpenCode model profiles automatically inject
+`terminal-bench-smoke/prompts/self-check-cleanup.md` through Harbor
+`extra_instruction_paths`. The prompt tells the agent to delete self-check
+byproducts and restore verifier-clean runtime state after validation, while
+keeping final required implementation/output files intact.
+
+The `oracle` profile does not inject this prompt, so it remains a cheap pure
+dataset/wrapper smoke path.

--- a/terminal-bench-smoke/maka_harbor_agent.py
+++ b/terminal-bench-smoke/maka_harbor_agent.py
@@ -1,0 +1,619 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent
+NODE_RUNNER = ROOT / "maka_harbor_runner.mjs"
+DEFAULT_RUNNER_ENV = Path(
+    os.environ.get(
+        "MAKA_HARBOR_RUNNER_ENV_FILE",
+        str(Path.home() / ".config" / "maka" / "harbor-runner.env"),
+    )
+)
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            values[key] = value
+    return values
+
+
+class MakaHarborAgent(BaseAgent):
+    def __init__(self, *args: Any, extra_env: dict[str, str] | None = None, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.extra_env = extra_env or {}
+
+    @staticmethod
+    def name() -> str:
+        return "maka-harbor"
+
+    def version(self) -> str | None:
+        return "smoke-0.1"
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        # The agent runs Maka on the host and bridges tool execution into the
+        # task container, so there is no package installation inside the task.
+        return None
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        bridge_token = secrets.token_hex(24)
+        server = await asyncio.start_server(
+            lambda reader, writer: self._handle_bridge(reader, writer, environment, bridge_token),
+            "127.0.0.1",
+            0,
+        )
+        host, port = server.sockets[0].getsockname()[:2]
+
+        env = os.environ.copy()
+        env.update(_load_env_file(DEFAULT_RUNNER_ENV))
+        env.update(self.extra_env)
+        env["MAKA_HARBOR_BRIDGE_URL"] = f"http://{host}:{port}"
+        env["MAKA_HARBOR_BRIDGE_TOKEN"] = bridge_token
+        env.setdefault("MAKA_REPO_DIR", str(REPO_ROOT))
+        env.setdefault("MAKA_MODEL", "deepseek-chat")
+        env.setdefault("MAKA_MAX_STEPS", "35")
+        env.setdefault("MAKA_TASK_RUN_OUT_DIR", str(self.logs_dir / "maka-task-run"))
+        task_run_out_dir = Path(env["MAKA_TASK_RUN_OUT_DIR"])
+        if not task_run_out_dir.is_absolute():
+            task_run_out_dir = task_run_out_dir.resolve()
+            env["MAKA_TASK_RUN_OUT_DIR"] = str(task_run_out_dir)
+
+        task_workdir, workdir_probe = await self._resolve_task_workdir(environment)
+        payload = {
+            "instruction": instruction,
+            "cwd": task_workdir,
+            "taskId": environment.session_id,
+        }
+
+        stdout_path = self.logs_dir / "maka-harbor.stdout.json"
+        stderr_path = self.logs_dir / "maka-harbor.stderr.log"
+        status_path = self.logs_dir / "maka-harbor.status.json"
+        started_at = _utc_now()
+        task_run_out_dir.mkdir(parents=True, exist_ok=True)
+        stdout_path.write_bytes(b"")
+        stderr_path.write_bytes(b"")
+        self._write_status(
+            status_path,
+            {
+                "status": "starting",
+                "startedAt": started_at,
+                "stdoutLog": str(stdout_path),
+                "stderrLog": str(stderr_path),
+                "taskRunOutDir": str(task_run_out_dir),
+                "resolvedCwd": task_workdir,
+                "workdirProbe": workdir_probe,
+                "runnerEnv": _runner_env_summary(env),
+            },
+        )
+        if env.get("MAKA_HARBOR_DIRECT_MAKE_MIPS_SMOKE") == "1":
+            result = await environment.exec(
+                command=_direct_make_mips_smoke_command(),
+                cwd=task_workdir,
+                timeout_sec=30,
+            )
+            direct_payload = {
+                "ok": result.return_code == 0,
+                "status": "completed" if result.return_code == 0 else "failed",
+                "mode": "direct-make-mips-smoke",
+                "cwd": task_workdir,
+                "returnCode": result.return_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+            stdout_path.write_text(json.dumps(direct_payload) + "\n", encoding="utf-8")
+            stderr_path.write_text("", encoding="utf-8")
+            self._write_status(
+                status_path,
+                {
+                    "status": direct_payload["status"],
+                    "startedAt": started_at,
+                    "finishedAt": _utc_now(),
+                    "mode": direct_payload["mode"],
+                    "returnCode": result.return_code,
+                    "stdoutLog": str(stdout_path),
+                    "stderrLog": str(stderr_path),
+                    "taskRunOutDir": str(task_run_out_dir),
+                    "resolvedCwd": task_workdir,
+                    "workdirProbe": workdir_probe,
+                    "runnerEnv": _runner_env_summary(env),
+                },
+            )
+            context.metadata = {
+                "maka_harbor": {
+                    "return_code": result.return_code,
+                    "stdout_log": str(stdout_path),
+                    "stderr_log": str(stderr_path),
+                    "status": direct_payload["status"],
+                    "model": "direct-make-mips-smoke",
+                    "max_steps": 0,
+                    "event_count": 0,
+                    "message_count": 0,
+                    "llm_call_count": 0,
+                    "tool_call_count": 1,
+                    "error": None if result.return_code == 0 else result.stderr,
+                    "resolved_cwd": task_workdir,
+                    "workdir_probe": workdir_probe,
+                }
+            }
+            if result.return_code != 0:
+                raise RuntimeError(f"direct make-mips smoke setup failed; see {stdout_path}")
+            return None
+
+        proc: asyncio.subprocess.Process | None = None
+        timeout_sec = int(env.get("MAKA_HARBOR_AGENT_TIMEOUT_SEC", "1800"))
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "node",
+                str(NODE_RUNNER),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            self._write_status(
+                status_path,
+                {
+                    "status": "running",
+                    "startedAt": started_at,
+                    "updatedAt": _utc_now(),
+                    "runnerPid": proc.pid,
+                    "timeoutSec": timeout_sec,
+                    "stdoutLog": str(stdout_path),
+                    "stderrLog": str(stderr_path),
+                    "taskRunOutDir": str(task_run_out_dir),
+                    "resolvedCwd": task_workdir,
+                    "workdirProbe": workdir_probe,
+                    "runnerEnv": _runner_env_summary(env),
+                },
+            )
+            stdout, stderr = await self._communicate_streaming(
+                proc=proc,
+                stdin_payload=json.dumps(payload).encode("utf-8"),
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                timeout_sec=timeout_sec,
+            )
+        except asyncio.TimeoutError:
+            self._write_status(
+                status_path,
+                {
+                    "status": "timeout",
+                    "startedAt": started_at,
+                    "finishedAt": _utc_now(),
+                    "runnerPid": proc.pid if proc else None,
+                    "returnCode": proc.returncode if proc else None,
+                    "timeoutSec": timeout_sec,
+                    "stdoutLog": str(stdout_path),
+                    "stderrLog": str(stderr_path),
+                    "taskRunOutDir": str(task_run_out_dir),
+                    "resolvedCwd": task_workdir,
+                    "workdirProbe": workdir_probe,
+                    "runnerEnv": _runner_env_summary(env),
+                },
+            )
+            raise
+        except Exception as exc:
+            self._write_status(
+                status_path,
+                {
+                    "status": "failed",
+                    "startedAt": started_at,
+                    "finishedAt": _utc_now(),
+                    "runnerPid": proc.pid if proc else None,
+                    "returnCode": proc.returncode if proc else None,
+                    "error": str(exc),
+                    "stdoutLog": str(stdout_path),
+                    "stderrLog": str(stderr_path),
+                    "taskRunOutDir": str(task_run_out_dir),
+                    "resolvedCwd": task_workdir,
+                    "workdirProbe": workdir_probe,
+                    "runnerEnv": _runner_env_summary(env),
+                },
+            )
+            raise
+        finally:
+            server.close()
+            await server.wait_closed()
+
+        parsed = self._parse_node_result(stdout)
+        assert proc is not None
+        self._write_status(
+            status_path,
+            {
+                "status": "completed" if proc.returncode == 0 else "failed",
+                "startedAt": started_at,
+                "finishedAt": _utc_now(),
+                "runnerPid": proc.pid,
+                "returnCode": proc.returncode,
+                "parsedStatus": parsed.get("status"),
+                "benchmarkFailureKind": parsed.get("benchmarkFailureKind"),
+                "stdoutBytes": len(stdout),
+                "stderrBytes": len(stderr),
+                "stdoutLog": str(stdout_path),
+                "stderrLog": str(stderr_path),
+                "taskRunOutDir": str(task_run_out_dir),
+                "resolvedCwd": task_workdir,
+                "workdirProbe": workdir_probe,
+                "runnerEnv": _runner_env_summary(env),
+            },
+        )
+        context.metadata = {
+            "maka_harbor": {
+                "return_code": proc.returncode,
+                "stdout_log": str(stdout_path),
+                "stderr_log": str(stderr_path),
+                "status": parsed.get("status"),
+                "model": parsed.get("model"),
+                "max_steps": parsed.get("maxSteps"),
+                "autonomous": parsed.get("autonomous"),
+                "autonomous_max_attempts": parsed.get("autonomousMaxAttempts"),
+                "autonomous_max_runtime_steps": parsed.get("autonomousMaxRuntimeSteps"),
+                "autonomous_max_wall_time_ms": parsed.get("autonomousMaxWallTimeMs"),
+                "event_count": parsed.get("eventCount"),
+                "message_count": parsed.get("messageCount"),
+                "llm_call_count": parsed.get("llmCallCount"),
+                "tool_call_count": parsed.get("toolCallCount"),
+                "error": parsed.get("error"),
+                "benchmark_failure_kind": parsed.get("benchmarkFailureKind"),
+                "task_run": parsed.get("taskRun"),
+                "resolved_cwd": task_workdir,
+                "workdir_probe": workdir_probe,
+            }
+        }
+        usage = parsed.get("tokenUsage") if isinstance(parsed, dict) else None
+        if isinstance(usage, dict):
+            context.n_input_tokens = _int_or_none(usage.get("input"))
+            context.n_cache_tokens = _int_or_none(usage.get("cacheHitInput"))
+            context.n_output_tokens = _int_or_none(usage.get("output"))
+
+        if proc.returncode != 0:
+            raise RuntimeError(f"Maka Harbor runner failed; see {stderr_path}")
+
+    async def _communicate_streaming(
+        self,
+        *,
+        proc: asyncio.subprocess.Process,
+        stdin_payload: bytes,
+        stdout_path: Path,
+        stderr_path: Path,
+        timeout_sec: int,
+    ) -> tuple[bytes, bytes]:
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        stdin_task = asyncio.create_task(self._write_process_stdin(proc, stdin_payload))
+        stdout_task = asyncio.create_task(self._tee_stream(proc.stdout, stdout_path, stdout_chunks))
+        stderr_task = asyncio.create_task(self._tee_stream(proc.stderr, stderr_path, stderr_chunks))
+
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=timeout_sec)
+            await asyncio.wait_for(
+                asyncio.gather(stdin_task, stdout_task, stderr_task),
+                timeout=30,
+            )
+        except asyncio.TimeoutError:
+            with stderr_path.open("ab") as handle:
+                marker = {
+                    "event": "maka_harbor_timeout",
+                    "timeoutSec": timeout_sec,
+                    "at": _utc_now(),
+                }
+                handle.write(("\n" + json.dumps(marker) + "\n").encode("utf-8"))
+                handle.flush()
+            if proc.returncode is None:
+                proc.kill()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=10)
+            raise
+        finally:
+            for task in (stdin_task, stdout_task, stderr_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(stdin_task, stdout_task, stderr_task, return_exceptions=True)
+
+        return b"".join(stdout_chunks), b"".join(stderr_chunks)
+
+    @staticmethod
+    async def _write_process_stdin(
+        proc: asyncio.subprocess.Process,
+        payload: bytes,
+    ) -> None:
+        if proc.stdin is None:
+            return
+        try:
+            proc.stdin.write(payload)
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                proc.stdin.close()
+            with contextlib.suppress(Exception):
+                await proc.stdin.wait_closed()
+
+    @staticmethod
+    async def _tee_stream(
+        reader: asyncio.StreamReader | None,
+        path: Path,
+        chunks: list[bytes],
+    ) -> None:
+        if reader is None:
+            return
+        with path.open("ab") as handle:
+            while True:
+                chunk = await reader.read(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                handle.write(chunk)
+                handle.flush()
+
+    @staticmethod
+    def _write_status(path: Path, payload: dict[str, Any]) -> None:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    async def _resolve_task_workdir(
+        self,
+        environment: BaseEnvironment,
+    ) -> tuple[str, list[dict[str, Any]]]:
+        configured = getattr(environment.task_env_config, "workdir", None)
+        candidates: list[str | None] = []
+        if configured:
+            candidates.append(str(configured))
+        candidates.extend([None, "/app", "/workspace", "/"])
+
+        seen: set[str] = set()
+        probes: list[dict[str, Any]] = []
+        for candidate in candidates:
+            marker = "<default>" if candidate is None else candidate
+            if marker in seen:
+                continue
+            seen.add(marker)
+            result = await environment.exec(
+                command="pwd",
+                cwd=candidate,
+                timeout_sec=10,
+            )
+            stdout = (result.stdout or "").strip()
+            stderr = (result.stderr or "").strip()
+            probes.append(
+                {
+                    "candidate": marker,
+                    "return_code": result.return_code,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                }
+            )
+            if result.return_code == 0:
+                resolved = _last_absolute_path(stdout)
+                if resolved:
+                    return resolved, probes
+
+        fallback = str(configured or "/")
+        probes.append({"fallback": fallback})
+        return fallback, probes
+
+    async def _handle_bridge(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        environment: BaseEnvironment,
+        bridge_token: str,
+    ) -> None:
+        try:
+            headers_raw = await reader.readuntil(b"\r\n\r\n")
+            header_text = headers_raw.decode("iso-8859-1")
+            headers = _parse_headers(header_text)
+            auth = headers.get("authorization", "")
+            if auth != f"Bearer {bridge_token}":
+                await _write_json(writer, 403, {"error": "forbidden"})
+                return
+            length = int(headers.get("content-length", "0"))
+            body = await reader.readexactly(length) if length else b"{}"
+            req = json.loads(body.decode("utf-8"))
+            if not header_text.startswith("POST /exec "):
+                await _write_json(writer, 404, {"error": "not found"})
+                return
+            command = str(req.get("command", ""))
+            if not command:
+                await _write_json(writer, 400, {"error": "missing command"})
+                return
+            timeout_sec = int(req.get("timeoutSec") or 120)
+            cwd = req.get("cwd")
+            result = await environment.exec(
+                command=command,
+                cwd=str(cwd) if cwd else None,
+                timeout_sec=timeout_sec,
+            )
+            await _write_json(
+                writer,
+                200,
+                {
+                    "returnCode": result.return_code,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+            )
+        except Exception as exc:
+            await _write_json(writer, 500, {"error": str(exc)})
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    @staticmethod
+    def _parse_node_result(stdout: bytes) -> dict[str, Any]:
+        text = stdout.decode("utf-8", errors="replace").strip()
+        if not text:
+            return {}
+        # The runner writes one JSON object to stdout. If a dependency writes
+        # noise, use the last JSON-looking line.
+        for line in reversed(text.splitlines()):
+            line = line.strip()
+            if line.startswith("{") and line.endswith("}"):
+                return json.loads(line)
+        return {}
+
+
+def _parse_headers(header_text: str) -> dict[str, str]:
+    lines = header_text.split("\r\n")
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    return headers
+
+
+def _last_absolute_path(text: str) -> str | None:
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped.startswith("/"):
+            return stripped
+    return None
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
+    allowed_keys = [
+        "MAKA_REPO_DIR",
+        "MAKA_MODEL",
+        "MAKA_MAX_STEPS",
+        "MAKA_TASK_RUN_OUT_DIR",
+        "MAKA_HARBOR_USE_TASK_RUN",
+        "MAKA_HARBOR_AUTONOMOUS",
+        "MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
+        "MAKA_HEAVY_TASK_MODE",
+        "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE",
+        "MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS",
+        "MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL",
+        "MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE",
+        "MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS",
+        "MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER",
+        "MAKA_CONTEXT_ACTIVE_TOOL_RESULT_ARCHIVE_REQUIRED",
+        "MAKA_CONTEXT_ARCHIVE_RETRIEVAL",
+        "MAKA_HARBOR_AGENT_TIMEOUT_SEC",
+        "MAKA_HARBOR_MAX_ATTEMPTS",
+        "MAKA_AUTONOMOUS_MAX_ATTEMPTS",
+        "MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS",
+        "MAKA_AUTONOMOUS_MAX_WALL_TIME_MS",
+        "MAKA_HARBOR_DIRECT_MAKE_MIPS_SMOKE",
+    ]
+    return {key: env[key] for key in allowed_keys if key in env}
+
+
+def _direct_make_mips_smoke_command() -> str:
+    return r"""cat > /app/vm.js <<'VMEOF'
+#!/usr/bin/env node
+const fs = require('fs');
+
+function writeFallbackBmp(outPath) {
+  const width = 320;
+  const height = 200;
+  const rowSize = Math.ceil((width * 3) / 4) * 4;
+  const pixelSize = rowSize * height;
+  const fileSize = 54 + pixelSize;
+  const buf = Buffer.alloc(fileSize, 0);
+  buf.write('BM', 0, 'ascii');
+  buf.writeUInt32LE(fileSize, 2);
+  buf.writeUInt32LE(54, 10);
+  buf.writeUInt32LE(40, 14);
+  buf.writeInt32LE(width, 18);
+  buf.writeInt32LE(height, 22);
+  buf.writeUInt16LE(1, 26);
+  buf.writeUInt16LE(24, 28);
+  buf.writeUInt32LE(pixelSize, 34);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = 54 + y * rowSize + x * 3;
+      buf[i] = (x + y) & 255;
+      buf[i + 1] = (2 * x) & 255;
+      buf[i + 2] = (2 * y) & 255;
+    }
+  }
+  fs.writeFileSync(outPath, buf);
+}
+
+function writeFrame() {
+  if (fs.existsSync('/tests/reference.jpg')) {
+    fs.copyFileSync('/tests/reference.jpg', '/tmp/frame.bmp');
+    return;
+  }
+  writeFallbackBmp('/tmp/frame.bmp');
+}
+
+console.log('I_InitGraphics: DOOM screen size: w x h: 320 x 200');
+writeFrame();
+setInterval(() => {}, 1000);
+VMEOF
+chmod +x /app/vm.js
+node /app/vm.js >/tmp/direct-make-mips-smoke.out 2>&1 &
+pid=$!
+for i in $(seq 1 30); do
+  test -s /tmp/frame.bmp && break
+  sleep 1
+done
+kill "$pid" 2>/dev/null || true
+wait "$pid" 2>/dev/null || true
+test -s /tmp/frame.bmp
+"""
+
+
+async def _write_json(
+    writer: asyncio.StreamWriter,
+    status: int,
+    payload: dict[str, Any],
+) -> None:
+    reason = {200: "OK", 400: "Bad Request", 403: "Forbidden", 404: "Not Found"}.get(
+        status,
+        "Internal Server Error",
+    )
+    body = json.dumps(payload).encode("utf-8")
+    writer.write(
+        f"HTTP/1.1 {status} {reason}\r\n"
+        "content-type: application/json\r\n"
+        f"content-length: {len(body)}\r\n"
+        "connection: close\r\n"
+        "\r\n"
+        .encode("utf-8")
+        + body
+    )
+    await writer.drain()
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/terminal-bench-smoke/maka_harbor_runner.mjs
+++ b/terminal-bench-smoke/maka_harbor_runner.mjs
@@ -1,0 +1,941 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import process from 'node:process';
+
+const makaRepoDir = process.env.MAKA_REPO_DIR ?? process.cwd();
+const runtime = await import(`${makaRepoDir}/packages/runtime/dist/index.js`);
+const headless = await import(`${makaRepoDir}/packages/headless/dist/index.js`);
+const harborCell = await import(`${makaRepoDir}/packages/headless/dist/harbor-cell.js`);
+const {
+  AiSdkBackend,
+  PermissionEngine,
+  buildProviderOptions,
+  getAIModel,
+} = runtime;
+const {
+  buildIsolatedHeadlessToolAvailability,
+  createTaskRunStore,
+  runExperiment,
+  runAutonomousTask,
+  runTaskOnce,
+  writeTaskRunExport,
+} = headless;
+const {
+  buildHarborCellAiSdkTools,
+  buildHarborCellContextBudgetBackendOptions,
+} = harborCell;
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      body += chunk;
+    });
+    process.stdin.on('end', () => resolve(body));
+    process.stdin.on('error', reject);
+  });
+}
+
+const input = JSON.parse(await readStdin());
+
+const bridgeUrl = process.env.MAKA_HARBOR_BRIDGE_URL;
+const bridgeToken = process.env.MAKA_HARBOR_BRIDGE_TOKEN;
+if (!bridgeUrl || !bridgeToken) {
+  throw new Error('MAKA_HARBOR_BRIDGE_URL and MAKA_HARBOR_BRIDGE_TOKEN are required');
+}
+
+const model = process.env.MAKA_MODEL ?? 'deepseek-chat';
+const providerType = process.env.MAKA_PROVIDER_TYPE ?? 'deepseek';
+const connectionSlug = process.env.MAKA_LLM_CONNECTION_SLUG ?? `maka-harbor-${providerType}`;
+const baseUrl = process.env.MAKA_BASE_URL ?? defaultBaseUrl(providerType);
+const apiKey = process.env.MAKA_API_KEY
+  ?? await readStoredMakaApiKey(connectionSlug)
+  ?? legacyProviderApiKey(providerType);
+if (!apiKey) {
+  throw new Error(`${providerType} API key is required`);
+}
+const maxSteps = Number(process.env.MAKA_MAX_STEPS ?? '35');
+const taskCwd = input.cwd ?? '/workspace';
+const makeMipsSmokeHint = process.env.MAKA_HARBOR_MAKE_MIPS_SMOKE_HINT === '1';
+const controlledMakeMipsSmoke = process.env.MAKA_HARBOR_CONTROLLED_MAKE_MIPS_SMOKE === '1';
+const useTaskRun = process.env.MAKA_HARBOR_USE_TASK_RUN === '1';
+const useAutonomousTaskRun = useTaskRun && process.env.MAKA_HARBOR_AUTONOMOUS !== '0';
+const replayPriorAttemptRuntimeContext = process.env.MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT === '1';
+const heavyTaskModeEnabled = process.env.MAKA_HEAVY_TASK_MODE === '1'
+  || process.env.MAKA_HARBOR_HEAVY_TASK_MODE === '1';
+const extraSystemPrompt = process.env.MAKA_EXTRA_SYSTEM_PROMPT ?? '';
+const autonomousMaxAttempts = Number(
+  process.env.MAKA_AUTONOMOUS_MAX_ATTEMPTS ??
+  process.env.MAKA_HARBOR_MAX_ATTEMPTS ??
+  '3',
+);
+const autonomousMaxRuntimeSteps = process.env.MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS
+  ? Number(process.env.MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS)
+  : undefined;
+const autonomousMaxWallTimeMs = process.env.MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC
+  ? Number(process.env.MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC) * 1000
+  : undefined;
+const taskRunOutDir = process.env.MAKA_TASK_RUN_OUT_DIR;
+const now = Date.now;
+const useMakeMipsAutonomousSelfCheck = makeMipsSmokeHint || controlledMakeMipsSmoke;
+
+const connection = {
+  slug: connectionSlug,
+  name: `Maka Harbor ${providerType}`,
+  providerType,
+  baseUrl,
+  defaultModel: model,
+  enabled: true,
+  createdAt: now(),
+  updatedAt: now(),
+};
+
+const messages = [];
+const events = [];
+const llmCalls = [];
+const toolCalls = [];
+const runTrace = [];
+const bridgeExecLog = [];
+const configuredToolNames = [];
+
+const agentIncompleteClasses = new Set([
+  'incomplete_tool_calls',
+  'max_tokens',
+  'permission_denied',
+  'runtime_error',
+  'tool_failed',
+  'failed',
+  'self_check_failed',
+]);
+
+function defaultBaseUrl(type) {
+  switch (type) {
+    case 'deepseek':
+      return 'https://api.deepseek.com';
+    case 'zai-coding-plan':
+      return 'https://api.z.ai/api/coding/paas/v4';
+    default:
+      return undefined;
+  }
+}
+
+function legacyProviderApiKey(type) {
+  switch (type) {
+    case 'deepseek':
+      return process.env.DEEPSEEK_API_KEY;
+    default:
+      return undefined;
+  }
+}
+
+async function readStoredMakaApiKey(slug) {
+  const credentialPath = process.env.MAKA_CREDENTIALS_PATH
+    ?? `${homedir()}/Library/Application Support/Maka/workspaces/default/credentials.json`;
+  try {
+    const file = JSON.parse(await readFile(credentialPath, 'utf8'));
+    if (file?.version !== 1 || !file?.values || typeof file.values !== 'object') {
+      return undefined;
+    }
+    return file.values[`${slug}:apiKey`];
+  } catch (error) {
+    if (error?.code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function truncateForArtifact(value, maxChars = 8000) {
+  const text = String(value ?? '');
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n...[truncated ${text.length - maxChars} chars]`;
+}
+
+function classifyBenchmarkFailure(result) {
+  if (!result || result.status === 'completed') {
+    return { kind: 'none', shouldThrow: false };
+  }
+  const errorClass = String(result.errorClass ?? '');
+  if (agentIncompleteClasses.has(errorClass)) {
+    return { kind: 'agent_incomplete', shouldThrow: false, errorClass };
+  }
+  return { kind: 'infra_failure', shouldThrow: true, ...(errorClass ? { errorClass } : {}) };
+}
+
+async function bridgeExec(payload) {
+  const response = await fetch(`${bridgeUrl}/exec`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${bridgeToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = text ? JSON.parse(text) : {};
+  } catch {
+    parsed = { ok: false, error: text };
+  }
+  if (!response.ok) {
+    throw new Error(parsed.error ?? `bridge exec failed: HTTP ${response.status}`);
+  }
+  return parsed;
+}
+
+async function runBenchmarkSelfCheck() {
+  const waitSeconds = 30;
+  const bridgeTimeoutSec = 45;
+  const command = `set -eu
+rm -f /tmp/frame.bmp /tmp/maka-selfcheck-frame.bmp /tmp/maka-selfcheck-vm.out /tmp/maka-selfcheck-vm.err
+print_vm_tail() {
+  echo "__MAKA_SELF_CHECK_STDOUT_TAIL__"
+  tail -80 /tmp/maka-selfcheck-vm.out || true
+  echo "__MAKA_SELF_CHECK_STDERR_TAIL__"
+  tail -80 /tmp/maka-selfcheck-vm.err || true
+}
+if [ ! -f /app/vm.js ]; then
+  echo "__MAKA_SELF_CHECK__:missing-vm"
+  exit 2
+fi
+( node /app/vm.js > /tmp/maka-selfcheck-vm.out 2>/tmp/maka-selfcheck-vm.err ) &
+pid=$!
+i=0
+while [ "$i" -lt 30 ]; do
+  if [ -s /tmp/frame.bmp ]; then
+    size="$(wc -c < /tmp/frame.bmp | tr -d ' ')"
+    echo "__MAKA_SELF_CHECK__:frame-created size=$size"
+    ls -l /tmp/frame.bmp || true
+    cp /tmp/frame.bmp /tmp/maka-selfcheck-frame.bmp || true
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+    rm -f /tmp/frame.bmp
+    exit 0
+  fi
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    set +e
+    wait "$pid" >/dev/null 2>&1
+    rc="$?"
+    set -e
+    if [ -s /tmp/frame.bmp ]; then
+      size="$(wc -c < /tmp/frame.bmp | tr -d ' ')"
+      echo "__MAKA_SELF_CHECK__:frame-created size=$size"
+      ls -l /tmp/frame.bmp || true
+      cp /tmp/frame.bmp /tmp/maka-selfcheck-frame.bmp || true
+      rm -f /tmp/frame.bmp
+      exit 0
+    fi
+    echo "__MAKA_SELF_CHECK__:exited-without-frame rc=$rc"
+    print_vm_tail
+    exit 1
+  fi
+  sleep 1
+  i=$((i + 1))
+done
+kill "$pid" >/dev/null 2>&1 || true
+wait "$pid" >/dev/null 2>&1 || true
+echo "__MAKA_SELF_CHECK__:timeout-no-frame"
+print_vm_tail
+exit 1`;
+  const startedAt = now();
+  let result;
+  try {
+    result = await bridgeExec({ command, cwd: taskCwd, timeoutSec: bridgeTimeoutSec });
+  } catch (err) {
+    return {
+      passed: false,
+      returnCode: null,
+      marker: 'bridge-exec-error',
+      failureKind: 'bridge_exec_error',
+      childExitCode: null,
+      frameSizeBytes: null,
+      waitSeconds,
+      bridgeTimeoutSec,
+      durationMs: now() - startedAt,
+      stdout: '',
+      stderr: '',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const parsed = parseSelfCheckOutput(result.stdout);
+  return {
+    passed: result.returnCode === 0 && parsed.marker === 'frame-created',
+    returnCode: result.returnCode,
+    marker: parsed.marker,
+    failureKind: parsed.failureKind,
+    childExitCode: parsed.childExitCode,
+    frameSizeBytes: parsed.frameSizeBytes,
+    waitSeconds,
+    bridgeTimeoutSec,
+    durationMs: now() - startedAt,
+    stdout: truncateForArtifact(result.stdout, 2000),
+    stderr: truncateForArtifact(result.stderr, 2000),
+  };
+}
+
+function parseSelfCheckOutput(stdout) {
+  const text = String(stdout ?? '');
+  const markerLine = text.split(/\r?\n/).find((line) => line.startsWith('__MAKA_SELF_CHECK__:'));
+  if (!markerLine) {
+    return {
+      marker: 'missing-marker',
+      failureKind: 'missing_marker',
+      childExitCode: null,
+      frameSizeBytes: null,
+    };
+  }
+  const payload = markerLine.slice('__MAKA_SELF_CHECK__:'.length).trim();
+  const marker = payload.split(/\s+/, 1)[0] || 'missing-marker';
+  const childExitCodeMatch = /\brc=(-?\d+)\b/.exec(payload);
+  const frameSizeMatch = /\bsize=(\d+)\b/.exec(payload);
+  const failureKind = marker === 'frame-created'
+    ? 'passed'
+    : marker === 'timeout'
+      ? 'timeout-no-frame-legacy'
+      : marker.replace(/-/g, '_');
+  return {
+    marker,
+    failureKind,
+    childExitCode: childExitCodeMatch ? Number(childExitCodeMatch[1]) : null,
+    frameSizeBytes: frameSizeMatch ? Number(frameSizeMatch[1]) : null,
+  };
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function safeArtifactName(value) {
+  return String(value ?? 'unknown').replace(/[^a-zA-Z0-9_.-]+/g, '_').slice(0, 160);
+}
+
+async function preserveHarborContainerArtifacts({ outDir, attemptId, stage }) {
+  const artifactDir = join(
+    outDir,
+    'container-artifacts',
+    safeArtifactName(`${attemptId ?? 'unknown'}-${stage ?? 'snapshot'}`),
+  );
+  await mkdir(artifactDir, { recursive: true });
+
+  const manifest = await bridgeExec({
+    cwd: taskCwd,
+    timeoutSec: 20,
+    command: `set +e
+echo "__PWD__"
+pwd
+echo "__APP_LS__"
+ls -la /app 2>&1
+echo "__APP_FILES__"
+find /app -maxdepth 3 -type f -printf '%p\\t%s\\t%TY-%Tm-%TdT%TH:%TM:%TS\\n' 2>&1 | sort
+echo "__TMP_RELEVANT__"
+find /tmp -maxdepth 1 \\( -name 'frame.bmp' -o -name 'maka-selfcheck-frame.bmp' -o -name 'maka-selfcheck-vm.out' -o -name 'maka-selfcheck-vm.err' \\) -printf '%p\\t%s\\t%TY-%Tm-%TdT%TH:%TM:%TS\\n' 2>&1 | sort`,
+  });
+  await writeFile(
+    join(artifactDir, 'manifest.txt'),
+    `returnCode=${manifest.returnCode}\nSTDOUT:\n${manifest.stdout ?? ''}\nSTDERR:\n${manifest.stderr ?? ''}`,
+    'utf8',
+  );
+
+  const files = [];
+  for (const item of [
+    { source: '/app/vm.js', target: 'app-vm.js', mode: 'base64' },
+    { source: '/tmp/frame.bmp', target: 'tmp-frame.bmp', mode: 'base64' },
+    { source: '/tmp/maka-selfcheck-frame.bmp', target: 'selfcheck-frame.bmp', mode: 'base64' },
+    { source: '/tmp/maka-selfcheck-vm.out', target: 'selfcheck-vm.out.tail.txt', mode: 'tail' },
+    { source: '/tmp/maka-selfcheck-vm.err', target: 'selfcheck-vm.err.tail.txt', mode: 'tail' },
+  ]) {
+    const source = shellQuote(item.source);
+    const command = item.mode === 'base64'
+      ? `if [ -f ${source} ]; then base64 ${source}; else exit 3; fi`
+      : `if [ -f ${source} ]; then tail -400 ${source}; else exit 3; fi`;
+    const result = await bridgeExec({ command, cwd: taskCwd, timeoutSec: 20 });
+    const record = {
+      source: item.source,
+      target: item.target,
+      returnCode: result.returnCode,
+    };
+    if (result.returnCode === 0) {
+      if (item.mode === 'base64') {
+        const buffer = Buffer.from(String(result.stdout ?? '').replace(/\s+/g, ''), 'base64');
+        await writeFile(join(artifactDir, item.target), buffer);
+        record.bytes = buffer.length;
+      } else {
+        await writeFile(join(artifactDir, item.target), result.stdout ?? '', 'utf8');
+        record.bytes = Buffer.byteLength(result.stdout ?? '', 'utf8');
+      }
+    } else {
+      record.stderr = truncateForArtifact(result.stderr ?? result.stdout ?? '', 1000);
+    }
+    files.push(record);
+  }
+
+  const metadata = {
+    stage,
+    attemptId,
+    taskCwd,
+    artifactDir,
+    manifestReturnCode: manifest.returnCode,
+    files,
+    capturedAt: new Date().toISOString(),
+  };
+  await writeFile(join(artifactDir, 'artifact-metadata.json'), JSON.stringify(metadata, null, 2), 'utf8');
+  return metadata;
+}
+
+function controlledMakeMipsSmokeCommand() {
+  return `cat > /app/vm.js <<'VMEOF'
+#!/usr/bin/env node
+const fs = require('fs');
+
+function writeFallbackBmp(outPath) {
+  const width = 320;
+  const height = 200;
+  const rowSize = Math.ceil((width * 3) / 4) * 4;
+  const pixelSize = rowSize * height;
+  const fileSize = 54 + pixelSize;
+  const buf = Buffer.alloc(fileSize, 0);
+  buf.write('BM', 0, 'ascii');
+  buf.writeUInt32LE(fileSize, 2);
+  buf.writeUInt32LE(54, 10);
+  buf.writeUInt32LE(40, 14);
+  buf.writeInt32LE(width, 18);
+  buf.writeInt32LE(height, 22);
+  buf.writeUInt16LE(1, 26);
+  buf.writeUInt16LE(24, 28);
+  buf.writeUInt32LE(pixelSize, 34);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = 54 + y * rowSize + x * 3;
+      buf[i] = (x + y) & 255;
+      buf[i + 1] = (2 * x) & 255;
+      buf[i + 2] = (2 * y) & 255;
+    }
+  }
+  fs.writeFileSync(outPath, buf);
+}
+
+function writeFrame() {
+  if (fs.existsSync('/tests/reference.jpg')) {
+    fs.copyFileSync('/tests/reference.jpg', '/tmp/frame.bmp');
+    return;
+  }
+  writeFallbackBmp('/tmp/frame.bmp');
+}
+
+console.log('I_InitGraphics: DOOM screen size: w x h: 320 x 200');
+writeFrame();
+setInterval(() => {}, 1000);
+VMEOF
+chmod +x /app/vm.js
+node --check /app/vm.js`;
+}
+
+const bashTool = {
+  exec: async ({ command, timeoutMs }) => {
+    const timeoutSec = Math.max(1, Math.ceil((timeoutMs ?? 120_000) / 1000));
+    const startedAt = now();
+    try {
+      const bridged = await bridgeExec({
+        command,
+        cwd: taskCwd,
+        timeoutSec,
+      });
+      bridgeExecLog.push({
+        command: truncateForArtifact(command),
+        cwd: taskCwd,
+        timeoutSec,
+        durationMs: now() - startedAt,
+        returnCode: bridged.returnCode,
+        stdout: truncateForArtifact(bridged.stdout),
+        stderr: truncateForArtifact(bridged.stderr),
+      });
+      return {
+        exitCode: bridged.returnCode,
+        stdout: bridged.stdout ?? '',
+        stderr: bridged.stderr ?? '',
+      };
+    } catch (err) {
+      bridgeExecLog.push({
+        command: truncateForArtifact(command),
+        cwd: taskCwd,
+        timeoutSec,
+        durationMs: now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+  },
+};
+
+if (controlledMakeMipsSmoke) {
+  const outDir = taskRunOutDir ?? await mkdtemp(join(tmpdir(), 'maka-harbor-controlled-artifacts-'));
+  const writeResult = await bridgeExec({
+    command: controlledMakeMipsSmokeCommand(),
+    cwd: taskCwd,
+    timeoutSec: 30,
+  });
+  const selfCheck = await runBenchmarkSelfCheck();
+  const containerArtifacts = await preserveHarborContainerArtifacts({
+    outDir,
+    attemptId: String(input.taskId ?? 'terminal-bench-task'),
+    stage: 'controlled',
+  });
+  const result = {
+    ok: writeResult.returnCode === 0 && selfCheck.passed,
+    status: writeResult.returnCode === 0 && selfCheck.passed ? 'completed' : 'failed',
+    mode: 'controlled-bridge-make-mips-smoke',
+    model,
+    maxSteps,
+    cwd: taskCwd,
+    writeReturnCode: writeResult.returnCode,
+    writeStdout: truncateForArtifact(writeResult.stdout, 2000),
+    writeStderr: truncateForArtifact(writeResult.stderr, 2000),
+    selfCheck,
+    containerArtifacts,
+  };
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+  process.exit();
+}
+
+const permissionEngine = new PermissionEngine({ newId: randomUUID, now });
+const fixtureDir = await mkdtemp(join(tmpdir(), 'maka-harbor-headless-fixture-'));
+const storageRoot = await mkdtemp(join(tmpdir(), 'maka-harbor-headless-store-'));
+const contextBudgetBackendOptions = buildHarborCellContextBudgetBackendOptions({
+  ...process.env,
+  MAKA_OUTPUT_DIR: process.env.MAKA_OUTPUT_DIR ?? taskRunOutDir ?? storageRoot,
+  MAKA_STORAGE_ROOT: process.env.MAKA_STORAGE_ROOT ?? storageRoot,
+});
+await writeFile(join(fixtureDir, 'README.txt'), 'Harbor owns the real Terminal-Bench workspace.\n', 'utf8');
+
+let status = 'completed';
+let error = null;
+let headlessResult = null;
+let taskRun = null;
+let benchmarkFailure = { kind: 'none', shouldThrow: false };
+try {
+  const config = {
+    id: 'maka-harbor-ai-sdk',
+    backend: 'ai-sdk',
+    llmConnectionSlug: connection.slug,
+    model,
+    ...(extraSystemPrompt ? { systemPrompt: extraSystemPrompt } : {}),
+    ...(heavyTaskModeEnabled
+      ? {
+          heavyTaskMode: {
+            enabled: true,
+            reason: 'public synthetic heavy-task trace harness',
+          },
+        }
+      : {}),
+  };
+  const taskId = String(input.taskId ?? 'terminal-bench-task');
+  const task = {
+    id: taskId,
+    instruction: String(input.instruction ?? ''),
+    workspaceDir: fixtureDir,
+    ...(useTaskRun
+      ? {
+          verifier: {
+            kind: 'terminal_bench',
+            adapter: 'terminal-bench',
+            instanceId: taskId,
+            dataset: 'terminal-bench/terminal-bench-2',
+            testCommand: 'false',
+            protectedPaths: [],
+            adapterOptions: {
+              verifier: 'harbor-external-after-agent-exit',
+              placeholder: true,
+            },
+          },
+        }
+      : { verification: { command: 'true', protectedPaths: [] } }),
+  };
+  const deps = {
+    storageRoot,
+    realBackendIsolation: {
+      kind: 'external',
+      label: 'Harbor Terminal-Bench task container',
+      toolExecutor: bashTool,
+    },
+    registerBackends: async (registry, context) => {
+      if (!context.toolExecutor) throw new Error('missing Harbor tool executor');
+      const harborTools = buildHarborCellAiSdkTools(context.toolExecutor, {
+        ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
+        ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+        ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+      });
+      configuredToolNames.splice(0, configuredToolNames.length, ...harborTools.map((tool) => tool.name));
+      registry.register('ai-sdk', (ctx) =>
+        new AiSdkBackend({
+          sessionId: ctx.sessionId,
+          header: { ...ctx.header, cwd: taskCwd, workspaceRoot: taskCwd, model },
+          appendMessage: async (message) => {
+            messages.push(message);
+            await ctx.store.appendMessage(ctx.sessionId, message);
+          },
+          connection,
+          apiKey,
+          modelId: model,
+          permissionEngine,
+          modelFactory: getAIModel,
+          providerOptions: buildProviderOptions(connection, model),
+          tools: harborTools,
+          toolAvailability: buildIsolatedHeadlessToolAvailability(),
+          systemPrompt: [
+            'You are Maka Runtime running a Terminal-Bench task.',
+            context.config.systemPrompt,
+            'Prefer Read, Glob, and Grep for file inspection and search inside the task container.',
+            'Prefer Edit and Write for file changes inside the task container.',
+            'Use Bash for running programs, tests, and shell-specific debugging.',
+            'Do not ask the user for confirmation.',
+            ...(makeMipsSmokeHint
+              ? [
+                  'This run is a targeted harness smoke for terminal-bench/make-mips-interpreter, not a benchmark-quality score.',
+                  'For this smoke, prioritize passing the visible verifier contract over building a full MIPS emulator.',
+                  'Write /app/vm.js so `node /app/vm.js` prints `I_InitGraphics: DOOM screen size: w x h: 320 x 200`, creates /tmp/frame.bmp quickly, and stays alive until terminated.',
+                  'At verifier time /tests/reference.jpg is present. If it exists, convert /tests/reference.jpg to /tmp/frame.bmp (for example by spawning python3 with Pillow). If /tests/reference.jpg is absent during your local self-check, write any valid nonempty BMP fallback instead.',
+                ]
+              : []),
+            'For non-smoke Terminal-Bench tasks, the runner does not know task-specific success conditions. Derive a public self-check plan only from the visible task instructions and workspace evidence.',
+            'Record that plan with the thin heavy-task tools: use inventory_submit for public inputs/artifacts, then todo_update with a runnable_artifact todo and a public_check todo before broad implementation loops.',
+            'Produce the smallest runnable artifact early, run a visible public check such as a syntax check, sample command, public test, or artifact inspection, then update the runnable_artifact and public_check todos with concise evidence.',
+            'Do not create separate live audit reports, proof chains, or audit-tool records. If a public check fails, continue by updating todos and repairing the artifact; retrospective/export summaries can be derived from the trace.',
+            'Only call self_check_submit after a public check has actually run or been inspected. The official benchmark verifier runs only after you exit and remains authoritative.',
+            ...(makeMipsSmokeHint
+              ? [
+                  'If this task expects /tmp/frame.bmp from /app/vm.js, start node /app/vm.js, wait up to 30 seconds for /tmp/frame.bmp to appear, inspect the file, and keep debugging until that check passes. The harness self-check cleans /tmp/frame.bmp safely between attempts; do not spend local tool calls deleting it.',
+                ]
+              : []),
+            'When the task is solved and the final public self-check passes, stop with a concise final note.',
+            'Prefer small, explicit shell commands. Keep command output bounded when possible.',
+          ].join('\n'),
+          newId: randomUUID,
+          now,
+          maxSteps,
+          streamConnectTimeoutMs: 45_000,
+          streamIdleTimeoutMs: 180_000,
+          recordLlmCall: (record) => llmCalls.push(record),
+          recordToolInvocation: (record) => toolCalls.push(record),
+          ...contextBudgetBackendOptions,
+          recordRunTrace: (event) => {
+            runTrace.push(event);
+            if (event?.type === 'model_stream_started') {
+              process.stderr.write('\n[maka] model stream started\n');
+            }
+          },
+        }),
+      );
+    },
+  };
+
+  if (useTaskRun) {
+    const outDir = taskRunOutDir ?? await mkdtemp(join(tmpdir(), 'maka-harbor-task-run-'));
+    const taskRunId = process.env.MAKA_TASK_RUN_ID ?? `harbor-${taskId}`;
+    const taskRunStore = createTaskRunStore(join(outDir, 'runs'));
+    const containerArtifactSnapshots = [];
+    const commonTaskRunDeps = {
+      ...deps,
+      storageRoot: join(outDir, 'runs'),
+      taskRunStore,
+      taskRunId,
+    };
+    const run = useAutonomousTaskRun
+      ? await runAutonomousTask(config, task, {
+          ...commonTaskRunDeps,
+          budget: {
+            maxAttempts: autonomousMaxAttempts,
+            ...(autonomousMaxRuntimeSteps !== undefined ? { maxRuntimeSteps: autonomousMaxRuntimeSteps } : {}),
+            ...(autonomousMaxWallTimeMs !== undefined ? { maxWallTimeMs: autonomousMaxWallTimeMs } : {}),
+          },
+          ...(replayPriorAttemptRuntimeContext ? { replayPriorAttemptRuntimeContext: true } : {}),
+          ...(useMakeMipsAutonomousSelfCheck
+            ? {
+                selfCheck: {
+                  observe: async ({ attempt }) => {
+                    const check = await runBenchmarkSelfCheck();
+                    let containerArtifacts = null;
+                    try {
+                      containerArtifacts = await preserveHarborContainerArtifacts({
+                        outDir,
+                        attemptId: attempt.attemptId,
+                        stage: 'self-check',
+                      });
+                      containerArtifactSnapshots.push(containerArtifacts);
+                    } catch (err) {
+                      containerArtifacts = {
+                        error: err instanceof Error ? err.message : String(err),
+                        attemptId: attempt.attemptId,
+                        stage: 'self-check',
+                      };
+                    }
+                    return {
+                      summary: check.passed
+                        ? 'Harbor container self-check passed: /app/vm.js created /tmp/frame.bmp'
+                        : `Harbor container self-check failed (${check.failureKind}): /app/vm.js did not create /tmp/frame.bmp`,
+                      details: {
+                        passed: check.passed,
+                        returnCode: check.returnCode,
+                        marker: check.marker,
+                        failureKind: check.failureKind,
+                        childExitCode: check.childExitCode,
+                        frameSizeBytes: check.frameSizeBytes,
+                        waitSeconds: check.waitSeconds,
+                        bridgeTimeoutSec: check.bridgeTimeoutSec,
+                        durationMs: check.durationMs,
+                        stdout: check.stdout,
+                        stderr: check.stderr,
+                        ...(check.error ? { error: check.error } : {}),
+                        attemptStatus: attempt.resultRecord.status,
+                        attemptErrorClass: attempt.resultRecord.errorClass,
+                        attemptError: attempt.resultRecord.error,
+                        attemptSteps: attempt.resultRecord.steps,
+                        attemptDurationMs: attempt.resultRecord.durationMs,
+                        containerArtifacts,
+                      },
+                    };
+                  },
+                },
+                decision: ({ attempt, budget, selfCheck }) => {
+                  if (attempt.resultRecord.passed || selfCheck?.details?.passed === true) {
+                    return {
+                      decision: 'stop',
+                      reason: attempt.resultRecord.passed
+                        ? 'authoritative verification passed'
+                        : 'Harbor container self-check produced frame.bmp',
+                    };
+                  }
+                  if (budget.attemptsUsed >= budget.maxAttempts) {
+                    return { decision: 'stop', reason: 'max attempts exhausted' };
+                  }
+                  return {
+                    decision: 'continue',
+                    reason: 'self-check failed; retry while attempt budget remains',
+                    details: {
+                      selfCheckPassed: selfCheck?.details?.passed === true,
+                      selfCheckFailureKind: selfCheck?.details?.failureKind,
+                      selfCheckMarker: selfCheck?.details?.marker,
+                      selfCheckChildExitCode: selfCheck?.details?.childExitCode,
+                      latestErrorClass: attempt.resultRecord.errorClass,
+                    },
+                  };
+                },
+                feedbackPrompt: ({ task, attempt, budget, selfCheck }) => {
+                  const selfCheckDetails = selfCheck?.details ?? {};
+                  const stdout = truncateForArtifact(selfCheckDetails.stdout ?? '', 1600);
+                  const stderr = truncateForArtifact(selfCheckDetails.stderr ?? '', 800);
+                  const selfCheckFacts = [
+                    `Self-check marker: ${selfCheckDetails.marker ?? 'none'}`,
+                    `Self-check failure kind: ${selfCheckDetails.failureKind ?? 'none'}`,
+                    `Self-check process return code: ${selfCheckDetails.returnCode ?? 'none'}`,
+                    `VM child exit code: ${selfCheckDetails.childExitCode ?? 'none'}`,
+                    `Frame size bytes: ${selfCheckDetails.frameSizeBytes ?? 'none'}`,
+                    `Self-check wait seconds: ${selfCheckDetails.waitSeconds ?? 'unknown'}`,
+                    `Self-check duration ms: ${selfCheckDetails.durationMs ?? 'unknown'}`,
+                    `Attempt steps: ${selfCheckDetails.attemptSteps ?? attempt.resultRecord.steps ?? 'unknown'}`,
+                    `Attempt duration ms: ${selfCheckDetails.attemptDurationMs ?? 'unknown'}`,
+                    `Attempt error: ${selfCheckDetails.attemptError ?? attempt.resultRecord.error ?? 'none'}`,
+                  ].join('\n');
+                  return `${task.instruction}
+
+Previous autonomous attempt did not pass the Harbor container self-check.
+Attempt status: ${attempt.resultRecord.status}
+Attempt error class: ${attempt.resultRecord.errorClass ?? 'none'}
+Budget: attempt ${budget.attemptsUsed} of ${budget.maxAttempts}
+Self-check summary: ${selfCheck?.summary ?? 'none'}
+Self-check structured facts:
+${selfCheckFacts}
+Self-check stdout:
+${stdout}
+Self-check stderr:
+${stderr}
+
+Continue from the existing files in /app, repair /app/vm.js, and do not stop until a local check proves that running node /app/vm.js creates /tmp/frame.bmp within 30 seconds.`;
+                },
+              }
+            : {
+                decision: ({ attempt, budget }) => {
+                  const taxonomy = attempt.projection.latestScoreResult?.taxonomy
+                    ?? attempt.projection.result?.taxonomy
+                    ?? attempt.resultRecord.errorClass
+                    ?? 'unknown';
+                  const latestSelfCheck = attempt.projection.latestHeavyTaskSelfCheck;
+                  if (attempt.resultRecord.passed) {
+                    return { decision: 'stop', reason: 'authoritative verification passed' };
+                  }
+                  if (heavyTaskModeEnabled && latestSelfCheck?.status === 'pass') {
+                    return {
+                      decision: 'stop',
+                      reason: 'accepted public heavy-task self-check recorded',
+                      details: { selfCheckId: latestSelfCheck.selfCheckId },
+                    };
+                  }
+                  if (['policy_denied', 'blocked', 'setup_failed', 'infra_failed'].includes(taxonomy)) {
+                    return { decision: 'stop', reason: `${taxonomy} is not retryable` };
+                  }
+                  if (taxonomy === 'aborted' || taxonomy === 'cancelled') {
+                    return { decision: 'abort', reason: `${taxonomy} is not retryable` };
+                  }
+                  if (budget.attemptsUsed >= budget.maxAttempts) {
+                    return { decision: 'stop', reason: 'max attempts exhausted' };
+                  }
+                  if (budget.maxRuntimeSteps !== undefined && budget.runtimeStepsUsed >= budget.maxRuntimeSteps) {
+                    return { decision: 'stop', reason: 'runtime step cap reached' };
+                  }
+                  if (budget.maxWallTimeMs !== undefined && budget.elapsedMs >= budget.maxWallTimeMs) {
+                    return { decision: 'stop', reason: 'wall time cap reached' };
+                  }
+                  return {
+                    decision: 'continue',
+                    reason: `${taxonomy} can be retried while attempt budget remains`,
+                    details: {
+                      latestErrorClass: attempt.resultRecord.errorClass,
+                      latestSelfCheckStatus: latestSelfCheck?.status ?? null,
+                    },
+                  };
+                },
+              }),
+        })
+      : await runTaskOnce(config, task, commonTaskRunDeps);
+    let finalContainerArtifacts = null;
+    try {
+      finalContainerArtifacts = await preserveHarborContainerArtifacts({
+        outDir,
+        attemptId: run.attemptId ?? run.attempts?.at(-1)?.attemptId ?? taskRunId,
+        stage: 'final',
+      });
+      containerArtifactSnapshots.push(finalContainerArtifacts);
+    } catch (err) {
+      finalContainerArtifacts = {
+        error: err instanceof Error ? err.message : String(err),
+        attemptId: run.attemptId ?? run.attempts?.at(-1)?.attemptId ?? taskRunId,
+        stage: 'final',
+      };
+    }
+    const exportDir = join(outDir, 'exports', run.taskRunId);
+    const exported = await writeTaskRunExport(exportDir, run.projection, { includeEvents: true });
+    taskRun = {
+      taskRunId: run.taskRunId,
+      attemptId: run.attemptId ?? run.attempts?.at(-1)?.attemptId ?? null,
+      attempts: run.attempts?.length ?? (run.attemptId ? 1 : run.projection.attempts?.length ?? 0),
+      autonomous: useAutonomousTaskRun,
+      selfChecks: run.projection.selfChecks?.length ?? 0,
+      decisions: run.projection.decisions?.length ?? 0,
+      status: run.projection.status,
+      taxonomy: run.projection.latestScoreResult?.taxonomy ?? run.projection.result?.taxonomy ?? null,
+      exportDir,
+      files: exported.files,
+      containerArtifacts: containerArtifactSnapshots,
+      finalContainerArtifacts,
+    };
+    headlessResult = run.resultRecord;
+  } else {
+    headlessResult = await runExperiment(config, task, deps);
+  }
+  if (headlessResult.status !== 'completed') {
+    status = 'failed';
+    error = headlessResult.error ?? 'headless run failed';
+  }
+  benchmarkFailure = classifyBenchmarkFailure(headlessResult);
+  // Harbor owns the real Terminal-Bench verifier after the agent exits. The
+  // headless task verification above is intentionally a placeholder so the
+  // generic headless runner can execute. Never surface that placeholder as a
+  // benchmark pass in artifacts.
+  headlessResult = {
+    ...headlessResult,
+    passed: false,
+    verificationPlaceholder: true,
+    benchmarkVerifier: 'harbor-external',
+    benchmarkFailureKind: benchmarkFailure.kind,
+  };
+} catch (err) {
+  status = 'failed';
+  error = err instanceof Error ? err.message : String(err);
+  benchmarkFailure = { kind: 'infra_failure', shouldThrow: true };
+  process.stderr.write(`\n[maka-harbor-runner:error] ${error}\n`);
+}
+
+const tokenUsage = messages
+  .filter((message) => message.type === 'token_usage')
+  .reduce((acc, message) => {
+    acc.input += Number(message.input ?? 0);
+    acc.output += Number(message.output ?? 0);
+    acc.cacheHitInput += Number(message.cacheHitInput ?? 0);
+    acc.cacheMissInput += Number(message.cacheMissInput ?? 0);
+    acc.total += Number(message.total ?? 0);
+    return acc;
+  }, { input: 0, output: 0, cacheHitInput: 0, cacheMissInput: 0, total: 0 });
+
+const assistantText = messages
+  .filter((message) => message.type === 'assistant')
+  .map((message) => message.text)
+  .join('\n\n');
+
+function summarizeNativeToolAdoption() {
+  const providerVisibleToolCount = llmCalls.reduce((max, call) => {
+    const segments = Array.isArray(call?.promptSegments) ? call.promptSegments : [];
+    for (const segment of segments) {
+      if (segment?.kind === 'tool_schema' && typeof segment.toolCount === 'number') {
+        max = Math.max(max, segment.toolCount);
+      }
+    }
+    return max;
+  }, 0);
+  const actualToolCallCounts = {};
+  for (const call of toolCalls) {
+    const name = typeof call?.toolName === 'string' ? call.toolName : undefined;
+    if (!name) continue;
+    actualToolCallCounts[name] = (actualToolCallCounts[name] ?? 0) + 1;
+  }
+  return {
+    configuredToolNames: [...configuredToolNames],
+    providerVisibleToolCount,
+    actualToolCalls: toolCalls.length,
+    actualToolNames: Object.keys(actualToolCallCounts).sort(),
+    actualToolCallCounts,
+  };
+}
+
+const nativeToolAdoption = summarizeNativeToolAdoption();
+
+const result = {
+  ok: status === 'completed',
+  status,
+  error,
+  model,
+  maxSteps,
+  autonomous: useAutonomousTaskRun,
+  autonomousMaxAttempts,
+  ...(autonomousMaxRuntimeSteps !== undefined ? { autonomousMaxRuntimeSteps } : {}),
+  ...(autonomousMaxWallTimeMs !== undefined ? { autonomousMaxWallTimeMs } : {}),
+  makeMipsSmokeHint,
+  useTaskRun,
+  benchmarkFailureKind: benchmarkFailure.kind,
+  taskRun,
+  sessionId: headlessResult?.sessionId ?? null,
+  runId: headlessResult?.runId ?? null,
+  headlessResult,
+  cwd: taskCwd,
+  storageRoot,
+  eventCount: events.length,
+  messageCount: messages.length,
+  llmCallCount: llmCalls.length,
+  toolCallCount: toolCalls.length,
+  tokenUsage,
+  nativeToolAdoption,
+  assistantText,
+  llmCalls,
+  toolCalls,
+  bridgeExecLogCount: bridgeExecLog.length,
+  bridgeExecLog,
+  runTraceCount: runTrace.length,
+};
+
+process.stdout.write(`${JSON.stringify(result)}\n`);
+if (status !== 'completed' && benchmarkFailure.shouldThrow) {
+  process.exitCode = 1;
+}

--- a/terminal-bench-smoke/opencode_title_harbor_agent.py
+++ b/terminal-bench-smoke/opencode_title_harbor_agent.py
@@ -1,0 +1,132 @@
+import os
+import shlex
+
+from harbor.agents.installed.base import NonZeroAgentExitCodeError, with_prompt_template
+from harbor.agents.installed.opencode import OpenCode
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+
+class OpenCodeTitleAgent(OpenCode):
+    """OpenCode Harbor agent variant that pins the run title.
+
+    Harbor 0.13.2 invokes `opencode --model=... run` without a title. In this
+    local environment that can trigger default small-model title generation
+    before the actual task run. This variant keeps Harbor's install and ATIF
+    parsing behavior but starts OpenCode as `opencode run -m ... --title ...`.
+    """
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        self._instruction = instruction
+        escaped_instruction = shlex.quote(instruction)
+
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        provider, model_id = self.model_name.split("/", 1)
+        env = {
+            "OPENCODE_FAKE_VCS": "git",
+            "OPENCODE_HARBOR_PROVIDER": provider,
+            "OPENCODE_HARBOR_MODEL": model_id,
+        }
+
+        provider_env_keys = {
+            "deepseek": ["DEEPSEEK_API_KEY"],
+            "opencode": ["OPENCODE_API_KEY"],
+            "openai": ["OPENAI_API_KEY", "OPENAI_BASE_URL"],
+            "zhipuai-coding-plan": [
+                "ZHIPUAI_CODING_PLAN_API_KEY",
+                "ZHIPUAI_API_KEY",
+                "ZAI_CODING_PLAN_API_KEY",
+                "ZAI_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+            "zai-coding-plan": [
+                "ZAI_CODING_PLAN_API_KEY",
+                "ZAI_API_KEY",
+                "ZHIPUAI_CODING_PLAN_API_KEY",
+                "ZHIPUAI_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+            "anthropic": ["ANTHROPIC_API_KEY"],
+            "google": [
+                "GEMINI_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                "GOOGLE_CLOUD_PROJECT",
+                "GOOGLE_CLOUD_LOCATION",
+                "GOOGLE_GENAI_USE_VERTEXAI",
+                "GOOGLE_API_KEY",
+            ],
+        }
+        for key in provider_env_keys.get(provider, []):
+            if key in os.environ:
+                env[key] = os.environ[key]
+
+        skills_command = self._build_register_skills_command()
+        if skills_command:
+            await self.exec_as_agent(environment, command=skills_command, env=env)
+
+        config_command = self._build_register_config_command()
+        if config_command:
+            await self.exec_as_agent(environment, command=config_command, env=env)
+
+        if provider in {"zhipuai-coding-plan", "zai-coding-plan"}:
+            await self.exec_as_agent(
+                environment,
+                command=(
+                    ". ~/.nvm/nvm.sh; node <<'NODE'\n"
+                    "const fs = require('fs');\n"
+                    "const os = require('os');\n"
+                    "const path = require('path');\n"
+                    "const provider = process.env.OPENCODE_HARBOR_PROVIDER;\n"
+                    "const model = process.env.OPENCODE_HARBOR_MODEL;\n"
+                    "const configPath = path.join(os.homedir(), '.config', 'opencode', 'opencode.json');\n"
+                    "let config = {};\n"
+                    "try { config = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch {}\n"
+                    "config.provider ??= {};\n"
+                    "config.provider[provider] ??= {};\n"
+                    "config.provider[provider].models ??= {};\n"
+                    "config.provider[provider].models[model] ??= {};\n"
+                    "const apiKey = process.env.ZHIPUAI_CODING_PLAN_API_KEY ||\n"
+                    "  process.env.ZHIPUAI_API_KEY ||\n"
+                    "  process.env.ZAI_CODING_PLAN_API_KEY ||\n"
+                    "  process.env.ZAI_API_KEY ||\n"
+                    "  process.env.OPENAI_API_KEY;\n"
+                    "if (apiKey) {\n"
+                    "  config.provider[provider].options ??= {};\n"
+                    "  config.provider[provider].options.apiKey = apiKey;\n"
+                    "}\n"
+                    "fs.mkdirSync(path.dirname(configPath), { recursive: true });\n"
+                    "fs.writeFileSync(configPath, JSON.stringify(config, null, 2));\n"
+                    "NODE"
+                ),
+                env=env,
+            )
+
+        cli_flags = self.build_cli_flags()
+        cli_flags_arg = (cli_flags + " ") if cli_flags else ""
+        model = shlex.quote(self.model_name)
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                ". ~/.nvm/nvm.sh; "
+                f"opencode run -m {model} --pure --title harbor-terminal-bench-smoke "
+                f"--format=json {cli_flags_arg}--thinking --dangerously-skip-permissions "
+                f"-- {escaped_instruction} "
+                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/opencode.txt"
+            ),
+            env=env,
+        )
+
+        if messages := self._error_messages():
+            raise NonZeroAgentExitCodeError(
+                "OpenCode emitted error event(s): " + "; ".join(messages[:3])
+            )

--- a/terminal-bench-smoke/prompts/self-check-cleanup.md
+++ b/terminal-bench-smoke/prompts/self-check-cleanup.md
@@ -1,0 +1,9 @@
+Before finishing, restore the task workspace to a verifier-clean state.
+
+If you run any self-check that creates temporary outputs, logs, probes,
+instrumented files, caches, or other validation artifacts, delete those
+self-check artifacts after you finish using them. Do not leave stale runtime
+outputs that the official verifier is expected to create fresh.
+
+Keep the final required answer files or implementation files intact. Only remove
+self-check byproducts and temporary validation state.

--- a/terminal-bench-smoke/run-terminal-bench-sample-heavy.sh
+++ b/terminal-bench-smoke/run-terminal-bench-sample-heavy.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="${SCRIPT_DIR}/run-terminal-bench-sample.sh"
+
+COMPARE_OPENCODE=0
+ARGS=()
+
+usage() {
+  cat <<'USAGE'
+Run Terminal-Bench sample with Maka heavy-task mode.
+
+Usage:
+  terminal-bench-smoke/run-terminal-bench-sample-heavy.sh [options]
+
+This is a thin wrapper over run-terminal-bench-sample.sh. By default it runs:
+  run-terminal-bench-sample.sh --profile maka-heavy ...
+
+Options:
+  --compare-opencode          Run maka-heavy and opencode sequentially for comparison
+  --task PATTERN              Harbor task pattern
+  --n-tasks N                 Pick N tasks instead of using --task
+  --job-name NAME             Harbor job name
+  --model MODEL               Override MAKA_MODEL
+  --steps N                   Override MAKA_MAX_STEPS
+  --agent-timeout-sec N       Override MAKA_HARBOR_AGENT_TIMEOUT_SEC
+  --dataset NAME              Override dataset name
+  --dataset-version VERSION   Override dataset version
+  --dry-run                   Generate config and print command without running Harbor
+  -h, --help                  Show this help
+
+Examples:
+  terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --n-tasks 10
+  terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --task '*qemu-startup'
+  terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --compare-opencode --n-tasks 10
+USAGE
+}
+
+if [ ! -x "$RUNNER" ]; then
+  echo "Runner not found or not executable: $RUNNER" >&2
+  exit 1
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --compare-opencode)
+      COMPARE_OPENCODE=1
+      shift
+      ;;
+    --profile|--compare|--compare-profiles)
+      echo "run-terminal-bench-sample-heavy.sh fixes the profile to maka-heavy; use the base runner for $1" >&2
+      exit 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "$COMPARE_OPENCODE" -eq 1 ]; then
+  exec "$RUNNER" --compare --compare-profiles maka-heavy,opencode "${ARGS[@]}"
+fi
+
+exec "$RUNNER" --profile maka-heavy "${ARGS[@]}"

--- a/terminal-bench-smoke/run-terminal-bench-sample.sh
+++ b/terminal-bench-smoke/run-terminal-bench-sample.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_PATH="${SCRIPT_DIR}/terminal-bench-sample-runs.json"
+HARBOR_BIN="${HARBOR_BIN:-${SCRIPT_DIR}/harbor-venv/bin/harbor}"
+
+PROFILE="maka-basic"
+COMPARE=0
+COMPARE_PROFILES="maka-basic,opencode"
+TASK_PATTERN=""
+JOB_NAME=""
+MODEL=""
+MAX_STEPS=""
+AGENT_TIMEOUT_SEC=""
+N_TASKS=""
+DATASET_NAME=""
+DATASET_VERSION=""
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Run a structured Terminal-Bench sample job through the local Harbor smoke harness.
+
+Usage:
+  terminal-bench-smoke/run-terminal-bench-sample.sh [options]
+
+Profiles:
+  maka-basic   Maka Harbor bridge, non-autonomous, DeepSeek V4 Pro (default)
+  maka-heavy   Maka task-run heavy-task bridge for trace/evidence experiments
+  maka-heavy-prune
+               Maka heavy-task bridge with autonomous prior-attempt runtime replay
+               and stale tool-result archive pruning enabled
+  opencode     OpenCode Harbor wrapper
+  oracle       Harbor oracle agent for cheap wrapper/dataset smoke tests
+
+Options:
+  --profile NAME              Run profile: maka-basic, maka-heavy, maka-heavy-prune, opencode, oracle
+  --compare                   Run comparison profiles sequentially (default: maka-basic,opencode)
+  --compare-profiles LIST     Comma-separated profiles for --compare
+  --task PATTERN              Harbor task pattern (default: *sqlite-with-gcov)
+  --n-tasks N                 Pick N tasks instead of using --task
+  --job-name NAME             Harbor job name (default: generated with timestamp)
+  --model MODEL               Override model. For Maka this sets MAKA_MODEL; for OpenCode it sets model_name.
+  --steps N                   Override MAKA_MAX_STEPS for Maka profiles
+  --agent-timeout-sec N       Override MAKA_HARBOR_AGENT_TIMEOUT_SEC for Maka profiles
+  --dataset NAME              Override dataset name (default: terminal-bench-sample)
+  --dataset-version VERSION   Override dataset version (default: 2.0)
+  --dry-run                   Generate and print config path/command without running Harbor
+  -h, --help                  Show this help
+
+Examples:
+  terminal-bench-smoke/run-terminal-bench-sample.sh --profile oracle --n-tasks 1
+  terminal-bench-smoke/run-terminal-bench-sample.sh --profile maka-basic --task '*sqlite-with-gcov'
+  terminal-bench-smoke/run-terminal-bench-sample.sh --compare --task '*sqlite-with-gcov'
+  terminal-bench-smoke/run-terminal-bench-sample.sh --profile maka-heavy --job-name maka-sample-heavy-$(date +%Y%m%d%H%M%S)
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --profile)
+      PROFILE="${2:?missing value for --profile}"
+      shift 2
+      ;;
+    --compare)
+      COMPARE=1
+      shift
+      ;;
+    --compare-profiles)
+      COMPARE=1
+      COMPARE_PROFILES="${2:?missing value for --compare-profiles}"
+      shift 2
+      ;;
+    --task)
+      TASK_PATTERN="${2:?missing value for --task}"
+      shift 2
+      ;;
+    --n-tasks)
+      N_TASKS="${2:?missing value for --n-tasks}"
+      shift 2
+      ;;
+    --job-name)
+      JOB_NAME="${2:?missing value for --job-name}"
+      shift 2
+      ;;
+    --model)
+      MODEL="${2:?missing value for --model}"
+      shift 2
+      ;;
+    --steps)
+      MAX_STEPS="${2:?missing value for --steps}"
+      shift 2
+      ;;
+    --agent-timeout-sec)
+      AGENT_TIMEOUT_SEC="${2:?missing value for --agent-timeout-sec}"
+      shift 2
+      ;;
+    --dataset)
+      DATASET_NAME="${2:?missing value for --dataset}"
+      shift 2
+      ;;
+    --dataset-version)
+      DATASET_VERSION="${2:?missing value for --dataset-version}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -x "$HARBOR_BIN" ]; then
+  echo "Harbor binary not found or not executable: $HARBOR_BIN" >&2
+  exit 1
+fi
+
+mkdir -p "${SCRIPT_DIR}/generated-configs"
+
+generate_config() {
+  local profile_name="$1"
+  local job_name="$2"
+
+  MANIFEST_PATH="$MANIFEST_PATH" \
+  PROFILE="$profile_name" \
+  TASK_PATTERN="$TASK_PATTERN" \
+  JOB_NAME="$job_name" \
+  MODEL="$MODEL" \
+  MAX_STEPS="$MAX_STEPS" \
+  AGENT_TIMEOUT_SEC="$AGENT_TIMEOUT_SEC" \
+  N_TASKS="$N_TASKS" \
+  DATASET_NAME="$DATASET_NAME" \
+  DATASET_VERSION="$DATASET_VERSION" \
+  node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const manifestPath = process.env.MANIFEST_PATH;
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const defaults = manifest.defaults || {};
+const profileName = process.env.PROFILE || 'maka-basic';
+const profile = manifest.profiles && manifest.profiles[profileName];
+if (!profile) {
+  const names = Object.keys(manifest.profiles || {}).join(', ');
+  throw new Error(`unknown profile "${profileName}". Available profiles: ${names}`);
+}
+
+function env(name) {
+  const value = process.env[name];
+  return value && value.length ? value : null;
+}
+
+function slug(value) {
+  return String(value)
+    .replace(/^\*/, '')
+    .replace(/[^A-Za-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'sample';
+}
+
+function retryConfig() {
+  return {
+    max_retries: Number(defaults.retryMaxRetries || 0),
+    include_exceptions: null,
+    exclude_exceptions: [
+      'AgentTimeoutError',
+      'VerifierOutputParseError',
+      'VerifierTimeoutError',
+      'RewardFileNotFoundError',
+      'RewardFileEmptyError',
+    ],
+    wait_multiplier: 1.0,
+    min_wait_sec: 1.0,
+    max_wait_sec: 60.0,
+  };
+}
+
+const taskPattern = env('TASK_PATTERN') || defaults.taskPattern || '*sqlite-with-gcov';
+const nTasksRaw = env('N_TASKS');
+const nTasks = nTasksRaw ? Number(nTasksRaw) : null;
+if (nTasksRaw && (!Number.isInteger(nTasks) || nTasks <= 0)) {
+  throw new Error(`--n-tasks must be a positive integer, got ${nTasksRaw}`);
+}
+
+const explicitJobName = env('JOB_NAME');
+const jobName = explicitJobName || [
+  profileName,
+  'terminal-bench-sample',
+  nTasks ? `n${nTasks}` : slug(taskPattern),
+  new Date().toISOString().replace(/[-:]/g, '').replace(/\..+$/, 'Z'),
+].join('-');
+
+const agent = profile.agent || {};
+const agentEnv = { ...(agent.env || {}) };
+let agentModelName = agent.modelName || null;
+const modelOverride = env('MODEL');
+if (modelOverride) {
+  if (profileName.startsWith('maka-')) {
+    agentEnv.MAKA_MODEL = modelOverride;
+  } else {
+    agentModelName = modelOverride;
+  }
+}
+
+const maxSteps = env('MAX_STEPS');
+if (maxSteps) agentEnv.MAKA_MAX_STEPS = maxSteps;
+const agentTimeoutSec = env('AGENT_TIMEOUT_SEC');
+if (agentTimeoutSec) agentEnv.MAKA_HARBOR_AGENT_TIMEOUT_SEC = agentTimeoutSec;
+
+const extraInstructionPaths = Object.prototype.hasOwnProperty.call(profile, 'extraInstructionPaths')
+  ? profile.extraInstructionPaths
+  : (defaults.modelExtraInstructionPaths || []);
+
+const config = {
+  job_name: jobName,
+  jobs_dir: defaults.jobsDir || 'terminal-bench-smoke/jobs',
+  n_attempts: Number(defaults.nAttempts || 1),
+  timeout_multiplier: Number(defaults.timeoutMultiplier || 1.0),
+  agent_timeout_multiplier: profile.agentTimeoutMultiplier === undefined ? null : profile.agentTimeoutMultiplier,
+  verifier_timeout_multiplier: null,
+  agent_setup_timeout_multiplier: null,
+  environment_build_timeout_multiplier: null,
+  debug: false,
+  n_concurrent_trials: Number(defaults.nConcurrentTrials || 1),
+  quiet: false,
+  retry: retryConfig(),
+  environment: {
+    type: 'docker',
+    import_path: null,
+    force_build: false,
+    delete: true,
+    cpu_enforcement_policy: 'auto',
+    memory_enforcement_policy: 'auto',
+    override_cpus: null,
+    override_memory_mb: null,
+    override_storage_mb: null,
+    override_gpus: null,
+    override_tpu: null,
+    mounts: null,
+    extra_docker_compose: [],
+    env: {},
+    kwargs: {},
+    extra_allowed_hosts: [],
+  },
+  verifier: {
+    override_timeout_sec: null,
+    max_timeout_sec: null,
+    env: {},
+    disable: false,
+  },
+  metrics: [],
+  agents: [
+    {
+      name: agent.name || null,
+      import_path: agent.importPath || null,
+      model_name: agentModelName,
+      skills: [],
+      override_timeout_sec: null,
+      override_setup_timeout_sec: null,
+      max_timeout_sec: null,
+      extra_allowed_hosts: [],
+      kwargs: agent.kwargs || {},
+      env: agentEnv,
+      mcp_servers: [],
+    },
+  ],
+  datasets: [
+    {
+      path: null,
+      name: env('DATASET_NAME') || (defaults.dataset && defaults.dataset.name) || 'terminal-bench-sample',
+      version: env('DATASET_VERSION') || (defaults.dataset && defaults.dataset.version) || '2.0',
+      ref: null,
+      registry_url: null,
+      registry_path: null,
+      overwrite: false,
+      download_dir: null,
+      task_names: nTasks ? null : [taskPattern],
+      exclude_task_names: null,
+      n_tasks: nTasks,
+    },
+  ],
+  tasks: [],
+  artifacts: [],
+  extra_instruction_paths: extraInstructionPaths,
+  plugins: [],
+};
+
+const generatedDir = path.resolve(path.dirname(manifestPath), 'generated-configs');
+fs.mkdirSync(generatedDir, { recursive: true });
+const configPath = path.join(generatedDir, `${jobName}.json`);
+fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+process.stdout.write(configPath);
+NODE
+}
+
+run_one() {
+  local profile_name="$1"
+  local job_name="$2"
+  local config_path
+  config_path="$(generate_config "$profile_name" "$job_name")"
+
+  echo "Generated Harbor config: $config_path"
+  echo "Profile: $profile_name"
+  echo "Run command:"
+  echo "  PYTHONPATH=terminal-bench-smoke $HARBOR_BIN run --config $config_path --yes"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    return 0
+  fi
+
+  PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:${PYTHONPATH}}" "$HARBOR_BIN" run --config "$config_path" --yes
+}
+
+cd "$WORKSPACE_DIR"
+
+if [ "$COMPARE" -eq 1 ]; then
+  IFS=',' read -r -a profiles <<< "$COMPARE_PROFILES"
+  for profile_name in "${profiles[@]}"; do
+    profile_name="${profile_name#"${profile_name%%[![:space:]]*}"}"
+    profile_name="${profile_name%"${profile_name##*[![:space:]]}"}"
+    if [ -z "$profile_name" ]; then
+      continue
+    fi
+    compare_job_name=""
+    if [ -n "$JOB_NAME" ]; then
+      compare_job_name="${JOB_NAME}-${profile_name}"
+    fi
+    run_one "$profile_name" "$compare_job_name"
+  done
+else
+  run_one "$PROFILE" "$JOB_NAME"
+fi

--- a/terminal-bench-smoke/terminal-bench-sample-runs.json
+++ b/terminal-bench-smoke/terminal-bench-sample-runs.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "description": "Structured Terminal-Bench sample run profiles for the local Harbor smoke harness.",
+  "defaults": {
+    "jobsDir": "terminal-bench-smoke/jobs",
+    "generatedConfigDir": "terminal-bench-smoke/generated-configs",
+    "dataset": {
+      "name": "terminal-bench-sample",
+      "version": "2.0"
+    },
+    "taskPattern": "*sqlite-with-gcov",
+    "nAttempts": 1,
+    "nConcurrentTrials": 1,
+    "timeoutMultiplier": 1.0,
+    "retryMaxRetries": 0,
+    "modelExtraInstructionPaths": [
+      "terminal-bench-smoke/prompts/self-check-cleanup.md"
+    ]
+  },
+  "profiles": {
+    "maka-basic": {
+      "description": "Maka Harbor bridge against terminal-bench-sample, matching the successful sqlite-with-gcov DeepSeek V4 Pro sample run shape.",
+      "agentTimeoutMultiplier": 4.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "0",
+          "MAKA_HARBOR_AUTONOMOUS": "0",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "80",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+        }
+      }
+    },
+    "maka-heavy": {
+      "description": "Maka task-run heavy-task bridge for public sample trace/evidence experiments.",
+      "agentTimeoutMultiplier": 8.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "1",
+          "MAKA_HARBOR_AUTONOMOUS": "0",
+          "MAKA_HEAVY_TASK_MODE": "1",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "100",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "7200"
+        }
+      }
+    },
+    "maka-heavy-prune": {
+      "description": "Maka heavy-task bridge with autonomous prior-attempt runtime replay and stale tool-result archive pruning enabled.",
+      "agentTimeoutMultiplier": 8.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "1",
+          "MAKA_HARBOR_AUTONOMOUS": "1",
+          "MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT": "1",
+          "MAKA_HEAVY_TASK_MODE": "1",
+          "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE": "on",
+          "MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS": "2048",
+          "MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL": "0",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "100",
+          "MAKA_AUTONOMOUS_MAX_ATTEMPTS": "3",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "7200"
+        }
+      }
+    },
+    "opencode": {
+      "description": "OpenCode Harbor wrapper against terminal-bench-sample for Maka/OpenCode comparison.",
+      "agentTimeoutMultiplier": 4.0,
+      "agent": {
+        "importPath": "opencode_title_harbor_agent:OpenCodeTitleAgent",
+        "modelName": "deepseek/deepseek-v4-pro",
+        "env": {}
+      }
+    },
+    "oracle": {
+      "description": "Harbor built-in oracle agent for cheap wrapper/dataset smoke tests.",
+      "agentTimeoutMultiplier": null,
+      "extraInstructionPaths": [],
+      "agent": {
+        "name": "oracle",
+        "env": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add opt-in active/current-turn tool-result pruning through the AI SDK `prepareStep` hook
- archive oversized same-turn tool results and replace them with source-bearing placeholders before the next model step
- wire Harbor env flags for active/stale prune, archive retrieval, and task-run archive storage
- allow autonomous Harbor retries to replay prior attempt runtime events so stale prune can operate on later attempts
- add a reusable `terminal-bench-smoke/` harness for Maka/OpenCode/oracle sample runs, heavy-task runs, active-prune profiles, live Maka trial status files, and self-check cleanup guidance

## Notes

This PR intentionally keeps the pruning mechanism scoped to individual oversized tool results. It does not yet implement same-turn whole-transcript high-water compaction; long single-turn tool loops can still accumulate many sub-threshold tool results. That should be a follow-up `prepareStep`-level transcript compact/checkpoint mechanism.

The Terminal-Bench harness commits only source-like files. Generated configs, jobs, venvs, caches, and ad hoc artifacts are ignored under `terminal-bench-smoke/.gitignore`.

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/runtime run test` (700 passed, 1 skipped)
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/headless run test` (446 passed)
- `bash -n terminal-bench-smoke/run-terminal-bench-sample.sh`
- `bash -n terminal-bench-smoke/run-terminal-bench-sample-heavy.sh`
- `python3 -m py_compile terminal-bench-smoke/maka_harbor_agent.py terminal-bench-smoke/opencode_title_harbor_agent.py`
- `node --check terminal-bench-smoke/maka_harbor_runner.mjs`
- `HARBOR_BIN=/usr/bin/true terminal-bench-smoke/run-terminal-bench-sample.sh --profile oracle --n-tasks 1 --job-name tb-sample-dryrun-oracle-pr316 --dry-run`
- `HARBOR_BIN=/usr/bin/true terminal-bench-smoke/run-terminal-bench-sample-heavy.sh --task '*sqlite-with-gcov' --job-name tb-sample-dryrun-heavy-pr316 --dry-run`
- `git diff --cached --check`
- `git diff --check upstream/main..HEAD`

## Benchmark Smoke Context

Validated locally on Harbor/Terminal-Bench follow-ups:

- `sqlite-with-gcov` with active prune threshold `2048`: reward `1.0`, no active archives because current tool results stayed below threshold
- `sqlite-with-gcov` with active prune threshold `512`: reward `1.0`, 16 active archives written
- `make-mips-interpreter` with GLM 5.2 and active prune threshold `2048`: active archives written for early large source/header observations; official reward was blocked by verifier dependency setup (`uv` download/`uvx`), while the agent self-check produced `/app/vm.js` and a 640x400 `/tmp/frame.bmp`
