### PR TITLE
fix(ui): stop leaking the raw absolute MEMORY.md path in settings

### DIFF
--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -674,8 +674,10 @@ export function MemorySettingsPage(props: {
         </div>
       )}
 
-      <div className="settingsConnectionMeta">
-        <span>{effective.path || '等待创建 MEMORY.md'}</span>
+      <div className="settingsConnectionMeta settingsMemoryMeta">
+        <span className="settingsMemoryPath" title={effective.path || undefined}>
+          {effective.path ? displayMemoryPath(effective.path) : '等待创建 MEMORY.md'}
+        </span>
         {effective.latestBackup ? (
           <span className="settingsMemoryBackupState">
             上一版 {localMemoryBackupKindLabel(effective.latestBackup.kind)} · {localMemoryBackupSummary(effective.latestBackup)} · <RelativeTime ts={effective.latestBackup.updatedAt} />
@@ -1138,6 +1140,18 @@ function memoryEntryStatusLabel(status: LocalMemoryState['entries'][number]['sta
 function formatLocalMemorySaveSummary(state: LocalMemoryState): string {
   const archived = state.archivedEntryCount > 0 ? ` / ${state.archivedEntryCount} 条已归档` : '';
   return `当前 ${state.activeEntryCount} 条生效${archived}；已保留上一版备份。`;
+}
+
+/** Display-only path shortening: the full absolute MEMORY.md path used
+ * to render as a full-width mono line that shoved the sibling status
+ * words into a cramped stack (and leaked the raw absolute path into
+ * the renderer, against the UI quality plan). Show the meaningful
+ * trailing segments; the full path stays available via title= and the
+ * copy-path action. */
+function displayMemoryPath(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length <= 3) return path;
+  return `…/${parts.slice(-3).join('/')}`;
 }
 
 function localMemoryBackupKindLabel(kind: NonNullable<LocalMemoryState['latestBackup']>['kind']): string {

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -330,4 +330,26 @@
     min-height: 480px;
     grid-template-columns: minmax(190px, 0.7fr) minmax(250px, 1fr);
   }
+
+  /* Memory page meta row: the absolute MEMORY.md path used to render
+     full-width mono text that shoved the sibling status words into a
+     cramped vertical stack. Give the path its own full row with
+     head-side ellipsis (RTL trick keeps the meaningful .../MEMORY.md
+     tail visible; title= carries the full path on hover). */
+  .settingsMemoryMeta {
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+
+  .settingsMemoryPath {
+    /* The component already shortens the path for display
+       (displayMemoryPath); this is just the safety net so an
+       unexpectedly long tail can never shove the status words into a
+       cramped stack again. */
+    flex: 1 1 100%;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
Round 5 of the fixture-screenshot visual audit (follow-up to #436/#438/#439/#440).

The 记忆 settings meta row rendered the **full absolute path** (`/private/var/folders/…/MEMORY.md`) as a full-width mono line:
- the sibling status words (上一版备份 / 草稿已保存 / N 条生效) got shoved into a cramped vertical stack
- a raw absolute path leaked into the renderer — against the UI quality plan §3.6 ("No absolute path in renderer")

Fix (display layer only):
- `displayMemoryPath()` shows the meaningful trailing `…/<workspace>/memory/MEMORY.md` segments
- `title=` keeps the full path on hover; the copy-path action still copies the real path
- meta row wraps; nowrap/ellipsis safety net on the path span

Contract kept: `等待创建 MEMORY.md` stays inline in `MemorySettingsPage` (local-memory-ui-contract).

## Verification
- before/after settings-memory fixture screenshots (zoomed crops)
- `npm --workspace @maka/desktop test`: 1671/1671 pass