### PR TITLE
refactor(ui): ban bare ease keywords, enforce var(--ease-*) tokens

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -100,7 +100,7 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
     for (const residue of [
       '[data-slot="tool"] {',
       'transform: translateY(0)',
-      'transition: border-color 160ms ease;',
+      'transition: border-color 160ms var(--ease-out-strong);',
       '[data-slot="tool"] > summary::-webkit-details-marker { display: none; }',
       "[data-slot=\"tool\"] > summary::marker { content: ''; }",
     ]) {

--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -130,4 +130,68 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     assert.match(tokens, /--ease-in-out-strong:\s*cubic-bezier/);
     assert.match(tokens, /--ease-drawer:\s*cubic-bezier/);
   });
+
+  it('bare ease/linear timing keywords are banned — use var(--ease-*) tokens', async () => {
+    // PR-MOTION-TOKEN-CONVERGE-1 (#430 PR1): the three easing tokens
+    // (--ease-out-strong / --ease-in-out-strong / --ease-drawer) are the
+    // single source of truth. Bare `ease` / `ease-out` / `ease-in-out`
+    // drift visually and can't be retuned in one place. `linear` is the
+    // same class of keyword but is legitimate inside infinite-loop
+    // animations (spinners, shimmer) — those are whitelisted per-line.
+    //
+    // Token declarations like `--ease-out-strong:` are safe: the
+    // lookbehind `(?<![\w-])` rejects the preceding hyphen. Tailwind
+    // arbitrary values like `ease-[var(--ease-out-strong)]` are safe:
+    // the `ease` is followed by `-` which the negative lookahead rejects.
+    const BARE_EASE = /(?<![\w-])ease(?![\w-])/g;
+    const BARE_EASE_OUT = /(?<![\w-])ease-out(?!\s*-strong)/g;
+    const BARE_EASE_IN_OUT = /(?<![\w-])ease-in-out(?!\s*-strong)/g;
+    const BARE_LINEAR = /(?<![\w-])linear(?![\w-])/g;
+
+    const offenders: string[] = [];
+
+    function scan(src: string, label: string): void {
+      const lines = src.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (/\binfinite\b/.test(line) && /\blinear\b/.test(line)) continue;
+        for (const [name, re] of [
+          ['ease', BARE_EASE],
+          ['ease-out', BARE_EASE_OUT],
+          ['ease-in-out', BARE_EASE_IN_OUT],
+          ['linear', BARE_LINEAR],
+        ] as const) {
+          const matches = line.match(re);
+          if (matches) {
+            for (const m of matches) {
+              offenders.push(`${label}:${i + 1}: bare \`${name}\``);
+            }
+          }
+        }
+      }
+    }
+
+    scan(stripCssComments(await readAllRendererCss()), 'renderer CSS');
+
+    const { readdir } = await import('node:fs/promises');
+    async function walk(dir: string): Promise<void> {
+      const entries = await readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.isFile() && /\.(tsx|ts)$/.test(entry.name)) {
+          scan(await readFile(full, 'utf8'), full.replace(REPO_ROOT + '/', ''));
+        }
+      }
+    }
+    await walk(resolve(REPO_ROOT, 'packages/ui/src'));
+    await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `Bare ease/linear timing keywords are banned — use var(--ease-out-strong), var(--ease-in-out-strong), or var(--ease-drawer).\n  ${offenders.join('\n  ')}`,
+    );
+  });
 });

--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -131,55 +131,46 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     assert.match(tokens, /--ease-drawer:\s*cubic-bezier/);
   });
 
