### PR TITLE
chore: add AstroHan mailmap entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,3 +4,4 @@
 # Keep shared history immutable, but make Git/GitHub contributor views fold
 # those commits under the canonical GitHub identity.
 likun666661 <90952590+likun666661@users.noreply.github.com> likun <kunli@alva.xyz>
+AstroHan <lei.yuhan@outlook.com> Yuhan Lei <lei.yuhan@outlook.com>


### PR DESCRIPTION
## Summary
- Add a mailmap entry that folds the historical `Yuhan Lei` author name into `AstroHan` for the same email address.

## Testing
- `git shortlog -sn --no-merges HEAD`
- `git log --no-merges --use-mailmap --format='%aN <%aE>' | sort | uniq -c | sort -nr`

No code changes, no history rewrite.