### PR TITLE
feat(core): unify model availability readiness

### DIFF
--- a/packages/core/src/__tests__/connection-readiness.test.ts
+++ b/packages/core/src/__tests__/connection-readiness.test.ts
@@ -70,4 +70,25 @@ describe('isConnectionReady — model capability gate', () => {
 
     assert.deepEqual(verdict, { ready: true, model: 'custom-chat' });
   });
+
+  it('returns the normalized model id after validating a whitespace-padded model', () => {
+    assert.deepEqual(
+      isConnectionReady({
+        connection: connection({
+          defaultModel: ' gpt-4.1 ',
+        }),
+        hasSecret: true,
+      }),
+      { ready: true, model: 'gpt-4.1' },
+    );
+
+    assert.deepEqual(
+      isConnectionReady({
+        connection: connection(),
+        hasSecret: true,
+        requestedModel: ' gpt-4.1 ',
+      }),
+      { ready: true, model: 'gpt-4.1' },
+    );
+  });
 });

--- a/packages/core/src/__tests__/connection-readiness.test.ts
+++ b/packages/core/src/__tests__/connection-readiness.test.ts
@@ -71,6 +71,19 @@ describe('isConnectionReady — model capability gate', () => {
     assert.deepEqual(verdict, { ready: true, model: 'custom-chat' });
   });
 
