### PR TITLE
Filter task-run metadata from active compact summaries

### DIFF
--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -451,6 +451,7 @@ describe('active full compact PR1 foundation', () => {
     assert.equal(rewritten.decision, 'replaced');
     assert.equal(rewritten.messages.length, 2);
     assert.equal(rewritten.messages[1], messages[2]);
+    assert.equal((rewritten.messages[0] as { role?: unknown }).role, 'user');
     const rendered = (rewritten.messages[0] as { content?: unknown }).content;
     assert.equal(typeof rendered, 'string');
     assert.match(rendered as string, /maka_active_full_compact_block/);

--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -649,6 +649,41 @@ describe('active full compact PR1 foundation', () => {
     ));
   });
 
+  test('QEMU summary drops task-run metadata while keeping operational facts', () => {
+    const rewritten = rewriteActiveFullCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      invocationId: 'inv-1',
+      messages: qemuStyleMessages(),
+      runtimeEvents: qemuStyleRuntimeEventsWithTaskRunMetadata(),
+      policy: {
+        enabled: true,
+        minStepNumber: 1,
+        minRecentMessages: 1,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        maxSummaryEstimatedTokens: 1200,
+      },
+      stepNumber: 4,
+      now: 100,
+      charsPerToken: 4,
+    });
+
+    assert.equal(rewritten.decision, 'replaced');
+    assert.ok(rewritten.block);
+    const replacementJson = JSON.stringify(rewritten.messages);
+    assert.match(replacementJson, /qemu-system-x86_64/);
+    assert.match(replacementJson, /guest reached login prompt/);
+    assert.match(replacementJson, /\/app\/alpine\.iso/);
+    assert.match(replacementJson, /\/boot\/vmlinuz-lts/);
+    assert.doesNotMatch(replacementJson, /task_run_created/);
+    assert.doesNotMatch(replacementJson, /taskRunId/);
+    assert.doesNotMatch(replacementJson, /sessionId/);
+    assert.doesNotMatch(replacementJson, /runtime-events\.jsonl/);
+    assert.doesNotMatch(replacementJson, /maka-task-run/);
+  });
+
   test('QEMU/source-ref cliff validates visible replacement while retaining audit metadata', () => {
     const messages = [
       ...Array.from({ length: 96 }, (_, index) => ({
@@ -969,6 +1004,25 @@ function qemuStyleRuntimeEvents(): RuntimeEvent[] {
       ].join('\n'),
     }),
   ];
+}
+
+function qemuStyleRuntimeEventsWithTaskRunMetadata(): RuntimeEvent[] {
+  return qemuStyleRuntimeEvents().map((event) => {
+    if (event.id !== 'event-qemu-boot-result' || event.content?.kind !== 'function_response') return event;
+    return {
+      ...event,
+      content: {
+        ...event.content,
+        result: [
+          '{"event":"task_run_created","taskRunId":"task-run-1","sessionId":"session-1","runId":"run-1","status":"queued"}',
+          '{"event":"task_run_queued","taskRunId":"task-run-1","invocationId":"inv-1","status":"queued"}',
+          '/Users/likun/work/agent/maka-task-run/runs/sessions/session-1/runs/run-1/runtime-events.jsonl',
+          'qemu-system-x86_64 direct kernel boot used /app/alpine.iso and /boot/vmlinuz-lts',
+          String(event.content.result),
+        ].join('\n'),
+      },
+    };
+  });
 }
 
 function fixtureSummary(sourceIds: string[]): ActiveFullCompactSummary {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -1875,11 +1875,18 @@ describe('AiSdkBackend usage telemetry', () => {
     }
 
     assert.equal(streamCalls, 2);
+    const secondPromptMessages = model.doStreamCalls[1]?.prompt ?? [];
     const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt.map((message) => ({
       role: message.role,
       content: message.content,
     })));
     assert.match(secondPrompt, /maka_active_full_compact_block/);
+    assert.equal(secondPromptMessages.some((message) =>
+      message.role === 'user' && JSON.stringify(message.content).includes('maka_active_full_compact_block')
+    ), true);
+    assert.equal(secondPromptMessages.some((message) =>
+      message.role === 'system' && JSON.stringify(message.content).includes('maka_active_full_compact_block')
+    ), false);
     assert.match(secondPrompt, /artifact-tool-1/);
     assert.equal(secondPrompt.includes('ACTIVE_FULL_COMPACT_RAW_TOOL_OUTPUT'), false);
     assert.doesNotMatch(secondPrompt, /providerSourceIds=/);

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -563,7 +563,7 @@ export function buildDeterministicProcessStateActiveFullCompactSummary(input: {
 
 export function activeFullCompactBlockToModelMessage(block: ActiveFullCompactBlock): ModelMessage {
   return {
-    role: 'system',
+    role: 'user',
     content: renderActiveFullCompactBlock(block),
   } as ModelMessage;
 }

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -1336,6 +1336,7 @@ function splitCandidateLines(text: string): string[] {
       line.length > 0
       && line.length <= 1000
       && !isPlaceholderMetadataLine(line)
+      && !isTaskRunMetadataLine(line)
       && !isLowSignalRawLogLine(line)
     );
 }
@@ -1351,6 +1352,7 @@ function sanitizeFactLine(line: string): string {
 function sanitizePath(value: string): string | undefined {
   const path = value.replace(/[.,;:)>\]}]+$/, '').trim();
   if (path.length < 3 || path.length > 180) return undefined;
+  if (isLowSignalInternalPath(path)) return undefined;
   return path;
 }
 
@@ -1361,10 +1363,40 @@ function isPlaceholderMetadataLine(line: string): boolean {
     || line.includes('originalEstimatedTokens');
 }
 
+function isTaskRunMetadataLine(line: string): boolean {
+  const normalized = line.toLowerCase();
+  if (/\btask_run_(created|queued|started|updated|completed|failed|cancelled)\b/.test(normalized)) return true;
+  if (/\b(taskrunid|task_run_id|runtimeeventid|runtime_event_id|invocationid|invocation_id)\b/.test(normalized)) {
+    return !containsOperationalSignal(normalized);
+  }
+  if (
+    /["'](?:sessionid|session_id|turnid|turn_id|runid|run_id)["']?\s*[:=]/i.test(line)
+    && /["'](?:status|taxonomy|event|type|createdat|created_at)["']?\s*[:=]/i.test(line)
+  ) {
+    return !containsOperationalSignal(normalized);
+  }
+  return false;
+}
+
 function isLowSignalRawLogLine(line: string): boolean {
   return /\b(noise|spam|debug spam)\b/i.test(line)
     || /\braw\b.*\b(log|output|noise|spam)\b/i.test(line)
     || /do[_-]?not[_-]?leak/i.test(line);
+}
+
+function containsOperationalSignal(normalizedLine: string): boolean {
+  return /\b(command|cmd|qemu|xorriso|mount|boot|kernel|initramfs|ssh|sshd|port|pid|exit code|failure|failed|timeout)\b/.test(normalizedLine)
+    || /(?:^|[\s"'])\/(?:app|boot|tmp|workspace|etc|var)\//.test(normalizedLine);
+}
+
+function isLowSignalInternalPath(path: string): boolean {
+  return /\/maka-task-run\//.test(path)
+    || /\/runs\/sessions\//.test(path)
+    || /\/exports\/harbor-/.test(path)
+    || /\/runtime-events\.jsonl$/.test(path)
+    || /\/events\.jsonl$/.test(path)
+    || /\/task-run\.json$/.test(path)
+    || /\/result\.json$/.test(path);
 }
 
 function uniqueInOrder(values: readonly string[]): string[] {


### PR DESCRIPTION
## Summary

Stacked on PR #341 while that role-fix PR is still open. The new cleanup commit is `97c1deb4 Filter active compact task-run metadata`.

This patch tightens active full compact's deterministic process-state extraction after the GLM/QEMU offline replay showed task-run JSON snippets leaking into `process_state` / `vm_state`.

Changes:
- filter low-signal task-run / runtime metadata rows from compact fact-line extraction;
- filter internal task-run/export JSONL paths from provider-visible `artifact_paths`;
- add a QEMU-style regression fixture that mixes task-run metadata with real QEMU facts and verifies the compact block keeps `/app`/`/boot` operational facts while dropping runner metadata.

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test dist/__tests__/active-full-compact.test.js` (`21` pass)
- `npm --workspace @maka/runtime test` (`731` pass / `1` skipped)
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `git diff --check`
