### PR TITLE
feat(ui): migrate chat turn markers onto @maka/ui Marker primitive (#332)

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -91,6 +91,10 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       // footer + footer action (models.css)
       'opacity-[0.72] hover:opacity-100 focus-within:opacity-100',
       'min-h-[28px]',
+      // `h-8` (→30px) is folded into the footer-action / lineage-badge shells
+      // now that the call sites use `UiButton size="nav"` (bare); it used to
+      // come implicitly from `size="sm"`.
+      'h-8',
       '[&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)]',
       'data-[pending=true]:opacity-[0.78]',
       'data-[copy-feedback=copied]:text-[color:var(--accent)]',

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/**
+ * Zero-visual governance contract for issue #332 PR2 — the per-turn status /
+ * lineage / footer chrome (`summary` / `aborted` / `failed` / `lineage` /
+ * `footer`) moved onto the `@maka/ui` `Marker` chat primitive. These lock the
+ * two halves of "zero visual change": the bespoke `.maka-turn-*` *marker* shell
+ * CSS is retired, while the still-hand-written turn *container* (and the
+ * deferred reasoning `<details>`) keep their exact styling.
+ */
+describe('chat Marker shell migration contract (#332 PR2)', () => {
+  it('retires the bespoke turn marker shell selectors', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    for (const selector of [
+      '.maka-turn-summary',
+      '.maka-turn-summary-chip',
+      '.maka-turn-summary-chip-switched',
+      '.maka-turn-aborted-marker',
+      '.maka-turn-failed-banner',
+      '.maka-turn-failed-icon',
+      '.maka-turn-failed-recovery',
+      '.maka-turn-lineage-row',
+      '.maka-turn-lineage-row-reverse',
+      '.maka-turn-lineage-badge',
+      '.maka-turn-footer',
+      '.maka-turn-footer-action',
+      // The measure-column re-anchor PR1 parked in tool-output.css for PR2 to
+      // consume — folded into the Marker container variants, so it's gone too.
+      '[data-slot="message"][data-role="assistant"] .maka-turn-footer',
+      '[data-slot="message"][data-role="assistant"] .maka-turn-lineage-row',
+    ]) {
+      assert.ok(
+        !css.includes(selector),
+        `retired turn-marker selector "${selector}" still present in renderer CSS`,
+      );
+    }
+  });
+
+  it('keeps the turn container + deferred reasoning chrome (out of scope)', async () => {
+    const css = await readAllRendererCss();
+    for (const selector of [
+      // The `.maka-turn` flex/measure container is NOT a marker — it stays.
+      '.maka-turn {',
+      '.maka-turn-tools',
+      '.maka-turn-streaming',
+      '.maka-turn[data-search-highlight="true"]',
+      // `.maka-turn-thinking` is explicitly deferred (pseudo-element chevron +
+      // @starting-style fade don't reduce to leaf utilities); it stays authored.
+      '.maka-turn-thinking',
+      '.maka-turn-thinking summary',
+    ]) {
+      assert.ok(css.includes(selector), `out-of-scope turn rule "${selector}" must be preserved`);
+    }
+  });
+
+  it('pins the Marker variants to the retired turn-marker pixels/tokens', async () => {
+    const rawSrc = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx'),
+      'utf8',
+    );
+    // Strip comments so the assertions reflect real classNames, not prose.
+    const chatSrc = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    const markerBlock = chatSrc.slice(chatSrc.indexOf('markerVariants'));
+    // Each fragment is a LITERAL arbitrary utility that compiles 1:1 to the
+    // declaration it replaces on a leaf element — asserting the source string is
+    // equivalent to asserting the computed style, no browser. Values mirror the
+    // retired `.maka-turn-*` rules exactly (pixels, oklch relative-color tints,
+    // var() tokens) and never the semantic scale.
+    for (const literal of [
+      // summary strip + chip + switched pill (maka-tokens.css)
+      'max-w-[var(--maka-chat-measure,680px)]',
+      "[&:not(:first-child)]:before:content-['·']",
+      '[&_code]:[font-family:var(--font-mono)]',
+      'data-[kind=model]:[&_code]:text-[color:var(--foreground-60)]',
+      'data-[state=in-progress]:text-[color:var(--accent)]',
+      'bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)]',
+      // aborted marker (models.css)
+      'bg-[var(--foreground-5)]',
+      '[&_em]:italic',
+      // failed banner + recovery (models.css)
+      'bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)]',
+      'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]',
+      "before:content-['·']",
+      // lineage badge directions (models.css)
+      'data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]',
+      'data-[direction=reverse]:text-[oklch(from_var(--brand-deep)_calc(l_-_0.04)_c_h)]',
+      // footer + footer action (models.css)
+      'opacity-[0.72] hover:opacity-100 focus-within:opacity-100',
+      'min-h-[28px]',
+      '[&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)]',
+      'data-[pending=true]:opacity-[0.78]',
+      'data-[copy-feedback=copied]:text-[color:var(--accent)]',
+    ]) {
+      assert.ok(
+        markerBlock.includes(literal),
+        `Marker variant must carry the literal "${literal}" mirroring the retired turn-marker CSS`,
+      );
+    }
+    // Never the semantic scale or a primary/accent recolor of the neutral chips.
+    for (const banned of ['rounded-lg', 'rounded-md', 'bg-primary', 'bg-accent', 'text-primary']) {
+      assert.ok(
+        !markerBlock.includes(banned),
+        `Marker variants must stay literal, not the scale/recolor utility "${banned}"`,
+      );
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -96,6 +96,12 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       // come implicitly from `size="sm"`.
       'h-8',
       '[&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)]',
+      // focus-visible is a non-leaf conflict (the footer action's outline vs
+      // UiButton's box-shadow ring), so the rendered-style script can't force
+      // it reliably; this exact literalization of the retired
+      // `outline: 2px solid var(--accent)` pins it here instead.
+      'focus-visible:[outline:2px_solid_var(--accent)]',
+      'focus-visible:[outline-offset:2px]',
       'data-[pending=true]:opacity-[0.78]',
       'data-[copy-feedback=copied]:text-[color:var(--accent)]',
     ]) {

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -76,7 +76,14 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       "[&:not(:first-child)]:before:content-['·']",
       '[&_code]:[font-family:var(--font-mono)]',
       'data-[kind=model]:[&_code]:text-[color:var(--foreground-60)]',
+      // every chip `data-[kind]` conditional is pinned, not just `model`, so
+      // dropping the tools tint / duration+tokens tabular-nums / tokens mono
+      // fails the contract.
+      'data-[kind=tools]:text-[color:var(--foreground-50)]',
+      'data-[kind=duration]:[font-variant-numeric:tabular-nums]',
+      'data-[kind=tokens]:[font-family:var(--font-mono)]',
       'data-[state=in-progress]:text-[color:var(--accent)]',
+      'data-[state=in-progress]:font-semibold',
       'bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)]',
       // aborted marker (models.css)
       'bg-[var(--foreground-5)]',
@@ -103,6 +110,12 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       'focus-visible:[outline:2px_solid_var(--accent)]',
       'focus-visible:[outline-offset:2px]',
       'data-[pending=true]:opacity-[0.78]',
+      // the combined disabled+pending guards: a copy button can be both
+      // `disabled` and `data-pending` (transient copy click), and the retired
+      // CSS kept the 0.78 pending dim winning over the 0.45 disabled dim — these
+      // raise the specificity so emit order can't flip it.
+      'disabled:data-[pending=true]:opacity-[0.78]',
+      'aria-disabled:data-[pending=true]:opacity-[0.78]',
       'data-[copy-feedback=copied]:text-[color:var(--accent)]',
     ]) {
       assert.ok(

--- a/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
@@ -48,12 +48,10 @@ describe('chat primitive shell migration contract (#332 PR1)', () => {
     const css = await readAllRendererCss();
     // The centered reading column / entrance animation stay authored.
     assert.ok(css.includes('.maka-message-row'), '.maka-message-row row base must stay');
-    // Lineage row + footer (PR2, still hand-written) ride the primitive's
-    // data hook so their measure column survives until they migrate.
-    assert.ok(
-      css.includes('[data-slot="message"][data-role="assistant"] .maka-turn-footer'),
-      'turn footer layout must be re-anchored to the Message primitive',
-    );
+    // The turn lineage row + footer measure column that PR1 parked on this
+    // primitive's data hook migrated onto the `@maka/ui` Marker variants in PR2
+    // (chat-marker-cascade-contract.test.ts), so the re-anchor is gone now.
+    // The system-note `pre` re-anchor stays — that prose is still hand-written.
     assert.ok(
       css.includes('[data-slot="message"][data-role="system"] pre'),
       'system note pre styling must be re-anchored to the Message primitive',

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -495,22 +495,29 @@ describe('turn footer copy feedback contract', () => {
   });
 
   it('styles footer copy pending and failure states', async () => {
-    const src = await readRendererContractCss();
+    // The footer action shell migrated onto the `@maka/ui` Marker primitive
+    // (issue #332 PR2): the pending / copy-feedback styling now lives as literal
+    // arbitrary utilities in `markerVariants('footer-action')` instead of
+    // `.maka-turn-footer-action[…]` CSS. Asserting them on the primitive source
+    // (which compiles 1:1) keeps the same "pending/failure is visibly styled"
+    // guarantee — see chat-marker-cascade-contract.test.ts for the full set.
+    const chatPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'primitives', 'chat.tsx');
+    const src = await readFile(chatPath, 'utf8');
 
     assert.match(
       src,
-      /\.maka-turn-footer-action\[data-pending\]\s*\{[\s\S]*cursor:\s*progress;/,
+      /data-\[pending=true\]:cursor-progress/,
       'Turn footer pending copy should visibly indicate in-progress work.',
     );
     assert.match(
       src,
-      /\.maka-turn-footer-action\[data-copy-feedback="copied"\]/,
-      'Turn footer copied state should have a stable CSS selector.',
+      /data-\[copy-feedback=copied\]:text-\[color:var\(--accent\)\]/,
+      'Turn footer copied state should have a stable styling hook.',
     );
     assert.match(
       src,
-      /\.maka-turn-footer-action\[data-copy-feedback="failed"\]/,
-      'Turn footer failed copy state should have a stable CSS selector.',
+      /data-\[copy-feedback=failed\]:text-\[color:var\(--destructive\)\]/,
+      'Turn footer failed copy state should have a stable styling hook.',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -519,6 +519,14 @@ describe('turn footer copy feedback contract', () => {
       /data-\[copy-feedback=failed\]:text-\[color:var\(--destructive\)\]/,
       'Turn footer failed copy state should have a stable styling hook.',
     );
+    // Copy-in-progress is disabled AND pending at once; the pending 0.78 dim
+    // must beat the disabled 0.45 dim by specificity (combined-modifier guard),
+    // not by Tailwind emit order — so it stays stable across rebuilds.
+    assert.match(
+      src,
+      /disabled:data-\[pending=true\]:opacity-\[0\.78\]/,
+      'Pending copy opacity must outrank the disabled dim by specificity, not source order.',
+    );
   });
 });
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -906,88 +906,10 @@
     padding: 0 8px 0 0;
   }
 
-  /* Compact turn summary chips between the user message and the rest of
-   * the turn. Surfaces "用了哪个模型，跑了几个工具，耗时多少，token 多少"
-   * inline so each turn answers @kenji's UI-04 follow-up questions. */
-  /* PR-CHAT-CHROME-FOLLOWUP-0: the summary reads as ONE quiet caption
-     line (model · tools · duration · tokens) at the shared 12px chrome
-     size, not a cluster of 9-10px pills. Middot separators carry the
-     rhythm; the chips themselves drop their pill chrome. */
-  .maka-turn-summary {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 2px;
-    color: var(--foreground-50);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .maka-turn-summary-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    color: var(--foreground-50);
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 1.4;
-  }
-
-  .maka-turn-summary-chip:not(:first-child)::before {
-    content: "·";
-    margin-right: 4px;
-    color: var(--foreground-40);
-    font-weight: 400;
-  }
-
-  .maka-turn-summary-chip code {
-    background: transparent;
-    color: inherit;
-    font-family: var(--font-mono);
-    font-size: 12px;
-  }
-
-  .maka-turn-summary-chip[data-kind="model"] code {
-    color: var(--foreground-60);
-    font-weight: 600;
-  }
-
-  .maka-turn-summary-chip[data-kind="tools"] {
-    color: var(--foreground-50);
-  }
-
-  .maka-turn-summary-chip[data-kind="duration"] {
-    font-variant-numeric: tabular-nums;
-  }
-
-  .maka-turn-summary-chip[data-kind="tokens"] {
-    font-variant-numeric: tabular-nums;
-    font-family: var(--font-mono);
-    font-size: 12px;
-  }
-
-  .maka-turn-summary-chip[data-state="in-progress"] {
-    color: var(--accent);
-    font-weight: 600;
-  }
-
-  /* PR-CHAT-NON-DEFAULT-MODEL-CHIP-0: emphasize a per-turn model
-     switch — the "切换" pill renders inside the chip in a muted tone
-     so the user notices that this turn departed from the sticky
-     session model (kenji 3-way decision lock). */
-  .maka-turn-summary-chip[data-kind="model"][data-switched="true"] code {
-    color: var(--foreground-60);
-  }
-
-  .maka-turn-summary-chip-switched {
-    margin-left: 4px;
-    padding: 1px 6px;
-    border-radius: 999px;
-    background: oklch(from var(--foreground) l c h / 0.06);
-    color: var(--foreground-60);
-    font-size: 11px;
-    font-weight: 600;
-  }
+  /* Turn summary strip + chips (model · tools · duration · tokens) and the
+   * "切换" pill retired to the `@maka/ui` Marker chat primitive
+   * (`summary` / `summary-chip` / `summary-switched`), issue #332 PR2 —
+   * packages/ui/src/primitives/chat.tsx. */
 
   /* Optional reasoning block — collapsed by default, expandable to inspect
    * the model's chain of thought without cluttering the answer.
@@ -1475,8 +1397,9 @@
     background: transparent;
   }
   /* (The user-turn meta-row copy renders via MessageCopyButton's
-     `footerStyle`, so it reuses `.maka-turn-footer-action` directly and
-     needs no bespoke override here.) */
+     `footerStyle`, so it reuses the Marker `footer-action` shell
+     (`markerVariants('footer-action')`) directly and needs no bespoke
+     override here.) */
   .maka-bubble-with-actions:hover .maka-message-copy,
   .maka-bubble-with-actions:focus-within .maka-message-copy,
   .maka-message-copy:focus-visible {

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -973,8 +973,7 @@
  * `footer-action`), issue #332 PR2 — packages/ui/src/primitives/chat.tsx.
  * The measure-column geometry the `tool-output.css` re-anchor used to add
  * to the summary / lineage rows / footer is folded into those Marker
- * variants. `data-priority` is still emitted on footer actions for any
- * downstream styling but no longer drives visibility. */
+ * variants. */
 
 /* PR109f: branched session banner. Renders above the chat scroll area
    when the active session has a parentSessionId. Inline button-styled

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -955,10 +955,10 @@
 }
 
 
-/* PR109d-c: Aborted turn marker. Sits above the assistant message body
- * to surface "(已中断)" + muted Ban icon when turn.status === aborted.
- * Uses muted tone — aborted is dormant history, NOT an error state
- * (per @kenji review #2: aborted does NOT use destructive red). */
+/* Search-highlight ring on the turn the search panel just navigated to.
+ * This styles the `.maka-turn` container (NOT a per-turn marker), so it
+ * stays hand-written here alongside the other model-catalog-preview turn
+ * chrome. */
 .maka-turn[data-search-highlight="true"] {
   border-radius: 12px;
   outline: 1px solid oklch(from var(--accent) l c h / 0.34);
@@ -966,167 +966,15 @@
   background: oklch(from var(--accent) l c h / 0.045);
 }
 
-.maka-turn-aborted-marker {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin: 2px 0 4px;
-  padding: 2px 6px;
-  border-radius: 6px;
-  background: var(--foreground-5);
-  color: var(--foreground-60);
-  font-size: 12px;
-  font-style: italic;
-  width: fit-content;
-}
-.maka-turn-aborted-marker em {
-  font-style: italic;
-}
-
-
-/* PR109d-b: Turn footer action row. Sits below the assistant message
- * bubble; icon+text buttons for 重试/重新生成/分支/复制. Disabled
- * buttons remain rendered (per @kenji review: user should see what
- * actions exist on the turn) but click handlers no-op. */
-.maka-turn-footer {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-top: 2px;
-  padding: 0;
-  flex-wrap: wrap;
-  opacity: 0.72;
-}
-/* PR-UI-PIXEL-6 (2026-06-21): turn-footer actions read as subtle borderless
-   ghost buttons (reference's footer is icon-light, no bordered pills) — the
-   border only appears implicitly via the hover fill. */
-.maka-turn-footer-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 28px;
-  padding: 4px 8px;
-  border-radius: 8px;
-  border: 0;
-  background: transparent;
-  color: var(--foreground-50);
-  font-size: 12px;
-  transition: background 120ms ease, color 120ms ease, opacity 120ms ease;
-}
-.maka-turn-footer:hover,
-.maka-turn-footer:focus-within {
-  opacity: 1;
-}
-.maka-turn-footer-action:hover:not(:disabled) {
-  background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground);
-}
-.maka-turn-footer-action:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.maka-turn-footer-action:disabled,
-.maka-turn-footer-action[aria-disabled="true"] {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-.maka-turn-footer-action[data-pending] {
-  opacity: 0.78;
-  cursor: progress;
-}
-.maka-turn-footer-action[data-copy-feedback="copied"] {
-  color: var(--accent);
-}
-.maka-turn-footer-action[data-copy-feedback="failed"] {
-  color: var(--destructive);
-}
-
-/* PR-CHAT-CHROME-FOLLOWUP-0: footer actions render uniformly — icon +
- * label, always visible, at the shared 12px chrome size. This supersedes
- * the PR-UI-17 primary/secondary collapse, which hid branch/copy (and,
- * after #212, retry/regenerate too) behind a hover-to-expand width
- * animation. That left an unclear, undeclared priority split and made
- * the most common action — copy — hard to find. The strip stays quiet at
- * rest via the toolbar's 0.72 opacity and lifts to full on hover/focus;
- * the label is no longer width-collapsed. `data-priority` is retained on
- * the element for downstream styling but no longer drives visibility. */
-
-
-/* PR109e-d: Failed turn banner. Lives above the assistant message body
- * when turn.status === failed. Uses destructive tone — failed IS a
- * fault state (distinct from aborted which is dormant muted).
- * Copy is generalized Chinese (errorClass → Chinese phrase) per
- * @kenji gate #3 — never exposes the raw enum identifier. */
-.maka-turn-failed-banner {
-  display: inline-flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin: 2px 0 6px;
-  padding: 4px 8px;
-  border-radius: 6px;
-  background: oklch(from var(--destructive) l c h / 0.10);
-  border: 1px solid oklch(from var(--destructive) l c h / 0.28);
-  color: var(--destructive);
-  font-size: 12px;
-  width: fit-content;
-}
-.maka-turn-failed-icon {
-  display: inline-flex;
-  align-items: center;
-}
-.maka-turn-failed-recovery {
-  color: var(--text-muted);
-}
-.maka-turn-failed-recovery::before {
-  content: "·";
-  margin-right: 6px;
-  color: var(--border-strong);
-}
-
-/* PR109e-e: Lineage badges. Forward badges sit at the top of the turn
- * ("重试自 turn X"); reverse badges sit at the bottom ("已重试 →
- * turn Y"). Same visual treatment + interactive button so screen
- * readers and keyboard users can navigate. */
-.maka-turn-lineage-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 3px;
-  margin: 2px 0 4px;
-  opacity: 0.82;
-}
-.maka-turn-lineage-row-reverse {
-  margin-top: 4px;
-}
-.maka-turn-lineage-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  padding: 1px 5px;
-  border-radius: 999px;
-  border: 0;
-  background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground-48);
-  font-size: 9px;
-  transition: background 150ms var(--ease-out-strong), color 150ms var(--ease-out-strong);
-}
-.maka-turn-lineage-badge:hover {
-  background: oklch(from var(--foreground) l c h / 0.08);
-  color: var(--foreground);
-}
-.maka-turn-lineage-badge:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.maka-turn-lineage-badge[data-direction="forward"] {
-  background: oklch(from var(--info) l c h / 0.06);
-  color: oklch(from var(--info-text) calc(l - 0.06) c h);
-}
-.maka-turn-lineage-badge[data-direction="reverse"] {
-  background: oklch(from var(--brand-deep) l c h / 0.06);
-  color: oklch(from var(--brand-deep) calc(l - 0.04) c h);
-}
+/* Turn aborted marker / failed banner / lineage rows + badges / footer +
+ * footer actions retired to the `@maka/ui` Marker chat primitive
+ * (`aborted` / `failed-banner` / `failed-icon` / `failed-recovery` /
+ * `lineage-row` / `lineage-row-reverse` / `lineage-badge` / `footer` /
+ * `footer-action`), issue #332 PR2 — packages/ui/src/primitives/chat.tsx.
+ * The measure-column geometry the `tool-output.css` re-anchor used to add
+ * to the summary / lineage rows / footer is folded into those Marker
+ * variants. `data-priority` is still emitted on footer actions for any
+ * downstream styling but no longer drives visibility. */
 
 /* PR109f: branched session banner. Renders above the chat scroll area
    when the active session has a parentSessionId. Inline button-styled

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -44,21 +44,10 @@
   gap: 6px;
 }
 
-/* Turn summary / lineage / footer share the assistant turn's left-anchored
-   measure column. The `[data-role="assistant"]` parts ride the chat Message
-   primitive (issue #332 PR1) — the lineage row + footer are still hand-written
-   (PR2), so this rule keeps their layout until they migrate. */
-.maka-turn > .maka-turn-summary,
-.maka-turn > .maka-turn-lineage-row,
-[data-slot="message"][data-role="assistant"] .maka-turn-lineage-row,
-[data-slot="message"][data-role="assistant"] .maka-turn-footer {
-  display: flex;
-  max-width: var(--maka-chat-measure, 680px);
-  width: 100%;
-  margin-left: 0;
-  margin-right: auto;
-  justify-content: flex-start;
-}
+/* Turn summary / lineage rows / footer measure column folded into the
+   `@maka/ui` Marker chat primitive's own variants (issue #332 PR2 —
+   packages/ui/src/primitives/chat.tsx); the layout is now location-
+   independent instead of keyed on a `[data-role="assistant"]` descendant. */
 
 [data-slot="message"] pre {
   margin: 0;

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -59,22 +59,27 @@ test('markerVariants resolves a leaf shell string the UiButton call sites can ap
 });
 
 // The footer action + lineage badge are the only NON-leaf marker call sites:
