### PR TITLE
feat(ui): migrate ToolActivity card shell onto @maka/ui chat primitives (#332 PR3b)

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -120,6 +120,40 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
     }
   });
 
+  it('keeps the computed-style fixture covering every production tool status', async () => {
+    // The zero-visual proof is only as complete as the statuses it renders. The
+    // truth source is components.tsx's `STATUS_LABEL` (a `Record` over the full
+    // `ToolActivityItem['status']` union — its keys ARE every production status).
+    // The harness must render a card for each: a new status that escapes the
+    // fixture would have NO diffed row, so its tint could drift unseen (the
+    // `pending` gap this guard was added to close). No card-level exclusions —
+    // even `running` renders a card; only its animated DOT id is left out of IDS.
+    const componentsSrc = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'components.tsx'),
+      'utf8',
+    );
+    // Anchor on the FULL `ToolActivityItem` signature — a bare `const STATUS_LABEL`
+    // prefix-matches the unrelated session-status `STATUS_LABEL_BY_STATUS` map.
+    const labelStart = componentsSrc.indexOf("const STATUS_LABEL: Record<ToolActivityItem['status']");
+    assert.ok(labelStart !== -1, 'failed to locate the tool STATUS_LABEL declaration in components.tsx');
+    const labelBlock = componentsSrc.slice(labelStart, componentsSrc.indexOf('};', labelStart));
+    const statuses = [...labelBlock.matchAll(/^\s*(\w+):/gm)].map((m) => m[1]);
+    assert.ok(statuses.length >= 5, 'failed to parse STATUS_LABEL keys from components.tsx');
+
+    const harnessSrc = await readFile(
+      resolve(REPO_ROOT, 'scripts', 'check-chat-marker-computed-style.mjs'),
+      'utf8',
+    );
+    const statBlock = harnessSrc.slice(harnessSrc.indexOf('const STAT ='));
+    const stat = [...statBlock.slice(0, statBlock.indexOf(']')).matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    for (const status of statuses) {
+      assert.ok(
+        stat.includes(status),
+        `computed-style fixture STAT must render the "${status}" card so its zero-visual proof has a diffed row`,
+      );
+    }
+  });
+
   it('pins the running-dot escape literals in chat.tsx + guards against scale drift', async () => {
     const rawSrc = await readFile(
       resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx'),

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -150,6 +150,14 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
         `tool dot must use the governed maka-tool-pulse ring, not "${banned}"`,
       );
     }
+    // The open/collapsed divider — the one card surface that differs by state
+    // (the collapsed default has no bottom border). The computed-diff proves both
+    // states, but that harness is manual (no CI), so pin the `[open]>summary`
+    // literal here as the automated guard.
+    assert.ok(
+      block.includes('[&[open]>summary]:[border-bottom:1px_solid_var(--border)]'),
+      'item must keep the `[open]>summary` divider literal (collapsed default has none)',
+    );
     // Anti-drift: the literalize vehicle stays arbitrary-value (immune to a later
     // scale/token re-tuning silently shifting pixels). Pin the distinctive
     // literals and ban the semantic-scale forms they would be swapped for.

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/**
+ * Zero-visual governance contract for issue #332 PR3b — the `ToolActivity` card
+ * shell (the inline section + count pill, the `<details>` card, its `<summary>`
+ * header row + status dot, the body / intent, and the args `<pre>` override)
+ * moved onto the `@maka/ui` chat substrate's `toolVariants` literalize table.
+ *
+ * The SHELL halves of "zero visual change" are proven by the computed-style diff
+ * harness (`npm run check:chat-visual`): each retired `.maka-tool*` / `.toolInline`
+ * / `.toolItem` / `.toolArgs` declaration compiles 1:1 to its literal utility, so
+ * this test does NOT re-assert those literals — that would only mirror the
+ * implementation. It locks the three things the diff cannot cover:
+ *   1. the ABSENCE of the retired selectors (a diff of computed styles can't show
+ *      a selector is gone), scoped so the still-bespoke `.maka-tool-error*`
+ *      (PR3c), `.maka-tool-diff*` / `.maka-tool-terminal*` (result previews, out
+ *      of scope), and shared `.maka-code` base survive untouched;
+ *   2. the running status dot's `@keyframes maka-tool-pulse` ring frames — an
+ *      animation can't be a leaf-literal and `getComputedStyle` reads a phase-
+ *      dependent value, so the breath is pinned here + by the `chat.tsx` literal;
+ *   3. the card mount entrance (`transition` + `@starting-style`) and native
+ *      `<summary>` marker reset — re-keyed off the retired `.maka-tool` class onto
+ *      the governed `[data-slot="tool"]` hook, kept as a named CSS residue because
+ *      `@starting-style` paints only on the first frame and pseudo-element resets
+ *      have no leaf-utility form.
+ */
+describe('chat tool-card migration contract (#332 PR3b)', () => {
+  it('retires the bespoke tool-card shell selectors (without touching error/preview/maka-code)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    for (const selector of [
+      // inline section + args override (styles/tool-output.css)
+      '.toolInline',
+      '.toolItem',
+      '.toolArgs',
+      // summary header row + status dot + body / intent / count (maka-tokens.css)
+      '.maka-tool-header',
+      '.maka-tool-name',
+      '.maka-tool-meta',
+      '.maka-tool-duration',
+      '.maka-tool-status-label',
+      '.maka-tool-status-dot',
+      '.maka-tool-body',
+      '.maka-tool-intent',
+      '.maka-tool-count',
+      // the `<details>` card base + its status / open / summary selectors
+      '.maka-tool {',
+      '.maka-tool >',
+      '.maka-tool[open]',
+      '.maka-tool[data-status',
+    ]) {
+      assert.ok(
+        !css.includes(selector),
+        `retired tool-card selector "${selector}" still present in renderer CSS`,
+      );
+    }
+
+    // Adjacent concerns that PR3b must leave alone: the error banner (PR3c), the
+    // result-preview renderers (out of scope), and the shared inline-code base.
+    for (const kept of [
+      '.maka-tool-error',
+      '.maka-tool-diff',
+      '.maka-tool-terminal',
+      '.maka-code',
+    ]) {
+      assert.ok(
+        css.includes(kept),
+        `PR3b must not retire the out-of-scope selector "${kept}"`,
+      );
+    }
+  });
+
+  it('keeps the @keyframes maka-tool-pulse ring frames (the dot breath the diff cannot see)', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    assert.ok(
+      tokens.includes('@keyframes maka-tool-pulse'),
+      '`@keyframes maka-tool-pulse` must stay in maka-tokens.css — a keyframe is a global rule, not an element property',
+    );
+    const pulse = tokens.slice(
+      tokens.indexOf('@keyframes maka-tool-pulse'),
+      tokens.indexOf('@keyframes maka-tool-pulse') + 220,
+    );
+    // The box-shadow RING grows 3px → 5px and fades 0.15 → 0.06. This is the
+    // running dot's zero-visual proof; it can't be machine-diffed, so it is pinned.
+    for (const frame of [
+      'box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.15)',
+      'box-shadow: 0 0 0 5px oklch(from var(--accent) l c h / 0.06)',
+    ]) {
+      assert.ok(pulse.includes(frame), `maka-tool-pulse must pin the retired ring frame "${frame}"`);
+    }
+  });
+
+  it('keeps the card entrance + marker reset residue, re-keyed onto [data-slot="tool"]', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    // The retired `.maka-tool` class no longer carries the entrance — it moved to
+    // the governed slot hook. (The class form lives only as `.maka-tool-error*`
+    // now, asserted out-of-scope above.)
+    assert.ok(
+      !tokens.includes('.maka-tool {') && !tokens.includes('@starting-style {\n    .maka-tool'),
+      'the entrance must no longer hang off the retired `.maka-tool` class',
+    );
+    for (const residue of [
+      // the mount entrance: explicit rest values + the transition…
+      '[data-slot="tool"] {',
+      'transform: translateY(0)',
+      'transition:\n      opacity 200ms ease-out,\n      transform 200ms var(--ease-out-strong),\n      border-color 160ms ease;',
+      // …and the `@starting-style` first-frame start (no at-rest computed style)
+      '[data-slot="tool"] { opacity: 0; transform: translateY(4px); }',
+      // the native disclosure-triangle suppression (pseudo-elements, no utility form)
+      '[data-slot="tool"] > summary::-webkit-details-marker { display: none; }',
+      "[data-slot=\"tool\"] > summary::marker { content: ''; }",
+    ]) {
+      assert.ok(
+        tokens.includes(residue),
+        `tool-card residue must keep "${residue}" on the [data-slot="tool"] hook`,
+      );
+    }
+  });
+
+  it('pins the running-dot escape literals in chat.tsx + guards against scale drift', async () => {
+    const rawSrc = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx'),
+      'utf8',
+    );
+    const chatSrc = rawSrc.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    const start = chatSrc.indexOf('const toolVariants');
+    const block = chatSrc.slice(start, chatSrc.indexOf('export { toolVariants }', start));
+    assert.ok(start !== -1 && block.length > 0, 'toolVariants table must exist in chat.tsx');
+
+    // The diff harness proves the static shell; the running dot's animation is the
+    // one part it cannot reach. Pin the breath + its leaf box-shadow ring here.
+    for (const literal of [
+      '[animation:maka-tool-pulse_1.5s_ease-in-out_infinite]',
+      '[box-shadow:0_0_0_3px_oklch(from_var(--accent)_l_c_h_/_0.15)]',
+    ]) {
+      assert.ok(
+        block.includes(literal),
+        `running dot must carry the literal "${literal}" mirroring the retired CSS`,
+      );
+    }
+    // The dot must never fall back to Tailwind's built-in `animate-pulse` (a
+    // different opacity-only keyframe) nor reuse the LiveIndicator breath — the
+    // tool dot's ring pulse is a distinct keyframe.
+    for (const banned of ['animate-pulse', 'maka-pulse_']) {
+      assert.ok(
+        !block.includes(banned),
+        `tool dot must use the governed maka-tool-pulse ring, not "${banned}"`,
+      );
+    }
+    // Anti-drift: the literalize vehicle stays arbitrary-value (immune to a later
+    // scale/token re-tuning silently shifting pixels). Pin the distinctive
+    // literals and ban the semantic-scale forms they would be swapped for.
+    for (const literal of ['rounded-[10px]', 'text-[12.5px]', 'gap-[10px]', 'min-w-[22px]']) {
+      assert.ok(block.includes(literal), `toolVariants must keep the literal "${literal}"`);
+    }
+    for (const scale of ['rounded-lg', 'rounded-xl', 'text-sm', 'text-xs']) {
+      assert.ok(
+        !block.includes(scale),
+        `toolVariants must stay literal, not adopt the semantic-scale "${scale}"`,
+      );
+    }
+
+    // The `waiting_permission` status must keep the `String.raw` `\_` escape: a
+    // bare `data-[status=waiting_permission]` compiles to `[data-status="waiting
+    // permission"]` (Tailwind `_`→space) and silently falls back to the base
+    // color — a zero-visual break the diff harness caught but a careless
+    // "simplification" could reintroduce. Assert the escaped form is present and
+    // the bare form is absent across the whole module.
+    assert.ok(
+      chatSrc.includes('waiting\\_permission'),
+      'waiting_permission must keep its `String.raw` `\\_` escape so the emitted class matches',
+    );
+    assert.ok(
+      !chatSrc.includes('data-[status=waiting_permission]'),
+      'the bare (underscore-as-space) `data-[status=waiting_permission]` form must never appear',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1447,19 +1447,20 @@
 
   /* ---- Tool activity ---------------------------------------------- */
 
-  .maka-tool {
-    border: 1px solid var(--border);
-    /* PR-UI-LAYOUT-9: tool card chrome aligns with the new card
-     * language — radius 8 → 10 matches the chip / search / settings
-     * radius family; background `--foreground-2` tint stays so tool
-     * cards still feel like inline-code blocks on the warm canvas. */
-    border-radius: 10px;
-    background: var(--foreground-2);
-    padding: 8px 12px;
-    margin-top: 8px;
-    font-family: var(--font-mono);
-    font-size: 12.5px;
-    color: var(--foreground-80);
+  /* The tool-activity card shell (the inline section + count pill, the
+     `<details>` card, its `<summary>` header row, the body / intent, and the
+     args `<pre>` override) moved onto the `@maka/ui` chat substrate's
+     `toolVariants` literalize table (issue #332 PR3b —
+     packages/ui/src/primitives/chat.tsx). What stays here is the irreducible
+     residue that escapes the computed-style proof, re-keyed on the governed
+     `[data-slot="tool"]` hook instead of the retired `.maka-tool` class: the
+     mount entrance (transition + `@starting-style`, which only paints on the
+     first frame, so it has no at-rest computed style to diff) and the native
+     `<summary>` marker reset (pseudo-elements with no leaf-utility form). Both
+     are pinned by the PR3b cascade contract. The running status dot's
+     `@keyframes maka-tool-pulse` (below) likewise stays — a keyframe is a global
+     rule, not an element property. */
+  [data-slot="tool"] {
     /* Same entrance as message rows — opacity + tiny lift on first paint. */
     opacity: 1;
     transform: translateY(0);
@@ -1469,64 +1470,13 @@
       border-color 160ms ease;
   }
   @starting-style {
-    .maka-tool { opacity: 0; transform: translateY(4px); }
+    [data-slot="tool"] { opacity: 0; transform: translateY(4px); }
   }
-  /* Native <details>/<summary> styling — the summary becomes the
-     collapsed/expanded header, and clicking it toggles the body. */
-  .maka-tool { padding: 0; }
-  .maka-tool > summary {
-    list-style: none;
-    padding: 8px 12px;
-  }
-  .maka-tool > summary::-webkit-details-marker { display: none; }
-  .maka-tool > summary::marker { content: ''; }
-  .maka-tool[open] > summary { border-bottom: 1px solid var(--border); }
-
-  .maka-tool-header {
-    display: grid;
-    grid-template-columns: 8px minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 10px;
-    color: var(--foreground-70);
-  }
-  .maka-tool-name {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--foreground);
-    font-weight: 500;
-    font-family: var(--font-mono);
-  }
-  .maka-tool-meta {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--foreground-50);
-    font-size: 11px;
-  }
-  .maka-tool-duration {
-    font-variant-numeric: tabular-nums;
-  }
-  .maka-tool-status-label {
-    color: var(--foreground-60);
-  }
-  .maka-tool-status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 999px;
-    background: var(--foreground-30);
-    flex: 0 0 auto;
-  }
-  .maka-tool-status-dot[data-status="waiting_permission"] { background: var(--info); }
-  .maka-tool-status-dot[data-status="running"] {
-    background: var(--accent);
-    box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.15);
-    animation: maka-tool-pulse 1.5s ease-in-out infinite;
-  }
-  .maka-tool-status-dot[data-status="completed"] { background: var(--success); }
-  .maka-tool-status-dot[data-status="errored"] { background: var(--destructive); }
-  .maka-tool-status-dot[data-status="interrupted"] { background: var(--foreground-30); }
+  /* Native <details>/<summary> marker reset — the summary IS the header row
+     (laid out by `toolVariants({ part: 'header' })`), so the default disclosure
+     triangle is suppressed. */
+  [data-slot="tool"] > summary::-webkit-details-marker { display: none; }
+  [data-slot="tool"] > summary::marker { content: ''; }
 
   @keyframes maka-tool-pulse {
     0%, 100% { box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.15); }
