### PR TITLE
feat(headless): add AHE evidence export

### DIFF
--- a/docs/ahe-evidence-export.md
+++ b/docs/ahe-evidence-export.md
@@ -1,0 +1,49 @@
+# Maka AHE Evidence Export
+
+Maka can export the baseline evidence files that an external AHE loop needs to
+start analysis against a source-backed Maka snapshot. This is a read-only
+headless boundary: it does not run AHE, apply patches, or change the desktop
+runtime.
+
+## Command
+
+After a headless task run has been recorded in a task-run store:
+
+```sh
+maka-headless ahe export <taskRunId...> \
+  --store <out>/runs \
+  --repo <maka-repo-root> \
+  --out <evidence-dir> \
+  [--run-id <id>] \
+  [--source-label <label>] \
+  [--include-events]
+```
+
+The command validates the current AHE component map against `--repo`, reads the
+requested `TaskRunProjection` rows from the existing store, and writes:
+
+- `target-snapshot.json`: `MakaAheTargetSnapshot` for the current source-backed
+  component map.
+- `harness-results.json`: `MakaAheHarnessResults` for the selected task runs.
+- `trace-index.json`: `MakaAheTraceIndex` pointing at per-run trace exports.
+- `traces/<taskRunId>/`: ordinary Maka task-run exports, including
+  `task-run.json`, `result.json`, `result.md`, and optional `events.jsonl`.
+
+## Authority Rules
+
+`official_pass` and `official_fail` are emitted only when Maka has authoritative
+official verifier/scorer evidence. Non-authoritative local checks and
+self-checks are exported as `self_check_only` or `unscored`; infra, excluded,
+and unscored cells stay in separate buckets so AHE cannot confuse advisory
+evidence with official benchmark truth.
+
+## API
+
+Programmatic callers can use:
+
+- `buildMakaAheTargetSnapshot`
+- `makaAheEvidenceFromTaskRunProjections`
+- `writeMakaAheEvidenceExport`
+- `validateMakaAheSourceRefs`
+
+These functions live in `@maka/headless/ahe-evidence-export`.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -13,6 +13,10 @@
     "./ahe-target-protocol": {
       "types": "./dist/ahe-target-protocol.d.ts",
       "default": "./dist/ahe-target-protocol.js"
+    },
+    "./ahe-evidence-export": {
+      "types": "./dist/ahe-evidence-export.d.ts",
+      "default": "./dist/ahe-evidence-export.js"
     }
   },
   "imports": {

--- a/packages/headless/src/__tests__/ahe-evidence-export.test.ts
+++ b/packages/headless/src/__tests__/ahe-evidence-export.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL,
+  buildMakaAheTargetSnapshot,
+  makaAheEvidenceFromTaskRunProjections,
+  validateMakaAheSourceRefs,
+  writeMakaAheEvidenceExport,
+} from '../ahe-evidence-export.js';
+import type { MakaAheTargetComponent } from '../ahe-target-protocol.js';
+import type { ScoreResult, TaskEvent } from '../task-contracts.js';
+import { projectTaskRun } from '../task-run-store.js';
+
+describe('AHE evidence export', () => {
+  test('builds a deterministic target snapshot after validating repo source refs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-ahe-snapshot-'));
+    try {
+      await mkdir(join(dir, 'src'), { recursive: true });
+      await writeFile(join(dir, 'src', 'prompt.ts'), 'export const prompt = "ok";\n', 'utf8');
+      const components = fixtureComponents('src/prompt.ts');
+
+      const first = await buildMakaAheTargetSnapshot({
+        repoRoot: dir,
+        components,
+        createdAt: '2026-07-01T00:00:00.000Z',
+      });
+      const second = await buildMakaAheTargetSnapshot({
+        repoRoot: dir,
+        components,
+        createdAt: '2026-07-02T00:00:00.000Z',
+      });
+
+      assert.equal(first.protocolVersion, 'maka.ahe-target.v1');
+      assert.equal(first.sourceLabel, MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL);
+      assert.equal(first.snapshotId, second.snapshotId);
+      assert.equal(first.components[0]?.sourceRefs[0]?.path, 'src/prompt.ts');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects missing and unsafe target source refs', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-ahe-bad-snapshot-'));
+    try {
+      const missing = await validateMakaAheSourceRefs(dir, fixtureComponents('src/missing.ts'));
+      assert.equal(missing[0]?.path, 'components[0].sourceRefs[0].path');
+      assert.match(missing[0]?.message ?? '', /does not exist/);
+
+      const unsafe = await validateMakaAheSourceRefs(dir, fixtureComponents('../outside.ts'));
+      assert.match(unsafe[0]?.message ?? '', /traverse/);
+
+      await assert.rejects(
+        () => buildMakaAheTargetSnapshot({ repoRoot: dir, components: fixtureComponents('/abs.ts') }),
+        /repo-relative POSIX/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('maps task-run projections to AHE results with conservative authority buckets', () => {
+    const official = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-official', ts: 1, taskId: 'task-b', configId: 'cfg-1' },
+      officialVerifierEvent('run-official', true),
+      officialScoreEvent('run-official', true),
+      { type: 'task_run_completed', id: 'e4', taskRunId: 'run-official', ts: 4, finishedAt: 4 },
+    ], 'run-official');
+    const selfCheck = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId: 'run-self-check', ts: 1, taskId: 'task-a', configId: 'cfg-1' },
+      {
+        type: 'self_check_observed',
+        id: 'e2',
+        taskRunId: 'run-self-check',
+        ts: 2,
+        observation: { id: 'self-check-1', taskRunId: 'run-self-check', ts: 2, summary: 'local check passed' },
+      },
+      scoreEvent({
+        id: 'score-self-check',
+        taskRunId: 'run-self-check',
+        ts: 3,
+        passed: true,
+        scored: true,
+        eligible: true,
+        score: 1,
+        maxScore: 1,
+        taxonomy: 'passed',
+        authority: { source: 'self_check', authoritative: true },
+      }),
+    ], 'run-self-check');
+
+    const evidence = makaAheEvidenceFromTaskRunProjections([official, selfCheck], {
+      snapshotId: 'snapshot-baseline',
+      runId: 'baseline-run',
+      exportedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    assert.deepEqual(evidence.harnessResults.results.map((result) => result.taskId), ['task-a', 'task-b']);
+    assert.equal(evidence.harnessResults.results[0]?.status, 'self_check_only');
+    assert.equal(evidence.harnessResults.results[0]?.scoreAuthority, 'self_check');
+    assert.match(evidence.harnessResults.results[0]?.warnings?.join('\n') ?? '', /non-authoritative/);
+    assert.equal(evidence.harnessResults.results[1]?.status, 'official_pass');
+    assert.equal(evidence.harnessResults.results[1]?.scoreAuthority, 'official_scorer');
+    assert.equal(evidence.traceIndex.entries[0]?.transcript?.ref, 'traces/run-self-check/result.md');
+  });
+
+  test('keeps excluded, infra, and unscored cells explicit', () => {
+    assert.equal(statusForScore({
+      id: 'score-excluded',
+      taskRunId: 'run-bucket',
+      ts: 2,
+      passed: false,
+      scored: false,
+      eligible: false,
+      taxonomy: 'unsupported_adapter',
+      excludedReason: 'no official adapter',
+      authority: { source: 'system', authoritative: false },
+    }), 'excluded');
+    assert.equal(statusForScore({
+      id: 'score-infra',
+      taskRunId: 'run-bucket',
+      ts: 2,
+      passed: false,
+      scored: true,
+      eligible: true,
+      taxonomy: 'infra_failed',
+      errorClass: 'infra_failed',
+      authority: { source: 'official_harbor_verifier', authoritative: true },
+    }), 'infra_failed');
+    assert.equal(
+      makaAheEvidenceFromTaskRunProjections([
+        projectTaskRun([
+          { type: 'task_run_created', id: 'e1', taskRunId: 'run-unscored', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+        ], 'run-unscored'),
+      ], { snapshotId: 'snapshot-baseline' }).harnessResults.results[0]?.status,
+      'unscored',
+    );
+  });
+
+  test('writes deterministic AHE files and per-task trace exports', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-ahe-repo-'));
+    const out = await mkdtemp(join(tmpdir(), 'maka-ahe-out-'));
+    try {
+      await mkdir(join(repo, 'src'), { recursive: true });
+      await writeFile(join(repo, 'src', 'prompt.ts'), 'export const prompt = "ok";\n', 'utf8');
+      const snapshot = await buildMakaAheTargetSnapshot({
+        repoRoot: repo,
+        components: fixtureComponents('src/prompt.ts'),
+        createdAt: '2026-07-01T00:00:00.000Z',
+      });
+      const projection = projectTaskRun([
+        { type: 'task_run_created', id: 'e1', taskRunId: 'run-official', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+        officialVerifierEvent('run-official', false),
+        officialScoreEvent('run-official', false),
+        { type: 'task_run_completed', id: 'e4', taskRunId: 'run-official', ts: 4, finishedAt: 4 },
+      ], 'run-official');
+
+      const first = await writeMakaAheEvidenceExport(out, {
+        snapshot,
+        projections: [projection],
+        runId: 'baseline-run',
+        exportedAt: '2026-07-01T00:00:00.000Z',
+        includeEvents: true,
+      });
+      const firstHarness = await readFile(first.files.harnessResultsJson, 'utf8');
+      const second = await writeMakaAheEvidenceExport(out, {
+        snapshot,
+        projections: [projection],
+        runId: 'baseline-run',
+        exportedAt: '2026-07-01T00:00:00.000Z',
+        includeEvents: true,
+      });
+
+      assert.equal(firstHarness, await readFile(second.files.harnessResultsJson, 'utf8'));
+      const parsedHarness = JSON.parse(firstHarness);
+      assert.equal(parsedHarness.results[0].status, 'official_fail');
+      assert.equal(parsedHarness.results[0].traceRef.ref, 'traces/run-official/task-run.json');
+      const traceIndexJson = await readFile(join(out, 'trace-index.json'), 'utf8');
+      assert.match(traceIndexJson, /traces\/run-official\/result.md/);
+      assert.match(traceIndexJson, /traces\/run-official\/events.jsonl/);
+      assert.match(await readFile(join(out, 'traces', 'run-official', 'task-run.json'), 'utf8'), /maka.task_run_export.v1/);
+      assert.match(await readFile(join(out, 'traces', 'run-official', 'events.jsonl'), 'utf8'), /task_run_created/);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(out, { recursive: true, force: true });
+    }
+  });
+});
+
+function fixtureComponents(sourcePath: string): readonly MakaAheTargetComponent[] {
+  return [{
+    id: 'fixture-prompt',
+    category: 'system_prompt',
+    label: 'Fixture prompt',
+    description: 'Fixture source-backed prompt component',
+    editable: true,
+    sourceRefs: [{ path: sourcePath }],
+  }];
+}
+
+function statusForScore(score: ScoreResult): string | undefined {
+  const projection = projectTaskRun([
+    { type: 'task_run_created', id: 'e1', taskRunId: 'run-bucket', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
+    scoreEvent(score),
+  ], 'run-bucket');
+  return makaAheEvidenceFromTaskRunProjections([projection], { snapshotId: 'snapshot-baseline' }).harnessResults.results[0]?.status;
+}
+
+function scoreEvent(result: ScoreResult): TaskEvent {
+  return { type: 'score_result_recorded', id: `event-${result.id}`, taskRunId: result.taskRunId, ts: result.ts, result };
+}
+
+function officialVerifierEvent(taskRunId: string, passed: boolean): TaskEvent {
+  return {
+    type: 'verifier_result_recorded',
+    id: `verifier-${taskRunId}`,
+    taskRunId,
+    ts: 2,
+    result: {
+      id: `verifier-${taskRunId}`,
+      taskRunId,
+      ts: 2,
+      kind: 'terminal_bench',
+      passed,
+      exitCode: passed ? 0 : 1,
+      score: passed ? 1 : 0,
+      maxScore: 1,
+      authority: { source: 'official_harbor_verifier', authoritative: true },
+    },
+  };
+}
+
+function officialScoreEvent(taskRunId: string, passed: boolean): TaskEvent {
+  return scoreEvent({
+    id: `score-${taskRunId}`,
+    taskRunId,
+    ts: 3,
+    passed,
+    scored: true,
+    eligible: true,
+    score: passed ? 1 : 0,
+    maxScore: 1,
+    taxonomy: passed ? 'passed' : 'verification_failed',
+    authority: { source: 'official_harbor_verifier', authoritative: true },
+  });
+}

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -8,6 +8,7 @@ import { describe, test } from 'node:test';
 import { readResults } from '../results.js';
 
 const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
 
 function runCli(
   args: string[],
@@ -370,6 +371,26 @@ describe('maka-headless CLI', () => {
       assert.equal(taskRunJson.verifier.authority.authoritative, false);
       assert.equal(taskRunJson.verifier.benchmark.verificationPlaceholder, true);
       assert.match(await readFile(join(exportDir, 'events.jsonl'), 'utf8'), /verifier_result_recorded/);
+
+      const aheExportDir = join(dir, 'ahe-export');
+      const aheExported = await runCli([
+        'ahe',
+        'export',
+        'task-run-1',
+        '--store',
+        join(outDir, 'runs'),
+        '--repo',
+        repoRoot,
+        '--out',
+        aheExportDir,
+        '--include-events',
+      ]);
+      assert.equal(aheExported.code, 0, aheExported.stderr);
+      assert.match(aheExported.stdout, /harnessResults:/);
+      const aheResults = JSON.parse(await readFile(join(aheExportDir, 'harness-results.json'), 'utf8'));
+      assert.equal(aheResults.results[0].status, 'excluded');
+      assert.equal(aheResults.results[0].scoreAuthority, 'self_check');
+      assert.match(await readFile(join(aheExportDir, 'trace-index.json'), 'utf8'), /traces\/task-run-1\/result.md/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/ahe-evidence-export.ts
+++ b/packages/headless/src/ahe-evidence-export.ts
@@ -1,0 +1,426 @@
+import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import {
+  MAKA_AHE_CURRENT_COMPONENTS,
+  MAKA_AHE_TARGET_PROTOCOL_VERSION,
+  MAKA_AHE_TARGET_SOURCE_LABEL,
+  type MakaAheArtifactRef,
+  type MakaAheHarnessResults,
+  type MakaAheResultStatus,
+  type MakaAheRunResult,
+  type MakaAheScoreAuthority,
+  type MakaAheSnapshotIdentity,
+  type MakaAheTargetComponent,
+  type MakaAheTargetSnapshot,
+  type MakaAheTraceIndex,
+  type MakaAheTraceIndexEntry,
+  type MakaAheValidationIssue,
+  validateMakaAheRunResult,
+  validateMakaAheTargetComponents,
+} from './ahe-target-protocol.js';
+import {
+  exportContentHash,
+  taskRunExportFromProjection,
+  writeTaskRunExport,
+  type TaskRunExport,
+} from './result-export.js';
+import type { ScoreResult, TaskRunArtifact, VerifierResult } from './task-contracts.js';
+import type { TaskRunProjection } from './task-run-store.js';
+
+export const MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL = 'ahe-evidence-export-20260701' as const;
+
+export interface BuildMakaAheTargetSnapshotOptions {
+  repoRoot: string;
+  sourceLabel?: string;
+  createdAt?: string;
+  components?: readonly MakaAheTargetComponent[];
+  git?: MakaAheSnapshotIdentity['git'];
+}
+
+export interface MakaAheRunEvidenceOptions {
+  snapshotId: string;
+  runId?: string;
+  exportedAt?: string;
+  traceBaseRef?: string;
+  includeEvents?: boolean;
+}
+
+export interface MakaAheRunEvidence {
+  harnessResults: MakaAheHarnessResults;
+  traceIndex: MakaAheTraceIndex;
+}
+
+export interface WriteMakaAheEvidenceExportOptions {
+  snapshot: MakaAheTargetSnapshot;
+  projections: readonly TaskRunProjection[];
+  runId?: string;
+  exportedAt?: string;
+  includeEvents?: boolean;
+}
+
+export interface WriteMakaAheEvidenceExportResult extends MakaAheRunEvidence {
+  targetSnapshot: MakaAheTargetSnapshot;
+  files: {
+    targetSnapshotJson: string;
+    harnessResultsJson: string;
+    traceIndexJson: string;
+    traceDirs: Record<string, string>;
+  };
+}
+
+export async function validateMakaAheSourceRefs(
+  repoRoot: string,
+  components: readonly MakaAheTargetComponent[] = MAKA_AHE_CURRENT_COMPONENTS,
+): Promise<MakaAheValidationIssue[]> {
+  const errors: MakaAheValidationIssue[] = [];
+  const componentResult = validateMakaAheTargetComponents(components);
+  if (!componentResult.ok) {
+    errors.push(...componentResult.errors);
+    return errors;
+  }
+
+  await Promise.all(components.flatMap((component, componentIndex) => component.sourceRefs.map(async (sourceRef, refIndex) => {
+    const path = `components[${componentIndex}].sourceRefs[${refIndex}].path`;
+    const issue = unsafeRepoPathReason(sourceRef.path);
+    if (issue) {
+      errors.push({ path, message: issue });
+      return;
+    }
+    const root = resolve(repoRoot);
+    const resolved = resolve(root, sourceRef.path);
+    if (!isWithinRoot(root, resolved)) {
+      errors.push({ path, message: `source ref "${sourceRef.path}" resolves outside the repo root` });
+      return;
+    }
+    try {
+      await stat(resolved);
+    } catch {
+      errors.push({ path, message: `source ref "${sourceRef.path}" does not exist under repo root` });
+    }
+  })));
+
+  return errors.sort((a, b) => a.path.localeCompare(b.path) || a.message.localeCompare(b.message));
+}
+
+export async function buildMakaAheTargetSnapshot(
+  options: BuildMakaAheTargetSnapshotOptions,
+): Promise<MakaAheTargetSnapshot> {
+  const components = options.components ?? MAKA_AHE_CURRENT_COMPONENTS;
+  const errors = await validateMakaAheSourceRefs(options.repoRoot, components);
+  if (errors.length > 0) {
+    throw new Error(`invalid Maka AHE target snapshot source refs:\n${errors.map((error) => `- ${error.path}: ${error.message}`).join('\n')}`);
+  }
+
+  const sourceLabel = options.sourceLabel ?? MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL;
+  const identity = {
+    protocolVersion: MAKA_AHE_TARGET_PROTOCOL_VERSION,
+    sourceLabel,
+    ...(options.git ? { git: options.git } : {}),
+    components,
+  };
+
+  return {
+    protocolVersion: MAKA_AHE_TARGET_PROTOCOL_VERSION,
+    sourceLabel,
+    snapshotId: `maka-ahe-${shortHash(identity)}`,
+    createdAt: options.createdAt ?? new Date().toISOString(),
+    ...(options.git ? { git: options.git } : {}),
+    components,
+  };
+}
+
+export function makaAheEvidenceFromTaskRunProjections(
+  projections: readonly TaskRunProjection[],
+  options: MakaAheRunEvidenceOptions,
+): MakaAheRunEvidence {
+  const sorted = sortProjections(projections);
+  const runId = options.runId ?? `maka-ahe-run-${shortHash({
+    snapshotId: options.snapshotId,
+    taskRunIds: sorted.map((projection) => projection.taskRunId),
+  })}`;
+  const traceBaseRef = trimTrailingSlash(options.traceBaseRef ?? 'traces');
+  const results: MakaAheRunResult[] = [];
+  const entries: MakaAheTraceIndexEntry[] = [];
+
+  for (const projection of sorted) {
+    const exported = taskRunExportFromProjection(projection, { exportedAt: options.exportedAt });
+    const taskRunRef = `${traceBaseRef}/${safePathSegment(projection.taskRunId)}`;
+    const result = runResultFromProjection(projection, exported, {
+      snapshotId: options.snapshotId,
+      runId,
+      taskRunRef,
+    });
+    const validation = validateMakaAheRunResult(result);
+    if (!validation.ok) {
+      throw new Error(`invalid Maka AHE run result for ${projection.taskRunId}:\n${validation.errors.map((error) => `- ${error.path}: ${error.message}`).join('\n')}`);
+    }
+    results.push(result);
+    entries.push(traceIndexEntryFromProjection(projection, exported, {
+      snapshotId: options.snapshotId,
+      runId,
+      taskRunRef,
+      includeEvents: options.includeEvents,
+    }));
+  }
+
+  return {
+    harnessResults: {
+      protocolVersion: MAKA_AHE_TARGET_PROTOCOL_VERSION,
+      snapshotId: options.snapshotId,
+      runId,
+      results,
+      traceIndexRef: { kind: 'file', ref: 'trace-index.json', mediaType: 'application/json' },
+    },
+    traceIndex: {
+      protocolVersion: MAKA_AHE_TARGET_PROTOCOL_VERSION,
+      snapshotId: options.snapshotId,
+      entries,
+    },
+  };
+}
+
+export async function writeMakaAheEvidenceExport(
+  outDir: string,
+  options: WriteMakaAheEvidenceExportOptions,
+): Promise<WriteMakaAheEvidenceExportResult> {
+  await mkdir(outDir, { recursive: true });
+  const evidence = makaAheEvidenceFromTaskRunProjections(options.projections, {
+    snapshotId: options.snapshot.snapshotId,
+    runId: options.runId,
+    exportedAt: options.exportedAt,
+    includeEvents: options.includeEvents,
+  });
+  const files: WriteMakaAheEvidenceExportResult['files'] = {
+    targetSnapshotJson: join(outDir, 'target-snapshot.json'),
+    harnessResultsJson: join(outDir, 'harness-results.json'),
+    traceIndexJson: join(outDir, 'trace-index.json'),
+    traceDirs: {},
+  };
+
+  await writeStableJson(files.targetSnapshotJson, options.snapshot);
+  await writeStableJson(files.harnessResultsJson, evidence.harnessResults);
+  await writeStableJson(files.traceIndexJson, evidence.traceIndex);
+
+  for (const projection of sortProjections(options.projections)) {
+    const traceDir = join(outDir, 'traces', safePathSegment(projection.taskRunId));
+    files.traceDirs[projection.taskRunId] = traceDir;
+    await writeTaskRunExport(traceDir, projection, {
+      includeEvents: options.includeEvents,
+      exportedAt: options.exportedAt,
+    });
+  }
+
+  return { targetSnapshot: options.snapshot, ...evidence, files };
+}
+
+function runResultFromProjection(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+  ids: { snapshotId: string; runId: string; taskRunRef: string },
+): MakaAheRunResult {
+  const authority = scoreAuthority(exported.score, exported.verifier, projection);
+  const status = resultStatus(exported, projection, authority);
+  const normalized = normalizedScore(exported.score, exported.verifier);
+  const warnings = resultWarnings(exported, projection, status, authority);
+  return {
+    protocolVersion: MAKA_AHE_TARGET_PROTOCOL_VERSION,
+    runId: ids.runId,
+    snapshotId: ids.snapshotId,
+    taskId: exported.taskRun.taskId,
+    status,
+    scoreAuthority: authority,
+    ...(normalized !== undefined ? { score: normalized } : {}),
+    ...(exported.verifier ? { verifierRef: verifierRef(exported.verifier, ids.taskRunRef) } : {}),
+    traceRef: { kind: 'file', ref: `${ids.taskRunRef}/task-run.json`, mediaType: 'application/json' },
+    ...(status === 'official_pass' ? {} : { failureTaxonomy: failureTaxonomy(exported) }),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+function traceIndexEntryFromProjection(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+  ids: { snapshotId: string; runId: string; taskRunRef: string; includeEvents?: boolean },
+): MakaAheTraceIndexEntry {
+  return {
+    taskId: exported.taskRun.taskId,
+    runId: ids.runId,
+    snapshotId: ids.snapshotId,
+    ...(ids.includeEvents || (exported.runtime.trajectoryRefs.runtimeEventIds && exported.runtime.trajectoryRefs.runtimeEventIds.length > 0)
+      ? { runtimeEventsJsonl: { kind: 'file', ref: `${ids.taskRunRef}/events.jsonl`, mediaType: 'application/jsonl' } }
+      : {}),
+    ...(exported.runtime.agentRunId ? { agentRun: { kind: 'other', ref: `maka-agent-run:${exported.runtime.agentRunId}` } } : {}),
+    transcript: { kind: 'file', ref: `${ids.taskRunRef}/result.md`, mediaType: 'text/markdown' },
+    toolResults: projection.artifacts.filter((artifact) => artifact.kind === 'runtime_trace').map(artifactRefFromTaskRunArtifact),
+    artifacts: exported.artifacts.items.map(artifactRefFromTaskRunArtifact),
+  };
+}
+
+function resultStatus(
+  exported: TaskRunExport,
+  projection: TaskRunProjection,
+  authority: MakaAheScoreAuthority,
+): MakaAheResultStatus {
+  if (isExcluded(exported.score)) return 'excluded';
+  if (isInfraFailure(exported)) return 'infra_failed';
+  if (authority === 'official_scorer' || authority === 'official_verifier') {
+    return (exported.score?.passed ?? exported.verifier?.passed ?? false) ? 'official_pass' : 'official_fail';
+  }
+  if (hasSelfCheckEvidence(projection, exported.score, exported.verifier)) return 'self_check_only';
+  if (exported.score?.scored === false) return 'unscored';
+  return 'unscored';
+}
+
+function scoreAuthority(
+  score: ScoreResult | undefined,
+  verifier: VerifierResult | undefined,
+  projection: TaskRunProjection,
+): MakaAheScoreAuthority {
+  if (isOfficialAuthority(score?.authority)) return 'official_scorer';
+  if (isOfficialAuthority(verifier?.authority)) return 'official_verifier';
+  if (hasSelfCheckEvidence(projection, score, verifier)) return 'self_check';
+  return 'analysis_only';
+}
+
+function isOfficialAuthority(authority: { source: string; authoritative: boolean } | undefined): boolean {
+  return authority?.authoritative === true && authority.source === 'official_harbor_verifier';
+}
+
+function hasSelfCheckEvidence(
+  projection: TaskRunProjection,
+  score: ScoreResult | undefined,
+  verifier: VerifierResult | undefined,
+): boolean {
+  return score?.authority?.source === 'self_check'
+    || verifier?.authority?.source === 'self_check'
+    || projection.selfChecks.length > 0
+    || projection.heavyTaskSelfChecks.length > 0
+    || projection.heavyTaskEvidence.some((item) => item.kind === 'check');
+}
+
+function isExcluded(score: ScoreResult | undefined): boolean {
+  return score?.eligible === false || Boolean(score?.excludedReason);
+}
+
+function isInfraFailure(exported: TaskRunExport): boolean {
+  const taxonomy = String(exported.taxonomy.value);
+  const fields = [
+    taxonomy,
+    exported.taxonomy.errorClass,
+    exported.taskRun.error?.class,
+    exported.score?.errorClass,
+    exported.verifier?.errorClass,
+  ].filter((value): value is string => typeof value === 'string');
+  return fields.some((field) => [
+    'infra_failed',
+    'setup_failed',
+    'verification_error',
+    'agent_failed',
+    'agent_incomplete',
+    'budget_exhausted',
+    'aborted',
+    'blocked',
+    'cancelled',
+  ].includes(field));
+}
+
+function normalizedScore(score: ScoreResult | undefined, verifier: VerifierResult | undefined): number | undefined {
+  const rawScore = score?.score ?? verifier?.score;
+  const maxScore = score?.maxScore ?? verifier?.maxScore;
+  if (typeof rawScore !== 'number') return undefined;
+  if (typeof maxScore === 'number' && maxScore > 0) return rawScore / maxScore;
+  return rawScore;
+}
+
+function failureTaxonomy(exported: TaskRunExport): string[] {
+  return uniqueStrings([
+    String(exported.taxonomy.value),
+    exported.taxonomy.errorClass,
+    exported.taxonomy.excludedReason,
+    exported.score?.taxonomy,
+    exported.score?.errorClass,
+    exported.score?.excludedReason,
+    exported.verifier?.errorClass,
+    exported.taskRun.error?.class,
+  ]);
+}
+
+function resultWarnings(
+  exported: TaskRunExport,
+  projection: TaskRunProjection,
+  status: MakaAheResultStatus,
+  authority: MakaAheScoreAuthority,
+): string[] {
+  const warnings = [...exported.warnings];
+  const hasNonOfficialPass = exported.score?.passed === true || exported.verifier?.passed === true || exported.taxonomy.passed === true;
+  if (status !== 'official_pass' && authority !== 'official_scorer' && authority !== 'official_verifier' && hasNonOfficialPass) {
+    warnings.push('non-authoritative pass evidence was exported outside official pass/fail buckets');
+  }
+  if (projection.latestHeavyTaskSelfCheck && status !== 'official_pass' && status !== 'official_fail') {
+    warnings.push('self-check evidence is advisory and was exported as non-official evidence');
+  }
+  return uniqueStrings(warnings);
+}
+
+function verifierRef(verifier: VerifierResult, taskRunRef: string): MakaAheArtifactRef {
+  return {
+    kind: 'file',
+    ref: `${taskRunRef}/task-run.json`,
+    mediaType: 'application/json',
+    description: `${verifier.kind} verifier result ${verifier.id}`,
+  };
+}
+
+function artifactRefFromTaskRunArtifact(artifact: TaskRunArtifact): MakaAheArtifactRef {
+  const ref = artifact.artifactRef ?? artifact.path ?? artifact.workspacePath ?? artifact.artifactId;
+  return {
+    kind: artifactRefKind(ref, artifact),
+    ref,
+    ...(artifact.mimeType ? { mediaType: artifact.mimeType } : {}),
+    ...(artifact.label ?? artifact.kind ? { description: artifact.label ?? artifact.kind } : {}),
+  };
+}
+
+function artifactRefKind(ref: string, artifact: TaskRunArtifact): MakaAheArtifactRef['kind'] {
+  if (ref.startsWith('http://') || ref.startsWith('https://')) return 'url';
+  if (artifact.kind === 'container_workspace') return 'directory';
+  if (artifact.artifactRef && !artifact.artifactRef.startsWith('/')) return 'blob';
+  if (artifact.path || artifact.workspacePath) return 'file';
+  return 'other';
+}
+
+function sortProjections(projections: readonly TaskRunProjection[]): TaskRunProjection[] {
+  return [...projections].sort((a, b) => a.taskId.localeCompare(b.taskId) || a.taskRunId.localeCompare(b.taskRunId));
+}
+
+function unsafeRepoPathReason(path: string): string | undefined {
+  if (path.trim().length === 0) return 'source ref path must be non-empty';
+  if (path.startsWith('/') || path.includes('\\')) return 'source ref path must be a repo-relative POSIX path';
+  if (path === '.' || path === '..' || path.includes('../') || path.includes('/..')) return 'source ref path must not traverse outside the repo';
+  return undefined;
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const normalizedRoot = root.endsWith(sep) ? root : `${root}${sep}`;
+  return candidate === root || candidate.startsWith(normalizedRoot);
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '') || shortHash(value);
+}
+
+function shortHash(value: unknown): string {
+  return exportContentHash(value).replace(/^sha256:/, '').slice(0, 16);
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '') || '.';
+}
+
+async function writeStableJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function uniqueStrings(values: readonly (string | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -7,6 +7,7 @@ import { runAutonomousTask } from './autonomous-agent-loop.js';
 import { harborCommand } from './harbor-cli.js';
 import { runMatrix, type ExperimentSpec } from './matrix.js';
 import { planMatrixRetry, readMatrixPriorRecords } from './matrix-resume.js';
+import { buildMakaAheTargetSnapshot, writeMakaAheEvidenceExport } from './ahe-evidence-export.js';
 import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
 import { runTaskOnce } from './task-agent-controller.js';
@@ -202,6 +203,49 @@ async function taskExportCommand(args: string[]): Promise<number> {
   return 0;
 }
 
+async function aheCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (subcommand === 'export') return aheExportCommand(rest);
+  console.error('maka-headless ahe commands:\n');
+  console.error('  ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]');
+  return 1;
+}
+
+async function aheExportCommand(args: string[]): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(args, ['store', 'repo', 'out', 'run-id', 'source-label'], ['include-events']);
+  } catch (error) {
+    console.error(`${(error as Error).message}\nusage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]`);
+    return 1;
+  }
+  if (parsed.positional.length === 0 || !parsed.flags.store || !parsed.flags.repo || !parsed.flags.out) {
+    console.error('usage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]');
+    return 1;
+  }
+  try {
+    const store = createTaskRunStore(resolve(parsed.flags.store));
+    const projections = await Promise.all(parsed.positional.map((taskRunId) => store.project(taskRunId)));
+    const snapshot = await buildMakaAheTargetSnapshot({
+      repoRoot: resolve(parsed.flags.repo),
+      sourceLabel: parsed.flags['source-label'],
+    });
+    const result = await writeMakaAheEvidenceExport(resolve(parsed.flags.out), {
+      snapshot,
+      projections,
+      runId: parsed.flags['run-id'],
+      includeEvents: parsed.bools['include-events'],
+    });
+    console.log(`targetSnapshot: ${result.files.targetSnapshotJson}`);
+    console.log(`harnessResults: ${result.files.harnessResultsJson}`);
+    console.log(`traceIndex: ${result.files.traceIndexJson}`);
+    return 0;
+  } catch (error) {
+    console.error(`maka-headless ahe export: ${(error as Error).message}`);
+    return 1;
+  }
+}
+
 async function taskResumeCommand(args: string[]): Promise<number> {
   let parsed: ParsedArgs;
   try {
@@ -354,6 +398,7 @@ function printUsage(): void {
   console.error('  maka-headless eval <spec.json> [--out <dir>]   run configs × tasks, write results + table');
   console.error('  maka-headless compare <results.jsonl>          print the comparison table');
   console.error('  maka-headless task <command> ...               run, inspect, resume, retry, export task runs');
+  console.error('  maka-headless ahe <command> ...                export AHE target snapshots and evidence');
   console.error('  maka-headless harbor <command> ...             run Harbor real-backend task/cell flows');
 }
 
@@ -371,6 +416,7 @@ async function main(argv: string[]): Promise<number> {
   if (cmd === 'eval') return evalCommand(rest);
   if (cmd === 'compare') return compareCommand(rest);
   if (cmd === 'task') return taskCommand(rest);
+  if (cmd === 'ahe') return aheCommand(rest);
   if (cmd === 'harbor') return harborCommand(rest);
   printUsage();
   return cmd ? 1 : 0;

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -171,6 +171,20 @@ export {
   type ExternalHarborBenchmarkFailureKind,
 } from './harbor-failure-policy.js';
 export type {
+  BuildMakaAheTargetSnapshotOptions,
+  MakaAheRunEvidence,
+  MakaAheRunEvidenceOptions,
+  WriteMakaAheEvidenceExportOptions,
+  WriteMakaAheEvidenceExportResult,
+} from './ahe-evidence-export.js';
+export {
+  MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL,
+  buildMakaAheTargetSnapshot,
+  makaAheEvidenceFromTaskRunProjections,
+  validateMakaAheSourceRefs,
+  writeMakaAheEvidenceExport,
+} from './ahe-evidence-export.js';
+export type {
   MakaAheArtifactRef,
   MakaAheChangeEvaluation,
   MakaAheChangeEvaluationCell,


### PR DESCRIPTION
## Summary

- add a headless AHE evidence export API for target snapshots, harness results, and trace indexes
- add `maka-headless ahe export` to export existing task-run projections into AHE evidence files
- keep official pass/fail authority restricted to the Harbor verifier; local/self-check evidence is never promoted to official
- document the export surface and add focused API/CLI tests

Refs #345.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/ahe-evidence-export.test.js packages/headless/dist/__tests__/cli.test.js`
- `npm --workspace @maka/headless test` (95 suites, 659 tests, 658 pass, 1 skipped)
