### PR TITLE
refactor(ui): converge font-size to two-tier token scale (#430 PR2)

### DIFF
--- a/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
@@ -1,0 +1,160 @@
+/**
+ * PR-TYPOGRAPHY-CONVERGE-0 (issue #430 PR2, 2026-07-03):
+ * lock the typography vocabulary so individual PRs can't silently drift
+ * back to ad-hoc font-size values.
+ *
+ * Three invariants:
+ *
+ * 1. CSS `font-size` must reference a whitelisted `--font-size-*` token,
+ *    use `em` (relative scaling off the 15px root), or be a literal
+ *    (`inherit` / `initial` / `0`). Bare `Npx` and `Nrem` drift visually
+ *    and bypass the three-tier scale.
+ *
+ * 2. `--font-size-{base,ui,caption}` tokens are defined in `maka-tokens.css`
+ *    with pinned values (15 / 13 / 11). A rename or value change gets
+ *    flagged at the test layer before any styles site drifts.
+ *
+ * 3. Tailwind `--text-{xs,sm,base}` aliases in `styles.css` `@theme inline`
+ *    map to the token scale so TSX `text-*` utilities stay single-sourced
+ *    with hand-written CSS.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+// --- token whitelist --------------------------------------------------------
+
+const FONT_SIZE_TOKEN_WHITELIST = new Set([
+  '--font-size-base',
+  '--font-size-ui',
+  '--font-size-caption',
+]);
+
+const BARE_PX_RE = /font-size:\s*\d+(?:\.\d+)?px\b/gi;
+const BARE_REM_RE = /font-size:\s*\d+(?:\.\d+)?rem\b/gi;
+
+/** Allowed em values — relative scaling off the 15px root. Any em is OK
+ *  (headings, inline code, display titles all use em legitimately). */
+const EM_RE = /font-size:\s*\d+(?:\.\d+)?em\b/gi;
+
+const LITERAL_OK = /^(?:inherit|initial|0)$/;
+
+function extractFontSizeValue(decl: string): string {
+  return decl.replace(/^font-size:\s*/i, '').replace(/;$/, '').trim();
+}
+
+// --- CSS scanning -----------------------------------------------------------
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+
+  // Find every font-size declaration
+  const decls = [...stripped.matchAll(/font-size:\s*[^;}\n]+/gi)];
+  for (const m of decls) {
+    const raw = m[0].trim();
+    const value = extractFontSizeValue(raw);
+
+    // Allowed: var(--font-size-*)
+    if (/^var\(\s*--font-size-[\w-]+\s*\)$/.test(value)) {
+      const tok = value.match(/^var\(\s*(--font-size-[\w-]+)\s*\)$/)?.[1];
+      if (tok && FONT_SIZE_TOKEN_WHITELIST.has(tok)) continue;
+      offenders.push(`${label}: ${raw} (unknown token)`);
+      continue;
+    }
+
+    // Allowed: em values (relative scaling)
+    if (/^\d+(?:\.\d+)?em$/.test(value)) continue;
+
+    // Allowed: literals
+    if (LITERAL_OK.test(value)) continue;
+
+    // Everything else is a violation
+    offenders.push(`${label}: ${raw}`);
+  }
+
+  return offenders;
+}
+
+// === tests ==================================================================
+
+describe('PR-TYPOGRAPHY-CONVERGE-0 contract', () => {
+  it('CSS uses only whitelisted --font-size-* tokens, em, or literals (no bare Npx/Nrem)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css uses only whitelisted --font-size-* tokens, em, or literals', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    // Strip the token declaration lines themselves (they legitimately spell px)
+    const stripped = tokens
+      .replace(/^\s*--font-size-base:\s*15px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-ui:\s*13px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-caption:\s*11px\s*;?\s*$/gm, '');
+    const offenders = findCssOffenders(stripped, 'maka-tokens.css');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--font-size-{base,ui,caption} tokens are defined with pinned values', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--font-size-base:\s*15px/, '--font-size-base must be 15px');
+    assert.match(tokens, /--font-size-ui:\s*13px/, '--font-size-ui must be 13px');
+    assert.match(tokens, /--font-size-caption:\s*11px/, '--font-size-caption must be 11px');
+  });
+
+  it('Tailwind --text-{xs,sm,base} aliases map to --font-size-* tokens in @theme inline', async () => {
+    const styles = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles.css'), 'utf8');
+    assert.match(styles, /--text-xs:\s*var\(--font-size-caption\)/, '--text-xs must alias --font-size-caption');
+    assert.match(styles, /--text-sm:\s*var\(--font-size-ui\)/, '--text-sm must alias --font-size-ui');
+    assert.match(styles, /--text-base:\s*var\(--font-size-base\)/, '--text-base must alias --font-size-base');
+  });
+
+  it('no bare Npx/Nrem font-size remains in the full CSS import chain', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const combined = css + '\n' + tokens;
+
+    // Strip the token declaration lines
+    const stripped = combined
+      .replace(/^\s*--font-size-base:\s*15px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-ui:\s*13px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-caption:\s*11px\s*;?\s*$/gm, '');
+
+    const barePx = stripped.match(BARE_PX_RE) ?? [];
+    const bareRem = stripped.match(BARE_REM_RE) ?? [];
+    const total = barePx.length + bareRem.length;
+    assert.equal(
+      total,
+      0,
+      `Found ${total} bare px/rem font-size value(s). Use var(--font-size-*), em, or a literal.\n  px: ${barePx.join(', ')}\n  rem: ${bareRem.join(', ')}`,
+    );
+  });
+});
+
+describe('typography whitelist negative cases', () => {
+  it('rejects typos and private tokens in var()', () => {
+    const offenders = findCssOffenders('font-size: var(--font-size-mata)', 'test');
+    assert.ok(offenders.length > 0, 'typo must fail');
+    const offenders2 = findCssOffenders('font-size: var(--font-size-private)', 'test');
+    assert.ok(offenders2.length > 0, 'private token must fail');
+  });
+
+  it('accepts valid tokens, em, and literals', () => {
+    assert.deepEqual(findCssOffenders('font-size: var(--font-size-ui)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-size: var(--font-size-base)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-size: var(--font-size-caption)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-size: 1.2em', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-size: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-size: 0', 'test'), []);
+  });
+
+  it('rejects bare px and rem', () => {
+    assert.ok(findCssOffenders('font-size: 12px', 'test').length > 0, 'bare px must fail');
+    assert.ok(findCssOffenders('font-size: 0.75rem', 'test').length > 0, 'bare rem must fail');
+    assert.ok(findCssOffenders('font-size: 12.5px', 'test').length > 0, 'half-pixel px must fail');
+  });
+});

--- a/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
@@ -33,13 +33,6 @@ const FONT_SIZE_TOKEN_WHITELIST = new Set([
   '--font-size-caption',
 ]);
 
-const BARE_PX_RE = /font-size:\s*\d+(?:\.\d+)?px\b/gi;
-const BARE_REM_RE = /font-size:\s*\d+(?:\.\d+)?rem\b/gi;
-
-/** Allowed em values — relative scaling off the 15px root. Any em is OK
- *  (headings, inline code, display titles all use em legitimately). */
-const EM_RE = /font-size:\s*\d+(?:\.\d+)?em\b/gi;
-
 const LITERAL_OK = /^(?:inherit|initial|0)$/;
 
 function extractFontSizeValue(decl: string): string {
@@ -111,27 +104,6 @@ describe('PR-TYPOGRAPHY-CONVERGE-0 contract', () => {
     assert.match(styles, /--text-xs:\s*var\(--font-size-caption\)/, '--text-xs must alias --font-size-caption');
     assert.match(styles, /--text-sm:\s*var\(--font-size-ui\)/, '--text-sm must alias --font-size-ui');
     assert.match(styles, /--text-base:\s*var\(--font-size-base\)/, '--text-base must alias --font-size-base');
-  });
-
-  it('no bare Npx/Nrem font-size remains in the full CSS import chain', async () => {
-    const css = stripCssComments(await readAllRendererCss());
-    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
-    const combined = css + '\n' + tokens;
-
-    // Strip the token declaration lines
-    const stripped = combined
-      .replace(/^\s*--font-size-base:\s*15px\s*;?\s*$/gm, '')
-      .replace(/^\s*--font-size-ui:\s*13px\s*;?\s*$/gm, '')
-      .replace(/^\s*--font-size-caption:\s*11px\s*;?\s*$/gm, '');
-
-    const barePx = stripped.match(BARE_PX_RE) ?? [];
-    const bareRem = stripped.match(BARE_REM_RE) ?? [];
-    const total = barePx.length + bareRem.length;
-    assert.equal(
-      total,
-      0,
-      `Found ${total} bare px/rem font-size value(s). Use var(--font-size-*), em, or a literal.\n  px: ${barePx.join(', ')}\n  rem: ${bareRem.join(', ')}`,
-    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
@@ -39,6 +39,11 @@ function extractFontSizeValue(decl: string): string {
   return decl.replace(/^font-size:\s*/i, '').replace(/;$/, '').trim();
 }
 
+/** Bare px/rem inside `font:` shorthand, e.g. `font: 12px/1.4 var(--font-sans)`.
+ *  Catches the shorthand bypass that `font-size:` scanning misses. */
+const FONT_SHORTHAND_PX_RE = /\bfont:\s*[^;}\n]*\d+(?:\.\d+)?px\b/gi;
+const FONT_SHORTHAND_REM_RE = /\bfont:\s*[^;}\n]*\d+(?:\.\d+)?rem\b/gi;
+
 // --- CSS scanning -----------------------------------------------------------
 
 function findCssOffenders(css: string, label: string): string[] {
@@ -67,6 +72,13 @@ function findCssOffenders(css: string, label: string): string[] {
 
     // Everything else is a violation
     offenders.push(`${label}: ${raw}`);
+  }
+
+  // Catch `font:` shorthand with bare px/rem size — bypasses font-size scanning
+  for (const re of [FONT_SHORTHAND_PX_RE, FONT_SHORTHAND_REM_RE]) {
+    for (const m of stripped.matchAll(re)) {
+      offenders.push(`${label}: ${m[0].trim()}`);
+    }
   }
 
   return offenders;
@@ -128,5 +140,15 @@ describe('typography whitelist negative cases', () => {
     assert.ok(findCssOffenders('font-size: 12px', 'test').length > 0, 'bare px must fail');
     assert.ok(findCssOffenders('font-size: 0.75rem', 'test').length > 0, 'bare rem must fail');
     assert.ok(findCssOffenders('font-size: 12.5px', 'test').length > 0, 'half-pixel px must fail');
+  });
+
+  it('rejects bare px/rem inside font: shorthand', () => {
+    assert.ok(findCssOffenders('font: 12px/1.4 var(--font-sans)', 'test').length > 0, 'shorthand px must fail');
+    assert.ok(findCssOffenders('font: 0.875rem sans-serif', 'test').length > 0, 'shorthand rem must fail');
+  });
+
+  it('accepts font: inherit and font: initial', () => {
+    assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -233,8 +233,19 @@
   --font-mono: "Geist Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
   --font-default: var(--font-sans);
 
-  /* === layout === */
+  /* === typography ===
+     PR-TYPOGRAPHY-CONVERGE-0 (issue #430 PR2, 2026-07-03):
+     three-tier scale. Body 15 is the root (html font-size); UI 13 is the
+     chrome/control tier (sidebar rows, labels, buttons, form fields);
+     caption 11 is dense meta (timestamps, badges, kbd, overlines).
+     9/10/10.5/11/11.5px and sub-0.8rem collapse to caption;
+     12/12.5/13/13.5/14px and 0.8-0.95rem collapse to ui.
+     Bubble h1-h4 scale in em off body 15 so they track the root automatically. */
   --font-size-base: 15px;
+  --font-size-ui: 13px;
+  --font-size-caption: 11px;
+
+  /* === layout === */
   --radius: 0rem;
   --radius-control: 6px;
   --radius-surface: 8px;
@@ -788,7 +799,7 @@
     align-items: center;
     gap: 4px;
     padding: 2px 8px;
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
     font-weight: 500;
     color: var(--foreground-80);
     background: var(--foreground-5);
@@ -842,7 +853,7 @@
     justify-content: space-between;
     border-bottom: 1px solid var(--border);
     font-weight: 600;
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     letter-spacing: 0.02em;
     text-transform: uppercase;
     color: var(--foreground-60);
@@ -857,7 +868,7 @@
     padding: 6px 10px;
     border-radius: var(--radius-control);
     color: var(--foreground-80);
-    font-size: 14px;
+    font-size: var(--font-size-ui);
     line-height: 1.4;
     user-select: none;
     transition: background 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong);
@@ -883,7 +894,7 @@
     padding: 4px 8px;
     border-radius: var(--radius-control);
     color: var(--foreground-60);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
   .maka-sidebar-button:hover { background: var(--hover); color: var(--foreground); }
 
@@ -902,7 +913,7 @@
     align-items: center;
     gap: 12px;
     padding: 0 16px;
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-70);
   }
   .maka-titlebar strong { color: var(--foreground); font-weight: 500; }
@@ -976,7 +987,7 @@
     border: 1px dashed oklch(from var(--focus-ring) l c h / 0.25);
     border-radius: var(--radius-surface);
     background: oklch(from var(--focus-ring) l c h / 0.03);
-    font-size: 12.5px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-70);
   }
 
@@ -1012,7 +1023,7 @@
   }
 
   .maka-turn-thinking-note {
-    font-size: 10px;
+    font-size: var(--font-size-caption);
     font-weight: 500;
     letter-spacing: 0.04em;
     color: var(--foreground-50);
@@ -1156,10 +1167,10 @@
   .maka-bubble-assistant code {
     font-variant-numeric: tabular-nums;
   }
-  .maka-bubble-assistant h1 { font-size: 22px; }
-  .maka-bubble-assistant h2 { font-size: 19px; }
-  .maka-bubble-assistant h3 { font-size: 16px; }
-  .maka-bubble-assistant h4 { font-size: 14px; color: var(--foreground-80); }
+  .maka-bubble-assistant h1 { font-size: 1.4667em; }
+  .maka-bubble-assistant h2 { font-size: 1.2667em; }
+  .maka-bubble-assistant h3 { font-size: 1.0667em; }
+  .maka-bubble-assistant h4 { font-size: 0.9333em; color: var(--foreground-80); }
   .maka-bubble-assistant ul,
   .maka-bubble-assistant ol {
     margin: 0 0 12px;
@@ -1220,7 +1231,7 @@
     background: var(--foreground-5);
     color: var(--foreground-60);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     letter-spacing: 0.02em;
   }
   .maka-code-block-lang {
@@ -1270,7 +1281,7 @@
     background: transparent;
     overflow-x: auto;
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
     white-space: pre;
   }
@@ -1335,7 +1346,7 @@
     width: 100%;
     margin: 0 0 12px;
     border-collapse: collapse;
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     overflow: hidden;
     /* PR-UI-LAYOUT-28: table radius 8 → 10 joins the card family,
      * and a hairline outer border gives the table chrome a clean
@@ -1419,7 +1430,7 @@
     align-items: center;
     gap: 6px;
     padding: 3px 8px;
-    font-size: 10.5px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     opacity: 1;
     background: transparent;
@@ -1579,7 +1590,7 @@
     background: transparent;
     color: var(--foreground);
     font-family: var(--font-default);
-    font-size: 15px;
+    font-size: var(--font-size-base);
     line-height: 1.5;
     min-height: var(--h-composer-min);
     max-height: 240px;
@@ -1603,7 +1614,7 @@
     justify-content: space-between;
     gap: 8px;
     color: var(--foreground-60);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
   }
 
   /* ---- Buttons ---------------------------------------------------- */
@@ -1620,7 +1631,7 @@
     color: var(--foreground);
     padding: 7px 14px;
     border-radius: var(--radius-control);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-weight: 500;
     line-height: 1.2;
     transition: background 120ms var(--ease-out-strong), border-color 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), transform 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
@@ -1667,13 +1678,13 @@
     border-bottom: 1px solid var(--border);
   }
   .maka-modal-title {
-    font-size: 15px;
+    font-size: var(--font-size-base);
     font-weight: 600;
     color: var(--foreground);
     letter-spacing: 0;
   }
   .maka-modal-subtitle {
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-60);
     margin-top: 2px;
   }
