### PR TITLE
Raise semantic compact generation budget

### DIFF
--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -62,6 +62,7 @@ describe('semantic compact', () => {
 
     assert.equal(result.decision, 'replaced');
     assert.ok(requestSeen, 'expected injected summarizer to be called');
+    assert.equal(requestSeen.maxOutputTokens, 4096);
     assert.equal(result.block?.kind, 'maka.semantic_compact_block');
     assert.equal(result.block?.acceptance.decision, 'accepted');
     assert.ok((result.block?.estimatedTokensSavedSigned ?? 0) > 0);
@@ -86,7 +87,7 @@ describe('semantic compact', () => {
     assert.equal(typeof result.diagnosticPatch.highWaterRequestShapeHashAfter, 'string');
   });
 
-  test('fails open when signed savings do not meet the configured margin', async () => {
+  test('accepts with a warning when signed savings do not meet the configured margin', async () => {
     const messages = semanticFixtureMessages();
     const result = await rewriteSemanticCompactInMessages({
       sessionId: 'session-1',
@@ -123,20 +124,22 @@ describe('semantic compact', () => {
       }),
     });
 
-    assert.equal(result.decision, 'unchanged');
+    assert.equal(result.decision, 'replaced');
     assert.equal(result.reason, 'below_min_savings_tokens');
-    assert.deepEqual(result.messages, messages);
-    assert.equal(result.block?.acceptance.decision, 'rejected');
+    assert.notDeepEqual(result.messages, messages);
+    assert.equal(result.block?.acceptance.decision, 'accepted');
+    assert.equal(result.block?.acceptance.reason, 'below_min_savings_tokens');
     const decision = result.diagnosticPatch.compactionDecisions?.[0];
     assert.equal(decision?.boundaryKind, 'semanticCompact');
-    assert.equal(decision?.decision, 'unchanged');
+    assert.equal(decision?.decision, 'replaced');
     assert.equal(decision?.reason, 'below_min_savings_tokens');
+    assert.deepEqual(decision?.skippedReasonCounts, { below_min_savings_tokens: 1 });
     assert.equal(typeof decision?.estimatedTokensSaved, 'number');
     assert.equal(decision?.compactCallInputTokens, 5);
     assert.equal(decision?.compactCallTotalTokens, 11);
   });
 
-  test('rejects summaries that newly surface private verifier material', async () => {
+  test('accepts summaries that newly surface private verifier material with a warning', async () => {
     const result = await rewriteSemanticCompactInMessages({
       sessionId: 'session-1',
       turnId: 'turn-1',
@@ -171,13 +174,17 @@ describe('semantic compact', () => {
       }),
     });
 
-    assert.equal(result.decision, 'unchanged');
-    assert.equal(result.reason, 'private_verifier_surface');
+    assert.equal(result.decision, 'replaced');
+    assert.equal(result.block?.acceptance.decision, 'accepted');
+    assert.equal(result.block?.acceptance.reason, 'private_verifier_surface');
     assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.reason, 'private_verifier_surface');
+    assert.deepEqual(result.diagnosticPatch.compactionDecisions?.[0]?.skippedReasonCounts, {
+      private_verifier_surface: 1,
+    });
     assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.compactCallTotalTokens, 7);
   });
 
-  test('rejects JSON summaries that do not satisfy the required schema contract', async () => {
+  test('falls back to raw summary text when JSON summaries do not satisfy the schema contract', async () => {
     const baseInput = {
       sessionId: 'session-1',
       turnId: 'turn-1',
@@ -199,8 +206,9 @@ describe('semantic compact', () => {
       ...baseInput,
       summarizer: () => ({ text: JSON.stringify({ next_action: 'Continue from preserved context.' }) }),
     });
-    assert.equal(missingObjective.decision, 'unchanged');
-    assert.equal(missingObjective.reason, 'summary_missing_current_objective');
+    assert.equal(missingObjective.decision, 'replaced');
+    assert.equal(missingObjective.block?.acceptance.decision, 'accepted');
+    assert.equal(missingObjective.block?.acceptance.reason, 'summary_missing_current_objective');
     assert.equal(
       missingObjective.diagnosticPatch.compactionDecisions?.[0]?.reason,
       'summary_missing_current_objective',
@@ -210,15 +218,47 @@ describe('semantic compact', () => {
       ...baseInput,
       summarizer: () => ({ text: JSON.stringify({ current_objective: 'Solve the task.' }) }),
     });
-    assert.equal(missingNextAction.decision, 'unchanged');
-    assert.equal(missingNextAction.reason, 'summary_missing_next_action');
+    assert.equal(missingNextAction.decision, 'replaced');
+    assert.equal(missingNextAction.block?.acceptance.decision, 'accepted');
+    assert.equal(missingNextAction.block?.acceptance.reason, 'summary_missing_next_action');
     assert.equal(
       missingNextAction.diagnosticPatch.compactionDecisions?.[0]?.reason,
       'summary_missing_next_action',
     );
+    assert.match(renderSemanticCompactBlock(missingNextAction.block!), /raw_semantic_summary_fallback/);
   });
 
-  test('rejects compact when provider savings do not beat compact-call token cost', async () => {
+  test('does not reject valid summaries just because they exceed the soft summary target', async () => {
+    const result = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy: {
+        enabled: true,
+        maxActiveEstimatedTokens: 1,
+        highWaterRatio: 0.1,
+        minRecentMessages: 1,
+        maxSummaryEstimatedTokens: 1,
+        minSavingsTokens: 1,
+        minSavingsRatio: 0,
+      },
+      summarizer: () => ({
+        text: semanticSummary({
+          objective: 'Continue after compact with complete continuity state.',
+          nextAction: 'Resume with the preserved recent tool result.',
+          commands: ['Earlier output showed a large build log that does not need to remain verbatim.'],
+        }),
+      }),
+    });
+
+    assert.equal(result.decision, 'replaced');
+    assert.equal(result.block?.acceptance.decision, 'accepted');
+    assert.notEqual(result.reason, 'summary_too_large');
+  });
+
+  test('accepts compact with a warning when provider savings do not beat compact-call token cost', async () => {
     const result = await rewriteSemanticCompactInMessages({
       sessionId: 'session-1',
       turnId: 'turn-1',
@@ -255,13 +295,14 @@ describe('semantic compact', () => {
       }),
     });
 
-    assert.equal(result.decision, 'unchanged');
-    assert.equal(result.reason, 'below_min_net_savings_tokens');
+    assert.equal(result.decision, 'replaced');
+    assert.equal(result.block?.acceptance.decision, 'accepted');
     assert.equal(result.block?.acceptance.reason, 'below_min_net_savings_tokens');
+    assert.equal(result.diagnosticPatch.compactionDecisions?.[0]?.reason, 'below_min_net_savings_tokens');
     assert.ok((result.block?.estimatedNetTokensSavedSigned ?? 0) < 0);
   });
 
-  test('brakes semantic compact calls after repeated invalid summaries', async () => {
+  test('does not brake semantic compact calls after malformed summary fallbacks', async () => {
     const controllerState = {
       consecutiveInvalidSummaries: 0,
       totalInvalidSummaries: 0,
@@ -295,8 +336,80 @@ describe('semantic compact', () => {
         return { text: JSON.stringify({ next_action: 'Continue.' }) };
       },
     });
-    assert.equal(invalid.reason, 'summary_missing_current_objective');
+    assert.equal(invalid.decision, 'replaced');
+    assert.equal(invalid.block?.acceptance.reason, 'summary_missing_current_objective');
     assert.equal(calls, 1);
+    assert.equal(controllerState.consecutiveInvalidSummaries, 0);
+
+    const cooled = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 3,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        return { text: semanticSummary({ objective: 'Should not run.', nextAction: 'Should not run.' }) };
+      },
+    });
+    assert.equal(cooled.decision, 'replaced');
+    assert.notEqual(cooled.reason, 'semantic_compact_cooldown');
+    assert.equal(calls, 2);
+
+    const resumed = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 6,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        return { text: semanticSummary({ objective: 'Runs after cooldown.', nextAction: 'Continue.' }) };
+      },
+    });
+    assert.notEqual(resumed.reason, 'semantic_compact_cooldown');
+    assert.equal(calls, 3);
+  });
+
+  test('brakes semantic compact calls after repeated summarizer failures', async () => {
+    const controllerState = {
+      consecutiveInvalidSummaries: 0,
+      totalInvalidSummaries: 0,
+      compactCallCount: 0,
+      compactCallTotalTokens: 0,
+      acceptedEstimatedTokensSaved: 0,
+    };
+    let calls = 0;
+    const policy = {
+      enabled: true,
+      maxActiveEstimatedTokens: 1,
+      highWaterRatio: 0.1,
+      minRecentMessages: 1,
+      maxSummaryEstimatedTokens: 512,
+      minSavingsTokens: 1,
+      minSavingsRatio: 0,
+      maxConsecutiveInvalidSummaries: 1,
+      invalidSummaryCooldownSteps: 3,
+    } as const;
+
+    const failed = await rewriteSemanticCompactInMessages({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      messages: semanticFixtureMessages(),
+      stepNumber: 2,
+      charsPerToken: 1,
+      policy,
+      controllerState,
+      summarizer: () => {
+        calls += 1;
+        throw new Error('boom');
+      },
+    });
+    assert.equal(failed.reason, 'summarizer_failed');
     assert.equal(controllerState.consecutiveInvalidSummaries, 1);
 
     const cooled = await rewriteSemanticCompactInMessages({
@@ -315,22 +428,6 @@ describe('semantic compact', () => {
     assert.equal(cooled.decision, 'unchanged');
     assert.equal(cooled.reason, 'semantic_compact_cooldown');
     assert.equal(calls, 1);
-
-    const resumed = await rewriteSemanticCompactInMessages({
-      sessionId: 'session-1',
-      turnId: 'turn-1',
-      messages: semanticFixtureMessages(),
-      stepNumber: 6,
-      charsPerToken: 1,
-      policy,
-      controllerState,
-      summarizer: () => {
-        calls += 1;
-        return { text: semanticSummary({ objective: 'Runs after cooldown.', nextAction: 'Continue.' }) };
-      },
-    });
-    assert.notEqual(resumed.reason, 'semantic_compact_cooldown');
-    assert.equal(calls, 2);
   });
 
   test('renders restoration cards and archive refs without raw source hashes as prose', async () => {

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -23,6 +23,8 @@ import type { CompactSummaryResult, NormalizedAiSdkUsage } from './model-adapter
 
 const DEFAULT_CHARS_PER_TOKEN = 4;
 const DEFAULT_MAX_SUMMARY_TOKENS = 768;
+const DEFAULT_MAX_COMPACT_CALL_TOKENS = 4096;
+const FALLBACK_RAW_SUMMARY_MAX_CHARS = 12_000;
 const DEFAULT_MIN_SAVINGS_TOKENS = 256;
 const DEFAULT_MIN_SAVINGS_RATIO = 0.05;
 const DEFAULT_COMPACT_CALL_TOKEN_COST_WEIGHT = 1;
@@ -258,22 +260,7 @@ export async function rewriteSemanticCompactInMessages(
     archiveRequired: policy.archiveRequired,
     charsPerToken,
   });
-  if (!validation.valid) {
-    return {
-      messages,
-      decision: 'failedOpen',
-      validation,
-      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
-        decision: 'failedOpen',
-        boundaryIds: [validationBlock.blockId],
-        coverage: validationBlock.coverage,
-        estimatedTokensBefore: index.estimatedTokens,
-        estimatedTokensAfter: index.estimatedTokens,
-        failOpenReason: validation.reasons[0] ?? 'coverage_miss',
-        validationReasonCounts: validation.reasonCounts,
-      }),
-    };
-  }
+  const warningReasons: string[] = validation.valid ? [] : [...validation.reasons];
 
   const stateCards = buildSemanticStateCards({
     selection,
@@ -294,7 +281,7 @@ export async function rewriteSemanticCompactInMessages(
         policy,
         charsPerToken,
       }),
-      maxOutputTokens: Math.floor(policy.maxCompactCallTokens ?? policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS),
+      maxOutputTokens: Math.floor(policy.maxCompactCallTokens ?? DEFAULT_MAX_COMPACT_CALL_TOKENS),
       abortSignal: input.abortSignal,
     }, policy.timeoutMs);
   } catch {
@@ -305,20 +292,14 @@ export async function rewriteSemanticCompactInMessages(
   const compactCallUsage = summary.usage ? compactUsage(summary.usage) : undefined;
   recordCompactCall(input.controllerState, compactCallUsage);
   const parsedSummary = parseSemanticCompactSummary(summary.text);
-  if (!parsedSummary.ok) {
-    recordInvalidSummary(input.controllerState, policy, parsedSummary.reason, input.stepNumber);
-    return rejected(messages, index, parsedSummary.reason, compactCallUsage);
-  }
+  if (!parsedSummary.ok) warningReasons.push(parsedSummary.reason);
   recordValidSummary(input.controllerState);
-  const summaryText = renderStructuredSemanticSummary(parsedSummary.summary);
-  const maxSummaryTokens = Math.floor(policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS);
-  if (estimateTokens(summaryText.length, charsPerToken) > maxSummaryTokens) {
-    recordInvalidSummary(input.controllerState, policy, 'summary_too_large', input.stepNumber);
-    return rejected(messages, index, 'summary_too_large', compactCallUsage);
-  }
+  const structuredSummary = parsedSummary.ok
+    ? parsedSummary.summary
+    : fallbackSemanticCompactSummary(summary.text, parsedSummary.reason);
+  const summaryText = renderStructuredSemanticSummary(structuredSummary);
   if (newPrivateVerifierSurface(`${summary.text}\n${summaryText}`, selectedSourceText(selection, messages))) {
-    recordInvalidSummary(input.controllerState, policy, 'private_verifier_surface', input.stepNumber);
-    return rejected(messages, index, 'private_verifier_surface', compactCallUsage);
+    warningReasons.push('private_verifier_surface');
   }
 
   const requestShapeHashBefore = input.requestShapeHashBefore ?? input.requestShapeHashForMessages?.(messages);
@@ -326,7 +307,7 @@ export async function rewriteSemanticCompactInMessages(
     input,
     index,
     selection,
-    structuredSummary: parsedSummary.summary,
+    structuredSummary,
     summaryText,
     stateCards,
     usage: summary.usage,
@@ -348,27 +329,10 @@ export async function rewriteSemanticCompactInMessages(
   block.estimatedNetTokensSavedSigned = estimateSemanticNetTokensSaved(block, policy);
 
   const economicsReason = semanticSavingsRejectionReason(block, policy);
-  if (economicsReason) {
-    block.acceptance = { decision: 'rejected', reason: economicsReason };
-    return {
-      messages,
-      decision: 'unchanged',
-      reason: economicsReason,
-      block,
-      validation,
-      diagnosticPatch: semanticCompactDecisionDiagnosticPatch({
-        decision: 'unchanged',
-        boundaryIds: [block.blockId],
-        coverage: block.coverage,
-        estimatedTokensBefore: index.estimatedTokens,
-        estimatedTokensAfter: block.postReplacementEstimatedTokens,
-        estimatedTokensSaved: block.estimatedTokensSavedSigned,
-        compactCallUsage: block.compactCallUsage,
-        reason: economicsReason,
-        validationReasonCounts: validation.reasonCounts,
-      }),
-    };
-  }
+  if (economicsReason) warningReasons.push(economicsReason);
+  const uniqueWarningReasons = uniqueStrings(warningReasons);
+  const warningReasonCounts = countStringReasons(uniqueWarningReasons);
+  const primaryWarningReason = uniqueWarningReasons[0];
 
   if (policy.mode === 'validate_only' || policy.mode === 'prepare_step_dry_run') {
     block.acceptance = { decision: 'dry_run', reason: policy.mode };
@@ -387,16 +351,20 @@ export async function rewriteSemanticCompactInMessages(
         estimatedTokensSaved: block.estimatedTokensSavedSigned,
         compactCallUsage: block.compactCallUsage,
         reason: policy.mode,
+        ...(primaryWarningReason ? { skippedReasonCounts: warningReasonCounts } : {}),
         validationReasonCounts: validation.reasonCounts,
       }),
     };
   }
 
-  block.acceptance = { decision: 'accepted' };
+  block.acceptance = primaryWarningReason
+    ? { decision: 'accepted', reason: primaryWarningReason, validationReasons: uniqueWarningReasons }
+    : { decision: 'accepted' };
   recordAcceptedSemanticCompact(input.controllerState, block);
   return {
     messages: replacementMessages,
     decision: 'replaced',
+    ...(primaryWarningReason ? { reason: primaryWarningReason } : {}),
     block,
     validation,
     diagnosticPatch: {
@@ -408,6 +376,7 @@ export async function rewriteSemanticCompactInMessages(
         estimatedTokensAfter: block.postReplacementEstimatedTokens,
         estimatedTokensSaved: block.estimatedTokensSavedSigned,
         compactCallUsage: block.compactCallUsage,
+        ...(primaryWarningReason ? { reason: primaryWarningReason, skippedReasonCounts: warningReasonCounts } : {}),
         validationReasonCounts: validation.reasonCounts,
       }),
       ...(requestShapeHashBefore && requestShapeHashAfter
@@ -552,7 +521,7 @@ function buildSummarizerMessages(input: {
     'Do not invent command results, file contents, process state, credentials, verifier results, or hidden/private evaluation facts.',
     'Summarize continuity only. Durable source refs, hashes, and archive audit metadata are stored outside this provider-visible summary.',
     'Preserve objective, constraints, decisions, failed attempts, commands/results that matter, files/artifacts, active process/build state, public verification state, and exact next action.',
-    `Keep the answer under ${input.policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS} estimated tokens.`,
+    `Prefer concise JSON around ${input.policy.maxSummaryEstimatedTokens ?? DEFAULT_MAX_SUMMARY_TOKENS} estimated tokens when possible; complete valid JSON is more important than brevity.`,
     `context_boundary: ${JSON.stringify(contextBoundary)}`,
     `restoration_cards: ${JSON.stringify(restorationCards)}`,
   ].join('\n');
@@ -890,6 +859,23 @@ function parseSemanticCompactSummary(text: string): {
   return { ok: false, reason: 'summary_invalid_json' };
 }
 
+function fallbackSemanticCompactSummary(rawText: string, reason: string): SemanticCompactStructuredSummary {
+  const fallbackText = boundedSingleLine(rawText, FALLBACK_RAW_SUMMARY_MAX_CHARS);
+  return {
+    currentObjective: 'Continue the current task from the semantic compact fallback summary and preserved recent context.',
+    userConstraints: [],
+    importantFilesAndArtifacts: [],
+    commandsAndResults: fallbackText ? [`raw_semantic_summary_fallback: ${fallbackText}`] : [],
+    errorsAndFixes: [],
+    failedHypotheses: [],
+    operationalState: [`Semantic compact summarizer output did not satisfy the requested structure (${reason}); using raw text fallback.`],
+    publicVerificationState: 'No public verification state claimed by structured summary.',
+    remainingWork: ['Continue from the preserved recent messages after this compact block.'],
+    nextAction: 'Continue from the preserved recent context.',
+    archiveRefsToRereadIfNeeded: [],
+  };
+}
+
 function renderStructuredSemanticSummary(summary: SemanticCompactStructuredSummary): string {
   return [
     `current_objective: ${summary.currentObjective}`,
@@ -1121,6 +1107,23 @@ function uniqueSorted(values: readonly string[]): string[] {
   return [...new Set(values)].sort();
 }
 
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function countStringReasons(values: readonly string[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const value of values) counts[value] = (counts[value] ?? 0) + 1;
+  return counts;
+}
+
 function nonEmpty(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
@@ -1135,4 +1138,10 @@ function escapeAttribute(value: string): string {
 
 function singleLine(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+function boundedSingleLine(value: string, maxChars: number): string {
+  const clean = singleLine(value);
+  if (clean.length <= maxChars) return clean;
+  return `${clean.slice(0, Math.max(0, maxChars - 3))}...`;
 }


### PR DESCRIPTION
## Summary
- raise the default semantic compact summarizer generation cap to 4096 tokens
- stop deriving generation budget from maxSummaryEstimatedTokens
- make semantic compact validation weak-model friendly: JSON/schema/private-surface/coverage/economics failures now continue as accepted compact replacements with warning diagnostics instead of hard rejection
- use raw text fallback when the summarizer does not produce the requested structured JSON, and avoid invalid-summary cooldown for malformed-but-usable model output

## Verification
- npm --workspace @maka/runtime test
- npm --workspace @maka/headless run build
- git diff --check