### PR TITLE
Guard destructive headless Bash commands

### DIFF
--- a/packages/headless/src/__tests__/destructive-command-guard.test.ts
+++ b/packages/headless/src/__tests__/destructive-command-guard.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { checkDestructiveShellCommand, formatDestructiveCommandGuardMessage } from '../destructive-command-guard.js';
+
+describe('destructive-command guard', () => {
+  test('allows ordinary build, test, and inspection commands', () => {
+    for (const command of [
+      'npm test',
+      'python -m pytest tests/test_app.py',
+      'grep -R needle src',
+      'echo "rm -rf /app" # quoted/documentary text only',
+      'chmod 644 output.txt',
+    ]) {
+      assert.equal(checkDestructiveShellCommand(command).allowed, true, command);
+    }
+  });
+
+  test('blocks direct deletion and truncation commands', () => {
+    for (const command of [
+      'rm -f *.gcda *.gcno *.gcov',
+      'rmdir build',
+      'truncate -s 0 /app/report.jsonl',
+      '/bin/rm /var/www/html/hello.html',
+    ]) {
+      const result = checkDestructiveShellCommand(command);
+      assert.equal(result.allowed, false, command);
+      assert.match(formatDestructiveCommandGuardMessage(result), /refused this Bash command/);
+    }
+  });
+
+  test('blocks find/xargs deletion forms and recursive ownership changes', () => {
+    for (const command of [
+      'find . -name "*.gcno" -delete',
+      'find . -type f -exec rm -f {} ;',
+      'printf "%s\\n" a b | xargs rm -f',
+      'chmod -R 777 /app',
+      'chown --recursive root:root .',
+    ]) {
+      assert.equal(checkDestructiveShellCommand(command).allowed, false, command);
+    }
+  });
+
+  test('blocks process and service control commands', () => {
+    for (const command of [
+      'kill $(ps aux | awk \'/qemu/ {print $2}\')',
+      'pkill -f qemu',
+      'killall node',
+      'systemctl stop ssh',
+      'service main restart',
+    ]) {
+      assert.equal(checkDestructiveShellCommand(command).allowed, false, command);
+    }
+  });
+
+  test('blocks nested shell -c destructive commands through common wrappers', () => {
+    for (const command of [
+      "sh -c 'rm -rf /app/tmp'",
+      "bash -lc 'find . -delete'",
+      "env FOO=bar timeout 10s sudo rm -rf /app",
+    ]) {
+      assert.equal(checkDestructiveShellCommand(command).allowed, false, command);
+    }
+  });
+
+  test('blocks forceful mv but allows non-recursive permission edits', () => {
+    assert.equal(checkDestructiveShellCommand('mv -f new.txt report.txt').allowed, false);
+    assert.equal(checkDestructiveShellCommand('mv draft.txt final.txt').allowed, true);
+    assert.equal(checkDestructiveShellCommand('chown user:group report.txt').allowed, true);
+  });
+});

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -86,6 +86,31 @@ describe('isolated headless tools', () => {
     assert.ok(result.stdout.length < big.length);
   });
 