+  it('treats an enumerated fallback model list as the local send gate', () => {
+    const verdict = isConnectionReady({
+      connection: connection({
+        defaultModel: 'custom-chat',
+        models: [{ id: 'relay-static-model' }],
+        modelSource: 'fallback',
+      }),
+      hasSecret: true,
+    });
+
+    assert.deepEqual(verdict, { ready: false, reason: 'model_not_enabled' });
+  });
+
   it('returns the normalized model id after validating a whitespace-padded model', () => {
     assert.deepEqual(
       isConnectionReady({

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -3,11 +3,42 @@ import { describe, it } from 'node:test';
 import {
   buildConnectionModelCatalogEntries,
   buildModelCatalogEntries,
+  evaluateChatModelAvailability,
   validateChatDefaultModel,
 } from '../model-catalog.js';
 import type { LlmConnection, ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('ModelCatalogEntry', () => {
+  it('evaluates chat model availability with live inventory and stale cache semantics', () => {
+    assert.deepEqual(
+      evaluateChatModelAvailability({
+        model: 'glm-removed',
+        models: [{ id: 'glm-4.7' }],
+        modelSource: 'fetched',
+        modelsFetchedAt: 1_800_000_000_000,
+        now: 1_800_000_001_000,
+      }),
+      { ok: false, reason: 'not_in_live_list' },
+    );
+
+    assert.deepEqual(
+      evaluateChatModelAvailability({
+        model: 'claude-sonnet-4-5-20250929',
+        models: [{ id: 'claude-sonnet-4-5-20250929', capabilities: { reasoning: true } }],
+        modelSource: 'fetched',
+        modelsFetchedAt: 1_700_000_000_000,
+        now: 1_800_000_000_000,
+        staleAfterMs: 7 * 24 * 60 * 60 * 1000,
+      }),
+      {
+        ok: true,
+        model: 'claude-sonnet-4-5-20250929',
+        warning: 'stale',
+        entry: { id: 'claude-sonnet-4-5-20250929', capabilities: { reasoning: true } },
+      },
+    );
+  });
+
   it('normalizes Z.ai fetched models as provider_api facts without guessing unknown capabilities', () => {
     const models: ModelInfo[] = [
       { id: 'glm-4.5' },
@@ -62,6 +93,24 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entries[0]?.provenance.modelSource, 'fallback');
     assert.equal(entries[0]?.unavailableReason, 'none');
     assert.equal(entries[0]?.canUseAsChatDefault, true);
+  });
+
+  it('tracks provider inventory, static metadata, and connection default as separate source facts', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'openai',
+      defaultModel: 'gpt-5.5',
+      models: [{ id: 'gpt-5.5' }],
+      modelSource: 'fetched',
+      modelsFetchedAt: 1_800_000_000_000,
+    });
+
+    assert.deepEqual(entry?.provenance.sources, {
+      providerInventory: true,
+      staticCatalog: true,
+      userChoice: ['connection_default'],
+    });
+    assert.equal(entry?.source, 'provider_api');
+    assert.equal(entry?.displayName, 'GPT-5.5');
   });
 
   it('adds a blocked default entry when a live provider list no longer contains the selected model', () => {
@@ -166,7 +215,12 @@ describe('ModelCatalogEntry', () => {
 
     const entries = buildConnectionModelCatalogEntries({
       connection,
-      savedModelIds: ['glm-session', 'glm-daily-review', 'glm-4.7', ' '],
+      savedModelIds: [
+        { id: 'glm-session', source: 'session_model' },
+        { id: 'glm-daily-review', source: 'daily_review_model' },
+        'glm-4.7',
+        ' ',
+      ],
       now: 1_800_000_001_000,
     });
 
@@ -182,6 +236,9 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entries[1]?.source, 'provider_api');
     assert.equal(entries[2]?.source, 'unknown');
     assert.equal(entries[2]?.provenance.userChoice, true);
+    assert.deepEqual(entries[0]?.provenance.sources?.userChoice, ['connection_default']);
+    assert.deepEqual(entries[2]?.provenance.sources?.userChoice, ['session_model']);
+    assert.deepEqual(entries[3]?.provenance.sources?.userChoice, ['daily_review_model']);
   });
 
   it('falls back to provider defaults for a connection without fetched models', () => {

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -135,6 +135,20 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entry?.displayName, 'GPT-5.5');
   });
 
+  it('marks a fetched model as default when the saved default id has surrounding whitespace', () => {
+    const entries = buildModelCatalogEntries({
+      providerType: 'openai',
+      defaultModel: ' gpt-4.1 ',
+      models: [{ id: 'gpt-4.1' }],
+      modelSource: 'fetched',
+    });
+
+    assert.deepEqual(
+      entries.map((entry) => [entry.id, entry.isDefault, entry.provenance.sources?.userChoice]),
+      [['gpt-4.1', true, ['connection_default']]],
+    );
+  });
+
   it('adds a blocked default entry when a live provider list no longer contains the selected model', () => {
     const entries = buildModelCatalogEntries({
       providerType: 'zai-coding-plan',

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -5,6 +5,7 @@ import {
   buildModelCatalogEntries,
   validateChatDefaultModel,
 } from '../model-catalog.js';
+import { isConnectionReady } from '../connection-readiness.js';
 import type { LlmConnection, ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('ModelCatalogEntry', () => {
@@ -149,7 +150,7 @@ describe('ModelCatalogEntry', () => {
     assert.equal(withProviderFailure[0]?.unavailableReason, 'provider_removed');
   });
 
-  it('keeps fallback missing saved choices recoverable instead of treating them as live-list removals', () => {
+  it('keeps fallback missing saved choices visible without making them directly sendable', () => {
     const entries = buildModelCatalogEntries({
       providerType: 'openai-compatible',
       defaultModel: 'custom-default',
@@ -161,11 +162,45 @@ describe('ModelCatalogEntry', () => {
     assert.deepEqual(
       entries.map((entry) => [entry.id, entry.unavailableReason, entry.availability, entry.canUseAsChatDefault]),
       [
-        ['custom-default', 'none', 'available', true],
+        ['custom-default', 'not_in_live_list', 'blocked', false],
         ['relay-static-model', 'none', 'available', true],
-        ['custom-session', 'none', 'available', true],
+        ['custom-session', 'not_in_live_list', 'blocked', false],
       ],
     );
+  });
+
+  it('does not allow fallback missing defaults that the local send gate will reject', () => {
+    const input = {
+      providerType: 'openai-compatible' as const,
+      defaultModel: 'custom-default',
+      models: [{ id: 'relay-static-model' }],
+      modelSource: 'fallback' as const,
+    };
+
+    const [missingDefault] = buildModelCatalogEntries(input);
+    const validation = validateChatDefaultModel(input);
+    const readiness = isConnectionReady({
+      connection: {
+        slug: 'relay',
+        name: 'Relay',
+        providerType: 'openai-compatible',
+        defaultModel: 'custom-default',
+        enabled: true,
+        models: [{ id: 'relay-static-model' }],
+        modelSource: 'fallback',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      hasSecret: true,
+    });
+
+    assert.equal(missingDefault?.id, 'custom-default');
+    assert.equal(missingDefault?.canUseAsChatDefault, false);
+    assert.deepEqual(
+      validation.ok ? validation : { ok: validation.ok, reason: validation.reason },
+      { ok: false, reason: 'not_in_live_list' },
+    );
+    assert.deepEqual(readiness, { ready: false, reason: 'model_not_enabled' });
   });
 
   it('blocks explicitly image-only models from becoming a chat default', () => {

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -39,6 +39,28 @@ describe('ModelCatalogEntry', () => {
     );
   });
 
+  it('keeps auth and provider state ahead of live-list membership failures', () => {
+    assert.deepEqual(
+      evaluateChatModelAvailability({
+        model: 'glm-removed',
+        models: [{ id: 'glm-4.7' }],
+        modelSource: 'fetched',
+        authOk: false,
+      }),
+      { ok: false, reason: 'auth' },
+    );
+
+    assert.deepEqual(
+      evaluateChatModelAvailability({
+        model: 'glm-removed',
+        models: [{ id: 'glm-4.7' }],
+        modelSource: 'fetched',
+        providerAvailable: false,
+      }),
+      { ok: false, reason: 'provider_removed' },
+    );
+  });
+
   it('normalizes Z.ai fetched models as provider_api facts without guessing unknown capabilities', () => {
     const models: ModelInfo[] = [
       { id: 'glm-4.5' },
@@ -142,6 +164,25 @@ describe('ModelCatalogEntry', () => {
     assert.deepEqual(
       validation.ok ? validation : { ok: validation.ok, reason: validation.reason },
       { ok: false, reason: 'not_in_live_list' },
+    );
+  });
+
+  it('keeps fallback missing saved choices recoverable instead of treating them as live-list removals', () => {
+    const entries = buildModelCatalogEntries({
+      providerType: 'openai-compatible',
+      defaultModel: 'custom-default',
+      models: [{ id: 'relay-static-model' }],
+      modelSource: 'fallback',
+      savedModelIds: [{ id: 'custom-session', source: 'session_model' }],
+    });
+
+    assert.deepEqual(
+      entries.map((entry) => [entry.id, entry.unavailableReason, entry.availability, entry.canUseAsChatDefault]),
+      [
+        ['custom-default', 'none', 'available', true],
+        ['relay-static-model', 'none', 'available', true],
+        ['custom-session', 'none', 'available', true],
+      ],
     );
   });
 

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -3,64 +3,11 @@ import { describe, it } from 'node:test';
 import {
   buildConnectionModelCatalogEntries,
   buildModelCatalogEntries,
-  evaluateChatModelAvailability,
   validateChatDefaultModel,
 } from '../model-catalog.js';
 import type { LlmConnection, ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('ModelCatalogEntry', () => {
-  it('evaluates chat model availability with live inventory and stale cache semantics', () => {
-    assert.deepEqual(
-      evaluateChatModelAvailability({
-        model: 'glm-removed',
-        models: [{ id: 'glm-4.7' }],
-        modelSource: 'fetched',
-        modelsFetchedAt: 1_800_000_000_000,
-        now: 1_800_000_001_000,
-      }),
-      { ok: false, reason: 'not_in_live_list' },
-    );
-
-    assert.deepEqual(
-      evaluateChatModelAvailability({
-        model: 'claude-sonnet-4-5-20250929',
-        models: [{ id: 'claude-sonnet-4-5-20250929', capabilities: { reasoning: true } }],
-        modelSource: 'fetched',
-        modelsFetchedAt: 1_700_000_000_000,
-        now: 1_800_000_000_000,
-        staleAfterMs: 7 * 24 * 60 * 60 * 1000,
-      }),
-      {
-        ok: true,
-        model: 'claude-sonnet-4-5-20250929',
-        warning: 'stale',
-        entry: { id: 'claude-sonnet-4-5-20250929', capabilities: { reasoning: true } },
-      },
-    );
-  });
-
-  it('keeps auth and provider state ahead of live-list membership failures', () => {
-    assert.deepEqual(
-      evaluateChatModelAvailability({
-        model: 'glm-removed',
-        models: [{ id: 'glm-4.7' }],
-        modelSource: 'fetched',
-        authOk: false,
-      }),
-      { ok: false, reason: 'auth' },
-    );
-
-    assert.deepEqual(
-      evaluateChatModelAvailability({
-        model: 'glm-removed',
-        models: [{ id: 'glm-4.7' }],
-        modelSource: 'fetched',
-        providerAvailable: false,
-      }),
-      { ok: false, reason: 'provider_removed' },
-    );
-  });
-
   it('normalizes Z.ai fetched models as provider_api facts without guessing unknown capabilities', () => {
     const models: ModelInfo[] = [
       { id: 'glm-4.5' },
@@ -179,6 +126,27 @@ describe('ModelCatalogEntry', () => {
       validation.ok ? validation : { ok: validation.ok, reason: validation.reason },
       { ok: false, reason: 'not_in_live_list' },
     );
+  });
+
+  it('keeps auth and provider state ahead of live-list missing entries', () => {
+    const withAuthFailure = buildModelCatalogEntries({
+      providerType: 'zai-coding-plan',
+      defaultModel: 'glm-removed',
+      models: [{ id: 'glm-4.7' }],
+      modelSource: 'fetched',
+      authOk: false,
+    });
+
+    const withProviderFailure = buildModelCatalogEntries({
+      providerType: 'zai-coding-plan',
+      defaultModel: 'glm-removed',
+      models: [{ id: 'glm-4.7' }],
+      modelSource: 'fetched',
+      providerAvailable: false,
+    });
+
+    assert.equal(withAuthFailure[0]?.unavailableReason, 'auth');
+    assert.equal(withProviderFailure[0]?.unavailableReason, 'provider_removed');
   });
 
   it('keeps fallback missing saved choices recoverable instead of treating them as live-list removals', () => {

--- a/packages/core/src/connection-readiness.ts
+++ b/packages/core/src/connection-readiness.ts
@@ -24,7 +24,10 @@
  */
 
 import { PROVIDER_DEFAULTS, type LlmConnection } from './llm-connections.js';
-import { isModelExplicitlyUnsupportedForChat } from './model-catalog.js';
+import {
+  evaluateChatModelAvailability,
+  type ChatModelAvailabilityReason,
+} from './model-catalog.js';
 
 /**
  * Canonical reasons why an LlmConnection is not ready to send.
@@ -115,18 +118,14 @@ export function isConnectionReady(input: IsConnectionReadyInput): IsConnectionRe
   if (!model) {
     return { ready: false, reason: 'missing_model' };
   }
-  if (connection.models) {
-    const enabled = new Map(connection.models.map((entry) => [entry.id, entry]));
-    if (enabled.size === 0) {
-      return { ready: false, reason: 'empty_model_list' };
-    }
-    const modelEntry = enabled.get(model);
-    if (!modelEntry) {
-      return { ready: false, reason: 'model_not_enabled' };
-    }
-    if (isModelExplicitlyUnsupportedForChat(modelEntry)) {
-      return { ready: false, reason: 'model_not_chat_capable' };
-    }
+  const modelAvailability = evaluateChatModelAvailability({
+    model,
+    models: connection.models,
+    modelSource: connection.modelSource,
+    modelsFetchedAt: connection.modelsFetchedAt,
+  });
+  if (!modelAvailability.ok) {
+    return { ready: false, reason: chatModelAvailabilityReasonToReadiness(modelAvailability.reason) };
   }
   return { ready: true, model };
 }
@@ -151,4 +150,20 @@ function isFakeBackend(connection: Pick<LlmConnection, 'providerType'>): boolean
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
   if (!defaults) return true; // unknown providerType → treat as non-real
   return defaults.backendKind === 'fake';
+}
+
+function chatModelAvailabilityReasonToReadiness(reason: ChatModelAvailabilityReason): ChatConfigurationReason {
+  switch (reason) {
+    case 'missing_model':
+      return 'missing_model';
+    case 'empty_model_list':
+      return 'empty_model_list';
+    case 'not_in_live_list':
+    case 'provider_removed':
+      return 'model_not_enabled';
+    case 'unsupported_for_chat':
+      return 'model_not_chat_capable';
+    case 'auth':
+      return 'missing_api_key';
+  }
 }

--- a/packages/core/src/connection-readiness.ts
+++ b/packages/core/src/connection-readiness.ts
@@ -114,7 +114,7 @@ export function isConnectionReady(input: IsConnectionReadyInput): IsConnectionRe
   if (authKind !== 'none' && !hasSecret) {
     return { ready: false, reason: 'missing_api_key' };
   }
-  const model = requestedModel || connection.defaultModel;
+  const model = (requestedModel || connection.defaultModel)?.trim();
   if (!model) {
     return { ready: false, reason: 'missing_model' };
   }
@@ -127,7 +127,7 @@ export function isConnectionReady(input: IsConnectionReadyInput): IsConnectionRe
   if (!modelAvailability.ok) {
     return { ready: false, reason: chatModelAvailabilityReasonToReadiness(modelAvailability.reason) };
   }
-  return { ready: true, model };
+  return { ready: true, model: modelAvailability.model };
 }
 
 /**

--- a/packages/core/src/connection-readiness.ts
+++ b/packages/core/src/connection-readiness.ts
@@ -24,10 +24,7 @@
  */
 
 import { PROVIDER_DEFAULTS, type LlmConnection } from './llm-connections.js';
-import {
-  evaluateChatModelAvailability,
-  type ChatModelAvailabilityReason,
-} from './model-catalog.js';
+import { isModelExplicitlyUnsupportedForChat } from './model-catalog.js';
 
 /**
  * Canonical reasons why an LlmConnection is not ready to send.
@@ -118,16 +115,24 @@ export function isConnectionReady(input: IsConnectionReadyInput): IsConnectionRe
   if (!model) {
     return { ready: false, reason: 'missing_model' };
   }
-  const modelAvailability = evaluateChatModelAvailability({
-    model,
-    models: connection.models,
-    modelSource: connection.modelSource,
-    modelsFetchedAt: connection.modelsFetchedAt,
-  });
-  if (!modelAvailability.ok) {
-    return { ready: false, reason: chatModelAvailabilityReasonToReadiness(modelAvailability.reason) };
+  if (connection.models) {
+    const enabled = new Map<string, (typeof connection.models)[number]>();
+    for (const entry of connection.models) {
+      const id = entry.id.trim();
+      if (id) enabled.set(id, entry);
+    }
+    if (enabled.size === 0) {
+      return { ready: false, reason: 'empty_model_list' };
+    }
+    const modelEntry = enabled.get(model);
+    if (!modelEntry) {
+      return { ready: false, reason: 'model_not_enabled' };
+    }
+    if (isModelExplicitlyUnsupportedForChat(modelEntry)) {
+      return { ready: false, reason: 'model_not_chat_capable' };
+    }
   }
-  return { ready: true, model: modelAvailability.model };
+  return { ready: true, model };
 }
 
 /**
@@ -150,20 +155,4 @@ function isFakeBackend(connection: Pick<LlmConnection, 'providerType'>): boolean
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
   if (!defaults) return true; // unknown providerType → treat as non-real
   return defaults.backendKind === 'fake';
-}
-
-function chatModelAvailabilityReasonToReadiness(reason: ChatModelAvailabilityReason): ChatConfigurationReason {
-  switch (reason) {
-    case 'missing_model':
-      return 'missing_model';
-    case 'empty_model_list':
-      return 'empty_model_list';
-    case 'not_in_live_list':
-    case 'provider_removed':
-      return 'model_not_enabled';
-    case 'unsupported_for_chat':
-      return 'model_not_chat_capable';
-    case 'auth':
-      return 'missing_api_key';
-  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -649,11 +649,17 @@ export type {
   ModelCatalogAvailability,
   ModelCatalogEntry,
   ModelCatalogPricing,
+  ModelCatalogProvenanceSources,
+  ModelCatalogUserChoiceSource,
   ModelUnavailableReason,
+  SavedModelChoice,
+  ChatModelAvailabilityReason,
+  ChatModelAvailabilityResult,
 } from './model-catalog.js';
 export {
   buildConnectionModelCatalogEntries,
   buildModelCatalogEntries,
+  evaluateChatModelAvailability,
   isModelExplicitlyUnsupportedForChat,
   validateChatDefaultModel,
 } from './model-catalog.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -653,13 +653,10 @@ export type {
   ModelCatalogUserChoiceSource,
   ModelUnavailableReason,
   SavedModelChoice,
-  ChatModelAvailabilityReason,
-  ChatModelAvailabilityResult,
 } from './model-catalog.js';
 export {
   buildConnectionModelCatalogEntries,
   buildModelCatalogEntries,
-  evaluateChatModelAvailability,
   isModelExplicitlyUnsupportedForChat,
   validateChatDefaultModel,
 } from './model-catalog.js';

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -24,6 +24,24 @@ export type ModelUnavailableReason =
 
 export type ModelCatalogAvailability = 'available' | 'warning' | 'blocked';
 
+export type ChatModelAvailabilityReason =
+  | 'missing_model'
+  | 'empty_model_list'
+  | Exclude<ModelUnavailableReason, 'none' | 'stale'>;
+
+export type ChatModelAvailabilityResult =
+  | {
+      ok: true;
+      model: string;
+      entry?: ModelInfo;
+      warning?: Extract<ModelUnavailableReason, 'stale'>;
+    }
+  | {
+      ok: false;
+      reason: ChatModelAvailabilityReason;
+      entry?: ModelInfo;
+    };
+
 export interface KnownModelCapabilities {
   chat?: true;
   vision?: true;
@@ -38,6 +56,25 @@ export interface ModelCatalogPricing {
   cacheReadUsdPer1M?: number;
   cacheWriteUsdPer1M?: number;
   source: 'builtin' | 'user_override';
+}
+
+export type ModelCatalogUserChoiceSource =
+  | 'connection_default'
+  | 'saved_model'
+  | 'session_model'
+  | 'daily_review_model';
+
+export type SavedModelChoice =
+  | string
+  | {
+      id: string;
+      source: Exclude<ModelCatalogUserChoiceSource, 'connection_default'>;
+    };
+
+export interface ModelCatalogProvenanceSources {
+  providerInventory?: true;
+  staticCatalog?: true;
+  userChoice?: ModelCatalogUserChoiceSource[];
 }
 
 export interface ModelCatalogEntry {
@@ -60,6 +97,7 @@ export interface ModelCatalogEntry {
     modelsFetchedAt?: number;
     pricingModelKey?: string;
     userChoice?: true;
+    sources?: ModelCatalogProvenanceSources;
   };
 }
 
@@ -68,7 +106,7 @@ export interface BuildConnectionModelCatalogInput {
     LlmConnection,
     'slug' | 'providerType' | 'defaultModel' | 'models' | 'modelSource' | 'modelsFetchedAt'
   >;
-  savedModelIds?: Iterable<string | undefined | null>;
+  savedModelIds?: Iterable<SavedModelChoice | undefined | null>;
   fallbackModels?: string[];
   now?: number;
   staleAfterMs?: number;
@@ -92,7 +130,7 @@ export interface BuildModelCatalogInput {
   authOk?: boolean;
   pricing?: Iterable<PricingConfig>;
   pricingSource?: 'builtin' | 'user_override';
-  savedModelIds?: Iterable<string | undefined | null>;
+  savedModelIds?: Iterable<SavedModelChoice | undefined | null>;
 }
 
 const DEFAULT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
@@ -107,6 +145,7 @@ export function buildModelCatalogEntries(input: BuildModelCatalogInput): ModelCa
     id,
     ...displayNameForKnownModel(input.providerType, id),
   }));
+  const savedChoiceSources = savedChoiceSourcesById(input.savedModelIds);
   const seen = new Set<string>();
   const entries = rawModels
     .filter((model) => {
@@ -115,18 +154,18 @@ export function buildModelCatalogEntries(input: BuildModelCatalogInput): ModelCa
       seen.add(id);
       return true;
     })
-    .map((model) => makeEntry(input, model, source, modelSource));
+    .map((model) => makeEntry(input, model, source, modelSource, savedChoiceSources));
 
   const defaultModel = input.defaultModel?.trim();
   if (defaultModel && !seen.has(defaultModel)) {
-    entries.unshift(makeMissingDefaultEntry(input, defaultModel, source, modelSource));
+    entries.unshift(makeMissingDefaultEntry(input, defaultModel, modelSource, savedChoiceSources));
     seen.add(defaultModel);
   }
 
-  for (const id of normalizedSavedModelIds(input.savedModelIds)) {
+  for (const id of savedChoiceSources.keys()) {
     if (seen.has(id)) continue;
     seen.add(id);
-    entries.push(makeMissingUserChoiceEntry(input, id, source, modelSource));
+    entries.push(makeMissingUserChoiceEntry(input, id, modelSource, savedChoiceSources));
   }
 
   return entries;
@@ -177,11 +216,58 @@ export function validateChatDefaultModel(input: BuildModelCatalogInput): {
   return { ok: false, reason, entry };
 }
 
+export function evaluateChatModelAvailability(input: {
+  model?: string;
+  models?: ModelInfo[];
+  modelSource?: ModelDiscoverySource;
+  modelsFetchedAt?: number;
+  now?: number;
+  staleAfterMs?: number;
+  providerAvailable?: boolean;
+  authOk?: boolean;
+}): ChatModelAvailabilityResult {
+  const model = input.model?.trim();
+  if (!model) return { ok: false, reason: 'missing_model' };
+  if (input.models) {
+    const entries = new Map(
+      input.models
+        .map((entry): [string, ModelInfo] => [entry.id.trim(), entry])
+        .filter(([id]) => id.length > 0),
+    );
+    if (entries.size === 0) return { ok: false, reason: 'empty_model_list' };
+    const entry = entries.get(model);
+    if (!entry) return { ok: false, reason: 'not_in_live_list' };
+    const unavailableReason = deriveModelUnavailableReason(input, entry);
+    const blockingReason = blockingChatAvailabilityReason(unavailableReason);
+    if (blockingReason) {
+      return { ok: false, reason: blockingReason, entry };
+    }
+    return {
+      ok: true,
+      model,
+      entry,
+      ...(unavailableReason === 'stale' ? { warning: unavailableReason } : {}),
+    };
+  }
+
+  const unavailableReason = deriveModelUnavailableReason(input, { id: model });
+  const blockingReason = blockingChatAvailabilityReason(unavailableReason);
+  if (blockingReason) {
+    return { ok: false, reason: blockingReason };
+  }
+  return {
+    ok: true,
+    model,
+    ...(unavailableReason === 'stale' ? { warning: unavailableReason } : {}),
+  };
+}
+
 function makeEntry(
   input: BuildModelCatalogInput,
   model: ModelInfo,
   source: ModelCatalogEntry['source'],
   modelSource: ModelDiscoverySource,
+  savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
 ): ModelCatalogEntry {
   const unavailableReason = deriveUnavailableReason(input, model);
   const pricing = findPricing(input, model.id);
@@ -204,6 +290,7 @@ function makeEntry(
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
       ...(pricing ? { pricingModelKey: `${input.providerType}:${model.id}` } : {}),
+      sources: provenanceSources(input, model.id, source, savedChoiceSources),
     },
   };
 }
@@ -211,16 +298,12 @@ function makeEntry(
 function makeMissingDefaultEntry(
   input: BuildModelCatalogInput,
   id: string,
-  source: ModelCatalogEntry['source'],
   modelSource: ModelDiscoverySource,
+  savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
 ): ModelCatalogEntry {
-  const unavailableReason = input.providerAvailable === false
-    ? 'provider_removed'
-    : input.authOk === false
-      ? 'auth'
-      : source === 'provider_api'
-        ? 'not_in_live_list'
-        : 'none';
+  const unavailableReason = modelUnavailableReasonFromAvailability(
+    evaluateChatModelAvailability({ ...input, model: id }),
+  );
   return {
     id,
     ...displayNameForKnownModel(input.providerType, id),
@@ -236,6 +319,7 @@ function makeMissingDefaultEntry(
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
+      sources: provenanceSources(input, id, 'unknown', savedChoiceSources),
     },
   };
 }
@@ -243,16 +327,12 @@ function makeMissingDefaultEntry(
 function makeMissingUserChoiceEntry(
   input: BuildModelCatalogInput,
   id: string,
-  source: ModelCatalogEntry['source'],
   modelSource: ModelDiscoverySource,
+  savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
 ): ModelCatalogEntry {
-  const unavailableReason = input.providerAvailable === false
-    ? 'provider_removed'
-    : input.authOk === false
-      ? 'auth'
-      : source === 'provider_api'
-        ? 'not_in_live_list'
-        : 'none';
+  const unavailableReason = modelUnavailableReasonFromAvailability(
+    evaluateChatModelAvailability({ ...input, model: id }),
+  );
   return {
     id,
     ...displayNameForKnownModel(input.providerType, id),
@@ -269,6 +349,7 @@ function makeMissingUserChoiceEntry(
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
       userChoice: true,
+      sources: provenanceSources(input, id, 'unknown', savedChoiceSources),
     },
   };
 }
@@ -284,7 +365,50 @@ function displayNameForKnownModel(providerType: ProviderType, id: string): { dis
   return displayName ? { displayName } : {};
 }
 
+function provenanceSources(
+  input: Pick<BuildModelCatalogInput, 'providerType' | 'defaultModel'>,
+  id: string,
+  source: ModelCatalogEntry['source'],
+  savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+): ModelCatalogProvenanceSources {
+  const userChoice = userChoiceSources(input, id, savedChoiceSources);
+  return {
+    ...(source === 'provider_api' ? { providerInventory: true as const } : {}),
+    ...(source === 'static_catalog' || hasStaticModelMetadata(input.providerType, id)
+      ? { staticCatalog: true as const }
+      : {}),
+    ...(userChoice.length > 0 ? { userChoice } : {}),
+  };
+}
+
+function hasStaticModelMetadata(providerType: ProviderType, id: string): boolean {
+  return Object.keys(lookupModelMetadata(providerType, id)).length > 0;
+}
+
+function userChoiceSources(
+  input: Pick<BuildModelCatalogInput, 'defaultModel'>,
+  id: string,
+  savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+): ModelCatalogUserChoiceSource[] {
+  const sources: ModelCatalogUserChoiceSource[] = [];
+  if (id === input.defaultModel?.trim()) sources.push('connection_default');
+  for (const source of savedChoiceSources.get(id) ?? []) {
+    if (!sources.includes(source)) sources.push(source);
+  }
+  return sources;
+}
+
 function deriveUnavailableReason(input: BuildModelCatalogInput, model: ModelInfo): ModelUnavailableReason {
+  return deriveModelUnavailableReason(input, model);
+}
+
+function deriveModelUnavailableReason(
+  input: Pick<
+    BuildModelCatalogInput,
+    'providerAvailable' | 'authOk' | 'modelSource' | 'modelsFetchedAt' | 'now' | 'staleAfterMs'
+  >,
+  model: ModelInfo,
+): ModelUnavailableReason {
   if (input.providerAvailable === false) return 'provider_removed';
   if (input.authOk === false) return 'auth';
   if (isModelExplicitlyUnsupportedForChat(model)) return 'unsupported_for_chat';
@@ -292,7 +416,25 @@ function deriveUnavailableReason(input: BuildModelCatalogInput, model: ModelInfo
   return 'none';
 }
 
-function isStale(input: BuildModelCatalogInput): boolean {
+function modelUnavailableReasonFromAvailability(result: ChatModelAvailabilityResult): ModelUnavailableReason {
+  if (result.ok) return result.warning ?? 'none';
+  switch (result.reason) {
+    case 'missing_model':
+      return 'not_in_live_list';
+    case 'empty_model_list':
+      return 'not_in_live_list';
+    default:
+      return result.reason;
+  }
+}
+
+function blockingChatAvailabilityReason(
+  reason: ModelUnavailableReason,
+): Exclude<ModelUnavailableReason, 'none' | 'stale'> | null {
+  return reason === 'none' || reason === 'stale' ? null : reason;
+}
+
+function isStale(input: Pick<BuildModelCatalogInput, 'modelSource' | 'modelsFetchedAt' | 'now' | 'staleAfterMs'>): boolean {
   if (input.modelSource !== 'fetched' || input.modelsFetchedAt === undefined) return false;
   const now = input.now ?? Date.now();
   const staleAfterMs = input.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
@@ -331,15 +473,19 @@ function canUseUnavailableReasonAsDefault(reason: ModelUnavailableReason): boole
   return reason === 'none' || reason === 'stale';
 }
 
-function normalizedSavedModelIds(ids: Iterable<string | undefined | null> | undefined): string[] {
-  if (!ids) return [];
-  const result: string[] = [];
-  const seen = new Set<string>();
-  for (const id of ids) {
-    const trimmed = id?.trim();
-    if (!trimmed || seen.has(trimmed)) continue;
-    seen.add(trimmed);
-    result.push(trimmed);
+function savedChoiceSourcesById(
+  choices: Iterable<SavedModelChoice | undefined | null> | undefined,
+): Map<string, ModelCatalogUserChoiceSource[]> {
+  const result = new Map<string, ModelCatalogUserChoiceSource[]>();
+  if (!choices) return result;
+  for (const choice of choices) {
+    if (!choice) continue;
+    const id = typeof choice === 'string' ? choice.trim() : choice.id.trim();
+    if (!id) continue;
+    const source = typeof choice === 'string' ? 'saved_model' : choice.source;
+    const sources = result.get(id) ?? [];
+    if (!sources.includes(source)) sources.push(source);
+    result.set(id, sources);
   }
   return result;
 }

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -228,6 +228,8 @@ export function evaluateChatModelAvailability(input: {
 }): ChatModelAvailabilityResult {
   const model = input.model?.trim();
   if (!model) return { ok: false, reason: 'missing_model' };
+  const providerOrAuthReason = providerOrAuthUnavailableReason(input);
+  if (providerOrAuthReason) return { ok: false, reason: providerOrAuthReason };
   if (input.models) {
     const entries = new Map(
       input.models
@@ -301,9 +303,7 @@ function makeMissingDefaultEntry(
   modelSource: ModelDiscoverySource,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
 ): ModelCatalogEntry {
-  const unavailableReason = modelUnavailableReasonFromAvailability(
-    evaluateChatModelAvailability({ ...input, model: id }),
-  );
+  const unavailableReason = missingEntryUnavailableReason(input, modelSource);
   return {
     id,
     ...displayNameForKnownModel(input.providerType, id),
@@ -330,9 +330,7 @@ function makeMissingUserChoiceEntry(
   modelSource: ModelDiscoverySource,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
 ): ModelCatalogEntry {
-  const unavailableReason = modelUnavailableReasonFromAvailability(
-    evaluateChatModelAvailability({ ...input, model: id }),
-  );
+  const unavailableReason = missingEntryUnavailableReason(input, modelSource);
   return {
     id,
     ...displayNameForKnownModel(input.providerType, id),
@@ -409,23 +407,28 @@ function deriveModelUnavailableReason(
   >,
   model: ModelInfo,
 ): ModelUnavailableReason {
-  if (input.providerAvailable === false) return 'provider_removed';
-  if (input.authOk === false) return 'auth';
+  const providerOrAuthReason = providerOrAuthUnavailableReason(input);
+  if (providerOrAuthReason) return providerOrAuthReason;
   if (isModelExplicitlyUnsupportedForChat(model)) return 'unsupported_for_chat';
   if (isStale(input)) return 'stale';
   return 'none';
 }
 
-function modelUnavailableReasonFromAvailability(result: ChatModelAvailabilityResult): ModelUnavailableReason {
-  if (result.ok) return result.warning ?? 'none';
-  switch (result.reason) {
-    case 'missing_model':
-      return 'not_in_live_list';
-    case 'empty_model_list':
-      return 'not_in_live_list';
-    default:
-      return result.reason;
-  }
+function providerOrAuthUnavailableReason(
+  input: Pick<BuildModelCatalogInput, 'providerAvailable' | 'authOk'>,
+): Extract<ModelUnavailableReason, 'provider_removed' | 'auth'> | null {
+  if (input.providerAvailable === false) return 'provider_removed';
+  if (input.authOk === false) return 'auth';
+  return null;
+}
+
+function missingEntryUnavailableReason(
+  input: Pick<BuildModelCatalogInput, 'providerAvailable' | 'authOk'>,
+  modelSource: ModelDiscoverySource,
+): ModelUnavailableReason {
+  const providerOrAuthReason = providerOrAuthUnavailableReason(input);
+  if (providerOrAuthReason) return providerOrAuthReason;
+  return modelSource === 'fetched' ? 'not_in_live_list' : 'none';
 }
 
 function blockingChatAvailabilityReason(

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -138,6 +138,7 @@ const DEFAULT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 export function buildModelCatalogEntries(input: BuildModelCatalogInput): ModelCatalogEntry[] {
   const liveModels = input.models;
   const modelSource = input.modelSource ?? (liveModels ? 'fetched' : 'fallback');
+  const normalizedDefaultModel = input.defaultModel?.trim();
   const source = liveModels
     ? modelSource === 'fetched' ? 'provider_api' : 'static_catalog'
     : 'static_catalog';
@@ -154,18 +155,17 @@ export function buildModelCatalogEntries(input: BuildModelCatalogInput): ModelCa
       seen.add(id);
       return true;
     })
-    .map((model) => makeEntry(input, model, source, modelSource, savedChoiceSources));
+    .map((model) => makeEntry(input, model, source, modelSource, savedChoiceSources, normalizedDefaultModel));
 
-  const defaultModel = input.defaultModel?.trim();
-  if (defaultModel && !seen.has(defaultModel)) {
-    entries.unshift(makeMissingDefaultEntry(input, defaultModel, modelSource, savedChoiceSources));
-    seen.add(defaultModel);
+  if (normalizedDefaultModel && !seen.has(normalizedDefaultModel)) {
+    entries.unshift(makeMissingDefaultEntry(input, normalizedDefaultModel, modelSource, savedChoiceSources, normalizedDefaultModel));
+    seen.add(normalizedDefaultModel);
   }
 
   for (const id of savedChoiceSources.keys()) {
     if (seen.has(id)) continue;
     seen.add(id);
-    entries.push(makeMissingUserChoiceEntry(input, id, modelSource, savedChoiceSources));
+    entries.push(makeMissingUserChoiceEntry(input, id, modelSource, savedChoiceSources, normalizedDefaultModel));
   }
 
   return entries;
@@ -270,12 +270,14 @@ function makeEntry(
   source: ModelCatalogEntry['source'],
   modelSource: ModelDiscoverySource,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+  normalizedDefaultModel: string | undefined,
 ): ModelCatalogEntry {
-  const unavailableReason = deriveUnavailableReason(input, model);
-  const pricing = findPricing(input, model.id);
+  const normalizedModel = { ...model, id: model.id.trim() };
+  const unavailableReason = deriveUnavailableReason(input, normalizedModel);
+  const pricing = findPricing(input, normalizedModel.id);
   return {
-    id: model.id,
-    ...displayNameForModel(input.providerType, model),
+    id: normalizedModel.id,
+    ...displayNameForModel(input.providerType, normalizedModel),
     providerType: input.providerType,
     ...(input.connectionSlug ? { connectionSlug: input.connectionSlug } : {}),
     source,
@@ -283,16 +285,16 @@ function makeEntry(
     unavailableReason,
     availability: availabilityOf(unavailableReason),
     canUseAsChatDefault: canUseUnavailableReasonAsDefault(unavailableReason),
-    isDefault: model.id === input.defaultModel,
-    capabilities: normalizeCapabilities(model),
+    isDefault: normalizedModel.id === normalizedDefaultModel,
+    capabilities: normalizeCapabilities(normalizedModel),
     ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
     ...(model.maxOutputTokens ? { maxOutputTokens: model.maxOutputTokens } : {}),
     ...(pricing ? { pricing } : {}),
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
-      ...(pricing ? { pricingModelKey: `${input.providerType}:${model.id}` } : {}),
-      sources: provenanceSources(input, model.id, source, savedChoiceSources),
+      ...(pricing ? { pricingModelKey: `${input.providerType}:${normalizedModel.id}` } : {}),
+      sources: provenanceSources(input, normalizedModel.id, source, savedChoiceSources, normalizedDefaultModel),
     },
   };
 }
@@ -302,6 +304,7 @@ function makeMissingDefaultEntry(
   id: string,
   modelSource: ModelDiscoverySource,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+  normalizedDefaultModel: string | undefined,
 ): ModelCatalogEntry {
   const unavailableReason = missingEntryUnavailableReason(input, modelSource);
   return {
@@ -319,7 +322,7 @@ function makeMissingDefaultEntry(
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
-      sources: provenanceSources(input, id, 'unknown', savedChoiceSources),
+      sources: provenanceSources(input, id, 'unknown', savedChoiceSources, normalizedDefaultModel),
     },
   };
 }
@@ -329,6 +332,7 @@ function makeMissingUserChoiceEntry(
   id: string,
   modelSource: ModelDiscoverySource,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+  normalizedDefaultModel: string | undefined,
 ): ModelCatalogEntry {
   const unavailableReason = missingEntryUnavailableReason(input, modelSource);
   return {
@@ -341,13 +345,13 @@ function makeMissingUserChoiceEntry(
     unavailableReason,
     availability: availabilityOf(unavailableReason),
     canUseAsChatDefault: canUseUnavailableReasonAsDefault(unavailableReason),
-    isDefault: id === input.defaultModel,
+    isDefault: id === normalizedDefaultModel,
     capabilities: {},
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
       userChoice: true,
-      sources: provenanceSources(input, id, 'unknown', savedChoiceSources),
+      sources: provenanceSources(input, id, 'unknown', savedChoiceSources, normalizedDefaultModel),
     },
   };
 }
@@ -364,12 +368,13 @@ function displayNameForKnownModel(providerType: ProviderType, id: string): { dis
 }
 
 function provenanceSources(
-  input: Pick<BuildModelCatalogInput, 'providerType' | 'defaultModel'>,
+  input: Pick<BuildModelCatalogInput, 'providerType'>,
   id: string,
   source: ModelCatalogEntry['source'],
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+  normalizedDefaultModel: string | undefined,
 ): ModelCatalogProvenanceSources {
-  const userChoice = userChoiceSources(input, id, savedChoiceSources);
+  const userChoice = userChoiceSources(id, savedChoiceSources, normalizedDefaultModel);
   return {
     ...(source === 'provider_api' ? { providerInventory: true as const } : {}),
     ...(source === 'static_catalog' || hasStaticModelMetadata(input.providerType, id)
@@ -384,12 +389,12 @@ function hasStaticModelMetadata(providerType: ProviderType, id: string): boolean
 }
 
 function userChoiceSources(
-  input: Pick<BuildModelCatalogInput, 'defaultModel'>,
   id: string,
   savedChoiceSources: ReadonlyMap<string, ModelCatalogUserChoiceSource[]>,
+  normalizedDefaultModel: string | undefined,
 ): ModelCatalogUserChoiceSource[] {
   const sources: ModelCatalogUserChoiceSource[] = [];
-  if (id === input.defaultModel?.trim()) sources.push('connection_default');
+  if (id === normalizedDefaultModel) sources.push('connection_default');
   for (const source of savedChoiceSources.get(id) ?? []) {
     if (!sources.includes(source)) sources.push(source);
   }

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -362,12 +362,12 @@ function providerOrAuthUnavailableReason(
 }
 
 function missingEntryUnavailableReason(
-  input: Pick<BuildModelCatalogInput, 'providerAvailable' | 'authOk'>,
+  input: Pick<BuildModelCatalogInput, 'providerAvailable' | 'authOk' | 'models'>,
   modelSource: ModelDiscoverySource,
 ): ModelUnavailableReason {
   const providerOrAuthReason = providerOrAuthUnavailableReason(input);
   if (providerOrAuthReason) return providerOrAuthReason;
-  return modelSource === 'fetched' ? 'not_in_live_list' : 'none';
+  return modelSource === 'fetched' || input.models ? 'not_in_live_list' : 'none';
 }
 
 function isStale(input: Pick<BuildModelCatalogInput, 'modelSource' | 'modelsFetchedAt' | 'now' | 'staleAfterMs'>): boolean {

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -207,7 +207,7 @@ function makeEntry(
   normalizedDefaultModel: string | undefined,
 ): ModelCatalogEntry {
   const normalizedModel = { ...model, id: model.id.trim() };
-  const unavailableReason = deriveUnavailableReason(input, normalizedModel);
+  const unavailableReason = deriveModelUnavailableReason(input, normalizedModel);
   const pricing = findPricing(input, normalizedModel.id);
   return {
     id: normalizedModel.id,
@@ -333,10 +333,6 @@ function userChoiceSources(
     if (!sources.includes(source)) sources.push(source);
   }
   return sources;
-}
-
-function deriveUnavailableReason(input: BuildModelCatalogInput, model: ModelInfo): ModelUnavailableReason {
-  return deriveModelUnavailableReason(input, model);
 }
 
 function deriveModelUnavailableReason(

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -24,24 +24,6 @@ export type ModelUnavailableReason =
 
 export type ModelCatalogAvailability = 'available' | 'warning' | 'blocked';
 
-export type ChatModelAvailabilityReason =
-  | 'missing_model'
-  | 'empty_model_list'
-  | Exclude<ModelUnavailableReason, 'none' | 'stale'>;
-
-export type ChatModelAvailabilityResult =
-  | {
-      ok: true;
-      model: string;
-      entry?: ModelInfo;
-      warning?: Extract<ModelUnavailableReason, 'stale'>;
-    }
-  | {
-      ok: false;
-      reason: ChatModelAvailabilityReason;
-      entry?: ModelInfo;
-    };
-
 export interface KnownModelCapabilities {
   chat?: true;
   vision?: true;
@@ -216,54 +198,6 @@ export function validateChatDefaultModel(input: BuildModelCatalogInput): {
   return { ok: false, reason, entry };
 }
 
-export function evaluateChatModelAvailability(input: {
-  model?: string;
-  models?: ModelInfo[];
-  modelSource?: ModelDiscoverySource;
-  modelsFetchedAt?: number;
-  now?: number;
-  staleAfterMs?: number;
-  providerAvailable?: boolean;
-  authOk?: boolean;
-}): ChatModelAvailabilityResult {
-  const model = input.model?.trim();
-  if (!model) return { ok: false, reason: 'missing_model' };
-  const providerOrAuthReason = providerOrAuthUnavailableReason(input);
-  if (providerOrAuthReason) return { ok: false, reason: providerOrAuthReason };
-  if (input.models) {
-    const entries = new Map(
-      input.models
-        .map((entry): [string, ModelInfo] => [entry.id.trim(), entry])
-        .filter(([id]) => id.length > 0),
-    );
-    if (entries.size === 0) return { ok: false, reason: 'empty_model_list' };
-    const entry = entries.get(model);
-    if (!entry) return { ok: false, reason: 'not_in_live_list' };
-    const unavailableReason = deriveModelUnavailableReason(input, entry);
-    const blockingReason = blockingChatAvailabilityReason(unavailableReason);
-    if (blockingReason) {
-      return { ok: false, reason: blockingReason, entry };
-    }
-    return {
-      ok: true,
-      model,
-      entry,
-      ...(unavailableReason === 'stale' ? { warning: unavailableReason } : {}),
-    };
-  }
-
-  const unavailableReason = deriveModelUnavailableReason(input, { id: model });
-  const blockingReason = blockingChatAvailabilityReason(unavailableReason);
-  if (blockingReason) {
-    return { ok: false, reason: blockingReason };
-  }
-  return {
-    ok: true,
-    model,
-    ...(unavailableReason === 'stale' ? { warning: unavailableReason } : {}),
-  };
-}
-
 function makeEntry(
   input: BuildModelCatalogInput,
   model: ModelInfo,
@@ -434,12 +368,6 @@ function missingEntryUnavailableReason(
   const providerOrAuthReason = providerOrAuthUnavailableReason(input);
   if (providerOrAuthReason) return providerOrAuthReason;
   return modelSource === 'fetched' ? 'not_in_live_list' : 'none';
-}
-
-function blockingChatAvailabilityReason(
-  reason: ModelUnavailableReason,
-): Exclude<ModelUnavailableReason, 'none' | 'stale'> | null {
-  return reason === 'none' || reason === 'stale' ? null : reason;
 }
 
 function isStale(input: Pick<BuildModelCatalogInput, 'modelSource' | 'modelsFetchedAt' | 'now' | 'staleAfterMs'>): boolean {


### PR DESCRIPTION
## Summary

- Add model catalog provenance source facts for provider inventory, static metadata, connection default, saved model, session model, and Daily Review model choices.
- Keep missing fetched defaults blocked; when a fallback/static `models` list is enumerated, missing choices stay visible but are not directly valid chat defaults.
- Normalize model ids consistently in catalog default marking and readiness results.
- Keep `isConnectionReady` as a local send gate with model-list and chat-capability checks, without depending on catalog display helpers.

## Why

Refs #322

This separates catalog display/provenance from runtime readiness so later Settings/Chat/Daily Review surfaces can explain model availability without expanding or coupling the send-path gate.

## Scope

Changed:

- `packages/core/src/model-catalog.ts` builds richer catalog entries with source provenance, missing user-choice entries, enumerated-list blocking for missing catalog entries, auth/provider precedence, stale warnings, and chat-capability default validation.
- `packages/core/src/connection-readiness.ts` trims effective model ids, returns the normalized id on success, and keeps the existing enumerated-model send gate local.
- Core tests cover catalog provenance, trimmed defaults, fetched vs fallback missing entries, auth/provider precedence, stale warnings, chat-capability blocking, fallback/static readiness authority, and normalized readiness model ids.

Not included:

- No UI rendering changes.
- No provider fetcher changes.
- No changes to stored model ids or provider default fallback ordering.
- No public barrel export for a generic availability helper.

## Verification

- `npm run -w @maka/core test`
- `npm run typecheck --workspaces --if-present`
- `npm run check:stale`
- `git diff --check`

## User-facing impact

None directly. This is core catalog/readiness plumbing for clearer model availability behavior.

## Reviewer notes

`isConnectionReady` intentionally keeps `connection.models` as the local send gate even when `modelSource === 'fallback'`; catalog now mirrors that for missing defaults/saved choices when an enumerated list exists, while still displaying those choices for recovery/reselection.