### PR TITLE
fix(renderer): clear leftover ring-shadow vars on wrapper-owned textareas

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -56,6 +56,11 @@ const ALLOWLIST: ImportantAllowance[] = [
     reason: 'shared field ring shadow override',
   },
   {
+    fileSuffix: 'apps/desktop/src/renderer/styles/module-pages.css',
+    anchor: '.maka-skill-search input',
+    reason: 'shared input ring reset inside wrapper-owned surface, defensive against the global focus rule above being scoped away',
+  },
+  {
     fileSuffix: 'apps/desktop/src/renderer/styles/onboarding.css',
     anchor: '.maka-onboarding-quickchat-input',
     reason: 'shared textarea chrome reset inside wrapper-owned surface',

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1239,7 +1239,16 @@
      `.maka-skill-search` label — reading as two stacked search
      bars. The fix zeroes every visual property the primitive can
      paint, so the inner `<input>` reads as a bare text field and
-     the outer label is the only box. */
+     the outer label is the only box.
+     Defensive addition (double-border textarea sweep): `border: 0` /
+     `box-shadow: none` here only wins today because the global
+     `:where(input, select, textarea):focus` rule below happens to
+     `!important`-override the primitive's `focus-visible:ring-2`
+     box-shadow too. If that global rule is ever scoped away, this
+     input's own `--tw-ring-shadow` / `--tw-ring-offset-shadow` would
+     re-surface the same double-box bug — see the composer/onboarding
+     textarea fixes for the pattern. Reset them here directly so this
+     rule doesn't depend on an unrelated global fallback. */
   min-width: 0;
   width: 100%;
   height: 30px;
@@ -1251,6 +1260,8 @@
   outline: none;
   padding: 0;
   font-size: 13px;
+  --tw-ring-shadow: 0 0 #0000 !important;
+  --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
 
 .maka-skill-search input::placeholder {

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1241,14 +1241,11 @@
      paint, so the inner `<input>` reads as a bare text field and
      the outer label is the only box.
      Correction (double-border textarea sweep, verified live via CDP):
-     `box-shadow: none` here does NOT actually win while the input is
-     focused — the global `:where(input, select, textarea):focus` rule
-     below sets its own `!important` inset box-shadow on every focused
-     field, and `!important` always beats a non-`!important` declaration
-     regardless of this selector's specificity. That repaints the exact
-     nested-box bug on focus. `border-radius`/`background` don't need
-     `!important` (nothing else sets them on focus), but `box-shadow`
-     and the ring-var reset do. */
+     `box-shadow`/ring-var reset need `!important` to beat the global
+     `:where(input, select, textarea):focus` rule below on focus — see
+     `.composer .maka-composer-textarea` in tool-output.css for why.
+     `border-radius`/`background` don't need it (nothing else sets them
+     on focus). */
   min-width: 0;
   width: 100%;
   height: 30px;

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1240,15 +1240,15 @@
      bars. The fix zeroes every visual property the primitive can
      paint, so the inner `<input>` reads as a bare text field and
      the outer label is the only box.
-     Defensive addition (double-border textarea sweep): `border: 0` /
-     `box-shadow: none` here only wins today because the global
-     `:where(input, select, textarea):focus` rule below happens to
-     `!important`-override the primitive's `focus-visible:ring-2`
-     box-shadow too. If that global rule is ever scoped away, this
-     input's own `--tw-ring-shadow` / `--tw-ring-offset-shadow` would
-     re-surface the same double-box bug — see the composer/onboarding
-     textarea fixes for the pattern. Reset them here directly so this
-     rule doesn't depend on an unrelated global fallback. */
+     Correction (double-border textarea sweep, verified live via CDP):
+     `box-shadow: none` here does NOT actually win while the input is
+     focused — the global `:where(input, select, textarea):focus` rule
+     below sets its own `!important` inset box-shadow on every focused
+     field, and `!important` always beats a non-`!important` declaration
+     regardless of this selector's specificity. That repaints the exact
+     nested-box bug on focus. `border-radius`/`background` don't need
+     `!important` (nothing else sets them on focus), but `box-shadow`
+     and the ring-var reset do. */
   min-width: 0;
   width: 100%;
   height: 30px;
@@ -1256,7 +1256,7 @@
   border: 0;
   border-radius: 0;
   background: transparent;
-  box-shadow: none;
+  box-shadow: none !important;
   outline: none;
   padding: 0;
   font-size: 13px;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -480,23 +480,19 @@
     0 0 0 4px oklch(from var(--accent) l c h / 0.08),
     0 1px 0 oklch(from var(--foreground) 1 0 h / 0.75) inset;
 }
