### PR TITLE
Add active full compact process summary fixture

### DIFF
--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -507,6 +507,79 @@ describe('active full compact PR1 foundation', () => {
     assert.equal(rewritten.block?.archiveRefs?.[0]?.artifactId, 'artifact-call-archived');
     assert.match(String((rewritten.messages[0] as { content?: unknown }).content), /artifact-call-archived/);
   });
+
+  test('QEMU-style long process compact preserves state and archive refs without raw output', () => {
+    const messages = qemuStyleMessages();
+    const runtimeEvents = qemuStyleRuntimeEvents();
+
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      runtimeEvents,
+      stepNumber: 4,
+      charsPerToken: 4,
+    });
+    const selection = selectActiveFullCompactCoveredSpan(index, {
+      enabled: true,
+      minStepNumber: 1,
+      minRecentMessages: 1,
+      maxActiveEstimatedTokens: 1,
+      highWaterRatio: 0.1,
+      maxSummaryEstimatedTokens: 1200,
+    });
+    assert.equal(selection.decision, 'selected');
+    if (selection.decision !== 'selected') assert.fail('expected selected');
+    assert.equal(selection.endMessageIndex, messages.length - 2);
+
+    const rewritten = rewriteActiveFullCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      invocationId: 'inv-1',
+      messages,
+      runtimeEvents,
+      policy: {
+        enabled: true,
+        minStepNumber: 1,
+        minRecentMessages: 1,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        maxSummaryEstimatedTokens: 1200,
+      },
+      stepNumber: 4,
+      now: 100,
+      charsPerToken: 4,
+    });
+
+    assert.equal(rewritten.decision, 'replaced');
+    assert.equal(rewritten.validation?.valid, true);
+    assert.ok(rewritten.block);
+    const replacementJson = JSON.stringify(rewritten.messages);
+    assert.match(replacementJson, /maka_active_full_compact_block/);
+    assert.doesNotMatch(replacementJson, /QEMU_RAW_BOOT_SPAM_DO_NOT_LEAK/);
+    assert.doesNotMatch(replacementJson, /QEMU_RAW_VERIFY_SPAM_DO_NOT_LEAK/);
+    assert.match(replacementJson, /pid=4242/);
+    assert.match(replacementJson, /127\.0\.0\.1:2222/);
+    assert.match(replacementJson, /guest reached login prompt/);
+    assert.match(replacementJson, /\/tmp\/qemu-run\.sh/);
+    assert.match(replacementJson, /\/workspace\/solution\.sh/);
+    assert.match(replacementJson, /VERIFIER FAILURE: expected ssh service reachable/);
+    assert.match(replacementJson, /Failed hypothesis: networking is broken because hostfwd was missing/);
+    assert.match(replacementJson, /Current hypothesis: sshd is not started inside the guest/);
+    assert.match(replacementJson, /Next action: retry SSH after boot and rerun verifier/);
+    assert.match(replacementJson, /artifact-qemu-boot/);
+    assert.match(replacementJson, /artifact-qemu-verify/);
+    assert.match(replacementJson, /providerSourceIds=/);
+    assert.equal(rewritten.messages[1], messages[messages.length - 1]);
+    assert.deepEqual(
+      rewritten.block.archiveRefs?.map((ref) => ref.artifactId).sort(),
+      ['artifact-qemu-boot', 'artifact-qemu-verify'],
+    );
+    assert.ok(rewritten.block.summary.commandsTried?.some((command) =>
+      command.command.includes('qemu-system-x86_64') && command.sourceIds?.length
+    ));
+  });
 });
 
 function textMessages(values: string[]): ModelMessage[] {
@@ -581,19 +654,157 @@ function runtimeEvent(
   };
 }
 
