### PR TITLE
fix(desktop): remove stray parenthesis in chat-header.css

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -46,7 +46,7 @@
        the neighboring alert badge and toolbar icon buttons instead of
        towering over them. */
     padding: 1px 7px;
-    border-radius: var(--radius-pill);)
+    border-radius: var(--radius-pill);
     border: 1px solid transparent;
     font-size: 11px;
     font-weight: 600;


### PR DESCRIPTION
## Fix

Remove the stray trailing parenthesis in `.maka-chat-header-status`'s `border-radius` declaration in `apps/desktop/src/renderer/styles/chat-header.css`.

## Context

This syntax error was introduced in #418 (`689bd7ba`). It caused `@tailwindcss/vite` to throw:

Pre-transform error: Missing opening (

and prevented `npm run dev` from starting the desktop renderer.

## Verification

- `npm --workspace @maka/desktop test` ✅
- `npm --workspace @maka/desktop run build:renderer` ✅
- `npm --workspace @maka/desktop run typecheck` ✅

Related: #418