### PR TITLE
Add headless Harbor real-backend CLI

### DIFF
--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -9,9 +9,14 @@ import { readResults } from '../results.js';
 
 const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url));
 
-function runCli(args: string[]): Promise<{ code: number | null; stdout: string; stderr: string }> {
+function runCli(
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [cliPath, ...args]);
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      env: { ...process.env, ...options.env },
+    });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (d: Buffer) => { stdout += d.toString('utf8'); });
@@ -104,6 +109,157 @@ describe('maka-headless CLI', () => {
       const result = await runCli(['eval', specPath, '--out', join(dir, 'out')]);
       assert.equal(result.code, 1);
       assert.match(result.stderr, /isolated executor/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('harbor run refuses real backend without explicit isolation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      const result = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'ai-sdk',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        join(dir, 'fixture'),
+      ]);
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /requires --isolation harbor-local\|harbor-http/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('harbor run preflights host bridge URL and token', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      const missingUrl = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'fake',
+        '--isolation',
+        'harbor-http',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        join(dir, 'fixture'),
+      ]);
+      assert.equal(missingUrl.code, 1);
+      assert.match(missingUrl.stderr, /MAKA_HARBOR_TOOL_EXECUTOR_URL is required/);
+
+      const missingToken = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'fake',
+        '--isolation',
+        'harbor-http',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        join(dir, 'fixture'),
+      ], { env: { MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1' } });
+      assert.equal(missingToken.code, 1);
+      assert.match(missingToken.stderr, /MAKA_HARBOR_TOOL_EXECUTOR_TOKEN is required/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('harbor run task-run writes external Harbor verifier export without fake verifier authority', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      const fixture = join(dir, 'fixture');
+      const outDir = join(dir, 'out');
+      await mkdir(fixture, { recursive: true });
+      await writeFile(join(fixture, 'README.txt'), 'Harbor owns the task workspace.\n', 'utf8');
+
+      const result = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'fake',
+        '--isolation',
+        'none',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        fixture,
+        '--task-id',
+        'tb-real-backend',
+        '--task-run-id',
+        'harbor-run-1',
+        '--out',
+        outDir,
+        '--include-events',
+      ]);
+      assert.equal(result.code, 0, result.stderr);
+      const summary = JSON.parse(result.stdout);
+      assert.equal(summary.taskRunId, 'harbor-run-1');
+      assert.equal(summary.mode, 'task-run');
+      assert.equal(summary.scored, false);
+      assert.equal(summary.authoritative, false);
+
+      const taskRunJson = JSON.parse(await readFile(join(outDir, 'exports', 'harbor-run-1', 'task-run.json'), 'utf8'));
+      assert.equal(taskRunJson.verifier.kind, 'terminal_bench');
+      assert.equal(taskRunJson.verifier.benchmark.instanceId, 'tb-real-backend');
+      assert.equal(taskRunJson.verifier.benchmark.pendingExternalHarborVerifier, true);
+      assert.equal(taskRunJson.verifier.authority.authoritative, false);
+      assert.equal(taskRunJson.verifier.authority.label, 'external Harbor verifier pending');
+      const events = await readFile(join(outDir, 'exports', 'harbor-run-1', 'events.jsonl'), 'utf8');
+      assert.doesNotMatch(events, /"testCommand":"false"/);
+      assert.doesNotMatch(events, /"placeholder":true/);
+      assert.doesNotMatch(events, /verificationPlaceholder/);
+      assert.doesNotMatch(events, /unsupported local benchmark placeholder/);
+      const resultJson = await readFile(join(outDir, 'exports', 'harbor-run-1', 'result.json'), 'utf8');
+      assert.doesNotMatch(resultJson, /verificationPlaceholder/);
+      assert.doesNotMatch(resultJson, /unsupported local benchmark placeholder/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('harbor-http task-run accepts a remote workspace path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      const outDir = join(dir, 'out');
+      const result = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'fake',
+        '--isolation',
+        'harbor-http',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        '/app',
+        '--task-id',
+        'tb-remote-workspace',
+        '--task-run-id',
+        'harbor-remote-run-1',
+        '--out',
+        outDir,
+        '--include-events',
+      ], {
+        env: {
+          MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
+          MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+        },
+      });
+      assert.equal(result.code, 0, result.stderr);
+
+      const taskRunJson = JSON.parse(await readFile(join(outDir, 'exports', 'harbor-remote-run-1', 'task-run.json'), 'utf8'));
+      assert.match(taskRunJson.workspace.lease.sourceWorkspaceDir, /host-workspace-source$/);
+      assert.notEqual(taskRunJson.workspace.lease.sourceWorkspaceDir, '/app');
+      assert.equal(taskRunJson.isolation.policy.label, 'Harbor task container via host adapter');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
+import { harborCommand } from './harbor-cli.js';
 import { runMatrix, type ExperimentSpec } from './matrix.js';
 import { planMatrixRetry, readMatrixPriorRecords } from './matrix-resume.js';
 import { writeTaskRunExport } from './result-export.js';
@@ -353,6 +354,7 @@ function printUsage(): void {
   console.error('  maka-headless eval <spec.json> [--out <dir>]   run configs × tasks, write results + table');
   console.error('  maka-headless compare <results.jsonl>          print the comparison table');
   console.error('  maka-headless task <command> ...               run, inspect, resume, retry, export task runs');
+  console.error('  maka-headless harbor <command> ...             run Harbor real-backend task/cell flows');
 }
 
 function printTaskUsage(): void {
@@ -369,6 +371,7 @@ async function main(argv: string[]): Promise<number> {
   if (cmd === 'eval') return evalCommand(rest);
   if (cmd === 'compare') return compareCommand(rest);
   if (cmd === 'task') return taskCommand(rest);
+  if (cmd === 'harbor') return harborCommand(rest);
   printUsage();
   return cmd ? 1 : 0;
 }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -556,6 +556,7 @@ export function buildAiSdkCellBackendRegistration(input: {
   env: RunHarborCellEnv;
   now: () => number;
   newId: () => string;
+  maxSteps?: number;
 }): NonNullable<RunHarborCellInput['registerBackends']> {
   const { connection, apiKey } = resolveHarborCellAiSdkEnv({
     provider: input.provider,
@@ -594,6 +595,7 @@ export function buildAiSdkCellBackendRegistration(input: {
         systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
         lookupPricing,
         ...contextBudgetBackendOptions,
+        ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
         newId: input.newId,
         now: input.now,
         recordRunTrace: ctx.recordRunTrace,
@@ -602,6 +604,8 @@ export function buildAiSdkCellBackendRegistration(input: {
     );
   };
 }
+
+export const buildHarborAiSdkBackendRegistration = buildAiSdkCellBackendRegistration;
 
 export function buildHarborCellAiSdkTools(
   executor: IsolatedToolExecutor,
@@ -892,6 +896,39 @@ export function buildHarborCellContextBudgetPolicySnapshot(
 
 export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
+export function createHarborHttpToolExecutor(env: RunHarborCellEnv = process.env): IsolatedToolExecutor {
+  const baseUrl = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_URL');
+  const token = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_TOKEN');
+  return {
+    exec: async (input) => {
+      const timeoutSec = input.timeoutMs === undefined
+        ? undefined
+        : Math.max(1, Math.ceil(input.timeoutMs / 1000));
+      const response = await fetch(new URL('/exec', baseUrl), {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...input,
+          ...(timeoutSec !== undefined ? { timeoutSec } : {}),
+        }),
+      });
+      const body = await response.text();
+      if (!response.ok) return { exitCode: 1, stdout: '', stderr: body };
+      const parsed: unknown = JSON.parse(body);
+      if (!isRecord(parsed)) return { exitCode: 1, stdout: '', stderr: 'Harbor bridge returned a non-object response' };
+      const exitCode = parsed.exitCode ?? parsed.returnCode;
+      return {
+        exitCode: typeof exitCode === 'number' && Number.isInteger(exitCode) ? exitCode : 1,
+        stdout: typeof parsed.stdout === 'string' ? parsed.stdout : '',
+        stderr: typeof parsed.stderr === 'string' ? parsed.stderr : '',
+      };
+    },
+  };
+}
+
 export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = process.env): IsolatedToolExecutor {
   const childEnv = childProcessEnv(env);
   // A command that does not request its own timeout falls back to this. Some
@@ -947,6 +984,12 @@ export function createHarborCellLocalToolExecutor(env: RunHarborCellEnv = proces
       }
     },
   };
+}
+
+function requiredHarborEnv(env: RunHarborCellEnv, name: string): string {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
 }
 
 // When the cell is given an explicit system prompt (MAKA_SYSTEM_PROMPT), it is

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -1,0 +1,596 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import type { BackendKind, ProviderType } from '@maka/core';
+import { PROVIDER_DEFAULTS } from '@maka/core';
+import type { Config, Task } from './contracts.js';
+import { runAutonomousTask } from './autonomous-agent-loop.js';
+import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
+import {
+  buildHarborAiSdkBackendRegistration,
+  buildHarborCellContextBudgetPolicySnapshot,
+  createHarborCellLocalToolExecutor,
+  createHarborHttpToolExecutor,
+  runHarborCell,
+  type RunHarborCellEnv,
+  type RunHarborCellInput,
+} from './harbor-cell.js';
+import type { RealBackendIsolation } from './isolation.js';
+import { writeTaskRunExport } from './result-export.js';
+import { backendNeedsIsolation } from './runner.js';
+import { runTaskOnce } from './task-agent-controller.js';
+import { taxonomyFromResultRecord } from './task-contracts.js';
+import { createTaskRunStore } from './task-run-store.js';
+
+type HarborMode = 'cell' | 'task-run';
+type HarborIsolationMode = 'none' | 'harbor-local' | 'harbor-http';
+type OfficialVerifier = 'external-harbor';
+
+interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string>;
+  bools: Record<string, boolean>;
+}
+
+interface HarborRunOptions {
+  mode: HarborMode;
+  backend: BackendKind;
+  isolation: HarborIsolationMode | undefined;
+  officialVerifier: OfficialVerifier;
+  instruction: string;
+  workdir: string;
+  sourceWorkspaceDir: string;
+  outDir: string;
+  storageRoot: string;
+  taskId: string;
+  taskRunId: string;
+  env: RunHarborCellEnv;
+  config: Config;
+  contextBudgetPolicy: ReturnType<typeof buildHarborCellContextBudgetPolicySnapshot>;
+  includeEvents: boolean;
+  autonomous: boolean;
+  maxAttempts: number;
+  maxRuntimeSteps?: number;
+  maxWallTimeMs?: number;
+  replayPriorAttemptRuntimeContext: boolean;
+  now: () => number;
+  newId: () => string;
+  registerBackends?: RunHarborCellInput['registerBackends'];
+  realBackendIsolation?: RealBackendIsolation;
+}
+
+const HARBOR_RUN_FLAGS = [
+  'mode',
+  'backend',
+  'isolation',
+  'instruction',
+  'instruction-file',
+  'workdir',
+  'task-id',
+  'task-run-id',
+  'out',
+  'storage-root',
+  'provider',
+  'model',
+  'base-url',
+  'api-key-file',
+  'connection-slug',
+  'config-id',
+  'system-prompt',
+  'official-verifier',
+  'benchmark',
+  'instance-id',
+  'max-steps',
+  'max-attempts',
+  'max-runtime-steps',
+  'max-wall-time-sec',
+];
+
+const HARBOR_RUN_BOOLS = [
+  'include-events',
+  'autonomous',
+  'replay-prior-attempt-runtime-context',
+  'heavy-task',
+];
+
+export async function harborCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === 'run') return harborRunCommand(rest);
+  printHarborUsage();
+  return 1;
+}
+
+async function harborRunCommand(args: string[]): Promise<number> {
+  let options: HarborRunOptions;
+  try {
+    options = await resolveHarborRunOptions(args, process.env);
+  } catch (error) {
+    console.error(`${(error as Error).message}\n${harborRunUsage()}`);
+    return 1;
+  }
+
+  try {
+    if (options.mode === 'cell') return await runHarborCellMode(options);
+    return await runHarborTaskRunMode(options);
+  } catch (error) {
+    console.error(`maka-headless harbor run: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
+async function runHarborCellMode(options: HarborRunOptions): Promise<number> {
+  const result = await runHarborCell({
+    config: options.config,
+    instruction: options.instruction,
+    cwd: options.workdir,
+    outputDir: options.outDir,
+    storageRoot: options.storageRoot,
+    ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
+    ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
+    ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
+    now: options.now,
+    newId: options.newId,
+  });
+  process.stdout.write(`${JSON.stringify({
+    mode: 'cell',
+    status: result.output.status,
+    errorClass: result.output.errorClass,
+    outputPath: result.outputPath,
+    runtimeEventsPath: result.runtimeEventsPath,
+  })}\n`);
+  return result.output.status === 'completed' ? 0 : 1;
+}
+
+async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> {
+  await mkdir(options.outDir, { recursive: true });
+  if (options.sourceWorkspaceDir !== options.workdir) {
+    await mkdir(options.sourceWorkspaceDir, { recursive: true });
+  }
+  const store = createTaskRunStore(options.storageRoot);
+  const task = buildHarborTask(options);
+  const common = {
+    storageRoot: options.storageRoot,
+    taskRunStore: store,
+    taskRunId: options.taskRunId,
+    benchmarkAdapters: externalHarborBenchmarkAdapters(),
+    ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
+    ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
+    now: options.now,
+    newId: options.newId,
+  };
+  const run = options.autonomous
+    ? await runAutonomousTask(options.config, task, {
+        ...common,
+        budget: {
+          maxAttempts: options.maxAttempts,
+          ...(options.maxRuntimeSteps !== undefined ? { maxRuntimeSteps: options.maxRuntimeSteps } : {}),
+          ...(options.maxWallTimeMs !== undefined ? { maxWallTimeMs: options.maxWallTimeMs } : {}),
+        },
+        ...(options.replayPriorAttemptRuntimeContext ? { replayPriorAttemptRuntimeContext: true } : {}),
+        decision: ({ attempt, budget }) => {
+          const taxonomy = attempt.projection.latestScoreResult?.taxonomy
+            ?? attempt.projection.result?.taxonomy
+            ?? taxonomyFromResultRecord(attempt.resultRecord);
+          if (taxonomy === 'unsupported_adapter') {
+            return { decision: 'stop', reason: 'official Harbor verifier is external and pending' };
+          }
+          if (['policy_denied', 'blocked', 'setup_failed', 'infra_failed'].includes(taxonomy)) {
+            return { decision: 'stop', reason: `${taxonomy} is not retryable` };
+          }
+          if (attempt.resultRecord.passed) return { decision: 'stop', reason: 'authoritative verification passed' };
+          if (budget.attemptsUsed >= budget.maxAttempts) return { decision: 'stop', reason: 'max attempts exhausted' };
+          if (budget.maxRuntimeSteps !== undefined && budget.runtimeStepsUsed >= budget.maxRuntimeSteps) {
+            return { decision: 'stop', reason: 'runtime step cap reached' };
+          }
+          if (budget.maxWallTimeMs !== undefined && budget.elapsedMs >= budget.maxWallTimeMs) {
+            return { decision: 'stop', reason: 'wall time cap reached' };
+          }
+          return { decision: 'continue', reason: `${taxonomy} can be retried while budget remains` };
+        },
+      })
+    : await runTaskOnce(options.config, task, common);
+
+  const exportDir = join(options.outDir, 'exports', run.taskRunId);
+  const exported = await writeTaskRunExport(exportDir, run.projection, { includeEvents: options.includeEvents });
+  const latestScore = run.projection.latestScoreResult;
+  process.stdout.write(`${JSON.stringify({
+    mode: 'task-run',
+    taskRunId: run.taskRunId,
+    status: run.projection.status,
+    taxonomy: latestScore?.taxonomy ?? run.projection.result?.taxonomy ?? taxonomyFromResultRecord(run.resultRecord),
+    scored: latestScore?.scored ?? run.resultRecord.scored ?? false,
+    authoritative: latestScore?.authority?.authoritative ?? false,
+    exportDir,
+    files: exported.files,
+    result: {
+      status: run.resultRecord.status,
+      passed: run.resultRecord.passed,
+      errorClass: run.resultRecord.errorClass,
+    },
+    runtimeRefs: latestScore?.details?.runtimeRefs,
+  })}\n`);
+  return run.resultRecord.status === 'failed' ? 1 : 0;
+}
+
+async function resolveHarborRunOptions(args: string[], baseEnv: NodeJS.ProcessEnv): Promise<HarborRunOptions> {
+  const parsed = parseArgs(args, HARBOR_RUN_FLAGS, HARBOR_RUN_BOOLS);
+  if (parsed.positional.length > 0) throw new Error(`unexpected positional argument: ${parsed.positional[0]}`);
+  const env = cliEnv(parsed, baseEnv);
+  const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
+  const backend = backendKind(valueOf(parsed, env, 'backend', 'MAKA_BACKEND') ?? 'ai-sdk');
+  const isolation = optionalIsolation(valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION);
+  preflightIsolation(backend, isolation, env);
+
+  const outDir = resolve(valueOf(parsed, env, 'out', 'MAKA_OUTPUT_DIR') ?? '/logs/agent');
+  const storageRoot = resolve(
+    valueOf(parsed, env, 'storage-root', 'MAKA_STORAGE_ROOT') ??
+    (mode === 'task-run' ? join(outDir, 'runs') : join(outDir, 'maka-storage')),
+  );
+  const taskId = valueOf(parsed, env, 'task-id', 'MAKA_TASK_ID') ?? env.HARBOR_SESSION_ID ?? 'terminal-bench-task';
+  const taskRunId = valueOf(parsed, env, 'task-run-id', 'MAKA_TASK_RUN_ID') ?? `harbor-${taskId}`;
+  const requestedWorkdir = valueOf(parsed, env, 'workdir', 'MAKA_WORKDIR') ?? process.cwd();
+  const workdir = isolation === 'harbor-http' ? requestedWorkdir : resolve(requestedWorkdir);
+  const sourceWorkspaceDir = isolation === 'harbor-http'
+    ? resolve(join(outDir, 'host-workspace-source'))
+    : workdir;
+  const instruction = await instructionFromOptions(parsed, env);
+  const officialVerifier = officialVerifierKind(
+    valueOf(parsed, env, 'official-verifier', 'MAKA_OFFICIAL_VERIFIER') ?? 'external-harbor',
+  );
+  const now = Date.now;
+  const newId = randomUUID;
+  const contextBudgetPolicy = buildHarborCellContextBudgetPolicySnapshot(env);
+  const maxSteps = optionalPositiveInt(valueOf(parsed, env, 'max-steps', 'MAKA_MAX_STEPS'), '--max-steps');
+  const maxRuntimeSteps = optionalPositiveInt(
+    valueOf(parsed, env, 'max-runtime-steps', 'MAKA_MAX_RUNTIME_STEPS'),
+    '--max-runtime-steps',
+  );
+  const maxWallTimeSec = optionalPositiveInt(
+    valueOf(parsed, env, 'max-wall-time-sec', 'MAKA_MAX_WALL_TIME_SEC'),
+    '--max-wall-time-sec',
+  );
+  const config = buildConfig({
+    parsed,
+    env,
+    backend,
+    heavyTask: parsed.bools['heavy-task'] || truthyEnv(env.MAKA_HEAVY_TASK_MODE),
+  });
+  const registerBackends = buildBackendRegistration({ backend, env, now, newId, maxSteps });
+  const realBackendIsolation = buildIsolation(isolation, env, workdir);
+  return {
+    mode,
+    backend,
+    isolation,
+    officialVerifier,
+    instruction,
+    workdir,
+    sourceWorkspaceDir,
+    outDir,
+    storageRoot,
+    taskId,
+    taskRunId,
+    env,
+    config,
+    contextBudgetPolicy,
+    includeEvents: parsed.bools['include-events'],
+    autonomous: parsed.bools.autonomous || truthyEnv(env.MAKA_AUTONOMOUS),
+    maxAttempts: positiveInt(
+      valueOf(parsed, env, 'max-attempts', 'MAKA_MAX_ATTEMPTS') ?? '1',
+      '--max-attempts',
+    ),
+    ...(maxRuntimeSteps !== undefined ? { maxRuntimeSteps } : {}),
+    ...(maxWallTimeSec !== undefined ? { maxWallTimeMs: maxWallTimeSec * 1000 } : {}),
+    replayPriorAttemptRuntimeContext: parsed.bools['replay-prior-attempt-runtime-context'] ||
+      truthyEnv(env.MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT),
+    now,
+    newId,
+    ...(registerBackends ? { registerBackends } : {}),
+    ...(realBackendIsolation ? { realBackendIsolation } : {}),
+  };
+}
+
+function buildHarborTask(options: HarborRunOptions): Task {
+  return {
+    id: options.taskId,
+    instruction: options.instruction,
+    workspaceDir: options.sourceWorkspaceDir,
+    verifier: {
+      kind: 'terminal_bench',
+      adapter: 'terminal-bench',
+      instanceId: options.env.MAKA_INSTANCE_ID ?? options.taskId,
+      dataset: options.env.MAKA_BENCHMARK_DATASET ?? 'terminal-bench/terminal-bench-2',
+      protectedPaths: [],
+      adapterOptions: {
+        officialVerifier: options.officialVerifier,
+        authority: 'external_harbor_post_exit',
+      },
+    },
+    benchmark: {
+      source: 'terminal_bench',
+      instanceId: options.env.MAKA_INSTANCE_ID ?? options.taskId,
+      official: true,
+      metadata: {
+        remoteWorkspaceDir: options.workdir,
+      },
+    },
+  };
+}
+
+function externalHarborBenchmarkAdapters(): BenchmarkAdapterRegistry {
+  return {
+    'terminal-bench': {
+      name: 'terminal-bench',
+      runVerifier: ({ verifier }) => {
+        if (verifier.kind !== 'terminal_bench') {
+          throw new Error(`external Harbor adapter received unsupported verifier kind: ${verifier.kind}`);
+        }
+        return {
+          kind: 'terminal_bench',
+          passed: false,
+          exitCode: null,
+          error: 'official Harbor verifier runs after the agent exits',
+          errorClass: 'external_verifier_pending',
+          authority: { source: 'system', authoritative: false, label: 'external Harbor verifier pending' },
+          details: {
+            adapter: verifier.adapter,
+            instanceId: verifier.instanceId,
+            ...(verifier.dataset ? { dataset: verifier.dataset } : {}),
+            ...(verifier.datasetPath ? { datasetPath: verifier.datasetPath } : {}),
+            ...(verifier.taskDir ? { taskDir: verifier.taskDir } : {}),
+            ...(verifier.taskDescriptionKey ? { taskDescriptionKey: verifier.taskDescriptionKey } : {}),
+            officialVerifier: 'external_harbor_post_exit',
+            pendingExternalHarborVerifier: true,
+          },
+        };
+      },
+    },
+  };
+}
+
+function buildConfig(input: {
+  parsed: ParsedArgs;
+  env: RunHarborCellEnv;
+  backend: BackendKind;
+  heavyTask: boolean;
+}): Config {
+  if (input.backend === 'fake') {
+    return {
+      id: input.parsed.flags['config-id'] ?? input.env.MAKA_CONFIG_ID ?? 'harbor-fake',
+      backend: 'fake',
+      llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
+      model: input.env.MAKA_MODEL ?? input.env.HARBOR_MODEL ?? 'fake',
+      ...(input.heavyTask ? { heavyTaskMode: { enabled: true, reason: 'maka-headless harbor run --heavy-task' } } : {}),
+    };
+  }
+  if (input.backend !== 'ai-sdk') {
+    throw new Error(`maka-headless harbor run task-run currently supports backend fake or ai-sdk, got ${input.backend}`);
+  }
+  const modelSpec = parseModelSpec(
+    input.env.MAKA_MODEL ?? input.env.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash',
+    input.env.MAKA_PROVIDER,
+  );
+  return {
+    id: input.parsed.flags['config-id'] ?? input.env.MAKA_CONFIG_ID ?? `harbor-${modelSpec.provider}`,
+    backend: 'ai-sdk',
+    llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
+    model: modelSpec.model,
+    ...(input.env.MAKA_SYSTEM_PROMPT !== undefined ? { systemPrompt: input.env.MAKA_SYSTEM_PROMPT } : {}),
+    ...(input.heavyTask ? { heavyTaskMode: { enabled: true, reason: 'maka-headless harbor run --heavy-task' } } : {}),
+  };
+}
+
+function buildBackendRegistration(input: {
+  backend: BackendKind;
+  env: RunHarborCellEnv;
+  now: () => number;
+  newId: () => string;
+  maxSteps?: number;
+}): RunHarborCellInput['registerBackends'] | undefined {
+  if (input.backend === 'fake') return undefined;
+  if (input.backend !== 'ai-sdk') throw new Error(`unsupported Harbor backend: ${input.backend}`);
+  const modelSpec = parseModelSpec(
+    input.env.MAKA_MODEL ?? input.env.HARBOR_MODEL ?? 'deepseek/deepseek-v4-flash',
+    input.env.MAKA_PROVIDER,
+  );
+  return buildHarborAiSdkBackendRegistration({
+    provider: modelSpec.provider,
+    model: modelSpec.model,
+    env: input.env,
+    now: input.now,
+    newId: input.newId,
+    ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
+  });
+}
+
+function buildIsolation(
+  mode: HarborIsolationMode | undefined,
+  env: RunHarborCellEnv,
+  workdir: string,
+): RealBackendIsolation | undefined {
+  if (!mode || mode === 'none') return undefined;
+  if (mode === 'harbor-local') {
+    return {
+      kind: 'external',
+      label: 'Harbor task container',
+      workspaceDir: workdir,
+      toolExecutor: createHarborCellLocalToolExecutor(env),
+    };
+  }
+  return {
+    kind: 'external',
+    label: 'Harbor task container via host adapter',
+    workspaceDir: workdir,
+    toolExecutor: createHarborHttpToolExecutor(env),
+  };
+}
+
+function preflightIsolation(backend: BackendKind, isolation: HarborIsolationMode | undefined, env: RunHarborCellEnv): void {
+  if (backendNeedsIsolation(backend) && (!isolation || isolation === 'none')) {
+    throw new Error(`backend "${backend}" requires --isolation harbor-local|harbor-http for maka-headless harbor run`);
+  }
+  if (isolation === 'harbor-http') {
+    if (!env.MAKA_HARBOR_TOOL_EXECUTOR_URL) throw new Error('MAKA_HARBOR_TOOL_EXECUTOR_URL is required for --isolation harbor-http');
+    if (!env.MAKA_HARBOR_TOOL_EXECUTOR_TOKEN) throw new Error('MAKA_HARBOR_TOOL_EXECUTOR_TOKEN is required for --isolation harbor-http');
+  }
+}
+
+function cliEnv(parsed: ParsedArgs, baseEnv: NodeJS.ProcessEnv): RunHarborCellEnv {
+  const env: RunHarborCellEnv = { ...baseEnv };
+  setFlagEnv(env, parsed, 'provider', 'MAKA_PROVIDER');
+  setFlagEnv(env, parsed, 'model', 'MAKA_MODEL');
+  setFlagEnv(env, parsed, 'base-url', 'MAKA_BASE_URL');
+  setFlagEnv(env, parsed, 'connection-slug', 'MAKA_LLM_CONNECTION_SLUG');
+  setFlagEnv(env, parsed, 'instruction', 'MAKA_INSTRUCTION');
+  setFlagEnv(env, parsed, 'instruction-file', 'MAKA_INSTRUCTION_FILE');
+  setFlagEnv(env, parsed, 'workdir', 'MAKA_WORKDIR');
+  setFlagEnv(env, parsed, 'task-id', 'MAKA_TASK_ID');
+  setFlagEnv(env, parsed, 'task-run-id', 'MAKA_TASK_RUN_ID');
+  setFlagEnv(env, parsed, 'out', 'MAKA_OUTPUT_DIR');
+  setFlagEnv(env, parsed, 'storage-root', 'MAKA_STORAGE_ROOT');
+  setFlagEnv(env, parsed, 'system-prompt', 'MAKA_SYSTEM_PROMPT');
+  setFlagEnv(env, parsed, 'instance-id', 'MAKA_INSTANCE_ID');
+  if (parsed.flags.benchmark && parsed.flags.benchmark !== 'terminal-bench') {
+    throw new Error('--benchmark currently supports only terminal-bench');
+  }
+  if (parsed.flags['api-key-file']) {
+    const provider = providerFromValue(parsed.flags.provider ?? env.MAKA_PROVIDER ?? providerFromModel(env.MAKA_MODEL ?? env.HARBOR_MODEL));
+    env[apiKeyFileEnvName(provider)] = parsed.flags['api-key-file'];
+  }
+  return env;
+}
+
+async function instructionFromOptions(parsed: ParsedArgs, env: RunHarborCellEnv): Promise<string> {
+  if (parsed.flags.instruction !== undefined || env.MAKA_INSTRUCTION !== undefined) {
+    return (parsed.flags.instruction ?? env.MAKA_INSTRUCTION) as string;
+  }
+  const filePath = parsed.flags['instruction-file'] ?? env.MAKA_INSTRUCTION_FILE;
+  if (filePath) return await readFile(filePath, 'utf8');
+  throw new Error('--instruction, --instruction-file, MAKA_INSTRUCTION, or MAKA_INSTRUCTION_FILE is required');
+}
+
+function valueOf(parsed: ParsedArgs, env: RunHarborCellEnv, flag: string, envName: string): string | undefined {
+  return parsed.flags[flag] ?? env[envName];
+}
+
+function setFlagEnv(env: RunHarborCellEnv, parsed: ParsedArgs, flag: string, envName: string): void {
+  const value = parsed.flags[flag];
+  if (value !== undefined) env[envName] = value;
+}
+
+function parseArgs(args: string[], knownFlags: readonly string[], boolFlags: readonly string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  const bools: Record<string, boolean> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (!arg.startsWith('--')) {
+      positional.push(arg);
+      continue;
+    }
+    const name = arg.slice(2);
+    if (boolFlags.includes(name)) {
+      bools[name] = true;
+      continue;
+    }
+    if (!knownFlags.includes(name)) throw new Error(`unknown flag: ${arg}`);
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith('--')) throw new Error(`flag ${arg} needs a value`);
+    flags[name] = value;
+    i++;
+  }
+  return { positional, flags, bools };
+}
+
+function harborMode(value: string): HarborMode {
+  if (value === 'cell' || value === 'task-run') return value;
+  throw new Error(`--mode must be cell or task-run, got ${JSON.stringify(value)}`);
+}
+
+function optionalIsolation(value: string | undefined): HarborIsolationMode | undefined {
+  if (value === undefined || value === '') return undefined;
+  if (value === 'none' || value === 'harbor-local' || value === 'harbor-http') return value;
+  throw new Error(`--isolation must be none, harbor-local, or harbor-http, got ${JSON.stringify(value)}`);
+}
+
+function officialVerifierKind(value: string): OfficialVerifier {
+  if (value === 'external-harbor') return value;
+  throw new Error(`--official-verifier must be external-harbor, got ${JSON.stringify(value)}`);
+}
+
+function backendKind(value: string): BackendKind {
+  if (value === 'fake' || value === 'ai-sdk' || value === 'pi-agent') return value;
+  throw new Error(`--backend must be fake, ai-sdk, or pi-agent, got ${JSON.stringify(value)}`);
+}
+
+function parseModelSpec(rawModel: string, rawProvider: string | undefined): { provider: ProviderType; model: string } {
+  if (rawProvider !== undefined) return { provider: providerFromValue(rawProvider), model: requireModel(rawModel) };
+  const separator = rawModel.indexOf('/');
+  const provider = separator >= 0 ? rawModel.slice(0, separator) : 'deepseek';
+  const model = separator >= 0 ? rawModel.slice(separator + 1) : rawModel;
+  return { provider: providerFromValue(provider), model: requireModel(model) };
+}
+
+function providerFromModel(rawModel: string | undefined): ProviderType {
+  const model = rawModel ?? 'deepseek/deepseek-v4-flash';
+  const separator = model.indexOf('/');
+  return providerFromValue(separator >= 0 ? model.slice(0, separator) : 'deepseek');
+}
+
+function providerFromValue(value: string | undefined): ProviderType {
+  if (!value || !(value in PROVIDER_DEFAULTS)) throw new Error(`unsupported MAKA_PROVIDER: ${value ?? ''}`);
+  return value as ProviderType;
+}
+
+function requireModel(value: string): string {
+  if (!value) throw new Error('MAKA_MODEL must include a model id');
+  return value;
+}
+
+function apiKeyFileEnvName(provider: ProviderType): string {
+  switch (provider) {
+    case 'deepseek':
+      return 'DEEPSEEK_API_KEY_FILE';
+    case 'moonshot':
+      return 'MOONSHOT_API_KEY_FILE';
+    case 'google':
+      return 'GOOGLE_API_KEY_FILE';
+    case 'anthropic':
+    case 'kimi-coding-plan':
+    case 'claude-subscription':
+      return 'ANTHROPIC_API_KEY_FILE';
+    case 'zai-coding-plan':
+      return 'ZAI_API_KEY_FILE';
+    case 'openai':
+    case 'openai-compatible':
+    default:
+      return 'OPENAI_API_KEY_FILE';
+  }
+}
+
+function optionalPositiveInt(raw: string | undefined, flagName: string): number | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined;
+  return positiveInt(raw, flagName);
+}
+
+function positiveInt(raw: string, flagName: string): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${flagName} must be a positive integer`);
+  return value;
+}
+
+function truthyEnv(raw: string | undefined): boolean {
+  if (!raw) return false;
+  return ['1', 'true', 'yes', 'on', 'enabled'].includes(raw.trim().toLowerCase());
+}
+
+function printHarborUsage(): void {
+  console.error('maka-headless harbor commands:\n');
+  console.error(harborRunUsage());
+}
+
+function harborRunUsage(): string {
+  return [
+    'usage: maka-headless harbor run --instruction <text>|--instruction-file <path> --isolation harbor-local|harbor-http [options]',
+    '       real backends fail closed without explicit isolation; harbor-http requires MAKA_HARBOR_TOOL_EXECUTOR_URL and MAKA_HARBOR_TOOL_EXECUTOR_TOKEN',
+  ].join('\n');
+}

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -130,6 +130,13 @@ export interface ExternalRealBackendIsolation {
    */
   label: string;
   /**
+   * Agent-visible workspace path when the external boundary owns the real
+   * filesystem. For Harbor HTTP this is the container cwd (for example `/app`),
+   * while the task-run control plane may still keep a local empty source
+   * workspace for ledger snapshots.
+   */
+  workspaceDir?: string;
+  /**
    * Optional command executor for callers that want to reuse the built-in
    * headless Bash tool. A caller may omit this when its registered backend is
    * already isolated internally.

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -96,6 +96,7 @@ export async function runExperiment(
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
+    const agentWorkspaceDir = deps.realBackendIsolation?.workspaceDir ?? workspace.dir;
     const verifier = normalizeVerifier(task);
     const backends = new BackendRegistry();
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
@@ -103,7 +104,7 @@ export async function runExperiment(
     await registerBackends(backends, {
       config,
       task,
-      workspaceDir: workspace.dir,
+      workspaceDir: agentWorkspaceDir,
       ...(backendNeedsIsolation(config.backend)
         ? { realBackendIsolation: deps.realBackendIsolation, toolExecutor: deps.realBackendIsolation?.toolExecutor }
         : {}),
@@ -127,7 +128,7 @@ export async function runExperiment(
     });
 
     const session = await manager.createSession({
-      cwd: workspace.dir,
+      cwd: agentWorkspaceDir,
       backend: config.backend,
       llmConnectionSlug: config.llmConnectionSlug,
       model: config.model,

--- a/packages/headless/src/scorer.ts
+++ b/packages/headless/src/scorer.ts
@@ -61,7 +61,7 @@ export const defaultFinalScorer: FinalScorer = (input) => {
       excludedReason: 'official benchmark verifier result is missing',
       details: {
         verifierAuthority: verifier.authority,
-        verificationPlaceholder: verifier.details?.verificationPlaceholder === true,
+        ...(verifier.details?.verificationPlaceholder === true ? { verificationPlaceholder: true } : {}),
       },
     };
   }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -217,6 +217,7 @@ export async function runTaskOnce(
 
   const workspace = await prepareWorkspace(task.workspaceDir);
   try {
+    const agentWorkspaceDir = deps.realBackendIsolation?.workspaceDir ?? workspace.dir;
     await appendTaskEvent(taskRunStore, taskRunId, {
       type: 'workspace_lease_recorded',
       id: newId(),
@@ -254,7 +255,7 @@ export async function runTaskOnce(
     await registerBackends(backends, {
       config: effectiveConfig,
       task,
-      workspaceDir: workspace.dir,
+      workspaceDir: agentWorkspaceDir,
       heavyTaskMode,
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
       ...(heavyTaskSelfCheck ? { heavyTaskSelfCheck } : {}),
@@ -265,7 +266,7 @@ export async function runTaskOnce(
     });
 
     const header = await sessionStore.create({
-      cwd: workspace.dir,
+      cwd: agentWorkspaceDir,
       backend: config.backend,
       llmConnectionSlug: effectiveConfig.llmConnectionSlug,
       model: effectiveConfig.model,

--- a/terminal-bench-smoke/maka_harbor_agent.py
+++ b/terminal-bench-smoke/maka_harbor_agent.py
@@ -16,7 +16,7 @@ from harbor.models.agent.context import AgentContext
 
 ROOT = Path(__file__).resolve().parent
 REPO_ROOT = ROOT.parent
-NODE_RUNNER = ROOT / "maka_harbor_runner.mjs"
+HEADLESS_CLI = REPO_ROOT / "packages" / "headless" / "dist" / "cli.js"
 DEFAULT_RUNNER_ENV = Path(
     os.environ.get(
         "MAKA_HARBOR_RUNNER_ENV_FILE",
@@ -44,7 +44,7 @@ def _load_env_file(path: Path) -> dict[str, str]:
 class MakaHarborAgent(BaseAgent):
     def __init__(self, *args: Any, extra_env: dict[str, str] | None = None, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        self.extra_env = extra_env or {}
+        self._extra_env = extra_env or {}
 
     @staticmethod
     def name() -> str:
@@ -75,9 +75,10 @@ class MakaHarborAgent(BaseAgent):
 
         env = os.environ.copy()
         env.update(_load_env_file(DEFAULT_RUNNER_ENV))
-        env.update(self.extra_env)
-        env["MAKA_HARBOR_BRIDGE_URL"] = f"http://{host}:{port}"
-        env["MAKA_HARBOR_BRIDGE_TOKEN"] = bridge_token
+        env.update(self._extra_env)
+        env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = f"http://{host}:{port}"
+        env["MAKA_HARBOR_TOOL_EXECUTOR_TOKEN"] = bridge_token
+        _normalize_cli_env(env)
         env.setdefault("MAKA_REPO_DIR", str(REPO_ROOT))
         env.setdefault("MAKA_MODEL", "deepseek-chat")
         env.setdefault("MAKA_MAX_STEPS", "35")
@@ -88,17 +89,14 @@ class MakaHarborAgent(BaseAgent):
             env["MAKA_TASK_RUN_OUT_DIR"] = str(task_run_out_dir)
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)
-        payload = {
-            "instruction": instruction,
-            "cwd": task_workdir,
-            "taskId": environment.session_id,
-        }
 
         stdout_path = self.logs_dir / "maka-harbor.stdout.json"
         stderr_path = self.logs_dir / "maka-harbor.stderr.log"
         status_path = self.logs_dir / "maka-harbor.status.json"
+        instruction_path = self.logs_dir / "instruction.txt"
         started_at = _utc_now()
         task_run_out_dir.mkdir(parents=True, exist_ok=True)
+        instruction_path.write_text(instruction, encoding="utf-8")
         stdout_path.write_bytes(b"")
         stderr_path.write_bytes(b"")
         self._write_status(
@@ -170,10 +168,17 @@ class MakaHarborAgent(BaseAgent):
 
         proc: asyncio.subprocess.Process | None = None
         timeout_sec = int(env.get("MAKA_HARBOR_AGENT_TIMEOUT_SEC", "1800"))
+        command = _headless_harbor_command(
+            instruction_path=instruction_path,
+            task_workdir=task_workdir,
+            task_id=environment.session_id,
+            out_dir=task_run_out_dir,
+            env=env,
+        )
         try:
             proc = await asyncio.create_subprocess_exec(
-                "node",
-                str(NODE_RUNNER),
+                *command,
+                cwd=str(REPO_ROOT),
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -193,11 +198,12 @@ class MakaHarborAgent(BaseAgent):
                     "resolvedCwd": task_workdir,
                     "workdirProbe": workdir_probe,
                     "runnerEnv": _runner_env_summary(env),
+                    "command": _redacted_command(command),
                 },
             )
             stdout, stderr = await self._communicate_streaming(
                 proc=proc,
-                stdin_payload=json.dumps(payload).encode("utf-8"),
+                stdin_payload=b"",
                 stdout_path=stdout_path,
                 stderr_path=stderr_path,
                 timeout_sec=timeout_sec,
@@ -218,6 +224,7 @@ class MakaHarborAgent(BaseAgent):
                     "resolvedCwd": task_workdir,
                     "workdirProbe": workdir_probe,
                     "runnerEnv": _runner_env_summary(env),
+                    "command": _redacted_command(command),
                 },
             )
             raise
@@ -237,6 +244,7 @@ class MakaHarborAgent(BaseAgent):
                     "resolvedCwd": task_workdir,
                     "workdirProbe": workdir_probe,
                     "runnerEnv": _runner_env_summary(env),
+                    "command": _redacted_command(command),
                 },
             )
             raise
@@ -264,6 +272,7 @@ class MakaHarborAgent(BaseAgent):
                 "resolvedCwd": task_workdir,
                 "workdirProbe": workdir_probe,
                 "runnerEnv": _runner_env_summary(env),
+                "command": _redacted_command(command),
             },
         )
         context.metadata = {
@@ -284,7 +293,7 @@ class MakaHarborAgent(BaseAgent):
                 "tool_call_count": parsed.get("toolCallCount"),
                 "error": parsed.get("error"),
                 "benchmark_failure_kind": parsed.get("benchmarkFailureKind"),
-                "task_run": parsed.get("taskRun"),
+                "task_run": parsed.get("taskRun") or _task_run_summary(parsed),
                 "resolved_cwd": task_workdir,
                 "workdir_probe": workdir_probe,
             }
@@ -451,12 +460,13 @@ class MakaHarborAgent(BaseAgent):
             result = await environment.exec(
                 command=command,
                 cwd=str(cwd) if cwd else None,
-                timeout_sec=timeout_sec,
+                timeout_sec=timeout_sec_from_request(req),
             )
             await _write_json(
                 writer,
                 200,
                 {
+                    "exitCode": result.return_code,
                     "returnCode": result.return_code,
                     "stdout": result.stdout,
                     "stderr": result.stderr,
@@ -511,9 +521,15 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_MODEL",
         "MAKA_MAX_STEPS",
         "MAKA_TASK_RUN_OUT_DIR",
+        "MAKA_OUTPUT_DIR",
+        "MAKA_STORAGE_ROOT",
+        "MAKA_BACKEND",
+        "MAKA_PROVIDER",
         "MAKA_HARBOR_USE_TASK_RUN",
         "MAKA_HARBOR_AUTONOMOUS",
+        "MAKA_AUTONOMOUS",
         "MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
+        "MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
         "MAKA_HEAVY_TASK_MODE",
         "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE",
         "MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS",
@@ -543,6 +559,124 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_HARBOR_DIRECT_MAKE_MIPS_SMOKE",
     ]
     return {key: env[key] for key in allowed_keys if key in env}
+
+
+def _normalize_cli_env(env: dict[str, str]) -> None:
+    provider = env.get("MAKA_PROVIDER") or env.get("MAKA_PROVIDER_TYPE")
+    if provider:
+        env.setdefault("MAKA_PROVIDER", provider)
+    if env.get("MAKA_API_KEY"):
+        env.setdefault(_provider_api_key_env(env.get("MAKA_PROVIDER") or provider or "deepseek"), env["MAKA_API_KEY"])
+    if env.get("MAKA_TASK_RUN_OUT_DIR"):
+        env.setdefault("MAKA_OUTPUT_DIR", env["MAKA_TASK_RUN_OUT_DIR"])
+        env.setdefault("MAKA_STORAGE_ROOT", str(Path(env["MAKA_TASK_RUN_OUT_DIR"]) / "runs"))
+    if env.get("MAKA_HARBOR_MAX_ATTEMPTS"):
+        env.setdefault("MAKA_MAX_ATTEMPTS", env["MAKA_HARBOR_MAX_ATTEMPTS"])
+    if env.get("MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS"):
+        env.setdefault("MAKA_MAX_RUNTIME_STEPS", env["MAKA_AUTONOMOUS_MAX_RUNTIME_STEPS"])
+    if env.get("MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC"):
+        env.setdefault("MAKA_MAX_WALL_TIME_SEC", env["MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC"])
+    if env.get("MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT"):
+        env.setdefault(
+            "MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
+            env["MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT"],
+        )
+    if env.get("MAKA_HARBOR_HEAVY_TASK_MODE"):
+        env.setdefault("MAKA_HEAVY_TASK_MODE", env["MAKA_HARBOR_HEAVY_TASK_MODE"])
+    env.setdefault("MAKA_BACKEND", "ai-sdk")
+
+
+def _provider_api_key_env(provider: str) -> str:
+    if provider == "zai-coding-plan":
+        return "ZAI_API_KEY"
+    if provider == "moonshot":
+        return "MOONSHOT_API_KEY"
+    if provider == "google":
+        return "GOOGLE_API_KEY"
+    if provider in {"anthropic", "kimi-coding-plan", "claude-subscription"}:
+        return "ANTHROPIC_API_KEY"
+    if provider in {"openai", "openai-compatible"}:
+        return "OPENAI_API_KEY"
+    return "DEEPSEEK_API_KEY"
+
+
+def _headless_harbor_command(
+    *,
+    instruction_path: Path,
+    task_workdir: str,
+    task_id: str,
+    out_dir: Path,
+    env: dict[str, str],
+) -> list[str]:
+    command = [
+        "node",
+        str(HEADLESS_CLI),
+        "harbor",
+        "run",
+        "--mode",
+        "task-run",
+        "--backend",
+        env.get("MAKA_BACKEND", "ai-sdk"),
+        "--isolation",
+        "harbor-http",
+        "--instruction-file",
+        str(instruction_path),
+        "--workdir",
+        task_workdir,
+        "--task-id",
+        task_id,
+        "--task-run-id",
+        env.get("MAKA_TASK_RUN_ID", f"harbor-{task_id}"),
+        "--out",
+        str(out_dir),
+        "--storage-root",
+        env.get("MAKA_STORAGE_ROOT", str(out_dir / "runs")),
+        "--include-events",
+    ]
+    if env.get("MAKA_PROVIDER"):
+        command.extend(["--provider", env["MAKA_PROVIDER"]])
+    if env.get("MAKA_MODEL"):
+        command.extend(["--model", env["MAKA_MODEL"]])
+    if env.get("MAKA_HARBOR_USE_TASK_RUN") == "1" and env.get("MAKA_HARBOR_AUTONOMOUS", "1") != "0":
+        command.append("--autonomous")
+    if env.get("MAKA_HEAVY_TASK_MODE") in {"1", "true", "TRUE", "yes", "on", "enabled"}:
+        command.append("--heavy-task")
+    return command
+
+
+def _redacted_command(command: list[str]) -> list[str]:
+    redacted: list[str] = []
+    skip_next = False
+    for arg in command:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(arg)
+        if arg in {"--api-key", "--api-key-file"}:
+            skip_next = True
+    return redacted
+
+
+def _task_run_summary(parsed: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "taskRunId": parsed.get("taskRunId"),
+        "status": parsed.get("status"),
+        "taxonomy": parsed.get("taxonomy"),
+        "scored": parsed.get("scored"),
+        "authoritative": parsed.get("authoritative"),
+        "exportDir": parsed.get("exportDir"),
+        "files": parsed.get("files"),
+        "result": parsed.get("result"),
+    }
+
+
+def timeout_sec_from_request(req: dict[str, Any]) -> int:
+    if req.get("timeoutSec"):
+        return int(req["timeoutSec"])
+    if req.get("timeoutMs"):
+        return max(1, (int(req["timeoutMs"]) + 999) // 1000)
+    return 120
 
 
 def _direct_make_mips_smoke_command() -> str:


### PR DESCRIPTION
## Summary
- add `maka-headless harbor run` for Harbor/Terminal-Bench task-run execution with real model backends
- add the `harbor-http` isolation bridge/tool executor path so Harbor's Python agent wrapper drives the headless CLI instead of the old local runner shim
- keep external Harbor verifier authority out of Maka's internal placeholder scoring, exporting `pendingExternalHarborVerifier` until Harbor runs its official post-agent verifier
- support remote Harbor workspace paths like `/app` while keeping a local host workspace source for ledger/snapshot exports

## Verification
- `python3 -m py_compile terminal-bench-smoke/maka_harbor_agent.py`
- `git diff --check HEAD~1..HEAD`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/cli.test.js` (15/15)
- `node --test packages/headless/dist/__tests__/scorer.test.js packages/headless/dist/__tests__/result-export.test.js` (12/12)

## Real smoke
- Harbor 0.16.1 task: `terminal-bench-sample@2.0` `sqlite-with-gcov__cYgNDft`
- job: `maka-headless-harbor-cli-deepseek-v4pro-smoke-20260628c`
- official Harbor result: 1/1, exceptions 0, mean/reward 1.000, runtime 5m22s
- agent command confirmed new path: `node packages/headless/dist/cli.js harbor run --mode task-run --backend ai-sdk --isolation harbor-http --workdir /app --model deepseek-v4-pro`
- placeholder scan across export/status/stdout had no hits for the old placeholder verifier or old `maka_harbor_runner.mjs` path
