### PR TITLE
feat(core): enrich model catalog metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -421,6 +421,11 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /自定义 OpenAI 兼容接口/);
     assert.match(src, /添加 OpenAI 兼容接口/);
     assert.match(src, /智谱 · OpenAI 兼容/);
+    assert.match(
+      src,
+      /case 'codex-subscription':\s*return \{ name: 'OpenAI OAuth', description: 'ChatGPT \/ Codex 账号登录；登录后自动成为可用模型连接。' \}/,
+      'OpenAI OAuth account path should not be presented as a Codex subscription in provider settings',
+    );
     assert.doesNotMatch(
       src,
       /OpenAI-compatible|endpoint/,

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -2078,7 +2078,7 @@ export function providerDisplay(type: ProviderType): { name: string; description
     case 'claude-subscription':
       return { name: 'Claude Subscription', description: 'Claude Pro / Max 订阅账号登录；登录后自动成为可用模型连接。' };
     case 'codex-subscription':
-      return { name: 'Codex Subscription', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' };
+      return { name: 'OpenAI OAuth', description: 'ChatGPT / Codex 账号登录；登录后自动成为可用模型连接。' };
     case 'gemini-cli':
       return { name: 'Gemini CLI', description: 'Google 账号登录暂未接入聊天发送。' };
   }

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -185,6 +185,11 @@ describe('validateConnectionBaseUrl (PR-UI-IPC-1, @kenji msg 35260e29)', () => {
 });
 
 describe('provider URL defaults', () => {
+  it('labels the ChatGPT account path as OpenAI OAuth, not Codex subscription', () => {
+    assert.equal(PROVIDER_DEFAULTS['codex-subscription'].label, 'OpenAI OAuth (ChatGPT / Codex)');
+    assert.equal(PROVIDER_DEFAULTS['codex-subscription'].description, 'ChatGPT/Codex account OAuth path for OpenAI Responses models.');
+  });
+
   it('keeps Kimi Coding Plan separate from Moonshot API key access', () => {
     assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].baseUrl, 'https://api.kimi.com/coding/v1');
     assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].signupUrl, 'https://www.kimi.com/code/console');

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -135,6 +135,57 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entry?.canUseAsChatDefault, true);
   });
 
