### PR TITLE
Enable desktop semantic compaction by default

### DIFF
--- a/apps/desktop/src/main/context-budget-policy.ts
+++ b/apps/desktop/src/main/context-budget-policy.ts
@@ -14,6 +14,7 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
   const synthesisCache = buildSynthesisCachePolicy();
   const historyCompact = buildHistoryCompactPolicy();
   const historyRewrite = buildHistoryRewriteGatePolicy();
+  const semanticCompact = buildSemanticCompactPolicy();
   if (
     maxHistoryEstimatedTokens === undefined &&
     maxHistoryTurns === undefined &&
@@ -22,6 +23,7 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
     historySearch === undefined &&
     synthesisCache === undefined &&
     historyCompact === undefined &&
+    semanticCompact === undefined &&
     historyRewrite === undefined
   ) {
     return undefined;
@@ -35,6 +37,7 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
     ...(historySearch !== undefined ? { historySearch } : {}),
     ...(synthesisCache !== undefined ? { synthesisCache } : {}),
     ...(historyCompact !== undefined ? { historyCompact } : {}),
+    ...(semanticCompact !== undefined ? { semanticCompact } : {}),
     ...(historyRewrite !== undefined ? { historyRewrite } : {}),
     minRecentTurns,
   };
@@ -125,6 +128,65 @@ function buildHistoryRewriteGatePolicy(): NonNullable<ContextBudgetPolicy['histo
   };
 }
 
