### PR TITLE
fix(scripts): allowlist dynamic palette swatch classes in dead-CSS check

### DIFF
--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -51,6 +51,21 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'is-untested',
   'is-verified',
   'is-warn',
+  // Appearance palette swatches — composed at runtime via
+  // `settingsPaletteSwatch-${palette}` in settings/appearance-settings-page.tsx
+  // (#308), so the per-palette variants never appear as string literals in
+  // source. Keep in sync with PALETTE_GROUPS in that file.
+  'settingsPaletteSwatch-default',
+  'settingsPaletteSwatch-onedark',
+  'settingsPaletteSwatch-catppuccin-mocha',
+  'settingsPaletteSwatch-tokyo-night',
+  'settingsPaletteSwatch-nord',
+  'settingsPaletteSwatch-coral',
+  'settingsPaletteSwatch-azure',
+  'settingsPaletteSwatch-forest',
+  'settingsPaletteSwatch-dusk',
+  'settingsPaletteSwatch-sand',
+  'settingsPaletteSwatch-mono',
 ]);
 
 async function readCssFiles(dir) {


### PR DESCRIPTION
## Problem

`check:release` currently fails on `main`: `node scripts/check-dead-css.mjs --check` exits 1, reporting 11 "dead" CSS classes:

`.settingsPaletteSwatch-default`, `-onedark`, `-catppuccin-mocha`, `-tokyo-night`, `-nord`, `-coral`, `-azure`, `-forest`, `-dusk`, `-sand`, `-mono`

## Root cause

These classes are **not dead**. They were added in #308 and are composed at runtime in `apps/desktop/src/renderer/settings/appearance-settings-page.tsx`:

```tsx
<span className={`settingsPaletteSwatch settingsPaletteSwatch-${palette}`} aria-hidden="true" />
```

The detector greps source for each class as a string literal, so the per-palette variants (only ever produced through the `${palette}` template) never match and are reported as false positives. The 11 flagged classes map exactly to `PALETTE_GROUPS` in that file.

## Fix

Register the 11 palette swatch classes in the script's existing `DYNAMIC_STYLE_HOOKS` allowlist — the same mechanism already used for other runtime-generated classes (`is-ok`, `os-scrollbar-*`, ...).

## Validation

- `node scripts/check-dead-css.mjs` → `no dead classes found ✓`
- `node scripts/check-dead-css.mjs --check` → exit 0 (was exit 1)

## Note / possible follow-up

This allowlist must be kept in sync if palettes are added/removed. A more robust alternative would be to teach the detector to recognize dynamically-composed prefixes (`settingsPaletteSwatch-${...}`) directly; kept out of scope here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