@@ -1544,17 +1494,6 @@
   @keyframes maka-pulse {
     0%, 100% { opacity: 0.55; transform: scale(1); }
     50%      { opacity: 1;    transform: scale(1.1); }
-  }
-
-  .maka-tool-body {
-    padding: 10px 12px 12px;
-  }
-  .maka-tool-intent {
-    margin: 0 0 8px;
-    color: var(--foreground-60);
-    font-family: var(--font-default);
-    font-size: 12px;
-    line-height: 1.4;
   }
 
   /* Inline failure banner shown at the top of an errored tool body so the
@@ -1604,25 +1543,6 @@
     align-items: center;
     gap: 4px;
     font-size: 11px;
-  }
-  .maka-tool[data-status="waiting_permission"] { border-color: oklch(from var(--info) l c h / 0.4); }
-  .maka-tool[data-status="running"]            { border-color: oklch(from var(--accent) l c h / 0.4); }
-  .maka-tool[data-status="completed"]          { border-color: var(--border); }
-  .maka-tool[data-status="errored"]            { border-color: oklch(from var(--destructive) l c h / 0.4); background: oklch(from var(--destructive) l c h / 0.04); }
-  .maka-tool[data-status="interrupted"]        { border-color: var(--border); background: var(--foreground-3); opacity: 0.7; }
-
-  .maka-tool-count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 22px;
-    height: 18px;
-    padding: 0 6px;
-    border-radius: 999px;
-    background: var(--foreground-5);
-    color: var(--foreground-60);
-    font-size: 11px;
-    font-variant-numeric: tabular-nums;
   }
 
   /* ---- Composer --------------------------------------------------- */

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -63,31 +63,12 @@
   font-size: 10px;
 }
 
