### PR TITLE
fix(storage): skip legacy migration lock for v1 credentials

### DIFF
--- a/packages/storage/src/__tests__/credential-migration.test.ts
+++ b/packages/storage/src/__tests__/credential-migration.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -102,6 +102,19 @@ describe('migrateLegacyCredentialFile', () => {
 
       await migrateLegacyCredentialFile(path, fakeDecryptor(true));
       assert.equal(await readFile(path, 'utf8'), v1); // unchanged
+    });
+  });
+
+  it('does not wait on a leftover lock when the file is already v1', async () => {
+    await withWorkspace(async (path) => {
+      const v1 = JSON.stringify({ version: 1, values: { 'openai:apiKey': 'sk-1' } });
+      await writeFile(path, v1, 'utf8');
+      await mkdir(`${path}.lock`);
+
+      await migrateLegacyCredentialFile(path, fakeDecryptor(true));
+
+      assert.equal(await readFile(path, 'utf8'), v1); // unchanged
+      await stat(`${path}.lock`); // still owned by whoever left it behind
     });
   });
 

--- a/packages/storage/src/credential-store.ts
+++ b/packages/storage/src/credential-store.ts
@@ -82,13 +82,15 @@ export interface LegacyCredentialDecryptor {
  * One-time migration of a legacy (pre-version, externally-encrypted)
  * credentials.json to the shared v1 plaintext-0600 shape, in place.
  *
- * Runs under the SAME cross-process lock as the live store and re-reads inside
- * it, so a racing process that already migrated (and a live writer that added a
- * newer secret) is never clobbered by a stale snapshot. Idempotent: a no-op
- * when the file is missing or already v1. Fails closed: an unexpected version,
- * a malformed `values`, or a decryptor that is unavailable while there are
- * values to decrypt throws and leaves the file untouched rather than risk
- * tombstoning unrecoverable secrets.
+ * Idempotent: a no-op when the file is missing or already v1. Missing and
+ * current-v1 files return before locking so stale legacy locks do not block
+ * startup. The legacy migration path still runs under the SAME cross-process
+ * lock as the live store and re-reads inside it, so a racing process that
+ * already migrated (and a live writer that added a newer secret) is never
+ * clobbered by a stale snapshot. Fails closed: an unexpected version, a
+ * malformed `values`, or a decryptor that is unavailable while there are values
+ * to decrypt throws and leaves the file untouched rather than risk tombstoning
+ * unrecoverable secrets.
  *
  * Tombstone, not dual-active: a successful run rewrites every value as
  * plaintext, so no decryptable copy survives.

--- a/packages/storage/src/credential-store.ts
+++ b/packages/storage/src/credential-store.ts
@@ -97,6 +97,21 @@ export async function migrateLegacyCredentialFile(
   path: string,
   decryptor: LegacyCredentialDecryptor,
 ): Promise<void> {
+  let snapshot: string;
+  try {
+    snapshot = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as { code?: string }).code === 'ENOENT') return; // nothing to migrate
+    throw error;
+  }
+
+  try {
+    const parsed = JSON.parse(snapshot) as { version?: number };
+    if (parsed.version === CREDENTIAL_SCHEMA_VERSION) return; // already migrated; do not wait on stale legacy locks
+  } catch {
+    // Preserve the fail-closed lock path below for malformed files.
+  }
+
   await withCredentialFileLock(path, async () => {
     let raw: string;
     try {


### PR DESCRIPTION
## Summary

- Skip the legacy credential migration lock when `credentials.json` is already v1.
- Keep legacy and malformed credential files on the existing locked fail-closed path.
- Add a regression test for v1 credentials with a leftover lock directory.

## Why

A stale `credentials.json.lock` directory can make desktop startup repeatedly log `credentials.json is locked by another process` even after the workspace credentials file has already migrated to v1. The migration path should not wait on a legacy lock when there is nothing left to migrate.

Closes: none

## Scope

Changed:

- `migrateLegacyCredentialFile` now returns before acquiring the migration lock when the credentials file is missing or already v1.
- The lock-protected path is preserved for legacy, malformed, and future-version files.
- `credential-migration.test.ts` covers v1 credentials with a leftover lock directory.

Not included:

- No automatic stale-lock deletion or lock stealing.
- No credential schema changes.
- No desktop-layer credential schema parsing.

## Verification

- `npm run -w @maka/storage test`
- `git diff --check HEAD~1..HEAD`
- `npm run -w @maka/desktop dev:hmr` with the real stale `credentials.json.lock` still present; confirmed the credentials migration warning no longer appears.

## User-facing impact

Desktop startup no longer logs the legacy credential migration lock warning for workspaces whose credentials file is already v1, even if an old lock directory remains. No changelog, docs, breaking changes, or migrations required.

## Reviewer notes

The change deliberately does not auto-remove stale locks. Legacy files still use the existing lock behavior so credential migration remains fail-closed.