### PR TITLE
refactor(ui): unify chat model pickers onto the grouped settings-select form

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -67,8 +67,8 @@ describe('home composer new-chat model picker', () => {
       (await readRepo('packages/ui/src/components.tsx')) +
       '\n' +
       (await readRepo('packages/ui/src/chat-model-switcher.tsx'));
-    assert.match(ui, /function ModelChoiceOptions\(\{ groups \}/, 'shared ModelChoiceOptions list component must exist');
-    const usages = ui.match(/<ModelChoiceOptions groups=\{grouped\} \/>/g) ?? [];
+    assert.match(ui, /function ModelChoiceOptions\(\{\s*groups,/, 'shared ModelChoiceOptions list component must exist');
+    const usages = ui.match(/<ModelChoiceOptions groups=\{grouped\} renderProviderMark=\{props\.renderProviderMark\} \/>/g) ?? [];
     assert.equal(
       usages.length,
       2,

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -151,12 +151,12 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(ui, /<SelectRoot<string>[\s\S]*items=\{modelSelectItems\}[\s\S]*value=\{currentValue\}[\s\S]*onValueChange=\{\(value\) => \{/);
     assert.match(ui, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{8\}/);
     assert.match(ui, /<SelectList>/);
-    // The grouped menu body now renders through the shared SettingsSelectGroups
-    // form — one governed list, keyed by connection, with the provider brand
-    // mark injected on each heading (kept out of @maka/ui via renderProviderMark).
-    assert.match(ui, /<SettingsSelectGroups\b/);
-    assert.match(ui, /key: group\.connectionSlug,/);
-    assert.match(ui, /logo: renderProviderMark\?\.\(group\.providerType\)/);
+    // The grouped menu renders provider groups keyed by connection, each heading
+    // carrying the injected brand mark (kept out of @maka/ui via renderProviderMark),
+    // on the shared `.settingsSelectMenu*` recipe.
+    assert.match(ui, /<SelectGroup key=\{group\.connectionSlug\}/);
+    assert.match(ui, /renderProviderMark\?\.\(group\.providerType\)/);
+    assert.match(ui, /className="settingsSelectMenuGroupLogo"/);
     assert.match(uiPrimitives, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseSelect\.ItemIndicator>/);
     assert.match(uiPrimitives, /<span className="min-w-0">[\s\S]*<BaseSelect\.ItemText>\{children\}<\/BaseSelect\.ItemText>/);
     assert.doesNotMatch(ui, /<select\b[\s\S]*aria-label="切换当前会话模型"/);

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -151,7 +151,12 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(ui, /<SelectRoot<string>[\s\S]*items=\{modelSelectItems\}[\s\S]*value=\{currentValue\}[\s\S]*onValueChange=\{\(value\) => \{/);
     assert.match(ui, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{8\}/);
     assert.match(ui, /<SelectList>/);
-    assert.match(ui, /<SelectGroup key=\{group\.connectionSlug\}/);
+    // The grouped menu body now renders through the shared SettingsSelectGroups
+    // form — one governed list, keyed by connection, with the provider brand
+    // mark injected on each heading (kept out of @maka/ui via renderProviderMark).
+    assert.match(ui, /<SettingsSelectGroups\b/);
+    assert.match(ui, /key: group\.connectionSlug,/);
+    assert.match(ui, /logo: renderProviderMark\?\.\(group\.providerType\)/);
     assert.match(uiPrimitives, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseSelect\.ItemIndicator>/);
     assert.match(uiPrimitives, /<span className="min-w-0">[\s\S]*<BaseSelect\.ItemText>\{children\}<\/BaseSelect\.ItemText>/);
     assert.doesNotMatch(ui, /<select\b[\s\S]*aria-label="切换当前会话模型"/);
@@ -159,8 +164,11 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(styles, /\.maka-model-switcher\s*\{/);
     assert.match(styles, /\.maka-model-switcher\[data-pending="true"\]\s*\{[\s\S]*cursor: progress;[\s\S]*\}/);
     assert.match(styles, /\.maka-model-switcher-trigger\s*\{/);
-    assert.match(styles, /\.maka-model-switcher-positioner\s*\{[\s\S]*z-index: var\(--z-dropdown\);[\s\S]*\}/);
-    assert.match(styles, /\.maka-model-switcher-popup\s*\{/);
+    // Popup/positioner/rows now come from the shared settings-select menu recipe
+    // (the bespoke `.maka-model-switcher-popup` chrome was folded into it); the
+    // trigger above stays the composer pill.
+    assert.match(styles, /\.settingsSelectMenuPopup\s*\{/);
+    assert.match(styles, /\.settingsSelectMenuPopup \[role="option"\]\s*\{[\s\S]*min-height: 32px;[\s\S]*\}/);
   });
 
   it('flags per-turn model departures against the session sticky model', async () => {

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -79,6 +79,7 @@ import { OnboardingHero } from './OnboardingHero';
 import { FirstRunChecklist } from './FirstRunChecklist';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
 import { ProviderLogo } from './settings/ProvidersPanel';
+import { ProviderBrandMark } from './settings/provider-brand-marks';
 import { ArtifactPane } from './artifact-pane';
 import { BrowserPanel } from './browser-panel';
 import { deriveChatHeaderAlert } from './chat-header-alert';
@@ -3180,6 +3181,7 @@ function AppShell() {
                 activeModel={activeModel}
                 activeModelLabel={activeModelLabel}
                 modelChoices={chatModelChoices}
+                renderProviderMark={(type) => <ProviderBrandMark type={type} />}
                 modelChangePending={activeId ? pendingSessionModelBySession[activeId] === true : false}
                 onModelChange={(input) => setSessionModel(input)}
                 newChatModel={newChatModel}

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -851,6 +851,68 @@
   justify-content: center;
 }
 
+/* Grouped menu form of the settings-select family (`SettingsSelectGroups`):
+   provider groups, each heading carrying a brand mark, over the shared
+   checkmark rows. The chat model pickers render this body inside their own
+   pill trigger; any future grouped select reuses it. Geometry traces to the
+   former bespoke model-switcher menu (max-content hug, 32px rows), now folded
+   into this one family instead of a parallel `.maka-model-switcher-*` recipe. */
+.settingsSelectMenuPopup {
+  width: max-content;
+  min-width: 200px;
+  max-width: min(320px, calc(100vw - 32px));
+  max-height: min(420px, var(--available-height));
+  padding: 8px;
+  border-radius: 12px;
+  background: var(--background);
+  box-shadow: var(--shadow-maka-panel);
+}
+
+.settingsSelectMenuPopup [role="option"] {
+  min-height: 32px;
+  align-items: center;
+  border-radius: 8px;
+  padding: 6px 12px;
+}
+
+.settingsSelectMenuOption {
+  display: block;
+  color: var(--foreground);
+  font-size: 0.875rem; /* text-sm on the 15px root — same scale as headings */
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+/* Heading: same 13px as the rows; hierarchy comes from weight 500 + muted ink
+   + the brand mark, not a different size or an uppercase eyebrow. The mark sits
+   in the 1rem leading column so it lines up under each row's selected check. */
+.settingsSelectMenuPopup .settingsSelectMenuGroupLabel {
+  display: grid;
+  grid-template-columns: 1rem 1fr;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 4px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--muted-foreground);
+}
+
+.settingsSelectMenuGroupLogo {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  color: var(--foreground); /* monochrome marks read full-ink, not muted */
+}
+
+.settingsSelectMenuGroupLogo svg {
+  width: 100%;
+  height: 100%;
+}
+
 .maka-plan-search-summary {
   display: flex;
   min-width: 0;

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -862,6 +862,12 @@
   min-width: 200px;
   max-width: min(320px, calc(100vw - 32px));
   max-height: min(420px, var(--available-height));
+  /* The popup itself is the scroll container: the row list can exceed the cap
+     when a provider exposes many models, and the inner SelectList's
+     `--available-height` ceiling is too tall to engage here, so without this
+     the overflow rows spill out below the rounded box. */
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 8px;
   border-radius: 12px;
   background: var(--background);

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -2136,55 +2136,6 @@
   font-weight: 600;
 }
 
-.maka-model-switcher-positioner {
-  z-index: var(--z-dropdown);
-  outline: none;
-}
-
-.maka-model-switcher-popup {
-  /* Hug the widest row instead of a fixed slab: short model ids
-     (`gpt-5.5`) no longer sit in a half-empty 330px box. Floor keeps it
-     from getting cramped; cap tames long custom model names and narrow
-     viewports. */
-  width: max-content;
-  min-width: 200px;
-  max-width: min(320px, calc(100vw - 32px));
-  max-height: min(420px, var(--available-height));
-  padding: 8px;
-  border-radius: 12px;
-  background: var(--background);
-  /* Reuse the governed panel-elevation token. A bespoke shadow derived from
-     `--foreground` turned WHITE in dark mode (foreground is near-white there),
-     painting a luminous ring around the menu. `--shadow-maka-panel` is a fixed
-     dark slate, stable across themes, and matches every other popover/dialog. */
-  box-shadow: var(--shadow-maka-panel);
-}
-
-/* Provider grouping heading. Type is governed to the shared scale: same
-   text-sm (0.875rem ≈ 13px) as the rows; hierarchy comes from uppercase +
-   weight + muted ink, not from a different size. Replaces the former
-   hairline between groups. */
-.maka-model-switcher-popup .maka-model-switcher-group-label {
-  padding: 6px 12px 4px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  line-height: 1.4;
-  color: var(--muted-foreground);
-}
-
-.maka-model-switcher-popup [role="option"] {
-  min-height: 32px;
-  align-items: center;
-  border-radius: 8px;
-  padding: 6px 12px;
-}
-
-.maka-model-switcher-item-main {
-  display: block;
-  color: var(--foreground);
-  font-size: 0.875rem; /* text-sm on a 15px root — governed, not a hand-tuned px */
-  font-weight: 500;
-  line-height: 1.4;
-}
+/* The popup, group headings, and option rows now render through the shared
+   `.settingsSelectMenu*` recipe (see the settings-select family above); the
+   trigger chrome above stays bespoke to the composer pill. */

--- a/packages/ui/src/__tests__/chat-model-helpers.test.ts
+++ b/packages/ui/src/__tests__/chat-model-helpers.test.ts
@@ -40,6 +40,20 @@ test('cross-provider same model name stays in separate, distinguishable groups',
   assert.equal(new Set(groups.map((g) => g.heading)).size, 2);
 });
 
+test('each group carries its providerType so the menu can pick the right brand mark', () => {
+  // The grouped menu renders a provider brand mark on each heading, keyed off
+  // this field; a regression that dropped it would silently show the wrong logo.
+  const groups = modelMenuGroups([
+    choice('zai-live', 'zai-coding-plan', 'glm-4.6'),
+    choice('zai-live', 'zai-coding-plan', 'glm-5'),
+    choice('anthropic-main', 'anthropic', 'claude-opus-4-8'),
+  ]);
+  const bySlug = new Map(groups.map((g) => [g.connectionSlug, g]));
+  assert.equal(bySlug.get('zai-live')?.providerType, 'zai-coding-plan');
+  assert.equal(bySlug.get('zai-live')?.choices.length, 2, 'models of one connection stay in one group');
+  assert.equal(bySlug.get('anthropic-main')?.providerType, 'anthropic');
+});
+
 test('headings never leak an account email (no @), even with slug disambiguation', () => {
   // modelMenuGroups never receives connection.name, so a leak is impossible by
   // construction; this guards against a future regression that reintroduces it.

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -56,6 +56,8 @@ const PROVIDER_SHORT_LABEL = {
 
 export interface ModelMenuGroup {
   connectionSlug: string;
+  /** Provider of this group, so the menu can render its brand mark on the heading. */
+  providerType: ProviderType;
   /**
    * Leak-safe, de-duplicated heading. Derived from `providerType` (plus the
    * slug when the same provider has multiple connections); never from
@@ -97,6 +99,7 @@ export function modelMenuGroups(choices: ChatModelChoice[]): ModelMenuGroup[] {
     const ambiguous = (connectionsPerType.get(group.providerType) ?? 0) > 1;
     return {
       connectionSlug: group.connectionSlug,
+      providerType: group.providerType,
       heading: ambiguous ? `${label} · ${group.connectionSlug}` : label,
       choices: group.choices,
     };

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -13,6 +13,8 @@
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button as UiButton,
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectList,
   SelectPopup,
@@ -23,7 +25,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from './ui.js';
-import { SettingsSelectGroups } from './primitives/settings-select.js';
 import { Settings } from './icons.js';
 import {
   type ChatModelChoice,
@@ -35,14 +36,15 @@ import {
 import { type ProviderType, type SessionSummary } from '@maka/core';
 
 /**
- * Shared grouped option rows for both model pickers, rendered through the
- * governed `SettingsSelectGroups` menu body: one row per model, grouped under a
- * leak-safe heading from `modelMenuGroups` — the short provider label,
- * disambiguated by connection slug when the same provider has multiple
- * connections. The heading never derives from the connection name (which embeds
- * the OAuth account email). Its brand mark is injected by the desktop app via
- * `renderProviderMark` so `@maka/ui` stays free of the provider SVG library.
- * The selected-row check is the `SelectItem` primitive's built-in `ItemIndicator`.
+ * Shared grouped option rows for both model pickers: one `<SelectItem>` per
+ * model, grouped under a leak-safe heading from `modelMenuGroups` — the short
+ * provider label, disambiguated by connection slug when the same provider has
+ * multiple connections. The heading never derives from the connection name
+ * (which embeds the OAuth account email). Its brand mark is injected by the
+ * desktop app via `renderProviderMark` so `@maka/ui` stays free of the provider
+ * SVG library. Headings + rows wear the shared `.settingsSelectMenu*` recipe so
+ * the menu reads as the governed grouped form; the selected-row check is the
+ * `SelectItem` primitive's built-in `ItemIndicator`.
  */
 function ModelChoiceOptions({
   groups,
@@ -52,17 +54,31 @@ function ModelChoiceOptions({
   renderProviderMark?: (type: ProviderType) => ReactNode;
 }) {
   return (
-    <SettingsSelectGroups
-      groups={groups.map((group) => ({
-        key: group.connectionSlug,
-        heading: group.heading,
-        logo: renderProviderMark?.(group.providerType),
-        options: group.choices.map(
-          (choice) =>
-            [modelChoiceValue(choice.connectionSlug, choice.model), choice.label] as const,
-        ),
-      }))}
-    />
+    <>
+      {groups.map((group) => {
+        const logo = renderProviderMark?.(group.providerType);
+        return (
+          <SelectGroup key={group.connectionSlug}>
+            <SelectGroupLabel className="settingsSelectMenuGroupLabel">
+              {logo ? (
+                <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{logo}</span>
+              ) : (
+                <span aria-hidden="true" />
+              )}
+              <span>{group.heading}</span>
+            </SelectGroupLabel>
+            {group.choices.map((choice) => {
+              const value = modelChoiceValue(choice.connectionSlug, choice.model);
+              return (
+                <SelectItem key={value} value={value}>
+                  <span className="settingsSelectMenuOption">{choice.label}</span>
+                </SelectItem>
+              );
+            })}
+          </SelectGroup>
+        );
+      })}
+    </>
   );
 }
 

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -10,11 +10,9 @@
  * `@maka/ui` Composer surface).
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button as UiButton,
-  SelectGroup,
-  SelectGroupLabel,
   SelectItem,
   SelectList,
   SelectPopup,
@@ -25,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from './ui.js';
+import { SettingsSelectGroups } from './primitives/settings-select.js';
 import { Settings } from './icons.js';
 import {
   type ChatModelChoice,
@@ -33,33 +32,37 @@ import {
   modelChoiceValue,
   parseModelChoiceValue,
 } from './chat-model-helpers.js';
-import { type SessionSummary } from '@maka/core';
+import { type ProviderType, type SessionSummary } from '@maka/core';
 
 /**
- * Shared grouped option rows for both model pickers: one `<SelectItem>` per
- * model, grouped under a leak-safe heading from `modelMenuGroups` — the short
- * provider label, disambiguated by connection slug when the same provider has
- * multiple connections. The heading never derives from the connection name
- * (which embeds the OAuth account email). The selected-row check is the
- * `SelectItem` primitive's built-in `ItemIndicator`.
+ * Shared grouped option rows for both model pickers, rendered through the
+ * governed `SettingsSelectGroups` menu body: one row per model, grouped under a
+ * leak-safe heading from `modelMenuGroups` — the short provider label,
+ * disambiguated by connection slug when the same provider has multiple
+ * connections. The heading never derives from the connection name (which embeds
+ * the OAuth account email). Its brand mark is injected by the desktop app via
+ * `renderProviderMark` so `@maka/ui` stays free of the provider SVG library.
+ * The selected-row check is the `SelectItem` primitive's built-in `ItemIndicator`.
  */
-function ModelChoiceOptions({ groups }: { groups: ModelMenuGroup[] }) {
+function ModelChoiceOptions({
+  groups,
+  renderProviderMark,
+}: {
+  groups: ModelMenuGroup[];
+  renderProviderMark?: (type: ProviderType) => ReactNode;
+}) {
   return (
-    <>
-      {groups.map((group) => (
-        <SelectGroup key={group.connectionSlug} className="maka-model-switcher-group">
-          <SelectGroupLabel className="maka-model-switcher-group-label">{group.heading}</SelectGroupLabel>
-          {group.choices.map((choice) => (
-            <SelectItem
-              key={modelChoiceValue(choice.connectionSlug, choice.model)}
-              value={modelChoiceValue(choice.connectionSlug, choice.model)}
-            >
-              <span className="maka-model-switcher-item-main">{choice.label}</span>
-            </SelectItem>
-          ))}
-        </SelectGroup>
-      ))}
-    </>
+    <SettingsSelectGroups
+      groups={groups.map((group) => ({
+        key: group.connectionSlug,
+        heading: group.heading,
+        logo: renderProviderMark?.(group.providerType),
+        options: group.choices.map(
+          (choice) =>
+            [modelChoiceValue(choice.connectionSlug, choice.model), choice.label] as const,
+        ),
+      }))}
+    />
   );
 }
 
@@ -71,6 +74,7 @@ export function ChatModelSwitcher(props: {
   choices: ChatModelChoice[];
   pending?: boolean;
   disabledReason?: string;
+  renderProviderMark?(type: ProviderType): ReactNode;
   onChange?(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
 }) {
   const [localPending, setLocalPending] = useState(false);
@@ -171,8 +175,8 @@ export function ChatModelSwitcher(props: {
           <SelectValue className="maka-model-switcher-value" />
         </SelectTrigger>
         <SelectPortal>
-          <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="maka-model-switcher-positioner">
-            <SelectPopup className="maka-model-switcher-popup">
+          <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="settingsSelectPositioner">
+            <SelectPopup className="settingsSelectMenuPopup">
               {/* PR-CHAT-CHROME-FIX-0 (WAWQAQ msg `ccce4a31`):
                    menu rows show only the raw model name. The
                    group label (connection + email) and the meta
@@ -186,12 +190,12 @@ export function ChatModelSwitcher(props: {
                 {!currentKnownChoice && (
                   <>
                     <SelectItem value={currentValue}>
-                      <span className="maka-model-switcher-item-main">{currentModel}</span>
+                      <span className="settingsSelectMenuOption">{currentModel}</span>
                     </SelectItem>
                     {grouped.length > 0 && <SelectSeparator />}
                   </>
                 )}
-                <ModelChoiceOptions groups={grouped} />
+                <ModelChoiceOptions groups={grouped} renderProviderMark={props.renderProviderMark} />
               </SelectList>
             </SelectPopup>
           </SelectPositioner>
@@ -212,6 +216,7 @@ export function NewChatModelPicker(props: {
   label: string;
   choices: ChatModelChoice[];
   currentValue?: string;
+  renderProviderMark?(type: ProviderType): ReactNode;
   onPick(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
 }) {
   const grouped = modelMenuGroups(props.choices);
@@ -238,10 +243,10 @@ export function NewChatModelPicker(props: {
         {/* SelectTrigger already renders a BaseSelect.Icon chevron — no manual one. */}
       </SelectTrigger>
       <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="maka-model-switcher-positioner">
-          <SelectPopup className="maka-model-switcher-popup">
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="settingsSelectPositioner">
+          <SelectPopup className="settingsSelectMenuPopup">
             <SelectList>
-              <ModelChoiceOptions groups={grouped} />
+              <ModelChoiceOptions groups={grouped} renderProviderMark={props.renderProviderMark} />
             </SelectList>
           </SelectPopup>
         </SelectPositioner>

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -5384,6 +5384,9 @@ export const Composer = forwardRef<
     activeModel?: string;
     activeModelLabel?: string;
     modelChoices?: ChatModelChoice[];
+    /** Renders the provider brand mark on each group heading of the model menus;
+     *  injected by the desktop app to keep the provider SVG library out of @maka/ui. */
+    renderProviderMark?(type: ProviderType): ReactNode;
     modelChangePending?: boolean;
     onModelChange?(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
     /**
@@ -5911,6 +5914,7 @@ export const Composer = forwardRef<
                     choices={props.modelChoices ?? []}
                     pending={props.modelChangePending}
                     disabledReason={modelSwitcherDisabledReason}
+                    renderProviderMark={props.renderProviderMark}
                     onChange={props.onModelChange}
                   />
                 ) : props.onPickNewChatModel && (props.modelChoices?.length ?? 0) > 0 ? (
@@ -5922,6 +5926,7 @@ export const Composer = forwardRef<
                         ? modelChoiceValue(props.newChatModel.llmConnectionSlug, props.newChatModel.model)
                         : undefined
                     }
+                    renderProviderMark={props.renderProviderMark}
                     onPick={props.onPickNewChatModel}
                   />
                 ) : (

--- a/packages/ui/src/primitives/settings-select.tsx
+++ b/packages/ui/src/primitives/settings-select.tsx
@@ -3,6 +3,8 @@
 import type { ReactElement, ReactNode } from "react";
 import { cn } from "../utils.js";
 import {
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectPopup,
   SelectPortal,
@@ -123,5 +125,53 @@ export function SettingsSelect<T extends string>(
         </SelectPositioner>
       </SelectPortal>
     </SelectRoot>
+  );
+}
+
+/**
+ * One provider-style group in a grouped select menu: a heading (with an
+ * optional leading brand mark) over its option rows. `key` is the React key
+ * and group identity (e.g. the connection slug); `heading` is already
+ * leak-safe display copy; `logo` is injected by the app so `@maka/ui` stays
+ * free of the provider SVG library.
+ */
+export interface SettingsSelectGroup<T extends string> {
+  key: string;
+  heading: string;
+  logo?: ReactNode;
+  options: ReadonlyArray<readonly [T, string]>;
+}
+
+/**
+ * Grouped popup body for a select menu: provider headings (optional brand
+ * mark) over checkmark rows built on the shared `SelectItem` primitive. Render
+ * this inside a caller-owned `SelectPopup` when the trigger is bespoke (e.g.
+ * the composer's pill) — `SettingsSelect` above owns the flat, settings-chrome
+ * form. Both share the `.settingsSelect*` family so every menu reads the same;
+ * the grouped form pins its roomier geometry via `.settingsSelectMenu*`.
+ */
+export function SettingsSelectGroups<T extends string>(
+  { groups }: { groups: ReadonlyArray<SettingsSelectGroup<T>> },
+): ReactElement {
+  return (
+    <>
+      {groups.map((group) => (
+        <SelectGroup key={group.key}>
+          <SelectGroupLabel className="settingsSelectMenuGroupLabel">
+            {group.logo ? (
+              <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{group.logo}</span>
+            ) : (
+              <span aria-hidden="true" />
+            )}
+            <span>{group.heading}</span>
+          </SelectGroupLabel>
+          {group.options.map(([value, label]) => (
+            <SelectItem key={value} value={value}>
+              <span className="settingsSelectMenuOption">{label}</span>
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      ))}
+    </>
   );
 }

--- a/packages/ui/src/primitives/settings-select.tsx
+++ b/packages/ui/src/primitives/settings-select.tsx
@@ -3,8 +3,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { cn } from "../utils.js";
 import {
-  SelectGroup,
-  SelectGroupLabel,
   SelectItem,
   SelectPopup,
   SelectPortal,
@@ -125,53 +123,5 @@ export function SettingsSelect<T extends string>(
         </SelectPositioner>
       </SelectPortal>
     </SelectRoot>
-  );
-}
-
-/**
- * One provider-style group in a grouped select menu: a heading (with an
- * optional leading brand mark) over its option rows. `key` is the React key
- * and group identity (e.g. the connection slug); `heading` is already
- * leak-safe display copy; `logo` is injected by the app so `@maka/ui` stays
- * free of the provider SVG library.
- */
-export interface SettingsSelectGroup<T extends string> {
-  key: string;
-  heading: string;
-  logo?: ReactNode;
-  options: ReadonlyArray<readonly [T, string]>;
-}
-
-/**
- * Grouped popup body for a select menu: provider headings (optional brand
- * mark) over checkmark rows built on the shared `SelectItem` primitive. Render
- * this inside a caller-owned `SelectPopup` when the trigger is bespoke (e.g.
- * the composer's pill) — `SettingsSelect` above owns the flat, settings-chrome
- * form. Both share the `.settingsSelect*` family so every menu reads the same;
- * the grouped form pins its roomier geometry via `.settingsSelectMenu*`.
- */
-export function SettingsSelectGroups<T extends string>(
-  { groups }: { groups: ReadonlyArray<SettingsSelectGroup<T>> },
-): ReactElement {
-  return (
-    <>
-      {groups.map((group) => (
-        <SelectGroup key={group.key}>
-          <SelectGroupLabel className="settingsSelectMenuGroupLabel">
-            {group.logo ? (
-              <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{group.logo}</span>
-            ) : (
-              <span aria-hidden="true" />
-            )}
-            <span>{group.heading}</span>
-          </SelectGroupLabel>
-          {group.options.map(([value, label]) => (
-            <SelectItem key={value} value={value}>
-              <span className="settingsSelectMenuOption">{label}</span>
-            </SelectItem>
-          ))}
-        </SelectGroup>
-      ))}
-    </>
   );
 }


### PR DESCRIPTION
## Summary

Unifies the two chat model pickers (in-session `ChatModelSwitcher`, new-chat `NewChatModelPicker`) onto one governed dropdown form. Their grouped list, provider headings, and checkmark rows now wear the shared `.settingsSelectMenu*` recipe in the `settings-select` family — replacing the bespoke `.maka-model-switcher-*` popup CSS — and group headings carry the provider brand mark.

## Why

Two chat pickers each hand-rolled their own popup/heading/row CSS, drifting from the governed `settings-select` look. Folding the grouped-menu look into that one CSS family gives every picker the same list, headings, and checkmark selection, with brand logos on the provider groups, instead of a parallel recipe each future reader must decode.

Closes # _(no linked issue)_

## Scope

**Changed:**
- `feat(ui)` — add the `.settingsSelectMenu*` CSS recipe (grouped popup geometry, provider heading with a brand-mark gutter, checkmark rows) to the `settings-select` family.
- `refactor(ui)` — render both chat pickers' grouped list through it via the shared `ModelChoiceOptions`; delete the bespoke `.maka-model-switcher-*` popup/positioner/heading/row CSS (trigger CSS kept). Headings drop the uppercase eyebrow for sentence-case at weight 500. Brand mark injected from the desktop app via the existing `renderProviderMark` seam so the provider SVG library stays out of `@maka/ui`. `ModelMenuGroup` gains `providerType` to pick the mark.
- `fix(ui)` — make the capped menu popup the scroll container; it capped at 420px with overflow visible, so a provider with many models spilled its overflow rows below the rounded box. Now they clip and scroll (keyboard nav to the last row verified over CDP).
- `test(ui)` — behavioral coverage for `ModelMenuGroup.providerType`; contract tests re-pointed to the new chrome.

**Not included:**
- The composer pill **trigger** is deliberately untouched — its 22px pill chrome (status dot, pending state, press feedback) is composer-layout concern, not model selection, and folding it into the settings trigger would add CSS with no payoff. This PR governs the *list*, not the trigger.
- The sticky-model **send-path** contract guards (`session-sticky-model-contract.test.ts`) are intact — only the picker-chrome assertions move.
- No new React render-test harness: the repo has none (pure-logic `node:test` + source contracts + CDP visual smoke). Interactive behavior is verified over CDP; introducing RTL is out of scope.

## Verification

- `npm run typecheck` (all workspaces) — clean
- `npm run -w @maka/desktop test` — 1608 pass
- `npm run -w @maka/ui test` — 13 pass
- Live-app CDP (turn-narrative fixture): grouped menu renders Z.AI / 自定义 / Anthropic / OpenAI headings with brand marks (Anthropic in brand orange) + checkmark on the selected row; overflow clips + scrolls; ArrowDown/End reaches and reveals the last row (`lastFullyVisibleInPopup: true`).

<img width="2560" height="1720" alt="image" src="https://github.com/user-attachments/assets/f53482d0-6a47-4682-9b94-011ef3c994ca" />

## User-facing impact

The in-session and new-chat model menus now group models by provider with a brand mark on each heading; selection is the standard checkmark. No behavior change to model switching or new-chat creation. No docs / CHANGELOG / migration.

## Reviewer notes

- Heading weight is **500** (not the old 600): 600 propped up an uppercase eyebrow; sentence-case + a colored brand mark + muted ink already differentiate headings from full-ink rows, so 500 is the calmer, lower-surprise choice (matches the base `SelectGroupLabel` default).
- No premature abstraction: the grouped body lives in `ModelChoiceOptions` (shared by both pickers); the only cross-cutting governance is the `.settingsSelectMenu*` CSS recipe. A reusable component waits for a second, non-chat grouped select.
- Net production LOC is roughly flat — the value is consolidating the grouped-menu look into one owned style family, not a raw line reduction.