@@ -1702,7 +1713,7 @@
 
   .maka-code {
     font-family: var(--font-mono);
-    font-size: 12.5px;
+    font-size: var(--font-size-ui);
     background: var(--foreground-3);
     border: 1px solid var(--border);
     border-radius: var(--radius-surface);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -64,5 +64,10 @@
   --radius-md: var(--radius-surface);
   --radius-lg: var(--radius-surface);
   --radius-xl: var(--radius-modal);
+
+  --text-xs: var(--font-size-caption);
+  --text-sm: var(--font-size-ui);
+  --text-base: var(--font-size-base);
+
   --shadow-maka-panel: 0 0 0 1px var(--border), 0 1px 2px rgba(15, 23, 42, 0.04), 0 14px 40px rgba(15, 23, 42, 0.08);
 }

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -7,7 +7,7 @@
     margin-bottom: 3px;
     border-radius: var(--radius-pill);
     border: 1px solid transparent;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0.02em;
     white-space: nowrap;
@@ -48,7 +48,7 @@
     padding: 1px 7px;
     border-radius: var(--radius-pill);
     border: 1px solid transparent;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     line-height: 1.4;
     /* Spacing from neighboring badges comes from the parent
@@ -192,14 +192,14 @@
   .maka-error-copy h2 {
     margin: 0;
     color: var(--foreground);
-    font-size: 14px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
 
   .maka-error-copy p {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
     max-width: 56ch;
   }
@@ -214,7 +214,7 @@
     color: var(--foreground-80);
     overflow: auto;
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--font-size-caption);
     line-height: 1.5;
     white-space: pre-wrap;
     word-break: break-word;
@@ -258,7 +258,7 @@
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 
@@ -356,14 +356,14 @@
 
 .maka-toast-copy strong {
   color: var(--foreground);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   text-wrap: balance;
 }
 
 .maka-toast-copy small {
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   line-height: 1.4;
   text-wrap: pretty;
 }
@@ -375,7 +375,7 @@
   background: var(--background);
   color: var(--toast-accent);
   padding: 3px 9px;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
@@ -452,7 +452,7 @@
   gap: 4px;
   margin-bottom: 4px;
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -468,7 +468,7 @@
 .maka-help-section h3 {
   margin: 0 0 4px;
   color: var(--foreground-70);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -487,7 +487,7 @@
 
 .maka-help-section dt {
   color: var(--foreground-80);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
@@ -507,7 +507,7 @@
 
 .maka-help-plus {
   color: var(--foreground-40);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-palette-backdrop {
@@ -549,7 +549,7 @@
 
 .maka-palette-input {
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
   -webkit-user-select: text;
   user-select: text;
@@ -564,7 +564,7 @@
   align-items: center;
   gap: 6px;
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   white-space: nowrap;
 }
 
@@ -588,7 +588,7 @@
   box-shadow: inset 0 1px 0 oklch(from var(--background) l c h / 0.45);
   color: var(--foreground-60);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
 }
@@ -616,7 +616,7 @@
 .maka-palette-group-label {
   padding: 4px 8px 3px;
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -636,7 +636,7 @@
   color: var(--foreground);
   padding: 5px 8px;
   text-align: left;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   cursor: default;
   transform: translateY(0);
   transition:
@@ -716,7 +716,7 @@
   align-items: center;
   gap: 4px;
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
@@ -737,7 +737,7 @@
   border-top: 1px solid var(--border);
   background: var(--foreground-2);
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-palette-footer .maka-shortcut-group,
@@ -752,7 +752,7 @@
 .maka-palette-footer .maka-shortcut-kbd {
   padding: 1px 5px;
   background: var(--background);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 /* PR-UI-1 (@yuejing 2026-05-22): unified hero chrome.

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -21,7 +21,7 @@
     border-radius: var(--radius-modal);
     background: var(--foreground-3);
     color: var(--foreground-50);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     line-height: 1;
     white-space: nowrap;
@@ -65,7 +65,7 @@
     border: 4px solid oklch(from var(--brand-deep) l c h / 0.12);
     background: oklch(0.93 0.035 70);
     color: var(--foreground);
-    font-size: 22px;
+    font-size: 1.4667em;
     font-weight: 700;
   }
 
@@ -74,7 +74,7 @@
     align-items: center;
     gap: 6px;
     color: var(--brand-deep);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -90,7 +90,7 @@
        tracking + setting font-variation-settings wdth 105 gives the
        hero the same "wider, slightly heavier, optically distinct from
        chrome" feel without adding a second variable font asset. */
-    font-size: 32px;
+    font-size: 2.1333em;
     font-weight: 550;
     letter-spacing: -0.018em;
     line-height: 1.1;
@@ -102,7 +102,7 @@
     margin: 0;
     max-width: 54ch;
     color: var(--foreground-60);
-    font-size: 14.5px;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
     text-wrap: pretty;
   }
@@ -114,7 +114,7 @@
     }
 
     .maka-hero-bubble {
-      font-size: 11px;
+      font-size: var(--font-size-caption);
       padding-inline: 10px;
     }
 

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -72,7 +72,7 @@
   background: transparent;
   color: var(--foreground-50);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.25;
   text-align: left;
   transition: color var(--duration-quick) var(--ease-out-strong);
@@ -115,7 +115,7 @@
   align-items: center;
   gap: 8px;
   color: var(--foreground-70);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 /* Streaming indicator — 3-dot typing pattern (the center dot is the
@@ -228,7 +228,7 @@
   gap: 5px;
   margin-top: 10px;
   color: var(--foreground-70);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 /* PR30 Permission dialog: per-reason iconography + per-tool summary block */
