### PR TITLE
feat(headless): wire RSI R2 attribution into prompt loop

### DIFF
--- a/packages/headless/src/__tests__/meta-agent-completion.test.ts
+++ b/packages/headless/src/__tests__/meta-agent-completion.test.ts
@@ -22,6 +22,7 @@ const connection: LlmConnection = {
 const base = { connection, apiKey: 'unused', modelId: 'deepseek-v4-flash' } as const;
 const candidateRationale = {
   failurePattern: 'coverage_regression',
+  evidenceRefs: [],
   hypothesis: 'coverage fell after the previous prompt change',
   targetedFix: 'keep the completion criteria explicit and conservative',
   predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -165,6 +165,66 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('projects prompt attribution before exposing it to the meta-agent or rendered prompt', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      const unsafePromptAttribution = {
+        candidateCommitSha: 'commit-secret',
+        predictedFixes: [{ taskId: 'task-a', outcome: 'improved' }],
+        riskTasks: [],
+        unexpectedHeldInFlips: [],
+        decision: { decision: 'discard', reason: 'held_out_regressed' },
+        decisionReason: 'coverage_regressed',
+        rootCauseSignalMatch: 'matched',
+      };
+
+      let seenInput: MetaAgentPromptInput | undefined;
+      await runPromptCandidateRound({
+        runId: 'run-1',
+        roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: ['task-a'],
+        heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+        promptAttribution: unsafePromptAttribution as unknown as MetaAgentPromptInput['promptAttribution'],
+        metaAgent: async (input): Promise<MetaAgentPromptResult> => {
+          seenInput = input;
+          return candidatePromptResult();
+        },
+        git: gitNoop(dir),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.ok(seenInput);
+      assert.deepEqual(seenInput.promptAttribution, {
+        predictedFixes: [{ taskId: 'task-a', outcome: 'improved' }],
+        riskTasks: [],
+        unexpectedHeldInFlips: [],
+        rootCauseSignalMatch: 'matched',
+      });
+
+      const rendered = renderMetaAgentPrompt(seenInput);
+      assert.equal(rendered.includes('commit-secret'), false);
+      assert.equal(rendered.includes('candidateCommitSha'), false);
+      assert.equal(rendered.includes('held_out_regressed'), false);
+      assert.equal(rendered.includes('coverage_regressed'), false);
+      assert.equal(rendered.includes('decisionReason'), false);
+      assert.equal(rendered.includes('"decision"'), false);
+      assert.match(rendered, /"predictedFixes"/);
+      assert.match(rendered, /"rootCauseSignalMatch"/);
+    });
+  });
+
   test('rejects meta-agent output without candidateRationale before writing or committing', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -97,6 +97,7 @@ describe('prompt candidate loop', () => {
           summary: 'tightened output instruction',
           promptHash: hashSystemPrompt('candidate prompt\n'),
           heldInTaskSetHash: expectedHeldInTaskSetHash(['task-a']),
+          heldInTaskIds: ['task-a'],
           candidateRationaleHash: expectedCandidateRationaleHash(committedCandidateRationale),
           candidateRationale: committedCandidateRationale,
         },
@@ -275,6 +276,49 @@ describe('prompt candidate loop', () => {
       validCandidateRationale({ riskTasks: ['held-out-secret'] }),
       /candidateRationale.riskTasks contains non-held-in task id: held-out-secret/,
     );
+  });
+
+  test('rejects candidateRationale evidence refs outside the current RSI analysis', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          runId: 'run-1',
+          roundId: 'round-1',
+          agentCwdPath: await testAgentCwd(dir),
+          programPath,
+          systemPromptPath,
+          resultsTsvPath,
+          resultsJsonlPath: join(dir, 'results.jsonl'),
+          heldInTaskIds: ['task-a'],
+          heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+          rsiAnalysis: {
+            heldInTaskSetHash: 'sha256:held-in',
+            transitionVsLastKept: [],
+            transitionVsPreviousCandidate: [],
+            coverageRegressionTaskIds: [],
+            errorClassDistribution: [],
+            toolFailureClusters: [],
+            signals: [{ id: 'rsi-sig:known', kind: 'coverage_regression', taskIds: ['task-a'] }],
+          },
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({ evidenceRefs: ['rsi-sig:unknown'] }),
+          }),
+          git: gitNoop(dir),
+          now: () => 100,
+          newId: idFactory(),
+        }),
+        /candidateRationale.evidenceRefs contains unknown analysis signal id: rsi-sig:unknown/,
+      );
+
+      assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
+    });
   });
 
   test('rejects unsafe or oversized candidateRationale text before writing', async () => {
@@ -1296,7 +1340,7 @@ describe('prompt candidate loop', () => {
     assert.match(prompt, /task-a/);
     assert.match(prompt, /original prompt/);
     assert.match(prompt, /candidateRationale/);
-    assert.equal(prompt.includes('evidenceRefs'), false);
+    assert.match(prompt, /evidenceRefs/);
 
     const metaAgent = createScriptedMetaAgent({
       complete: async ({ prompt: renderedPrompt }) => {
@@ -1798,6 +1842,7 @@ function candidatePromptResult(input: {
 function validCandidateRationale(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     failurePattern: 'coverage_regression',
+    evidenceRefs: [],
     hypothesis: 'coverage fell after the previous prompt change',
     targetedFix: 'keep the completion criteria explicit and conservative',
     predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -321,6 +321,68 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('requires evidence refs when current RSI analysis has signals for a typed failure pattern', async () => {
+    await withDir(async (dir) => {
+      const programPath = join(dir, 'program.md');
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsTsvPath = join(dir, 'results.tsv');
+      await writeFile(programPath, 'Improve the prompt conservatively.\n', 'utf8');
+      await writeFile(systemPromptPath, 'original prompt\n', 'utf8');
+      await writeFile(resultsTsvPath, 'task_id\tpassed\ntask-a\tfalse\n', 'utf8');
+
+      const baseInput = {
+        runId: 'run-1',
+        roundId: 'round-1',
+        agentCwdPath: await testAgentCwd(dir),
+        programPath,
+        systemPromptPath,
+        resultsTsvPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        heldInTaskIds: ['task-a'],
+        heldInDigests: [{ taskId: 'task-a', summary: 'failed held-in task' }],
+        git: gitNoop(dir),
+        now: () => 100,
+        newId: idFactory(),
+      };
+
+      await assert.rejects(
+        runPromptCandidateRound({
+          ...baseInput,
+          rsiAnalysis: {
+            heldInTaskSetHash: 'sha256:held-in',
+            transitionVsLastKept: [],
+            transitionVsPreviousCandidate: [],
+            coverageRegressionTaskIds: [],
+            errorClassDistribution: [],
+            toolFailureClusters: [],
+            signals: [{ id: 'rsi-sig:known', kind: 'coverage_regression', taskIds: ['task-a'] }],
+          },
+          metaAgent: async () => candidatePromptResult({
+            candidateRationale: validCandidateRationale({ evidenceRefs: [] }),
+          }),
+        }),
+        /candidateRationale.evidenceRefs must cite at least one current analysis signal/,
+      );
+
+      await runPromptCandidateRound({
+        ...baseInput,
+        resultsJsonlPath: join(dir, 'allowed-empty-refs.jsonl'),
+        rsiAnalysis: {
+          heldInTaskSetHash: 'sha256:held-in',
+          transitionVsLastKept: [],
+          transitionVsPreviousCandidate: [],
+          coverageRegressionTaskIds: [],
+          errorClassDistribution: [],
+          toolFailureClusters: [],
+          signals: [],
+        },
+        metaAgent: async () => candidatePromptResult({
+          candidateRationale: validCandidateRationale({ evidenceRefs: [] }),
+        }),
+      });
+    });
+  });
+
   test('rejects unsafe or oversized candidateRationale text before writing', async () => {
     await assertRejectsCandidateRationale(
       validCandidateRationale({ hypothesis: 'held-out regressed after reading tests/test.sh' }),

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -176,9 +176,11 @@ describe('prompt candidate loop', () => {
 
       const unsafePromptAttribution = {
         candidateCommitSha: 'commit-secret',
-        predictedFixes: [{ taskId: 'task-a', outcome: 'improved' }],
-        riskTasks: [],
-        unexpectedHeldInFlips: [],
+        predictedFixes: [{ taskId: 'task-a', outcome: 'improved', candidateCommitSha: 'nested-commit-secret' }],
+        riskTasks: [{ taskId: 'task-a', outcome: 'safe', threshold: 'nested-threshold-secret' }],
+        unexpectedHeldInFlips: [
+          { taskId: 'task-a', from: 'fail', to: 'pass', heldOutMetric: 'nested-held-out-secret' },
+        ],
         decision: { decision: 'discard', reason: 'held_out_regressed' },
         decisionReason: 'coverage_regressed',
         rootCauseSignalMatch: 'matched',
@@ -208,8 +210,8 @@ describe('prompt candidate loop', () => {
       assert.ok(seenInput);
       assert.deepEqual(seenInput.promptAttribution, {
         predictedFixes: [{ taskId: 'task-a', outcome: 'improved' }],
-        riskTasks: [],
-        unexpectedHeldInFlips: [],
+        riskTasks: [{ taskId: 'task-a', outcome: 'safe' }],
+        unexpectedHeldInFlips: [{ taskId: 'task-a', from: 'fail', to: 'pass' }],
         rootCauseSignalMatch: 'matched',
       });
 
@@ -219,6 +221,11 @@ describe('prompt candidate loop', () => {
       assert.equal(rendered.includes('held_out_regressed'), false);
       assert.equal(rendered.includes('coverage_regressed'), false);
       assert.equal(rendered.includes('decisionReason'), false);
+      assert.equal(rendered.includes('nested-commit-secret'), false);
+      assert.equal(rendered.includes('nested-threshold-secret'), false);
+      assert.equal(rendered.includes('nested-held-out-secret'), false);
+      assert.equal(rendered.includes('heldOutMetric'), false);
+      assert.equal(rendered.includes('threshold'), false);
       assert.equal(rendered.includes('"decision"'), false);
       assert.match(rendered, /"predictedFixes"/);
       assert.match(rendered, /"rootCauseSignalMatch"/);

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -5,8 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
-import { hashSystemPrompt, type HarborTaskRunInput, type HarborTaskRunOutput } from '../fixed-prompt-controller.js';
-import { createCliPromptCandidateGit, type MetaAgent } from '../prompt-candidate-loop.js';
+import { hashSystemPrompt, readFixedPromptWal, type HarborTaskRunInput, type HarborTaskRunOutput } from '../fixed-prompt-controller.js';
+import { createCliPromptCandidateGit, type MetaAgent, type MetaAgentPromptInput } from '../prompt-candidate-loop.js';
 import { runPromptOptimizationLoop, type PromptOptimizationLoopInput } from '../prompt-optimization-loop.js';
 import type { Config } from '../contracts.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
@@ -59,6 +59,67 @@ describe('runPromptOptimizationLoop', () => {
       assert.equal(result.smoke.quarantineCount, 0);
       assert.equal(result.smoke.taskEvents.infraFailed, 0);
       assert.equal(result.smoke.taskEvents.plumbingFailed, 0);
+    });
+  });
+
+  test('persists attribution and feeds held-in-only R2 feedback into the next prompt', async () => {
+    await withHarness(async (harness) => {
+      const promptInputs: MetaAgentPromptInput[] = [];
+      const heldInTasks = makeTasks('hin', 2);
+      const heldOutTasks = makeTasks('hout', 1);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        if (roundId.startsWith('baseline-')) return taskIndex(taskId) === 0 ? 1 : 0;
+        return roundId === 'round-0' ? 0 : taskIndex(taskId) === 0 ? 1 : 0;
+      };
+
+      await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        metaAgent: async (promptInput) => {
+          promptInputs.push(promptInput);
+          return {
+            systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
+            summary: `tuned for ${promptInput.roundId}`,
+            candidateRationale: {
+              failurePattern: 'coverage_regression',
+              hypothesis: 'avoid losing held-in scored artifacts',
+              targetedFix: 'state artifact completion constraints plainly',
+              predictedFixes: ['hin-1'],
+              riskTasks: ['hin-0'],
+            },
+          };
+        },
+      });
+
+      assert.equal(promptInputs.length, 2);
+      assert.ok(promptInputs[0]?.rsiAnalysis);
+      assert.equal(promptInputs[0]?.promptAttribution, undefined);
+      assert.ok(promptInputs[1]?.rsiAnalysis);
+      assert.deepEqual(promptInputs[1]?.promptAttribution?.predictedFixes, [
+        { taskId: 'hin-1', outcome: 'unchanged' },
+      ]);
+      assert.deepEqual(promptInputs[1]?.promptAttribution?.riskTasks, [
+        { taskId: 'hin-0', outcome: 'regressed' },
+      ]);
+      assert.equal(JSON.stringify(promptInputs[1]?.promptAttribution).includes('hout-'), false);
+      assert.equal(JSON.stringify(promptInputs[1]?.promptAttribution).includes('held_out'), false);
+
+      const events = await readFixedPromptWal(harness.resultsJsonlPath);
+      assert.equal(events.filter((event) => event.type === 'rsi_controller_attribution').length, 2);
+      for (const decision of events.filter((event) => event.type === 'prompt_candidate_decided')) {
+        const decisionIndex = events.indexOf(decision);
+        const attributionIndex = events.findIndex((event) => (
+          event.type === 'rsi_controller_attribution'
+          && event.runId === decision.runId
+          && event.roundId === decision.roundId
+          && event.candidateCommitSha === decision.candidateCommitSha
+        ));
+        assert.ok(attributionIndex > decisionIndex);
+      }
     });
   });
 
@@ -450,6 +511,7 @@ interface RunLoopOptions {
   /** Per-task baseline duration (ms); defaults to 10. Exercises the too-slow cap. */
   durationMsFor?: (roundId: string, taskId: string) => number;
   onTaskRun?: (roundId: string, taskId: string) => void;
+  metaAgent?: MetaAgent;
 }
 
 async function runLoop(harness: Harness, options: RunLoopOptions) {
@@ -472,7 +534,7 @@ async function runLoop(harness: Harness, options: RunLoopOptions) {
     heldOutTasks: options.heldOutTasks,
     config: CONFIG,
     harborRunner: fakeHarborRunner(harness.eventsDir, options.rewardFor, options.shouldFail, options.durationMsFor, options.onTaskRun),
-    metaAgent: fakeMetaAgent(),
+    metaAgent: options.metaAgent ?? fakeMetaAgent(),
     git: createCliPromptCandidateGit({ cwd: harness.repoDir, systemPromptPath: harness.systemPromptPath }),
     originalCommitSha: harness.originalCommitSha,
     rewardHackVerifierPatternsByTaskId,

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -125,6 +125,54 @@ describe('runPromptOptimizationLoop', () => {
     });
   });
 
+  test('matches attribution root cause against prompt-time analysis after coverage signal is fixed', async () => {
+    await withHarness(async (harness) => {
+      const promptInputs: MetaAgentPromptInput[] = [];
+      const heldInTasks = makeTasks('hin', 2);
+      const heldOutTasks = makeTasks('hout', 1);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        if (roundId.startsWith('baseline-')) return 1;
+        return roundId === 'round-0' && taskId === 'hin-0' ? 0 : 1;
+      };
+
+      await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        shouldFail: (roundId, taskId) => roundId === 'round-0' && taskId === 'hin-0',
+        metaAgent: async (promptInput) => {
+          promptInputs.push(promptInput);
+          return {
+            systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
+            summary: `tuned for ${promptInput.roundId}`,
+            candidateRationale: {
+              failurePattern: 'coverage_regression',
+              evidenceRefs: evidenceRefsFor(promptInput),
+              hypothesis: 'restore coverage for held-in tasks',
+              targetedFix: 'make artifact completion constraints explicit',
+              predictedFixes: ['hin-0'],
+              riskTasks: [],
+            },
+          };
+        },
+      });
+
+      const promptTimeCoverageSignal = promptInputs[1]?.rsiAnalysis?.signals.find((signal) => signal.kind === 'coverage_regression');
+      assert.ok(promptTimeCoverageSignal);
+      const events = await readFixedPromptWal(harness.resultsJsonlPath);
+      const secondAttribution = events.find((event) => event.type === 'rsi_controller_attribution' && event.roundId === 'round-1');
+      assert.equal(secondAttribution?.type, 'rsi_controller_attribution');
+      if (secondAttribution?.type === 'rsi_controller_attribution') {
+        assert.deepEqual(secondAttribution.evidenceRefs, [promptTimeCoverageSignal.id]);
+        assert.deepEqual(secondAttribution.predictedFixes, [{ taskId: 'hin-0', outcome: 'unchanged' }]);
+        assert.equal(secondAttribution.rootCauseSignalMatch, 'matched');
+      }
+    });
+  });
+
   test('does not teach held-out coverage discard reasons to the next prompt', async () => {
     await withHarness(async (harness) => {
       const promptInputs: MetaAgentPromptInput[] = [];
@@ -611,8 +659,9 @@ function fakeMetaAgent(): MetaAgent {
 }
 
 function evidenceRefsFor(promptInput: MetaAgentPromptInput): string[] {
-  const firstSignal = promptInput.rsiAnalysis?.signals[0];
-  return firstSignal ? [firstSignal.id] : [];
+  const signal = promptInput.rsiAnalysis?.signals.find((item) => item.kind === 'coverage_regression')
+    ?? promptInput.rsiAnalysis?.signals[0];
+  return signal ? [signal.id] : [];
 }
 
 /** A Harbor runner that fabricates a completed, correctly-hashed cell per task

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -86,7 +86,7 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               failurePattern: 'coverage_regression',
-              evidenceRefs: [],
+              evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
               targetedFix: 'state artifact completion constraints plainly',
               predictedFixes: ['hin-1'],
@@ -150,7 +150,7 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               failurePattern: 'coverage_regression',
-              evidenceRefs: [],
+              evidenceRefs: evidenceRefsFor(promptInput),
               hypothesis: 'avoid losing held-in scored artifacts',
               targetedFix: 'state artifact completion constraints plainly',
               predictedFixes: ['hin-19'],
@@ -601,13 +601,18 @@ function fakeMetaAgent(): MetaAgent {
     summary: `tuned for ${promptInput.roundId}`,
     candidateRationale: {
       failurePattern: 'coverage_regression',
-      evidenceRefs: [],
+      evidenceRefs: evidenceRefsFor(promptInput),
       hypothesis: 'stable held-in coverage can improve with a clearer prompt',
       targetedFix: 'make the success criteria explicit without adding task-specific answers',
       predictedFixes: [],
       riskTasks: [],
     },
   });
+}
+
+function evidenceRefsFor(promptInput: MetaAgentPromptInput): string[] {
+  const firstSignal = promptInput.rsiAnalysis?.signals[0];
+  return firstSignal ? [firstSignal.id] : [];
 }
 
 /** A Harbor runner that fabricates a completed, correctly-hashed cell per task

--- a/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop.test.ts
@@ -86,6 +86,7 @@ describe('runPromptOptimizationLoop', () => {
             summary: `tuned for ${promptInput.roundId}`,
             candidateRationale: {
               failurePattern: 'coverage_regression',
+              evidenceRefs: [],
               hypothesis: 'avoid losing held-in scored artifacts',
               targetedFix: 'state artifact completion constraints plainly',
               predictedFixes: ['hin-1'],
@@ -105,6 +106,7 @@ describe('runPromptOptimizationLoop', () => {
       assert.deepEqual(promptInputs[1]?.promptAttribution?.riskTasks, [
         { taskId: 'hin-0', outcome: 'regressed' },
       ]);
+      assert.equal('decisionReason' in (promptInputs[1]?.promptAttribution ?? {}), false);
       assert.equal(JSON.stringify(promptInputs[1]?.promptAttribution).includes('hout-'), false);
       assert.equal(JSON.stringify(promptInputs[1]?.promptAttribution).includes('held_out'), false);
 
@@ -120,6 +122,50 @@ describe('runPromptOptimizationLoop', () => {
         ));
         assert.ok(attributionIndex > decisionIndex);
       }
+    });
+  });
+
+  test('does not teach held-out coverage discard reasons to the next prompt', async () => {
+    await withHarness(async (harness) => {
+      const promptInputs: MetaAgentPromptInput[] = [];
+      const heldInTasks = makeTasks('hin', 20);
+      const heldOutTasks = makeTasks('hout', 2);
+      const rewardFor = (roundId: string, taskId: string): number => {
+        if (taskId.startsWith('hout-')) return 1;
+        if (roundId.startsWith('baseline-')) return taskIndex(taskId) < 10 ? 1 : 0;
+        return 1;
+      };
+
+      await runLoop(harness, {
+        heldInTasks,
+        heldOutTasks,
+        rewardFor,
+        rounds: 2,
+        baselineRuns: 2,
+        shouldFail: (roundId, taskId) => roundId === 'round-0' && taskId === 'hout-1',
+        metaAgent: async (promptInput) => {
+          promptInputs.push(promptInput);
+          return {
+            systemPrompt: `candidate prompt ${promptInput.roundId}\n`,
+            summary: `tuned for ${promptInput.roundId}`,
+            candidateRationale: {
+              failurePattern: 'coverage_regression',
+              evidenceRefs: [],
+              hypothesis: 'avoid losing held-in scored artifacts',
+              targetedFix: 'state artifact completion constraints plainly',
+              predictedFixes: ['hin-19'],
+              riskTasks: [],
+            },
+          };
+        },
+      });
+
+      assert.equal(promptInputs.length, 2);
+      const visible = JSON.stringify(promptInputs[1]?.promptAttribution);
+      assert.equal('decisionReason' in (promptInputs[1]?.promptAttribution ?? {}), false);
+      assert.equal(visible.includes('coverage_regressed'), false);
+      assert.equal(visible.includes('held_out'), false);
+      assert.equal(visible.includes('hout-'), false);
     });
   });
 
@@ -555,6 +601,7 @@ function fakeMetaAgent(): MetaAgent {
     summary: `tuned for ${promptInput.roundId}`,
     candidateRationale: {
       failurePattern: 'coverage_regression',
+      evidenceRefs: [],
       hypothesis: 'stable held-in coverage can improve with a clearer prompt',
       targetedFix: 'make the success criteria explicit without adding task-specific answers',
       predictedFixes: [],

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -459,6 +459,26 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(wrongOrderReport.roundsWithoutRsiAttribution, ['round-1']);
   });
 
+  test('fails R2 smoke when attribution is appended after the next candidate starts', () => {
+    const events = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      committedEvent('round-2'),
+      attributionEvent('round-1'),
+    ];
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['rsi_attribution_missing']);
+    assert.deepEqual(report.roundsWithoutRsiAttribution, ['round-1']);
+  });
+
   test('fails R2 smoke when attribution hashes or held-in task scope are invalid', () => {
     const hashMismatch = [
       committedEvent('round-1'),

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { FixedPromptWalEvent, PromptCandidateRewardHackScan } from '../fixed-prompt-controller.js';
+import type { FixedPromptWalEvent, PromptCandidateRationale, PromptCandidateRewardHackScan } from '../fixed-prompt-controller.js';
 import {
   promptStructuralSmokeReport,
   renderPromptStructuralSmokeMarkdown,
@@ -489,8 +489,76 @@ describe('prompt structural smoke report', () => {
     });
 
     assert.equal(taskScopeReport.status, 'fail');
-    assert.deepEqual(taskScopeReport.failures, ['rsi_attribution_task_scope_invalid']);
+    assert.deepEqual(taskScopeReport.failures, ['rsi_attribution_malformed', 'rsi_attribution_task_scope_invalid']);
     assert.deepEqual(taskScopeReport.roundsWithOutOfScopeRsiAttribution, ['round-1']);
+  });
+
+  test('fails R2 smoke when attribution disagrees with committed candidate rationale', () => {
+    const committedRationale = candidateRationale({
+      evidenceRefs: ['rsi-sig:coverage'],
+      predictedFixes: ['task-1'],
+      riskTasks: ['task-2'],
+    });
+
+    const evidenceMismatch = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['task-1', 'task-2'], committedRationale),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', {
+        evidenceRefs: ['rsi-sig:other'],
+        predictedFixes: [{ taskId: 'task-1', outcome: 'improved' }],
+        riskTasks: [{ taskId: 'task-2', outcome: 'safe' }],
+      }),
+    ];
+
+    const evidenceReport = promptStructuralSmokeReport({
+      events: evidenceMismatch,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(evidenceReport.status, 'fail');
+    assert.deepEqual(evidenceReport.failures, ['rsi_attribution_malformed']);
+    assert.deepEqual(evidenceReport.roundsWithMalformedRsiAttribution, ['round-1']);
+
+    const taskListMismatch = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['task-1', 'task-2'], committedRationale),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', {
+        evidenceRefs: ['rsi-sig:coverage'],
+        predictedFixes: [{ taskId: 'task-2', outcome: 'improved' }],
+        riskTasks: [{ taskId: 'task-1', outcome: 'safe' }],
+      }),
+    ];
+    const taskListReport = promptStructuralSmokeReport({
+      events: taskListMismatch,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(taskListReport.status, 'fail');
+    assert.deepEqual(taskListReport.failures, ['rsi_attribution_malformed']);
+    assert.deepEqual(taskListReport.roundsWithMalformedRsiAttribution, ['round-1']);
+  });
+
+  test('fails R2 smoke when attribution decision disagrees with the preceding decision event', () => {
+    const events = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', { decision: { decision: 'keep', reason: 'held_in_improved' } }),
+    ];
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['rsi_attribution_malformed']);
+    assert.deepEqual(report.roundsWithMalformedRsiAttribution, ['round-1']);
   });
 });
 
@@ -499,6 +567,7 @@ function committedEvent(
   runId = 'run-1',
   promptHash = promptHashForRound(roundId),
   heldInTaskIds: readonly string[] = [`task-${roundId.slice('round-'.length)}`],
+  rationale = candidateRationale(),
 ): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
@@ -513,11 +582,11 @@ function committedEvent(
     heldInTaskSetHash: 'sha256:held-in-task-set',
     heldInTaskIds,
     candidateRationaleHash: 'sha256:candidate-rationale',
-    candidateRationale: candidateRationale(),
+    candidateRationale: rationale,
   };
 }
 
-function candidateRationale() {
+function candidateRationale(overrides: Partial<PromptCandidateRationale> = {}): PromptCandidateRationale {
   return {
     failurePattern: 'coverage_regression' as const,
     evidenceRefs: [],
@@ -525,6 +594,7 @@ function candidateRationale() {
     targetedFix: 'make success criteria explicit without task-specific answers',
     predictedFixes: [],
     riskTasks: [],
+    ...overrides,
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -458,12 +458,47 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(wrongOrderReport.failures, ['rsi_attribution_missing']);
     assert.deepEqual(wrongOrderReport.roundsWithoutRsiAttribution, ['round-1']);
   });
+
+  test('fails R2 smoke when attribution hashes or held-in task scope are invalid', () => {
+    const hashMismatch = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', { candidateRationaleHash: 'sha256:wrong-rationale' }),
+    ];
+    const hashReport = promptStructuralSmokeReport({
+      events: hashMismatch,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(hashReport.status, 'fail');
+    assert.deepEqual(hashReport.failures, ['rsi_attribution_malformed']);
+    assert.deepEqual(hashReport.roundsWithMalformedRsiAttribution, ['round-1']);
+
+    const taskScopeMismatch = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['task-1']),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', { predictedFixes: [{ taskId: 'held-out-secret', outcome: 'improved' }] }),
+    ];
+    const taskScopeReport = promptStructuralSmokeReport({
+      events: taskScopeMismatch,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(taskScopeReport.status, 'fail');
+    assert.deepEqual(taskScopeReport.failures, ['rsi_attribution_task_scope_invalid']);
+    assert.deepEqual(taskScopeReport.roundsWithOutOfScopeRsiAttribution, ['round-1']);
+  });
 });
 
 function committedEvent(
   roundId: string,
   runId = 'run-1',
   promptHash = promptHashForRound(roundId),
+  heldInTaskIds: readonly string[] = [`task-${roundId.slice('round-'.length)}`],
 ): FixedPromptWalEvent {
   return {
     schemaVersion: 1,
@@ -476,6 +511,7 @@ function committedEvent(
     summary: `candidate ${roundId}`,
     promptHash,
     heldInTaskSetHash: 'sha256:held-in-task-set',
+    heldInTaskIds,
     candidateRationaleHash: 'sha256:candidate-rationale',
     candidateRationale: candidateRationale(),
   };
@@ -484,6 +520,7 @@ function committedEvent(
 function candidateRationale() {
   return {
     failurePattern: 'coverage_regression' as const,
+    evidenceRefs: [],
     hypothesis: 'held-in coverage can improve with a clearer prompt',
     targetedFix: 'make success criteria explicit without task-specific answers',
     predictedFixes: [],
@@ -549,8 +586,8 @@ function completedEvent(
   };
 }
 
-function attributionEvent(roundId: string): FixedPromptWalEvent {
-  return {
+function attributionEvent(roundId: string, overrides: Partial<Extract<FixedPromptWalEvent, { type: 'rsi_controller_attribution' }>> = {}): FixedPromptWalEvent {
+  const event: Extract<FixedPromptWalEvent, { type: 'rsi_controller_attribution' }> = {
     schemaVersion: 1,
     type: 'rsi_controller_attribution',
     id: `attribution-${roundId}`,
@@ -560,12 +597,14 @@ function attributionEvent(roundId: string): FixedPromptWalEvent {
     candidateCommitSha: `candidate-${roundId}`,
     heldInTaskSetHash: 'sha256:held-in-task-set',
     candidateRationaleHash: 'sha256:candidate-rationale',
+    evidenceRefs: [],
     predictedFixes: [],
     riskTasks: [],
     unexpectedHeldInFlips: [],
     decision: { decision: 'discard', reason: 'held_in_within_noise' },
     rootCauseSignalMatch: 'unknown',
   };
+  return { ...event, ...overrides };
 }
 
 function promptHashForRound(roundId: string): string {

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -560,6 +560,45 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(report.failures, ['rsi_attribution_malformed']);
     assert.deepEqual(report.roundsWithMalformedRsiAttribution, ['round-1']);
   });
+
+  test('passes R2 smoke when safety-plane decision reasons stay out of prompt projection', () => {
+    const events = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_out_regressed', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', { decision: { decision: 'discard', reason: 'held_out_regressed' } }),
+    ];
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(report.status, 'pass');
+    assert.deepEqual(report.failures, []);
+  });
+
+  test('fails R2 smoke when prompt attribution projection contains held-out markers', () => {
+    const events = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['held-out-secret']),
+      completedEvent('round-1', 'held-out-secret', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', {
+        unexpectedHeldInFlips: [{ taskId: 'held-out-secret', from: 'fail', to: 'pass' }],
+      }),
+    ];
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(report.status, 'fail');
+    assert.deepEqual(report.failures, ['rsi_attribution_malformed']);
+    assert.deepEqual(report.roundsWithMalformedRsiAttribution, ['round-1']);
+  });
 });
 
 function committedEvent(

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -425,6 +425,39 @@ describe('prompt structural smoke report', () => {
     ]);
     assert.deepEqual(report.failures, ['task_evidence_missing']);
   });
+
+  test('fails R2 smoke when controller attribution is missing or appended before decision', () => {
+    const missingAttribution = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+    ];
+    const missingReport = promptStructuralSmokeReport({
+      events: missingAttribution,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(missingReport.status, 'fail');
+    assert.deepEqual(missingReport.failures, ['rsi_attribution_missing']);
+    assert.deepEqual(missingReport.roundsWithoutRsiAttribution, ['round-1']);
+
+    const wrongOrder = [
+      committedEvent('round-1'),
+      completedEvent('round-1', 'task-1', 0.1),
+      attributionEvent('round-1'),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+    ];
+    const wrongOrderReport = promptStructuralSmokeReport({
+      events: wrongOrder,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(wrongOrderReport.status, 'fail');
+    assert.deepEqual(wrongOrderReport.failures, ['rsi_attribution_missing']);
+    assert.deepEqual(wrongOrderReport.roundsWithoutRsiAttribution, ['round-1']);
+  });
 });
 
 function committedEvent(
@@ -513,6 +546,25 @@ function completedEvent(
     durationMs: 10,
     runtimeEventsPath: `/logs/${roundId}/${taskId}.jsonl`,
     harbor: { reward: 0 },
+  };
+}
+
+function attributionEvent(roundId: string): FixedPromptWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'rsi_controller_attribution',
+    id: `attribution-${roundId}`,
+    ts: 1,
+    runId: 'run-1',
+    roundId,
+    candidateCommitSha: `candidate-${roundId}`,
+    heldInTaskSetHash: 'sha256:held-in-task-set',
+    candidateRationaleHash: 'sha256:candidate-rationale',
+    predictedFixes: [],
+    riskTasks: [],
+    unexpectedHeldInFlips: [],
+    decision: { decision: 'discard', reason: 'held_in_within_noise' },
+    rootCauseSignalMatch: 'unknown',
   };
 }
 

--- a/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
+++ b/packages/headless/src/__tests__/prompt-structural-smoke.test.ts
@@ -599,6 +599,33 @@ describe('prompt structural smoke report', () => {
     assert.deepEqual(report.failures, []);
   });
 
+  test('passes R2 smoke when nested controller-only fields stay out of prompt projection', () => {
+    const events = [
+      committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['task-1'], candidateRationale({
+        predictedFixes: ['task-1'],
+        riskTasks: ['task-1'],
+      })),
+      completedEvent('round-1', 'task-1', 0.1),
+      decisionEvent('round-1', 'discard', 'held_in_within_noise', 'run-1', { decision: 'clean' }),
+      attributionEvent('round-1', ({
+        predictedFixes: [{ taskId: 'task-1', outcome: 'improved', candidateCommitSha: 'nested-commit-secret' }],
+        riskTasks: [{ taskId: 'task-1', outcome: 'safe', threshold: 'nested-threshold-secret' }],
+        unexpectedHeldInFlips: [
+          { taskId: 'task-1', from: 'fail', to: 'pass', heldOutMetric: 'nested-held-out-secret' },
+        ],
+      } as unknown) as Partial<Extract<FixedPromptWalEvent, { type: 'rsi_controller_attribution' }>>),
+    ];
+
+    const report = promptStructuralSmokeReport({
+      events,
+      minimumRounds: 1,
+      requireRsiR2Evidence: true,
+    });
+
+    assert.equal(report.status, 'pass');
+    assert.deepEqual(report.failures, []);
+  });
+
   test('fails R2 smoke when prompt attribution projection contains held-out markers', () => {
     const events = [
       committedEvent('round-1', 'run-1', promptHashForRound('round-1'), ['held-out-secret']),

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { readFixedPromptWal, type FixedPromptTaskWalEvent, type PromptCandidateRationale } from '../fixed-prompt-controller.js';
-import { appendRsiControllerAttribution, buildRsiControllerAttribution } from '../rsi-controller-attribution.js';
+import { appendRsiControllerAttribution, buildRsiControllerAttribution, projectRsiPromptAttribution } from '../rsi-controller-attribution.js';
 import type { RsiRoundAnalysis } from '../rsi-round-analysis.js';
 import type { PromptAcceptanceResult } from '../prompt-acceptance-policy.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
@@ -120,6 +120,40 @@ describe('RSI controller attribution', () => {
         assert.equal(events[0].rootCauseSignalMatch, 'unknown');
       }
     });
+  });
+
+  test('projects held-out safety decisions as generic prompt feedback', () => {
+    const attribution = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'other',
+        hypothesis: 'unknown held-in behavior changed',
+        targetedFix: 'make prompt wording simpler',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis: {
+        heldInTaskSetHash: 'sha256:held-in',
+        transitionVsLastKept: [],
+        transitionVsPreviousCandidate: [],
+        coverageRegressionTaskIds: [],
+        errorClassDistribution: [],
+        toolFailureClusters: [],
+        signals: [],
+      },
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: true })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'held_out_regressed' }),
+    });
+
+    const promptAttribution = projectRsiPromptAttribution(attribution);
+
+    assert.equal(promptAttribution.decisionReason, 'discarded_by_controller_safety_gate');
+    assert.equal(JSON.stringify(promptAttribution).includes('held_out_regressed'), false);
   });
 });
 

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -13,6 +13,7 @@ describe('RSI controller attribution', () => {
   test('compares candidate rationale predictions to held-in outcomes', () => {
     const rationale: PromptCandidateRationale = {
       failurePattern: 'coverage_regression',
+      evidenceRefs: ['rsi-sig:coverage'],
       hypothesis: 'restore coverage for the unstable held-in task',
       targetedFix: 'keep artifact creation requirements explicit',
       predictedFixes: ['task-a', 'task-b'],
@@ -69,6 +70,7 @@ describe('RSI controller attribution', () => {
     assert.deepEqual(attribution.unexpectedHeldInFlips, [
       { taskId: 'task-d', from: 'fail', to: 'pass' },
     ]);
+    assert.deepEqual(attribution.evidenceRefs, ['rsi-sig:coverage']);
     assert.equal(attribution.rootCauseSignalMatch, 'matched');
     assert.equal(JSON.stringify(attribution).includes('held-out-secret'), false);
   });
@@ -83,6 +85,7 @@ describe('RSI controller attribution', () => {
         candidateRationaleHash: 'sha256:rationale',
         candidateRationale: {
           failurePattern: 'other',
+          evidenceRefs: [],
           hypothesis: 'unknown held-in behavior changed',
           targetedFix: 'make prompt wording simpler',
           predictedFixes: [],
@@ -122,7 +125,7 @@ describe('RSI controller attribution', () => {
     });
   });
 
-  test('projects held-out safety decisions as generic prompt feedback', () => {
+  test('projects prompt attribution without controller decision reasons', () => {
     const attribution = buildRsiControllerAttribution({
       runId: 'run-1',
       roundId: 'round-0',
@@ -130,6 +133,7 @@ describe('RSI controller attribution', () => {
       candidateRationaleHash: 'sha256:rationale',
       candidateRationale: {
         failurePattern: 'other',
+        evidenceRefs: [],
         hypothesis: 'unknown held-in behavior changed',
         targetedFix: 'make prompt wording simpler',
         predictedFixes: [],
@@ -152,8 +156,41 @@ describe('RSI controller attribution', () => {
 
     const promptAttribution = projectRsiPromptAttribution(attribution);
 
-    assert.equal(promptAttribution.decisionReason, 'discarded_by_controller_safety_gate');
+    assert.equal('decisionReason' in promptAttribution, false);
     assert.equal(JSON.stringify(promptAttribution).includes('held_out_regressed'), false);
+    assert.equal(JSON.stringify(promptAttribution).includes('coverage_regressed'), false);
+  });
+
+  test('keeps root cause match unknown when the rationale cites no evidence refs', () => {
+    const attribution = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'coverage_regression',
+        evidenceRefs: [],
+        hypothesis: 'coverage fell after the previous prompt change',
+        targetedFix: 'make prompt wording simpler',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis: {
+        heldInTaskSetHash: 'sha256:held-in',
+        transitionVsLastKept: [],
+        transitionVsPreviousCandidate: [],
+        coverageRegressionTaskIds: ['task-a'],
+        errorClassDistribution: [],
+        toolFailureClusters: [],
+        signals: [{ id: 'rsi-sig:coverage', kind: 'coverage_regression', taskIds: ['task-a'] }],
+      },
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: false, scored: false })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
+    });
+
+    assert.equal(attribution.rootCauseSignalMatch, 'unknown');
   });
 });
 

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -1,10 +1,7 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { readFixedPromptWal, type FixedPromptTaskWalEvent, type PromptCandidateRationale } from '../fixed-prompt-controller.js';
-import { appendRsiControllerAttribution, buildRsiControllerAttribution, projectRsiPromptAttribution } from '../rsi-controller-attribution.js';
+import { type FixedPromptTaskWalEvent, type PromptCandidateRationale } from '../fixed-prompt-controller.js';
+import { buildRsiControllerAttribution, projectRsiPromptAttribution } from '../rsi-controller-attribution.js';
 import type { RsiRoundAnalysis } from '../rsi-round-analysis.js';
 import type { PromptAcceptanceResult } from '../prompt-acceptance-policy.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
@@ -75,56 +72,6 @@ describe('RSI controller attribution', () => {
     assert.equal(JSON.stringify(attribution).includes('held-out-secret'), false);
   });
 
-  test('persists controller attribution as a WAL event', async () => {
-    await withDir(async (dir) => {
-      const resultsJsonlPath = join(dir, 'results.jsonl');
-      const attribution = buildRsiControllerAttribution({
-        runId: 'run-1',
-        roundId: 'round-0',
-        candidateCommitSha: 'commit-1',
-        candidateRationaleHash: 'sha256:rationale',
-        candidateRationale: {
-          failurePattern: 'other',
-          evidenceRefs: [],
-          hypothesis: 'unknown held-in behavior changed',
-          targetedFix: 'make prompt wording simpler',
-          predictedFixes: [],
-          riskTasks: [],
-        },
-        analysis: {
-          heldInTaskSetHash: 'sha256:held-in',
-          transitionVsLastKept: [],
-          transitionVsPreviousCandidate: [],
-          coverageRegressionTaskIds: [],
-          errorClassDistribution: [],
-          toolFailureClusters: [],
-          signals: [],
-        },
-        heldInTaskIds: ['task-a'],
-        lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
-        candidateEvents: [completed({ taskId: 'task-a', passed: true })],
-        decision: acceptanceResult({ decision: 'keep', reason: 'held_in_improved' }),
-      });
-
-      const event = await appendRsiControllerAttribution({
-        resultsJsonlPath,
-        id: 'attr-event-1',
-        ts: 2,
-        attribution,
-      });
-      const events = await readFixedPromptWal(resultsJsonlPath);
-
-      assert.equal(event.type, 'rsi_controller_attribution');
-      assert.deepEqual(events, [event]);
-      assert.equal(events[0]?.type, 'rsi_controller_attribution');
-      if (events[0]?.type === 'rsi_controller_attribution') {
-        assert.equal(events[0].candidateCommitSha, 'commit-1');
-        assert.equal(events[0].heldInTaskSetHash, 'sha256:held-in');
-        assert.equal(events[0].rootCauseSignalMatch, 'unknown');
-      }
-    });
-  });
-
   test('projects prompt attribution without controller decision reasons', () => {
     const attribution = buildRsiControllerAttribution({
       runId: 'run-1',
@@ -191,6 +138,64 @@ describe('RSI controller attribution', () => {
     });
 
     assert.equal(attribution.rootCauseSignalMatch, 'unknown');
+  });
+
+  test('matches root cause only against cited analysis signals', () => {
+    const analysis: RsiRoundAnalysis = {
+      heldInTaskSetHash: 'sha256:held-in',
+      transitionVsLastKept: [],
+      transitionVsPreviousCandidate: [],
+      coverageRegressionTaskIds: ['task-a'],
+      errorClassDistribution: [],
+      toolFailureClusters: [],
+      signals: [
+        { id: 'rsi-sig:coverage', kind: 'coverage_regression', taskIds: ['task-a'] },
+        { id: 'rsi-sig:tool', kind: 'tool_failure_cluster', taskIds: ['task-b'], cluster: { name: 'shell', count: 1, taskIds: ['task-b'] } },
+      ],
+    };
+
+    const matched = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'coverage_regression',
+        evidenceRefs: ['rsi-sig:coverage'],
+        hypothesis: 'coverage fell after the previous prompt change',
+        targetedFix: 'restore the missing artifact instruction',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis,
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: false, scored: false })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
+    });
+
+    const contradicted = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'coverage_regression',
+        evidenceRefs: ['rsi-sig:tool'],
+        hypothesis: 'coverage fell after the previous prompt change',
+        targetedFix: 'restore the missing artifact instruction',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis,
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: false, scored: false })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
+    });
+
+    assert.equal(matched.rootCauseSignalMatch, 'matched');
+    assert.equal(contradicted.rootCauseSignalMatch, 'contradicted');
   });
 });
 
@@ -263,13 +268,4 @@ function partitionSummary(): PromptAcceptanceResult['metrics']['candidate']['hel
     plumbingFailedTaskIds: [],
     missingTaskIds: [],
   };
-}
-
-async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
-  const dir = await mkdtemp(join(tmpdir(), 'maka-rsi-attribution-'));
-  try {
-    await fn(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
 }

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -103,7 +103,12 @@ describe('RSI controller attribution', () => {
 
     const promptAttribution = projectRsiPromptAttribution(attribution);
 
+    assert.equal('candidateCommitSha' in promptAttribution, false);
     assert.equal('decisionReason' in promptAttribution, false);
+    assert.deepEqual(promptAttribution.predictedFixes, []);
+    assert.deepEqual(promptAttribution.riskTasks, []);
+    assert.deepEqual(promptAttribution.unexpectedHeldInFlips, []);
+    assert.equal(promptAttribution.rootCauseSignalMatch, 'unknown');
     assert.equal(JSON.stringify(promptAttribution).includes('held_out_regressed'), false);
     assert.equal(JSON.stringify(promptAttribution).includes('coverage_regressed'), false);
   });
@@ -191,6 +196,64 @@ describe('RSI controller attribution', () => {
       heldInTaskIds: ['task-a'],
       lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
       candidateEvents: [completed({ taskId: 'task-a', passed: false, scored: false })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
+    });
+
+    assert.equal(matched.rootCauseSignalMatch, 'matched');
+    assert.equal(contradicted.rootCauseSignalMatch, 'contradicted');
+  });
+
+  test('matches runtime error root cause against cited error-class signals', () => {
+    const analysis: RsiRoundAnalysis = {
+      heldInTaskSetHash: 'sha256:held-in',
+      transitionVsLastKept: [],
+      transitionVsPreviousCandidate: [],
+      coverageRegressionTaskIds: [],
+      errorClassDistribution: [{ errorClass: 'runtime_error', count: 1 }],
+      toolFailureClusters: [],
+      signals: [
+        { id: 'rsi-sig:runtime', kind: 'error_class', taskIds: ['task-a'], errorClass: 'runtime_error', count: 1 },
+        { id: 'rsi-sig:max-tokens', kind: 'error_class', taskIds: ['task-b'], errorClass: 'max_tokens', count: 1 },
+      ],
+    };
+
+    const matched = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'runtime_error',
+        evidenceRefs: ['rsi-sig:runtime'],
+        hypothesis: 'runtime errors block held-in progress',
+        targetedFix: 'make execution constraints explicit',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis,
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: false, errorClass: 'runtime_error' })],
+      decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
+    });
+
+    const contradicted = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'runtime_error',
+        evidenceRefs: ['rsi-sig:max-tokens'],
+        hypothesis: 'runtime errors block held-in progress',
+        targetedFix: 'make execution constraints explicit',
+        predictedFixes: [],
+        riskTasks: [],
+      },
+      analysis,
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: false, errorClass: 'runtime_error' })],
       decision: acceptanceResult({ decision: 'discard', reason: 'coverage_regressed' }),
     });
 

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -260,6 +260,49 @@ describe('RSI controller attribution', () => {
     assert.equal(matched.rootCauseSignalMatch, 'matched');
     assert.equal(contradicted.rootCauseSignalMatch, 'contradicted');
   });
+
+  test('matches root cause against prompt-time analysis when post-eval signals disappear', () => {
+    const attribution = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: {
+        failurePattern: 'coverage_regression',
+        evidenceRefs: ['rsi-sig:coverage'],
+        hypothesis: 'coverage fell before this candidate',
+        targetedFix: 'restore the missing completion requirement',
+        predictedFixes: ['task-a'],
+        riskTasks: [],
+      },
+      promptTimeAnalysis: {
+        heldInTaskSetHash: 'sha256:held-in-before',
+        transitionVsLastKept: [],
+        transitionVsPreviousCandidate: [],
+        coverageRegressionTaskIds: ['task-a'],
+        errorClassDistribution: [],
+        toolFailureClusters: [],
+        signals: [{ id: 'rsi-sig:coverage', kind: 'coverage_regression', taskIds: ['task-a'] }],
+      },
+      analysis: {
+        heldInTaskSetHash: 'sha256:held-in-after',
+        transitionVsLastKept: [{ taskId: 'task-a', from: 'fail', to: 'pass' }],
+        transitionVsPreviousCandidate: [],
+        coverageRegressionTaskIds: [],
+        errorClassDistribution: [],
+        toolFailureClusters: [],
+        signals: [],
+      },
+      heldInTaskIds: ['task-a'],
+      lastKeptEvents: [completed({ taskId: 'task-a', passed: false })],
+      candidateEvents: [completed({ taskId: 'task-a', passed: true })],
+      decision: acceptanceResult({ decision: 'keep', reason: 'held_in_improved' }),
+    });
+
+    assert.equal(attribution.heldInTaskSetHash, 'sha256:held-in-after');
+    assert.deepEqual(attribution.predictedFixes, [{ taskId: 'task-a', outcome: 'improved' }]);
+    assert.equal(attribution.rootCauseSignalMatch, 'matched');
+  });
 });
 
 function completed(input: {

--- a/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
+++ b/packages/headless/src/__tests__/rsi-controller-attribution.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { readFixedPromptWal, type FixedPromptTaskWalEvent, type PromptCandidateRationale } from '../fixed-prompt-controller.js';
+import { appendRsiControllerAttribution, buildRsiControllerAttribution } from '../rsi-controller-attribution.js';
+import type { RsiRoundAnalysis } from '../rsi-round-analysis.js';
+import type { PromptAcceptanceResult } from '../prompt-acceptance-policy.js';
+import { tokenSummary } from './helpers/cell-output-fixtures.js';
+
+describe('RSI controller attribution', () => {
+  test('compares candidate rationale predictions to held-in outcomes', () => {
+    const rationale: PromptCandidateRationale = {
+      failurePattern: 'coverage_regression',
+      hypothesis: 'restore coverage for the unstable held-in task',
+      targetedFix: 'keep artifact creation requirements explicit',
+      predictedFixes: ['task-a', 'task-b'],
+      riskTasks: ['task-c'],
+    };
+    const analysis: RsiRoundAnalysis = {
+      heldInTaskSetHash: 'sha256:held-in',
+      transitionVsLastKept: [
+        { taskId: 'task-a', from: 'fail', to: 'pass' },
+        { taskId: 'task-b', from: 'pass', to: 'unscored' },
+        { taskId: 'task-c', from: 'pass', to: 'fail' },
+        { taskId: 'task-d', from: 'fail', to: 'pass' },
+      ],
+      transitionVsPreviousCandidate: [],
+      coverageRegressionTaskIds: ['task-b'],
+      errorClassDistribution: [{ errorClass: 'max_tokens', count: 1 }],
+      toolFailureClusters: [],
+      signals: [
+        { id: 'rsi-sig:coverage', kind: 'coverage_regression', taskIds: ['task-b'] },
+      ],
+    };
+
+    const attribution = buildRsiControllerAttribution({
+      runId: 'run-1',
+      roundId: 'round-0',
+      candidateCommitSha: 'commit-1',
+      candidateRationaleHash: 'sha256:rationale',
+      candidateRationale: rationale,
+      analysis,
+      heldInTaskIds: ['task-a', 'task-b', 'task-c', 'task-d'],
+      lastKeptEvents: [
+        completed({ taskId: 'task-a', passed: false }),
+        completed({ taskId: 'task-b', passed: true }),
+        completed({ taskId: 'task-c', passed: true }),
+        completed({ taskId: 'task-d', passed: false }),
+      ],
+      candidateEvents: [
+        completed({ taskId: 'task-a', passed: true }),
+        completed({ taskId: 'task-b', passed: false, scored: false, errorClass: 'max_tokens' }),
+        completed({ taskId: 'task-c', passed: false }),
+        completed({ taskId: 'task-d', passed: true }),
+        completed({ taskId: 'held-out-secret', passed: false }),
+      ],
+      decision: acceptanceResult({ reason: 'coverage_regressed', decision: 'discard' }),
+    });
+
+    assert.deepEqual(attribution.predictedFixes, [
+      { taskId: 'task-a', outcome: 'improved' },
+      { taskId: 'task-b', outcome: 'unscored' },
+    ]);
+    assert.deepEqual(attribution.riskTasks, [
+      { taskId: 'task-c', outcome: 'regressed' },
+    ]);
+    assert.deepEqual(attribution.unexpectedHeldInFlips, [
+      { taskId: 'task-d', from: 'fail', to: 'pass' },
+    ]);
+    assert.equal(attribution.rootCauseSignalMatch, 'matched');
+    assert.equal(JSON.stringify(attribution).includes('held-out-secret'), false);
+  });
+
+  test('persists controller attribution as a WAL event', async () => {
+    await withDir(async (dir) => {
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      const attribution = buildRsiControllerAttribution({
+        runId: 'run-1',
+        roundId: 'round-0',
+        candidateCommitSha: 'commit-1',
+        candidateRationaleHash: 'sha256:rationale',
+        candidateRationale: {
+          failurePattern: 'other',
+          hypothesis: 'unknown held-in behavior changed',
+          targetedFix: 'make prompt wording simpler',
+          predictedFixes: [],
+          riskTasks: [],
+        },
+        analysis: {
+          heldInTaskSetHash: 'sha256:held-in',
+          transitionVsLastKept: [],
+          transitionVsPreviousCandidate: [],
+          coverageRegressionTaskIds: [],
+          errorClassDistribution: [],
+          toolFailureClusters: [],
+          signals: [],
+        },
+        heldInTaskIds: ['task-a'],
+        lastKeptEvents: [completed({ taskId: 'task-a', passed: true })],
+        candidateEvents: [completed({ taskId: 'task-a', passed: true })],
+        decision: acceptanceResult({ decision: 'keep', reason: 'held_in_improved' }),
+      });
+
+      const event = await appendRsiControllerAttribution({
+        resultsJsonlPath,
+        id: 'attr-event-1',
+        ts: 2,
+        attribution,
+      });
+      const events = await readFixedPromptWal(resultsJsonlPath);
+
+      assert.equal(event.type, 'rsi_controller_attribution');
+      assert.deepEqual(events, [event]);
+      assert.equal(events[0]?.type, 'rsi_controller_attribution');
+      if (events[0]?.type === 'rsi_controller_attribution') {
+        assert.equal(events[0].candidateCommitSha, 'commit-1');
+        assert.equal(events[0].heldInTaskSetHash, 'sha256:held-in');
+        assert.equal(events[0].rootCauseSignalMatch, 'unknown');
+      }
+    });
+  });
+});
+
+function completed(input: {
+  taskId: string;
+  passed: boolean;
+  scored?: boolean;
+  errorClass?: string;
+}): FixedPromptTaskWalEvent {
+  return {
+    schemaVersion: 1,
+    type: 'task_completed',
+    id: `${input.taskId}-event`,
+    ts: 1,
+    runId: 'run-1',
+    roundId: 'round-1',
+    taskId: input.taskId,
+    status: input.passed ? 'completed' : 'failed',
+    passed: input.passed,
+    scored: input.scored ?? true,
+    eligible: true,
+    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+    promptHash: 'sha256:prompt',
+    tokenSummary: tokenSummary({ input: 1, output: 1, reasoning: 0, total: 2, costUsd: 0.01 }),
+    steps: 1,
+    durationMs: 10,
+    runtimeEventsPath: '/tmp/runtime-events.jsonl',
+    harbor: { reward: input.passed ? 1 : 0 },
+  };
+}
+
+function acceptanceResult(input: {
+  decision: 'keep' | 'discard';
+  reason: PromptAcceptanceResult['reason'];
+}): PromptAcceptanceResult {
+  return {
+    runId: 'run-1',
+    roundId: 'round-0',
+    decision: input.decision,
+    reason: input.reason,
+    candidateCommitSha: 'commit-1',
+    previousLastKeptCommitSha: 'commit-0',
+    lastKeptCommitSha: input.decision === 'keep' ? 'commit-1' : 'commit-0',
+    previousHeldInReferencePassEligibleRate: 0.5,
+    heldInReferencePassEligibleRate: 0.5,
+    originalCommitSha: 'commit-0',
+    originalHeldOutPassEligibleRate: 0.5,
+    heldInPassRateNoiseBand: 0.1,
+    heldOutPassRateNoiseBand: 0.1,
+    rewardHackScan: { decision: 'clean' },
+    metrics: {
+      original: { heldOut: partitionSummary() },
+      lastKept: { heldIn: partitionSummary() },
+      candidate: { heldIn: partitionSummary(), heldOut: partitionSummary() },
+    },
+  };
+}
+
+function partitionSummary(): PromptAcceptanceResult['metrics']['candidate']['heldIn'] {
+  return {
+    taskCount: 0,
+    observed: 0,
+    eligible: 0,
+    scored: 0,
+    passed: 0,
+    passEligibleRate: null,
+    coverageRate: null,
+    unscoredTaskIds: [],
+    infraFailedTaskIds: [],
+    plumbingFailedTaskIds: [],
+    missingTaskIds: [],
+  };
+}
+
+async function withDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-rsi-attribution-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -151,6 +151,7 @@ export interface PromptCandidateCommittedEvent {
   summary: string;
   promptHash: string;
   heldInTaskSetHash: string;
+  heldInTaskIds: readonly string[];
   candidateRationaleHash: string;
   candidateRationale: PromptCandidateRationale;
 }
@@ -168,6 +169,7 @@ export type PromptCandidateFailurePattern = typeof PROMPT_CANDIDATE_FAILURE_PATT
 
 export interface PromptCandidateRationale {
   failurePattern: PromptCandidateFailurePattern;
+  evidenceRefs: readonly string[];
   hypothesis: string;
   targetedFix: string;
   predictedFixes: readonly string[];
@@ -214,6 +216,7 @@ export interface RsiControllerAttributionEvent {
   candidateCommitSha: string;
   heldInTaskSetHash: string;
   candidateRationaleHash: string;
+  evidenceRefs: readonly string[];
   predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
   riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
   unexpectedHeldInFlips: Array<{ taskId: string; from: string; to: string }>;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -200,13 +200,38 @@ export interface PromptCandidateDecisionEvent {
   metrics: unknown;
 }
 
+export type RsiPredictedFixOutcome = 'improved' | 'unchanged' | 'regressed' | 'unscored' | 'missing';
+export type RsiRiskTaskOutcome = 'safe' | 'regressed' | 'unscored' | 'missing';
+export type RsiRootCauseSignalMatch = 'matched' | 'contradicted' | 'unknown';
+
+export interface RsiControllerAttributionEvent {
+  schemaVersion: typeof FIXED_PROMPT_WAL_SCHEMA_VERSION;
+  type: 'rsi_controller_attribution';
+  id: string;
+  ts: number;
+  runId: string;
+  roundId: string;
+  candidateCommitSha: string;
+  heldInTaskSetHash: string;
+  candidateRationaleHash: string;
+  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: Array<{ taskId: string; from: string; to: string }>;
+  decision: {
+    decision: 'keep' | 'discard';
+    reason: string;
+  };
+  rootCauseSignalMatch: RsiRootCauseSignalMatch;
+}
+
 export type FixedPromptWalEvent =
   | FixedPromptTaskCompletedEvent
   | FixedPromptTaskInfraFailedEvent
   | FixedPromptTaskBudgetExhaustedEvent
   | FixedPromptTaskPlumbingFailedEvent
   | PromptCandidateCommittedEvent
-  | PromptCandidateDecisionEvent;
+  | PromptCandidateDecisionEvent
+  | RsiControllerAttributionEvent;
 
 export type FixedPromptTaskWalEvent =
   | FixedPromptTaskCompletedEvent

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -13,7 +13,10 @@ import {
   type PromptCandidateFailurePattern,
   type PromptCandidateRationale,
 } from './fixed-prompt-controller.js';
-import type { RsiPromptAttribution } from './rsi-controller-attribution.js';
+import {
+  projectRsiPromptAttribution,
+  type ProjectRsiPromptAttributionInput,
+} from './rsi-controller-attribution.js';
 import type { RsiRoundAnalysis } from './rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
@@ -76,7 +79,7 @@ export interface MetaAgentPromptInput {
   resultsTsv: string;
   heldInDigests: readonly TrajectoryDigest[];
   rsiAnalysis?: RsiRoundAnalysis;
-  promptAttribution?: RsiPromptAttribution;
+  promptAttribution?: ProjectRsiPromptAttributionInput;
 }
 
 export interface MetaAgentPromptResult {
@@ -123,7 +126,7 @@ export interface RunPromptCandidateRoundInput {
   heldInTaskIds: readonly string[];
   heldInDigests: readonly TrajectoryDigest[];
   rsiAnalysis?: RsiRoundAnalysis;
-  promptAttribution?: RsiPromptAttribution;
+  promptAttribution?: ProjectRsiPromptAttributionInput;
   heldOutDigests?: readonly TrajectoryDigest[];
   heldOutArtifactPaths?: readonly string[];
   metaAgent: MetaAgent;
@@ -170,6 +173,9 @@ export async function runPromptCandidateRound(
     await readFile(input.resultsTsvPath, 'utf8'),
     input.heldInTaskIds,
   );
+  const promptAttribution = input.promptAttribution
+    ? projectRsiPromptAttribution(input.promptAttribution)
+    : undefined;
   const result = await input.metaAgent({
     runId: input.runId,
     roundId: input.roundId,
@@ -178,7 +184,7 @@ export async function runPromptCandidateRound(
     resultsTsv,
     heldInDigests: input.heldInDigests,
     ...(input.rsiAnalysis ? { rsiAnalysis: input.rsiAnalysis } : {}),
-    ...(input.promptAttribution ? { promptAttribution: input.promptAttribution } : {}),
+    ...(promptAttribution ? { promptAttribution } : {}),
   });
   const candidateRationale = validateCandidateRationale(result.candidateRationale, input.heldInTaskIds, input.rsiAnalysis);
 
@@ -416,10 +422,10 @@ function renderRsiAnalysis(analysis: RsiRoundAnalysis | undefined): string[] {
   ] : [];
 }
 
-function renderPromptAttribution(attribution: RsiPromptAttribution | undefined): string[] {
+function renderPromptAttribution(attribution: ProjectRsiPromptAttributionInput | undefined): string[] {
   return attribution ? [
     '# RSI R2 Previous Prompt Attribution',
-    JSON.stringify(attribution, null, 2),
+    JSON.stringify(projectRsiPromptAttribution(attribution), null, 2),
   ] : [];
 }
 

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -180,7 +180,7 @@ export async function runPromptCandidateRound(
     ...(input.rsiAnalysis ? { rsiAnalysis: input.rsiAnalysis } : {}),
     ...(input.promptAttribution ? { promptAttribution: input.promptAttribution } : {}),
   });
-  const candidateRationale = validateCandidateRationale(result.candidateRationale, input.heldInTaskIds);
+  const candidateRationale = validateCandidateRationale(result.candidateRationale, input.heldInTaskIds, input.rsiAnalysis);
 
   await writeFile(input.systemPromptPath, result.systemPrompt, 'utf8');
   let commitSha: string;
@@ -390,8 +390,8 @@ export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): Me
 export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
   return [
     'You are improving one system prompt for benchmark tasks.',
-    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
-    'candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
+    'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["rsi-sig:id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
+    'candidateRationale.evidenceRefs may only reference RSI R2 Held-In Analysis signal ids from the prompt. candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
     'Do not include held-out tasks, verifier internals, expected outputs, raw traces, file paths, code fences, or multiline text in candidateRationale.',
     '',
     '# Program',
@@ -464,8 +464,13 @@ export function parseMetaAgentResult(raw: string): MetaAgentPromptResult {
   return { systemPrompt, summary, candidateRationale };
 }
 
-function validateCandidateRationale(value: unknown, heldInTaskIds: readonly string[]): CandidateRationale {
+function validateCandidateRationale(
+  value: unknown,
+  heldInTaskIds: readonly string[],
+  rsiAnalysis: RsiRoundAnalysis | undefined,
+): CandidateRationale {
   const candidateRationale = parseCandidateRationaleShape(value);
+  validateEvidenceRefs(candidateRationale.evidenceRefs, rsiAnalysis);
   validateHeldInTaskIds(candidateRationale.predictedFixes, 'predictedFixes', heldInTaskIds);
   validateHeldInTaskIds(candidateRationale.riskTasks, 'riskTasks', heldInTaskIds);
   return candidateRationale;
@@ -484,15 +489,32 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   }
   const hypothesis = parseRationaleTextShape(value.hypothesis, 'hypothesis');
   const targetedFix = parseRationaleTextShape(value.targetedFix, 'targetedFix');
+  const evidenceRefs = parseTaskIdArrayShape(value.evidenceRefs, 'evidenceRefs');
   const predictedFixes = parseTaskIdArrayShape(value.predictedFixes, 'predictedFixes');
   const riskTasks = parseTaskIdArrayShape(value.riskTasks, 'riskTasks');
   return {
     failurePattern: value.failurePattern as CandidateFailurePattern,
+    evidenceRefs,
     hypothesis,
     targetedFix,
     predictedFixes,
     riskTasks,
   };
+}
+
+function validateEvidenceRefs(evidenceRefs: readonly string[], rsiAnalysis: RsiRoundAnalysis | undefined): void {
+  if (!rsiAnalysis) {
+    if (evidenceRefs.length > 0) {
+      throw new Error('candidateRationale.evidenceRefs require current RSI analysis signals');
+    }
+    return;
+  }
+  const known = new Set(rsiAnalysis.signals.map((signal) => signal.id));
+  for (const ref of evidenceRefs) {
+    if (!known.has(ref)) {
+      throw new Error(`candidateRationale.evidenceRefs contains unknown analysis signal id: ${ref}`);
+    }
+  }
 }
 
 function parseRationaleTextShape(value: unknown, field: string): string {
@@ -555,6 +577,7 @@ function promptCandidateCommittedEvent(input: {
     summary: input.summary,
     promptHash: hashSystemPrompt(input.systemPrompt),
     heldInTaskSetHash: hashHeldInTaskSet(input.heldInTaskIds),
+    heldInTaskIds: [...new Set(input.heldInTaskIds)].sort((a, b) => a.localeCompare(b)),
     candidateRationaleHash: hashCandidateRationale(input.candidateRationale),
     candidateRationale: input.candidateRationale,
   };

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -391,7 +391,7 @@ export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
   return [
     'You are improving one system prompt for benchmark tasks.',
     'Return JSON only: {"systemPrompt":"...","summary":"...","candidateRationale":{"failurePattern":"coverage_regression|tool_failed|max_tokens|runtime_error|verification_failed|other","evidenceRefs":["rsi-sig:id"],"hypothesis":"short plain text","targetedFix":"short plain text","predictedFixes":["held-in-task-id"],"riskTasks":["held-in-task-id"]}}.',
-    'candidateRationale.evidenceRefs may only reference RSI R2 Held-In Analysis signal ids from the prompt. candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
+    'candidateRationale.evidenceRefs may only reference RSI R2 Held-In Analysis signal ids from the prompt; when signals exist and failurePattern is not "other", cite at least one signal. candidateRationale.predictedFixes and riskTasks may only reference held-in task ids from the prompt.',
     'Do not include held-out tasks, verifier internals, expected outputs, raw traces, file paths, code fences, or multiline text in candidateRationale.',
     '',
     '# Program',
@@ -470,7 +470,7 @@ function validateCandidateRationale(
   rsiAnalysis: RsiRoundAnalysis | undefined,
 ): CandidateRationale {
   const candidateRationale = parseCandidateRationaleShape(value);
-  validateEvidenceRefs(candidateRationale.evidenceRefs, rsiAnalysis);
+  validateEvidenceRefs(candidateRationale, rsiAnalysis);
   validateHeldInTaskIds(candidateRationale.predictedFixes, 'predictedFixes', heldInTaskIds);
   validateHeldInTaskIds(candidateRationale.riskTasks, 'riskTasks', heldInTaskIds);
   return candidateRationale;
@@ -502,12 +502,16 @@ function parseCandidateRationaleShape(value: unknown): CandidateRationale {
   };
 }
 
-function validateEvidenceRefs(evidenceRefs: readonly string[], rsiAnalysis: RsiRoundAnalysis | undefined): void {
+function validateEvidenceRefs(candidateRationale: CandidateRationale, rsiAnalysis: RsiRoundAnalysis | undefined): void {
+  const { evidenceRefs } = candidateRationale;
   if (!rsiAnalysis) {
     if (evidenceRefs.length > 0) {
       throw new Error('candidateRationale.evidenceRefs require current RSI analysis signals');
     }
     return;
+  }
+  if (rsiAnalysis.signals.length > 0 && candidateRationale.failurePattern !== 'other' && evidenceRefs.length === 0) {
+    throw new Error('candidateRationale.evidenceRefs must cite at least one current analysis signal');
   }
   const known = new Set(rsiAnalysis.signals.map((signal) => signal.id));
   for (const ref of evidenceRefs) {

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -13,6 +13,8 @@ import {
   type PromptCandidateFailurePattern,
   type PromptCandidateRationale,
 } from './fixed-prompt-controller.js';
+import type { RsiPromptAttribution } from './rsi-controller-attribution.js';
+import type { RsiRoundAnalysis } from './rsi-round-analysis.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -73,6 +75,8 @@ export interface MetaAgentPromptInput {
   currentSystemPrompt: string;
   resultsTsv: string;
   heldInDigests: readonly TrajectoryDigest[];
+  rsiAnalysis?: RsiRoundAnalysis;
+  promptAttribution?: RsiPromptAttribution;
 }
 
 export interface MetaAgentPromptResult {
@@ -118,6 +122,8 @@ export interface RunPromptCandidateRoundInput {
   resultsJsonlPath: string;
   heldInTaskIds: readonly string[];
   heldInDigests: readonly TrajectoryDigest[];
+  rsiAnalysis?: RsiRoundAnalysis;
+  promptAttribution?: RsiPromptAttribution;
   heldOutDigests?: readonly TrajectoryDigest[];
   heldOutArtifactPaths?: readonly string[];
   metaAgent: MetaAgent;
@@ -135,6 +141,9 @@ export interface PromptCandidateRoundResult {
   systemPrompt: string;
   summary: string;
   commitSha: string;
+  candidateRationale: CandidateRationale;
+  candidateRationaleHash: string;
+  heldInTaskSetHash: string;
 }
 
 export async function runPromptCandidateRound(
@@ -168,6 +177,8 @@ export async function runPromptCandidateRound(
     currentSystemPrompt,
     resultsTsv,
     heldInDigests: input.heldInDigests,
+    ...(input.rsiAnalysis ? { rsiAnalysis: input.rsiAnalysis } : {}),
+    ...(input.promptAttribution ? { promptAttribution: input.promptAttribution } : {}),
   });
   const candidateRationale = validateCandidateRationale(result.candidateRationale, input.heldInTaskIds);
 
@@ -200,6 +211,9 @@ export async function runPromptCandidateRound(
     systemPrompt: result.systemPrompt,
     summary: result.summary,
     commitSha,
+    candidateRationale,
+    candidateRationaleHash: hashCandidateRationale(candidateRationale),
+    heldInTaskSetHash: hashHeldInTaskSet(input.heldInTaskIds),
   };
 }
 
@@ -387,10 +401,26 @@ export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
     '# Results TSV',
     input.resultsTsv,
     ...renderToolFailureSummary(input.heldInDigests),
+    ...renderRsiAnalysis(input.rsiAnalysis),
+    ...renderPromptAttribution(input.promptAttribution),
     '# Held-In Digests',
     JSON.stringify(stripPromptOnlyToolFailures(input.heldInDigests), null, 2),
     '',
   ].join('\n');
+}
+
+function renderRsiAnalysis(analysis: RsiRoundAnalysis | undefined): string[] {
+  return analysis ? [
+    '# RSI R2 Held-In Analysis',
+    JSON.stringify(analysis, null, 2),
+  ] : [];
+}
+
+function renderPromptAttribution(attribution: RsiPromptAttribution | undefined): string[] {
+  return attribution ? [
+    '# RSI R2 Previous Prompt Attribution',
+    JSON.stringify(attribution, null, 2),
+  ] : [];
 }
 
 export function filterResultsTsvForHeldIn(

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -459,6 +459,7 @@ export async function runPromptOptimizationLoop(
       candidateCommitSha: candidate.commitSha,
       candidateRationaleHash: candidate.candidateRationaleHash,
       candidateRationale: candidate.candidateRationale,
+      promptTimeAnalysis: promptAnalysis,
       analysis: await analyzeRsiRound({
         heldInTaskIds: stableHeldInTaskIds,
         lastKeptEvents: lastKeptHeldInEvents,

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import type { Config } from './contracts.js';
 import {
+  appendFixedPromptWalEvent,
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
   runFixedPromptController,
   readFixedPromptWal,
   type FixedPromptControllerResult,
@@ -9,6 +11,7 @@ import {
   type FixedPromptTaskWalEvent,
   type HarborTaskRunner,
   type PromptCandidateRewardHackScan,
+  type RsiControllerAttributionEvent,
 } from './fixed-prompt-controller.js';
 import {
   extractTrajectoryDigest,
@@ -35,7 +38,6 @@ import {
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
 import { analyzeRsiRound } from './rsi-round-analysis.js';
 import {
-  appendRsiControllerAttribution,
   buildRsiControllerAttribution,
   projectRsiPromptAttribution,
   type RsiPromptAttribution,
@@ -468,12 +470,14 @@ export async function runPromptOptimizationLoop(
       candidateEvents: heldIn.events,
       decision: result,
     });
-    await appendRsiControllerAttribution({
-      resultsJsonlPath: input.resultsJsonlPath,
+    const attributionEvent: RsiControllerAttributionEvent = {
+      schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+      type: 'rsi_controller_attribution',
       id: newId(),
       ts: now(),
-      attribution: controllerAttribution,
-    });
+      ...controllerAttribution,
+    };
+    await appendFixedPromptWalEvent(input.resultsJsonlPath, attributionEvent);
     nextPromptAttribution = projectRsiPromptAttribution(controllerAttribution);
     decisions.push(result);
 

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -33,6 +33,13 @@ import {
   type PromptStructuralSmokeReport,
 } from './prompt-structural-smoke.js';
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
+import { analyzeRsiRound } from './rsi-round-analysis.js';
+import {
+  appendRsiControllerAttribution,
+  buildRsiControllerAttribution,
+  projectRsiPromptAttribution,
+  type RsiPromptAttribution,
+} from './rsi-controller-attribution.js';
 
 /**
  * Top-level driver for the RSI prompt-optimization loop (Issue #64).
@@ -336,6 +343,9 @@ export async function runPromptOptimizationLoop(
   let lastKeptCommitSha = input.originalCommitSha;
   let heldInReference = baseline.heldIn.referencePassEligibleRate;
   let lastKeptHeldInEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(baselineRunsData[0]!.heldInEvents);
+  let previousCandidateHeldInEvents: readonly FixedPromptTaskWalEvent[] | undefined;
+  let latestHeldInFeedbackEvents: readonly FixedPromptTaskWalEvent[] = stableHeldIn(baselineRunsData[baselineRunsData.length - 1]!.heldInEvents);
+  let nextPromptAttribution: RsiPromptAttribution | undefined;
   let nextHeldInDigests = await digestsFor(stableHeldIn(baselineRunsData[baselineRunsData.length - 1]!.heldInEvents));
 
   // 2. Candidate rounds.
@@ -350,6 +360,12 @@ export async function runPromptOptimizationLoop(
       break;
     }
     const roundId = `round-${round}`;
+    const promptAnalysis = await analyzeRsiRound({
+      heldInTaskIds: stableHeldInTaskIds,
+      lastKeptEvents: lastKeptHeldInEvents,
+      ...(previousCandidateHeldInEvents ? { previousCandidateEvents: previousCandidateHeldInEvents } : {}),
+      candidateEvents: latestHeldInFeedbackEvents,
+    });
     const candidate = await runPromptCandidateRound({
       runId: input.runId,
       roundId,
@@ -360,6 +376,8 @@ export async function runPromptOptimizationLoop(
       resultsJsonlPath: input.resultsJsonlPath,
       heldInTaskIds: stableHeldInTaskIds,
       heldInDigests: nextHeldInDigests,
+      rsiAnalysis: promptAnalysis,
+      ...(nextPromptAttribution ? { promptAttribution: nextPromptAttribution } : {}),
       // The held-out TSV is controller-only; always hide it so a careless caller
       // cannot leak held-out results into the meta-agent's view.
       heldOutArtifactPaths: [input.heldOutResultsTsvPath, ...(input.heldOutArtifactPaths ?? [])],
@@ -433,6 +451,30 @@ export async function runPromptOptimizationLoop(
       ts: now(),
       result,
     });
+    const controllerAttribution = buildRsiControllerAttribution({
+      runId: input.runId,
+      roundId,
+      candidateCommitSha: candidate.commitSha,
+      candidateRationaleHash: candidate.candidateRationaleHash,
+      candidateRationale: candidate.candidateRationale,
+      analysis: await analyzeRsiRound({
+        heldInTaskIds: stableHeldInTaskIds,
+        lastKeptEvents: lastKeptHeldInEvents,
+        ...(previousCandidateHeldInEvents ? { previousCandidateEvents: previousCandidateHeldInEvents } : {}),
+        candidateEvents: heldIn.events,
+      }),
+      heldInTaskIds: stableHeldInTaskIds,
+      lastKeptEvents: lastKeptHeldInEvents,
+      candidateEvents: heldIn.events,
+      decision: result,
+    });
+    await appendRsiControllerAttribution({
+      resultsJsonlPath: input.resultsJsonlPath,
+      id: newId(),
+      ts: now(),
+      attribution: controllerAttribution,
+    });
+    nextPromptAttribution = projectRsiPromptAttribution(controllerAttribution);
     decisions.push(result);
 
     if (result.decision === 'keep') {
@@ -443,6 +485,8 @@ export async function runPromptOptimizationLoop(
 
     // The most recent attempt seeds the next round's meta-agent feedback, even
     // when discarded — "this change did not help" is useful signal.
+    previousCandidateHeldInEvents = heldIn.events;
+    latestHeldInFeedbackEvents = heldIn.events;
     nextHeldInDigests = await digestsFor(heldIn.events);
   }
 
@@ -451,6 +495,7 @@ export async function runPromptOptimizationLoop(
   const smoke = promptStructuralSmokeReport({
     events,
     minimumRounds: input.rounds,
+    requireRsiR2Evidence: true,
     ...(input.costCeilingUsd !== undefined ? { costCeilingUsd: input.costCeilingUsd } : {}),
   });
 

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -192,16 +192,27 @@ function roundsWithoutPostDecisionRsiAttribution(events: readonly FixedPromptWal
     }
     if (event.type === 'prompt_candidate_decided') {
       const candidateKey = decisionCandidateEvidenceKey(event);
-      const hasLaterAttribution = events.slice(index + 1).some((later) => (
-        later.type === 'rsi_controller_attribution'
-        && attributionCandidateEvidenceKey(later) === candidateKey
-      ));
+      const hasLaterAttribution = hasPostDecisionAttributionBeforeNextCandidate(events, index, candidateKey);
       if (!hasLaterAttribution || attributedCandidates.has(candidateKey)) {
         missingRounds.set(roundEvidenceKey(event), event.roundId);
       }
     }
   });
   return [...missingRounds.values()];
+}
+
+function hasPostDecisionAttributionBeforeNextCandidate(
+  events: readonly FixedPromptWalEvent[],
+  decisionIndex: number,
+  candidateKey: string,
+): boolean {
+  for (const later of events.slice(decisionIndex + 1)) {
+    if (later.type === 'rsi_controller_attribution' && attributionCandidateEvidenceKey(later) === candidateKey) {
+      return true;
+    }
+    if (later.type === 'prompt_candidate_committed') return false;
+  }
+  return false;
 }
 
 function malformedRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): string[] {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -1,5 +1,6 @@
 import type { FixedPromptTaskWalEvent, FixedPromptWalEvent } from './fixed-prompt-controller.js';
 import { PROMPT_REWARD_HACK_QUARANTINE_REASON } from './prompt-acceptance-policy.js';
+import { projectRsiPromptAttribution } from './rsi-controller-attribution.js';
 
 export type PromptStructuralSmokeFailure =
   | 'minimum_rounds_not_met'
@@ -222,11 +223,24 @@ function malformedRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): 
       || !sameStringSet(event.riskTasks.map((item) => item.taskId), commit.candidateRationale.riskTasks)
       || event.decision.decision !== decision.decision
       || event.decision.reason !== decision.reason
+      || hasUnsafePromptAttributionProjection(event)
     ) {
       rounds.set(roundEvidenceKey(event), event.roundId);
     }
   }
   return [...rounds.values()];
+}
+
+function hasUnsafePromptAttributionProjection(event: Extract<FixedPromptWalEvent, { type: 'rsi_controller_attribution' }>): boolean {
+  const projection = projectRsiPromptAttribution(event);
+  const allowedFields = new Set([
+    'predictedFixes',
+    'riskTasks',
+    'unexpectedHeldInFlips',
+    'rootCauseSignalMatch',
+  ]);
+  if (Object.keys(projection).some((field) => !allowedFields.has(field))) return true;
+  return /decisionReason|held[-_ ]?out|coverage_regressed|held_out_regressed/i.test(JSON.stringify(projection));
 }
 
 function promptCandidateDecisionsByCandidateKey(events: readonly FixedPromptWalEvent[]): Map<string, Extract<FixedPromptWalEvent, { type: 'prompt_candidate_decided' }>> {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -8,12 +8,14 @@ export type PromptStructuralSmokeFailure =
   | 'cost_ceiling_exceeded'
   | 'plumbing_failures_present'
   | 'reward_hack_scan_missing'
-  | 'reward_hack_quarantine_present';
+  | 'reward_hack_quarantine_present'
+  | 'rsi_attribution_missing';
 
 export interface PromptStructuralSmokeReportInput {
   events: readonly FixedPromptWalEvent[];
   minimumRounds?: number;
   costCeilingUsd?: number;
+  requireRsiR2Evidence?: boolean;
 }
 
 export interface PromptStructuralSmokeReport {
@@ -32,6 +34,7 @@ export interface PromptStructuralSmokeReport {
   };
   quarantineCount: number;
   roundsWithoutTaskEvidence: string[];
+  roundsWithoutRsiAttribution: string[];
   totalCostUsd: number;
   costCeilingUsd?: number;
   failures: PromptStructuralSmokeFailure[];
@@ -48,6 +51,10 @@ export function promptStructuralSmokeReport(
   const observedRunCount = new Set(decisionEvents.map((event) => event.runId)).size;
   const roundsWithoutTaskEvidence = roundsWithoutPriorTaskEvidence(input.events)
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const roundsWithoutRsiAttribution = input.requireRsiR2Evidence
+    ? roundsWithoutPostDecisionRsiAttribution(input.events)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    : [];
   const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const missingRewardHackScanCount = decisionEvents.filter((event) => event.rewardHackScan === undefined).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
@@ -65,6 +72,7 @@ export function promptStructuralSmokeReport(
   }
   if (missingRewardHackScanCount > 0) failures.push('reward_hack_scan_missing');
   if (quarantineCount > 0) failures.push('reward_hack_quarantine_present');
+  if (roundsWithoutRsiAttribution.length > 0) failures.push('rsi_attribution_missing');
 
   return {
     schemaVersion: 'maka.prompt_structural_smoke.v1',
@@ -82,6 +90,7 @@ export function promptStructuralSmokeReport(
     },
     quarantineCount,
     roundsWithoutTaskEvidence,
+    roundsWithoutRsiAttribution,
     totalCostUsd,
     ...(input.costCeilingUsd !== undefined ? { costCeilingUsd: input.costCeilingUsd } : {}),
     failures,
@@ -149,11 +158,36 @@ function roundsWithoutPriorTaskEvidence(events: readonly FixedPromptWalEvent[]):
   return [...missingRounds.values()];
 }
 
+function roundsWithoutPostDecisionRsiAttribution(events: readonly FixedPromptWalEvent[]): string[] {
+  const attributedCandidates = new Set<string>();
+  const missingRounds = new Map<string, string>();
+  events.forEach((event, index) => {
+    if (event.type === 'rsi_controller_attribution') {
+      attributedCandidates.add(attributionCandidateEvidenceKey(event));
+    }
+    if (event.type === 'prompt_candidate_decided') {
+      const candidateKey = decisionCandidateEvidenceKey(event);
+      const hasLaterAttribution = events.slice(index + 1).some((later) => (
+        later.type === 'rsi_controller_attribution'
+        && attributionCandidateEvidenceKey(later) === candidateKey
+      ));
+      if (!hasLaterAttribution || attributedCandidates.has(candidateKey)) {
+        missingRounds.set(roundEvidenceKey(event), event.roundId);
+      }
+    }
+  });
+  return [...missingRounds.values()];
+}
+
 function candidateEvidenceKey(event: { runId: string; roundId: string; commitSha: string }): string {
   return `${event.runId}\0${event.roundId}\0${event.commitSha}`;
 }
 
 function decisionCandidateEvidenceKey(event: { runId: string; roundId: string; candidateCommitSha: string }): string {
+  return `${event.runId}\0${event.roundId}\0${event.candidateCommitSha}`;
+}
+
+function attributionCandidateEvidenceKey(event: { runId: string; roundId: string; candidateCommitSha: string }): string {
   return `${event.runId}\0${event.roundId}\0${event.candidateCommitSha}`;
 }
 

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -205,19 +205,36 @@ function roundsWithoutPostDecisionRsiAttribution(events: readonly FixedPromptWal
 
 function malformedRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): string[] {
   const commits = promptCandidateCommitsByCandidateKey(events);
+  const decisions = promptCandidateDecisionsByCandidateKey(events);
   const rounds = new Map<string, string>();
   for (const event of events) {
     if (event.type !== 'rsi_controller_attribution') continue;
-    const commit = commits.get(attributionCandidateEvidenceKey(event));
+    const candidateKey = attributionCandidateEvidenceKey(event);
+    const commit = commits.get(candidateKey);
+    const decision = decisions.get(candidateKey);
     if (
       !commit
+      || !decision
       || event.heldInTaskSetHash !== commit.heldInTaskSetHash
       || event.candidateRationaleHash !== commit.candidateRationaleHash
+      || !sameStringSet(event.evidenceRefs, commit.candidateRationale.evidenceRefs)
+      || !sameStringSet(event.predictedFixes.map((item) => item.taskId), commit.candidateRationale.predictedFixes)
+      || !sameStringSet(event.riskTasks.map((item) => item.taskId), commit.candidateRationale.riskTasks)
+      || event.decision.decision !== decision.decision
+      || event.decision.reason !== decision.reason
     ) {
       rounds.set(roundEvidenceKey(event), event.roundId);
     }
   }
   return [...rounds.values()];
+}
+
+function promptCandidateDecisionsByCandidateKey(events: readonly FixedPromptWalEvent[]): Map<string, Extract<FixedPromptWalEvent, { type: 'prompt_candidate_decided' }>> {
+  const decisions = new Map<string, Extract<FixedPromptWalEvent, { type: 'prompt_candidate_decided' }>>();
+  for (const event of events) {
+    if (event.type === 'prompt_candidate_decided') decisions.set(decisionCandidateEvidenceKey(event), event);
+  }
+  return decisions;
 }
 
 function outOfScopeRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): string[] {
@@ -254,6 +271,17 @@ function attributionCandidateEvidenceKey(event: { runId: string; roundId: string
 
 function roundPromptHashEvidenceKey(event: { runId: string; roundId: string }, promptHash: string): string {
   return `${roundEvidenceKey(event)}\0${promptHash}`;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  const sortedLeft = sortedUnique(left);
+  const sortedRight = sortedUnique(right);
+  return sortedLeft.length === sortedRight.length
+    && sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
 }
 
 function isQuarantineDecision(event: { reason: string; rewardHackScan?: unknown }): boolean {

--- a/packages/headless/src/prompt-structural-smoke.ts
+++ b/packages/headless/src/prompt-structural-smoke.ts
@@ -9,7 +9,9 @@ export type PromptStructuralSmokeFailure =
   | 'plumbing_failures_present'
   | 'reward_hack_scan_missing'
   | 'reward_hack_quarantine_present'
-  | 'rsi_attribution_missing';
+  | 'rsi_attribution_missing'
+  | 'rsi_attribution_malformed'
+  | 'rsi_attribution_task_scope_invalid';
 
 export interface PromptStructuralSmokeReportInput {
   events: readonly FixedPromptWalEvent[];
@@ -35,6 +37,8 @@ export interface PromptStructuralSmokeReport {
   quarantineCount: number;
   roundsWithoutTaskEvidence: string[];
   roundsWithoutRsiAttribution: string[];
+  roundsWithMalformedRsiAttribution: string[];
+  roundsWithOutOfScopeRsiAttribution: string[];
   totalCostUsd: number;
   costCeilingUsd?: number;
   failures: PromptStructuralSmokeFailure[];
@@ -55,6 +59,14 @@ export function promptStructuralSmokeReport(
     ? roundsWithoutPostDecisionRsiAttribution(input.events)
       .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
     : [];
+  const roundsWithMalformedRsiAttribution = input.requireRsiR2Evidence
+    ? malformedRsiAttributionRounds(input.events)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    : [];
+  const roundsWithOutOfScopeRsiAttribution = input.requireRsiR2Evidence
+    ? outOfScopeRsiAttributionRounds(input.events)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    : [];
   const quarantineCount = decisionEvents.filter((event) => isQuarantineDecision(event)).length;
   const missingRewardHackScanCount = decisionEvents.filter((event) => event.rewardHackScan === undefined).length;
   const totalCostUsd = roundCost(sum(taskEvents.map((event) => (
@@ -73,6 +85,8 @@ export function promptStructuralSmokeReport(
   if (missingRewardHackScanCount > 0) failures.push('reward_hack_scan_missing');
   if (quarantineCount > 0) failures.push('reward_hack_quarantine_present');
   if (roundsWithoutRsiAttribution.length > 0) failures.push('rsi_attribution_missing');
+  if (roundsWithMalformedRsiAttribution.length > 0) failures.push('rsi_attribution_malformed');
+  if (roundsWithOutOfScopeRsiAttribution.length > 0) failures.push('rsi_attribution_task_scope_invalid');
 
   return {
     schemaVersion: 'maka.prompt_structural_smoke.v1',
@@ -91,10 +105,20 @@ export function promptStructuralSmokeReport(
     quarantineCount,
     roundsWithoutTaskEvidence,
     roundsWithoutRsiAttribution,
+    roundsWithMalformedRsiAttribution,
+    roundsWithOutOfScopeRsiAttribution,
     totalCostUsd,
     ...(input.costCeilingUsd !== undefined ? { costCeilingUsd: input.costCeilingUsd } : {}),
     failures,
   };
+}
+
+function promptCandidateCommitsByCandidateKey(events: readonly FixedPromptWalEvent[]): Map<string, Extract<FixedPromptWalEvent, { type: 'prompt_candidate_committed' }>> {
+  const commits = new Map<string, Extract<FixedPromptWalEvent, { type: 'prompt_candidate_committed' }>>();
+  for (const event of events) {
+    if (event.type === 'prompt_candidate_committed') commits.set(candidateEvidenceKey(event), event);
+  }
+  return commits;
 }
 
 export function renderPromptStructuralSmokeMarkdown(report: PromptStructuralSmokeReport): string {
@@ -177,6 +201,43 @@ function roundsWithoutPostDecisionRsiAttribution(events: readonly FixedPromptWal
     }
   });
   return [...missingRounds.values()];
+}
+
+function malformedRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): string[] {
+  const commits = promptCandidateCommitsByCandidateKey(events);
+  const rounds = new Map<string, string>();
+  for (const event of events) {
+    if (event.type !== 'rsi_controller_attribution') continue;
+    const commit = commits.get(attributionCandidateEvidenceKey(event));
+    if (
+      !commit
+      || event.heldInTaskSetHash !== commit.heldInTaskSetHash
+      || event.candidateRationaleHash !== commit.candidateRationaleHash
+    ) {
+      rounds.set(roundEvidenceKey(event), event.roundId);
+    }
+  }
+  return [...rounds.values()];
+}
+
+function outOfScopeRsiAttributionRounds(events: readonly FixedPromptWalEvent[]): string[] {
+  const commits = promptCandidateCommitsByCandidateKey(events);
+  const rounds = new Map<string, string>();
+  for (const event of events) {
+    if (event.type !== 'rsi_controller_attribution') continue;
+    const commit = commits.get(attributionCandidateEvidenceKey(event));
+    if (!commit) continue;
+    const heldIn = new Set(commit.heldInTaskIds);
+    const taskIds = [
+      ...event.predictedFixes.map((item) => item.taskId),
+      ...event.riskTasks.map((item) => item.taskId),
+      ...event.unexpectedHeldInFlips.map((item) => item.taskId),
+    ];
+    if (taskIds.some((taskId) => !heldIn.has(taskId))) {
+      rounds.set(roundEvidenceKey(event), event.roundId);
+    }
+  }
+  return [...rounds.values()];
 }
 
 function candidateEvidenceKey(event: { runId: string; roundId: string; commitSha: string }): string {

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -30,6 +30,15 @@ export interface RsiControllerAttribution {
   rootCauseSignalMatch: RsiRootCauseSignalMatch;
 }
 
+export interface RsiPromptAttribution {
+  candidateCommitSha: string;
+  decisionReason: PromptAcceptanceResult['reason'] | 'discarded_by_controller_safety_gate';
+  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: RsiTaskTransition[];
+  rootCauseSignalMatch: RsiRootCauseSignalMatch;
+}
+
 export interface BuildRsiControllerAttributionInput {
   runId: string;
   roundId: string;
@@ -98,6 +107,23 @@ export async function appendRsiControllerAttribution(
   };
   await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
   return event;
+}
+
+export function projectRsiPromptAttribution(attribution: RsiControllerAttribution): RsiPromptAttribution {
+  return {
+    candidateCommitSha: attribution.candidateCommitSha,
+    decisionReason: promptSafeDecisionReason(attribution.decision.reason),
+    predictedFixes: attribution.predictedFixes,
+    riskTasks: attribution.riskTasks,
+    unexpectedHeldInFlips: attribution.unexpectedHeldInFlips,
+    rootCauseSignalMatch: attribution.rootCauseSignalMatch,
+  };
+}
+
+function promptSafeDecisionReason(
+  reason: PromptAcceptanceResult['reason'],
+): RsiPromptAttribution['decisionReason'] {
+  return reason === 'held_out_regressed' ? 'discarded_by_controller_safety_gate' : reason;
 }
 
 function eventsByTask(

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -20,6 +20,7 @@ export interface RsiControllerAttribution {
   candidateCommitSha: string;
   heldInTaskSetHash: string;
   candidateRationaleHash: string;
+  evidenceRefs: string[];
   predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
   riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
   unexpectedHeldInFlips: RsiTaskTransition[];
@@ -32,7 +33,6 @@ export interface RsiControllerAttribution {
 
 export interface RsiPromptAttribution {
   candidateCommitSha: string;
-  decisionReason: PromptAcceptanceResult['reason'] | 'discarded_by_controller_safety_gate';
   predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
   riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
   unexpectedHeldInFlips: RsiTaskTransition[];
@@ -83,6 +83,7 @@ export function buildRsiControllerAttribution(
     candidateCommitSha: input.candidateCommitSha,
     heldInTaskSetHash: input.analysis.heldInTaskSetHash,
     candidateRationaleHash: input.candidateRationaleHash,
+    evidenceRefs: sortedUnique(input.candidateRationale.evidenceRefs),
     predictedFixes,
     riskTasks,
     unexpectedHeldInFlips: input.analysis.transitionVsLastKept
@@ -112,18 +113,11 @@ export async function appendRsiControllerAttribution(
 export function projectRsiPromptAttribution(attribution: RsiControllerAttribution): RsiPromptAttribution {
   return {
     candidateCommitSha: attribution.candidateCommitSha,
-    decisionReason: promptSafeDecisionReason(attribution.decision.reason),
     predictedFixes: attribution.predictedFixes,
     riskTasks: attribution.riskTasks,
     unexpectedHeldInFlips: attribution.unexpectedHeldInFlips,
     rootCauseSignalMatch: attribution.rootCauseSignalMatch,
   };
-}
-
-function promptSafeDecisionReason(
-  reason: PromptAcceptanceResult['reason'],
-): RsiPromptAttribution['decisionReason'] {
-  return reason === 'held_out_regressed' ? 'discarded_by_controller_safety_gate' : reason;
 }
 
 function eventsByTask(
@@ -168,7 +162,10 @@ function rootCauseSignalMatch(
   rationale: PromptCandidateRationale,
   analysis: RsiRoundAnalysis,
 ): RsiRootCauseSignalMatch {
-  const signalKinds = new Set(analysis.signals.map((signal) => signal.kind));
+  if (rationale.evidenceRefs.length === 0) return 'unknown';
+  const referenced = new Set(rationale.evidenceRefs);
+  const referencedSignals = analysis.signals.filter((signal) => referenced.has(signal.id));
+  const signalKinds = new Set(referencedSignals.map((signal) => signal.kind));
   if (rationale.failurePattern === 'coverage_regression') {
     return signalKinds.has('coverage_regression') ? 'matched' : 'contradicted';
   }
@@ -176,7 +173,7 @@ function rootCauseSignalMatch(
     return signalKinds.has('tool_failure_cluster') ? 'matched' : 'contradicted';
   }
   if (rationale.failurePattern === 'max_tokens' || rationale.failurePattern === 'verification_failed') {
-    return analysis.errorClassDistribution.some((group) => group.errorClass === rationale.failurePattern)
+    return referencedSignals.some((signal) => signal.kind === 'error_class' && signal.errorClass === rationale.failurePattern)
       ? 'matched'
       : 'contradicted';
   }

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -1,11 +1,6 @@
 import type {
   FixedPromptTaskWalEvent,
   PromptCandidateRationale,
-  RsiControllerAttributionEvent,
-} from './fixed-prompt-controller.js';
-import {
-  appendFixedPromptWalEvent,
-  FIXED_PROMPT_WAL_SCHEMA_VERSION,
 } from './fixed-prompt-controller.js';
 import type { PromptAcceptanceResult } from './prompt-acceptance-policy.js';
 import type { RsiRoundAnalysis, RsiTaskOutcome, RsiTaskTransition } from './rsi-round-analysis.js';
@@ -52,13 +47,6 @@ export interface BuildRsiControllerAttributionInput {
   decision: PromptAcceptanceResult;
 }
 
-export interface AppendRsiControllerAttributionInput {
-  resultsJsonlPath: string;
-  id: string;
-  ts: number;
-  attribution: RsiControllerAttribution;
-}
-
 export function buildRsiControllerAttribution(
   input: BuildRsiControllerAttributionInput,
 ): RsiControllerAttribution {
@@ -94,20 +82,6 @@ export function buildRsiControllerAttribution(
     },
     rootCauseSignalMatch: rootCauseSignalMatch(input.candidateRationale, input.analysis),
   };
-}
-
-export async function appendRsiControllerAttribution(
-  input: AppendRsiControllerAttributionInput,
-): Promise<RsiControllerAttributionEvent> {
-  const event: RsiControllerAttributionEvent = {
-    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
-    type: 'rsi_controller_attribution',
-    id: input.id,
-    ts: input.ts,
-    ...input.attribution,
-  };
-  await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
-  return event;
 }
 
 export function projectRsiPromptAttribution(attribution: RsiControllerAttribution): RsiPromptAttribution {

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -46,6 +46,7 @@ export interface BuildRsiControllerAttributionInput {
   candidateCommitSha: string;
   candidateRationaleHash: string;
   candidateRationale: PromptCandidateRationale;
+  promptTimeAnalysis?: RsiRoundAnalysis;
   analysis: RsiRoundAnalysis;
   heldInTaskIds: readonly string[];
   lastKeptEvents: readonly FixedPromptTaskWalEvent[];
@@ -86,7 +87,7 @@ export function buildRsiControllerAttribution(
       decision: input.decision.decision,
       reason: input.decision.reason,
     },
-    rootCauseSignalMatch: rootCauseSignalMatch(input.candidateRationale, input.analysis),
+    rootCauseSignalMatch: rootCauseSignalMatch(input.candidateRationale, input.promptTimeAnalysis ?? input.analysis),
   };
 }
 

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -1,13 +1,18 @@
 import type {
   FixedPromptTaskWalEvent,
   PromptCandidateRationale,
+  RsiPredictedFixOutcome,
+  RsiRiskTaskOutcome,
+  RsiRootCauseSignalMatch,
 } from './fixed-prompt-controller.js';
 import type { PromptAcceptanceResult } from './prompt-acceptance-policy.js';
 import type { RsiRoundAnalysis, RsiTaskOutcome, RsiTaskTransition } from './rsi-round-analysis.js';
 
-export type RsiPredictedFixOutcome = 'improved' | 'unchanged' | 'regressed' | 'unscored' | 'missing';
-export type RsiRiskTaskOutcome = 'safe' | 'regressed' | 'unscored' | 'missing';
-export type RsiRootCauseSignalMatch = 'matched' | 'contradicted' | 'unknown';
+export type {
+  RsiPredictedFixOutcome,
+  RsiRiskTaskOutcome,
+  RsiRootCauseSignalMatch,
+} from './fixed-prompt-controller.js';
 
 export interface RsiControllerAttribution {
   runId: string;

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -27,10 +27,16 @@ export interface RsiControllerAttribution {
 }
 
 export interface RsiPromptAttribution {
-  candidateCommitSha: string;
-  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
-  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
-  unexpectedHeldInFlips: RsiTaskTransition[];
+  predictedFixes: ReadonlyArray<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: ReadonlyArray<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: ReadonlyArray<{ taskId: string; from: string; to: string }>;
+  rootCauseSignalMatch: RsiRootCauseSignalMatch;
+}
+
+export interface ProjectRsiPromptAttributionInput {
+  predictedFixes: ReadonlyArray<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: ReadonlyArray<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: ReadonlyArray<{ taskId: string; from: string; to: string }>;
   rootCauseSignalMatch: RsiRootCauseSignalMatch;
 }
 
@@ -84,9 +90,8 @@ export function buildRsiControllerAttribution(
   };
 }
 
-export function projectRsiPromptAttribution(attribution: RsiControllerAttribution): RsiPromptAttribution {
+export function projectRsiPromptAttribution(attribution: ProjectRsiPromptAttributionInput): RsiPromptAttribution {
   return {
-    candidateCommitSha: attribution.candidateCommitSha,
     predictedFixes: attribution.predictedFixes,
     riskTasks: attribution.riskTasks,
     unexpectedHeldInFlips: attribution.unexpectedHeldInFlips,
@@ -146,12 +151,18 @@ function rootCauseSignalMatch(
   if (rationale.failurePattern === 'tool_failed') {
     return signalKinds.has('tool_failure_cluster') ? 'matched' : 'contradicted';
   }
-  if (rationale.failurePattern === 'max_tokens' || rationale.failurePattern === 'verification_failed') {
+  if (isErrorClassBackedFailurePattern(rationale.failurePattern)) {
     return referencedSignals.some((signal) => signal.kind === 'error_class' && signal.errorClass === rationale.failurePattern)
       ? 'matched'
       : 'contradicted';
   }
   return 'unknown';
+}
+
+function isErrorClassBackedFailurePattern(failurePattern: PromptCandidateRationale['failurePattern']): boolean {
+  return failurePattern === 'max_tokens'
+    || failurePattern === 'runtime_error'
+    || failurePattern === 'verification_failed';
 }
 
 function sortedUnique(values: readonly string[]): string[] {

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -38,12 +38,7 @@ export interface RsiPromptAttribution {
   rootCauseSignalMatch: RsiRootCauseSignalMatch;
 }
 
-export interface ProjectRsiPromptAttributionInput {
-  predictedFixes: ReadonlyArray<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
-  riskTasks: ReadonlyArray<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
-  unexpectedHeldInFlips: ReadonlyArray<{ taskId: string; from: string; to: string }>;
-  rootCauseSignalMatch: RsiRootCauseSignalMatch;
-}
+export type ProjectRsiPromptAttributionInput = RsiPromptAttribution;
 
 export interface BuildRsiControllerAttributionInput {
   runId: string;
@@ -97,9 +92,9 @@ export function buildRsiControllerAttribution(
 
 export function projectRsiPromptAttribution(attribution: ProjectRsiPromptAttributionInput): RsiPromptAttribution {
   return {
-    predictedFixes: attribution.predictedFixes,
-    riskTasks: attribution.riskTasks,
-    unexpectedHeldInFlips: attribution.unexpectedHeldInFlips,
+    predictedFixes: attribution.predictedFixes.map(({ taskId, outcome }) => ({ taskId, outcome })),
+    riskTasks: attribution.riskTasks.map(({ taskId, outcome }) => ({ taskId, outcome })),
+    unexpectedHeldInFlips: attribution.unexpectedHeldInFlips.map(({ taskId, from, to }) => ({ taskId, from, to })),
     rootCauseSignalMatch: attribution.rootCauseSignalMatch,
   };
 }

--- a/packages/headless/src/rsi-controller-attribution.ts
+++ b/packages/headless/src/rsi-controller-attribution.ts
@@ -1,0 +1,166 @@
+import type {
+  FixedPromptTaskWalEvent,
+  PromptCandidateRationale,
+  RsiControllerAttributionEvent,
+} from './fixed-prompt-controller.js';
+import {
+  appendFixedPromptWalEvent,
+  FIXED_PROMPT_WAL_SCHEMA_VERSION,
+} from './fixed-prompt-controller.js';
+import type { PromptAcceptanceResult } from './prompt-acceptance-policy.js';
+import type { RsiRoundAnalysis, RsiTaskOutcome, RsiTaskTransition } from './rsi-round-analysis.js';
+
+export type RsiPredictedFixOutcome = 'improved' | 'unchanged' | 'regressed' | 'unscored' | 'missing';
+export type RsiRiskTaskOutcome = 'safe' | 'regressed' | 'unscored' | 'missing';
+export type RsiRootCauseSignalMatch = 'matched' | 'contradicted' | 'unknown';
+
+export interface RsiControllerAttribution {
+  runId: string;
+  roundId: string;
+  candidateCommitSha: string;
+  heldInTaskSetHash: string;
+  candidateRationaleHash: string;
+  predictedFixes: Array<{ taskId: string; outcome: RsiPredictedFixOutcome }>;
+  riskTasks: Array<{ taskId: string; outcome: RsiRiskTaskOutcome }>;
+  unexpectedHeldInFlips: RsiTaskTransition[];
+  decision: {
+    decision: PromptAcceptanceResult['decision'];
+    reason: PromptAcceptanceResult['reason'];
+  };
+  rootCauseSignalMatch: RsiRootCauseSignalMatch;
+}
+
+export interface BuildRsiControllerAttributionInput {
+  runId: string;
+  roundId: string;
+  candidateCommitSha: string;
+  candidateRationaleHash: string;
+  candidateRationale: PromptCandidateRationale;
+  analysis: RsiRoundAnalysis;
+  heldInTaskIds: readonly string[];
+  lastKeptEvents: readonly FixedPromptTaskWalEvent[];
+  candidateEvents: readonly FixedPromptTaskWalEvent[];
+  decision: PromptAcceptanceResult;
+}
+
+export interface AppendRsiControllerAttributionInput {
+  resultsJsonlPath: string;
+  id: string;
+  ts: number;
+  attribution: RsiControllerAttribution;
+}
+
+export function buildRsiControllerAttribution(
+  input: BuildRsiControllerAttributionInput,
+): RsiControllerAttribution {
+  const heldInTaskIds = [...new Set(input.heldInTaskIds)].sort(compareStrings);
+  const heldIn = new Set(heldInTaskIds);
+  const previous = eventsByTask(input.lastKeptEvents, heldIn);
+  const current = eventsByTask(input.candidateEvents, heldIn);
+  const predictedFixes = sortedUnique(input.candidateRationale.predictedFixes)
+    .map((taskId) => ({
+      taskId,
+      outcome: predictedFixOutcome(taskOutcome(previous.get(taskId)), taskOutcome(current.get(taskId))),
+    }));
+  const riskTasks = sortedUnique(input.candidateRationale.riskTasks)
+    .map((taskId) => ({
+      taskId,
+      outcome: riskTaskOutcome(taskOutcome(previous.get(taskId)), taskOutcome(current.get(taskId))),
+    }));
+  const predictedOrRisk = new Set([...input.candidateRationale.predictedFixes, ...input.candidateRationale.riskTasks]);
+  return {
+    runId: input.runId,
+    roundId: input.roundId,
+    candidateCommitSha: input.candidateCommitSha,
+    heldInTaskSetHash: input.analysis.heldInTaskSetHash,
+    candidateRationaleHash: input.candidateRationaleHash,
+    predictedFixes,
+    riskTasks,
+    unexpectedHeldInFlips: input.analysis.transitionVsLastKept
+      .filter((transition) => heldIn.has(transition.taskId) && !predictedOrRisk.has(transition.taskId)),
+    decision: {
+      decision: input.decision.decision,
+      reason: input.decision.reason,
+    },
+    rootCauseSignalMatch: rootCauseSignalMatch(input.candidateRationale, input.analysis),
+  };
+}
+
+export async function appendRsiControllerAttribution(
+  input: AppendRsiControllerAttributionInput,
+): Promise<RsiControllerAttributionEvent> {
+  const event: RsiControllerAttributionEvent = {
+    schemaVersion: FIXED_PROMPT_WAL_SCHEMA_VERSION,
+    type: 'rsi_controller_attribution',
+    id: input.id,
+    ts: input.ts,
+    ...input.attribution,
+  };
+  await appendFixedPromptWalEvent(input.resultsJsonlPath, event);
+  return event;
+}
+
+function eventsByTask(
+  events: readonly FixedPromptTaskWalEvent[],
+  heldIn: ReadonlySet<string>,
+): Map<string, FixedPromptTaskWalEvent> {
+  const byTask = new Map<string, FixedPromptTaskWalEvent>();
+  for (const event of events) {
+    if (heldIn.has(event.taskId)) byTask.set(event.taskId, event);
+  }
+  return byTask;
+}
+
+function predictedFixOutcome(from: RsiTaskOutcome, to: RsiTaskOutcome): RsiPredictedFixOutcome {
+  if (to === 'missing') return 'missing';
+  if (to === 'unscored' || to === 'infra' || to === 'budget' || to === 'plumbing') return 'unscored';
+  if (score(to) > score(from)) return 'improved';
+  if (score(to) < score(from)) return 'regressed';
+  return 'unchanged';
+}
+
+function riskTaskOutcome(from: RsiTaskOutcome, to: RsiTaskOutcome): RsiRiskTaskOutcome {
+  if (to === 'missing') return 'missing';
+  if (to === 'unscored' || to === 'infra' || to === 'budget' || to === 'plumbing') return 'unscored';
+  return score(to) < score(from) ? 'regressed' : 'safe';
+}
+
+function taskOutcome(event: FixedPromptTaskWalEvent | undefined): RsiTaskOutcome {
+  if (!event) return 'missing';
+  if (event.type === 'task_infra_failed') return 'infra';
+  if (event.type === 'task_budget_exhausted') return 'budget';
+  if (event.type === 'task_plumbing_failed') return 'plumbing';
+  if (!event.eligible || !event.scored) return 'unscored';
+  return event.passed ? 'pass' : 'fail';
+}
+
+function score(outcome: RsiTaskOutcome): number {
+  return outcome === 'pass' ? 1 : 0;
+}
+
+function rootCauseSignalMatch(
+  rationale: PromptCandidateRationale,
+  analysis: RsiRoundAnalysis,
+): RsiRootCauseSignalMatch {
+  const signalKinds = new Set(analysis.signals.map((signal) => signal.kind));
+  if (rationale.failurePattern === 'coverage_regression') {
+    return signalKinds.has('coverage_regression') ? 'matched' : 'contradicted';
+  }
+  if (rationale.failurePattern === 'tool_failed') {
+    return signalKinds.has('tool_failure_cluster') ? 'matched' : 'contradicted';
+  }
+  if (rationale.failurePattern === 'max_tokens' || rationale.failurePattern === 'verification_failed') {
+    return analysis.errorClassDistribution.some((group) => group.errorClass === rationale.failurePattern)
+      ? 'matched'
+      : 'contradicted';
+  }
+  return 'unknown';
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort(compareStrings);
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Add controller-owned RSI attribution records that compare candidate rationale predictions against held-in outcomes.
- Persist attribution in the fixed-prompt WAL after each prompt decision.
- Project held-in-safe attribution plus deterministic analysis into the next meta-agent prompt and require R2 attribution evidence in loop structural smoke.

## Why
R2 needs the prompt optimizer to close the loop from held-in evidence to candidate rationale to actual outcome to next-round learning signal without changing keep/discard semantics or leaking held-out safety details.

Refs #311

## Scope
Changed:
- packages/headless/src/rsi-controller-attribution.ts attribution model, WAL append helper, and prompt-safe projection.
- Prompt candidate input/rendering to accept deterministic rsiAnalysis and prior promptAttribution.
- Prompt optimization loop to generate analysis before candidate render, append attribution after decisions, and pass prompt-safe feedback to the next round.
- Structural smoke to require post-decision R2 attribution when the loop enables R2 evidence checks.

Not included:
- Real R2 validation run/report.
- New LLM call sites or automatic rationale repair.
- Any change to prompt acceptance keep/discard semantics.

## Verification
- npm run -w @maka/headless test
- npm run -w @maka/headless typecheck

## User-facing impact
No desktop UI impact. Headless RSI prompt optimization now records R2 attribution and feeds held-in-only attribution into subsequent candidate prompts.

## Reviewer notes
- This PR intentionally keeps the full attribution in controller WAL and only passes promptAttribution into the meta-agent.
- held_out_regressed is projected as discarded_by_controller_safety_gate for prompt-visible feedback.
- Branch contains two review commits: attribution model first, loop/projection/smoke second.