### PR TITLE
fix(desktop): stop chat header status badges overlapping the workspace toolbar

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { readRendererContractCss } from './contract-css-helpers.js';
+
+const REPO_ROOT = join(process.cwd(), '..', '..');
+
+async function readRepo(relativePath: string): Promise<string> {
+  return readFile(join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css);
+  assert.ok(match, `${selector} rule should exist`);
+  return match[1] ?? '';
+}
+
+describe('chat status cluster layout contract', () => {
+  it('keeps alert/status badges in flow between the header and first chat content', async () => {
+    const src = await readRepo('packages/ui/src/chat-view.tsx');
+
+    assert.match(
+      src,
+      /<header className="maka-chat-header">[\s\S]*?<\/header>\s*\{\(props\.sessionStatusBadge \|\| props\.connectionAlert \|\| props\.eventStreamAlert\) && \(/,
+      'status badges should render after the header, not inside the header toolbar row',
+    );
+    assert.match(
+      src,
+      /<div className="maka-chat-status-cluster">[\s\S]*?<\/div>\s*\)\}\s*\{isLocalSimulationBackend && \(/,
+      'status badges should stay before the fake-backend banner so normal flow reserves vertical space before first content',
+    );
+  });
+
+  it('uses an in-flow wrapping row instead of absolute positioning', async () => {
+    const css = await readRendererContractCss();
+    const body = ruleBody(css, '.maka-chat-status-cluster');
+
+    assert.doesNotMatch(
+      body,
+      /position:\s*absolute/,
+      'wrapped multi-badge rows must not be absolute-positioned over first-screen chat content',
+    );
+    assert.doesNotMatch(
+      body,
+      /\btop:\s*calc\(var\(--maka-workspace-top-actions-bottom\)/,
+      'the status row should no longer depend on toolbar bottom geometry',
+    );
+    assert.match(body, /flex-wrap:\s*wrap/);
+    assert.match(body, /justify-content:\s*flex-end/);
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -299,6 +299,13 @@
   --maka-titlebar-control-safe-left: 94px;
   --maka-titlebar-control-safe-top: 20px;
 
+  /* Bottom edge of .maka-workspace-top-actions (see sidebar.css): its
+     `top` baseline plus the 24px icon-button height. .maka-chat-status-
+     cluster anchors its own `top` off of this so the status/alert
+     badges sit in a second row directly under the toolbar instead of
+     competing with it for the same row. */
+  --maka-workspace-top-actions-bottom: calc(var(--maka-titlebar-control-safe-top) - 17px + 24px);
+
   /* session list geometry */
   --w-sessionlist: 240px;
   --h-list-header: 52px;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -299,12 +299,15 @@
   --maka-titlebar-control-safe-left: 94px;
   --maka-titlebar-control-safe-top: 20px;
 
-  /* Bottom edge of .maka-workspace-top-actions (see sidebar.css): its
-     `top` baseline plus the 24px icon-button height. .maka-chat-status-
-     cluster anchors its own `top` off of this so the status/alert
-     badges sit in a second row directly under the toolbar instead of
-     competing with it for the same row. */
-  --maka-workspace-top-actions-bottom: calc(var(--maka-titlebar-control-safe-top) - 17px + 24px);
+  /* Single source of truth for .maka-workspace-top-actions' geometry
+     (sidebar.css) and .maka-chat-status-cluster's (module-pages.css),
+     which anchors below + shares the same right edge as the toolbar.
+     Previously each rule hard-coded its own copy of these numbers —
+     PR review flagged that as a duplicated layout contract. */
+  --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 17px);
+  --maka-workspace-top-actions-height: 24px;
+  --maka-workspace-top-actions-right: 24px;
+  --maka-workspace-top-actions-bottom: calc(var(--maka-workspace-top-actions-top) + var(--maka-workspace-top-actions-height));
 
   /* session list geometry */
   --w-sessionlist: 240px;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -299,15 +299,12 @@
   --maka-titlebar-control-safe-left: 94px;
   --maka-titlebar-control-safe-top: 20px;
 
-  /* Single source of truth for .maka-workspace-top-actions' geometry
-     (sidebar.css) and .maka-chat-status-cluster's (module-pages.css),
-     which anchors below + shares the same right edge as the toolbar.
-     Previously each rule hard-coded its own copy of these numbers —
-     PR review flagged that as a duplicated layout contract. */
+  /* Shared top chrome geometry for .maka-workspace-top-actions
+     (sidebar.css) and the in-flow chat status row (module-pages.css).
+     The status row only shares the toolbar's right edge; it no longer
+     anchors off the toolbar bottom. */
   --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 17px);
-  --maka-workspace-top-actions-height: 24px;
   --maka-workspace-top-actions-right: 24px;
-  --maka-workspace-top-actions-bottom: calc(var(--maka-workspace-top-actions-top) + var(--maka-workspace-top-actions-height));
 
   /* session list geometry */
   --w-sessionlist: 240px;

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -41,10 +41,14 @@
   .maka-chat-header-status {
     display: inline-flex;
     align-items: center;
-    padding: 2px 8px;
+    /* PR-CHAT-HEADER-BADGE-SCALE-0: matches .maka-chat-header-alert's
+       footprint so the status pill reads at the same visual scale as
+       the neighboring alert badge and toolbar icon buttons instead of
+       towering over them. */
+    padding: 1px 7px;
     border-radius: 999px;
     border: 1px solid transparent;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 600;
     line-height: 1.4;
     margin-right: 6px;

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -51,7 +51,8 @@
     font-size: 11px;
     font-weight: 600;
     line-height: 1.4;
-    margin-right: 6px;
+    /* Spacing from neighboring badges comes from the parent
+       .maka-chat-status-cluster's `gap`, not a local margin. */
     -webkit-app-region: no-drag;
     white-space: nowrap;
     flex: 0 0 auto;

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1957,15 +1957,24 @@
    underneath .maka-workspace-top-actions (top-right toolbar) once more
    than one badge was showing at once. Pulled them out of the header's
    flow and anchored them in their own row, directly below the toolbar,
-   sharing its `right: 24px` baseline. */
+   sharing its geometry (see --maka-workspace-top-actions-* in
+   maka-tokens.css — single source of truth for both rules).
+   `max-width` + `flex-wrap` cap how far the row can grow: with three
+   badges and long Chinese labels in a narrow window, an unbounded
+   shrink-to-fit row could run past the left edge of the header/window.
+   Capped rows wrap onto a second line (still right-aligned) instead. */
 .maka-chat-status-cluster {
   position: absolute;
   z-index: var(--z-panel-action);
   top: calc(var(--maka-workspace-top-actions-bottom) + 6px);
-  right: 24px;
+  right: var(--maka-workspace-top-actions-right);
+  max-width: min(60vw, 320px);
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 4px;
+  row-gap: 4px;
   -webkit-app-region: no-drag;
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1951,6 +1951,24 @@
   -webkit-app-region: drag;
 }
 
+/* PR-CHAT-HEADER-STATUS-CLUSTER-0: the session-status / connection /
+   event-stream alert badges used to render inline in .maka-chat-header,
+   right-aligned via the header's flex spacer — which put them directly
+   underneath .maka-workspace-top-actions (top-right toolbar) once more
+   than one badge was showing at once. Pulled them out of the header's
+   flow and anchored them in their own row, directly below the toolbar,
+   sharing its `right: 24px` baseline. */
+.maka-chat-status-cluster {
+  position: absolute;
+  z-index: var(--z-panel-action);
+  top: calc(var(--maka-workspace-top-actions-bottom) + 6px);
+  right: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  -webkit-app-region: no-drag;
+}
+
 /* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
    browser-style session tab + the duplicate "新建对话" plus button at
    the top-left of the chat header are removed. ~95 LOC of .maka-chat-tab*

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1953,29 +1953,33 @@
 
 /* PR-CHAT-HEADER-STATUS-CLUSTER-0: the session-status / connection /
    event-stream alert badges used to render inline in .maka-chat-header,
-   right-aligned via the header's flex spacer — which put them directly
-   underneath .maka-workspace-top-actions (top-right toolbar) once more
-   than one badge was showing at once. Pulled them out of the header's
-   flow and anchored them in their own row, directly below the toolbar,
-   sharing its geometry (see --maka-workspace-top-actions-* in
-   maka-tokens.css — single source of truth for both rules).
-   `max-width` + `flex-wrap` cap how far the row can grow: with three
-   badges and long Chinese labels in a narrow window, an unbounded
-   shrink-to-fit row could run past the left edge of the header/window.
-   Capped rows wrap onto a second line (still right-aligned) instead. */
+   right-aligned via the header's flex spacer, which put them underneath
+   .maka-workspace-top-actions once more than one badge was visible.
+   Keep the badge cluster in normal flow between the header and chat
+   content so wrapped rows reserve vertical space instead of covering
+   the first message or the fake-backend banner. */
 .maka-chat-status-cluster {
-  position: absolute;
-  z-index: var(--z-panel-action);
-  top: calc(var(--maka-workspace-top-actions-bottom) + 6px);
-  right: var(--maka-workspace-top-actions-right);
-  max-width: min(60vw, 320px);
-  display: inline-flex;
+  width: min(60vw, 320px, calc(100% - var(--maka-workspace-top-actions-right) - 24px));
+  margin: 4px var(--maka-workspace-top-actions-right) 0 auto;
+  display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
-  row-gap: 4px;
   -webkit-app-region: no-drag;
+}
+
+.maka-chat-status-cluster .maka-chat-header-alert,
+.maka-chat-status-cluster .maka-chat-header-status {
+  max-width: 100%;
+  min-width: 0;
+  white-space: normal;
+}
+
+.maka-chat-status-cluster .maka-chat-header-alert > span,
+.maka-chat-status-cluster .maka-chat-header-status > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -222,9 +222,12 @@
      was bare `z-index: 4`. Tokenized to `--z-panel-action`.
      Identical visual stacking, but referenceable + contract-locked. */
   z-index: var(--z-panel-action);
-  /* Same baseline; 17px correction = 12px half-icon + 5px detail-panel inset. */
-  top: calc(var(--maka-titlebar-control-safe-top) - 17px);
-  right: 24px;
+  /* Same baseline; 17px correction = 12px half-icon + 5px detail-panel
+     inset. Tokenized in maka-tokens.css (--maka-workspace-top-actions-*)
+     so .maka-chat-status-cluster (module-pages.css) can anchor off the
+     same geometry instead of duplicating it. */
+  top: var(--maka-workspace-top-actions-top);
+  right: var(--maka-workspace-top-actions-right);
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -223,9 +223,8 @@
      Identical visual stacking, but referenceable + contract-locked. */
   z-index: var(--z-panel-action);
   /* Same baseline; 17px correction = 12px half-icon + 5px detail-panel
-     inset. Tokenized in maka-tokens.css (--maka-workspace-top-actions-*)
-     so .maka-chat-status-cluster (module-pages.css) can anchor off the
-     same geometry instead of duplicating it. */
+     inset. Tokenized in maka-tokens.css so the chat status row can
+     share the toolbar's right edge without duplicating the value. */
   top: var(--maka-workspace-top-actions-top);
   right: var(--maka-workspace-top-actions-right);
   display: inline-flex;

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -468,13 +468,21 @@ export function ChatView(props: {
             <span>深度研究</span>
           </span>
         )}
-        {props.sessionStatusBadge && <SessionStatusBadge badge={props.sessionStatusBadge} />}
-        {props.connectionAlert && <ChatHeaderAlertBadge alert={props.connectionAlert} />}
-        {props.eventStreamAlert && <ChatHeaderAlertBadge alert={props.eventStreamAlert} />}
         {/* PR-MOVE-PERMISSION-MODE: switcher relocated into the
             composer left-controls. Header keeps the per-session status
             chips only. */}
       </header>
+      {(props.sessionStatusBadge || props.connectionAlert || props.eventStreamAlert) && (
+        /* Anchored below the top-right workspace toolbar (see
+           .maka-chat-status-cluster) rather than inline in
+           .maka-chat-header — keeps the badges from overlapping the
+           toolbar's icon buttons when more than one is showing. */
+        <div className="maka-chat-status-cluster">
+          {props.sessionStatusBadge && <SessionStatusBadge badge={props.sessionStatusBadge} />}
+          {props.connectionAlert && <ChatHeaderAlertBadge alert={props.connectionAlert} />}
+          {props.eventStreamAlert && <ChatHeaderAlertBadge alert={props.eventStreamAlert} />}
+        </div>
+      )}
       {isLocalSimulationBackend && (
         <Alert variant="info" className="maka-fake-backend-banner" role="status">
           <AlertTriangle size={14} strokeWidth={1.75} aria-hidden="true" />

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -473,10 +473,9 @@ export function ChatView(props: {
             chips only. */}
       </header>
       {(props.sessionStatusBadge || props.connectionAlert || props.eventStreamAlert) && (
-        /* Anchored below the top-right workspace toolbar (see
-           .maka-chat-status-cluster) rather than inline in
-           .maka-chat-header — keeps the badges from overlapping the
-           toolbar's icon buttons when more than one is showing. */
+        /* In normal flow below the header (see .maka-chat-status-cluster)
+           so wrapped multi-badge rows reserve space before banners and
+           messages. */
         <div className="maka-chat-status-cluster">
           {props.sessionStatusBadge && <SessionStatusBadge badge={props.sessionStatusBadge} />}
           {props.connectionAlert && <ChatHeaderAlertBadge alert={props.connectionAlert} />}


### PR DESCRIPTION
Before:
<img width="203" height="43" alt="image" src="https://github.com/user-attachments/assets/a02ffcc3-899d-41d3-8942-ffe87f4977bb" />
<img width="164" height="54" alt="image" src="https://github.com/user-attachments/assets/a963b06f-c2bb-428a-9086-6709b6397104" />


After:

<img width="205" height="61" alt="image" src="https://github.com/user-attachments/assets/174c94b8-5976-499d-8386-6a152515aa2f" />
<img width="154" height="61" alt="image" src="https://github.com/user-attachments/assets/2da19ba0-3f9b-4da4-b8c0-abaaa27604da" />



## Summary
- The session-status / connection / event-stream alert badges rendered inline in `.maka-chat-header`, right-aligned via the header's flex spacer — which put them directly underneath the absolutely-positioned `.maka-workspace-top-actions` toolbar (top-right corner) once more than one badge was showing at once (e.g. "已中止" + "事件流恢复中").
- Moved the badge cluster out of the header's flex flow into its own row (`.maka-chat-status-cluster`), anchored directly below the toolbar and sharing its `right: 24px` baseline.
- Trimmed `.maka-chat-header-status`'s padding/font-size to match the neighboring alert badge's visual scale, so it no longer visually dominates next to the toolbar icons.

## Test plan
- [x] `npm --workspace @maka/ui run typecheck`
- [x] `npm --workspace @maka/desktop run typecheck`
- [x] `node scripts/check-dead-css.mjs --check`
- [x] Built the renderer and captured the `workstation-statuses` visual-smoke fixture (`node scripts/capture-screenshots.mjs --scenario workstation-statuses`) — confirms the "进行中" status badge renders cleanly below the toolbar with no overlap.
