### PR TITLE
Add semantic compact service

### DIFF
--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -61,6 +61,7 @@ export type AgentRunEventType =
   | 'permission_failed'
   | 'usage_recorded'
   | 'active_full_compact_block_recorded'
+  | 'semantic_compact_block_recorded'
   | 'abort_requested'
   | 'run_completed'
   | 'run_failed'

--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -54,6 +54,8 @@ export interface UsageBucket {
 export interface UsageLogRow {
   id: string;
   ts: number;
+  callKind?: 'main' | 'semantic_compact';
+  callId?: string;
   connectionSlug?: string;
   providerId: string;
   modelId: string;
@@ -93,6 +95,13 @@ export interface PricingConfig {
 export interface LlmCallRecord {
   sessionId?: string;
   turnId?: string;
+  /**
+   * Distinguishes the main agent stream from auxiliary model calls such as
+   * semantic compaction. Omitted means the historical main stream call.
+   */
+  callKind?: 'main' | 'semantic_compact';
+  /** Stable id for auxiliary calls so multiple records in one turn do not collide. */
+  callId?: string;
   connectionSlug?: string;
   providerId: string;
   modelId: string;
@@ -213,6 +222,11 @@ export interface CompactionDecisionDiagnostic {
   estimatedTokensBefore?: number;
   estimatedTokensAfter?: number;
   estimatedTokensSaved?: number;
+  compactCallInputTokens?: number;
+  compactCallOutputTokens?: number;
+  compactCallCacheReadInputTokens?: number;
+  compactCallCacheWriteInputTokens?: number;
+  compactCallTotalTokens?: number;
   reason?: string;
   failOpenReason?: string;
   skippedReasonCounts?: Record<string, number>;
@@ -240,6 +254,8 @@ export interface ContextBudgetDiagnostic {
   activePrunedToolResults?: number;
   activeArchiveFailures?: number;
   activeEstimatedTokensSaved?: number;
+  semanticCompactEnabled?: boolean;
+  semanticCompactMode?: 'off' | 'validate_only' | 'prepare_step_dry_run' | 'replace';
   compactionDecisions?: CompactionDecisionDiagnostic[];
   archiveRetrievalMode?: 'eager' | 'history_search_gated';
   archiveRetrievalEligibleTurns?: number;

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -202,6 +202,17 @@ describe('Harbor cell output contract', () => {
                   archiveRetrievalSkippedReasonCounts: { max_bytes: 2, max_results: 1 },
                   archiveRetrievalFailures: 1,
                   archiveRetrievalFailureReasonCounts: { corrupt: 1 },
+                  compactionDecisions: [{
+                    stage: 'activeStep',
+                    sourceKind: 'providerMessages',
+                    decision: 'replaced',
+                    boundaryKind: 'semanticCompact',
+                    compactCallInputTokens: 31,
+                    compactCallOutputTokens: 11,
+                    compactCallCacheReadInputTokens: 7,
+                    compactCallCacheWriteInputTokens: 2,
+                    compactCallTotalTokens: 42,
+                  }],
                 },
               },
             },
@@ -253,6 +264,11 @@ describe('Harbor cell output contract', () => {
       archiveRetrievalSkippedReasonCounts: { max_bytes: 2, max_results: 1 },
       archiveRetrievalFailures: 1,
       archiveRetrievalFailureReasonCounts: { corrupt: 1 },
+      semanticCompactCallInputTokens: 31,
+      semanticCompactCallOutputTokens: 11,
+      semanticCompactCallCacheReadInputTokens: 7,
+      semanticCompactCallCacheWriteInputTokens: 2,
+      semanticCompactCallTotalTokens: 42,
     });
     assert.deepEqual(validateHarborCellOutput(output), output);
   });

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -924,6 +924,11 @@ describe('fixed prompt controller', () => {
         archiveRetrievalSkippedReasonCounts: {},
         archiveRetrievalFailures: 0,
         archiveRetrievalFailureReasonCounts: {},
+        semanticCompactCallInputTokens: 0,
+        semanticCompactCallOutputTokens: 0,
+        semanticCompactCallCacheReadInputTokens: 0,
+        semanticCompactCallCacheWriteInputTokens: 0,
+        semanticCompactCallTotalTokens: 0,
       };
       const contextBudgetPolicy = {
         enabled: true as const,

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1221,6 +1221,54 @@ describe('runHarborCell', () => {
     assert.equal(snapshot.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 2048);
   });
 
+  test('Harbor parses semantic compact policy for headless runs', () => {
+    const options = buildHarborCellContextBudgetBackendOptions({
+      MAKA_CONTEXT_SEMANTIC_COMPACT: 'on',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MODE: 'replace',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_STEP_NUMBER: '2',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ACTIVE_ESTIMATED_TOKENS: '4096',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_MESSAGES: '3',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS: '2',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS: '512',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS: '128',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO: '0.2',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS: '768',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS: '30000',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED: 'true',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS: 'true',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL: 'compact-model',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION: 'prompt-v-test',
+    });
+
+    assert.equal(options.contextBudget?.semanticCompact?.enabled, true);
+    assert.equal(options.contextBudget?.semanticCompact?.mode, 'replace');
+    assert.equal(options.contextBudget?.semanticCompact?.minStepNumber, 2);
+    assert.equal(options.contextBudget?.semanticCompact?.maxActiveEstimatedTokens, 4096);
+    assert.equal(options.contextBudget?.semanticCompact?.minRecentMessages, 3);
+    assert.equal(options.contextBudget?.semanticCompact?.minRecentToolPairs, 2);
+    assert.equal(options.contextBudget?.semanticCompact?.maxSummaryEstimatedTokens, 512);
+    assert.equal(options.contextBudget?.semanticCompact?.minSavingsTokens, 128);
+    assert.equal(options.contextBudget?.semanticCompact?.minSavingsRatio, 0.2);
+    assert.equal(options.contextBudget?.semanticCompact?.maxCompactCallTokens, 768);
+    assert.equal(options.contextBudget?.semanticCompact?.timeoutMs, 30000);
+    assert.equal(options.contextBudget?.semanticCompact?.archiveRequired, true);
+    assert.equal(options.contextBudget?.semanticCompact?.benchmarkStateCards, true);
+    assert.equal(options.contextBudget?.semanticCompact?.summarizerModel, 'compact-model');
+    assert.equal(options.contextBudget?.semanticCompact?.promptVersion, 'prompt-v-test');
+
+    const snapshot = buildHarborCellContextBudgetPolicySnapshot({
+      MAKA_CONTEXT_SEMANTIC_COMPACT: 'on',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MODE: 'validate_only',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS: '1',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS: '64',
+    });
+    assert.equal(snapshot?.enabled, true);
+    if (!snapshot?.enabled) throw new Error('expected context budget snapshot to be enabled');
+    assert.equal(snapshot.semanticCompact?.mode, 'validate_only');
+    assert.equal(snapshot.semanticCompact?.minRecentToolPairs, 1);
+    assert.equal(snapshot.semanticCompact?.minSavingsTokens, 64);
+  });
+
   test('Harbor tool builder keeps the six container-native tools non-interactive', () => {
     const tools = buildHarborCellAiSdkTools(fakeToolExecutor());
     const names = tools.map((tool) => tool.name);

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1232,7 +1232,11 @@ describe('runHarborCell', () => {
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS: '512',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS: '128',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO: '0.2',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS: '256',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT: '0.5',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS: '768',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES: '3',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS: '11',
       MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS: '30000',
       MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED: 'true',
       MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS: 'true',
@@ -1249,7 +1253,11 @@ describe('runHarborCell', () => {
     assert.equal(options.contextBudget?.semanticCompact?.maxSummaryEstimatedTokens, 512);
     assert.equal(options.contextBudget?.semanticCompact?.minSavingsTokens, 128);
     assert.equal(options.contextBudget?.semanticCompact?.minSavingsRatio, 0.2);
+    assert.equal(options.contextBudget?.semanticCompact?.minNetSavingsTokens, 256);
+    assert.equal(options.contextBudget?.semanticCompact?.compactCallTokenCostWeight, 0.5);
     assert.equal(options.contextBudget?.semanticCompact?.maxCompactCallTokens, 768);
+    assert.equal(options.contextBudget?.semanticCompact?.maxConsecutiveInvalidSummaries, 3);
+    assert.equal(options.contextBudget?.semanticCompact?.invalidSummaryCooldownSteps, 11);
     assert.equal(options.contextBudget?.semanticCompact?.timeoutMs, 30000);
     assert.equal(options.contextBudget?.semanticCompact?.archiveRequired, true);
     assert.equal(options.contextBudget?.semanticCompact?.benchmarkStateCards, true);

--- a/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
+++ b/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
@@ -94,6 +94,11 @@ export function contextBudgetSummary(
     archiveRetrievalSkippedReasonCounts: {},
     archiveRetrievalFailures: 0,
     archiveRetrievalFailureReasonCounts: {},
+    semanticCompactCallInputTokens: 0,
+    semanticCompactCallOutputTokens: 0,
+    semanticCompactCallCacheReadInputTokens: 0,
+    semanticCompactCallCacheWriteInputTokens: 0,
+    semanticCompactCallTotalTokens: 0,
     ...input,
   };
 }

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -619,8 +619,20 @@ function validateSemanticCompactSnapshot(value: unknown): NonNullable<ContextBud
     ...(optionalNumber(value.minSavingsRatio, 'contextBudgetPolicy.semanticCompact.minSavingsRatio') !== undefined
       ? { minSavingsRatio: optionalNumber(value.minSavingsRatio, 'contextBudgetPolicy.semanticCompact.minSavingsRatio') }
       : {}),
+    ...(optionalNumber(value.minNetSavingsTokens, 'contextBudgetPolicy.semanticCompact.minNetSavingsTokens') !== undefined
+      ? { minNetSavingsTokens: optionalNumber(value.minNetSavingsTokens, 'contextBudgetPolicy.semanticCompact.minNetSavingsTokens') }
+      : {}),
+    ...(optionalNumber(value.compactCallTokenCostWeight, 'contextBudgetPolicy.semanticCompact.compactCallTokenCostWeight') !== undefined
+      ? { compactCallTokenCostWeight: optionalNumber(value.compactCallTokenCostWeight, 'contextBudgetPolicy.semanticCompact.compactCallTokenCostWeight') }
+      : {}),
     ...(optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') !== undefined
       ? { maxCompactCallTokens: optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') }
+      : {}),
+    ...(optionalNumber(value.maxConsecutiveInvalidSummaries, 'contextBudgetPolicy.semanticCompact.maxConsecutiveInvalidSummaries') !== undefined
+      ? { maxConsecutiveInvalidSummaries: optionalNumber(value.maxConsecutiveInvalidSummaries, 'contextBudgetPolicy.semanticCompact.maxConsecutiveInvalidSummaries') }
+      : {}),
+    ...(optionalNumber(value.invalidSummaryCooldownSteps, 'contextBudgetPolicy.semanticCompact.invalidSummaryCooldownSteps') !== undefined
+      ? { invalidSummaryCooldownSteps: optionalNumber(value.invalidSummaryCooldownSteps, 'contextBudgetPolicy.semanticCompact.invalidSummaryCooldownSteps') }
       : {}),
     ...(optionalNumber(value.timeoutMs, 'contextBudgetPolicy.semanticCompact.timeoutMs') !== undefined
       ? { timeoutMs: optionalNumber(value.timeoutMs, 'contextBudgetPolicy.semanticCompact.timeoutMs') }

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -39,6 +39,11 @@ export interface HarborCellContextBudgetSummary {
   archiveRetrievalSkippedReasonCounts: Record<string, number>;
   archiveRetrievalFailures: number;
   archiveRetrievalFailureReasonCounts: Record<string, number>;
+  semanticCompactCallInputTokens: number;
+  semanticCompactCallOutputTokens: number;
+  semanticCompactCallCacheReadInputTokens: number;
+  semanticCompactCallCacheWriteInputTokens: number;
+  semanticCompactCallTotalTokens: number;
 }
 
 export type HarborCellContextBudgetPolicySnapshot = ({ enabled: false } | ({ enabled: true } & ContextBudgetPolicy));
@@ -301,6 +306,11 @@ export function summarizeCellContextBudget(
     archiveRetrievalSkippedReasonCounts: {},
     archiveRetrievalFailures: 0,
     archiveRetrievalFailureReasonCounts: {},
+    semanticCompactCallInputTokens: 0,
+    semanticCompactCallOutputTokens: 0,
+    semanticCompactCallCacheReadInputTokens: 0,
+    semanticCompactCallCacheWriteInputTokens: 0,
+    semanticCompactCallTotalTokens: 0,
   };
 
   for (const event of events) {
@@ -327,6 +337,14 @@ export function summarizeCellContextBudget(
     mergeCountRecord(summary.archiveRetrievalSkippedReasonCounts, diagnostic.archiveRetrievalSkippedReasonCounts);
     summary.archiveRetrievalFailures += diagnostic.archiveRetrievalFailures ?? 0;
     mergeCountRecord(summary.archiveRetrievalFailureReasonCounts, diagnostic.archiveRetrievalFailureReasonCounts);
+    for (const decision of diagnostic.compactionDecisions ?? []) {
+      if (decision.boundaryKind !== 'semanticCompact') continue;
+      summary.semanticCompactCallInputTokens += decision.compactCallInputTokens ?? 0;
+      summary.semanticCompactCallOutputTokens += decision.compactCallOutputTokens ?? 0;
+      summary.semanticCompactCallCacheReadInputTokens += decision.compactCallCacheReadInputTokens ?? 0;
+      summary.semanticCompactCallCacheWriteInputTokens += decision.compactCallCacheWriteInputTokens ?? 0;
+      summary.semanticCompactCallTotalTokens += decision.compactCallTotalTokens ?? 0;
+    }
   }
 
   return summary.diagnosticEvents > 0 ? summary : undefined;
@@ -434,6 +452,26 @@ function validateContextBudgetSummary(value: unknown): HarborCellContextBudgetSu
       value.archiveRetrievalFailureReasonCounts,
       'contextBudgetSummary.archiveRetrievalFailureReasonCounts',
     ) ?? {},
+    semanticCompactCallInputTokens: optionalNumber(
+      value.semanticCompactCallInputTokens,
+      'contextBudgetSummary.semanticCompactCallInputTokens',
+    ) ?? 0,
+    semanticCompactCallOutputTokens: optionalNumber(
+      value.semanticCompactCallOutputTokens,
+      'contextBudgetSummary.semanticCompactCallOutputTokens',
+    ) ?? 0,
+    semanticCompactCallCacheReadInputTokens: optionalNumber(
+      value.semanticCompactCallCacheReadInputTokens,
+      'contextBudgetSummary.semanticCompactCallCacheReadInputTokens',
+    ) ?? 0,
+    semanticCompactCallCacheWriteInputTokens: optionalNumber(
+      value.semanticCompactCallCacheWriteInputTokens,
+      'contextBudgetSummary.semanticCompactCallCacheWriteInputTokens',
+    ) ?? 0,
+    semanticCompactCallTotalTokens: optionalNumber(
+      value.semanticCompactCallTotalTokens,
+      'contextBudgetSummary.semanticCompactCallTotalTokens',
+    ) ?? 0,
   };
 }
 
@@ -475,6 +513,9 @@ function validateContextBudgetPolicySnapshot(value: unknown): HarborCellContextB
       : {}),
     ...(value.activeFullCompact !== undefined
       ? { activeFullCompact: validateActiveFullCompactSnapshot(value.activeFullCompact) }
+      : {}),
+    ...(value.semanticCompact !== undefined
+      ? { semanticCompact: validateSemanticCompactSnapshot(value.semanticCompact) }
       : {}),
     ...(value.archiveRetrieval !== undefined
       ? { archiveRetrieval: validateArchiveRetrievalSnapshot(value.archiveRetrieval) }
@@ -537,6 +578,67 @@ function validateActiveFullCompactSnapshot(value: unknown): NonNullable<ContextB
       : {}),
     ...(value.highWaterName !== undefined
       ? { highWaterName: requireString(value.highWaterName, 'contextBudgetPolicy.activeFullCompact.highWaterName') }
+      : {}),
+  };
+}
+
+function validateSemanticCompactSnapshot(value: unknown): NonNullable<ContextBudgetPolicy['semanticCompact']> {
+  if (!isRecord(value)) throw new Error('contextBudgetPolicy.semanticCompact must be a JSON object');
+  return {
+    enabled: requireBoolean(value.enabled, 'contextBudgetPolicy.semanticCompact.enabled'),
+    ...(value.mode !== undefined
+      ? { mode: requireStringUnion(value.mode, 'contextBudgetPolicy.semanticCompact.mode', ['off', 'validate_only', 'prepare_step_dry_run', 'replace'] as const) }
+      : {}),
+    ...(optionalNumber(value.minStepNumber, 'contextBudgetPolicy.semanticCompact.minStepNumber') !== undefined
+      ? { minStepNumber: optionalNumber(value.minStepNumber, 'contextBudgetPolicy.semanticCompact.minStepNumber') }
+      : {}),
+    ...(optionalNumber(value.highWaterRatio, 'contextBudgetPolicy.semanticCompact.highWaterRatio') !== undefined
+      ? { highWaterRatio: optionalNumber(value.highWaterRatio, 'contextBudgetPolicy.semanticCompact.highWaterRatio') }
+      : {}),
+    ...(optionalNumber(value.forceRatio, 'contextBudgetPolicy.semanticCompact.forceRatio') !== undefined
+      ? { forceRatio: optionalNumber(value.forceRatio, 'contextBudgetPolicy.semanticCompact.forceRatio') }
+      : {}),
+    ...(optionalNumber(value.targetRatio, 'contextBudgetPolicy.semanticCompact.targetRatio') !== undefined
+      ? { targetRatio: optionalNumber(value.targetRatio, 'contextBudgetPolicy.semanticCompact.targetRatio') }
+      : {}),
+    ...(optionalNumber(value.maxActiveEstimatedTokens, 'contextBudgetPolicy.semanticCompact.maxActiveEstimatedTokens') !== undefined
+      ? { maxActiveEstimatedTokens: optionalNumber(value.maxActiveEstimatedTokens, 'contextBudgetPolicy.semanticCompact.maxActiveEstimatedTokens') }
+      : {}),
+    ...(optionalNumber(value.minRecentMessages, 'contextBudgetPolicy.semanticCompact.minRecentMessages') !== undefined
+      ? { minRecentMessages: optionalNumber(value.minRecentMessages, 'contextBudgetPolicy.semanticCompact.minRecentMessages') }
+      : {}),
+    ...(optionalNumber(value.minRecentToolPairs, 'contextBudgetPolicy.semanticCompact.minRecentToolPairs') !== undefined
+      ? { minRecentToolPairs: optionalNumber(value.minRecentToolPairs, 'contextBudgetPolicy.semanticCompact.minRecentToolPairs') }
+      : {}),
+    ...(optionalNumber(value.maxSummaryEstimatedTokens, 'contextBudgetPolicy.semanticCompact.maxSummaryEstimatedTokens') !== undefined
+      ? { maxSummaryEstimatedTokens: optionalNumber(value.maxSummaryEstimatedTokens, 'contextBudgetPolicy.semanticCompact.maxSummaryEstimatedTokens') }
+      : {}),
+    ...(optionalNumber(value.minSavingsTokens, 'contextBudgetPolicy.semanticCompact.minSavingsTokens') !== undefined
+      ? { minSavingsTokens: optionalNumber(value.minSavingsTokens, 'contextBudgetPolicy.semanticCompact.minSavingsTokens') }
+      : {}),
+    ...(optionalNumber(value.minSavingsRatio, 'contextBudgetPolicy.semanticCompact.minSavingsRatio') !== undefined
+      ? { minSavingsRatio: optionalNumber(value.minSavingsRatio, 'contextBudgetPolicy.semanticCompact.minSavingsRatio') }
+      : {}),
+    ...(optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') !== undefined
+      ? { maxCompactCallTokens: optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') }
+      : {}),
+    ...(optionalNumber(value.timeoutMs, 'contextBudgetPolicy.semanticCompact.timeoutMs') !== undefined
+      ? { timeoutMs: optionalNumber(value.timeoutMs, 'contextBudgetPolicy.semanticCompact.timeoutMs') }
+      : {}),
+    ...(value.archiveRequired !== undefined
+      ? { archiveRequired: requireBoolean(value.archiveRequired, 'contextBudgetPolicy.semanticCompact.archiveRequired') }
+      : {}),
+    ...(value.benchmarkStateCards !== undefined
+      ? { benchmarkStateCards: requireBoolean(value.benchmarkStateCards, 'contextBudgetPolicy.semanticCompact.benchmarkStateCards') }
+      : {}),
+    ...(value.summarizerModel !== undefined
+      ? { summarizerModel: requireString(value.summarizerModel, 'contextBudgetPolicy.semanticCompact.summarizerModel') }
+      : {}),
+    ...(value.promptVersion !== undefined
+      ? { promptVersion: requireString(value.promptVersion, 'contextBudgetPolicy.semanticCompact.promptVersion') }
+      : {}),
+    ...(value.highWaterName !== undefined
+      ? { highWaterName: requireString(value.highWaterName, 'contextBudgetPolicy.semanticCompact.highWaterName') }
       : {}),
   };
 }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -158,6 +158,27 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_ACTIVE_FULL_COMPACT_SUMMARY_MAX_ESTIMATED_TOKENS',
   'MAKA_CONTEXT_ACTIVE_FULL_COMPACT_ARCHIVE_REQUIRED',
   'MAKA_CONTEXT_ACTIVE_FULL_COMPACT_HIGH_WATER_NAME',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MODE',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_STEP_NUMBER',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_RATIO',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_FORCE_RATIO',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_TARGET_RATIO',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ACTIVE_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_MESSAGES',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_SUMMARY_MAX_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_NAME',
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL',
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MODE',
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_RESULTS',
@@ -600,6 +621,7 @@ export function buildAiSdkCellBackendRegistration(input: {
         now: input.now,
         recordRunTrace: ctx.recordRunTrace,
         recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
+        recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
       }),
     );
   };
@@ -646,7 +668,12 @@ export function buildHarborCellContextBudgetBackendOptions(
     env.MAKA_HARBOR_CONTEXT_ACTIVE_FULL_COMPACT,
     'MAKA_CONTEXT_ACTIVE_FULL_COMPACT',
   ) ?? false;
-  if (!pruneEnabled && !activePruneEnabled && !archiveRetrievalEnabled && !activeFullCompactEnabled) return {};
+  const semanticCompactEnabled = booleanEnv(
+    env.MAKA_CONTEXT_SEMANTIC_COMPACT ??
+    env.MAKA_HARBOR_CONTEXT_SEMANTIC_COMPACT,
+    'MAKA_CONTEXT_SEMANTIC_COMPACT',
+  ) ?? false;
+  if (!pruneEnabled && !activePruneEnabled && !archiveRetrievalEnabled && !activeFullCompactEnabled && !semanticCompactEnabled) return {};
 
   const contextBudget: ContextBudgetPolicy = {
     name: env.MAKA_CONTEXT_BUDGET_NAME ?? 'harbor-cell-context-budget',
@@ -752,6 +779,71 @@ export function buildHarborCellContextBudgetBackendOptions(
       ...(archiveRequired !== undefined ? { archiveRequired } : {}),
       ...(env.MAKA_CONTEXT_ACTIVE_FULL_COMPACT_HIGH_WATER_NAME
         ? { highWaterName: env.MAKA_CONTEXT_ACTIVE_FULL_COMPACT_HIGH_WATER_NAME }
+        : {}),
+    };
+  }
+
+  if (semanticCompactEnabled) {
+    const mode = semanticCompactModeEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE);
+    const maxActiveEstimatedTokens = positiveIntEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ACTIVE_ESTIMATED_TOKENS ??
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ESTIMATED_TOKENS,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ACTIVE_ESTIMATED_TOKENS',
+    );
+    const minStepNumber = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_STEP_NUMBER']);
+    const minRecentMessages = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_MESSAGES']);
+    const minRecentToolPairs = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS']);
+    const maxSummaryEstimatedTokens = positiveIntEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS ??
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_SUMMARY_MAX_ESTIMATED_TOKENS,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS',
+    );
+    const minSavingsTokens = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS']);
+    const maxCompactCallTokens = positiveIntEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
+    );
+    const timeoutMs = positiveIntEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS',
+    );
+    const archiveRequired = booleanEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED',
+    );
+    const benchmarkStateCards = booleanEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS',
+    );
+    const highWaterRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_RATIO);
+    const forceRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_FORCE_RATIO);
+    const targetRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_TARGET_RATIO);
+    const minSavingsRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO);
+    contextBudget.semanticCompact = {
+      enabled: true,
+      ...(mode ? { mode } : {}),
+      ...(minStepNumber !== undefined ? { minStepNumber } : {}),
+      ...(highWaterRatio !== undefined ? { highWaterRatio } : {}),
+      ...(forceRatio !== undefined ? { forceRatio } : {}),
+      ...(targetRatio !== undefined ? { targetRatio } : {}),
+      ...(maxActiveEstimatedTokens !== undefined ? { maxActiveEstimatedTokens } : {}),
+      ...(minRecentMessages !== undefined ? { minRecentMessages } : {}),
+      ...(minRecentToolPairs !== undefined ? { minRecentToolPairs } : {}),
+      ...(maxSummaryEstimatedTokens !== undefined ? { maxSummaryEstimatedTokens } : {}),
+      ...(minSavingsTokens !== undefined ? { minSavingsTokens } : {}),
+      ...(minSavingsRatio !== undefined ? { minSavingsRatio } : {}),
+      ...(maxCompactCallTokens !== undefined ? { maxCompactCallTokens } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(archiveRequired !== undefined ? { archiveRequired } : {}),
+      ...(benchmarkStateCards !== undefined ? { benchmarkStateCards } : {}),
+      ...(env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL
+        ? { summarizerModel: env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL }
+        : {}),
+      ...(env.MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION
+        ? { promptVersion: env.MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION }
+        : {}),
+      ...(env.MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_NAME
+        ? { highWaterName: env.MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_NAME }
         : {}),
     };
   }
