### PR TITLE
fix(headless): retry malformed meta-agent candidates

### DIFF
--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1595,6 +1595,34 @@ describe('prompt candidate loop', () => {
     assert.match(prompts[1], /candidateRationale\.evidenceRefs must be an array/);
   });
 
+  test('does not echo invalid JSON text into the meta-agent retry prompt', async () => {
+    const input: MetaAgentPromptInput = {
+      runId: 'run-1',
+      roundId: 'round-1',
+      program: 'Improve conservatively.',
+      currentSystemPrompt: 'original prompt',
+      resultsTsv: 'task_id\tpassed\ntask-a\tfalse\n',
+      heldInDigests: [{ taskId: 'task-a', summary: 'failed verification' }],
+    };
+    const prompts: string[] = [];
+    const expected = candidatePromptResult({
+      systemPrompt: 'candidate prompt after retry\n',
+      summary: 'valid JSON after retry',
+    });
+    const metaAgent = createScriptedMetaAgent({
+      complete: async ({ prompt }) => {
+        prompts.push(prompt);
+        if (prompts.length === 1) return 'SECRET_CANARY not json';
+        return JSON.stringify(expected);
+      },
+    });
+
+    assert.deepEqual(await metaAgent(input), expected);
+    assert.equal(prompts.length, 2);
+    assert.match(prompts[1], /meta-agent output was not valid JSON/);
+    assert.equal(prompts[1].includes('SECRET_CAN'), false);
+  });
+
   test('CLI git adapter commits only system_prompt.md with the round message', async () => {
     await withDir(async (dir) => {
       await execFileAsync('git', ['init'], { cwd: dir });

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -1556,6 +1556,45 @@ describe('prompt candidate loop', () => {
     });
   });
 
+  test('retries scripted meta-agent after candidateRationale schema errors', async () => {
+    const input: MetaAgentPromptInput = {
+      runId: 'run-1',
+      roundId: 'round-1',
+      program: 'Improve conservatively.',
+      currentSystemPrompt: 'original prompt',
+      resultsTsv: 'task_id\tpassed\ntask-a\tfalse\n',
+      heldInDigests: [
+        {
+          taskId: 'task-a',
+          errorClass: 'verification_failed',
+          summary: 'missing expected line',
+        },
+      ],
+    };
+    const prompts: string[] = [];
+    const expected = candidatePromptResult({
+      systemPrompt: 'candidate prompt after retry\n',
+      summary: 'ask for exact output line after retry',
+      candidateRationale: validCandidateRationale(),
+    });
+    const metaAgent = createScriptedMetaAgent({
+      complete: async ({ prompt }) => {
+        prompts.push(prompt);
+        if (prompts.length === 1) {
+          return JSON.stringify(candidatePromptResult({
+            candidateRationale: validCandidateRationale({ evidenceRefs: 'rsi-sig:not-an-array' }),
+          }));
+        }
+        return JSON.stringify(expected);
+      },
+    });
+
+    assert.deepEqual(await metaAgent(input), expected);
+    assert.equal(prompts.length, 2);
+    assert.match(prompts[1], /previous meta-agent response was invalid/i);
+    assert.match(prompts[1], /candidateRationale\.evidenceRefs must be an array/);
+  });
+
   test('CLI git adapter commits only system_prompt.md with the round message', async () => {
     await withDir(async (dir) => {
       await execFileAsync('git', ['init'], { cwd: dir });

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -420,6 +420,7 @@ function renderMetaAgentRetryPrompt(basePrompt: string, attempt: number, validat
 }
 
 function formatMetaAgentParseError(error: unknown): string {
+  if (error instanceof SyntaxError) return 'meta-agent output was not valid JSON';
   const message = error instanceof Error ? error.message : String(error);
   return message.replace(/\s+/g, ' ').slice(0, META_AGENT_RETRY_ERROR_MAX_CHARS);
 }

--- a/packages/headless/src/prompt-candidate-loop.ts
+++ b/packages/headless/src/prompt-candidate-loop.ts
@@ -24,6 +24,8 @@ const execFileAsync = promisify(execFile);
 const CANDIDATE_RATIONALE_MAX_TASK_IDS = 16;
 const CANDIDATE_RATIONALE_MAX_TEXT_CHARS = 280;
 const CANDIDATE_RATIONALE_MAX_SERIALIZED_CHARS = 2000;
+const META_AGENT_MAX_ATTEMPTS = 3;
+const META_AGENT_RETRY_ERROR_MAX_CHARS = 240;
 const FORBIDDEN_RATIONALE_TEXT_RE = /```|\r|\n|held[-_]out|verifier|expected[- ]output|\/app\/|tests\/|test\.sh|canary|runtime-events|events\.jsonl|raw trace/i;
 
 export interface TrajectoryDigest {
@@ -388,9 +390,38 @@ export async function scanRuntimeEventsForRewardHack(
 
 export function createScriptedMetaAgent(input: CreateScriptedMetaAgentInput): MetaAgent {
   return async (promptInput) => {
-    const raw = await input.complete({ prompt: renderMetaAgentPrompt(promptInput) });
-    return parseMetaAgentResult(raw);
+    const basePrompt = renderMetaAgentPrompt(promptInput);
+    let lastParseError = 'unknown schema error';
+    for (let attempt = 1; attempt <= META_AGENT_MAX_ATTEMPTS; attempt += 1) {
+      const raw = await input.complete({
+        prompt: attempt === 1 ? basePrompt : renderMetaAgentRetryPrompt(basePrompt, attempt, lastParseError),
+      });
+      try {
+        return parseMetaAgentResult(raw);
+      } catch (error) {
+        if (attempt === META_AGENT_MAX_ATTEMPTS) throw error;
+        lastParseError = formatMetaAgentParseError(error);
+      }
+    }
+    throw new Error('meta-agent output parsing exhausted retry attempts');
   };
+}
+
+function renderMetaAgentRetryPrompt(basePrompt: string, attempt: number, validationError: string): string {
+  return [
+    basePrompt.trimEnd(),
+    '',
+    '# Retry Feedback',
+    `The previous meta-agent response was invalid for the required JSON schema on attempt ${attempt - 1}.`,
+    `Validation error: ${validationError}`,
+    'Return JSON only using the exact required schema. Arrays must be JSON arrays even when they contain one item.',
+    '',
+  ].join('\n');
+}
+
+function formatMetaAgentParseError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/\s+/g, ' ').slice(0, META_AGENT_RETRY_ERROR_MAX_CHARS);
 }
 
 export function renderMetaAgentPrompt(input: MetaAgentPromptInput): string {


### PR DESCRIPTION
## Summary

- Retry scripted meta-agent completions when returned JSON fails the required `candidateRationale` schema.
- Feed back a bounded validation error on retry without including the raw invalid model output.
- Add regression coverage for the `candidateRationale.evidenceRefs` string-vs-array crash and invalid JSON retry prompt redaction.

Closes #311.

## Why

A real RSI pilot crashed after round-0 because the meta-agent returned `candidateRationale.evidenceRefs` as a string instead of an array. That is a recoverable schema correction, not a reason to kill the whole run after Harbor work has already been spent.

With #311 scoped to first accepted pilot evidence, this PR also carries the closing validation: the fixed pilot run completed, discarded one flat candidate, kept one improving candidate, passed structural smoke, and preserved the R2 safety boundary.

## Scope

Changed:

- `packages/headless/src/prompt-candidate-loop.ts`
- `packages/headless/src/__tests__/prompt-candidate-loop.test.ts`

Not included:

- No RSI gate or acceptance-threshold changes.
- No task-set, profile, budget, provider, or Harbor adapter changes.
- No reward-hack or trace-attribution behavior changes.
- No full 10-round Harbor run.

## Verification

- RED: `node --test --test-name-pattern "retries scripted meta-agent after candidateRationale schema errors" packages/headless/dist/__tests__/prompt-candidate-loop.test.js` failed with `candidateRationale.evidenceRefs must be an array` before the fix.
- RED: `node --test --test-name-pattern "does not echo invalid JSON text into the meta-agent retry prompt" packages/headless/dist/__tests__/prompt-candidate-loop.test.js` failed before the redaction fix because the retry prompt contained `SECRET_CAN` from `SyntaxError.message`.
- GREEN: `node --test --test-name-pattern "retries scripted meta-agent after candidateRationale schema errors|does not echo invalid JSON text into the meta-agent retry prompt" packages/headless/dist/__tests__/prompt-candidate-loop.test.js`
- `npm run -w @maka/headless test`
- Real pilot run: `rsi-meta-retry-pilot-light-20260701-011258`
  - structural smoke: pass
  - stopReason: `rounds_complete`
  - decisions: keep=1, discard=1
  - task events: completed=30, infra_failed=0, plumbing_failed=0
  - cost: `0.119795 / 1.25`
  - round-0 decision: `discard/held_in_within_noise`
  - round-1 decision: `keep/held_in_improved`
  - held-in improved from `6/8` to `7/8`; held-out passed `3/3`

## User-facing impact

No desktop UI impact. Headless RSI prompt-optimization runs are less likely to waste a run when the meta-agent returns a fixable JSON schema mistake.

## Reviewer notes

Run artifacts are under `/Users/yuhan/workspace/oss/maka-agent/maka-eval/rsi-runs/rsi-meta-retry-pilot-light-20260701-011258` on the local machine.
