### PR TITLE
fix(ui): keep first-run CTA above the fold; unsquash skills capability-audit strip

### DIFF
--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -271,7 +271,7 @@ function NeedsConnectionHero(props: {
             return (
               <li key={entry.type}>
                 <Item
-                  className="maka-firstrun-row px-3.5 py-3 rounded-none"
+                  className="maka-firstrun-row px-3.5 py-2 rounded-none"
                   render={
                     <button
                       type="button"

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1153,6 +1153,15 @@
   overflow: auto;
 }
 
+/* The skills module stacks THREE direct children (header, capability
+   audit strip, library) but the shared template only defines two rows,
+   so the strip landed in the minmax(0,1fr) row, collapsed to ~0 height,
+   and its caption bled over the banner below. Give any module main that
+   hosts the strip directly a third row. */
+.maka-module-main:has(> .maka-capability-audit-strip) {
+  grid-template-rows: auto auto minmax(0, 1fr);
+}
+
 .maka-module-main[data-module="daily-review"] {
   grid-template-rows: auto auto;
   align-content: start;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -64,6 +64,22 @@
   gap: 0;
 }
 
+/* PR-FIRSTRUN-FOLD-0: keep the primary CTA above the fold at the default
+   1280x800 window. Three stacked paddings (home-surface chatContent
+   clamp(72px,10vh,116px) + onboarding-stack clamp(40px,7vh,76px) + a 56vh
+   provider list) pushed the footer button below the viewport, so the very
+   first screen rendered a half-clipped CTA. First-run flattens the outer
+   padding stack; the other onboarding states keep their centered rhythm. */
+.mainColumn[data-home-surface="true"] .maka-chatContent:has(.maka-firstrun) {
+  padding-top: clamp(24px, 3.5vh, 44px);
+  align-content: start;
+}
+
+.maka-onboarding-stack:has(.maka-firstrun) {
+  min-height: 0;
+  padding-top: clamp(12px, 2vh, 24px);
+}
+
 /* PR-FRONTEND-AUDIT-CLEANUP-0 F1 (WAWQAQ msg `dde696a1`): the earlier
    `maka-agents-fade-in 150ms` block + nth-child delay ladder was
    completely overridden by the `maka-card-enter 280ms` block below,
@@ -185,7 +201,10 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  max-height: 56vh;
+  /* PR-FIRSTRUN-FOLD-0: 56vh let the list eat the CTA's room at short
+     windows. The clamp keeps all six compact rows visible at 800px-tall
+     windows while still bounding growth as more providers are added. */
+  max-height: clamp(240px, 42vh, 420px);
   overflow-y: auto;
 }
 .maka-firstrun-list li + li {


### PR DESCRIPTION
## Summary

Two visual-audit fixes from fresh 1280x800 fixture screenshot review (visual smoke pipeline):

### 1. first-run: primary CTA rendered half-clipped below the fold
Three stacked paddings — home-surface `.maka-chatContent` `clamp(72px,10vh,116px)` + `.maka-onboarding-stack` `clamp(40px,7vh,76px)` + a `56vh` provider list — pushed the 「打开设置 · 模型」 button below the viewport. The very first screen a new user sees showed a half-cut button with no scroll affordance.

Fix (scoped to `.maka-firstrun` only, other onboarding states keep their centered rhythm):
- flatten the outer padding stack via `:has(.maka-firstrun)` overrides
- bound the provider list at `clamp(240px, 42vh, 420px)`
- compress provider rows `py-3` → `py-2`

All six providers plus the CTA now fit at the default window size.

### 2. module-skills: capability-audit strip squashed to ~0 height
`.maka-module-main` defines two grid rows (`auto minmax(0,1fr)`) but the skills page stacks **three** direct children (header / audit strip / library). The strip landed in the `minmax(0,1fr)` row, collapsed, and its caption bled over the banner below. The 定时任务 page was unaffected because its strip nests inside `.maka-plan-panel`.

Fix: `.maka-module-main:has(> .maka-capability-audit-strip)` gets `auto auto minmax(0,1fr)`.

## Verification
- before/after fixture screenshots reviewed (first-run + module-skills, light-1280)
- `npm --workspace @maka/desktop test`: 1671/1671 pass
- `:has()` has existing precedent in renderer CSS (sidebar.css:874, daily-review.css:471)