@@ -874,6 +966,65 @@ export function buildHarborCellContextBudgetPolicySnapshot(
               : {}),
             ...(contextBudget.activeFullCompact.highWaterName
               ? { highWaterName: contextBudget.activeFullCompact.highWaterName }
+              : {}),
+          },
+        }
+      : {}),
+    ...(contextBudget.semanticCompact
+      ? {
+          semanticCompact: {
+            enabled: contextBudget.semanticCompact.enabled,
+            ...(contextBudget.semanticCompact.mode ? { mode: contextBudget.semanticCompact.mode } : {}),
+            ...(contextBudget.semanticCompact.minStepNumber !== undefined
+              ? { minStepNumber: contextBudget.semanticCompact.minStepNumber }
+              : {}),
+            ...(contextBudget.semanticCompact.highWaterRatio !== undefined
+              ? { highWaterRatio: contextBudget.semanticCompact.highWaterRatio }
+              : {}),
+            ...(contextBudget.semanticCompact.forceRatio !== undefined
+              ? { forceRatio: contextBudget.semanticCompact.forceRatio }
+              : {}),
+            ...(contextBudget.semanticCompact.targetRatio !== undefined
+              ? { targetRatio: contextBudget.semanticCompact.targetRatio }
+              : {}),
+            ...(contextBudget.semanticCompact.maxActiveEstimatedTokens !== undefined
+              ? { maxActiveEstimatedTokens: contextBudget.semanticCompact.maxActiveEstimatedTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.minRecentMessages !== undefined
+              ? { minRecentMessages: contextBudget.semanticCompact.minRecentMessages }
+              : {}),
+            ...(contextBudget.semanticCompact.minRecentToolPairs !== undefined
+              ? { minRecentToolPairs: contextBudget.semanticCompact.minRecentToolPairs }
+              : {}),
+            ...(contextBudget.semanticCompact.maxSummaryEstimatedTokens !== undefined
+              ? { maxSummaryEstimatedTokens: contextBudget.semanticCompact.maxSummaryEstimatedTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.minSavingsTokens !== undefined
+              ? { minSavingsTokens: contextBudget.semanticCompact.minSavingsTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.minSavingsRatio !== undefined
+              ? { minSavingsRatio: contextBudget.semanticCompact.minSavingsRatio }
+              : {}),
+            ...(contextBudget.semanticCompact.maxCompactCallTokens !== undefined
+              ? { maxCompactCallTokens: contextBudget.semanticCompact.maxCompactCallTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.timeoutMs !== undefined
+              ? { timeoutMs: contextBudget.semanticCompact.timeoutMs }
+              : {}),
+            ...(contextBudget.semanticCompact.archiveRequired !== undefined
+              ? { archiveRequired: contextBudget.semanticCompact.archiveRequired }
+              : {}),
+            ...(contextBudget.semanticCompact.benchmarkStateCards !== undefined
+              ? { benchmarkStateCards: contextBudget.semanticCompact.benchmarkStateCards }
+              : {}),
+            ...(contextBudget.semanticCompact.summarizerModel
+              ? { summarizerModel: contextBudget.semanticCompact.summarizerModel }
+              : {}),
+            ...(contextBudget.semanticCompact.promptVersion
+              ? { promptVersion: contextBudget.semanticCompact.promptVersion }
+              : {}),
+            ...(contextBudget.semanticCompact.highWaterName
+              ? { highWaterName: contextBudget.semanticCompact.highWaterName }
               : {}),
           },
         }
@@ -1078,6 +1229,19 @@ function activeFullCompactModeEnv(
   }
   throw new Error(
     `MAKA_CONTEXT_ACTIVE_FULL_COMPACT_MODE must be one of off, index_only, validate_only, prepare_step_dry_run, got ${JSON.stringify(raw)}`,
+  );
+}
+
+function semanticCompactModeEnv(
+  raw: string | undefined,
+): NonNullable<ContextBudgetPolicy['semanticCompact']>['mode'] | undefined {
+  const value = raw?.trim();
+  if (value === undefined || value === '') return undefined;
+  if (value === 'off' || value === 'validate_only' || value === 'prepare_step_dry_run' || value === 'replace') {
+    return value;
+  }
+  throw new Error(
+    `MAKA_CONTEXT_SEMANTIC_COMPACT_MODE must be one of off, validate_only, prepare_step_dry_run, replace, got ${JSON.stringify(raw)}`,
   );
 }
 

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -172,7 +172,11 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_SEMANTIC_COMPACT_SUMMARY_MAX_ESTIMATED_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS',
@@ -799,10 +803,13 @@ export function buildHarborCellContextBudgetBackendOptions(
       'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS',
     );
     const minSavingsTokens = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS']);
+    const minNetSavingsTokens = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS']);
     const maxCompactCallTokens = positiveIntEnv(
       env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS,
       'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
     );
+    const maxConsecutiveInvalidSummaries = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES']);
+    const invalidSummaryCooldownSteps = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS']);
     const timeoutMs = positiveIntEnv(
       env.MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS,
       'MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS',
@@ -819,6 +826,7 @@ export function buildHarborCellContextBudgetBackendOptions(
     const forceRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_FORCE_RATIO);
     const targetRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_TARGET_RATIO);
     const minSavingsRatio = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO);
+    const compactCallTokenCostWeight = numericEnv(env.MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT);
     contextBudget.semanticCompact = {
       enabled: true,
       ...(mode ? { mode } : {}),
@@ -832,7 +840,11 @@ export function buildHarborCellContextBudgetBackendOptions(
       ...(maxSummaryEstimatedTokens !== undefined ? { maxSummaryEstimatedTokens } : {}),
       ...(minSavingsTokens !== undefined ? { minSavingsTokens } : {}),
       ...(minSavingsRatio !== undefined ? { minSavingsRatio } : {}),
+      ...(minNetSavingsTokens !== undefined ? { minNetSavingsTokens } : {}),
+      ...(compactCallTokenCostWeight !== undefined ? { compactCallTokenCostWeight } : {}),
       ...(maxCompactCallTokens !== undefined ? { maxCompactCallTokens } : {}),
+      ...(maxConsecutiveInvalidSummaries !== undefined ? { maxConsecutiveInvalidSummaries } : {}),
+      ...(invalidSummaryCooldownSteps !== undefined ? { invalidSummaryCooldownSteps } : {}),
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(archiveRequired !== undefined ? { archiveRequired } : {}),
       ...(benchmarkStateCards !== undefined ? { benchmarkStateCards } : {}),
@@ -1005,8 +1017,20 @@ export function buildHarborCellContextBudgetPolicySnapshot(
             ...(contextBudget.semanticCompact.minSavingsRatio !== undefined
               ? { minSavingsRatio: contextBudget.semanticCompact.minSavingsRatio }
               : {}),
+            ...(contextBudget.semanticCompact.minNetSavingsTokens !== undefined
+              ? { minNetSavingsTokens: contextBudget.semanticCompact.minNetSavingsTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.compactCallTokenCostWeight !== undefined
+              ? { compactCallTokenCostWeight: contextBudget.semanticCompact.compactCallTokenCostWeight }
+              : {}),
             ...(contextBudget.semanticCompact.maxCompactCallTokens !== undefined
               ? { maxCompactCallTokens: contextBudget.semanticCompact.maxCompactCallTokens }
+              : {}),
+            ...(contextBudget.semanticCompact.maxConsecutiveInvalidSummaries !== undefined
+              ? { maxConsecutiveInvalidSummaries: contextBudget.semanticCompact.maxConsecutiveInvalidSummaries }
+              : {}),
+            ...(contextBudget.semanticCompact.invalidSummaryCooldownSteps !== undefined
+              ? { invalidSummaryCooldownSteps: contextBudget.semanticCompact.invalidSummaryCooldownSteps }
               : {}),
             ...(contextBudget.semanticCompact.timeoutMs !== undefined
               ? { timeoutMs: contextBudget.semanticCompact.timeoutMs }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -809,6 +809,7 @@ function createSingleRunActiveSession(
           store,
           recordRunTrace: (event) => boundRun?.recordRunTrace(event),
           recordActiveFullCompactBlock: (block) => boundRun?.recordActiveFullCompactBlock(block),
+          recordSemanticCompactBlock: (block) => boundRun?.recordSemanticCompactBlock(block),
         });
         active = {
           sessionId,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -17,6 +17,7 @@
     "./model-factory": "./dist/model-factory.js",
     "./context-budget": "./dist/context-budget.js",
     "./active-full-compact": "./dist/active-full-compact.js",
+    "./semantic-compact": "./dist/semantic-compact.js",
     "./test-connection": "./dist/test-connection.js",
     "./model-fetcher": "./dist/model-fetcher.js",
     "./materializer": "./dist/materializer.js",

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -38,6 +38,7 @@ import {
 } from '../context-budget.js';
 import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
 import type { ActiveFullCompactBlock } from '../active-full-compact.js';
+import type { SemanticCompactBlock } from '../semantic-compact.js';
 
 describe('AiSdkBackend model history', () => {
   test('prefers RuntimeEvent prior messages and appends current user once', async () => {
@@ -2083,6 +2084,138 @@ describe('AiSdkBackend usage telemetry', () => {
 
     assert.equal(recordedBlocks.length, 1);
     assert.equal(recordedBlocks[0]?.blockId, 'afcompact-sync-test');
+  });
+
+  test('semantic compact records a separate no-tools summarizer LLM call', async () => {
+    const messages: unknown[] = [];
+    const events: SessionEvent[] = [];
+    const llmRecords: LlmCallRecord[] = [];
+    const recordedBlocks: SemanticCompactBlock[] = [];
+    const largeBody = 'SEMANTIC_COMPACT_RAW_TOOL_OUTPUT'.repeat(180);
+    let streamCalls = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: {
+        content: [{
+          type: 'text',
+          text: [
+            'current_objective: Finish the benchmark task.',
+            'user_constraints: Continue from public provider-visible context only.',
+            'important_files_and_artifacts: none',
+            'commands_and_results: Read returned a large raw tool output.',
+            'errors_and_fixes: none',
+            'failed_hypotheses: none',
+            'operational_state: Continue in the same session.',
+            'public_verification_state: No verifier result claimed.',
+            'remaining_work: Continue after compact.',
+            'next_action: Use the preserved recent tail to continue.',
+            'archive_refs_to_reread_if_needed: none',
+          ].join('\n'),
+        }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: { total: 21, noCache: 19, cacheRead: 2, cacheWrite: 0 },
+          outputTokens: { total: 13, text: 13, reasoning: 0 },
+        },
+        warnings: [],
+      },
+      doStream: async () => {
+        streamCalls += 1;
+        const chunks: LanguageModelV3StreamPart[] = streamCalls === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: 'tool-semantic',
+                toolName: 'Read',
+                input: JSON.stringify({ path: 'large.log' }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } },
+              },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'finish', finishReason: { unified: 'stop', raw: 'stop' }, usage: { inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 }, outputTokens: { total: 1, text: 1, reasoning: 0 } } },
+            ];
+        return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        messages.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [{
+        name: 'Read',
+        description: 'Read description',
+        parameters: z.object({ path: z.string() }),
+        permissionRequired: false,
+        impl: async () => ({ body: largeBody }),
+      }],
+      contextBudget: {
+        charsPerToken: 1,
+        semanticCompact: {
+          enabled: true,
+          mode: 'replace',
+          minStepNumber: 1,
+          minRecentMessages: 0,
+          maxActiveEstimatedTokens: 1,
+          highWaterRatio: 0.1,
+          maxSummaryEstimatedTokens: 1024,
+          minSavingsTokens: 1,
+          minSavingsRatio: 0,
+        },
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordLlmCall: (record) => {
+        llmRecords.push(record);
+      },
+      recordSemanticCompactBlock: (block) => {
+        recordedBlocks.push(block);
+      },
+    });
+
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(streamCalls, 2);
+    assert.equal(model.doGenerateCalls.length, 1);
+    assert.equal(recordedBlocks.length, 1);
+    assert.equal(recordedBlocks[0]?.kind, 'maka.semantic_compact_block');
+    const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt.map((message) => ({
+      role: message.role,
+      content: message.content,
+    })));
+    assert.match(secondPrompt, /maka_semantic_compact_block/);
+    assert.doesNotMatch(secondPrompt, /SEMANTIC_COMPACT_RAW_TOOL_OUTPUT/);
+
+    const semanticRecord = llmRecords.find((record) => record.callKind === 'semantic_compact');
+    assert.ok(semanticRecord, 'expected semantic compact LLM record');
+    assert.match(semanticRecord.callId ?? '', /^semantic_compact_turn-1_1_/);
+    assert.equal(semanticRecord.inputTokens, 21);
+    assert.equal(semanticRecord.outputTokens, 13);
+    assert.equal(semanticRecord.cacheHitInputTokens, 2);
+    assert.equal(semanticRecord.totalTokens, 34);
+
+    const usageEvent = events.find((event) => event.type === 'token_usage') as
+      | (Extract<SessionEvent, { type: 'token_usage' }> & { contextBudget?: Record<string, unknown> })
+      | undefined;
+    const decisions = usageEvent?.contextBudget?.compactionDecisions as Array<Record<string, unknown>> | undefined;
+    assert.equal(decisions?.some((decision) =>
+      decision.boundaryKind === 'semanticCompact'
+        && decision.decision === 'replaced'
+        && decision.compactCallTotalTokens === 34
+    ), true);
   });
 
   test('active full compact keeps the accepted boundary projection across later AI SDK steps', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2097,19 +2097,19 @@ describe('AiSdkBackend usage telemetry', () => {
       doGenerate: {
         content: [{
           type: 'text',
-          text: [
-            'current_objective: Finish the benchmark task.',
-            'user_constraints: Continue from public provider-visible context only.',
-            'important_files_and_artifacts: none',
-            'commands_and_results: Read returned a large raw tool output.',
-            'errors_and_fixes: none',
-            'failed_hypotheses: none',
-            'operational_state: Continue in the same session.',
-            'public_verification_state: No verifier result claimed.',
-            'remaining_work: Continue after compact.',
-            'next_action: Use the preserved recent tail to continue.',
-            'archive_refs_to_reread_if_needed: none',
-          ].join('\n'),
+          text: JSON.stringify({
+            current_objective: 'Finish the benchmark task.',
+            user_constraints: ['Continue from public provider-visible context only.'],
+            important_files_and_artifacts: [],
+            commands_and_results: ['Read returned a large raw tool output.'],
+            errors_and_fixes: [],
+            failed_hypotheses: [],
+            operational_state: ['Continue in the same session.'],
+            public_verification_state: 'No verifier result claimed.',
+            remaining_work: ['Continue after compact.'],
+            next_action: 'Use the preserved recent tail to continue.',
+            archive_refs_to_reread_if_needed: [],
+          }),
         }],
         finishReason: { unified: 'stop', raw: 'stop' },
         usage: {

--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -36,11 +36,13 @@ describe('semantic compact', () => {
         assert.equal('toolChoice' in request, false);
         assert.equal('prepareStep' in request, false);
         assert.doesNotMatch(JSON.stringify(request.messages), /recent-result/);
+        assert.match(JSON.stringify(request.messages), /Return ONLY a valid JSON object/);
+        assert.doesNotMatch(JSON.stringify(request.messages), /source_manifest/);
         return {
           text: semanticSummary({
             objective: 'Solve the task while keeping the service running.',
             nextAction: 'Continue from the preserved recent tool result.',
-            commands: 'Earlier output showed a large build log.',
+            commands: ['Earlier output showed a large build log.'],
           }),
           usage: {
             inputTokens: 10,
@@ -175,7 +177,7 @@ describe('semantic compact', () => {
     assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.compactCallTotalTokens, 7);
   });
 
-  test('rejects summaries that do not satisfy the required field contract', async () => {
+  test('rejects JSON summaries that do not satisfy the required schema contract', async () => {
     const baseInput = {
       sessionId: 'session-1',
       turnId: 'turn-1',
@@ -195,7 +197,7 @@ describe('semantic compact', () => {
 
     const missingObjective = await rewriteSemanticCompactInMessages({
       ...baseInput,
-      summarizer: () => ({ text: 'next_action: Continue from preserved context.' }),
+      summarizer: () => ({ text: JSON.stringify({ next_action: 'Continue from preserved context.' }) }),
     });
     assert.equal(missingObjective.decision, 'unchanged');
     assert.equal(missingObjective.reason, 'summary_missing_current_objective');
@@ -206,7 +208,7 @@ describe('semantic compact', () => {
 
     const missingNextAction = await rewriteSemanticCompactInMessages({
       ...baseInput,
-      summarizer: () => ({ text: 'current_objective: Solve the task.' }),
+      summarizer: () => ({ text: JSON.stringify({ current_objective: 'Solve the task.' }) }),
     });
     assert.equal(missingNextAction.decision, 'unchanged');
     assert.equal(missingNextAction.reason, 'summary_missing_next_action');
@@ -214,6 +216,121 @@ describe('semantic compact', () => {
       missingNextAction.diagnosticPatch.compactionDecisions?.[0]?.reason,
       'summary_missing_next_action',
     );
+  });
+
+  test('rejects compact when provider savings do not beat compact-call token cost', async () => {
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 1,
+        minNetSavingsTokens: 1,
+        compactCallTokenCostWeight: 1,
+        minSavingsRatio: 0,
+      },
+      summarizer: () => ({
+        text: semanticSummary({
+          objective: 'Continue after compact.',
+          nextAction: 'Resume with preserved tail.',
+        }),
+        usage: {
+          inputTokens: 999_999,
+          outputTokens: 1,
+          cacheHitInputTokens: 0,
+          cacheMissInputTokens: 999_999,
+          cacheMissInputSource: 'explicit',
+          cacheWriteInputTokens: 0,
+          reasoningTokens: 0,
+          totalTokens: 1_000_000,
+          cachedInputTokens: 0,
+        },
+      }),
+    });
+
+    assert.equal(result.decision, 'unchanged');
+    assert.equal(result.reason, 'below_min_net_savings_tokens');
+    assert.equal(result.block?.acceptance.reason, 'below_min_net_savings_tokens');
+    assert.ok((result.block?.estimatedNetTokensSavedSigned ?? 0) < 0);
+  });
+
+  test('brakes semantic compact calls after repeated invalid summaries', async () => {
+    const controllerState = {
+      consecutiveInvalidSummaries: 0,
+      totalInvalidSummaries: 0,
+      compactCallCount: 0,
+      compactCallTotalTokens: 0,
+      acceptedEstimatedTokensSaved: 0,
+    };
+    let calls = 0;
+    const policy = {
+      enabled: true,
+      maxActiveEstimatedTokens: 1,
+      highWaterRatio: 0.1,
+      minRecentMessages: 1,
+      maxSummaryEstimatedTokens: 512,
+      minSavingsTokens: 1,
+      minSavingsRatio: 0,
+      maxConsecutiveInvalidSummaries: 1,
+      invalidSummaryCooldownSteps: 3,
+    } as const;
+
+    const invalid = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        return { text: JSON.stringify({ next_action: 'Continue.' }) };
+      },
+    });
+    assert.equal(invalid.reason, 'summary_missing_current_objective');
+    assert.equal(calls, 1);
+    assert.equal(controllerState.consecutiveInvalidSummaries, 1);
+
+    const cooled = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 3,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        return { text: semanticSummary({ objective: 'Should not run.', nextAction: 'Should not run.' }) };
+      },
+    });
+    assert.equal(cooled.decision, 'unchanged');
+    assert.equal(cooled.reason, 'semantic_compact_cooldown');
+    assert.equal(calls, 1);
+
+    const resumed = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 6,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        return { text: semanticSummary({ objective: 'Runs after cooldown.', nextAction: 'Continue.' }) };
+      },
+    });
+    assert.notEqual(resumed.reason, 'semantic_compact_cooldown');
+    assert.equal(calls, 2);
   });
 
   test('renders restoration cards and archive refs without raw source hashes as prose', async () => {
@@ -275,19 +392,19 @@ function semanticFixtureMessages(): ModelMessage[] {
 function semanticSummary(input: {
   objective: string;
   nextAction: string;
-  commands?: string;
+  commands?: string[];
 }): string {
-  return [
-    `current_objective: ${input.objective}`,
-    'user_constraints: Keep task-local state and public context only.',
-    'important_files_and_artifacts: none',
-    `commands_and_results: ${input.commands ?? 'No important command result.'}`,
-    'errors_and_fixes: none',
-    'failed_hypotheses: none',
-    'operational_state: Continue in the same session.',
-    'public_verification_state: No verifier result claimed.',
-    'remaining_work: Continue the task.',
-    `next_action: ${input.nextAction}`,
-    'archive_refs_to_reread_if_needed: none',
-  ].join('\n');
+  return JSON.stringify({
+    current_objective: input.objective,
+    user_constraints: ['Keep task-local state and public context only.'],
+    important_files_and_artifacts: [],
+    commands_and_results: input.commands ?? ['No important command result.'],
+    errors_and_fixes: [],
+    failed_hypotheses: [],
+    operational_state: ['Continue in the same session.'],
+    public_verification_state: 'No verifier result claimed.',
+    remaining_work: ['Continue the task.'],
+    next_action: input.nextAction,
+    archive_refs_to_reread_if_needed: [],
+  });
 }

--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -1,0 +1,293 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { ModelMessage } from 'ai';
+
+import {
+  renderSemanticCompactBlock,
+  rewriteSemanticCompactInMessages,
+  type SemanticCompactSummaryRequest,
+} from '../semantic-compact.js';
+
+describe('semantic compact', () => {
+  test('replaces an older span with a no-tools LLM summary and preserves recent tool pairs', async () => {
+    let requestSeen: SemanticCompactSummaryRequest | undefined;
+    const messages = semanticFixtureMessages();
+
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        minRecentToolPairs: 1,
+        maxSummaryEstimatedTokens: 1024,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+      },
+      requestShapeHashForMessages: (stepMessages) => `shape:${stepMessages.length}:${JSON.stringify(stepMessages).length}`,
+      summarizer: (request) => {
+        requestSeen = request;
+        assert.equal('tools' in request, false);
+        assert.equal('toolChoice' in request, false);
+        assert.equal('prepareStep' in request, false);
+        assert.doesNotMatch(JSON.stringify(request.messages), /recent-result/);
+        return {
+          text: semanticSummary({
+            objective: 'Solve the task while keeping the service running.',
+            nextAction: 'Continue from the preserved recent tool result.',
+            commands: 'Earlier output showed a large build log.',
+          }),
+          usage: {
+            inputTokens: 10,
+            outputTokens: 12,
+            cacheHitInputTokens: 0,
+            cacheMissInputTokens: 10,
+            cacheMissInputSource: 'explicit',
+            cacheWriteInputTokens: 0,
+            reasoningTokens: 0,
+            totalTokens: 22,
+            cachedInputTokens: 0,
+          },
+          finishReason: 'stop',
+        };
+      },
+    });
+
+    assert.equal(result.decision, 'replaced');
+    assert.ok(requestSeen, 'expected injected summarizer to be called');
+    assert.equal(result.block?.kind, 'maka.semantic_compact_block');
+    assert.equal(result.block?.acceptance.decision, 'accepted');
+    assert.ok((result.block?.estimatedTokensSavedSigned ?? 0) > 0);
+    assert.deepEqual(result.block?.preservedTail.toolCallIds, ['tool-recent']);
+    assert.equal(result.messages.some((message) =>
+      message.role === 'user' && JSON.stringify(message.content).includes('maka_semantic_compact_block')
+    ), true);
+    assert.equal(result.messages.some((message) =>
+      message.role === 'assistant' && JSON.stringify(message.content).includes('tool-recent')
+    ), true);
+    assert.equal(result.messages.some((message) =>
+      message.role === 'tool' && JSON.stringify(message.content).includes('recent-result')
+    ), true);
+
+    const decisions = result.diagnosticPatch.compactionDecisions ?? [];
+    assert.equal(decisions[0]?.boundaryKind, 'semanticCompact');
+    assert.equal(decisions[0]?.decision, 'replaced');
+    assert.equal(decisions[0]?.compactCallInputTokens, 10);
+    assert.equal(decisions[0]?.compactCallOutputTokens, 12);
+    assert.equal(decisions[0]?.compactCallTotalTokens, 22);
+    assert.equal(typeof result.diagnosticPatch.highWaterRequestShapeHashBefore, 'string');
+    assert.equal(typeof result.diagnosticPatch.highWaterRequestShapeHashAfter, 'string');
+  });
+
+  test('fails open when signed savings do not meet the configured margin', async () => {
+    const messages = semanticFixtureMessages();
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages,
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        minRecentToolPairs: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 50_000,
+        minSavingsRatio: 0,
+      },
+      summarizer: () => ({
+        text: semanticSummary({
+          objective: 'Solve the task.',
+          nextAction: 'Continue from preserved context.',
+        }),
+        usage: {
+          inputTokens: 5,
+          outputTokens: 6,
+          cacheHitInputTokens: 0,
+          cacheMissInputTokens: 5,
+          cacheMissInputSource: 'explicit',
+          cacheWriteInputTokens: 0,
+          reasoningTokens: 0,
+          totalTokens: 11,
+          cachedInputTokens: 0,
+        },
+      }),
+    });
+
+    assert.equal(result.decision, 'unchanged');
+    assert.equal(result.reason, 'below_min_savings_tokens');
+    assert.deepEqual(result.messages, messages);
+    assert.equal(result.block?.acceptance.decision, 'rejected');
+    const decision = result.diagnosticPatch.compactionDecisions?.[0];
+    assert.equal(decision?.boundaryKind, 'semanticCompact');
+    assert.equal(decision?.decision, 'unchanged');
+    assert.equal(decision?.reason, 'below_min_savings_tokens');
+    assert.equal(typeof decision?.estimatedTokensSaved, 'number');
+    assert.equal(decision?.compactCallInputTokens, 5);
+    assert.equal(decision?.compactCallTotalTokens, 11);
+  });
+
+  test('rejects summaries that newly surface private verifier material', async () => {
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+      },
+      summarizer: () => ({
+        text: semanticSummary({
+          objective: 'The hidden verifier says this will pass.',
+          nextAction: 'Continue.',
+        }),
+        usage: {
+          inputTokens: 3,
+          outputTokens: 4,
+          cacheHitInputTokens: 0,
+          cacheMissInputTokens: 3,
+          cacheMissInputSource: 'explicit',
+          cacheWriteInputTokens: 0,
+          reasoningTokens: 0,
+          totalTokens: 7,
+          cachedInputTokens: 0,
+        },
+      }),
+    });
+
+    assert.equal(result.decision, 'unchanged');
+    assert.equal(result.reason, 'private_verifier_surface');
+    assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.reason, 'private_verifier_surface');
+    assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.compactCallTotalTokens, 7);
+  });
+
+  test('rejects summaries that do not satisfy the required field contract', async () => {
+    const baseInput = {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+      },
+    } as const;
+
+    const missingObjective = await rewriteSemanticCompactInMessages({
+      ...baseInput,
+      summarizer: () => ({ text: 'next_action: Continue from preserved context.' }),
+    });
+    assert.equal(missingObjective.decision, 'unchanged');
+    assert.equal(missingObjective.reason, 'summary_missing_current_objective');
+    assert.equal(
+      missingObjective.diagnosticPatch.compactionDecisions?.[0]?.reason,
+      'summary_missing_current_objective',
+    );
+
+    const missingNextAction = await rewriteSemanticCompactInMessages({
+      ...baseInput,
+      summarizer: () => ({ text: 'current_objective: Solve the task.' }),
+    });
+    assert.equal(missingNextAction.decision, 'unchanged');
+    assert.equal(missingNextAction.reason, 'summary_missing_next_action');
+    assert.equal(
+      missingNextAction.diagnosticPatch.compactionDecisions?.[0]?.reason,
+      'summary_missing_next_action',
+    );
+  });
+
+  test('renders restoration cards and archive refs without raw source hashes as prose', async () => {
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+      },
+      summarizer: () => ({
+        text: semanticSummary({
+          objective: 'Continue after compact.',
+          nextAction: 'Resume with preserved tail.',
+        }),
+      }),
+    });
+
+    assert.equal(result.decision, 'replaced');
+    const rendered = renderSemanticCompactBlock(result.block!);
+    assert.match(rendered, /maka_semantic_compact_block/);
+    assert.match(rendered, /restoration_state_cards|coverage:/);
+    assert.doesNotMatch(rendered, /providerSourceIds=/);
+  });
+});
+
+function semanticFixtureMessages(): ModelMessage[] {
+  return [
+    { role: 'user', content: 'Please fix the build and keep the service running. '.repeat(80) } as ModelMessage,
+    { role: 'assistant', content: 'I ran configure and saw a linker failure. '.repeat(80) } as ModelMessage,
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'tool-old', toolName: 'Bash', input: { command: 'make test' } }],
+    } as ModelMessage,
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'tool-old', toolName: 'Bash', result: { body: 'OLD_BUILD_LOG '.repeat(800) } }],
+    } as unknown as ModelMessage,
+    {
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'tool-recent', toolName: 'Bash', input: { command: 'ps aux' } }],
+    } as ModelMessage,
+    {
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'tool-recent', toolName: 'Bash', result: { body: 'recent-result service still running' } }],
+    } as unknown as ModelMessage,
+    { role: 'user', content: 'Continue.' } as ModelMessage,
+  ];
+}
+
+function semanticSummary(input: {
+  objective: string;
+  nextAction: string;
+  commands?: string;
+}): string {
+  return [
+    `current_objective: ${input.objective}`,
+    'user_constraints: Keep task-local state and public context only.',
+    'important_files_and_artifacts: none',
+    `commands_and_results: ${input.commands ?? 'No important command result.'}`,
+    'errors_and_fixes: none',
+    'failed_hypotheses: none',
+    'operational_state: Continue in the same session.',
+    'public_verification_state: No verifier result claimed.',
+    'remaining_work: Continue the task.',
+    `next_action: ${input.nextAction}`,
+    'archive_refs_to_reread_if_needed: none',
+  ].join('\n');
+}

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -17,6 +17,7 @@ import type { AgentBackend } from './ai-sdk-backend.js';
 import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