@@ -269,7 +269,7 @@
 
 .maka-permission-tool {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   padding: 0 5px;
   border-radius: var(--radius-control);
   background: var(--foreground-5);
@@ -279,7 +279,7 @@
 
 .maka-permission-age {
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   white-space: nowrap;
 }
 
@@ -304,7 +304,7 @@
 .maka-permission-line {
   margin: 0;
   color: var(--foreground-80);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-permission-path {
@@ -313,7 +313,7 @@
 
 .maka-permission-path code {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   padding: 1px 5px;
   border-radius: var(--radius-control);
   background: var(--foreground-5);
@@ -331,7 +331,7 @@
 .maka-permission-meta {
   margin: 0;
   color: var(--foreground-60);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-permission-hint {
@@ -339,7 +339,7 @@
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
   padding: 6px 10px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.4;
 }
 
@@ -349,7 +349,7 @@
 .maka-permission-danger-note {
   margin: 0;
   color: var(--destructive);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   font-weight: 600;
 }

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -41,7 +41,7 @@
 
   .maka-daily-review-info-body {
     margin: 0;
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
     color: var(--foreground-80);
   }
@@ -53,7 +53,7 @@
 
   .maka-daily-review-info-hint {
     margin: 0;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.5;
     color: var(--foreground-50);
   }
@@ -85,7 +85,7 @@
 }
 
 .maka-daily-review-quick-run {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   white-space: nowrap;
 }
 
@@ -109,7 +109,7 @@
   }
 
   .maka-daily-review-archive-count {
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     color: var(--foreground-40);
     font-variant-numeric: tabular-nums;
   }
@@ -168,7 +168,7 @@
 @layer components {
   .maka-daily-review-archive-row-title {
     color: var(--foreground);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -177,7 +177,7 @@
 
   .maka-daily-review-archive-row-meta {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-variant-numeric: tabular-nums;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -198,7 +198,7 @@
   .maka-daily-review-archive-body[data-empty="true"],
   .maka-daily-review-archive-empty {
     color: var(--foreground-50);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 
@@ -212,7 +212,7 @@
   .maka-daily-review-archive-body-header h4 {
     margin: 0;
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     letter-spacing: 0;
   }
@@ -220,7 +220,7 @@
   .maka-daily-review-archive-body-header p {
     margin: 2px 0 0;
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.45;
     overflow-wrap: anywhere;
   }
@@ -230,7 +230,7 @@
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-pill);
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1;
     padding: 4px 7px;
     white-space: nowrap;
@@ -250,7 +250,7 @@
   .maka-daily-review-archive-error {
     margin: 0;
     color: var(--destructive, var(--foreground));
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 
@@ -267,7 +267,7 @@
   .maka-daily-review-archive-section h5 {
     margin: 0;
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0;
   }
@@ -275,7 +275,7 @@
   .maka-daily-review-archive-section p {
     margin: 0;
     color: var(--foreground-80);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.6;
     overflow-wrap: anywhere;
     white-space: pre-wrap;
@@ -284,7 +284,7 @@
   .maka-daily-review-day {
     text-align: center;
     font-weight: 600;
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.005em;
     color: var(--foreground);
@@ -314,13 +314,13 @@
 
 .maka-daily-review-range-tab {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-daily-review-copy,
 .maka-daily-review-append,
 .maka-daily-review-save {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   white-space: nowrap;
 }
 
@@ -341,7 +341,7 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning, var(--info)) l c h / 0.08);
     color: var(--warning-text, var(--foreground));
-    font-size: 12px;
+    font-size: var(--font-size-ui);
   }
 
   .maka-daily-review-alert > span {
@@ -351,7 +351,7 @@
 
 .maka-daily-review-alert-retry {
   flex: none;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 @media (max-width: 720px) {
@@ -391,14 +391,14 @@
   }
 
   .maka-daily-review-totals-value {
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
     font-variant-numeric: tabular-nums;
   }
 
   .maka-daily-review-totals-label {
-    font-size: 10px;
+    font-size: var(--font-size-caption);
     text-transform: none;
     letter-spacing: 0;
     color: var(--foreground-50);
@@ -428,7 +428,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    font-size: 10px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -510,13 +510,13 @@
 
   .maka-daily-review-session-time {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
   }
 
   .maka-daily-review-session-preview {
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-50);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -529,7 +529,7 @@
   }
 
   .maka-daily-review-top-meta {
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
     font-variant-numeric: tabular-nums;
   }

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -26,13 +26,13 @@
   }
   .settingsHealthIntro h3 {
     margin: 0 0 6px;
-    font-size: 0.95rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
   .settingsHealthIntro p {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 0.85rem;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 60ch;
   }
@@ -48,7 +48,7 @@
   }
   .settingsHealthMeta small {
     color: var(--foreground-60);
-    font-size: 0.75rem;
+    font-size: var(--font-size-caption);
   }
 }
 
@@ -61,7 +61,7 @@
   border-radius: var(--radius-control);
   padding: 4px 10px;
   color: var(--foreground-80);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-ui);
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
 .settingsHealthRefresh:hover {
@@ -86,11 +86,11 @@
     color: var(--destructive-text);
   }
   .settingsHealthError strong {
-    font-size: 0.9rem;
+    font-size: var(--font-size-ui);
   }
   .settingsHealthError small {
     color: var(--foreground-70);
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
   }
   .settingsHealthError button {
     align-self: flex-start;
@@ -119,12 +119,12 @@
     background: var(--background);
   }
   .settingsHealthSummaryTile strong {
-    font-size: 1.4rem;
+    font-size: 1.4em;
     font-weight: 600;
     line-height: 1.1;
   }
   .settingsHealthSummaryTile small {
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
@@ -173,13 +173,13 @@
   }
   .settingsHealthLayer > header h4 {
     margin: 0 0 2px;
-    font-size: 0.875rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
   }
   .settingsHealthLayer > header small {
     color: var(--foreground-60);
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
   }
 
   .settingsHealthSignalList {
@@ -222,23 +222,23 @@
     gap: 2px;
   }
   .settingsHealthSignalHeading strong {
-    font-size: 0.875rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
   .settingsHealthSignalScope {
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
     letter-spacing: 0.04em;
   }
 
   .settingsHealthSignalMessage {
     margin: 0;
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
     color: var(--foreground-80);
     line-height: 1.5;
   }
   .settingsHealthSignalDetail {
-    font-size: 0.76rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-60);
     line-height: 1.45;
   }
@@ -248,7 +248,7 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 10px;
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
   .settingsHealthSignalMeta code {
@@ -259,7 +259,7 @@
     color: var(--foreground-70);
   }
   .settingsHealthSignalBlocker {
-    font-size: 0.7rem;
+    font-size: var(--font-size-caption);
     padding: 1px 8px;
     border-radius: var(--radius-pill);
     border: 1px solid var(--border);
@@ -282,7 +282,7 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     color: var(--foreground-60);
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
     line-height: 1.55;
   }
 }

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -53,7 +53,7 @@
 .maka-plan-eyebrow {
   margin: 0;
   color: var(--foreground-40);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
 }
@@ -61,7 +61,7 @@
 .maka-plan-heading h2 {
   margin: 0;
   color: var(--foreground);
-  font-size: 30px;
+  font-size: 2em;
   font-weight: 600;
   letter-spacing: -0.012em;
   line-height: 1.15;
@@ -70,7 +70,7 @@
 .maka-plan-heading p:last-child {
   margin: 0;
   color: var(--foreground-60);
-  font-size: 13.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }
 
@@ -88,7 +88,7 @@
   color: var(--foreground);
   border-color: transparent;
   border-radius: var(--radius-pill);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -104,7 +104,7 @@
     inset 0 1px 0 oklch(1 0 0 / 0.15),
     0 1px 2px oklch(0 0 0 / 0.10);
   color: oklch(1 0 0);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
@@ -189,7 +189,7 @@
   grid-row: 1;
   justify-self: end;
   color: var(--foreground-40);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   letter-spacing: 1px;
   line-height: 20px;
 }
@@ -247,13 +247,13 @@
 
 .maka-plan-template-title {
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   line-height: 1.2;
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-title {
-  font-size: 15px;
+  font-size: var(--font-size-base);
   line-height: 1.3;
 }
 
@@ -262,7 +262,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   line-height: 1.35;
 }
@@ -273,7 +273,7 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 
@@ -286,7 +286,7 @@
   border-radius: var(--radius-pill);
   background: var(--foreground-2);
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
   padding: 3px 6px;
@@ -358,7 +358,7 @@
 .maka-plan-system-alert-switch {
   flex: 0 0 auto;
   color: oklch(0.38 0.075 245);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -395,7 +395,7 @@
 
 .maka-capability-audit-kicker {
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 700;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -403,14 +403,14 @@
 
 .maka-capability-audit-copy strong {
   color: var(--foreground);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
   line-height: 1.25;
 }
 
 .maka-capability-audit-copy small {
   color: var(--foreground-60);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.45;
 }
@@ -433,7 +433,7 @@
 
 .maka-capability-audit-metrics dt {
   color: var(--foreground-40);
-  font-size: 9px;
+  font-size: var(--font-size-caption);
   font-weight: 700;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -442,7 +442,7 @@
 .maka-capability-audit-metrics dd {
   margin: 0;
   color: var(--foreground-80);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 700;
   line-height: 1.3;
   overflow-wrap: anywhere;
@@ -478,7 +478,7 @@
   border-radius: 0;
   background: transparent;
   color: var(--foreground-40);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -504,7 +504,7 @@
 
 .maka-plan-tab span {
   color: var(--foreground-40);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
 }
 
@@ -650,7 +650,7 @@
 .maka-plan-form-title {
   margin: 0;
   color: var(--foreground);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   line-height: 1.2;
 }
@@ -665,7 +665,7 @@
   display: grid;
   gap: 3px;
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -677,7 +677,7 @@
   background: var(--background);
   color: var(--foreground);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   padding: 7px 8px;
   outline: none;
@@ -698,7 +698,7 @@
 
 .maka-plan-preset {
   min-width: 0;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -715,7 +715,7 @@
   border-radius: var(--radius-control);
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground-80);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.4;
   padding: 4px 8px;
@@ -730,7 +730,7 @@
 .maka-plan-delivery-help {
   margin: 0;
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   line-height: 1.4;
 }
@@ -744,7 +744,7 @@
   display: grid;
   gap: 4px;
   color: var(--foreground-60);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -781,7 +781,7 @@
   background: var(--background);
   color: var(--foreground);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   outline: none;
   padding: 7px 8px;
@@ -804,7 +804,7 @@
   height: 34px;
   justify-content: space-between;
   border-radius: var(--radius-control);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -869,7 +869,7 @@
 .settingsSelectMenuOption {
   display: block;
   color: var(--foreground);
-  font-size: 0.875rem; /* text-sm on the 15px root — same scale as headings */
+  font-size: var(--font-size-ui); /* text-sm on the 15px root — same scale as headings */
   font-weight: 500;
   line-height: 1.4;
 }
@@ -883,7 +883,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px 4px;
-  font-size: 0.875rem;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   line-height: 1.4;
   color: var(--muted-foreground);
@@ -911,7 +911,7 @@
   justify-content: space-between;
   gap: 6px;
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -938,7 +938,7 @@
   margin: 0;
   min-width: 0;
   color: var(--foreground);
-  font-size: 15.5px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   line-height: 1.3;
   overflow: hidden;
@@ -975,7 +975,7 @@
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--foreground-60);
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
   padding: 3px 8px;
@@ -996,7 +996,7 @@
   background: oklch(from var(--nav-active) l c h / 0.10);
   color: var(--nav-active);
   font-weight: 600;
-  font-size: 9px;
+  font-size: var(--font-size-caption);
   letter-spacing: 0;
 }
 
@@ -1004,7 +1004,7 @@
    description), replacing the single-line ellipsis used by the old row layout. */
 .maka-plan-card-note {
   color: var(--foreground-60);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   margin: 0;
   padding: 0;
@@ -1030,7 +1030,7 @@
   border-radius: var(--radius-pill);
   background: var(--foreground-3);
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   padding: 2px 6px;
 }
@@ -1054,7 +1054,7 @@
 
 .maka-plan-run-main strong {
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1063,7 +1063,7 @@
 .maka-plan-run-main span,
 .maka-plan-run-row time {
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   line-height: 1.35;
 }
 
@@ -1184,7 +1184,7 @@
 .maka-module-main-header h2 {
   margin: 0;
   color: var(--foreground);
-  font-size: 30px;
+  font-size: 2em;
   font-weight: 600;
   letter-spacing: -0.012em;
   line-height: 1.15;
@@ -1193,7 +1193,7 @@
 .maka-module-main-header p {
   margin: 4px 0 0;
   color: var(--foreground-60);
-  font-size: 13.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }
 
@@ -1250,7 +1250,7 @@
   box-shadow: none !important;
   outline: none;
   padding: 0;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   --tw-ring-shadow: 0 0 #0000 !important;
   --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
@@ -1273,7 +1273,7 @@
     inset 0 1px 0 #ffffff26,
     0 1px 2px #0c0c0d1a;
   color: #fff;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -1333,7 +1333,7 @@
 .maka-skill-featured-banner h3 {
   margin: 0;
   color: oklch(0.26 0.025 224);
-  font-size: 18px;
+  font-size: 1.2em;
   font-weight: 600;
   line-height: 1.25;
 }
@@ -1342,7 +1342,7 @@
   max-width: 540px;
   margin: 10px 0 0;
   color: oklch(0.42 0.02 220);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }
 
@@ -1379,15 +1379,15 @@
 }
 
 .maka-skill-featured-art strong {
-  color: oklch(0.34 0.02 224);
-  font-size: 10px;
+color: oklch(0.34 0.02 224);
+  font-size: var(--font-size-caption);
   font-weight: 650;
   line-height: 1.1;
 }
 
 .maka-skill-featured-art small {
-  color: oklch(0.55 0.015 220);
-  font-size: 8px;
+color: oklch(0.55 0.015 220);
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.1;
 }
@@ -1447,7 +1447,7 @@
   border-radius: 0;
   background: transparent;
   color: var(--foreground-50);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   padding: 0 1px;
 }
@@ -1477,7 +1477,7 @@
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.06);
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 650;
   padding: 0 5px;
 }
@@ -1495,7 +1495,7 @@
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground-70);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   padding: 0 12px;
   opacity: 1;
@@ -1515,7 +1515,7 @@
 
 .maka-skill-section-row small {
   color: var(--foreground-40);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -1557,7 +1557,7 @@
 .maka-skill-market-card h3 {
   margin: 0;
   color: var(--foreground);
-  font-size: 15px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   line-height: 1.25;
 }
@@ -1565,7 +1565,7 @@
 .maka-skill-market-card small,
 .maka-skill-market-card-foot span {
   color: var(--foreground-40);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -1573,7 +1573,7 @@
   min-height: 40px;
   margin: 0;
   color: var(--foreground-60);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -1610,7 +1610,7 @@
   background: var(--background);
   color: var(--foreground-40);
   cursor: not-allowed;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 650;
   padding: 0 14px;
 }
@@ -1626,7 +1626,7 @@
 
 .maka-skill-section-label {
   color: var(--foreground-60);
-  font-size: 9.5px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1680,7 +1680,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   line-height: 1.3;
 }
@@ -1688,7 +1688,7 @@
 .maka-skill-template-copy span {
   min-width: 0;
   color: var(--foreground-60);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
@@ -1699,7 +1699,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground-40);
-  font-size: 9px;
+  font-size: var(--font-size-caption);
   line-height: 1.35;
 }
 
@@ -1807,7 +1807,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -1817,7 +1817,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground-60);
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
@@ -1827,7 +1827,7 @@
   align-items: center;
   gap: 6px;
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   white-space: nowrap;
   min-width: 0;
   overflow: hidden;
@@ -1845,7 +1845,7 @@
   background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--foreground-50);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   letter-spacing: -0.01em;
 }
 