+  test('Bash destructive-command guard refuses dangerous commands before executor invocation', async () => {
+    const emitted: Array<{ stream: string; chunk: string }> = [];
+    const bash = buildIsolatedBashTool({
+      async exec() {
+        throw new Error('destructive commands must not reach the isolated executor');
+      },
+    });
+
+    const result = await bash.impl(
+      { command: 'rm -f *.gcda *.gcno *.gcov' },
+      {
+        sessionId: 's',
+        turnId: 't',
+        cwd: '/workspace',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: (stream, chunk) => emitted.push({ stream, chunk }),
+      },
+    ) as { exitCode: number; stderr: string };
+
+    assert.equal(result.exitCode, 126);
+    assert.match(result.stderr, /destructive-command guard refused/);
+    assert.deepEqual(emitted, [{ stream: 'stderr', chunk: result.stderr }]);
+  });
+
   test('only Bash opts into bounded-tail; Read/Glob/Grep request full output', async () => {
     // Records the boundedTail flag of every exec() and returns empty output, so
     // the command-backed Read/Glob/Grep complete without running anything.

--- a/packages/headless/src/destructive-command-guard.ts
+++ b/packages/headless/src/destructive-command-guard.ts
@@ -1,0 +1,265 @@
+export interface DestructiveCommandViolation {
+  command: string;
+  reason: string;
+  segment: string;
+}
+
+export interface DestructiveCommandGuardResult {
+  allowed: boolean;
+  violations: DestructiveCommandViolation[];
+}
+
+interface ShellWord {
+  kind: 'word';
+  value: string;
+}
+
+interface ShellSeparator {
+  kind: 'separator';
+}
+
+type ShellToken = ShellWord | ShellSeparator;
+
+const BLOCKED_COMMANDS = new Set([
+  'kill',
+  'killall',
+  'pkill',
+  'rm',
+  'rmdir',
+  'service',
+  'shred',
+  'systemctl',
+  'truncate',
+  'unlink',
+]);
+
+const WRAPPER_COMMANDS = new Set(['builtin', 'command', 'doas', 'exec', 'sudo']);
+const SHELL_COMMANDS = new Set(['bash', 'dash', 'sh', 'zsh']);
+
+export function checkDestructiveShellCommand(command: string): DestructiveCommandGuardResult {
+  const violations = scanTokens(tokenizeShell(command), 0);
+  return {
+    allowed: violations.length === 0,
+    violations,
+  };
+}
+
+export function formatDestructiveCommandGuardMessage(result: DestructiveCommandGuardResult): string {
+  const first = result.violations[0];
+  if (!first) return 'Maka destructive-command guard allowed the command.';
+  const detail = result.violations.length === 1
+    ? first.reason
+    : `${first.reason} (${result.violations.length} policy violations found)`;
+  return [
+    `Maka destructive-command guard refused this Bash command: ${detail}.`,
+    'Use Read/Grep for inspection and Write/Edit for targeted file changes; avoid broad delete, service-control, or process-kill operations in benchmark containers.',
+  ].join('\n');
+}
+
+function scanTokens(tokens: ShellToken[], depth: number): DestructiveCommandViolation[] {
+  if (depth > 3) return [];
+  const violations: DestructiveCommandViolation[] = [];
+  let segment: string[] = [];
+  for (const token of tokens) {
+    if (token.kind === 'separator') {
+      violations.push(...scanSegment(segment, depth));
+      segment = [];
+    } else {
+      segment.push(token.value);
+    }
+  }
+  violations.push(...scanSegment(segment, depth));
+  return violations;
+}
+
+function scanSegment(words: string[], depth: number): DestructiveCommandViolation[] {
+  const compact = words.filter((word) => word.length > 0);
+  if (compact.length === 0) return [];
+  const normalized = unwrapCommand(compact);
+  if (normalized.length === 0) return [];
+  const command = commandName(normalized[0]);
+  const segment = compact.join(' ');
+
+  if (SHELL_COMMANDS.has(command)) {
+    return scanNestedShellCommand(normalized, depth);
+  }
+
+  if (command === 'find') return scanFindCommand(normalized, segment);
+  if (command === 'chmod' || command === 'chown' || command === 'chgrp') {
+    if (hasRecursiveFlag(normalized.slice(1))) {
+      return [violation(command, 'recursive permission/ownership changes are blocked', segment)];
+    }
+    return [];
+  }
+  if (command === 'mv') {
+    if (normalized.slice(1).some(isForceFlag)) {
+      return [violation(command, 'forceful mv can overwrite or remove task artifacts', segment)];
+    }
+    return [];
+  }
+  if (command === 'xargs') return scanXargsCommand(normalized, segment);
+  if (BLOCKED_COMMANDS.has(command)) {
+    return [violation(command, `${command} is blocked in model-authored Bash`, segment)];
+  }
+  return [];
+}
+
+function unwrapCommand(words: string[]): string[] {
+  let rest = stripAssignments(words);
+  let changed = true;
+  while (changed && rest.length > 0) {
+    changed = false;
+    const command = commandName(rest[0]);
+    if (WRAPPER_COMMANDS.has(command)) {
+      rest = stripAssignments(rest.slice(1));
+      changed = true;
+    } else if (command === 'env') {
+      rest = unwrapEnv(rest.slice(1));
+      changed = true;
+    } else if (command === 'timeout') {
+      rest = unwrapTimeout(rest.slice(1));
+      changed = true;
+    }
+  }
+  return rest;
+}
+
+function stripAssignments(words: string[]): string[] {
+  let index = 0;
+  while (index < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index])) {
+    index += 1;
+  }
+  return words.slice(index);
+}
+
+function unwrapEnv(words: string[]): string[] {
+  let index = 0;
+  while (index < words.length) {
+    const word = words[index];
+    if (word === '-i' || word === '-' || word.startsWith('-S') || word.startsWith('-0')) {
+      index += 1;
+    } else if (word === '-u' || word === '--unset') {
+      index += 2;
+    } else if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(word)) {
+      index += 1;
+    } else {
+      break;
+    }
+  }
+  return stripAssignments(words.slice(index));
+}
+
+function unwrapTimeout(words: string[]): string[] {
+  let index = 0;
+  while (index < words.length && words[index].startsWith('-')) {
+    index += optionConsumesValue(words[index]) ? 2 : 1;
+  }
+  if (index < words.length) index += 1;
+  return stripAssignments(words.slice(index));
+}
+
+function optionConsumesValue(option: string): boolean {
+  return option === '-s' || option === '--signal' || option === '-k' || option === '--kill-after';
+}
+
+function scanNestedShellCommand(words: string[], depth: number): DestructiveCommandViolation[] {
+  const cIndex = words.findIndex((word) => word === '-c' || word.endsWith('c') && /^-[A-Za-z]+$/.test(word));
+  if (cIndex < 0 || cIndex + 1 >= words.length) return [];
+  const nestedCommand = words[cIndex + 1];
+  return scanTokens(tokenizeShell(nestedCommand), depth + 1);
+}
+
+function scanFindCommand(words: string[], segment: string): DestructiveCommandViolation[] {
+  const violations: DestructiveCommandViolation[] = [];
+  if (words.includes('-delete')) {
+    violations.push(violation('find', 'find -delete is blocked', segment));
+  }
+  for (let index = 1; index < words.length - 1; index += 1) {
+    if (words[index] !== '-exec' && words[index] !== '-execdir') continue;
+    const nested = commandName(words[index + 1]);
+    if (BLOCKED_COMMANDS.has(nested) || nested === 'mv') {
+      violations.push(violation('find', `find ${words[index]} ${nested} is blocked`, segment));
+    }
+  }
+  return violations;
+}
+
+function scanXargsCommand(words: string[], segment: string): DestructiveCommandViolation[] {
+  const nested = words.map(commandName).find((word) => BLOCKED_COMMANDS.has(word) || word === 'mv');
+  return nested ? [violation('xargs', `xargs ${nested} is blocked`, segment)] : [];
+}
+
+function hasRecursiveFlag(words: string[]): boolean {
+  return words.some((word) => word === '--recursive' || /^-[^-]*R/.test(word));
+}
+
+function isForceFlag(word: string): boolean {
+  return word === '-f' || word === '--force' || /^-[^-]*f/.test(word);
+}
+
+function violation(command: string, reason: string, segment: string): DestructiveCommandViolation {
+  return { command, reason, segment };
+}
+
+function commandName(word: string): string {
+  const trimmed = word.trim();
+  const slash = trimmed.lastIndexOf('/');
+  return (slash >= 0 ? trimmed.slice(slash + 1) : trimmed).toLowerCase();
+}
+
+function tokenizeShell(input: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let current = '';
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  const pushWord = () => {
+    if (current.length > 0) {
+      tokens.push({ kind: 'word', value: current });
+      current = '';
+    }
+  };
+  const pushSeparator = () => {
+    pushWord();
+    if (tokens[tokens.length - 1]?.kind !== 'separator') tokens.push({ kind: 'separator' });
+  };
+
+  for (let index = 0; index < input.length; index += 1) {
+    const ch = input[index];
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = undefined;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '#') {
+      while (index < input.length && input[index] !== '\n') index += 1;
+      pushSeparator();
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      pushWord();
+      if (ch === '\n') pushSeparator();
+      continue;
+    }
+    if (ch === ';' || ch === '|' || ch === '&' || ch === '(' || ch === ')') {
+      pushSeparator();
+      continue;
+    }
+    current += ch;
+  }
+  pushWord();
+  return tokens;
+}

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1005,6 +1005,7 @@ function harborCellSystemPrompt(configPrompt: string | undefined): string {
     'Prefer Read, Glob, and Grep for file inspection and search.',
     'Prefer Edit and Write for file changes.',
     'Use Bash for running programs, tests, and shell-specific debugging only.',
+    'Do not use Bash for broad deletes, process kills, or service control; guarded commands fail. Use Edit/Write for targeted file changes.',
   ].join('\n');
 }
 

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -12,6 +12,7 @@ import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
 import type { IsolatedToolExecutor } from './isolation.js';
