### PR TITLE
Persist model stream error diagnostics

### DIFF
--- a/packages/runtime/src/__tests__/run-trace.test.ts
+++ b/packages/runtime/src/__tests__/run-trace.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { RunTrace, type RunTraceEvent } from '../run-trace.js';
+
+describe('RunTrace error diagnostics', () => {
+  test('model stream failures keep generic copy plus redacted raw diagnostics', () => {
+    const events: RunTraceEvent[] = [];
+    const trace = new RunTrace({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      connectionSlug: 'deepseek',
+      providerId: 'openai-compatible',
+      modelId: 'deepseek-v4-pro',
+      newId: () => `trace-${events.length + 1}`,
+      now: () => 123,
+      record: (event) => events.push(event),
+    });
+    const error = new TypeError(
+      'Cannot read properties of undefined (reading "role") token=sk-live-secret-token-value',
+    );
+    error.stack = [
+      'TypeError: Cannot read properties of undefined (reading "role") token=sk-live-secret-token-value',
+      '    at prepareStep (file:///repo/packages/runtime/src/ai-sdk-backend.ts:123:45)',
+    ].join('\n');
+
+    trace.modelStreamFailed('TypeError', error);
+
+    assert.equal(events.length, 1);
+    const data = events[0]?.data ?? {};
+    assert.equal(data.errorClass, 'TypeError');
+    assert.equal(data.error, 'Operation failed');
+    assert.equal(data.rawErrorName, 'TypeError');
+    assert.equal(data.rawErrorType, 'object');
+    assert.match(String(data.redactedErrorMessage), /Cannot read properties/);
+    assert.match(String(data.redactedErrorMessage), /token=\[redacted\]/);
+    assert.match(String(data.redactedErrorMessageSha256), /^sha256:[a-f0-9]{64}$/);
+    assert.match(String(data.redactedErrorStackSha256), /^sha256:[a-f0-9]{64}$/);
+    assert.equal(JSON.stringify(data).includes('sk-live-secret-token-value'), false);
+  });
+
+  test('model stream failure diagnostics are bounded', () => {
+    const events: RunTraceEvent[] = [];
+    const trace = new RunTrace({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      connectionSlug: 'deepseek',
+      providerId: 'openai-compatible',
+      modelId: 'deepseek-v4-pro',
+      newId: () => `trace-${events.length + 1}`,
+      now: () => 123,
+      record: (event) => events.push(event),
+    });
+
+    trace.modelStreamFailed(undefined, new Error('x'.repeat(3_000)));
+
+    const data = events[0]?.data ?? {};
+    assert.equal(String(data.redactedErrorMessage).length, 2_048);
+    assert.equal(data.redactedErrorMessageTruncated, true);
+    assert.match(String(data.redactedErrorMessageSha256), /^sha256:[a-f0-9]{64}$/);
+  });
+});

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -1,4 +1,5 @@
-import { generalizedErrorMessage } from '@maka/core/redaction';
+import { createHash } from 'node:crypto';
+import { generalizedErrorMessage, redactSecrets } from '@maka/core/redaction';
 import type {
   CacheMissInputSource,
   ContextBudgetDiagnostic,
@@ -38,6 +39,8 @@ export interface RunTraceEvent {
 }
 
 export type RunTraceRecorder = (event: RunTraceEvent) => void;
+
+const REDACTED_ERROR_MESSAGE_MAX_CHARS = 2_048;
 
 export interface RunTraceInput {
   sessionId: string;
@@ -128,6 +131,7 @@ export class RunTrace {
     this.emit('model', 'model_stream_failed', 'Model stream failed', {
       ...(errorClass ? { errorClass } : {}),
       error: explainError(error),
+      ...diagnoseError(error),
     });
   }
 
@@ -191,6 +195,51 @@ export interface RunTraceLike {
 
 export function explainError(error: unknown): string {
   return generalizedErrorMessage(error);
+}
+
+function diagnoseError(error: unknown): Record<string, unknown> {
+  const rawMessage = rawErrorMessage(error);
+  const redactedMessage = redactSecrets(rawMessage);
+  const stack = error instanceof Error && typeof error.stack === 'string'
+    ? redactSecrets(error.stack)
+    : undefined;
+  const message = truncate(redactedMessage, REDACTED_ERROR_MESSAGE_MAX_CHARS);
+
+  return {
+    rawErrorName: rawErrorName(error),
+    rawErrorType: typeof error,
+    redactedErrorMessage: message.text,
+    redactedErrorMessageSha256: sha256(redactedMessage),
+    ...(message.truncated ? { redactedErrorMessageTruncated: true } : {}),
+    ...(stack ? { redactedErrorStackSha256: sha256(stack) } : {}),
+  };
+}
+
+function rawErrorName(error: unknown): string {
+  if (error instanceof Error && typeof error.name === 'string' && error.name.length > 0) {
+    return error.name;
+  }
+  if (error === null) return 'null';
+  return typeof error;
+}
+
+function rawErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return String(error);
+  } catch {
+    return '[unprintable error]';
+  }
+}
+
+function truncate(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) return { text: value, truncated: false };
+  return { text: value.slice(0, maxChars), truncated: true };
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
 }
 
 function sanitizeTraceData(data: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- keep the existing generalized model_stream_failed error field for compatibility
- add redacted raw error diagnostics to model_stream_failed traces: error name/type, bounded redacted message, message digest, and stack digest
- add focused RunTrace tests proving secrets are redacted, messages are bounded, and digests are emitted

## Verification
- npm --workspace @maka/runtime run typecheck
- node --test packages/runtime/dist/__tests__/run-trace.test.js
- npm --workspace @maka/runtime test
- git diff --check
- git diff --cached --check