### PR TITLE
Refactor(ui): Refactor desktop shell chrome controls

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-chrome-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-chrome-contract.test.ts
@@ -1,0 +1,50 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const RENDERER_ROOT = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer');
+const SESSION_LIST_PANEL_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'session-list-panel.tsx');
+
+describe('app shell chrome contract', () => {
+  it('keeps shell chrome and workspace actions split out of app-shell', async () => {
+    const appShell = await readFile(resolve(RENDERER_ROOT, 'app-shell.tsx'), 'utf8');
+    const chromeActions = await readFile(resolve(RENDERER_ROOT, 'app-shell-chrome-actions.tsx'), 'utf8');
+    const combined = await readRendererShellCombinedSource();
+
+    assert.match(appShell, /from '\.\/app-shell-chrome-actions'/, 'app-shell.tsx must import shell chrome actions');
+    assert.match(appShell, /<AppShellTopbarActions\b/, 'app-shell.tsx must render shell-level chrome through AppShellTopbarActions');
+    assert.match(appShell, /<AppShellWorkspaceTopActions\b/, 'app-shell.tsx must render workspace chrome through AppShellWorkspaceTopActions');
+
+    assert.doesNotMatch(appShell, /className="maka-shell-topbar-rail"/, 'app-shell.tsx should not own shell chrome DOM details');
+    assert.doesNotMatch(appShell, /className="maka-workspace-top-actions"/, 'app-shell.tsx should not own workspace chrome DOM details');
+
+    assert.match(chromeActions, /export function AppShellTopbarActions/, 'chrome actions source must define shell topbar chrome');
+    assert.match(chromeActions, /export function AppShellWorkspaceTopActions/, 'chrome actions source must define workspace actions chrome');
+    assert.match(combined, /maka-shell-topbar-rail/, 'renderer shell sources must still define shell topbar chrome');
+    assert.match(combined, /className="maka-workspace-top-actions"/, 'renderer shell sources must still define workspace actions chrome');
+  });
+
+  it('keeps sidebar expand and collapse actions in the same shell rail', async () => {
+    const combined = await readRendererShellCombinedSource();
+    const sessionListPanel = await readFile(SESSION_LIST_PANEL_PATH, 'utf8');
+
+    assert.match(combined, /sidebarCollapsed \? 'is-collapsed' : 'is-expanded'/);
+    assert.match(combined, /PanelLeftClose/, 'expanded shell rail must expose collapse action');
+    assert.match(combined, /PanelLeftOpen/, 'collapsed shell rail must expose expand action');
+    assert.match(combined, /\{props\.sidebarCollapsed && \(/, 'new-session action should stay collapsed-only');
+
+    assert.doesNotMatch(
+      sessionListPanel,
+      /className="maka-sidebar-search-button"/,
+      'sidebar should not own a separate search button with different geometry',
+    );
+    assert.doesNotMatch(
+      sessionListPanel,
+      /className="maka-sidebar-toggle"/,
+      'sidebar should not own a separate collapse button with different geometry',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/main-window-safe-send-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/main-window-safe-send-contract.test.ts
@@ -38,11 +38,18 @@ describe('main-process safe-send to renderer contract', () => {
       'No raw mainWindow.webContents.send( call may remain either — use safeSendToRenderer instead',
     );
 
-    // Sanity: the menu accelerator we observed crashing must now use the helper.
+    // The legacy native application menu has been retired in favor of in-app
+    // settings/navigation surfaces, so the old Cmd+, menu accelerator no
+    // longer exists as a main-process send site.
     assert.match(
       src,
-      /accelerator: 'CommandOrControl\+,'[\s\S]*?click: \(\) => safeSendToRenderer\('window:openSettings'\)/,
-      'The Cmd+, menu accelerator must route through safeSendToRenderer',
+      /function installApplicationMenu\(\): void \{[\s\S]*?Menu\.setApplicationMenu\(null\);[\s\S]*?\}/,
+      'The native application menu must stay disabled',
+    );
+    assert.doesNotMatch(
+      src,
+      /Menu\.buildFromTemplate\(/,
+      'No native application menu template should be installed',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -39,13 +39,12 @@ import { join, resolve } from 'node:path';
 import { readRendererContractCss } from './contract-css-helpers.js';
 import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
 
-// The desktop test runs with cwd=apps/desktop; the UI package lives
-// two levels up. Resolve once.
-const COMPONENTS_PATH = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-view.tsx');
-const SEARCH_MODAL_PATH = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'search-modal.tsx');
-const MODAL_A11Y_PATH = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'modal-a11y.ts');
-const SESSION_LIST_PANEL_PATH = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'session-list-panel.tsx');
-const COMMAND_PALETTE_CONTENT_PATH = join(process.cwd(), 'src', 'renderer', 'command-palette-content-search.ts');
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const COMPONENTS_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'chat-view.tsx');
+const SEARCH_MODAL_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'search-modal.tsx');
+const MODAL_A11Y_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'modal-a11y.ts');
+const SESSION_LIST_PANEL_PATH = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'session-list-panel.tsx');
+const COMMAND_PALETTE_CONTENT_PATH = join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'command-palette-content-search.ts');
 
 describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', () => {
   it('SearchModal signature has close and navigation callbacks — NO `open` prop (conditional-mount contract)', async () => {
@@ -77,16 +76,13 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
     const src = await readFile(SEARCH_MODAL_PATH, 'utf8');
     const startIdx = src.indexOf('export function SearchModal');
     assert.notEqual(startIdx, -1);
-    // Find the start of the function body — the first `{` after
-    // the signature.
-    const bodyStart = src.indexOf('{', startIdx);
+    const signatureEnd = src.indexOf(') {', startIdx);
+    assert.notEqual(signatureEnd, -1);
+    const bodyStart = signatureEnd + 2;
     assert.notEqual(bodyStart, -1);
-    // Find the closing `}` of the function. SearchModal is
-    // top-level (no nesting), so the next `^}` at column 0 ends it.
-    const after = src.slice(bodyStart);
-    const closingIdx = after.search(/\n\}\n/);
-    assert.notEqual(closingIdx, -1);
-    const body = after.slice(0, closingIdx);
+    const bodyEnd = findMatchingBrace(src, bodyStart);
+    assert.notEqual(bodyEnd, -1);
+    const body = src.slice(bodyStart, bodyEnd);
     assert.doesNotMatch(
       body,
       /if\s*\(\s*!props\.open\s*\)\s*return\s*null/,
@@ -119,20 +115,14 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
   });
 
   it('returns focus to the sidebar Search trigger when the modal closes', async () => {
-    const components = await readFile(SESSION_LIST_PANEL_PATH, 'utf8');
     const main = await readRendererShellCombinedSource();
-    // PR-SIDEBAR-HEADER-BUTTONS-PRIMITIVE-0 (round 5/30): the sidebar
-    // search trigger was a raw <button> until routed through UiButton.
-    // Match either close tag so the contract pin tracks the primitive
-    // routing. The `data-maka-search-trigger` attribute still reaches
-    // the underlying DOM button because UiButton spreads data-* props.
-    const sidebarSearchButton = components.match(/className="maka-sidebar-search-button"[\s\S]*?<\/(?:button|UiButton)>/)?.[0] ?? '';
+    const shellSearchButton = main.match(/className="maka-shell-topbar-button"[\s\S]*?data-maka-search-trigger="true"[\s\S]*?<\/UiButton>/)?.[0] ?? '';
     const closeSearchModal = main.match(/function closeSearchModal\(options\?: \{ restoreFocus\?: boolean \}\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(
-      sidebarSearchButton,
+      shellSearchButton,
       /data-maka-search-trigger="true"[\s\S]*aria-label="搜索对话"/,
-      'Sidebar top Search trigger must be queryable for focus restoration after modal close',
+      'Shell top Search trigger must be queryable for focus restoration after modal close',
     );
     assert.match(
       closeSearchModal,
@@ -454,3 +444,16 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
     assert.doesNotMatch(groupingBlock, /尚未发送/, 'Session group labels should not read like unfinished implementation copy');
   });
 });
+
+function findMatchingBrace(source: string, openBraceIndex: number): number {
+  let depth = 0;
+  for (let i = openBraceIndex; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}

--- a/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readRendererContractCss } from './contract-css-helpers.js';
+
+describe('sidebar topbar rail geometry contract', () => {
+  it('anchors expanded and collapsed shell controls to the same top-left geometry', async () => {
+    const css = await readRendererContractCss();
+
+    const tokenRule = extractRuleBody(css, '.maka-shell-2col');
+    assert.ok(tokenRule, '.maka-shell-2col must define the shared topbar geometry tokens');
+    for (const token of [
+      '--maka-sidebar-topbar-button-size',
+      '--maka-sidebar-topbar-gap',
+      '--maka-sidebar-topbar-offset-y',
+      '--maka-sidebar-topbar-offset-x',
+    ]) {
+      assert.match(tokenRule, new RegExp(`${escapeRegExp(token)}\\s*:`), `${token} must be defined once on the shell`);
+    }
+
+    const shellRail = extractRuleBody(css, '.maka-shell-topbar-rail');
+    assert.ok(shellRail, '.maka-shell-topbar-rail rule must exist');
+    assert.match(shellRail, /top:\s*var\(--maka-sidebar-topbar-offset-y\)/);
+    assert.match(shellRail, /left:\s*var\(--maka-sidebar-topbar-offset-x\)/);
+    assert.match(shellRail, /gap:\s*var\(--maka-sidebar-topbar-gap\)/);
+    assert.doesNotMatch(
+      shellRail,
+      /var\(--maka-session-list-width/,
+      'shell controls must not move horizontally when the sidebar width changes',
+    );
+
+    const shellButtons = extractRuleBody(css, '.maka-shell-topbar-button');
+    assert.ok(shellButtons, 'shell rail buttons must share one rule');
+    assert.match(shellButtons, /width:\s*var\(--maka-sidebar-topbar-button-size\)/);
+    assert.match(shellButtons, /height:\s*var\(--maka-sidebar-topbar-button-size\)/);
+  });
+});
+
+function extractRuleBody(css: string, selector: string | string[]): string | undefined {
+  const expected = Array.isArray(selector) ? selector : [selector];
+  for (const rule of iterateRules(css)) {
+    const selectors = rule.selector.split(',').map((part) => part.trim());
+    if (selectors.length === expected.length && expected.every((part) => selectors.includes(part))) {
+      return rule.body;
+    }
+  }
+  return undefined;
+}
+
+function* iterateRules(css: string): Generator<{ selector: string; body: string }> {
+  let i = 0;
+  while (i < css.length) {
+    const braceIdx = css.indexOf('{', i);
+    if (braceIdx === -1) return;
+    const selector = css.slice(i, braceIdx).trim();
+    let depth = 1;
+    let j = braceIdx + 1;
+    while (j < css.length && depth > 0) {
+      const ch = css[j];
+      if (ch === '{') depth += 1;
+      if (ch === '}') depth -= 1;
+      j += 1;
+    }
+    if (selector && !selector.startsWith('@')) {
+      yield { selector, body: css.slice(braceIdx + 1, j - 1) };
+    }
+    i = j;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -125,7 +125,6 @@ describe('Storybook baseline contract', () => {
     ]) {
       assert.match(src, new RegExp(`export const ${storyName}\\b`));
     }
-    assert.match(src, /onOpenSearchModal/);
     assert.match(src, /statusGroups/);
     assert.doesNotMatch(src, /app-shell/, 'Sidebar stories must not import the desktop app shell.');
   });

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -391,56 +391,5 @@ function emitRealWindowSmokeDiagnostic(stage: string): void {
 }
 
 function installApplicationMenu(): void {
-  // App menu labels match the in-app Chinese-leaning UI per the PR69/70/71
-  // localization sweep. Role-based items (cut/copy/paste/reload/etc.) keep
-  // their OS-localized labels — those auto-translate when the user's system
-  // language matches; we only override the explicit `label` strings.
-  Menu.setApplicationMenu(
-    Menu.buildFromTemplate([
-      {
-        label: 'Maka',
-        submenu: [
-          { role: 'about', label: '关于 Maka' },
-          {
-            label: '设置…',
-            accelerator: 'CommandOrControl+,',
-            click: () => safeSendToRenderer('window:openSettings'),
-          },
-          { type: 'separator' },
-          { role: 'hide', label: '隐藏 Maka' },
-          { role: 'hideOthers' },
-          { role: 'unhide' },
-          { type: 'separator' },
-          { role: 'quit', label: '退出 Maka' },
-        ],
-      },
-      { label: '文件', submenu: [{ role: 'close' }] },
-      {
-        label: '编辑',
-        submenu: [
-          { role: 'undo' },
-          { role: 'redo' },
-          { type: 'separator' },
-          { role: 'cut' },
-          { role: 'copy' },
-          { role: 'paste' },
-          { role: 'selectAll' },
-        ],
-      },
-      {
-        label: '视图',
-        submenu: [
-          { role: 'reload' },
-          { role: 'toggleDevTools' },
-          { type: 'separator' },
-          { role: 'resetZoom' },
-          { role: 'zoomIn' },
-          { role: 'zoomOut' },
-          { type: 'separator' },
-          { role: 'togglefullscreen' },
-        ],
-      },
-      { label: '窗口', submenu: [{ role: 'minimize' }, { role: 'zoom' }] },
-    ]),
-  );
+  Menu.setApplicationMenu(null);
 }

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -1,18 +1,24 @@
-import { CircleGauge, Grid3X3, HelpCircle, MessageCircleQuestion, PanelLeftOpen, Search, SquarePen } from '@maka/ui/icons';
+import { CircleGauge, Grid3X3, HelpCircle, MessageCircleQuestion, PanelLeftClose, PanelLeftOpen, Search, SquarePen } from '@maka/ui/icons';
 import { Button as UiButton } from '@maka/ui';
 
-export function AppShellCollapsedTopbarActions(props: {
+export function AppShellTopbarActions(props: {
+  sidebarCollapsed: boolean;
   onOpenSearchModal(): void;
+  onCollapseSidebar(): void;
   onExpandSidebar(): void;
   onCreateSession(): void;
 }) {
   return (
-    <div className="maka-collapsed-topbar-actions">
+    <div
+      className={`maka-shell-topbar-rail ${props.sidebarCollapsed ? 'is-collapsed' : 'is-expanded'}`}
+      aria-label="窗口快捷操作"
+    >
       <UiButton
-        className="maka-collapsed-topbar-button"
+        className="maka-shell-topbar-button"
         variant="quiet"
         size="icon-sm"
         type="button"
+        data-maka-search-trigger="true"
         onClick={props.onOpenSearchModal}
         aria-label="搜索对话"
         title="搜索对话"
@@ -20,27 +26,34 @@ export function AppShellCollapsedTopbarActions(props: {
         <Search size={16} strokeWidth={1.65} aria-hidden="true" />
       </UiButton>
       <UiButton
-        className="maka-collapsed-topbar-button"
+        className="maka-shell-topbar-button"
         variant="quiet"
         size="icon-sm"
         type="button"
-        onClick={props.onExpandSidebar}
-        aria-label="展开侧边栏"
-        title="展开侧边栏"
+        onClick={props.sidebarCollapsed ? props.onExpandSidebar : props.onCollapseSidebar}
+        aria-label={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
+        aria-expanded={!props.sidebarCollapsed}
+        title={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
       >
-        <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
+        {props.sidebarCollapsed ? (
+          <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
+        ) : (
+          <PanelLeftClose size={16} strokeWidth={1.65} aria-hidden="true" />
+        )}
       </UiButton>
-      <UiButton
-        className="maka-collapsed-topbar-button"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.onCreateSession}
-        aria-label="新任务"
-        title="新任务"
-      >
-        <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
-      </UiButton>
+      {props.sidebarCollapsed && (
+        <UiButton
+          className="maka-shell-topbar-button"
+          variant="quiet"
+          size="icon-sm"
+          type="button"
+          onClick={props.onCreateSession}
+          aria-label="新任务"
+          title="新任务"
+        >
+          <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
+        </UiButton>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -68,7 +68,7 @@ import {
 import { buildChatModelChoices, chatModelChoiceLabel, normalizeActiveChatModel } from './chat-model-selection';
 import { basenameFromPath } from './app-shell-copy';
 import type { AppShellCommandListOptions } from './app-shell-command-actions';
-import { AppShellCollapsedTopbarActions, AppShellWorkspaceTopActions } from './app-shell-chrome-actions';
+import { AppShellTopbarActions, AppShellWorkspaceTopActions } from './app-shell-chrome-actions';
 import { AppShellOverlays } from './app-shell-overlays';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
 import { createAppShellPlanActions } from './app-shell-plan-actions';
@@ -1146,6 +1146,13 @@ export function AppShell() {
           '--maka-resize-handle-width': '0px',
         } as CSSProperties}
       >
+        <AppShellTopbarActions
+          sidebarCollapsed={sessionListCollapsed}
+          onOpenSearchModal={() => setSearchModalOpen(true)}
+          onCollapseSidebar={() => setSessionListCollapsed(true)}
+          onExpandSidebar={() => setSessionListCollapsed(false)}
+          onCreateSession={createSession}
+        />
         <div
           className="maka-panel maka-panel-list maka-floating-panel"
           aria-hidden={sessionListCollapsed ? 'true' : undefined}
@@ -1171,7 +1178,6 @@ export function AppShell() {
             onOpenSettings={openSettings}
             userLabel={userLabel}
             onNew={createSession}
-            onOpenSearchModal={() => setSearchModalOpen(true)}
             onRefreshPlanReminders={() => refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive })}
             onCreatePlanReminder={(input) => createPlanReminder(input)}
             onUpdatePlanReminder={(id, patch) => updatePlanReminder(id, patch)}
@@ -1191,7 +1197,6 @@ export function AppShell() {
               onDelete: (sessionId) => deleteSession(sessionId),
             }}
             sidebarCollapsed={sessionListCollapsed}
-            onToggleSidebar={() => setSessionListCollapsed((current) => !current)}
           />
         </div>
         <div
@@ -1220,15 +1225,6 @@ export function AppShell() {
                   : navSelection.section
           }
         >
-          {sessionListCollapsed && (
-            <div className="maka-collapsed-drag-strip" aria-label="侧边栏已收起">
-              <AppShellCollapsedTopbarActions
-                onOpenSearchModal={() => setSearchModalOpen(true)}
-                onExpandSidebar={() => setSessionListCollapsed(false)}
-                onCreateSession={createSession}
-              />
-            </div>
-          )}
           <AppShellWorkspaceTopActions
             onOpenFeedback={() => openSettingsSection('about')}
             onOpenPalette={openPalette}

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -20,6 +20,11 @@
 }
 
 .maka-shell-2col {
+  --maka-sidebar-topbar-button-size: 24px;
+  --maka-sidebar-topbar-gap: 8px;
+  --maka-sidebar-topbar-offset-y: calc(var(--maka-titlebar-control-safe-top) - 18px);
+  --maka-sidebar-topbar-offset-x: calc(var(--maka-titlebar-control-safe-left) - 10px);
+  position: relative;
   display: grid;
   grid-template-columns:
     var(--maka-session-list-width, var(--w-sessionlist))
@@ -89,32 +94,33 @@
   border-right: 0;
 }
 
-.maka-collapsed-drag-strip {
-  min-height: 38px;
+.maka-shell-topbar-rail {
+  position: absolute;
+  z-index: 12;
+  top: var(--maka-sidebar-topbar-offset-y);
+  left: var(--maka-sidebar-topbar-offset-x);
+  min-height: 34px;
   display: flex;
   align-items: center;
-  gap: 0;
-  /* 17px correction = 12px half-icon + 5px detail-panel inset. */
-  padding: calc(var(--maka-titlebar-control-safe-top) - 17px) 12px 0 var(--maka-titlebar-control-safe-left);
-  -webkit-app-region: drag;
-}
-
-.maka-collapsed-topbar-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
+  gap: var(--maka-sidebar-topbar-gap);
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+  transition:
+    opacity var(--duration-quick) var(--ease-out-strong),
+    transform var(--duration-base) var(--ease-out-strong);
   -webkit-app-region: no-drag;
 }
 
-.maka-collapsed-topbar-button {
-  width: 24px;
-  height: 24px;
+.maka-shell-topbar-button {
+  width: var(--maka-sidebar-topbar-button-size);
+  height: var(--maka-sidebar-topbar-button-size);
   border-radius: 6px;
   color: var(--foreground-70);
   -webkit-app-region: no-drag;
 }
 
-.maka-collapsed-topbar-button:hover {
+.maka-shell-topbar-button:hover {
   color: var(--foreground);
   background: var(--foreground-5);
 }
@@ -482,53 +488,8 @@
 
 .maka-sidebar-drag-strip {
   min-height: 34px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
   box-sizing: border-box;
-  /* Same baseline; 18px correction = 12px half-icon + 6px sidebar-header pad. */
-  padding-top: calc(var(--maka-titlebar-control-safe-top) - 18px);
-  padding-left: calc(var(--maka-titlebar-control-safe-left) - 10px);
   -webkit-app-region: drag;
-}
-
-.maka-sidebar-search-button,
-.maka-sidebar-toggle {
-  -webkit-app-region: no-drag;
-  width: 24px;
-  height: 24px;
-  display: inline-grid;
-  place-items: center;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--foreground-55);
-  transition: background var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-sidebar-search-button:hover,
-.maka-sidebar-toggle:hover {
-  background: oklch(from var(--foreground) l c h / 0.06);
-  color: var(--foreground);
-}
-
-.maka-sidebar-search-button:focus-visible,
-.maka-sidebar-toggle:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.14);
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-session-panel-header {
-  padding: 6px 8px 8px;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-sidebar-drag-strip {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 4px;
-  padding-left: 8px;
 }
 
 .maka-session-panel[data-collapsed="true"] .maka-session-panel-footer {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -96,7 +96,7 @@
 
 .maka-shell-topbar-rail {
   position: absolute;
-  z-index: 12;
+  z-index: var(--z-panel-action);
   top: var(--maka-sidebar-topbar-offset-y);
   left: var(--maka-sidebar-topbar-offset-x);
   min-height: 34px;

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -173,7 +173,7 @@ html[data-os="darwin"] .maka-nav-row {
   .maka-plan-heading,
   .maka-skill-tab,
   .maka-plan-tab,
-  .maka-sidebar-search-button {
+  .maka-shell-topbar-button {
     -webkit-user-select: none;
     user-select: none;
   }

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -13,12 +13,9 @@ import {
   LineChart,
   Loader2,
   MessageSquare,
-  PanelLeftClose,
-  PanelLeftOpen,
   Pencil,
   Pin,
   PinOff,
-  Search,
   Settings,
   ShieldAlert,
   Sparkles,
@@ -42,19 +39,14 @@ import { Button as UiButton } from './ui.js';
  * but it is no longer rendered as a top-level nav row: "新任务" creates
  * the chat/task, while the history list below shows prior sessions.
  *
- * Includes `search` even though it is not a `NavSelection.section` —
- * search is a modal trigger and needs a label/icon but no section.
  */
-type ModuleNavId = NavSelection['section'] | 'search';
+type ModuleNavId = NavSelection['section'];
 
 /**
  * Top-level module nav labels. Chinese-first per xuan `47e204f2` #5.
- * Keyed by `ModuleNavId` so the `search` modal trigger gets a label
- * even though it is not a `NavSelection.section`.
  */
 const MODULE_NAV_LABEL: Record<ModuleNavId, string> = {
   sessions: '会话',
-  search: '搜索',
   automations: '定时任务',
   skills: '技能',
   'daily-review': '每日回顾',
@@ -120,14 +112,6 @@ export function SessionListPanel(props: {
   userLabel?: string;
   onNew(): void;
   onOpenSkill?(skillId: string): void;
-  /**
-   * PR-SIDEBAR-IA-0 Phase 2 fixup (xuan `91401163` + `94c7bf0f`):
-   * Sidebar `搜索` nav row click handler. Opens a dedicated Search
-   * modal hosted by the application shell; does NOT change
-   * `selection`. The shell owns the real search backend and modal
-   * lifecycle behind this callback.
-   */
-  onOpenSearchModal?(): void;
   onRefreshPlanReminders?(): void | Promise<void>;
   onCreatePlanReminder?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
   onUpdatePlanReminder?(id: string, patch: PlanReminderUpdatePatch): boolean | Promise<boolean> | void | Promise<void>;
@@ -148,7 +132,6 @@ export function SessionListPanel(props: {
   dailyReviewBridge?: DailyReviewBridge;
   rowActions?: SessionRowActions;
   sidebarCollapsed?: boolean;
-  onToggleSidebar?(): void;
 }) {
   // 参考实现 keeps the lower sidebar region as stable chat history
   // even when Skills / Scheduled Tasks are open in the main pane.
@@ -216,20 +199,14 @@ export function SessionListPanel(props: {
   }
 
   // PR-PARCHMENT-HOME-9 (WAWQAQ msg `781852eb`): restored module nav
-  // helpers. `search` is a transient modal trigger and never
-  // "active". Plan count shows unread reminders as a small chip.
+  // helpers. Plan count shows unread reminders as a small chip.
   const isModuleActive = (id: ModuleNavId) => {
-    if (id === 'search') return false;
     return props.selection.section === id;
   };
   const activePlanReminderCount = (props.planReminders ?? [])
     .filter((reminder) => reminder.status !== 'completed')
     .length;
   function selectModule(id: ModuleNavId) {
-    if (id === 'search') {
-      props.onOpenSearchModal?.();
-      return;
-    }
     if (id === 'sessions') {
       props.onSelect({ section: 'sessions', filter: 'chats' });
       return;
@@ -246,50 +223,7 @@ export function SessionListPanel(props: {
       data-collapsed={props.sidebarCollapsed ? 'true' : undefined}
     >
       <header className="maka-session-panel-header">
-        <div className="maka-sidebar-drag-strip">
-          {/* PR-SIDEBAR-HEADER-BUTTONS-PRIMITIVE-0 (round 5/30):
-              both icon affordances in the sidebar drag strip now
-              flow through UiButton. variant="quiet" + size="icon-sm"
-              match the 24×24 quiet-icon shape; the custom class
-              still owns -webkit-app-region + the bespoke
-              focus-visible ring (3px accent shadow). */}
-          {/* PR-SIDEBAR-WORDMARK-KILL-0 (WAWQAQ msg `1fae5521` 2026-06-24
-              "现在侧边栏左上角有Maka这个单词，好丑啊"): dropped the
-              Georgia serif `Maka` wordmark that PR #190 added next
-              to the traffic lights. The app icon + window title bar
-              already carry the brand identity; the wordmark inside
-              the sidebar drag strip read as redundant chrome. */}
-          {props.onOpenSearchModal && (
-            <UiButton
-              className="maka-sidebar-search-button"
-              variant="quiet"
-              size="icon-sm"
-              type="button"
-              data-maka-search-trigger="true"
-              onClick={props.onOpenSearchModal}
-              aria-label="搜索对话"
-              title="搜索对话"
-            >
-              <Search size={16} strokeWidth={1.65} aria-hidden="true" />
-            </UiButton>
-          )}
-          <UiButton
-            className="maka-sidebar-toggle"
-            variant="quiet"
-            size="icon-sm"
-            type="button"
-            onClick={props.onToggleSidebar}
-            aria-label={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-            aria-expanded={!props.sidebarCollapsed}
-            title={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-          >
-            {props.sidebarCollapsed ? (
-              <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
-            ) : (
-              <PanelLeftClose size={16} strokeWidth={1.65} aria-hidden="true" />
-            )}
-          </UiButton>
-        </div>
+        <div className="maka-sidebar-drag-strip" />
       </header>
 
       {/*
@@ -319,10 +253,9 @@ export function SessionListPanel(props: {
           <span>新任务</span>
         </UiButton>
         {/* PR-UI-PIXEL-5 (2026-06-21): the standalone 搜索 nav row was
-            removed — search is reachable from the dedicated search button in
-            the sidebar header (`.maka-sidebar-search-button`) and ⌘K, so a
-            second entry point was redundant. The `search` module id + label
-            are kept for those triggers. */}
+            removed — search is reachable from the shell topbar button and
+            ⌘K/Ctrl+K, so a second entry point was redundant. The `search`
+            module id + label are kept for those triggers. */}
         <UiButton
           variant="quiet"
           size="nav"

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -88,9 +88,7 @@ function panelProps(input: {
     onSelect: noop,
     onOpenSettings: noop,
     onNew: noop,
-    onOpenSearchModal: noop,
     rowActions,
-    onToggleSidebar: noop,
   };
 }
 


### PR DESCRIPTION
## Summary

Refs #390

This PR refactors the desktop shell chrome so top-level window/sidebar controls have a single owner and stable geometry across sidebar states.

## Changes

- Remove the native Electron application menu via `Menu.setApplicationMenu(null)`.
- Split desktop shell chrome into dedicated `ShellChrome` and `WorkspaceSurface` components.
- Move search, sidebar expand/collapse, and collapsed-state new-task controls into one shell-level topbar rail.
- Use shared CSS variables for topbar button size, gap, top offset, and left offset.
- Remove duplicate sidebar-header controls from `SessionListPanel`.
- Update Storybook and contract tests for the new shell chrome ownership model.

## Verification

- `npm --workspace @maka/ui run build`
- `npm --workspace @maka/desktop run build:main`
- `npm --workspace @maka/desktop run build:renderer`
- `node --test apps/desktop/dist/main/__tests__/app-shell-chrome-contract.test.js`
- `node --test apps/desktop/dist/main/__tests__/sidebar-topbar-rail-contract.test.js`
- `node --test apps/desktop/dist/main/__tests__/search-modal-lifecycle-contract.test.js`
- `node --test apps/desktop/dist/main/__tests__/storybook-baseline-contract.test.js`