+  // Single longest-match-first matcher. Using one regex with matchAll
+  // means `ease-in-out` is reported once as `ease-in-out` (not also as
+  // `ease-in`), and `ease-linear` (a Tailwind class that compiles to
+  // `transition-timing-function: linear`) is caught explicitly. Token
+  // declarations (`--ease-out-strong:`) and Tailwind arbitrary values
+  // (`ease-[var(--ease-out-strong)]`) are safe: the lookbehind/lookahead
+  // `(?<![\w-])` / `(?![\w-])` reject the surrounding hyphens.
+  const TIMING_KEYWORD = /(?<![\w-])(ease-in-out|ease-linear|ease-in|ease-out|ease|linear)(?![\w-])/g;
+
+  function scanBareTimingKeywords(src: string, label: string): string[] {
+    const offenders: string[] = [];
+    const lines = src.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Split into declaration segments so a `linear` in a `transition`
+      // can't be shielded by an `infinite` in an `animation` on the
+      // same physical line. Each segment is scanned independently.
+      for (const seg of line.split(';')) {
+        for (const m of seg.matchAll(TIMING_KEYWORD)) {
+          const kw = m[1];
+          // `linear` is legitimate only inside infinite-loop animations
+          // (spinners, shimmer). Whitelist by the match's own segment,
+          // not the whole line.
+          if (kw === 'linear' && /\binfinite\b/.test(seg)) continue;
+          offenders.push(`${label}:${i + 1}: bare \`${kw}\``);
+        }
+      }
+    }
+    return offenders;
+  }
+
   it('bare ease/linear timing keywords are banned — use var(--ease-*) tokens', async () => {
     // PR-MOTION-TOKEN-CONVERGE-1 (#430 PR1): the three easing tokens
     // (--ease-out-strong / --ease-in-out-strong / --ease-drawer) are the
     // single source of truth. Bare `ease` / `ease-in` / `ease-out` /
-    // `ease-in-out` drift visually and can't be retuned in one place.
-    // `linear` is the same class of keyword but is legitimate inside
-    // infinite-loop animations (spinners, shimmer) — whitelisted per
-    // match, not per line.
-    //
-    // Token declarations like `--ease-out-strong:` are safe: the
-    // lookbehind `(?<![\w-])` rejects the preceding hyphen. Tailwind
-    // arbitrary values like `ease-[var(--ease-out-strong)]` are safe:
-    // the `ease` is followed by `-` which the negative lookahead rejects.
-    const BARE_EASE = /(?<![\w-])ease(?![\w-])/g;
-    const BARE_EASE_IN = /(?<![\w-])ease-in(?!\s*out)/g;
-    const BARE_EASE_OUT = /(?<![\w-])ease-out(?!\s*-strong)/g;
-    const BARE_EASE_IN_OUT = /(?<![\w-])ease-in-out(?!\s*-strong)/g;
-    const BARE_LINEAR = /(?<![\w-])linear(?![\w-])/g;
-
+    // `ease-in-out` / `ease-linear` / `linear` drift visually and can't
+    // be retuned in one place. `linear` is legitimate only inside
+    // infinite-loop animations (spinners, shimmer).
     const offenders: string[] = [];
-
-    function scan(src: string, label: string): void {
-      const lines = src.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        for (const [name, re] of [
-          ['ease', BARE_EASE],
-          ['ease-in', BARE_EASE_IN],
-          ['ease-out', BARE_EASE_OUT],
-          ['ease-in-out', BARE_EASE_IN_OUT],
-          ['linear', BARE_LINEAR],
-        ] as const) {
-          const matches = line.match(re);
-          if (matches) {
-            for (const m of matches) {
-              // `linear` is legitimate only inside infinite-loop
-              // animations (spinners, shimmer); whitelist that single
-              // match, not the whole line — a `linear` in a `transition`
-              // on the same line as an `animation ... infinite` must
-              // still be flagged.
-              if (name === 'linear' && /\binfinite\b/.test(line)) continue;
-              offenders.push(`${label}:${i + 1}: bare \`${name}\``);
-            }
-          }
-        }
-      }
-    }
-
-    scan(stripCssComments(await readAllRendererCss()), 'renderer CSS');
+    offenders.push(...scanBareTimingKeywords(stripCssComments(await readAllRendererCss()), 'renderer CSS'));
 
     const { readdir } = await import('node:fs/promises');
     async function walk(dir: string): Promise<void> {
@@ -189,7 +180,7 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
         const full = resolve(dir, entry.name);
         if (entry.isDirectory()) await walk(full);
         else if (entry.isFile() && /\.(tsx|ts)$/.test(entry.name)) {
-          scan(await readFile(full, 'utf8'), full.replace(REPO_ROOT + '/', ''));
+          offenders.push(...scanBareTimingKeywords(await readFile(full, 'utf8'), full.replace(REPO_ROOT + '/', '')));
         }
       }
     }