+function buildSemanticCompactPolicy(): NonNullable<ContextBudgetPolicy['semanticCompact']> | undefined {
+  const enabled = parseOptionalBoolean(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT, 'MAKA_CONTEXT_SEMANTIC_COMPACT');
+  if (enabled === false) return undefined;
+  const mode = parseSemanticCompactMode(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE);
+  if (mode === 'off') return undefined;
+  const rejectInvalidSummaries = parseOptionalBoolean(
+    process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_REJECT_INVALID_SUMMARIES,
+    'MAKA_CONTEXT_SEMANTIC_COMPACT_REJECT_INVALID_SUMMARIES',
+  );
+  const archiveRequired = parseOptionalBoolean(
+    process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED,
+    'MAKA_CONTEXT_SEMANTIC_COMPACT_ARCHIVE_REQUIRED',
+  );
+  const benchmarkStateCards = parseOptionalBoolean(
+    process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS,
+    'MAKA_CONTEXT_SEMANTIC_COMPACT_BENCHMARK_STATE_CARDS',
+  );
+  return {
+    enabled: true,
+    mode: mode ?? 'replace',
+    minStepNumber: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_STEP_NUMBER) ?? 2,
+    highWaterRatio: parseOptionalRatio(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_RATIO) ?? 0.5,
+    forceRatio: parseOptionalRatio(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_FORCE_RATIO),
+    targetRatio: parseOptionalRatio(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_TARGET_RATIO),
+    maxActiveEstimatedTokens:
+      parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ACTIVE_ESTIMATED_TOKENS) ??
+      parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_ESTIMATED_TOKENS) ??
+      16_384,
+    minRecentMessages: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_MESSAGES) ?? 4,
+    minRecentToolPairs: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_RECENT_TOOL_PAIRS) ?? 1,
+    maxSummaryEstimatedTokens:
+      parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_SUMMARY_ESTIMATED_TOKENS) ??
+      parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_SUMMARY_MAX_ESTIMATED_TOKENS) ??
+      768,
+    minSavingsTokens: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_TOKENS) ?? 256,
+    minSavingsRatio: parseOptionalRatio(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_SAVINGS_RATIO),
+    minNetSavingsTokens: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MIN_NET_SAVINGS_TOKENS) ?? 256,
+    compactCallTokenCostWeight: parseOptionalNonNegativeNumber(
+      process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_CALL_TOKEN_COST_WEIGHT,
+    ),
+    maxCompactCallTokens: parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CALL_TOKENS) ?? 4096,
+    maxConsecutiveInvalidSummaries:
+      parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MAX_CONSECUTIVE_INVALID_SUMMARIES) ?? 2,
+    invalidSummaryCooldownSteps:
+      parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_INVALID_SUMMARY_COOLDOWN_STEPS) ?? 8,
+    ...(rejectInvalidSummaries !== undefined ? { rejectInvalidSummaries } : {}),
+    timeoutMs: parseOptionalPositiveInt(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_TIMEOUT_MS),
+    ...(archiveRequired !== undefined ? { archiveRequired } : {}),
+    ...(benchmarkStateCards !== undefined ? { benchmarkStateCards } : {}),
+    ...(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL
+      ? { summarizerModel: process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODEL }
+      : {}),
+    ...(process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION
+      ? { promptVersion: process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_PROMPT_VERSION }
+      : {}),
+    highWaterName: process.env.MAKA_CONTEXT_SEMANTIC_COMPACT_HIGH_WATER_NAME ?? 'desktop-semantic-compact',
+  };
+}
+
 function defaultHistoryBudgetTokens(connection: LlmConnection): number | undefined {
   if (connection.providerType === 'deepseek') return undefined;
   return 32_000;
@@ -141,6 +203,18 @@ function parseOptionalPositiveInt(value: string | undefined): number | undefined
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function parseOptionalNonNegativeInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseOptionalNonNegativeNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
 function parseOptionalRatio(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseFloat(value);
@@ -154,6 +228,33 @@ function parseSynthesisCacheMode(value: string | undefined): 'lookup' | 'read_wr
 function parseHistoryCompactMode(value: string | undefined): NonNullable<ContextBudgetPolicy['historyCompact']>['mode'] {
   if (value === 'lookup' || value === 'read_write' || value === 'deterministic') return value;
   return 'lookup';
+}
+
+function parseSemanticCompactMode(value: string | undefined): NonNullable<ContextBudgetPolicy['semanticCompact']>['mode'] | undefined {
+  if (!value) return undefined;
+  if (value === 'off' || value === 'validate_only' || value === 'prepare_step_dry_run' || value === 'replace') return value;
+  return undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined, name: string): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  switch (normalized) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+    case 'enabled':
+      return true;
+    case '0':
+    case 'false':
+    case 'no':
+    case 'off':
+    case 'disabled':
+      return false;
+    default:
+      throw new Error(`${name} must be a boolean, got ${JSON.stringify(value)}`);
+  }
 }
 
 function parseArchiveRetrievalMode(value: string | undefined): NonNullable<ContextBudgetPolicy['archiveRetrieval']>['mode'] | undefined {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -601,6 +601,7 @@ backends.register('ai-sdk', async (ctx) => {
     }),
     recordRunTrace: ctx.recordRunTrace,
     recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
+    recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
     newId: randomUUID,
     now: Date.now,
   });


### PR DESCRIPTION
## Summary
- enable runtime LLM semantic compaction for desktop default sessions via `buildContextBudgetPolicy()`
- persist accepted semantic compact blocks from desktop sessions into the AgentRun ledger
- keep `MAKA_CONTEXT_SEMANTIC_COMPACT=off` and `MAKA_CONTEXT_SEMANTIC_COMPACT_*` env overrides for disabling/tuning, including opt-in reject-invalid behavior

## Defaults
- `mode=replace`
- `minStepNumber=2`
- `highWaterRatio=0.5`
- `maxActiveEstimatedTokens=16384`
- preserve recent `4` messages and `1` tool pair
- `maxCompactCallTokens=4096`
- `minSavingsTokens=256`, `minNetSavingsTokens=256`
- invalid summary brake: `2` invalid summaries / `8` cooldown steps

## Verification
- `npx tsc -p tsconfig.main.json --noEmit` from `apps/desktop`
- `git diff --check HEAD~1..HEAD`

Full `npm --workspace @maka/desktop run typecheck` still fails in existing renderer code unrelated to this main-process/backend patch:

- `src/renderer/artifact-preview.tsx(39,14): Module "@maka/ui" has no exported member "previewVariants"`
- `src/renderer/settings/general-settings-page.tsx(153,11): Property "optionGroups" does not exist on type "SettingsSelectProps<string>"`