-// they render as `UiButton`, so the real on-element class string is
-// `cn(buttonVariants({ variant:'quiet', size:'sm' }), markerVariants(...))`.
-// Unlike the pure-container variants, "source string == computed style" does
-// NOT hold for free here — tailwind-merge has to drop the button's conflicting
-// shell utilities so the retired `.maka-turn-*` pixels win. This pins that merge
-// resolution (deterministic, no browser, no screenshot rasterization noise),
-// covering the exact regression risk PR2 introduced for these two elements.
-test('footer-action merge drops the UiButton shell so the retired footer pixels win', () => {
+// they render as `UiButton variant="quiet" size="nav"`, so the real on-element
+// class string is `cn(buttonVariants({ quiet, nav }), markerVariants(...))`.
+// `nav` is the bare size (emits nothing), so the marker shell — including its
+// own `h-8` height — fully owns the geometry; the only conflicts left to drop
+// are `buttonVariants`' BASE/quiet utilities (`gap-2`, `rounded-md`,
+// `text-muted-foreground`), not a `size` token. Unlike the pure-container
+// variants, "source string == computed style" doesn't hold for free here, so
+// this pins the merge resolution deterministically (no browser, no screenshot
+// rasterization noise) — the exact regression risk PR2 introduced for these two.
+test('footer-action merge drops the UiButton base shell so the retired footer pixels win', () => {
   const merged = cn(
-    buttonVariants({ variant: 'quiet', size: 'sm' }),
+    buttonVariants({ variant: 'quiet', size: 'nav' }),
     markerVariants({ variant: 'footer-action' }),
   );
-  // The retired `.maka-turn-footer-action` declarations survive…
+  // The retired `.maka-turn-footer-action` declarations survive (incl. the now
+  // explicit `h-8` height that `size="sm"` used to supply implicitly)…
   for (const win of [
     'gap-[6px]',
     'min-h-[28px]',
+    'h-8',
+    'leading-[16px]',
     'px-[8px]',
     'py-[4px]',
     'rounded-[8px]',
@@ -83,10 +88,10 @@ test('footer-action merge drops the UiButton shell so the retired footer pixels 
   ]) {
     assert.ok(merged.includes(win), `footer pixel "${win}" must survive the merge`);
   }
-  // …and the conflicting UiButton quiet/sm utilities are dropped, so they can't
-  // override the footer shell (px-2.5 padding, rounded-md radius, text-xs size,
-  // gap-2 gap, muted-foreground color).
-  for (const dropped of ['px-2.5', 'rounded-md', 'text-xs', 'gap-2', 'text-muted-foreground']) {
+  // …and the conflicting `buttonVariants` base/quiet utilities are dropped, so
+  // they can't override the footer shell (rounded-md radius, gap-2 gap,
+  // muted-foreground color).
+  for (const dropped of ['rounded-md', 'gap-2', 'text-muted-foreground']) {
     assert.ok(
       !merged.split(/\s+/).includes(dropped),
       `conflicting UiButton utility "${dropped}" must be merged out of the footer action`,
@@ -94,12 +99,14 @@ test('footer-action merge drops the UiButton shell so the retired footer pixels 
   }
 });
 
-test('lineage-badge merge drops the UiButton shell so the retired badge pixels win', () => {
+test('lineage-badge merge drops the UiButton base shell so the retired badge pixels win', () => {
   const merged = cn(
-    buttonVariants({ variant: 'quiet', size: 'sm' }),
+    buttonVariants({ variant: 'quiet', size: 'nav' }),
     markerVariants({ variant: 'lineage-badge' }),
   );
   for (const win of [
+    'h-8',
+    'leading-[12px]',
     'gap-[3px]',
     'px-[5px]',
     'py-[1px]',
@@ -109,7 +116,7 @@ test('lineage-badge merge drops the UiButton shell so the retired badge pixels w
   ]) {
     assert.ok(merged.includes(win), `lineage pixel "${win}" must survive the merge`);
   }
-  for (const dropped of ['px-2.5', 'rounded-md', 'text-xs', 'gap-2', 'text-muted-foreground']) {
+  for (const dropped of ['rounded-md', 'gap-2', 'text-muted-foreground']) {
     assert.ok(
       !merged.split(/\s+/).includes(dropped),
       `conflicting UiButton utility "${dropped}" must be merged out of the lineage badge`,

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { Bubble, Message } from '../primitives/chat.js';
+import { Bubble, Marker, markerVariants, Message } from '../primitives/chat.js';
 
 // The re-anchored renderer selectors key off the primitives' own `data-slot` /
 // `data-role` / `data-variant`, so a consumer must never be able to clobber
@@ -27,4 +27,32 @@ test('Bubble keeps its own data-slot/data-variant over conflicting props', () =>
   const props = el.props as Record<string, unknown>;
   assert.equal(props['data-slot'], 'bubble');
   assert.equal(props['data-variant'], 'user');
+});
+
+test('Marker keeps its own data-slot/data-variant but forwards the styling data-* hooks', () => {
+  const el = Marker({
+    variant: 'summary-chip',
+    as: 'span',
+    'data-slot': 'spoofed',
+    'data-variant': 'aborted',
+    // The literalized `data-[kind=…]:` variants read this off the element, so it
+    // must flow through unchanged.
+    'data-kind': 'model',
+  } as never);
+  const props = el.props as Record<string, unknown>;
+  assert.equal(el.type, 'span');
+  assert.equal(props['data-slot'], 'marker');
+  assert.equal(props['data-variant'], 'summary-chip');
+  assert.equal(props['data-kind'], 'model');
+});
+
+test('markerVariants resolves a leaf shell string the UiButton call sites can apply', () => {
+  // The lineage badge + footer action render as UiButton and apply the shell via
+  // className, so the cva must return a non-empty literal utility string.
+  const footerAction = markerVariants({ variant: 'footer-action' });
+  assert.match(footerAction, /min-h-\[28px\]/);
+  assert.match(footerAction, /data-\[copy-feedback=copied\]:text-\[color:var\(--accent\)\]/);
+  const lineageBadge = markerVariants({ variant: 'lineage-badge' });
+  assert.match(lineageBadge, /rounded-\[999px\]/);
+  assert.match(lineageBadge, /data-\[direction=forward\]:/);
 });

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Bubble, Marker, markerVariants, Message } from '../primitives/chat.js';
+import { buttonVariants, cn } from '../ui.js';
 
 // The re-anchored renderer selectors key off the primitives' own `data-slot` /
 // `data-role` / `data-variant`, so a consumer must never be able to clobber
@@ -55,4 +56,63 @@ test('markerVariants resolves a leaf shell string the UiButton call sites can ap
   const lineageBadge = markerVariants({ variant: 'lineage-badge' });
   assert.match(lineageBadge, /rounded-\[999px\]/);
   assert.match(lineageBadge, /data-\[direction=forward\]:/);
+});
+
+// The footer action + lineage badge are the only NON-leaf marker call sites:
+// they render as `UiButton`, so the real on-element class string is
+// `cn(buttonVariants({ variant:'quiet', size:'sm' }), markerVariants(...))`.
+// Unlike the pure-container variants, "source string == computed style" does
+// NOT hold for free here — tailwind-merge has to drop the button's conflicting
+// shell utilities so the retired `.maka-turn-*` pixels win. This pins that merge
+// resolution (deterministic, no browser, no screenshot rasterization noise),
+// covering the exact regression risk PR2 introduced for these two elements.
+test('footer-action merge drops the UiButton shell so the retired footer pixels win', () => {
+  const merged = cn(
+    buttonVariants({ variant: 'quiet', size: 'sm' }),
+    markerVariants({ variant: 'footer-action' }),
+  );
+  // The retired `.maka-turn-footer-action` declarations survive…
+  for (const win of [
+    'gap-[6px]',
+    'min-h-[28px]',
+    'px-[8px]',
+    'py-[4px]',
+    'rounded-[8px]',
+    'text-[color:var(--foreground-50)]',
+    'text-[12px]',
+  ]) {
+    assert.ok(merged.includes(win), `footer pixel "${win}" must survive the merge`);
+  }
+  // …and the conflicting UiButton quiet/sm utilities are dropped, so they can't
+  // override the footer shell (px-2.5 padding, rounded-md radius, text-xs size,
+  // gap-2 gap, muted-foreground color).
+  for (const dropped of ['px-2.5', 'rounded-md', 'text-xs', 'gap-2', 'text-muted-foreground']) {
+    assert.ok(
+      !merged.split(/\s+/).includes(dropped),
+      `conflicting UiButton utility "${dropped}" must be merged out of the footer action`,
+    );
+  }
+});
+
+test('lineage-badge merge drops the UiButton shell so the retired badge pixels win', () => {
+  const merged = cn(
+    buttonVariants({ variant: 'quiet', size: 'sm' }),
+    markerVariants({ variant: 'lineage-badge' }),
+  );
+  for (const win of [
+    'gap-[3px]',
+    'px-[5px]',
+    'py-[1px]',
+    'rounded-[999px]',
+    'text-[color:var(--foreground-48)]',
+    'text-[9px]',
+  ]) {
+    assert.ok(merged.includes(win), `lineage pixel "${win}" must survive the merge`);
+  }
+  for (const dropped of ['px-2.5', 'rounded-md', 'text-xs', 'gap-2', 'text-muted-foreground']) {
+    assert.ok(
+      !merged.split(/\s+/).includes(dropped),
+      `conflicting UiButton utility "${dropped}" must be merged out of the lineage badge`,
+    );
+  }
 });

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -59,8 +59,12 @@ test('markerVariants resolves a leaf shell string the UiButton call sites can ap
 });
 
 // The footer action + lineage badge are the only NON-leaf marker call sites:
-// they render as `UiButton variant="quiet" size="nav"`, so the real on-element
-// class string is `cn(buttonVariants({ quiet, nav }), markerVariants(...))`.
+// they render as `UiButton variant="quiet" size="nav"` in EVERY state — the
+// pending footer action no longer switches the Button to `secondary` (the
+// marker shell overrides the variant either way, so the switch was visually
+// inert and is dropped), which means `quiet` is now the only merge path to
+// pin. The real on-element class string is
+// `cn(buttonVariants({ quiet, nav }), markerVariants(...))`.
 // `nav` is the bare size (emits nothing), so the marker shell — including its
 // own `h-8` height — fully owns the geometry; the only conflicts left to drop
 // are `buttonVariants`' BASE/quiet utilities (`gap-2`, `rounded-md`,

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4481,11 +4481,11 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
   }
 
   // `footerStyle` renders this copy as the SAME quiet ghost action the
-  // assistant turn footer uses (`markerVariants('footer-action')`, also a
-  // UiButton variant="quiet" size="sm" with icon + "复制"). The user-message copy and
-  // the assistant copy then read as one button by construction — same
-  // primitive, same class, same icon metrics — instead of a look-alike
-  // bespoke treatment.
+  // assistant turn footer uses (`markerVariants('footer-action')` on a
+  // UiButton variant="quiet" size="nav" — the bare size, with icon + "复制").
+  // The user-message copy and the assistant copy then read as one button by
+  // construction — same primitive, same class, same icon metrics — instead
+  // of a look-alike bespoke treatment.
   const footer = props.footerStyle === true;
   const visibleLabel = footer ? (props.label ?? '复制') : props.label;
   const iconSize = footer ? 12 : 14;
@@ -5023,17 +5023,11 @@ function TurnFooterActions(props: {
       {props.actions.map((action) => {
         // Per @kenji review: pending state must keep the original button
         // label visible (not a spinner-only) so screen readers can hear
-        // which action is processing. `aria-busy="true"` is the AT signal.
+        // which action is processing. `data-pending` + `aria-busy="true"`
+        // are the signals — the `footer-action` marker shell renders as a
+        // bare `quiet` button in every state, so pending never keys off the
+        // Button `variant`, and no presentation-priority hook is emitted.
         const isPending = action.tooltip === '正在处理…';
-        // PR-UI-17 (@yuejing 2026-05-22): action priority is presentation
-        // only — has NO bearing on the lifecycle/status semantics encoded
-        // by `deriveTurnFooterActions`. Pending state always forces
-        // priority back to "primary" (surfaced via `data-priority`) so the
-        // full label + icon stay visible while the action processes — that
-        // visibility is driven by the label/icon render below, NOT by the
-        // Button `variant`, which the `footer-action` marker shell fully
-        // overrides regardless. So the shell renders as a bare `quiet`
-        // button in every state; the variant no longer keys off priority.
         const isCopyAction = action.id === 'copy';
         const copyIsPending = isCopyAction && copyPhase === 'pending';
         const copyFeedbackLabel = copyPhase === 'pending'
@@ -5044,7 +5038,6 @@ function TurnFooterActions(props: {
               ? '复制失败'
               : action.label;
         const isActionPending = isPending || copyIsPending;
-        const priority = isActionPending ? 'primary' : 'secondary';
         return (
           <UiButton
             key={action.id}
@@ -5053,7 +5046,6 @@ function TurnFooterActions(props: {
             variant="quiet"
             size="nav"
             data-action={action.id}
-            data-priority={priority}
             data-pending={isActionPending || undefined}
             data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
             disabled={!action.enabled || copyIsPending}

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -4503,7 +4503,10 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
       type="button"
       className={footer ? markerVariants({ variant: 'footer-action' }) : 'maka-message-copy'}
       variant="quiet"
-      size={footer ? 'sm' : 'icon-sm'}
+      // `nav` is the bare size: the footer-action marker shell owns its own
+      // height/padding/font (see `markerVariants`), so it doesn't inherit —
+      // and then have to merge out — `sm`'s `h-8`/`px-2.5`/`text-xs`.
+      size={footer ? 'nav' : 'icon-sm'}
       onClick={() => void copy()}
       aria-label={copyPhase ? `${actionLabel} · ${baseLabel}` : baseLabel}
       aria-busy={copyPending ? 'true' : undefined}
@@ -4759,7 +4762,7 @@ function TurnView(props: {
               type="button"
               className={markerVariants({ variant: 'lineage-badge' })}
               variant="quiet"
-              size="sm"
+              size="nav"
               data-direction="forward"
               title={badge.tooltip ?? badge.label}
               onClick={() => props.onLineageBadgeClick?.(badge.targetTurnId)}
@@ -4856,7 +4859,7 @@ function TurnView(props: {
                   type="button"
                   className={markerVariants({ variant: 'lineage-badge' })}
                   variant="quiet"
-                  size="sm"
+                  size="nav"
                   data-direction="reverse"
                   title={badge.tooltip ?? badge.label}
                   onClick={() => props.onLineageBadgeClick?.(badge.targetTurnId)}
@@ -5044,7 +5047,7 @@ function TurnFooterActions(props: {
             type="button"
             className={markerVariants({ variant: 'footer-action' })}
             variant={priority === 'primary' ? 'secondary' : 'quiet'}
-            size="sm"
+            size="nav"
             data-action={action.id}
             data-priority={priority}
             data-pending={isActionPending || undefined}

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -194,7 +194,7 @@ import {
   cn,
 } from './ui.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
-import { Bubble, Message } from './primitives/chat.js';
+import { Bubble, Marker, markerVariants, Message } from './primitives/chat.js';
 import { Button as PrimitiveButton } from './primitives/button.js';
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './primitives/empty.js';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './primitives/input-group.js';
@@ -4446,7 +4446,7 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
     // The time is no longer hover-gated (was `opacity: 0` until hover, which
     // hid it from touch + assistive tech). Copy reuses MessageCopyButton in
     // `footerStyle`, so it's the same quiet ghost action as the assistant
-    // turn footer's copy (same primitive + `.maka-turn-footer-action`).
+    // turn footer's copy (same primitive + `markerVariants('footer-action')`).
     return (
       <>
         <Bubble variant="user">
@@ -4481,8 +4481,8 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
   }
 
   // `footerStyle` renders this copy as the SAME quiet ghost action the
-  // assistant turn footer uses (`.maka-turn-footer-action`, also a UiButton
-  // variant="quiet" size="sm" with icon + "复制"). The user-message copy and
+  // assistant turn footer uses (`markerVariants('footer-action')`, also a
+  // UiButton variant="quiet" size="sm" with icon + "复制"). The user-message copy and
   // the assistant copy then read as one button by construction — same
   // primitive, same class, same icon metrics — instead of a look-alike
   // bespoke treatment.
@@ -4501,7 +4501,7 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
   return (
     <UiButton
       type="button"
-      className={footer ? 'maka-turn-footer-action' : 'maka-message-copy'}
+      className={footer ? markerVariants({ variant: 'footer-action' }) : 'maka-message-copy'}
       variant="quiet"
       size={footer ? 'sm' : 'icon-sm'}
       onClick={() => void copy()}
@@ -4640,10 +4640,11 @@ function TurnSummary(props: { turn: TurnViewModel; previousModelId?: string }) {
   const hasCost = turn.tokens?.costUsd !== undefined && turn.tokens.costUsd > 0;
   if (!hasModel && !hasTools && !hasDuration && !hasTokens && !inProgress) return null;
   return (
-    <div className="maka-turn-summary" aria-label="本轮对话摘要">
+    <Marker variant="summary" aria-label="本轮对话摘要">
       {hasModel && (
-        <span
-          className="maka-turn-summary-chip"
+        <Marker
+          as="span"
+          variant="summary-chip"
           data-kind="model"
           data-switched={modelSwitched ? 'true' : undefined}
           title={
@@ -4654,36 +4655,37 @@ function TurnSummary(props: { turn: TurnViewModel; previousModelId?: string }) {
         >
           <code>{turn.modelId}</code>
           {modelSwitched && (
-            <span className="maka-turn-summary-chip-switched" aria-label="本轮切换了模型">
+            <Marker as="span" variant="summary-switched" aria-label="本轮切换了模型">
               切换
-            </span>
+            </Marker>
           )}
-        </span>
+        </Marker>
       )}
       {hasTools && (
-        <span className="maka-turn-summary-chip" data-kind="tools">
+        <Marker as="span" variant="summary-chip" data-kind="tools">
           {turn.tools.length} 个工具
-        </span>
+        </Marker>
       )}
       {hasDuration ? (
-        <span className="maka-turn-summary-chip" data-kind="duration">
+        <Marker as="span" variant="summary-chip" data-kind="duration">
           {formatTurnDuration(turn.durationMs!)}
-        </span>
+        </Marker>
       ) : inProgress ? (
-        <span className="maka-turn-summary-chip" data-kind="duration" data-state="in-progress">
+        <Marker as="span" variant="summary-chip" data-kind="duration" data-state="in-progress">
           进行中
-        </span>
+        </Marker>
       ) : null}
       {hasTokens && (
-        <span
-          className="maka-turn-summary-chip"
+        <Marker
+          as="span"
+          variant="summary-chip"
           data-kind="tokens"
           title={hasCost ? `$${turn.tokens!.costUsd!.toFixed(4)}` : undefined}
         >
           {turn.tokens!.input.toLocaleString()} → {turn.tokens!.output.toLocaleString()} tok
-        </span>
+        </Marker>
       )}
-    </div>
+    </Marker>
   );
 }
 
@@ -4750,12 +4752,12 @@ function TurnView(props: {
       tabIndex={props.searchHighlighted ? -1 : undefined}
     >
       {forwardBadges.length > 0 && (
-        <div className="maka-turn-lineage-row" aria-label="本轮回答的来源">
+        <Marker variant="lineage-row" aria-label="本轮回答的来源">
           {forwardBadges.map((badge) => (
             <UiButton
               key={badge.id}
               type="button"
-              className="maka-turn-lineage-badge"
+              className={markerVariants({ variant: 'lineage-badge' })}
               variant="quiet"
               size="sm"
               data-direction="forward"
@@ -4766,7 +4768,7 @@ function TurnView(props: {
               <span>{badge.label}</span>
             </UiButton>
           ))}
-        </div>
+        </Marker>
       )}
       {turn.user && (
         <Message
@@ -4822,10 +4824,10 @@ function TurnView(props: {
                 Copy button below still copies the assistant text without
                 the prefix. */}
             {turn.status === 'aborted' && (
-              <div className="maka-turn-aborted-marker" role="status">
+              <Marker variant="aborted" role="status">
                 <Ban size={12} strokeWidth={2} aria-hidden="true" />
                 <em>{turnAbortMarkerLabel(turn.abortSource)}</em>
-              </div>
+              </Marker>
             )}
             {/* PR109e-d: failed turn AlertOctagon banner with generalized
                 Chinese copy (no raw `errorClass` leak per @kenji gate #3).
@@ -4834,25 +4836,25 @@ function TurnView(props: {
                 that mapping lives in `session-status-presentation.ts`
                 via `describeTurnErrorClass()`. */}
             {turn.status === 'failed' && props.failedReasonLabel && (
-              <div className="maka-turn-failed-banner" role="alert">
-                <span className="maka-turn-failed-icon" aria-hidden="true">
+              <Marker variant="failed-banner" role="alert">
+                <Marker as="span" variant="failed-icon" aria-hidden="true">
                   <AlertOctagon size={14} strokeWidth={2} />
-                </span>
+                </Marker>
                 <span>{props.failedReasonLabel}</span>
                 {props.failedRecoveryLabel && (
-                  <span className="maka-turn-failed-recovery">{props.failedRecoveryLabel}</span>
+                  <Marker as="span" variant="failed-recovery">{props.failedRecoveryLabel}</Marker>
                 )}
-              </div>
+              </Marker>
             )}
             <MessageBody role="assistant" text={turn.assistant.text} ts={turn.assistant.ts} />
           </div>
           {reverseBadges.length > 0 && (
-            <div className="maka-turn-lineage-row maka-turn-lineage-row-reverse" aria-label="本轮回答的衍生">
+            <Marker variant="lineage-row-reverse" aria-label="本轮回答的衍生">
               {reverseBadges.map((badge) => (
                 <UiButton
                   key={badge.id}
                   type="button"
-                  className="maka-turn-lineage-badge"
+                  className={markerVariants({ variant: 'lineage-badge' })}
                   variant="quiet"
                   size="sm"
                   data-direction="reverse"
@@ -4863,7 +4865,7 @@ function TurnView(props: {
                   <span>{badge.label}</span>
                 </UiButton>
               ))}
-            </div>
+            </Marker>
           )}
           {props.footerActions && props.footerActions.length > 0 && (
             <TurnFooterActions
@@ -5014,7 +5016,7 @@ function TurnFooterActions(props: {
     props.onAction?.(action.id);
   }
   return (
-    <div className="maka-turn-footer" role="toolbar" aria-label="本轮回答操作">
+    <Marker variant="footer" role="toolbar" aria-label="本轮回答操作">
       {props.actions.map((action) => {
         // Per @kenji review: pending state must keep the original button
         // label visible (not a spinner-only) so screen readers can hear
@@ -5040,7 +5042,7 @@ function TurnFooterActions(props: {
           <UiButton
             key={action.id}
             type="button"
-            className="maka-turn-footer-action"
+            className={markerVariants({ variant: 'footer-action' })}
             variant={priority === 'primary' ? 'secondary' : 'quiet'}
             size="sm"
             data-action={action.id}
@@ -5058,7 +5060,7 @@ function TurnFooterActions(props: {
           </UiButton>
         );
       })}
-    </div>
+    </Marker>
   );
 }
 

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5044,7 +5044,7 @@ function TurnFooterActions(props: {
               ? '复制失败'
               : action.label;
         const isActionPending = isPending || copyIsPending;
-        const priority = isActionPending ? 'primary' : STATUS_FOOTER_PRIORITY[action.id];
+        const priority = isActionPending ? 'primary' : 'secondary';
         return (
           <UiButton
             key={action.id}
@@ -5076,25 +5076,6 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
   regenerate: <RefreshCcw size={12} strokeWidth={2} aria-hidden="true" />,
   branch: <GitBranch size={12} strokeWidth={2} aria-hidden="true" />,
   copy: <Copy size={12} strokeWidth={2} aria-hidden="true" />,
-};
-
-/**
- * PR-UI-17 (audit §3.4): action priority controls visual density —
- * `primary` actions render with full icon+label always; `secondary`
- * actions render icon-only by default with a hover/focus-within
- * expansion that reveals the label. This addresses the noise complaint
- * "重试 + 重新生成 + 分支 + 复制 buttons accumulate visually when
- * combined with lineage badges + status pills" without dropping any
- * functionality or changing the lifecycle semantics encoded by
- * `deriveTurnFooterActions`. The action label is always present in
- * the DOM (aria + visually-hidden when collapsed) so screen readers
- * read it identically regardless of presentation state.
- */
-const STATUS_FOOTER_PRIORITY: Record<TurnFooterActionMeta['id'], 'primary' | 'secondary'> = {
-  retry: 'secondary',
-  regenerate: 'secondary',
-  branch: 'secondary',
-  copy: 'secondary',
 };
 
 /**

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5028,8 +5028,12 @@ function TurnFooterActions(props: {
         // PR-UI-17 (@yuejing 2026-05-22): action priority is presentation
         // only — has NO bearing on the lifecycle/status semantics encoded
         // by `deriveTurnFooterActions`. Pending state always forces
-        // priority back to "primary" so the user sees full label + icon
-        // while the action processes.
+        // priority back to "primary" (surfaced via `data-priority`) so the
+        // full label + icon stay visible while the action processes — that
+        // visibility is driven by the label/icon render below, NOT by the
+        // Button `variant`, which the `footer-action` marker shell fully
+        // overrides regardless. So the shell renders as a bare `quiet`
+        // button in every state; the variant no longer keys off priority.
         const isCopyAction = action.id === 'copy';
         const copyIsPending = isCopyAction && copyPhase === 'pending';
         const copyFeedbackLabel = copyPhase === 'pending'
@@ -5046,7 +5050,7 @@ function TurnFooterActions(props: {
             key={action.id}
             type="button"
             className={markerVariants({ variant: 'footer-action' })}
-            variant={priority === 'primary' ? 'secondary' : 'quiet'}
+            variant="quiet"
             size="nav"
             data-action={action.id}
             data-priority={priority}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,7 +27,19 @@ export * from './utils.js';
 // consumers can `import { Alert, Empty, Sidebar, ... } from '@maka/ui'`.
 export * from './bot-brand.js';
 export * from './primitives/alert.js';
-export * from './primitives/chat.js';
+// `markerVariants` is deliberately NOT re-exported here: it is an internal
+// styling table the chat call sites apply via relative import, so keeping it off
+// the package barrel preserves the governance goal — the variant set stays
+// renamable/removable without a public-API break. Only `Marker` + its types are
+// public. (Contrast `buttonVariants`, which IS public because it has external
+// consumers.)
+export { Bubble, Marker, Message } from './primitives/chat.js';
+export type {
+  BubbleProps,
+  MarkerProps,
+  MarkerVariant,
+  MessageProps,
+} from './primitives/chat.js';
 export * from './primitives/empty.js';
 export * from './primitives/item.js';
 export * from './primitives/spinner.js';

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -184,7 +184,12 @@ const markerVariants = cva("", {
       // `.maka-turn-lineage-badge` (UiButton) — tiny pill, `[data-direction]`
       // recolors it forward (info) / reverse (brand-deep).
       "lineage-badge":
-        "inline-flex items-center gap-[3px] px-[5px] py-[1px] rounded-[999px] border-0 bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--foreground-48)] text-[9px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
+        // `h-8` + `leading-[12px]` explicit for the same reason as
+        // `footer-action` (UiButton `size="nav"`): preserves the 30px height and
+        // the 4/3 line-height (9px font × 4/3 = 12px) that `size="sm"`'s `h-8` /
+        // `text-xs` used to supply implicitly on `main`, so geometry lives in
+        // the marker shell.
+        "inline-flex items-center h-8 gap-[3px] px-[5px] py-[1px] rounded-[999px] [border:0] bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--foreground-48)] text-[9px] leading-[12px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
         + " hover:bg-[oklch(from_var(--foreground)_l_c_h_/_0.08)] hover:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--accent)] focus-visible:[outline-offset:2px]"
         + " data-[direction=forward]:bg-[oklch(from_var(--info)_l_c_h_/_0.06)] data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]"
@@ -197,7 +202,14 @@ const markerVariants = cva("", {
       // reused by the user-message copy (`MessageCopyButton footerStyle`), so
       // it carries only the button look, never the footer's measure column.
       "footer-action":
-        "inline-flex items-center gap-[6px] min-h-[28px] px-[8px] py-[4px] rounded-[8px] border-0 bg-transparent text-[color:var(--foreground-50)] text-[12px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
+        // `h-8` (→30px) + `leading-[16px]` are explicit because the call sites
+        // pass `UiButton size="nav"` (the bare size whose docstring says the
+        // consumer's className owns height/padding/font). On `main` both came
+        // implicitly from `size="sm"` — its `h-8`, and `text-xs`'s 4/3
+        // line-height ratio over the 12px font (12 × 4/3 = 16px exactly).
+        // Folding them in keeps the exact pixels while the marker shell owns its
+        // geometry (verified equal to `main` by computed style, headless electron).
+        "inline-flex items-center gap-[6px] min-h-[28px] h-8 px-[8px] py-[4px] rounded-[8px] [border:0] bg-transparent text-[color:var(--foreground-50)] text-[12px] leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
         + " [&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not(:disabled)]:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--accent)] focus-visible:[outline-offset:2px]"
         + " disabled:opacity-[0.45] disabled:cursor-not-allowed aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -99,3 +99,141 @@ export function Bubble({
     />
   );
 }
+
+/**
+ * `Marker` — the per-turn status / lineage / footer chrome (issue #332, PR2).
+ *
+ * Retires the bespoke `.maka-turn-summary*`, `.maka-turn-aborted-marker`,
+ * `.maka-turn-failed-*`, `.maka-turn-lineage-*`, and `.maka-turn-footer*` shell
+ * CSS (spread across `maka-tokens.css`, `styles/settings/models.css`, and the
+ * re-anchored measure-column block in `styles/tool-output.css`), moving each
+ * onto this one Tailwind substrate.
+ *
+ * Every value is a LITERAL arbitrary utility (`gap-[6px]`, `rounded-[999px]`,
+ * `bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)]`, `data-[kind=model]:…`),
+ * never the semantic scale — the literal is the faithful, self-evidently-equal
+ * translation of the retired pixels/tokens and is immune to later re-tuning
+ * (the visual refresh, not this governance pass, owns adopting the scale). Each
+ * leaf variant compiles 1:1 to the declarations it replaces, so the cva source
+ * string IS the computed-style proof — the cascade contract asserts the exact
+ * strings, no browser needed.
+ *
+ * The measure-column geometry the old `tool-output.css` re-anchor applied to
+ * the summary / lineage rows / footer (`max-width:var(--maka-chat-measure)`,
+ * `margin-right:auto`) is folded directly into those container variants here,
+ * so the layout is location-independent instead of coupled to a
+ * `[data-role="assistant"]` descendant selector.
+ *
+ * `markerVariants` is exported (shadcn `buttonVariants` style) so the lineage
+ * badge + footer action — which render as `UiButton` and can't be wrapped —
+ * apply the shell via `className`; `Button` runs it through `cn`/tailwind-merge
+ * last, so it wins over the button's own variant utilities.
+ *
+ * NOTE: `.maka-turn-thinking` (the committed-turn reasoning `<details>`) is
+ * deliberately NOT migrated here. Its chrome lives in `summary::before` /
+ * `::-webkit-details-marker` pseudo-elements and an `@starting-style` body fade
+ * that don't reduce to leaf utilities (so the source-string == computed-style
+ * proof wouldn't hold), and `maka-tokens.css` already documents an intended
+ * Base UI Accordion path for it. It stays hand-written for that later effort.
+ */
+const markerVariants = cva("", {
+  variants: {
+    variant: {
+      // `.maka-turn-summary` + the `tool-output.css` measure-column re-anchor:
+      // one quiet caption line (model · tools · duration · tokens).
+      summary:
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-[6px] mb-[2px] ml-0 mr-auto text-[color:var(--foreground-50)] [font-variant-numeric:tabular-nums]",
+      // `.maka-turn-summary-chip` (+ `::before` middot, nested `code`, and the
+      // `[data-kind]` / `[data-state]` / `[data-switched]` conditionals). The
+      // call site keeps passing `data-kind` / `data-state` / `data-switched`,
+      // which the literalized `data-[…]:` variants read.
+      "summary-chip":
+        "inline-flex items-center gap-[4px] text-[color:var(--foreground-50)] text-[12px] font-medium leading-[1.4]"
+        + " [&:not(:first-child)]:before:content-['·'] [&:not(:first-child)]:before:mr-[4px] [&:not(:first-child)]:before:text-[color:var(--foreground-40)] [&:not(:first-child)]:before:font-normal"
+        + " [&_code]:bg-transparent [&_code]:text-[color:inherit] [&_code]:[font-family:var(--font-mono)] [&_code]:text-[12px]"
+        + " data-[kind=model]:[&_code]:text-[color:var(--foreground-60)] data-[kind=model]:[&_code]:font-semibold"
+        + " data-[kind=tools]:text-[color:var(--foreground-50)]"
+        + " data-[kind=duration]:[font-variant-numeric:tabular-nums]"
+        + " data-[kind=tokens]:[font-variant-numeric:tabular-nums] data-[kind=tokens]:[font-family:var(--font-mono)] data-[kind=tokens]:text-[12px]"
+        + " data-[state=in-progress]:text-[color:var(--accent)] data-[state=in-progress]:font-semibold"
+        + " data-[kind=model]:data-[switched=true]:[&_code]:text-[color:var(--foreground-60)]",
+      // `.maka-turn-summary-chip-switched` — the muted "切换" pill.
+      "summary-switched":
+        "ml-[4px] px-[6px] py-[1px] rounded-[999px] bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)] text-[color:var(--foreground-60)] text-[11px] font-semibold",
+      // `.maka-turn-aborted-marker` (+ its italic `em`) — dormant, muted.
+      aborted:
+        "inline-flex w-fit items-center gap-[4px] mx-0 mt-[2px] mb-[4px] px-[6px] py-[2px] rounded-[6px] bg-[var(--foreground-5)] text-[color:var(--foreground-60)] text-[12px] italic [&_em]:italic",
+      // `.maka-turn-failed-banner` — fault state, destructive tone.
+      "failed-banner":
+        "inline-flex w-fit flex-wrap items-center gap-[6px] mx-0 mt-[2px] mb-[6px] px-[8px] py-[4px] rounded-[6px] border border-[oklch(from_var(--destructive)_l_c_h_/_0.28)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] text-[color:var(--destructive)] text-[12px]",
+      // `.maka-turn-failed-icon`
+      "failed-icon": "inline-flex items-center",
+      // `.maka-turn-failed-recovery` (+ `::before` middot separator).
+      "failed-recovery":
+        "text-[color:var(--text-muted)] before:content-['·'] before:mr-[6px] before:text-[color:var(--border-strong)]",
+      // `.maka-turn-lineage-row` + the measure-column re-anchor (forward row).
+      "lineage-row":
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-[3px] mt-[2px] mb-[4px] ml-0 mr-auto opacity-[0.82]",
+      // `.maka-turn-lineage-row.maka-turn-lineage-row-reverse` — same, but the
+      // `-reverse` class bumps margin-top 2px → 4px.
+      "lineage-row-reverse":
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-[3px] mt-[4px] mb-[4px] ml-0 mr-auto opacity-[0.82]",
+      // `.maka-turn-lineage-badge` (UiButton) — tiny pill, `[data-direction]`
+      // recolors it forward (info) / reverse (brand-deep).
+      "lineage-badge":
+        "inline-flex items-center gap-[3px] px-[5px] py-[1px] rounded-[999px] border-0 bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--foreground-48)] text-[9px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
+        + " hover:bg-[oklch(from_var(--foreground)_l_c_h_/_0.08)] hover:text-[color:var(--foreground)]"
+        + " focus-visible:[outline:2px_solid_var(--accent)] focus-visible:[outline-offset:2px]"
+        + " data-[direction=forward]:bg-[oklch(from_var(--info)_l_c_h_/_0.06)] data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]"
+        + " data-[direction=reverse]:bg-[oklch(from_var(--brand-deep)_l_c_h_/_0.06)] data-[direction=reverse]:text-[oklch(from_var(--brand-deep)_calc(l_-_0.04)_c_h)]",
+      // `.maka-turn-footer` (+ measure-column re-anchor) — quiet toolbar that
+      // lifts to full opacity on hover / focus-within.
+      footer:
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-[2px] mt-[2px] ml-0 mr-auto p-0 opacity-[0.72] hover:opacity-100 focus-within:opacity-100",
+      // `.maka-turn-footer-action` (UiButton) — borderless ghost action. Also
+      // reused by the user-message copy (`MessageCopyButton footerStyle`), so
+      // it carries only the button look, never the footer's measure column.
+      "footer-action":
+        "inline-flex items-center gap-[6px] min-h-[28px] px-[8px] py-[4px] rounded-[8px] border-0 bg-transparent text-[color:var(--foreground-50)] text-[12px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
+        + " [&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not(:disabled)]:text-[color:var(--foreground)]"
+        + " focus-visible:[outline:2px_solid_var(--accent)] focus-visible:[outline-offset:2px]"
+        + " disabled:opacity-[0.45] disabled:cursor-not-allowed aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
+        + " data-[pending=true]:opacity-[0.78] data-[pending=true]:cursor-progress"
+        + " data-[copy-feedback=copied]:text-[color:var(--accent)] data-[copy-feedback=failed]:text-[color:var(--destructive)]",
+    },
+  },
+});
+
+export type MarkerVariant = NonNullable<
+  VariantProps<typeof markerVariants>["variant"]
+>;
+
+export { markerVariants };
+
+export interface MarkerProps extends React.ComponentPropsWithoutRef<"div"> {
+  variant: MarkerVariant;
+  // The summary chips and the failed-banner sub-spans were authored as inline
+  // `<span>`s; the containers/markers as `<div>`s. Keep the original tag so the
+  // migration is structurally identical (zero behavioral change).
+  as?: "div" | "span";
+}
+
+export function Marker({
+  className,
+  variant,
+  as: Tag = "div",
+  ...props
+}: MarkerProps): React.ReactElement {
+  return (
+    // `{...props}` first so the `data-slot` / `data-variant` hooks land last and
+    // can't be clobbered by a consumer (mirrors Message / Bubble). The styling
+    // `data-kind` / `data-state` / `data-direction` etc. flow through `...props`
+    // and are read by the literalized `data-[…]:` variants above.
+    <Tag
+      {...props}
+      data-slot="marker"
+      data-variant={variant}
+      className={cn(markerVariants({ variant }), className)}
+    />
+  );
+}

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -124,10 +124,13 @@ export function Bubble({
  * so the layout is location-independent instead of coupled to a
  * `[data-role="assistant"]` descendant selector.
  *
- * `markerVariants` is exported (shadcn `buttonVariants` style) so the lineage
- * badge + footer action — which render as `UiButton` and can't be wrapped —
- * apply the shell via `className`; `Button` runs it through `cn`/tailwind-merge
- * last, so it wins over the button's own variant utilities.
+ * `markerVariants` is exported from THIS module (shadcn `buttonVariants` style)
+ * so the lineage badge + footer action — which render as `UiButton` and can't
+ * be wrapped — apply the shell via `className`; `Button` runs it through
+ * `cn`/tailwind-merge last, so it wins over the button's own variant utilities.
+ * It is intentionally kept OFF the `@maka/ui` package barrel (see `index.ts`):
+ * the only consumers import it by relative path, so the variant table stays an
+ * internal, freely-removable styling detail rather than public API.
  *
  * NOTE: `.maka-turn-thinking` (the committed-turn reasoning `<details>`) is
  * deliberately NOT migrated here. Its chrome lives in `summary::before` /
@@ -199,6 +202,14 @@ const markerVariants = cva("", {
         + " focus-visible:[outline:2px_solid_var(--accent)] focus-visible:[outline-offset:2px]"
         + " disabled:opacity-[0.45] disabled:cursor-not-allowed aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
         + " data-[pending=true]:opacity-[0.78] data-[pending=true]:cursor-progress"
+        // Copy-in-progress sets BOTH `disabled` and `data-pending`. The plain
+        // `data-[pending=true]:opacity-[0.78]` and `disabled:opacity-[0.45]`
+        // utilities have equal specificity (0,2,0), so the pending value would
+        // only win on Tailwind's source order. These combined-modifier guards
+        // raise pending to (0,3,0) so it beats the disabled dim by specificity,
+        // not order — keeping the in-progress 0.78 stable regardless of emit
+        // sequence. (Both `disabled`/`aria-disabled` are always set together.)
+        + " disabled:data-[pending=true]:opacity-[0.78] aria-disabled:data-[pending=true]:opacity-[0.78]"
         + " data-[copy-feedback=copied]:text-[color:var(--accent)] data-[copy-feedback=failed]:text-[color:var(--destructive)]",
     },
   },

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -6,18 +6,44 @@
  * cascade contract tests + before/after screenshots". The cascade
  * contract tests (apps/desktop/.../chat-marker-cascade-contract.test.ts,
  * packages/ui/.../chat-primitives.test.ts) assert the source strings.
- * This script is the rendered-style half: a re-runnable before/after
- * check that loads the REAL built renderer CSS from both `main` and the
- * PR branch into a headless window and diffs `getComputedStyle` for every
- * migrated chrome element. It is the deterministic equivalent of a
- * before/after screenshot — `scripts/diff-screenshots.mjs` documents why
+ * This script is the rendered half: a re-runnable before/after check that
+ * loads the REAL built renderer CSS from both `main` and the PR branch
+ * into a headless window and diffs `getComputedStyle` for the migrated
+ * chrome. It is the deterministic equivalent of a before/after screenshot
+ * for the resting surface — `scripts/diff-screenshots.mjs` documents why
  * byte/pixel image diffs are too jittery to gate on (font rasterization
- * drifts ~70/88 PNGs between runs); computed style does not drift.
+ * drifts ~70/88 PNGs between runs); computed style does not.
  *
- * Each element is wrapped in the same
- * `[data-slot=message][data-role=assistant] > .maka-turn` ancestor so the
- * descendant measure-column re-anchors that the retired `tool-output.css`
- * applied on `main` still take effect — an apples-to-apples comparison.
+ * What this renders + diffs `main` vs head: the resting box / typography /
+ * color / transition style of all 9 migrated families, plus the footer
+ * action across resting / pending / copy-pending / copied / failed —
+ * including `main`'s old pending `secondary` variant vs the new always-
+ * `quiet` shell, which proves that variant switch was visually inert (the
+ * reason this PR drops it). The DOM mirrors `TurnView` nesting (chips in a
+ * summary, actions in a footer, badges in a lineage row) so positional
+ * pseudo-classes and inheritance resolve as in production.
+ *
+ * What is NOT rendered here, and why — locked by the cascade contract's
+ * exact source-string literals instead (each a LEAF literalization where
+ * source == computed holds by construction):
+ *   - `:hover` / `:focus-visible` / `:focus-within`: a headless
+ *     (`show: false`) window has no live pointer/focus, and NEITHER the
+ *     DevTools `CSS.forcePseudoState` protocol NOR a synthetic
+ *     `sendInputEvent` mouse-move changes what `getComputedStyle` returns
+ *     here (verified: resting == "hovered"). So these can't be rendered in
+ *     this harness. Their NON-leaf merge winner is instead a deterministic
+ *     specificity fact: the marker's `[&:hover:not(:disabled)]` (0,3,0)
+ *     outranks UiButton quiet's `hover:bg-muted` (0,2,0), exactly as the
+ *     retired `.maka-turn-footer-action:hover:not(:disabled)` did on main.
+ *   - the `::before` middot pseudo-elements (summary-chip / failed-recovery):
+ *     Tailwind compiles `before:content-['·']` through a `--tw-content`
+ *     registered `@property`, which `getComputedStyle(el, '::before')` reads
+ *     back as `content: none` in this isolated-CSS harness — a rendered
+ *     probe would be a misleading green.
+ * So this is a rendered proof of the RESTING surface, not a complete
+ * screenshot equivalent. (Buttons may also read the UA `buttonface`
+ * background here identically on both sides; the diff is what's asserted,
+ * not absolute production fidelity for that one property.)
  *
  * Usage (run from repo root, needs Electron + both built CSS bundles):
  *
@@ -31,21 +57,18 @@
  *   # 4. Diff:
  *   npx electron scripts/check-chat-marker-computed-style.mjs /tmp/main.css /tmp/head.css
  *
- * Exits 0 when every migrated element is identical across both bundles,
- * non-zero (with a per-property diff dump) otherwise.
+ * Exits 0 when every element is identical across both bundles, non-zero
+ * (with a per-property diff dump) otherwise.
  */
 
 import { app, BrowserWindow } from 'electron';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const uiDist = pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/ui.js')).href;
-const chatDist = pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href;
-const { buttonVariants, cn } = await import(uiDist);
-const { markerVariants } = await import(chatDist);
+const { buttonVariants, cn } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/ui.js')).href);
+const { markerVariants } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href);
 
 const mainCssPath = process.argv[2] && resolve(process.argv[2]);
 const headCssPath = process.argv[3] && resolve(process.argv[3]);
@@ -57,45 +80,48 @@ if (!mainCssPath || !headCssPath || !existsSync(mainCssPath) || !existsSync(head
 
 const bv = (variant, size) => buttonVariants({ variant, size });
 const mv = (v) => markerVariants({ variant: v });
+const pair = (m, h) => ({ main: m, head: h });
+// `main` class (UiButton sm + bespoke, or pure bespoke) vs head class
+// (UiButton nav + marker, or pure marker). The footer action is `quiet` in
+// EVERY head state — the inert pending `secondary` branch is dropped — so
+// its head column is always `quiet`, matched against `main`'s pending-time
+// `secondary` to prove that switch was pixel-equal.
+const fa = (variant) => pair(cn(bv(variant, 'sm'), 'maka-turn-footer-action'), cn(bv('quiet', 'nav'), mv('footer-action')));
+const lb = pair(cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), cn(bv('quiet', 'nav'), mv('lineage-badge')));
 
-// For each migrated element: the class string `main` rendered (UiButton
-// `sm` + bespoke `.maka-turn-*`, or pure bespoke) vs what the PR branch
-// renders (UiButton `nav` + marker shell, or pure marker). The footer
-// action is `quiet` in EVERY state on the PR branch — pending no longer
-// switches the Button to `secondary`; the marker shell owns the pixels —
-// so its `head` column is always `quiet`, matched against `main`'s
-// pending-time `secondary` to prove that switch was visually inert.
-const footerMain = (variant, attrs) => ({ main: cn(bv(variant, 'sm'), 'maka-turn-footer-action'), head: cn(bv('quiet', 'nav'), mv('footer-action')), attrs });
-const specs = [
-  { id: 'footer-rest', tag: 'button', ...footerMain('quiet', '') },
-  { id: 'footer-pending', tag: 'button', ...footerMain('secondary', 'data-pending="true" aria-busy="true"') },
-  { id: 'footer-copy-pending', tag: 'button', ...footerMain('secondary', 'data-pending="true" data-copy-feedback="pending" aria-busy="true" disabled aria-disabled="true"') },
-  { id: 'footer-copied', tag: 'button', ...footerMain('quiet', 'data-copy-feedback="copied"') },
-  { id: 'footer-failed', tag: 'button', ...footerMain('quiet', 'data-copy-feedback="failed"') },
-  { id: 'lineage-fwd', tag: 'button', attrs: 'data-direction="forward"', main: cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), head: cn(bv('quiet', 'nav'), mv('lineage-badge')) },
-  { id: 'lineage-rev', tag: 'button', attrs: 'data-direction="reverse"', main: cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), head: cn(bv('quiet', 'nav'), mv('lineage-badge')) },
-  { id: 'summary', tag: 'div', attrs: '', main: 'maka-turn-summary', head: mv('summary') },
-  { id: 'summary-chip', tag: 'span', attrs: 'data-kind="model"', main: 'maka-turn-summary-chip', head: mv('summary-chip') },
-  { id: 'failed-banner', tag: 'div', attrs: '', main: 'maka-turn-failed-banner', head: mv('failed-banner') },
-  { id: 'footer', tag: 'div', attrs: '', main: 'maka-turn-footer', head: mv('footer') },
-  { id: 'lineage-row', tag: 'div', attrs: '', main: 'maka-turn-lineage-row', head: mv('lineage-row') },
-  { id: 'aborted', tag: 'div', attrs: '', main: 'maka-turn-aborted-marker', head: mv('aborted') },
-];
+// DOM tree mirroring TurnView nesting.
+const TREE = (side) => {
+  const C = (p) => p[side];
+  const el = (tag, id, p, attrs, kids = '') => `<${tag} id="${id}" class="${C(p)}" ${attrs}>${kids}</${tag}>`;
+  const action = (id, p, attrs) => el('button', id, p, `${attrs} type="button"`, '<svg width="11" height="11"></svg><span>复制中…</span>');
+  const chip = (id) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model"', '<span>x</span>');
+  return [
+    el('div', 'summary', pair('maka-turn-summary', mv('summary')), '', chip('summary-chip-1') + chip('summary-chip-2')),
+    el('div', 'footer', pair('maka-turn-footer', mv('footer')), 'role="toolbar"',
+      action('footer-rest', fa('quiet'), '') +
+      action('footer-pending', fa('secondary'), 'data-pending="true" aria-busy="true"') +
+      action('footer-copy-pending', fa('secondary'), 'data-pending="true" data-copy-feedback="pending" aria-busy="true" disabled aria-disabled="true"') +
+      action('footer-copied', fa('quiet'), 'data-copy-feedback="copied"') +
+      action('footer-failed', fa('quiet'), 'data-copy-feedback="failed"')),
+    el('div', 'lineage-row', pair('maka-turn-lineage-row', mv('lineage-row')), '',
+      action('lineage-fwd', lb, 'data-direction="forward"') + action('lineage-rev', lb, 'data-direction="reverse"')),
+    el('div', 'aborted', pair('maka-turn-aborted-marker', mv('aborted')), '', '<span>x</span>'),
+    el('div', 'failed-banner', pair('maka-turn-failed-banner', mv('failed-banner')), '',
+      '<span>x</span>' + el('span', 'failed-recovery', pair('maka-turn-failed-recovery', mv('failed-recovery')), '', '<span>x</span>')),
+  ].join('\n');
+};
 
 const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderTopStyle', 'borderTopLeftRadius', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'fontVariantNumeric', 'whiteSpace', 'textAlign', 'cursor'];
+const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery'];
 
 function pageHtml(cssPath, side) {
-  const els = specs.map((s) => {
-    const kid = s.tag === 'button' ? '<svg width="11" height="11"></svg><span>复制中…</span>' : '<span>x</span>';
-    return `<${s.tag} id="${s.id}" class="${s[side]}" ${s.attrs}>${kid}</${s.tag}>`;
-  }).join('\n');
   return `<!doctype html><html><head><meta charset="utf8"><link rel="stylesheet" href="${pathToFileURL(cssPath).href}"></head>
-<body style="background:#fff"><div data-slot="message" data-role="assistant"><div class="maka-turn" style="width:680px">${els}</div></div></body></html>`;
+<body style="background:#fff"><div data-slot="message" data-role="assistant"><div class="maka-turn" style="width:680px">${TREE(side)}</div></div></body></html>`;
 }
 
-async function read(win, html) {
-  await win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
-  return win.webContents.executeJavaScript(`(${JSON.stringify(specs.map((s) => s.id))}).reduce((acc, id) => {
+async function read(win, cssPath, side) {
+  await win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(pageHtml(cssPath, side)));
+  return win.webContents.executeJavaScript(`(${JSON.stringify(IDS)}).reduce((acc, id) => {
     const cs = getComputedStyle(document.getElementById(id));
     const o = {}; for (const p of ${JSON.stringify(PROPS)}) o[p] = cs[p];
     acc[id] = o; return acc;
@@ -105,16 +131,15 @@ async function read(win, html) {
 app.commandLine.appendSwitch('disable-gpu');
 app.whenReady().then(async () => {
   const win = new BrowserWindow({ show: false, width: 900, height: 700, webPreferences: { sandbox: false } });
-  const mainCS = await read(win, pageHtml(mainCssPath, 'main'));
-  const headCS = await read(win, pageHtml(headCssPath, 'head'));
+  const main = await read(win, mainCssPath, 'main');
+  const head = await read(win, headCssPath, 'head');
   let total = 0;
-  for (const s of specs) {
-    const m = mainCS[s.id], h = headCS[s.id];
-    const diffs = PROPS.filter((p) => m[p] !== h[p]).map((p) => `${p}: main=${JSON.stringify(m[p])} head=${JSON.stringify(h[p])}`);
+  for (const id of IDS) {
+    const diffs = PROPS.filter((p) => main[id][p] !== head[id][p]).map((p) => `${p}: main=${JSON.stringify(main[id][p])} head=${JSON.stringify(head[id][p])}`);
     total += diffs.length;
-    if (diffs.length === 0) console.log(`  ok ${s.id}: ${PROPS.length}/${PROPS.length} identical`);
-    else { console.log(`  XX ${s.id}: ${diffs.length} DIFF`); for (const d of diffs) console.log(`       ${d}`); }
+    if (diffs.length === 0) console.log(`  ok ${id}: ${PROPS.length}/${PROPS.length} identical`);
+    else { console.log(`  XX ${id}: ${diffs.length} DIFF`); for (const d of diffs) console.log(`       ${d}`); }
   }
-  console.log(`\n${specs.length} elements x ${PROPS.length} properties — TOTAL DIFFS: ${total}`);
+  console.log(`\n${IDS.length} resting element/state rows x ${PROPS.length} properties — TOTAL DIFFS: ${total}`);
   app.exit(total === 0 ? 0 : 1);
 });

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -103,6 +103,10 @@ const TREE = (side) => {
   const el = (tag, id, p, attrs, kids = '') => `<${tag} id="${id}" class="${C(p)}" ${attrs}>${kids}</${tag}>`;
   const action = (id, p, attrs) => el('button', id, p, `${attrs} type="button"`, '<svg width="11" height="11"></svg><span>复制中…</span>');
   const chip = (id) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model"', '<span>x</span>');
+  // Every other chip `data-[kind]` (and the in-progress `data-[state]`) gets a
+  // row too, so the tools tint / duration+tokens tabular-nums / in-progress
+  // accent+semibold are diffed for real, not only pinned as source strings.
+  const kindChip = (id, attrs) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), attrs, '<span>x</span>');
   // The "切换" pill nests inside a model chip carrying `data-switched=true`,
   // exactly as TurnSummary renders it — both the switched-model chip path and
   // the pill itself are migrated variants, so each is measured as its own row.
@@ -111,7 +115,12 @@ const TREE = (side) => {
       '<code>m</code>' + el('span', pillId, pair('maka-turn-summary-chip-switched', mv('summary-switched')), '', '切换'));
   return [
     el('div', 'summary', pair('maka-turn-summary', mv('summary')), '',
-      chip('summary-chip-1') + chip('summary-chip-2') + switchedChip('summary-chip-switched', 'summary-switched')),
+      chip('summary-chip-1') + chip('summary-chip-2')
+      + kindChip('summary-chip-tools', 'data-kind="tools"')
+      + kindChip('summary-chip-duration', 'data-kind="duration"')
+      + kindChip('summary-chip-tokens', 'data-kind="tokens"')
+      + kindChip('summary-chip-inprogress', 'data-kind="duration" data-state="in-progress"')
+      + switchedChip('summary-chip-switched', 'summary-switched')),
     el('div', 'footer', pair('maka-turn-footer', mv('footer')), 'role="toolbar"',
       action('footer-rest', fa('quiet'), '') +
       action('footer-pending', fa('secondary'), 'data-pending="true" aria-busy="true"') +
@@ -131,7 +140,7 @@ const TREE = (side) => {
 };
 
 const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderTopStyle', 'borderTopLeftRadius', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'fontVariantNumeric', 'whiteSpace', 'textAlign', 'cursor'];
-const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-switched', 'summary-switched', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery'];
+const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools', 'summary-chip-duration', 'summary-chip-tokens', 'summary-chip-inprogress', 'summary-chip-switched', 'summary-switched', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery'];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).
 // summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -14,6 +14,14 @@
  * byte/pixel image diffs are too jittery to gate on (font rasterization
  * drifts ~70/88 PNGs between runs); computed style does not.
  *
+ * The CSS is INLINED into a `<style>` block of a file:// temp document, NOT
+ * linked. An earlier version `<link>`ed the bundle from a `data:`/`file:`
+ * page, which silently applied NOTHING (cross-origin subresource): every
+ * element read its UA default identically on both sides, so the diff was 0
+ * but VACUOUS. Inlining removes the subresource, so the renderer CSS truly
+ * applies — verify any future change by spot-checking a real value (e.g.
+ * `footer-rest` must read `border-radius: 8px`, not the UA `0px`).
+ *
  * What this renders + diffs `main` vs head: the resting box / typography /
  * color / transition style of all 9 migrated families, plus the footer
  * action across resting / pending / copy-pending / copied / failed —
@@ -21,29 +29,28 @@
  * `quiet` shell, which proves that variant switch was visually inert (the
  * reason this PR drops it). The DOM mirrors `TurnView` nesting (chips in a
  * summary, actions in a footer, badges in a lineage row) so positional
- * pseudo-classes and inheritance resolve as in production.
+ * pseudo-classes and inheritance resolve as in production — including the
+ * `summary-switched` "切换" pill nested in a `data-switched` model chip, the
+ * `lineage-row-reverse` container, and the `::before` middot separators on
+ * summary chips / failed-recovery (all migrated variants, all real once the
+ * CSS is inlined).
  *
- * What is NOT rendered here, and why — locked by the cascade contract's
- * exact source-string literals instead (each a LEAF literalization where
- * source == computed holds by construction):
+ * What is STILL not observable here, and why — locked by the cascade
+ * contract's exact source-string literals instead (each a LEAF
+ * literalization where source == computed holds by construction):
  *   - `:hover` / `:focus-visible` / `:focus-within`: a headless
- *     (`show: false`) window has no live pointer/focus, and NEITHER the
- *     DevTools `CSS.forcePseudoState` protocol NOR a synthetic
- *     `sendInputEvent` mouse-move changes what `getComputedStyle` returns
- *     here (verified: resting == "hovered"). So these can't be rendered in
- *     this harness. Their NON-leaf merge winner is instead a deterministic
- *     specificity fact: the marker's `[&:hover:not(:disabled)]` (0,3,0)
- *     outranks UiButton quiet's `hover:bg-muted` (0,2,0), exactly as the
- *     retired `.maka-turn-footer-action:hover:not(:disabled)` did on main.
- *   - the `::before` middot pseudo-elements (summary-chip / failed-recovery):
- *     Tailwind compiles `before:content-['·']` through a `--tw-content`
- *     registered `@property`, which `getComputedStyle(el, '::before')` reads
- *     back as `content: none` in this isolated-CSS harness — a rendered
- *     probe would be a misleading green.
- * So this is a rendered proof of the RESTING surface, not a complete
- * screenshot equivalent. (Buttons may also read the UA `buttonface`
- * background here identically on both sides; the diff is what's asserted,
- * not absolute production fidelity for that one property.)
+ *     (`show: false`) window has no live pointer/focus, and `getComputedStyle`
+ *     does NOT reflect a DevTools `CSS.forcePseudoState` force (a known
+ *     Chromium behavior — the force drives the inspector, not in-page
+ *     computed style; verified resting == forced-"hover" even with the CSS
+ *     applied). The rules themselves DO compile into the bundle (greppable:
+ *     `…:hover:not(:disabled){background-color:oklch(…/ .05)}`). Their
+ *     NON-leaf merge winner is a deterministic specificity fact: the marker's
+ *     `[&:hover:not(:disabled)]` (0,3,0) outranks UiButton quiet's
+ *     `hover:bg-muted` (0,2,0), exactly as the retired
+ *     `.maka-turn-footer-action:hover:not(:disabled)` did on main.
+ * So this is a rendered proof of the RESTING surface plus the `::before`
+ * middots, with only the interactive pseudo-states pinned by source string.
  *
  * Usage (run from repo root, needs Electron + both built CSS bundles):
  *
@@ -62,8 +69,9 @@
  */
 
 import { app, BrowserWindow } from 'electron';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
@@ -95,8 +103,15 @@ const TREE = (side) => {
   const el = (tag, id, p, attrs, kids = '') => `<${tag} id="${id}" class="${C(p)}" ${attrs}>${kids}</${tag}>`;
   const action = (id, p, attrs) => el('button', id, p, `${attrs} type="button"`, '<svg width="11" height="11"></svg><span>复制中…</span>');
   const chip = (id) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model"', '<span>x</span>');
+  // The "切换" pill nests inside a model chip carrying `data-switched=true`,
+  // exactly as TurnSummary renders it — both the switched-model chip path and
+  // the pill itself are migrated variants, so each is measured as its own row.
+  const switchedChip = (id, pillId) =>
+    el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model" data-switched="true"',
+      '<code>m</code>' + el('span', pillId, pair('maka-turn-summary-chip-switched', mv('summary-switched')), '', '切换'));
   return [
-    el('div', 'summary', pair('maka-turn-summary', mv('summary')), '', chip('summary-chip-1') + chip('summary-chip-2')),
+    el('div', 'summary', pair('maka-turn-summary', mv('summary')), '',
+      chip('summary-chip-1') + chip('summary-chip-2') + switchedChip('summary-chip-switched', 'summary-switched')),
     el('div', 'footer', pair('maka-turn-footer', mv('footer')), 'role="toolbar"',
       action('footer-rest', fa('quiet'), '') +
       action('footer-pending', fa('secondary'), 'data-pending="true" aria-busy="true"') +
@@ -104,7 +119,11 @@ const TREE = (side) => {
       action('footer-copied', fa('quiet'), 'data-copy-feedback="copied"') +
       action('footer-failed', fa('quiet'), 'data-copy-feedback="failed"')),
     el('div', 'lineage-row', pair('maka-turn-lineage-row', mv('lineage-row')), '',
-      action('lineage-fwd', lb, 'data-direction="forward"') + action('lineage-rev', lb, 'data-direction="reverse"')),
+      action('lineage-fwd', lb, 'data-direction="forward"')),
+    // Reverse lineage lives in its own `-reverse` container (margin-top 4px vs
+    // the forward row's 2px), a separately migrated container variant.
+    el('div', 'lineage-row-reverse', pair('maka-turn-lineage-row maka-turn-lineage-row-reverse', mv('lineage-row-reverse')), '',
+      action('lineage-rev', lb, 'data-direction="reverse"')),
     el('div', 'aborted', pair('maka-turn-aborted-marker', mv('aborted')), '', '<span>x</span>'),
     el('div', 'failed-banner', pair('maka-turn-failed-banner', mv('failed-banner')), '',
       '<span>x</span>' + el('span', 'failed-recovery', pair('maka-turn-failed-recovery', mv('failed-recovery')), '', '<span>x</span>')),
@@ -112,20 +131,43 @@ const TREE = (side) => {
 };
 
 const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderTopStyle', 'borderTopLeftRadius', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'fontVariantNumeric', 'whiteSpace', 'textAlign', 'cursor'];
-const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery'];
+const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-switched', 'summary-switched', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery'];
+// `::before` middot separators are now diffed for real (they render once the
+// CSS is inlined — the old `<link>` build couldn't apply them, masking this).
+// summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);
+// failed-recovery carries the always-on `before:content-['·']`.
+const PSEUDO_IDS = ['summary-chip-2', 'failed-recovery'];
+const PSEUDO_PROPS = ['content', 'marginRight', 'color', 'fontWeight'];
 
-function pageHtml(cssPath, side) {
-  return `<!doctype html><html><head><meta charset="utf8"><link rel="stylesheet" href="${pathToFileURL(cssPath).href}"></head>
+function pageHtml(cssText, side) {
+  // INLINE the stylesheet as a <style> block (not a <link href=file://…>): the
+  // page is loaded from a file:// temp document, and a file:// page silently
+  // refuses to apply a cross-origin file:// <link> subresource — which made an
+  // earlier <link>-based version a false green (every element read its UA
+  // default identically on both sides, so the diff was 0 but vacuous). Inlining
+  // removes the subresource entirely, so the real renderer CSS actually applies.
+  return `<!doctype html><html><head><meta charset="utf8"><style>${cssText}</style></head>
 <body style="background:#fff"><div data-slot="message" data-role="assistant"><div class="maka-turn" style="width:680px">${TREE(side)}</div></div></body></html>`;
 }
 
 async function read(win, cssPath, side) {
-  await win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(pageHtml(cssPath, side)));
-  return win.webContents.executeJavaScript(`(${JSON.stringify(IDS)}).reduce((acc, id) => {
-    const cs = getComputedStyle(document.getElementById(id));
-    const o = {}; for (const p of ${JSON.stringify(PROPS)}) o[p] = cs[p];
-    acc[id] = o; return acc;
-  }, {})`);
+  const tmp = join(tmpdir(), `chat-marker-${side}.html`);
+  writeFileSync(tmp, pageHtml(readFileSync(cssPath, 'utf8'), side));
+  await win.loadFile(tmp);
+  return win.webContents.executeJavaScript(`(() => {
+    const acc = {};
+    for (const id of ${JSON.stringify(IDS)}) {
+      const cs = getComputedStyle(document.getElementById(id));
+      const o = {}; for (const p of ${JSON.stringify(PROPS)}) o[p] = cs[p];
+      acc[id] = o;
+    }
+    for (const id of ${JSON.stringify(PSEUDO_IDS)}) {
+      const cs = getComputedStyle(document.getElementById(id), '::before');
+      const o = {}; for (const p of ${JSON.stringify(PSEUDO_PROPS)}) o[p] = cs[p];
+      acc[id + '::before'] = o;
+    }
+    return acc;
+  })()`);
 }
 
 app.commandLine.appendSwitch('disable-gpu');
@@ -133,13 +175,17 @@ app.whenReady().then(async () => {
   const win = new BrowserWindow({ show: false, width: 900, height: 700, webPreferences: { sandbox: false } });
   const main = await read(win, mainCssPath, 'main');
   const head = await read(win, headCssPath, 'head');
+  const ROWS = [
+    ...IDS.map((id) => [id, PROPS]),
+    ...PSEUDO_IDS.map((id) => [`${id}::before`, PSEUDO_PROPS]),
+  ];
   let total = 0;
-  for (const id of IDS) {
-    const diffs = PROPS.filter((p) => main[id][p] !== head[id][p]).map((p) => `${p}: main=${JSON.stringify(main[id][p])} head=${JSON.stringify(head[id][p])}`);
+  for (const [key, props] of ROWS) {
+    const diffs = props.filter((p) => main[key][p] !== head[key][p]).map((p) => `${p}: main=${JSON.stringify(main[key][p])} head=${JSON.stringify(head[key][p])}`);
     total += diffs.length;
-    if (diffs.length === 0) console.log(`  ok ${id}: ${PROPS.length}/${PROPS.length} identical`);
-    else { console.log(`  XX ${id}: ${diffs.length} DIFF`); for (const d of diffs) console.log(`       ${d}`); }
+    if (diffs.length === 0) console.log(`  ok ${key}: ${props.length}/${props.length} identical`);
+    else { console.log(`  XX ${key}: ${diffs.length} DIFF`); for (const d of diffs) console.log(`       ${d}`); }
   }
-  console.log(`\n${IDS.length} resting element/state rows x ${PROPS.length} properties — TOTAL DIFFS: ${total}`);
+  console.log(`\n${IDS.length} resting element/state rows + ${PSEUDO_IDS.length} ::before middots — TOTAL DIFFS: ${total}`);
   app.exit(total === 0 ? 0 : 1);
 });

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Zero-visual proof for the chat `Marker` migration (#332 / PR2 #337).
+ *
+ * #332 requires the governance pass to be "locked by computed-style /
+ * cascade contract tests + before/after screenshots". The cascade
+ * contract tests (apps/desktop/.../chat-marker-cascade-contract.test.ts,
+ * packages/ui/.../chat-primitives.test.ts) assert the source strings.
+ * This script is the rendered-style half: a re-runnable before/after
+ * check that loads the REAL built renderer CSS from both `main` and the
+ * PR branch into a headless window and diffs `getComputedStyle` for every
+ * migrated chrome element. It is the deterministic equivalent of a
+ * before/after screenshot — `scripts/diff-screenshots.mjs` documents why
+ * byte/pixel image diffs are too jittery to gate on (font rasterization
+ * drifts ~70/88 PNGs between runs); computed style does not drift.
+ *
+ * Each element is wrapped in the same
+ * `[data-slot=message][data-role=assistant] > .maka-turn` ancestor so the
+ * descendant measure-column re-anchors that the retired `tool-output.css`
+ * applied on `main` still take effect — an apples-to-apples comparison.
+ *
+ * Usage (run from repo root, needs Electron + both built CSS bundles):
+ *
+ *   # 1. Build THIS branch's renderer CSS:
+ *   npm --workspace @maka/desktop run build:renderer
+ *   cp apps/desktop/dist/renderer/assets/*.css /tmp/head.css
+ *   # 2. Build the @maka/ui dist this script imports the cva tables from:
+ *   npm --workspace @maka/ui run build
+ *   # 3. Build `main`'s renderer CSS the same way from a clean checkout of
+ *   #    the 6 migrated files, save to /tmp/main.css, restore HEAD.
+ *   # 4. Diff:
+ *   npx electron scripts/check-chat-marker-computed-style.mjs /tmp/main.css /tmp/head.css
+ *
+ * Exits 0 when every migrated element is identical across both bundles,
+ * non-zero (with a per-property diff dump) otherwise.
+ */
+
+import { app, BrowserWindow } from 'electron';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pathToFileURL } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const uiDist = pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/ui.js')).href;
+const chatDist = pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href;
+const { buttonVariants, cn } = await import(uiDist);
+const { markerVariants } = await import(chatDist);
+
+const mainCssPath = process.argv[2] && resolve(process.argv[2]);
+const headCssPath = process.argv[3] && resolve(process.argv[3]);
+if (!mainCssPath || !headCssPath || !existsSync(mainCssPath) || !existsSync(headCssPath)) {
+  console.error('usage: npx electron scripts/check-chat-marker-computed-style.mjs <main.css> <head.css>');
+  console.error('(see the file header for how to build the two renderer CSS bundles)');
+  process.exit(2);
+}
+
+const bv = (variant, size) => buttonVariants({ variant, size });
+const mv = (v) => markerVariants({ variant: v });
+
+// For each migrated element: the class string `main` rendered (UiButton
+// `sm` + bespoke `.maka-turn-*`, or pure bespoke) vs what the PR branch
+// renders (UiButton `nav` + marker shell, or pure marker). The footer
+// action is `quiet` in EVERY state on the PR branch — pending no longer
+// switches the Button to `secondary`; the marker shell owns the pixels —
+// so its `head` column is always `quiet`, matched against `main`'s
+// pending-time `secondary` to prove that switch was visually inert.
+const footerMain = (variant, attrs) => ({ main: cn(bv(variant, 'sm'), 'maka-turn-footer-action'), head: cn(bv('quiet', 'nav'), mv('footer-action')), attrs });
+const specs = [
+  { id: 'footer-rest', tag: 'button', ...footerMain('quiet', '') },
+  { id: 'footer-pending', tag: 'button', ...footerMain('secondary', 'data-pending="true" aria-busy="true"') },
+  { id: 'footer-copy-pending', tag: 'button', ...footerMain('secondary', 'data-pending="true" data-copy-feedback="pending" aria-busy="true" disabled aria-disabled="true"') },
+  { id: 'footer-copied', tag: 'button', ...footerMain('quiet', 'data-copy-feedback="copied"') },
+  { id: 'footer-failed', tag: 'button', ...footerMain('quiet', 'data-copy-feedback="failed"') },
+  { id: 'lineage-fwd', tag: 'button', attrs: 'data-direction="forward"', main: cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), head: cn(bv('quiet', 'nav'), mv('lineage-badge')) },
+  { id: 'lineage-rev', tag: 'button', attrs: 'data-direction="reverse"', main: cn(bv('quiet', 'sm'), 'maka-turn-lineage-badge'), head: cn(bv('quiet', 'nav'), mv('lineage-badge')) },
+  { id: 'summary', tag: 'div', attrs: '', main: 'maka-turn-summary', head: mv('summary') },
+  { id: 'summary-chip', tag: 'span', attrs: 'data-kind="model"', main: 'maka-turn-summary-chip', head: mv('summary-chip') },
+  { id: 'failed-banner', tag: 'div', attrs: '', main: 'maka-turn-failed-banner', head: mv('failed-banner') },
+  { id: 'footer', tag: 'div', attrs: '', main: 'maka-turn-footer', head: mv('footer') },
+  { id: 'lineage-row', tag: 'div', attrs: '', main: 'maka-turn-lineage-row', head: mv('lineage-row') },
+  { id: 'aborted', tag: 'div', attrs: '', main: 'maka-turn-aborted-marker', head: mv('aborted') },
+];
+
+const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderTopStyle', 'borderTopLeftRadius', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'fontVariantNumeric', 'whiteSpace', 'textAlign', 'cursor'];
+
+function pageHtml(cssPath, side) {
+  const els = specs.map((s) => {
+    const kid = s.tag === 'button' ? '<svg width="11" height="11"></svg><span>复制中…</span>' : '<span>x</span>';
+    return `<${s.tag} id="${s.id}" class="${s[side]}" ${s.attrs}>${kid}</${s.tag}>`;
+  }).join('\n');
+  return `<!doctype html><html><head><meta charset="utf8"><link rel="stylesheet" href="${pathToFileURL(cssPath).href}"></head>
+<body style="background:#fff"><div data-slot="message" data-role="assistant"><div class="maka-turn" style="width:680px">${els}</div></div></body></html>`;
+}
+
+async function read(win, html) {
+  await win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+  return win.webContents.executeJavaScript(`(${JSON.stringify(specs.map((s) => s.id))}).reduce((acc, id) => {
+    const cs = getComputedStyle(document.getElementById(id));
+    const o = {}; for (const p of ${JSON.stringify(PROPS)}) o[p] = cs[p];
+    acc[id] = o; return acc;
+  }, {})`);
+}
+
+app.commandLine.appendSwitch('disable-gpu');
+app.whenReady().then(async () => {
+  const win = new BrowserWindow({ show: false, width: 900, height: 700, webPreferences: { sandbox: false } });
+  const mainCS = await read(win, pageHtml(mainCssPath, 'main'));
+  const headCS = await read(win, pageHtml(headCssPath, 'head'));
+  let total = 0;
+  for (const s of specs) {
+    const m = mainCS[s.id], h = headCS[s.id];
+    const diffs = PROPS.filter((p) => m[p] !== h[p]).map((p) => `${p}: main=${JSON.stringify(m[p])} head=${JSON.stringify(h[p])}`);
+    total += diffs.length;
+    if (diffs.length === 0) console.log(`  ok ${s.id}: ${PROPS.length}/${PROPS.length} identical`);
+    else { console.log(`  XX ${s.id}: ${diffs.length} DIFF`); for (const d of diffs) console.log(`       ${d}`); }
+  }
+  console.log(`\n${specs.length} elements x ${PROPS.length} properties — TOTAL DIFFS: ${total}`);
+  app.exit(total === 0 ? 0 : 1);
+});


### PR DESCRIPTION
## Summary

PR2 of #332. Moves the per-turn status / lineage / footer chrome onto a new `@maka/ui` `Marker` chat primitive and retires the bespoke `.maka-turn-*` shell CSS. **Zero visual change** — same governance pass as PR1, not a redesign.

Migrated families: turn **summary** strip + chips (incl. the "切换" pill), **aborted** marker, **failed** banner (+ icon + recovery), **lineage** rows + badges (forward/reverse), and the **footer** + footer actions (also reused by the user-message copy via `MessageCopyButton footerStyle`).

## Why

Closes one more slice of #332: collapse the last bespoke chat-flow island onto the shadcn Base UI + Tailwind substrate (one substrate + a contract-test net). Each retired declaration becomes a literal arbitrary utility that compiles 1:1 to what it replaced, so the cva source string *is* the computed-style proof — the cascade contract asserts the exact strings, no browser needed.

## Scope

Changed:
- `packages/ui/src/primitives/chat.tsx` — add `Marker` + a `markerVariants` cva (kept internal, see below). Literalized pixels / oklch relative-color tints / `var()` tokens; `data-[kind|state|switched|direction|pending|copy-feedback]` conditionals; `::before` middot separators; `[&:hover:not(:disabled)]` / `focus-visible` / `disabled` / `aria-disabled` states. The measure-column geometry the old `tool-output.css` re-anchor applied to summary / lineage / footer is folded into those container variants (location-independent, no longer keyed on a `[data-role=assistant]` descendant).
- `scripts/check-chat-marker-computed-style.mjs` — **new, re-runnable** headless-Electron before/after check (the rendered half of #332's lock): loads the real built renderer CSS from `main` and this branch and diffs `getComputedStyle` for every migrated element, in a DOM that mirrors `TurnView` nesting. Not production code — a verification script alongside `diff-screenshots.mjs`. It **inlines** the bundle into a `<style>` block (an earlier `<link>` form applied no CSS and was a vacuous 0-diff; see Verification). Its header documents what it can and can't observe (resting surface + `::before` middots yes; the interactive `:hover`/`:focus-visible` pseudo-states no — `getComputedStyle` can't see a forced pseudo).
- `packages/ui/src/components.tsx` — wire `TurnSummary` / `TurnView` / `TurnFooterActions` + the reused footer-style copy onto `Marker` / `markerVariants`. No new responsibilities added to the sink. The `footer-action` / `lineage-badge` call sites render as `UiButton variant="quiet" size="nav"` (the bare size), with the geometry `size="sm"` used to supply implicitly — `h-8` (→30px), `text-xs`'s 4/3 line-height (`leading-[16px]`/`[12px]`), and `[border:0]` — folded explicitly into the marker variants so the shell fully owns its own pixels instead of inheriting-then-overriding a size token. The footer action is now `quiet` in **every** state: the pending branch that used to switch the Button to `variant="secondary"` is dropped — the marker shell fully overrides the variant either way, so the switch was visually inert (proven below), and `quiet` is now the single, already-pinned merge path (no untested `secondary` merge, and no reliance on stylesheet source-order to suppress `secondary`'s `border` / `border-border`). Pending still surfaces via `data-pending` / `aria-busy` and the full label+icon stay visible, exactly as before. The `STATUS_FOOTER_PRIORITY` map (all four actions were statically `secondary`) and its stale PR-UI-17 hover-expansion comment are removed; the `priority` variable and its `data-priority` attribute go with them — a grep shows no CSS / test / runtime consumer of `data-priority`, so it was a dead presentation hook (YAGNI).
- Delete retired marker CSS in `maka-tokens.css` (summary), `styles/settings/models.css` (aborted / failed / lineage / footer), and the `styles/tool-output.css` measure-column re-anchor; each removal replaced with a one-line pointer comment.
- Tests: new `chat-marker-cascade-contract.test.ts`; update the PR1 contract's footer re-anchor assertion and the copy-hygiene footer-state assertions to the primitive; add `Marker` hook tests + the non-leaf merge-resolution tests in `@maka/ui`.

Not included:
- **`.maka-turn-thinking` is deferred** (decision surfaced per the issue): the committed-turn reasoning `<details>` styles itself via `summary::before` / `::-webkit-details-marker` pseudo-elements and an `@starting-style` body fade that don't reduce to leaf utilities (the source-string == computed-style proof wouldn't hold), and `maka-tokens.css` already documents an intended Base UI Accordion path for it. It stays hand-written for that later effort.
- The `.maka-turn` container, `.maka-turn-tools`, `.maka-turn-streaming`, and `.maka-turn[data-search-highlight]` are turn-*container* concerns, not markers — kept.
- **The *broader* `footer-action` / `UiButton` consolidation is deferred** (reviewer P3, partial). Done here: `size="sm"`→`"nav"`, and the footer action is now `variant="quiet"` in every state (the inert `secondary` pending branch is gone). What remains deferred is making the `footer-action` shell *stop declaring its own* `focus-visible` / `hover` pixels and instead inherit `UiButton variant="quiet"`'s. That would change the rendered result — the footer's `focus-visible` outline vs `UiButton`'s `ring`, and its `oklch(… / 0.05)` hover tint vs quiet's `bg-muted` — so it's a visual **redesign**, not a zero-visual refactor, and belongs in the follow-up "consolidate the chat button story" PR that owns that decision. The remaining two-cva overlap is pre-existing (`main` already wrapped these in `UiButton`).

## Verification

- `@maka/ui` test: 10/10 (incl. 2 `Marker` hook tests + 2 non-leaf merge-resolution tests).
- desktop `node --test`: 1595/1595 (incl. the new marker cascade contract, updated PR1 contract, updated copy-hygiene contract, and dead-CSS pruning contract).
- `npm run typecheck` clean across workspaces.
- **Zero-visual proof — `main` vs head computed style (reviewer P2), now a committed re-runnable artifact:** `scripts/check-chat-marker-computed-style.mjs` (checked in this PR) loads the *real built renderer CSS* from both `main` and this branch and reads `getComputedStyle` for the migrated chrome on each — footer action (**resting + pending + copy-pending + copied + failed**), forward/reverse lineage badge, summary strip, summary chips for **every `data-kind` (model / tools / duration / tokens) + the in-progress `data-state` + the `summary-switched` "切换" pill** in a `data-switched` chip, failed banner + recovery, footer toolbar, **both the forward `lineage-row` and the `lineage-row-reverse` container**, aborted marker (**22 resting element/state rows**), plus the **`::before` middot separators** on a non-first summary chip and the failed-recovery (**2 pseudo rows**), in a DOM that mirrors `TurnView` nesting (chips in a summary, actions in a footer, badges in a lineage row) so positional pseudo-classes and inheritance resolve as in production, all under the same `[data-slot=message][data-role=assistant] > .maka-turn` ancestor so `main`'s descendant re-anchors apply too. Result across 36 box/typography/color/transition properties per element row (4 per pseudo row): **identical on every row — TOTAL DIFFS: 0**, exits non-zero on any drift. Two findings the rendered diff *caught* that the source strings hid: (a) two latent deltas the old `size="sm"` form had masked (a `text-xs` line-height and `border:0`'s style/color), now folded into the variants and pinned by the merge-resolution unit tests; (b) the pending footer action's `secondary`-vs-`quiet` Button variant is visually inert (the marker shell overrides it), so that branch is dropped — the `footer-pending` / `footer-copy-pending` rows verify `main`'s old `secondary` path is pixel-equal to the new `quiet` one.
  - **The script had to be fixed to mean anything** (surfaced while extending coverage for reviewer P2): an earlier version `<link>`ed the CSS bundle from a `data:`/`file:` page, which a browser silently refuses to apply as a cross-origin subresource — so *every* element read its UA default identically on both sides and the 0-diff was **vacuous**. It now **inlines** the bundle into a `<style>` block of a `file://` temp document; with the CSS actually applied, all 22 element rows read their real literalized values (e.g. `footer-rest` → `border-radius: 8px`, `summary-switched` → `oklch(0.17 0.005 75 / 0.06)` bg / `11px` / `600`, `lineage-row-reverse` → `margin-top: 4px`, the in-progress chip → accent `oklch(0.7 0.135 152)` + `font-weight: 600`), and the `::before` middots resolve to a real `content: "·"` — both previously misattributed to harness limits that were really just the unloaded stylesheet.
  - **Scope of the rendered proof (honest):** it now covers the **resting** surface **and the `::before` middots** for real. The only thing still not observable is the **interactive** pseudo-states — `:hover` / `:focus-visible` / `:focus-within` — because `getComputedStyle` does not reflect a DevTools `CSS.forcePseudoState` force (a known Chromium behavior: the force drives the inspector, not in-page computed style; verified resting == forced-"hover" even with the CSS applied), and a headless window has no live pointer. Those rules **do** compile into the bundle (greppable: `…:hover:not(:disabled){background-color:oklch(… / .05)}`) and are pinned by the **cascade contract's exact source-string literals** (`focus-visible:[outline:2px_solid_var(--accent)]`, the hover tint) in `chat-marker-cascade-contract.test.ts`. The one genuinely **non-leaf** interactive case — does the footer action's hover/focus win the `cn(buttonVariants, markerVariants)` merge? — is a deterministic **specificity** fact, not a rendering question: the marker's `[&:hover:not(:disabled)]` (0,3,0) outranks UiButton quiet's `hover:bg-muted` (0,2,0), exactly as the retired `.maka-turn-footer-action:hover:not(:disabled)` did on `main`. So this script is a rendered proof of the resting surface + middots, with only the interactive states pinned by source string.
- The non-leaf `footer-action` / `lineage-badge` (the only markers that render as `UiButton`) have their `cn(buttonVariants({quiet,nav}), markerVariants(...))` merge pinned: the marker shell's pixels win, and the `buttonVariants` base/quiet conflicts (`gap-2`, `rounded-md`, `text-muted-foreground`) drop out.
- `.maka-turn-*` is shared-by-file-location with `styles/settings/models.css`, but static analysis confirms **no** `.maka-turn-summary/-aborted/-failed/-lineage/-footer` className exists outside `components.tsx` (only doc comments), and `TurnView` renders only in the main chat — so deleting the CSS orphans nothing. (`maka-tokens.css` isn't scanned by `check-dead-css.mjs`; verified by grep + the contract test instead.)

## User-facing impact

None — zero visual change, now proven by a re-runnable `main`-vs-head computed-style diff (0 deltas across 22 resting element/state rows × 36 properties + 2 `::before` middot rows, with the CSS actually applied — see the inlining fix in Verification), and the interactive `:hover`/`:focus-visible` states pinned by the cascade contract source strings (which now also pin every chip `data-kind` conditional and the combined `disabled`/`aria-disabled` + `data-pending` opacity guards).

## Reviewer notes

- The faithful-translation claim rests on literalization: please sanity-check a couple of variant strings in `chat.tsx` against the deleted CSS rather than trusting the diff wholesale.
- `markerVariants` is intentionally **not** re-exported from the `@maka/ui` barrel — only `Marker` + its types are public. The lineage badge / footer action import it by relative path, so the variant table stays an internal, freely-removable styling detail (the whole point of a governance pass). Contrast `buttonVariants`, which is public because it has external consumers.
- When a footer copy button is simultaneously `disabled` and `data-pending` (transient, during a copy click), the pending `0.78` dim now outranks the disabled `0.45` dim by **specificity** — combined-modifier guards (`disabled:data-[pending=true]:opacity-[0.78]`) raise it to `(0,3,0)`, so the value stays `0.78` (matching the retired CSS) regardless of Tailwind emit order, not by source order.