+import { checkDestructiveShellCommand, formatDestructiveCommandGuardMessage } from './destructive-command-guard.js';
 
 export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
@@ -74,7 +75,9 @@ export function buildIsolatedBashTool(
 ): MakaTool {
   return {
     name: 'Bash',
-    description: 'Run a shell command in the isolated headless task workspace.',
+    description:
+      'Run a shell command in the isolated headless task workspace. '
+      + 'Broad delete, process-kill, and service-control commands are refused; use Write/Edit for targeted file changes.',
     parameters: z.object({
       command: z.string().describe('The shell command to execute'),
       timeout_ms: z.number().int().positive().max(600_000).optional(),
@@ -87,6 +90,24 @@ export function buildIsolatedBashTool(
         cwd,
         timeoutMs: timeout_ms ?? 120_000,
       };
+      const guard = checkDestructiveShellCommand(command);
+      if (!guard.allowed) {
+        const result = {
+          exitCode: 126,
+          stdout: '',
+          stderr: `${formatDestructiveCommandGuardMessage(guard)}\n`,
+        };
+        emitOutput('stderr', result.stderr);
+        await options.heavyTaskEvidence?.recordToolEvidence({ name: 'Bash', input, result }, ctx);
+        return {
+          kind: 'terminal',
+          cwd,
+          cmd: command,
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        };
+      }
       // boundedTail: Bash is the one caller that wants a recoverable tail of a
       // huge, never-killed output. Read/Glob/Grep deliberately omit it so they
       // get full, head-first content from the executor.


### PR DESCRIPTION
## Summary
- add a headless destructive-command guard for model-authored Bash before commands reach the Harbor/tool executor
- block high-risk deletes, truncation, recursive chmod/chown/chgrp, `find -delete` / `find -exec rm`, `xargs rm`, forceful `mv`, process kills, and service control
- return a normal terminal result with exit code `126` and a model-visible guard message instead of throwing, so the agent can continue with safer Read/Write/Edit actions
- keep internal Read/Write/Edit/Grep/Glob shell fallbacks outside this guard, and add a Harbor prompt/tool-description nudge about the policy

## Why
Recent Terminal-Bench runs showed the agent cleaning up verifier-required artifacts (`*.gcno`, served `hello.html`) and killing the task container's main service via broad `qemu` process matching. This adds a first-pass hard stop at the Bash tool boundary.

## Verification
- `npm ci`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/destructive-command-guard.test.js packages/headless/dist/__tests__/tools.test.js packages/headless/dist/__tests__/harbor-cell-bash.test.js` (39/39)
- `node --test packages/headless/dist/__tests__/cli.test.js` (15/15)
- `git diff --check`
- `git diff --cached --check`
