### PR TITLE
fix(desktop): keep topbar icon clicks out of drag regions

### DIFF
--- a/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
@@ -116,6 +116,33 @@ describe('app-region hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5)', ()
       }
     }
   });
+
+  it('topbar chrome buttons and their icon subtrees carve out no-drag hit regions', async () => {
+    const stylesSources = [
+      ['renderer CSS', await readRendererContractCss()],
+      [TOKENS_PATH, await readFile(TOKENS_PATH, 'utf8')],
+    ] as const;
+    const selectors = new Set<string>();
+    for (const [, src] of stylesSources) {
+      for (const rule of findRulesWithDeclaration(src, '-webkit-app-region: no-drag')) {
+        for (const selector of rule.selector.split(',')) {
+          selectors.add(selector.trim());
+        }
+      }
+    }
+
+    for (const selector of [
+      '.maka-shell-topbar-button',
+      '.maka-shell-topbar-button *',
+      '.maka-workspace-icon-action',
+      '.maka-workspace-icon-action *',
+    ]) {
+      assert.ok(
+        selectors.has(selector),
+        `${selector} must declare \`-webkit-app-region: no-drag\` so clicks on topbar icons are not treated as titlebar drags`,
+      );
+    }
+  });
 });
 
 /**

--- a/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
@@ -36,6 +36,12 @@ import { readRendererContractCss } from './contract-css-helpers.js';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const TOKENS_PATH = join(process.cwd(), 'src', 'renderer', 'maka-tokens.css');
+const APP_SHELL_CHROME_ACTIONS_PATH = join(
+  process.cwd(),
+  'src',
+  'renderer',
+  'app-shell-chrome-actions.tsx',
+);
 
 /**
  * Selectors that, if they ever carry `-webkit-app-region: drag`,
@@ -117,7 +123,15 @@ describe('app-region hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5)', ()
     }
   });
 
-  it('topbar chrome buttons and their icon subtrees carve out no-drag hit regions', async () => {
+  it('topbar chrome UiButtons and their icon subtrees carve out no-drag hit regions', async () => {
+    const topbarButtonClasses = extractStaticUiButtonClassNames(
+      await readFile(APP_SHELL_CHROME_ACTIONS_PATH, 'utf8'),
+    );
+    assert.ok(
+      topbarButtonClasses.length > 0,
+      'app-shell-chrome-actions.tsx must expose topbar UiButton class names for app-region hygiene checks',
+    );
+
     const stylesSources = [
       ['renderer CSS', await readRendererContractCss()],
       [TOKENS_PATH, await readFile(TOKENS_PATH, 'utf8')],
@@ -131,16 +145,13 @@ describe('app-region hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5)', ()
       }
     }
 
-    for (const selector of [
-      '.maka-shell-topbar-button',
-      '.maka-shell-topbar-button *',
-      '.maka-workspace-icon-action',
-      '.maka-workspace-icon-action *',
-    ]) {
-      assert.ok(
-        selectors.has(selector),
-        `${selector} must declare \`-webkit-app-region: no-drag\` so clicks on topbar icons are not treated as titlebar drags`,
-      );
+    for (const className of topbarButtonClasses) {
+      for (const selector of [`.${className}`, `.${className} *`]) {
+        assert.ok(
+          selectors.has(selector),
+          `${selector} must declare \`-webkit-app-region: no-drag\` so clicks on topbar icons are not treated as titlebar drags`,
+        );
+      }
     }
   });
 });
@@ -172,6 +183,24 @@ function findRulesWithDeclaration(
     }
   }
   return out;
+}
+
+function extractStaticUiButtonClassNames(src: string): string[] {
+  const classes = new Set<string>();
+  const uiButtonBlocks = src.match(/<UiButton\b[\s\S]*?<\/UiButton>/g) ?? [];
+  for (const block of uiButtonBlocks) {
+    const match = block.match(/\bclassName="([^"]+)"/);
+    assert.ok(
+      match,
+      'Each app-shell chrome UiButton must use a static className so app-region hygiene can be contract-checked',
+    );
+    for (const className of match[1]!.split(/\s+/)) {
+      if (className.length > 0) {
+        classes.add(className);
+      }
+    }
+  }
+  return [...classes].sort();
 }
 
 /**

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -117,7 +117,6 @@
   height: var(--maka-sidebar-topbar-button-size);
   border-radius: 6px;
   color: var(--foreground-70);
-  -webkit-app-region: no-drag;
 }
 
 .maka-shell-topbar-button:hover {
@@ -244,6 +243,13 @@
   height: 24px;
   border-radius: 6px;
   color: var(--foreground-60);
+}
+
+.maka-shell-topbar-button,
+.maka-shell-topbar-button *,
+.maka-workspace-icon-action,
+.maka-workspace-icon-action * {
+  -webkit-app-region: no-drag;
 }
 
 .maka-workspace-icon-action:hover {


### PR DESCRIPTION
## Summary

Ensure the top-left shell controls and top-right workspace toolbar keep the full icon hit target out of Electron drag regions.

## Why

Clicking these topbar icons could be treated as a titlebar drag because the button containers were marked `no-drag`, but their nested `svg/path` hit targets were not. The React handlers were wired, but native app-region hit testing could intercept icon clicks before the UI saw them.

## Scope

Changed:

- Apply `-webkit-app-region: no-drag` to topbar buttons and their icon subtrees.
- Add an app-region hygiene contract so future topbar icons must carve out no-drag hit regions.
- Derive the topbar no-drag contract from the actual `UiButton` class names in `app-shell-chrome-actions.tsx`, so a future new topbar button class must add both the button and subtree `no-drag` selectors.

Not included:

- No visual layout or toolbar geometry changes.
- No changes to modal behavior, command palette behavior, or sidebar state logic.
- No Electron E2E harness; this remains a static contract plus computed-style verification.

## Verification

- RED: `node --test dist/main/__tests__/app-region-hygiene-contract.test.js` failed on missing `.maka-shell-topbar-button *` no-drag coverage.
- RED mutation: temporarily added a probe topbar `UiButton` class without matching CSS, and the upgraded contract failed on the missing `no-drag` selector.
- GREEN: `node --test dist/main/__tests__/app-region-hygiene-contract.test.js`
- `npm --workspace @maka/desktop test`
- `npm run check:stale`
- CDP computed-style check after renderer rebuild: all topbar button, `svg`, and `path` hit targets report `-webkit-app-region: no-drag`.

## User-facing impact

Topbar icon clicks should open their intended actions instead of being swallowed as titlebar drags. No docs, migrations, or breaking changes.

## Reviewer notes

`git blame` points the current CSS mostly at the later CSS split, but the earliest ancestor-chain introduction of the incomplete topbar no-drag carve-out appears in `a1e78b47` (`Consolidate settings and workspace layout polish`). `5d696e46` later carried the same shape into the unified shell chrome controls.
