### PR TITLE
Experiment with aggressive semantic compact interval trigger

### DIFF
--- a/packages/core/src/usage-stats/types.ts
+++ b/packages/core/src/usage-stats/types.ts
@@ -227,6 +227,10 @@ export interface CompactionDecisionDiagnostic {
   compactCallCacheReadInputTokens?: number;
   compactCallCacheWriteInputTokens?: number;
   compactCallTotalTokens?: number;
+  triggerReason?: string;
+  toolCallCount?: number;
+  toolCallInterval?: number;
+  relaxedAcceptance?: boolean;
   reason?: string;
   failOpenReason?: string;
   skippedReasonCounts?: Record<string, number>;

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1235,6 +1235,7 @@ describe('runHarborCell', () => {
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS: '256',
       MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT: '0.5',
       MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL: '20',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_RELAXED_ACCEPTANCE: 'true',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS: '768',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES: '3',
       MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS: '11',
@@ -1257,6 +1258,7 @@ describe('runHarborCell', () => {
     assert.equal(options.contextBudget?.semanticCompact?.minNetSavingsTokens, 256);
     assert.equal(options.contextBudget?.semanticCompact?.compactCallTokenCostWeight, 0.5);
     assert.equal(options.contextBudget?.semanticCompact?.toolCallInterval, 20);
+    assert.equal(options.contextBudget?.semanticCompact?.relaxedAcceptance, true);
     assert.equal(options.contextBudget?.semanticCompact?.maxCompactCallTokens, 768);
     assert.equal(options.contextBudget?.semanticCompact?.maxConsecutiveInvalidSummaries, 3);
     assert.equal(options.contextBudget?.semanticCompact?.invalidSummaryCooldownSteps, 11);
@@ -1271,12 +1273,16 @@ describe('runHarborCell', () => {
       MAKA_CONTEXT_SEMANTIC_COMPACT_MODE: 'validate_only',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS: '1',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS: '64',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL: '20',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_RELAXED_ACCEPTANCE: 'true',
     });
     assert.equal(snapshot?.enabled, true);
     if (!snapshot?.enabled) throw new Error('expected context budget snapshot to be enabled');
     assert.equal(snapshot.semanticCompact?.mode, 'validate_only');
     assert.equal(snapshot.semanticCompact?.minRecentToolPairs, 1);
     assert.equal(snapshot.semanticCompact?.minSavingsTokens, 64);
+    assert.equal(snapshot.semanticCompact?.toolCallInterval, 20);
+    assert.equal(snapshot.semanticCompact?.relaxedAcceptance, true);
   });
 
   test('Harbor tool builder keeps the six container-native tools non-interactive', () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1234,6 +1234,7 @@ describe('runHarborCell', () => {
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO: '0.2',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS: '256',
       MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT: '0.5',
+      MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL: '20',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS: '768',
       MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES: '3',
       MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS: '11',
@@ -1255,6 +1256,7 @@ describe('runHarborCell', () => {
     assert.equal(options.contextBudget?.semanticCompact?.minSavingsRatio, 0.2);
     assert.equal(options.contextBudget?.semanticCompact?.minNetSavingsTokens, 256);
     assert.equal(options.contextBudget?.semanticCompact?.compactCallTokenCostWeight, 0.5);
+    assert.equal(options.contextBudget?.semanticCompact?.toolCallInterval, 20);
     assert.equal(options.contextBudget?.semanticCompact?.maxCompactCallTokens, 768);
     assert.equal(options.contextBudget?.semanticCompact?.maxConsecutiveInvalidSummaries, 3);
     assert.equal(options.contextBudget?.semanticCompact?.invalidSummaryCooldownSteps, 11);

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -625,6 +625,12 @@ function validateSemanticCompactSnapshot(value: unknown): NonNullable<ContextBud
     ...(optionalNumber(value.compactCallTokenCostWeight, 'contextBudgetPolicy.semanticCompact.compactCallTokenCostWeight') !== undefined
       ? { compactCallTokenCostWeight: optionalNumber(value.compactCallTokenCostWeight, 'contextBudgetPolicy.semanticCompact.compactCallTokenCostWeight') }
       : {}),
+    ...(optionalNumber(value.toolCallInterval, 'contextBudgetPolicy.semanticCompact.toolCallInterval') !== undefined
+      ? { toolCallInterval: optionalNumber(value.toolCallInterval, 'contextBudgetPolicy.semanticCompact.toolCallInterval') }
+      : {}),
+    ...(value.relaxedAcceptance !== undefined
+      ? { relaxedAcceptance: requireBoolean(value.relaxedAcceptance, 'contextBudgetPolicy.semanticCompact.relaxedAcceptance') }
+      : {}),
     ...(optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') !== undefined
       ? { maxCompactCallTokens: optionalNumber(value.maxCompactCallTokens, 'contextBudgetPolicy.semanticCompact.maxCompactCallTokens') }
       : {}),

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -175,6 +175,7 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_RELAXED_ACCEPTANCE',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS',
@@ -809,6 +810,10 @@ export function buildHarborCellContextBudgetBackendOptions(
       env.MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL,
       'MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL',
     );
+    const relaxedAcceptance = booleanEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_RELAXED_ACCEPTANCE,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_RELAXED_ACCEPTANCE',
+    );
     const maxCompactCallTokens = positiveIntEnv(
       env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS,
       'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
@@ -848,6 +853,7 @@ export function buildHarborCellContextBudgetBackendOptions(
       ...(minNetSavingsTokens !== undefined ? { minNetSavingsTokens } : {}),
       ...(compactCallTokenCostWeight !== undefined ? { compactCallTokenCostWeight } : {}),
       ...(toolCallInterval !== undefined ? { toolCallInterval } : {}),
+      ...(relaxedAcceptance !== undefined ? { relaxedAcceptance } : {}),
       ...(maxCompactCallTokens !== undefined ? { maxCompactCallTokens } : {}),
       ...(maxConsecutiveInvalidSummaries !== undefined ? { maxConsecutiveInvalidSummaries } : {}),
       ...(invalidSummaryCooldownSteps !== undefined ? { invalidSummaryCooldownSteps } : {}),
@@ -1031,6 +1037,9 @@ export function buildHarborCellContextBudgetPolicySnapshot(
               : {}),
             ...(contextBudget.semanticCompact.toolCallInterval !== undefined
               ? { toolCallInterval: contextBudget.semanticCompact.toolCallInterval }
+              : {}),
+            ...(contextBudget.semanticCompact.relaxedAcceptance !== undefined
+              ? { relaxedAcceptance: contextBudget.semanticCompact.relaxedAcceptance }
               : {}),
             ...(contextBudget.semanticCompact.maxCompactCallTokens !== undefined
               ? { maxCompactCallTokens: contextBudget.semanticCompact.maxCompactCallTokens }

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -174,6 +174,7 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT',
+  'MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES',
   'MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS',
@@ -804,6 +805,10 @@ export function buildHarborCellContextBudgetBackendOptions(
     );
     const minSavingsTokens = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS']);
     const minNetSavingsTokens = firstContextNonNegativeIntEnv(env, ['MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS']);
+    const toolCallInterval = positiveIntEnv(
+      env.MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL,
+      'MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL',
+    );
     const maxCompactCallTokens = positiveIntEnv(
       env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS,
       'MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS',
@@ -842,6 +847,7 @@ export function buildHarborCellContextBudgetBackendOptions(
       ...(minSavingsRatio !== undefined ? { minSavingsRatio } : {}),
       ...(minNetSavingsTokens !== undefined ? { minNetSavingsTokens } : {}),
       ...(compactCallTokenCostWeight !== undefined ? { compactCallTokenCostWeight } : {}),
+      ...(toolCallInterval !== undefined ? { toolCallInterval } : {}),
       ...(maxCompactCallTokens !== undefined ? { maxCompactCallTokens } : {}),
       ...(maxConsecutiveInvalidSummaries !== undefined ? { maxConsecutiveInvalidSummaries } : {}),
       ...(invalidSummaryCooldownSteps !== undefined ? { invalidSummaryCooldownSteps } : {}),
@@ -1022,6 +1028,9 @@ export function buildHarborCellContextBudgetPolicySnapshot(
               : {}),
             ...(contextBudget.semanticCompact.compactCallTokenCostWeight !== undefined
               ? { compactCallTokenCostWeight: contextBudget.semanticCompact.compactCallTokenCostWeight }
+              : {}),
+            ...(contextBudget.semanticCompact.toolCallInterval !== undefined
+              ? { toolCallInterval: contextBudget.semanticCompact.toolCallInterval }
               : {}),
             ...(contextBudget.semanticCompact.maxCompactCallTokens !== undefined
               ? { maxCompactCallTokens: contextBudget.semanticCompact.maxCompactCallTokens }

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2167,8 +2167,9 @@ describe('AiSdkBackend usage telemetry', () => {
           mode: 'replace',
           minStepNumber: 1,
           minRecentMessages: 0,
-          maxActiveEstimatedTokens: 1,
-          highWaterRatio: 0.1,
+          maxActiveEstimatedTokens: 1_000_000,
+          highWaterRatio: 1,
+          toolCallInterval: 1,
           maxSummaryEstimatedTokens: 1024,
           minSavingsTokens: 1,
           minSavingsRatio: 0,
@@ -2192,6 +2193,9 @@ describe('AiSdkBackend usage telemetry', () => {
     assert.equal(model.doGenerateCalls.length, 1);
     assert.equal(recordedBlocks.length, 1);
     assert.equal(recordedBlocks[0]?.kind, 'maka.semantic_compact_block');
+    assert.equal(recordedBlocks[0]?.trigger.reason, 'tool_call_interval');
+    assert.equal(recordedBlocks[0]?.trigger.toolCallCount, 1);
+    assert.equal(recordedBlocks[0]?.trigger.toolCallInterval, 1);
     const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt.map((message) => ({
       role: message.role,
       content: message.content,

--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -304,6 +304,61 @@ describe('semantic compact', () => {
     assert.equal(result.block?.trigger.thresholdTokens, undefined);
   });
 
+  test('relaxed interval acceptance bypasses schema, private-surface, recent-tail, and economics gates', async () => {
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 20,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1_000_000,
+        highWaterRatio: 1,
+        minRecentMessages: 999,
+        minRecentToolPairs: 99,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 999_999,
+        minNetSavingsTokens: 999_999,
+        compactCallTokenCostWeight: 1,
+        minSavingsRatio: 1,
+        toolCallInterval: 20,
+        relaxedAcceptance: true,
+      },
+      trigger: {
+        reason: 'tool_call_interval',
+        toolCallCount: 20,
+        toolCallInterval: 20,
+      },
+      summarizer: () => ({
+        text: 'The hidden verifier says continue with the compacted experiment. Next action: keep going.',
+        usage: {
+          inputTokens: 999_999,
+          outputTokens: 1,
+          cacheHitInputTokens: 0,
+          cacheMissInputTokens: 999_999,
+          cacheMissInputSource: 'explicit',
+          cacheWriteInputTokens: 0,
+          reasoningTokens: 0,
+          totalTokens: 1_000_000,
+          cachedInputTokens: 0,
+        },
+      }),
+    });
+
+    assert.equal(result.decision, 'replaced');
+    assert.equal(result.block?.acceptance.decision, 'accepted');
+    assert.match(result.block?.acceptance.reason ?? '', /^relaxed_tool_call_interval:summary_invalid_json$/);
+    assert.ok((result.block?.estimatedNetTokensSavedSigned ?? 0) < 0);
+    assert.equal(result.block?.trigger.reason, 'tool_call_interval');
+    const decision = result.diagnosticPatch.compactionDecisions?.[0];
+    assert.equal(decision?.decision, 'replaced');
+    assert.equal(decision?.triggerReason, 'tool_call_interval');
+    assert.equal(decision?.toolCallCount, 20);
+    assert.equal(decision?.toolCallInterval, 20);
+    assert.equal(decision?.relaxedAcceptance, true);
+  });
+
   test('brakes semantic compact calls after repeated invalid summaries', async () => {
     const controllerState = {
       consecutiveInvalidSummaries: 0,

--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -261,6 +261,49 @@ describe('semantic compact', () => {
     assert.ok((result.block?.estimatedNetTokensSavedSigned ?? 0) < 0);
   });
 
+  test('tool-call interval trigger attempts compact below high-water', async () => {
+    let calls = 0;
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 20,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1_000_000,
+        highWaterRatio: 1,
+        minRecentMessages: 1,
+        minRecentToolPairs: 1,
+        maxSummaryEstimatedTokens: 512,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+        toolCallInterval: 20,
+      },
+      trigger: {
+        reason: 'tool_call_interval',
+        toolCallCount: 20,
+        toolCallInterval: 20,
+      },
+      summarizer: () => {
+        calls += 1;
+        return {
+          text: semanticSummary({
+            objective: 'Continue after interval compact.',
+            nextAction: 'Resume with preserved tail.',
+          }),
+        };
+      },
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(result.decision, 'replaced');
+    assert.equal(result.block?.trigger.reason, 'tool_call_interval');
+    assert.equal(result.block?.trigger.toolCallCount, 20);
+    assert.equal(result.block?.trigger.toolCallInterval, 20);
+    assert.equal(result.block?.trigger.thresholdTokens, undefined);
+  });
+
   test('brakes semantic compact calls after repeated invalid summaries', async () => {
     const controllerState = {
       consecutiveInvalidSummaries: 0,
@@ -268,6 +311,7 @@ describe('semantic compact', () => {
       compactCallCount: 0,
       compactCallTotalTokens: 0,
       acceptedEstimatedTokensSaved: 0,
+      lastToolCallIntervalAttemptCount: 0,
     };
     let calls = 0;
     const policy = {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1490,6 +1490,14 @@ export class AiSdkBackend implements AgentBackend {
           })
         : model;
       const summarizerModelId = policy.summarizerModel ?? this.input.modelId;
+      const toolCallInterval = positiveInteger(policy.toolCallInterval);
+      const toolCallIntervalTrigger = toolCallInterval !== undefined
+        ? semanticToolCallIntervalTrigger({
+            state: controllerState,
+            toolCallInterval,
+            toolCallCount: collectPrepareStepToolCallIds(options.steps ?? []).size,
+          })
+        : undefined;
       const rewritten = await rewriteSemanticCompactInMessages({
         sessionId: this.sessionId,
         turnId,
@@ -1501,6 +1509,7 @@ export class AiSdkBackend implements AgentBackend {
         now: this.now(),
         charsPerToken: this.input.contextBudget?.charsPerToken,
         requestShapeHashForMessages: (messages) => requestShapeHashForMessages(messages, activeToolsForStep),
+        trigger: toolCallIntervalTrigger,
         abortSignal: this.abortController?.signal,
         summarizer: async (request) => {
           const startedAt = this.now();
@@ -2127,6 +2136,29 @@ export function repairMakaToolCall(input: {
       tool: requestedName,
       error: formatSyntheticToolErrorText(input.error),
     }),
+  };
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.floor(value);
+  return rounded > 0 ? rounded : undefined;
+}
+
+function semanticToolCallIntervalTrigger(input: {
+  state: SemanticCompactControllerState;
+  toolCallInterval: number;
+  toolCallCount: number;
+}): { reason: 'tool_call_interval'; toolCallCount: number; toolCallInterval: number } | undefined {
+  if (input.toolCallCount < input.toolCallInterval) return undefined;
+  const bucket = Math.floor(input.toolCallCount / input.toolCallInterval) * input.toolCallInterval;
+  const lastAttempt = input.state.lastToolCallIntervalAttemptCount ?? 0;
+  if (bucket <= lastAttempt) return undefined;
+  input.state.lastToolCallIntervalAttemptCount = bucket;
+  return {
+    reason: 'tool_call_interval',
+    toolCallCount: input.toolCallCount,
+    toolCallInterval: input.toolCallInterval,
   };
 }
 

--- a/packages/runtime/src/compaction-boundary.ts
+++ b/packages/runtime/src/compaction-boundary.ts
@@ -76,6 +76,10 @@ export interface CompactionDecision {
     cacheWriteInputTokens?: number;
     totalTokens?: number;
   };
+  triggerReason?: string;
+  toolCallCount?: number;
+  toolCallInterval?: number;
+  relaxedAcceptance?: boolean;
   reason?: string;
   failOpenReason?: string;
   skippedReasonCounts?: Readonly<Record<string, number>>;
@@ -195,6 +199,10 @@ export function compactionDecisionToDiagnostic(
     ...(decision.compactCallUsage?.totalTokens !== undefined
       ? { compactCallTotalTokens: decision.compactCallUsage.totalTokens }
       : {}),
+    ...(decision.triggerReason ? { triggerReason: decision.triggerReason } : {}),
+    ...(decision.toolCallCount !== undefined ? { toolCallCount: decision.toolCallCount } : {}),
+    ...(decision.toolCallInterval !== undefined ? { toolCallInterval: decision.toolCallInterval } : {}),
+    ...(decision.relaxedAcceptance !== undefined ? { relaxedAcceptance: decision.relaxedAcceptance } : {}),
     ...(decision.reason ? { reason: decision.reason } : {}),
     ...(decision.failOpenReason ? { failOpenReason: decision.failOpenReason } : {}),
     ...(decision.skippedReasonCounts ? { skippedReasonCounts: { ...decision.skippedReasonCounts } } : {}),

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -54,6 +54,13 @@ export interface SemanticCompactPolicy {
    * current AI SDK turn, attempt semantic compact even if high-water is not met.
    */
   toolCallInterval?: number;
+  /**
+   * Experimental acceptance mode for tool-call-interval attempts. When enabled,
+   * interval-triggered compaction uses best-effort summaries and skips the
+   * production acceptance gates so benchmark experiments can observe actual
+   * provider-visible replacement behavior.
+   */
+  relaxedAcceptance?: boolean;
   maxCompactCallTokens?: number;
   maxConsecutiveInvalidSummaries?: number;
   invalidSummaryCooldownSteps?: number;
@@ -206,9 +213,11 @@ export async function rewriteSemanticCompactInMessages(
   if (policy?.enabled !== true || policy.mode === 'off') {
     return unchanged(messages, 'disabled');
   }
-  const brakeReason = semanticCompactBrakeReason(policy, input.controllerState, input.stepNumber);
+  const relaxedAcceptance = isRelaxedIntervalAcceptance(policy, input.trigger);
+  const triggerDiagnostic = semanticCompactTriggerDiagnostic(input.trigger, relaxedAcceptance);
+  const brakeReason = relaxedAcceptance ? undefined : semanticCompactBrakeReason(policy, input.controllerState, input.stepNumber);
   if (brakeReason) {
-    return unchanged(messages, brakeReason);
+    return unchanged(messages, brakeReason, triggerDiagnostic);
   }
 
   const index = buildActiveFullCompactSourceIndex({
@@ -221,7 +230,7 @@ export async function rewriteSemanticCompactInMessages(
     stepNumber: input.stepNumber,
     charsPerToken,
   });
-  const selectionPolicy = policyForSemanticSelection(policy, messages, input.trigger?.reason === 'tool_call_interval');
+  const selectionPolicy = policyForSemanticSelection(policy, messages, input.trigger?.reason === 'tool_call_interval', relaxedAcceptance);
   const selection = selectActiveFullCompactCoveredSpan(index, selectionPolicy);
   if (selection.decision !== 'selected') {
     const decision = selection.decision === 'failedOpen' ? 'failedOpen' : 'unchanged';
@@ -235,6 +244,7 @@ export async function rewriteSemanticCompactInMessages(
         estimatedTokensBefore: index.estimatedTokens,
         estimatedTokensAfter: index.estimatedTokens,
         skippedReasonCounts: selection.skippedReasonCounts,
+        ...triggerDiagnostic,
       }),
     };
   }
@@ -271,7 +281,7 @@ export async function rewriteSemanticCompactInMessages(
     archiveRequired: policy.archiveRequired,
     charsPerToken,
   });
-  if (!validation.valid) {
+  if (!validation.valid && !relaxedAcceptance) {
     return {
       messages,
       decision: 'failedOpen',
@@ -284,6 +294,7 @@ export async function rewriteSemanticCompactInMessages(
         estimatedTokensAfter: index.estimatedTokens,
         failOpenReason: validation.reasons[0] ?? 'coverage_miss',
         validationReasonCounts: validation.reasonCounts,
+        ...triggerDiagnostic,
       }),
     };
   }
@@ -312,26 +323,33 @@ export async function rewriteSemanticCompactInMessages(
     }, policy.timeoutMs);
   } catch {
     recordInvalidSummary(input.controllerState, policy, 'summarizer_failed', input.stepNumber);
-    return rejected(messages, index, 'summarizer_failed');
+    return rejected(messages, index, 'summarizer_failed', undefined, triggerDiagnostic);
   }
 
   const compactCallUsage = summary.usage ? compactUsage(summary.usage) : undefined;
   recordCompactCall(input.controllerState, compactCallUsage);
   const parsedSummary = parseSemanticCompactSummary(summary.text);
-  if (!parsedSummary.ok) {
+  let structuredSummary: SemanticCompactStructuredSummary;
+  let relaxedSummaryReason: string | undefined;
+  if (parsedSummary.ok) {
+    structuredSummary = parsedSummary.summary;
+  } else if (relaxedAcceptance) {
+    structuredSummary = relaxedSemanticCompactSummary(summary.text, stateCards);
+    relaxedSummaryReason = parsedSummary.reason;
+  } else {
     recordInvalidSummary(input.controllerState, policy, parsedSummary.reason, input.stepNumber);
-    return rejected(messages, index, parsedSummary.reason, compactCallUsage);
+    return rejected(messages, index, parsedSummary.reason, compactCallUsage, triggerDiagnostic);
   }
   recordValidSummary(input.controllerState);
-  const summaryText = renderStructuredSemanticSummary(parsedSummary.summary);
+  const summaryText = renderStructuredSemanticSummary(structuredSummary);
   const maxSummaryTokens = Math.floor(policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS);
-  if (estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
+  if (!relaxedAcceptance && estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
     recordInvalidSummary(input.controllerState, policy, 'summary_too_large', input.stepNumber);
-    return rejected(messages, index, 'summary_too_large', compactCallUsage);
+    return rejected(messages, index, 'summary_too_large', compactCallUsage, triggerDiagnostic);
   }
-  if (newPrivateVerifierSurface(`${summary.text}\n${summaryText}`, selectedSourceText(selection, messages))) {
+  if (!relaxedAcceptance && newPrivateVerifierSurface(`${summary.text}\n${summaryText}`, selectedSourceText(selection, messages))) {
     recordInvalidSummary(input.controllerState, policy, 'private_verifier_surface', input.stepNumber);
-    return rejected(messages, index, 'private_verifier_surface', compactCallUsage);
+    return rejected(messages, index, 'private_verifier_surface', compactCallUsage, triggerDiagnostic);
   }
 
   const requestShapeHashBefore = input.requestShapeHashBefore ?? input.requestShapeHashForMessages?.(messages);
@@ -339,7 +357,7 @@ export async function rewriteSemanticCompactInMessages(
     input,
     index,
     selection,
-    structuredSummary: parsedSummary.summary,
+    structuredSummary,
     summaryText,
     stateCards,
     usage: summary.usage,
@@ -360,7 +378,7 @@ export async function rewriteSemanticCompactInMessages(
   block.estimatedTokensSavedSigned = index.estimatedTokens - block.postReplacementEstimatedTokens;
   block.estimatedNetTokensSavedSigned = estimateSemanticNetTokensSaved(block, policy);
 
-  const economicsReason = semanticSavingsRejectionReason(block, policy);
+  const economicsReason = relaxedAcceptance ? undefined : semanticSavingsRejectionReason(block, policy);
   if (economicsReason) {
     block.acceptance = { decision: 'rejected', reason: economicsReason };
     return {
@@ -379,6 +397,7 @@ export async function rewriteSemanticCompactInMessages(
         compactCallUsage: block.compactCallUsage,
         reason: economicsReason,
         validationReasonCounts: validation.reasonCounts,
+        ...triggerDiagnostic,
       }),
     };
   }
@@ -401,11 +420,22 @@ export async function rewriteSemanticCompactInMessages(
         compactCallUsage: block.compactCallUsage,
         reason: policy.mode,
         validationReasonCounts: validation.reasonCounts,
+        ...triggerDiagnostic,
       }),
     };
   }
 
-  block.acceptance = { decision: 'accepted' };
+  block.acceptance = {
+    decision: 'accepted',
+    ...(relaxedAcceptance
+      ? {
+          reason: relaxedSummaryReason
+            ? `relaxed_tool_call_interval:${relaxedSummaryReason}`
+            : 'relaxed_tool_call_interval',
+          ...(!validation.valid ? { validationReasons: validation.reasons } : {}),
+        }
+      : {}),
+  };
   recordAcceptedSemanticCompact(input.controllerState, block);
   return {
     messages: replacementMessages,
@@ -422,6 +452,7 @@ export async function rewriteSemanticCompactInMessages(
         estimatedTokensSaved: block.estimatedTokensSavedSigned,
         compactCallUsage: block.compactCallUsage,
         validationReasonCounts: validation.reasonCounts,
+        ...triggerDiagnostic,
       }),
       ...(requestShapeHashBefore && requestShapeHashAfter
         ? {
@@ -463,11 +494,15 @@ function policyForSemanticSelection(
   policy: SemanticCompactPolicy,
   messages: readonly ModelMessage[],
   bypassHighWater: boolean,
+  relaxedAcceptance: boolean,
 ): ActiveFullCompactPolicy {
-  const minRecentMessages = Math.max(
-    Math.floor(policy.minRecentMessages ?? 1),
-    recentMessageCountForToolPairs(messages, Math.floor(policy.minRecentToolPairs ?? 0)),
-  );
+  const minRecentToolPairs = relaxedAcceptance ? 0 : Math.floor(policy.minRecentToolPairs ?? 0);
+  const minRecentMessages = relaxedAcceptance
+    ? 0
+    : Math.max(
+        Math.floor(policy.minRecentMessages ?? 1),
+        recentMessageCountForToolPairs(messages, minRecentToolPairs),
+      );
   return {
     enabled: true,
     minStepNumber: policy.minStepNumber,
@@ -476,7 +511,7 @@ function policyForSemanticSelection(
     targetRatio: policy.targetRatio,
     ...(bypassHighWater ? {} : { maxActiveEstimatedTokens: policy.maxActiveEstimatedTokens }),
     minRecentMessages,
-    minRecentToolPairs: policy.minRecentToolPairs,
+    minRecentToolPairs,
     maxSummaryEstimatedTokens: policy.maxSummaryEstimatedTokens,
     archiveRequired: policy.archiveRequired,
     highWaterName: policy.highWaterName,
@@ -735,6 +770,29 @@ function estimateSemanticNetTokensSaved(block: SemanticCompactBlock, policy: Sem
   return block.estimatedTokensSavedSigned - Math.ceil(compactCallTokens * weight);
 }
 
+function isRelaxedIntervalAcceptance(
+  policy: SemanticCompactPolicy,
+  trigger: SemanticCompactRewriteInput['trigger'],
+): boolean {
+  return policy.relaxedAcceptance === true && trigger?.reason === 'tool_call_interval';
+}
+
+function semanticCompactTriggerDiagnostic(
+  trigger: SemanticCompactRewriteInput['trigger'],
+  relaxedAcceptance: boolean,
+): Pick<Parameters<typeof semanticCompactDecisionDiagnosticPatch>[0], 'triggerReason' | 'toolCallCount' | 'toolCallInterval' | 'relaxedAcceptance'> {
+  return {
+    ...(trigger ? { triggerReason: trigger.reason } : {}),
+    ...(trigger?.reason === 'tool_call_interval'
+      ? {
+          toolCallCount: trigger.toolCallCount,
+          toolCallInterval: trigger.toolCallInterval,
+        }
+      : {}),
+    ...(relaxedAcceptance ? { relaxedAcceptance: true } : {}),
+  };
+}
+
 function semanticCompactBrakeReason(
   policy: SemanticCompactPolicy,
   state: SemanticCompactControllerState | undefined,
@@ -806,6 +864,10 @@ function semanticCompactDecisionDiagnosticPatch(input: {
   estimatedTokensAfter?: number;
   estimatedTokensSaved?: number;
   compactCallUsage?: SemanticCompactBlock['compactCallUsage'];
+  triggerReason?: string;
+  toolCallCount?: number;
+  toolCallInterval?: number;
+  relaxedAcceptance?: boolean;
   reason?: string;
   failOpenReason?: string;
   skippedReasonCounts?: Readonly<Record<string, number>>;
@@ -832,6 +894,10 @@ function semanticCompactDecisionDiagnosticPatch(input: {
       ...(input.estimatedTokensAfter !== undefined ? { estimatedTokensAfter: input.estimatedTokensAfter } : {}),
       ...(input.estimatedTokensSaved !== undefined ? { estimatedTokensSaved: input.estimatedTokensSaved } : {}),
       ...(input.compactCallUsage ? { compactCallUsage: input.compactCallUsage } : {}),
+      ...(input.triggerReason ? { triggerReason: input.triggerReason } : {}),
+      ...(input.toolCallCount !== undefined ? { toolCallCount: input.toolCallCount } : {}),
+      ...(input.toolCallInterval !== undefined ? { toolCallInterval: input.toolCallInterval } : {}),
+      ...(input.relaxedAcceptance !== undefined ? { relaxedAcceptance: input.relaxedAcceptance } : {}),
       ...(input.reason ? { reason: input.reason } : {}),
       ...(input.failOpenReason ? { failOpenReason: input.failOpenReason } : {}),
       ...(input.skippedReasonCounts ? { skippedReasonCounts: input.skippedReasonCounts } : {}),
@@ -924,6 +990,60 @@ function renderStructuredSemanticSummary(summary: SemanticCompactStructuredSumma
     `next_action: ${summary.nextAction}`,
     ...renderSummaryList('archive_refs_to_reread_if_needed', summary.archiveRefsToRereadIfNeeded),
   ].join('\n').trim();
+}
+
+function relaxedSemanticCompactSummary(
+  rawText: string,
+  stateCards: readonly SemanticCompactStateCard[],
+): SemanticCompactStructuredSummary {
+  const raw = rawText.trim();
+  const objective = firstMeaningfulLine(raw)
+    ?? 'Continue the task from the aggressive semantic compact summary.';
+  const nextAction = extractSummaryField(raw, SUMMARY_FIELD_LABELS.nextAction)
+    ?? stateCards.find((card) => card.kind === 'next_action')?.text
+    ?? 'Continue from the semantic compact block and preserved context.';
+  const commandCards = stateCards
+    .filter((card) => card.kind === 'command')
+    .map((card) => card.text)
+    .slice(0, 8);
+  const operationalCards = stateCards
+    .filter((card) => card.kind === 'process' || card.kind === 'vm' || card.kind === 'artifact')
+    .map((card) => card.text)
+    .slice(0, 8);
+  const constraintCards = stateCards
+    .filter((card) => card.kind === 'constraint')
+    .map((card) => card.text)
+    .slice(0, 8);
+  const verifierCard = stateCards.find((card) => card.kind === 'verifier')?.text ?? '';
+  return {
+    currentObjective: objective,
+    userConstraints: constraintCards,
+    importantFilesAndArtifacts: stateCards
+      .filter((card) => card.kind === 'artifact')
+      .map((card) => card.text)
+      .slice(0, 8),
+    commandsAndResults: commandCards.length > 0 ? commandCards : boundedSummaryLines(raw),
+    errorsAndFixes: [],
+    failedHypotheses: [],
+    operationalState: operationalCards,
+    publicVerificationState: verifierCard,
+    remainingWork: [],
+    nextAction,
+    archiveRefsToRereadIfNeeded: [],
+  };
+}
+
+function firstMeaningfulLine(raw: string): string | undefined {
+  return raw.split(/\r?\n/)
+    .map((line) => singleLine(line.replace(/^[-*#\s]+/, '')))
+    .find(nonEmpty);
+}
+
+function boundedSummaryLines(raw: string): string[] {
+  return raw.split(/\r?\n/)
+    .map((line) => singleLine(line.replace(/^[-*#\s]+/, '')))
+    .filter(nonEmpty)
+    .slice(0, 8);
 }
 
 function renderSummaryList(label: string, values: readonly string[]): string[] {
@@ -1054,6 +1174,7 @@ function rejected(
   index: ActiveFullCompactSourceIndex,
   reason: string,
   compactCallUsage?: SemanticCompactBlock['compactCallUsage'],
+  diagnostic?: Pick<Parameters<typeof semanticCompactDecisionDiagnosticPatch>[0], 'triggerReason' | 'toolCallCount' | 'toolCallInterval' | 'relaxedAcceptance'>,
 ): SemanticCompactRewriteResult {
   return {
     messages,
@@ -1066,11 +1187,16 @@ function rejected(
       estimatedTokensAfter: index.estimatedTokens,
       estimatedTokensSaved: 0,
       ...(compactCallUsage ? { compactCallUsage } : {}),
+      ...(diagnostic ?? {}),
     }),
   };
 }
 
-function unchanged(messages: ModelMessage[], reason: string): SemanticCompactRewriteResult {
+function unchanged(
+  messages: ModelMessage[],
+  reason: string,
+  diagnostic?: Pick<Parameters<typeof semanticCompactDecisionDiagnosticPatch>[0], 'triggerReason' | 'toolCallCount' | 'toolCallInterval' | 'relaxedAcceptance'>,
+): SemanticCompactRewriteResult {
   return {
     messages,
     decision: 'unchanged',
@@ -1078,6 +1204,7 @@ function unchanged(messages: ModelMessage[], reason: string): SemanticCompactRew
     diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
       decision: 'unchanged',
       reason,
+      ...(diagnostic ?? {}),
     }),
   };
 }

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -49,6 +49,11 @@ export interface SemanticCompactPolicy {
   minSavingsRatio?: number;
   minNetSavingsTokens?: number;
   compactCallTokenCostWeight?: number;
+  /**
+   * Experimental active-loop trigger: after each N cumulative tool calls in the
+   * current AI SDK turn, attempt semantic compact even if high-water is not met.
+   */
+  toolCallInterval?: number;
   maxCompactCallTokens?: number;
   maxConsecutiveInvalidSummaries?: number;
   invalidSummaryCooldownSteps?: number;
@@ -77,6 +82,7 @@ export interface SemanticCompactControllerState {
   compactCallCount: number;
   compactCallTotalTokens: number;
   acceptedEstimatedTokensSaved: number;
+  lastToolCallIntervalAttemptCount?: number;
   suppressedUntilStep?: number;
   lastInvalidReason?: string;
 }
@@ -113,8 +119,10 @@ export interface SemanticCompactBlock {
   highWaterName: string;
   highWaterSeq: number;
   trigger: {
-    reason: 'high_water' | 'force_ratio' | 'predictive_growth' | 'reactive_prompt_too_long' | 'manual_test';
+    reason: 'high_water' | 'force_ratio' | 'predictive_growth' | 'reactive_prompt_too_long' | 'manual_test' | 'tool_call_interval';
     stepNumber?: number;
+    toolCallCount?: number;
+    toolCallInterval?: number;
     estimatedTokensBefore?: number;
     thresholdTokens?: number;
   };
@@ -171,6 +179,11 @@ export interface SemanticCompactRewriteInput {
   charsPerToken?: number;
   requestShapeHashBefore?: string;
   requestShapeHashForMessages?: (messages: readonly ModelMessage[]) => string;
+  trigger?: {
+    reason: 'tool_call_interval';
+    toolCallCount: number;
+    toolCallInterval: number;
+  };
   summarizer: SemanticCompactSummarizer;
   abortSignal?: AbortSignal;
 }
@@ -208,7 +221,7 @@ export async function rewriteSemanticCompactInMessages(
     stepNumber: input.stepNumber,
     charsPerToken,
   });
-  const selectionPolicy = policyForSemanticSelection(policy, messages);
+  const selectionPolicy = policyForSemanticSelection(policy, messages, input.trigger?.reason === 'tool_call_interval');
   const selection = selectActiveFullCompactCoveredSpan(index, selectionPolicy);
   if (selection.decision !== 'selected') {
     const decision = selection.decision === 'failedOpen' ? 'failedOpen' : 'unchanged';
@@ -449,6 +462,7 @@ export function renderSemanticCompactBlock(block: SemanticCompactBlock): string 
 function policyForSemanticSelection(
   policy: SemanticCompactPolicy,
   messages: readonly ModelMessage[],
+  bypassHighWater: boolean,
 ): ActiveFullCompactPolicy {
   const minRecentMessages = Math.max(
     Math.floor(policy.minRecentMessages ?? 1),
@@ -460,7 +474,7 @@ function policyForSemanticSelection(
     highWaterRatio: policy.highWaterRatio,
     forceRatio: policy.forceRatio,
     targetRatio: policy.targetRatio,
-    maxActiveEstimatedTokens: policy.maxActiveEstimatedTokens,
+    ...(bypassHighWater ? {} : { maxActiveEstimatedTokens: policy.maxActiveEstimatedTokens }),
     minRecentMessages,
     minRecentToolPairs: policy.minRecentToolPairs,
     maxSummaryEstimatedTokens: policy.maxSummaryEstimatedTokens,
@@ -653,10 +667,16 @@ function buildSemanticCompactBlock(input: {
     highWaterName: policy.highWaterName ?? 'semantic-compact-high-water',
     highWaterSeq: input.input.stepNumber,
     trigger: {
-      reason: 'high_water',
+      reason: input.input.trigger?.reason ?? 'high_water',
       stepNumber: input.input.stepNumber,
+      ...(input.input.trigger?.reason === 'tool_call_interval'
+        ? {
+            toolCallCount: input.input.trigger.toolCallCount,
+            toolCallInterval: input.input.trigger.toolCallInterval,
+          }
+        : {}),
       estimatedTokensBefore: input.index.estimatedTokens,
-      ...(policy.maxActiveEstimatedTokens !== undefined
+      ...(input.input.trigger?.reason !== 'tool_call_interval' && policy.maxActiveEstimatedTokens !== undefined
         ? { thresholdTokens: Math.floor(policy.maxActiveEstimatedTokens * finiteRatio(policy.highWaterRatio, 0.8)) }
         : {}),
     },


### PR DESCRIPTION
## Summary
- add an experimental `semanticCompact.toolCallInterval` policy knob
- wire Harbor env `MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL`
- when configured, the active-loop semantic compact path attempts an LLM compact once per N cumulative tool calls, bypassing the normal high-water skip while preserving cooldown, validation, and economics gates

## Notes
- intended as an isolated experiment branch for benchmark comparison, not a proposed default policy
- example: `MAKA_CONTEXT_SEMANTIC_COMPACT_TOOL_CALL_INTERVAL=20`

## Verification
- `npm --workspace @maka/runtime test`
- `node --test --test-name-pattern 'semantic compact policy' packages/headless/dist/__tests__/harbor-cell.test.js`
- `git diff --check`