+import type { SemanticCompactBlock } from './semantic-compact.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { projectRuntimeEventsToStoredMessages } from './runtime-event-read-model.js';
 import { backfillRuntimeEventsFromStoredMessages } from './runtime-event-backfill.js';
@@ -140,6 +141,27 @@ export class AgentRun {
           highWaterName: block.highWaterName,
           highWaterSeq: block.highWaterSeq,
           boundaryKind: 'activeFullCompact',
+          block,
+        },
+      });
+    });
+  }
+
+  recordSemanticCompactBlock(block: SemanticCompactBlock): void {
+    if (!this.input.runStore || !this.runStoreAvailable) return;
+    this.enqueueRunStore('append semantic compact block', async () => {
+      await this.input.runStore?.appendEvent(this.sessionId, this.runId, {
+        type: 'semantic_compact_block_recorded',
+        id: this.input.newId(),
+        runId: this.runId,
+        sessionId: this.sessionId,
+        turnId: block.turnId || this.turnId,
+        ts: this.input.now(),
+        data: {
+          blockId: block.blockId,
+          highWaterName: block.highWaterName,
+          highWaterSeq: block.highWaterSeq,
+          boundaryKind: 'semanticCompact',
           block,
         },
       });

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -105,6 +105,7 @@ import {
 import {
   rewriteSemanticCompactInMessages,
   type SemanticCompactBlock,
+  type SemanticCompactControllerState,
 } from './semantic-compact.js';
 import {
   compactionDecisionDiagnosticPatch,
@@ -1466,6 +1467,13 @@ export class AiSdkBackend implements AgentBackend {
     if (policy?.enabled !== true || policy.mode === 'off') return undefined;
 
     let acceptedProjection: ActiveFullCompactPrepareStepProjection | undefined;
+    const controllerState: SemanticCompactControllerState = {
+      consecutiveInvalidSummaries: 0,
+      totalInvalidSummaries: 0,
+      compactCallCount: 0,
+      compactCallTotalTokens: 0,
+      acceptedEstimatedTokensSaved: 0,
+    };
     return async (options) => {
       const activeToolsForStep = (options as PrepareStepLike & { activeTools?: readonly string[] }).activeTools;
       const dryRun = policy.mode === 'validate_only' || policy.mode === 'prepare_step_dry_run';
@@ -1487,6 +1495,7 @@ export class AiSdkBackend implements AgentBackend {
         turnId,
         messages: messagesForRewrite,
         policy,
+        controllerState,
         runtimeEvents: runtimeEvents?.filter((event) => event.turnId === turnId),
         stepNumber: options.stepNumber,
         now: this.now(),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -103,6 +103,10 @@ import {
   type ActiveFullCompactBlock,
 } from './active-full-compact.js';
 import {
+  rewriteSemanticCompactInMessages,
+  type SemanticCompactBlock,
+} from './semantic-compact.js';
+import {
   compactionDecisionDiagnosticPatch,
   historyCompactBlockToCompactionBoundary,
 } from './compaction-boundary.js';
@@ -356,6 +360,7 @@ export type HistoryCompactWriter = (
   input: HistoryCompactWriteInput,
 ) => Promise<HistoryCompactWriteResult | void> | HistoryCompactWriteResult | void;
 export type ActiveFullCompactBlockRecorder = (block: ActiveFullCompactBlock) => void | Promise<void>;
+export type SemanticCompactBlockRecorder = (block: SemanticCompactBlock) => void | Promise<void>;
 
 export interface AiSdkBackendInput {
   // ── Session context ────────────────────────────────────────────────────
@@ -450,6 +455,8 @@ export interface AiSdkBackendInput {
   writeHistoryCompact?: HistoryCompactWriter;
   /** Optional best-effort durable recorder for accepted active full compact blocks. */
   recordActiveFullCompactBlock?: ActiveFullCompactBlockRecorder;
+  /** Optional best-effort durable recorder for accepted semantic compact blocks. */
+  recordSemanticCompactBlock?: SemanticCompactBlockRecorder;
 }
 
 export interface SystemPromptContext {
@@ -601,7 +608,7 @@ export class AiSdkBackend implements AgentBackend {
     );
     const providerTools = plan.providerTools;
     let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};
-    let activeFullCompactDiagnosticPatch: Partial<ContextBudgetDiagnostic> | undefined;
+    let activeCompactDiagnosticPatch: Partial<ContextBudgetDiagnostic> | undefined;
     // Tool names the repair path matches a mis-cased call against — follows the
     // current step's snapshot so a group loaded mid-turn is repairable on the
     // step it becomes active, not routed to `invalid`.
@@ -751,13 +758,24 @@ export class AiSdkBackend implements AgentBackend {
               patch,
             );
           }),
-          this.buildActiveFullCompactPrepareStep(
+          this.buildSemanticCompactPrepareStep(
+            turnId,
+            model,
+            input.runtimeContext,
+            (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
+            (patch) => {
+              activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+                activeCompactDiagnosticPatch,
+                patch,
+              );
+            },
+          ) ?? this.buildActiveFullCompactPrepareStep(
             turnId,
             input.runtimeContext,
             (messagesForStep, activeToolsForStep) => stepRequestShapeHash(messagesForStep, activeToolsForStep),
             (patch) => {
-              activeFullCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
-                activeFullCompactDiagnosticPatch,
+              activeCompactDiagnosticPatch = mergeContextBudgetDiagnosticPatches(
+                activeCompactDiagnosticPatch,
                 patch,
               );
             },
@@ -888,7 +906,7 @@ export class AiSdkBackend implements AgentBackend {
             const contextBudgetForUsage = contextBudgetWithActivePrepareStepDiagnostics(
               contextBudgetForTelemetry,
               activeToolResultPruneDiagnosticPatch,
-              activeFullCompactDiagnosticPatch,
+              activeCompactDiagnosticPatch,
             );
             const tu: TokenUsageMessage = {
               type: 'token_usage',
@@ -995,7 +1013,7 @@ export class AiSdkBackend implements AgentBackend {
         contextBudgetForTelemetry = contextBudgetWithActivePrepareStepDiagnostics(
           contextBudgetForTelemetry,
           activeToolResultPruneDiagnosticPatch,
-          activeFullCompactDiagnosticPatch,
+          activeCompactDiagnosticPatch,
         );
         this.input.recordLlmCall?.({
           sessionId: this.sessionId,
@@ -1434,6 +1452,100 @@ export class AiSdkBackend implements AgentBackend {
     };
   }
 
+  private buildSemanticCompactPrepareStep(
+    turnId: string,
+    model: unknown,
+    runtimeEvents: readonly RuntimeEvent[] | undefined,
+    requestShapeHashForMessages: (
+      messages: readonly ModelMessage[],
+      activeToolsForStep: readonly string[] | undefined,
+    ) => string,
+    onDiagnosticPatch?: (patch: Partial<ContextBudgetDiagnostic>) => void,
+  ): PrepareStepFunctionLike | undefined {
+    const policy = this.input.contextBudget?.semanticCompact;
+    if (policy?.enabled !== true || policy.mode === 'off') return undefined;
+
+    let acceptedProjection: ActiveFullCompactPrepareStepProjection | undefined;
+    return async (options) => {
+      const activeToolsForStep = (options as PrepareStepLike & { activeTools?: readonly string[] }).activeTools;
+      const dryRun = policy.mode === 'validate_only' || policy.mode === 'prepare_step_dry_run';
+      const incomingMessages = options.messages;
+      const projectedMessages = dryRun
+        ? undefined
+        : projectAcceptedActiveFullCompactMessages(incomingMessages, acceptedProjection);
+      const messagesForRewrite = projectedMessages ?? incomingMessages;
+      const summarizerModel = policy.summarizerModel
+        ? this.input.modelFactory({
+            connection: this.input.connection,
+            apiKey: this.input.apiKey,
+            modelId: policy.summarizerModel,
+          })
+        : model;
+      const summarizerModelId = policy.summarizerModel ?? this.input.modelId;
+      const rewritten = await rewriteSemanticCompactInMessages({
+        sessionId: this.sessionId,
+        turnId,
+        messages: messagesForRewrite,
+        policy,
+        runtimeEvents: runtimeEvents?.filter((event) => event.turnId === turnId),
+        stepNumber: options.stepNumber,
+        now: this.now(),
+        charsPerToken: this.input.contextBudget?.charsPerToken,
+        requestShapeHashForMessages: (messages) => requestShapeHashForMessages(messages, activeToolsForStep),
+        abortSignal: this.abortController?.signal,
+        summarizer: async (request) => {
+          const startedAt = this.now();
+          const callId = `semantic_compact_${turnId}_${options.stepNumber}_${startedAt}`;
+          try {
+            const result = await this.modelAdapter.generateCompactSummary({
+              model: summarizerModel,
+              system: request.system,
+              messages: request.messages,
+              maxOutputTokens: request.maxOutputTokens,
+              abortSignal: request.abortSignal,
+            });
+            this.recordSemanticCompactSummaryCall({
+              callId,
+              turnId,
+              modelId: summarizerModelId,
+              startedAt,
+              latencyMs: Math.max(0, this.now() - startedAt),
+              usage: result.usage,
+              finishReason: result.finishReason,
+              status: 'success',
+            });
+            return result;
+          } catch (error) {
+            this.recordSemanticCompactSummaryCall({
+              callId,
+              turnId,
+              modelId: summarizerModelId,
+              startedAt,
+              latencyMs: Math.max(0, this.now() - startedAt),
+              status: request.abortSignal?.aborted ? 'aborted' : 'error',
+              errorClass: this.modelAdapter.classifyError(error),
+            });
+            throw error;
+          }
+        },
+      });
+      onDiagnosticPatch?.({
+        semanticCompactEnabled: true,
+        semanticCompactMode: policy.mode ?? 'replace',
+        ...rewritten.diagnosticPatch,
+      });
+      if (!dryRun && rewritten.decision === 'replaced') {
+        if (rewritten.block) this.recordSemanticCompactBlock(rewritten.block);
+        acceptedProjection = {
+          sourceSignatures: incomingMessages.map(modelMessageSignature),
+          projectedMessages: rewritten.messages,
+        };
+        return { messages: rewritten.messages };
+      }
+      return !dryRun && projectedMessages ? { messages: projectedMessages } : undefined;
+    };
+  }
+
   private buildActiveFullCompactPrepareStep(
     turnId: string,
     runtimeEvents: readonly RuntimeEvent[] | undefined,
@@ -1479,6 +1591,64 @@ export class AiSdkBackend implements AgentBackend {
       }
       return !dryRun && projectedMessages ? { messages: projectedMessages } : undefined;
     };
+  }
+
+  private recordSemanticCompactSummaryCall(input: {
+    callId: string;
+    turnId: string;
+    modelId: string;
+    startedAt: number;
+    latencyMs: number;
+    usage?: NormalizedAiSdkUsage;
+    finishReason?: string;
+    status: LlmCallRecord['status'];
+    errorClass?: string;
+  }): void {
+    const costUsd = input.usage ? this.computeTokenUsageCostUsd(input.usage) : 0;
+    this.input.recordLlmCall?.({
+      sessionId: this.sessionId,
+      turnId: input.turnId,
+      callKind: 'semantic_compact',
+      callId: input.callId,
+      connectionSlug: this.input.connection.slug,
+      providerId: this.input.connection.providerType,
+      modelId: input.modelId,
+      inputTokens: input.usage?.inputTokens ?? 0,
+      outputTokens: input.usage?.outputTokens ?? 0,
+      cacheHitInputTokens: input.usage?.cacheHitInputTokens ?? 0,
+      cacheMissInputTokens: input.usage?.cacheMissInputTokens ?? 0,
+      ...(input.usage?.cacheMissInputSource !== undefined
+        ? { cacheMissInputSource: input.usage.cacheMissInputSource }
+        : {}),
+      cachedInputTokens: input.usage?.cachedInputTokens ?? 0,
+      cacheWriteInputTokens: input.usage?.cacheWriteInputTokens ?? 0,
+      reasoningTokens: input.usage?.reasoningTokens ?? 0,
+      totalTokens: input.usage?.totalTokens,
+      ...(input.finishReason !== undefined ? { rawFinishReason: input.finishReason } : {}),
+      ...(input.usage?.raw !== undefined ? { rawUsage: input.usage.raw } : {}),
+      latencyMs: input.latencyMs,
+      status: input.status,
+      ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+      startedAt: input.startedAt,
+      ...(costUsd !== undefined ? { costUsd } : {}),
+    });
+  }
+
+  private recordSemanticCompactBlock(block: SemanticCompactBlock): void {
+    const recorder = this.input.recordSemanticCompactBlock;
+    if (!recorder) return;
+    try {
+      const result = recorder(block);
+      if (result && typeof (result as PromiseLike<void>).then === 'function') {
+        void Promise.resolve(result).catch(() => {
+          // Semantic compact persistence is diagnostic/storage-only and must
+          // never perturb provider request projection or tool-loop progress.
+        });
+      }
+    } catch {
+      // Semantic compact persistence is diagnostic/storage-only and must never
+      // perturb provider request projection or tool-loop progress.
+    }
   }
 
   private recordActiveFullCompactBlock(block: ActiveFullCompactBlock): void {

--- a/packages/runtime/src/compaction-boundary.ts
+++ b/packages/runtime/src/compaction-boundary.ts
@@ -10,7 +10,8 @@ export type CompactionBoundaryKind =
   | 'synthesisCache'
   | 'staleToolResultPrune'
   | 'activeToolResultPrune'
-  | 'activeFullCompact';
+  | 'activeFullCompact'
+  | 'semanticCompact';
 export type CompactionDecisionKind = 'unchanged' | 'replaced' | 'failedOpen';
 
 export interface CompactionCoverage {
@@ -68,6 +69,13 @@ export interface CompactionDecision {
   estimatedTokensBefore?: number;
   estimatedTokensAfter?: number;
   estimatedTokensSaved?: number;
+  compactCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+    totalTokens?: number;
+  };
   reason?: string;
   failOpenReason?: string;
   skippedReasonCounts?: Readonly<Record<string, number>>;
@@ -172,6 +180,21 @@ export function compactionDecisionToDiagnostic(
       ? { estimatedTokensAfter: decision.estimatedTokensAfter }
       : {}),
     ...(estimatedTokensSaved !== undefined ? { estimatedTokensSaved } : {}),
+    ...(decision.compactCallUsage?.inputTokens !== undefined
+      ? { compactCallInputTokens: decision.compactCallUsage.inputTokens }
+      : {}),
+    ...(decision.compactCallUsage?.outputTokens !== undefined
+      ? { compactCallOutputTokens: decision.compactCallUsage.outputTokens }
+      : {}),
+    ...(decision.compactCallUsage?.cacheReadInputTokens !== undefined
+      ? { compactCallCacheReadInputTokens: decision.compactCallUsage.cacheReadInputTokens }
+      : {}),
+    ...(decision.compactCallUsage?.cacheWriteInputTokens !== undefined
+      ? { compactCallCacheWriteInputTokens: decision.compactCallUsage.cacheWriteInputTokens }
+      : {}),
+    ...(decision.compactCallUsage?.totalTokens !== undefined
+      ? { compactCallTotalTokens: decision.compactCallUsage.totalTokens }
+      : {}),
     ...(decision.reason ? { reason: decision.reason } : {}),
     ...(decision.failOpenReason ? { failOpenReason: decision.failOpenReason } : {}),
     ...(decision.skippedReasonCounts ? { skippedReasonCounts: { ...decision.skippedReasonCounts } } : {}),

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -11,6 +11,7 @@ import {
   historyCompactBlockToCompactionBoundary,
 } from './compaction-boundary.js';
 import type { ActiveFullCompactPolicy } from './active-full-compact.js';
+import type { SemanticCompactPolicy } from './semantic-compact.js';
 import type { CompactionDecisionKind } from './compaction-boundary.js';
 
 export interface ContextBudgetPolicy {
@@ -38,6 +39,11 @@ export interface ContextBudgetPolicy {
    * replace a validated older provider-message span with a source-bearing block.
    */
   activeFullCompact?: ActiveFullCompactPolicy;
+  /**
+   * Optional current-turn LLM semantic compact replacement. Runs after active
+   * tool-result pruning and before the next provider step.
+   */
+  semanticCompact?: SemanticCompactPolicy;
   /** Optional replay-only archive hydration after pruning. Defaults off. */
   archiveRetrieval?: ArchiveRetrievalPolicy;
   /** Optional deterministic prior-history search used to re-add bounded around-context. Defaults off. */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -55,6 +55,7 @@ export type {
   SynthesisCacheWriteResult,
   ToolResultArchiveRecorder,
   ToolResultArchiveRecorderInput,
+  SemanticCompactBlockRecorder,
 } from './ai-sdk-backend.js';
 export { PiAgentBackend, normalizePiAgentFrame } from './pi-agent-backend.js';
 export type {
@@ -259,6 +260,21 @@ export type {
   ActiveFullCompactValidationResult,
   BuildActiveFullCompactBlockInput,
 } from './active-full-compact.js';
+export {
+  renderSemanticCompactBlock,
+  rewriteSemanticCompactInMessages,
+  semanticCompactBlockToModelMessage,
+} from './semantic-compact.js';
+export type {
+  SemanticCompactBlock,
+  SemanticCompactDecision,
+  SemanticCompactPolicy,
+  SemanticCompactRewriteInput,
+  SemanticCompactRewriteResult,
+  SemanticCompactStateCard,
+  SemanticCompactSummarizer,
+  SemanticCompactSummaryRequest,
+} from './semantic-compact.js';
 export { testConnection } from './test-connection.js';
 export { fetchProviderModels } from './model-fetcher.js';
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -71,6 +71,21 @@ export type PrepareStepFunctionLike = (
   options: PrepareStepLike,
 ) => PrepareStepResultLike | undefined | PromiseLike<PrepareStepResultLike | undefined>;
 
+export interface CompactSummaryRequest {
+  model: unknown;
+  system: string;
+  messages: readonly ModelMessage[];
+  maxOutputTokens: number;
+  abortSignal?: AbortSignal;
+}
+
+export interface CompactSummaryResult {
+  text: string;
+  usage?: NormalizedAiSdkUsage;
+  finishReason?: string;
+  providerRequestId?: string;
+}
+
 export interface ModelAdapterStreamInput {
   model: unknown;
   messages: ModelMessage[];
@@ -141,6 +156,39 @@ export class ModelAdapter {
       stopWhen: stepCountIs(this.input.maxSteps),
       abortSignal: input.abortSignal,
     });
+  }
+
+  async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
+    const ai = await import('ai').catch((err) => {
+      throw new Error(`Failed to load 'ai' package. Run \`npm install ai\`. Inner: ${(err as Error).message}`);
+    });
+    const { generateText } = ai as unknown as {
+      generateText: (opts: Record<string, unknown>) => Promise<{
+        text?: string;
+        usage?: AiSdkUsageLike;
+        totalUsage?: AiSdkUsageLike;
+        finishReason?: unknown;
+        providerMetadata?: unknown;
+        response?: { id?: string };
+      }>;
+    };
+
+    const result = await generateText({
+      model: input.model,
+      system: input.system,
+      messages: input.messages,
+      maxOutputTokens: input.maxOutputTokens,
+      abortSignal: input.abortSignal,
+    });
+    const usage = normalizeAiSdkUsage(result.totalUsage ?? result.usage, {
+      rawFinishReason: result.finishReason,
+    });
+    return {
+      text: result.text ?? '',
+      ...(usage ? { usage } : {}),
+      ...(result.finishReason !== undefined ? { finishReason: rawFinishReasonString(result.finishReason) } : {}),
+      ...(typeof result.response?.id === 'string' ? { providerRequestId: result.response.id } : {}),
+    };
   }
 
   handleStreamChunk(

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -311,6 +311,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
         const run = runId ? active?.activeRuns.get(runId) : undefined;
         run?.recordActiveFullCompactBlock(block);
       },
+      recordSemanticCompactBlock: (block) => {
+        const active = this.active.get(sessionId);
+        const runId = active?.turnToRunId.get(block.turnId);
+        const run = runId ? active?.activeRuns.get(runId) : undefined;
+        run?.recordSemanticCompactBlock(block);
+      },
     });
     const entry: ActiveSession = {
       sessionId,
@@ -354,6 +360,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
         const runId = active?.turnToRunId.get(block.turnId);
         const run = runId ? active?.activeRuns.get(runId) : undefined;
         run?.recordActiveFullCompactBlock(block);
+      },
+      recordSemanticCompactBlock: (block) => {
+        const active = this.childActive.get(activeKey);
+        const runId = active?.turnToRunId.get(block.turnId);
+        const run = runId ? active?.activeRuns.get(runId) : undefined;
+        run?.recordSemanticCompactBlock(block);
       },
     });
     const entry: ActiveSession = {

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -1,0 +1,869 @@
+import { createHash } from 'node:crypto';
+import type { ModelMessage } from 'ai';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
+import {
+  activeFullCompactCoverageFromEntries,
+  buildActiveFullCompactBlockFromSummary,
+  buildActiveFullCompactSourceIndex,
+  buildDeterministicActiveFullCompactSummary,
+  selectActiveFullCompactCoveredSpan,
+  validateActiveFullCompactBlockForSourceIndex,
+  type ActiveFullCompactArchiveRef,
+  type ActiveFullCompactCoverage,
+  type ActiveFullCompactPolicy,
+  type ActiveFullCompactSourceEntry,
+  type ActiveFullCompactSourceIndex,
+  type ActiveFullCompactSourceRef,
+  type ActiveFullCompactValidationResult,
+} from './active-full-compact.js';
+import { compactionDecisionDiagnosticPatch } from './compaction-boundary.js';
+import { estimateTokens } from './context-budget.js';
+import type { CompactSummaryResult, NormalizedAiSdkUsage } from './model-adapter.js';
+
+const DEFAULT_CHARS_PER_TOKEN = 4;
+const DEFAULT_MAX_SUMMARY_TOKENS = 768;
+const DEFAULT_MIN_SAVINGS_TOKENS = 256;
+const DEFAULT_MIN_SAVINGS_RATIO = 0.05;
+const PRIVATE_VERIFIER_PATTERN = /\b(hidden|private|official)\s+(verifier|evaluation|eval|test|assertion|oracle)\b/i;
+const SUMMARY_FIELD_LABELS = {
+  objective: ['current_objective', 'current objective'],
+  nextAction: ['next_action', 'next action'],
+} as const;
+
+export interface SemanticCompactPolicy {
+  enabled: boolean;
+  mode?: 'off' | 'validate_only' | 'prepare_step_dry_run' | 'replace';
+  minStepNumber?: number;
+  highWaterRatio?: number;
+  forceRatio?: number;
+  targetRatio?: number;
+  maxActiveEstimatedTokens?: number;
+  minRecentMessages?: number;
+  minRecentToolPairs?: number;
+  maxSummaryEstimatedTokens?: number;
+  minSavingsTokens?: number;
+  minSavingsRatio?: number;
+  maxCompactCallTokens?: number;
+  summarizerModel?: string;
+  timeoutMs?: number;
+  archiveRequired?: boolean;
+  benchmarkStateCards?: boolean;
+  promptVersion?: string;
+  highWaterName?: string;
+}
+
+export interface SemanticCompactSummaryRequest {
+  system: string;
+  messages: readonly ModelMessage[];
+  maxOutputTokens: number;
+  abortSignal?: AbortSignal;
+}
+
+export type SemanticCompactSummarizer = (
+  request: SemanticCompactSummaryRequest,
+) => Promise<CompactSummaryResult> | CompactSummaryResult;
+
+export interface SemanticCompactStateCard {
+  kind: 'process' | 'vm' | 'artifact' | 'command' | 'constraint' | 'verifier' | 'next_action' | 'generic';
+  text: string;
+  sourceIds: string[];
+}
+
+export interface SemanticCompactBlock {
+  kind: 'maka.semantic_compact_block';
+  version: 1;
+  blockId: string;
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  createdAt: number;
+  highWaterName: string;
+  highWaterSeq: number;
+  trigger: {
+    reason: 'high_water' | 'force_ratio' | 'predictive_growth' | 'reactive_prompt_too_long' | 'manual_test';
+    stepNumber?: number;
+    estimatedTokensBefore?: number;
+    thresholdTokens?: number;
+  };
+  coverage: ActiveFullCompactCoverage;
+  sourceRefs: ActiveFullCompactSourceRef[];
+  archiveRefs?: ActiveFullCompactArchiveRef[];
+  preservedTail: {
+    messageIndexes: number[];
+    toolCallIds: string[];
+    sourceIds: string[];
+  };
+  summary: {
+    promptVersion: string;
+    text: string;
+    limitations?: string[];
+    nextAction?: string;
+  };
+  stateCards?: SemanticCompactStateCard[];
+  requestShapeHashBefore?: string;
+  requestShapeHashAfter?: string;
+  preActiveContextEstimatedTokens: number;
+  postReplacementEstimatedTokens: number;
+  estimatedTokensSavedSigned: number;
+  compactCallUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+    totalTokens?: number;
+  };
+  finishReason?: string;
+  providerRequestId?: string;
+  acceptance: {
+    decision: 'accepted' | 'rejected' | 'dry_run';
+    reason?: string;
+    validationReasons?: string[];
+  };
+}
+
+export type SemanticCompactDecision = 'unchanged' | 'replaced' | 'failedOpen';
+
+export interface SemanticCompactRewriteInput {
+  sessionId: string;
+  turnId: string;
+  runId?: string;
+  invocationId?: string;
+  messages: readonly ModelMessage[];
+  policy: SemanticCompactPolicy | undefined;
+  runtimeEvents?: readonly RuntimeEvent[];
+  stepNumber: number;
+  now?: number;
+  charsPerToken?: number;
+  requestShapeHashBefore?: string;
+  requestShapeHashForMessages?: (messages: readonly ModelMessage[]) => string;
+  summarizer: SemanticCompactSummarizer;
+  abortSignal?: AbortSignal;
+}
+
+export interface SemanticCompactRewriteResult {
+  messages: ModelMessage[];
+  decision: SemanticCompactDecision;
+  reason?: string;
+  diagnosticPatch: Partial<ContextBudgetDiagnostic>;
+  block?: SemanticCompactBlock;
+  validation?: ActiveFullCompactValidationResult;
+}
+
+export async function rewriteSemanticCompactInMessages(
+  input: SemanticCompactRewriteInput,
+): Promise<SemanticCompactRewriteResult> {
+  const messages = [...input.messages];
+  const policy = input.policy;
+  const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+  if (policy?.enabled !== true || policy.mode === 'off') {
+    return unchanged(messages, 'disabled');
+  }
+
+  const index = buildActiveFullCompactSourceIndex({
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.invocationId ? { invocationId: input.invocationId } : {}),
+    messages,
+    runtimeEvents: input.runtimeEvents,
+    stepNumber: input.stepNumber,
+    charsPerToken,
+  });
+  const selectionPolicy = policyForSemanticSelection(policy, messages);
+  const selection = selectActiveFullCompactCoveredSpan(index, selectionPolicy);
+  if (selection.decision !== 'selected') {
+    const decision = selection.decision === 'failedOpen' ? 'failedOpen' : 'unchanged';
+    return {
+      messages,
+      decision,
+      reason: selection.reason,
+      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+        decision,
+        reason: selection.reason,
+        estimatedTokensBefore: index.estimatedTokens,
+        estimatedTokensAfter: index.estimatedTokens,
+        skippedReasonCounts: selection.skippedReasonCounts,
+      }),
+    };
+  }
+
+  const validationBlock = buildActiveFullCompactBlockFromSummary({
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.invocationId ? { invocationId: input.invocationId } : {}),
+    entries: selection.entries,
+    summary: {
+      schemaVersion: 1,
+      text: 'Semantic compact source validation block.',
+      nextActions: ['Continue from semantic compact summary and preserved recent tail.'],
+    },
+    highWaterName: policy.highWaterName ?? 'semantic-compact-high-water',
+    highWaterSeq: input.stepNumber,
+    trigger: {
+      reason: 'high_water',
+      stepNumber: input.stepNumber,
+      estimatedTokensBefore: index.estimatedTokens,
+      ...(policy.maxActiveEstimatedTokens !== undefined
+        ? { thresholdTokens: Math.floor(policy.maxActiveEstimatedTokens * finiteRatio(policy.highWaterRatio, 0.8)) }
+        : {}),
+    },
+    now: input.now,
+    charsPerToken,
+    requestShapeHashBefore: input.requestShapeHashBefore ?? input.requestShapeHashForMessages?.(messages),
+    preActiveContextEstimatedTokens: index.estimatedTokens,
+  });
+  const validation = validateActiveFullCompactBlockForSourceIndex(validationBlock, index, {
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    archiveRequired: policy.archiveRequired,
+    charsPerToken,
+  });
+  if (!validation.valid) {
+    return {
+      messages,
+      decision: 'failedOpen',
+      validation,
+      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+        decision: 'failedOpen',
+        boundaryIds: [validationBlock.blockId],
+        coverage: validationBlock.coverage,
+        estimatedTokensBefore: index.estimatedTokens,
+        estimatedTokensAfter: index.estimatedTokens,
+        failOpenReason: validation.reasons[0] ?? 'coverage_miss',
+        validationReasonCounts: validation.reasonCounts,
+      }),
+    };
+  }
+
+  const stateCards = buildSemanticStateCards({
+    selection,
+    messages,
+    runtimeEvents: input.runtimeEvents,
+    policy,
+    charsPerToken,
+  });
+  let summary: CompactSummaryResult;
+  try {
+    summary = await callSummarizerWithTimeout(input.summarizer, {
+      system: semanticCompactSystemPrompt(policy),
+      messages: buildSummarizerMessages({
+        selection,
+        messages,
+        index,
+        stateCards,
+        policy,
+        charsPerToken,
+      }),
+      maxOutputTokens: Math.floor(policy.maxCompactCallTokens ?? policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS),
+      abortSignal: input.abortSignal,
+    }, policy.timeoutMs);
+  } catch {
+    return rejected(messages, index, 'summarizer_failed');
+  }
+
+  const compactCallUsage = summary.usage ? compactUsage(summary.usage) : undefined;
+  const summaryText = normalizeSummaryText(summary.text);
+  if (!summaryText) return rejected(messages, index, 'summary_missing', compactCallUsage);
+  const maxSummaryTokens = Math.floor(policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS);
+  if (estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
+    return rejected(messages, index, 'summary_too_large', compactCallUsage);
+  }
+  const summaryContractReason = semanticSummaryContractRejectionReason(summaryText);
+  if (summaryContractReason) return rejected(messages, index, summaryContractReason, compactCallUsage);
+  if (newPrivateVerifierSurface(summaryText, selectedSourceText(selection, messages))) {
+    return rejected(messages, index, 'private_verifier_surface', compactCallUsage);
+  }
+
+  const requestShapeHashBefore = input.requestShapeHashBefore ?? input.requestShapeHashForMessages?.(messages);
+  const block = buildSemanticCompactBlock({
+    input,
+    index,
+    selection,
+    summaryText,
+    stateCards,
+    usage: summary.usage,
+    finishReason: summary.finishReason,
+    providerRequestId: summary.providerRequestId,
+    requestShapeHashBefore,
+    charsPerToken,
+  });
+  const replacementMessage = semanticCompactBlockToModelMessage(block);
+  const replacementMessages = [
+    ...messages.slice(0, selection.startMessageIndex),
+    replacementMessage,
+    ...messages.slice(selection.endMessageIndex + 1),
+  ];
+  const requestShapeHashAfter = input.requestShapeHashForMessages?.(replacementMessages);
+  if (requestShapeHashAfter) block.requestShapeHashAfter = requestShapeHashAfter;
+  block.postReplacementEstimatedTokens = estimatePostReplacementTokens(index, selection.estimatedTokens, renderSemanticCompactBlock(block), charsPerToken);
+  block.estimatedTokensSavedSigned = index.estimatedTokens - block.postReplacementEstimatedTokens;
+
+  const economicsReason = semanticSavingsRejectionReason(block, policy);
+  if (economicsReason) {
+    block.acceptance = { decision: 'rejected', reason: economicsReason };
+    return {
+      messages,
+      decision: 'unchanged',
+      reason: economicsReason,
+      block,
+      validation,
+      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+        decision: 'unchanged',
+        boundaryIds: [block.blockId],
+        coverage: block.coverage,
+        estimatedTokensBefore: index.estimatedTokens,
+        estimatedTokensAfter: block.postReplacementEstimatedTokens,
+        estimatedTokensSaved: block.estimatedTokensSavedSigned,
+        compactCallUsage: block.compactCallUsage,
+        reason: economicsReason,
+        validationReasonCounts: validation.reasonCounts,
+      }),
+    };
+  }
+
+  if (policy.mode === 'validate_only' || policy.mode === 'prepare_step_dry_run') {
+    block.acceptance = { decision: 'dry_run', reason: policy.mode };
+    return {
+      messages,
+      decision: 'unchanged',
+      reason: policy.mode,
+      block,
+      validation,
+      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+        decision: 'unchanged',
+        boundaryIds: [block.blockId],
+        coverage: block.coverage,
+        estimatedTokensBefore: index.estimatedTokens,
+        estimatedTokensAfter: block.postReplacementEstimatedTokens,
+        estimatedTokensSaved: block.estimatedTokensSavedSigned,
+        compactCallUsage: block.compactCallUsage,
+        reason: policy.mode,
+        validationReasonCounts: validation.reasonCounts,
+      }),
+    };
+  }
+
+  block.acceptance = { decision: 'accepted' };
+  return {
+    messages: replacementMessages,
+    decision: 'replaced',
+    block,
+    validation,
+    diagnosticPatch: {
+      ...semanticCompactDecisionDiagnosticPatch({
+        decision: 'replaced',
+        boundaryIds: [block.blockId],
+        coverage: block.coverage,
+        estimatedTokensBefore: index.estimatedTokens,
+        estimatedTokensAfter: block.postReplacementEstimatedTokens,
+        estimatedTokensSaved: block.estimatedTokensSavedSigned,
+        compactCallUsage: block.compactCallUsage,
+        validationReasonCounts: validation.reasonCounts,
+      }),
+      ...(requestShapeHashBefore && requestShapeHashAfter
+        ? {
+            highWaterRequestShapeHashBefore: requestShapeHashBefore,
+            highWaterRequestShapeHashAfter: requestShapeHashAfter,
+          }
+        : {}),
+    },
+  };
+}
+
+export function semanticCompactBlockToModelMessage(block: SemanticCompactBlock): ModelMessage {
+  return {
+    role: 'user',
+    content: renderSemanticCompactBlock(block),
+  } as ModelMessage;
+}
+
+export function renderSemanticCompactBlock(block: SemanticCompactBlock): string {
+  const archiveLines = (block.archiveRefs ?? []).slice(0, 12).map((ref) =>
+    `- ${ref.artifactId} tool=${ref.toolName ?? 'unknown'} call=${ref.toolCallId ?? 'unknown'} sha256=${ref.bodySha256.slice(0, 16)}`
+  );
+  const stateLines = (block.stateCards ?? []).map((card) =>
+    `- ${card.kind}: ${singleLine(card.text)}`
+  );
+  return [
+    `<maka_semantic_compact_block id="${escapeAttribute(block.blockId)}" high_water="${escapeAttribute(block.highWaterName)}" seq="${block.highWaterSeq}" version="${block.version}">`,
+    'summary:',
+    block.summary.text,
+    stateLines.length > 0 ? 'restoration_state_cards:' : '',
+    ...stateLines,
+    archiveLines.length > 0 ? 'archives:' : '',
+    ...archiveLines,
+    `coverage: ${block.coverage.providerMessageSourceIds.length} provider source entries, ${block.coverage.toolCallIds.length} tool calls, ${block.coverage.bodySha256.length} source hashes retained in durable compact block.`,
+    `preserved_tail: messages=${block.preservedTail.messageIndexes.join(',') || 'none'} toolCalls=${block.preservedTail.toolCallIds.join(',') || 'none'}`,
+    'instructions: Continue from this semantic summary plus the exact preserved recent messages that follow it. Use archive refs for raw evidence recovery when needed.',
+    '</maka_semantic_compact_block>',
+  ].filter((line) => line !== '').join('\n');
+}
+
+function policyForSemanticSelection(
+  policy: SemanticCompactPolicy,
+  messages: readonly ModelMessage[],
+): ActiveFullCompactPolicy {
+  const minRecentMessages = Math.max(
+    Math.floor(policy.minRecentMessages ?? 1),
+    recentMessageCountForToolPairs(messages, Math.floor(policy.minRecentToolPairs ?? 0)),
+  );
+  return {
+    enabled: true,
+    minStepNumber: policy.minStepNumber,
+    highWaterRatio: policy.highWaterRatio,
+    forceRatio: policy.forceRatio,
+    targetRatio: policy.targetRatio,
+    maxActiveEstimatedTokens: policy.maxActiveEstimatedTokens,
+    minRecentMessages,
+    minRecentToolPairs: policy.minRecentToolPairs,
+    maxSummaryEstimatedTokens: policy.maxSummaryEstimatedTokens,
+    archiveRequired: policy.archiveRequired,
+    highWaterName: policy.highWaterName,
+  };
+}
+
+function recentMessageCountForToolPairs(messages: readonly ModelMessage[], minPairs: number): number {
+  if (minPairs <= 0) return 0;
+  const retained = new Set<number>();
+  const callsById = new Map<string, number>();
+  const resultsById = new Map<string, number>();
+  messages.forEach((message, index) => {
+    for (const id of messageToolCallIds(message)) callsById.set(id, index);
+    for (const id of messageToolResultIds(message)) resultsById.set(id, index);
+  });
+  let pairs = 0;
+  for (let index = messages.length - 1; index >= 0 && pairs < minPairs; index -= 1) {
+    for (const id of messageToolResultIds(messages[index]!)) {
+      const callIndex = callsById.get(id);
+      const resultIndex = resultsById.get(id);
+      if (callIndex === undefined || resultIndex === undefined) continue;
+      retained.add(callIndex);
+      retained.add(resultIndex);
+      pairs += 1;
+      if (pairs >= minPairs) break;
+    }
+  }
+  if (retained.size === 0) return 0;
+  return messages.length - Math.min(...retained);
+}
+
+function messageToolCallIds(message: ModelMessage): string[] {
+  const content = (message as { content?: unknown }).content;
+  const parts = Array.isArray(content) ? content : [];
+  return parts
+    .map((part) => isRecord(part) && part.type === 'tool-call' ? part.toolCallId ?? part.tool_call_id : undefined)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+function messageToolResultIds(message: ModelMessage): string[] {
+  if ((message as { role?: string }).role !== 'tool') return [];
+  const content = (message as { content?: unknown }).content;
+  const parts = Array.isArray(content) ? content : [];
+  return parts
+    .map((part) => isRecord(part) && part.type === 'tool-result' ? part.toolCallId ?? part.tool_call_id : undefined)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+function buildSummarizerMessages(input: {
+  selection: Extract<ReturnType<typeof selectActiveFullCompactCoveredSpan>, { decision: 'selected' }>;
+  messages: readonly ModelMessage[];
+  index: ActiveFullCompactSourceIndex;
+  stateCards: readonly SemanticCompactStateCard[];
+  policy: SemanticCompactPolicy;
+  charsPerToken: number;
+}): ModelMessage[] {
+  const sourceManifest = {
+    providerMessageSourceIds: input.selection.coverage.providerMessageSourceIds,
+    toolCallIds: input.selection.coverage.toolCallIds,
+    contentKinds: input.selection.coverage.contentKinds,
+    archiveRefs: input.selection.entries.map((entry) => entry.archiveRef?.artifactId).filter(Boolean),
+  };
+  const request = [
+    'Create a concise semantic compact summary for the Maka agent to continue this same task.',
+    'Return structured plain text with these exact labels: current_objective:, user_constraints:, important_files_and_artifacts:, commands_and_results:, errors_and_fixes:, failed_hypotheses:, operational_state:, public_verification_state:, remaining_work:, next_action:, archive_refs_to_reread_if_needed:.',
+    'The current_objective and next_action fields are required and must be non-empty.',
+    'Use only the public provider-visible messages above, source manifest, archive placeholders, and restoration hints.',
+    'Do not invent command results, file contents, process state, credentials, verifier results, or hidden/private evaluation facts.',
+    'Preserve objective, constraints, decisions, failed attempts, commands/results that matter, files/artifacts, active process/build state, and exact next action.',
+    `Keep the answer under ${input.policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS} estimated tokens.`,
+    `source_manifest: ${JSON.stringify(sourceManifest)}`,
+    `restoration_hints: ${JSON.stringify(input.stateCards)}`,
+  ].join('\n');
+  return [
+    ...input.messages.slice(input.selection.startMessageIndex, input.selection.endMessageIndex + 1),
+    { role: 'user', content: request } as ModelMessage,
+  ];
+}
+
+function semanticCompactSystemPrompt(policy: SemanticCompactPolicy): string {
+  return [
+    'You compress a Maka agent session for current-turn context compaction.',
+    'No tools are available. Return only concise structured summary text.',
+    'Do not include hidden/private verifier material unless it was explicitly present in public provider-visible input.',
+    `Prompt version: ${policy.promptVersion ?? 'maka-semantic-compact-v1'}.`,
+  ].join('\n');
+}
+
+function buildSemanticStateCards(input: {
+  selection: Extract<ReturnType<typeof selectActiveFullCompactCoveredSpan>, { decision: 'selected' }>;
+  messages: readonly ModelMessage[];
+  runtimeEvents?: readonly RuntimeEvent[];
+  policy: SemanticCompactPolicy;
+  charsPerToken: number;
+}): SemanticCompactStateCard[] {
+  if (input.policy.benchmarkStateCards === false) return [];
+  const deterministic = buildDeterministicActiveFullCompactSummary({
+    selection: input.selection,
+    messages: input.messages,
+    runtimeEvents: input.runtimeEvents,
+    maxSummaryEstimatedTokens: Math.min(input.policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS, 384),
+    charsPerToken: input.charsPerToken,
+  });
+  const allSourceIds = input.selection.entries.map((entry) => entry.sourceId);
+  const cards: SemanticCompactStateCard[] = [];
+  for (const text of deterministic.processState ?? []) cards.push({ kind: 'process', text, sourceIds: allSourceIds });
+  for (const text of deterministic.vmState ?? []) cards.push({ kind: 'vm', text, sourceIds: allSourceIds });
+  for (const text of deterministic.artifactPaths ?? []) cards.push({ kind: 'artifact', text, sourceIds: allSourceIds });
+  for (const command of deterministic.commandsTried ?? []) {
+    cards.push({ kind: 'command', text: `${command.command}: ${command.outcome}`, sourceIds: command.sourceIds ?? allSourceIds });
+  }
+  for (const text of deterministic.constraints ?? []) cards.push({ kind: 'constraint', text, sourceIds: allSourceIds });
+  if (deterministic.latestVerifierFailure) {
+    cards.push({ kind: 'verifier', text: deterministic.latestVerifierFailure, sourceIds: allSourceIds });
+  }
+  for (const text of deterministic.nextActions ?? []) cards.push({ kind: 'next_action', text, sourceIds: allSourceIds });
+  return cards.slice(0, 16);
+}
+
+function buildSemanticCompactBlock(input: {
+  input: SemanticCompactRewriteInput;
+  index: ActiveFullCompactSourceIndex;
+  selection: Extract<ReturnType<typeof selectActiveFullCompactCoveredSpan>, { decision: 'selected' }>;
+  summaryText: string;
+  stateCards: readonly SemanticCompactStateCard[];
+  usage?: NormalizedAiSdkUsage;
+  finishReason?: string;
+  providerRequestId?: string;
+  requestShapeHashBefore?: string;
+  charsPerToken: number;
+}): SemanticCompactBlock {
+  const policy = input.input.policy!;
+  const archiveRefs = uniqueArchiveRefs(input.selection.entries.map((entry) => entry.archiveRef).filter(isArchiveRef));
+  const sourceRefs = input.selection.entries.map((entry): ActiveFullCompactSourceRef => ({
+    kind: entry.archiveRef ? 'active_archive_placeholder' : entry.runtimeEventId ? 'runtime_event' : 'provider_message',
+    sourceId: entry.sourceId,
+    messageIndex: entry.messageIndex,
+    ...(entry.partIndex !== undefined ? { partIndex: entry.partIndex } : {}),
+    sessionId: input.input.sessionId,
+    turnId: entry.turnId,
+    ...(entry.runtimeEventId ? { runtimeEventId: entry.runtimeEventId } : {}),
+    ...(entry.toolCallId ? { toolCallId: entry.toolCallId } : {}),
+    ...(entry.toolName ? { toolName: entry.toolName } : {}),
+    contentKind: entry.contentKind,
+    bodySha256: entry.bodySha256,
+    ...(entry.archiveRef ? { archiveRef: entry.archiveRef } : {}),
+  }));
+  const preservedTailIndexes = preservedTailMessageIndexes(input.index, input.selection);
+  const preservedTailEntries = input.index.entries.filter((entry) => preservedTailIndexes.includes(entry.messageIndex));
+  const draft = {
+    sessionId: input.input.sessionId,
+    turnId: input.input.turnId,
+    coverage: activeFullCompactCoverageFromEntries(input.selection.entries),
+    summaryText: input.summaryText,
+    highWaterSeq: input.input.stepNumber,
+  };
+  const nextAction = extractSummaryField(input.summaryText, SUMMARY_FIELD_LABELS.nextAction);
+  const block: SemanticCompactBlock = {
+    kind: 'maka.semantic_compact_block',
+    version: 1,
+    blockId: `semcompact-${sha256(stableStringify(draft)).slice(0, 32)}`,
+    sessionId: input.input.sessionId,
+    turnId: input.input.turnId,
+    ...(input.input.runId ? { runId: input.input.runId } : {}),
+    ...(input.input.invocationId ? { invocationId: input.input.invocationId } : {}),
+    createdAt: input.input.now ?? Date.now(),
+    highWaterName: policy.highWaterName ?? 'semantic-compact-high-water',
+    highWaterSeq: input.input.stepNumber,
+    trigger: {
+      reason: 'high_water',
+      stepNumber: input.input.stepNumber,
+      estimatedTokensBefore: input.index.estimatedTokens,
+      ...(policy.maxActiveEstimatedTokens !== undefined
+        ? { thresholdTokens: Math.floor(policy.maxActiveEstimatedTokens * finiteRatio(policy.highWaterRatio, 0.8)) }
+        : {}),
+    },
+    coverage: activeFullCompactCoverageFromEntries(input.selection.entries),
+    sourceRefs,
+    ...(archiveRefs.length > 0 ? { archiveRefs } : {}),
+    preservedTail: {
+      messageIndexes: preservedTailIndexes,
+      toolCallIds: uniqueSorted(preservedTailEntries.map((entry) => entry.toolCallId).filter(nonEmpty)),
+      sourceIds: uniqueSorted(preservedTailEntries.map((entry) => entry.sourceId)),
+    },
+    summary: {
+      promptVersion: policy.promptVersion ?? 'maka-semantic-compact-v1',
+      text: input.summaryText,
+      limitations: ['LLM semantic compact summary is bounded by public provider-visible context and deterministic restoration cards.'],
+      ...(nextAction !== undefined ? { nextAction } : {}),
+    },
+    ...(input.stateCards.length > 0 ? { stateCards: [...input.stateCards] } : {}),
+    ...(input.requestShapeHashBefore ? { requestShapeHashBefore: input.requestShapeHashBefore } : {}),
+    preActiveContextEstimatedTokens: input.index.estimatedTokens,
+    postReplacementEstimatedTokens: input.index.estimatedTokens,
+    estimatedTokensSavedSigned: 0,
+    ...(input.usage ? { compactCallUsage: compactUsage(input.usage) } : {}),
+    ...(input.finishReason ? { finishReason: input.finishReason } : {}),
+    ...(input.providerRequestId ? { providerRequestId: input.providerRequestId } : {}),
+    acceptance: { decision: 'rejected', reason: 'pending_acceptance' },
+  };
+  block.postReplacementEstimatedTokens = estimatePostReplacementTokens(
+    input.index,
+    input.selection.estimatedTokens,
+    renderSemanticCompactBlock(block),
+    input.charsPerToken,
+  );
+  block.estimatedTokensSavedSigned = input.index.estimatedTokens - block.postReplacementEstimatedTokens;
+  return block;
+}
+
+function semanticSavingsRejectionReason(block: SemanticCompactBlock, policy: SemanticCompactPolicy): string | undefined {
+  const minSavingsTokens = Math.max(0, Math.floor(policy.minSavingsTokens ?? DEFAULT_MIN_SAVINGS_TOKENS));
+  if (block.estimatedTokensSavedSigned < minSavingsTokens) return 'below_min_savings_tokens';
+  const minSavingsRatio = Math.max(0, policy.minSavingsRatio ?? DEFAULT_MIN_SAVINGS_RATIO);
+  const savingsRatio = block.preActiveContextEstimatedTokens > 0
+    ? block.estimatedTokensSavedSigned / block.preActiveContextEstimatedTokens
+    : 0;
+  if (savingsRatio < minSavingsRatio) return 'below_min_savings_ratio';
+  return undefined;
+}
+
+function semanticCompactDecisionDiagnosticPatch(input: {
+  decision: 'unchanged' | 'replaced' | 'failedOpen';
+  boundaryIds?: readonly string[];
+  coverage?: ActiveFullCompactCoverage;
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  estimatedTokensSaved?: number;
+  compactCallUsage?: SemanticCompactBlock['compactCallUsage'];
+  reason?: string;
+  failOpenReason?: string;
+  skippedReasonCounts?: Readonly<Record<string, number>>;
+  validationReasonCounts?: Readonly<Record<string, number>>;
+}): Partial<ContextBudgetDiagnostic> {
+  return {
+    semanticCompactEnabled: true,
+    ...compactionDecisionDiagnosticPatch({
+      stage: 'activeStep',
+      sourceKind: 'providerMessages',
+      boundaryKind: 'semanticCompact',
+      decision: input.decision,
+      ...(input.boundaryIds ? { boundaryIds: input.boundaryIds } : {}),
+      ...(input.coverage ? {
+        coverage: {
+          turnIds: input.coverage.turnIds,
+          runtimeEventIds: input.coverage.runtimeEventIds,
+          toolCallIds: input.coverage.toolCallIds,
+          contentKinds: input.coverage.contentKinds,
+          bodySha256: input.coverage.bodySha256,
+        },
+      } : {}),
+      ...(input.estimatedTokensBefore !== undefined ? { estimatedTokensBefore: input.estimatedTokensBefore } : {}),
+      ...(input.estimatedTokensAfter !== undefined ? { estimatedTokensAfter: input.estimatedTokensAfter } : {}),
+      ...(input.estimatedTokensSaved !== undefined ? { estimatedTokensSaved: input.estimatedTokensSaved } : {}),
+      ...(input.compactCallUsage ? { compactCallUsage: input.compactCallUsage } : {}),
+      ...(input.reason ? { reason: input.reason } : {}),
+      ...(input.failOpenReason ? { failOpenReason: input.failOpenReason } : {}),
+      ...(input.skippedReasonCounts ? { skippedReasonCounts: input.skippedReasonCounts } : {}),
+      ...(input.validationReasonCounts ? { validationReasonCounts: input.validationReasonCounts } : {}),
+    }),
+  };
+}
+
+async function callSummarizerWithTimeout(
+  summarizer: SemanticCompactSummarizer,
+  request: SemanticCompactSummaryRequest,
+  timeoutMs: number | undefined,
+): Promise<CompactSummaryResult> {
+  if (!timeoutMs || timeoutMs <= 0) return Promise.resolve(summarizer(request));
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error('semantic compact summarizer timeout')), timeoutMs);
+  const parentAbort = () => controller.abort(request.abortSignal?.reason);
+  request.abortSignal?.addEventListener('abort', parentAbort, { once: true });
+  try {
+    return await Promise.resolve(summarizer({ ...request, abortSignal: controller.signal }));
+  } finally {
+    clearTimeout(timer);
+    request.abortSignal?.removeEventListener('abort', parentAbort);
+  }
+}
+
+function estimatePostReplacementTokens(
+  index: ActiveFullCompactSourceIndex,
+  selectedTokens: number,
+  renderedReplacement: string,
+  charsPerToken: number,
+): number {
+  return Math.max(0, index.estimatedTokens - selectedTokens + estimateTokens(renderedReplacement.length, charsPerToken));
+}
+
+function preservedTailMessageIndexes(
+  index: ActiveFullCompactSourceIndex,
+  selection: { endMessageIndex: number },
+): number[] {
+  const indexes = new Set<number>();
+  for (let cursor = selection.endMessageIndex + 1; cursor < index.providerMessageCount; cursor += 1) {
+    indexes.add(cursor);
+  }
+  return [...indexes].sort((a, b) => a - b);
+}
+
+function selectedSourceText(
+  selection: { startMessageIndex: number; endMessageIndex: number },
+  messages: readonly ModelMessage[],
+): string {
+  return stableStringify(messages.slice(selection.startMessageIndex, selection.endMessageIndex + 1));
+}
+
+function normalizeSummaryText(text: string): string {
+  return text.trim().replace(/\n{4,}/g, '\n\n\n');
+}
+
+function semanticSummaryContractRejectionReason(summaryText: string): string | undefined {
+  if (!extractSummaryField(summaryText, SUMMARY_FIELD_LABELS.objective)) {
+    return 'summary_missing_current_objective';
+  }
+  if (!extractSummaryField(summaryText, SUMMARY_FIELD_LABELS.nextAction)) {
+    return 'summary_missing_next_action';
+  }
+  return undefined;
+}
+
+function extractSummaryField(summaryText: string, labels: readonly string[]): string | undefined {
+  const lines = summaryText.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_ ]{0,64})\s*:\s*(.*)$/);
+    if (!match) continue;
+    const label = match[1]!.trim().toLowerCase().replace(/\s+/g, ' ');
+    const wanted = labels.map((value) => value.toLowerCase().replace(/_/g, ' '));
+    if (!wanted.includes(label.replace(/_/g, ' '))) continue;
+    const inlineValue = match[2]!.trim();
+    if (inlineValue.length > 0) return inlineValue;
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      if (/^\s*[A-Za-z_][A-Za-z0-9_ ]{0,64}\s*:/.test(lines[cursor]!)) break;
+      const continuation = lines[cursor]!.trim();
+      if (continuation.length > 0) return continuation;
+    }
+  }
+  return undefined;
+}
+
+function newPrivateVerifierSurface(summaryText: string, publicSourceText: string): boolean {
+  return PRIVATE_VERIFIER_PATTERN.test(summaryText) && !PRIVATE_VERIFIER_PATTERN.test(publicSourceText);
+}
+
+function rejected(
+  messages: ModelMessage[],
+  index: ActiveFullCompactSourceIndex,
+  reason: string,
+  compactCallUsage?: SemanticCompactBlock['compactCallUsage'],
+): SemanticCompactRewriteResult {
+  return {
+    messages,
+    decision: 'unchanged',
+    reason,
+    diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+      decision: 'unchanged',
+      reason,
+      estimatedTokensBefore: index.estimatedTokens,
+      estimatedTokensAfter: index.estimatedTokens,
+      estimatedTokensSaved: 0,
+      ...(compactCallUsage ? { compactCallUsage } : {}),
+    }),
+  };
+}
+
+function unchanged(messages: ModelMessage[], reason: string): SemanticCompactRewriteResult {
+  return {
+    messages,
+    decision: 'unchanged',
+    reason,
+    diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
+      decision: 'unchanged',
+      reason,
+    }),
+  };
+}
+
+function compactUsage(usage: NormalizedAiSdkUsage): NonNullable<SemanticCompactBlock['compactCallUsage']> {
+  return {
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cacheReadInputTokens: usage.cacheHitInputTokens,
+    cacheWriteInputTokens: usage.cacheWriteInputTokens,
+    totalTokens: usage.totalTokens,
+  };
+}
+
+function uniqueArchiveRefs(refs: readonly ActiveFullCompactArchiveRef[]): ActiveFullCompactArchiveRef[] {
+  const seen = new Set<string>();
+  const out: ActiveFullCompactArchiveRef[] = [];
+  for (const ref of refs) {
+    const key = `${ref.kind}:${ref.artifactId}:${ref.bodySha256}:${ref.toolCallId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(ref);
+  }
+  return out;
+}
+
+function isArchiveRef(value: unknown): value is ActiveFullCompactArchiveRef {
+  return isRecord(value)
+    && (value.kind === 'toolResult' || value.kind === 'compactSource')
+    && typeof value.artifactId === 'string'
+    && typeof value.bodySha256 === 'string';
+}
+
+function finiteRatio(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.max(0, Math.min(1, value));
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, sortJson(value[key])]),
+  );
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -25,6 +25,9 @@ const DEFAULT_CHARS_PER_TOKEN = 4;
 const DEFAULT_MAX_SUMMARY_TOKENS = 768;
 const DEFAULT_MIN_SAVINGS_TOKENS = 256;
 const DEFAULT_MIN_SAVINGS_RATIO = 0.05;
+const DEFAULT_COMPACT_CALL_TOKEN_COST_WEIGHT = 1;
+const DEFAULT_MAX_CONSECUTIVE_INVALID_SUMMARIES = 2;
+const DEFAULT_INVALID_SUMMARY_COOLDOWN_STEPS = 8;
 const PRIVATE_VERIFIER_PATTERN = /\b(hidden|private|official)\s+(verifier|evaluation|eval|test|assertion|oracle)\b/i;
 const SUMMARY_FIELD_LABELS = {
   objective: ['current_objective', 'current objective'],
@@ -44,7 +47,11 @@ export interface SemanticCompactPolicy {
   maxSummaryEstimatedTokens?: number;
   minSavingsTokens?: number;
   minSavingsRatio?: number;
+  minNetSavingsTokens?: number;
+  compactCallTokenCostWeight?: number;
   maxCompactCallTokens?: number;
+  maxConsecutiveInvalidSummaries?: number;
+  invalidSummaryCooldownSteps?: number;
   summarizerModel?: string;
   timeoutMs?: number;
   archiveRequired?: boolean;
@@ -64,10 +71,34 @@ export type SemanticCompactSummarizer = (
   request: SemanticCompactSummaryRequest,
 ) => Promise<CompactSummaryResult> | CompactSummaryResult;
 
+export interface SemanticCompactControllerState {
+  consecutiveInvalidSummaries: number;
+  totalInvalidSummaries: number;
+  compactCallCount: number;
+  compactCallTotalTokens: number;
+  acceptedEstimatedTokensSaved: number;
+  suppressedUntilStep?: number;
+  lastInvalidReason?: string;
+}
+
 export interface SemanticCompactStateCard {
   kind: 'process' | 'vm' | 'artifact' | 'command' | 'constraint' | 'verifier' | 'next_action' | 'generic';
   text: string;
   sourceIds: string[];
+}
+
+export interface SemanticCompactStructuredSummary {
+  currentObjective: string;
+  userConstraints: string[];
+  importantFilesAndArtifacts: string[];
+  commandsAndResults: string[];
+  errorsAndFixes: string[];
+  failedHypotheses: string[];
+  operationalState: string[];
+  publicVerificationState: string;
+  remainingWork: string[];
+  nextAction: string;
+  archiveRefsToRereadIfNeeded: string[];
 }
 
 export interface SemanticCompactBlock {
@@ -107,6 +138,7 @@ export interface SemanticCompactBlock {
   preActiveContextEstimatedTokens: number;
   postReplacementEstimatedTokens: number;
   estimatedTokensSavedSigned: number;
+  estimatedNetTokensSavedSigned?: number;
   compactCallUsage?: {
     inputTokens?: number;
     outputTokens?: number;
@@ -134,6 +166,7 @@ export interface SemanticCompactRewriteInput {
   policy: SemanticCompactPolicy | undefined;
   runtimeEvents?: readonly RuntimeEvent[];
   stepNumber: number;
+  controllerState?: SemanticCompactControllerState;
   now?: number;
   charsPerToken?: number;
   requestShapeHashBefore?: string;
@@ -159,6 +192,10 @@ export async function rewriteSemanticCompactInMessages(
   const charsPerToken = input.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
   if (policy?.enabled !== true || policy.mode === 'off') {
     return unchanged(messages, 'disabled');
+  }
+  const brakeReason = semanticCompactBrakeReason(policy, input.controllerState, input.stepNumber);
+  if (brakeReason) {
+    return unchanged(messages, brakeReason);
   }
 
   const index = buildActiveFullCompactSourceIndex({
@@ -261,19 +298,26 @@ export async function rewriteSemanticCompactInMessages(
       abortSignal: input.abortSignal,
     }, policy.timeoutMs);
   } catch {
+    recordInvalidSummary(input.controllerState, policy, 'summarizer_failed', input.stepNumber);
     return rejected(messages, index, 'summarizer_failed');
   }
 
   const compactCallUsage = summary.usage ? compactUsage(summary.usage) : undefined;
-  const summaryText = normalizeSummaryText(summary.text);
-  if (!summaryText) return rejected(messages, index, 'summary_missing', compactCallUsage);
+  recordCompactCall(input.controllerState, compactCallUsage);
+  const parsedSummary = parseSemanticCompactSummary(summary.text);
+  if (!parsedSummary.ok) {
+    recordInvalidSummary(input.controllerState, policy, parsedSummary.reason, input.stepNumber);
+    return rejected(messages, index, parsedSummary.reason, compactCallUsage);
+  }
+  recordValidSummary(input.controllerState);
+  const summaryText = renderStructuredSemanticSummary(parsedSummary.summary);
   const maxSummaryTokens = Math.floor(policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS);
   if (estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
+    recordInvalidSummary(input.controllerState, policy, 'summary_too_large', input.stepNumber);
     return rejected(messages, index, 'summary_too_large', compactCallUsage);
   }
-  const summaryContractReason = semanticSummaryContractRejectionReason(summaryText);
-  if (summaryContractReason) return rejected(messages, index, summaryContractReason, compactCallUsage);
-  if (newPrivateVerifierSurface(summaryText, selectedSourceText(selection, messages))) {
+  if (newPrivateVerifierSurface(`${summary.text}\n${summaryText}`, selectedSourceText(selection, messages))) {
+    recordInvalidSummary(input.controllerState, policy, 'private_verifier_surface', input.stepNumber);
     return rejected(messages, index, 'private_verifier_surface', compactCallUsage);
   }
 
@@ -282,6 +326,7 @@ export async function rewriteSemanticCompactInMessages(
     input,
     index,
     selection,
+    structuredSummary: parsedSummary.summary,
     summaryText,
     stateCards,
     usage: summary.usage,
@@ -300,6 +345,7 @@ export async function rewriteSemanticCompactInMessages(
   if (requestShapeHashAfter) block.requestShapeHashAfter = requestShapeHashAfter;
   block.postReplacementEstimatedTokens = estimatePostReplacementTokens(index, selection.estimatedTokens, renderSemanticCompactBlock(block), charsPerToken);
   block.estimatedTokensSavedSigned = index.estimatedTokens - block.postReplacementEstimatedTokens;
+  block.estimatedNetTokensSavedSigned = estimateSemanticNetTokensSaved(block, policy);
 
   const economicsReason = semanticSavingsRejectionReason(block, policy);
   if (economicsReason) {
@@ -347,6 +393,7 @@ export async function rewriteSemanticCompactInMessages(
   }
 
   block.acceptance = { decision: 'accepted' };
+  recordAcceptedSemanticCompact(input.controllerState, block);
   return {
     messages: replacementMessages,
     decision: 'replaced',
@@ -381,21 +428,18 @@ export function semanticCompactBlockToModelMessage(block: SemanticCompactBlock):
 }
 
 export function renderSemanticCompactBlock(block: SemanticCompactBlock): string {
-  const archiveLines = (block.archiveRefs ?? []).slice(0, 12).map((ref) =>
-    `- ${ref.artifactId} tool=${ref.toolName ?? 'unknown'} call=${ref.toolCallId ?? 'unknown'} sha256=${ref.bodySha256.slice(0, 16)}`
-  );
   const stateLines = (block.stateCards ?? []).map((card) =>
     `- ${card.kind}: ${singleLine(card.text)}`
   );
+  const archiveCount = block.archiveRefs?.length ?? 0;
   return [
     `<maka_semantic_compact_block id="${escapeAttribute(block.blockId)}" high_water="${escapeAttribute(block.highWaterName)}" seq="${block.highWaterSeq}" version="${block.version}">`,
     'summary:',
     block.summary.text,
     stateLines.length > 0 ? 'restoration_state_cards:' : '',
     ...stateLines,
-    archiveLines.length > 0 ? 'archives:' : '',
-    ...archiveLines,
-    `coverage: ${block.coverage.providerMessageSourceIds.length} provider source entries, ${block.coverage.toolCallIds.length} tool calls, ${block.coverage.bodySha256.length} source hashes retained in durable compact block.`,
+    archiveCount > 0 ? `durable_archives_available: ${archiveCount} raw evidence refs retained outside provider-visible context.` : '',
+    `durable_coverage: ${block.coverage.providerMessageSourceIds.length} provider source entries and ${block.coverage.toolCallIds.length} tool calls retained in the compact audit side-channel.`,
     `preserved_tail: messages=${block.preservedTail.messageIndexes.join(',') || 'none'} toolCalls=${block.preservedTail.toolCallIds.join(',') || 'none'}`,
     'instructions: Continue from this semantic summary plus the exact preserved recent messages that follow it. Use archive refs for raw evidence recovery when needed.',
     '</maka_semantic_compact_block>',
@@ -475,22 +519,42 @@ function buildSummarizerMessages(input: {
   policy: SemanticCompactPolicy;
   charsPerToken: number;
 }): ModelMessage[] {
-  const sourceManifest = {
-    providerMessageSourceIds: input.selection.coverage.providerMessageSourceIds,
-    toolCallIds: input.selection.coverage.toolCallIds,
+  const contextBoundary = {
+    coveredProviderSourceEntries: input.selection.coverage.providerMessageSourceIds.length,
+    coveredToolCalls: input.selection.coverage.toolCallIds.length,
     contentKinds: input.selection.coverage.contentKinds,
-    archiveRefs: input.selection.entries.map((entry) => entry.archiveRef?.artifactId).filter(Boolean),
+    durableArchiveRefCount: input.selection.entries.filter((entry) => entry.archiveRef).length,
+  };
+  const restorationCards = input.stateCards.map((card) => ({
+    kind: card.kind,
+    text: card.text,
+  }));
+  const schema = {
+    current_objective: 'string, required, one sentence',
+    user_constraints: ['strings, public constraints only'],
+    important_files_and_artifacts: ['strings, paths/artifacts that matter'],
+    commands_and_results: ['strings, only commands/results needed for continuity'],
+    errors_and_fixes: ['strings'],
+    failed_hypotheses: ['strings'],
+    operational_state: ['strings, process/build/vm/service state'],
+    public_verification_state: 'string, public verifier/test state only',
+    remaining_work: ['strings'],
+    next_action: 'string, required, exact next action',
+    archive_refs_to_reread_if_needed: ['strings, names/descriptions only'],
   };
   const request = [
     'Create a concise semantic compact summary for the Maka agent to continue this same task.',
-    'Return structured plain text with these exact labels: current_objective:, user_constraints:, important_files_and_artifacts:, commands_and_results:, errors_and_fixes:, failed_hypotheses:, operational_state:, public_verification_state:, remaining_work:, next_action:, archive_refs_to_reread_if_needed:.',
-    'The current_objective and next_action fields are required and must be non-empty.',
-    'Use only the public provider-visible messages above, source manifest, archive placeholders, and restoration hints.',
+    'Return ONLY a valid JSON object. Do not wrap it in markdown. Do not add prose before or after JSON.',
+    `JSON schema: ${JSON.stringify(schema)}`,
+    'The current_objective and next_action string fields are required and must be non-empty.',
+    'Use arrays for list fields. Keep each list to at most 6 short items.',
+    'Use only the public provider-visible messages above and the bounded restoration cards below.',
     'Do not invent command results, file contents, process state, credentials, verifier results, or hidden/private evaluation facts.',
-    'Preserve objective, constraints, decisions, failed attempts, commands/results that matter, files/artifacts, active process/build state, and exact next action.',
+    'Summarize continuity only. Durable source refs, hashes, and archive audit metadata are stored outside this provider-visible summary.',
+    'Preserve objective, constraints, decisions, failed attempts, commands/results that matter, files/artifacts, active process/build state, public verification state, and exact next action.',
     `Keep the answer under ${input.policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS} estimated tokens.`,
-    `source_manifest: ${JSON.stringify(sourceManifest)}`,
-    `restoration_hints: ${JSON.stringify(input.stateCards)}`,
+    `context_boundary: ${JSON.stringify(contextBoundary)}`,
+    `restoration_cards: ${JSON.stringify(restorationCards)}`,
   ].join('\n');
   return [
     ...input.messages.slice(input.selection.startMessageIndex, input.selection.endMessageIndex + 1),
@@ -501,9 +565,9 @@ function buildSummarizerMessages(input: {
 function semanticCompactSystemPrompt(policy: SemanticCompactPolicy): string {
   return [
     'You compress a Maka agent session for current-turn context compaction.',
-    'No tools are available. Return only concise structured summary text.',
+    'No tools are available. Return only valid JSON matching the requested schema.',
     'Do not include hidden/private verifier material unless it was explicitly present in public provider-visible input.',
-    `Prompt version: ${policy.promptVersion ?? 'maka-semantic-compact-v1'}.`,
+    `Prompt version: ${policy.promptVersion ?? 'maka-semantic-compact-json-v2'}.`,
   ].join('\n');
 }
 
@@ -542,6 +606,7 @@ function buildSemanticCompactBlock(input: {
   input: SemanticCompactRewriteInput;
   index: ActiveFullCompactSourceIndex;
   selection: Extract<ReturnType<typeof selectActiveFullCompactCoveredSpan>, { decision: 'selected' }>;
+  structuredSummary: SemanticCompactStructuredSummary;
   summaryText: string;
   stateCards: readonly SemanticCompactStateCard[];
   usage?: NormalizedAiSdkUsage;
@@ -572,10 +637,10 @@ function buildSemanticCompactBlock(input: {
     sessionId: input.input.sessionId,
     turnId: input.input.turnId,
     coverage: activeFullCompactCoverageFromEntries(input.selection.entries),
-    summaryText: input.summaryText,
+    summaryText: input.structuredSummary.currentObjective,
+    nextAction: input.structuredSummary.nextAction,
     highWaterSeq: input.input.stepNumber,
   };
-  const nextAction = extractSummaryField(input.summaryText, SUMMARY_FIELD_LABELS.nextAction);
   const block: SemanticCompactBlock = {
     kind: 'maka.semantic_compact_block',
     version: 1,
@@ -604,10 +669,10 @@ function buildSemanticCompactBlock(input: {
       sourceIds: uniqueSorted(preservedTailEntries.map((entry) => entry.sourceId)),
     },
     summary: {
-      promptVersion: policy.promptVersion ?? 'maka-semantic-compact-v1',
+      promptVersion: policy.promptVersion ?? 'maka-semantic-compact-json-v2',
       text: input.summaryText,
       limitations: ['LLM semantic compact summary is bounded by public provider-visible context and deterministic restoration cards.'],
-      ...(nextAction !== undefined ? { nextAction } : {}),
+      nextAction: input.structuredSummary.nextAction,
     },
     ...(input.stateCards.length > 0 ? { stateCards: [...input.stateCards] } : {}),
     ...(input.requestShapeHashBefore ? { requestShapeHashBefore: input.requestShapeHashBefore } : {}),
@@ -637,7 +702,80 @@ function semanticSavingsRejectionReason(block: SemanticCompactBlock, policy: Sem
     ? block.estimatedTokensSavedSigned / block.preActiveContextEstimatedTokens
     : 0;
   if (savingsRatio < minSavingsRatio) return 'below_min_savings_ratio';
+  const minNetSavingsTokens = Math.max(0, Math.floor(policy.minNetSavingsTokens ?? minSavingsTokens));
+  if ((block.estimatedNetTokensSavedSigned ?? block.estimatedTokensSavedSigned) < minNetSavingsTokens) {
+    return 'below_min_net_savings_tokens';
+  }
   return undefined;
+}
+
+function estimateSemanticNetTokensSaved(block: SemanticCompactBlock, policy: SemanticCompactPolicy): number {
+  const compactCallTokens = block.compactCallUsage?.totalTokens ?? 0;
+  const weight = finiteNonNegativeNumber(policy.compactCallTokenCostWeight, DEFAULT_COMPACT_CALL_TOKEN_COST_WEIGHT);
+  return block.estimatedTokensSavedSigned - Math.ceil(compactCallTokens * weight);
+}
+
+function semanticCompactBrakeReason(
+  policy: SemanticCompactPolicy,
+  state: SemanticCompactControllerState | undefined,
+  stepNumber: number,
+): string | undefined {
+  if (!state) return undefined;
+  if (state.suppressedUntilStep !== undefined) {
+    if (stepNumber <= state.suppressedUntilStep) return 'semantic_compact_cooldown';
+    delete state.suppressedUntilStep;
+    state.consecutiveInvalidSummaries = 0;
+    delete state.lastInvalidReason;
+  }
+  const maxConsecutiveInvalid = Math.floor(policy.maxConsecutiveInvalidSummaries ?? DEFAULT_MAX_CONSECUTIVE_INVALID_SUMMARIES);
+  if (maxConsecutiveInvalid > 0 && state.consecutiveInvalidSummaries >= maxConsecutiveInvalid) {
+    const cooldownSteps = Math.floor(policy.invalidSummaryCooldownSteps ?? DEFAULT_INVALID_SUMMARY_COOLDOWN_STEPS);
+    if (cooldownSteps > 0) {
+      state.suppressedUntilStep = Math.max(state.suppressedUntilStep ?? 0, stepNumber + cooldownSteps);
+      return 'semantic_compact_cooldown';
+    }
+  }
+  return undefined;
+}
+
+function recordCompactCall(
+  state: SemanticCompactControllerState | undefined,
+  usage: SemanticCompactBlock['compactCallUsage'] | undefined,
+): void {
+  if (!state) return;
+  state.compactCallCount += 1;
+  state.compactCallTotalTokens += usage?.totalTokens ?? 0;
+}
+
+function recordInvalidSummary(
+  state: SemanticCompactControllerState | undefined,
+  policy: SemanticCompactPolicy,
+  reason: string,
+  stepNumber: number,
+): void {
+  if (!state) return;
+  state.consecutiveInvalidSummaries += 1;
+  state.totalInvalidSummaries += 1;
+  state.lastInvalidReason = reason;
+  const maxConsecutiveInvalid = Math.floor(policy.maxConsecutiveInvalidSummaries ?? DEFAULT_MAX_CONSECUTIVE_INVALID_SUMMARIES);
+  const cooldownSteps = Math.floor(policy.invalidSummaryCooldownSteps ?? DEFAULT_INVALID_SUMMARY_COOLDOWN_STEPS);
+  if (maxConsecutiveInvalid > 0 && cooldownSteps > 0 && state.consecutiveInvalidSummaries >= maxConsecutiveInvalid) {
+    state.suppressedUntilStep = Math.max(state.suppressedUntilStep ?? 0, stepNumber + cooldownSteps);
+  }
+}
+
+function recordValidSummary(state: SemanticCompactControllerState | undefined): void {
+  if (!state) return;
+  state.consecutiveInvalidSummaries = 0;
+  delete state.lastInvalidReason;
+}
+
+function recordAcceptedSemanticCompact(
+  state: SemanticCompactControllerState | undefined,
+  block: SemanticCompactBlock,
+): void {
+  if (!state) return;
+  state.acceptedEstimatedTokensSaved += block.estimatedTokensSavedSigned;
 }
 
 function semanticCompactDecisionDiagnosticPatch(input: {
@@ -727,18 +865,144 @@ function selectedSourceText(
   return stableStringify(messages.slice(selection.startMessageIndex, selection.endMessageIndex + 1));
 }
 
-function normalizeSummaryText(text: string): string {
-  return text.trim().replace(/\n{4,}/g, '\n\n\n');
+function parseSemanticCompactSummary(text: string): {
+  ok: true;
+  summary: SemanticCompactStructuredSummary;
+} | {
+  ok: false;
+  reason: string;
+} {
+  const raw = text.trim();
+  if (!raw) return { ok: false, reason: 'summary_missing' };
+  const jsonText = extractJsonObjectText(raw);
+  if (jsonText) {
+    try {
+      const parsed = JSON.parse(jsonText);
+      const normalized = normalizeStructuredSummary(parsed);
+      if (normalized.ok) return normalized;
+      return { ok: false, reason: normalized.reason };
+    } catch {
+      return { ok: false, reason: 'summary_invalid_json' };
+    }
+  }
+  const legacy = parseLegacyLabeledSummary(raw);
+  if (legacy.ok) return legacy;
+  return { ok: false, reason: 'summary_invalid_json' };
 }
 
-function semanticSummaryContractRejectionReason(summaryText: string): string | undefined {
-  if (!extractSummaryField(summaryText, SUMMARY_FIELD_LABELS.objective)) {
-    return 'summary_missing_current_objective';
-  }
-  if (!extractSummaryField(summaryText, SUMMARY_FIELD_LABELS.nextAction)) {
-    return 'summary_missing_next_action';
-  }
+function renderStructuredSemanticSummary(summary: SemanticCompactStructuredSummary): string {
+  return [
+    `current_objective: ${summary.currentObjective}`,
+    ...renderSummaryList('user_constraints', summary.userConstraints),
+    ...renderSummaryList('important_files_and_artifacts', summary.importantFilesAndArtifacts),
+    ...renderSummaryList('commands_and_results', summary.commandsAndResults),
+    ...renderSummaryList('errors_and_fixes', summary.errorsAndFixes),
+    ...renderSummaryList('failed_hypotheses', summary.failedHypotheses),
+    ...renderSummaryList('operational_state', summary.operationalState),
+    `public_verification_state: ${summary.publicVerificationState || 'No public verification state claimed.'}`,
+    ...renderSummaryList('remaining_work', summary.remainingWork),
+    `next_action: ${summary.nextAction}`,
+    ...renderSummaryList('archive_refs_to_reread_if_needed', summary.archiveRefsToRereadIfNeeded),
+  ].join('\n').trim();
+}
+
+function renderSummaryList(label: string, values: readonly string[]): string[] {
+  const clean = values.map(singleLine).filter(nonEmpty).slice(0, 8);
+  if (clean.length === 0) return [`${label}: none`];
+  if (clean.length === 1) return [`${label}: ${clean[0]}`];
+  return [`${label}:`, ...clean.map((value) => `- ${value}`)];
+}
+
+function extractJsonObjectText(raw: string): string | undefined {
+  const fence = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+  const candidate = fence?.[1]?.trim() ?? raw;
+  if (candidate.startsWith('{') && candidate.endsWith('}')) return candidate;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start >= 0 && end > start) return candidate.slice(start, end + 1);
   return undefined;
+}
+
+function normalizeStructuredSummary(value: unknown): {
+  ok: true;
+  summary: SemanticCompactStructuredSummary;
+} | {
+  ok: false;
+  reason: string;
+} {
+  if (!isRecord(value)) return { ok: false, reason: 'summary_schema_invalid' };
+  const currentObjective = stringField(value, 'current_objective');
+  if (!currentObjective) return { ok: false, reason: 'summary_missing_current_objective' };
+  const nextAction = stringField(value, 'next_action');
+  if (!nextAction) return { ok: false, reason: 'summary_missing_next_action' };
+  return {
+    ok: true,
+    summary: {
+      currentObjective,
+      userConstraints: stringListField(value, 'user_constraints'),
+      importantFilesAndArtifacts: stringListField(value, 'important_files_and_artifacts'),
+      commandsAndResults: stringListField(value, 'commands_and_results'),
+      errorsAndFixes: stringListField(value, 'errors_and_fixes'),
+      failedHypotheses: stringListField(value, 'failed_hypotheses'),
+      operationalState: stringListField(value, 'operational_state'),
+      publicVerificationState: stringField(value, 'public_verification_state') ?? '',
+      remainingWork: stringListField(value, 'remaining_work'),
+      nextAction,
+      archiveRefsToRereadIfNeeded: stringListField(value, 'archive_refs_to_reread_if_needed'),
+    },
+  };
+}
+
+function parseLegacyLabeledSummary(raw: string): {
+  ok: true;
+  summary: SemanticCompactStructuredSummary;
+} | {
+  ok: false;
+  reason: string;
+} {
+  const currentObjective = extractSummaryField(raw, SUMMARY_FIELD_LABELS.objective);
+  if (!currentObjective) return { ok: false, reason: 'summary_missing_current_objective' };
+  const nextAction = extractSummaryField(raw, SUMMARY_FIELD_LABELS.nextAction);
+  if (!nextAction) return { ok: false, reason: 'summary_missing_next_action' };
+  return {
+    ok: true,
+    summary: {
+      currentObjective,
+      userConstraints: fieldListFromLegacy(raw, ['user_constraints', 'user constraints']),
+      importantFilesAndArtifacts: fieldListFromLegacy(raw, ['important_files_and_artifacts', 'important files and artifacts']),
+      commandsAndResults: fieldListFromLegacy(raw, ['commands_and_results', 'commands and results']),
+      errorsAndFixes: fieldListFromLegacy(raw, ['errors_and_fixes', 'errors and fixes']),
+      failedHypotheses: fieldListFromLegacy(raw, ['failed_hypotheses', 'failed hypotheses']),
+      operationalState: fieldListFromLegacy(raw, ['operational_state', 'operational state']),
+      publicVerificationState: extractSummaryField(raw, ['public_verification_state', 'public verification state']) ?? '',
+      remainingWork: fieldListFromLegacy(raw, ['remaining_work', 'remaining work']),
+      nextAction,
+      archiveRefsToRereadIfNeeded: fieldListFromLegacy(raw, ['archive_refs_to_reread_if_needed', 'archive refs to reread if needed']),
+    },
+  };
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key];
+  if (typeof field !== 'string') return undefined;
+  const trimmed = singleLine(field);
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function stringListField(value: Record<string, unknown>, key: string): string[] {
+  const field = value[key];
+  if (Array.isArray(field)) return field.map((item) => typeof item === 'string' ? singleLine(item) : '').filter(nonEmpty).slice(0, 8);
+  if (typeof field === 'string') {
+    const trimmed = singleLine(field);
+    return trimmed.length > 0 && trimmed.toLowerCase() !== 'none' ? [trimmed] : [];
+  }
+  return [];
+}
+
+function fieldListFromLegacy(raw: string, labels: readonly string[]): string[] {
+  const field = extractSummaryField(raw, labels);
+  if (!field || field.toLowerCase() === 'none') return [];
+  return field.split(/\n|;|\u2022/g).map((part) => singleLine(part.replace(/^-+\s*/, ''))).filter(nonEmpty).slice(0, 8);
 }
 
 function extractSummaryField(summaryText: string, labels: readonly string[]): string | undefined {
@@ -830,6 +1094,11 @@ function isArchiveRef(value: unknown): value is ActiveFullCompactArchiveRef {
 function finiteRatio(value: number | undefined, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return fallback;
   return Math.max(0, Math.min(1, value));
+}
+
+function finiteNonNegativeNumber(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return fallback;
+  return value;
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -58,6 +58,7 @@ import { inspectAgentRunReadModel, type AgentRunInspectModel } from './agent-run
 import type { AgentBackend, MakaTool } from './ai-sdk-backend.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
+import type { SemanticCompactBlock } from './semantic-compact.js';
 import type { AgentRunLineage } from './agent-run.js';
 import { classifyAgentRunRecovery, type AgentRunRecoveryDecision } from './agent-run-recovery.js';
 import type {
@@ -192,6 +193,7 @@ export interface BackendFactoryContext {
   tools?: readonly MakaTool[];
   recordRunTrace?: RunTraceRecorder;
   recordActiveFullCompactBlock?: (block: ActiveFullCompactBlock) => void;
+  recordSemanticCompactBlock?: (block: SemanticCompactBlock) => void;
 }
 
 export type BackendFactory = (ctx: BackendFactoryContext) => AgentBackend | Promise<AgentBackend>;

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -33,9 +33,12 @@ export function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): voi
         deps.lookupPricing(`${record.providerId}:${record.modelId}`),
       ).totalCost;
       const ts = record.startedAt + record.latencyMs;
+      const recordId = record.callId
+        ? `usage_${record.callId}`
+        : `usage_${record.turnId ?? randomUUID()}`;
       deps.repo.insertLlmCall({
         ...record,
-        id: `usage_${record.turnId ?? randomUUID()}`,
+        id: recordId,
         cacheHitInputTokens,
         cacheMissInputTokens,
         ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),

--- a/packages/storage/src/__tests__/telemetry-repo.test.ts
+++ b/packages/storage/src/__tests__/telemetry-repo.test.ts
@@ -66,6 +66,22 @@ describe('FileTelemetryRepo', () => {
     });
   });
 
+  test('carries auxiliary LLM call identity through logs()', async () => {
+    await withRepo(async (repo) => {
+      await repo.load();
+      repo.insertLlmCall(llmRecord({
+        id: 'usage_semantic_compact_turn_1_2_3',
+        callKind: 'semantic_compact',
+        callId: 'semantic_compact_turn_1_2_3',
+      }));
+      await flushWrites();
+
+      const row = repo.logs({ range: 'all' }).rows[0];
+      assert.equal(row?.callKind, 'semantic_compact');
+      assert.equal(row?.callId, 'semantic_compact_turn_1_2_3');
+    });
+  });
+
   test('filters logs by range, status, provider, model, and pagination', async () => {
     await withRepo(async (repo) => {
       await repo.load();

--- a/packages/storage/src/telemetry-repo.ts
+++ b/packages/storage/src/telemetry-repo.ts
@@ -140,6 +140,8 @@ class FileTelemetryRepo implements TelemetryRepo {
       .map((row) => ({
         id: row.id,
         ts: row.ts,
+        ...(row.callKind ? { callKind: row.callKind } : {}),
+        ...(row.callId ? { callId: row.callId } : {}),
         ...(row.connectionSlug ? { connectionSlug: row.connectionSlug } : {}),
         providerId: row.providerId,
         modelId: row.modelId,


### PR DESCRIPTION
## Summary
- add runtime-owned semantic compaction for current-turn AI SDK prepareStep using a no-tools LLM summary
- validate summary contract, preserve recent tool pairs, retain source/coverage metadata, and gate replacement on signed savings
- record semantic compact calls as separate LLM telemetry records and surface compact-call usage in context-budget diagnostics / Harbor output
- add headless env parsing and durable semantic compact block plumbing through AgentRun

## Verification
- npm --workspace @maka/core run build
- npm --workspace @maka/runtime run typecheck
- npm --workspace @maka/runtime run build
- node --test packages/runtime/dist/__tests__/semantic-compact.test.js
- node --test --test-name-pattern 'semantic compact|active full compact' packages/runtime/dist/__tests__/ai-sdk-backend.test.js
- npm --workspace @maka/storage run build
- node --test packages/storage/dist/__tests__/telemetry-repo.test.js
- npm --workspace @maka/headless run build
- node --test packages/headless/dist/__tests__/cell-output.test.js
- node --test packages/headless/dist/__tests__/harbor-cell.test.js
- node --test --test-name-pattern 'context budget summary' packages/headless/dist/__tests__/fixed-prompt-controller.test.js
- git diff --check
- git diff --cached --check