### PR TITLE
fix(desktop): stop chat header mode pill overlapping the top-actions toolbar

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readRendererContractCss } from './contract-css-helpers.js';
+
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css);
+  assert.ok(match, `${selector} rule should exist`);
+  return match[1] ?? '';
+}
+
+describe('chat header actions inset contract', () => {
+  // Companion to chat-status-cluster-layout-contract: PR-CHAT-HEADER-STATUS-CLUSTER-0
+  // only relocated the status badge cluster. The in-header mode pill
+  // (.maka-chat-header-mode-pill) and model switcher still flowed underneath the
+  // absolutely-positioned .maka-workspace-top-actions toolbar in the top-right
+  // corner. The header must reserve horizontal space for that toolbar.
+  it('derives the toolbar inset token from the shared right baseline', async () => {
+    const css = await readRendererContractCss();
+    assert.match(
+      css,
+      /--maka-workspace-top-actions-inset:\s*calc\(\s*var\(--maka-workspace-top-actions-right\)/,
+      'the inset token should extend the shared toolbar right baseline, not hardcode an unrelated value',
+    );
+  });
+
+  it('reserves the toolbar inset as chat-header right padding', async () => {
+    const css = await readRendererContractCss();
+    const body = ruleBody(css, '.maka-chat-header');
+    assert.match(
+      body,
+      /padding:[^;]*var\(--maka-workspace-top-actions-inset\)/,
+      '.maka-chat-header must reserve --maka-workspace-top-actions-inset as right padding so right-aligned content does not render under .maka-workspace-top-actions',
+    );
+    assert.doesNotMatch(
+      body,
+      /padding:\s*0\s+10px\s*;/,
+      'the header should no longer use the pre-fix symmetric 10px padding that let pills overlap the toolbar',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
@@ -1,12 +1,37 @@
 import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import { readRendererContractCss } from './contract-css-helpers.js';
+import { CONTRACT_REPO_ROOT, readRendererContractCss } from './contract-css-helpers.js';
+
+const CHAT_HEADER_TOOLBAR_CLEARANCE_PX = 12;
 
 function ruleBody(css: string, selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css);
   assert.ok(match, `${selector} rule should exist`);
   return match[1] ?? '';
+}
+
+function pxDeclaration(body: string, property: string): number {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}:\\s*(\\d+)px\\s*;`).exec(body);
+  assert.ok(match, `${property} should be a px declaration`);
+  return Number(match[1]);
+}
+
+function workspaceTopActionsInsetAddend(css: string): number {
+  const match = /--maka-workspace-top-actions-inset:\s*calc\(\s*var\(--maka-workspace-top-actions-right\)\s*\+\s*(\d+)px\s*\)\s*;/.exec(css);
+  assert.ok(match, '--maka-workspace-top-actions-inset should add a px toolbar footprint');
+  return Number(match[1]);
+}
+
+async function workspaceTopActionButtonCount(): Promise<number> {
+  const source = await readFile(join(CONTRACT_REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'app-shell-chrome-actions.tsx'), 'utf8');
+  const start = source.indexOf('export function AppShellWorkspaceTopActions');
+  assert.notEqual(start, -1, 'AppShellWorkspaceTopActions should exist');
+  const block = source.slice(start);
+  return [...block.matchAll(/className="maka-workspace-icon-action"/g)].length;
 }
 
 describe('chat header actions inset contract', () => {
@@ -21,6 +46,28 @@ describe('chat header actions inset contract', () => {
       css,
       /--maka-workspace-top-actions-inset:\s*calc\(\s*var\(--maka-workspace-top-actions-right\)/,
       'the inset token should extend the shared toolbar right baseline, not hardcode an unrelated value',
+    );
+  });
+
+  it('sizes the inset from the toolbar buttons, gaps, and clearance', async () => {
+    const css = await readRendererContractCss();
+    const buttonCount = await workspaceTopActionButtonCount();
+    const toolbarBody = ruleBody(css, '.maka-workspace-top-actions');
+    const iconBody = ruleBody(css, '.maka-workspace-icon-action');
+
+    const buttonWidth = pxDeclaration(iconBody, 'width');
+    const buttonHeight = pxDeclaration(iconBody, 'height');
+    const gap = pxDeclaration(toolbarBody, 'gap');
+    const insetAddend = workspaceTopActionsInsetAddend(css);
+
+    assert.equal(buttonCount, 4, 'current top-actions toolbar renders four icon buttons');
+    assert.equal(buttonWidth, 24, 'top-actions icon buttons are 24px wide');
+    assert.equal(buttonHeight, buttonWidth, 'top-actions icon buttons should stay square');
+    assert.equal(gap, 6, 'top-actions icon buttons use a 6px gap');
+    assert.equal(
+      insetAddend,
+      (buttonCount * buttonWidth) + ((buttonCount - 1) * gap) + CHAT_HEADER_TOOLBAR_CLEARANCE_PX,
+      'the chat-header inset addend must match the rendered toolbar footprint plus 12px clearance',
     );
   });
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -305,6 +305,14 @@
      anchors off the toolbar bottom. */
   --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 17px);
   --maka-workspace-top-actions-right: 24px;
+  /* Horizontal footprint the absolutely-positioned .maka-workspace-top-actions
+     toolbar occupies in the top-right corner: its right offset + four 24px icon
+     buttons with 6px gaps (114px) + a 12px clearance gap. Right-aligned
+     chat-header content (model switcher, .maka-chat-header-mode-pill, memory
+     pill) reserves this as right padding so it does not render underneath the
+     toolbar. Companion to PR-CHAT-HEADER-STATUS-CLUSTER-0, which only relocated
+     the status cluster and left the in-header pills overlapping. */
+  --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 126px);
 
   /* session list geometry */
   --w-sessionlist: 240px;

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1945,7 +1945,11 @@
   display: flex;
   align-items: flex-end;
   gap: 4px;
-  padding: 0 10px;
+  /* Right padding reserves space for the absolutely-positioned
+     .maka-workspace-top-actions toolbar so right-aligned content
+     (.maka-chat-header-mode-pill, .maka-model-switcher, memory pill) stops
+     before the toolbar instead of rendering underneath it. */
+  padding: 0 var(--maka-workspace-top-actions-inset) 0 10px;
   background: transparent;
   border-bottom: 0;
   -webkit-app-region: drag;


### PR DESCRIPTION
## Problem

In the chat view, the read-only mode pill `.maka-chat-header-mode-pill` ("深度研究 / 只读探索") — and the model switcher — render on top of the top-right toolbar icons: the **help** and **health-center** icons sit directly over the "深度研究" pill text.

## Root cause

`.maka-workspace-top-actions` (the top-right toolbar: feedback / command-palette / help / health-center) is `position: absolute; z-index: 4`, i.e. out of normal flow. `.maka-chat-header` is a flex row whose right-aligned content is pushed right by `.maka-chat-header-spacer`, but the header only reserved `padding: 0 10px`. Because the toolbar is absolute, the header never reserved horizontal space for it, so the right-aligned pills flowed *underneath* the toolbar.

Measured against the running app (1410px viewport):

- toolbar `.maka-workspace-top-actions`: x **1268–1382**
- mode pill (before fix): x 1317–**1392** → overlaps the toolbar's 1317–1382 span

`PR-CHAT-HEADER-STATUS-CLUSTER-0` (#419) fixed exactly this collision for the *status badge cluster* by relocating it to its own in-flow row constrained to the toolbar's right baseline. The in-header pills were not covered by that change.

## Fix

- Add `--maka-workspace-top-actions-inset` to `maka-tokens.css`, derived from the existing shared `--maka-workspace-top-actions-right` baseline plus the toolbar's icon-button footprint.
- Reserve it as `.maka-chat-header`'s right padding so right-aligned in-flow content clears the toolbar.
- Add `chat-header-actions-inset-contract.test.ts`, mirroring the existing `chat-status-cluster-layout-contract` static contract.

## Validation

- After fix, the mode pill's right edge moves to x **1252** — a **16px gap** before the toolbar's left edge (x 1268); no overlap. Confirmed visually and via `document.getBoundingClientRect()` in the running app.
- `npm --workspace @maka/desktop run test` → new + existing contract tests pass, full suite green.
- `node scripts/check-dead-css.mjs --check` → `no dead classes found ✓` (no classes added).
- `npm run build` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
