### PR TITLE
Add AHE messages and official result export

### DIFF
--- a/packages/headless/src/__tests__/ahe-evidence-export.test.ts
+++ b/packages/headless/src/__tests__/ahe-evidence-export.test.ts
@@ -7,6 +7,7 @@ import {
   MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL,
   buildMakaAheTargetSnapshot,
   makaAheEvidenceFromTaskRunProjections,
+  readMakaAheHarborOfficialResult,
   validateMakaAheSourceRefs,
   writeMakaAheEvidenceExport,
 } from '../ahe-evidence-export.js';
@@ -104,6 +105,50 @@ describe('AHE evidence export', () => {
     assert.equal(evidence.harnessResults.results[1]?.status, 'official_pass');
     assert.equal(evidence.harnessResults.results[1]?.scoreAuthority, 'official_scorer');
     assert.equal(evidence.traceIndex.entries[0]?.transcript?.ref, 'traces/run-self-check/result.md');
+    assert.equal(evidence.traceIndex.entries[0]?.agentRun?.ref, 'traces/run-self-check/messages.json');
+  });
+
+  test('overlays Harbor post-exit official results during AHE bucketing', async () => {
+    const trial = await mkdtemp(join(tmpdir(), 'maka-ahe-harbor-trial-'));
+    try {
+      await mkdir(join(trial, 'verifier'), { recursive: true });
+      await writeFile(join(trial, 'result.json'), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }), 'utf8');
+      await writeFile(join(trial, 'verifier', 'reward.txt'), '1\n', 'utf8');
+      await writeFile(join(trial, 'verifier', 'test-stdout.txt'), '3 passed\n', 'utf8');
+      const selfCheckOnlyProjection = projectTaskRun([
+        { type: 'task_run_created', id: 'e1', taskRunId: 'run-harbor', ts: 1, taskId: 'task-a', configId: 'cfg-1' },
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'e2',
+          taskRunId: 'run-harbor',
+          ts: 2,
+          selfCheck: acceptedHeavySelfCheck('run-harbor', false),
+        },
+        scoreEvent({
+          id: 'score-self-check',
+          taskRunId: 'run-harbor',
+          ts: 3,
+          passed: false,
+          scored: false,
+          eligible: true,
+          taxonomy: 'verification_failed',
+          authority: { source: 'self_check', authoritative: false },
+        }),
+      ], 'run-harbor');
+      const official = await readMakaAheHarborOfficialResult(trial, selfCheckOnlyProjection);
+
+      const evidence = makaAheEvidenceFromTaskRunProjections([selfCheckOnlyProjection], {
+        snapshotId: 'snapshot-baseline',
+        officialResults: { 'run-harbor': official },
+      });
+
+      assert.equal(evidence.harnessResults.results[0]?.status, 'official_pass');
+      assert.equal(evidence.harnessResults.results[0]?.scoreAuthority, 'official_scorer');
+      assert.equal(evidence.harnessResults.results[0]?.verifierRef?.ref, 'traces/run-harbor/official-harbor-result.json');
+      assert.match(evidence.traceIndex.entries[0]?.artifacts?.[0]?.ref ?? '', /official-harbor-result\.json/);
+    } finally {
+      await rm(trial, { recursive: true, force: true });
+    }
   });
 
   test('keeps excluded, infra, and unscored cells explicit', () => {
@@ -156,6 +201,14 @@ describe('AHE evidence export', () => {
         officialScoreEvent('run-official', false),
         { type: 'task_run_completed', id: 'e4', taskRunId: 'run-official', ts: 4, finishedAt: 4 },
       ], 'run-official');
+      const sessionMessages = {
+        'run-official': [
+          { type: 'user', id: 'u1', turnId: 't1', ts: 1, text: 'compile sqlite with gcov' },
+          { type: 'tool_call', id: 'tool-1', turnId: 't1', ts: 2, toolName: 'Bash', args: { command: 'make' } },
+          { type: 'tool_result', id: 'tool-r1', turnId: 't1', ts: 3, toolUseId: 'tool-1', isError: false, content: { kind: 'text', text: 'ok' } },
+          { type: 'assistant', id: 'a1', turnId: 't1', ts: 4, text: 'SQLite is installed with gcov instrumentation.', modelId: 'fake-model' },
+        ],
+      };
 
       const first = await writeMakaAheEvidenceExport(out, {
         snapshot,
@@ -163,6 +216,7 @@ describe('AHE evidence export', () => {
         runId: 'baseline-run',
         exportedAt: '2026-07-01T00:00:00.000Z',
         includeEvents: true,
+        sessionMessages,
       });
       const firstHarness = await readFile(first.files.harnessResultsJson, 'utf8');
       const second = await writeMakaAheEvidenceExport(out, {
@@ -171,6 +225,7 @@ describe('AHE evidence export', () => {
         runId: 'baseline-run',
         exportedAt: '2026-07-01T00:00:00.000Z',
         includeEvents: true,
+        sessionMessages,
       });
 
       assert.equal(firstHarness, await readFile(second.files.harnessResultsJson, 'utf8'));
@@ -180,8 +235,17 @@ describe('AHE evidence export', () => {
       const traceIndexJson = await readFile(join(out, 'trace-index.json'), 'utf8');
       assert.match(traceIndexJson, /traces\/run-official\/result.md/);
       assert.match(traceIndexJson, /traces\/run-official\/events.jsonl/);
+      assert.match(traceIndexJson, /traces\/run-official\/messages.json/);
       assert.match(await readFile(join(out, 'traces', 'run-official', 'task-run.json'), 'utf8'), /maka.task_run_export.v1/);
       assert.match(await readFile(join(out, 'traces', 'run-official', 'events.jsonl'), 'utf8'), /task_run_created/);
+      const messages = JSON.parse(await readFile(join(out, 'traces', 'run-official', 'messages.json'), 'utf8'));
+      assert.equal(messages.trace_id, 'run-official');
+      assert.equal(messages.messages[0].role, 'system');
+      assert.equal(messages.messages[1].role, 'user');
+      assert.match(messages.messages[1].content, /compile sqlite with gcov/);
+      assert.equal(messages.messages[2].role, 'assistant');
+      assert.match(messages.messages[2].content, /tool_call/);
+      assert.match(JSON.stringify(messages), /task_run_created/);
     } finally {
       await rm(repo, { recursive: true, force: true });
       await rm(out, { recursive: true, force: true });
@@ -245,4 +309,24 @@ function officialScoreEvent(taskRunId: string, passed: boolean): TaskEvent {
     taxonomy: passed ? 'passed' : 'verification_failed',
     authority: { source: 'official_harbor_verifier', authoritative: true },
   });
+}
+
+function acceptedHeavySelfCheck(taskRunId: string, passed: boolean) {
+  return {
+    schemaVersion: 1 as const,
+    selfCheckId: 'self-check-1',
+    taskRunId,
+    ts: 2,
+    status: passed ? 'pass' as const : 'fail' as const,
+    publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    commandEvidence: [{ command: 'npm test', exitCode: passed ? 0 : 1, outputExcerpt: passed ? 'ok' : 'fail' }],
+    artifactEvidence: [],
+    guard: {
+      status: 'accepted' as const,
+      checkedAt: 2,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+    source: { kind: 'model_tool' as const, toolCallId: 'tool-1' },
+  };
 }

--- a/packages/headless/src/__tests__/ahe-evidence-export.test.ts
+++ b/packages/headless/src/__tests__/ahe-evidence-export.test.ts
@@ -197,7 +197,31 @@ describe('AHE evidence export', () => {
       });
       const projection = projectTaskRun([
         { type: 'task_run_created', id: 'e1', taskRunId: 'run-official', ts: 1, taskId: 'task-1', configId: 'cfg-1' },
-        officialVerifierEvent('run-official', false),
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'self-check-event',
+          taskRunId: 'run-official',
+          ts: 2,
+          selfCheck: acceptedHeavySelfCheck('run-official', true),
+        },
+        {
+          type: 'verifier_result_recorded',
+          id: 'verifier-run-official',
+          taskRunId: 'run-official',
+          ts: 3,
+          result: {
+            id: 'verifier-run-official',
+            taskRunId: 'run-official',
+            ts: 3,
+            kind: 'terminal_bench',
+            passed: false,
+            exitCode: 1,
+            score: 0,
+            maxScore: 1,
+            stdout: 'AssertionError: expected move e2e4 but got e2g4\n',
+            authority: { source: 'official_harbor_verifier', authoritative: true },
+          },
+        },
         officialScoreEvent('run-official', false),
         { type: 'task_run_completed', id: 'e4', taskRunId: 'run-official', ts: 4, finishedAt: 4 },
       ], 'run-official');
@@ -236,8 +260,16 @@ describe('AHE evidence export', () => {
       assert.match(traceIndexJson, /traces\/run-official\/result.md/);
       assert.match(traceIndexJson, /traces\/run-official\/events.jsonl/);
       assert.match(traceIndexJson, /traces\/run-official\/messages.json/);
+      assert.match(traceIndexJson, /traces\/run-official\/failure-digest.json/);
       assert.match(await readFile(join(out, 'traces', 'run-official', 'task-run.json'), 'utf8'), /maka.task_run_export.v1/);
       assert.match(await readFile(join(out, 'traces', 'run-official', 'events.jsonl'), 'utf8'), /task_run_created/);
+      const failureDigest = JSON.parse(await readFile(join(out, 'traces', 'run-official', 'failure-digest.json'), 'utf8'));
+      assert.equal(failureDigest.schemaVersion, 'maka.ahe.failure_digest.v1');
+      assert.equal(failureDigest.status, 'official_fail');
+      assert.equal(failureDigest.selfCheck.divergence, 'self_check_pass_official_fail');
+      assert.equal(failureDigest.selfCheck.heavyTaskSelfChecks[0].status, 'pass');
+      assert.match(failureDigest.officialHarbor.verifier.stdoutExcerpt, /expected move e2e4/);
+      assert.equal(failureDigest.debugRefs.messages.ref, 'traces/run-official/messages.json');
       const messages = JSON.parse(await readFile(join(out, 'traces', 'run-official', 'messages.json'), 'utf8'));
       assert.equal(messages.trace_id, 'run-official');
       assert.equal(messages.messages[0].role, 'system');

--- a/packages/headless/src/ahe-evidence-export.ts
+++ b/packages/headless/src/ahe-evidence-export.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import {
   MAKA_AHE_CURRENT_COMPONENTS,
@@ -19,12 +19,15 @@ import {
   validateMakaAheTargetComponents,
 } from './ahe-target-protocol.js';
 import {
+  exportableTaskEvents,
   exportContentHash,
   taskRunExportFromProjection,
   writeTaskRunExport,
   type TaskRunExport,
 } from './result-export.js';
-import type { ScoreResult, TaskRunArtifact, VerifierResult } from './task-contracts.js';
+import { harborOfficialVerifierOutputFromArtifacts } from './harbor-official-artifacts.js';
+import type { BenchmarkVerifierOutput } from './benchmark-adapters.js';
+import type { AutonomousResultTaxonomy, ScoreResult, TaskRunArtifact, VerifierResult } from './task-contracts.js';
 import type { TaskRunProjection } from './task-run-store.js';
 
 export const MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL = 'ahe-evidence-export-20260701' as const;
@@ -43,6 +46,7 @@ export interface MakaAheRunEvidenceOptions {
   exportedAt?: string;
   traceBaseRef?: string;
   includeEvents?: boolean;
+  officialResults?: MakaAheOfficialResultOverlays;
 }
 
 export interface MakaAheRunEvidence {
@@ -56,7 +60,23 @@ export interface WriteMakaAheEvidenceExportOptions {
   runId?: string;
   exportedAt?: string;
   includeEvents?: boolean;
+  officialResults?: MakaAheOfficialResultOverlays;
+  sessionMessages?: MakaAheSessionMessagesByTaskRun;
 }
+
+export interface MakaAheOfficialResultOverlay {
+  verifier: VerifierResult;
+  score: ScoreResult;
+  sourceRef?: MakaAheArtifactRef;
+}
+
+export type MakaAheSessionMessagesByTaskRun =
+  | ReadonlyMap<string, readonly unknown[]>
+  | Record<string, readonly unknown[]>;
+
+export type MakaAheOfficialResultOverlays =
+  | ReadonlyMap<string, MakaAheOfficialResultOverlay>
+  | Record<string, MakaAheOfficialResultOverlay>;
 
 export interface WriteMakaAheEvidenceExportResult extends MakaAheRunEvidence {
   targetSnapshot: MakaAheTargetSnapshot;
@@ -66,6 +86,28 @@ export interface WriteMakaAheEvidenceExportResult extends MakaAheRunEvidence {
     traceIndexJson: string;
     traceDirs: Record<string, string>;
   };
+}
+
+export async function readMakaAheHarborOfficialResult(
+  trialDir: string,
+  projection: TaskRunProjection,
+): Promise<MakaAheOfficialResultOverlay> {
+  const resultJson = await readOptionalJson(join(trialDir, 'result.json'));
+  const rewardText = await readOptionalText(join(trialDir, 'verifier', 'reward.txt'));
+  const stdout = await readOptionalText(join(trialDir, 'verifier', 'test-stdout.txt'));
+  const output = harborOfficialVerifierOutputFromArtifacts({
+    resultJson,
+    rewardText,
+    stdout,
+    details: {
+      trialDir,
+      taskRunId: projection.taskRunId,
+      taskId: projection.taskId,
+      source: 'harbor_post_exit_trial',
+    },
+  });
+  const ts = projection.finishedAt ?? projection.events.at(-1)?.ts ?? 0;
+  return officialOverlayFromHarborOutput(output, projection, ts, trialDir);
 }
 
 export async function validateMakaAheSourceRefs(
@@ -144,22 +186,26 @@ export function makaAheEvidenceFromTaskRunProjections(
 
   for (const projection of sorted) {
     const exported = taskRunExportFromProjection(projection, { exportedAt: options.exportedAt });
+    const official = officialResultFor(options.officialResults, projection.taskRunId);
+    const effectiveExport = official ? taskRunExportWithOfficialOverlay(exported, official) : exported;
     const taskRunRef = `${traceBaseRef}/${safePathSegment(projection.taskRunId)}`;
-    const result = runResultFromProjection(projection, exported, {
+    const result = runResultFromProjection(projection, effectiveExport, {
       snapshotId: options.snapshotId,
       runId,
       taskRunRef,
+      officialResultRef: official ? `${taskRunRef}/official-harbor-result.json` : undefined,
     });
     const validation = validateMakaAheRunResult(result);
     if (!validation.ok) {
       throw new Error(`invalid Maka AHE run result for ${projection.taskRunId}:\n${validation.errors.map((error) => `- ${error.path}: ${error.message}`).join('\n')}`);
     }
     results.push(result);
-    entries.push(traceIndexEntryFromProjection(projection, exported, {
+    entries.push(traceIndexEntryFromProjection(projection, effectiveExport, {
       snapshotId: options.snapshotId,
       runId,
       taskRunRef,
       includeEvents: options.includeEvents,
+      officialResultRef: official ? `${taskRunRef}/official-harbor-result.json` : undefined,
     }));
   }
 
@@ -189,6 +235,7 @@ export async function writeMakaAheEvidenceExport(
     runId: options.runId,
     exportedAt: options.exportedAt,
     includeEvents: options.includeEvents,
+    officialResults: options.officialResults,
   });
   const files: WriteMakaAheEvidenceExportResult['files'] = {
     targetSnapshotJson: join(outDir, 'target-snapshot.json'),
@@ -208,6 +255,13 @@ export async function writeMakaAheEvidenceExport(
       includeEvents: options.includeEvents,
       exportedAt: options.exportedAt,
     });
+    const exported = taskRunExportFromProjection(projection, { exportedAt: options.exportedAt });
+    const official = officialResultFor(options.officialResults, projection.taskRunId);
+    const sessionMessages = sessionMessagesFor(options.sessionMessages, projection.taskRunId);
+    await writeStableJson(join(traceDir, 'messages.json'), aheAgentRunMessages(projection, exported, official, sessionMessages));
+    if (official) {
+      await writeStableJson(join(traceDir, 'official-harbor-result.json'), official);
+    }
   }
 
   return { targetSnapshot: options.snapshot, ...evidence, files };
@@ -216,7 +270,7 @@ export async function writeMakaAheEvidenceExport(
 function runResultFromProjection(
   projection: TaskRunProjection,
   exported: TaskRunExport,
-  ids: { snapshotId: string; runId: string; taskRunRef: string },
+  ids: { snapshotId: string; runId: string; taskRunRef: string; officialResultRef?: string },
 ): MakaAheRunResult {
   const authority = scoreAuthority(exported.score, exported.verifier, projection);
   const status = resultStatus(exported, projection, authority);
@@ -230,7 +284,7 @@ function runResultFromProjection(
     status,
     scoreAuthority: authority,
     ...(normalized !== undefined ? { score: normalized } : {}),
-    ...(exported.verifier ? { verifierRef: verifierRef(exported.verifier, ids.taskRunRef) } : {}),
+    ...(exported.verifier ? { verifierRef: verifierRef(exported.verifier, ids.taskRunRef, ids.officialResultRef) } : {}),
     traceRef: { kind: 'file', ref: `${ids.taskRunRef}/task-run.json`, mediaType: 'application/json' },
     ...(status === 'official_pass' ? {} : { failureTaxonomy: failureTaxonomy(exported) }),
     ...(warnings.length > 0 ? { warnings } : {}),
@@ -240,8 +294,17 @@ function runResultFromProjection(
 function traceIndexEntryFromProjection(
   projection: TaskRunProjection,
   exported: TaskRunExport,
-  ids: { snapshotId: string; runId: string; taskRunRef: string; includeEvents?: boolean },
+  ids: { snapshotId: string; runId: string; taskRunRef: string; includeEvents?: boolean; officialResultRef?: string },
 ): MakaAheTraceIndexEntry {
+  const artifacts = [
+    ...(ids.officialResultRef ? [{
+      kind: 'file' as const,
+      ref: ids.officialResultRef,
+      mediaType: 'application/json',
+      description: 'Harbor post-exit official verifier result imported for AHE scoring',
+    }] : []),
+    ...exported.artifacts.items.map(artifactRefFromTaskRunArtifact),
+  ];
   return {
     taskId: exported.taskRun.taskId,
     runId: ids.runId,
@@ -249,10 +312,15 @@ function traceIndexEntryFromProjection(
     ...(ids.includeEvents || (exported.runtime.trajectoryRefs.runtimeEventIds && exported.runtime.trajectoryRefs.runtimeEventIds.length > 0)
       ? { runtimeEventsJsonl: { kind: 'file', ref: `${ids.taskRunRef}/events.jsonl`, mediaType: 'application/jsonl' } }
       : {}),
-    ...(exported.runtime.agentRunId ? { agentRun: { kind: 'other', ref: `maka-agent-run:${exported.runtime.agentRunId}` } } : {}),
+    agentRun: {
+      kind: 'file',
+      ref: `${ids.taskRunRef}/messages.json`,
+      mediaType: 'application/json',
+      ...(exported.runtime.agentRunId ? { description: `normalized AHE messages for maka-agent-run:${exported.runtime.agentRunId}` } : {}),
+    },
     transcript: { kind: 'file', ref: `${ids.taskRunRef}/result.md`, mediaType: 'text/markdown' },
     toolResults: projection.artifacts.filter((artifact) => artifact.kind === 'runtime_trace').map(artifactRefFromTaskRunArtifact),
-    artifacts: exported.artifacts.items.map(artifactRefFromTaskRunArtifact),
+    artifacts,
   };
 }
 
@@ -362,13 +430,262 @@ function resultWarnings(
   return uniqueStrings(warnings);
 }
 
-function verifierRef(verifier: VerifierResult, taskRunRef: string): MakaAheArtifactRef {
+function verifierRef(verifier: VerifierResult, taskRunRef: string, officialResultRef: string | undefined): MakaAheArtifactRef {
   return {
     kind: 'file',
-    ref: `${taskRunRef}/task-run.json`,
+    ref: officialResultRef ?? `${taskRunRef}/task-run.json`,
     mediaType: 'application/json',
     description: `${verifier.kind} verifier result ${verifier.id}`,
   };
+}
+
+function taskRunExportWithOfficialOverlay(exported: TaskRunExport, official: MakaAheOfficialResultOverlay): TaskRunExport {
+  return {
+    ...exported,
+    verifier: official.verifier,
+    score: official.score,
+    taxonomy: {
+      value: official.score.taxonomy,
+      passed: official.score.passed,
+      scored: official.score.scored,
+      eligible: official.score.eligible,
+      errorClass: official.score.errorClass,
+      excludedReason: official.score.excludedReason,
+    },
+    warnings: uniqueStrings([...exported.warnings, 'Harbor post-exit official verifier result was imported for AHE scoring']),
+  };
+}
+
+function officialResultFor(
+  overlays: MakaAheOfficialResultOverlays | undefined,
+  taskRunId: string,
+): MakaAheOfficialResultOverlay | undefined {
+  if (!overlays) return undefined;
+  if (isReadonlyMap(overlays)) return overlays.get(taskRunId);
+  return overlays[taskRunId];
+}
+
+function isReadonlyMap<T>(
+  value: ReadonlyMap<string, T> | Record<string, T>,
+): value is ReadonlyMap<string, T> {
+  return typeof (value as { get?: unknown }).get === 'function';
+}
+
+function officialOverlayFromHarborOutput(
+  output: BenchmarkVerifierOutput,
+  projection: TaskRunProjection,
+  ts: number,
+  trialDir: string,
+): MakaAheOfficialResultOverlay {
+  const verifier: VerifierResult = {
+    id: `harbor-official-verifier-${shortHash({ taskRunId: projection.taskRunId, trialDir, output })}`,
+    taskRunId: projection.taskRunId,
+    ts,
+    kind: output.kind,
+    passed: output.passed,
+    exitCode: output.exitCode,
+    ...(output.durationMs !== undefined ? { durationMs: output.durationMs } : {}),
+    ...(output.stdout ? { stdout: output.stdout } : {}),
+    ...(output.stderr ? { stderr: output.stderr } : {}),
+    ...(output.error ? { error: output.error } : {}),
+    ...(output.errorClass ? { errorClass: output.errorClass } : {}),
+    ...(output.score !== undefined ? { score: output.score } : {}),
+    ...(output.maxScore !== undefined ? { maxScore: output.maxScore } : {}),
+    ...(output.authority ? { authority: output.authority } : {}),
+    ...(output.artifacts ? { artifacts: output.artifacts.map((artifact, index) => taskRunArtifactFromDescriptor(artifact, projection, ts + index)) } : {}),
+    ...(output.details ? { details: output.details } : {}),
+  };
+  const authoritative = isOfficialAuthority(verifier.authority);
+  const score: ScoreResult = {
+    id: `harbor-official-score-${shortHash({ taskRunId: projection.taskRunId, trialDir, output })}`,
+    taskRunId: projection.taskRunId,
+    ts,
+    passed: output.passed,
+    scored: authoritative && output.score !== undefined,
+    eligible: authoritative,
+    ...(output.score !== undefined ? { score: output.score } : {}),
+    ...(output.maxScore !== undefined ? { maxScore: output.maxScore } : {}),
+    taxonomy: officialScoreTaxonomy(output),
+    ...(output.errorClass ? { errorClass: output.errorClass } : {}),
+    ...(output.authority ? { authority: output.authority } : {}),
+    details: {
+      source: 'harbor_post_exit_trial',
+      trialDir,
+      verifierResultId: verifier.id,
+      ...(output.details ? { verifierDetails: output.details } : {}),
+    },
+  };
+  return {
+    verifier,
+    score,
+    sourceRef: { kind: 'file', ref: 'official-harbor-result.json', mediaType: 'application/json' },
+  };
+}
+
+function officialScoreTaxonomy(output: BenchmarkVerifierOutput): AutonomousResultTaxonomy {
+  if (output.passed) return 'passed';
+  switch (output.errorClass) {
+    case 'verification_error':
+    case 'agent_failed':
+    case 'agent_incomplete':
+    case 'invalid_setup':
+    case 'unsupported_adapter':
+    case 'isolation_required':
+    case 'setup_failed':
+    case 'infra_failed':
+    case 'policy_denied':
+    case 'budget_exhausted':
+    case 'aborted':
+    case 'blocked':
+    case 'cancelled':
+      return output.errorClass;
+    default:
+      return 'verification_failed';
+  }
+}
+
+function taskRunArtifactFromDescriptor(
+  descriptor: Omit<TaskRunArtifact, 'schemaVersion' | 'artifactId' | 'taskRunId' | 'ts'> & {
+    artifactId?: string;
+    taskRunId?: string;
+    ts?: number;
+  },
+  projection: TaskRunProjection,
+  fallbackTs: number,
+): TaskRunArtifact {
+  return {
+    schemaVersion: 1,
+    artifactId: descriptor.artifactId ?? `harbor-official-artifact-${shortHash({ projection: projection.taskRunId, descriptor })}`,
+    taskRunId: descriptor.taskRunId ?? projection.taskRunId,
+    ts: descriptor.ts ?? fallbackTs,
+    kind: descriptor.kind,
+    authority: descriptor.authority,
+    ...(descriptor.attemptId ? { attemptId: descriptor.attemptId } : {}),
+    ...(descriptor.label ? { label: descriptor.label } : {}),
+    ...(descriptor.path ? { path: descriptor.path } : {}),
+    ...(descriptor.workspacePath ? { workspacePath: descriptor.workspacePath } : {}),
+    ...(descriptor.artifactRef ? { artifactRef: descriptor.artifactRef } : {}),
+    ...(descriptor.hash ? { hash: descriptor.hash } : {}),
+    ...(descriptor.mimeType ? { mimeType: descriptor.mimeType } : {}),
+    ...(descriptor.metadata ? { metadata: descriptor.metadata } : {}),
+  };
+}
+
+function aheAgentRunMessages(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+  official: MakaAheOfficialResultOverlay | undefined,
+  sessionMessages: readonly unknown[] | undefined,
+): { trace_id: string; messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> } {
+  const publicEvents = projection.events.flatMap(exportableTaskEvents);
+  const normalizedSessionMessages = (sessionMessages ?? []).flatMap(aheMessagesFromStoredSessionMessage);
+  return {
+    trace_id: projection.taskRunId,
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You are analyzing a Maka task-run evidence export for Agentic Harness Engineering.',
+          'Use official Harbor scorer authority when present; treat self-check evidence as advisory only.',
+        ].join(' '),
+      },
+      ...normalizedSessionMessages,
+      {
+        role: 'user',
+        content: JSON.stringify({
+          taskRun: exported,
+          publicEvents,
+          officialHarborResult: official,
+        }, null, 2),
+      },
+      {
+        role: 'assistant',
+        content: 'Ready to analyze this Maka task-run evidence, including runtime events, advisory self-checks, and any imported official Harbor result.',
+      },
+    ],
+  };
+}
+
+function sessionMessagesFor(
+  messages: MakaAheSessionMessagesByTaskRun | undefined,
+  taskRunId: string,
+): readonly unknown[] | undefined {
+  if (!messages) return undefined;
+  if (isReadonlyMap(messages)) return messages.get(taskRunId);
+  return messages[taskRunId];
+}
+
+function aheMessagesFromStoredSessionMessage(message: unknown): Array<{ role: 'user' | 'assistant'; content: string }> {
+  if (!message || typeof message !== 'object') return [];
+  const record = message as Record<string, unknown>;
+  switch (record.type) {
+    case 'user':
+      return stringField(record, 'text')
+        ? [{ role: 'user', content: stringField(record, 'text')! }]
+        : [];
+    case 'assistant': {
+      const parts = [
+        stringField(record, 'thinking') ? `[thinking]\n${stringField(record, 'thinking')}` : undefined,
+        stringField(record, 'text'),
+      ].filter((part): part is string => Boolean(part));
+      return parts.length > 0 ? [{ role: 'assistant', content: parts.join('\n\n') }] : [];
+    }
+    case 'tool_call':
+      return [{
+        role: 'assistant',
+        content: JSON.stringify({
+          kind: 'tool_call',
+          id: stringField(record, 'id'),
+          toolName: stringField(record, 'toolName'),
+          args: record.args,
+          ts: record.ts,
+        }, null, 2),
+      }];
+    case 'tool_result':
+      return [{
+        role: 'user',
+        content: JSON.stringify({
+          kind: 'tool_result',
+          toolUseId: stringField(record, 'toolUseId'),
+          isError: record.isError,
+          content: record.content,
+          durationMs: record.durationMs,
+          ts: record.ts,
+        }, null, 2),
+      }];
+    case 'system_note':
+      return stringField(record, 'text')
+        ? [{ role: 'user', content: `[system_note]\n${stringField(record, 'text')}` }]
+        : [];
+    default:
+      return [];
+  }
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  if (typeof value === 'string') return value;
+  if (key === 'thinking' && value && typeof value === 'object') {
+    const text = (value as { text?: unknown }).text;
+    return typeof text === 'string' ? text : undefined;
+  }
+  return undefined;
+}
+
+async function readOptionalJson(path: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+async function readOptionalText(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return undefined;
+  }
 }
 
 function artifactRefFromTaskRunArtifact(artifact: TaskRunArtifact): MakaAheArtifactRef {

--- a/packages/headless/src/ahe-evidence-export.ts
+++ b/packages/headless/src/ahe-evidence-export.ts
@@ -85,7 +85,87 @@ export interface WriteMakaAheEvidenceExportResult extends MakaAheRunEvidence {
     harnessResultsJson: string;
     traceIndexJson: string;
     traceDirs: Record<string, string>;
+    failureDigests: Record<string, string>;
   };
+}
+
+export interface MakaAheFailureDigest {
+  schemaVersion: 'maka.ahe.failure_digest.v1';
+  taskRunId: string;
+  taskId: string;
+  exportedAt: string;
+  status: MakaAheResultStatus;
+  scoreAuthority: MakaAheScoreAuthority;
+  score?: number;
+  failureTaxonomy: string[];
+  warnings: string[];
+  officialHarbor: {
+    imported: boolean;
+    verifier?: CompactVerifierResult;
+    score?: CompactScoreResult;
+    sourceRef?: MakaAheArtifactRef;
+  };
+  selfCheck: {
+    divergence: 'self_check_pass_official_fail' | 'self_check_fail_official_pass' | 'aligned' | 'no_self_check' | 'unscored';
+    heavyTaskSelfChecks: TaskRunProjection['heavyTaskSelfChecks'];
+    legacySelfChecks: TaskRunProjection['selfChecks'];
+  };
+  finalState: {
+    taskRun: TaskRunExport['taskRun'];
+    workspace: TaskRunExport['workspace'];
+    artifacts: Array<{
+      kind: string;
+      ref: string;
+      label?: string;
+      authority?: string;
+      hash?: string;
+      metadata?: Record<string, unknown>;
+    }>;
+    progress?: TaskRunExport['progress'];
+    recentEvidence: Array<{
+      kind: string;
+      ts: number;
+      source?: Record<string, unknown>;
+      tool?: Record<string, unknown>;
+      artifact?: Record<string, unknown>;
+      check?: Record<string, unknown>;
+    }>;
+  };
+  debugRefs: {
+    taskRun: MakaAheArtifactRef;
+    messages: MakaAheArtifactRef;
+    transcript: MakaAheArtifactRef;
+    runtimeEventsJsonl?: MakaAheArtifactRef;
+    officialHarborResult?: MakaAheArtifactRef;
+  };
+}
+
+interface CompactVerifierResult {
+  id: string;
+  kind: string;
+  passed: boolean;
+  exitCode?: number | null;
+  score?: number;
+  maxScore?: number;
+  errorClass?: string;
+  error?: string;
+  stdoutExcerpt?: string;
+  stderrExcerpt?: string;
+  authority?: VerifierResult['authority'];
+  details?: Record<string, unknown>;
+}
+
+interface CompactScoreResult {
+  id: string;
+  passed: boolean;
+  scored: boolean;
+  eligible: boolean;
+  score?: number;
+  maxScore?: number;
+  taxonomy: AutonomousResultTaxonomy;
+  errorClass?: string;
+  excludedReason?: string;
+  authority?: ScoreResult['authority'];
 }
 
 export async function readMakaAheHarborOfficialResult(
@@ -242,6 +322,7 @@ export async function writeMakaAheEvidenceExport(
     harnessResultsJson: join(outDir, 'harness-results.json'),
     traceIndexJson: join(outDir, 'trace-index.json'),
     traceDirs: {},
+    failureDigests: {},
   };
 
   await writeStableJson(files.targetSnapshotJson, options.snapshot);
@@ -257,10 +338,21 @@ export async function writeMakaAheEvidenceExport(
     });
     const exported = taskRunExportFromProjection(projection, { exportedAt: options.exportedAt });
     const official = officialResultFor(options.officialResults, projection.taskRunId);
+    const effectiveExport = official ? taskRunExportWithOfficialOverlay(exported, official) : exported;
     const sessionMessages = sessionMessagesFor(options.sessionMessages, projection.taskRunId);
     await writeStableJson(join(traceDir, 'messages.json'), aheAgentRunMessages(projection, exported, official, sessionMessages));
     if (official) {
       await writeStableJson(join(traceDir, 'official-harbor-result.json'), official);
+    }
+    const failureDigest = failureDigestFromProjection(projection, effectiveExport, {
+      official,
+      exportedAt: options.exportedAt,
+      includeEvents: options.includeEvents,
+    });
+    if (failureDigest) {
+      const failureDigestPath = join(traceDir, 'failure-digest.json');
+      files.failureDigests[projection.taskRunId] = failureDigestPath;
+      await writeStableJson(failureDigestPath, failureDigest);
     }
   }
 
@@ -303,6 +395,12 @@ function traceIndexEntryFromProjection(
       mediaType: 'application/json',
       description: 'Harbor post-exit official verifier result imported for AHE scoring',
     }] : []),
+    ...(shouldWriteFailureDigest(projection, exported) ? [{
+      kind: 'file' as const,
+      ref: `${ids.taskRunRef}/failure-digest.json`,
+      mediaType: 'application/json',
+      description: 'AHE failure digest with official verifier excerpts, self-check blocks, and final artifact state',
+    }] : []),
     ...exported.artifacts.items.map(artifactRefFromTaskRunArtifact),
   ];
   return {
@@ -321,6 +419,61 @@ function traceIndexEntryFromProjection(
     transcript: { kind: 'file', ref: `${ids.taskRunRef}/result.md`, mediaType: 'text/markdown' },
     toolResults: projection.artifacts.filter((artifact) => artifact.kind === 'runtime_trace').map(artifactRefFromTaskRunArtifact),
     artifacts,
+  };
+}
+
+function shouldWriteFailureDigest(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+): boolean {
+  const authority = scoreAuthority(exported.score, exported.verifier, projection);
+  return resultStatus(exported, projection, authority) !== 'official_pass';
+}
+
+function failureDigestFromProjection(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+  options: { official?: MakaAheOfficialResultOverlay; exportedAt?: string; includeEvents?: boolean },
+): MakaAheFailureDigest | undefined {
+  const authority = scoreAuthority(exported.score, exported.verifier, projection);
+  const status = resultStatus(exported, projection, authority);
+  if (status === 'official_pass') return undefined;
+  const taskRunRef = `traces/${safePathSegment(projection.taskRunId)}`;
+  return {
+    schemaVersion: 'maka.ahe.failure_digest.v1',
+    taskRunId: projection.taskRunId,
+    taskId: projection.taskId,
+    exportedAt: options.exportedAt ?? new Date().toISOString(),
+    status,
+    scoreAuthority: authority,
+    ...(normalizedScore(exported.score, exported.verifier) !== undefined ? { score: normalizedScore(exported.score, exported.verifier) } : {}),
+    failureTaxonomy: failureTaxonomy(exported),
+    warnings: resultWarnings(exported, projection, status, authority),
+    officialHarbor: {
+      imported: Boolean(options.official),
+      ...(exported.verifier ? { verifier: compactVerifierResult(exported.verifier) } : {}),
+      ...(exported.score ? { score: compactScoreResult(exported.score) } : {}),
+      ...(options.official?.sourceRef ? { sourceRef: options.official.sourceRef } : {}),
+    },
+    selfCheck: {
+      divergence: selfCheckDivergence(projection, exported),
+      heavyTaskSelfChecks: projection.heavyTaskSelfChecks,
+      legacySelfChecks: projection.selfChecks,
+    },
+    finalState: {
+      taskRun: exported.taskRun,
+      workspace: exported.workspace,
+      artifacts: exported.artifacts.items.map(compactArtifact),
+      ...(exported.progress ? { progress: exported.progress } : {}),
+      recentEvidence: projection.heavyTaskEvidence.slice(-20).map(compactHeavyTaskEvidence),
+    },
+    debugRefs: {
+      taskRun: { kind: 'file', ref: `${taskRunRef}/task-run.json`, mediaType: 'application/json' },
+      messages: { kind: 'file', ref: `${taskRunRef}/messages.json`, mediaType: 'application/json' },
+      transcript: { kind: 'file', ref: `${taskRunRef}/result.md`, mediaType: 'text/markdown' },
+      ...(options.includeEvents ? { runtimeEventsJsonl: { kind: 'file', ref: `${taskRunRef}/events.jsonl`, mediaType: 'application/jsonl' } } : {}),
+      ...(options.official ? { officialHarborResult: { kind: 'file', ref: `${taskRunRef}/official-harbor-result.json`, mediaType: 'application/json' } } : {}),
+    },
   };
 }
 
@@ -428,6 +581,93 @@ function resultWarnings(
     warnings.push('self-check evidence is advisory and was exported as non-official evidence');
   }
   return uniqueStrings(warnings);
+}
+
+function selfCheckDivergence(
+  projection: TaskRunProjection,
+  exported: TaskRunExport,
+): MakaAheFailureDigest['selfCheck']['divergence'] {
+  const latest = projection.latestHeavyTaskSelfCheck;
+  const officialPassed = exported.score?.authority?.source === 'official_harbor_verifier'
+    || exported.verifier?.authority?.source === 'official_harbor_verifier'
+    ? exported.score?.passed ?? exported.verifier?.passed
+    : undefined;
+  if (!latest && projection.selfChecks.length === 0) return 'no_self_check';
+  if (officialPassed === undefined) return 'unscored';
+  if (latest?.status === 'pass' && officialPassed === false) return 'self_check_pass_official_fail';
+  if (latest?.status === 'fail' && officialPassed === true) return 'self_check_fail_official_pass';
+  return 'aligned';
+}
+
+function compactVerifierResult(verifier: VerifierResult): CompactVerifierResult {
+  return {
+    id: verifier.id,
+    kind: verifier.kind,
+    passed: verifier.passed,
+    ...(verifier.exitCode !== undefined ? { exitCode: verifier.exitCode } : {}),
+    ...(verifier.score !== undefined ? { score: verifier.score } : {}),
+    ...(verifier.maxScore !== undefined ? { maxScore: verifier.maxScore } : {}),
+    ...(verifier.errorClass ? { errorClass: verifier.errorClass } : {}),
+    ...(verifier.error ? { error: truncateText(verifier.error, 4000) } : {}),
+    ...(verifier.stdout ? { stdoutExcerpt: truncateText(verifier.stdout, 20000, 'tail') } : {}),
+    ...(verifier.stderr ? { stderrExcerpt: truncateText(verifier.stderr, 12000, 'tail') } : {}),
+    ...(verifier.authority ? { authority: verifier.authority } : {}),
+    ...(recordValue(verifier.details) ? { details: verifier.details as Record<string, unknown> } : {}),
+  };
+}
+
+function compactScoreResult(score: ScoreResult): CompactScoreResult {
+  return {
+    id: score.id,
+    passed: score.passed,
+    scored: score.scored ?? false,
+    eligible: score.eligible ?? false,
+    ...(score.score !== undefined ? { score: score.score } : {}),
+    ...(score.maxScore !== undefined ? { maxScore: score.maxScore } : {}),
+    taxonomy: score.taxonomy,
+    ...(score.errorClass ? { errorClass: score.errorClass } : {}),
+    ...(score.excludedReason ? { excludedReason: score.excludedReason } : {}),
+    ...(score.authority ? { authority: score.authority } : {}),
+  };
+}
+
+function compactArtifact(artifact: TaskRunArtifact): MakaAheFailureDigest['finalState']['artifacts'][number] {
+  return {
+    kind: artifact.kind,
+    ref: artifact.artifactRef ?? artifact.path ?? artifact.workspacePath ?? artifact.artifactId,
+    ...(artifact.label ? { label: artifact.label } : {}),
+    ...(artifact.authority ? { authority: artifact.authority.source } : {}),
+    ...(artifact.hash ? { hash: artifact.hash } : {}),
+    ...(recordValue(artifact.metadata) ? { metadata: artifact.metadata as Record<string, unknown> } : {}),
+  };
+}
+
+function compactHeavyTaskEvidence(
+  evidence: TaskRunProjection['heavyTaskEvidence'][number],
+): MakaAheFailureDigest['finalState']['recentEvidence'][number] {
+  return {
+    kind: evidence.kind,
+    ts: evidence.ts,
+    source: compactRecord(evidence.source),
+    ...(evidence.tool ? { tool: compactRecord({
+      name: evidence.tool.name,
+      inputSummary: evidence.tool.inputSummary,
+      exitCode: evidence.tool.exitCode,
+      timedOut: evidence.tool.timedOut,
+      ok: evidence.tool.ok,
+      outputs: evidence.tool.outputs,
+      diff: evidence.tool.diff,
+    }) } : {}),
+    ...(evidence.artifact ? { artifact: compactRecord(evidence.artifact) } : {}),
+    ...(evidence.check ? { check: compactRecord(evidence.check) } : {}),
+  };
+}
+
+function compactRecord(value: unknown): Record<string, unknown> {
+  if (!recordValue(value)) return {};
+  return JSON.parse(JSON.stringify(value, (_key, inner) => (
+    typeof inner === 'string' ? truncateText(inner, 4000) : inner
+  ))) as Record<string, unknown>;
 }
 
 function verifierRef(verifier: VerifierResult, taskRunRef: string, officialResultRef: string | undefined): MakaAheArtifactRef {
@@ -672,6 +912,13 @@ function stringField(record: Record<string, unknown>, key: string): string | und
   return undefined;
 }
 
+function truncateText(text: string, maxChars: number, mode: 'head' | 'tail' = 'head'): string {
+  if (text.length <= maxChars) return text;
+  const marker = `\n...[truncated ${text.length - maxChars} chars]`;
+  if (mode === 'tail') return `${marker}\n${text.slice(-maxChars)}`;
+  return `${text.slice(0, maxChars)}${marker}`;
+}
+
 async function readOptionalJson(path: string): Promise<unknown> {
   try {
     return JSON.parse(await readFile(path, 'utf8'));
@@ -740,4 +987,8 @@ async function writeStableJson(path: string, value: unknown): Promise<void> {
 
 function uniqueStrings(values: readonly (string | undefined)[]): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}
+
+function recordValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
 import { randomUUID } from 'node:crypto';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { runAutonomousTask } from './autonomous-agent-loop.js';
 import { harborCommand } from './harbor-cli.js';
 import { runMatrix, type ExperimentSpec } from './matrix.js';
 import { planMatrixRetry, readMatrixPriorRecords } from './matrix-resume.js';
-import { buildMakaAheTargetSnapshot, writeMakaAheEvidenceExport } from './ahe-evidence-export.js';
+import {
+  buildMakaAheTargetSnapshot,
+  readMakaAheHarborOfficialResult,
+  writeMakaAheEvidenceExport,
+  type MakaAheOfficialResultOverlay,
+  type MakaAheSessionMessagesByTaskRun,
+} from './ahe-evidence-export.js';
 import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
 import { runTaskOnce } from './task-agent-controller.js';
@@ -207,25 +213,31 @@ async function aheCommand(args: string[]): Promise<number> {
   const [subcommand, ...rest] = args;
   if (subcommand === 'export') return aheExportCommand(rest);
   console.error('maka-headless ahe commands:\n');
-  console.error('  ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]');
+  console.error('  ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--harbor-trial-dir <dir>] [--include-events]');
   return 1;
 }
 
 async function aheExportCommand(args: string[]): Promise<number> {
   let parsed: ParsedArgs;
   try {
-    parsed = parseArgs(args, ['store', 'repo', 'out', 'run-id', 'source-label'], ['include-events']);
+    parsed = parseArgs(args, ['store', 'repo', 'out', 'run-id', 'source-label', 'harbor-trial-dir'], ['include-events']);
   } catch (error) {
-    console.error(`${(error as Error).message}\nusage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]`);
+    console.error(`${(error as Error).message}\nusage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--harbor-trial-dir <dir>] [--include-events]`);
     return 1;
   }
   if (parsed.positional.length === 0 || !parsed.flags.store || !parsed.flags.repo || !parsed.flags.out) {
-    console.error('usage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--include-events]');
+    console.error('usage: maka-headless ahe export <taskRunId...> --store <out>/runs --repo <repo-root> --out <dir> [--run-id <id>] [--source-label <label>] [--harbor-trial-dir <dir>] [--include-events]');
     return 1;
   }
   try {
-    const store = createTaskRunStore(resolve(parsed.flags.store));
+    const storeRoot = resolve(parsed.flags.store);
+    const store = createTaskRunStore(storeRoot);
     const projections = await Promise.all(parsed.positional.map((taskRunId) => store.project(taskRunId)));
+    const officialResults = await aheOfficialResultsForCli(projections, {
+      storeRoot,
+      harborTrialDir: parsed.flags['harbor-trial-dir'] ? resolve(parsed.flags['harbor-trial-dir']) : undefined,
+    });
+    const sessionMessages = await aheSessionMessagesForCli(projections, storeRoot);
     const snapshot = await buildMakaAheTargetSnapshot({
       repoRoot: resolve(parsed.flags.repo),
       sourceLabel: parsed.flags['source-label'],
@@ -235,6 +247,8 @@ async function aheExportCommand(args: string[]): Promise<number> {
       projections,
       runId: parsed.flags['run-id'],
       includeEvents: parsed.bools['include-events'],
+      officialResults,
+      sessionMessages,
     });
     console.log(`targetSnapshot: ${result.files.targetSnapshotJson}`);
     console.log(`harnessResults: ${result.files.harnessResultsJson}`);
@@ -243,6 +257,70 @@ async function aheExportCommand(args: string[]): Promise<number> {
   } catch (error) {
     console.error(`maka-headless ahe export: ${(error as Error).message}`);
     return 1;
+  }
+}
+
+async function aheOfficialResultsForCli(
+  projections: readonly TaskRunProjection[],
+  options: { storeRoot: string; harborTrialDir?: string },
+): Promise<Record<string, MakaAheOfficialResultOverlay> | undefined> {
+  if (options.harborTrialDir && projections.length !== 1) {
+    throw new Error('--harbor-trial-dir currently supports exactly one taskRunId');
+  }
+  const overlays: Record<string, MakaAheOfficialResultOverlay> = {};
+  if (options.harborTrialDir) {
+    const projection = projections[0]!;
+    overlays[projection.taskRunId] = await readMakaAheHarborOfficialResult(options.harborTrialDir, projection);
+    return overlays;
+  }
+
+  if (projections.length === 1) {
+    const inferred = resolve(options.storeRoot, '..', '..', '..');
+    if (await looksLikeHarborTrialDir(inferred)) {
+      const projection = projections[0]!;
+      overlays[projection.taskRunId] = await readMakaAheHarborOfficialResult(inferred, projection);
+      return overlays;
+    }
+  }
+  return undefined;
+}
+
+async function looksLikeHarborTrialDir(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, 'result.json'));
+    await stat(join(dir, 'verifier', 'reward.txt'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function aheSessionMessagesForCli(
+  projections: readonly TaskRunProjection[],
+  storeRoot: string,
+): Promise<MakaAheSessionMessagesByTaskRun | undefined> {
+  const messagesByTaskRun: Record<string, readonly unknown[]> = {};
+  for (const projection of projections) {
+    if (!projection.sessionId) continue;
+    const messages = await readSessionMessages(join(storeRoot, 'sessions', projection.sessionId, 'session.jsonl'));
+    if (messages.length > 0) {
+      messagesByTaskRun[projection.taskRunId] = messages;
+    }
+  }
+  return Object.keys(messagesByTaskRun).length > 0 ? messagesByTaskRun : undefined;
+}
+
+async function readSessionMessages(path: string): Promise<unknown[]> {
+  try {
+    const text = await readFile(path, 'utf8');
+    return text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as unknown)
+      .filter((record) => Boolean((record as { type?: unknown }).type));
+  } catch {
+    return [];
   }
 }
 

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -393,7 +393,7 @@ function eventsJsonl(events: readonly TaskEvent[]): string {
   return body.length > 0 ? `${body}\n` : '';
 }
 
-function exportableTaskEvents(event: TaskEvent): TaskEvent[] {
+export function exportableTaskEvents(event: TaskEvent): TaskEvent[] {
   if (event.type === 'heavy_task_self_check_recorded') {
     return isAcceptedHeavyTaskSelfCheck(event.selfCheck) ? [event] : [];
   }


### PR DESCRIPTION
## Summary

- export normalized AHE `messages.json` for each task-run trace instead of leaving `agentRun` as an opaque `maka-agent-run:*` ref
- read stored session history from `runs/sessions/<sessionId>/session.jsonl` when available, so `messages.json` includes the actual user prompt, assistant/tool-call rows, tool-result rows, and final assistant message
- import Harbor post-exit official verifier results into AHE harness bucketing via `official-harbor-result.json`
- extend `maka-headless ahe export` with optional `--harbor-trial-dir` and single-trial inference from the task-run store layout

## Verification

- `git diff --check`
- `git diff --cached --check`
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/ahe-evidence-export.test.js packages/headless/dist/__tests__/cli.test.js`
- `npm --workspace @maka/headless test` (95 suites, 660 tests, 659 pass, 1 skipped)
- real sqlite-gcov AHE export smoke:
  `node packages/headless/dist/cli.js ahe export harbor-sqlite-with-gcov__LyVFRcM --store terminal-bench-smoke/jobs/maka-heavy-semcompact-toolprune-sqlite-gcov-v4flash-ahe-20260701a/sqlite-with-gcov__LyVFRcM/agent/maka-task-run/runs --repo . --out /tmp/maka-ahe-export-pr417-amended --include-events`
- AHE/ADB + GLM 5.2 smoke on the amended export:
  `uv run adb ask -t /tmp/maka-ahe-export-pr417-amended/traces/harbor-sqlite-with-gcov__LyVFRcM/messages.json --trace-type openai_messages --format json`

The real export smoke produced `official_pass`, score `1`, `scoreAuthority=official_scorer`, `official-harbor-result.json`, and a 95-message `messages.json` trajectory. The AHE/ADB GLM 5.2 smoke returned `status=success`, empty stderr, and confirmed the normalized trajectory plus authoritative Harbor official pass score `1/1`; it also confirmed self-check evidence remains advisory.
