### PR TITLE
Add active full compact foundation

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,7 @@
     "./stream-watchdog": "./dist/stream-watchdog.js",
     "./model-factory": "./dist/model-factory.js",
     "./context-budget": "./dist/context-budget.js",
+    "./active-full-compact": "./dist/active-full-compact.js",
     "./test-connection": "./dist/test-connection.js",
     "./model-fetcher": "./dist/model-fetcher.js",
     "./materializer": "./dist/materializer.js",

--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -1,0 +1,420 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { ModelMessage } from 'ai';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+
+import {
+  activeFullCompactBlockToCompactionBoundary,
+  activeFullCompactCoverageFromEntries,
+  activeFullCompactDecisionDiagnosticPatch,
+  buildActiveFullCompactBlockFromSummary,
+  buildActiveFullCompactSourceIndex,
+  renderActiveFullCompactBlock,
+  selectActiveFullCompactCoveredSpan,
+  validateActiveFullCompactBlockForSourceIndex,
+  validateActiveFullCompactBlockShape,
+  type ActiveFullCompactFailOpenReason,
+  type ActiveFullCompactSummary,
+  type ActiveFullCompactValidationResult,
+} from '../active-full-compact.js';
+import {
+  ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+  ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+  type ActiveArchivedToolResultPlaceholder,
+} from '../context-budget.js';
+
+describe('active full compact PR1 foundation', () => {
+  test('source index maps RuntimeEvents to provider entries', () => {
+    const runtimeEvents = fixtureRuntimeEvents();
+    const messages = fixtureMessages();
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      invocationId: 'inv-1',
+      messages,
+      runtimeEvents,
+      stepNumber: 2,
+      charsPerToken: 2,
+    });
+
+    assert.equal(index.entries.length, 3);
+    assert.deepEqual(
+      index.entries.map((entry) => entry.runtimeEventId),
+      ['event-user', 'event-call', 'event-response'],
+    );
+    assert.deepEqual(
+      index.entries.map((entry) => entry.contentKind),
+      ['text', 'function_call', 'function_response'],
+    );
+    const response = index.entries[2]!;
+    assert.equal(response.toolCallId, 'call-1');
+    assert.equal(response.toolName, 'Read');
+    assert.match(response.bodySha256, /^[a-f0-9]{64}$/);
+    assert.ok(response.estimatedTokens > 0);
+  });
+
+  test('source index recognizes active prune placeholders', () => {
+    const placeholder = activePlaceholder();
+    const messages: ModelMessage[] = [{
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-archived',
+        toolName: 'Bash',
+        output: { type: 'text', value: JSON.stringify(placeholder) },
+      }],
+    } as unknown as ModelMessage];
+
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      charsPerToken: 1,
+    });
+
+    const entry = index.entries[0]!;
+    assert.equal(entry.contentKind, 'active_archive_placeholder');
+    assert.equal(entry.archiveRef?.kind, 'toolResult');
+    assert.equal(entry.archiveRef?.artifactId, 'artifact-call-archived');
+    assert.equal(entry.archiveRef?.bodySha256, placeholder.bodySha256);
+    assert.equal(entry.originalEstimatedTokens, 123);
+    assert.equal(entry.originalBytes, 456);
+    assert.equal(entry.toolCallId, 'call-archived');
+  });
+
+  test('coverage derives stable ids and hashes', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+
+    const coverage = activeFullCompactCoverageFromEntries([...index.entries].reverse());
+
+    assert.deepEqual(coverage.runtimeEventIds, ['event-call', 'event-response', 'event-user']);
+    assert.deepEqual(coverage.providerMessageSourceIds, ['provider:0', 'provider:1:0', 'provider:2:0']);
+    assert.deepEqual(coverage.toolCallIds, ['call-1']);
+    assert.deepEqual(coverage.contentKinds, ['function_call', 'function_response', 'text']);
+    assert.equal(coverage.bodySha256.length, 3);
+  });
+
+  test('block builder, renderer, and shape validator work', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const summary = fixtureSummary(index.entries.map((entry) => entry.sourceId));
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      invocationId: 'inv-1',
+      entries: index.entries,
+      summary,
+      highWaterName: 'test-active-full-compact',
+      highWaterSeq: 7,
+      now: 100,
+    });
+    const sameBlock = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      invocationId: 'inv-1',
+      entries: index.entries,
+      summary,
+      highWaterName: 'test-active-full-compact',
+      highWaterSeq: 7,
+      now: 200,
+    });
+
+    assert.equal(block.blockId, sameBlock.blockId);
+    assert.equal(validateActiveFullCompactBlockShape(block, 'session-1'), true);
+    const rendered = renderActiveFullCompactBlock(block);
+    assert.match(rendered, /<maka_active_full_compact_block/);
+    assert.match(rendered, /commands_tried:/);
+    assert.doesNotMatch(rendered, /SECRET_RAW_OUTPUT/);
+  });
+
+  test('block-to-boundary mapping uses shared vocabulary', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      preservedAnchor: {
+        tailRuntimeEventIds: ['event-response'],
+        tailProviderMessageSourceIds: ['provider:2:0'],
+        tailTurnIds: ['turn-1'],
+      },
+      now: 100,
+    });
+
+    const boundary = activeFullCompactBlockToCompactionBoundary(block, {
+      validationStatus: 'valid',
+      validationReason: 'ok',
+    });
+
+    assert.equal(boundary.kind, 'activeFullCompact');
+    assert.equal(boundary.stage, 'activeStep');
+    assert.equal(boundary.boundaryId, block.blockId);
+    assert.deepEqual(boundary.coverage.runtimeEventIds, block.coverage.runtimeEventIds);
+    assert.deepEqual(boundary.sourceHashes, block.coverage.bodySha256);
+    assert.equal(boundary.validationStatus, 'valid');
+    assert.match(boundary.renderedText ?? '', /providerSourceIds=/);
+    assert.deepEqual(boundary.preservedAnchor?.tailProviderMessageSourceIds, ['provider:2:0']);
+  });
+
+  test('validation fails open on source hash mismatch and maps diagnostics', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+    });
+    block.coverage.bodySha256 = ['bad-hash'];
+
+    const validation = validateActiveFullCompactBlockForSourceIndex(block, index);
+    assert.equal(validation.valid, false);
+    assert.deepEqual(validation.reasons, ['source_hash_mismatch']);
+
+    const patch = activeFullCompactDecisionDiagnosticPatch({
+      decision: 'failedOpen',
+      boundaryIds: [block.blockId],
+      coverage: block.coverage,
+      failOpenReason: 'source_hash_mismatch',
+      validationReasonCounts: validation.reasonCounts,
+    });
+    assert.equal(patch.compactionDecisions?.[0]?.decision, 'failedOpen');
+    assert.equal(patch.compactionDecisions?.[0]?.stage, 'activeStep');
+    assert.equal(patch.compactionDecisions?.[0]?.sourceKind, 'providerMessages');
+    assert.equal(patch.compactionDecisions?.[0]?.boundaryKind, 'activeFullCompact');
+  });
+
+  test('validation fails open without throwing for malformed blocks', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+    });
+    const malformedBlocks: Array<{ name: string; value: unknown; extraReason?: ActiveFullCompactFailOpenReason }> = [
+      { name: 'missing coverage', value: { ...block, coverage: undefined } },
+      { name: 'missing summary', value: { ...block, summary: undefined }, extraReason: 'summary_missing' },
+      {
+        name: 'invalid coverage arrays',
+        value: { ...block, coverage: { ...block.coverage, providerMessageSourceIds: 'provider:0' } },
+      },
+      { name: 'malformed archive refs', value: { ...block, archiveRefs: [{ kind: 'toolResult' }] } },
+    ];
+
+    for (const { name, value, extraReason } of malformedBlocks) {
+      let validation: ActiveFullCompactValidationResult | undefined;
+      assert.doesNotThrow(() => {
+        validation = validateActiveFullCompactBlockForSourceIndex(value, index);
+      }, name);
+      assert.equal(validation?.valid, false, name);
+      assert.ok(validation?.reasons.includes('invalid_schema_version'), name);
+      if (extraReason) assert.ok(validation?.reasons.includes(extraReason), name);
+    }
+  });
+
+  test('span selection fails open on tool pair split', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+      stepNumber: 3,
+      charsPerToken: 1,
+    });
+
+    const selection = selectActiveFullCompactCoveredSpan(index, {
+      enabled: true,
+      minStepNumber: 1,
+      minRecentMessages: 1,
+      maxActiveEstimatedTokens: 1,
+      highWaterRatio: 0.1,
+    });
+
+    assert.equal(selection.decision, 'failedOpen');
+    assert.equal(selection.reason, 'tool_pair_split');
+  });
+
+  test('helper calls leave provider request shape unchanged', () => {
+    const messages = fixtureMessages();
+    const before = JSON.stringify(messages);
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+    });
+    validateActiveFullCompactBlockForSourceIndex(block, index);
+    activeFullCompactBlockToCompactionBoundary(block);
+
+    assert.equal(JSON.stringify(messages), before);
+  });
+
+  test('active archive refs and diagnostics coexist with active prune fields', () => {
+    const placeholder = activePlaceholder();
+    const messages: ModelMessage[] = [{
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-archived',
+        toolName: 'Bash',
+        result: placeholder,
+      }],
+    } as unknown as ModelMessage];
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+    });
+
+    assert.equal(block.archiveRefs?.[0]?.kind, 'toolResult');
+    const patch = activeFullCompactDecisionDiagnosticPatch({
+      decision: 'replaced',
+      boundaryIds: [block.blockId],
+      coverage: block.coverage,
+      estimatedTokensBefore: 500,
+      estimatedTokensAfter: 100,
+    });
+    assert.equal(patch.compactionDecisions?.[0]?.estimatedTokensSaved, 400);
+  });
+});
+
+function fixtureMessages(): ModelMessage[] {
+  return [
+    { role: 'user', content: 'hello world' },
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'Read',
+        input: { path: 'README.md' },
+      }],
+    } as ModelMessage,
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-1',
+        toolName: 'Read',
+        output: { type: 'json', value: { ok: true, body: 'short result' } },
+      }],
+    } as ModelMessage,
+  ];
+}
+
+function fixtureRuntimeEvents(): RuntimeEvent[] {
+  return [
+    runtimeEvent('event-user', 'user', 'user', { kind: 'text', text: 'hello world' }),
+    runtimeEvent('event-call', 'model', 'agent', {
+      kind: 'function_call',
+      id: 'call-1',
+      name: 'Read',
+      args: { path: 'README.md' },
+    }),
+    runtimeEvent('event-response', 'tool', 'tool', {
+      kind: 'function_response',
+      id: 'call-1',
+      name: 'Read',
+      result: { ok: true, body: 'short result' },
+    }),
+  ];
+}
+
+function runtimeEvent(
+  id: string,
+  role: RuntimeEvent['role'],
+  author: RuntimeEvent['author'],
+  content: NonNullable<RuntimeEvent['content']>,
+): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 10,
+    partial: false,
+    role,
+    author,
+    content,
+    refs: content.kind === 'function_call' || content.kind === 'function_response'
+      ? { toolCallId: content.id }
+      : undefined,
+  };
+}
+
+function activePlaceholder(): ActiveArchivedToolResultPlaceholder {
+  return {
+    kind: ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
+    rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
+    artifactId: 'artifact-call-archived',
+    turnId: 'turn-1',
+    toolCallId: 'call-archived',
+    toolName: 'Bash',
+    bodySha256: 'a'.repeat(64),
+    originalEstimatedTokens: 123,
+    originalBytes: 456,
+    reason: 'active_current_turn_tool_result_pruned_before_next_step',
+  };
+}
+
+function fixtureSummary(sourceIds: string[]): ActiveFullCompactSummary {
+  return {
+    schemaVersion: 1,
+    text: 'Terminal task progressed through file inspection and a short verifier run.',
+    processState: ['no long-running process observed'],
+    vmState: ['guest state unchanged'],
+    artifactPaths: ['README.md'],
+    commandsTried: [{ command: 'npm test', outcome: 'failed before archived raw output was inspected', sourceIds }],
+    latestVerifierFailure: 'unit verifier still red',
+    constraints: ['do not alter provider request shape in PR1'],
+    failedHypotheses: ['raw output alone is enough context'],
+    currentHypothesis: 'source-bearing summary can cover the active span',
+    nextActions: ['wire provider-visible replacement in PR2'],
+    archiveRefs: ['artifact-call-archived'],
+  };
+}

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -1,0 +1,1099 @@
+import { createHash } from 'node:crypto';
+import type { ModelMessage } from 'ai';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
+import {
+  compactionDecisionDiagnosticPatch,
+  type CompactionArchiveRef,
+  type CompactionBoundary,
+  type CompactionDecisionKind,
+} from './compaction-boundary.js';
+import {
+  estimateTokens,
+  serializeToolResultForArchive,
+  type ActiveArchivedToolResultPlaceholder,
+} from './context-budget.js';
+import { isActiveArchivedToolResultPlaceholder } from './active-tool-result-prune.js';
+
+const DEFAULT_CHARS_PER_TOKEN = 4;
+
+export interface ActiveFullCompactPolicy {
+  enabled: boolean;
+  mode?: 'off' | 'index_only' | 'validate_only' | 'prepare_step_dry_run';
+  minStepNumber?: number;
+  highWaterRatio?: number;
+  forceRatio?: number;
+  targetRatio?: number;
+  maxActiveEstimatedTokens?: number;
+  minRecentMessages?: number;
+  minRecentToolPairs?: number;
+  maxSummaryEstimatedTokens?: number;
+  summarySchemaVersion?: 1;
+  archiveRequired?: boolean;
+  highWaterName?: string;
+}
+
+export interface ActiveFullCompactSourceIndexInput {
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  messages: readonly ModelMessage[];
+  runtimeEvents?: readonly RuntimeEvent[];
+  stepNumber?: number;
+  charsPerToken?: number;
+}
+
+export type ActiveFullCompactProviderRole = 'system' | 'user' | 'assistant' | 'tool';
+export type ActiveFullCompactContentKind =
+  | 'text'
+  | 'thinking'
+  | 'function_call'
+  | 'function_response'
+  | 'tool_result'
+  | 'active_archive_placeholder'
+  | 'unknown';
+
+export interface ActiveFullCompactArchiveRef {
+  kind: 'toolResult' | 'compactSource';
+  sessionId?: string;
+  turnId?: string;
+  runtimeEventId?: string;
+  toolCallId?: string;
+  toolName?: string;
+  artifactId: string;
+  bodySha256: string;
+  originalEstimatedTokens?: number;
+  originalBytes?: number;
+}
+
+export interface ActiveFullCompactSourceEntry {
+  sourceId: string;
+  messageIndex: number;
+  partIndex?: number;
+  role: ActiveFullCompactProviderRole;
+  runtimeEventId?: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  toolCallId?: string;
+  toolName?: string;
+  contentKind: ActiveFullCompactContentKind;
+  bodySha256: string;
+  estimatedTokens: number;
+  originalEstimatedTokens?: number;
+  originalBytes?: number;
+  archiveRef?: ActiveFullCompactArchiveRef;
+}
+
+export interface ActiveFullCompactSourceIndex {
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  stepNumber?: number;
+  providerMessageCount: number;
+  entries: ActiveFullCompactSourceEntry[];
+  estimatedTokens: number;
+}
+
+export interface ActiveFullCompactCoverage {
+  turnIds: string[];
+  runtimeEventIds: string[];
+  providerMessageSourceIds: string[];
+  toolCallIds: string[];
+  contentKinds: string[];
+  bodySha256: string[];
+}
+
+export type ActiveFullCompactSelection =
+  | {
+      decision: 'selected';
+      startMessageIndex: number;
+      endMessageIndex: number;
+      entries: ActiveFullCompactSourceEntry[];
+      coverage: ActiveFullCompactCoverage;
+      estimatedTokens: number;
+    }
+  | {
+      decision: 'unchanged' | 'failedOpen';
+      reason: ActiveFullCompactFailOpenReason | 'disabled' | 'below_min_step' | 'below_high_water' | 'no_candidate';
+      skippedReasonCounts: Readonly<Record<string, number>>;
+    };
+
+export interface ActiveFullCompactSummary {
+  schemaVersion: 1;
+  text: string;
+  processState?: string[];
+  vmState?: string[];
+  artifactPaths?: string[];
+  commandsTried?: Array<{ command: string; outcome: string; sourceIds?: string[] }>;
+  latestVerifierFailure?: string;
+  constraints?: string[];
+  failedHypotheses?: string[];
+  currentHypothesis?: string;
+  nextActions?: string[];
+  archiveRefs?: string[];
+}
+
+export interface ActiveFullCompactSourceRef {
+  kind: 'provider_message' | 'runtime_event' | 'active_archive_placeholder';
+  sourceId: string;
+  messageIndex: number;
+  partIndex?: number;
+  sessionId: string;
+  turnId: string;
+  runtimeEventId?: string;
+  toolCallId?: string;
+  toolName?: string;
+  contentKind: ActiveFullCompactContentKind;
+  bodySha256: string;
+  archiveRef?: ActiveFullCompactArchiveRef;
+}
+
+export interface ActiveFullCompactBlock {
+  kind: 'maka.active_full_compact_block';
+  version: 1;
+  blockId: string;
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  createdAt: number;
+  highWaterName: string;
+  highWaterSeq: number;
+  trigger: {
+    reason: 'high_water' | 'force_ratio' | 'predictive_growth' | 'reactive_prompt_too_long' | 'manual_test';
+    stepNumber?: number;
+    estimatedTokensBefore?: number;
+    thresholdTokens?: number;
+  };
+  coverage: ActiveFullCompactCoverage;
+  preservedAnchor?: {
+    headRuntimeEventIds?: string[];
+    tailRuntimeEventIds?: string[];
+    tailProviderMessageSourceIds?: string[];
+    tailTurnIds?: string[];
+  };
+  summary: ActiveFullCompactSummary;
+  limitations: string[];
+  sourceRefs: ActiveFullCompactSourceRef[];
+  archiveRefs?: ActiveFullCompactArchiveRef[];
+  estimatedTokens?: number;
+  preActiveContextEstimatedTokens?: number;
+  postReplacementEstimatedTokens?: number;
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+  willRetriggerImmediately?: boolean;
+  compactCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+export type ActiveFullCompactFailOpenReason =
+  | 'invalid_schema_version'
+  | 'session_mismatch'
+  | 'turn_mismatch'
+  | 'source_missing'
+  | 'coverage_miss'
+  | 'source_hash_mismatch'
+  | 'tool_pair_split'
+  | 'archive_missing'
+  | 'archive_mismatch'
+  | 'summary_missing'
+  | 'summary_too_large'
+  | 'max_block_tokens'
+  | 'provider_message_only_when_runtime_required';
+
+export interface ActiveFullCompactValidationResult {
+  valid: boolean;
+  reasons: ActiveFullCompactFailOpenReason[];
+  reasonCounts: Readonly<Record<ActiveFullCompactFailOpenReason, number>>;
+}
+
+export interface BuildActiveFullCompactBlockInput {
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  entries: readonly ActiveFullCompactSourceEntry[];
+  summary: ActiveFullCompactSummary;
+  highWaterName?: string;
+  highWaterSeq?: number;
+  trigger?: ActiveFullCompactBlock['trigger'];
+  preservedAnchor?: ActiveFullCompactBlock['preservedAnchor'];
+  limitations?: readonly string[];
+  now?: number;
+  charsPerToken?: number;
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+  preActiveContextEstimatedTokens?: number;
+  postReplacementEstimatedTokens?: number;
+  willRetriggerImmediately?: boolean;
+  compactCallUsage?: ActiveFullCompactBlock['compactCallUsage'];
+}
+
+export function buildActiveFullCompactSourceIndex(
+  input: ActiveFullCompactSourceIndexInput,
+): ActiveFullCompactSourceIndex {
+  const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  const runtimeIndex = buildRuntimeEventIndex(input.runtimeEvents ?? [], charsPerToken);
+  const entries: ActiveFullCompactSourceEntry[] = [];
+
+  input.messages.forEach((message, messageIndex) => {
+    const role = normalizeProviderRole(message.role);
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === 'string') {
+      entries.push(entryFromProviderPart({
+        sourceId: providerSourceId(messageIndex),
+        messageIndex,
+        role,
+        turnId: input.turnId,
+        runId: input.runId,
+        invocationId: input.invocationId,
+        contentKind: 'text',
+        body: content,
+        charsPerToken,
+        runtimeIndex,
+      }));
+      return;
+    }
+
+    if (!Array.isArray(content)) {
+      entries.push(entryFromProviderPart({
+        sourceId: providerSourceId(messageIndex),
+        messageIndex,
+        role,
+        turnId: input.turnId,
+        runId: input.runId,
+        invocationId: input.invocationId,
+        contentKind: 'unknown',
+        body: content,
+        charsPerToken,
+        runtimeIndex,
+      }));
+      return;
+    }
+
+    content.forEach((part, partIndex) => {
+      entries.push(entryFromProviderPart({
+        sourceId: providerSourceId(messageIndex, partIndex),
+        messageIndex,
+        partIndex,
+        role,
+        turnId: input.turnId,
+        runId: input.runId,
+        invocationId: input.invocationId,
+        ...providerPartBody(part),
+        charsPerToken,
+        runtimeIndex,
+      }));
+    });
+  });
+
+  return {
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.invocationId ? { invocationId: input.invocationId } : {}),
+    ...(input.stepNumber !== undefined ? { stepNumber: input.stepNumber } : {}),
+    providerMessageCount: input.messages.length,
+    entries,
+    estimatedTokens: estimateActiveFullCompactTokens(entries),
+  };
+}
+
+export function activeFullCompactCoverageFromEntries(
+  entries: readonly ActiveFullCompactSourceEntry[],
+): ActiveFullCompactCoverage {
+  return {
+    turnIds: uniqueSorted(entries.map((entry) => entry.turnId)),
+    runtimeEventIds: uniqueSorted(entries.map((entry) => entry.runtimeEventId).filter(nonEmpty)),
+    providerMessageSourceIds: uniqueSorted(entries.map((entry) => entry.sourceId)),
+    toolCallIds: uniqueSorted(entries.map((entry) => entry.toolCallId).filter(nonEmpty)),
+    contentKinds: uniqueSorted(entries.map((entry) => entry.contentKind)),
+    bodySha256: uniqueSorted(entries.map((entry) => entry.bodySha256)),
+  };
+}
+
+export function estimateActiveFullCompactTokens(
+  entries: readonly ActiveFullCompactSourceEntry[],
+): number {
+  return entries.reduce((total, entry) => total + entry.estimatedTokens, 0);
+}
+
+export function selectActiveFullCompactCoveredSpan(
+  index: ActiveFullCompactSourceIndex,
+  policy: ActiveFullCompactPolicy | undefined,
+): ActiveFullCompactSelection {
+  if (policy?.enabled !== true || policy.mode === 'off') {
+    return skippedSelection('unchanged', 'disabled');
+  }
+  const minStepNumber = Math.max(0, Math.floor(policy.minStepNumber ?? 1));
+  if ((index.stepNumber ?? 0) < minStepNumber) {
+    return skippedSelection('unchanged', 'below_min_step');
+  }
+
+  const highWaterRatio = finiteRatio(policy.highWaterRatio, 0.8);
+  const maxActiveEstimatedTokens = finitePositive(policy.maxActiveEstimatedTokens);
+  if (
+    maxActiveEstimatedTokens !== undefined &&
+    index.estimatedTokens <= Math.floor(maxActiveEstimatedTokens * highWaterRatio)
+  ) {
+    return skippedSelection('unchanged', 'below_high_water');
+  }
+
+  const minRecentMessages = Math.max(0, Math.floor(policy.minRecentMessages ?? 1));
+  const endExclusive = Math.max(0, index.providerMessageCount - minRecentMessages);
+  const entries = index.entries.filter((entry) => entry.messageIndex < endExclusive);
+  if (entries.length === 0) return skippedSelection('unchanged', 'no_candidate');
+  if (entries.some((entry) => !nonEmpty(entry.sourceId) || !nonEmpty(entry.bodySha256))) {
+    return skippedSelection('failedOpen', 'source_missing');
+  }
+  if (policy.archiveRequired === true && entries.some((entry) => !entry.runtimeEventId && !entry.archiveRef)) {
+    return skippedSelection('failedOpen', 'provider_message_only_when_runtime_required');
+  }
+  if (toolPairSplit(entries, index.entries)) {
+    return skippedSelection('failedOpen', 'tool_pair_split');
+  }
+
+  return {
+    decision: 'selected',
+    startMessageIndex: Math.min(...entries.map((entry) => entry.messageIndex)),
+    endMessageIndex: Math.max(...entries.map((entry) => entry.messageIndex)),
+    entries,
+    coverage: activeFullCompactCoverageFromEntries(entries),
+    estimatedTokens: estimateActiveFullCompactTokens(entries),
+  };
+}
+
+export function buildActiveFullCompactBlockFromSummary(
+  input: BuildActiveFullCompactBlockInput,
+): ActiveFullCompactBlock {
+  const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  const highWaterName = input.highWaterName ?? 'active-full-compact-high-water';
+  const coverage = activeFullCompactCoverageFromEntries(input.entries);
+  const createdAt = input.now ?? Date.now();
+  const highWaterSeq = input.highWaterSeq ?? input.trigger?.stepNumber ?? createdAt;
+  const summary = normalizeSummary(input.summary);
+  const archiveRefs = uniqueArchiveRefs(input.entries.map((entry) => entry.archiveRef).filter(isArchiveRef));
+  const sourceRefs = input.entries.map((entry): ActiveFullCompactSourceRef => ({
+    kind: entry.archiveRef ? 'active_archive_placeholder' : entry.runtimeEventId ? 'runtime_event' : 'provider_message',
+    sourceId: entry.sourceId,
+    messageIndex: entry.messageIndex,
+    ...(entry.partIndex !== undefined ? { partIndex: entry.partIndex } : {}),
+    sessionId: input.sessionId,
+    turnId: entry.turnId,
+    ...(entry.runtimeEventId ? { runtimeEventId: entry.runtimeEventId } : {}),
+    ...(entry.toolCallId ? { toolCallId: entry.toolCallId } : {}),
+    ...(entry.toolName ? { toolName: entry.toolName } : {}),
+    contentKind: entry.contentKind,
+    bodySha256: entry.bodySha256,
+    ...(entry.archiveRef ? { archiveRef: entry.archiveRef } : {}),
+  }));
+  const blockDraft = {
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    coverage,
+    summarySchemaVersion: summary.schemaVersion,
+    summaryText: summary.text,
+    highWaterName,
+    highWaterSeq,
+  };
+
+  const block: ActiveFullCompactBlock = {
+    kind: 'maka.active_full_compact_block',
+    version: 1,
+    blockId: stableActiveFullCompactBlockId(blockDraft),
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.invocationId ? { invocationId: input.invocationId } : {}),
+    createdAt,
+    highWaterName,
+    highWaterSeq,
+    trigger: input.trigger ?? {
+      reason: 'manual_test',
+      estimatedTokensBefore: estimateActiveFullCompactTokens(input.entries),
+    },
+    coverage,
+    ...(input.preservedAnchor ? { preservedAnchor: input.preservedAnchor } : {}),
+    summary,
+    limitations: [
+      ...(input.limitations ?? []),
+      'PR1 active full compact block is source-bearing only; provider-visible replacement is intentionally not wired.',
+      ...(archiveRefs.length === 0
+        ? ['No active archive refs are attached; source coverage is by provider source ids and optional RuntimeEvent ids.']
+        : []),
+    ],
+    sourceRefs,
+    ...(archiveRefs.length > 0 ? { archiveRefs } : {}),
+    ...(input.requestShapeHashBefore ? { requestShapeHashBefore: input.requestShapeHashBefore } : {}),
+    ...(input.requestShapeHashAfter ? { requestShapeHashAfter: input.requestShapeHashAfter } : {}),
+    ...(input.preActiveContextEstimatedTokens !== undefined
+      ? { preActiveContextEstimatedTokens: input.preActiveContextEstimatedTokens }
+      : {}),
+    ...(input.postReplacementEstimatedTokens !== undefined
+      ? { postReplacementEstimatedTokens: input.postReplacementEstimatedTokens }
+      : {}),
+    ...(input.willRetriggerImmediately !== undefined
+      ? { willRetriggerImmediately: input.willRetriggerImmediately }
+      : {}),
+    ...(input.compactCallUsage ? { compactCallUsage: input.compactCallUsage } : {}),
+  };
+  block.estimatedTokens = estimateTokens(renderActiveFullCompactBlock(block).length, charsPerToken);
+  return block;
+}
+
+export function renderActiveFullCompactBlock(block: ActiveFullCompactBlock): string {
+  const lines = [
+    `<maka_active_full_compact_block id="${escapeAttribute(block.blockId)}" high_water="${escapeAttribute(block.highWaterName)}" seq="${block.highWaterSeq}" version="${block.version}">`,
+    `summary: ${block.summary.text}`,
+    ...renderSummarySections(block.summary),
+    `coverage: turnIds=[${block.coverage.turnIds.join(', ')}], runtimeEventIds=[${block.coverage.runtimeEventIds.join(', ')}], providerSourceIds=[${block.coverage.providerMessageSourceIds.join(', ')}], toolCallIds=[${block.coverage.toolCallIds.join(', ')}], contentKinds=[${block.coverage.contentKinds.join(', ')}], bodySha256=[${block.coverage.bodySha256.join(', ')}]`,
+    `limitations: ${block.limitations.join('; ')}`,
+    `sources: ${block.sourceRefs.map(renderSourceRef).join('; ')}`,
+    ...(block.archiveRefs && block.archiveRefs.length > 0
+      ? [`archives: ${block.archiveRefs.map(renderArchiveRef).join('; ')}`]
+      : []),
+    '</maka_active_full_compact_block>',
+  ];
+  return lines.join('\n');
+}
+
+export function validateActiveFullCompactBlockShape(
+  value: unknown,
+  sessionId?: string,
+): value is ActiveFullCompactBlock {
+  if (!value || typeof value !== 'object') return false;
+  const block = value as Partial<ActiveFullCompactBlock>;
+  return block.kind === 'maka.active_full_compact_block'
+    && block.version === 1
+    && nonEmpty(block.blockId)
+    && nonEmpty(block.sessionId)
+    && (sessionId === undefined || block.sessionId === sessionId)
+    && nonEmpty(block.turnId)
+    && Number.isFinite(block.createdAt)
+    && nonEmpty(block.highWaterName)
+    && Number.isFinite(block.highWaterSeq)
+    && !!block.trigger
+    && isTriggerReason(block.trigger.reason)
+    && !!block.coverage
+    && Array.isArray(block.coverage.turnIds)
+    && Array.isArray(block.coverage.runtimeEventIds)
+    && Array.isArray(block.coverage.providerMessageSourceIds)
+    && Array.isArray(block.coverage.toolCallIds)
+    && Array.isArray(block.coverage.contentKinds)
+    && Array.isArray(block.coverage.bodySha256)
+    && allNonEmpty(block.coverage.turnIds)
+    && allNonEmpty(block.coverage.providerMessageSourceIds)
+    && allNonEmpty(block.coverage.contentKinds)
+    && allNonEmpty(block.coverage.bodySha256)
+    && !!block.summary
+    && block.summary.schemaVersion === 1
+    && nonEmpty(block.summary.text)
+    && Array.isArray(block.limitations)
+    && Array.isArray(block.sourceRefs)
+    && block.sourceRefs.length > 0
+    && block.sourceRefs.every(isValidSourceRef)
+    && (block.archiveRefs === undefined || (Array.isArray(block.archiveRefs) && block.archiveRefs.every(isArchiveRef)))
+    && optionalNonNegativeFiniteNumber(block.estimatedTokens);
+}
+
+export function validateActiveFullCompactBlockForSourceIndex(
+  value: unknown,
+  index: ActiveFullCompactSourceIndex,
+  options: {
+    sessionId?: string;
+    turnId?: string;
+    archiveRequired?: boolean;
+    requireRuntimeEventCoverage?: boolean;
+    maxSummaryEstimatedTokens?: number;
+    maxBlockEstimatedTokens?: number;
+    charsPerToken?: number;
+  } = {},
+): ActiveFullCompactValidationResult {
+  const reasons: ActiveFullCompactFailOpenReason[] = [];
+  const charsPerToken = options.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  const add = (reason: ActiveFullCompactFailOpenReason) => {
+    if (!reasons.includes(reason)) reasons.push(reason);
+  };
+
+  if (!validateActiveFullCompactBlockShape(value, options.sessionId ?? index.sessionId)) {
+    add('invalid_schema_version');
+    if (value && typeof value === 'object') {
+      const partial = value as Partial<ActiveFullCompactBlock>;
+      if (partial.sessionId !== undefined && (partial.sessionId !== index.sessionId || (options.sessionId && partial.sessionId !== options.sessionId))) {
+        add('session_mismatch');
+      }
+      if (partial.turnId !== undefined && (partial.turnId !== index.turnId || (options.turnId && partial.turnId !== options.turnId))) {
+        add('turn_mismatch');
+      }
+      const summaryText = partial.summary && typeof partial.summary === 'object'
+        ? (partial.summary as Partial<ActiveFullCompactSummary>).text
+        : undefined;
+      if (!nonEmpty(summaryText)) add('summary_missing');
+      const maxSummaryTokens = finitePositive(options.maxSummaryEstimatedTokens);
+      if (maxSummaryTokens !== undefined && nonEmpty(summaryText) && estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
+        add('summary_too_large');
+      }
+      const maxBlockTokens = finitePositive(options.maxBlockEstimatedTokens);
+      if (
+        maxBlockTokens !== undefined
+        && typeof partial.estimatedTokens === 'number'
+        && Number.isFinite(partial.estimatedTokens)
+        && partial.estimatedTokens > maxBlockTokens
+      ) {
+        add('max_block_tokens');
+      }
+    } else {
+      add('summary_missing');
+    }
+    return {
+      valid: false,
+      reasons,
+      reasonCounts: countReasons(reasons),
+    };
+  }
+  const block = value;
+  if (block.sessionId !== index.sessionId || (options.sessionId && block.sessionId !== options.sessionId)) {
+    add('session_mismatch');
+  }
+  if (block.turnId !== index.turnId || (options.turnId && block.turnId !== options.turnId)) {
+    add('turn_mismatch');
+  }
+  if (!nonEmpty(block.summary?.text)) add('summary_missing');
+  const maxSummaryTokens = finitePositive(options.maxSummaryEstimatedTokens);
+  if (maxSummaryTokens !== undefined && estimateTokens(block.summary.text.length, charsPerToken) > maxSummaryTokens) {
+    add('summary_too_large');
+  }
+  const maxBlockTokens = finitePositive(options.maxBlockEstimatedTokens);
+  if (maxBlockTokens !== undefined) {
+    const blockTokens = block.estimatedTokens ?? estimateTokens(renderActiveFullCompactBlock(block).length, charsPerToken);
+    if (blockTokens > maxBlockTokens) add('max_block_tokens');
+  }
+
+  const entriesBySource = new Map(index.entries.map((entry) => [entry.sourceId, entry]));
+  const selectedEntries: ActiveFullCompactSourceEntry[] = [];
+  for (const sourceId of block.coverage.providerMessageSourceIds) {
+    const entry = entriesBySource.get(sourceId);
+    if (!entry) {
+      add('source_missing');
+      continue;
+    }
+    selectedEntries.push(entry);
+    if (!block.coverage.turnIds.includes(entry.turnId)) add('coverage_miss');
+    if (entry.runtimeEventId && !block.coverage.runtimeEventIds.includes(entry.runtimeEventId)) add('coverage_miss');
+    if (entry.toolCallId && !block.coverage.toolCallIds.includes(entry.toolCallId)) add('coverage_miss');
+    if (!block.coverage.contentKinds.includes(entry.contentKind)) add('coverage_miss');
+    if (!block.coverage.bodySha256.includes(entry.bodySha256)) add('source_hash_mismatch');
+    if (options.requireRuntimeEventCoverage === true && !entry.runtimeEventId) {
+      add('provider_message_only_when_runtime_required');
+    }
+    if (options.archiveRequired === true && entry.contentKind === 'active_archive_placeholder' && !entry.archiveRef) {
+      add('archive_missing');
+    }
+  }
+  for (const hash of block.coverage.bodySha256) {
+    if (!selectedEntries.some((entry) => entry.bodySha256 === hash)) add('source_hash_mismatch');
+  }
+  if (toolPairSplit(selectedEntries, index.entries)) add('tool_pair_split');
+  if (block.archiveRefs) {
+    for (const ref of block.archiveRefs) {
+      const match = selectedEntries.find((entry) => archiveRefsEqual(entry.archiveRef, ref));
+      if (!match) add('archive_mismatch');
+    }
+  }
+
+  return {
+    valid: reasons.length === 0,
+    reasons,
+    reasonCounts: countReasons(reasons),
+  };
+}
+
+export function activeFullCompactBlockToCompactionBoundary(
+  block: ActiveFullCompactBlock,
+  options: {
+    renderedText?: string;
+    validationStatus?: CompactionBoundary['validationStatus'];
+    validationReason?: string;
+  } = {},
+): CompactionBoundary {
+  return {
+    kind: 'activeFullCompact',
+    stage: 'activeStep',
+    schemaVersion: block.version,
+    boundaryId: block.blockId,
+    sessionId: block.sessionId,
+    createdAt: block.createdAt,
+    highWaterName: block.highWaterName,
+    highWaterSeq: block.highWaterSeq,
+    coverage: {
+      turnIds: block.coverage.turnIds,
+      runtimeEventIds: block.coverage.runtimeEventIds,
+      toolCallIds: block.coverage.toolCallIds,
+      contentKinds: block.coverage.contentKinds,
+      bodySha256: block.coverage.bodySha256,
+    },
+    ...(block.preservedAnchor ? { preservedAnchor: block.preservedAnchor } : {}),
+    ...(block.archiveRefs && block.archiveRefs.length > 0
+      ? { archiveRefs: block.archiveRefs.map(activeArchiveRefToBoundaryArchiveRef) }
+      : {}),
+    sourceHashes: block.coverage.bodySha256,
+    renderedText: options.renderedText ?? renderActiveFullCompactBlock(block),
+    ...(block.estimatedTokens !== undefined ? { estimatedTokens: block.estimatedTokens } : {}),
+    validationStatus: options.validationStatus ?? 'notValidated',
+    ...(options.validationReason ? { validationReason: options.validationReason } : {}),
+  };
+}
+
+export function activeFullCompactDecisionDiagnosticPatch(input: {
+  decision: CompactionDecisionKind;
+  boundaryIds?: readonly string[];
+  coverage?: ActiveFullCompactCoverage;
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  reason?: string;
+  failOpenReason?: ActiveFullCompactFailOpenReason;
+  skippedReasonCounts?: Readonly<Record<string, number>>;
+  validationReasonCounts?: Readonly<Record<string, number>>;
+}): Partial<ContextBudgetDiagnostic> {
+  return compactionDecisionDiagnosticPatch({
+    stage: 'activeStep',
+    sourceKind: 'providerMessages',
+    boundaryKind: 'activeFullCompact',
+    decision: input.decision,
+    ...(input.boundaryIds ? { boundaryIds: input.boundaryIds } : {}),
+    ...(input.coverage ? {
+      coverage: {
+        turnIds: input.coverage.turnIds,
+        runtimeEventIds: input.coverage.runtimeEventIds,
+        toolCallIds: input.coverage.toolCallIds,
+        contentKinds: input.coverage.contentKinds,
+        bodySha256: input.coverage.bodySha256,
+      },
+    } : {}),
+    ...(input.estimatedTokensBefore !== undefined ? { estimatedTokensBefore: input.estimatedTokensBefore } : {}),
+    ...(input.estimatedTokensAfter !== undefined ? { estimatedTokensAfter: input.estimatedTokensAfter } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+    ...(input.failOpenReason ? { failOpenReason: input.failOpenReason } : {}),
+    ...(input.skippedReasonCounts ? { skippedReasonCounts: input.skippedReasonCounts } : {}),
+    ...(input.validationReasonCounts ? { validationReasonCounts: input.validationReasonCounts } : {}),
+  });
+}
+
+function entryFromProviderPart(input: {
+  sourceId: string;
+  messageIndex: number;
+  partIndex?: number;
+  role: ActiveFullCompactProviderRole;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  contentKind: ActiveFullCompactContentKind;
+  body: unknown;
+  toolCallId?: string;
+  toolName?: string;
+  placeholder?: ActiveArchivedToolResultPlaceholder;
+  charsPerToken: number;
+  runtimeIndex: RuntimeEventIndex;
+}): ActiveFullCompactSourceEntry {
+  const bodyText = typeof input.body === 'string' ? input.body : stableStringify(input.body);
+  const bodySha256 = input.placeholder?.bodySha256 ?? sha256(bodyText);
+  const runtimeEvent = matchRuntimeEvent(input.runtimeIndex, {
+    bodySha256,
+    toolCallId: input.toolCallId,
+    contentKind: input.contentKind,
+  });
+  const contentKind = input.placeholder
+    ? 'active_archive_placeholder'
+    : runtimeEvent?.content?.kind === 'function_response'
+      ? 'function_response'
+      : runtimeEvent?.content?.kind === 'function_call'
+        ? 'function_call'
+        : runtimeEvent?.content?.kind === 'thinking'
+          ? 'thinking'
+          : input.contentKind;
+  const archiveRef = input.placeholder
+    ? {
+        kind: 'toolResult' as const,
+        turnId: input.placeholder.turnId,
+        ...(runtimeEvent?.sessionId ? { sessionId: runtimeEvent.sessionId } : {}),
+        ...(runtimeEvent?.id ? { runtimeEventId: runtimeEvent.id } : {}),
+        toolCallId: input.placeholder.toolCallId,
+        toolName: input.placeholder.toolName,
+        artifactId: input.placeholder.artifactId,
+        bodySha256: input.placeholder.bodySha256,
+        originalEstimatedTokens: input.placeholder.originalEstimatedTokens,
+        originalBytes: input.placeholder.originalBytes,
+      }
+    : undefined;
+  return {
+    sourceId: input.sourceId,
+    messageIndex: input.messageIndex,
+    ...(input.partIndex !== undefined ? { partIndex: input.partIndex } : {}),
+    role: input.role,
+    ...(runtimeEvent?.id ? { runtimeEventId: runtimeEvent.id } : {}),
+    turnId: runtimeEvent?.turnId ?? input.placeholder?.turnId ?? input.turnId,
+    ...(runtimeEvent?.runId ?? input.runId ? { runId: runtimeEvent?.runId ?? input.runId } : {}),
+    ...(runtimeEvent?.invocationId ?? input.invocationId
+      ? { invocationId: runtimeEvent?.invocationId ?? input.invocationId }
+      : {}),
+    ...(input.toolCallId ?? runtimeToolCallId(runtimeEvent) ? { toolCallId: input.toolCallId ?? runtimeToolCallId(runtimeEvent) } : {}),
+    ...(input.toolName ?? runtimeToolName(runtimeEvent) ? { toolName: input.toolName ?? runtimeToolName(runtimeEvent) } : {}),
+    contentKind,
+    bodySha256,
+    estimatedTokens: estimateTokens(bodyText.length, input.charsPerToken),
+    ...(input.placeholder ? { originalEstimatedTokens: input.placeholder.originalEstimatedTokens } : {}),
+    ...(input.placeholder ? { originalBytes: input.placeholder.originalBytes } : {}),
+    ...(archiveRef ? { archiveRef } : {}),
+  };
+}
+
+function providerPartBody(part: unknown): {
+  contentKind: ActiveFullCompactContentKind;
+  body: unknown;
+  toolCallId?: string;
+  toolName?: string;
+  placeholder?: ActiveArchivedToolResultPlaceholder;
+} {
+  if (!part || typeof part !== 'object') return { contentKind: 'unknown', body: part };
+  const candidate = part as Record<string, unknown>;
+  if (candidate.type === 'text') return { contentKind: 'text', body: candidate.text ?? '' };
+  if (candidate.type === 'reasoning' || candidate.type === 'thinking') {
+    return { contentKind: 'thinking', body: candidate.text ?? candidate.reasoning ?? '' };
+  }
+  if (candidate.type === 'tool-call') {
+    return {
+      contentKind: 'function_call',
+      body: candidate.input ?? candidate.args ?? candidate,
+      ...(typeof candidate.toolCallId === 'string' ? { toolCallId: candidate.toolCallId } : {}),
+      ...(typeof candidate.toolName === 'string' ? { toolName: candidate.toolName } : {}),
+    };
+  }
+  if (candidate.type === 'tool-result') {
+    const payload = toolResultPayload(candidate);
+    const placeholder = activePlaceholderFromPayload(payload);
+    return {
+      contentKind: placeholder ? 'active_archive_placeholder' : 'tool_result',
+      body: payload,
+      ...(typeof candidate.toolCallId === 'string' ? { toolCallId: candidate.toolCallId } : {}),
+      ...(typeof candidate.toolName === 'string' ? { toolName: candidate.toolName } : {}),
+      ...(placeholder ? { placeholder } : {}),
+    };
+  }
+  return { contentKind: 'unknown', body: candidate };
+}
+
+function toolResultPayload(part: Record<string, unknown>): unknown {
+  if ('result' in part) return part.result;
+  const output = part.output;
+  if (output && typeof output === 'object' && 'value' in output) {
+    return (output as { value?: unknown }).value;
+  }
+  return output ?? part;
+}
+
+function activePlaceholderFromPayload(payload: unknown): ActiveArchivedToolResultPlaceholder | undefined {
+  if (isActiveArchivedToolResultPlaceholder(payload)) return payload;
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload) as unknown;
+      return isActiveArchivedToolResultPlaceholder(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+interface RuntimeEventIndex {
+  byToolCallId: Map<string, RuntimeEvent[]>;
+  byBodySha256: Map<string, RuntimeEvent[]>;
+}
+
+function buildRuntimeEventIndex(events: readonly RuntimeEvent[], charsPerToken: number): RuntimeEventIndex {
+  const byToolCallId = new Map<string, RuntimeEvent[]>();
+  const byBodySha256 = new Map<string, RuntimeEvent[]>();
+  for (const event of events) {
+    const toolCallId = runtimeToolCallId(event);
+    if (toolCallId) pushMap(byToolCallId, toolCallId, event);
+    pushMap(byBodySha256, runtimeEventBodySha256(event, charsPerToken), event);
+  }
+  return { byToolCallId, byBodySha256 };
+}
+
+function matchRuntimeEvent(
+  index: RuntimeEventIndex,
+  input: { bodySha256: string; toolCallId?: string; contentKind: ActiveFullCompactContentKind },
+): RuntimeEvent | undefined {
+  const toolMatches = input.toolCallId ? index.byToolCallId.get(input.toolCallId) ?? [] : [];
+  const bodyMatches = index.byBodySha256.get(input.bodySha256) ?? [];
+  const candidates = [...toolMatches, ...bodyMatches];
+  if (candidates.length === 0) return undefined;
+  const preferredKind = input.contentKind === 'function_call'
+    ? 'function_call'
+    : input.contentKind === 'tool_result' || input.contentKind === 'active_archive_placeholder'
+      ? 'function_response'
+      : input.contentKind;
+  return candidates.find((event) => event.content?.kind === preferredKind)
+    ?? bodyMatches[0]
+    ?? toolMatches[0];
+}
+
+function runtimeEventBodySha256(event: RuntimeEvent, charsPerToken: number): string {
+  void charsPerToken;
+  const content = event.content;
+  if (!content) return sha256('');
+  switch (content.kind) {
+    case 'text':
+    case 'thinking':
+      return sha256(content.text);
+    case 'function_call':
+      return sha256(stableStringify(content.args));
+    case 'function_response':
+      return sha256(serializeToolResultForArchive(content.result));
+    case 'error':
+      return sha256(stableStringify(content));
+  }
+}
+
+function runtimeToolCallId(event: RuntimeEvent | undefined): string | undefined {
+  if (!event) return undefined;
+  if (event.content?.kind === 'function_call' || event.content?.kind === 'function_response') return event.content.id;
+  return event.refs?.toolCallId;
+}
+
+function runtimeToolName(event: RuntimeEvent | undefined): string | undefined {
+  if (!event) return undefined;
+  if (event.content?.kind === 'function_call' || event.content?.kind === 'function_response') return event.content.name;
+  return undefined;
+}
+
+function toolPairSplit(
+  selectedEntries: readonly ActiveFullCompactSourceEntry[],
+  allEntries: readonly ActiveFullCompactSourceEntry[],
+): boolean {
+  const selectedSourceIds = new Set(selectedEntries.map((entry) => entry.sourceId));
+  const toolCallIds = uniqueSorted(selectedEntries.map((entry) => entry.toolCallId).filter(nonEmpty));
+  for (const toolCallId of toolCallIds) {
+    const allKinds = allEntries
+      .filter((entry) => entry.toolCallId === toolCallId)
+      .map((entry) => entry.contentKind);
+    const hasCall = allKinds.includes('function_call');
+    const hasResult = allKinds.some((kind) =>
+      kind === 'function_response' || kind === 'tool_result' || kind === 'active_archive_placeholder'
+    );
+    if (!hasCall || !hasResult) continue;
+    const selectedKinds = allEntries
+      .filter((entry) => entry.toolCallId === toolCallId && selectedSourceIds.has(entry.sourceId))
+      .map((entry) => entry.contentKind);
+    const selectedHasCall = selectedKinds.includes('function_call');
+    const selectedHasResult = selectedKinds.some((kind) =>
+      kind === 'function_response' || kind === 'tool_result' || kind === 'active_archive_placeholder'
+    );
+    if (selectedHasCall !== selectedHasResult) return true;
+  }
+  return false;
+}
+
+function normalizeSummary(summary: ActiveFullCompactSummary): ActiveFullCompactSummary {
+  return {
+    ...summary,
+    schemaVersion: 1,
+    text: summary.text,
+  };
+}
+
+function renderSummarySections(summary: ActiveFullCompactSummary): string[] {
+  const lines: string[] = [];
+  pushSection(lines, 'process_state', summary.processState);
+  pushSection(lines, 'vm_state', summary.vmState);
+  pushSection(lines, 'artifact_paths', summary.artifactPaths);
+  if (summary.commandsTried && summary.commandsTried.length > 0) {
+    lines.push(`commands_tried: ${summary.commandsTried.map((command) =>
+      `${command.command} => ${command.outcome}${command.sourceIds?.length ? ` [${command.sourceIds.join(', ')}]` : ''}`
+    ).join('; ')}`);
+  }
+  if (summary.latestVerifierFailure) lines.push(`latest_verifier_failure: ${summary.latestVerifierFailure}`);
+  pushSection(lines, 'constraints', summary.constraints);
+  pushSection(lines, 'failed_hypotheses', summary.failedHypotheses);
+  if (summary.currentHypothesis) lines.push(`current_hypothesis: ${summary.currentHypothesis}`);
+  pushSection(lines, 'next_actions', summary.nextActions);
+  pushSection(lines, 'archive_refs', summary.archiveRefs);
+  return lines;
+}
+
+function renderSourceRef(ref: ActiveFullCompactSourceRef): string {
+  return `source(kind=${ref.kind}, sourceId=${ref.sourceId}, runtimeEventId=${ref.runtimeEventId ?? ''}, toolCallId=${ref.toolCallId ?? ''}, contentKind=${ref.contentKind}, bodySha256=${ref.bodySha256})`;
+}
+
+function renderArchiveRef(ref: ActiveFullCompactArchiveRef): string {
+  return `archive(kind=${ref.kind}, artifactId=${ref.artifactId}, toolCallId=${ref.toolCallId ?? ''}, bodySha256=${ref.bodySha256})`;
+}
+
+function activeArchiveRefToBoundaryArchiveRef(ref: ActiveFullCompactArchiveRef): CompactionArchiveRef {
+  return {
+    kind: ref.kind === 'toolResult' ? 'toolResult' : 'compactSource',
+    ...(ref.sessionId ? { sessionId: ref.sessionId } : {}),
+    ...(ref.turnId ? { turnId: ref.turnId } : {}),
+    ...(ref.runtimeEventId ? { runtimeEventId: ref.runtimeEventId } : {}),
+    ...(ref.toolCallId ? { toolCallId: ref.toolCallId } : {}),
+    ...(ref.toolName ? { toolName: ref.toolName } : {}),
+    artifactId: ref.artifactId,
+    bodySha256: ref.bodySha256,
+    ...(ref.originalEstimatedTokens !== undefined ? { originalEstimatedTokens: ref.originalEstimatedTokens } : {}),
+    ...(ref.originalBytes !== undefined ? { originalBytes: ref.originalBytes } : {}),
+  };
+}
+
+function skippedSelection(
+  decision: 'unchanged' | 'failedOpen',
+  reason: ActiveFullCompactSelection extends infer T
+    ? T extends { reason: infer R } ? R : never
+    : never,
+): ActiveFullCompactSelection {
+  return { decision, reason, skippedReasonCounts: { [reason]: 1 } } as ActiveFullCompactSelection;
+}
+
+function isTriggerReason(value: unknown): value is ActiveFullCompactBlock['trigger']['reason'] {
+  return value === 'high_water'
+    || value === 'force_ratio'
+    || value === 'predictive_growth'
+    || value === 'reactive_prompt_too_long'
+    || value === 'manual_test';
+}
+
+function isValidSourceRef(value: unknown): value is ActiveFullCompactSourceRef {
+  if (!value || typeof value !== 'object') return false;
+  const ref = value as Partial<ActiveFullCompactSourceRef>;
+  return (ref.kind === 'provider_message' || ref.kind === 'runtime_event' || ref.kind === 'active_archive_placeholder')
+    && nonEmpty(ref.sourceId)
+    && Number.isFinite(ref.messageIndex)
+    && nonEmpty(ref.sessionId)
+    && nonEmpty(ref.turnId)
+    && isContentKind(ref.contentKind)
+    && nonEmpty(ref.bodySha256);
+}
+
+function isArchiveRef(value: unknown): value is ActiveFullCompactArchiveRef {
+  if (!value || typeof value !== 'object') return false;
+  const ref = value as Partial<ActiveFullCompactArchiveRef>;
+  return (ref.kind === 'toolResult' || ref.kind === 'compactSource')
+    && nonEmpty(ref.artifactId)
+    && nonEmpty(ref.bodySha256)
+    && optionalNonNegativeFiniteNumber(ref.originalEstimatedTokens)
+    && optionalNonNegativeFiniteNumber(ref.originalBytes);
+}
+
+function isContentKind(value: unknown): value is ActiveFullCompactContentKind {
+  return value === 'text'
+    || value === 'thinking'
+    || value === 'function_call'
+    || value === 'function_response'
+    || value === 'tool_result'
+    || value === 'active_archive_placeholder'
+    || value === 'unknown';
+}
+
+function archiveRefsEqual(left: ActiveFullCompactArchiveRef | undefined, right: ActiveFullCompactArchiveRef): boolean {
+  return Boolean(left)
+    && left?.kind === right.kind
+    && left.artifactId === right.artifactId
+    && left.bodySha256 === right.bodySha256
+    && left.toolCallId === right.toolCallId
+    && left.toolName === right.toolName;
+}
+
+function uniqueArchiveRefs(refs: readonly ActiveFullCompactArchiveRef[]): ActiveFullCompactArchiveRef[] {
+  const seen = new Set<string>();
+  const result: ActiveFullCompactArchiveRef[] = [];
+  for (const ref of refs) {
+    const key = `${ref.kind}:${ref.artifactId}:${ref.bodySha256}:${ref.toolCallId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(ref);
+  }
+  return result;
+}
+
+function countReasons(
+  reasons: readonly ActiveFullCompactFailOpenReason[],
+): Readonly<Record<ActiveFullCompactFailOpenReason, number>> {
+  const counts: Partial<Record<ActiveFullCompactFailOpenReason, number>> = {};
+  for (const reason of reasons) counts[reason] = (counts[reason] ?? 0) + 1;
+  return counts as Readonly<Record<ActiveFullCompactFailOpenReason, number>>;
+}
+
+function providerSourceId(messageIndex: number, partIndex?: number): string {
+  return partIndex === undefined
+    ? `provider:${messageIndex}`
+    : `provider:${messageIndex}:${partIndex}`;
+}
+
+function normalizeProviderRole(role: string): ActiveFullCompactProviderRole {
+  if (role === 'system' || role === 'user' || role === 'assistant' || role === 'tool') return role;
+  return 'user';
+}
+
+function stableActiveFullCompactBlockId(value: unknown): string {
+  return `afcompact-${sha256(stableStringify(value)).slice(0, 32)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return '';
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? '';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(object[key])}`).join(',')}}`;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function allNonEmpty(values: readonly unknown[]): boolean {
+  return values.every(nonEmpty);
+}
+
+function optionalNonNegativeFiniteNumber(value: unknown): boolean {
+  return value === undefined || (typeof value === 'number' && Number.isFinite(value) && value >= 0);
+}
+
+function finitePositive(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function finiteRatio(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(1, value);
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function pushMap<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const existing = map.get(key);
+  if (existing) existing.push(value);
+  else map.set(key, [value]);
+}
+
+function pushSection(lines: string[], label: string, values: readonly string[] | undefined): void {
+  if (values && values.length > 0) lines.push(`${label}: ${values.join('; ')}`);
+}
+
+function escapeAttribute(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+}

--- a/packages/runtime/src/compaction-boundary.ts
+++ b/packages/runtime/src/compaction-boundary.ts
@@ -47,6 +47,7 @@ export interface CompactionBoundary {
   preservedAnchor?: {
     headRuntimeEventIds?: readonly string[];
     tailRuntimeEventIds?: readonly string[];
+    tailProviderMessageSourceIds?: readonly string[];
     tailTurnIds?: readonly string[];
   };
   archiveRefs?: readonly CompactionArchiveRef[];

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -10,6 +10,7 @@ import {
   compactionDecisionDiagnosticPatch,
   historyCompactBlockToCompactionBoundary,
 } from './compaction-boundary.js';
+import type { ActiveFullCompactPolicy } from './active-full-compact.js';
 import type { CompactionDecisionKind } from './compaction-boundary.js';
 
 export interface ContextBudgetPolicy {
@@ -32,6 +33,11 @@ export interface ContextBudgetPolicy {
    * AI SDK step. Defaults off and does not mutate persisted session messages.
    */
   activeToolResultPrune?: ActiveToolResultPrunePolicy;
+  /**
+   * Optional active-loop full compact foundation. PR1 only indexes and validates
+   * source-bearing blocks; provider-visible prepareStep replacement is PR2.
+   */
+  activeFullCompact?: ActiveFullCompactPolicy;
   /** Optional replay-only archive hydration after pruning. Defaults off. */
   archiveRetrieval?: ArchiveRetrievalPolicy;
   /** Optional deterministic prior-history search used to re-add bounded around-context. Defaults off. */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -223,6 +223,35 @@ export type {
   ActiveArchivedToolResultPlaceholder,
   PromptSegmentInput,
 } from './context-budget.js';
+export {
+  activeFullCompactBlockToCompactionBoundary,
+  activeFullCompactCoverageFromEntries,
+  activeFullCompactDecisionDiagnosticPatch,
+  buildActiveFullCompactBlockFromSummary,
+  buildActiveFullCompactSourceIndex,
+  estimateActiveFullCompactTokens,
+  renderActiveFullCompactBlock,
+  selectActiveFullCompactCoveredSpan,
+  validateActiveFullCompactBlockForSourceIndex,
+  validateActiveFullCompactBlockShape,
+} from './active-full-compact.js';
+export type {
+  ActiveFullCompactArchiveRef,
+  ActiveFullCompactBlock,
+  ActiveFullCompactContentKind,
+  ActiveFullCompactCoverage,
+  ActiveFullCompactFailOpenReason,
+  ActiveFullCompactPolicy,
+  ActiveFullCompactProviderRole,
+  ActiveFullCompactSelection,
+  ActiveFullCompactSourceEntry,
+  ActiveFullCompactSourceIndex,
+  ActiveFullCompactSourceIndexInput,
+  ActiveFullCompactSourceRef,
+  ActiveFullCompactSummary,
+  ActiveFullCompactValidationResult,
+  BuildActiveFullCompactBlockInput,
+} from './active-full-compact.js';
 export { testConnection } from './test-connection.js';
 export { fetchProviderModels } from './model-fetcher.js';
 


### PR DESCRIPTION
## Summary

This is PR1 from issue #327's active full compact split. It adds the source-bearing foundation for active-loop full compaction without changing provider-visible request shape yet.

- Adds `active-full-compact` source indexing for active provider messages, optional RuntimeEvent matches, and existing active tool-result archive placeholders.
- Adds active full compact block build/render/shape validation and source-index validation helpers with fail-open diagnostics.
- Maps active full compact blocks into the shared `CompactionBoundary` / compaction decision vocabulary from #330.
- Adds `ContextBudgetPolicy.activeFullCompact` as an opt-in skeleton and exports the runtime subpath.

## Deliberately not in this PR

- No `AiSdkBackend.prepareStep` replacement wiring.
- No provider-visible active full compact summary injection.
- No durable active boundary persistence/replay beyond the shared boundary mapping helpers.

## Rive / Review

Rive workflow: `maka.active-full-compact-pr1@1`, run `wfrun_f62ecce6a4104b7a9d63a8198a922691`.

The Rive review found one blocker: malformed loaded/generated compact blocks could throw during validation instead of failing open. This PR includes the fix and malformed-block regression coverage.

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/active-full-compact.test.js`
- `node --test packages/runtime/dist/__tests__/active-tool-result-prune.test.js packages/runtime/dist/__tests__/context-budget.test.js packages/runtime/dist/__tests__/request-shape.test.js`
- `npm --workspace @maka/runtime run test` (`717 pass / 1 skipped / 0 fail`)
- `git diff --check`
- `git diff --cached --check`