-.toolInline {
-  width: min(680px, 100%);
-  margin: 2px auto 0;
-  padding: 0 16px;
-}
-
-.toolInline > header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 3px;
-  color: var(--foreground-50);
-  font-size: 10px;
-}
-
-.toolItem {
-  overflow: hidden;
-  box-shadow: var(--shadow-minimal-flat);
-}
-
-.toolArgs {
-  margin: 0;
-  max-height: 110px;
-  overflow: auto;
-}
+/* `.toolInline` (inline section + header), `.toolItem` (the `<details>` card's
+   overflow + flat shadow), and `.toolArgs` (the args `<pre>` override) moved onto
+   the `@maka/ui` `toolVariants` literalize table (issue #332 PR3b —
+   packages/ui/src/primitives/chat.tsx). The shared `.maka-code` base the args
+   `<pre>` layers over stays in maka-tokens.css (Markdown / artifact previews use
+   it too). */
 
 .maka-overlay-preview {
   margin: 5px 0 0;

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { Bubble, LiveIndicator, Marker, markerVariants, Message, streamVariants } from '../primitives/chat.js';
+import { Bubble, LiveIndicator, Marker, markerVariants, Message, streamVariants, toolVariants } from '../primitives/chat.js';
 import { buttonVariants, cn } from '../ui.js';
 
 // The re-anchored renderer selectors key off the primitives' own `data-slot` /
@@ -163,4 +163,33 @@ test('LiveIndicator pins the canonical pulse + reduced-motion fallback over conf
   assert.match(className, /motion-reduce:opacity-\[0\.8\]/);
   // never the Tailwind `animate-pulse` (a different opacity-only keyframe).
   assert.ok(!className.split(/\s+/).includes('animate-pulse'), 'must use the governed maka-pulse, not animate-pulse');
+});
+
+// PR3b — the tool-activity card shell. The full per-part shell is proven by the
+// computed-style diff harness (20 rows, 0 delta), so this does NOT enumerate the
+// leaf literals. It keeps two guards the diff can't make at the source level:
+// the shell stays LITERAL (no semantic scale a refactor could swap in), and —
+// the subtle one — cva's RUNTIME output must preserve the `waiting_permission`
+// `\_` escape as a SINGLE backslash. Tailwind turns a bare `_` in an arbitrary
+// value into a space; the `String.raw` source keeps source==runtime at one `\_`,
+// and any build/refactor that re-doubles or drops it silently breaks the
+// `waiting_permission` border/dot tint (invisible until rendered — the diff
+// harness caught exactly this).
+test('toolVariants stays literal and emits the single-backslash waiting_permission escape', () => {
+  const item = toolVariants({ part: 'item' });
+  const dot = toolVariants({ part: 'dot' });
+  for (const cls of [item, dot]) {
+    assert.ok(
+      !cls.split(/\s+/).some((u) => ['rounded-lg', 'rounded-md', 'rounded-xl', 'text-sm', 'text-xs', 'bg-primary'].includes(u)),
+      'tool shell must stay literal, not the semantic scale / a recolor',
+    );
+  }
+  // exactly one backslash before the underscore (source == runtime via String.raw)
+  assert.ok(item.includes('data-[status=waiting\\_permission]:[border-color:'), 'item must keep the single-backslash waiting_permission border escape');
+  assert.ok(dot.includes('data-[status=waiting\\_permission]:bg-[var(--info)]'), 'dot must keep the single-backslash waiting_permission bg escape');
+  // never the bare underscore form (Tailwind would read it as a space)
+  assert.ok(!item.includes('data-[status=waiting_permission]') && !dot.includes('data-[status=waiting_permission]'), 'the bare waiting_permission form must never reach the className');
+  // the running dot keeps the governed ring keyframe, never Tailwind animate-pulse
+  assert.match(dot, /\[animation:maka-tool-pulse_1\.5s_ease-in-out_infinite\]/);
+  assert.ok(!dot.split(/\s+/).includes('animate-pulse'), 'running dot must use the governed maka-tool-pulse ring');
 });

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -194,7 +194,7 @@ import {
   cn,
 } from './ui.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
