### PR TITLE
fix(settings): pick default model by connection model

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -153,6 +153,7 @@ declare global {
         list(): Promise<LlmConnection[]>;
         getDefault(): Promise<string | null>;
         setDefault(slug: string | null): Promise<void>;
+        setDefaultModel(input: { slug: string; model: string } | null): Promise<void>;
         create(input: CreateConnectionInput): Promise<LlmConnection>;
         update(slug: string, patch: UpdateConnectionInput): Promise<LlmConnection>;
         delete(slug: string): Promise<void>;

--- a/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
@@ -5,6 +5,9 @@ import { join, resolve } from 'node:path';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
 const SETTINGS_MODAL = join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'settings', 'SettingsModal.tsx');
+const MAIN_SOURCE = join(REPO_ROOT, 'apps', 'desktop', 'src', 'main', 'main.ts');
+const PRELOAD_SOURCE = join(REPO_ROOT, 'apps', 'desktop', 'src', 'preload', 'preload.ts');
+const GLOBAL_DTS = join(REPO_ROOT, 'apps', 'desktop', 'src', 'global.d.ts');
 
 /**
  * PR-GENERAL-DEFAULTS-CONFIGURABLE-0 (WAWQAQ msg `d3ea9a33` 2026-06-26).
@@ -41,7 +44,7 @@ describe('General settings configurable contract', () => {
     );
   });
 
-  it('renders a real <GeneralDefaultsCard> that persists the default model via connections.setDefault', async () => {
+  it('renders a real <GeneralDefaultsCard> that persists the default model via model-level IPC', async () => {
     const src = await readFile(SETTINGS_MODAL, 'utf8');
     // The card must be defined and used.
     assert.match(
@@ -55,16 +58,28 @@ describe('General settings configurable contract', () => {
       '<GeneralDefaultsCard> must be mounted by the General-page render branch with connections / defaultSlug / onRefresh wired through',
     );
     // The actual select + persistence must use the shared SettingsSelect
-    // and the existing connections.setDefault IPC.
+    // and the model-level default IPC. The old connection-only selector used
+    // `connection.name`, which can embed OAuth account email; default-model
+    // choices are now grouped from safe model catalog choices.
     assert.match(
       src,
-      /<SettingsSelect[\s\S]*ariaLabel="默认模型连接"[\s\S]*onChange=/,
+      /<SettingsSelect[\s\S]*ariaLabel="默认模型"[\s\S]*optionGroups=\{optionGroups\}[\s\S]*onChange=/,
       'GeneralDefaultsCard must use the shared <SettingsSelect> primitive (not a custom dropdown) so the popup layering, keyboard nav, and chrome match the rest of Settings',
     );
     assert.match(
       src,
-      /window\.maka\.connections\.setDefault\(/,
-      'GeneralDefaultsCard must persist the choice through the existing connections.setDefault IPC; no new app-settings field needed',
+      /buildCatalogChatModelChoices\(props\.connections\)[\s\S]*modelMenuGroups\(modelChoices\)[\s\S]*modelChoiceValue\(choice\.connectionSlug, choice\.model\)/,
+      'GeneralDefaultsCard must flatten safe model catalog choices into grouped connection/model options',
+    );
+    assert.doesNotMatch(
+      src,
+      /opts\.push\(\[connection\.slug, connection\.name\]\)/,
+      'GeneralDefaultsCard must not use connection.name as option copy because OAuth connection names can carry account emails',
+    );
+    assert.match(
+      src,
+      /window\.maka\.connections\.setDefaultModel\(/,
+      'GeneralDefaultsCard must persist the selected connection+model pair through a model-level default IPC',
     );
   });
 
@@ -87,13 +102,27 @@ describe('General settings configurable contract', () => {
     );
     assert.match(
       cardBlock,
-      /if \(savingRef\.current\) return;[\s\S]*savingRef\.current = true;[\s\S]*setSaving\(true\);[\s\S]*await window\.maka\.connections\.setDefault/,
+      /if \(savingRef\.current\) return;[\s\S]*savingRef\.current = true;[\s\S]*setSaving\(true\);[\s\S]*await window\.maka\.connections\.setDefaultModel/,
       'GeneralDefaultsCard must take the synchronous savingRef lock before awaiting the IPC; React state alone is not enough to block double-clicks',
     );
     assert.match(
       cardBlock,
       /catch \(error\)[\s\S]*if \(mountedRef\.current\) \{[\s\S]*toast\.error\('保存默认模型失败'/,
       'GeneralDefaultsCard failures must surface a localized toast and only while still mounted — silent unhandled rejection regressed the page before',
+    );
+  });
+
+  it('exposes a default-model IPC that validates the model against chat-selectable catalog entries', async () => {
+    const main = await readFile(MAIN_SOURCE, 'utf8');
+    const preload = await readFile(PRELOAD_SOURCE, 'utf8');
+    const globalDts = await readFile(GLOBAL_DTS, 'utf8');
+
+    assert.match(preload, /setDefaultModel\(input: \{ slug: string; model: string \} \| null\): Promise<void> \{[\s\S]*ipcRenderer\.invoke\('connections:setDefaultModel', input\)/);
+    assert.match(globalDts, /setDefaultModel\(input: \{ slug: string; model: string \} \| null\): Promise<void>;/);
+    assert.match(
+      main,
+      /ipcMain\.handle\('connections:setDefaultModel'[\s\S]*normalizeConnectionSlugForIpc\(input\.slug, 'connection slug'\)[\s\S]*buildConnectionModelCatalogEntries\(\{ connection \}\)[\s\S]*entry\.id === model && entry\.canUseAsChatDefault[\s\S]*connectionStore\.update\(slug, \{ defaultModel: model \}\)[\s\S]*connectionStore\.setDefault\(slug\)/,
+      'main process must validate slug/model, reject non-chat defaults, update the connection default model, then set the default connection in one IPC',
     );
   });
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -10,6 +10,7 @@ import {
   generalizedErrorMessageChinese,
   redactSecrets,
   buildHealthSnapshot,
+  buildConnectionModelCatalogEntries,
   healthSignalFromCapability,
   healthSignalFromConnection,
   healthSignalFromConnectionRuntime,
@@ -3236,6 +3237,32 @@ function registerIpc(): void {
       throw new Error(`No such connection: ${normalizedSlug}`);
     }
     await connectionStore.setDefault(normalizedSlug);
+    emitConnectionListChanged();
+  });
+  ipcMain.handle('connections:setDefaultModel', async (_event, input: { slug: string; model: string } | null) => {
+    if (input === null) {
+      await connectionStore.setDefault(null);
+      emitConnectionListChanged();
+      return;
+    }
+    if (!input || typeof input !== 'object' || typeof input.slug !== 'string' || typeof input.model !== 'string') {
+      throw new Error('Default model input must include slug and model');
+    }
+    const slug = normalizeConnectionSlugForIpc(input.slug, 'connection slug');
+    const model = input.model.trim();
+    if (!model) throw new Error('Default model must not be empty');
+    const connection = await connectionStore.get(slug);
+    if (!connection) throw new Error(`No such connection: ${slug}`);
+    if (!connection.enabled) throw new Error(`Connection is disabled: ${slug}`);
+    const selectable = buildConnectionModelCatalogEntries({ connection })
+      .some((entry) => entry.id === model && entry.canUseAsChatDefault);
+    if (!selectable) {
+      throw new Error(`Model is not available for chat default: ${model}`);
+    }
+    if (connection.defaultModel !== model) {
+      await connectionStore.update(slug, { defaultModel: model });
+    }
+    await connectionStore.setDefault(slug);
     emitConnectionListChanged();
   });
   ipcMain.handle('connections:create', async (_event, input: CreateConnectionInput) => {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -216,6 +216,9 @@ contextBridge.exposeInMainWorld('maka', {
     setDefault(slug: string | null): Promise<void> {
       return ipcRenderer.invoke('connections:setDefault', slug);
     },
+    setDefaultModel(input: { slug: string; model: string } | null): Promise<void> {
+      return ipcRenderer.invoke('connections:setDefaultModel', input);
+    },
     create(input: CreateConnectionInput): Promise<LlmConnection> {
       return ipcRenderer.invoke('connections:create', input);
     },

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -95,6 +95,9 @@ import {
   RelativeTime,
   SettingsSegmented as Segmented,
   SettingsSelect,
+  modelChoiceValue,
+  modelMenuGroups,
+  parseModelChoiceValue,
   SettingsSwitch as Switch,
   PrimitiveBadge,
   Textarea,
@@ -103,7 +106,7 @@ import {
   useToast,
 } from '@maka/ui';
 import { normalizeSearchUrl } from '@maka/core';
-import { ProvidersPanel } from './ProvidersPanel';
+import { ProviderLogo, ProvidersPanel } from './ProvidersPanel';
 import { PasswordInput } from './password-input';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { applyUiLocale, type UiLocalePreference } from '../theme';
@@ -118,7 +121,7 @@ import {
   presentConnectionUiStatus,
   type ConnectionUiStatus,
 } from '../connection-status';
-import { buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
+import { buildCatalogChatModelChoices, buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
 import {
   NAV_GROUP_ORDER,
   type SettingsNavGroup,
@@ -1067,9 +1070,9 @@ function SettingsSurface(props: {
  * (启动 / 新对话模式 / 默认模型) that read like settings but had no
  * configurable backing — the static text was the entire UI. Drop the
  * two without backing storage; replace the third with a real
- * `<SettingsSelect>` that lets the user pick the default LLM
- * connection inline. The `connections.setDefault(slug)` IPC already
- * exists; this just wires it up.
+ * `<SettingsSelect>` that lets the user pick the default LLM model
+ * inline. The selection is grouped by connection, but the persisted
+ * default is the pair `{ slug, model }` via `connections.setDefaultModel`.
  */
 function GeneralDefaultsCard(props: {
   connections: readonly LlmConnection[];
@@ -1089,23 +1092,41 @@ function GeneralDefaultsCard(props: {
     };
   }, []);
 
+  const modelChoices = useMemo(() => buildCatalogChatModelChoices(props.connections), [props.connections]);
+  const optionGroups = useMemo(() => {
+    return modelMenuGroups(modelChoices).map((group) => ({
+      label: group.heading,
+      icon: <ProviderLogo type={group.providerType} compact />,
+      options: group.choices.map((choice) => [
+        modelChoiceValue(choice.connectionSlug, choice.model),
+        choice.label,
+      ] as const),
+    }));
+  }, [modelChoices]);
   const options = useMemo<ReadonlyArray<readonly [string, string]>>(() => {
-    const opts: Array<readonly [string, string]> = [['', '未设置']];
-    for (const connection of props.connections) {
-      if (!connection.enabled) continue;
-      opts.push([connection.slug, connection.name]);
-    }
-    return opts;
-  }, [props.connections]);
+    return [
+      ['', '未设置'],
+      ...optionGroups.flatMap((group) => group.options),
+    ];
+  }, [optionGroups]);
+  const selectedValue = useMemo(() => {
+    if (!props.defaultSlug) return '';
+    const connection = props.connections.find((candidate) => candidate.slug === props.defaultSlug);
+    if (!connection?.defaultModel) return '';
+    const value = modelChoiceValue(connection.slug, connection.defaultModel);
+    return options.some(([candidate]) => candidate === value) ? value : '';
+  }, [options, props.connections, props.defaultSlug]);
 
