### PR TITLE
fix(desktop): enable permission mode toggle for new conversations

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -107,6 +107,33 @@ describe('home composer new-chat model picker', () => {
     );
   });
 
+  it('wires the picked new-chat permission mode to one sessions.create call only', async () => {
+    const renderer = await readRendererShellCombinedSource();
+    const setPermissionModeBlock = renderer.match(/async function setPermissionMode[\s\S]*?async function setSessionModel/)?.[0] ?? '';
+    const sendBlock = renderer.match(/async function send\(text: string\): Promise<boolean> \{[\s\S]*?\n  async function importTextFilePrompt/)?.[0] ?? '';
+
+    assert.match(
+      renderer,
+      /const \[pendingNewChatPermissionMode, setPendingNewChatPermissionMode\] = useState<PermissionMode \| null>\(null\)/,
+      'AppShell must keep the picked empty-state permission mode in renderer-only state',
+    );
+    assert.match(
+      setPermissionModeBlock,
+      /if \(!sessionId\) \{[\s\S]*setPendingNewChatPermissionMode\(mode\);[\s\S]*return;[\s\S]*\}/,
+      'permission-mode picks without an active session must update pendingNewChatPermissionMode instead of calling IPC',
+    );
+    assert.match(
+      sendBlock,
+      /permissionMode: pendingNewChatPermissionMode \?\? 'ask'/,
+      'new-chat sessions.create must receive the picked pending permission mode',
+    );
+    assert.match(
+      sendBlock,
+      /setPendingNewChatPermissionMode\(null\);/,
+      'pending new-chat permission mode must be one-shot and reset after creating a session',
+    );
+  });
+
   it('does not let stale new-chat send creation steal the active session after navigation', async () => {
     const renderer = await readRendererShellCombinedSource();
     const sendBlock = renderer.match(/async function send\(text: string\): Promise<boolean> \{[\s\S]*?\n  async function importTextFilePrompt/)?.[0] ?? '';

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -198,8 +198,8 @@ describe('permission mode transition guard copy', () => {
     assert.match(renderer, /const \[pendingPermissionModeBySession, setPendingPermissionModeBySession\] = useState<Record<string, boolean>>\(\{\}\);/);
     assert.match(
       setPermissionModeBlock,
-      /const sessionId = activeIdRef\.current;[\s\S]*if \(!sessionId\) return;[\s\S]*pendingPermissionModeChangesRef\.current\.has\(sessionId\)/,
-      'Permission mode changes must capture the active session id and gate duplicate changes for that session',
+      /const sessionId = activeIdRef\.current;[\s\S]*if \(!sessionId\) \{[\s\S]*setPendingNewChatPermissionMode\(mode\);[\s\S]*return;[\s\S]*\}[\s\S]*pendingPermissionModeChangesRef\.current\.has\(sessionId\)/,
+      'Permission mode changes must capture the active session id, store no-session picks for the next chat, and gate duplicate changes for active sessions',
     );
     assert.match(setPermissionModeBlock, /pendingPermissionModeChangesRef\.current\.add\(sessionId\);[\s\S]*setPendingPermissionModeBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: true \}\)\);/);
     assert.match(setPermissionModeBlock, /sessionsRef\.current\.find\(\(session\) => session\.id === sessionId\)/);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -446,6 +446,11 @@ export function AppShell() {
   // changed) and is forwarded to sessions.create in `send()`. Renderer-only —
   // it never mutates the persisted Settings · 模型 default.
   const [pendingNewChatModel, setPendingNewChatModel] = useState<{ llmConnectionSlug: string; model: string } | null>(null);
+  // New-chat permission mode, mirroring pendingNewChatModel: when no session is
+  // active the composer chip shows this mode and `send()` forwards it to
+  // sessions.create so the user can pick a permission mode before the first
+  // message. Null = inherit the default ('ask').
+  const [pendingNewChatPermissionMode, setPendingNewChatPermissionMode] = useState<PermissionMode | null>(null);
   // A pick only stays in effect while it is still an offered choice. If the user
   // later disables/removes that connection or model, fall back to the default so
   // the home chip never shows — nor sends — a model that no longer exists.
@@ -1501,7 +1506,10 @@ export function AppShell() {
   }
   async function setPermissionMode(mode: PermissionMode) {
     const sessionId = activeIdRef.current;
-    if (!sessionId) return;
+    if (!sessionId) {
+      setPendingNewChatPermissionMode(mode);
+      return;
+    }
     if (pendingPermissionModeChangesRef.current.has(sessionId)) return;
     const current = sessionsRef.current.find((session) => session.id === sessionId);
     if (!current || current.permissionMode === mode) return;
@@ -1899,7 +1907,7 @@ export function AppShell() {
       const turnId = crypto.randomUUID();
       if (!initialSessionId) {
         const session = await window.maka.sessions.create({
-          permissionMode: 'ask',
+          permissionMode: pendingNewChatPermissionMode ?? 'ask',
           name: text.slice(0, 42) || '新建对话',
           ...(validPendingNewChatModel
             ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }
@@ -3133,16 +3141,16 @@ export function AppShell() {
                     void selectProjectDirectory();
                   },
                 }}
-                permissionMode={activeSessionForView?.permissionMode}
+                permissionMode={activeSessionForView?.permissionMode ?? pendingNewChatPermissionMode ?? undefined}
                 permissionModePending={activeId ? pendingPermissionModeBySession[activeId] === true : false}
                 permissionModeDisabledReason={
                   activeId && pendingPermissionModeBySession[activeId] === true
                     ? '权限模式正在切换，完成后再继续操作。'
-                    : activeStreaming.length > 0
+                    : activeId && activeStreaming.length > 0
                       ? '当前对话正在流式输出，等结束后再切换权限模式。'
-                      : activeSessionForView?.status === 'running'
+                      : activeId && activeSessionForView?.status === 'running'
                         ? '当前对话正在运行，等结束后再切换权限模式。'
-                        : activeSessionForView?.status === 'waiting_for_user'
+                        : activeId && activeSessionForView?.status === 'waiting_for_user'
                           ? '当前有工具调用正在等待确认，处理后再切换权限模式。'
                           : undefined
                 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1913,6 +1913,7 @@ export function AppShell() {
             ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }
             : {}),
         });
+        setPendingNewChatPermissionMode(null);
         upsertSessionSummary(session);
         optimisticSessionId = session.id;
         optimisticTurnId = turnId;


### PR DESCRIPTION
Add pendingNewChatPermissionMode state (mirroring pendingNewChatModel) so users can pick a permission mode before sending the first message. Remove the !activeId guard that disabled the chip with '请先开始对话再切换权限模式。' and forward the chosen mode to sessions.create instead of hardcoding 'ask'.