### PR TITLE
fix(ui): pin artifact toolbar separator to a 1px hairline

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -871,6 +871,15 @@
 }
 
 .maka-artifact-toolbar-separator {
+  /* Pin the separator to a literal 1px hairline. At narrow pane widths
+     the toolbar wraps and this element rendered as a ~15px bordered
+     pill next to the delete button — visual noise that read as an
+     empty broken button. */
+  flex: 0 0 1px;
+  width: 1px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
   min-height: 22px;
   background: var(--border);
 }


### PR DESCRIPTION
Round 3 of the fixture-screenshot visual audit (follow-up to #436 / #438).

At narrow artifact-pane widths the toolbar wraps, and the `ToolbarSeparator` rendered as a ~15px bordered pill next to the 删除 button — visual noise that read as an empty, broken button (visible in both artifact-pane and artifact-errors fixtures).

Fix is CSS-only: pin `.maka-artifact-toolbar-separator` to `flex: 0 0 1px; width: 1px` with no padding/border/radius. The markup is locked by `artifact-pane-lifecycle-contract` and stays untouched.

## Verification
- before/after artifact-errors fixture screenshots
- `npm --workspace @maka/desktop test`: 1671/1671 pass