### PR TITLE
Fix active full compact provider boundary

### DIFF
--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -172,7 +172,8 @@ describe('active full compact PR1 foundation', () => {
     assert.deepEqual(boundary.coverage.runtimeEventIds, block.coverage.runtimeEventIds);
     assert.deepEqual(boundary.sourceHashes, block.coverage.bodySha256);
     assert.equal(boundary.validationStatus, 'valid');
-    assert.match(boundary.renderedText ?? '', /providerSourceIds=/);
+    assert.doesNotMatch(boundary.renderedText ?? '', /providerSourceIds=/);
+    assert.doesNotMatch(boundary.renderedText ?? '', /bodySha256=/);
     assert.deepEqual(boundary.preservedAnchor?.tailProviderMessageSourceIds, ['provider:2:0']);
   });
 
@@ -242,6 +243,33 @@ describe('active full compact PR1 foundation', () => {
       assert.ok(validation?.reasons.includes('invalid_schema_version'), name);
       if (extraReason) assert.ok(validation?.reasons.includes(extraReason), name);
     }
+  });
+
+  test('validation remeasures provider-visible block tokens instead of trusting stale estimates', () => {
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: fixtureMessages(),
+      runtimeEvents: fixtureRuntimeEvents(),
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+      charsPerToken: 1,
+    });
+    block.summary.processState = ['visible provider replacement detail '.repeat(20)];
+    block.estimatedTokens = 1;
+
+    const validation = validateActiveFullCompactBlockForSourceIndex(block, index, {
+      maxBlockEstimatedTokens: 20,
+      charsPerToken: 1,
+    });
+
+    assert.equal(validation.valid, false);
+    assert.ok(validation.reasons.includes('max_block_tokens'));
   });
 
   test('span selection fails open on tool pair split', () => {
@@ -321,6 +349,43 @@ describe('active full compact PR1 foundation', () => {
       estimatedTokensAfter: 100,
     });
     assert.equal(patch.compactionDecisions?.[0]?.estimatedTokensSaved, 400);
+  });
+
+  test('provider-visible archive refs are capped while durable audit refs remain complete', () => {
+    const messages: ModelMessage[] = Array.from({ length: 20 }, (_, index) => ({
+      role: 'tool',
+      content: [{
+        type: 'tool-result',
+        toolCallId: `call-archived-${index}`,
+        toolName: 'Bash',
+        result: activePlaceholder({
+          artifactId: `artifact-call-archived-${String(index).padStart(2, '0')}`,
+          toolCallId: `call-archived-${index}`,
+          bodySha256: String(index % 10).repeat(64),
+        }),
+      }],
+    } as unknown as ModelMessage));
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+    });
+    const block = buildActiveFullCompactBlockFromSummary({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      entries: index.entries,
+      summary: fixtureSummary(index.entries.map((entry) => entry.sourceId)),
+      now: 100,
+    });
+
+    const rendered = renderActiveFullCompactBlock(block);
+
+    assert.equal(block.archiveRefs?.length, 20);
+    assert.match(rendered, /artifact-call-archived-00/);
+    assert.match(rendered, /artifact-call-archived-11/);
+    assert.doesNotMatch(rendered, /artifact-call-archived-12/);
+    assert.match(rendered, /8 additional archive refs retained off-prompt/);
+    assert.doesNotMatch(rendered, /bodySha256/);
   });
 
   test('deterministic summary is bounded and metadata-first', () => {
@@ -570,7 +635,9 @@ describe('active full compact PR1 foundation', () => {
     assert.match(replacementJson, /Next action: retry SSH after boot and rerun verifier/);
     assert.match(replacementJson, /artifact-qemu-boot/);
     assert.match(replacementJson, /artifact-qemu-verify/);
-    assert.match(replacementJson, /providerSourceIds=/);
+    assert.doesNotMatch(replacementJson, /providerSourceIds=/);
+    assert.doesNotMatch(replacementJson, /bodySha256=/);
+    assert.doesNotMatch(replacementJson, /source\(kind=/);
     assert.equal(rewritten.messages[1], messages[messages.length - 1]);
     assert.deepEqual(
       rewritten.block.archiveRefs?.map((ref) => ref.artifactId).sort(),
@@ -579,6 +646,102 @@ describe('active full compact PR1 foundation', () => {
     assert.ok(rewritten.block.summary.commandsTried?.some((command) =>
       command.command.includes('qemu-system-x86_64') && command.sourceIds?.length
     ));
+  });
+
+  test('QEMU/source-ref cliff validates visible replacement while retaining audit metadata', () => {
+    const messages = [
+      ...Array.from({ length: 96 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `QEMU/source-ref covered message ${index} ` + 'raw output chunk '.repeat(6),
+      } as ModelMessage)),
+      { role: 'user', content: 'recent tail remains visible' } as ModelMessage,
+    ];
+
+    const rewritten = rewriteActiveFullCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      policy: {
+        enabled: true,
+        minStepNumber: 1,
+        minRecentMessages: 1,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        maxSummaryEstimatedTokens: 256,
+      },
+      stepNumber: 7,
+      now: 100,
+      charsPerToken: 1,
+    });
+
+    assert.equal(rewritten.decision, 'replaced');
+    assert.equal(rewritten.validation?.valid, true);
+    assert.ok(rewritten.block);
+    assert.equal(rewritten.block.sourceRefs.length, 96);
+    assert.equal(rewritten.block.coverage.providerMessageSourceIds.length, 96);
+    assert.ok(rewritten.block.coverage.bodySha256.length > 80);
+    assert.ok((rewritten.block.estimatedTokens ?? Infinity) <= 2048);
+
+    const visibleReplacement = String((rewritten.messages[0] as { content?: unknown }).content);
+    assert.match(visibleReplacement, /maka_active_full_compact_block/);
+    assert.doesNotMatch(visibleReplacement, /providerSourceIds=/);
+    assert.doesNotMatch(visibleReplacement, /bodySha256=/);
+    assert.doesNotMatch(visibleReplacement, /source\(kind=/);
+
+    const decision = rewritten.diagnosticPatch.compactionDecisions?.[0];
+    assert.equal(decision?.decision, 'replaced');
+    assert.equal(decision?.coverageHashes?.length, rewritten.block.coverage.bodySha256.length);
+  });
+
+  test('selection treats an already-rendered active compact block as the next boundary', () => {
+    const first = rewriteActiveFullCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: textMessages([
+        'old raw payload alpha '.repeat(20),
+        'old assistant payload beta '.repeat(20),
+        'tail after first compact',
+      ]),
+      policy: {
+        enabled: true,
+        minStepNumber: 1,
+        minRecentMessages: 1,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        maxSummaryEstimatedTokens: 512,
+      },
+      stepNumber: 2,
+      now: 100,
+      charsPerToken: 1,
+    });
+    assert.equal(first.decision, 'replaced');
+
+    const messages = [
+      ...first.messages,
+      { role: 'assistant', content: 'post-compact work output '.repeat(20) } as ModelMessage,
+      { role: 'user', content: 'recent tail after second compact' } as ModelMessage,
+    ];
+    const index = buildActiveFullCompactSourceIndex({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      stepNumber: 3,
+      charsPerToken: 1,
+    });
+    const selection = selectActiveFullCompactCoveredSpan(index, {
+      enabled: true,
+      minStepNumber: 1,
+      minRecentMessages: 1,
+      maxActiveEstimatedTokens: 1,
+      highWaterRatio: 0.1,
+      maxSummaryEstimatedTokens: 512,
+    });
+
+    assert.equal(selection.decision, 'selected');
+    if (selection.decision !== 'selected') assert.fail('expected selected');
+    assert.equal(index.activeCompactMessageIndexes?.[0], 0);
+    assert.equal(selection.startMessageIndex > 0, true);
+    assert.equal(selection.entries.some((entry) => entry.messageIndex === 0), false);
   });
 });
 

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1882,6 +1882,9 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.match(secondPrompt, /maka_active_full_compact_block/);
     assert.match(secondPrompt, /artifact-tool-1/);
     assert.equal(secondPrompt.includes('ACTIVE_FULL_COMPACT_RAW_TOOL_OUTPUT'), false);
