### PR TITLE
test(ui): add provider settings stories

### DIFF
--- a/apps/desktop/.storybook/main.ts
+++ b/apps/desktop/.storybook/main.ts
@@ -10,6 +10,7 @@ const UI_SRC = resolve(REPO_ROOT, 'packages/ui/src');
 const config: StorybookConfig = {
   stories: [
     '../../../packages/ui/stories/**/*.stories.@(ts|tsx)',
+    resolve(REPO_ROOT, 'apps/desktop/stories/**/*.stories.@(ts|tsx)'),
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -174,6 +174,37 @@ describe('Storybook baseline contract', () => {
     assert.match(story, /autoCopyLabel/, 'stories must expose copy feedback rather than only idle copy buttons');
   });
 
+  it('storyboards provider settings states before visual polish', () => {
+    const main = readFileSync(join(REPO_ROOT, 'apps', 'desktop', '.storybook', 'main.ts'), 'utf8');
+    const storyPath = join(REPO_ROOT, 'apps', 'desktop', 'stories', 'settings', 'provider-settings.stories.tsx');
+    assert.match(main, /apps\/desktop\/stories\/\*\*\/\*\.stories\.\@\(ts\|tsx\)/);
+    assert.ok(existsSync(storyPath), 'Provider settings states must be inspectable in Storybook');
+
+    const story = readFileSync(storyPath, 'utf8');
+    assert.match(story, /title:\s*['"]Product\/Settings\/Providers['"]/);
+    assert.match(story, /satisfies\s+Meta/);
+    assert.match(story, /\bProvidersPanel\b/);
+    assert.match(story, /ToastProvider/);
+    assert.match(story, /className="settingsSurface"/);
+
+    for (const storyName of [
+      'Loading',
+      'LoadError',
+      'Empty',
+      'ConfiguredProviders',
+      'ProblemConnections',
+      'SelectedDetail',
+      'AddProvider',
+      'OAuthCards',
+    ]) {
+      assert.match(story, new RegExp(`export const ${storyName}: Story`), `${storyName} story must be exported`);
+    }
+
+    assert.match(story, /ConnectionsBridge/, 'stories must drive ProvidersPanel through its bridge seam');
+    assert.match(story, /claudeSubscription/, 'OAuth cards must render against story-local subscription fixtures');
+    assert.doesNotMatch(storyPath, /src\/renderer/, 'desktop Storybook stories must stay out of the renderer build tree');
+  });
+
   it('keeps Storybook stories out of the regular @maka/ui TypeScript build', () => {
     const config = readTypescriptConfig(REPO_ROOT, join(REPO_ROOT, 'packages', 'ui', 'tsconfig.json'));
 

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -13,11 +13,10 @@ const NOW = Date.parse('2026-07-01T08:00:00Z');
 
 const meta = {
   title: 'Product/Settings/Providers',
-  component: ProvidersPanel,
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof ProvidersPanel>;
+} satisfies Meta;
 
 export default meta;
 
@@ -122,7 +121,7 @@ function createBridge(input: {
   loading?: boolean;
 }): ConnectionsBridge {
   let connections = [...(input.connections ?? [])];
-  let defaultSlug = input.defaultSlug ?? connections[0]?.slug ?? null;
+  let defaultSlug: string | null = input.defaultSlug ?? connections[0]?.slug ?? null;
 
   return {
     async list() {
@@ -196,7 +195,7 @@ function createBridge(input: {
 }
 
 function installSubscriptionFixtures() {
-  const target = window as Window & {
+  const target = window as unknown as {
     maka?: Record<string, unknown>;
   };
   target.maka = {
@@ -257,13 +256,14 @@ function ProviderStoryFrame(props: {
   }, []);
 
   useEffect(() => {
-    if (!props.autoOpen) return;
+    const autoOpen = props.autoOpen;
+    if (!autoOpen) return;
     clickedRef.current = false;
     const interval = window.setInterval(() => {
       if (clickedRef.current) return;
       const root = rootRef.current;
       if (!root) return;
-      clickedRef.current = clickAutoOpenTarget(root, props.autoOpen);
+      clickedRef.current = clickAutoOpenTarget(root, autoOpen);
       if (clickedRef.current) window.clearInterval(interval);
     }, 60);
     return () => window.clearInterval(interval);

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ToastProvider } from '@maka/ui';
+import type {
+  ConnectionTestResult,
+  LlmConnection,
+  ModelDiscoveryResult,
+  ProviderType,
+} from '@maka/core';
+import { ProvidersPanel, type ConnectionsBridge } from '../../src/renderer/settings/ProvidersPanel';
+
+const NOW = Date.parse('2026-07-01T08:00:00Z');
+
+const meta = {
+  title: 'Product/Settings/Providers',
+  component: ProvidersPanel,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof ProvidersPanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+type AutoOpenTarget = 'detail' | 'add' | 'oauth';
+
+function makeConnection(input: {
+  slug: string;
+  name: string;
+  providerType: ProviderType;
+  baseUrl?: string;
+  defaultModel?: string;
+  enabled?: boolean;
+  lastTestStatus?: LlmConnection['lastTestStatus'];
+  lastTestMessage?: string;
+  models?: LlmConnection['models'];
+  modelSource?: LlmConnection['modelSource'];
+}): LlmConnection {
+  return {
+    slug: input.slug,
+    name: input.name,
+    providerType: input.providerType,
+    ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+    defaultModel: input.defaultModel ?? 'glm-4.7',
+    enabled: input.enabled ?? true,
+    ...(input.models ? { models: input.models } : {}),
+    ...(input.modelSource ? { modelSource: input.modelSource } : {}),
+    modelsFetchedAt: NOW - 18 * 60 * 1000,
+    ...(input.lastTestStatus ? { lastTestStatus: input.lastTestStatus } : {}),
+    lastTestAt: new Date(NOW - 12 * 60 * 1000).toISOString(),
+    ...(input.lastTestMessage ? { lastTestMessage: input.lastTestMessage } : {}),
+    createdAt: NOW - 6 * 24 * 60 * 60 * 1000,
+    updatedAt: NOW - 12 * 60 * 1000,
+  };
+}
+
+const configuredConnections = [
+  makeConnection({
+    slug: 'zai-live',
+    name: 'Z.AI Live',
+    providerType: 'zai-coding-plan',
+    defaultModel: 'glm-4.7',
+    lastTestStatus: 'verified',
+    models: [
+      { id: 'glm-4.7', displayName: 'GLM 4.7' },
+      { id: 'glm-4.6', displayName: 'GLM 4.6' },
+    ],
+    modelSource: 'fetched',
+  }),
+  makeConnection({
+    slug: 'zai-bench',
+    name: 'Z.AI Bench',
+    providerType: 'zai-coding-plan',
+    defaultModel: 'glm-4.6',
+  }),
+  makeConnection({
+    slug: 'openai-review',
+    name: 'OpenAI Review',
+    providerType: 'openai',
+    defaultModel: 'gpt-5',
+    lastTestStatus: 'verified',
+    models: [
+      { id: 'gpt-5', displayName: 'GPT-5' },
+      { id: 'gpt-4o', displayName: 'GPT-4o' },
+    ],
+    modelSource: 'fetched',
+  }),
+  makeConnection({
+    slug: 'ollama-local',
+    name: 'Ollama Local',
+    providerType: 'ollama',
+    defaultModel: 'qwen2.5-coder',
+    lastTestStatus: 'verified',
+  }),
+];
+
+const problemConnections = [
+  configuredConnections[0],
+  makeConnection({
+    slug: 'claude-subscription',
+    name: 'Claude Code',
+    providerType: 'claude-subscription',
+    defaultModel: 'claude-sonnet-4-5-20250929',
+    enabled: false,
+    lastTestStatus: 'needs_reauth',
+    lastTestMessage: '订阅账号需要重新登录。',
+  }),
+  makeConnection({
+    slug: 'openai-rate-limit',
+    name: 'OpenAI Rate Limited',
+    providerType: 'openai',
+    defaultModel: 'gpt-5',
+    lastTestStatus: 'error',
+    lastTestMessage: '上次验证触发 429 限流。',
+  }),
+];
+
+function createBridge(input: {
+  connections?: LlmConnection[];
+  defaultSlug?: string | null;
+  failLoad?: boolean;
+  loading?: boolean;
+}): ConnectionsBridge {
+  let connections = [...(input.connections ?? [])];
+  let defaultSlug = input.defaultSlug ?? connections[0]?.slug ?? null;
+
+  return {
+    async list() {
+      if (input.loading) return new Promise<LlmConnection[]>(() => undefined);
+      if (input.failLoad) throw new Error('模型连接服务暂时不可用');
+      return connections;
+    },
+    async getDefault() {
+      if (input.loading) return new Promise<string | null>(() => undefined);
+      return defaultSlug;
+    },
+    async setDefault(slug) {
+      defaultSlug = slug;
+    },
+    async create(next) {
+      const connection = makeConnection({
+        slug: next.slug,
+        name: next.name,
+        providerType: next.providerType,
+        baseUrl: next.baseUrl,
+        defaultModel: next.defaultModel,
+        lastTestStatus: 'verified',
+      });
+      connections = [...connections, connection];
+      defaultSlug ??= connection.slug;
+      return connection;
+    },
+    async update(slug, patch) {
+      const current = connections.find((connection) => connection.slug === slug);
+      if (!current) throw new Error('连接不存在');
+      const updated: LlmConnection = {
+        ...current,
+        ...patch,
+        updatedAt: NOW,
+      };
+      connections = connections.map((connection) => connection.slug === slug ? updated : connection);
+      return updated;
+    },
+    async delete(slug) {
+      connections = connections.filter((connection) => connection.slug !== slug);
+      if (defaultSlug === slug) defaultSlug = connections[0]?.slug ?? null;
+    },
+    async test(slug): Promise<ConnectionTestResult> {
+      if (slug.includes('rate-limit')) {
+        return {
+          ok: false,
+          statusCode: 429,
+          errorClass: 'provider_unavailable',
+          errorMessage: 'rate limit',
+        };
+      }
+      return { ok: true, latencyMs: 328, modelTested: 'glm-4.7' };
+    },
+    async fetchModels(slug): Promise<ModelDiscoveryResult> {
+      return {
+        models: [
+          { id: slug.includes('openai') ? 'gpt-5' : 'glm-4.7' },
+          { id: slug.includes('openai') ? 'gpt-4o' : 'glm-4.6' },
+        ],
+        source: 'fetched',
+        fetchedAt: NOW,
+      };
+    },
+    async hasSecret() {
+      return true;
+    },
+    subscribeEvents() {
+      return () => undefined;
+    },
+  };
+}
+
+function installSubscriptionFixtures() {
+  const target = window as Window & {
+    maka?: Record<string, unknown>;
+  };
+  target.maka = {
+    ...(target.maka ?? {}),
+    claudeSubscription: {
+      getAccountState: async () => ({
+        runtimeState: 'authenticated',
+        profile: { email: 'claude@example.com' },
+      }),
+      isExperimentalEnabled: async () => true,
+      getAuthUrl: async () => ({ authRequestId: 'storybook-claude', stateHint: 'storybook' }),
+      openAuthUrl: async () => ({ ok: true }),
+      completeAuthorization: async () => ({ ok: true }),
+      cancelAuthorization: async () => ({ ok: true }),
+      logout: async () => ({ ok: true }),
+      refreshQuota: async () => ({ ok: true }),
+    },
+    codexSubscription: browserSubscriptionFixture({
+      runtimeState: 'authenticated',
+      email: 'codex@example.com',
+      plan: 'Plus',
+    }),
+    cursorSubscription: browserSubscriptionFixture({
+      runtimeState: 'not_logged_in',
+    }),
+    antigravitySubscription: browserSubscriptionFixture({
+      runtimeState: 'storage_failed',
+      errorMessage: '需要 Google client_id 后才能完成登录。',
+    }),
+  };
+}
+
+function browserSubscriptionFixture(state: {
+  runtimeState: string;
+  email?: string;
+  plan?: string;
+  errorMessage?: string;
+}) {
+  return {
+    getAccountState: async () => state,
+    getAuthUrl: async () => ({ authRequestId: 'storybook-oauth', stateHint: 'storybook' }),
+    openAuthUrl: async () => ({ ok: true }),
+    completeAuthorization: async () => ({ ok: true }),
+    cancelAuthorization: async () => ({ ok: true }),
+    logout: async () => ({ ok: true }),
+  };
+}
+
+function ProviderStoryFrame(props: {
+  bridge: ConnectionsBridge;
+  autoOpen?: AutoOpenTarget;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const clickedRef = useRef(false);
+
+  useEffect(() => {
+    installSubscriptionFixtures();
+  }, []);
+
+  useEffect(() => {
+    if (!props.autoOpen) return;
+    clickedRef.current = false;
+    const interval = window.setInterval(() => {
+      if (clickedRef.current) return;
+      const root = rootRef.current;
+      if (!root) return;
+      clickedRef.current = clickAutoOpenTarget(root, props.autoOpen);
+      if (clickedRef.current) window.clearInterval(interval);
+    }, 60);
+    return () => window.clearInterval(interval);
+  }, [props.autoOpen, props.bridge]);
+
+  return (
+    <ToastProvider>
+      <div
+        ref={rootRef}
+        className="settingsSurface"
+        data-modal="true"
+        data-maka-visual-smoke="true"
+        style={{
+          gridTemplateColumns: 'minmax(0, 1fr)',
+          height: 700,
+          margin: '0 auto',
+          maxWidth: 1040,
+          minHeight: 0,
+          overflow: 'hidden',
+          width: '100%',
+        }}
+      >
+        <section className="settingsMainPane agents-content-area" data-agents-view="settings">
+          <div className="settingsPageContent" style={{ overflow: 'auto' }}>
+            <div className="settingsPageContentInner">
+              <div className="settingsStructuredPage settingsModelsPage">
+                <ProvidersPanel bridge={props.bridge} />
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </ToastProvider>
+  );
+}
+
+function clickAutoOpenTarget(root: HTMLElement, target: AutoOpenTarget): boolean {
+  if (target === 'detail') {
+    const detailButton = root.querySelector<HTMLButtonElement>('button[aria-label*="模型连接：Z.AI Live"]');
+    detailButton?.click();
+    return Boolean(detailButton);
+  }
+  if (target === 'oauth') {
+    const oauthTab = root.querySelector<HTMLButtonElement>('button[data-catalog-tab="oauth"]');
+    oauthTab?.click();
+    return Boolean(oauthTab);
+  }
+
+  const addButton = Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+    .find((button) => button.textContent?.trim() === '自定义');
+  addButton?.click();
+  return Boolean(addButton);
+}
+
+function ProviderStory(props: {
+  bridge: ConnectionsBridge;
+  autoOpen?: AutoOpenTarget;
+}): ReactNode {
+  return <ProviderStoryFrame bridge={props.bridge} autoOpen={props.autoOpen} />;
+}
+
+export const Loading: Story = {
+  render: () => <ProviderStory bridge={createBridge({ loading: true })} />,
+};
+
+export const LoadError: Story = {
+  render: () => <ProviderStory bridge={createBridge({ failLoad: true })} />,
+};
+
+export const Empty: Story = {
+  render: () => <ProviderStory bridge={createBridge({ connections: [], defaultSlug: null })} />,
+};
+
+export const ConfiguredProviders: Story = {
+  render: () => <ProviderStory bridge={createBridge({ connections: configuredConnections, defaultSlug: 'zai-live' })} />,
+};
+
+export const ProblemConnections: Story = {
+  render: () => <ProviderStory bridge={createBridge({ connections: problemConnections, defaultSlug: 'zai-live' })} />,
+};
+
+export const SelectedDetail: Story = {
+  render: () => (
+    <ProviderStory
+      bridge={createBridge({ connections: configuredConnections, defaultSlug: 'zai-live' })}
+      autoOpen="detail"
+    />
+  ),
+};
+
+export const AddProvider: Story = {
+  render: () => (
+    <ProviderStory
+      bridge={createBridge({ connections: configuredConnections, defaultSlug: 'zai-live' })}
+      autoOpen="add"
+    />
+  ),
+};
+
+export const OAuthCards: Story = {
+  render: () => (
+    <ProviderStory
+      bridge={createBridge({ connections: problemConnections, defaultSlug: 'zai-live' })}
+      autoOpen="oauth"
+    />
+  ),
+};


### PR DESCRIPTION
## Summary
- Add desktop Storybook discovery for renderer-owned stories under `apps/desktop/stories`.
- Add a provider settings storyboard covering loading, load error, empty, configured, problem, detail, add-provider, and OAuth-card states.
- Extend the Storybook baseline contract so PR5 settings coverage remains present and outside `src/renderer`.

## Why
Refs #390 PR5. Provider/OAuth settings are high-risk for polish because they combine async loading, validation, status rollups, details, and account-login state.

## Scope
Changed:
- `apps/desktop/.storybook/main.ts`
- `apps/desktop/stories/settings/provider-settings.stories.tsx`
- `apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts`

Not included:
- No visual polish.
- No Electron main/preload/storage/runtime behavior changes.
- No full SettingsModal Storybook runtime mock.

## Verification
- `npm run -w @maka/desktop build:main && node --test apps/desktop/dist/main/__tests__/storybook-baseline-contract.test.js`
- `npm run -w @maka/desktop build-storybook`
- `npm run typecheck`
- `node node_modules/typescript/bin/tsc --noEmit --incremental false --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck --esModuleInterop --jsx react-jsx --types vite/client apps/desktop/src/global.d.ts apps/desktop/stories/settings/provider-settings.stories.tsx`

## Fresh-eye review
- Round 1 found one P2: the new story file was not strict-TS clean. Fixed in `c27db71d`.
- Round 2 found no P0-P3 issues.

## User-facing impact
None. Storybook/test-only coverage for reviewability.

## Reviewer notes
The story lives in `apps/desktop/stories` rather than `src/renderer` so it remains desktop-owned without joining the production renderer typecheck tree.