-  const selectedValue = props.defaultSlug ?? '';
-
-  async function persistDefault(nextSlug: string) {
+  async function persistDefault(nextValue: string) {
     if (savingRef.current) return;
     savingRef.current = true;
     setSaving(true);
     try {
-      await window.maka.connections.setDefault(nextSlug || null);
+      const parsed = parseModelChoiceValue(nextValue);
+      await window.maka.connections.setDefaultModel(parsed ? {
+        slug: parsed.llmConnectionSlug,
+        model: parsed.model,
+      } : null);
       if (!mountedRef.current) return;
       await props.onRefresh();
     } catch (error) {
@@ -1125,12 +1146,13 @@ function GeneralDefaultsCard(props: {
       <div className="settingsRow" data-control-width="select">
         <div>
           <strong>默认模型</strong>
-          <small>新对话默认使用的模型连接；可在「模型」页里管理具体连接。</small>
+          <small>新对话默认使用的具体模型；按连接分组，不显示 OAuth 账号邮箱。</small>
         </div>
         <SettingsSelect
           value={selectedValue}
-          ariaLabel="默认模型连接"
+          ariaLabel="默认模型"
           options={options}
+          optionGroups={optionGroups}
           disabled={saving}
           onChange={(value) => {
             void persistDefault(value);

--- a/packages/ui/src/primitives/settings-select.tsx
+++ b/packages/ui/src/primitives/settings-select.tsx
@@ -3,11 +3,14 @@
 import type { ReactElement, ReactNode } from "react";
 import { cn } from "../utils.js";
 import {
+  SelectGroup,
+  SelectGroupLabel,
   SelectItem,
   SelectPopup,
   SelectPortal,
   SelectPositioner,
   SelectRoot,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "../ui.js";
@@ -43,9 +46,16 @@ export type SettingsSelectOption<T extends string> =
   | readonly [T, string]
   | readonly [T, string, ReactNode];
 
+export interface SettingsSelectOptionGroup<T extends string> {
+  label: string;
+  icon?: ReactNode;
+  options: ReadonlyArray<SettingsSelectOption<T>>;
+}
+
 export interface SettingsSelectProps<T extends string> {
   value: T;
   options: ReadonlyArray<SettingsSelectOption<T>>;
+  optionGroups?: ReadonlyArray<SettingsSelectOptionGroup<T>>;
   onChange(value: T): void;
   ariaLabel: string;
   disabled?: boolean;
@@ -65,6 +75,14 @@ export function SettingsSelect<T extends string>(
   props: SettingsSelectProps<T>,
 ): ReactElement {
   const width = props.width ?? "select";
+  const groupedValues = new Set<T>();
+  for (const group of props.optionGroups ?? []) {
+    for (const [value] of group.options) groupedValues.add(value);
+  }
+  const ungroupedOptions = props.optionGroups
+    ? props.options.filter(([value]) => !groupedValues.has(value))
+    : props.options;
+  const hasOptionGroups = Boolean(props.optionGroups && props.optionGroups.length > 0);
   // Build a value → {label, icon} lookup so the selected-state trigger
   // can render the same icon + label row as the popup items. Without
   // this the collapsed trigger drops the icon — see Plan Reminder bug
@@ -109,8 +127,8 @@ export function SettingsSelect<T extends string>(
       </SelectTrigger>
       <SelectPortal>
         <SelectPositioner alignItemWithTrigger={false} sideOffset={6} className="settingsSelectPositioner">
-          <SelectPopup className="settingsSelectPopup">
-            {props.options.map((option) => {
+          <SelectPopup className={cn("settingsSelectPopup", hasOptionGroups ? "settingsSelectMenuPopup" : null)}>
+            {ungroupedOptions.map((option) => {
               const [value, label] = option;
               const icon = option.length === 3 ? option[2] : null;
               return (
@@ -119,6 +137,32 @@ export function SettingsSelect<T extends string>(
                 </SelectItem>
               );
             })}
+            {ungroupedOptions.length > 0 && props.optionGroups && props.optionGroups.length > 0 && (
+              <SelectSeparator />
+            )}
+            {props.optionGroups?.map((group) => (
+              <SelectGroup key={group.label}>
+                <SelectGroupLabel className="settingsSelectMenuGroupLabel">
+                  {group.icon ? (
+                    <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{group.icon}</span>
+                  ) : (
+                    <span aria-hidden="true" />
+                  )}
+                  <span>{group.label}</span>
+                </SelectGroupLabel>
+                {group.options.map((option) => {
+                  const [value, label] = option;
+                  const icon = option.length === 3 ? option[2] : null;
+                  return (
+                    <SelectItem key={value} value={value}>
+                      <span className="settingsSelectMenuOption">
+                        {renderOptionRow(label, icon)}
+                      </span>
+                    </SelectItem>
+                  );
+                })}
+              </SelectGroup>
+            ))}
           </SelectPopup>
         </SelectPositioner>
       </SelectPortal>


### PR DESCRIPTION
## Summary
- General default model selector now lists concrete connection + model options instead of connection-only choices.
- Adds a model-level default IPC path with main-process validation against chat-selectable catalog entries.
- Uses safe provider/connection labels in the picker so OAuth account emails are not leaked as default-model labels.

## Tests
- npm -w @maka/ui run typecheck
- npm -w @maka/ui run build
- npm -w @maka/desktop run typecheck
- npm -w @maka/desktop run build:main
- node --test dist/main/__tests__/general-settings-configurable-contract.test.js dist/main/__tests__/model-oauth-section-contract.test.js dist/main/__tests__/settings-form-a11y-contract.test.js
- npm -w @maka/desktop run build

Note: `npm -w @maka/desktop run test -- general-settings-configurable-contract model-oauth-section-contract` still invokes the full compiled desktop suite instead of filtering. That exposed unrelated existing failures in `daily-review-copy-feedback-contract.test.js` and `real-window-smoke-contract.test.js`; the focused compiled contract command above passes.