+    assert.doesNotMatch(secondPrompt, /providerSourceIds=/);
+    assert.doesNotMatch(secondPrompt, /bodySha256=/);
+    assert.doesNotMatch(secondPrompt, /source\(kind=/);
 
     const usageMessage = messages.find((message) =>
       (message as { type?: string }).type === 'token_usage'
@@ -1903,6 +1906,104 @@ describe('AiSdkBackend usage telemetry', () => {
         contextBudget?.highWaterRequestShapeHashBefore,
       );
     }
+  });
+
+  test('active full compact keeps the accepted boundary projection across later AI SDK steps', async () => {
+    const messages: unknown[] = [];
+    const events: SessionEvent[] = [];
+    const rawOne = 'ACTIVE_FULL_COMPACT_BOUNDARY_RAW_ONE'.repeat(160);
+    const rawTwo = 'ACTIVE_FULL_COMPACT_BOUNDARY_RAW_TWO'.repeat(160);
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV3StreamPart[] = streamCalls === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: 'tool-boundary-1',
+                toolName: 'Read',
+                input: JSON.stringify({ path: 'one.md' }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+              },
+            ]
+          : streamCalls === 2
+            ? [
+                { type: 'stream-start', warnings: [] },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'tool-boundary-2',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'two.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } } },
+              ];
+        return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        messages.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [{
+        name: 'Read',
+        description: 'Read description',
+        parameters: z.object({ path: z.string() }),
+        permissionRequired: false,
+        impl: async ({ path }) => ({ body: path === 'one.md' ? rawOne : rawTwo }),
+      }],
+      contextBudget: {
+        charsPerToken: 1,
+        activeFullCompact: {
+          enabled: true,
+          minStepNumber: 1,
+          minRecentMessages: 0,
+          maxActiveEstimatedTokens: 1,
+          highWaterRatio: 0.1,
+          maxSummaryEstimatedTokens: 512,
+        },
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(streamCalls, 3);
+    const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })));
+    const thirdPrompt = JSON.stringify(model.doStreamCalls[2]?.prompt.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })));
+    assert.equal(countActiveFullCompactMarkers(secondPrompt), 1);
+    assert.equal(countActiveFullCompactMarkers(thirdPrompt), 2);
+    assert.equal(thirdPrompt.includes('ACTIVE_FULL_COMPACT_BOUNDARY_RAW_ONE'), false);
+    assert.equal(thirdPrompt.includes('ACTIVE_FULL_COMPACT_BOUNDARY_RAW_TWO'), false);
   });
 
   test('active full compact validate_only records diagnostics without replacing the next step prompt', async () => {
@@ -4122,6 +4223,10 @@ function compactPrompt(model: MockLanguageModelV3): unknown {
     role: message.role,
     content: message.content,
   }));
