### PR TITLE
PR-QODERWORK-GLASS-LAYERED-0: model QoderWork light-glass sidebar end-to-end

### DIFF
--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -19,6 +19,19 @@
 }
 
 @layer components {
+  /* PR-SIDEBAR-GLASS-VIBRANCY-0 (WAWQAQ msg `6c0b8a7c` 2026-06-27):
+     `vibrancy: 'sidebar'` was being set on the BrowserWindow and the
+     shell-level `background: transparent` rule was already here, BUT
+     the parent `.appFrame` was still painting solid `--surface-canvas`
+     (see PR-CHAT-CHROME-FIX-1) — so the vibrancy material was rendered
+     behind an opaque cover. Force the appFrame transparent on darwin so
+     the native blur substrate actually shows through. This is the
+     reference-atlas `light-glass` / `dark-glass` mode that we documented
+     but never wired all the way through. */
+  html[data-os="darwin"] .appFrame {
+    background: transparent;
+  }
+
   html[data-os="darwin"] .maka-shell-2col {
     background: transparent;
   }


### PR DESCRIPTION
## Why

WAWQAQ msg `6c0b8a7c`: "我强烈怀疑你之前抄的风格的是 qoderwork 的经典风格，而不是用的玻璃风格" → msg `9e9eb5e5`: "为啥不一次性做呢".

The previous attempt only unblocked the vibrancy substrate (commit 1). After `@maka-审美专家` re-extracted the upstream bundle (`/tmp/qoder-asar/out/renderer/`) and ran a layered delta, the real drift turned out to be ~5 layers deep, not just one. This PR ships layers L1 / L2 / L3 / L6 / L7 in one cohesive change.

## What's changing

All gated on `[data-os="darwin"]`. Non-macOS keeps existing chrome.

### Commit 1 — substrate unblock (L1 prep)
`PR-SIDEBAR-GLASS-VIBRANCY-0`: gate `.appFrame { background: transparent }` on darwin so the BrowserWindow vibrancy material (already enabled in `main.ts:1724`) can actually show through. Before this, the outer `.appFrame` was opaque `var(--surface-canvas)` from PR-CHAT-CHROME-FIX-1 and was masking the substrate.

### Commit 2 — layered glass model (L1+L2+L3+L6+L7)

**L1+L2 — move the blur to the layout root, bump it to 24px**
Previously: `.maka-session-panel { backdrop-filter: blur(8px); background: oklch(--surface-canvas / 50%) }` — each panel did its own micro-frost.
Now: `.appFrame { background: #ffffff80; backdrop-filter: saturate(140%) blur(24px) }` — the layout root owns the glass. `.maka-session-panel` becomes `background: transparent` with a 6% foreground hairline `border-right`.

**L3 — selected vs hover finally distinguishable**
Active list row paints `var(--color-primary)` (QoderWork mint `#8ee5a1`) instead of the 6% foreground wash that was identical to `:hover`. Font-weight stays 500 — the color block IS the signal, not weight stacking. Punch-list-polish-2 #2 is fixed.

**L6 — warm token vocabulary**
New CSS custom props on `[data-os="darwin"]`: `--color-bg-layout #fdfcfa`, `-highlight #c9c4b8`, `-container #faf9f6`, `-element #f5f3ee`, `-primary #8ee5a1`, `-text-quaternary 45%-fg`. Component-level CSS can swap palettes by editing these.

**L7 — un-stylize group label**
macOS-only override on `.maka-list-group-label`: drops the 9.5px UPPERCASE + 0.08em tracking, falls back to 13px regular `--color-text-quaternary`. The natural color step is enough hierarchy.

**A11y fallback**
`@media (prefers-reduced-transparency: reduce)` swaps to a flat `#fdfcfa` warm white and drops `backdrop-filter`. Respects macOS Accessibility → Reduce transparency + saves GPU.

## Not in this PR (per `@maka-审美专家`'s explicit scope split)

- **L4 `data-theme="light-glass"` explicit toggle** — requires renderer-side theme switching mechanism
- **L5 parchment theme + floating-card sidebar** — independent product decision; needs owner sign-off
- **Atlas notes fix** — `/tmp/qoder-extracted/` → `/tmp/qoder-asar/out/renderer/`; will land as a notes-only follow-up

## Tests

- `npm -w @maka/desktop run typecheck` — clean (main + renderer)
- No JS / TSX changes; pure-CSS layered glass model
- Visual verification needs a real macOS BrowserWindow with vibrancy active — pure-CSS-only change, no node-side test impact

## Suggested contract test follow-ups (per `@maka-审美专家`)

- backdrop-filter must be on `.appFrame` (layout root), not `.maka-session-panel`
- `.maka-session-panel` must remain `background: transparent` on darwin
- Selected `.maka-list-row[data-active="true"]` must use `var(--color-primary)`, not a foreground/alpha wash