### PR TITLE
refactor(ui): migrate sidebar visual properties to cva variants

### DIFF
--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -101,11 +101,8 @@ describe('session row actions fail soft', () => {
     assert.match(sessionRow, /aria-busy=\{pendingAction === 'flag' \? 'true' : undefined\}/);
     assert.match(sessionRow, /data-pending=\{pendingAction === 'archive' \? 'true' : undefined\}/);
     assert.match(sessionRow, /aria-busy=\{pendingAction === 'delete' \? 'true' : undefined\}/);
-    assert.match(
-      sessionRow,
-      /cn\('maka-list-row-action', rowActionVariants/,
-      'row action buttons must call rowActionVariants so pending/active classes are applied at runtime',
-    );
+    const rowActionVariantCalls = [...sessionRow.matchAll(/cn\('maka-list-row-action', rowActionVariants/g)];
+    assert.equal(rowActionVariantCalls.length, 4, 'all 4 row action buttons (flag, rename, archive, delete) must call rowActionVariants');
     assert.match(
       ui,
       /data-\[pending=true\]:cursor-progress data-\[pending=true\]:bg-foreground\/5 data-\[pending=true\]:text-foreground data-\[pending=true\]:opacity-78/,

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { readRendererContractCss } from './contract-css-helpers.js';
 import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
 
 const SESSION_LIST_PANEL_PATH = join(process.cwd(), '../../packages/ui/src/session-list-panel.tsx');
@@ -79,7 +78,6 @@ describe('session row actions fail soft', () => {
 
   it('renders visible busy state while a sidebar row action is pending', async () => {
     const ui = await readFile(SESSION_LIST_PANEL_PATH, 'utf8');
-    const css = await readRendererContractCss();
     const sessionRow = ui.slice(ui.indexOf('function SessionRow'), ui.indexOf('interface SessionGroup'));
 
     assert.match(ui, /type SessionRowActionId = 'flag' \| 'archive' \| 'rename' \| 'delete';/);
@@ -103,6 +101,10 @@ describe('session row actions fail soft', () => {
     assert.match(sessionRow, /aria-busy=\{pendingAction === 'flag' \? 'true' : undefined\}/);
     assert.match(sessionRow, /data-pending=\{pendingAction === 'archive' \? 'true' : undefined\}/);
     assert.match(sessionRow, /aria-busy=\{pendingAction === 'delete' \? 'true' : undefined\}/);
-    assert.match(css, /\.maka-list-row-action\[data-pending="true"\] \{[\s\S]*cursor: progress;[\s\S]*opacity: 0\.78;[\s\S]*\}/);
+    assert.match(
+      ui,
+      /data-\[pending=true\]:cursor-progress data-\[pending=true\]:bg-foreground\/5 data-\[pending=true\]:text-foreground data-\[pending=true\]:opacity-78/,
+      'rowActionVariants cva must carry a visible pending state (cursor + bg + opacity)',
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -102,6 +102,11 @@ describe('session row actions fail soft', () => {
     assert.match(sessionRow, /data-pending=\{pendingAction === 'archive' \? 'true' : undefined\}/);
     assert.match(sessionRow, /aria-busy=\{pendingAction === 'delete' \? 'true' : undefined\}/);
     assert.match(
+      sessionRow,
+      /cn\('maka-list-row-action', rowActionVariants/,
+      'row action buttons must call rowActionVariants so pending/active classes are applied at runtime',
+    );
+    assert.match(
       ui,
       /data-\[pending=true\]:cursor-progress data-\[pending=true\]:bg-foreground\/5 data-\[pending=true\]:text-foreground data-\[pending=true\]:opacity-78/,
       'rowActionVariants cva must carry a visible pending state (cursor + bg + opacity)',

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -659,15 +659,9 @@
 .maka-list-row-name {
   display: flex;
   align-items: center;
-  /* PR-UI-3: tighten badge gap 8→6 so streaming dot / status icon /
-   * stale pill / name cluster reads as one unit, not 4 disconnected
-   * elements. */
   gap: 6px;
   overflow: hidden;
-  /* PR-SIDEBAR-IA-0 Phase 3: 14→13px + 600→500 weight reads as a list
-   * item (Slack/Linear) instead of a card title. Bold cards felt
-   * heavy when stacked 60-deep. */
-  font-size: 13px;
+  font-size: 0.875rem;
   font-weight: 500;
   min-width: 0;
 }
@@ -722,14 +716,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* Phase 4A — tighten meta typography. 11/50 was reading too loud:
-     the date stamp dominated visual hierarchy when it should sit
-     under the title. 9/42 mirrors reference's secondary-meta tier. */
-  color: var(--foreground-42);
-  font-size: 9.5px;
+  color: var(--foreground-50);
+  font-size: 11px;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0.01em;
   flex-shrink: 0;
 }
 
@@ -840,14 +830,12 @@
 .maka-list-group-toggle {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 6px;
   width: 100%;
-  padding: 0;
   background: transparent;
   border: 0;
   text-align: left;
-  font: inherit;
-  color: inherit;
 }
 .maka-list-group-toggle:focus-visible {
   outline: 2px solid var(--accent);
@@ -857,7 +845,7 @@
 .maka-list-group-count {
   font-variant-numeric: tabular-nums;
   color: var(--foreground-35);
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 500;
 }
 
@@ -873,9 +861,8 @@
    * "已过期" is a degraded-state signal, not informational. */
   background: oklch(from var(--warning, var(--info)) l c h / 0.18);
   color: var(--warning-text, var(--info-text));
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.02em;
   line-height: 1.4;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -546,27 +546,9 @@
    widget was removed (WAWQAQ msg cad3dec4: "现在左下角怎么还有 账户部分,
    我们没有账户"). About / version still reachable via Settings → 关于. */
 .maka-sidebar-settings-button {
-  width: 100%;
-  min-width: 0;
   display: inline-grid;
   grid-template-columns: 24px minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--foreground-65);
-  padding: 6px 8px;
-  text-align: left;
-  font-size: 12px;
-  font-weight: 500;
-  transition: background-color var(--duration-base) var(--ease-out-strong),
-              color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-sidebar-settings-button:hover {
-  background: oklch(from var(--foreground) l c h / 0.06);
-  color: var(--foreground);
 }
 
 .maka-sidebar-settings-button .maka-nav-icon {
@@ -596,71 +578,11 @@
 .maka-nav-row {
   width: calc(100% - 12px);
   margin-inline: 6px;
-  min-height: 30px;
   display: grid;
   grid-template-columns: var(--icon-size) minmax(0, 1fr) auto;
   align-items: center;
-  gap: 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--foreground-80);
   -webkit-app-region: no-drag;
-  padding: 3px 6px;
   text-align: left;
-  /* PR-NAV-NEW-TASK-WEIGHT-0 (2026-06-23): reference-atlas §2 type
-     scale uses text-sm (14px / 20px line-height) for sidebar nav
-     rows. Maka was sitting at 13px / 1.25 (≈16.25px line-height),
-     a half-step smaller that read tighter than the reference. */
-  font-size: 14px;
-  line-height: 1.43;
-  transition:
-    background var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-nav-row:hover {
-  /* PR-GRAY-CARD-LIFT-4 (WAWQAQ msg `d4277aba` round 2): hover bg
-     was `--foreground-3` (3% mix into background = ~oklch(0.97 0 0)),
-     which on the new `--surface-canvas` (oklch(0.935 0 0)) was almost
-     invisible. Switch to alpha overlay so the hover state lifts
-     consistently regardless of the plate tone behind it. */
-  background: oklch(from var(--foreground) l c h / 0.06);
-  color: var(--foreground);
-}
-
-.maka-nav-row[data-active="true"] {
-  background: oklch(from var(--foreground) l c h / 0.07);
-  color: var(--foreground);
-  font-weight: 600;
-  box-shadow: none;
-}
-.maka-nav-row[data-active="true"] .maka-nav-icon {
-  color: var(--foreground);
-}
-
-.maka-nav-new-task {
-  /* PR-NAV-NEW-TASK-WEIGHT-0 (2026-06-23): "新任务" should not render
-     bold by default — the active-state already carries weight: 600,
-     and a permanently-bold idle entry reads as "this is the active
-     page" even when nothing is selected. Reference nav rows are all
-     normal weight at rest; the create-action stays a normal-weight
-     row with the SquarePen glyph carrying the affordance. */
-  color: var(--foreground);
-}
-
-.maka-nav-new-task .maka-nav-icon {
-  color: var(--foreground-70);
-}
-
-.maka-nav-row[aria-disabled="true"],
-.maka-nav-row[data-disabled="true"] {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-.maka-nav-row[aria-disabled="true"]:hover,
-.maka-nav-row[data-disabled="true"]:hover {
-  background: transparent;
 }
 
 .maka-nav-row span:nth-child(2) {
@@ -671,8 +593,6 @@
 }
 
 .maka-nav-row small {
-  color: var(--foreground-40);
-  font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
 
@@ -740,19 +660,17 @@
   border-top: 1px solid oklch(from var(--foreground) l c h / 0.05);
 }
 
-/* Group label as "data-tier section header" — tighter typography,
-   uppercase tracking, slight monospace flavor. Mirrors the
-   reference's `.sidebar-section-title` (foreground-quaternary at 90%). */
+/* Group label — section header for session groups. Weight-based
+   hierarchy (not uppercase/letter-spacing) so Chinese labels read
+   cleanly without artificial tracking. */
 .maka-list-group-label {
   display: flex;
   align-items: baseline;
   gap: 3px;
   padding: 0 6px 3px;
-  color: var(--foreground-45);
-  font-size: 9.5px;
+  color: var(--foreground-50);
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   font-variant-numeric: tabular-nums;
 }
 
@@ -833,10 +751,11 @@
   }
 }
 
-/* PR-UI-PIXEL-6 (2026-06-21): selected session row uses a clearly readable
-   neutral gray (≈#efefef), still flat and accent-free like 参考实现. */
+/* Active session row: slightly stronger than hover so the current
+   session is distinguishable from hover, but lighter than nav-row
+   active (0.09) so the main navigation reads as the primary surface. */
 .maka-list-row[data-active="true"] {
-  background: oklch(from var(--foreground) l c h / 0.06);
+  background: oklch(from var(--foreground) l c h / 0.07);
 }
 
 .maka-list-row[data-active="true"] .maka-list-row-name {
@@ -937,63 +856,9 @@
   );
 }
 
-.maka-list-row-action {
-  width: 26px;
-  height: 26px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  /* PR-UI-LAYOUT-26: row action toggles (rename / flag / archive)
-   * radius 6 → 8 to match the new tap-target family + add
-   * focus-visible ring; missing focus state was a a11y gap. */
-  border-radius: 8px;
-  background: transparent;
-  color: var(--foreground-60);
-  transition: background var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong), box-shadow var(--duration-quick) var(--ease-out-strong);
-}
-
-.maka-list-row-action:hover {
-  color: var(--foreground);
-  background: var(--foreground-5);
-}
-
-.maka-list-row-action:focus-visible {
-  outline: none;
-  color: var(--foreground);
-  background: var(--foreground-5);
-  box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.14);
-}
-
-.maka-list-row-action[data-active="true"] {
-  color: var(--accent);
-}
-
-.maka-list-row-action-danger:hover {
-  color: var(--destructive-text);
-  background: oklch(from var(--destructive) l c h / 0.10);
-}
-
-.maka-list-row-action-danger:focus-visible {
-  color: var(--destructive-text);
-  background: oklch(from var(--destructive) l c h / 0.10);
-  box-shadow: 0 0 0 3px oklch(from var(--destructive) l c h / 0.18);
-}
-
-.maka-list-row-action:disabled,
-.maka-list-row-action:disabled:hover,
-.maka-list-row-action:disabled:focus-visible {
-  color: var(--foreground-45);
-  background: transparent;
-  box-shadow: none;
-  cursor: default;
-}
-
-.maka-list-row-action[data-pending="true"] {
-  color: var(--foreground);
-  background: var(--foreground-5);
-  cursor: progress;
-  opacity: 0.78;
-}
+/* Row action buttons: visual via rowActionVariants cva.
+   .maka-list-row-action class kept as a stable hook for the
+   action overlay positioning + reveal animation on the parent. */
 
 .maka-list-row-rename-input {
   width: 100%;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -603,15 +603,9 @@
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  background: oklch(from var(--foreground) l c h / 0.06);
   padding: 0 4px;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
-}
-
-.maka-nav-row[data-active="true"] .maka-nav-count {
-  background: oklch(from var(--foreground) l c h / 0.08);
-  color: var(--foreground);
 }
 
 .maka-session-panel[data-collapsed="true"] .maka-sidebar-modules {

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -43,14 +43,15 @@ const navRowVariants = cva(
     'hover:bg-foreground/6 hover:text-foreground',
     'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
     'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
-    '[&_.maka-nav-count]:text-[var(--foreground-40)]',
+    '[&_.maka-nav-count]:bg-foreground/6 [&_.maka-nav-count]:text-[var(--foreground-40)]',
+    'data-[active=true]:[&_.maka-nav-count]:bg-foreground/8 data-[active=true]:[&_.maka-nav-count]:text-foreground',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
     'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
   ],
   {
     variants: {
       tone: {
-        default: 'text-[var(--foreground-80)]',
+        default: '',
         newTask: 'text-foreground [&_.maka-nav-icon]:text-[var(--foreground-70)]',
       },
     },

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -42,6 +42,8 @@ const navRowVariants = cva(
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/6 hover:text-foreground',
     'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
+    'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
+    '[&_.maka-nav-count]:text-[var(--foreground-40)]',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
     'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
   ],
@@ -49,7 +51,7 @@ const navRowVariants = cva(
     variants: {
       tone: {
         default: 'text-[var(--foreground-80)]',
-        newTask: 'text-foreground',
+        newTask: 'text-foreground [&_.maka-nav-icon]:text-[var(--foreground-70)]',
       },
     },
     defaultVariants: {
@@ -60,14 +62,11 @@ const navRowVariants = cva(
 
 type NavRowVariants = VariantProps<typeof navRowVariants>;
 
-const settingsButtonVariants = cva(
-  [
-    'w-full min-w-0 gap-2 rounded-md border-0 bg-transparent px-2 py-1.5',
-    'text-left text-sm font-medium text-[var(--foreground-65)]',
-    'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
-    'hover:bg-foreground/6 hover:text-foreground',
-  ],
-);
+const settingsButtonClass =
+  'w-full min-w-0 gap-2 rounded-md border-0 bg-transparent px-2 py-1.5 ' +
+  'text-left text-sm font-medium text-[var(--foreground-65)] ' +
+  'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
+  'hover:bg-foreground/6 hover:text-foreground';
 
 const rowActionVariants = cva(
   [
@@ -444,7 +443,7 @@ export function SessionListPanel(props: {
             this panel. The custom class still owns the
             full-width grid layout (24px icon + 1fr label). */}
         <UiButton
-          className={cn('maka-sidebar-settings-button', settingsButtonVariants())}
+          className={cn('maka-sidebar-settings-button', settingsButtonClass)}
           variant="quiet"
           size="nav"
           type="button"

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -32,7 +32,70 @@ import type {
 } from './module-panel-types.js';
 import { EmptyState } from './empty-state.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
-import { Button as UiButton } from './ui.js';
+import { Button as UiButton, cn } from './ui.js';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const navRowVariants = cva(
+  [
+    'min-h-[30px] gap-2 rounded-md border-0 bg-transparent px-1.5 py-[3px]',
+    'text-left text-sm leading-[1.43] text-[var(--foreground-80)]',
+    'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
+    'hover:bg-foreground/6 hover:text-foreground',
+    'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
+    'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
+    'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
+  ],
+  {
+    variants: {
+      tone: {
+        default: 'text-[var(--foreground-80)]',
+        newTask: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      tone: 'default',
+    },
+  },
+);
+
+type NavRowVariants = VariantProps<typeof navRowVariants>;
+
+const settingsButtonVariants = cva(
+  [
+    'w-full min-w-0 gap-2 rounded-md border-0 bg-transparent px-2 py-1.5',
+    'text-left text-sm font-medium text-[var(--foreground-65)]',
+    'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
+    'hover:bg-foreground/6 hover:text-foreground',
+  ],
+);
+
+const rowActionVariants = cva(
+  [
+    'grid h-[26px] w-[26px] place-items-center rounded-md border-0 bg-transparent',
+    'text-[var(--foreground-60)]',
+    'transition-[background-color,color,box-shadow] duration-[var(--duration-quick)] ease-[var(--ease-out-strong)]',
+    'hover:bg-foreground/5 hover:text-foreground',
+    'focus-visible:outline-none focus-visible:bg-foreground/5 focus-visible:text-foreground focus-visible:ring-[3px] focus-visible:ring-accent/14',
+    'disabled:cursor-default disabled:bg-transparent disabled:text-[var(--foreground-45)] disabled:shadow-none',
+    'disabled:hover:bg-transparent disabled:hover:text-[var(--foreground-45)]',
+    'data-[active=true]:text-accent',
+    'data-[pending=true]:cursor-progress data-[pending=true]:bg-foreground/5 data-[pending=true]:text-foreground data-[pending=true]:opacity-78',
+  ],
+  {
+    variants: {
+      tone: {
+        default: '',
+        danger: [
+          'hover:bg-destructive/10 hover:text-destructive-text',
+          'focus-visible:bg-destructive/10 focus-visible:text-destructive-text focus-visible:ring-destructive/18',
+        ],
+      },
+    },
+    defaultVariants: {
+      tone: 'default',
+    },
+  },
+);
 
 /**
  * Sidebar module ids. "sessions" is still the lower history region label,
@@ -244,7 +307,7 @@ export function SessionListPanel(props: {
         <UiButton
           variant="quiet"
           size="nav"
-          className="maka-nav-row maka-nav-new-task"
+          className={cn('maka-nav-row maka-nav-new-task', navRowVariants({ tone: 'newTask' }))}
           aria-label="新任务"
           type="button"
           onClick={props.onNew}
@@ -259,7 +322,7 @@ export function SessionListPanel(props: {
         <UiButton
           variant="quiet"
           size="nav"
-          className="maka-nav-row"
+          className={cn('maka-nav-row', navRowVariants())}
           data-active={isModuleActive('daily-review')}
           aria-current={isModuleActive('daily-review') ? 'page' : undefined}
           aria-label={MODULE_NAV_LABEL['daily-review']}
@@ -272,7 +335,7 @@ export function SessionListPanel(props: {
         <UiButton
           variant="quiet"
           size="nav"
-          className="maka-nav-row"
+          className={cn('maka-nav-row', navRowVariants())}
           data-active={isModuleActive('skills')}
           aria-current={isModuleActive('skills') ? 'page' : undefined}
           aria-label={MODULE_NAV_LABEL.skills}
@@ -285,7 +348,7 @@ export function SessionListPanel(props: {
         <UiButton
           variant="quiet"
           size="nav"
-          className="maka-nav-row"
+          className={cn('maka-nav-row', navRowVariants())}
           data-active={isModuleActive('automations')}
           aria-current={isModuleActive('automations') ? 'page' : undefined}
           type="button"
@@ -381,8 +444,9 @@ export function SessionListPanel(props: {
             this panel. The custom class still owns the
             full-width grid layout (24px icon + 1fr label). */}
         <UiButton
-          className="maka-sidebar-settings-button"
+          className={cn('maka-sidebar-settings-button', settingsButtonVariants())}
           variant="quiet"
+          size="nav"
           type="button"
           onClick={props.onOpenSettings}
           aria-label="设置"
@@ -469,6 +533,7 @@ function SessionListGroups(props: {
               <UiButton
                 type="button"
                 variant="quiet"
+                size="nav"
                 className="maka-list-group-label maka-list-group-toggle"
                 onClick={toggle}
                 aria-expanded={expanded}
@@ -890,8 +955,8 @@ function SessionRow(props: {
           <UiButton
             type="button"
             variant="quiet"
-            size="icon-sm"
-            className="maka-list-row-action"
+            size="nav"
+            className={cn('maka-list-row-action', rowActionVariants())}
             tabIndex={actionTabIndex}
             onClick={(event) => {
               stopPropagation(event);
@@ -911,8 +976,8 @@ function SessionRow(props: {
           <UiButton
             type="button"
             variant="quiet"
-            size="icon-sm"
-            className="maka-list-row-action"
+            size="nav"
+            className={cn('maka-list-row-action', rowActionVariants())}
             tabIndex={actionTabIndex}
             onClick={startRename}
             aria-label="重命名对话"
@@ -926,8 +991,8 @@ function SessionRow(props: {
           <UiButton
             type="button"
             variant="quiet"
-            size="icon-sm"
-            className="maka-list-row-action"
+            size="nav"
+            className={cn('maka-list-row-action', rowActionVariants())}
             tabIndex={actionTabIndex}
             onClick={(event) => {
               stopPropagation(event);
@@ -950,8 +1015,8 @@ function SessionRow(props: {
           <UiButton
             type="button"
             variant="quiet"
-            size="icon-sm"
-            className="maka-list-row-action maka-list-row-action-danger"
+            size="nav"
+            className={cn('maka-list-row-action', rowActionVariants({ tone: 'danger' }))}
             tabIndex={actionTabIndex}
             onClick={handleDelete}
             aria-label="删除对话"

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -352,12 +352,15 @@ export const LongTitlesAndNarrow: Story = {
 
 export const Collapsed: Story = {
   render: () => (
-    <StoryFrame width={72}>
-      <SessionListPanel {...panelProps({
-        sessions: coreSessions,
-        activeId: 'session-running',
-        sidebarCollapsed: true,
-      })} />
-    </StoryFrame>
+    <>
+      <style>{`.agents-sidebar[data-collapsed="true"] { width: 100% !important }`}</style>
+      <StoryFrame width={72}>
+        <SessionListPanel {...panelProps({
+          sessions: coreSessions,
+          activeId: 'session-running',
+          sidebarCollapsed: true,
+        })} />
+      </StoryFrame>
+    </>
   ),
 };


### PR DESCRIPTION
## Summary

Migrate sidebar `SessionListPanel` visual properties from hand-written `.maka-*` CSS to `cva` variants aligned with `ui.tsx` governance, and fix the collapsed Storybook story rendering.

## Why

Closes #390. The sidebar carried ~180 lines of visual CSS (hover, active, focus, disabled, pending states for nav-row, settings, row-action) duplicating what `cva` variants already govern through `buttonVariants` in `ui.tsx`. Font sizes had drifted to seven tiers (9.5/10/10.5/11/12/13/14px) with no design intent. The collapsed story was blank because `.agents-sidebar[data-collapsed="true"] { width: 0 }` (correct in the app, where an outer resizable container sets width) collapsed the panel inside Storybook's 72px block container.

## Scope

Changed:

- `packages/ui/src/session-list-panel.tsx` — add 3 cva variants (`navRowVariants`, `settingsButtonVariants`, `rowActionVariants`); unify all sidebar `UiButton` to `size="nav"` + cva variant.
- `apps/desktop/src/renderer/styles/sidebar.css` — remove ~180 lines of visual CSS; keep grid layout, `-webkit-app-region`, and stable class hooks only.
- `apps/desktop/src/renderer/styles/onboarding.css` — converge font sizes to 11/13/14px; remove `uppercase`/`letter-spacing` from group label; fix `.maka-list-group-toggle` `font: inherit` bug (was resetting weight/size to parent values); add `justify-content: flex-start` to override `UiButton`'s `justify-center`.
- `packages/ui/stories/session-list-panel.stories.tsx` — collapsed story adds inline `<style>` overriding `width: 0` so the 72px icon rail renders.
- `apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts` — check cva pending state instead of CSS rule.
- `apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts` — regex matches `cn()` className.

Not included:

- `primitives/sidebar.tsx` (740 lines, shadcn-style) remains dead code — out of scope.
- List-row container and list-row-main stay in CSS (single instance with state-coupled selectors, cva has no benefit).
- Action overlay gradient leak at 176px narrow width (low priority, `visibility: hidden` already mitigates meta/unread).

## Verification

- `npm run typecheck` — all workspaces pass.
- `npm run pretest` (check-console + check-a11y) — pass.
- Sidebar contract tests (`session-row-actions-fail-soft`, `search-modal-lifecycle`) — 23/23 pass.
- Storybook visual check across all 6 stories: before/after screenshots in `notes/screenshots/compare/`.
- Collapsed story: 0 visible icons → 7 visible icons (search, toggle, 4 nav, settings).

## User-facing impact

No behavioral change. Visual changes are within existing story contracts:

- Font sizes converge to 3 tiers (11/13/14px), reducing visual noise.
- Active-state hierarchy: nav active (0.09) > list active (0.07) > hover (0.06), clarifying which surface is primary.
- Group labels use weight-based hierarchy instead of uppercase/letter-spacing (better for Chinese).
- Radius unified to 8px (`rounded-md`); original 6px/8px mix had no design intent.

<img width="510" height="740" alt="image" src="https://github.com/user-attachments/assets/0d541f95-818d-4345-87b4-4ca0c6672363" />

## Reviewer notes

- Rebased on latest `main` after shell-chrome refactor moved search/toggle from sidebar header to shell topbar; `sidebarIconButtonVariants` was removed as it no longer has consumers in the sidebar.
- The collapsed story `<style>` override is a fixture fix, not a component change — in the real app the outer resizable grid column sets width, so `width: 0` on `.agents-sidebar[data-collapsed="true"]` is correct.
- `size="nav"` is an empty-string variant (no size utilities) that prevents `buttonVariants` from injecting conflicting size classes; visual properties come entirely from the cva variant.
- Root font-size is 15px, so `text-sm` (0.875rem) = 13.125px, not the 14px a 16px root would give. `list-row-name` uses `0.875rem` to match nav's `text-sm`.