+  it('fills missing provider limits and capabilities from static model metadata', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'deepseek',
+      defaultModel: 'deepseek-v4-pro',
+      models: [{ id: 'deepseek-v4-pro' }],
+      modelSource: 'fetched',
+    });
+
+    assert.equal(entry?.contextWindow, 1_000_000);
+    assert.equal(entry?.maxOutputTokens, 384_000);
+    assert.equal(entry?.capabilitySource, 'static_catalog');
+    assert.deepEqual(entry?.capabilities, { reasoning: true, functionCalling: true });
+  });
+
+  it('keeps provider limits and capabilities ahead of static model metadata', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'deepseek',
+      defaultModel: 'deepseek-v4-pro',
+      models: [{
+        id: 'deepseek-v4-pro',
+        contextWindow: 128_000,
+        maxOutputTokens: 8_192,
+        capabilities: { reasoning: false, functionCalling: false },
+      }],
+      modelSource: 'fetched',
+    });
+
+    assert.equal(entry?.contextWindow, 128_000);
+    assert.equal(entry?.maxOutputTokens, 8_192);
+    assert.equal(entry?.capabilitySource, 'provider_api');
+    assert.deepEqual(entry?.capabilities, {});
+  });
+
+  it('keeps static model facts on missing default entries without making them sendable', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'zai-coding-plan',
+      defaultModel: 'glm-4.7',
+      models: [{ id: 'glm-5.2' }],
+      modelSource: 'fetched',
+    });
+
+    assert.equal(entry?.id, 'glm-4.7');
+    assert.equal(entry?.source, 'unknown');
+    assert.equal(entry?.unavailableReason, 'not_in_live_list');
+    assert.equal(entry?.canUseAsChatDefault, false);
+    assert.equal(entry?.contextWindow, 204_800);
+    assert.equal(entry?.maxOutputTokens, 131_072);
+    assert.equal(entry?.capabilitySource, 'static_catalog');
+    assert.deepEqual(entry?.capabilities, { reasoning: true, functionCalling: true });
+  });
+
   it('marks a fetched model as default when the saved default id has surrounding whitespace', () => {
     const entries = buildModelCatalogEntries({
       providerType: 'openai',
@@ -457,12 +508,19 @@ describe('ModelCatalogEntry', () => {
           modelSource: 'fetched',
           modelsFetchedAt: 1_800_000_000_000,
         });
-        return [entry?.id, entry?.displayName];
+        return [
+          entry?.id,
+          entry?.displayName,
+          entry?.contextWindow,
+          entry?.maxOutputTokens,
+          entry?.capabilitySource,
+          entry?.capabilities,
+        ];
       }),
       [
-        ['gemini-1.5-pro', undefined],
-        ['moonshot-v1-8k', undefined],
-        ['kimi-for-coding', undefined],
+        ['gemini-1.5-pro', undefined, undefined, undefined, 'unknown', {}],
+        ['moonshot-v1-8k', undefined, undefined, undefined, 'unknown', {}],
+        ['kimi-for-coding', undefined, undefined, undefined, 'unknown', {}],
       ],
     );
   });

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -224,7 +224,7 @@ describe('ModelCatalogEntry', () => {
     assert.equal(apiEntry?.maxOutputTokens, 128_000);
     assert.equal(subscriptionEntry?.contextWindow, undefined);
     assert.equal(subscriptionEntry?.maxOutputTokens, undefined);
-    assert.deepEqual(subscriptionEntry?.capabilities, { reasoning: true, functionCalling: true });
+    assert.deepEqual(subscriptionEntry?.capabilities, {});
   });
 
   it('keeps static model facts on missing default entries without making them sendable', () => {
@@ -481,7 +481,7 @@ describe('ModelCatalogEntry', () => {
     assert.deepEqual(entries[3]?.provenance.sources?.userChoice, ['daily_review_model']);
   });
 
-  it('falls back to provider defaults for a connection without fetched models', () => {
+  it('uses curated catalog fallbacks for a connection without fetched models', () => {
     const connection: LlmConnection = {
       slug: 'openai-api',
       name: 'OpenAI',

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -209,6 +209,24 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entry?.maxOutputTokens, 128_000);
   });
 
+  it('keeps Claude subscription limits unknown instead of reusing Anthropic API context', () => {
+    const [[apiEntry], [subscriptionEntry]] = ([
+      ['anthropic', 'claude-sonnet-4-6'],
+      ['claude-subscription', 'claude-sonnet-4-6'],
+    ] as const).map(([providerType, model]) => buildModelCatalogEntries({
+      providerType,
+      defaultModel: model,
+      models: [{ id: model }],
+      modelSource: 'fetched',
+    }));
+
+    assert.equal(apiEntry?.contextWindow, 1_000_000);
+    assert.equal(apiEntry?.maxOutputTokens, 128_000);
+    assert.equal(subscriptionEntry?.contextWindow, undefined);
+    assert.equal(subscriptionEntry?.maxOutputTokens, undefined);
+    assert.deepEqual(subscriptionEntry?.capabilities, { reasoning: true, functionCalling: true });
+  });
+
   it('keeps static model facts on missing default entries without making them sendable', () => {
     const [entry] = buildModelCatalogEntries({
       providerType: 'zai-coding-plan',
@@ -367,6 +385,26 @@ describe('ModelCatalogEntry', () => {
       validation.ok ? validation : { ok: validation.ok, reason: validation.reason },
       { ok: false, reason: 'unsupported_for_chat' },
     );
+  });
+
+  it('uses merged static capabilities before deciding whether a partial provider model is chat-capable', () => {
+    const input = {
+      providerType: 'openai' as const,
+      defaultModel: 'gpt-5.4',
+      models: [{ id: 'gpt-5.4', capabilities: { imageGeneration: true } }],
+      modelSource: 'fetched' as const,
+    };
+    const [entry] = buildModelCatalogEntries(input);
+
+    assert.equal(entry?.unavailableReason, 'none');
+    assert.equal(entry?.availability, 'available');
+    assert.equal(entry?.canUseAsChatDefault, true);
+    assert.deepEqual(entry?.capabilities, {
+      reasoning: true,
+      functionCalling: true,
+      imageGeneration: true,
+    });
+    assert.equal(validateChatDefaultModel(input).ok, true);
   });
 
   it('treats stale fetchedAt as a warning, not a send-blocking failure', () => {

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -168,6 +168,47 @@ describe('ModelCatalogEntry', () => {
     assert.deepEqual(entry?.capabilities, {});
   });
 
+  it('fills only missing capability fields when provider capability facts are partial', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'deepseek',
+      defaultModel: 'deepseek-v4-pro',
+      models: [{ id: 'deepseek-v4-pro', capabilities: { chat: true, reasoning: false } }],
+      modelSource: 'fetched',
+    });
+
+    assert.equal(entry?.capabilitySource, 'provider_api');
+    assert.deepEqual(entry?.capabilities, { chat: true, functionCalling: true });
+  });
+
+  it('keeps OpenAI OAuth limits provider-specific instead of reusing OpenAI API context', () => {
+    const [[openaiEntry], [oauthEntry]] = ([
+      ['openai', 'gpt-5.5'],
+      ['codex-subscription', 'gpt-5.5'],
+    ] as const).map(([providerType, model]) => buildModelCatalogEntries({
+      providerType,
+      defaultModel: model,
+      models: [{ id: model }],
+      modelSource: 'fetched',
+    }));
+
+    assert.equal(openaiEntry?.contextWindow, 1_050_000);
+    assert.equal(oauthEntry?.contextWindow, 400_000);
+    assert.notEqual(oauthEntry?.contextWindow, openaiEntry?.contextWindow);
+    assert.equal(oauthEntry?.maxOutputTokens, 128_000);
+  });
+
+  it('uses provider-specific Anthropic output limits over stale aggregate catalog values', () => {
+    const [entry] = buildModelCatalogEntries({
+      providerType: 'anthropic',
+      defaultModel: 'claude-sonnet-4-6',
+      models: [{ id: 'claude-sonnet-4-6' }],
+      modelSource: 'fetched',
+    });
+
+    assert.equal(entry?.contextWindow, 1_000_000);
+    assert.equal(entry?.maxOutputTokens, 128_000);
+  });
+
   it('keeps static model facts on missing default entries without making them sendable', () => {
     const [entry] = buildModelCatalogEntries({
       providerType: 'zai-coding-plan',

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -249,8 +249,8 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
     catalogBadge: 'Experimental',
   },
   'codex-subscription': {
-    label: 'Codex Subscription (ChatGPT OAuth)',
-    description: 'ChatGPT/Codex account OAuth path for Codex Responses models.',
+    label: 'OpenAI OAuth (ChatGPT / Codex)',
+    description: 'ChatGPT/Codex account OAuth path for OpenAI Responses models.',
     baseUrl: 'https://chatgpt.com/backend-api/codex',
     authKind: 'oauth_token',
     backendKind: 'ai-sdk',

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -219,7 +219,7 @@ function makeEntry(
   const recommendedRank = recommendedRanks.get(normalizedModel.id);
   const contextWindow = normalizedModel.contextWindow ?? metadata.contextWindow;
   const maxOutputTokens = normalizedModel.maxOutputTokens ?? metadata.maxOutputTokens;
-  const capabilities = normalizedModel.capabilities ?? metadata.capabilities;
+  const capabilities = mergeCapabilities(normalizedModel.capabilities, metadata.capabilities);
   return {
     id: normalizedModel.id,
     ...displayNameForModel(input.providerType, normalizedModel),
@@ -244,6 +244,21 @@ function makeEntry(
       ...(pricing ? { pricingModelKey: `${input.providerType}:${normalizedModel.id}` } : {}),
       sources: provenanceSources(input, normalizedModel.id, source, savedChoiceSources, normalizedDefaultModel),
     },
+  };
+}
+
+function mergeCapabilities(
+  providerCapabilities: ModelInfo['capabilities'] | undefined,
+  metadataCapabilities: ModelInfo['capabilities'] | undefined,
+): ModelInfo['capabilities'] | undefined {
+  if (!providerCapabilities) return metadataCapabilities;
+  if (!metadataCapabilities) return providerCapabilities;
+  return {
+    chat: providerCapabilities.chat ?? metadataCapabilities.chat,
+    vision: providerCapabilities.vision ?? metadataCapabilities.vision,
+    reasoning: providerCapabilities.reasoning ?? metadataCapabilities.reasoning,
+    functionCalling: providerCapabilities.functionCalling ?? metadataCapabilities.functionCalling,
+    imageGeneration: providerCapabilities.imageGeneration ?? metadataCapabilities.imageGeneration,
   };
 }
 

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -213,13 +213,16 @@ function makeEntry(
   recommendedRanks: ReadonlyMap<string, number>,
 ): ModelCatalogEntry {
   const normalizedModel = { ...model, id: model.id.trim() };
-  const unavailableReason = deriveModelUnavailableReason(input, normalizedModel);
   const pricing = findPricing(input, normalizedModel.id);
   const metadata = lookupModelMetadata(input.providerType, normalizedModel.id);
   const recommendedRank = recommendedRanks.get(normalizedModel.id);
   const contextWindow = normalizedModel.contextWindow ?? metadata.contextWindow;
   const maxOutputTokens = normalizedModel.maxOutputTokens ?? metadata.maxOutputTokens;
   const capabilities = mergeCapabilities(normalizedModel.capabilities, metadata.capabilities);
+  const unavailableReason = deriveModelUnavailableReason(input, {
+    ...normalizedModel,
+    capabilities,
+  });
   return {
     id: normalizedModel.id,
     ...displayNameForModel(input.providerType, normalizedModel),

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -6,7 +6,7 @@ import type {
 } from './llm-connections.js';
 import { PROVIDER_DEFAULTS } from './llm-connections.js';
 import type { PricingConfig } from './usage-stats/types.js';
-import { catalogFallbackModelsForProvider, lookupModelMetadata } from './model-metadata.js';
+import { curatedCatalogFallbackModelsForProvider, lookupModelMetadata } from './model-metadata.js';
 
 export type ModelCapabilitySource =
   | 'provider_api'
@@ -161,7 +161,7 @@ export function buildModelCatalogEntries(input: BuildModelCatalogInput): ModelCa
 export function buildConnectionModelCatalogEntries(input: BuildConnectionModelCatalogInput): ModelCatalogEntry[] {
   const { connection } = input;
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
-  const catalogFallbackModels = catalogFallbackModelsForProvider(connection.providerType);
+  const catalogFallbackModels = curatedCatalogFallbackModelsForProvider(connection.providerType);
   return buildModelCatalogEntries({
     providerType: connection.providerType,
     connectionSlug: connection.slug,
@@ -374,7 +374,7 @@ function recommendedRanksForProvider(
   providerType: ProviderType,
   fallbackModels: readonly string[] | undefined,
 ): Map<string, number> {
-  const ids = catalogFallbackModelsForProvider(providerType) ?? fallbackModels ?? [];
+  const ids = curatedCatalogFallbackModelsForProvider(providerType) ?? fallbackModels ?? [];
   const result = new Map<string, number>();
   for (const id of ids) {
     const trimmed = id.trim();

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -217,23 +217,26 @@ function makeEntry(
   const pricing = findPricing(input, normalizedModel.id);
   const metadata = lookupModelMetadata(input.providerType, normalizedModel.id);
   const recommendedRank = recommendedRanks.get(normalizedModel.id);
+  const contextWindow = normalizedModel.contextWindow ?? metadata.contextWindow;
+  const maxOutputTokens = normalizedModel.maxOutputTokens ?? metadata.maxOutputTokens;
+  const capabilities = normalizedModel.capabilities ?? metadata.capabilities;
   return {
     id: normalizedModel.id,
     ...displayNameForModel(input.providerType, normalizedModel),
     providerType: input.providerType,
     ...(input.connectionSlug ? { connectionSlug: input.connectionSlug } : {}),
     source,
-    capabilitySource: model.capabilities ? source : 'unknown',
+    capabilitySource: normalizedModel.capabilities ? source : metadata.capabilities ? 'static_catalog' : 'unknown',
     unavailableReason,
     availability: availabilityOf(unavailableReason),
     canUseAsChatDefault: canUseUnavailableReasonAsDefault(unavailableReason),
     isDefault: normalizedModel.id === normalizedDefaultModel,
-    capabilities: normalizeCapabilities(normalizedModel),
+    capabilities: normalizeCapabilities(capabilities),
     lifecycle: metadata.lifecycle ?? 'unknown',
     ...(recommendedRank ? { recommendedRank } : {}),
     ...(metadata.docsUrl ? { docsUrl: metadata.docsUrl } : {}),
-    ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
-    ...(model.maxOutputTokens ? { maxOutputTokens: model.maxOutputTokens } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+    ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(pricing ? { pricing } : {}),
     provenance: {
       modelSource,
@@ -261,15 +264,17 @@ function makeMissingDefaultEntry(
     providerType: input.providerType,
     ...(input.connectionSlug ? { connectionSlug: input.connectionSlug } : {}),
     source: 'unknown',
-    capabilitySource: 'unknown',
+    capabilitySource: metadata.capabilities ? 'static_catalog' : 'unknown',
     unavailableReason,
     availability: availabilityOf(unavailableReason),
     canUseAsChatDefault: canUseUnavailableReasonAsDefault(unavailableReason),
     isDefault: true,
-    capabilities: {},
+    capabilities: normalizeCapabilities(metadata.capabilities),
     lifecycle: metadata.lifecycle ?? 'unknown',
     ...(recommendedRank ? { recommendedRank } : {}),
     ...(metadata.docsUrl ? { docsUrl: metadata.docsUrl } : {}),
+    ...(metadata.contextWindow !== undefined ? { contextWindow: metadata.contextWindow } : {}),
+    ...(metadata.maxOutputTokens !== undefined ? { maxOutputTokens: metadata.maxOutputTokens } : {}),
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
@@ -295,15 +300,17 @@ function makeMissingUserChoiceEntry(
     providerType: input.providerType,
     ...(input.connectionSlug ? { connectionSlug: input.connectionSlug } : {}),
     source: 'unknown',
-    capabilitySource: 'unknown',
+    capabilitySource: metadata.capabilities ? 'static_catalog' : 'unknown',
     unavailableReason,
     availability: availabilityOf(unavailableReason),
     canUseAsChatDefault: canUseUnavailableReasonAsDefault(unavailableReason),
     isDefault: id === normalizedDefaultModel,
-    capabilities: {},
+    capabilities: normalizeCapabilities(metadata.capabilities),
     lifecycle: metadata.lifecycle ?? 'unknown',
     ...(recommendedRank ? { recommendedRank } : {}),
     ...(metadata.docsUrl ? { docsUrl: metadata.docsUrl } : {}),
+    ...(metadata.contextWindow !== undefined ? { contextWindow: metadata.contextWindow } : {}),
+    ...(metadata.maxOutputTokens !== undefined ? { maxOutputTokens: metadata.maxOutputTokens } : {}),
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
@@ -420,8 +427,7 @@ export function isModelExplicitlyUnsupportedForChat(model: ModelInfo): boolean {
     caps.functionCalling !== true;
 }
 
-function normalizeCapabilities(model: ModelInfo): KnownModelCapabilities {
-  const caps = model.capabilities;
+function normalizeCapabilities(caps: ModelInfo['capabilities']): KnownModelCapabilities {
   if (!caps) return {};
   return {
     ...(caps.chat === true ? { chat: true as const } : {}),

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -13,8 +13,8 @@ export function lookupModelMetadata(providerType: ProviderType, modelId: string)
   return MODELS_DEV_METADATA[providerType]?.[modelId.trim()] ?? {};
 }
 
-export function catalogFallbackModelsForProvider(providerType: ProviderType): readonly string[] | undefined {
-  return CATALOG_FALLBACK_MODELS[providerType];
+export function curatedCatalogFallbackModelsForProvider(providerType: ProviderType): readonly string[] | undefined {
+  return CURATED_CATALOG_FALLBACK_MODELS[providerType];
 }
 
 const REASONING_FUNCTION_CALLING = { reasoning: true, functionCalling: true } satisfies ModelInfo['capabilities'];
@@ -99,11 +99,10 @@ function displayMetadataOnly(source: Record<string, ModelMetadata>): Record<stri
     displayName: metadata.displayName,
     lifecycle: metadata.lifecycle,
     docsUrl: metadata.docsUrl,
-    capabilities: metadata.capabilities,
   }])) as Record<string, ModelMetadata>;
 }
 
-const CATALOG_FALLBACK_MODELS: Partial<Record<ProviderType, readonly string[]>> = {
+const CURATED_CATALOG_FALLBACK_MODELS: Partial<Record<ProviderType, readonly string[]>> = {
   anthropic: [
     'claude-sonnet-4-6',
     'claude-opus-4-8',

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -1,9 +1,12 @@
-import type { ProviderType } from './llm-connections.js';
+import type { ModelInfo, ProviderType } from './llm-connections.js';
 
 export interface ModelMetadata {
   displayName?: string;
   lifecycle?: 'active' | 'deprecated' | 'retired';
   docsUrl?: string;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  capabilities?: ModelInfo['capabilities'];
 }
 
 export function lookupModelMetadata(providerType: ProviderType, modelId: string): ModelMetadata {
@@ -14,27 +17,54 @@ export function catalogFallbackModelsForProvider(providerType: ProviderType): re
   return CATALOG_FALLBACK_MODELS[providerType];
 }
 
+const REASONING_FUNCTION_CALLING = { reasoning: true, functionCalling: true } satisfies ModelInfo['capabilities'];
+const FUNCTION_CALLING_ONLY = { functionCalling: true } satisfies ModelInfo['capabilities'];
+
 const ANTHROPIC_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
-  'claude-sonnet-4-6': { displayName: 'Claude Sonnet 4.6', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-opus-4-8': { displayName: 'Claude Opus 4.8', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-fable-5': { displayName: 'Claude Fable 5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-sonnet-4-5': { displayName: 'Claude Sonnet 4.5 (latest)', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-sonnet-4-5-20250929': { displayName: 'Claude Sonnet 4.5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-opus-4-1-20250805': { displayName: 'Claude Opus 4.1', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-haiku-4-5': { displayName: 'Claude Haiku 4.5 (latest)', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-haiku-4-5-20251001': { displayName: 'Claude Haiku 4.5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
-  'claude-3-5-sonnet-20241022': { displayName: 'Claude Sonnet 3.5 v2', lifecycle: 'deprecated', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview' },
+  'claude-sonnet-4-6': { displayName: 'Claude Sonnet 4.6', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-opus-4-8': { displayName: 'Claude Opus 4.8', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-fable-5': { displayName: 'Claude Fable 5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-sonnet-4-5': { displayName: 'Claude Sonnet 4.5 (latest)', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-sonnet-4-5-20250929': { displayName: 'Claude Sonnet 4.5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-opus-4-1-20250805': { displayName: 'Claude Opus 4.1', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 32_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-haiku-4-5': { displayName: 'Claude Haiku 4.5 (latest)', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-haiku-4-5-20251001': { displayName: 'Claude Haiku 4.5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-3-5-sonnet-20241022': { displayName: 'Claude Sonnet 3.5 v2', lifecycle: 'deprecated', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 8_192, capabilities: FUNCTION_CALLING_ONLY },
 };
 
 const GOOGLE_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
-  'gemini-3.5-flash': { displayName: 'Gemini 3.5 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-3.1-pro-preview': { displayName: 'Gemini 3.1 Pro Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-3.1-flash-lite': { displayName: 'Gemini 3.1 Flash Lite', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-3-pro-preview': { displayName: 'Gemini 3 Pro Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-3-flash-preview': { displayName: 'Gemini 3 Flash Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-2.5-pro': { displayName: 'Gemini 2.5 Pro', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-2.5-flash': { displayName: 'Gemini 2.5 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
-  'gemini-2.0-flash': { displayName: 'Gemini 2.0 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models' },
+  'gemini-3.5-flash': { displayName: 'Gemini 3.5 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-3.1-pro-preview': { displayName: 'Gemini 3.1 Pro Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-3.1-flash-lite': { displayName: 'Gemini 3.1 Flash Lite', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-3-pro-preview': { displayName: 'Gemini 3 Pro Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-3-flash-preview': { displayName: 'Gemini 3 Flash Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-2.5-pro': { displayName: 'Gemini 2.5 Pro', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-2.5-flash': { displayName: 'Gemini 2.5 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
+  'gemini-2.0-flash': { displayName: 'Gemini 2.0 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 8_192, capabilities: FUNCTION_CALLING_ONLY },
+};
+
+const OPENAI_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
+  'gpt-5.5': { displayName: 'GPT-5.5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 1_050_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.5-pro': { displayName: 'GPT-5.5 Pro', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 1_050_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.4': { displayName: 'GPT-5.4', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 1_050_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.4-mini': { displayName: 'GPT-5.4 mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.3-codex-spark': { displayName: 'GPT-5.3 Codex Spark', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 128_000, maxOutputTokens: 32_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.3-codex': { displayName: 'GPT-5.3 Codex', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.2': { displayName: 'GPT-5.2', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.2-codex': { displayName: 'GPT-5.2 Codex', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-5.1-codex-mini': { displayName: 'GPT-5.1 Codex mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+  'gpt-4o-mini': { displayName: 'GPT-4o mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 128_000, maxOutputTokens: 16_384, capabilities: FUNCTION_CALLING_ONLY },
+  'gpt-4o': { displayName: 'GPT-4o', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 128_000, maxOutputTokens: 16_384, capabilities: FUNCTION_CALLING_ONLY },
+  'gpt-4-turbo': { displayName: 'GPT-4 Turbo', lifecycle: 'deprecated', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 128_000, maxOutputTokens: 4_096, capabilities: FUNCTION_CALLING_ONLY },
+  'gpt-5': { displayName: 'GPT-5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+};
+
+const CODEX_SUBSCRIPTION_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
+  'gpt-5.5': OPENAI_MODELS_DEV_METADATA['gpt-5.5']!,
+  'gpt-5.5-pro': OPENAI_MODELS_DEV_METADATA['gpt-5.5-pro']!,
+  'gpt-5.4': OPENAI_MODELS_DEV_METADATA['gpt-5.4']!,
+  'gpt-5.4-mini': OPENAI_MODELS_DEV_METADATA['gpt-5.4-mini']!,
+  'gpt-5.3-codex-spark': OPENAI_MODELS_DEV_METADATA['gpt-5.3-codex-spark']!,
 };
 
 // Curated from https://models.dev/api.json. Keep this small: the model catalog
@@ -42,43 +72,23 @@ const GOOGLE_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
 const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
   anthropic: ANTHROPIC_MODELS_DEV_METADATA,
   'claude-subscription': ANTHROPIC_MODELS_DEV_METADATA,
-  openai: {
-    'gpt-5.5': { displayName: 'GPT-5.5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.5-pro': { displayName: 'GPT-5.5 Pro', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.4': { displayName: 'GPT-5.4', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.4-mini': { displayName: 'GPT-5.4 mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.3-codex-spark': { displayName: 'GPT-5.3 Codex Spark', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.3-codex': { displayName: 'GPT-5.3 Codex', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.2': { displayName: 'GPT-5.2', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.2-codex': { displayName: 'GPT-5.2 Codex', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.1-codex-mini': { displayName: 'GPT-5.1 Codex mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-4o-mini': { displayName: 'GPT-4o mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-4o': { displayName: 'GPT-4o', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-4-turbo': { displayName: 'GPT-4 Turbo', lifecycle: 'deprecated', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5': { displayName: 'GPT-5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-  },
+  openai: OPENAI_MODELS_DEV_METADATA,
   google: GOOGLE_MODELS_DEV_METADATA,
   'gemini-cli': GOOGLE_MODELS_DEV_METADATA,
-  'codex-subscription': {
-    'gpt-5.5': { displayName: 'GPT-5.5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.5-pro': { displayName: 'GPT-5.5 Pro', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.4': { displayName: 'GPT-5.4', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.4-mini': { displayName: 'GPT-5.4 mini', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-    'gpt-5.3-codex-spark': { displayName: 'GPT-5.3 Codex Spark', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models' },
-  },
+  'codex-subscription': CODEX_SUBSCRIPTION_MODELS_DEV_METADATA,
   deepseek: {
-    'deepseek-v4-flash': { displayName: 'DeepSeek V4 Flash', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing' },
-    'deepseek-v4-pro': { displayName: 'DeepSeek V4 Pro', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing' },
-    'deepseek-reasoner': { displayName: 'DeepSeek Reasoner', lifecycle: 'deprecated', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing' },
-    'deepseek-chat': { displayName: 'DeepSeek Chat', lifecycle: 'deprecated', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing' },
+    'deepseek-v4-flash': { displayName: 'DeepSeek V4 Flash', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: REASONING_FUNCTION_CALLING },
+    'deepseek-v4-pro': { displayName: 'DeepSeek V4 Pro', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: REASONING_FUNCTION_CALLING },
+    'deepseek-reasoner': { displayName: 'DeepSeek Reasoner', lifecycle: 'deprecated', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: REASONING_FUNCTION_CALLING },
+    'deepseek-chat': { displayName: 'DeepSeek Chat', lifecycle: 'deprecated', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: FUNCTION_CALLING_ONLY },
   },
   'zai-coding-plan': {
-    'glm-5.2': { displayName: 'GLM-5.2', lifecycle: 'active', docsUrl: 'https://docs.z.ai' },
-    'glm-5.1': { displayName: 'GLM-5.1', lifecycle: 'active', docsUrl: 'https://docs.z.ai' },
-    'glm-5-turbo': { displayName: 'GLM-5-Turbo', lifecycle: 'active', docsUrl: 'https://docs.z.ai' },
-    'glm-5v-turbo': { displayName: 'GLM-5V-Turbo', lifecycle: 'active', docsUrl: 'https://docs.z.ai' },
-    'glm-4.7': { displayName: 'GLM-4.7', lifecycle: 'active', docsUrl: 'https://docs.z.ai' },
-    'glm-4.5-air': { displayName: 'GLM-4.5-Air', lifecycle: 'deprecated', docsUrl: 'https://docs.z.ai' },
+    'glm-5.2': { displayName: 'GLM-5.2', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 1_000_000, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
+    'glm-5.1': { displayName: 'GLM-5.1', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 200_000, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
+    'glm-5-turbo': { displayName: 'GLM-5-Turbo', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 200_000, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
+    'glm-5v-turbo': { displayName: 'GLM-5V-Turbo', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 200_000, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
+    'glm-4.7': { displayName: 'GLM-4.7', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 204_800, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
+    'glm-4.5-air': { displayName: 'GLM-4.5-Air', lifecycle: 'deprecated', docsUrl: 'https://docs.z.ai', contextWindow: 131_072, maxOutputTokens: 98_304, capabilities: REASONING_FUNCTION_CALLING },
   },
 };
 

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -21,7 +21,7 @@ const REASONING_FUNCTION_CALLING = { reasoning: true, functionCalling: true } sa
 const FUNCTION_CALLING_ONLY = { functionCalling: true } satisfies ModelInfo['capabilities'];
 
 const ANTHROPIC_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
-  'claude-sonnet-4-6': { displayName: 'Claude Sonnet 4.6', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
+  'claude-sonnet-4-6': { displayName: 'Claude Sonnet 4.6', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
   'claude-opus-4-8': { displayName: 'Claude Opus 4.8', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
   'claude-fable-5': { displayName: 'Claude Fable 5', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
   'claude-sonnet-4-5': { displayName: 'Claude Sonnet 4.5 (latest)', lifecycle: 'active', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 64_000, capabilities: REASONING_FUNCTION_CALLING },
@@ -59,10 +59,10 @@ const OPENAI_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
   'gpt-5': { displayName: 'GPT-5', lifecycle: 'active', docsUrl: 'https://platform.openai.com/docs/models', contextWindow: 400_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
 };
 
-const CODEX_SUBSCRIPTION_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
-  'gpt-5.5': OPENAI_MODELS_DEV_METADATA['gpt-5.5']!,
-  'gpt-5.5-pro': OPENAI_MODELS_DEV_METADATA['gpt-5.5-pro']!,
-  'gpt-5.4': OPENAI_MODELS_DEV_METADATA['gpt-5.4']!,
+const OPENAI_OAUTH_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
+  'gpt-5.5': { ...OPENAI_MODELS_DEV_METADATA['gpt-5.5']!, contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.5-pro': { ...OPENAI_MODELS_DEV_METADATA['gpt-5.5-pro']!, contextWindow: 400_000, maxOutputTokens: 128_000 },
+  'gpt-5.4': { ...OPENAI_MODELS_DEV_METADATA['gpt-5.4']!, contextWindow: 400_000, maxOutputTokens: 128_000 },
   'gpt-5.4-mini': OPENAI_MODELS_DEV_METADATA['gpt-5.4-mini']!,
   'gpt-5.3-codex-spark': OPENAI_MODELS_DEV_METADATA['gpt-5.3-codex-spark']!,
 };
@@ -75,7 +75,7 @@ const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMeta
   openai: OPENAI_MODELS_DEV_METADATA,
   google: GOOGLE_MODELS_DEV_METADATA,
   'gemini-cli': GOOGLE_MODELS_DEV_METADATA,
-  'codex-subscription': CODEX_SUBSCRIPTION_MODELS_DEV_METADATA,
+  'codex-subscription': OPENAI_OAUTH_MODELS_DEV_METADATA,
   deepseek: {
     'deepseek-v4-flash': { displayName: 'DeepSeek V4 Flash', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: REASONING_FUNCTION_CALLING },
     'deepseek-v4-pro': { displayName: 'DeepSeek V4 Pro', lifecycle: 'active', docsUrl: 'https://api-docs.deepseek.com/quick_start/pricing', contextWindow: 1_000_000, maxOutputTokens: 384_000, capabilities: REASONING_FUNCTION_CALLING },

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -32,6 +32,8 @@ const ANTHROPIC_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
   'claude-3-5-sonnet-20241022': { displayName: 'Claude Sonnet 3.5 v2', lifecycle: 'deprecated', docsUrl: 'https://docs.anthropic.com/en/docs/about-claude/models/overview', contextWindow: 200_000, maxOutputTokens: 8_192, capabilities: FUNCTION_CALLING_ONLY },
 };
 
+const CLAUDE_SUBSCRIPTION_MODELS_DEV_METADATA = displayMetadataOnly(ANTHROPIC_MODELS_DEV_METADATA);
+
 const GOOGLE_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
   'gemini-3.5-flash': { displayName: 'Gemini 3.5 Flash', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
   'gemini-3.1-pro-preview': { displayName: 'Gemini 3.1 Pro Preview', lifecycle: 'active', docsUrl: 'https://ai.google.dev/gemini-api/docs/models', contextWindow: 1_048_576, maxOutputTokens: 65_536, capabilities: REASONING_FUNCTION_CALLING },
@@ -67,11 +69,11 @@ const OPENAI_OAUTH_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
   'gpt-5.3-codex-spark': OPENAI_MODELS_DEV_METADATA['gpt-5.3-codex-spark']!,
 };
 
-// Curated from https://models.dev/api.json. Keep this small: the model catalog
-// consumes only stable display names here, while request routing keeps raw ids.
+// Provider/access-path-specific static facts. Keep limits unset unless the
+// source is authoritative for that provider path; request routing keeps raw ids.
 const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
   anthropic: ANTHROPIC_MODELS_DEV_METADATA,
-  'claude-subscription': ANTHROPIC_MODELS_DEV_METADATA,
+  'claude-subscription': CLAUDE_SUBSCRIPTION_MODELS_DEV_METADATA,
   openai: OPENAI_MODELS_DEV_METADATA,
   google: GOOGLE_MODELS_DEV_METADATA,
   'gemini-cli': GOOGLE_MODELS_DEV_METADATA,
@@ -91,6 +93,15 @@ const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMeta
     'glm-4.5-air': { displayName: 'GLM-4.5-Air', lifecycle: 'deprecated', docsUrl: 'https://docs.z.ai', contextWindow: 131_072, maxOutputTokens: 98_304, capabilities: REASONING_FUNCTION_CALLING },
   },
 };
+
+function displayMetadataOnly(source: Record<string, ModelMetadata>): Record<string, ModelMetadata> {
+  return Object.fromEntries(Object.entries(source).map(([id, metadata]) => [id, {
+    displayName: metadata.displayName,
+    lifecycle: metadata.lifecycle,
+    docsUrl: metadata.docsUrl,
+    capabilities: metadata.capabilities,
+  }])) as Record<string, ModelMetadata>;
+}
 
 const CATALOG_FALLBACK_MODELS: Partial<Record<ProviderType, readonly string[]>> = {
   anthropic: [

--- a/packages/ui/src/__tests__/chat-model-helpers.test.ts
+++ b/packages/ui/src/__tests__/chat-model-helpers.test.ts
@@ -38,6 +38,10 @@ test('cross-provider same model name stays in separate, distinguishable groups',
   ]);
   assert.equal(groups.length, 2);
   assert.equal(new Set(groups.map((g) => g.heading)).size, 2);
+  assert.deepEqual(
+    groups.map((g) => g.heading).sort(),
+    ['OpenAI', 'OpenAI OAuth'],
+  );
 });
 
 test('headings never leak an account email (no @), even with slug disambiguation', () => {

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -50,7 +50,7 @@ const PROVIDER_SHORT_LABEL = {
   'zai-coding-plan': 'Z.AI',
   'openai-compatible': '自定义',
   'claude-subscription': 'Claude 订阅',
-  'codex-subscription': 'Codex 订阅',
+  'codex-subscription': 'OpenAI OAuth',
   'gemini-cli': 'Gemini CLI',
 } satisfies Record<ProviderType, string>;
 


### PR DESCRIPTION
## Summary

Enrich core model catalog metadata with static limits and lightweight capabilities for curated models, then use provider/access-path-specific facts only when provider discovery did not return them.

## Why

Future context-budget and compaction decisions need per-model context window and max output token facts. Today the catalog can carry those fields, but many provider model-list responses do not include them, leaving known models with `undefined` limits.

## Scope

Changed:

- Added optional `contextWindow`, `maxOutputTokens`, and capability metadata to the curated model metadata table.
- Filled those facts for the existing curated Anthropic API, OpenAI API, OpenAI OAuth, Google/Gemini, DeepSeek, and Z.AI catalog entries from provider-specific sources, using `models.dev/api.json` where available.
- Kept Claude subscription metadata display-only, so it does not inherit Anthropic API limits or capabilities without subscription-specific evidence.
- Kept curated catalog fallback model lists explicit for no-live-model cases, so fallback choices can show current models without changing provider readiness/default-provider definitions.
- Updated catalog entry construction so provider-returned limits win, provider capability fields win per field, static metadata fills only missing fields, and availability is derived from merged capabilities.
- Presented the ChatGPT/Codex account path as OpenAI OAuth in provider defaults, settings provider cards, and chat model group headings.
- Added regression coverage for static fallback, curated catalog fallback, provider precedence, partial capability merge, availability from merged capabilities, OpenAI API vs OpenAI OAuth context differences, Anthropic API vs Claude subscription metadata differences, provider-specific Anthropic API limits, provider display labels, missing default entries, and unknown ids.

Not included:

- No provider key, IPC channel, file name, or environment variable rename for the existing `codex-subscription` internal identifier.
- No provider key, IPC channel, file name, or environment variable rename for the existing `claude-subscription` internal identifier.
- No readiness or send-gate changes.
- No runtime `ContextBudgetPolicy` or automatic compaction behavior changes.
- No `ModelCatalogEntry` shape change or per-field provenance object.

## Verification

- `npm run -w @maka/core test`
- `npm run -w @maka/ui test`
- `npm run -w @maka/desktop test -- --test-name-pattern "visible copy|OpenAI OAuth account path"`
- `npm run typecheck`
- `git diff --check`

## User-facing impact

Known model catalog entries now carry richer metadata that future budget/compaction work can consume. The ChatGPT/Codex OAuth account path is now labeled OpenAI OAuth in visible provider/model picker surfaces. When live model discovery is unavailable, catalog entries can use curated fallback choices so current known models still appear in the picker.

## Reviewer notes

Review fixes included: OpenAI OAuth no longer reuses OpenAI API GPT-5.5 limits, Claude subscription no longer reuses Anthropic API limits or capabilities, partial provider capabilities now merge per field while preserving explicit `false`, availability uses those merged capabilities, Anthropic API Sonnet 4.6 uses the provider-specific 128K max output limit, and curated catalog fallbacks are named and tested as an intentional no-live-model picker behavior. Internal subscription identifiers are intentionally left unchanged in this PR to avoid unrelated migrations.