@@ -1857,7 +1857,7 @@
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   text-align: center;
   opacity: 1;
@@ -2023,7 +2023,7 @@
   align-items: center;
   gap: 4px;
   padding: 1px 6px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   -webkit-app-region: no-drag;
   margin-right: 4px;
@@ -2050,7 +2050,7 @@
   align-items: center;
   gap: 4px;
   padding: 1px 6px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 650;
   -webkit-app-region: no-drag;
   margin-right: 4px;
@@ -2095,7 +2095,7 @@
   border-radius: var(--radius-pill);
   background: var(--foreground-5);
   color: var(--foreground);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   box-shadow: none;
   /* PR-MODEL-SWITCHER-TACTILE-0 (WAWQAQ msg `ed67a267`, skills round
      task #116): tactile press feedback so the switch-model flow
@@ -2134,7 +2134,7 @@
 
 .maka-model-switcher-label {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 650;
   color: var(--foreground-50);
 }
@@ -2146,7 +2146,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -40,7 +40,7 @@
   margin: 0;
   max-width: 32ch;
   color: var(--foreground);
-  font-size: 18px;
+  font-size: 1.2em;
   font-weight: 650;
   line-height: 1.25;
   letter-spacing: 0;
@@ -89,7 +89,7 @@
 .maka-firstrun-title {
   margin: 0;
   max-width: none;
-  font-size: 26px;
+  font-size: 1.7333em;
   font-weight: 680;
   line-height: 1.2;
   letter-spacing: -0.01em;
@@ -98,7 +98,7 @@
 
 .maka-firstrun-sub {
   margin: 8px 0 0;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   color: var(--foreground-50);
 }
@@ -128,14 +128,14 @@
   width: 21px;
   height: 21px;
   border-radius: var(--radius-pill);
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
   font-weight: 650;
   border: 1.5px solid var(--border-strong);
   color: var(--foreground-50);
 }
 
 .maka-firstrun-step-label {
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-50);
   white-space: nowrap;
 }
@@ -181,12 +181,12 @@
   margin: 30px 0 12px;
 }
 .maka-firstrun-pick-label {
-  font-size: 13.5px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: var(--foreground);
 }
 .maka-firstrun-pick-hint {
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-50);
 }
 
@@ -214,7 +214,7 @@
 /* --- "常用" tag inside a provider row title --- */
 .maka-firstrun-tag {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
   color: var(--nav-active);
@@ -283,7 +283,7 @@
   border-radius: var(--radius-pill);
   background: var(--background-elevated);
   color: var(--foreground-70);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
@@ -305,14 +305,14 @@
 
 .maka-onboarding-setup-step-copy strong {
   color: var(--foreground);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.2;
 }
 
 .maka-onboarding-setup-step-copy small {
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   line-height: 1.3;
 }
 
@@ -322,7 +322,7 @@
   border-radius: var(--radius-pill);
   background: var(--background-elevated);
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -355,7 +355,7 @@
      warm/amber for `warning` (info family), shifts destructive
      for `blocked` so a stranded user immediately sees gravity. */
 .maka-onboarding-setup header h1 {
-  font-size: 22px;
+  font-size: 1.4667em;
 }
 .maka-onboarding-setup header p {
   margin-top: 8px;
@@ -381,7 +381,7 @@
 
 .maka-onboarding-slug {
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   padding: 2px 6px;
   /* PR-UI-LAYOUT-25: slug radius 6 → 8 to join the form input
    * family (same chrome as inline code badges). */
@@ -395,7 +395,7 @@
    surface stays self-contained. */
 .maka-onboarding-ready header h1 {
   font-family: Georgia, "Times New Roman", Times, serif;
-  font-size: 29px;
+  font-size: 1.9333em;
   font-weight: 680;
   letter-spacing: 0;
   line-height: 1.18;
@@ -404,7 +404,7 @@
   /* Slightly larger subtitle so it carries the meaning without
      reading like fine print under the now-heavier h1. */
   margin-top: 6px;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   max-width: 56ch;
 }
@@ -461,7 +461,7 @@
   min-height: 90px;
   color: var(--foreground);
   font: inherit;
-  font-size: 15px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   outline: none;
   border: none !important;
@@ -496,7 +496,7 @@
   margin-bottom: 0;
   padding-inline: 0;
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
   font-style: italic;
 }
@@ -514,7 +514,7 @@
   padding: 4px 8px;
   color: var(--nav-active);
   background: color-mix(in srgb, var(--nav-active) 10%, transparent);
-  font-size: 0.78rem;
+  font-size: var(--font-size-caption);
   line-height: 1;
 }
 .maka-onboarding-quickchat-submit {
@@ -575,7 +575,7 @@
 }
 
 .maka-first-run-task-suggestions-header > strong {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-50);
   font-weight: 600;
 }
@@ -607,7 +607,7 @@
   height: auto;
   min-height: 38px;
   padding: 9px 18px;
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.2;
   text-align: center;
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.04);
@@ -680,7 +680,7 @@
   align-items: center;
   gap: 6px;
   overflow: hidden;
-  font-size: 0.875rem;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   min-width: 0;
 }
@@ -736,7 +736,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
@@ -864,7 +864,7 @@
 .maka-list-group-count {
   font-variant-numeric: tabular-nums;
   color: var(--foreground-30);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
 }
 
@@ -880,7 +880,7 @@
    * "已过期" is a degraded-state signal, not informational. */
   background: oklch(from var(--warning, var(--info)) l c h / 0.18);
   color: var(--warning-text, var(--info-text));
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.4;
 }
