### PR TITLE
test: allow Harbor CLI stderr output

### DIFF
--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -59,6 +59,10 @@ const ALLOW = new Map([
     'CLI entrypoint prints command progress, usage, and failures to stdout/stderr by design.',
   ],
   [
+    'packages/headless/src/harbor-cli.ts',
+    'Harbor CLI subcommand prints usage and command failures to stderr by design.',
+  ],
+  [
     'scripts/check-console.mjs',
     'this script — explicit allow.',
   ],


### PR DESCRIPTION
## Summary

Allow-list `packages/headless/src/harbor-cli.ts` in the console audit with a scoped reason for Harbor CLI stderr usage.

## Why

The desktop pretest runs `scripts/check-console.mjs`, and the Harbor CLI subcommand intentionally prints usage and command failures to stderr. Without this allow-list entry, the audit blocks the standard desktop test path.

## Scope

Changed:

- Added `packages/headless/src/harbor-cli.ts` to the `check-console` allow-list.

Not included:

- No Harbor CLI output behavior changes.
- No unrelated logging cleanup.

## Verification

- `node scripts/check-console.mjs`
- `npm run -w @maka/headless test`
- `npm run -w @maka/desktop test`

## User-facing impact

None. This only updates the local audit gate.

## Reviewer notes

The first desktop test attempt in this worktree exposed a local dependency layout issue: `node_modules/.bin/tsc` was missing after `worktree-bootstrap.mjs`. Running `npm install` inside the worktree populated the local bin entry; no lockfile or source changes resulted.