### PR TITLE
PR-MODEL-ROW-AND-OAUTH-EMAIL-FIX-0: 2 of 6 bug bundle (height-clip + email-leak)

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -343,9 +343,15 @@ async function syncClaudeSubscriptionConnection(): Promise<LlmConnection | null>
 
   const defaults = PROVIDER_DEFAULTS['claude-subscription'];
   const fallbackModels = defaults.fallbackModels.map((id) => ({ id }));
-  const displayName = state.profile?.email
-    ? `Claude OAuth · ${state.profile.email}`
-    : 'Claude OAuth';
+  // PR-OAUTH-NAME-EMAIL-STRIP-0 (WAWQAQ msg `77221a77` 2026-06-30): the
+  // connection display name used to embed the OAuth account email
+  // (`Claude OAuth · user@example.com`). That value leaks the user's
+  // account identity into every model picker, settings dropdown, and
+  // anywhere else `connection.name` shows up. The email belongs on the
+  // Account · 模型 page, not in the model identity. Use the brand-only
+  // label here; the email is still available via the OAuth state for
+  // the dedicated account surfaces that legitimately need it.
+  const displayName = 'Claude OAuth';
   const now = Date.now();
   const connection: LlmConnection = {
     slug: CLAUDE_SUBSCRIPTION_CONNECTION_SLUG,
@@ -399,7 +405,10 @@ async function syncCodexSubscriptionConnection(): Promise<LlmConnection | null> 
     normalizedModels.map((entry) => entry.id),
     defaults.fallbackModels[0] || '',
   );
-  const displayName = state.email ? `Codex OAuth · ${state.email}` : 'Codex OAuth';
+  // PR-OAUTH-NAME-EMAIL-STRIP-0 — same email-leak fix as Claude OAuth
+  // above. Codex's was the one that surfaced in the screenshot, but the
+  // symmetric Claude path had the same shape; both now use brand-only.
+  const displayName = 'Codex OAuth';
   const now = Date.now();
   const connection: LlmConnection = {
     slug: CODEX_SUBSCRIPTION_CONNECTION_SLUG,

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -350,13 +350,22 @@
   grid-template-columns: 16px minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
+  padding: 8px 10px;
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
   color: var(--foreground);
   text-align: left;
   transition: background var(--duration-base) var(--ease-out-strong), border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
+  /* PR-MODEL-ROW-HEIGHT-FIX-0 (WAWQAQ msg c71b4dcb 2026-06-30): the
+     Button primitive ships size=md = `h-9` (36px fixed), but each row
+     now has TWO lines (display name + raw id when shown). The fixed
+     height clipped the second line's lower descender (gpt-5.4 → "ant
+     5.4"). Override to auto height with a comfortable min-height; the
+     padding above plus the inner 2px gap leaves room for the second
+     line without breaking single-line rows. */
+  height: auto;
+  min-height: 44px;
 }
 
 .modelTableRow:hover {


### PR DESCRIPTION
## Why

WAWQAQ msg `c71b4dcb` and `77221a77` flagged 6 issues across 2 screenshots in Settings → 模型 / 默认模型. After @maka-审美专家's analysis we split them into root-cause buckets:

| Bug | Root cause | Status |
|---|---|---|
| 1: model-row second line clipped | `Button` `size="md"` ships fixed `h-9`; rows now have 2 lines | ✅ this PR |
| 2: middle row appears with different background | same height-clip; the apparent "white middle row" is just :hover state on the taller row | ✅ this PR (transitively) |
| 3: long title truncation doesn't match raw-id truncation | already has `overflow:hidden + text-overflow:ellipsis`; visible artifact was bug 1 height-clip misread | ✅ this PR (transitively) |
| 4: refresh button uses mint primary color (attributed to PR #329 L3) | PR #329 L3 was NOT merged; the mint button is the existing `--primary` token unchanged | ⚠ misdiagnosed |
| 5: default-model dropdown lacks model-within-connection selection | needs new `setDefault({slug, model})` IPC + GeneralDefaultsCard rewire onto grouped Select | 🔜 separate PR |
| 6: Codex OAuth dropdown leaks user email | `connection.name` built as `Codex OAuth · ${state.email}` at the source | ✅ this PR |

## What's fixed in this PR

### Bug 1: model row second line clipped (1 of 4 model-list bugs)

`.modelTableRow` is a `Button` recipe whose default `size="md"` ships `h-9` (36px fixed). Each row now has TWO text lines (display name + raw id when `showRawId`), so the second line's lower descender got clipped ("gpt-5.4" → "ant 5.4" in the screenshot). Recipe override:

```css
.modelTableRow {
  height: auto;
  min-height: 44px;
  padding: 8px 10px;  /* was 4px 8px */
}
```

This also resolves bug 2 (the apparent "middle row has a different background" is just the focused/hovered state on the taller row, reading as expected behavior with the height fixed) and bug 3 (`.modelTableRowId` already had truncation; the visible mismatch was the same height clip misread).

### Bug 6: OAuth display name leaks user email

`apps/desktop/src/main/main.ts:347` and `:402` were building the connection display name as `Claude OAuth · ${state.profile.email}` (and the symmetric Codex path). That value is persisted as `connection.name` and surfaces in every model picker, settings dropdown, account list, and capability audit — anywhere the connection is identified by name. The email belongs on the Account · 模型 page, not in the model identity. Both paths now use brand-only labels.

## What's deferred

### Bug 5 — separate PR

`GeneralDefaultsCard` currently shows ONLY connection options (e.g., "Claude OAuth", "Codex OAuth"); WAWQAQ wants the dropdown to also let the user pick a specific model within that connection. The fix requires:

- A new IPC contract `setDefault({slug, model})` (vs current `setDefault(slug)`)
- Rewiring `GeneralDefaultsCard` onto the grouped `Select` pattern that `ChatModelSwitcher` already uses (`packages/ui/src/chat-model-switcher.tsx`)
- Migrating existing stored defaults

This is a backend-touching change with its own contract scope. Filing as a separate PR per scope discipline.

### Bug 4 — misdiagnosed

The aesthetics expert's bug 4 claim ("mint button is PR #329 L3's fault") doesn't hold: PR #329 L3 commit `023b90b2` was NEVER merged (only the L1 vibrancy unblock from `7d008d51` shipped). The sage-green refresh button is the existing `Button variant="default"` rendering `--primary`, unchanged for weeks. No fix needed.

## Tests

`tsc --noEmit` clean against my edits. Two pre-existing TS errors (`displayName` in `model-catalog-choices.test.ts` and `recordActiveFullCompactBlock` in `main.ts:888`) also fail on `main` without my changes; unrelated.

Pure-CSS height change + main-process string-literal change; no JSX/IPC surface changes.