### PR TITLE
fix(headless): keep RSI trace feedback focused

### DIFF
--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -232,6 +232,34 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('does not summarize recovered tool failures from passed held-in tasks', () => {
+    const rendered = renderMetaAgentPrompt({
+      runId: 'run-1',
+      roundId: 'round-1',
+      program: 'Improve the prompt conservatively.\n',
+      currentSystemPrompt: 'original prompt\n',
+      resultsTsv: 'task_id\tpassed\npassed-task\ttrue\nfailed-task\tfalse\n',
+      heldInDigests: [
+        {
+          taskId: 'passed-task',
+          summary: 'passed after retry',
+          toolFailures: [{ name: 'Write', count: 1, errorClass: 'Validation', argsPreview: 'path' }],
+        },
+        {
+          taskId: 'failed-task',
+          errorClass: 'verification_failed',
+          summary: 'failed verification',
+          toolFailures: [{ name: 'Bash', count: 1, errorClass: 'RuntimeError', argsPreview: 'command' }],
+        },
+      ],
+    });
+
+    assert.match(rendered, /Bash x1 error=RuntimeError args=command tasks=failed-task/);
+    assert.equal(rendered.includes('passed-task'), true);
+    assert.equal(rendered.includes('Write x1'), false);
+    assert.equal(rendered.includes('tasks=passed-task'), false);
+  });
+
   test('rejects meta-agent output without candidateRationale before writing or committing', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');

--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -305,6 +305,33 @@ describe('RSI round analysis', () => {
     });
   });
 
