### PR TITLE
Add compaction boundary projection diagnostics

### DIFF
--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -196,6 +196,29 @@ export interface PromptSegmentEstimate {
   toolCount?: number;
 }
 
+export type CompactionStageDiagnostic = 'priorReplay' | 'activeStep';
+export type CompactionSourceDiagnosticKind = 'runtimeEvents' | 'providerMessages';
+export type CompactionDecisionDiagnosticKind = 'unchanged' | 'replaced' | 'failedOpen';
+
+export interface CompactionDecisionDiagnostic {
+  stage: CompactionStageDiagnostic;
+  sourceKind: CompactionSourceDiagnosticKind;
+  decision: CompactionDecisionDiagnosticKind;
+  boundaryKind?: string;
+  boundaryIds?: string[];
+  coveredTurns?: number;
+  coveredRuntimeEvents?: number;
+  coveredToolCalls?: number;
+  coverageHashes?: string[];
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  estimatedTokensSaved?: number;
+  reason?: string;
+  failOpenReason?: string;
+  skippedReasonCounts?: Record<string, number>;
+  validationReasonCounts?: Record<string, number>;
+}
+
 export interface ContextBudgetDiagnostic {
   enabled: boolean;
   policyName?: string;
@@ -217,6 +240,7 @@ export interface ContextBudgetDiagnostic {
   activePrunedToolResults?: number;
   activeArchiveFailures?: number;
   activeEstimatedTokensSaved?: number;
+  compactionDecisions?: CompactionDecisionDiagnostic[];
   archiveRetrievalMode?: 'eager' | 'history_search_gated';
   archiveRetrievalEligibleTurns?: number;
   retrievedArchiveToolResults?: number;

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -32,6 +32,7 @@
     "./runtime-event-read-model": "./dist/runtime-event-read-model.js",
     "./runtime-kernel": "./dist/runtime-kernel.js",
     "./agent-run-inspect": "./dist/agent-run-inspect.js",
+    "./compaction-boundary": "./dist/compaction-boundary.js",
     "./model-history": "./dist/model-history.js",
     "./invocation-context": "./dist/invocation-context.js",
     "./runtime-runner": "./dist/runtime-runner.js",

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1117,6 +1117,12 @@ describe('AiSdkBackend model history', () => {
     assert.equal(usage?.contextBudget?.historyCompactWritesAttempted, 1);
     assert.equal(usage?.contextBudget?.historyCompactBlocksWritten, 1);
     assert.equal(usage?.contextBudget?.highWaterReason, 'history_compact');
+    assert.deepEqual(
+      usage?.contextBudget?.compactionDecisions?.[0]?.boundaryIds,
+      usage?.contextBudget?.historyCompactWrittenBlockIds,
+    );
+    assert.equal(usage?.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
+    assert.equal(usage?.contextBudget?.compactionDecisions?.[0]?.boundaryKind, 'historyCompact');
   });
 
   test('loads persisted history compact blocks before replay and does not rewrite them', async () => {

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -21,6 +21,7 @@ import {
   validateSynthesisCacheBlockShape,
   type SynthesisCacheBlock,
 } from '../context-budget.js';
+import { historyCompactBlockToCompactionBoundary } from '../compaction-boundary.js';
 
 describe('context-budget archive retrieval', () => {
   test('deserializes JSON, undefined, and fallback strings', () => {
@@ -956,6 +957,25 @@ describe('context-budget history compact', () => {
     assert.equal(result.diagnostic.droppedTurns, 3);
     assert.equal(result.diagnostic.droppedEvents, 3);
     assert.equal(result.diagnostic.historyCompactBlockIds?.length, 1);
+    assert.deepEqual(result.diagnostic.compactionDecisions, [
+      {
+        stage: 'priorReplay',
+        sourceKind: 'runtimeEvents',
+        decision: 'replaced',
+        boundaryKind: 'historyCompact',
+        boundaryIds: result.diagnostic.historyCompactBlockIds,
+        coveredTurns: 3,
+        coveredRuntimeEvents: 4,
+        coverageHashes: result.diagnostic.historyCompactCoverageHashes,
+        estimatedTokensBefore: result.diagnostic.historyCompactedEstimatedTokensBefore,
+        estimatedTokensAfter: result.diagnostic.historyCompactedEstimatedTokensAfter,
+        estimatedTokensSaved: Math.max(
+          0,
+          (result.diagnostic.historyCompactedEstimatedTokensBefore ?? 0)
+          - (result.diagnostic.historyCompactedEstimatedTokensAfter ?? 0),
+        ),
+      },
+    ]);
     assert.equal(result.events.some((event) => event.id === 'old-1'), false);
     assert.equal(result.events.some((event) => event.id === 'old-result'), false);
     assert.equal(result.events.some((event) => event.id === 'recent-1'), true);
@@ -989,6 +1009,16 @@ describe('context-budget history compact', () => {
     assert.deepEqual(result.events.map((event) => event.id), ['short-1', 'short-2']);
     assert.equal(result.diagnostic.historyCompactEnabled, true);
     assert.deepEqual(result.diagnostic.historyCompactSkippedReasonCounts, { below_high_water: 1 });
+    assert.deepEqual(result.diagnostic.compactionDecisions, [
+      {
+        stage: 'priorReplay',
+        sourceKind: 'runtimeEvents',
+        decision: 'unchanged',
+        boundaryKind: 'historyCompact',
+        reason: 'below_high_water',
+        skippedReasonCounts: { below_high_water: 1 },
+      },
+    ]);
     assert.equal(result.diagnostic.highWaterReason, undefined);
   });
 
@@ -1015,6 +1045,17 @@ describe('context-budget history compact', () => {
     assert.equal(result.events.some((event) => event.id.startsWith('history-compact:')), false);
     assert.equal(result.diagnostic.historyCompactSkipped, 1);
     assert.deepEqual(result.diagnostic.historyCompactSkippedReasonCounts, { archive_missing: 1 });
+    assert.deepEqual(result.diagnostic.compactionDecisions, [
+      {
+        stage: 'priorReplay',
+        sourceKind: 'runtimeEvents',
+        decision: 'failedOpen',
+        boundaryKind: 'historyCompact',
+        reason: 'archive_missing',
+        failOpenReason: 'archive_missing',
+        skippedReasonCounts: { archive_missing: 1 },
+      },
+    ]);
     assert.equal(result.diagnostic.highWaterReason, undefined);
   });
 
@@ -1050,6 +1091,17 @@ describe('context-budget history compact', () => {
     assert.equal(validateHistoryCompactBlockShape(first.blocks[0], 'session-1'), true);
     assert.match(renderHistoryCompactBlock(first.blocks[0]!), /bodySha256=/);
     assert.equal(first.events[0]?.id, `history-compact:${first.blocks[0]?.blockId}`);
+    const boundary = historyCompactBlockToCompactionBoundary(first.blocks[0]!, {
+      renderedText: renderHistoryCompactBlock(first.blocks[0]!),
+      preservedAnchor: { tailTurnIds: ['turn-3'] },
+      validationStatus: 'valid',
+    });
+    assert.equal(boundary.kind, 'historyCompact');
+    assert.equal(boundary.stage, 'priorReplay');
+    assert.equal(boundary.boundaryId, first.blocks[0]?.blockId);
+    assert.deepEqual(boundary.coverage.runtimeEventIds, ['old-1', 'old-2']);
+    assert.deepEqual(boundary.preservedAnchor?.tailTurnIds, ['turn-3']);
+    assert.equal(boundary.validationStatus, 'valid');
   });
 
   test('selects a loaded compact block instead of rebuilding the folded region', () => {
@@ -1090,6 +1142,8 @@ describe('context-budget history compact', () => {
     assert.equal(result.diagnostic.historyCompactBlocksAvailable, 1);
     assert.equal(result.diagnostic.historyCompactBlocksSelected, 1);
     assert.deepEqual(result.diagnostic.historyCompactBlockIds, [loadedBlock.blockId]);
+    assert.equal(result.diagnostic.compactionDecisions?.[0]?.decision, 'replaced');
+    assert.deepEqual(result.diagnostic.compactionDecisions?.[0]?.boundaryIds, [loadedBlock.blockId]);
     assert.match(
       result.events[0]?.content?.kind === 'text' ? result.events[0].content.text : '',
       /LOADED_CONTEXT_COMPACT_SENTINEL/,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -58,7 +58,12 @@ import type {
 import type { AgentSpec } from '@maka/core/runtime-inputs';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
-import type { LlmCallRecord, PricingConfig, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import type {
+  CompactionDecisionDiagnostic,
+  LlmCallRecord,
+  PricingConfig,
+  ToolInvocationRecord,
+} from '@maka/core/usage-stats/types';
 import type {
   ContextBudgetDiagnostic,
   PromptSegmentEstimate,
@@ -93,6 +98,10 @@ import {
   rewriteActiveToolResultsInMessages,
   type ActiveToolResultPruneDiagnosticPatch,
 } from './active-tool-result-prune.js';
+import {
+  compactionDecisionDiagnosticPatch,
+  historyCompactBlockToCompactionBoundary,
+} from './compaction-boundary.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import { computeCost } from './telemetry/cost.js';
@@ -1562,6 +1571,28 @@ export class AiSdkBackend implements AgentBackend {
         }
       }
       const estimatedTokens = replacementBlocks.reduce((total, block) => total + (block.estimatedTokens ?? 0), 0);
+      const replacementRuntimeEventIds = new Set(replacementBlocks.flatMap((block) => block.coverage.runtimeEventIds));
+      const estimatedTokensBefore = estimateRuntimeEventsTokens(
+        input.priorRuntimeContext.filter((event) => replacementRuntimeEventIds.has(event.id)),
+        limits.charsPerToken,
+      );
+      const replacementDecisionPatch = replacementBlocks.length > 0
+        ? compactionDecisionDiagnosticPatch({
+            stage: 'priorReplay',
+            sourceKind: 'runtimeEvents',
+            decision: 'replaced',
+            boundaryKind: 'historyCompact',
+            boundaryIds: replacementBlocks.map((block) => historyCompactBlockToCompactionBoundary(block).boundaryId),
+            coverage: {
+              turnIds: Array.from(new Set(replacementBlocks.flatMap((block) => block.coverage.turnIds))),
+              runtimeEventIds: Array.from(replacementRuntimeEventIds),
+              contentKinds: Array.from(new Set(replacementBlocks.flatMap((block) => block.coverage.contentKinds))),
+              bodySha256: replacementBlocks.flatMap((block) => block.coverage.bodySha256),
+            },
+            estimatedTokensBefore,
+            estimatedTokensAfter: estimatedTokens,
+          })
+        : {};
       return {
         replacementBlocks,
         diagnosticPatch: {
@@ -1584,6 +1615,7 @@ export class AiSdkBackend implements AgentBackend {
           ...(Object.keys(skippedReasonCounts).length > 0
             ? { historyCompactWriteSkippedReasonCounts: skippedReasonCounts }
             : {}),
+          ...replacementDecisionPatch,
         },
       };
     } catch {
@@ -1951,6 +1983,7 @@ function mergeContextBudgetDiagnostic(
       base.historyCompactWriteSkippedReasonCounts,
       patch.historyCompactWriteSkippedReasonCounts,
     ),
+    ...mergeCompactionDecisionDiagnostics(base.compactionDecisions, patch.compactionDecisions),
   };
 }
 
@@ -2025,6 +2058,29 @@ function mergeCountRecords(
     out[key] = (out[key] ?? 0) + value;
   }
   return out;
+}
+
+function mergeCompactionDecisionDiagnostics(
+  left: readonly CompactionDecisionDiagnostic[] | undefined,
+  right: readonly CompactionDecisionDiagnostic[] | undefined,
+): { compactionDecisions: CompactionDecisionDiagnostic[] } | Record<string, never> {
+  if (!left && !right) return {};
+  if (!right || right.length === 0) return { compactionDecisions: [...(left ?? [])] };
+  const replacesHistoryCompact = right.some((decision) =>
+    decision.stage === 'priorReplay'
+    && decision.boundaryKind === 'historyCompact'
+    && decision.decision === 'replaced'
+  );
+  const retainedLeft = replacesHistoryCompact
+    ? (left ?? []).filter((decision) =>
+        !(
+          decision.stage === 'priorReplay'
+          && decision.boundaryKind === 'historyCompact'
+          && decision.decision === 'replaced'
+        )
+      )
+    : (left ?? []);
+  return { compactionDecisions: [...retainedLeft, ...right] };
 }
 
 function replaceHistoryCompactReplayBlocks(

--- a/packages/runtime/src/compaction-boundary.ts
+++ b/packages/runtime/src/compaction-boundary.ts
@@ -1,0 +1,187 @@
+import type {
+  CompactionDecisionDiagnostic,
+  ContextBudgetDiagnostic,
+} from '@maka/core/usage-stats/types';
+
+export type CompactionStage = 'priorReplay' | 'activeStep';
+export type CompactionSourceKind = 'runtimeEvents' | 'providerMessages';
+export type CompactionBoundaryKind =
+  | 'historyCompact'
+  | 'synthesisCache'
+  | 'staleToolResultPrune'
+  | 'activeToolResultPrune'
+  | 'activeFullCompact';
+export type CompactionDecisionKind = 'unchanged' | 'replaced' | 'failedOpen';
+
+export interface CompactionCoverage {
+  turnIds?: readonly string[];
+  runtimeEventIds?: readonly string[];
+  toolCallIds?: readonly string[];
+  contentKinds?: readonly string[];
+  bodySha256?: readonly string[];
+}
+
+export interface CompactionArchiveRef {
+  kind: 'toolResult' | 'runtimeEventSource' | 'compactSource';
+  sessionId?: string;
+  turnId?: string;
+  runtimeEventId?: string;
+  toolCallId?: string;
+  toolName?: string;
+  artifactId: string;
+  bodySha256: string;
+  originalEstimatedTokens?: number;
+  originalBytes?: number;
+}
+
+export interface CompactionBoundary {
+  kind: CompactionBoundaryKind;
+  stage: CompactionStage;
+  schemaVersion: number;
+  boundaryId: string;
+  sessionId: string;
+  createdAt?: number;
+  highWaterName?: string;
+  highWaterSeq?: number;
+  coverage: CompactionCoverage;
+  preservedAnchor?: {
+    headRuntimeEventIds?: readonly string[];
+    tailRuntimeEventIds?: readonly string[];
+    tailTurnIds?: readonly string[];
+  };
+  archiveRefs?: readonly CompactionArchiveRef[];
+  sourceHashes?: readonly string[];
+  renderedText?: string;
+  estimatedTokens?: number;
+  validationStatus?: 'valid' | 'invalid' | 'notValidated';
+  validationReason?: string;
+}
+
+export interface CompactionDecision {
+  stage: CompactionStage;
+  sourceKind: CompactionSourceKind;
+  decision: CompactionDecisionKind;
+  boundaryKind?: CompactionBoundaryKind;
+  boundaryIds?: readonly string[];
+  coverage?: CompactionCoverage;
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  estimatedTokensSaved?: number;
+  reason?: string;
+  failOpenReason?: string;
+  skippedReasonCounts?: Readonly<Record<string, number>>;
+  validationReasonCounts?: Readonly<Record<string, number>>;
+}
+
+export interface HistoryCompactBoundaryLike {
+  version: number;
+  blockId: string;
+  sessionId: string;
+  createdAt: number;
+  highWaterName: string;
+  highWaterSeq: number;
+  coverage: {
+    turnIds: readonly string[];
+    runtimeEventIds: readonly string[];
+    contentKinds: readonly string[];
+    bodySha256: readonly string[];
+  };
+  sourceArchiveRefs?: readonly {
+    runtimeEventId: string;
+    artifactId: string;
+    bodySha256: string;
+    originalEstimatedTokens: number;
+    originalBytes: number;
+  }[];
+  estimatedTokens?: number;
+}
+
+export function historyCompactBlockToCompactionBoundary(
+  block: HistoryCompactBoundaryLike,
+  options: {
+    stage?: CompactionStage;
+    renderedText?: string;
+    preservedAnchor?: CompactionBoundary['preservedAnchor'];
+    validationStatus?: CompactionBoundary['validationStatus'];
+    validationReason?: string;
+  } = {},
+): CompactionBoundary {
+  return {
+    kind: 'historyCompact',
+    stage: options.stage ?? 'priorReplay',
+    schemaVersion: block.version,
+    boundaryId: block.blockId,
+    sessionId: block.sessionId,
+    createdAt: block.createdAt,
+    highWaterName: block.highWaterName,
+    highWaterSeq: block.highWaterSeq,
+    coverage: {
+      turnIds: block.coverage.turnIds,
+      runtimeEventIds: block.coverage.runtimeEventIds,
+      contentKinds: block.coverage.contentKinds,
+      bodySha256: block.coverage.bodySha256,
+    },
+    ...(options.preservedAnchor ? { preservedAnchor: options.preservedAnchor } : {}),
+    ...(block.sourceArchiveRefs && block.sourceArchiveRefs.length > 0
+      ? {
+          archiveRefs: block.sourceArchiveRefs.map((ref) => ({
+            kind: 'runtimeEventSource' as const,
+            sessionId: block.sessionId,
+            runtimeEventId: ref.runtimeEventId,
+            artifactId: ref.artifactId,
+            bodySha256: ref.bodySha256,
+            originalEstimatedTokens: ref.originalEstimatedTokens,
+            originalBytes: ref.originalBytes,
+          })),
+        }
+      : {}),
+    sourceHashes: block.coverage.bodySha256,
+    ...(options.renderedText !== undefined ? { renderedText: options.renderedText } : {}),
+    ...(block.estimatedTokens !== undefined ? { estimatedTokens: block.estimatedTokens } : {}),
+    validationStatus: options.validationStatus ?? 'notValidated',
+    ...(options.validationReason ? { validationReason: options.validationReason } : {}),
+  };
+}
+
+export function compactionDecisionToDiagnostic(
+  decision: CompactionDecision,
+): CompactionDecisionDiagnostic {
+  const estimatedTokensSaved = decision.estimatedTokensSaved
+    ?? (
+      decision.estimatedTokensBefore !== undefined && decision.estimatedTokensAfter !== undefined
+        ? Math.max(0, decision.estimatedTokensBefore - decision.estimatedTokensAfter)
+        : undefined
+    );
+  return {
+    stage: decision.stage,
+    sourceKind: decision.sourceKind,
+    decision: decision.decision,
+    ...(decision.boundaryKind ? { boundaryKind: decision.boundaryKind } : {}),
+    ...(decision.boundaryIds ? { boundaryIds: [...decision.boundaryIds] } : {}),
+    ...(decision.coverage?.turnIds ? { coveredTurns: decision.coverage.turnIds.length } : {}),
+    ...(decision.coverage?.runtimeEventIds
+      ? { coveredRuntimeEvents: decision.coverage.runtimeEventIds.length }
+      : {}),
+    ...(decision.coverage?.toolCallIds ? { coveredToolCalls: decision.coverage.toolCallIds.length } : {}),
+    ...(decision.coverage?.bodySha256 ? { coverageHashes: [...decision.coverage.bodySha256] } : {}),
+    ...(decision.estimatedTokensBefore !== undefined
+      ? { estimatedTokensBefore: decision.estimatedTokensBefore }
+      : {}),
+    ...(decision.estimatedTokensAfter !== undefined
+      ? { estimatedTokensAfter: decision.estimatedTokensAfter }
+      : {}),
+    ...(estimatedTokensSaved !== undefined ? { estimatedTokensSaved } : {}),
+    ...(decision.reason ? { reason: decision.reason } : {}),
+    ...(decision.failOpenReason ? { failOpenReason: decision.failOpenReason } : {}),
+    ...(decision.skippedReasonCounts ? { skippedReasonCounts: { ...decision.skippedReasonCounts } } : {}),
+    ...(decision.validationReasonCounts
+      ? { validationReasonCounts: { ...decision.validationReasonCounts } }
+      : {}),
+  };
+}
+
+export function compactionDecisionDiagnosticPatch(
+  decision: CompactionDecision,
+): Partial<ContextBudgetDiagnostic> {
+  return { compactionDecisions: [compactionDecisionToDiagnostic(decision)] };
+}

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -6,6 +6,11 @@ import type {
   ContextBudgetDiagnostic,
   PromptSegmentEstimate,
 } from '@maka/core/usage-stats/types';
+import {
+  compactionDecisionDiagnosticPatch,
+  historyCompactBlockToCompactionBoundary,
+} from './compaction-boundary.js';
+import type { CompactionDecisionKind } from './compaction-boundary.js';
 
 export interface ContextBudgetPolicy {
   name?: string;
@@ -575,6 +580,7 @@ export function applyRuntimeEventHistoryCompact(
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
+        ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
       },
     };
   }
@@ -591,6 +597,7 @@ export function applyRuntimeEventHistoryCompact(
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
+        ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
       },
     };
   }
@@ -605,6 +612,7 @@ export function applyRuntimeEventHistoryCompact(
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
+        ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
       },
     };
   }
@@ -633,6 +641,7 @@ export function applyRuntimeEventHistoryCompact(
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
+        ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
       },
     };
   }
@@ -649,6 +658,7 @@ export function applyRuntimeEventHistoryCompact(
         ...basePatch,
         historyCompactSkipped: 1,
         historyCompactSkippedReasonCounts: skippedReasonCounts,
+        ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
       },
     };
   }
@@ -660,6 +670,15 @@ export function applyRuntimeEventHistoryCompact(
     skippedReasonCounts,
   );
   if (loadedBlock) {
+    const estimatedTokensBeforeFold = estimateRuntimeEventsTokens(foldedEvents, charsPerToken);
+    const loadedBlockText = renderHistoryCompactBlock(loadedBlock);
+    const estimatedTokensAfterFold =
+      loadedBlock.estimatedTokens ?? estimateTokens(loadedBlockText.length, charsPerToken);
+    const boundary = historyCompactBlockToCompactionBoundary(loadedBlock, {
+      renderedText: loadedBlockText,
+      preservedAnchor: { tailTurnIds: [...tailTurnIds] },
+      validationStatus: 'valid',
+    });
     const outputEvents = [historyCompactBlockToRuntimeEvent(loadedBlock), ...retainedEvents];
     return {
       events: outputEvents,
@@ -671,13 +690,22 @@ export function applyRuntimeEventHistoryCompact(
         historyCompactBlockIds: [loadedBlock.blockId],
         historyCompactedTurns: loadedBlock.coverage.turnIds.length,
         historyCompactedEvents: loadedBlock.coverage.runtimeEventIds.length,
-        historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(foldedEvents, charsPerToken),
-        historyCompactedEstimatedTokensAfter:
-          loadedBlock.estimatedTokens ?? estimateTokens(renderHistoryCompactBlock(loadedBlock).length, charsPerToken),
+        historyCompactedEstimatedTokensBefore: estimatedTokensBeforeFold,
+        historyCompactedEstimatedTokensAfter: estimatedTokensAfterFold,
         historyCompactCoverageHashes: loadedBlock.coverage.bodySha256,
         highWaterName: loadedBlock.highWaterName,
         highWaterSeq: loadedBlock.highWaterSeq,
         highWaterReason: 'history_compact',
+        ...compactionDecisionDiagnosticPatch({
+          stage: 'priorReplay',
+          sourceKind: 'runtimeEvents',
+          decision: 'replaced',
+          boundaryKind: boundary.kind,
+          boundaryIds: [boundary.boundaryId],
+          coverage: boundary.coverage,
+          estimatedTokensBefore: estimatedTokensBeforeFold,
+          estimatedTokensAfter: estimatedTokensAfterFold,
+        }),
       },
     };
   }
@@ -698,6 +726,7 @@ export function applyRuntimeEventHistoryCompact(
           ...basePatch,
           historyCompactSkipped: 1,
           historyCompactSkippedReasonCounts: skippedReasonCounts,
+          ...historyCompactSkippedDecisionPatch(skippedReasonCounts),
         },
       };
     }
@@ -706,6 +735,14 @@ export function applyRuntimeEventHistoryCompact(
   const block = buildHistoryCompactBlock(foldedEvents, compactPolicy, {
     charsPerToken,
     archiveRefs,
+  });
+  const estimatedTokensBeforeFold = estimateRuntimeEventsTokens(foldedEvents, charsPerToken);
+  const blockText = renderHistoryCompactBlock(block);
+  const estimatedTokensAfterFold = block.estimatedTokens ?? estimateTokens(blockText.length, charsPerToken);
+  const boundary = historyCompactBlockToCompactionBoundary(block, {
+    renderedText: blockText,
+    preservedAnchor: { tailTurnIds: [...tailTurnIds] },
+    validationStatus: 'valid',
   });
   const synthetic = historyCompactBlockToRuntimeEvent(block);
   const outputEvents = [synthetic, ...retainedEvents];
@@ -718,12 +755,22 @@ export function applyRuntimeEventHistoryCompact(
       historyCompactBlocksSelected: 1,
       historyCompactedTurns: block.coverage.turnIds.length,
       historyCompactedEvents: block.coverage.runtimeEventIds.length,
-      historyCompactedEstimatedTokensBefore: estimateRuntimeEventsTokens(foldedEvents, charsPerToken),
-      historyCompactedEstimatedTokensAfter: block.estimatedTokens ?? estimateTokens(renderHistoryCompactBlock(block).length, charsPerToken),
+      historyCompactedEstimatedTokensBefore: estimatedTokensBeforeFold,
+      historyCompactedEstimatedTokensAfter: estimatedTokensAfterFold,
       historyCompactCoverageHashes: block.coverage.bodySha256,
       highWaterName: block.highWaterName,
       highWaterSeq: block.highWaterSeq,
       highWaterReason: 'history_compact',
+      ...compactionDecisionDiagnosticPatch({
+        stage: 'priorReplay',
+        sourceKind: 'runtimeEvents',
+        decision: 'replaced',
+        boundaryKind: boundary.kind,
+        boundaryIds: [boundary.boundaryId],
+        coverage: boundary.coverage,
+        estimatedTokensBefore: estimatedTokensBeforeFold,
+        estimatedTokensAfter: estimatedTokensAfterFold,
+      }),
     },
   };
 }
@@ -1608,6 +1655,24 @@ function validateHistoryCompactArchiveCoverage(
     if (!historyCompactArchiveRefMatches(event, ref, charsPerToken)) return 'archive_mismatch';
   }
   return undefined;
+}
+
+function historyCompactSkippedDecisionPatch(
+  skippedReasonCounts: Readonly<Record<string, number>>,
+): Partial<ContextBudgetDiagnostic> {
+  const reason = Object.keys(skippedReasonCounts)[0];
+  const decision: CompactionDecisionKind = reason === 'archive_missing' || reason === 'archive_mismatch'
+    ? 'failedOpen'
+    : 'unchanged';
+  return compactionDecisionDiagnosticPatch({
+    stage: 'priorReplay',
+    sourceKind: 'runtimeEvents',
+    decision,
+    boundaryKind: 'historyCompact',
+    ...(reason ? { reason } : {}),
+    ...(decision === 'failedOpen' && reason ? { failOpenReason: reason } : {}),
+    skippedReasonCounts,
+  });
 }
 
 function historyCompactArchiveRefMatches(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -151,6 +151,21 @@ export type { StreamWatchdogInput, StreamWatchdogPhase, StreamWatchdogTimeout } 
 export { getAIModel, buildProviderOptions } from './model-factory.js';
 export type { ModelFactoryInput as GetAIModelInput } from './model-factory.js';
 export {
+  compactionDecisionDiagnosticPatch,
+  compactionDecisionToDiagnostic,
+  historyCompactBlockToCompactionBoundary,
+} from './compaction-boundary.js';
+export type {
+  CompactionArchiveRef,
+  CompactionBoundary,
+  CompactionBoundaryKind,
+  CompactionCoverage,
+  CompactionDecision,
+  CompactionDecisionKind,
+  CompactionSourceKind,
+  CompactionStage,
+} from './compaction-boundary.js';
+export {
   ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,


### PR DESCRIPTION
## Summary

Adds the first shared compaction boundary/projection abstraction for Maka's existing prior replay compaction path.

This is the cleanup/foundation slice from issue #327's updated design framing:

- RuntimeEvents/messages remain the append-only fact layer.
- Provider input is a projection over that layer.
- Prior replay and future active-step compaction share a boundary/decision vocabulary.
- Existing history compact behavior remains unchanged, but now emits shared `compactionDecisions` telemetry.

## Changes

- Adds `packages/runtime/src/compaction-boundary.ts` with shared types/helpers:
  - `CompactionStage`
  - `CompactionSourceKind`
  - `CompactionBoundary`
  - `CompactionDecision`
  - `historyCompactBlockToCompactionBoundary()`
  - diagnostic conversion helpers
- Adds optional `compactionDecisions` to `ContextBudgetDiagnostic`.
- Maps current prior-replay history compact outcomes to:
  - `unchanged`
  - `replaced`
  - `failedOpen`
- Keeps existing flat history compact diagnostics for compatibility.
- Fixes the read-write host compact path so shared diagnostics point at the final host-written block, not the draft deterministic block.
- Exports the new helper module from `@maka/runtime`.

## Rive

Workflow: `maka.compaction-boundary-projection@1`
Run: `wfrun_7d4ca0dcdbda425e96613cf80d025ae0`
Scheduler: `sched_60d5b7ff23694e548272eb8646c5ed44`
Output dir: `/tmp/rive-maka-compaction-boundary-projection-20260627/output/`

Rive review initially blocked on read-write history compact diagnostics keeping the draft boundary id after host replacement. I patched that locally and added the backend regression before opening this PR.

## Verification

- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/context-budget.test.js`
- `node --test packages/runtime/dist/__tests__/ai-sdk-backend.test.js`
- `npm --workspace @maka/runtime run test` (707 pass, 1 skipped, 0 fail)
- `npm --workspace @maka/headless run typecheck`
- `git diff --check`
- `git diff --cached --check`

## Out of scope

This PR does not implement active-loop full compaction. It creates the shared contract that a future `activeStep` compaction implementation can use.