@@ -924,14 +924,14 @@
 
 .maka-empty-state-title {
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .maka-empty-state-body {
   max-width: 30ch;
   color: var(--foreground-40);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
   text-wrap: pretty;
 }
@@ -956,19 +956,19 @@
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-title {
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-body {
   max-width: 22ch;
   color: var(--foreground-40);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-empty-state-code {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   padding: 1px 5px;
   border-radius: var(--radius-control);
   background: var(--foreground-5);

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -25,13 +25,13 @@
   }
   .settingsPermissionIntro h3 {
     margin: 0 0 6px;
-    font-size: 0.95rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
   .settingsPermissionIntro p {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 0.85rem;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 52ch;
   }
@@ -44,7 +44,7 @@
   }
   .settingsPermissionMeta small {
     color: var(--foreground-60);
-    font-size: 0.75rem;
+    font-size: var(--font-size-caption);
   }
 }
 
@@ -57,7 +57,7 @@
   border-radius: var(--radius-control);
   padding: 4px 10px;
   color: var(--foreground-80);
-  font-size: 0.8125rem;
+  font-size: var(--font-size-ui);
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
 .settingsPermissionRefresh:hover {
@@ -82,11 +82,11 @@
     color: var(--destructive-text);
   }
   .settingsPermissionError strong {
-    font-size: 0.9rem;
+    font-size: var(--font-size-ui);
   }
   .settingsPermissionError small {
     color: var(--foreground-70);
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
   }
   .settingsPermissionError button {
     align-self: flex-start;
@@ -99,13 +99,13 @@
   }
   .settingsPermissionSection > header h4 {
     margin: 0 0 2px;
-    font-size: 0.875rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
   }
   .settingsPermissionSection > header small {
     color: var(--foreground-60);
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
   }
 
   .settingsCapabilityList {
@@ -152,17 +152,17 @@
     gap: 2px;
   }
   .settingsCapabilityHeading strong {
-    font-size: 0.9rem;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
   .settingsCapabilityId {
     font-family: var(--font-mono);
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
   .settingsCapabilityDetail {
     margin: 0;
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
     color: var(--foreground-70);
     line-height: 1.5;
   }
@@ -182,7 +182,7 @@
     gap: 2px;
   }
   .settingsCapabilityLayers dt {
-    font-size: 0.7rem;
+    font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
@@ -190,14 +190,14 @@
   }
   .settingsCapabilityLayers dd {
     margin: 0;
-    font-size: 0.8125rem;
+    font-size: var(--font-size-ui);
     color: var(--foreground);
     display: flex;
     flex-direction: column;
     gap: 2px;
   }
   .settingsCapabilityLayers dd small {
-    font-size: 0.7rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
   .settingsCapabilityLayers dd[data-tone="success"] { color: var(--success-text); }
@@ -212,7 +212,7 @@
     gap: 6px;
   }
   .settingsCapabilityOsPermissions > span {
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
@@ -232,13 +232,13 @@
     padding: 3px 8px 3px 10px;
     border: 1px solid var(--border);
     border-radius: var(--radius-pill);
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
     background: var(--background);
     color: var(--foreground-80);
   }
   .settingsCapabilityOsPermissions li em {
     font-style: normal;
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     padding: 1px 6px;
     border-radius: var(--radius-pill);
     background: var(--foreground-5);
@@ -269,7 +269,7 @@
     background: var(--foreground-3);
   }
   .settingsCapabilityGuidance > span {
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     font-weight: 650;
     color: var(--foreground-70);
   }
@@ -277,7 +277,7 @@
     margin: 0;
     padding-left: 18px;
     color: var(--foreground-60);
-    font-size: 0.76rem;
+    font-size: var(--font-size-caption);
     line-height: 1.55;
   }
 
@@ -296,7 +296,7 @@
     border-radius: var(--radius-surface);
     background: var(--background);
     color: var(--foreground-70);
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     white-space: nowrap;
   }
 
@@ -309,7 +309,7 @@
 
   .settingsCapabilityGuidanceActions a {
     color: var(--foreground-70);
-    font-size: 0.76rem;
+    font-size: var(--font-size-caption);
     text-decoration: none;
   }
 
@@ -323,13 +323,13 @@
   }
   .settingsCapabilityAuditSlot small {
     color: var(--foreground-50);
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
   }
   .settingsCapabilityAuditSlot ul {
     list-style: disc;
     margin: 0;
     padding-left: 18px;
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-70);
   }
 
@@ -410,14 +410,14 @@
     flex-wrap: wrap;
   }
   .settingsOsPermissionHeading strong {
-    font-size: 15px;
+    font-size: var(--font-size-base);
     font-weight: 600;
     color: var(--foreground);
   }
 
   .settingsOsPermissionPurpose {
     color: var(--foreground-70);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     line-height: 1.55;
   }
 
@@ -425,7 +425,7 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-60);
     line-height: 1.45;
   }
@@ -436,14 +436,14 @@
     border-radius: var(--radius-pill);
     background: oklch(from var(--foreground) l c h / 0.05);
     color: var(--foreground-50);
-    font-size: 0.68rem;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0.04em;
   }
 
   .settingsOsPermissionReason {
     color: var(--foreground-50);
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     font-style: italic;
   }
 
@@ -515,14 +515,14 @@
       var(--card-highlight, none);
   }
   .settingsPermissionSummaryValue {
-    font-size: 1.5rem;
+    font-size: 1.5em;
     font-weight: 600;
     line-height: 1.1;
     font-variant-numeric: tabular-nums;
     color: var(--foreground);
   }
   .settingsPermissionSummaryLabel {
-    font-size: 0.72rem;
+    font-size: var(--font-size-caption);
     color: var(--foreground-60);
     letter-spacing: 0.02em;
   }
@@ -558,7 +558,7 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     color: var(--foreground-60);
-    font-size: 0.78rem;
+    font-size: var(--font-size-caption);
     line-height: 1.55;
   }
 }

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -27,7 +27,7 @@
     align-items: center;
     gap: 6px;
     padding: 4px 8px;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0.02em;
     color: var(--info-text);
