### PR TITLE
fix(desktop): recognize OAuth-subscription connections in onboarding

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -355,6 +355,37 @@ describe('Claude OAuth model connection bridge', () => {
     assert.match(src, /getApiKey:\s*\(slug:\s*string\)\s*=>\s*resolveConnectionSecret\(slug\)/, 'chat send readiness must use OAuth tokens through resolveConnectionSecret');
   });
 
+  it('onboarding checks Claude/Codex OAuth credential presence WITHOUT the send-path refresh (PR #389 review gate)', async () => {
+    const src = await readMainProcessCombinedSource();
+    const fnIdx = src.indexOf('async function hasConnectionSecret(connection: LlmConnection): Promise<boolean> {');
+    assert.notEqual(fnIdx, -1, 'hasConnectionSecret helper must exist as the read-only counterpart to resolveConnectionSecret');
+    // Window big enough to cover the whole function body but end
+    // before the enclosing factory's `return { ... }` — matches the
+    // windowing style already used elsewhere in this file (e.g. the
+    // handler-guard checks above) rather than a brace-counting regex.
+    const fnBody = src.slice(fnIdx, fnIdx + 600);
+    assert.match(
+      fnBody,
+      /providerType === 'claude-subscription'[\s\S]*claudeSubscription\.hasStoredCredential\(\)/,
+      'hasConnectionSecret must route claude-subscription through the read-only hasStoredCredential(), not getAccessTokenInternal()',
+    );
+    assert.match(
+      fnBody,
+      /providerType === 'codex-subscription'[\s\S]*codexSubscription\.hasStoredCredential\(\)/,
+      'hasConnectionSecret must route codex-subscription through the read-only hasStoredCredential(), not getAccessTokenInternal()',
+    );
+    assert.doesNotMatch(
+      fnBody,
+      /getAccessTokenInternal/,
+      'hasConnectionSecret must NEVER call the refreshing getAccessTokenInternal() — onboarding is a read-only status path and must not refresh tokens or hit the network just by being observed',
+    );
+    assert.match(
+      src,
+      /bindOnboardingDeps\(\{[\s\S]*hasCredential:\s*hasConnectionSecret,[\s\S]*\}\)/,
+      'onboarding must be wired to the read-only hasConnectionSecret, not the refreshing resolveConnectionSecret',
+    );
+  });
+
   it('model connection IPC does not accept custom baseUrl overrides for OAuth-token providers', async () => {
     const src = await readMainProcessCombinedSource();
     assert.match(

--- a/apps/desktop/src/main/__tests__/onboarding-service.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-service.test.ts
@@ -19,6 +19,7 @@ import type {
 } from '@maka/core';
 import type { LlmConnection } from '@maka/core';
 import {
+  bindOnboardingDeps,
   createOnboardingService,
   type OnboardingServiceDeps,
 } from '../onboarding-service.js';
@@ -122,6 +123,59 @@ describe('createOnboardingService.getSnapshot', () => {
     if (snapshot.state.kind === 'needs_connection_credentials') {
       assert.equal(snapshot.state.connectionSlug, 'broken');
     }
+  });
+});
+
+describe('bindOnboardingDeps — resolveSecret wiring', () => {
+  // Regression test: onboarding used to call a `hasApiKey` that only
+  // checked the API-key credential store, so an OAuth-subscription
+  // connection (Claude Subscription / Codex Subscription) marked as
+  // the default was always reported as `missing_api_key`, even when
+  // Settings showed it verified + default. The fix routes onboarding
+  // through the same `resolveSecret` the send-path uses
+  // (`resolveConnectionSecret` in main.ts), which special-cases
+  // OAuth-subscription connections. This test wires a fake
+  // `resolveSecret` that mirrors that split (API-key store for normal
+  // connections, a separate token store for OAuth subscriptions) and
+  // asserts the OAuth-subscription default resolves to `ready_empty`
+  // rather than being stuck on a credentials/default-connection step.
+  it('treats an OAuth-subscription default connection as credentialed', async () => {
+    const oauthConnection = realConnection({
+      slug: 'claude-oauth',
+      providerType: 'claude-subscription',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+    });
+    // Deliberately empty: the API-key store has nothing for this slug.
+    const apiKeyStore = new Map<string, string>();
+    // The OAuth-subscription token lives in a separate store, exactly
+    // like claudeSubscription.getAccessTokenInternal() in main.ts.
+    const subscriptionTokenStore = new Map<string, string>([['claude-oauth', 'sk-ant-oat-fake']]);
+
+    const service = createOnboardingService(
+      bindOnboardingDeps({
+        settingsStore: {
+          get: async () => ({ onboarding: { milestones: [] } }),
+          upsertOnboardingMilestone: async () => [],
+          clearOnboardingMilestone: async () => [],
+        },
+        connectionStore: {
+          list: async () => [oauthConnection],
+          getDefault: async () => 'claude-oauth',
+        },
+        resolveSecret: async (slug) => {
+          if (slug === oauthConnection.slug) return subscriptionTokenStore.get(slug) ?? null;
+          return apiKeyStore.get(slug) ?? null;
+        },
+        listSessions: async () => [],
+      }),
+    );
+
+    const snapshot = await service.getSnapshot();
+    assert.equal(
+      snapshot.state.kind,
+      'ready_empty',
+      `expected the OAuth-subscription default to be ready; got ${JSON.stringify(snapshot.state)}`,
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/onboarding-service.test.ts
+++ b/apps/desktop/src/main/__tests__/onboarding-service.test.ts
@@ -2,12 +2,15 @@
  * Tests for the onboarding service (PR110b).
  *
  * Validate the contract gates @kenji + @xuan signed off on:
- *   - getSnapshot resolves secrets in parallel (timing assertion)
+ *   - getSnapshot resolves credentials in parallel (timing assertion)
  *   - credential lookup errors are NEVER thrown to caller; the slug
  *     is treated as `hasSecret: false`
  *   - setMilestone rejects invalid id / status
  *   - setMilestone never accepts a renderer-supplied timestamp
  *   - last-valid-entry-wins dedup survives via the sanitizer
+ *   - `bindOnboardingDeps` passes the full `LlmConnection` (not just a
+ *     slug) to `hasCredential`, so OAuth-subscription connections are
+ *     recognized as credentialed via a read-only check
  */
 
 import { strict as assert } from 'node:assert';
@@ -63,7 +66,7 @@ function fakeDeps(overrides: Partial<OnboardingServiceDeps> = {}): OnboardingSer
       if (existingIdx >= 0) milestones.splice(existingIdx, 1);
       return milestones.slice();
     },
-    hasApiKey: async (_slug: string) => false,
+    hasCredential: async (_connection: LlmConnection) => false,
     ...overrides,
   };
 }
@@ -74,7 +77,7 @@ describe('createOnboardingService.getSnapshot', () => {
       fakeDeps({
         listConnections: async () => [realConnection({ slug: 'a' })],
         getDefaultSlug: async () => 'a',
-        hasApiKey: async (slug) => slug === 'a',
+        hasCredential: async (connection) => connection.slug === 'a',
         getMilestones: async () => [{ id: 'first_chat_sent', completedAt: 1_700_000_000_000 }],
       }),
     );
@@ -85,8 +88,8 @@ describe('createOnboardingService.getSnapshot', () => {
     ]);
   });
 
-  it('resolves per-connection secrets in PARALLEL (@kenji perf gate)', async () => {
-    // Each hasApiKey call sleeps 50ms. With 4 connections, serial =
+  it('resolves per-connection credentials in PARALLEL (@kenji perf gate)', async () => {
+    // Each hasCredential call sleeps 50ms. With 4 connections, serial =
     // 200ms; parallel = ~50ms. Assert <= 150ms to leave a generous
     // buffer for slow CI machines while still catching serialization.
     const conns = ['a', 'b', 'c', 'd'].map((slug) => realConnection({ slug }));
@@ -94,7 +97,7 @@ describe('createOnboardingService.getSnapshot', () => {
       fakeDeps({
         listConnections: async () => conns,
         getDefaultSlug: async () => 'a',
-        hasApiKey: async () => {
+        hasCredential: async () => {
           await new Promise((resolve) => setTimeout(resolve, 50));
           return true;
         },
@@ -103,7 +106,7 @@ describe('createOnboardingService.getSnapshot', () => {
     const start = Date.now();
     await service.getSnapshot();
     const elapsed = Date.now() - start;
-    assert.ok(elapsed < 150, `secret lookups must run in parallel; took ${elapsed}ms (serial would be ~200ms)`);
+    assert.ok(elapsed < 150, `credential lookups must run in parallel; took ${elapsed}ms (serial would be ~200ms)`);
   });
 
   it('credential-lookup error → treated as hasSecret=false, NEVER thrown to caller', async () => {
@@ -111,7 +114,7 @@ describe('createOnboardingService.getSnapshot', () => {
       fakeDeps({
         listConnections: async () => [realConnection({ slug: 'broken' })],
         getDefaultSlug: async () => 'broken',
-        hasApiKey: async () => {
+        hasCredential: async () => {
           throw new Error('safeStorage decrypt failed');
         },
       }),
@@ -126,19 +129,20 @@ describe('createOnboardingService.getSnapshot', () => {
   });
 });
 
-describe('bindOnboardingDeps — resolveSecret wiring', () => {
+describe('bindOnboardingDeps — hasCredential wiring', () => {
   // Regression test: onboarding used to call a `hasApiKey` that only
   // checked the API-key credential store, so an OAuth-subscription
   // connection (Claude Subscription / Codex Subscription) marked as
   // the default was always reported as `missing_api_key`, even when
   // Settings showed it verified + default. The fix routes onboarding
-  // through the same `resolveSecret` the send-path uses
-  // (`resolveConnectionSecret` in main.ts), which special-cases
-  // OAuth-subscription connections. This test wires a fake
-  // `resolveSecret` that mirrors that split (API-key store for normal
-  // connections, a separate token store for OAuth subscriptions) and
-  // asserts the OAuth-subscription default resolves to `ready_empty`
-  // rather than being stuck on a credentials/default-connection step.
+  // through a `hasCredential(connection)` resolver that special-cases
+  // OAuth-subscription connections via a READ-ONLY check (no refresh —
+  // see the "does not trigger OAuth refresh" test below). This test
+  // wires a fake `hasCredential` that mirrors that split (API-key
+  // store for normal connections, a separate token store for OAuth
+  // subscriptions) and asserts the OAuth-subscription default resolves
+  // to `ready_empty` rather than being stuck on a credentials/default
+  // -connection step.
   it('treats an OAuth-subscription default connection as credentialed', async () => {
     const oauthConnection = realConnection({
       slug: 'claude-oauth',
@@ -148,8 +152,8 @@ describe('bindOnboardingDeps — resolveSecret wiring', () => {
     // Deliberately empty: the API-key store has nothing for this slug.
     const apiKeyStore = new Map<string, string>();
     // The OAuth-subscription token lives in a separate store, exactly
-    // like claudeSubscription.getAccessTokenInternal() in main.ts.
-    const subscriptionTokenStore = new Map<string, string>([['claude-oauth', 'sk-ant-oat-fake']]);
+    // like claudeSubscription.hasStoredCredential() in main.ts.
+    const subscriptionTokenStore = new Set<string>(['claude-oauth']);
 
     const service = createOnboardingService(
       bindOnboardingDeps({
@@ -162,9 +166,11 @@ describe('bindOnboardingDeps — resolveSecret wiring', () => {
           list: async () => [oauthConnection],
           getDefault: async () => 'claude-oauth',
         },
-        resolveSecret: async (slug) => {
-          if (slug === oauthConnection.slug) return subscriptionTokenStore.get(slug) ?? null;
-          return apiKeyStore.get(slug) ?? null;
+        hasCredential: async (connection) => {
+          if (connection.providerType === 'claude-subscription') {
+            return subscriptionTokenStore.has(connection.slug);
+          }
+          return apiKeyStore.has(connection.slug);
         },
         listSessions: async () => [],
       }),
@@ -176,6 +182,105 @@ describe('bindOnboardingDeps — resolveSecret wiring', () => {
       'ready_empty',
       `expected the OAuth-subscription default to be ready; got ${JSON.stringify(snapshot.state)}`,
     );
+  });
+
+  // P3 review gate (PR #389, @Astro-Han): onboarding already holds the
+  // full `connections` snapshot from `listConnections()` — the bound
+  // `hasCredential` must receive that SAME connection object, not just
+  // a slug it has to re-resolve. Passing a fresh/different object here
+  // would mean the credential check could observe a different
+  // connection state than the one `deriveOnboardingState` reasons
+  // about, and would cost an avoidable extra store read in production.
+  it('passes the exact connection object from listConnections(), not a re-fetched copy', async () => {
+    const connection = realConnection({ slug: 'a' });
+    const receivedConnections: LlmConnection[] = [];
+
+    const service = createOnboardingService(
+      bindOnboardingDeps({
+        settingsStore: {
+          get: async () => ({ onboarding: { milestones: [] } }),
+          upsertOnboardingMilestone: async () => [],
+          clearOnboardingMilestone: async () => [],
+        },
+        connectionStore: {
+          list: async () => [connection],
+          getDefault: async () => 'a',
+        },
+        hasCredential: async (received) => {
+          receivedConnections.push(received);
+          return true;
+        },
+        listSessions: async () => [],
+      }),
+    );
+
+    await service.getSnapshot();
+    assert.equal(receivedConnections.length, 1);
+    assert.equal(
+      receivedConnections[0],
+      connection,
+      'hasCredential must receive the identical connection object listConnections() returned',
+    );
+  });
+
+  // P2 review gate (PR #389, @Astro-Han): getSnapshot is a read-only
+  // status path. It must be able to report an OAuth-subscription
+  // connection as credentialed WITHOUT triggering that provider's
+  // token-refresh side effect (network call + local token-state
+  // mutation) — refreshing on every onboarding read would mean simply
+  // opening the app can hit the network, and a failed incidental
+  // refresh could misreport a valid login as missing credentials. This
+  // mirrors `ClaudeSubscriptionService.hasStoredCredential()` /
+  // `CodexSubscriptionService.hasStoredCredential()`, which read the
+  // persisted token without ever calling `refreshTokens()`.
+  it('does not trigger OAuth refresh for a near-expiry token, and still reports credentialed', async () => {
+    const oauthConnection = realConnection({
+      slug: 'claude-oauth',
+      providerType: 'claude-subscription',
+    });
+    let refreshCalls = 0;
+    let readOnlyCalls = 0;
+    // Fake OAuth service: a token exists but is one second from
+    // expiring. `hasStoredCredential()` (read-only) must still report
+    // true without calling `refreshTokens()`.
+    const fakeClaudeSubscription = {
+      hasStoredCredential: async () => {
+        readOnlyCalls += 1;
+        return true; // persisted token exists locally, near-expiry
+      },
+      refreshTokens: async () => {
+        refreshCalls += 1;
+        return { ok: true };
+      },
+    };
+
+    const service = createOnboardingService(
+      bindOnboardingDeps({
+        settingsStore: {
+          get: async () => ({ onboarding: { milestones: [] } }),
+          upsertOnboardingMilestone: async () => [],
+          clearOnboardingMilestone: async () => [],
+        },
+        connectionStore: {
+          list: async () => [oauthConnection],
+          getDefault: async () => 'claude-oauth',
+        },
+        // Mirrors hasConnectionSecret() in main.ts: routes
+        // claude-subscription through the read-only check only.
+        hasCredential: async (connection) => {
+          if (connection.providerType === 'claude-subscription') {
+            return fakeClaudeSubscription.hasStoredCredential();
+          }
+          return false;
+        },
+        listSessions: async () => [],
+      }),
+    );
+
+    const snapshot = await service.getSnapshot();
+    assert.equal(snapshot.state.kind, 'ready_empty');
+    assert.equal(readOnlyCalls, 1, 'must check the read-only path exactly once');
+    assert.equal(refreshCalls, 0, 'getSnapshot must NEVER trigger an OAuth token refresh');
   });
 });
 
@@ -197,7 +302,7 @@ describe('createOnboardingService.clearMilestone — strict validation', () => {
       fakeDeps({
         listConnections: async () => [realConnection({ slug: 'a' })],
         getDefaultSlug: async () => 'a',
-        hasApiKey: async () => true,
+        hasCredential: async () => true,
         getMilestones: async () => stored,
         clearMilestone: async (id) => {
           stored = stored.filter((entry) => entry.id !== id);
@@ -250,7 +355,7 @@ describe('createOnboardingService.setMilestone — strict validation', () => {
       fakeDeps({
         listConnections: async () => [realConnection({ slug: 'a' })],
         getDefaultSlug: async () => 'a',
-        hasApiKey: async () => true,
+        hasCredential: async () => true,
         getMilestones: async () => stored,
         upsertMilestone: async (id, status) => {
           stored = [

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -643,13 +643,14 @@ botIncoming = createBotIncomingMainService({
 // PR110b: onboarding service composes existing stores + runtime to
 // derive `OnboardingState` and manage `OnboardingMilestone[]`.
 // Constructed AFTER `runtime` so `listSessions()` is bindable. The
-// service never reaches into credentialStore directly except through
-// the explicit `hasApiKey` predicate.
+// service resolves secrets through the same `resolveConnectionSecret`
+// the send-path uses, so OAuth-subscription connections (Claude/Codex)
+// are recognized as credentialed, not just API-key connections.
 const onboardingService = createOnboardingService(
   bindOnboardingDeps({
     settingsStore,
     connectionStore,
-    credentialStore,
+    resolveSecret: resolveConnectionSecret,
     listSessions: () => runtime.listSessions(),
   }),
 );

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -258,6 +258,23 @@ function syncOAuthModelConnections(): Promise<void> {
 function resolveConnectionSecret(slug: string): Promise<string | null> {
   return oauthModelConnections.resolveConnectionSecret(slug);
 }
+
+/**
+ * Read-only credential-presence check for status paths (onboarding's
+ * `getSnapshot`) that must not trigger `resolveConnectionSecret`'s
+ * OAuth near-expiry refresh — that refresh hits the network and
+ * mutates local token state, which a read-only status read must never
+ * do just by being observed. Send/test/fetch-models paths keep using
+ * `resolveConnectionSecret` so they still benefit from the refresh.
+ *
+ * Takes the `LlmConnection` directly rather than a slug: callers that
+ * already hold the connection list (onboarding does) skip the extra
+ * `connectionStore.get()` round trip and derive state from one
+ * consistent snapshot.
+ */
+function hasConnectionSecret(connection: LlmConnection): Promise<boolean> {
+  return oauthModelConnections.hasConnectionSecret(connection);
+}
 const cursorSubscription = new CursorSubscriptionService({
   userDataDir: app.getPath('userData'),
 });
@@ -643,14 +660,16 @@ botIncoming = createBotIncomingMainService({
 // PR110b: onboarding service composes existing stores + runtime to
 // derive `OnboardingState` and manage `OnboardingMilestone[]`.
 // Constructed AFTER `runtime` so `listSessions()` is bindable. The
-// service resolves secrets through the same `resolveConnectionSecret`
-// the send-path uses, so OAuth-subscription connections (Claude/Codex)
-// are recognized as credentialed, not just API-key connections.
+// service checks credential presence through `hasConnectionSecret`
+// (read-only — recognizes OAuth-subscription connections like the
+// send-path's `resolveConnectionSecret` does, but never refreshes),
+// so simply opening onboarding can't hit the network or mutate token
+// state.
 const onboardingService = createOnboardingService(
   bindOnboardingDeps({
     settingsStore,
     connectionStore,
-    resolveSecret: resolveConnectionSecret,
+    hasCredential: hasConnectionSecret,
     listSessions: () => runtime.listSessions(),
   }),
 );

--- a/apps/desktop/src/main/oauth-model-connections-main.ts
+++ b/apps/desktop/src/main/oauth-model-connections-main.ts
@@ -152,10 +152,36 @@ export function createOAuthModelConnectionsMainService(deps: OAuthModelConnectio
     return deps.credentialStore.getSecret(slug, 'api_key');
   }
 
+  /**
+   * Read-only credential-presence check for status paths (onboarding's
+   * `getSnapshot`) that must not trigger `resolveConnectionSecret`'s
+   * OAuth near-expiry refresh — that refresh hits the network and
+   * mutates local token state, which a read-only status read must
+   * never do just by being observed. Send/test/fetch-models paths
+   * keep using `resolveConnectionSecret` so they still benefit from
+   * the refresh.
+   *
+   * Takes the `LlmConnection` directly rather than a slug: callers
+   * that already hold the connection list (onboarding does) skip the
+   * extra `connectionStore.get()` round trip and derive state from
+   * one consistent snapshot.
+   */
+  async function hasConnectionSecret(connection: LlmConnection): Promise<boolean> {
+    if (connection.providerType === 'claude-subscription') {
+      return deps.claudeSubscription.hasStoredCredential();
+    }
+    if (connection.providerType === 'codex-subscription') {
+      return deps.codexSubscription.hasStoredCredential();
+    }
+    const key = await deps.credentialStore.getSecret(connection.slug, 'api_key');
+    return typeof key === 'string' && key.length > 0;
+  }
+
   return {
     isClaudeSubscriptionAuthenticatedState,
     isCodexSubscriptionAuthenticatedState,
     resolveConnectionSecret,
+    hasConnectionSecret,
     syncClaudeSubscriptionConnection,
     syncCodexSubscriptionConnection,
     syncOAuthModelConnections,

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -499,6 +499,22 @@ export class ClaudeSubscriptionService {
     return tokens.access_token;
   }
 
+  /**
+   * Whether a persisted OAuth token exists locally, WITHOUT
+   * triggering `getAccessTokenInternal()`'s near-expiry refresh.
+   *
+   * Read-only status paths (onboarding's `getSnapshot`) must be able
+   * to answer "is this connection credentialed?" without the side
+   * effect of a network refresh — refreshing on every onboarding read
+   * would let simply opening the app hit the network and mutate local
+   * token state, and would misreport an otherwise-valid login as
+   * missing credentials if that incidental refresh happened to fail.
+   */
+  async hasStoredCredential(): Promise<boolean> {
+    const tokens = await this.loadTokens();
+    return tokens !== null;
+  }
+
   // -----------------------------------------------------------
   // INTERNALS
   // -----------------------------------------------------------

--- a/apps/desktop/src/main/oauth/codex-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/codex-subscription-service.ts
@@ -364,6 +364,18 @@ export class CodexSubscriptionService {
     return tokens.access_token;
   }
 
+  /**
+   * Whether a persisted OAuth token exists locally, WITHOUT
+   * triggering `getAccessTokenInternal()`'s near-expiry refresh. See
+   * `ClaudeSubscriptionService.hasStoredCredential()` for the
+   * rationale — read-only status paths (onboarding) must not refresh
+   * or mutate token state just by being observed.
+   */
+  async hasStoredCredential(): Promise<boolean> {
+    const tokens = await this.loadTokens();
+    return tokens !== null;
+  }
+
   // -----------------------------------------------------------
   // INTERNALS
   // -----------------------------------------------------------

--- a/apps/desktop/src/main/onboarding-service.ts
+++ b/apps/desktop/src/main/onboarding-service.ts
@@ -31,7 +31,6 @@ import {
   type SessionSummary,
 } from '@maka/core';
 import type { LlmConnection } from '@maka/core/llm-connections';
-import type { CredentialStore } from './credential-store.js';
 
 export interface OnboardingSnapshot {
   state: OnboardingState;
@@ -214,7 +213,17 @@ export function bindOnboardingDeps(input: {
     list(): Promise<LlmConnection[]>;
     getDefault(): Promise<string | null>;
   };
-  credentialStore: Pick<CredentialStore, 'getSecret'>;
+  /**
+   * Resolves the effective secret for a connection slug, covering
+   * both API-key connections (credential store) and OAuth-subscription
+   * connections (claude-subscription / codex-subscription access
+   * tokens). Callers must pass the SAME resolver the send-path uses
+   * (`resolveConnectionSecret` in main.ts) — a resolver that only
+   * checks the API-key credential store makes every OAuth-subscription
+   * connection look like it's missing credentials, even when it's the
+   * verified default.
+   */
+  resolveSecret(slug: string): Promise<string | null>;
   listSessions(): Promise<SessionSummary[]>;
 }): OnboardingServiceDeps {
   return {
@@ -225,7 +234,7 @@ export function bindOnboardingDeps(input: {
     upsertMilestone: (id, status) => input.settingsStore.upsertOnboardingMilestone(id, status),
     clearMilestone: (id) => input.settingsStore.clearOnboardingMilestone(id),
     hasApiKey: async (slug) => {
-      const key = await input.credentialStore.getSecret(slug, 'api_key');
+      const key = await input.resolveSecret(slug);
       return typeof key === 'string' && key.length > 0;
     },
   };

--- a/apps/desktop/src/main/onboarding-service.ts
+++ b/apps/desktop/src/main/onboarding-service.ts
@@ -4,9 +4,15 @@
  *
  * The service produces `OnboardingSnapshot` via:
  *   1. ConnectionStore.list() + ConnectionStore.getDefault()
- *   2. Per-connection secret presence resolved in PARALLEL via the
- *      credential store (@kenji PR110b perf gate — never serialize
- *      these lookups).
+ *   2. Per-connection credential presence resolved in PARALLEL via
+ *      `hasCredential` (@kenji PR110b perf gate — never serialize
+ *      these lookups). `hasCredential` covers BOTH API-key connections
+ *      and OAuth-subscription connections (Claude/Codex), and MUST be
+ *      read-only — it must never refresh an OAuth token or otherwise
+ *      mutate credential state just because onboarding status was
+ *      read. See `hasConnectionSecret` in main.ts for the production
+ *      wiring and why it deliberately does NOT reuse the send-path's
+ *      refreshing `resolveConnectionSecret`.
  *   3. SessionStore.list() (the runtime layer's listSessions handles
  *      this for us; we pass it in as a callback)
  *   4. SettingsStore.get() for milestones (already sanitized by
@@ -14,8 +20,8 @@
  *   5. `deriveOnboardingState()` from @maka/core
  *
  * The service NEVER throws credential errors to the renderer; a
- * failed secret lookup is treated as "no secret" with a generalized
- * dev-safe log line.
+ * failed credential lookup is treated as "no credential" with a
+ * generalized dev-safe log line.
  *
  * Quick Chat input validation lives here too: setMilestone arguments
  * are checked against the closed enum + status union before reaching
@@ -47,7 +53,13 @@ export interface OnboardingServiceDeps {
     status: 'completed' | 'skipped',
   ): Promise<OnboardingMilestone[]>;
   clearMilestone(id: OnboardingMilestoneId): Promise<OnboardingMilestone[]>;
-  hasApiKey(slug: string): Promise<boolean>;
+  /**
+   * Whether `connection` has a usable credential — an API key OR (for
+   * OAuth-subscription providers) a stored OAuth token. MUST be
+   * read-only: implementations must not refresh tokens or otherwise
+   * mutate credential state as a side effect of this check.
+   */
+  hasCredential(connection: LlmConnection): Promise<boolean>;
 }
 
 export interface OnboardingService {
@@ -75,15 +87,15 @@ export function createOnboardingService(deps: OnboardingServiceDeps): Onboarding
         deps.getMilestones(),
       ]);
 
-      // @kenji PR110b perf gate: per-connection secret lookup must run
-      // in parallel, NOT serialized. Even with 4-5 connections, async
-      // safeStorage reads can add up to noticeable startup latency on
-      // cold open.
+      // @kenji PR110b perf gate: per-connection credential lookup must
+      // run in parallel, NOT serialized. Even with 4-5 connections,
+      // async safeStorage reads can add up to noticeable startup
+      // latency on cold open.
       const secretEntries = await Promise.all(
         connections.map(async (connection) => {
           try {
-            const hasKey = await deps.hasApiKey(connection.slug);
-            return [connection.slug, hasKey] as const;
+            const hasSecret = await deps.hasCredential(connection);
+            return [connection.slug, hasSecret] as const;
           } catch (error) {
             // @kenji + @xuan PR110b gate: credential errors must NOT
             // leak to the renderer. Log a generalized dev-safe line
@@ -91,7 +103,7 @@ export function createOnboardingService(deps: OnboardingServiceDeps): Onboarding
             // ends up on `needs_connection_credentials` for that
             // slug, which is the right user-facing fix path anyway.
             console.warn(
-              `[onboarding] failed to read secret for ${connection.slug}; treating as missing.`,
+              `[onboarding] failed to read credential for ${connection.slug}; treating as missing.`,
               describeErrorClass(error),
             );
             return [connection.slug, false] as const;
@@ -133,7 +145,7 @@ export function createOnboardingService(deps: OnboardingServiceDeps): Onboarding
       const secretEntries = await Promise.all(
         connections.map(async (connection) => {
           try {
-            return [connection.slug, await deps.hasApiKey(connection.slug)] as const;
+            return [connection.slug, await deps.hasCredential(connection)] as const;
           } catch {
             return [connection.slug, false] as const;
           }
@@ -162,7 +174,7 @@ export function createOnboardingService(deps: OnboardingServiceDeps): Onboarding
       const secretEntries = await Promise.all(
         connections.map(async (connection) => {
           try {
-            return [connection.slug, await deps.hasApiKey(connection.slug)] as const;
+            return [connection.slug, await deps.hasCredential(connection)] as const;
           } catch {
             return [connection.slug, false] as const;
           }
@@ -214,16 +226,18 @@ export function bindOnboardingDeps(input: {
     getDefault(): Promise<string | null>;
   };
   /**
-   * Resolves the effective secret for a connection slug, covering
-   * both API-key connections (credential store) and OAuth-subscription
-   * connections (claude-subscription / codex-subscription access
-   * tokens). Callers must pass the SAME resolver the send-path uses
-   * (`resolveConnectionSecret` in main.ts) — a resolver that only
-   * checks the API-key credential store makes every OAuth-subscription
+   * Read-only credential-presence check, covering both API-key
+   * connections (credential store) and OAuth-subscription connections
+   * (claude-subscription / codex-subscription stored tokens). Callers
+   * must pass a resolver that NEVER refreshes an OAuth token or
+   * otherwise mutates credential state — see `hasConnectionSecret` in
+   * main.ts, which deliberately does not reuse the send-path's
+   * refreshing `resolveConnectionSecret`. A resolver that only checks
+   * the API-key credential store makes every OAuth-subscription
    * connection look like it's missing credentials, even when it's the
    * verified default.
    */
-  resolveSecret(slug: string): Promise<string | null>;
+  hasCredential(connection: LlmConnection): Promise<boolean>;
   listSessions(): Promise<SessionSummary[]>;
 }): OnboardingServiceDeps {
   return {
@@ -233,9 +247,6 @@ export function bindOnboardingDeps(input: {
     getMilestones: async () => (await input.settingsStore.get()).onboarding.milestones,
     upsertMilestone: (id, status) => input.settingsStore.upsertOnboardingMilestone(id, status),
     clearMilestone: (id) => input.settingsStore.clearOnboardingMilestone(id),
-    hasApiKey: async (slug) => {
-      const key = await input.resolveSecret(slug);
-      return typeof key === 'string' && key.length > 0;
-    },
+    hasCredential: (connection) => input.hasCredential(connection),
   };
 }


### PR DESCRIPTION

<img width="817" height="246" alt="image" src="https://github.com/user-attachments/assets/90ba5839-e0c4-417a-8a3c-18464a143e41" />
<img width="796" height="720" alt="image" src="https://github.com/user-attachments/assets/90d58383-d2fa-42c4-8677-73528e3474e1" />


## Summary

- Onboarding's `hasApiKey` check only looked at the API-key credential store, so a connection using OAuth-subscription auth (Claude Subscription / Codex Subscription) was always classified as `missing_api_key` — even when it was the verified default shown in Settings — leaving the first-run flow permanently stuck on "select a connection as default" ("已经设好了？刷新检测" does not help, since it re-runs the same broken check).
- The send path already has the correct logic in `resolveConnectionSecret` (`apps/desktop/src/main/main.ts`), which special-cases `claude-subscription` / `codex-subscription` connections to read from their OAuth token store instead of the API-key credential store.
- This change routes `bindOnboardingDeps`'s secret resolution through that same `resolveConnectionSecret`, so onboarding and the send path agree on what "has credentials" means.

## Repro

1. Connect via Claude Subscription (OAuth) only, and set it as the default connection in Settings → Models — it shows "默认" + "凭据已验证".
2. First-run onboarding still shows step 2 "设为默认" as the current/incomplete step, and "刷新检测" doesn't change anything.

## Fix

- `apps/desktop/src/main/onboarding-service.ts`: `bindOnboardingDeps` now takes a `resolveSecret(slug)` function instead of a raw `credentialStore`, and `hasApiKey` delegates to it.
- `apps/desktop/src/main/main.ts`: wires `resolveConnectionSecret` (the same function the send path uses) into `bindOnboardingDeps`.
- `apps/desktop/src/main/__tests__/onboarding-service.test.ts`: added a regression test for `bindOnboardingDeps` (previously untested) that fails on the old code with `needs_connection_credentials` and passes with the fix (`ready_empty`).

## Test plan

- [x] `npm run typecheck --workspaces --if-present`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm --workspace @maka/desktop run test` — 1625 tests, 1 pre-existing unrelated failure (`real-window-smoke-contract.test.ts`'s check on the root `dev` script, broken by #374 before this branch, unrelated to onboarding)
- [x] New regression test verified to fail against the pre-fix code and pass against the fix