### PR TITLE
fix(runtime): require archived active tool pruning

### DIFF
--- a/apps/desktop/src/main/tool-result-archive-artifacts.ts
+++ b/apps/desktop/src/main/tool-result-archive-artifacts.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { ArtifactStore } from '@maka/storage';
 import {
-  ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   type ToolResultArchiveReaderInput,
   type ToolResultArchiveReadResult,
   type ToolResultArchiveRecorderInput,
@@ -14,10 +13,11 @@ export async function persistArchivedToolResultToArtifacts(
   const id = stableToolResultArchiveArtifactId(event);
   const existing = await artifactStore.get(id);
   if (existing?.status === 'live') {
-    const read = await readArchivedToolResultFromArtifacts(artifactStore, {
-      ...event,
-      kind: ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    const read = await readArchivedToolResultArtifact(artifactStore, {
       artifactId: id,
+      sessionId: event.sessionId,
+      bodySha256: event.bodySha256,
+      originalBytes: event.originalBytes,
     });
     if (!read.ok) throw new Error(`tool result archive artifact id conflict: ${read.reason}`);
     return { artifactId: id };
@@ -40,6 +40,13 @@ export async function persistArchivedToolResultToArtifacts(
 export async function readArchivedToolResultFromArtifacts(
   artifactStore: Pick<ArtifactStore, 'get' | 'readText'>,
   event: ToolResultArchiveReaderInput,
+): Promise<ToolResultArchiveReadResult> {
+  return readArchivedToolResultArtifact(artifactStore, event);
+}
+
+async function readArchivedToolResultArtifact(
+  artifactStore: Pick<ArtifactStore, 'get' | 'readText'>,
+  event: Pick<ToolResultArchiveReaderInput, 'artifactId' | 'sessionId' | 'bodySha256' | 'originalBytes' | 'maxBytes'>,
 ): Promise<ToolResultArchiveReadResult> {
   const record = await artifactStore.get(event.artifactId);
   if (!record) return { ok: false, reason: 'not_found' };

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -214,6 +214,9 @@ export interface ContextBudgetDiagnostic {
   archiveWriteFailures?: number;
   unarchivedToolResults?: number;
   archivePlaceholderReasonCounts?: Record<string, number>;
+  activePrunedToolResults?: number;
+  activeArchiveFailures?: number;
+  activeEstimatedTokensSaved?: number;
   archiveRetrievalMode?: 'eager' | 'history_search_gated';
   archiveRetrievalEligibleTurns?: number;
   retrievedArchiveToolResults?: number;

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -421,14 +421,10 @@ export function buildHarborCellContextBudgetBackendOptions(
       env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS,
     );
     const minStepNumber = numericEnv(env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER);
-    const archiveRequiredRaw =
-      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_ARCHIVE_REQUIRED ??
-      env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_ARCHIVE_REQUIRED;
     contextBudget.activeToolResultPrune = {
       enabled: true,
       ...(maxCurrentResultEstimatedTokens !== undefined ? { maxCurrentResultEstimatedTokens } : {}),
       ...(minStepNumber !== undefined ? { minStepNumber } : {}),
-      ...(archiveRequiredRaw !== undefined ? { archiveRequired: booleanEnv(archiveRequiredRaw) } : {}),
     };
   }
 

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -24,7 +24,6 @@ describe('active current-turn tool-result pruning', () => {
         messages: originalMessages,
         policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
         stepNumber: 1,
-        sessionId: 'session-1',
         turnId: 'turn-1',
         charsPerToken: 1,
         archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
@@ -90,7 +89,6 @@ describe('active current-turn tool-result pruning', () => {
           messages: options.messages,
           policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
           stepNumber: options.stepNumber,
-          sessionId: 'session-1',
           turnId: 'turn-1',
           charsPerToken: 1,
           archivedPlaceholders,
@@ -126,7 +124,6 @@ describe('active current-turn tool-result pruning', () => {
       messages,
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => {
@@ -147,7 +144,6 @@ describe('active current-turn tool-result pruning', () => {
       messages,
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1, archiveRequired: false } as never,
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => undefined,
@@ -166,7 +162,6 @@ describe('active current-turn tool-result pruning', () => {
       messages,
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => ({ artifactId: '' }),
@@ -179,13 +174,72 @@ describe('active current-turn tool-result pruning', () => {
     assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
   });
 
+  test('blank archive artifact id keeps the original tool result', async () => {
+    const messages = [largeToolMessage('Read', 'tool-1', 'KEEP_ME'.repeat(20))];
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => ({ artifactId: '   ' }),
+    });
+
+    assert.equal(rewritten.rewritten, 0);
+    assert.equal(rewritten.archiveFailures, 1);
+    assert.deepEqual(rewritten.messages, messages);
+    assert.match(JSON.stringify(rewritten.messages), /KEEP_ME/);
+    assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
+  });
+
+  test('empty-artifact placeholders are not treated as idempotent', async () => {
+    const placeholder = invalidActivePlaceholder();
+    const messages: ModelMessage[] = [
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'tool-json',
+          toolName: 'Read',
+          output: { type: 'json', value: placeholder as never },
+        }],
+      },
+      {
+        role: 'tool',
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'tool-text',
+          toolName: 'Read',
+          output: { type: 'text', value: JSON.stringify(placeholder) },
+        }],
+      },
+    ];
+    const archivedToolCallIds: string[] = [];
+
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: (candidate) => {
+        archivedToolCallIds.push(candidate.toolCallId);
+        return { artifactId: `artifact-${candidate.toolCallId}` };
+      },
+    });
+
+    assert.equal(rewritten.rewritten, 2);
+    assert.deepEqual(archivedToolCallIds, ['tool-json', 'tool-text']);
+    assert.match(JSON.stringify(rewritten.messages), /artifact-tool-json/);
+    assert.match(JSON.stringify(rewritten.messages), /artifact-tool-text/);
+  });
+
   test('text placeholder output is idempotent across active prune passes', async () => {
     const messages = [largeTextToolMessage('Read', 'tool-1', 'SECRET'.repeat(20))];
     const first = await rewriteActiveToolResultsInMessages({
       messages,
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
@@ -194,7 +248,6 @@ describe('active current-turn tool-result pruning', () => {
       messages: first.messages,
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 2,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => {
@@ -213,7 +266,6 @@ describe('active current-turn tool-result pruning', () => {
       messages: [largeToolMessage('Read', 'tool-1', 'SECRET'.repeat(200))],
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
@@ -222,7 +274,6 @@ describe('active current-turn tool-result pruning', () => {
       messages: [largeToolMessage('Read', 'tool-2', 'KEEP_ME'.repeat(20))],
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       archiveToolResult: () => undefined,
@@ -246,7 +297,6 @@ describe('active current-turn tool-result pruning', () => {
       ],
       policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
       stepNumber: 1,
-      sessionId: 'session-1',
       turnId: 'turn-1',
       charsPerToken: 1,
       eligibleToolCallIds: new Set(['current-tool-call']),
@@ -303,7 +353,6 @@ describe('active current-turn tool-result pruning', () => {
         messages: options.messages,
         policy: { enabled: true, maxCurrentResultEstimatedTokens: 1024 },
         stepNumber: options.stepNumber,
-        sessionId: 'session-1',
         turnId: 'turn-1',
         archiveToolResult: () => ({ artifactId: 'unused' }),
       });
@@ -347,6 +396,21 @@ function largeTextToolMessage(toolName: string, toolCallId: string, body: string
       toolName,
       output: { type: 'text', value: body },
     }],
+  };
+}
+
+function invalidActivePlaceholder(): Record<string, unknown> {
+  return {
+    kind: 'maka.active_archived_tool_result',
+    rewriteVersion: 1,
+    artifactId: '',
+    turnId: 'turn-1',
+    toolCallId: 'tool-old',
+    toolName: 'Read',
+    bodySha256: 'a'.repeat(64),
+    originalEstimatedTokens: 100,
+    originalBytes: 400,
+    reason: 'active_current_turn_tool_result_pruned_before_next_step',
   };
 }
 

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -141,6 +141,100 @@ describe('active current-turn tool-result pruning', () => {
     assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
   });
 
+  test('archiveRequired false still keeps original when no archive artifact is written', async () => {
+    const messages = [largeToolMessage('Read', 'tool-1', 'KEEP_ME'.repeat(20))];
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1, archiveRequired: false } as never,
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => undefined,
+    });
+
+    assert.equal(rewritten.rewritten, 0);
+    assert.equal(rewritten.archiveFailures, 1);
+    assert.deepEqual(rewritten.messages, messages);
+    assert.match(JSON.stringify(rewritten.messages), /KEEP_ME/);
+    assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
+  });
+
+  test('empty archive artifact id keeps the original tool result', async () => {
+    const messages = [largeToolMessage('Read', 'tool-1', 'KEEP_ME'.repeat(20))];
+    const rewritten = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => ({ artifactId: '' }),
+    });
+
+    assert.equal(rewritten.rewritten, 0);
+    assert.equal(rewritten.archiveFailures, 1);
+    assert.deepEqual(rewritten.messages, messages);
+    assert.match(JSON.stringify(rewritten.messages), /KEEP_ME/);
+    assert.doesNotMatch(JSON.stringify(rewritten.messages), /maka\.active_archived_tool_result/);
+  });
+
+  test('text placeholder output is idempotent across active prune passes', async () => {
+    const messages = [largeTextToolMessage('Read', 'tool-1', 'SECRET'.repeat(20))];
+    const first = await rewriteActiveToolResultsInMessages({
+      messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
+    });
+    const second = await rewriteActiveToolResultsInMessages({
+      messages: first.messages,
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 2,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => {
+        throw new Error('should not re-archive placeholder text');
+      },
+    });
+
+    assert.equal(first.rewritten, 1);
+    assert.equal(second.rewritten, 0);
+    assert.equal(second.archiveFailures, 0);
+    assert.deepEqual(second.messages, first.messages);
+  });
+
+  test('returns active prune diagnostics for rewritten and failed archives', async () => {
+    const success = await rewriteActiveToolResultsInMessages({
+      messages: [largeToolMessage('Read', 'tool-1', 'SECRET'.repeat(200))],
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => ({ artifactId: 'artifact-tool-1' }),
+    });
+    const failure = await rewriteActiveToolResultsInMessages({
+      messages: [largeToolMessage('Read', 'tool-2', 'KEEP_ME'.repeat(20))],
+      policy: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      stepNumber: 1,
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      charsPerToken: 1,
+      archiveToolResult: () => undefined,
+    });
+
+    assert.equal(success.diagnosticPatch.activePrunedToolResults, 1);
+    assert.equal(success.diagnosticPatch.activeArchiveFailures, undefined);
+    assert.ok((success.diagnosticPatch.activeEstimatedTokensSaved ?? 0) > 0);
+    assert.equal(failure.diagnosticPatch.activePrunedToolResults, undefined);
+    assert.equal(failure.diagnosticPatch.activeArchiveFailures, 1);
+  });
+
   test('eligible tool-call ids keep prior replay tool results untouched', async () => {
     const priorBody = 'PRIOR_REPLAY_RESULT_SHOULD_STAY_FULL'.repeat(20);
     const currentBody = 'CURRENT_STEP_RESULT_SHOULD_BE_ARCHIVED'.repeat(20);
@@ -240,6 +334,18 @@ function largeToolMessage(toolName: string, toolCallId: string, body: string): M
       toolCallId,
       toolName,
       output: { type: 'json', value: { body } },
+    }],
+  };
+}
+
+function largeTextToolMessage(toolName: string, toolCallId: string, body: string): ModelMessage {
+  return {
+    role: 'tool',
+    content: [{
+      type: 'tool-result',
+      toolCallId,
+      toolName,
+      output: { type: 'text', value: body },
     }],
   };
 }

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1716,6 +1716,71 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(llmRecords[0]?.rawFinishReason, 'stop');
   });
 
+  test('records active tool-result prune diagnostics in usage telemetry', async () => {
+    const llmRecords: LlmCallRecord[] = [];
+    const largeBody = 'SECRET_PAYLOAD_SHOULD_BE_ARCHIVED'.repeat(200);
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV3StreamPart[] = streamCalls === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: 'tool-1',
+                toolName: 'Read',
+                input: JSON.stringify({ path: 'notes.md' }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+              },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } } },
+            ];
+        return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [{
+        name: 'Read',
+        description: 'Read description',
+        parameters: z.object({ path: z.string() }),
+        permissionRequired: false,
+        impl: async () => ({ body: largeBody }),
+      }],
+      contextBudget: {
+        activeToolResultPrune: { enabled: true, maxCurrentResultEstimatedTokens: 1 },
+      },
+      archiveToolResult: async () => ({ artifactId: 'artifact-tool-1' }),
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordLlmCall: (record) => {
+        llmRecords.push(record);
+      },
+    });
+
+    await drain(backend.send({ turnId: 'turn-1', text: 'hi', context: [] }));
+
+    const contextBudget = llmRecords[0]?.contextBudget as Record<string, unknown> | undefined;
+    assert.equal(streamCalls, 2);
+    assert.equal(contextBudget?.activePrunedToolResults, 1);
+    assert.equal(contextBudget?.activeArchiveFailures, undefined);
+    assert.ok((contextBudget?.activeEstimatedTokensSaved as number | undefined ?? 0) > 0);
+  });
+
   test('normalizes cache and reasoning tokens to messages, events, and telemetry', async () => {
     const messages: unknown[] = [];
     const events: SessionEvent[] = [];

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1717,6 +1717,8 @@ describe('AiSdkBackend usage telemetry', () => {
   });
 
   test('records active tool-result prune diagnostics in usage telemetry', async () => {
+    const messages: unknown[] = [];
+    const events: SessionEvent[] = [];
     const llmRecords: LlmCallRecord[] = [];
     const largeBody = 'SECRET_PAYLOAD_SHOULD_BE_ARCHIVED'.repeat(200);
     let streamCalls = 0;
@@ -1748,7 +1750,9 @@ describe('AiSdkBackend usage telemetry', () => {
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
-      appendMessage: async () => {},
+      appendMessage: async (message) => {
+        messages.push(message);
+      },
       connection: connection(),
       apiKey: 'sk-test',
       modelId: 'mock-model-id',
@@ -1772,13 +1776,23 @@ describe('AiSdkBackend usage telemetry', () => {
       },
     });
 
-    await drain(backend.send({ turnId: 'turn-1', text: 'hi', context: [] }));
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
 
-    const contextBudget = llmRecords[0]?.contextBudget as Record<string, unknown> | undefined;
+    const usageMessage = messages.find((message) =>
+      (message as { type?: string }).type === 'token_usage'
+    ) as { contextBudget?: Record<string, unknown> } | undefined;
+    const usageEvent = events.find((event) => event.type === 'token_usage') as
+      | (Extract<SessionEvent, { type: 'token_usage' }> & { contextBudget?: Record<string, unknown> })
+      | undefined;
+    const recordContextBudget = llmRecords[0]?.contextBudget as Record<string, unknown> | undefined;
     assert.equal(streamCalls, 2);
-    assert.equal(contextBudget?.activePrunedToolResults, 1);
-    assert.equal(contextBudget?.activeArchiveFailures, undefined);
-    assert.ok((contextBudget?.activeEstimatedTokensSaved as number | undefined ?? 0) > 0);
+    for (const contextBudget of [usageMessage?.contextBudget, usageEvent?.contextBudget, recordContextBudget]) {
+      assert.equal(contextBudget?.activePrunedToolResults, 1);
+      assert.equal(contextBudget?.activeArchiveFailures, undefined);
+      assert.ok((contextBudget?.activeEstimatedTokensSaved as number | undefined ?? 0) > 0);
+    }
   });
 
   test('normalizes cache and reasoning tokens to messages, events, and telemetry', async () => {

--- a/packages/runtime/src/active-tool-result-prune.ts
+++ b/packages/runtime/src/active-tool-result-prune.ts
@@ -36,6 +36,13 @@ export interface ActiveToolResultPruneResult {
   messages: ModelMessage[];
   rewritten: number;
   archiveFailures: number;
+  diagnosticPatch: ActiveToolResultPruneDiagnosticPatch;
+}
+
+export interface ActiveToolResultPruneDiagnosticPatch {
+  activePrunedToolResults?: number;
+  activeArchiveFailures?: number;
+  activeEstimatedTokensSaved?: number;
 }
 
 type ToolResultPartish = {
@@ -49,7 +56,7 @@ type ToolResultPartish = {
 
 type Replacement =
   | { changed: false; archiveFailure?: boolean }
-  | { changed: true; part: ToolResultPartish };
+  | { changed: true; part: ToolResultPartish; estimatedTokensSaved: number };
 
 export async function rewriteActiveToolResultsInMessages(
   input: ActiveToolResultPruneInput,
@@ -57,18 +64,18 @@ export async function rewriteActiveToolResultsInMessages(
   const policy = input.policy;
   const minStepNumber = Math.max(0, Math.floor(policy?.minStepNumber ?? 1));
   if (policy?.enabled !== true || input.stepNumber < minStepNumber) {
-    return { messages: [...input.messages], rewritten: 0, archiveFailures: 0 };
+    return { messages: [...input.messages], rewritten: 0, archiveFailures: 0, diagnosticPatch: {} };
   }
 
   const maxResultEstimatedTokens =
     finitePositive(policy.maxCurrentResultEstimatedTokens)
     ?? DEFAULT_MAX_CURRENT_RESULT_ESTIMATED_TOKENS;
-  const archiveRequired = policy.archiveRequired !== false;
   const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
   const archivedPlaceholders = input.archivedPlaceholders ?? new Map<string, ActiveArchivedToolResultPlaceholder>();
 
   let rewritten = 0;
   let archiveFailures = 0;
+  let activeEstimatedTokensSaved = 0;
   let anyChanged = false;
   const nextMessages: ModelMessage[] = [];
 
@@ -93,7 +100,6 @@ export async function rewriteActiveToolResultsInMessages(
         turnId: input.turnId,
         charsPerToken,
         maxResultEstimatedTokens,
-        archiveRequired,
         eligibleToolCallIds: input.eligibleToolCallIds,
         archiveToolResult: input.archiveToolResult,
         archivedPlaceholders,
@@ -101,6 +107,7 @@ export async function rewriteActiveToolResultsInMessages(
 
       if (replacement.changed) {
         rewritten += 1;
+        activeEstimatedTokensSaved += replacement.estimatedTokensSaved;
         anyChanged = true;
         if (!nextContent) nextContent = originalContent.slice(0, index);
         nextContent.push(replacement.part);
@@ -121,6 +128,11 @@ export async function rewriteActiveToolResultsInMessages(
     messages: anyChanged ? nextMessages : [...input.messages],
     rewritten,
     archiveFailures,
+    diagnosticPatch: {
+      ...(rewritten > 0 ? { activePrunedToolResults: rewritten } : {}),
+      ...(archiveFailures > 0 ? { activeArchiveFailures: archiveFailures } : {}),
+      ...(activeEstimatedTokensSaved > 0 ? { activeEstimatedTokensSaved } : {}),
+    },
   };
 }
 
@@ -130,7 +142,6 @@ async function rewriteToolResultPart(input: {
   turnId: string;
   charsPerToken: number;
   maxResultEstimatedTokens: number;
-  archiveRequired: boolean;
   eligibleToolCallIds?: ReadonlySet<string>;
   archiveToolResult?: ActiveToolResultPruneInput['archiveToolResult'];
   archivedPlaceholders: Map<string, ActiveArchivedToolResultPlaceholder>;
@@ -145,6 +156,9 @@ async function rewriteToolResultPart(input: {
   const payload = extractPayload(input.part);
   if (!payload) return { changed: false };
   if (isActiveArchivedToolResultPlaceholder(payload.value)) return { changed: false };
+  if (typeof payload.value === 'string' && isActiveArchivedToolResultPlaceholderText(payload.value)) {
+    return { changed: false };
+  }
 
   const serializedResult = serializeToolResultForArchive(payload.value);
   const originalEstimatedTokens = estimateTokens(serializedResult.length, input.charsPerToken);
@@ -174,13 +188,13 @@ async function rewriteToolResultPart(input: {
     } catch {
       archived = undefined;
     }
-    if (!archived?.artifactId && input.archiveRequired) {
+    if (!isNonEmptyString(archived?.artifactId)) {
       return { changed: false, archiveFailure: true };
     }
     placeholder = {
       kind: ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
       rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
-      artifactId: archived?.artifactId ?? '',
+      artifactId: archived.artifactId,
       turnId: input.turnId,
       toolCallId: input.part.toolCallId,
       toolName: input.part.toolName,
@@ -192,9 +206,16 @@ async function rewriteToolResultPart(input: {
     input.archivedPlaceholders.set(cacheKey, placeholder);
   }
 
+  const placeholderText = payload.field === 'output'
+    && (payload.outputKind === 'text' || payload.outputKind === 'error-text')
+    ? activePlaceholderText(placeholder)
+    : serializeToolResultForArchive(placeholder);
+  const placeholderEstimatedTokens = estimateTokens(placeholderText.length, input.charsPerToken);
+
   return {
     changed: true,
     part: replacePayload(input.part, payload, placeholder),
+    estimatedTokensSaved: Math.max(0, originalEstimatedTokens - placeholderEstimatedTokens),
   };
 }
 
@@ -276,6 +297,18 @@ function isToolResultPartish(value: unknown): value is ToolResultPartish {
 
 function activePlaceholderText(placeholder: ActiveArchivedToolResultPlaceholder): string {
   return JSON.stringify(placeholder);
+}
+
+function isActiveArchivedToolResultPlaceholderText(value: string): boolean {
+  try {
+    return isActiveArchivedToolResultPlaceholder(JSON.parse(value));
+  } catch {
+    return false;
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }
 
 function utf8ByteLength(value: string): number {

--- a/packages/runtime/src/active-tool-result-prune.ts
+++ b/packages/runtime/src/active-tool-result-prune.ts
@@ -22,7 +22,6 @@ export interface ActiveToolResultPruneInput {
   messages: readonly ModelMessage[];
   policy: ActiveToolResultPrunePolicy | undefined;
   stepNumber: number;
-  sessionId: string;
   turnId: string;
   charsPerToken?: number;
   eligibleToolCallIds?: ReadonlySet<string>;
@@ -188,7 +187,7 @@ async function rewriteToolResultPart(input: {
     } catch {
       archived = undefined;
     }
-    if (!isNonEmptyString(archived?.artifactId)) {
+    if (!isUsableArtifactId(archived?.artifactId)) {
       return { changed: false, archiveFailure: true };
     }
     placeholder = {
@@ -274,6 +273,7 @@ export function isActiveArchivedToolResultPlaceholder(
   return candidate.kind === ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND
     && candidate.rewriteVersion === ARCHIVED_TOOL_RESULT_REWRITE_VERSION
     && typeof candidate.artifactId === 'string'
+    && isUsableArtifactId(candidate.artifactId)
     && typeof candidate.turnId === 'string'
     && candidate.turnId.length > 0
     && typeof candidate.toolCallId === 'string'
@@ -307,8 +307,8 @@ function isActiveArchivedToolResultPlaceholderText(value: string): boolean {
   }
 }
 
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0;
+function isUsableArtifactId(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 function utf8ByteLength(value: string): number {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -89,7 +89,10 @@ import {
   type PrepareStepResultLike,
   type RepairableAiSdkToolCall,
 } from './model-adapter.js';
-import { rewriteActiveToolResultsInMessages } from './active-tool-result-prune.js';
+import {
+  rewriteActiveToolResultsInMessages,
+  type ActiveToolResultPruneDiagnosticPatch,
+} from './active-tool-result-prune.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import { computeCost } from './telemetry/cost.js';
@@ -547,9 +550,15 @@ export class AiSdkBackend implements AgentBackend {
       (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
     );
     const providerTools = plan.providerTools;
+    let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};
     const prepareStep = composePrepareStep(
       plan.prepareStep,
-      this.buildActiveToolResultPrunePrepareStep(turnId),
+      this.buildActiveToolResultPrunePrepareStep(turnId, (patch) => {
+        activeToolResultPruneDiagnosticPatch = mergeActiveToolResultPruneDiagnosticPatches(
+          activeToolResultPruneDiagnosticPatch,
+          patch,
+        );
+      }),
     );
     // Tool names the repair path matches a mis-cased call against — follows the
     // current step's snapshot so a group loaded mid-turn is repairable on the
@@ -895,6 +904,12 @@ export class AiSdkBackend implements AgentBackend {
       } finally {
         watchdog?.stop();
         if (this.currentWatchdog === watchdog) this.currentWatchdog = null;
+        if (hasActiveToolResultPruneDiagnosticPatch(activeToolResultPruneDiagnosticPatch)) {
+          contextBudgetForTelemetry = {
+            ...(contextBudgetForTelemetry ?? minimalContextBudgetDiagnostic()),
+            ...activeToolResultPruneDiagnosticPatch,
+          } as ContextBudgetDiagnostic;
+        }
         this.input.recordLlmCall?.({
           sessionId: this.sessionId,
           turnId,
@@ -1298,7 +1313,10 @@ export class AiSdkBackend implements AgentBackend {
     };
   }
 
-  private buildActiveToolResultPrunePrepareStep(turnId: string): PrepareStepFunctionLike | undefined {
+  private buildActiveToolResultPrunePrepareStep(
+    turnId: string,
+    onDiagnosticPatch?: (patch: ActiveToolResultPruneDiagnosticPatch) => void,
+  ): PrepareStepFunctionLike | undefined {
     const policy = this.input.contextBudget?.activeToolResultPrune;
     if (policy?.enabled !== true) return undefined;
 
@@ -1323,6 +1341,9 @@ export class AiSdkBackend implements AgentBackend {
           }));
         },
       });
+      if (hasActiveToolResultPruneDiagnosticPatch(rewritten.diagnosticPatch)) {
+        onDiagnosticPatch?.(rewritten.diagnosticPatch);
+      }
       return rewritten.rewritten > 0 ? { messages: rewritten.messages } : undefined;
     };
   }
@@ -1940,6 +1961,46 @@ function mergeContextBudgetDiagnosticPatches(
   if (!left) return right;
   if (!right) return left;
   return mergeContextBudgetDiagnostic(left as ContextBudgetDiagnostic, right);
+}
+
+function mergeActiveToolResultPruneDiagnosticPatches(
+  left: ActiveToolResultPruneDiagnosticPatch,
+  right: ActiveToolResultPruneDiagnosticPatch,
+): ActiveToolResultPruneDiagnosticPatch {
+  return {
+    ...sumOptionalCounts('activePrunedToolResults', left, right),
+    ...sumOptionalCounts('activeArchiveFailures', left, right),
+    ...sumOptionalCounts('activeEstimatedTokensSaved', left, right),
+  };
+}
+
+function sumOptionalCounts<K extends keyof ActiveToolResultPruneDiagnosticPatch>(
+  key: K,
+  left: ActiveToolResultPruneDiagnosticPatch,
+  right: ActiveToolResultPruneDiagnosticPatch,
+): Pick<ActiveToolResultPruneDiagnosticPatch, K> | Record<string, never> {
+  const total = (left[key] ?? 0) + (right[key] ?? 0);
+  return total > 0 ? { [key]: total } as Pick<ActiveToolResultPruneDiagnosticPatch, K> : {};
+}
+
+function hasActiveToolResultPruneDiagnosticPatch(
+  patch: ActiveToolResultPruneDiagnosticPatch,
+): boolean {
+  return (patch.activePrunedToolResults ?? 0) > 0
+    || (patch.activeArchiveFailures ?? 0) > 0
+    || (patch.activeEstimatedTokensSaved ?? 0) > 0;
+}
+
+function minimalContextBudgetDiagnostic(): ContextBudgetDiagnostic {
+  return {
+    enabled: true,
+    estimatedTokensBefore: 0,
+    estimatedTokensAfter: 0,
+    keptTurns: 0,
+    droppedTurns: 0,
+    keptEvents: 0,
+    droppedEvents: 0,
+  };
 }
 
 function mergeCountRecords(

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -804,6 +804,10 @@ export class AiSdkBackend implements AgentBackend {
                 ? { toolAvailability: turnDiagnostics.requestShape.toolAvailability }
                 : {}),
             });
+            const contextBudgetForUsage = contextBudgetWithActiveToolResultPruneDiagnostics(
+              contextBudgetForTelemetry,
+              activeToolResultPruneDiagnosticPatch,
+            );
             const tu: TokenUsageMessage = {
               type: 'token_usage',
               id: this.newId(),
@@ -827,7 +831,7 @@ export class AiSdkBackend implements AgentBackend {
               requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
               requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
               promptSegments: turnDiagnostics.promptSegments,
-              ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
+              ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
             };
             await this.input.appendMessage(tu).catch(() => {});
             queue.push({
@@ -853,7 +857,7 @@ export class AiSdkBackend implements AgentBackend {
               requestShapeHash: turnDiagnostics.requestShape.requestShapeHash,
               requestShapeChangeReason: turnDiagnostics.requestShape.requestShapeChangeReason,
               promptSegments: turnDiagnostics.promptSegments,
-              ...(priorReplay.contextBudget ? { contextBudget: priorReplay.contextBudget } : {}),
+              ...(contextBudgetForUsage ? { contextBudget: contextBudgetForUsage } : {}),
             } satisfies TokenUsageEvent);
           }
         } catch {
@@ -904,12 +908,10 @@ export class AiSdkBackend implements AgentBackend {
       } finally {
         watchdog?.stop();
         if (this.currentWatchdog === watchdog) this.currentWatchdog = null;
-        if (hasActiveToolResultPruneDiagnosticPatch(activeToolResultPruneDiagnosticPatch)) {
-          contextBudgetForTelemetry = {
-            ...(contextBudgetForTelemetry ?? minimalContextBudgetDiagnostic()),
-            ...activeToolResultPruneDiagnosticPatch,
-          } as ContextBudgetDiagnostic;
-        }
+        contextBudgetForTelemetry = contextBudgetWithActiveToolResultPruneDiagnostics(
+          contextBudgetForTelemetry,
+          activeToolResultPruneDiagnosticPatch,
+        );
         this.input.recordLlmCall?.({
           sessionId: this.sessionId,
           turnId,
@@ -1328,7 +1330,6 @@ export class AiSdkBackend implements AgentBackend {
         messages: options.messages,
         policy,
         stepNumber: options.stepNumber,
-        sessionId: this.sessionId,
         turnId,
         charsPerToken: this.input.contextBudget?.charsPerToken,
         eligibleToolCallIds,
@@ -1989,6 +1990,17 @@ function hasActiveToolResultPruneDiagnosticPatch(
   return (patch.activePrunedToolResults ?? 0) > 0
     || (patch.activeArchiveFailures ?? 0) > 0
     || (patch.activeEstimatedTokensSaved ?? 0) > 0;
+}
+
+function contextBudgetWithActiveToolResultPruneDiagnostics(
+  base: ContextBudgetDiagnostic | undefined,
+  patch: ActiveToolResultPruneDiagnosticPatch,
+): ContextBudgetDiagnostic | undefined {
+  if (!hasActiveToolResultPruneDiagnosticPatch(patch)) return base;
+  return {
+    ...(base ?? minimalContextBudgetDiagnostic()),
+    ...patch,
+  } as ContextBudgetDiagnostic;
 }
 
 function minimalContextBudgetDiagnostic(): ContextBudgetDiagnostic {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -58,8 +58,6 @@ export interface ActiveToolResultPrunePolicy {
   maxCurrentResultEstimatedTokens?: number;
   /** Do not rewrite before this SDK step. Defaults to 1, so step 0 is untouched. */
   minStepNumber?: number;
-  /** Defaults to true: archive failure keeps the original payload. */
-  archiveRequired?: boolean;
 }
 
 export interface ArchiveRetrievalPolicy {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -151,6 +151,7 @@ export type { StreamWatchdogInput, StreamWatchdogPhase, StreamWatchdogTimeout } 
 export { getAIModel, buildProviderOptions } from './model-factory.js';
 export type { ModelFactoryInput as GetAIModelInput } from './model-factory.js';
 export {
+  ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventHistoryCompact,
@@ -204,6 +205,7 @@ export type {
   ToolResultArchiveReadResult,
   ToolResultArchiveRef,
   ArchivedToolResultPlaceholder,
+  ActiveArchivedToolResultPlaceholder,
   PromptSegmentInput,
 } from './context-budget.js';
 export { testConnection } from './test-connection.js';


### PR DESCRIPTION
## Summary

Require active/current-turn tool-result pruning to have a durable archive artifact before replacing provider-visible tool output.

## Why

PR #316 added active tool-result pruning, but the follow-up correctness path needed to fail closed when archive persistence is unavailable, keep text placeholders idempotent, surface active-prune diagnostics, and fix the desktop archive artifact type mismatch.

## Scope

Changed:

- Require non-empty archive artifact ids before active tool-result replacement.
- Remove the active `archiveRequired` policy/env override so archive failure always keeps the original payload.
- Detect active placeholder JSON inside text/error-text tool outputs to avoid re-pruning placeholders.
- Add active prune diagnostics to usage telemetry: `activePrunedToolResults`, `activeArchiveFailures`, `activeEstimatedTokensSaved`.
- Fix desktop artifact conflict checks so active archive writes do not need to masquerade as stale archive placeholders.
- Add regression coverage for archive throw/missing/empty cases, text idempotency, and telemetry diagnostics.

Not included:

- Aggregate current-turn high-water pruning.
- Current-turn pruning strategy/default changes.
- Historical stale prune behavior changes.

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/active-tool-result-prune.test.js packages/runtime/dist/__tests__/ai-sdk-backend.test.js`
- `npm --workspace @maka/headless run test`
- `npm --workspace @maka/desktop run build:main`

## User-facing impact

Active tool-result pruning now fails closed: if an archive cannot be written, the full tool result remains visible instead of being replaced with an unrecoverable placeholder. Diagnostics expose active prune activity in usage telemetry.

## Reviewer notes

This intentionally does not add an aggregate current-turn high-water cap; that remains a separate design discussion.
