### PR TITLE
Fix active compact role for OpenAI-compatible providers

### DIFF
--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -451,6 +451,7 @@ describe('active full compact PR1 foundation', () => {
     assert.equal(rewritten.decision, 'replaced');
     assert.equal(rewritten.messages.length, 2);
     assert.equal(rewritten.messages[1], messages[2]);
+    assert.equal((rewritten.messages[0] as { role?: unknown }).role, 'user');
     const rendered = (rewritten.messages[0] as { content?: unknown }).content;
     assert.equal(typeof rendered, 'string');
     assert.match(rendered as string, /maka_active_full_compact_block/);

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1875,11 +1875,18 @@ describe('AiSdkBackend usage telemetry', () => {
     }
 
     assert.equal(streamCalls, 2);
+    const secondPromptMessages = model.doStreamCalls[1]?.prompt ?? [];
     const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt.map((message) => ({
       role: message.role,
       content: message.content,
     })));
     assert.match(secondPrompt, /maka_active_full_compact_block/);
+    assert.equal(secondPromptMessages.some((message) =>
+      message.role === 'user' && JSON.stringify(message.content).includes('maka_active_full_compact_block')
+    ), true);
+    assert.equal(secondPromptMessages.some((message) =>
+      message.role === 'system' && JSON.stringify(message.content).includes('maka_active_full_compact_block')
+    ), false);
     assert.match(secondPrompt, /artifact-tool-1/);
     assert.equal(secondPrompt.includes('ACTIVE_FULL_COMPACT_RAW_TOOL_OUTPUT'), false);
     assert.doesNotMatch(secondPrompt, /providerSourceIds=/);

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -563,7 +563,7 @@ export function buildDeterministicProcessStateActiveFullCompactSummary(input: {
 
 export function activeFullCompactBlockToModelMessage(block: ActiveFullCompactBlock): ModelMessage {
   return {
-    role: 'system',
+    role: 'user',
     content: renderActiveFullCompactBlock(block),
   } as ModelMessage;
 }


### PR DESCRIPTION
## Summary
- emit active full compact replacement blocks as user messages instead of mid-history system messages
- keep the compact block provider-visible while preserving the global system prompt as the only system entry
- add regression coverage for the rewrite helper and AI SDK prompt shape

## Testing
- npm --workspace @maka/runtime run typecheck
- npm --workspace @maka/runtime run build
- node --test dist/__tests__/active-full-compact.test.js
- node --test dist/__tests__/ai-sdk-backend.test.js
- npm --workspace @maka/runtime test
- npm --workspace @maka/headless run typecheck
- npm --workspace @maka/headless run build
- git diff --check HEAD~1..HEAD