+  test('keeps useful runtime calls when partial events exceed raw JSONL limits', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime.jsonl');
+      const traceEventsPath = join(dir, 'trace.jsonl');
+      const noisyPartial = { content: { kind: 'thinking', text: 'x'.repeat(50_000), partial: true } };
+
+      await writeJsonl(runtimeEventsPath, [
+        ...Array.from({ length: 25 }, () => noisyPartial),
+        functionCall('call-a', 'Write', { path: '/app/output.txt', content: 'done' }),
+      ]);
+      await writeJsonl(traceEventsPath, [toolFailed('call-a', 'Write', 'Validation')]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath, traceEventsPath }),
+        ],
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        { name: 'Write', errorClass: 'Validation', argsPreview: 'content,path', count: 1, taskIds: ['task-a'] },
+      ]);
+      assert.deepEqual(traceUnavailableSignals(analysis), []);
+    });
+  });
+
   test('treats non-positive tool failure cluster limits as zero', async () => {
     await withDir(async (dir) => {
       const runtimeEventsPath = join(dir, 'runtime.jsonl');

--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -186,6 +186,48 @@ describe('RSI round analysis', () => {
     });
   });
 
+  test('does not aggregate recovered tool failures from passed held-in tasks', async () => {
+    await withDir(async (dir) => {
+      const passedRuntime = join(dir, 'passed-runtime.jsonl');
+      const passedTrace = join(dir, 'passed-trace.jsonl');
+      const failedRuntime = join(dir, 'failed-runtime.jsonl');
+      const failedTrace = join(dir, 'failed-trace.jsonl');
+
+      await writeJsonl(passedRuntime, [functionCall('passed-call', 'Read', { path: '/app/input.txt' })]);
+      await writeJsonl(passedTrace, [toolFailed('passed-call', 'Read', 'Error')]);
+      await writeJsonl(failedRuntime, [functionCall('failed-call', 'Write', { path: '/app/output.txt' })]);
+      await writeJsonl(failedTrace, [toolFailed('failed-call', 'Write', 'Error')]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['passed-task', 'failed-task'],
+        lastKeptEvents: [
+          completed({ taskId: 'passed-task', passed: true }),
+          completed({ taskId: 'failed-task', passed: false, errorClass: 'verification_failed' }),
+        ],
+        candidateEvents: [
+          completed({ taskId: 'passed-task', passed: true, runtimeEventsPath: passedRuntime, traceEventsPath: passedTrace }),
+          completed({ taskId: 'failed-task', passed: false, errorClass: 'verification_failed', runtimeEventsPath: failedRuntime, traceEventsPath: failedTrace }),
+        ],
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        { name: 'Write', errorClass: 'Error', argsPreview: 'path', count: 1, taskIds: ['failed-task'] },
+      ]);
+      assert.deepEqual(
+        analysis.signals
+          .filter((signal) => signal.kind === 'tool_failure_cluster')
+          .map(({ id: _id, ...signal }) => signal),
+        [
+          {
+            kind: 'tool_failure_cluster',
+            taskIds: ['failed-task'],
+            cluster: { name: 'Write', errorClass: 'Error', argsPreview: 'path', count: 1, taskIds: ['failed-task'] },
+          },
+        ],
+      );
+    });
+  });
+
   test('aggregates tool failure clusters from plumbing events with traces', async () => {
     await withDir(async (dir) => {
       const runtimeEventsPath = join(dir, 'runtime.jsonl');

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -407,7 +407,7 @@ export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {
     input.currentSystemPrompt,
     '# Results TSV',
     input.resultsTsv,
-    ...renderToolFailureSummary(input.heldInDigests),
+    ...renderToolFailureSummary(input.heldInDigests, input.resultsTsv),
     ...renderRsiAnalysis(input.rsiAnalysis),
     ...renderPromptAttribution(input.promptAttribution),
     '# Held-In Digests',
@@ -835,9 +835,11 @@ async function extractToolFailureDigests(
     .slice(0, 5);
 }
 
-function renderToolFailureSummary(digests: readonly TrajectoryDigest[]): string[] {
+function renderToolFailureSummary(digests: readonly TrajectoryDigest[], resultsTsv: string): string[] {
+  const passedByTask = passedResultsByTask(resultsTsv);
   const failures = new Map<string, { digest: TrajectoryToolFailureDigest; taskIds: Set<string> }>();
   for (const digest of digests) {
+    if (passedByTask?.get(digest.taskId) === true) continue;
     for (const failure of digest.toolFailures ?? []) {
       const key = [failure.name, failure.errorClass ?? '', failure.argsPreview ?? ''].join('\0');
       const current = failures.get(key) ?? { digest: { ...failure, count: 0 }, taskIds: new Set<string>() };
@@ -856,6 +858,23 @@ function renderToolFailureSummary(digests: readonly TrajectoryDigest[]): string[
       `tasks=${[...taskIds].sort((a, b) => a.localeCompare(b)).join(',')}`,
     ].join(' '));
   return lines.length > 0 ? ['# Held-In Tool Failure Summary', ...lines] : [];
+}
+
+function passedResultsByTask(resultsTsv: string): ReadonlyMap<string, boolean> | undefined {
+  const lines = resultsTsv.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const header = lines[0]?.split('\t');
+  if (!header) return undefined;
+  const taskIdIndex = header.indexOf('task_id');
+  const passedIndex = header.indexOf('passed');
+  if (taskIdIndex === -1 || passedIndex === -1) return undefined;
+  const passedByTask = new Map<string, boolean>();
+  for (const line of lines.slice(1)) {
+    const columns = line.split('\t');
+    const taskId = columns[taskIdIndex];
+    if (!taskId) continue;
+    passedByTask.set(taskId, columns[passedIndex] === 'true');
+  }
+  return passedByTask;
 }
 
 function functionCallDigest(event: unknown): TrajectoryToolCallDigest | undefined {

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
 import type { FixedPromptTaskWalEvent } from './fixed-prompt-controller.js';
 
 const DEFAULT_MAX_TOOL_FAILURE_CLUSTERS = 10;
@@ -344,7 +346,7 @@ async function functionCallsById(
   path: string,
   limits: NormalizedToolFailureLimits,
 ): Promise<FunctionCallsByIdResult> {
-  const runtimeEvents = await readBoundedJsonl(path, limits);
+  const runtimeEvents = await readProjectedJsonl(path, limits, isFunctionCallEvent);
   if (!runtimeEvents.ok) return runtimeEvents;
   const calls = new Map<string, { name: string; argsPreview: string }>();
   for (const event of runtimeEvents.events) {
@@ -357,6 +359,40 @@ async function functionCallsById(
     });
   }
   return { ok: true, value: calls };
+}
+
+async function readProjectedJsonl(
+  path: string,
+  limits: NormalizedToolFailureLimits,
+  keepEvent: (event: unknown) => boolean,
+): Promise<BoundedJsonlResult> {
+  const events: unknown[] = [];
+  let keptBytes = 0;
+  const stream = createReadStream(path, { encoding: 'utf8' });
+  const lines = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      if (line.trim().length === 0) continue;
+      let event: unknown;
+      try {
+        event = JSON.parse(line) as unknown;
+      } catch {
+        return { ok: false, reason: 'invalid_jsonl' };
+      }
+      if (!keepEvent(event)) continue;
+      keptBytes += Buffer.byteLength(line, 'utf8');
+      if (keptBytes > limits.maxJsonlBytes || events.length + 1 > limits.maxJsonlLines) {
+        return { ok: false, reason: 'input_limit_exceeded' };
+      }
+      events.push(event);
+    }
+  } catch (error) {
+    return { ok: false, reason: isNotFound(error) ? 'missing_file' : 'unreadable' };
+  } finally {
+    lines.close();
+    stream.destroy();
+  }
+  return { ok: true, events };
 }
 
 async function readBoundedJsonl(path: string, limits: NormalizedToolFailureLimits): Promise<BoundedJsonlResult> {
@@ -389,6 +425,12 @@ async function readBoundedJsonl(path: string, limits: NormalizedToolFailureLimit
     }
   }
   return { ok: true, events };
+}
+
+function isFunctionCallEvent(event: unknown): boolean {
+  return isRecord(event)
+    && isRecord(event.content)
+    && event.content.kind === 'function_call';
 }
 
 function toolFailureDigest(

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -294,6 +294,7 @@ async function toolFailureClusters(
   for (const taskId of heldInTaskIds) {
     const event = events.get(taskId);
     if (!event || !hasRuntimePath(event)) continue;
+    if (event.type === 'task_completed' && event.eligible && event.scored && event.passed) continue;
     if (!hasTracePath(event)) {
       addTraceUnavailable(traceUnavailable, taskId, 'trace', 'missing_path');
       continue;


### PR DESCRIPTION
## Summary

- Filter runtime event JSONL down to useful function-call events before applying RSI analysis size and line limits.
- Keep recovered tool failures from passed held-in tasks out of both the RSI analysis tool-failure clusters and the meta-agent tool failure summary.

## Why

The pilot trace artifacts contain lots of partial thinking/tool stream noise. The raw runtime file can exceed the JSONL limit even when the useful function-call context is small enough, which leaves RSI feedback without args context. Passed tasks can also contain recovered tool failures, and summarizing or signaling those made the meta-agent over-attribute root cause to incidental tools.

Closes: none

## Scope

Changed:

- `rsi-round-analysis` now projects runtime events before bounding function-call context.
- `rsi-round-analysis` no longer aggregates trace-derived tool failures from passed, scored, eligible held-in tasks.
- `prompt-candidate-loop` now filters tool failure summary rows using held-in pass/fail results.
- Added regression tests for these feedback paths.

Not included:

- No changes to Harbor execution, scoring, acceptance gates, or prompt optimization profiles.
- No broad trace artifact redesign.

## Verification

- `npm run -w @maka/headless test`

## User-facing impact

No desktop UI impact. RSI prompt optimization feedback should be less noisy and less likely to overfit to recovered tool errors.

## Reviewer notes

This is intentionally a narrow fix before rerunning a paid pilot. Trace JSONL bounding for trace-side tool failure events stays unchanged; only runtime function-call lookup now filters before bounding.