@@ -87,7 +87,7 @@
      dropped content. Same family as the A3 tool-output truncated
      pill: warning tone, rounded rect, cursor:help. */
   .maka-reasoning-panel-truncated[data-truncated="true"] {
-    font-size: 10px;
+    font-size: var(--font-size-caption);
     color: var(--warning-text, var(--info-text));
     border: 1px solid oklch(from var(--warning) l c h / 0.24);
     background: oklch(from var(--warning) l c h / 0.05);
@@ -102,7 +102,7 @@
      the same visual family. */
 
   .maka-reasoning-panel-chevron {
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1;
     color: var(--foreground-50);
     transition: transform var(--duration-base) var(--ease-out-strong);
@@ -119,7 +119,7 @@
     background: transparent;
     color: var(--foreground-70);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.55;
     max-height: 280px;
     overflow-y: auto;

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -38,7 +38,7 @@
 }
 
 .settingsBotList em {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-style: normal;
   color: var(--foreground-50);
 }
@@ -90,7 +90,7 @@
     place-items: center;
     background: transparent;
     color: var(--bot-brand-color, var(--bot-brand-default));
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-weight: 700;
     letter-spacing: 0;
     flex-shrink: 0;
@@ -104,7 +104,7 @@
   .settingsBotLogo[data-large="true"] {
     width: 44px;
     height: 44px;
-    font-size: 20px;
+    font-size: 1.3333em;
   }
 
   .settingsBotLogoStatusDot {
@@ -172,7 +172,7 @@
 
   .settingsBotHero h3 {
     margin: 0 0 4px;
-    font-size: 16px;
+    font-size: 1.0667em;
     display: flex;
     align-items: center;
     gap: 10px;
@@ -182,7 +182,7 @@
   .settingsBotHero small,
   .settingsHelpText {
     color: var(--foreground-50);
-    font-size: 12.5px;
+    font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 
@@ -210,7 +210,7 @@
     border-radius: var(--radius-pill);
     background: color-mix(in srgb, var(--foreground) 5%, transparent);
     color: var(--foreground-70);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 500;
     letter-spacing: 0.01em;
   }
@@ -257,20 +257,20 @@
   .settingsBotStatusGrid dt {
     margin-bottom: 4px;
     color: var(--foreground-40);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
   }
 
   .settingsBotStatusGrid dd {
     margin: 0;
     color: var(--foreground);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     word-break: break-word;
   }
 
   .settingsBotReason {
     border-left: 2px solid var(--focus-ring);
     color: var(--foreground-60);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.5;
     padding-left: 10px;
   }
@@ -315,7 +315,7 @@
   background: transparent;
   color: var(--foreground-60);
   padding: 0 8px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .settingsSegmented button[data-pressed] {
@@ -343,11 +343,11 @@
 .settingsMetricCard small,
 .settingsMetricCard span {
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 .settingsMetricCard strong {
-  font-size: 14px;
+  font-size: var(--font-size-ui);
 }
 
 .settingsStatsTable {
@@ -356,7 +356,7 @@
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-surface);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .settingsStatsTable th,
@@ -415,7 +415,7 @@
   background: var(--foreground-5);
   color: var(--foreground-60);
   padding: 0 6px;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 /* PR-SETTINGS-GROUPED-CARD-0 (WAWQAQ msg `1abecd66`): same grouped-

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -60,7 +60,7 @@
   .settingsQuotaRow {
     display: flex;
     justify-content: space-between;
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     font-variant-numeric: tabular-nums;
   }
 
@@ -80,7 +80,7 @@
     background: var(--background);
     color: var(--foreground);
     font-family: var(--mono-font, monospace);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     resize: vertical;
   }
   .settingsErrorText {
@@ -108,7 +108,7 @@
     border-radius: var(--radius-control);
     background: oklch(from var(--nav-active) l c h / 0.14);
     color: var(--nav-active);
-    font-size: 10px;
+    font-size: var(--font-size-caption);
     font-weight: 700;
     letter-spacing: 0;
   }
@@ -128,14 +128,14 @@
 
   .settingsConnectionRowText strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     font-weight: 600;
   }
 
   .settingsConnectionRowText small {
     color: var(--foreground-50);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
   }
 
   .settingsConnectionBadge {
@@ -144,7 +144,7 @@
     min-height: 20px;
     padding: 2px 8px;
     border-radius: var(--radius-control);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0;
     background: var(--foreground-5);
@@ -174,7 +174,7 @@
   .settingsConnectionDetail {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.45;
   }
 
@@ -198,13 +198,13 @@
 
   .settingsAuthContractText strong {
     color: var(--foreground);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     font-weight: 650;
   }
 
   .settingsAuthContractText span {
     color: var(--foreground-60);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.45;
   }
 
@@ -215,7 +215,7 @@
     min-height: 20px;
     border-radius: var(--radius-control);
     white-space: nowrap;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-weight: 650;
   }
 
@@ -254,7 +254,7 @@
     display: flex;
     gap: 12px;
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     font-family: var(--font-mono);
   }
 
@@ -315,7 +315,7 @@
     display: block;
     margin-top: 4px;
     color: var(--foreground-50);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.4;
   }
 

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -3,7 +3,7 @@
   margin: 0;
   border-radius: var(--radius-control);
   padding: 6px 10px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.4;
   color: var(--warning-text);
   background: oklch(from var(--warning) l c h / 0.10);
@@ -32,7 +32,7 @@
   width: fit-content;
   padding: 0 5px;
   border-radius: var(--radius-control);
-  font-size: 9px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -58,7 +58,7 @@
   list-style: none;
   padding: 5px 10px;
   color: var(--foreground-60);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-permission-raw > summary::-webkit-details-marker { display: none; }

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -37,7 +37,7 @@
 .enabledProviderTrigger:hover { background: var(--hover); }
 
 .enabledProviderName {
-  font-size: 13.5px;
+  font-size: var(--font-size-ui);
   font-weight: 620;
   letter-spacing: -0.002em;
   min-width: 0;
@@ -71,7 +71,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   white-space: nowrap;
   color: var(--foreground-50);
 }
@@ -123,7 +123,7 @@
 }
 
 .enabledDefaultTag {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 650;
   color: var(--nav-active);
   background: oklch(from var(--nav-active) l c h / 0.14);
@@ -176,7 +176,7 @@
 }
 
 .catalogPillTabs strong {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
 }
 
@@ -273,7 +273,7 @@
   background: transparent;
   color: var(--link);
   padding: 0 14px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
 }
 
@@ -371,7 +371,7 @@
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--text);
-  font-size: 15px;
+  font-size: var(--font-size-base);
   line-height: 1;
 }
 
@@ -393,7 +393,7 @@
   border-radius: var(--radius-control);
   background: var(--surface, var(--background));
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-browser-strip {
@@ -472,7 +472,7 @@
 }
 
 .maka-artifact-pane-title {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -480,7 +480,7 @@
 }
 
 .maka-artifact-pane-count {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   padding: 0 5px;
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
@@ -499,7 +499,7 @@
   border-radius: var(--radius-surface);
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-artifact-list-error svg {
@@ -509,7 +509,7 @@
 .maka-artifact-list-error strong {
   display: block;
   margin-bottom: 2px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -529,7 +529,7 @@
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-artifact-error-retry:hover {
@@ -591,7 +591,7 @@
   background: transparent;
   color: var(--foreground);
   text-align: left;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   transition:
     background 140ms var(--ease-out-strong),
     border-color 140ms var(--ease-out-strong),
@@ -643,7 +643,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 1px;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   color: oklch(from var(--foreground) l c h / 0.62);
   font-variant-numeric: tabular-nums;
 }
@@ -670,24 +670,24 @@
   align-items: center;
   justify-content: center;
   color: oklch(from var(--foreground) l c h / 0.5);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-artifact-preview-empty {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-artifact-preview-file {
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
 .maka-artifact-preview-diff {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-artifact-preview-html {
@@ -708,7 +708,7 @@
 }
 
 .maka-artifact-preview-external-links-bar {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   padding: 4px 6px;
   border-radius: var(--radius-control);
   background: oklch(from var(--info) l c h / 0.10);
@@ -753,14 +753,14 @@
 }
 
 .maka-artifact-preview-unsupported-title {
-  font-size: 0.95rem;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: var(--foreground);
 }
 
 .maka-artifact-preview-unsupported-body {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: var(--font-size-ui);
   line-height: 1.55;
   color: var(--foreground-70);
 }
@@ -771,7 +771,7 @@
   gap: 4px 16px;
   margin: 0;
   padding: 0;
-  font-size: 0.8rem;
+  font-size: var(--font-size-ui);
   color: var(--foreground-70);
 }
 .maka-artifact-preview-unsupported-meta > div {
@@ -806,7 +806,7 @@
 
 .maka-artifact-preview-pdf-fallback {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: oklch(from var(--foreground) l c h / 0.6);
 }
 
@@ -814,7 +814,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: oklch(from var(--foreground) l c h / 0.65);
 }
 
@@ -831,7 +831,7 @@
   padding: 10px 12px;
   border-radius: var(--radius-surface);
   border: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-artifact-preview-fail[data-tone="destructive"] {
@@ -852,7 +852,7 @@
 
 .maka-artifact-preview-fail-body {
   margin: 0;
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
   line-height: 1.55;
 }
 
@@ -903,7 +903,7 @@
   color: var(--foreground);
   border-radius: var(--radius-control);
   padding: 4px 8px;
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-artifact-toolbar-button:hover {
@@ -1011,7 +1011,7 @@
   border: 1px solid oklch(from var(--info) l c h / 0.20);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--info-text);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.4;
   transition: background var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong), border-color var(--duration-base) var(--ease-out-strong);
   align-self: flex-start;

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -731,10 +731,9 @@
   display: block;
   margin-top: 6px;
   color: var(--foreground-50);
-  /* PR-SETTINGS-MOTION-TYPO-TOKENS-0 (round 15/15): 13 → 14 to clear
-     the 14px legibility floor cited by baseline-ui + UIDB + Impeccable
-     `/typeset`. Hint is the most-read body text on the page. */
-  font-size: var(--font-size-ui);
+  /* Hint is the most-read body text on the page; use the base scale so
+     it clears the 14px legibility floor. */
+  font-size: var(--font-size-base);
   line-height: 1.5;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -41,7 +41,7 @@
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground-70);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   text-align: left;
   justify-content: initial;
@@ -75,12 +75,12 @@
   align-items: center;
   gap: 4px;
   color: var(--foreground);
-  font-size: 18px;
+  font-size: 1.2em;
   font-weight: 700;
 }
 
 .settingsSidebar header .maka-shortcut-kbd {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   padding: 0 4px;
 }
 
@@ -105,7 +105,7 @@
      instead of jamming against the prior item. */
   display: flex;
   align-items: center;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   letter-spacing: 0.05em;
   text-transform: none;
@@ -140,7 +140,7 @@
   padding: 6px 12px;
   text-align: left;
   justify-content: initial;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
   grid-template-columns: 20px minmax(0, 1fr) auto;
 }
@@ -169,7 +169,7 @@
   border-radius: var(--radius-control);
   background: oklch(from var(--nav-active) l c h / 0.12);
   color: var(--nav-active);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: none;
@@ -243,7 +243,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -263,7 +263,7 @@
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-80);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   width: fit-content;
   max-width: 100%;
@@ -305,7 +305,7 @@
 .settingsFeatureStatusHero h3 {
   margin: 0 0 3px;
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -313,7 +313,7 @@
   margin: 0;
   max-width: 56ch;
   color: var(--foreground-70);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
@@ -323,7 +323,7 @@
   display: grid;
   gap: 4px;
   color: var(--foreground-70);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
@@ -393,7 +393,7 @@
   border-radius: var(--radius-pill);
   background: oklch(from var(--nav-active) l c h / 0.12);
   color: var(--nav-active);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -484,7 +484,7 @@
      line. */
   margin: 0;
   color: var(--foreground);
-  font-size: 26px;
+  font-size: 1.7333em;
   font-weight: 650;
   letter-spacing: -0.012em;
   line-height: 1.2;
@@ -498,7 +498,7 @@
   margin: 0;
   max-width: 56ch;
   color: var(--foreground-50);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   text-wrap: pretty;
 }
@@ -570,7 +570,7 @@
 .settingsSectionHeading {
   margin: 24px 2px 10px;
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -585,7 +585,7 @@
   display: grid;
   place-items: center;
   color: var(--foreground-50);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
 }
 
 /* PR-SETTINGS-ROW-SPACIOUS-0 (2026-06-23, WAWQAQ msg `f7e9d166`):
@@ -721,7 +721,7 @@
 .settingsFormGrid label span {
   display: block;
   color: var(--foreground);
-  font-size: 15px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   line-height: 1.35;
 }
@@ -734,7 +734,7 @@
   /* PR-SETTINGS-MOTION-TYPO-TOKENS-0 (round 15/15): 13 → 14 to clear
      the 14px legibility floor cited by baseline-ui + UIDB + Impeccable
      `/typeset`. Hint is the most-read body text on the page. */
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -1,14 +1,14 @@
 .providerEditor h3 {
   margin: 0;
   color: var(--foreground);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .providerEditor p {
   margin: 0;
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
 }
 
@@ -40,13 +40,13 @@
 }
 
 .catalogTabs strong {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
 }
 
 .catalogTabs small {
   color: var(--foreground-50);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   line-height: 1.2;
 }
 
@@ -90,7 +90,7 @@
 .providerCatalogCount {
   margin-left: 8px;
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .providerCatalogChevron {
@@ -106,7 +106,7 @@
   background: var(--foreground-5);
   color: var(--foreground-60);
   padding: 2px 7px;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-style: normal;
   font-weight: 600;
   line-height: 1.35;
@@ -128,7 +128,7 @@
 }
 
 .providerUnavailableNotice span {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
 }
 
@@ -152,7 +152,7 @@
   display: grid;
   gap: 6px;
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
 }
 
@@ -172,7 +172,7 @@
   color: var(--foreground);
   padding: 0 12px;
   outline: none;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   transition: border-color 140ms var(--ease-out-strong), box-shadow 140ms var(--ease-out-strong), background 140ms var(--ease-out-strong);
 }
 
@@ -200,7 +200,7 @@
 .providerExternalLink {
   width: fit-content;
   color: var(--link);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   text-decoration: none;
   /* PR-UI-LAYOUT-33: explicit padding + radius so the focus halo
@@ -255,13 +255,13 @@
 }
 
 .modelTableHeaderText strong {
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
   color: var(--foreground);
 }
 
 .modelTableHeaderText small {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.5;
   color: var(--foreground-60);
 }
@@ -285,7 +285,7 @@
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-family: var(--font-mono);
   transition: border-color 140ms var(--ease-out-strong), box-shadow 140ms var(--ease-out-strong);
 }
@@ -303,7 +303,7 @@
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.55;
   text-align: center;
 }
@@ -318,7 +318,7 @@
   border: 1px solid oklch(from var(--focus-ring) l c h / 0.22);
   background: oklch(from var(--focus-ring) l c h / 0.06);
   color: var(--foreground);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.5;
   width: 100%;
 }
@@ -423,7 +423,7 @@
 .modelTableRowId {
   background: transparent;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-60);
   white-space: nowrap;
   overflow: hidden;
@@ -436,7 +436,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--warning-text);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .modelTableChips {
@@ -451,7 +451,7 @@
   border-radius: var(--radius-control);
   background: var(--foreground-5);
   color: var(--foreground-60);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -462,7 +462,7 @@
   border-radius: var(--radius-control);
   background: oklch(from var(--nav-active) l c h / 0.14);
   color: var(--nav-active);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   font-weight: 700;
   letter-spacing: 0;
 }
@@ -476,7 +476,7 @@
    the right-side value text). */
 .settingsRow strong {
   color: var(--foreground);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -488,7 +488,7 @@
      for any numeric data. */
   min-width: 0;
   color: var(--foreground-60);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
   text-align: right;
@@ -544,7 +544,7 @@
   border-radius: var(--radius-surface);
   background: color-mix(in srgb, var(--warning) 10%, var(--background));
   color: var(--warning-text);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
   padding: 9px 11px;
 }
@@ -555,7 +555,7 @@
 }
 
 .providerOAuthCardBadge {
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   letter-spacing: 0.02em;
 }