-import { Bubble, LiveIndicator, Marker, markerVariants, Message, streamVariants } from './primitives/chat.js';
+import { Bubble, LiveIndicator, Marker, markerVariants, Message, streamVariants, toolVariants } from './primitives/chat.js';
 import { Button as PrimitiveButton } from './primitives/button.js';
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './primitives/empty.js';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './primitives/input-group.js';
@@ -6172,10 +6172,10 @@ function formatDuration(ms: number | undefined): string | null {
 
 export function ToolActivity(props: { items: ToolActivityItem[] }) {
   return (
-    <section className="toolInline" aria-label="工具调用记录">
-      <header>
+    <section className={toolVariants({ part: 'container' })} aria-label="工具调用记录">
+      <header className={toolVariants({ part: 'container-header' })}>
         <strong>工具调用</strong>
-        <span className="maka-tool-count" aria-label={`${props.items.length} 次调用`}>{props.items.length}</span>
+        <span className={toolVariants({ part: 'count' })} aria-label={`${props.items.length} 次调用`}>{props.items.length}</span>
       </header>
       {props.items.map((item) => {
         const duration = formatDuration(item.durationMs);
@@ -6184,23 +6184,24 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
         return (
           <details
             key={item.toolUseId}
-            className="maka-tool toolItem"
+            data-slot="tool"
+            className={toolVariants({ part: 'item' })}
             data-status={item.status}
             open={isOpenByDefault(item.status)}
           >
-            <summary className="maka-tool-header">
-              <span className="maka-tool-status-dot" data-status={item.status} aria-hidden="true" />
-              <span className="maka-tool-name">{resolveToolDisplayName(item)}</span>
-              <span className="maka-tool-meta">
-                {duration && <span className="maka-tool-duration">{duration}</span>}
-                <span className="maka-tool-status-label">{STATUS_LABEL[item.status]}</span>
+            <summary className={toolVariants({ part: 'header' })}>
+              <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
+              <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
+              <span className={toolVariants({ part: 'meta' })}>
+                {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
+                <span className={toolVariants({ part: 'status-label' })}>{STATUS_LABEL[item.status]}</span>
               </span>
             </summary>
-            <div className="maka-tool-body">
+            <div className={toolVariants({ part: 'body' })}>
               {errored && <ToolErrorBanner result={item.result} />}
-              {item.intent && !permissionDenied && <p className="maka-tool-intent">{formatToolIntent(item.intent)}</p>}
+              {item.intent && !permissionDenied && <p className={toolVariants({ part: 'intent' })}>{formatToolIntent(item.intent)}</p>}
               {item.args !== undefined && !permissionDenied && (
-                <pre className="maka-code toolArgs">{formatRedactedJson(item.args)}</pre>
+                <pre className={`maka-code ${toolVariants({ part: 'args' })}`}>{formatRedactedJson(item.args)}</pre>
               )}
               {item.outputChunks && item.outputChunks.length > 0 && (
                 <ToolOutputStream

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,9 +27,10 @@ export * from './utils.js';
 // consumers can `import { Alert, Empty, Sidebar, ... } from '@maka/ui'`.
 export * from './bot-brand.js';
 export * from './primitives/alert.js';
-// `markerVariants` / `streamVariants` / `LiveIndicator` are deliberately NOT
-// re-exported here: they are internal styling tables / a single-consumer dot that
-// the chat call sites apply via relative import, so keeping them off the package
+// `markerVariants` / `streamVariants` / `toolVariants` / `LiveIndicator` are
+// deliberately NOT re-exported here: they are internal styling tables / a
+// single-consumer dot that the chat call sites apply via relative import, so
+// keeping them off the package
 // barrel preserves the governance goal — they stay renamable/removable without a
 // public-API break. (Contrast `buttonVariants`, which IS public because it has
 // external consumers.) `LiveIndicator` is exported to public only when the

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -417,18 +417,11 @@ export function LiveIndicator({
  * the `.toolArgs` override. The `ToolErrorBanner` (`Alert` + `.maka-tool-error*`)
  * is a separate concern on a different substrate and migrates in its own pass.
  */
-// The `waiting_permission` status carries a LITERAL underscore in its data value,
-// the one case the literalize table can't write as a plain string. Tailwind turns
-// a bare `_` in an arbitrary value into a SPACE (correct for the track-list /
-// box-shadow / oklch `_`s elsewhere, fatal here — it would compile the selector to
-// `[data-status="waiting permission"]`, which never matches). The escape is `\_`,
-// but a normal string literal (`"…waiting\\_permission…"`) makes the SCANNED
-// source text (`\\_`, two chars) disagree with cva's RUNTIME output (`\_`, one
-// char), so Tailwind emits a `\\\\_` selector the emitted class never matches.
-// `String.raw` makes the scanned source and the runtime string identical — a
-// single `\_` — the one form Tailwind compiles and cva emits the same way. (The
-// computed-style diff harness caught this; the four underscore-free statuses
-// never had the problem.)
+// `waiting_permission` carries a literal underscore, which Tailwind reads as a
+// SPACE in an arbitrary value (`[data-status="waiting permission"]` — never
+// matches). The escape is `\_`, but a plain string literal makes the SCANNED
+// source (`\\_`) disagree with cva's RUNTIME output (`\_`), so the emitted
+// selector misses the class. `String.raw` keeps both at a single `\_`.
 const WP_CARD_BORDER = String.raw`data-[status=waiting\_permission]:[border-color:oklch(from_var(--info)_l_c_h_/_0.4)]`;
 const WP_DOT_BG = String.raw`data-[status=waiting\_permission]:bg-[var(--info)]`;
 

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -365,3 +365,133 @@ export function LiveIndicator({
     />
   );
 }
+
+/**
+ * Tool-activity card shell (issue #332, PR3b).
+ *
+ * Retires the bespoke `ToolActivity` chrome — the inline section + count, the
+ * `<details>` card (`.maka-tool` / `.toolItem`), the `<summary>` header row
+ * (`.maka-tool-header` / `-name` / `-meta` / `-duration` / `-status-label` /
+ * `-status-dot`), the body / intent, and the args `<pre>` override
+ * (`.toolArgs`) — moving each onto this Tailwind substrate. The selectors lived
+ * across `maka-tokens.css`'s `@layer components` and `styles/tool-output.css`.
+ *
+ * Every value is a LITERAL arbitrary utility that compiles 1:1 to the
+ * declaration it replaces, so the cva source string IS the computed-style proof
+ * (the cascade contract asserts the exact strings, no browser needed). Literals
+ * over the semantic scale for the same reason as `markerVariants` / `streamVariants`:
+ * the retired CSS hardcoded these pixels, so the literal is the faithful,
+ * self-evidently-equal translation and is immune to later scale/token re-tuning
+ * (the visual refresh, not this governance pass, owns adopting the scale).
+ *
+ * Three pieces escape the computed-style proof and are NOT in this table — they
+ * stay a small named residue keyed on `[data-slot="tool"]` in maka-tokens.css,
+ * pinned by the PR3b cascade contract (source strings + keyframe frames) rather
+ * than the diff harness:
+ *   1. the running status dot's `[animation:maka-tool-pulse…]` breath (the
+ *      shorthand rides in the `dot` part here like `LiveIndicator`; only the
+ *      `@keyframes maka-tool-pulse` stays in CSS — a keyframe is a global rule,
+ *      not an element property, and `getComputedStyle` reads a phase-dependent
+ *      value). The running dot's box-shadow RING is a leaf rest-state literal, so
+ *      it stays here and IS diff-proven.
+ *   2. the card mount entrance (`transition` + `@starting-style` opacity/translate)
+ *      — `@starting-style` only applies on the first frame, so it has no at-rest
+ *      computed style to diff. Kept verbatim as residue.
+ *   3. the native `<summary>` marker reset (`::-webkit-details-marker` /
+ *      `::marker`) — pseudo-elements with no leaf-utility form. Kept as residue.
+ * (The reduced-motion / visual-smoke suppression both ride GLOBAL `*` rules in
+ * maka-tokens.css / base.css, so — unlike `LiveIndicator`, a reusable primitive
+ * that carries its own `motion-reduce:` guards — the dot and card need no
+ * per-element motion utilities; the same global rules cover them as before.)
+ *
+ * The single consumer (`ToolActivity`) keeps its semantic tags and applies these
+ * by `className`. `toolVariants` is kept OFF the package barrel for the same
+ * reason as `markerVariants` / `streamVariants`: the only consumer imports it by
+ * relative path, so the part set stays an internal, freely-removable styling
+ * detail. The `<details>` card stays native HTML here — the eventual Base UI
+ * Disclosure path (the intended convergence target for this card AND the
+ * `.maka-turn-thinking` block) is a later structural pass, not this lift.
+ *
+ * NOTE: the args `<pre>` keeps the shared `.maka-code` inline-code base (used by
+ * Markdown / artifact previews too — out of scope); the `args` part below is only
+ * the `.toolArgs` override. The `ToolErrorBanner` (`Alert` + `.maka-tool-error*`)
+ * is a separate concern on a different substrate and migrates in its own pass.
+ */
+// The `waiting_permission` status carries a LITERAL underscore in its data value,
+// the one case the literalize table can't write as a plain string. Tailwind turns
+// a bare `_` in an arbitrary value into a SPACE (correct for the track-list /
+// box-shadow / oklch `_`s elsewhere, fatal here — it would compile the selector to
+// `[data-status="waiting permission"]`, which never matches). The escape is `\_`,
+// but a normal string literal (`"…waiting\\_permission…"`) makes the SCANNED
+// source text (`\\_`, two chars) disagree with cva's RUNTIME output (`\_`, one
+// char), so Tailwind emits a `\\\\_` selector the emitted class never matches.
+// `String.raw` makes the scanned source and the runtime string identical — a
+// single `\_` — the one form Tailwind compiles and cva emits the same way. (The
+// computed-style diff harness caught this; the four underscore-free statuses
+// never had the problem.)
+const WP_CARD_BORDER = String.raw`data-[status=waiting\_permission]:[border-color:oklch(from_var(--info)_l_c_h_/_0.4)]`;
+const WP_DOT_BG = String.raw`data-[status=waiting\_permission]:bg-[var(--info)]`;
+
+const toolVariants = cva("", {
+  variants: {
+    part: {
+      // `.toolInline` — the inline section measure column.
+      container: "w-[min(680px,100%)] mx-auto mt-[2px] mb-0 px-[16px] py-0",
+      // `.toolInline > header` — the quiet "工具调用" caption row.
+      "container-header":
+        "flex items-center justify-between mb-[3px] text-[color:var(--foreground-50)] text-[10px]",
+      // `.maka-tool-count` — the call-count pill.
+      count:
+        "inline-flex items-center justify-center min-w-[22px] h-[18px] px-[6px] py-0 rounded-[999px] bg-[var(--foreground-5)] text-[color:var(--foreground-60)] text-[11px] [font-variant-numeric:tabular-nums]",
+      // `.maka-tool` (effective: the later `padding: 0` rule wins over `8px 12px`)
+      // + `.toolItem` + the `[open]>summary` divider + the `[data-status]` border /
+      // background / opacity swaps. `[border:…]` / `[border-color:…]` are arbitrary
+      // so the status overrides touch only the color, never width/style. The mount
+      // entrance (transition + `@starting-style`) and `<summary>` marker reset stay
+      // a residue keyed on `[data-slot="tool"]` (see docstring).
+      item:
+        "[border:1px_solid_var(--border)] rounded-[10px] bg-[var(--foreground-2)] p-0 mt-[8px] [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-80)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
+        + " [&[open]>summary]:[border-bottom:1px_solid_var(--border)]"
+        // `waiting_permission` border tint — see `WP_CARD_BORDER` above (String.raw).
+        + " " + WP_CARD_BORDER
+        + " data-[status=running]:[border-color:oklch(from_var(--accent)_l_c_h_/_0.4)]"
+        + " data-[status=completed]:[border-color:var(--border)]"
+        + " data-[status=errored]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.4)] data-[status=errored]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)]"
+        + " data-[status=interrupted]:[border-color:var(--border)] data-[status=interrupted]:bg-[var(--foreground-3)] data-[status=interrupted]:opacity-[0.7]",
+      // `.maka-tool > summary` (list-style + padding) + `.maka-tool-header` (the
+      // 8px · name · meta grid). Folded together since the summary IS the header.
+      header:
+        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-[10px] px-[12px] py-[8px] text-[color:var(--foreground-70)]",
+      // `.maka-tool-status-dot` (+ the `[data-status]` color swaps; running adds
+      // the box-shadow ring + `maka-tool-pulse` breath — keyframe stays in CSS).
+      dot:
+        "w-[8px] h-[8px] rounded-[999px] bg-[var(--foreground-30)] [flex:0_0_auto]"
+        // `waiting_permission` dot tint — see `WP_DOT_BG` above (String.raw).
+        + " " + WP_DOT_BG
+        + " data-[status=running]:bg-[var(--accent)] data-[status=running]:[box-shadow:0_0_0_3px_oklch(from_var(--accent)_l_c_h_/_0.15)] data-[status=running]:[animation:maka-tool-pulse_1.5s_ease-in-out_infinite]"
+        + " data-[status=completed]:bg-[var(--success)]"
+        + " data-[status=errored]:bg-[var(--destructive)]"
+        + " data-[status=interrupted]:bg-[var(--foreground-30)]",
+      // `.maka-tool-name` — the mono tool name, ellipsized.
+      name:
+        "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground)] font-medium [font-family:var(--font-mono)]",
+      // `.maka-tool-meta` — duration + status-label cluster.
+      meta:
+        "inline-flex items-center gap-[8px] text-[color:var(--foreground-50)] text-[11px]",
+      // `.maka-tool-duration`
+      duration: "[font-variant-numeric:tabular-nums]",
+      // `.maka-tool-status-label`
+      "status-label": "text-[color:var(--foreground-60)]",
+      // `.maka-tool-body`
+      body: "px-[12px] pt-[10px] pb-[12px]",
+      // `.maka-tool-intent`
+      intent:
+        "mx-0 mt-0 mb-[8px] text-[color:var(--foreground-60)] [font-family:var(--font-default)] text-[12px] leading-[1.4]",
+      // `.toolArgs` — the override layered over the shared `.maka-code` base
+      // (`.maka-code` stays in CSS; the call site keeps the class).
+      args: "m-0 max-h-[110px] overflow-auto",
+    },
+  },
+});
+
+export { toolVariants };

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -156,13 +156,15 @@ const streamPanel = (el, id, attrs) =>
 // either way — the collapsed body row still diffs its box / typography parity.)
 const tv = (part) => toolVariants({ part });
 const openByDefault = (s) => s === 'pending' || s === 'waiting_permission' || s === 'running' || s === 'errored';
+// The SINGLE source of truth for the tool-card fixture: every production
+// `ToolActivityItem['status']` (the keys of components.tsx's STATUS_LABEL). The
+// cards, the header count, and the diffed IDS all derive from this one list, so
+// they can't drift apart; the cascade contract asserts it stays complete, so a
+// new status can't silently escape the zero-visual proof. `pending` has NO
+// `data-[status=pending]` branch in toolVariants, so it falls back to the base
+// card border + gray dot; it renders OPEN (isOpenByDefault).
+const STAT = ['pending', 'waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
 const toolCardSection = (el) => {
-  // Every production `ToolActivityItem['status']` (the keys of components.tsx's
-  // STATUS_LABEL) renders a card here — the cascade contract asserts this set
-  // stays complete so a new status can't silently escape the zero-visual proof.
-  // `pending` has NO `data-[status=pending]` branch in toolVariants, so it falls
-  // back to the base card border + gray dot; it renders OPEN (isOpenByDefault).
-  const STAT = ['pending', 'waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
   const item = pair('maka-tool toolItem', tv('item'));
   const hdr = pair('maka-tool-header', tv('header'));
   const dot = pair('maka-tool-status-dot', tv('dot'));
@@ -200,7 +202,7 @@ const toolCardSection = (el) => {
   return el('section', 'tool-section', pair('toolInline', tv('container')), 'aria-label="工具调用记录"',
     el('header', 'tool-section-header', pair('', tv('container-header')), '',
       '<strong>工具调用</strong>'
-      + el('span', 'tool-count', pair('maka-tool-count', tv('count')), '', '5'))
+      + el('span', 'tool-count', pair('maka-tool-count', tv('count')), '', String(STAT.length)))
     + STAT.map(card).join('\n'));
 };
 
@@ -263,10 +265,14 @@ const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools'
   // status-invariant inner parts (on the open `errored` card), and the COLLAPSED
   // `completed` default — its summary (no `[open]` divider) + UA-hidden body.
   'tool-section', 'tool-section-header', 'tool-count',
-  'tool-item-pending', 'tool-item-waiting_permission', 'tool-item-running', 'tool-item-completed', 'tool-item-errored', 'tool-item-interrupted',
+  // Derived from the same STAT as the cards (no second hand-kept list to drift):
+  // every status' `[data-status]` container is diffed…
+  ...STAT.map((s) => `tool-item-${s}`),
   'tool-summary', 'tool-name', 'tool-meta', 'tool-duration', 'tool-statuslabel', 'tool-body', 'tool-intent', 'tool-args',
   'tool-summary-collapsed', 'tool-name-collapsed', 'tool-body-collapsed',
-  'tool-dot-pending', 'tool-dot-waiting_permission', 'tool-dot-completed', 'tool-dot-errored', 'tool-dot-interrupted'];
+  // …and every static dot, EXCEPT running's (its `maka-tool-pulse` ring is
+  // animated → phase-dependent `getComputedStyle`; pinned by the keyframe contract).
+  ...STAT.filter((s) => s !== 'running').map((s) => `tool-dot-${s}`)];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).
 // summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -135,43 +135,63 @@ const streamPanel = (el, id, attrs) =>
         + el('span', `${id}-chunk-redacted`, pair('maka-tool-output-stream-chunk', sv('chunk')), 'data-redacted="true"',
             'x' + el('span', `${id}-redacted-tag`, pair('maka-tool-output-stream-redacted-tag', sv('redacted-tag')), '', '[已脱敏]'))));
 
-// PR3b — the `ToolActivity` card shell. Resting, non-interactive; the only part
-// NOT diffed is the RUNNING status dot (its `maka-tool-pulse` ring is animated →
-// phase-dependent `getComputedStyle`), pinned by the cascade contract's keyframe
-// frames + chat.tsx literal instead. Every other surface — the inline section +
-// count, all five `[data-status]` card containers (border / bg / opacity swaps),
-// the summary header grid, the four static dot colors, name / meta / duration /
-// status-label / body / intent, and the args `<pre>` override layered over the
-// shared `.maka-code` base — is static and diffed in full. On `main` the inline
-// `<header>` and the args `<pre>` carry their bespoke classes; the head side uses
-// the `toolVariants` parts (+ the shared `maka-code` on args). `data-slot="tool"`
-// + `open` on each card activate the head residue (entrance transition) and the
-// `[open]>summary` divider on both sides.
+// PR3b — the `ToolActivity` card shell. The only part NOT diffed is the RUNNING
+// status dot (its `maka-tool-pulse` ring is animated → phase-dependent
+// `getComputedStyle`), pinned by the cascade contract's keyframe frames +
+// chat.tsx literal instead. Every other surface — the inline section + count, all
+// five `[data-status]` card containers (border / bg / opacity swaps), the summary
+// header grid, the static dot colors, name / meta / duration / status-label /
+// body / intent, and the args `<pre>` override over the shared `.maka-code` base
+// — is static and diffed in full.
+//
+// Each card carries its REAL `isOpenByDefault` state (components.tsx): pending /
+// waiting_permission / running / errored render OPEN, completed / interrupted
+// render COLLAPSED. That matters — the most common historical card is a settled,
+// collapsed `completed` tool, whose `[open]>summary` divider is absent. So the
+// rich inner parts ride the (open) `errored` card, and a COLLAPSED `completed`
+// card is diffed too. The non-vacuous collapsed signal is the summary's
+// border-bottom: 1px on the open card, 0px on the collapsed one (the `[open]`
+// gate), so the rows genuinely exercise both states. (The body is hidden via
+// Chromium's `::details-content` pseudo, so its child `display` stays `block`
+// either way — the collapsed body row still diffs its box / typography parity.)
 const tv = (part) => toolVariants({ part });
+const openByDefault = (s) => s === 'pending' || s === 'waiting_permission' || s === 'running' || s === 'errored';
 const toolCardSection = (el) => {
   const STAT = ['waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
   const item = pair('maka-tool toolItem', tv('item'));
   const hdr = pair('maka-tool-header', tv('header'));
   const dot = pair('maka-tool-status-dot', tv('dot'));
-  // The representative `completed` card is fully expanded so the status-invariant
-  // inner parts (name / meta / duration / status-label / body / intent / args)
-  // are each measured once; the other four cards exercise only the container +
-  // dot status swaps.
-  const innerFor = (s) => {
-    const dotId = s === 'running' ? `tool-dot-${s}` : `tool-dot-${s}`; // id always set; running excluded from IDS
-    const dotEl = el('span', dotId, dot, `data-status="${s}" aria-hidden="true"`);
-    if (s !== 'completed') return el('summary', `tool-sum-${s}`, hdr, '', dotEl);
-    return el('summary', 'tool-summary', hdr, '',
-        dotEl
+  const body = pair('maka-tool-body', tv('body'));
+  const dotEl = (s, id) => el('span', id, dot, `data-status="${s}" aria-hidden="true"`);
+  // The status-invariant inner parts (name / meta / duration / status-label /
+  // body / intent / args) ride the OPEN `errored` card so they're each measured
+  // once in their visible state — including the `[open]>summary` divider.
+  const erroredInner =
+    el('summary', 'tool-summary', hdr, '',
+        dotEl('errored', 'tool-dot-errored')
         + el('span', 'tool-name', pair('maka-tool-name', tv('name')), '', 'Bash')
         + el('span', 'tool-meta', pair('maka-tool-meta', tv('meta')), '',
             el('span', 'tool-duration', pair('maka-tool-duration', tv('duration')), '', '1.2s')
-            + el('span', 'tool-statuslabel', pair('maka-tool-status-label', tv('status-label')), '', '已完成')))
-      + el('div', 'tool-body', pair('maka-tool-body', tv('body')), '',
+            + el('span', 'tool-statuslabel', pair('maka-tool-status-label', tv('status-label')), '', '失败')))
+      + el('div', 'tool-body', body, '',
           el('p', 'tool-intent', pair('maka-tool-intent', tv('intent')), '', 'run a command')
           + el('pre', 'tool-args', pair('maka-code toolArgs', cn('maka-code', tv('args'))), '', '{ "cmd": "ls" }'));
-  };
-  const card = (s) => el('details', `tool-item-${s}`, item, `data-slot="tool" data-status="${s}" open`, innerFor(s));
+  // The COLLAPSED `completed` card — the default history state. The summary loses
+  // its `[open]>summary` divider (border-bottom 0px vs the open card's 1px — the
+  // non-vacuous proof the collapsed branch is really exercised); the body's box /
+  // typography parity is diffed too. Both read identical across main/head.
+  const completedInner =
+    el('summary', 'tool-summary-collapsed', hdr, '',
+        dotEl('completed', 'tool-dot-completed')
+        + el('span', 'tool-name-collapsed', pair('maka-tool-name', tv('name')), '', 'Read'))
+      + el('div', 'tool-body-collapsed', body, '', 'hidden while collapsed');
+  const inner = (s) =>
+    s === 'errored' ? erroredInner
+    : s === 'completed' ? completedInner
+    // running dot excluded from IDS (animated); other open/collapsed dots diffed.
+    : el('summary', `tool-sum-${s}`, hdr, '', dotEl(s, `tool-dot-${s}`));
+  const card = (s) =>
+    el('details', `tool-item-${s}`, item, `data-slot="tool" data-status="${s}" ${openByDefault(s) ? 'open' : ''}`, inner(s));
   return el('section', 'tool-section', pair('toolInline', tv('container')), 'aria-label="工具调用记录"',
     el('header', 'tool-section-header', pair('', tv('container-header')), '',
       '<strong>工具调用</strong>'
@@ -233,11 +253,14 @@ const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools'
   // (animated → phase-dependent computed style).
   'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
   // PR3b tool-card shell: section + count, all five `[data-status]` card
-  // containers, the summary header grid, the four STATIC dot colors (running dot
-  // excluded — animated ring), and the status-invariant inner parts.
+  // containers at their REAL default open/collapsed state, the summary header
+  // grid, the static dot colors (running dot excluded — animated ring), the
+  // status-invariant inner parts (on the open `errored` card), and the COLLAPSED
+  // `completed` default — its summary (no `[open]` divider) + UA-hidden body.
   'tool-section', 'tool-section-header', 'tool-count',
   'tool-item-waiting_permission', 'tool-item-running', 'tool-item-completed', 'tool-item-errored', 'tool-item-interrupted',
   'tool-summary', 'tool-name', 'tool-meta', 'tool-duration', 'tool-statuslabel', 'tool-body', 'tool-intent', 'tool-args',
+  'tool-summary-collapsed', 'tool-name-collapsed', 'tool-body-collapsed',
   'tool-dot-waiting_permission', 'tool-dot-completed', 'tool-dot-errored', 'tool-dot-interrupted'];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -139,7 +139,7 @@ const streamPanel = (el, id, attrs) =>
 // status dot (its `maka-tool-pulse` ring is animated → phase-dependent
 // `getComputedStyle`), pinned by the cascade contract's keyframe frames +
 // chat.tsx literal instead. Every other surface — the inline section + count, all
-// five `[data-status]` card containers (border / bg / opacity swaps), the summary
+// six `[data-status]` card containers (border / bg / opacity swaps), the summary
 // header grid, the static dot colors, name / meta / duration / status-label /
 // body / intent, and the args `<pre>` override over the shared `.maka-code` base
 // — is static and diffed in full.
@@ -157,7 +157,12 @@ const streamPanel = (el, id, attrs) =>
 const tv = (part) => toolVariants({ part });
 const openByDefault = (s) => s === 'pending' || s === 'waiting_permission' || s === 'running' || s === 'errored';
 const toolCardSection = (el) => {
-  const STAT = ['waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
+  // Every production `ToolActivityItem['status']` (the keys of components.tsx's
+  // STATUS_LABEL) renders a card here — the cascade contract asserts this set
+  // stays complete so a new status can't silently escape the zero-visual proof.
+  // `pending` has NO `data-[status=pending]` branch in toolVariants, so it falls
+  // back to the base card border + gray dot; it renders OPEN (isOpenByDefault).
+  const STAT = ['pending', 'waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
   const item = pair('maka-tool toolItem', tv('item'));
   const hdr = pair('maka-tool-header', tv('header'));
   const dot = pair('maka-tool-status-dot', tv('dot'));
@@ -252,16 +257,16 @@ const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools'
   // PR3 stream shell (resting + live border ring). The pulse dot is excluded
   // (animated → phase-dependent computed style).
   'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
-  // PR3b tool-card shell: section + count, all five `[data-status]` card
+  // PR3b tool-card shell: section + count, all six `[data-status]` card
   // containers at their REAL default open/collapsed state, the summary header
   // grid, the static dot colors (running dot excluded — animated ring), the
   // status-invariant inner parts (on the open `errored` card), and the COLLAPSED
   // `completed` default — its summary (no `[open]` divider) + UA-hidden body.
   'tool-section', 'tool-section-header', 'tool-count',
-  'tool-item-waiting_permission', 'tool-item-running', 'tool-item-completed', 'tool-item-errored', 'tool-item-interrupted',
+  'tool-item-pending', 'tool-item-waiting_permission', 'tool-item-running', 'tool-item-completed', 'tool-item-errored', 'tool-item-interrupted',
   'tool-summary', 'tool-name', 'tool-meta', 'tool-duration', 'tool-statuslabel', 'tool-body', 'tool-intent', 'tool-args',
   'tool-summary-collapsed', 'tool-name-collapsed', 'tool-body-collapsed',
-  'tool-dot-waiting_permission', 'tool-dot-completed', 'tool-dot-errored', 'tool-dot-interrupted'];
+  'tool-dot-pending', 'tool-dot-waiting_permission', 'tool-dot-completed', 'tool-dot-errored', 'tool-dot-interrupted'];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).
 // summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -84,7 +84,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const { buttonVariants, cn } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/ui.js')).href);
-const { markerVariants, streamVariants } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href);
+const { markerVariants, streamVariants, toolVariants } = await import(pathToFileURL(resolve(REPO_ROOT, 'packages/ui/dist/primitives/chat.js')).href);
 
 const mainCssPath = process.argv[2] && resolve(process.argv[2]);
 const headCssPath = process.argv[3] && resolve(process.argv[3]);
@@ -135,6 +135,50 @@ const streamPanel = (el, id, attrs) =>
         + el('span', `${id}-chunk-redacted`, pair('maka-tool-output-stream-chunk', sv('chunk')), 'data-redacted="true"',
             'x' + el('span', `${id}-redacted-tag`, pair('maka-tool-output-stream-redacted-tag', sv('redacted-tag')), '', '[已脱敏]'))));
 
+// PR3b — the `ToolActivity` card shell. Resting, non-interactive; the only part
+// NOT diffed is the RUNNING status dot (its `maka-tool-pulse` ring is animated →
+// phase-dependent `getComputedStyle`), pinned by the cascade contract's keyframe
+// frames + chat.tsx literal instead. Every other surface — the inline section +
+// count, all five `[data-status]` card containers (border / bg / opacity swaps),
+// the summary header grid, the four static dot colors, name / meta / duration /
+// status-label / body / intent, and the args `<pre>` override layered over the
+// shared `.maka-code` base — is static and diffed in full. On `main` the inline
+// `<header>` and the args `<pre>` carry their bespoke classes; the head side uses
+// the `toolVariants` parts (+ the shared `maka-code` on args). `data-slot="tool"`
+// + `open` on each card activate the head residue (entrance transition) and the
+// `[open]>summary` divider on both sides.
+const tv = (part) => toolVariants({ part });
+const toolCardSection = (el) => {
+  const STAT = ['waiting_permission', 'running', 'completed', 'errored', 'interrupted'];
+  const item = pair('maka-tool toolItem', tv('item'));
+  const hdr = pair('maka-tool-header', tv('header'));
+  const dot = pair('maka-tool-status-dot', tv('dot'));
+  // The representative `completed` card is fully expanded so the status-invariant
+  // inner parts (name / meta / duration / status-label / body / intent / args)
+  // are each measured once; the other four cards exercise only the container +
+  // dot status swaps.
+  const innerFor = (s) => {
+    const dotId = s === 'running' ? `tool-dot-${s}` : `tool-dot-${s}`; // id always set; running excluded from IDS
+    const dotEl = el('span', dotId, dot, `data-status="${s}" aria-hidden="true"`);
+    if (s !== 'completed') return el('summary', `tool-sum-${s}`, hdr, '', dotEl);
+    return el('summary', 'tool-summary', hdr, '',
+        dotEl
+        + el('span', 'tool-name', pair('maka-tool-name', tv('name')), '', 'Bash')
+        + el('span', 'tool-meta', pair('maka-tool-meta', tv('meta')), '',
+            el('span', 'tool-duration', pair('maka-tool-duration', tv('duration')), '', '1.2s')
+            + el('span', 'tool-statuslabel', pair('maka-tool-status-label', tv('status-label')), '', '已完成')))
+      + el('div', 'tool-body', pair('maka-tool-body', tv('body')), '',
+          el('p', 'tool-intent', pair('maka-tool-intent', tv('intent')), '', 'run a command')
+          + el('pre', 'tool-args', pair('maka-code toolArgs', cn('maka-code', tv('args'))), '', '{ "cmd": "ls" }'));
+  };
+  const card = (s) => el('details', `tool-item-${s}`, item, `data-slot="tool" data-status="${s}" open`, innerFor(s));
+  return el('section', 'tool-section', pair('toolInline', tv('container')), 'aria-label="工具调用记录"',
+    el('header', 'tool-section-header', pair('', tv('container-header')), '',
+      '<strong>工具调用</strong>'
+      + el('span', 'tool-count', pair('maka-tool-count', tv('count')), '', '5'))
+    + STAT.map(card).join('\n'));
+};
+
 // DOM tree mirroring TurnView nesting.
 const TREE = (side) => {
   const C = (p) => p[side];
@@ -178,14 +222,23 @@ const TREE = (side) => {
     // so the accent border + inset ring are diffed too.
     streamPanel(el, 'stream', ''),
     streamPanel(el, 'stream-live', 'data-live="true"'),
+    // The PR3b tool-activity card shell.
+    toolCardSection(el),
   ].join('\n');
 };
 
-const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderBottomColor', 'borderTopStyle', 'borderTopLeftRadius', 'boxShadow', 'overflowX', 'overflowY', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing', 'lineHeight', 'textTransform', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'flexDirection', 'fontVariantNumeric', 'whiteSpace', 'wordBreak', 'textAlign', 'cursor'];
+const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'maxHeight', 'minWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderBottomColor', 'borderTopStyle', 'borderTopLeftRadius', 'boxShadow', 'overflowX', 'overflowY', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing', 'lineHeight', 'textTransform', 'gridTemplateColumns', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'flexDirection', 'fontVariantNumeric', 'whiteSpace', 'wordBreak', 'textOverflow', 'textAlign', 'cursor'];
 const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools', 'summary-chip-duration', 'summary-chip-tokens', 'summary-chip-inprogress', 'summary-chip-switched', 'summary-switched', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery',
   // PR3 stream shell (resting + live border ring). The pulse dot is excluded
   // (animated → phase-dependent computed style).
-  'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live'];
+  'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
+  // PR3b tool-card shell: section + count, all five `[data-status]` card
+  // containers, the summary header grid, the four STATIC dot colors (running dot
+  // excluded — animated ring), and the status-invariant inner parts.
+  'tool-section', 'tool-section-header', 'tool-count',
+  'tool-item-waiting_permission', 'tool-item-running', 'tool-item-completed', 'tool-item-errored', 'tool-item-interrupted',
+  'tool-summary', 'tool-name', 'tool-meta', 'tool-duration', 'tool-statuslabel', 'tool-body', 'tool-intent', 'tool-args',
+  'tool-dot-waiting_permission', 'tool-dot-completed', 'tool-dot-errored', 'tool-dot-interrupted'];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).
 // summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);


### PR DESCRIPTION
## Summary

Moves the `ToolActivity` card shell — the inline section + count pill, the `<details>` card, its `<summary>` header row + status dot, the body / intent, and the args `<pre>` override — onto the `@maka/ui` chat substrate, retiring the bespoke `.maka-tool*` / `.toolInline` / `.toolItem` / `.toolArgs` CSS with zero visual change. This is PR3b of the #332 conversation-flow governance pass, following PR1 (#334, bubble/row shell), PR2 (#337, turn markers), and PR3a (#348, tool live-output stream).

The static shell literalizes onto a new internal `toolVariants` cva exactly as PR2/PR3a did. Three pieces escape the leaf-literal proof and stay a small named residue re-keyed off the retired `.maka-tool` class onto the governed `[data-slot="tool"]` hook: the card mount entrance (`transition` + `@starting-style`, which only paints on the first frame), the native `<summary>` marker reset (pseudo-elements), and the running dot's `@keyframes maka-tool-pulse` ring (a keyframe is a global rule, not an element property). These are pinned by a cascade contract + the diff harness instead.

## Why

Closes part of #332 (PR3b). The conversation-flow display is being migrated onto one `@maka/ui` substrate + a test net, one island at a time, with zero visual change. The tool card was the one remaining bespoke island between already-governed neighbours (bubble / marker / stream); lifting it now keeps the chat surface coherent and location-independent (status is a `data-*` vocabulary, not a descendant-selector coupling). The native `<details>` card and the `.maka-turn-thinking` block can later converge onto one Base UI Disclosure primitive — PR3b deliberately leaves both in the same shape (native details + named residue) so that structural pass is a clean follow-up, not a prerequisite.

## Scope

Changed (three atomic commits):
- **`feat(ui): add internal toolVariants chat primitive`** — `packages/ui/src/primitives/chat.tsx` (the cva table; every value a LITERAL arbitrary utility compiling 1:1 to the retired declaration), `packages/ui/src/index.ts` (kept OFF the barrel like `markerVariants` / `streamVariants` — single consumer, relative import).
- **`refactor(ui): migrate ToolActivity onto toolVariants and retire .maka-tool* CSS`** — `packages/ui/src/components.tsx` (rewire + `data-slot="tool"`), `apps/desktop/src/renderer/maka-tokens.css` + `styles/tool-output.css` (delete the migrated rules; keep the `[data-slot="tool"]` entrance/marker residue + the `@keyframes maka-tool-pulse` ring). Consumer + CSS removal land together so the renderer orphan-selector contract stays green.
- **`test(ui): lock the migration with cascade contract + diff harness`** — see Verification.

Not included:
- `ToolErrorBanner` + `.maka-tool-error*` — already on the `@maka/ui` `Alert` primitive; its dead grid/icon/body/title classes and live copy-feedback tints are coupled to `visible-copy-hygiene-contract`, a different review lens. Separate PR (PR3c).
- The result-preview renderers (`.maka-tool-diff*` / `.maka-tool-terminal*` / `.maka-office-document*` / `.maka-explore-agent*` / `.maka-load-tool-*` / `.maka-overlay-*`) — separate components rendered inside the tool body, a different concern.
- The shared `.maka-code` inline-code base (Markdown / artifact previews use it too) — untouched; the args `<pre>` keeps the class and only its `.toolArgs` override moves.
- Base UI Disclosure unification of the card + `.maka-turn-thinking` — a later structural pass.

## Verification

This repo has no CI; everything below was run locally.

- `npm run -w @maka/ui test` — 13/13 (adds a `toolVariants` literal/scale-drift + single-backslash `waiting_permission` runtime guard).
- `npm run -w @maka/desktop test` — 1613/1613 (adds `chat-tool-card-cascade-contract.test.ts`: retired selectors absent without touching `.maka-tool-error*` / `.maka-tool-diff*` / `.maka-tool-terminal*` / `.maka-code`; `@keyframes maka-tool-pulse` ring frames pinned; the `[data-slot="tool"]` entrance + marker residue pinned; the `[open]>summary` divider + running-dot literals + `String.raw` escape pinned; and a guard deriving the status set from `STATUS_LABEL` so every production status keeps a diffed row).
- `npm run typecheck` — clean across all workspaces.
- `npm run check:chat-visual -- <pre-PR2 baseline.css> <head.css>` (the computed-style diff, extended with a tool-card tree): against a pre-PR2 renderer CSS baseline (`e033a8c4~1`, which still carries the bespoke marker + stream + tool CSS), **TOTAL DIFFS: 0** across 61 element/state rows + 2 `::before` middots — including all 25 tool-card rows (every one of the six production statuses renders a card — `pending` included, proving the base border + gray-dot fallback it has no `data-[status]` branch for). Each card is rendered at its real `isOpenByDefault` state (pending/waiting/running/errored open, completed/interrupted collapsed), so the most common historical card — a settled, collapsed `completed` tool — is covered too: the collapsed summary's divider reads 0px vs the open card's 1px (the non-vacuous proof the collapsed branch is exercised), identical across main/head. Non-vacuous: the baseline and head bundles differ in source, yet the migrated chrome reads byte-identical computed style on both sides.
- The running dot is the one part the diff can't cover (animated → phase-dependent `getComputedStyle`); pinned by the `@keyframes maka-tool-pulse` frame contract + the `chat.tsx` literal.

## User-facing impact

None — zero visual change by design, locked by the contract + diff above.

## Reviewer notes

- The diff harness earned its keep: it caught a real literalization bug a source-only test would have missed. `waiting_permission` carries a literal underscore, and Tailwind turns a bare `_` in an arbitrary value into a SPACE — so `data-[status=waiting_permission]` compiled to `[data-status="waiting permission"]` and the card/dot tint silently fell back to the base color (3 diff rows). Fixed with a `String.raw` `\_` escape so the scanned source text and cva's runtime class agree on a single backslash; both contract tests now lock it (the four underscore-free statuses never had the problem).
- `toolVariants` is deliberately off the barrel (like `markerVariants` / `streamVariants`): one consumer, applied by relative import, so it stays an internal, freely-removable styling detail rather than public API.
- The status dot stays a `toolVariants` part, not a shared primitive like `LiveIndicator`: it is tool-specific (six states, a box-shadow ring pulse distinct from the `maka-pulse` opacity/scale breath), so there is no second consumer to justify promotion.
- The tests intentionally do NOT re-assert the static shell's per-part literals: that shell is proven by the computed-style diff, so re-stating the strings would only mirror the implementation. Source-string assertions are kept only for the escapes the diff cannot observe.
- Reduced-motion / visual-smoke suppression both ride GLOBAL `*` rules (maka-tokens.css / base.css), so — unlike `LiveIndicator`, a reusable primitive carrying its own `motion-reduce:` guards — the dot and card need no per-element motion utilities; the same global rules cover them as before.

