### PR TITLE
fix(ui): daily-review empty-state overlay + stale-session banner layout

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -243,7 +243,14 @@
 
 .maka-fake-backend-banner {
   display: flex;
-  align-items: center;
+  /* flex-start (not center): with multi-line copy a centered icon lands
+     on the middle line; the 1lh svg box from the Alert primitive aligns
+     it to the first line instead. */
+  align-items: flex-start;
+  /* The Alert primitive ships `w-full`; combined with the horizontal
+     margins that made the banner 28px wider than the pane, so its right
+     edge rendered clipped against the card. */
+  width: auto;
   gap: 8px;
   margin: 8px 14px 0;
   padding: 8px 12px;
@@ -257,6 +264,12 @@
 
 .maka-fake-backend-banner svg {
   flex: 0 0 auto;
+}
+
+/* AlertDescription is flex-col, which blockifies the inline copy around
+   the <strong> and broke one sentence into three stacked lines. */
+.maka-fake-backend-banner [data-slot="alert-description"] {
+  display: block;
 }
 
 .maka-fake-backend-banner strong {

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -539,14 +539,19 @@
     gap: 8px;
     padding: 8px 4px;
   }
+}
 
-  .maka-daily-review-summary-empty {
-    position: static;
-    left: auto;
-    top: auto;
-    width: 100%;
-    transform: none;
-    min-height: 120px;
-    align-content: center;
-  }
+/* Unlayered on purpose: the shared `.maka-empty-state` base
+   (onboarding.css) is unlayered `position: absolute` centering, and
+   unlayered rules always beat @layer rules — inside @layer components
+   this override silently never applied, so the "no activity" card
+   floated over the archived-report pane as a translucent overlay. */
+.maka-daily-review-panel .maka-daily-review-summary-empty {
+  position: static;
+  left: auto;
+  top: auto;
+  width: 100%;
+  transform: none;
+  min-height: 120px;
+  align-content: center;
 }


### PR DESCRIPTION
## Summary

Round 2 of the fixture-screenshot visual audit (follow-up to #436).

### 1. 每日回顾: empty state floated over the archived report
`.maka-daily-review-summary-empty` overrides the shared `.maka-empty-state` base — but the override sat inside `@layer components` while the base (onboarding.css:900, `position: absolute` + translate centering) is **unlayered**. Unlayered rules always beat layered ones, so the override silently never applied: the「等待记录今天活动」card rendered as a translucent overlay on top of the report text.

Fix: move the override out of the layer with panel-scoped specificity (`.maka-daily-review-panel .maka-daily-review-summary-empty`).

### 2. stale-session banner: clipped right edge, mis-anchored icon, shredded copy
Three stacked issues on `.maka-fake-backend-banner`:
- Alert primitive ships `w-full` → with 14px horizontal margins the banner was 28px wider than the pane, right edge clipped against the card
- `align-items: center` parked the ⚠️ icon on the middle of three lines
- `AlertDescription` is `flex flex-col`, which blockified the inline copy around `<strong>设置 · 模型</strong>` into three stacked fragments

Fix: `width: auto` + `align-items: flex-start` (the primitive's 1lh svg box then self-aligns to the first line) + `display: block` on the description. The banner is now one inline-flowing sentence with a correctly anchored icon.

## Verification
- before/after fixture screenshots reviewed (module-daily-review, stale-sessions × light-1280)
- `npm --workspace @maka/desktop test`: 1671/1671 pass