@@ -590,7 +590,7 @@
 .customProviderEntry h3 {
   margin: 0;
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
 }
 
@@ -599,7 +599,7 @@
 .customProviderEntry p {
   margin: 0;
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.35;
 }
 
@@ -622,5 +622,5 @@
   background: var(--background-elevated);
 }
 
-.enabledEmptyChip strong { font-size: 12px; font-weight: 700; }
-.enabledEmptyChip small { margin-top: 2px; color: var(--foreground-50); font-size: 11px; }
+.enabledEmptyChip strong { font-size: var(--font-size-caption); font-weight: 700; }
+.enabledEmptyChip small { margin-top: 2px; color: var(--foreground-50); font-size: var(--font-size-ui); }

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -16,7 +16,7 @@
   background: var(--background);
   color: var(--foreground);
   padding: 6px 10px;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
   outline: none;
   transition: border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
@@ -27,7 +27,7 @@
   padding: 8px 10px;
   line-height: 1.5;
   font-family: inherit;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
 }
 
 .settingsField input:focus,
@@ -49,7 +49,7 @@
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
   padding: 11px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }
 
@@ -106,14 +106,14 @@
 .settingsAboutHeading h2 {
   margin: 0;
   color: var(--foreground);
-  font-size: 22px;
+  font-size: 1.4667em;
   font-weight: 700;
   letter-spacing: -0.01em;
 }
 
 .settingsAboutVersion {
   font-family: var(--font-mono);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-70);
   padding: 2px 8px;
   border-radius: var(--radius-pill);
@@ -121,7 +121,7 @@
 }
 
 .settingsAboutChannel {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--accent);
   padding: 2px 8px;
   border-radius: var(--radius-pill);
@@ -132,7 +132,7 @@
 .settingsAboutTagline {
   margin: 0;
   color: var(--foreground-70);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.55;
 }
 
@@ -148,7 +148,7 @@
 .settingsAboutPrivacy h3 {
   margin: 0;
   color: var(--success);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -160,7 +160,7 @@
   display: grid;
   gap: 6px;
   color: var(--foreground-70);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.55;
 }
 
@@ -357,7 +357,7 @@
 }
 .settingsPaletteGroupHeading {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   color: var(--foreground-50);
   letter-spacing: 0;
@@ -424,7 +424,7 @@
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--accent);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
@@ -446,7 +446,7 @@
   font-style: normal;
   font-weight: 400;
   color: var(--foreground-50);
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
   margin-left: 6px;
 }
 
@@ -461,7 +461,7 @@
   background: oklch(from var(--info) l c h / 0.10);
   border: 1px solid oklch(from var(--info) l c h / 0.18);
   color: var(--info-text);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 .settingsBotInfoNoticeIcon {
@@ -491,7 +491,7 @@
 }
 .settingsBotScanLoginHeader h3 {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 .settingsBotScanLoginBody {
@@ -519,11 +519,11 @@
   background: var(--foreground-5);
   border: 1px dashed var(--border);
   color: var(--foreground-40);
-  font-size: 24px;
+  font-size: 1.6em;
 }
 .settingsBotScanLoginStatus {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   color: var(--foreground-70);
 }
@@ -549,7 +549,7 @@
   background: transparent;
   color: var(--foreground-50);
   padding: 4px 0;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 3px;
@@ -597,7 +597,7 @@
 
 .settingsWechatQrHeader h3 {
   margin: 0 0 4px;
-  font-size: 16px;
+  font-size: 1.0667em;
   font-weight: 650;
 }
 
@@ -605,7 +605,7 @@
 .settingsWechatQrCaption {
   margin: 0;
   color: var(--foreground-50);
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 
@@ -668,7 +668,7 @@
   background: var(--foreground-3);
   color: var(--foreground-60);
   padding: 18px;
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.5;
 }
 
@@ -702,7 +702,7 @@
   background: var(--background);
   color: var(--accent);
   padding: 0 12px;
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
 }
 
@@ -723,7 +723,7 @@
 
 .settingsThemeLabel strong {
   color: var(--foreground);
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -732,7 +732,7 @@
 
 .settingsThemeLabel small {
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
   overflow-wrap: anywhere;
 }
@@ -746,7 +746,7 @@
 .settingsSubheading {
   margin: 0;
   color: var(--foreground-70);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -298,7 +298,7 @@
 }
 .maka-search-modal-title {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: var(--foreground);
 }
@@ -308,7 +308,7 @@
   border: 0;
   background: transparent;
   color: var(--foreground-60);
-  font-size: 16px;
+  font-size: 1.0667em;
   line-height: 1;
   border-radius: var(--radius-control);
 }
@@ -339,7 +339,7 @@
 .maka-search-modal-input {
   width: 100%;
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.4;
 }
 .maka-search-modal-input::placeholder {
@@ -374,7 +374,7 @@
 }
 .maka-search-modal-placeholder {
   margin: 14px 8px;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-50);
   text-align: center;
 }
@@ -396,11 +396,11 @@
 }
 .maka-search-modal-state p {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: var(--foreground);
 }
 .maka-search-modal-state .maka-search-modal-state-detail {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--foreground-60);
 }
 
@@ -410,7 +410,7 @@
   justify-content: space-between;
   gap: 12px;
   padding: 0 6px 6px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--foreground-50);
 }
 