-function activePlaceholder(): ActiveArchivedToolResultPlaceholder {
+function activePlaceholder(input: Partial<ActiveArchivedToolResultPlaceholder> = {}): ActiveArchivedToolResultPlaceholder {
   return {
     kind: ACTIVE_ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
     rewriteVersion: ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
-    artifactId: 'artifact-call-archived',
+    artifactId: input.artifactId ?? 'artifact-call-archived',
     turnId: 'turn-1',
-    toolCallId: 'call-archived',
-    toolName: 'Bash',
-    bodySha256: 'a'.repeat(64),
-    originalEstimatedTokens: 123,
-    originalBytes: 456,
+    toolCallId: input.toolCallId ?? 'call-archived',
+    toolName: input.toolName ?? 'Bash',
+    bodySha256: input.bodySha256 ?? 'a'.repeat(64),
+    originalEstimatedTokens: input.originalEstimatedTokens ?? 123,
+    originalBytes: input.originalBytes ?? 456,
     reason: 'active_current_turn_tool_result_pruned_before_next_step',
   };
+}
+
+function qemuStyleMessages(): ModelMessage[] {
+  return [
+    {
+      role: 'user',
+      content: 'Task constraints: boot a tiny VM-like process, expose SSH-like port 2222, modify only visible files, and run the public verifier without hidden benchmark shortcuts.',
+    },
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'call-qemu-boot',
+        toolName: 'Bash',
+        input: { command: 'qemu-system-x86_64 -net user,hostfwd=tcp::2222-:22 -daemonize -pidfile /tmp/qemu.pid', cwd: '/workspace' },
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-qemu-boot',
+        toolName: 'Bash',
+        result: activePlaceholder({
+          artifactId: 'artifact-qemu-boot',
+          toolCallId: 'call-qemu-boot',
+          bodySha256: 'b'.repeat(64),
+          originalEstimatedTokens: 6000,
+          originalBytes: 24000,
+        }),
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'assistant',
+      content: 'Failed hypothesis: networking is broken because hostfwd was missing. Current hypothesis: sshd is not started inside the guest.',
+    },
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'call-write-artifacts',
+        toolName: 'Write',
+        input: { path: '/workspace/solution.sh', content: 'service ssh start\n' },
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-write-artifacts',
+        toolName: 'Write',
+        output: { type: 'text', value: 'wrote /workspace/solution.sh and updated /etc/network/interfaces' },
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'assistant',
+      content: [{
+        type: 'tool-call',
+        toolCallId: 'call-qemu-verify',
+        toolName: 'Bash',
+        input: { command: '/workspace/solution.sh && ./public-verifier.sh', cwd: '/workspace' },
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: 'call-qemu-verify',
+        toolName: 'Bash',
+        result: activePlaceholder({
+          artifactId: 'artifact-qemu-verify',
+          toolCallId: 'call-qemu-verify',
+          bodySha256: 'c'.repeat(64),
+          originalEstimatedTokens: 7000,
+          originalBytes: 28000,
+        }),
+      }],
+    } as unknown as ModelMessage,
+    {
+      role: 'assistant',
+      content: 'Next action: retry SSH after boot and rerun verifier from the preserved tail.',
+    },
+  ];
+}
+
+function qemuStyleRuntimeEvents(): RuntimeEvent[] {
+  return [
+    runtimeEvent('event-qemu-user', 'user', 'user', {
+      kind: 'text',
+      text: 'Task constraints: boot a tiny VM-like process, expose SSH-like port 2222, modify only visible files, and run the public verifier without hidden benchmark shortcuts.',
+    }),
+    runtimeEvent('event-qemu-boot-call', 'model', 'agent', {
+      kind: 'function_call',
+      id: 'call-qemu-boot',
+      name: 'Bash',
+      args: { command: 'qemu-system-x86_64 -net user,hostfwd=tcp::2222-:22 -daemonize -pidfile /tmp/qemu.pid', cwd: '/workspace' },
+    }),
+    runtimeEvent('event-qemu-boot-result', 'tool', 'tool', {
+      kind: 'function_response',
+      id: 'call-qemu-boot',
+      name: 'Bash',
+      result: [
+        'qemu raw boot noise QEMU_RAW_BOOT_SPAM_DO_NOT_LEAK\n'.repeat(200),
+        'process pid=4242 background=true command=qemu-system-x86_64 cwd=/workspace',
+        'listening on 127.0.0.1:2222 for ssh forwarding',
+        'guest reached login prompt; ssh refused until service starts',
+        'artifact script /tmp/qemu-run.sh created',
+      ].join('\n'),
+    }),
+    runtimeEvent('event-qemu-write-call', 'model', 'agent', {
+      kind: 'function_call',
+      id: 'call-write-artifacts',
+      name: 'Write',
+      args: { path: '/workspace/solution.sh', content: 'service ssh start\n' },
+    }),
+    runtimeEvent('event-qemu-write-result', 'tool', 'tool', {
+      kind: 'function_response',
+      id: 'call-write-artifacts',
+      name: 'Write',
+      result: 'wrote /workspace/solution.sh and updated /etc/network/interfaces',
+    }),
+    runtimeEvent('event-qemu-verify-call', 'model', 'agent', {
+      kind: 'function_call',
+      id: 'call-qemu-verify',
+      name: 'Bash',
+      args: { command: '/workspace/solution.sh && ./public-verifier.sh', cwd: '/workspace' },
+    }),
+    runtimeEvent('event-qemu-verify-result', 'tool', 'tool', {
+      kind: 'function_response',
+      id: 'call-qemu-verify',
+      name: 'Bash',
+      result: [
+        'qemu verifier noise QEMU_RAW_VERIFY_SPAM_DO_NOT_LEAK\n'.repeat(200),
+        'public verifier exit code=1',
+        'VERIFIER FAILURE: expected ssh service reachable on 127.0.0.1:2222',
+      ].join('\n'),
+    }),
+  ];
 }
 
 function fixtureSummary(sourceIds: string[]): ActiveFullCompactSummary {

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -453,7 +453,7 @@ export function buildActiveFullCompactBlockFromSummary(
     summary,
     limitations: [
       ...(input.limitations ?? []),
-      'PR2 active full compact uses a deterministic metadata-first summary for provider-visible active-step replacement.',
+      'Active full compact uses a deterministic source-bounded process/task summary for provider-visible active-step replacement.',
       ...(archiveRefs.length === 0
         ? ['No active archive refs are attached; source coverage is by provider source ids and optional RuntimeEvent ids.']
         : []),
@@ -480,36 +480,75 @@ export function buildActiveFullCompactBlockFromSummary(
 export function buildDeterministicActiveFullCompactSummary(input: {
   selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>;
   messages: readonly ModelMessage[];
+  runtimeEvents?: readonly RuntimeEvent[];
+  maxSummaryEstimatedTokens?: number;
+  charsPerToken?: number;
+}): ActiveFullCompactSummary {
+  return buildDeterministicProcessStateActiveFullCompactSummary(input);
+}
+
+export function buildDeterministicProcessStateActiveFullCompactSummary(input: {
+  selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>;
+  messages: readonly ModelMessage[];
+  runtimeEvents?: readonly RuntimeEvent[];
   maxSummaryEstimatedTokens?: number;
   charsPerToken?: number;
 }): ActiveFullCompactSummary {
   const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
   const maxSummaryEstimatedTokens = finitePositive(input.maxSummaryEstimatedTokens) ?? 512;
   const entries = input.selection.entries;
+  const slices = selectedSourceSlices(input.selection, input.messages, input.runtimeEvents ?? []);
   const providerMessages = uniqueSorted(entries.map((entry) => String(entry.messageIndex)));
   const archiveRefs = uniqueSorted(entries.map((entry) => entry.archiveRef?.artifactId).filter(nonEmpty));
   const toolCalls = uniqueSorted(entries.map((entry) => entry.toolCallId).filter(nonEmpty));
   const contentKinds = uniqueSorted(entries.map((entry) => entry.contentKind));
   const runtimeEvents = uniqueSorted(entries.map((entry) => entry.runtimeEventId).filter(nonEmpty));
-  const commandsTried = extractDeterministicCommands(input.selection, input.messages);
+  const commandsTried = extractProcessCommandAttempts(input.selection, input.messages, input.runtimeEvents ?? []);
+  const operationalSlices = slices.filter((slice) => slice.role !== 'system' && slice.role !== 'user');
+  const processState = extractFactLines(operationalSlices, PROCESS_FACT_PATTERN, 8, 220);
+  const vmState = extractFactLines(operationalSlices, VM_FACT_PATTERN, 8, 220);
+  const artifactPaths = extractArtifactPathsFromSlices(slices, 8);
+  const latestVerifierFailure = extractLatestVerifierFailure(slices);
+  const constraints = extractConstraintLines(slices, 8);
+  const failedHypotheses = extractFailedHypotheses(slices, 8);
+  const currentHypothesis = extractCurrentHypothesis(slices);
+  const nextActions = extractNextActions(slices, 8);
+  const hasProcessFacts = processState.length > 0
+    || vmState.length > 0
+    || artifactPaths.length > 0
+    || commandsTried.length > 0
+    || latestVerifierFailure !== undefined;
   const text = boundedSummaryText(
     [
-      `Earlier active provider messages were compacted by deterministic metadata summary.`,
+      hasProcessFacts
+        ? 'Earlier active provider messages were compacted into deterministic benchmark/process state.'
+        : 'Earlier active provider messages were compacted; only source and coverage metadata was extractable.',
       `Covered ${providerMessages.length} provider messages, ${entries.length} source entries, ${runtimeEvents.length} runtime events, ${toolCalls.length} tool calls, ${archiveRefs.length} archive refs.`,
+      'Raw covered payloads were replaced in the provider request while source/archive refs preserve evidence.',
       `Content kinds: ${contentKinds.join(', ') || 'none'}.`,
     ].join(' '),
-    maxSummaryEstimatedTokens,
+    Math.min(maxSummaryEstimatedTokens, 220),
     charsPerToken,
   );
 
-  return {
+  return fitActiveFullCompactSummaryToBudget({
     schemaVersion: 1,
     text,
+    ...(processState.length > 0 ? { processState } : {}),
+    ...(vmState.length > 0 ? { vmState } : {}),
+    ...(artifactPaths.length > 0 ? { artifactPaths } : {}),
     ...(commandsTried.length > 0 ? { commandsTried } : {}),
+    ...(latestVerifierFailure ? { latestVerifierFailure } : {}),
+    ...(constraints.length > 0
+      ? { constraints }
+      : { constraints: ['Provider-visible raw covered payloads were replaced with this source-bearing compact block.'] }),
+    ...(failedHypotheses.length > 0 ? { failedHypotheses } : {}),
+    ...(currentHypothesis ? { currentHypothesis } : {}),
+    nextActions: nextActions.length > 0
+      ? nextActions
+      : ['Continue from the preserved recent active provider messages after this compact block.'],
     ...(archiveRefs.length > 0 ? { archiveRefs } : {}),
-    constraints: ['Provider-visible raw covered payloads were replaced with this source-bearing compact block.'],
-    nextActions: ['Continue from the preserved recent active provider messages after this compact block.'],
-  };
+  }, maxSummaryEstimatedTokens, charsPerToken);
 }
 
 export function activeFullCompactBlockToModelMessage(block: ActiveFullCompactBlock): ModelMessage {
@@ -564,10 +603,11 @@ export function rewriteActiveFullCompactInMessages(
   const summary = buildDeterministicActiveFullCompactSummary({
     selection,
     messages,
+    runtimeEvents: input.runtimeEvents,
     maxSummaryEstimatedTokens: input.policy?.maxSummaryEstimatedTokens,
     charsPerToken: input.charsPerToken,
   });
-  const renderedSummaryTokens = estimateTokens(summary.text.length, input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN);
+  const renderedSummaryTokens = estimateTokens(stableStringify(summary).length, input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN);
   const maxSummaryTokens = finitePositive(input.policy?.maxSummaryEstimatedTokens);
   if (maxSummaryTokens !== undefined && renderedSummaryTokens > maxSummaryTokens) {
     return failedOpenRewrite(messages, selection, index, 'summary_too_large');
@@ -778,7 +818,11 @@ export function validateActiveFullCompactBlockForSourceIndex(
         : undefined;
       if (!nonEmpty(summaryText)) add('summary_missing');
       const maxSummaryTokens = finitePositive(options.maxSummaryEstimatedTokens);
-      if (maxSummaryTokens !== undefined && nonEmpty(summaryText) && estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
+      if (
+        maxSummaryTokens !== undefined
+        && partial.summary !== undefined
+        && estimateTokens(stableStringify(partial.summary).length, charsPerToken) > maxSummaryTokens
+      ) {
         add('summary_too_large');
       }
       const maxBlockTokens = finitePositive(options.maxBlockEstimatedTokens);
@@ -808,7 +852,7 @@ export function validateActiveFullCompactBlockForSourceIndex(
   }
   if (!nonEmpty(block.summary?.text)) add('summary_missing');
   const maxSummaryTokens = finitePositive(options.maxSummaryEstimatedTokens);
-  if (maxSummaryTokens !== undefined && estimateTokens(block.summary.text.length, charsPerToken) > maxSummaryTokens) {
+  if (maxSummaryTokens !== undefined && estimateTokens(stableStringify(block.summary).length, charsPerToken) > maxSummaryTokens) {
     add('summary_too_large');
   }
   const maxBlockTokens = finitePositive(options.maxBlockEstimatedTokens);
@@ -1048,34 +1092,345 @@ function replacementShapeValid(
   return true;
 }
 
-function extractDeterministicCommands(
+interface SelectedSourceSlice {
+  entry: ActiveFullCompactSourceEntry;
+  text: string;
+  role: ActiveFullCompactProviderRole;
+  sourceId: string;
+}
+
+const PROCESS_FACT_PATTERN = /\b(pid|process|listening|listen|port|127\.0\.0\.1|localhost|nc -l|server|service|background|foreground|timeout|url)\b/i;
+const VM_FACT_PATTERN = /\b(vm|guest|boot|booted|login|kernel|panic|mount|reachable|refused|guest ip|hostfwd)\b/i;
+const OUTCOME_FACT_PATTERN = /\b(exit code|exit=|status|failed|failure|error|timeout|assert|missing|listening|pid|port|reachable|refused|boot|login|self-check)\b/i;
+const VERIFIER_CONTEXT_PATTERN = /\b(verifier|self-check|self check|test|assert|check)\b/i;
+const FAILURE_PATTERN = /\b(fail|failed|failure|error|assert|expected|missing|timeout|red)\b/i;
+const CONSTRAINT_PATTERN = /\b(constraint|do not|must|only|without|avoid|no hidden|no task-specific|preserve|keep)\b/i;
+const FAILED_HYPOTHESIS_PATTERN = /\b(failed hypothesis|abandoned|hypothesis.+failed|tried.+failed|failed because|not enough|does not work|did not work)\b/i;
+const CURRENT_HYPOTHESIS_PATTERN = /\b(current hypothesis|working theory|next i think|i think)\b/i;
+const NEXT_ACTION_PATTERN = /\b(next action|next:|next i|retry|rerun|continue|check|inspect)\b/i;
+const PATH_PATTERN = /(?:\/[A-Za-z0-9._~+@%=-]+(?:\/[A-Za-z0-9._~+@%=-]+)+|(?:\.{1,2}\/)?[A-Za-z0-9._~+@%=-]+(?:\/[A-Za-z0-9._~+@%=-]+)+)/g;
+const SHELL_TOOL_PATTERN = /\b(bash|shell|exec|terminal|run|command|cmd|sh|powershell|zsh)\b/i;
+
+function selectedSourceSlices(
   selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>,
   messages: readonly ModelMessage[],
-): Array<{ command: string; outcome: string; sourceIds?: string[] }> {
-  const commands: Array<{ command: string; outcome: string; sourceIds?: string[] }> = [];
-  const entriesByMessage = new Map<number, ActiveFullCompactSourceEntry[]>();
-  for (const entry of selection.entries) pushMap(entriesByMessage, entry.messageIndex, entry);
+  runtimeEvents: readonly RuntimeEvent[],
+): SelectedSourceSlice[] {
+  const runtimeById = new Map(runtimeEvents.map((event) => [event.id, event]));
+  const runtimeByToolCallId = new Map<string, RuntimeEvent[]>();
+  for (const event of runtimeEvents) {
+    const toolCallId = runtimeToolCallId(event);
+    if (toolCallId) pushMap(runtimeByToolCallId, toolCallId, event);
+  }
 
-  for (const [messageIndex, entries] of entriesByMessage) {
-    const message = messages[messageIndex] as { content?: unknown } | undefined;
-    const content = message?.content;
-    const parts = Array.isArray(content) ? content : [];
-    for (const part of parts) {
-      if (!part || typeof part !== 'object') continue;
-      const record = part as Record<string, unknown>;
-      if (record.type !== 'tool-call') continue;
-      const toolName = typeof record.toolName === 'string' ? record.toolName : 'tool';
-      const input = 'input' in record ? record.input : record.args;
-      const command = `${toolName} ${clip(stableStringify(input), 160)}`;
-      commands.push({
-        command,
-        outcome: 'covered by active full compact source metadata',
-        sourceIds: entries.map((entry) => entry.sourceId),
-      });
-      if (commands.length >= 5) return commands;
+  return sortedSelectedEntries(selection).map((entry) => {
+    const providerText = providerEntryText(entry, messages);
+    const runtimeEvent = entry.runtimeEventId
+      ? runtimeById.get(entry.runtimeEventId)
+      : matchingRuntimeEventForEntry(entry, runtimeByToolCallId);
+    const runtimeText = runtimeEvent ? runtimeEventText(runtimeEvent) : '';
+    return {
+      entry,
+      sourceId: entry.sourceId,
+      role: entry.role,
+      text: uniqueSorted([providerText, runtimeText].filter(nonEmpty)).join('\n'),
+    };
+  });
+}
+
+function extractProcessCommandAttempts(
+  selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>,
+  messages: readonly ModelMessage[],
+  runtimeEvents: readonly RuntimeEvent[],
+): Array<{ command: string; outcome: string; sourceIds?: string[] }> {
+  const slices = selectedSourceSlices(selection, messages, runtimeEvents);
+  const commands: Array<{ command: string; outcome: string; sourceIds?: string[] }> = [];
+  const seen = new Set<string>();
+
+  for (const entry of sortedSelectedEntries(selection)) {
+    const part = providerEntryPart(entry, messages);
+    if (!part || typeof part !== 'object') continue;
+    const record = part as Record<string, unknown>;
+    if (record.type !== 'tool-call') continue;
+    const toolName = typeof record.toolName === 'string' ? record.toolName : entry.toolName ?? 'tool';
+    const input = 'input' in record ? record.input : record.args;
+    const command = commandTextFromToolInput(toolName, input);
+    const key = entry.toolCallId ?? `${entry.sourceId}:${command}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const related = slices.filter((slice) =>
+      (entry.toolCallId && slice.entry.toolCallId === entry.toolCallId) || slice.sourceId === entry.sourceId
+    );
+    commands.push({
+      command,
+      outcome: commandOutcome(related),
+      sourceIds: uniqueSorted(related.map((slice) => slice.sourceId)),
+    });
+    if (commands.length >= 10) break;
+  }
+
+  return commands;
+}
+
+function commandTextFromToolInput(toolName: string, input: unknown): string {
+  const command = stringField(input, ['command', 'cmd', 'script', 'shell', 'code']);
+  if (SHELL_TOOL_PATTERN.test(toolName) && command) return clip(sanitizeFactLine(command), 240);
+  const summary = clip(stableStringify(input), 200);
+  return `${toolName} ${summary}`;
+}
+
+function commandOutcome(slices: readonly SelectedSourceSlice[]): string {
+  const archiveRefs = uniqueSorted(slices.map((slice) => slice.entry.archiveRef?.artifactId).filter(nonEmpty));
+  const factLines = extractLinesFromText(
+    slices.map((slice) => slice.text).join('\n'),
+    OUTCOME_FACT_PATTERN,
+    2,
+    220,
+  );
+  const archiveText = archiveRefs.length > 0 ? `raw result archived as ${archiveRefs.join(', ')}` : '';
+  return [factLines.join(' | '), archiveText].filter(nonEmpty).join('; ')
+    || 'completed; detailed output covered by active full compact source refs';
+}
+
+function extractFactLines(
+  slices: readonly SelectedSourceSlice[],
+  pattern: RegExp,
+  maxItems: number,
+  maxChars: number,
+): string[] {
+  return uniqueInOrder(slices.flatMap((slice) => extractLinesFromText(slice.text, pattern, maxItems, maxChars))).slice(0, maxItems);
+}
+
+function extractArtifactPathsFromSlices(slices: readonly SelectedSourceSlice[], maxItems: number): string[] {
+  const paths: string[] = [];
+  for (const slice of slices) {
+    for (const match of slice.text.matchAll(PATH_PATTERN)) {
+      const path = sanitizePath(match[0]);
+      if (path) paths.push(path);
     }
   }
-  return commands;
+  return uniqueSorted(paths).slice(0, maxItems);
+}
+
+function extractLatestVerifierFailure(slices: readonly SelectedSourceSlice[]): string | undefined {
+  for (const slice of [...slices].reverse()) {
+    const lines = splitCandidateLines(slice.text).reverse();
+    for (const line of lines) {
+      if (VERIFIER_CONTEXT_PATTERN.test(line) && FAILURE_PATTERN.test(line)) {
+        return clip(sanitizeFactLine(line), 400);
+      }
+    }
+  }
+  return undefined;
+}
+
+function extractConstraintLines(slices: readonly SelectedSourceSlice[], maxItems: number): string[] {
+  return uniqueInOrder(slices
+    .filter((slice) => slice.role === 'system' || slice.role === 'user' || slice.role === 'assistant')
+    .flatMap((slice) => extractLinesFromText(slice.text, CONSTRAINT_PATTERN, maxItems, 220)))
+    .slice(0, maxItems);
+}
+
+function extractFailedHypotheses(slices: readonly SelectedSourceSlice[], maxItems: number): string[] {
+  return uniqueInOrder(slices
+    .filter((slice) => slice.role === 'assistant')
+    .flatMap((slice) => extractLinesFromText(slice.text, FAILED_HYPOTHESIS_PATTERN, maxItems, 220)))
+    .slice(0, maxItems);
+}
+
+function extractCurrentHypothesis(slices: readonly SelectedSourceSlice[]): string | undefined {
+  for (const slice of [...slices].reverse()) {
+    if (slice.role !== 'assistant') continue;
+    for (const line of splitCandidateLines(slice.text).reverse()) {
+      if (CURRENT_HYPOTHESIS_PATTERN.test(line)) return clip(sanitizeFactLine(line), 220);
+    }
+  }
+  return undefined;
+}
+
+function extractNextActions(slices: readonly SelectedSourceSlice[], maxItems: number): string[] {
+  return uniqueInOrder(slices
+    .filter((slice) => slice.role === 'assistant')
+    .flatMap((slice) => extractLinesFromText(slice.text, NEXT_ACTION_PATTERN, maxItems, 220)))
+    .slice(0, maxItems);
+}
+
+function fitActiveFullCompactSummaryToBudget(
+  summary: ActiveFullCompactSummary,
+  maxSummaryEstimatedTokens: number,
+  charsPerToken: number,
+): ActiveFullCompactSummary {
+  const maxTokens = Math.max(1, maxSummaryEstimatedTokens);
+  const fitted: ActiveFullCompactSummary = { ...summary };
+  const optionalDropOrder: Array<keyof ActiveFullCompactSummary> = [
+    'archiveRefs',
+    'failedHypotheses',
+    'nextActions',
+    'currentHypothesis',
+    'constraints',
+    'latestVerifierFailure',
+    'commandsTried',
+    'artifactPaths',
+    'vmState',
+    'processState',
+  ];
+  for (const key of optionalDropOrder) {
+    if (estimateTokens(stableStringify(fitted).length, charsPerToken) <= maxTokens) return fitted;
+    delete fitted[key];
+  }
+  if (estimateTokens(stableStringify(fitted).length, charsPerToken) <= maxTokens) return fitted;
+
+  const baseOverhead = stableStringify({ ...fitted, text: '' }).length;
+  const maxTextChars = Math.max(1, (maxTokens * charsPerToken) - baseOverhead);
+  return {
+    schemaVersion: 1,
+    text: clip(fitted.text, maxTextChars),
+  };
+}
+
+function extractLinesFromText(text: string, pattern: RegExp, maxItems: number, maxChars: number): string[] {
+  const lines: string[] = [];
+  for (const line of splitCandidateLines(text)) {
+    if (!pattern.test(line)) continue;
+    const cleaned = clip(sanitizeFactLine(line), maxChars);
+    if (!cleaned) continue;
+    lines.push(cleaned);
+    if (lines.length >= maxItems) break;
+  }
+  return lines;
+}
+
+function splitCandidateLines(text: string): string[] {
+  return text
+    .replaceAll('\\n', '\n')
+    .replaceAll('\r', '\n')
+    .split('\n')
+    .map(sanitizeFactLine)
+    .filter((line) =>
+      line.length > 0
+      && line.length <= 1000
+      && !isPlaceholderMetadataLine(line)
+      && !isLowSignalRawLogLine(line)
+    );
+}
+
+function sanitizeFactLine(line: string): string {
+  return line
+    .replace(/\s+/g, ' ')
+    .replace(/^[`"'[{( ]+/, '')
+    .replace(/[`"',\]}) ]+$/, '')
+    .trim();
+}
+
+function sanitizePath(value: string): string | undefined {
+  const path = value.replace(/[.,;:)>\]}]+$/, '').trim();
+  if (path.length < 3 || path.length > 180) return undefined;
+  return path;
+}
+
+function isPlaceholderMetadataLine(line: string): boolean {
+  return line.includes('maka.active_archived_tool_result')
+    || line.includes('rewriteVersion')
+    || line.includes('bodySha256')
+    || line.includes('originalEstimatedTokens');
+}
+
+function isLowSignalRawLogLine(line: string): boolean {
+  return /\b(noise|spam|debug spam)\b/i.test(line)
+    || /\braw\b.*\b(log|output|noise|spam)\b/i.test(line)
+    || /do[_-]?not[_-]?leak/i.test(line);
+}
+
+function uniqueInOrder(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function sortedSelectedEntries(
+  selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>,
+): ActiveFullCompactSourceEntry[] {
+  return [...selection.entries].sort((left, right) =>
+    left.messageIndex - right.messageIndex
+    || (left.partIndex ?? -1) - (right.partIndex ?? -1)
+    || left.sourceId.localeCompare(right.sourceId)
+  );
+}
+
+function providerEntryText(entry: ActiveFullCompactSourceEntry, messages: readonly ModelMessage[]): string {
+  const part = providerEntryPart(entry, messages);
+  return partText(part);
+}
+
+function providerEntryPart(entry: ActiveFullCompactSourceEntry, messages: readonly ModelMessage[]): unknown {
+  const message = messages[entry.messageIndex] as { content?: unknown } | undefined;
+  const content = message?.content;
+  if (!Array.isArray(content)) return content;
+  return entry.partIndex === undefined ? content : content[entry.partIndex];
+}
+
+function partText(part: unknown): string {
+  if (part === undefined || part === null) return '';
+  if (typeof part === 'string') return part;
+  if (typeof part !== 'object') return stableStringify(part);
+  const record = part as Record<string, unknown>;
+  if (record.type === 'text' && typeof record.text === 'string') return record.text;
+  if ((record.type === 'reasoning' || record.type === 'thinking') && typeof (record.text ?? record.reasoning) === 'string') {
+    return String(record.text ?? record.reasoning);
+  }
+  if (record.type === 'tool-call') return stableStringify(record.input ?? record.args ?? record);
+  if (record.type === 'tool-result') return payloadText(toolResultPayload(record));
+  return stableStringify(record);
+}
+
+function payloadText(payload: unknown): string {
+  if (typeof payload === 'string') return payload;
+  return serializeToolResultForArchive(payload);
+}
+
+function matchingRuntimeEventForEntry(
+  entry: ActiveFullCompactSourceEntry,
+  runtimeByToolCallId: ReadonlyMap<string, readonly RuntimeEvent[]>,
+): RuntimeEvent | undefined {
+  if (!entry.toolCallId) return undefined;
+  const candidates = runtimeByToolCallId.get(entry.toolCallId) ?? [];
+  const preferredKind = entry.contentKind === 'function_call'
+    ? 'function_call'
+    : entry.contentKind === 'function_response' || entry.contentKind === 'tool_result' || entry.contentKind === 'active_archive_placeholder'
+      ? 'function_response'
+      : undefined;
+  return candidates.find((event) => event.content?.kind === preferredKind) ?? candidates[0];
+}
+
+function runtimeEventText(event: RuntimeEvent): string {
+  const content = event.content;
+  if (!content) return '';
+  switch (content.kind) {
+    case 'text':
+    case 'thinking':
+      return content.text;
+    case 'function_call':
+      return stableStringify(content.args);
+    case 'function_response':
+      return serializeToolResultForArchive(content.result);
+    case 'error':
+      return stableStringify(content);
+  }
+}
+
+function stringField(value: unknown, keys: readonly string[]): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const candidate = record[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
 }
 
 function boundedSummaryText(text: string, maxEstimatedTokens: number, charsPerToken: number): string {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -229,6 +229,7 @@ export {
   activeFullCompactDecisionDiagnosticPatch,
   activeFullCompactBlockToModelMessage,
   buildDeterministicActiveFullCompactSummary,
+  buildDeterministicProcessStateActiveFullCompactSummary,
   buildActiveFullCompactBlockFromSummary,
   buildActiveFullCompactSourceIndex,
   estimateActiveFullCompactTokens,


### PR DESCRIPTION
## Summary

This is PR3 for issue #327, built on PR #331 and PR #333.

It adds a deterministic benchmark/process-state summary writer for active full compact and a QEMU-style fixture proving that large raw process output can be removed from the next provider request while process/task state, source refs, and archive refs remain visible.

## Scope

- Add `buildDeterministicProcessStateActiveFullCompactSummary()`.
- Make the existing deterministic active full compact summary delegate to the process/task-state writer.
- Feed current RuntimeEvents into the summary writer from the PR2 rewrite path.
- Enforce `maxSummaryEstimatedTokens` against the whole structured summary payload, not only `summary.text`.
- Extract bounded deterministic process/port state, VM/guest state, artifact paths, command outcomes, verifier failures, visible constraints, hypotheses, next actions, and archive refs from selected provider/runtime slices.
- Add a deterministic QEMU-style fixture with archived large process/verifier output.

## Deliberately not included

- Durable active boundary replay/export/inspection projection.
- Telemetry economics beyond existing active full compact diagnostics.
- Model-backed semantic summarization.
- Real QEMU/Harbor benchmark execution.
- Trigger tuning/default policy changes.

## Rive

- Workflow: `maka.active-full-compact-pr3@1`
- Run: `wfrun_9f4442d2050b46b5b3ffe1cb1bbd57de`
- Scheduler: `sched_f66f329ccc354fce965287e23a14d9af`
- Root: `work_681d2cdf2aa64195a795a46e385968c2`
- Review verdict: no blocking findings.

After the Rive review, I made one steward hardening patch: the fixture now uses multi-line raw spam and the extractor filters low-signal raw/noise lines, so short QEMU/verifier-looking log noise does not leak into the compact block just because it contains words like `boot` or `verifier`.

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/active-full-compact.test.js`
- `node --test packages/runtime/dist/__tests__/active-full-compact.test.js packages/runtime/dist/__tests__/ai-sdk-backend.test.js packages/runtime/dist/__tests__/active-tool-result-prune.test.js packages/runtime/dist/__tests__/context-budget.test.js packages/runtime/dist/__tests__/request-shape.test.js` (`121 pass / 0 fail`)
- `npm --workspace @maka/runtime run test` (`725 pass / 1 skipped / 0 fail`)
- `git diff --check`
- `git diff --cached --check`