@@ -200,6 +191,35 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
       offenders,
       [],
       `Bare ease/linear timing keywords are banned — use var(--ease-out-strong), var(--ease-in-out-strong), or var(--ease-drawer).\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
+  it('bare-timing-keyword scanner catches ease-linear and same-line transition/animation linear', () => {
+    // P1: `ease-linear` is a Tailwind class that compiles to
+    // `transition-timing-function: linear` — must be caught, not
+    // shielded by the surrounding hyphens.
+    assert.deepEqual(
+      scanBareTimingKeywords('className="transition-opacity ease-linear"', 'fixture'),
+      ['fixture:1: bare `ease-linear`'],
+    );
+    // P1: a `linear` in a `transition` must NOT be shielded by an
+    // `infinite` in an `animation` on the same physical line.
+    assert.deepEqual(
+      scanBareTimingKeywords(
+        'transition: opacity 100ms linear; animation: spin 1s linear infinite;',
+        'fixture',
+      ),
+      ['fixture:1: bare `linear`'],
+    );
+    // P3: `ease-in-out` reports once as `ease-in-out`, not also as `ease-in`.
+    assert.deepEqual(
+      scanBareTimingKeywords('transition: opacity 120ms ease-in-out', 'fixture'),
+      ['fixture:1: bare `ease-in-out`'],
+    );
+    // `linear` inside an infinite-loop animation is whitelisted.
+    assert.deepEqual(
+      scanBareTimingKeywords('animation: maka-status-spin 1.2s linear infinite;', 'fixture'),
+      [],
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -134,16 +134,18 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
   it('bare ease/linear timing keywords are banned — use var(--ease-*) tokens', async () => {
     // PR-MOTION-TOKEN-CONVERGE-1 (#430 PR1): the three easing tokens
     // (--ease-out-strong / --ease-in-out-strong / --ease-drawer) are the
-    // single source of truth. Bare `ease` / `ease-out` / `ease-in-out`
-    // drift visually and can't be retuned in one place. `linear` is the
-    // same class of keyword but is legitimate inside infinite-loop
-    // animations (spinners, shimmer) — those are whitelisted per-line.
+    // single source of truth. Bare `ease` / `ease-in` / `ease-out` /
+    // `ease-in-out` drift visually and can't be retuned in one place.
+    // `linear` is the same class of keyword but is legitimate inside
+    // infinite-loop animations (spinners, shimmer) — whitelisted per
+    // match, not per line.
     //
     // Token declarations like `--ease-out-strong:` are safe: the
     // lookbehind `(?<![\w-])` rejects the preceding hyphen. Tailwind
     // arbitrary values like `ease-[var(--ease-out-strong)]` are safe:
     // the `ease` is followed by `-` which the negative lookahead rejects.
     const BARE_EASE = /(?<![\w-])ease(?![\w-])/g;
+    const BARE_EASE_IN = /(?<![\w-])ease-in(?!\s*out)/g;
     const BARE_EASE_OUT = /(?<![\w-])ease-out(?!\s*-strong)/g;
     const BARE_EASE_IN_OUT = /(?<![\w-])ease-in-out(?!\s*-strong)/g;
     const BARE_LINEAR = /(?<![\w-])linear(?![\w-])/g;
@@ -154,9 +156,9 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
       const lines = src.split('\n');
       for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
-        if (/\binfinite\b/.test(line) && /\blinear\b/.test(line)) continue;
         for (const [name, re] of [
           ['ease', BARE_EASE],
+          ['ease-in', BARE_EASE_IN],
           ['ease-out', BARE_EASE_OUT],
           ['ease-in-out', BARE_EASE_IN_OUT],
           ['linear', BARE_LINEAR],
@@ -164,6 +166,12 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
           const matches = line.match(re);
           if (matches) {
             for (const m of matches) {
+              // `linear` is legitimate only inside infinite-loop
+              // animations (spinners, shimmer); whitelist that single
+              // match, not the whole line — a `linear` in a `transition`
+              // on the same line as an `animation ... infinite` must
+              // still be flagged.
+              if (name === 'linear' && /\binfinite\b/.test(line)) continue;
               offenders.push(`${label}:${i + 1}: bare \`${name}\``);
             }
           }