@@ -453,7 +453,7 @@
   opacity: 0.7;
 }
 .maka-search-modal-result-title {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: var(--foreground);
   overflow: hidden;
@@ -461,14 +461,14 @@
   white-space: nowrap;
 }
 .maka-search-modal-result-meta {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   color: var(--foreground-40);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .maka-search-modal-result-snippet {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--foreground-60);
   line-height: 1.45;
   /* Plain text snippet — backend redacts secrets + bounds to
@@ -612,7 +612,7 @@
   justify-content: center;
   border-radius: var(--radius-pill);
   padding: 0 4px;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
 }
 
@@ -671,7 +671,7 @@
   gap: 3px;
   padding: 0 6px 3px;
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -847,7 +847,7 @@
   background: transparent;
   color: var(--foreground);
   font: inherit;
-  font-size: 14px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   outline: 0;
   padding: 1px 0;
@@ -924,13 +924,13 @@
 
 .maka-prompt-chip-label {
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .maka-prompt-chip-hint {
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -960,14 +960,14 @@
   display: block;
   margin: 0 0 4px;
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
 }
 
 .maka-deep-research-workflow-body {
   display: block;
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }
 
@@ -987,7 +987,7 @@
 .maka-deep-research-progress h2 {
   margin: 0;
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   line-height: 1.3;
 }
 
@@ -1018,7 +1018,7 @@
 .maka-deep-research-evidence-title,
 .maka-deep-research-progress-title {
   color: var(--foreground);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 700;
   white-space: nowrap;
 }
@@ -1029,6 +1029,6 @@
 .maka-deep-research-progress-body {
   min-width: 0;
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
 }

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -108,7 +108,7 @@ html[data-os="darwin"] .maka-list-row[data-active="true"] .maka-list-row-name {
    the size / transform / tracking on macOS; the natural color step
    from --color-text-quaternary is enough hierarchy. */
 html[data-os="darwin"] .maka-list-group-label {
-  font-size: 13px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   letter-spacing: 0;
   text-transform: none;

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -5,7 +5,7 @@
 .maka-message-time-inline {
   display: inline-block;
   color: var(--foreground-40);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 500;
   line-height: 1;
   font-variant-numeric: tabular-nums;
@@ -37,7 +37,7 @@
   background: oklch(from var(--info) l c h / 0.08);
   color: var(--info-text);
   padding: 2px 7px;
-  font-size: 10px;
+  font-size: var(--font-size-caption);
 }
 
 /* `.toolInline` (inline section + header), `.toolItem` (the `<details>` card's
@@ -149,7 +149,7 @@
   min-height: var(--h-composer-min, 56px);
   color: var(--foreground);
   font-family: var(--font-default);
-  font-size: 15px;
+  font-size: var(--font-size-base);
   line-height: 1.55;
   border: none !important;
   box-shadow: none !important;
@@ -168,7 +168,7 @@
 }
 
 .maka-composer-streaming-hint .maka-shortcut-kbd {
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   padding: 1px 5px;
   background: var(--foreground-3);
   border: 1px solid var(--border);
@@ -211,7 +211,7 @@
   min-width: 0;
   flex: 1 1 auto;
   color: var(--foreground-40);
-  font-size: 10px;
+  font-size: var(--font-size-caption);
   text-align: center;
 }
 
@@ -226,7 +226,7 @@
   padding: 0 9px;
   background: oklch(from var(--background) l c h / 0.82);
   color: var(--foreground-60);
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
   white-space: nowrap;
   transition:
@@ -294,12 +294,12 @@
   min-width: 0;
 }
 .maka-composer-mode-menu-label {
-  font-size: 12.5px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   color: var(--foreground);
 }
 .maka-composer-mode-menu-hint {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--foreground-50);
   line-height: 1.4;
   white-space: normal;
@@ -311,7 +311,7 @@
 .maka-composer-right-controls .maka-model-switcher {
   margin: 0;
   max-width: min(180px, 28vw);
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
 }
 
 .maka-composer-right-controls .maka-model-switcher-trigger {
@@ -338,7 +338,7 @@
 .maka-composer-right-controls .maka-model-switcher-value {
   max-width: 128px;
   color: inherit;
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
 }
 

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -24,7 +24,7 @@
 
 .settingsWebSearchStatusCluster small {
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-family: var(--font-mono);
   white-space: nowrap;
 }
@@ -45,7 +45,7 @@
 
 .settingsWebSearchDisabledReason {
   color: var(--foreground-50);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
   text-align: right;
 }
@@ -79,14 +79,14 @@
 
   .settingsWebSearchResult small {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
 
   .settingsWebSearchResult p {
     margin: 0;
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-70);
     line-height: 1.45;
     white-space: pre-wrap;
@@ -141,19 +141,19 @@
   }
 
   .settingsMemoryPreview strong {
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     color: var(--foreground);
   }
 
   .settingsMemoryPreview small {
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
 
   .settingsMemoryPreview p {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;
@@ -182,7 +182,7 @@
 
   .settingsMemoryPromptPreviewHeader strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemoryPromptPreviewHeader div {
@@ -194,7 +194,7 @@
   .settingsMemoryPromptPreviewHeader span {
     flex-shrink: 0;
     color: var(--foreground-60);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
   }
 
   .settingsMemoryPromptPreview[data-active="true"] .settingsMemoryPromptPreviewHeader span {
@@ -203,7 +203,7 @@
 
   .settingsMemoryPromptPreview small {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.4;
   }
 
@@ -222,7 +222,7 @@
     background: var(--background);
     color: var(--foreground-80);
     font-family: var(--font-mono);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;
@@ -231,7 +231,7 @@
   .settingsMemoryPromptPreview p {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
   }
 
@@ -246,12 +246,12 @@
 
   .settingsMemoryEntryPreviewNotice strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemoryEntryPreviewNotice small {
     color: var(--foreground-70);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.4;
   }
 
@@ -266,17 +266,17 @@
 
   .settingsMemorySaveSummary strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemorySaveSummary small {
     color: var(--foreground-60);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemorySaveSummaryTime {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
   }
 
   .settingsMemoryBackupState {
@@ -298,7 +298,7 @@
 
   .settingsMemoryBackupList strong {
     color: var(--foreground);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
   }
 
   /* PR-MEMORY-BACKUP-LIST-A11Y-0 (round 16/30): selector
@@ -322,7 +322,7 @@
 
   .settingsMemoryBackupList small {
     color: var(--foreground-50);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.4;
   }
 
@@ -335,7 +335,7 @@
     border-radius: var(--radius-pill);
     background: var(--background);
     color: var(--foreground-60);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
   }
 }
 
@@ -359,13 +359,13 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     color: var(--foreground-60);
   }
 
   .settingsMemoryEntryGroupHeader strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemoryEntryDraftNotice {
@@ -375,7 +375,7 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning) l c h / 0.08);
     color: var(--foreground-70);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
   }
 
@@ -418,12 +418,12 @@
   }
 
   .settingsMemoryEntryCard strong {
-    font-size: 13px;
+    font-size: var(--font-size-ui);
     color: var(--foreground);
   }
 
   .settingsMemoryEntryCard small {
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
 
@@ -445,7 +445,7 @@
     border-radius: var(--radius-control);
     background: var(--foreground-5);
     color: var(--foreground-60);
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     line-height: 1.4;
   }
 
@@ -464,7 +464,7 @@
   .settingsMemoryEntryEmpty {
     margin: 0;
     color: var(--foreground-70);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;
@@ -490,13 +490,13 @@
   background: var(--background);
   color: var(--foreground);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   padding: 8px 9px;
 }
 
 .settingsMemoryFilter small {
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   white-space: nowrap;
 }
 
@@ -519,13 +519,13 @@
   .settingsMemoryFilterEmpty strong,
   .settingsMemoryListEmpty strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .settingsMemoryFilterEmpty small,
   .settingsMemoryListEmpty small {
     color: var(--foreground-60);
-    font-size: 12px;
+    font-size: var(--font-size-ui);
     line-height: 1.45;
   }
 }
@@ -546,12 +546,12 @@
 
 .settingsMemoryManualAddHeader strong {
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
 }
 
 .settingsMemoryManualAddHeader small {
   color: var(--foreground-50);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .settingsMemoryManualAddGrid {
@@ -567,7 +567,7 @@
   background: var(--background);
   color: var(--foreground);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   padding: 8px 9px;
 }
 
@@ -593,12 +593,12 @@
 
 .settingsMemoryDraftWarning strong {
   color: var(--foreground);
-  font-size: 13px;
+  font-size: var(--font-size-ui);
 }
 
 .settingsMemoryDraftWarning small {
   color: var(--foreground-70);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   line-height: 1.4;
 }
 
@@ -609,7 +609,7 @@
 
 .settingsMemoryEditor > span {
   color: var(--foreground-60);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
@@ -623,7 +623,7 @@
   background: var(--background-elevated, var(--background));
   color: var(--foreground);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.55;
 }
 
@@ -684,12 +684,12 @@
 
   .maka-first-run-checklist-header strong {
     color: var(--foreground);
-    font-size: 13px;
+    font-size: var(--font-size-ui);
   }
 
   .maka-first-run-checklist-count {
     margin-left: auto;
-    font-size: 11px;
+    font-size: var(--font-size-caption);
     letter-spacing: 0.04em;
     color: var(--foreground-50);
     font-variant-numeric: tabular-nums;
@@ -705,7 +705,7 @@
   border-radius: var(--radius-surface);
   background: oklch(from var(--warning, var(--info)) l c h / 0.08);
   color: var(--warning-text, var(--info-text));
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   line-height: 1.45;
   padding: 8px 10px;
 }
@@ -722,7 +722,7 @@
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--warning-text, var(--info-text));
-  font-size: 12px;
+  font-size: var(--font-size-ui);
 }
 
 .maka-first-run-checklist-error-action:hover {
@@ -804,14 +804,14 @@
 }
 
 .maka-first-run-checklist-copy strong {
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   font-weight: 600;
   white-space: nowrap;
 }
 
 .maka-first-run-checklist-copy small {
   display: none;
-  font-size: 12px;
+  font-size: var(--font-size-ui);
   color: var(--foreground-50);
   line-height: 1.45;
 }
@@ -834,7 +834,7 @@
   }
 
   .maka-onboarding-ready header h1 {
-    font-size: 24px;
+    font-size: 1.6em;
     line-height: 1.2;
   }
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -144,8 +144,22 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 | `--font-sans` | `"Geist Variable", system-ui, …, sans-serif` | 默认正文 / UI |
 | `--font-mono` | `"Geist Mono Variable", "JetBrains Mono", …, monospace` | 代码、tool 名称、model id、provider type、token 计数 |
 | `--font-default` | `var(--font-sans)` | `body` 兜底 |
-| `--font-size-base` | 15px | `html` 基准；勿在组件覆盖 |
+| `--font-size-base` | 15px | `html` 基准；正文、nav-item label、page hint |
+| `--font-size-ui` | 13px | chrome/control；sidebar row、form label、button、settings row、card title |
+| `--font-size-caption` | 11px | dense meta；timestamp、badge、kbd、overline、tool-card meta |
 | `kbd` | mono + 0.85em + `var(--foreground-5)` 底 + 1px border | composer hint / 设置帮助 |
+
+Tailwind alias：`--text-xs`→caption(11px), `--text-sm`→ui(13px), `--text-base`→base(15px)。
+
+**三档 scale**（PR-TYPOGRAPHY-CONVERGE-0, issue #430 PR2）：
+- **base 15px** — `html` root，不动。改它会全局 scale 所有 rem。
+- **ui 13px** — chrome/control。sidebar row、form label、button、settings row、card title。
+- **caption 11px** — dense meta。timestamp、badge、kbd、overline、tool-card meta。
+- 原来的 9/10/10.5/11/11.5px 和 0.68–0.78rem（15px root 下 10.2–11.7px）收敛到 caption。
+- 原来的 12/12.5/13/13.5/14px 和 0.8–0.95rem（15px root 下 12–14.25px）收敛到 ui。
+- 半像素值（12.5/11.5/10.5/13.5/14.5）归到最近 tier。
+
+**Heading em scaling**：`.maka-bubble-assistant h1-h4` 用 em off body 15（h1=1.47em, h2=1.27em, h3=1.07em, h4=0.93em），track root 自动。Surface-specific hero 大字（onboarding/settings title 16–32px）也用 em。
 
 **规则**：
 - 标识符（model id、provider type、tool name、file path、env key、API endpoint）
@@ -153,6 +167,8 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 - 文章标题、章节标题用 600 weight + `text-wrap: balance`（见
   `.maka-bubble-assistant h1..h4`）。
 - `tabular-nums` 用在数字会跳动的位置（duration / token count）。
+- `font-size` 不准裸写 `Npx` / `Nrem`，必须引用 `var(--font-size-*)` 或用 `em`。
+  `typography-converge-contract.test.ts` 锁住这条规则。
 
 ### 1.4 圆角（Radius）
 


### PR DESCRIPTION
## Summary

Ban bare `Npx`/`Nrem` `font-size` across all renderer CSS. 413 sites collapse into a three-tier token scale: `--font-size-base` (15px), `--font-size-ui` (13px), and `--font-size-caption` (11px). Bubble h1-h4 switch from px to em off body 15.

## Why

Issue #430 PR2. Maka's frontend had 436 bare `font-size` values across 22 CSS files — 9/10/11/12/12.5/13/13.5/14px plus rem-encoded meta (0.7-0.875rem under the 15px root). These were drift, not a deliberate ladder. The radius converge contract (#406) proved this pattern works; this PR applies it to typography.

An initial 2-tier attempt (base 15 / ui 13) was too aggressive: 150+ sites of dense meta (9-11px timestamps, badges, kbd, overlines) inflated to 13px, flattening the visual hierarchy between low-priority meta and chrome text. A third tier at 11px restores that distinction. Peer research across 8 projects confirmed 3-4 tiers is the norm; 2 was the fewest.

Closes #430

## Scope

Changed:
- **Token definitions** (`maka-tokens.css`): three-tier scale — `--font-size-base: 15px` (body/prose), `--font-size-ui: 13px` (chrome/control), `--font-size-caption: 11px` (dense meta).
- **Tailwind alias** (`styles.css @theme inline`): `--text-xs` → caption, `--text-sm` → ui, `--text-base` → base.
- **CSS convergence** (22 files, 413 sites):
  - 9/10/10.5/11/11.5px and 0.68-0.78rem → `var(--font-size-caption)` (196 sites)
  - 12/12.5/13/13.5/14px and 0.8-0.95rem → `var(--font-size-ui)` (217 sites)
  - 15px → `var(--font-size-base)`
- **Heading em scaling**: h1-h4 from px to em (1.4667/1.2667/1.0667/0.9333em off body 15).
- **Contract test**: bans bare `Npx`/`Nrem`; pins 15/13/11; verifies Tailwind alias mappings.
- **Docs** (`docs/design-system.md §1.3`): synced to three-tier scale.

Rebased onto main (11 new commits). Conflicts with PR #441 (`--accent` semantic split) resolved by keeping main's color tokens + our font-size tokens.

Not included:
- TSX inline `fontSize` scanning (0 sites exist).
- Spacing converge (#430 PR3) — separate PR.
- Icon size converge — out of scope per #430.

## Verification

- `npm test` — 1680 tests, 1678 pass, 2 fail. **Both failures are pre-existing on main** (PR #441 changed `--accent` to `--link` in `tool-activity.tsx` but `visible-copy-hygiene-contract.test.ts` still expects `--accent`). Not caused by this PR.
- `npm run build` — succeeds.
- `typography-converge-contract.test.ts` — all 8 cases pass.
- Screenshot capture for 6 scenarios (permission-destructive, first-run, streaming-sidebar, artifact-pane, settings-general, settings-appearance).

## Review responses

- **P1 docs inconsistency**: Fixed — `docs/design-system.md §1.3` synced to three-tier (15/13/11).
- **P1 permission text at caption**: Pushed back — all permission dialog selectors were originally 11px; caption (11px) is faithful convergence with zero visual regression. The suggestion to "restore to ui" would increase 11px→13px, a visual redesign beyond this PR's scope.
- **P2 mechanical vs semantic caption mapping**: Acknowledged as follow-up — semantic re-evaluation is a separate audit, not a blocker on token convergence.
- **P2 em bypass in test**: Pushed back — em is relative; the contract bans absolute values (px/rem), not relative scaling. Selector whitelists for em would be brittle.