-/* Justified: the wrapper owns the visible field chrome, so the textarea
-   stays bare. Tailwind's `border-0 shadow-none focus-visible:ring-0`
-   override classes on the JSX side only remove the utility classes from
-   the className string — they don't clear the underlying
-   `--tw-ring-shadow` / `--tw-ring-offset-shadow` custom properties the
-   base Textarea's `focus-visible:ring-2` utility sets. Without a scoped
-   reset here, the ring re-composites into `box-shadow` on focus and
-   renders as a second "framed" border nested inside the wrapper's own
-   border. Mirrors the same fix already applied to `.maka-composer-textarea`
-   in tool-output.css.
-   `border`/`box-shadow` must be `!important`: the global
-   `:where(input, select, textarea):focus` rule in module-pages.css sets
-   an `!important` inset box-shadow on every focused field, and without
-   matching `!important` here it wins over this rule regardless of this
-   selector's specificity, repainting the exact nested-border bug this
-   file exists to fix — but only while the field is focused. */
-.maka-onboarding-quickchat-input {
+/* Justified: bare-textarea chrome reset — see `.composer .maka-composer-
+   textarea` in tool-output.css for the full rationale (Tailwind's
+   `border-0 shadow-none focus-visible:ring-0` classes don't clear the
+   underlying `--tw-ring-shadow` custom properties, which re-composite
+   into `box-shadow` on focus).
+   Scoped to `.maka-onboarding-quickchat .maka-onboarding-quickchat-input`
+   (not the bare class) so this rule's specificity (0,2,0) beats the
+   global `:where(input, select, textarea):focus` rule in module-pages.css
+   (0,1,0) outright — `!important` alone isn't enough when both sides are
+   `!important` and this file loads *before* module-pages.css, since the
+   later rule then wins ties on source order. Same reasoning as
+   `.maka-skill-search input`'s extra type selector there. */
+.maka-onboarding-quickchat .maka-onboarding-quickchat-input {
   appearance: none;
   box-sizing: border-box;
   width: 100%;
@@ -512,7 +508,12 @@
   --tw-ring-shadow: 0 0 #0000 !important;
   --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
-.maka-onboarding-quickchat[data-drag-active="true"] .maka-onboarding-quickchat-input {
+/* Drag-active feedback lives on the wrapper, not the inner textarea: the
+   textarea's own `border`/`box-shadow` are hard-reset to `none !important`
+   above, which unconditionally wins over a non-`!important` declaration
+   regardless of selector specificity — so painting this on the textarea
+   was always dead code. */
+.maka-onboarding-quickchat[data-drag-active="true"] {
   border-color: oklch(from var(--accent) l c h / 0.46);
   background: oklch(from var(--accent) 0.98 calc(c * 0.20) h / 0.35);
   box-shadow:

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -480,7 +480,16 @@
     0 0 0 4px oklch(from var(--accent) l c h / 0.08),
     0 1px 0 oklch(from var(--foreground) 1 0 h / 0.75) inset;
 }
-/* The wrapper owns the visible field chrome; the inner textarea stays bare. */
+/* Justified: the wrapper owns the visible field chrome, so the textarea
+   stays bare. Tailwind's `border-0 shadow-none focus-visible:ring-0`
+   override classes on the JSX side only remove the utility classes from
+   the className string — they don't clear the underlying
+   `--tw-ring-shadow` / `--tw-ring-offset-shadow` custom properties the
+   base Textarea's `focus-visible:ring-2` utility sets. Without a scoped
+   reset here, the ring re-composites into `box-shadow` on focus and
+   renders as a second "framed" border nested inside the wrapper's own
+   border. Mirrors the same fix already applied to `.maka-composer-textarea`
+   in tool-output.css. */
 .maka-onboarding-quickchat-input {
   appearance: none;
   box-sizing: border-box;
@@ -492,6 +501,10 @@
   font-size: 15px;
   line-height: 1.5;
   outline: none;
+  border: none;
+  box-shadow: none;
+  --tw-ring-shadow: 0 0 #0000 !important;
+  --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
 .maka-onboarding-quickchat[data-drag-active="true"] .maka-onboarding-quickchat-input {
   border-color: oklch(from var(--accent) l c h / 0.46);

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -489,7 +489,13 @@
    reset here, the ring re-composites into `box-shadow` on focus and
    renders as a second "framed" border nested inside the wrapper's own
    border. Mirrors the same fix already applied to `.maka-composer-textarea`
-   in tool-output.css. */
+   in tool-output.css.
+   `border`/`box-shadow` must be `!important`: the global
+   `:where(input, select, textarea):focus` rule in module-pages.css sets
+   an `!important` inset box-shadow on every focused field, and without
+   matching `!important` here it wins over this rule regardless of this
+   selector's specificity, repainting the exact nested-border bug this
+   file exists to fix — but only while the field is focused. */
 .maka-onboarding-quickchat-input {
   appearance: none;
   box-sizing: border-box;
@@ -501,8 +507,8 @@
   font-size: 15px;
   line-height: 1.5;
   outline: none;
-  border: none;
-  box-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
   --tw-ring-shadow: 0 0 #0000 !important;
   --tw-ring-offset-shadow: 0 0 #0000 !important;
 }

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -152,7 +152,13 @@
 }
 
 /* Justified: the composer wrapper owns the visible field chrome, so the
-   textarea stays bare and keeps only the scoped ring-shadow reset here. */
+   textarea stays bare and keeps only the scoped ring-shadow reset here.
+   The JSX `border-0 shadow-none focus-visible:ring-0` override classes
+   only remove those utility classes from the className string — they
+   don't clear the base Textarea's `focus-visible:ring-2` custom
+   properties (`--tw-ring-shadow` / `--tw-ring-offset-shadow`), which
+   otherwise re-composite into `box-shadow` on focus and render as a
+   second "framed" border nested inside the composer's own border. */
 .composer .maka-composer-textarea {
   appearance: none;
   display: block;
@@ -162,6 +168,8 @@
   font-family: var(--font-default);
   font-size: 15px;
   line-height: 1.55;
+  border: none;
+  box-shadow: none;
   /* local: suppress tailwind ring shadow on this element */
   --tw-ring-shadow: 0 0 #0000 !important;
   --tw-ring-offset-shadow: 0 0 #0000 !important;

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -158,7 +158,13 @@
    don't clear the base Textarea's `focus-visible:ring-2` custom
    properties (`--tw-ring-shadow` / `--tw-ring-offset-shadow`), which
    otherwise re-composite into `box-shadow` on focus and render as a
-   second "framed" border nested inside the composer's own border. */
+   second "framed" border nested inside the composer's own border.
+   `border`/`box-shadow` must be `!important`: the global
+   `:where(input, select, textarea):focus` rule in module-pages.css sets
+   an `!important` inset box-shadow on every focused field, and without
+   matching `!important` here it wins over this rule regardless of this
+   selector's specificity, repainting the exact nested-border bug this
+   file exists to fix — but only while the field is focused. */
 .composer .maka-composer-textarea {
   appearance: none;
   display: block;
@@ -168,8 +174,8 @@
   font-family: var(--font-default);
   font-size: 15px;
   line-height: 1.55;
-  border: none;
-  box-shadow: none;
+  border: none !important;
+  box-shadow: none !important;
   /* local: suppress tailwind ring shadow on this element */
   --tw-ring-shadow: 0 0 #0000 !important;
   --tw-ring-offset-shadow: 0 0 #0000 !important;


### PR DESCRIPTION
<img width="770" height="170" alt="image" src="https://github.com/user-attachments/assets/13c5eb55-4e2f-4e78-aa3c-ba8f1439f4b7" />

## Summary

- Several inputs use the "outer wrapper owns the visible chrome, inner `Textarea`/`Input` stays bare" pattern via JSX overrides like `border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0`. Those overrides only remove the utility classes from the `className` string — they don't clear the base `Textarea`/`Input`'s `focus-visible:ring-2` custom properties (`--tw-ring-shadow` / `--tw-ring-offset-shadow`).
- Found while looking at the first-run onboarding quick-chat textarea, which visibly showed a double border. Audited the rest of the renderer for the same pattern and found two more.
- **Update:** the first version of this fix (`border: none; box-shadow: none;` without `!important`) turned out to be incomplete — see "Second pass" below. Confirmed via the reporter re-testing on a live build.

## Fixed

- **Onboarding quick-chat textarea** (`.maka-onboarding-quickchat-input`, `apps/desktop/src/renderer/styles/onboarding.css`): had no reset at all beyond the JSX override classes.
- **Composer textarea** (`.maka-composer-textarea`, `apps/desktop/src/renderer/styles/tool-output.css`): only had the ring-var reset, not `border`/`box-shadow`.
- **Skill search input** (`.maka-skill-search input`, `apps/desktop/src/renderer/styles/module-pages.css`): had `border: 0; box-shadow: none;` from an earlier fix (`PR-SKILL-SEARCH-DOUBLE-BOX-0`), but no `--tw-ring-*` reset.

Audited the rest of the renderer's `Input`/`Textarea` usages (30+ call sites) — everything else either passes no className override (safe, single-layer default styling) or uses the newer `InputGroupInput`/`SidebarInput` primitives, which are `unstyled` and paint chrome only on the outer wrapper (architecturally can't double-box).

## Second pass: the `!important` gap

The three resets above weren't `!important`, so they silently lost to a global rule in `module-pages.css`:

```css
:where(input, select, textarea):focus {
  box-shadow: inset 0 0 0 1px oklch(from var(--accent) l c h / 0.22) !important;
}
```

That rule paints its own inset accent ring on **every** focused field, and an `!important` declaration always wins over a non-`!important` one regardless of selector specificity. So the nested border reappeared specifically **while the field is focused** — the exact state every screenshot of this bug was taken in. My first round of verification screenshotted the *unfocused* state and missed it.

Fixed by adding `!important` to `border`/`box-shadow` on all three rules. This time verified via Chrome DevTools Protocol directly against the running app (production build and Vite HMR dev server both), not OS-level screenshots: `getComputedStyle` on the focused textarea reports `box-shadow: none`, and a CDP screenshot taken while focused shows a single border. Confirmed working by the reporter on a live rebuild.

## Test plan

- [x] `npm run typecheck --workspaces --if-present`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm --workspace @maka/desktop run test` — 1626/1626 passing, including the `!important` audit contract test updated for the new allowlist entry
- [x] Verified via CDP against a live, focused composer textarea (production build + Vite HMR dev server)
- [x] Confirmed fixed by the reporter on a local rebuild