### PR TITLE
fix(desktop): compile renderer Tailwind styles

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-tailwind-compile-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-tailwind-compile-contract.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { compile } from 'tailwindcss';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const requireFromRepo = createRequire(resolve(REPO_ROOT, 'package.json'));
+const STYLES_ENTRY = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles.css');
+
+const CSS_EXPORT_ALIASES = new Map<string, string>([
+  ['tailwindcss', 'tailwindcss/index.css'],
+]);
+
+describe('renderer Tailwind CSS compile contract', () => {
+  it('compiles the renderer CSS entry and all imported CSS files', async () => {
+    const css = await readFile(STYLES_ENTRY, 'utf8');
+
+    await assert.doesNotReject(
+      () => compile(css, {
+        from: STYLES_ENTRY,
+        base: dirname(STYLES_ENTRY),
+        async loadStylesheet(id, base) {
+          const path = id.startsWith('.')
+            ? resolve(base, id)
+            : requireFromRepo.resolve(CSS_EXPORT_ALIASES.get(id) ?? id);
+          return {
+            path,
+            base: dirname(path),
+            content: await readFile(path, 'utf8'),
+          };
+        },
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -46,7 +46,7 @@
        the neighboring alert badge and toolbar icon buttons instead of
        towering over them. */
     padding: 1px 7px;
-    border-radius: var(--radius-pill);)
+    border-radius: var(--radius-pill);
     border: 1px solid transparent;
     font-size: 11px;
     font-weight: 600;


### PR DESCRIPTION
## Summary

Fix the desktop renderer Tailwind startup/build blocker by correcting a malformed chat-header CSS declaration and locking renderer CSS parsing with a Tailwind compile contract.

## Why

Tailwind 4.3.1 reports `Missing opening (` while compiling the renderer CSS entry when any imported CSS file has invalid syntax. In this case the failure came from an extra `)` in `chat-header.css`, which made Electron/Vite startup and renderer builds fail at the Tailwind CSS generation step.

Closes: none

## Scope

Changed:

- Removed the stray `)` from `.maka-chat-header-status`'s `border-radius` declaration.
- Added a main-process contract test that compiles `apps/desktop/src/renderer/styles.css` through Tailwind and resolves imported stylesheets.

Not included:

- No Tailwind, Vite, Node, or dependency changes.
- No topbar/native mouse hit-test changes.
- No visual redesign or unrelated CSS cleanup.

## Verification

- `npm --workspace @maka/desktop run build`
- `node --test "apps/desktop/dist/main/__tests__/renderer-tailwind-compile-contract.test.js"`

## User-facing impact

Desktop renderer builds and dev startup no longer fail on the Tailwind `Missing opening (` CSS parse error.

## Reviewer notes

The new contract targets the failure mode directly: Tailwind compiles the renderer CSS entry and all imported CSS files, so future syntax errors in split renderer styles fail in tests instead of only during Vite/Electron startup.
