### PR TITLE
feat(ui): govern chat bubble/row shell onto @maka/ui chat primitives

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
@@ -68,27 +68,22 @@ describe('chat primitive shell migration contract (#332 PR1)', () => {
     // Strip comments so the assertions reflect real classNames, not prose that
     // happens to name the scale utilities it is telling us to avoid.
     const chatSrc = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
-    // The shell values are LITERAL Tailwind arbitrary utilities, so each one
-    // compiles 1:1 to its declaration on a leaf element with nothing to
-    // resolve or override — asserting the class string here is equivalent to
-    // asserting the computed style, without a browser. Values mirror the
+    // The shell values are LITERAL Tailwind arbitrary utilities, so the variant
+    // class string compiles 1:1 to its declarations on a leaf element with
+    // nothing to resolve or override — asserting the exact string here is
+    // equivalent to asserting the computed style, without a browser. Matching
+    // the WHOLE string (not just "contains each literal") also pins the set
+    // closed: a stray extra `rounded-[12px]` / `px-4` / second `max-w-*` that
+    // would silently override the shell makes this fail. Values mirror the
     // retired `.maka-bubble-user` exactly (border-radius:10px; padding:10px
-    // 14px; line-height:1.6; max-width:min(100%,640px); --chat-user-bg).
-    for (const literal of [
-      'rounded-[10px]',
-      'px-[14px]',
-      'py-[10px]',
-      'leading-[1.6]',
-      'max-w-[min(100%,640px)]',
-      'bg-[var(--chat-user-bg)]',
-    ]) {
-      assert.ok(chatSrc.includes(literal), `user bubble must keep the literal "${literal}"`);
-    }
-    // Never the semantic radius/spacing scale (would re-tune under a redesign)
-    // and never primary/accent (the neutral user-bubble token path is fixed).
-    assert.ok(
-      !/rounded-lg|bg-primary|bg-accent/.test(chatSrc),
-      'user bubble must not use semantic rounded-lg or primary/accent backgrounds',
+    // 14px; line-height:1.6; max-width:min(100%,640px); --chat-user-bg) and
+    // never the semantic scale (`rounded-lg`, `px-3.5`) or primary/accent.
+    const bubbleBlock = chatSrc.slice(chatSrc.indexOf('bubbleVariants'));
+    const userClass = bubbleBlock.match(/user:\s*"([^"]*)"/)?.[1];
+    assert.equal(
+      userClass,
+      'max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[10px] bg-[var(--chat-user-bg)] px-[14px] py-[10px] leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]',
+      'user bubble variant must match the retired .maka-bubble-user pixels exactly',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/**
+ * Zero-visual governance contract for issue #332 PR1 — the chat
+ * conversation-flow row/bubble *shell* moved onto the `@maka/ui` `Message` /
+ * `Bubble` primitives. These assertions lock the two halves of "zero visual
+ * change": the bespoke shell CSS is retired, while the Markdown prose and the
+ * still-hand-written turn machinery (PR2) keep their exact layout.
+ */
+describe('chat primitive shell migration contract (#332 PR1)', () => {
+  it('retires the bespoke bubble/row shell selectors', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    for (const selector of [
+      '.maka-bubble-user',
+      '.maka-bubble-truncated',
+      '.maka-bubble-assistant-stack',
+      '.message.user',
+      '.message.assistant',
+      '.message.system',
+      '.message >',
+      '.message pre',
+    ]) {
+      assert.ok(
+        !css.includes(selector),
+        `retired shell selector "${selector}" still present in renderer CSS`,
+      );
+    }
+  });
+
+  it('preserves the assistant Markdown prose (OUT of scope)', async () => {
+    const css = await readAllRendererCss();
+    for (const selector of [
+      '.maka-bubble-assistant {',
+      '.maka-bubble-assistant p',
+      '.maka-bubble-assistant pre',
+      '.maka-bubble-assistant table',
+      '.maka-bubble-assistant li.task-list-item',
+    ]) {
+      assert.ok(css.includes(selector), `prose rule "${selector}" must be preserved`);
+    }
+  });
+
+  it('keeps the row + re-anchors turn layout onto the Message primitive', async () => {
+    const css = await readAllRendererCss();
+    // The centered reading column / entrance animation stay authored.
+    assert.ok(css.includes('.maka-message-row'), '.maka-message-row row base must stay');
+    // Lineage row + footer (PR2, still hand-written) ride the primitive's
+    // data hook so their measure column survives until they migrate.
+    assert.ok(
+      css.includes('[data-slot="message"][data-role="assistant"] .maka-turn-footer'),
+      'turn footer layout must be re-anchored to the Message primitive',
+    );
+    assert.ok(
+      css.includes('[data-slot="message"][data-role="system"] pre'),
+      'system note pre styling must be re-anchored to the Message primitive',
+    );
+  });
+
+  it('keeps the user bubble on the neutral token path, never primary/accent', async () => {
+    const chatSrc = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx'),
+      'utf8',
+    );
+    assert.ok(
+      chatSrc.includes('bg-[var(--chat-user-bg)]'),
+      'user bubble must keep the --chat-user-bg token path',
+    );
+    assert.ok(
+      chatSrc.includes('max-w-[min(100%,640px)]'),
+      'user bubble width cap must match the retired .maka-bubble-user (min(100%,640px))',
+    );
+    assert.ok(
+      !/bg-primary|bg-accent/.test(chatSrc),
+      'user bubble must never switch to primary/accent backgrounds',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
@@ -60,22 +60,35 @@ describe('chat primitive shell migration contract (#332 PR1)', () => {
     );
   });
 
-  it('keeps the user bubble on the neutral token path, never primary/accent', async () => {
-    const chatSrc = await readFile(
+  it('pins the user bubble shell to the retired .maka-bubble-user pixels', async () => {
+    const rawSrc = await readFile(
       resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx'),
       'utf8',
     );
+    // Strip comments so the assertions reflect real classNames, not prose that
+    // happens to name the scale utilities it is telling us to avoid.
+    const chatSrc = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    // The shell values are LITERAL Tailwind arbitrary utilities, so each one
+    // compiles 1:1 to its declaration on a leaf element with nothing to
+    // resolve or override — asserting the class string here is equivalent to
+    // asserting the computed style, without a browser. Values mirror the
+    // retired `.maka-bubble-user` exactly (border-radius:10px; padding:10px
+    // 14px; line-height:1.6; max-width:min(100%,640px); --chat-user-bg).
+    for (const literal of [
+      'rounded-[10px]',
+      'px-[14px]',
+      'py-[10px]',
+      'leading-[1.6]',
+      'max-w-[min(100%,640px)]',
+      'bg-[var(--chat-user-bg)]',
+    ]) {
+      assert.ok(chatSrc.includes(literal), `user bubble must keep the literal "${literal}"`);
+    }
+    // Never the semantic radius/spacing scale (would re-tune under a redesign)
+    // and never primary/accent (the neutral user-bubble token path is fixed).
     assert.ok(
-      chatSrc.includes('bg-[var(--chat-user-bg)]'),
-      'user bubble must keep the --chat-user-bg token path',
-    );
-    assert.ok(
-      chatSrc.includes('max-w-[min(100%,640px)]'),
-      'user bubble width cap must match the retired .maka-bubble-user (min(100%,640px))',
-    );
-    assert.ok(
-      !/bg-primary|bg-accent/.test(chatSrc),
-      'user bubble must never switch to primary/accent backgrounds',
+      !/rounded-lg|bg-primary|bg-accent/.test(chatSrc),
+      'user bubble must not use semantic rounded-lg or primary/accent backgrounds',
     );
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1132,12 +1132,6 @@
     transform: rotate(45deg);
   }
 
-  .maka-bubble-assistant-stack {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-  }
-
   /* The streaming bubble (out-of-band, before the in-progress turn is
    * fully persisted) sits at the bottom of the chat surface; give it the
    * same horizontal frame as a real turn message. */
@@ -1147,25 +1141,10 @@
        previous turn while it lands. */
     box-sizing: border-box;
   }
-  /* User message: a tinted, width-capped block anchored to the right.
-     PR-CHAT-CHROME-FOLLOWUP-0: the previous treatment was transparent
-     right-aligned text — for a long message it filled most of the
-     column, so the right-anchor was imperceptible. Re-tinting with the
-     existing `--chat-user-bg` token + a width cap makes "what the human
-     said" read clearly on the right at any length. The block shrink-
-     wraps to its content because `.message.user` aligns items to
-     flex-end (so short messages stay compact). Radius 10px matches the
-     code-block family and stays under the sharp-identity ceiling. */
-  .maka-bubble-user {
-    background: var(--chat-user-bg);
-    color: var(--chat-user-foreground, var(--foreground));
-    border-radius: 10px;
-    padding: 10px 14px;
-    line-height: 1.6;
-    max-width: min(100%, 78%);
-    white-space: pre-wrap;
-    word-wrap: break-word;
-  }
+  /* User message: a tinted, width-capped block anchored to the right — now
+     the `Bubble variant="user"` chat primitive (issue #332 PR1). It keeps the
+     neutral `--chat-user-bg` token path; the shell utilities live in
+     packages/ui/src/primitives/chat.tsx. */
   /* Assistant: no bubble — just text on background, like an editor.
      The bubble itself flows naturally; child markdown elements (h*, p, ul,
      code blocks, tables, blockquotes) all need their own spacing/typography
@@ -1441,13 +1420,6 @@
     margin: 16px 0;
     border: 0;
     border-top: 1px solid var(--border);
-  }
-
-  /* User content stays verbatim text, but shares the same no-bubble body
-     language as assistant messages. */
-  .maka-bubble-user {
-    white-space: pre-wrap;
-    max-width: min(100%, 640px);
   }
 
   /* Hover-revealed copy button on assistant messages. The wrapper is

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -108,23 +108,10 @@
     cursor: help;
   }
 
-  /* PR-UI-Cx (@kenji msg cd09bcac) — "已截断" pill on the streaming
-     assistant bubble. Fires when `applyAssistantDelta` either tail-kept
-     a single oversize delta or head-capped the per-session total. Same
-     visual family as the reasoning-panel truncated pill, positioned as
-     a footer affordance under the bubble's Markdown body so it doesn't
-     compete with the running text. */
-  .maka-bubble-truncated {
-    display: inline-block;
-    margin-top: 6px;
-    font-size: 10px;
-    color: var(--warning-text, var(--info-text));
-    border: 1px solid oklch(from var(--warning) l c h / 0.24);
-    background: oklch(from var(--warning) l c h / 0.05);
-    border-radius: 4px;
-    padding: 0 5px;
-    cursor: help;
-  }
+  /* The streaming "已截断" pill (PR-UI-Cx, @kenji msg cd09bcac) moved onto the
+     `Bubble variant="assistant"` chat primitive as inline utilities (issue
+     #332 PR1); its sibling `.maka-reasoning-panel-truncated` pill below keeps
+     the same visual family. */
 
   .maka-reasoning-panel-chevron {
     font-size: 12px;

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -21,19 +21,6 @@
   animation: none;
 }
 
-.message > span {
-  display: block;
-  margin-bottom: 6px;
-  color: var(--foreground-50);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.message.user > span { color: var(--foreground-60); }
-.message.assistant > span { color: var(--accent); }
-.message.system > span { color: var(--info-text); }
-
 /* PR-CHAT-CHROME-FOLLOWUP-0: the relative time is always visible now
    (it was `opacity: 0` until hover, which hid it on touch + from
    assistive tech). It stays quiet — 12px at the shared chrome size,
@@ -49,28 +36,22 @@
 }
 
 /* User turn meta row: quiet time + a copy affordance, right-aligned
-   beneath the message block (the parent `.message.user` aligns items
-   to flex-end, so this row shrink-wraps and hugs the right edge). */
+   beneath the message block (the parent `Message role="user"` aligns its
+   items to flex-end, so this row shrink-wraps and hugs the right edge). */
 .maka-message-meta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.message.user {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  /* Separate the meta row from the bubble. Kept below the 8px turn
-     rhythm so the time + copy still read as belonging to the bubble
-     (proximity) rather than floating between turns. */
-  gap: 6px;
-}
-
+/* Turn summary / lineage / footer share the assistant turn's left-anchored
+   measure column. The `[data-role="assistant"]` parts ride the chat Message
+   primitive (issue #332 PR1) — the lineage row + footer are still hand-written
+   (PR2), so this rule keeps their layout until they migrate. */
 .maka-turn > .maka-turn-summary,
 .maka-turn > .maka-turn-lineage-row,
-.message.assistant .maka-turn-lineage-row,
-.message.assistant .maka-turn-footer {
+[data-slot="message"][data-role="assistant"] .maka-turn-lineage-row,
+[data-slot="message"][data-role="assistant"] .maka-turn-footer {
   display: flex;
   max-width: var(--maka-chat-measure, 680px);
   width: 100%;
@@ -79,20 +60,12 @@
   justify-content: flex-start;
 }
 
-.message.assistant,
-.message.system {
-  max-width: var(--maka-chat-measure, 680px);
-  width: 100%;
-  margin-left: 0;
-  margin-right: auto;
-}
-
-.message pre {
+[data-slot="message"] pre {
   margin: 0;
   font: inherit;
 }
 
-.message.system pre {
+[data-slot="message"][data-role="system"] pre {
   display: inline-flex;
   border-radius: 999px;
   background: oklch(from var(--info) l c h / 0.08);

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Bubble, Message } from '../primitives/chat.js';
+
+// The re-anchored renderer selectors key off the primitives' own `data-slot` /
+// `data-role` / `data-variant`, so a consumer must never be able to clobber
+// them. Both primitives are hook-free pure functions, so calling them directly
+// and inspecting the returned element's props proves the structural hooks win
+// over conflicting props — no DOM, no renderer needed.
+test('Message keeps its own data-slot/data-role over conflicting props', () => {
+  const el = Message({
+    variant: 'assistant',
+    'data-slot': 'spoofed',
+    'data-role': 'user',
+  } as never);
+  const props = el.props as Record<string, unknown>;
+  assert.equal(props['data-slot'], 'message');
+  assert.equal(props['data-role'], 'assistant');
+});
+
+test('Bubble keeps its own data-slot/data-variant over conflicting props', () => {
+  const el = Bubble({
+    variant: 'user',
+    'data-slot': 'spoofed',
+    'data-variant': 'assistant',
+  } as never);
+  const props = el.props as Record<string, unknown>;
+  assert.equal(props['data-slot'], 'bubble');
+  assert.equal(props['data-variant'], 'user');
+});

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4375,7 +4375,7 @@ export function ChatView(props: {
             // text_complete. Wrapping here makes streaming structurally
             // identical to TurnView's committed turn.
             <section className="maka-turn maka-turn-streaming">
-              <Message role="assistant">
+              <Message variant="assistant">
                 {/* PR-UI-LAYOUT-42: Reasoning panel for Anthropic-style
                  * extended thinking. Renders ABOVE the streaming
                  * answer because thinking always precedes the
@@ -4771,7 +4771,7 @@ function TurnView(props: {
       )}
       {turn.user && (
         <Message
-          role="user"
+          variant="user"
           aria-label="你发送的消息"
           title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts) : undefined}
         >
@@ -4783,7 +4783,7 @@ function TurnView(props: {
       {turn.notes.map((note) => (
         <Message
           key={note.id}
-          role="system"
+          variant="system"
           title={note.ts ? formatAbsoluteTimestamp(note.ts) : undefined}
         >
           <MessageBody role="system" text={note.text} ts={note.ts} />
@@ -4796,7 +4796,7 @@ function TurnView(props: {
       )}
       {turn.assistant && (
         <Message
-          role="assistant"
+          variant="assistant"
           data-turn-status={turn.status}
           aria-label="Maka 的回答"
           title={turn.assistant.ts ? formatAbsoluteTimestamp(turn.assistant.ts) : undefined}

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -195,6 +195,7 @@ import {
   cn,
 } from './ui.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
+import { Bubble, Message } from './primitives/chat.js';
 import { Button as PrimitiveButton } from './primitives/button.js';
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './primitives/empty.js';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './primitives/input-group.js';
@@ -4374,7 +4375,7 @@ export function ChatView(props: {
             // text_complete. Wrapping here makes streaming structurally
             // identical to TurnView's committed turn.
             <section className="maka-turn maka-turn-streaming">
-              <article className="maka-message-row message assistant streaming">
+              <Message role="assistant">
                 {/* PR-UI-LAYOUT-42: Reasoning panel for Anthropic-style
                  * extended thinking. Renders ABOVE the streaming
                  * answer because thinking always precedes the
@@ -4398,7 +4399,7 @@ export function ChatView(props: {
                     onSettled={props.onStreamingSettled}
                   />
                 )}
-              </article>
+              </Message>
             </section>
           )}
           {/* Defensive: if any tool ended up outside a turn (e.g. legacy
@@ -4449,9 +4450,9 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
     // turn footer's copy (same primitive + `.maka-turn-footer-action`).
     return (
       <>
-        <div className="maka-bubble-user">
+        <Bubble variant="user">
           <span>{props.text}</span>
-        </div>
+        </Bubble>
         <div className="maka-message-meta">
           {props.ts !== undefined && (
             <RelativeTime ts={props.ts} className="maka-message-time-inline" />
@@ -4464,9 +4465,9 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
   // Assistant / system body: open prose, no bubble. Per-turn timing lives in
   // the turn summary; copy + the other actions live in the turn footer.
   return (
-    <div className="maka-bubble-assistant maka-bubble-with-actions">
+    <Bubble variant="assistant" className="maka-bubble-with-actions">
       <Markdown text={props.text} />
-    </div>
+    </Bubble>
   );
 });
 
@@ -4769,24 +4770,24 @@ function TurnView(props: {
         </div>
       )}
       {turn.user && (
-        <article
-          className="maka-message-row message user"
+        <Message
+          role="user"
           aria-label="你发送的消息"
           title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts) : undefined}
         >
           <MessageBody role="user" text={turn.user.text} ts={turn.user.ts} />
-        </article>
+        </Message>
       )}
       <TurnSummary turn={turn} previousModelId={props.previousModelId} />
 
       {turn.notes.map((note) => (
-        <article
+        <Message
           key={note.id}
-          className="maka-message-row message system"
+          role="system"
           title={note.ts ? formatAbsoluteTimestamp(note.ts) : undefined}
         >
           <MessageBody role="system" text={note.text} ts={note.ts} />
-        </article>
+        </Message>
       ))}
       {turn.tools.length > 0 && (
         <div className="maka-turn-tools">
@@ -4794,13 +4795,13 @@ function TurnView(props: {
         </div>
       )}
       {turn.assistant && (
-        <article
-          className="maka-message-row message assistant"
+        <Message
+          role="assistant"
           data-turn-status={turn.status}
           aria-label="Maka 的回答"
           title={turn.assistant.ts ? formatAbsoluteTimestamp(turn.assistant.ts) : undefined}
         >
-          <div className="maka-bubble-assistant-stack">
+          <div className="flex flex-col">
             {turn.assistantThinking && (
               <details className="maka-turn-thinking">
                 <summary>
@@ -4872,7 +4873,7 @@ function TurnView(props: {
               assistantText={turn.assistant.text}
             />
           )}
-        </article>
+        </Message>
       )}
     </section>
   );
@@ -5157,11 +5158,11 @@ function StreamingAssistantBubble(props: { text: string; live: boolean; truncate
   }, [props.live, catchingUp, props.onSettled]);
 
   return (
-    <div className="maka-bubble-assistant maka-bubble-streaming">
+    <Bubble variant="assistant" className="maka-bubble-streaming">
       <Markdown text={displayed} />
       {props.truncated && (
         <div
-          className="maka-bubble-truncated"
+          className="mt-1.5 inline-block cursor-help rounded-[4px] border border-[oklch(from_var(--warning)_l_c_h_/_0.24)] bg-[oklch(from_var(--warning)_l_c_h_/_0.05)] px-[5px] text-[10px] text-[color:var(--warning-text,var(--info-text))]"
           role="status"
           aria-live="polite"
           title="助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。"
@@ -5169,7 +5170,7 @@ function StreamingAssistantBubble(props: { text: string; live: boolean; truncate
           已截断
         </div>
       )}
-    </div>
+    </Bubble>
   );
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,6 +27,7 @@ export * from './utils.js';
 // consumers can `import { Alert, Empty, Sidebar, ... } from '@maka/ui'`.
 export * from './bot-brand.js';
 export * from './primitives/alert.js';
+export * from './primitives/chat.js';
 export * from './primitives/empty.js';
 export * from './primitives/item.js';
 export * from './primitives/spinner.js';

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -22,9 +22,9 @@ import type React from "react";
  */
 
 const messageVariants = cva("maka-message-row", {
-  defaultVariants: { role: "assistant" },
+  defaultVariants: { variant: "assistant" },
   variants: {
-    role: {
+    variant: {
       // `.message.user`: shrink-wrap column, body hugs the right edge. No
       // margin override — the row stays centered (its `margin: 0 auto`).
       user: "flex flex-col items-end gap-1.5",
@@ -38,19 +38,23 @@ const messageVariants = cva("maka-message-row", {
 
 export interface MessageProps
   extends React.ComponentPropsWithoutRef<"article"> {
-  role: "user" | "assistant" | "system";
+  // The chat role. Named `variant` (not `role`) so it never shadows the native
+  // HTML/ARIA `role` attribute, which still flows through `...props`. Emitted
+  // to the DOM as `data-role` — the hook the turn lineage/footer and system
+  // `pre` rules anchor on.
+  variant: "user" | "assistant" | "system";
 }
 
 export function Message({
   className,
-  role,
+  variant,
   ...props
 }: MessageProps): React.ReactElement {
   return (
     <article
       data-slot="message"
-      data-role={role}
-      className={cn(messageVariants({ role }), className)}
+      data-role={variant}
+      className={cn(messageVariants({ variant }), className)}
       {...props}
     />
   );
@@ -61,8 +65,13 @@ const bubbleVariants = cva("", {
   variants: {
     variant: {
       // `.maka-bubble-user`: tinted, width-capped, right-anchored block.
-      // Keeps the neutral `--chat-user-bg` token path (never primary/accent).
-      user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-lg bg-[var(--chat-user-bg)] px-3.5 py-2.5 leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]",
+      // Values are LITERAL (`rounded-[10px]`, `px-[14px] py-[10px]`), not the
+      // design-system scale (`rounded-lg`, `px-3.5`): the retired CSS hardcoded
+      // these pixels, so the literal is the faithful, self-evidently-equal
+      // translation and immune to later scale/token re-tuning (the visual
+      // refresh, not this governance pass, owns adopting the scale). Keeps the
+      // neutral `--chat-user-bg` token path (never primary/accent).
+      user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[10px] bg-[var(--chat-user-bg)] px-[14px] py-[10px] leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]",
       // Assistant / system: open prose, no bubble. Typography stays authored
       // under `.maka-bubble-assistant` (Markdown prose, OUT of scope), so this
       // variant re-emits that class as the styling hook.

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -22,7 +22,6 @@ import type React from "react";
  */
 
 const messageVariants = cva("maka-message-row", {
-  defaultVariants: { variant: "assistant" },
   variants: {
     variant: {
       // `.message.user`: shrink-wrap column, body hugs the right edge. No
@@ -51,17 +50,19 @@ export function Message({
   ...props
 }: MessageProps): React.ReactElement {
   return (
+    // `{...props}` is spread first so the structural `data-*` hooks the
+    // re-anchored selectors depend on always land last and can't be clobbered
+    // by a consumer passing `data-slot` / `data-role`.
     <article
+      {...props}
       data-slot="message"
       data-role={variant}
       className={cn(messageVariants({ variant }), className)}
-      {...props}
     />
   );
 }
 
 const bubbleVariants = cva("", {
-  defaultVariants: { variant: "assistant" },
   variants: {
     variant: {
       // `.maka-bubble-user`: tinted, width-capped, right-anchored block.
@@ -91,10 +92,10 @@ export function Bubble({
 }: BubbleProps): React.ReactElement {
   return (
     <div
+      {...props}
       data-slot="bubble"
       data-variant={variant}
       className={cn(bubbleVariants({ variant }), className)}
-      {...props}
     />
   );
 }

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { cn } from "../utils.js";
+import { cva, type VariantProps } from "class-variance-authority";
+import type React from "react";
+
+/**
+ * Chat conversation-flow primitives (issue #332, PR1).
+ *
+ * `Message` is the per-turn row container; `Bubble` is the message body
+ * surface. They retire the bespoke `.message.{role}` / `.maka-bubble-user`
+ * shell CSS, moving the row/bubble *shell* onto the Tailwind substrate while
+ * leaving Markdown prose (`.maka-bubble-assistant *`, maka-tokens.css) and the
+ * turn machinery (summary / lineage / footer / markers — PR2) untouched.
+ *
+ * The row keeps the authored `.maka-message-row` base (centered reading column
+ * + entrance fade/animation + the `data-maka-visual-smoke` disable). That base
+ * lives in maka-tokens.css's `@layer components`, so the role utilities below
+ * (utilities layer) win over its `margin: 0 auto` for the left-anchored
+ * assistant/system rows. The neutral `--chat-user-bg` token path is preserved
+ * verbatim — the user bubble is never switched to `primary`/`accent`.
+ */
+
+const messageVariants = cva("maka-message-row", {
+  defaultVariants: { role: "assistant" },
+  variants: {
+    role: {
+      // `.message.user`: shrink-wrap column, body hugs the right edge. No
+      // margin override — the row stays centered (its `margin: 0 auto`).
+      user: "flex flex-col items-end gap-1.5",
+      // `.message.assistant` / `.message.system`: left-anchor inside the
+      // measure column (override the row's centering).
+      assistant: "ml-0 mr-auto",
+      system: "ml-0 mr-auto",
+    },
+  },
+});
+
+export interface MessageProps
+  extends React.ComponentPropsWithoutRef<"article"> {
+  role: "user" | "assistant" | "system";
+}
+
+export function Message({
+  className,
+  role,
+  ...props
+}: MessageProps): React.ReactElement {
+  return (
+    <article
+      data-slot="message"
+      data-role={role}
+      className={cn(messageVariants({ role }), className)}
+      {...props}
+    />
+  );
+}
+
+const bubbleVariants = cva("", {
+  defaultVariants: { variant: "assistant" },
+  variants: {
+    variant: {
+      // `.maka-bubble-user`: tinted, width-capped, right-anchored block.
+      // Keeps the neutral `--chat-user-bg` token path (never primary/accent).
+      user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-lg bg-[var(--chat-user-bg)] px-3.5 py-2.5 leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]",
+      // Assistant / system: open prose, no bubble. Typography stays authored
+      // under `.maka-bubble-assistant` (Markdown prose, OUT of scope), so this
+      // variant re-emits that class as the styling hook.
+      assistant: "maka-bubble-assistant",
+    },
+  },
+});
+
+export interface BubbleProps extends React.ComponentPropsWithoutRef<"div"> {
+  variant: VariantProps<typeof bubbleVariants>["variant"];
+}
+
+export function Bubble({
+  className,
+  variant,
+  ...props
+}: BubbleProps): React.ReactElement {
+  return (
+    <div
+      data-slot="bubble"
+      data-variant={variant}
+      className={cn(bubbleVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

PR1 of #332 — migrate the conversation-flow row/bubble **shell** onto a new `@maka/ui` `Message` + `Bubble` primitive pair (cva + `data-slot`), retiring the bespoke `.message.{role}` / `.maka-bubble-user` / `.maka-bubble-truncated` shell CSS with zero visual change. The Markdown prose and the turn machinery (summary / lineage / footer / markers — PR2) are untouched.

## Why

Part of #332. The chat conversation-flow display was the last bespoke island after the rest of `packages/ui/src/primitives/*` moved onto the shadcn Base UI + Tailwind substrate. This is governance — one substrate + a test net — not a redesign; the visual refresh is a separate follow-up.

## Scope

Changed:
- `packages/ui/src/primitives/chat.tsx` (new), exported from `packages/ui/src/index.ts`:
  - `Message` — per-turn row (`role` user/assistant/system). Keeps the authored `.maka-message-row` base (centered column + entrance fade/animation + the `data-maka-visual-smoke` disable); role layout moves to utilities. `.maka-message-row` lives in maka-tokens' `@layer components`, so the utilities (utilities layer) win — the assistant/system left-anchor (`ml-0 mr-auto`) overrides the row's centering exactly as the old `.message.assistant` did.
  - `Bubble` — `variant="user"` carries the tint as utilities on the neutral `--chat-user-bg` token path (never `primary`/`accent`); `variant="assistant"` re-emits `.maka-bubble-assistant` so the prose stays authored.
- `packages/ui/src/components.tsx` — wire `MessageBody`, the committed user/system/assistant rows, the streaming row, and the streaming "已截断" pill onto the primitives (net −66 lines; no new responsibility added to the sink).
- Retire shell CSS: `.maka-bubble-user` (both rules, incl. the effective `min(100%,640px)` width cap from the second rule), `.message.user/.assistant/.system`, the dead `.message > span` role labels, `.maka-bubble-assistant-stack`, `.maka-bubble-truncated`.
- Re-anchor (cleanup from the deletions): the still-hand-written turn lineage-row / footer (PR2) and the system `<pre>` reset/pill ride `[data-slot="message"][data-role=…]` at identical specificity, so their layout is pixel-stable until PR2 migrates them.
- `apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts` (new).

Not included:
- All `.maka-bubble-assistant` Markdown prose (task lists, code blocks, tables, blockquotes, links) — preserved verbatim.
- Marker / turn summary / lineage / footer (PR2), tool activity (PR3), preview surfaces (PR4), MessageScroller (later).
- No change to `.messages` scroll container, runtime, streaming, Markdown rendering, permission, turn model, tool output, or attachment IPC.

## Verification

- New `chat-primitive-cascade-contract.test.ts` locks: retired shell selectors gone, prose preserved, turn layout re-anchored onto the primitive, user bubble on `--chat-user-bg` with the 640px cap and never `primary`/`accent`.
- `@maka/desktop` typecheck clean; 1582/1582 desktop tests pass (incl. the renderer cascade + dead-CSS pruning contracts); 4/4 `@maka/ui` tests; `node scripts/check-dead-css.mjs --check` → no dead classes.
- Captured the `turn-narrative` scenario on this branch: user bubble tinted/rounded/right-anchored with the meta row beneath; assistant summary, tools, prose, and footer all left-anchored at the same measure column. The repo screenshot harness is a presence/dimension sanity gate, not a pixel diff (font drift makes byte-diff too noisy), so visual parity is held by the contract test + the capture rather than an automated before/after diff.

## User-facing impact

None — zero visual change by design. No `CHANGELOG.md`, docs, breaking changes, or migrations.

## Reviewer notes

- Two non-obvious points to check:
  1. `.maka-bubble-user` had **two** rules; the second overrides `max-width` to `min(100%,640px)` (not the first rule's `78%`). The primitive uses 640px, locked by the contract test.
  2. `.message.assistant` was the ancestor selector for the PR2 lineage/footer measure rule. Deleting it required re-anchoring those (and the system `<pre>` rules) onto `[data-slot="message"][data-role]` at identical specificity, so PR2 elements stay pixel-stable.
- Next slice: PR2 — Marker (turn summary / lineage / footer / status markers), flat off main after this lands.