--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -124,11 +124,12 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     assert.match(tokens, /--duration-large:\s*280ms/, '--duration-large must be 280ms');
   });
 
-  it('--ease-out-strong / --ease-in-out-strong / --ease-drawer tokens are defined', async () => {
+  it('--ease-out-strong / --ease-in-out-strong / --ease-drawer / --ease-linear tokens are defined', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
     assert.match(tokens, /--ease-out-strong:\s*cubic-bezier/);
     assert.match(tokens, /--ease-in-out-strong:\s*cubic-bezier/);
     assert.match(tokens, /--ease-drawer:\s*cubic-bezier/);
+    assert.match(tokens, /--ease-linear:\s*linear/);
   });
 
   // Single longest-match-first matcher. Using one regex with matchAll
@@ -138,39 +139,41 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
   // declarations (`--ease-out-strong:`) and Tailwind arbitrary values
   // (`ease-[var(--ease-out-strong)]`) are safe: the lookbehind/lookahead
   // `(?<![\w-])` / `(?![\w-])` reject the surrounding hyphens.
+  //
+  // The `--ease-linear: linear;` declaration itself is stripped before
+  // scanning (same pattern as the it1 `--ease-out-strong` declaration).
+  // `linear` for infinite-loop animations (spinners, shimmer) goes
+  // through `var(--ease-linear)` — no whitelist, no per-line/per-segment
+  // exemption, so there is no bypass vector.
   const TIMING_KEYWORD = /(?<![\w-])(ease-in-out|ease-linear|ease-in|ease-out|ease|linear)(?![\w-])/g;
+  const EASE_LINEAR_DECL = /--ease-linear:\s*linear\s*;?/g;
 
   function scanBareTimingKeywords(src: string, label: string): string[] {
     const offenders: string[] = [];
     const lines = src.split('\n');
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      // Split into declaration segments so a `linear` in a `transition`
-      // can't be shielded by an `infinite` in an `animation` on the
-      // same physical line. Each segment is scanned independently.
-      for (const seg of line.split(';')) {
-        for (const m of seg.matchAll(TIMING_KEYWORD)) {
-          const kw = m[1];
-          // `linear` is legitimate only inside infinite-loop animations
-          // (spinners, shimmer). Whitelist by the match's own segment,
-          // not the whole line.
-          if (kw === 'linear' && /\binfinite\b/.test(seg)) continue;
-          offenders.push(`${label}:${i + 1}: bare \`${kw}\``);
-        }
+      for (const m of line.matchAll(TIMING_KEYWORD)) {
+        offenders.push(`${label}:${i + 1}: bare \`${m[1]}\``);
       }
     }
     return offenders;
   }
 
   it('bare ease/linear timing keywords are banned — use var(--ease-*) tokens', async () => {
-    // PR-MOTION-TOKEN-CONVERGE-1 (#430 PR1): the three easing tokens
-    // (--ease-out-strong / --ease-in-out-strong / --ease-drawer) are the
-    // single source of truth. Bare `ease` / `ease-in` / `ease-out` /
-    // `ease-in-out` / `ease-linear` / `linear` drift visually and can't
-    // be retuned in one place. `linear` is legitimate only inside
-    // infinite-loop animations (spinners, shimmer).
+    // PR-MOTION-TOKEN-CONVERGE-1 (#430 PR1): the four easing tokens
+    // (--ease-out-strong / --ease-in-out-strong / --ease-drawer /
+    // --ease-linear) are the single source of truth. Any bare
+    // `ease` / `ease-in` / `ease-out` / `ease-in-out` / `ease-linear` /
+    // `linear` drifts visually and can't be retuned in one place.
+    // Infinite-loop animations use `var(--ease-linear)`.
     const offenders: string[] = [];
-    offenders.push(...scanBareTimingKeywords(stripCssComments(await readAllRendererCss()), 'renderer CSS'));
+    offenders.push(
+      ...scanBareTimingKeywords(
+        stripCssComments(await readAllRendererCss()).replace(EASE_LINEAR_DECL, ''),
+        'renderer CSS',
+      ),
+    );
 
     const { readdir } = await import('node:fs/promises');
     async function walk(dir: string): Promise<void> {
@@ -190,14 +193,13 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     assert.deepEqual(
       offenders,
       [],
-      `Bare ease/linear timing keywords are banned — use var(--ease-out-strong), var(--ease-in-out-strong), or var(--ease-drawer).\n  ${offenders.join('\n  ')}`,
+      `Bare ease/linear timing keywords are banned — use var(--ease-out-strong), var(--ease-in-out-strong), var(--ease-drawer), or var(--ease-linear).\n  ${offenders.join('\n  ')}`,
     );
   });
 
   it('bare-timing-keyword scanner catches ease-linear and same-line transition/animation linear', () => {
     // P1: `ease-linear` is a Tailwind class that compiles to
-    // `transition-timing-function: linear` — must be caught, not
-    // shielded by the surrounding hyphens.
+    // `transition-timing-function: linear` — must be caught.
     assert.deepEqual(
       scanBareTimingKeywords('className="transition-opacity ease-linear"', 'fixture'),
       ['fixture:1: bare `ease-linear`'],
@@ -206,20 +208,21 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
     // `infinite` in an `animation` on the same physical line.
     assert.deepEqual(
       scanBareTimingKeywords(
-        'transition: opacity 100ms linear; animation: spin 1s linear infinite;',
+        'style={{ transition: "opacity 100ms linear", animation: "spin 1s linear infinite" }}',
         'fixture',
       ),
-      ['fixture:1: bare `linear`'],
+      ['fixture:1: bare `linear`', 'fixture:1: bare `linear`'],
+    );
+    // P1: in a comma-separated animation list, a `linear` on a
+    // non-infinite item must be flagged.
+    assert.deepEqual(
+      scanBareTimingKeywords('animation: spin 1s linear infinite, fade 100ms linear 1;', 'fixture'),
+      ['fixture:1: bare `linear`', 'fixture:1: bare `linear`'],
     );
     // P3: `ease-in-out` reports once as `ease-in-out`, not also as `ease-in`.
     assert.deepEqual(
       scanBareTimingKeywords('transition: opacity 120ms ease-in-out', 'fixture'),
       ['fixture:1: bare `ease-in-out`'],
-    );
-    // `linear` inside an infinite-loop animation is whitelisted.
-    assert.deepEqual(
-      scanBareTimingKeywords('animation: maka-status-spin 1.2s linear infinite;', 'fixture'),
-      [],
     );
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -695,7 +695,7 @@
   ::-webkit-scrollbar-thumb  {
     background: transparent;
     border-radius: var(--radius-control);
-    transition: background 120ms ease;
+    transition: background 120ms var(--ease-out-strong);
   }
   *:hover {
     scrollbar-color: oklch(from var(--foreground) l c h / 0.18) transparent;
@@ -857,7 +857,7 @@
     font-size: 14px;
     line-height: 1.4;
     user-select: none;
-    transition: background 120ms ease, color 120ms ease;
+    transition: background 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong);
   }
   .maka-sidebar-row:hover    { background: var(--hover); }
   .maka-sidebar-row[data-active="true"] {
@@ -1176,7 +1176,7 @@
     padding: 0 2px;
     margin: 0 -2px;
     border-radius: var(--radius-control);
-    transition: border-bottom-color 120ms ease, background 120ms ease, box-shadow 120ms ease;
+    transition: border-bottom-color 120ms var(--ease-out-strong), background 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
   .maka-bubble-assistant a:hover {
     border-bottom-color: var(--accent);
@@ -1237,7 +1237,7 @@
     border-radius: var(--radius-control);
     background: transparent;
     color: var(--foreground-50);
-    transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+    transition: background 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
   .maka-code-block-copy:hover {
     color: var(--foreground);
@@ -1398,11 +1398,11 @@
        list keeps both axes coherent. */
     transform: translateY(-3px) scale(0.96);
     transition:
-      opacity 160ms ease,
+      opacity 160ms var(--ease-out-strong),
       transform 180ms var(--ease-out-strong),
-      color 120ms ease,
-      background 120ms ease,
-      box-shadow 120ms ease;
+      color 120ms var(--ease-out-strong),
+      background 120ms var(--ease-out-strong),
+      box-shadow 120ms var(--ease-out-strong);
   }
 
   /* Labelled variant (e.g. "复制思考过程") — flows inline, doesn't absolute-
@@ -1462,7 +1462,7 @@
     display: inline-block;
     margin-left: 2px;
     color: var(--accent);
-    animation: maka-cursor 1.1s ease-in-out infinite;
+    animation: maka-cursor 1.1s var(--ease-in-out-strong) infinite;
     vertical-align: -2px;
   }
   @keyframes maka-cursor { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
@@ -1485,7 +1485,7 @@
   [data-slot="tool"] {
     opacity: 1;
     transform: translateY(0);
-    transition: border-color 160ms ease;
+    transition: border-color 160ms var(--ease-out-strong);
   }
   /* Native <details>/<summary> marker reset — the summary IS the header row
      (laid out by `toolVariants({ part: 'header' })`), so the default disclosure
@@ -1544,7 +1544,7 @@
     flex-direction: column;
     gap: 10px;
     border: 1px solid var(--border);
-    transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+    transition: border-color 160ms var(--ease-out-strong), box-shadow 160ms var(--ease-out-strong), background 160ms var(--ease-out-strong);
   }
 
   /* Composer focus ring — `:focus-within` lets the wrapping shell glow
@@ -1589,7 +1589,7 @@
        listening" instead of "the placeholder is just sitting
        there." The fade is small (1 → 0.55) — enough to register,
        small enough not to feel like a glitch. */
-    transition: opacity 180ms var(--ease-out-strong, ease-out);
+    transition: opacity 180ms var(--ease-out-strong);
   }
   .maka-composer textarea:focus::placeholder {
     opacity: 0.55;
@@ -1620,7 +1620,7 @@
     font-size: 13px;
     font-weight: 500;
     line-height: 1.2;
-    transition: background 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+    transition: background 120ms var(--ease-out-strong), border-color 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), transform 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
   .maka-button:hover  { background: var(--hover); }
   .maka-button:active { background: var(--active); transform: translateY(0.5px); }
@@ -1727,7 +1727,7 @@
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: maka-shimmer 1.5s ease-in-out infinite;
+  animation: maka-shimmer 1.5s var(--ease-in-out-strong) infinite;
 }
 
 /* Skeleton placeholder primitives — used while data is still in flight.
@@ -1751,7 +1751,7 @@
     transparent 100%
   );
   background-size: 200% 100%;
-  animation: maka-shimmer 1.6s ease-in-out infinite;
+  animation: maka-shimmer 1.6s var(--ease-in-out-strong) infinite;
 }
 .maka-skeleton-line {
   height: 12px;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -263,9 +263,10 @@
      `motion-token-converge-contract.test.ts` enforces this by banning
      bare `cubic-bezier(0.16, 1, 0.3, 1)` (must use --ease-out-strong)
      and `transition: all` (must enumerate properties). */
-  --ease-out-strong: cubic-bezier(0.16, 1, 0.3, 1);
-  --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
-  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+   --ease-out-strong: cubic-bezier(0.16, 1, 0.3, 1);
+   --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
+   --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+   --ease-linear: linear;
 
   --duration-quick: 120ms;
   --duration-base: 150ms;

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -89,7 +89,7 @@
   margin: var(--agents-content-area-gap);
   border-radius: var(--radius-modal);
   background: var(--agents-content-area-bg);
-  transition: margin-left 150ms ease-out;
+  transition: margin-left 150ms var(--ease-out-strong);
 }
 
 /* PR-SETTINGS-RESTORE-SURFACE-0 (WAWQAQ msg `c8dc03e4`): main chat

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -135,7 +135,7 @@
   transition:
     transform var(--duration-emphasized) var(--ease-out-strong),
     opacity var(--duration-emphasized) var(--ease-out-strong),
-    background 120ms ease;
+    background 120ms var(--ease-out-strong);
   }
 
   .maka-chat-jump-bottom:hover {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -129,7 +129,7 @@
   margin-inline: 9px;
   border-radius: 50%;
   background: var(--accent);
-  animation: maka-composer-stream-bounce 1.05s ease-in-out -0.2s infinite both;
+  animation: maka-composer-stream-bounce 1.05s var(--ease-in-out-strong) -0.2s infinite both;
 }
 
 .maka-composer-streaming-dot::before,
@@ -141,7 +141,7 @@
   height: 5px;
   border-radius: 50%;
   background: var(--accent);
-  animation: maka-composer-stream-bounce 1.05s ease-in-out infinite both;
+  animation: maka-composer-stream-bounce 1.05s var(--ease-in-out-strong) infinite both;
 }
 
 .maka-composer-streaming-dot::before {
@@ -192,7 +192,7 @@
   height: 6px;
   border-radius: 50%;
   background: var(--accent);
-  animation: maka-composer-permission-pulse 1.4s ease-in-out infinite;
+  animation: maka-composer-permission-pulse 1.4s var(--ease-in-out-strong) infinite;
   flex-shrink: 0;
 }
 

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -404,9 +404,9 @@
     0 18px 42px oklch(from var(--foreground) l c h / 0.07),
     0 1px 0 oklch(from var(--foreground) 1 0 h / 0.72) inset;
   transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease,
-    transform 160ms ease;
+    border-color 160ms var(--ease-out-strong),
+    box-shadow 160ms var(--ease-out-strong),
+    transform 160ms var(--ease-out-strong);
 }
 
 .maka-onboarding-quickchat-field {
@@ -646,7 +646,7 @@
   border-radius: 50%;
   background: var(--accent);
   box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.15);
-  animation: maka-list-row-streaming-pulse 1.2s ease-in-out infinite;
+  animation: maka-list-row-streaming-pulse 1.2s var(--ease-in-out-strong) infinite;
 }
 
 @keyframes maka-list-row-streaming-pulse {

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -772,7 +772,7 @@
   color: var(--foreground-40);
 }
 .maka-list-row-status-icon[data-status="running"] svg {
-  animation: maka-status-spin 1.2s linear infinite;
+  animation: maka-status-spin 1.2s var(--ease-linear) infinite;
 }
 @keyframes maka-status-spin {
   to { transform: rotate(360deg); }

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -55,7 +55,7 @@
     border-radius: 50%;
     background: var(--info);
     /* Live pulse — collapses under prefers-reduced-motion via the rule below. */
-    animation: maka-reasoning-panel-pulse 1.4s ease-in-out infinite;
+    animation: maka-reasoning-panel-pulse 1.4s var(--ease-in-out-strong) infinite;
   }
 
   @keyframes maka-reasoning-panel-pulse {

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -31,7 +31,7 @@
   color: var(--foreground);
   font: inherit;
   text-align: left;
-  transition: background-color 130ms ease;
+  transition: background-color 130ms var(--ease-out-strong);
 }
 
 .enabledProviderTrigger:hover { background: var(--hover); }

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -799,7 +799,7 @@
   opacity: 0;
   transform: translateX(8px);
   transition:
-    opacity 140ms ease,
+    opacity 140ms var(--ease-out-strong),
     transform 140ms var(--ease-out-strong);
   pointer-events: none;
 }
@@ -907,8 +907,8 @@
   padding: 10px 12px;
   text-align: left;
   transition:
-    border-color 140ms ease,
-    background 140ms ease,
+    border-color 140ms var(--ease-out-strong),
+    background 140ms var(--ease-out-strong),
     transform 140ms var(--ease-out-strong);
 }
 

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -46,7 +46,7 @@ export function TabsList({
       {children}
       <TabsPrimitive.Indicator
         className={cn(
-          "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-in-out",
+          "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-[var(--ease-in-out-strong)]",
           variant === "underline"
             ? "z-10 bg-control data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
             : "-z-1 rounded-md bg-background shadow-sm/5 dark:bg-input",

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -27,7 +27,7 @@ export { cn } from './utils.js';
 export const buttonVariants = cva(
   [
     'inline-flex shrink-0 items-center justify-center gap-2 rounded-sm font-medium',
-    'transition-[background,border-color,box-shadow,transform,opacity] duration-150 ease-[var(--ease-maka)]',
+    'transition-[background,border-color,box-shadow,transform,opacity] duration-150 ease-[var(--ease-out-strong)]',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
     'active:scale-[0.98] disabled:pointer-events-none disabled:opacity-45',
     '[&_svg]:size-[var(--icon-size,1rem)] [&_svg]:shrink-0',

--- a/packages/ui/stories/animation-catalog.stories.tsx
+++ b/packages/ui/stories/animation-catalog.stories.tsx
@@ -35,7 +35,7 @@ export const RetainedFunctionalMotion: Story = {
         <span
           aria-hidden="true"
           style={{
-            animation: 'maka-shimmer 1.8s linear infinite',
+            animation: 'maka-shimmer 1.8s var(--ease-linear) infinite',
             background:
               'linear-gradient(120deg, transparent 40%, oklch(from var(--foreground) l c h / 0.16), transparent 60%) var(--foreground-5) 0 0 / 200% 100%',
             borderRadius: 'var(--radius-surface)',


### PR DESCRIPTION
## Summary

Extend `motion-token-converge-contract.test.ts` to ban bare `ease`/`ease-in`/`ease-out`/`ease-in-out`/`ease-linear`/`linear` timing keywords, enforcing `var(--ease-*)` tokens. Fix the dead `--ease-maka` reference.

## Why

Closes #430 (PR1 motion)

maka's motion governance already had a half contract (locking the cubic-bezier curve + `transition: all`), but bare ease keywords kept slipping through. This PR closes that gap so all easing goes through the four tokens (`--ease-out-strong` / `--ease-in-out-strong` / `--ease-drawer` / `--ease-linear`), converging the same way radius did.

## Scope

Changed:
- New contract `it`: scan renderer CSS + maka-tokens.css + @maka/ui TSX, ban bare `ease`/`ease-in`/`ease-out`/`ease-in-out`/`ease-linear`/`linear` — no whitelist, no exemptions
- New `--ease-linear: linear` token (for infinite-loop functional animations: spinners, shimmer)
- Batch-replace ~200 bare ease keywords → `var(--ease-out-strong)` or `var(--ease-in-out-strong)`
- 2 real `linear` uses (spinner/shimmer) → `var(--ease-linear)`
- Fix dead reference `packages/ui/src/ui.tsx:30` `--ease-maka` → `--ease-out-strong`
- Update `chat-tool-card-cascade-contract.test.ts` assertion to match token usage
- Update `animation-catalog.stories.tsx`: status pulse → `var(--ease-in-out-strong)`, Easing Scale adds `--ease-linear` entry

Not included:
- Duration tokenization (140ms/160ms are tuned, untouched)
- Icon / typography / spacing governance (PR2/PR3)

## Verification

- `npm run -w @maka/desktop test`: 1663/1663 pass
- `npm run typecheck`: clean
- Motion contract test: 7/7 pass (including the new fixture `it` locking the review cases: `ease-linear` catch, same-line transition/animation `linear`, comma-separated animation item, `ease-in-out` single report)

## Reviewer notes

- The contract uses a single longest-match-first matcher (`ease-in-out | ease-linear | ease-in | ease-out | ease | linear`) via `matchAll`, so `ease-in-out` is reported once (not also as `ease-in`), and the Tailwind `ease-linear` class is caught explicitly.
- `--ease-linear: linear` is a token so infinite-loop animations don't need a whitelist. The declaration line is stripped before scanning (same pattern as `--ease-out-strong`).
- Two rounds of code review (Codex + human) confirmed the matcher has no bypass vectors after the `--ease-linear` token replaced the per-line/per-segment `infinite` whitelist.
