### PR TITLE
test(ui): add sidebar session-list stories

### DIFF
--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -107,6 +107,29 @@ describe('Storybook baseline contract', () => {
     assert.doesNotMatch(src, /className=/, 'Story fixtures must not add story-only Tailwind classes.');
   });
 
+  it('storyboards the sidebar session list states before visual polish', () => {
+    const sidebarStories = join(REPO_ROOT, 'packages', 'ui', 'stories', 'session-list-panel.stories.tsx');
+    assert.ok(existsSync(sidebarStories), 'Sidebar session-list states must be inspectable in Storybook');
+
+    const src = readFileSync(sidebarStories, 'utf8');
+    assert.match(src, /title:\s*['"]Product\/Sidebar Session List['"]/);
+    assert.match(src, /SessionListPanel/);
+    assert.match(src, /satisfies\s+Meta/);
+    for (const storyName of [
+      'Empty',
+      'LongList',
+      'StatusGroups',
+      'RowActions',
+      'LongTitlesAndNarrow',
+      'Collapsed',
+    ]) {
+      assert.match(src, new RegExp(`export const ${storyName}\\b`));
+    }
+    assert.match(src, /onOpenSearchModal/);
+    assert.match(src, /statusGroups/);
+    assert.doesNotMatch(src, /app-shell/, 'Sidebar stories must not import the desktop app shell.');
+  });
+
   it('keeps Storybook stories out of the regular @maka/ui TypeScript build', () => {
     const config = readTypescriptConfig(REPO_ROOT, join(REPO_ROOT, 'packages', 'ui', 'tsconfig.json'));
 

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -7,11 +7,10 @@ const NOW = Date.now();
 
 const meta = {
   title: 'Product/Sidebar Session List',
-  component: SessionListPanel,
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof SessionListPanel>;
+} satisfies Meta;
 
 export default meta;
 

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { SessionBlockedReason, SessionStatus, SessionSummary } from '@maka/core';
+import { SessionListPanel } from '../src/session-list-panel.js';
+
+const NOW = Date.now();
+
+const meta = {
+  title: 'Product/Sidebar Session List',
+  component: SessionListPanel,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof SessionListPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+type SessionListPanelProps = Parameters<typeof SessionListPanel>[0];
+type StatusGroup = NonNullable<SessionListPanelProps['statusGroups']>[number];
+
+const noop = () => undefined;
+
+function makeSession(input: {
+  id: string;
+  name: string;
+  status?: SessionStatus;
+  blockedReason?: SessionBlockedReason;
+  lastMessageAt?: number;
+  isFlagged?: boolean;
+  isArchived?: boolean;
+  hasUnread?: boolean;
+  backend?: SessionSummary['backend'];
+  llmConnectionSlug?: string;
+}): SessionSummary {
+  const status = input.status ?? 'active';
+  const isArchived = input.isArchived ?? status === 'archived';
+  return {
+    id: input.id,
+    name: input.name,
+    isFlagged: input.isFlagged ?? false,
+    isArchived,
+    labels: [],
+    hasUnread: input.hasUnread ?? false,
+    status,
+    ...(input.blockedReason ? { blockedReason: input.blockedReason } : {}),
+    ...(input.lastMessageAt !== undefined ? { lastMessageAt: input.lastMessageAt } : {}),
+    backend: input.backend ?? 'ai-sdk',
+    llmConnectionSlug: input.llmConnectionSlug ?? 'zai-live',
+    model: 'glm-4.7',
+    permissionMode: 'ask',
+  };
+}
+
+function countSessions(sessions: readonly SessionSummary[]): SessionListPanelProps['sessionCounts'] {
+  return {
+    chats: sessions.filter((session) => !session.isArchived).length,
+    flagged: sessions.filter((session) => session.isFlagged).length,
+    archived: sessions.filter((session) => session.isArchived).length,
+  };
+}
+
+const rowActions: NonNullable<SessionListPanelProps['rowActions']> = {
+  onToggleFlag: noop,
+  onArchive: noop,
+  onUnarchive: noop,
+  onRename: noop,
+  onDelete: noop,
+};
+
+function panelProps(input: {
+  sessions: SessionSummary[];
+  activeId?: string;
+  statusGroups?: StatusGroup[];
+  streamingSessionIds?: Set<string>;
+  staleSessionIds?: Set<string>;
+  sidebarCollapsed?: boolean;
+}): SessionListPanelProps {
+  return {
+    selection: { section: 'sessions', filter: 'chats' },
+    sessionCounts: countSessions(input.sessions),
+    sessions: input.sessions,
+    ...(input.activeId ? { activeId: input.activeId } : {}),
+    ...(input.statusGroups ? { statusGroups: input.statusGroups } : {}),
+    ...(input.streamingSessionIds ? { streamingSessionIds: input.streamingSessionIds } : {}),
+    ...(input.staleSessionIds ? { staleSessionIds: input.staleSessionIds } : {}),
+    ...(input.sidebarCollapsed ? { sidebarCollapsed: input.sidebarCollapsed } : {}),
+    onSelectSession: noop,
+    onSelect: noop,
+    onOpenSettings: noop,
+    onNew: noop,
+    onOpenSearchModal: noop,
+    rowActions,
+    onToggleSidebar: noop,
+  };
+}
+
+function StoryFrame(props: {
+  children: ReactNode;
+  width?: number;
+  height?: number;
+  focusActiveRow?: boolean;
+}) {
+  const { children, width = 240, height = 680, focusActiveRow = false } = props;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!focusActiveRow) return;
+    const timeout = window.setTimeout(() => {
+      ref.current
+        ?.querySelector<HTMLButtonElement>('.maka-list-row[data-active="true"] .maka-list-row-main')
+        ?.focus({ preventScroll: true });
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [focusActiveRow]);
+
+  return (
+    <div
+      ref={ref}
+      data-maka-visual-smoke="true"
+      style={{
+        background: 'var(--surface-canvas)',
+        height,
+        overflow: 'hidden',
+        width,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const coreSessions = [
+  makeSession({
+    id: 'session-running',
+    name: '生成本周 benchmark 对比表',
+    status: 'running',
+    lastMessageAt: NOW - 2 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'session-active',
+    name: 'Harbor adapter metadata 对齐',
+    lastMessageAt: NOW - 18 * 60 * 1000,
+    hasUnread: true,
+  }),
+  makeSession({
+    id: 'session-stale',
+    name: '旧连接里的模型选择',
+    lastMessageAt: NOW - 42 * 60 * 1000,
+    backend: 'fake',
+    llmConnectionSlug: 'removed-connection',
+  }),
+  makeSession({
+    id: 'session-pinned',
+    name: 'PR #390 Storybook polish tracking',
+    lastMessageAt: NOW - 76 * 60 * 1000,
+    isFlagged: true,
+  }),
+];
+
+const statusSessions = [
+  makeSession({
+    id: 'status-running',
+    name: '运行中的工具链检查',
+    status: 'running',
+    lastMessageAt: NOW - 1 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'status-waiting',
+    name: '等待权限确认',
+    status: 'waiting_for_user',
+    lastMessageAt: NOW - 8 * 60 * 1000,
+    hasUnread: true,
+  }),
+  makeSession({
+    id: 'status-blocked',
+    name: 'OAuth 需要重新授权',
+    status: 'blocked',
+    blockedReason: 'auth',
+    lastMessageAt: NOW - 20 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'status-review',
+    name: '待审核的文件 diff',
+    status: 'review',
+    lastMessageAt: NOW - 37 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'status-done',
+    name: '已完成的 smoke run',
+    status: 'done',
+    lastMessageAt: NOW - 2 * 60 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'status-archived',
+    name: '归档的旧实验',
+    status: 'archived',
+    lastMessageAt: NOW - 8 * 24 * 60 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'status-aborted',
+    name: '中止的临时尝试',
+    status: 'aborted',
+    lastMessageAt: NOW - 15 * 24 * 60 * 60 * 1000,
+  }),
+];
+
+const statusGroups: StatusGroup[] = [
+  {
+    id: 'running',
+    label: '进行中',
+    sessions: statusSessions.filter((session) => session.status === 'running'),
+    collapsible: false,
+    defaultExpanded: true,
+  },
+  {
+    id: 'waiting_for_user',
+    label: '等待你',
+    sessions: statusSessions.filter((session) => session.status === 'waiting_for_user'),
+    collapsible: false,
+    defaultExpanded: true,
+  },
+  {
+    id: 'blocked',
+    label: '已阻塞',
+    sessions: statusSessions.filter((session) => session.status === 'blocked'),
+    collapsible: false,
+    defaultExpanded: true,
+  },
+  {
+    id: 'review',
+    label: '待审核',
+    sessions: statusSessions.filter((session) => session.status === 'review'),
+    collapsible: false,
+    defaultExpanded: true,
+  },
+  {
+    id: 'done',
+    label: '已完成',
+    sessions: statusSessions.filter((session) => session.status === 'done'),
+    collapsible: false,
+    defaultExpanded: true,
+  },
+  {
+    id: 'archived',
+    label: '归档',
+    sessions: statusSessions.filter((session) => session.status === 'archived'),
+    collapsible: true,
+    defaultExpanded: false,
+  },
+  {
+    id: 'aborted',
+    label: '已中止',
+    sessions: statusSessions.filter((session) => session.status === 'aborted'),
+    collapsible: true,
+    defaultExpanded: false,
+  },
+];
+
+const longListSessions = Array.from({ length: 36 }, (_, index) => makeSession({
+  id: `long-list-${index + 1}`,
+  name: `${index % 6 === 0 ? '已置顶 ' : ''}会话 ${String(index + 1).padStart(2, '0')} · ${
+    [
+      '整理发布前检查项',
+      '跟进 UI 回归截图',
+      '复盘运行时工具输出',
+      '确认 provider 配置',
+      '收敛 PR body',
+      '处理 review 反馈',
+    ][index % 6]
+  }`,
+  lastMessageAt: NOW - index * 47 * 60 * 1000,
+  isFlagged: index === 0 || index === 6,
+  hasUnread: index === 4 || index === 17,
+}));
+
+const longTitleSessions = [
+  makeSession({
+    id: 'long-title-active',
+    name: '这是一个非常长的中文会话标题，用来检查窄侧边栏里标题、状态和时间不会互相挤压',
+    lastMessageAt: NOW - 6 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'long-title-stale',
+    name: 'Artifact Pane 验收路径和 sidebar row action overlay 的长标题组合测试',
+    status: 'blocked',
+    blockedReason: 'permission_required',
+    lastMessageAt: NOW - 31 * 60 * 1000,
+  }),
+  makeSession({
+    id: 'long-title-pinned',
+    name: 'PR #390 Sidebar session-list storyboard 状态覆盖范围确认',
+    isFlagged: true,
+    lastMessageAt: NOW - 52 * 60 * 1000,
+  }),
+];
+
+export const Empty: Story = {
+  render: () => (
+    <StoryFrame>
+      <SessionListPanel {...panelProps({ sessions: [] })} />
+    </StoryFrame>
+  ),
+};
+
+export const LongList: Story = {
+  render: () => (
+    <StoryFrame>
+      <SessionListPanel {...panelProps({
+        sessions: longListSessions,
+        activeId: 'long-list-4',
+      })} />
+    </StoryFrame>
+  ),
+};
+
+export const StatusGroups: Story = {
+  render: () => (
+    <StoryFrame>
+      <SessionListPanel {...panelProps({
+        sessions: statusSessions,
+        activeId: 'status-waiting',
+        statusGroups,
+        streamingSessionIds: new Set(['status-running']),
+        staleSessionIds: new Set(['status-blocked']),
+      })} />
+    </StoryFrame>
+  ),
+};
+
+export const RowActions: Story = {
+  render: () => (
+    <StoryFrame focusActiveRow>
+      <SessionListPanel {...panelProps({
+        sessions: coreSessions,
+        activeId: 'session-active',
+        streamingSessionIds: new Set(['session-running']),
+        staleSessionIds: new Set(['session-stale']),
+      })} />
+    </StoryFrame>
+  ),
+};
+
+export const LongTitlesAndNarrow: Story = {
+  render: () => (
+    <StoryFrame width={176}>
+      <SessionListPanel {...panelProps({
+        sessions: longTitleSessions,
+        activeId: 'long-title-active',
+        staleSessionIds: new Set(['long-title-stale']),
+      })} />
+    </StoryFrame>
+  ),
+};
+
+export const Collapsed: Story = {
+  render: () => (
+    <StoryFrame width={72}>
+      <SessionListPanel {...panelProps({
+        sessions: coreSessions,
+        activeId: 'session-running',
+        sidebarCollapsed: true,
+      })} />
+    </StoryFrame>
+  ),
+};


### PR DESCRIPTION
## Summary

- Add `Product/Sidebar Session List` stories for empty, long-list, status-grouped, row-action, narrow-title, and collapsed sidebar states.
- Add a Storybook contract that keeps these sidebar states present before visual polish work starts.

## Why

Refs #390. This is PR1 for making Sidebar / `SessionListPanel` states inspectable in Storybook before any UI polish.

## Scope

Changed:

- `packages/ui/stories/session-list-panel.stories.tsx`
- `apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts`

Not included:

- No visual polish or CSS changes.
- No `app-shell.tsx` changes.
- No restored sidebar-local search input.

## Verification

- `npm exec -- tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck --esModuleInterop --forceConsistentCasingInFileNames --resolveJsonModule --isolatedModules --jsx react-jsx packages/ui/stories/session-list-panel.stories.tsx`
- `node --test apps/desktop/dist/main/__tests__/storybook-baseline-contract.test.js`
- `npm run -w @maka/desktop build-storybook`
- `npm run typecheck`
- `npm run -w @maka/desktop test`

## User-facing impact

No production UI behavior change. Storybook-only coverage for review and future polish.

## Reviewer notes

`RowActions` focuses the active row inside the story so the existing hover/focus action overlay is inspectable without changing `SessionListPanel`.

`SessionListPanel` no longer renders a visible local filter control; the storyboard covers the remaining visible grouping state through `StatusGroups` and the existing search-modal trigger through `onOpenSearchModal`.