+}
+
+function countActiveFullCompactMarkers(text: string): number {
+  return text.match(/<maka_active_full_compact_block/g)?.length ?? 0;
 }
 
 function modelCallSettings(model: MockLanguageModelV3): unknown {

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -16,6 +16,7 @@ import {
 import { isActiveArchivedToolResultPlaceholder } from './active-tool-result-prune.js';
 
 const DEFAULT_CHARS_PER_TOKEN = 4;
+const MAX_PROVIDER_VISIBLE_ARCHIVE_REFS = 12;
 
 export interface ActiveFullCompactPolicy {
   enabled: boolean;
@@ -94,6 +95,7 @@ export interface ActiveFullCompactSourceIndex {
   stepNumber?: number;
   providerMessageCount: number;
   entries: ActiveFullCompactSourceEntry[];
+  activeCompactMessageIndexes?: number[];
   estimatedTokens: number;
 }
 
@@ -271,10 +273,14 @@ export function buildActiveFullCompactSourceIndex(
   const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
   const runtimeIndex = buildRuntimeEventIndex(input.runtimeEvents ?? [], charsPerToken);
   const entries: ActiveFullCompactSourceEntry[] = [];
+  const activeCompactMessageIndexes: number[] = [];
 
   input.messages.forEach((message, messageIndex) => {
     const role = normalizeProviderRole(message.role);
     const content = (message as { content?: unknown }).content;
+    if (messageContentContainsActiveFullCompactBlock(content)) {
+      activeCompactMessageIndexes.push(messageIndex);
+    }
     if (typeof content === 'string') {
       entries.push(entryFromProviderPart({
         sourceId: providerSourceId(messageIndex),
@@ -331,6 +337,7 @@ export function buildActiveFullCompactSourceIndex(
     ...(input.stepNumber !== undefined ? { stepNumber: input.stepNumber } : {}),
     providerMessageCount: input.messages.length,
     entries,
+    ...(activeCompactMessageIndexes.length > 0 ? { activeCompactMessageIndexes } : {}),
     estimatedTokens: estimateActiveFullCompactTokens(entries),
   };
 }
@@ -377,7 +384,10 @@ export function selectActiveFullCompactCoveredSpan(
 
   const minRecentMessages = Math.max(0, Math.floor(policy.minRecentMessages ?? 1));
   const endExclusive = Math.max(0, index.providerMessageCount - minRecentMessages);
-  const entries = index.entries.filter((entry) => entry.messageIndex < endExclusive);
+  const latestActiveCompactMessageIndex = latestActiveFullCompactMessageIndex(index);
+  const entries = index.entries.filter((entry) =>
+    entry.messageIndex > latestActiveCompactMessageIndex && entry.messageIndex < endExclusive
+  );
   if (entries.length === 0) return skippedSelection('unchanged', 'no_candidate');
   if (entries.some((entry) => !nonEmpty(entry.sourceId) || !nonEmpty(entry.bodySha256))) {
     return skippedSelection('failedOpen', 'source_missing');
@@ -636,8 +646,12 @@ export function rewriteActiveFullCompactInMessages(
     charsPerToken: input.charsPerToken,
     requestShapeHashBefore,
     preActiveContextEstimatedTokens: index.estimatedTokens,
-    postReplacementEstimatedTokens: estimatePostReplacementTokens(index, selection, summary, input.charsPerToken),
   });
+  block.postReplacementEstimatedTokens = estimatePostReplacementTokens(
+    index,
+    selection,
+    estimateActiveFullCompactProviderTokens(block, input.charsPerToken),
+  );
   const validation = validateActiveFullCompactBlockForSourceIndex(block, index, {
     sessionId: input.sessionId,
     turnId: input.turnId,
@@ -734,12 +748,11 @@ export function renderActiveFullCompactBlock(block: ActiveFullCompactBlock): str
     `<maka_active_full_compact_block id="${escapeAttribute(block.blockId)}" high_water="${escapeAttribute(block.highWaterName)}" seq="${block.highWaterSeq}" version="${block.version}">`,
     `summary: ${block.summary.text}`,
     ...renderSummarySections(block.summary),
-    `coverage: turnIds=[${block.coverage.turnIds.join(', ')}], runtimeEventIds=[${block.coverage.runtimeEventIds.join(', ')}], providerSourceIds=[${block.coverage.providerMessageSourceIds.join(', ')}], toolCallIds=[${block.coverage.toolCallIds.join(', ')}], contentKinds=[${block.coverage.contentKinds.join(', ')}], bodySha256=[${block.coverage.bodySha256.join(', ')}]`,
     `limitations: ${block.limitations.join('; ')}`,
-    `sources: ${block.sourceRefs.map(renderSourceRef).join('; ')}`,
     ...(block.archiveRefs && block.archiveRefs.length > 0
-      ? [`archives: ${block.archiveRefs.map(renderArchiveRef).join('; ')}`]
+      ? [`archives: ${renderProviderVisibleArchiveRefs(block.archiveRefs).join('; ')}`]
       : []),
+    `audit: full coverage, source refs, source hashes, and archive refs are retained on the durable active compact block and diagnostics.`,
     '</maka_active_full_compact_block>',
   ];
   return lines.join('\n');
@@ -857,7 +870,7 @@ export function validateActiveFullCompactBlockForSourceIndex(
   }
   const maxBlockTokens = finitePositive(options.maxBlockEstimatedTokens);
   if (maxBlockTokens !== undefined) {
-    const blockTokens = block.estimatedTokens ?? estimateTokens(renderActiveFullCompactBlock(block).length, charsPerToken);
+    const blockTokens = estimateActiveFullCompactProviderTokens(block, charsPerToken);
     if (blockTokens > maxBlockTokens) add('max_block_tokens');
   }
 
@@ -1034,10 +1047,19 @@ function selectedSpanContainsActiveFullCompactBlock(
 ): boolean {
   for (let index = selection.startMessageIndex; index <= selection.endMessageIndex; index += 1) {
     const content = (messages[index] as { content?: unknown } | undefined)?.content;
-    if (typeof content === 'string' && content.includes('maka_active_full_compact_block')) return true;
-    if (stableStringify(content).includes('maka_active_full_compact_block')) return true;
+    if (messageContentContainsActiveFullCompactBlock(content)) return true;
   }
   return false;
+}
+
+function latestActiveFullCompactMessageIndex(index: ActiveFullCompactSourceIndex): number {
+  return Math.max(-1, ...(index.activeCompactMessageIndexes ?? []));
+}
+
+function messageContentContainsActiveFullCompactBlock(content: unknown): boolean {
+  return typeof content === 'string'
+    ? content.includes('maka_active_full_compact_block')
+    : stableStringify(content).includes('maka_active_full_compact_block');
 }
 
 function preservedAnchorAfterSelection(
@@ -1055,16 +1077,20 @@ function preservedAnchorAfterSelection(
 function estimatePostReplacementTokens(
   index: ActiveFullCompactSourceIndex,
   selection: Extract<ActiveFullCompactSelection, { decision: 'selected' }>,
-  summary: ActiveFullCompactSummary,
-  charsPerToken?: number,
+  replacementEstimatedTokens: number,
 ): number {
-  const chars = charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
   const selectedIds = new Set(selection.entries.map((entry) => entry.sourceId));
   const retainedTokens = index.entries
     .filter((entry) => !selectedIds.has(entry.sourceId))
     .reduce((total, entry) => total + entry.estimatedTokens, 0);
-  const summaryTokens = estimateTokens(stableStringify(summary).length, chars);
-  return retainedTokens + summaryTokens;
+  return retainedTokens + replacementEstimatedTokens;
+}
+
+function estimateActiveFullCompactProviderTokens(
+  block: ActiveFullCompactBlock,
+  charsPerToken?: number,
+): number {
+  return estimateTokens(renderActiveFullCompactBlock(block).length, charsPerToken ?? DEFAULT_CHARS_PER_TOKEN);
 }
 
 function maxActiveFullCompactBlockTokens(maxSummaryEstimatedTokens: number | undefined): number | undefined {
@@ -1673,7 +1699,7 @@ function renderSummarySections(summary: ActiveFullCompactSummary): string[] {
   pushSection(lines, 'artifact_paths', summary.artifactPaths);
   if (summary.commandsTried && summary.commandsTried.length > 0) {
     lines.push(`commands_tried: ${summary.commandsTried.map((command) =>
-      `${command.command} => ${command.outcome}${command.sourceIds?.length ? ` [${command.sourceIds.join(', ')}]` : ''}`
+      `${command.command} => ${command.outcome}`
     ).join('; ')}`);
   }
   if (summary.latestVerifierFailure) lines.push(`latest_verifier_failure: ${summary.latestVerifierFailure}`);
@@ -1685,12 +1711,16 @@ function renderSummarySections(summary: ActiveFullCompactSummary): string[] {
   return lines;
 }
 
-function renderSourceRef(ref: ActiveFullCompactSourceRef): string {
-  return `source(kind=${ref.kind}, sourceId=${ref.sourceId}, runtimeEventId=${ref.runtimeEventId ?? ''}, toolCallId=${ref.toolCallId ?? ''}, contentKind=${ref.contentKind}, bodySha256=${ref.bodySha256})`;
+function renderArchiveRef(ref: ActiveFullCompactArchiveRef): string {
+  return `archive(artifactId=${ref.artifactId})`;
 }
 
-function renderArchiveRef(ref: ActiveFullCompactArchiveRef): string {
-  return `archive(kind=${ref.kind}, artifactId=${ref.artifactId}, toolCallId=${ref.toolCallId ?? ''}, bodySha256=${ref.bodySha256})`;
+function renderProviderVisibleArchiveRefs(refs: readonly ActiveFullCompactArchiveRef[]): string[] {
+  const visible = refs.slice(0, MAX_PROVIDER_VISIBLE_ARCHIVE_REFS).map(renderArchiveRef);
+  const hiddenCount = refs.length - visible.length;
+  return hiddenCount > 0
+    ? [...visible, `${hiddenCount} additional archive refs retained off-prompt`]
+    : visible;
 }
 
 function activeArchiveRefToBoundaryArchiveRef(ref: ActiveFullCompactArchiveRef): CompactionArchiveRef {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -230,6 +230,28 @@ function collectPrepareStepToolCallIds(steps: PrepareStepLike['steps']): Set<str
   return out;
 }
 
+interface ActiveFullCompactPrepareStepProjection {
+  sourceSignatures: readonly string[];
+  projectedMessages: readonly ModelMessage[];
+}
+
+function projectAcceptedActiveFullCompactMessages(
+  incomingMessages: readonly ModelMessage[],
+  acceptedProjection: ActiveFullCompactPrepareStepProjection | undefined,
+): ModelMessage[] | undefined {
+  if (!acceptedProjection) return undefined;
+  if (incomingMessages.length < acceptedProjection.sourceSignatures.length) return undefined;
+  for (let index = 0; index < acceptedProjection.sourceSignatures.length; index += 1) {
+    if (modelMessageSignature(incomingMessages[index]!) !== acceptedProjection.sourceSignatures[index]) {
+      return undefined;
+    }
+  }
+  return [
+    ...acceptedProjection.projectedMessages,
+    ...incomingMessages.slice(acceptedProjection.sourceSignatures.length),
+  ];
+}
+
 // ============================================================================
 // Constructor input — single object matches @kabi's BackendRegistry call site
 // ============================================================================
@@ -1411,13 +1433,19 @@ export class AiSdkBackend implements AgentBackend {
     const policy = this.input.contextBudget?.activeFullCompact;
     if (policy?.enabled !== true || policy.mode === 'index_only' || policy.mode === 'off') return undefined;
 
+    let acceptedProjection: ActiveFullCompactPrepareStepProjection | undefined;
     return (options) => {
       const activeToolsForStep = (options as PrepareStepLike & { activeTools?: readonly string[] }).activeTools;
       const dryRun = policy.mode === 'validate_only' || policy.mode === 'prepare_step_dry_run';
+      const incomingMessages = options.messages;
+      const projectedMessages = dryRun
+        ? undefined
+        : projectAcceptedActiveFullCompactMessages(incomingMessages, acceptedProjection);
+      const messagesForRewrite = projectedMessages ?? incomingMessages;
       const rewritten = rewriteActiveFullCompactInMessages({
         sessionId: this.sessionId,
         turnId,
-        messages: options.messages,
+        messages: messagesForRewrite,
         policy,
         runtimeEvents: runtimeEvents?.filter((event) => event.turnId === turnId),
         stepNumber: options.stepNumber,
@@ -1428,7 +1456,14 @@ export class AiSdkBackend implements AgentBackend {
         ...(dryRun ? { dryRunReason: policy.mode } : {}),
       });
       onDiagnosticPatch?.(rewritten.diagnosticPatch);
-      return !dryRun && rewritten.decision === 'replaced' ? { messages: rewritten.messages } : undefined;
+      if (!dryRun && rewritten.decision === 'replaced') {
+        acceptedProjection = {
+          sourceSignatures: incomingMessages.map(modelMessageSignature),
+          projectedMessages: rewritten.messages,
+        };
+        return { messages: rewritten.messages };
+      }
+      return !dryRun && projectedMessages ? { messages: projectedMessages } : undefined;
     };
   }
 
@@ -1868,6 +1903,20 @@ function toolResultOutput(value: unknown, isError: boolean): AiSdkToolResultOutp
 
 function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
+}
+
+function modelMessageSignature(message: ModelMessage): string {
+  return sha256(stableStringifyForSignature(message));
+}
+
+function stableStringifyForSignature(value: unknown): string {
+  if (value === undefined) return '';
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? '';
+  if (Array.isArray(value)) return `[${value.map(stableStringifyForSignature).join(',')}]`;
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) =>
+    `${JSON.stringify(key)}:${stableStringifyForSignature(object[key])}`
+  ).join(',')}}`;
 }
 
 function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolean {


### PR DESCRIPTION
## Summary

Fixes the active full compact `max_block_tokens` cliff from issue #327 by separating the provider-visible compact replacement from durable audit/provenance data.

- Removes provider-visible coverage arrays, source refs, provider source ids, and body hashes from rendered active compact blocks while preserving them on durable `ActiveFullCompactBlock`, compaction boundaries, and diagnostics.
- Treats an accepted active compact replacement as the same-turn boundary for later AI SDK steps by retaining the accepted projection in the `prepareStep` closure.
- Caps provider-visible archive refs and keeps the full archive list off-prompt.
- Recomputes block validation/token accounting from the actual provider-visible replacement instead of trusting stale block estimates.

## Rive

- Workflow: `maka.active-full-compact-boundary-pr4@1`
- Run: `wfrun_a836ea2257404ca896f98346db93f4ce`
- Scheduler: `sched_470d329634ac47838465cd526cde65eb`
- Design artifact: `/tmp/rive-maka-active-full-compact-boundary-pr4-20260628/output/01-active-full-compact-boundary-design.md`
- Implementation artifact: `/tmp/rive-maka-active-full-compact-boundary-pr4-20260628/output/02-active-full-compact-boundary-implementation.md`
- Review artifact: `/tmp/rive-maka-active-full-compact-boundary-pr4-20260628/output/03-active-full-compact-boundary-review.md`

The Rive review found two blockers (same-turn AI SDK projection state and unbounded visible archive refs); this PR includes steward patches and regression tests for both.

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/active-full-compact.test.js`
- `node --test --test-name-pattern "active full compact" packages/runtime/dist/__tests__/ai-sdk-backend.test.js`
- `npm --workspace @maka/runtime run test` (`730 pass / 1 skipped / 0 fail`)
- `git diff --check`

Refs #327
