### PR TITLE
fix(ui): artifact file list crushed to 40% of its own content height

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -414,7 +414,13 @@
   flex: 0 0 auto;
   width: 320px;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  /* Row 2 (file list): content-sized but never past 40% of the pane.
+     fit-content(40%) resolves against the pane's definite height —
+     unlike max-height:40% on the list itself, which Chromium resolved
+     against the auto track's content height and collapsed the list to
+     40% of its own rows (#443). minmax(auto,40%) is wrong too: the
+     maximize-tracks step inflates it to the full 40% even for one row. */
+  grid-template-rows: auto fit-content(40%) minmax(0, 1fr) auto;
   border-left: 1px solid var(--border);
   background: var(--background);
   overflow: hidden;
@@ -555,7 +561,11 @@
   padding: 4px 4px 0;
   overflow-y: auto;
   border-bottom: 1px solid var(--border);
-  max-height: 40%;
+  /* No max-height here: a percentage on the item resolves against the
+     auto grid track's own content height (Chromium), which crushed the
+     list to 40% of ITSELF — a single-file list showed only ~12px of
+     its one row (#443). The 40%-of-pane cap lives on the grid track
+     (minmax) in .maka-artifact-pane instead. */
 }
 
 .maka-artifact-list-item {


### PR DESCRIPTION
Fixes #443 (round 6 of the fixture-screenshot visual audit).

## Root cause
`.maka-artifact-list { max-height: 40% }` sits in an **auto-sized grid row**. Chromium resolves that percentage against the track's own content height — so the list was permanently crushed to 40% of ITSELF:
- 1-file pane (artifact-preview-image): list = **16px**, only ~12px of the single row visible, the preview surface visually overlapped it
- 6-file pane (artifact-errors): only ~2.2 rows visible

## Fix
Move the cap onto the grid track: `grid-template-rows: auto fit-content(40%) minmax(0,1fr) auto`. `fit-content(40%)` resolves against the pane's **definite** height = content-sized up to 40% of the pane, then scroll. (`minmax(auto, 40%)` is wrong too — the maximize-tracks step inflates it to the full 40% even for one row; verified.)

## Verification (DOM geometry dumps via a temporary executeJavaScript probe)
| fixture | before | after |
|---|---|---|
| artifact-preview-image (1 file) | list h=16px, row clipped | list h=39px, row fully visible |
| artifact-errors (6 files) | ~2.2 rows visible | h=208px, **all 6 rows visible**, preview 489px |

`npm --workspace @maka/desktop test`: 1671/1671 pass.