### PR TITLE
fix(desktop): keep collapsed topbar actions clickable

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
@@ -71,18 +71,18 @@ describe('chat header actions inset contract', () => {
     );
   });
 
-  it('reserves the toolbar inset as chat-header right padding', async () => {
+  it('reserves the toolbar inset by ending the chat-header drag box before the actions', async () => {
     const css = await readRendererContractCss();
     const body = ruleBody(css, '.maka-chat-header');
     assert.match(
       body,
-      /padding:[^;]*var\(--maka-workspace-top-actions-inset\)/,
-      '.maka-chat-header must reserve --maka-workspace-top-actions-inset as right padding so right-aligned content does not render under .maka-workspace-top-actions',
+      /margin-right:\s*var\(--maka-workspace-top-actions-inset\)/,
+      '.maka-chat-header must reserve --maka-workspace-top-actions-inset in its box geometry so the drag region does not cover .maka-workspace-top-actions',
     );
-    assert.doesNotMatch(
+    assert.match(
       body,
       /padding:\s*0\s+10px\s*;/,
-      'the header should no longer use the pre-fix symmetric 10px padding that let pills overlap the toolbar',
+      'after margin-right reserves the toolbar footprint, the header can keep compact symmetric padding for its own content',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
@@ -1,71 +1,24 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { CONTRACT_REPO_ROOT, readRendererContractCss } from './contract-css-helpers.js';
-
-const SHELL_TOPBAR_CLEARANCE_PX = 8;
-
-async function shellTopbarButtonCount(): Promise<number> {
-  const source = await readFile(
-    join(CONTRACT_REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'app-shell-chrome-actions.tsx'),
-    'utf8',
-  );
-  const start = source.indexOf('export function AppShellTopbarActions');
-  const end = source.indexOf('export function AppShellWorkspaceTopActions');
-  assert.notEqual(start, -1, 'AppShellTopbarActions should exist');
-  assert.notEqual(end, -1, 'AppShellWorkspaceTopActions should exist');
-  const block = source.slice(start, end);
-  return [...block.matchAll(/className="maka-shell-topbar-button"/g)].length;
-}
+import { readRendererContractCss } from './contract-css-helpers.js';
 
 describe('sidebar topbar rail geometry contract', () => {
-  it('keeps expanded and collapsed shell controls on the shared titlebar geometry', async () => {
+  it('keeps shell titlebar actions in place while drag strips avoid their hit boxes', async () => {
     const css = await readRendererContractCss();
-    const buttonCount = await shellTopbarButtonCount();
 
-    const tokenRule = extractRuleBody(css, '.maka-shell-2col');
-    assert.ok(tokenRule, '.maka-shell-2col must define the shared topbar geometry tokens');
-    for (const token of [
-      '--maka-sidebar-topbar-button-size',
-      '--maka-sidebar-topbar-gap',
-      '--maka-sidebar-topbar-offset-y',
-      '--maka-sidebar-topbar-offset-x',
-      '--maka-sidebar-collapsed-topbar-inset',
-    ]) {
-      assert.match(tokenRule, new RegExp(`${escapeRegExp(token)}\\s*:`), `${token} must be defined once on the shell`);
-    }
-    const insetValue = customPropertyValue(tokenRule, '--maka-sidebar-collapsed-topbar-inset');
-    assert.match(insetValue, /var\(--maka-sidebar-topbar-offset-x\)/);
-    assert.equal(
-      countMatches(insetValue, /var\(--maka-sidebar-topbar-button-size\)/g),
-      buttonCount,
-      'collapsed chat header drag strip must reserve the collapsed titlebar button footprint',
-    );
-    assert.equal(
-      countMatches(insetValue, /var\(--maka-sidebar-topbar-gap\)/g),
-      buttonCount - 1,
-      'collapsed chat header drag strip must include the gaps between titlebar buttons',
-    );
+    const tokenRule = ruleBody(css, '.maka-shell-2col');
     assert.match(
-      insetValue,
-      new RegExp(`${SHELL_TOPBAR_CLEARANCE_PX}px`),
-      'collapsed chat header drag strip must keep a small clearance after the titlebar buttons',
+      tokenRule,
+      /--maka-sidebar-collapsed-topbar-inset\s*:/,
+      'collapsed chat header drag strip must have a left inset for the titlebar actions',
     );
-
-    const shellRail = extractRuleBody(css, '.maka-shell-topbar-rail');
-    assert.ok(shellRail, '.maka-shell-topbar-rail rule must exist');
-    assert.match(shellRail, /top:\s*var\(--maka-sidebar-topbar-offset-y\)/);
-    assert.match(shellRail, /left:\s*var\(--maka-sidebar-topbar-offset-x\)/);
-    assert.match(shellRail, /gap:\s*var\(--maka-sidebar-topbar-gap\)/);
     assert.doesNotMatch(
-      shellRail,
-      /var\(--maka-session-list-width/,
-      'shell controls must not move horizontally when the sidebar width changes',
+      css,
+      /--maka-sidebar-collapsed-topbar-offset-y/,
+      'do not fix collapsed hit testing by moving the titlebar actions below the titlebar',
     );
 
-    const collapsedRail = extractRuleBody(css, '.maka-shell-topbar-rail.is-collapsed');
-    assert.doesNotMatch(css, /--maka-sidebar-collapsed-topbar-offset-y/, 'do not reintroduce a below-titlebar collapsed rail offset');
+    const collapsedRail = optionalRuleBody(css, '.maka-shell-topbar-rail.is-collapsed');
     if (collapsedRail) {
       assert.doesNotMatch(
         collapsedRail,
@@ -74,57 +27,35 @@ describe('sidebar topbar rail geometry contract', () => {
       );
     }
 
-    const shellButtons = extractRuleBody(css, '.maka-shell-topbar-button');
-    assert.ok(shellButtons, 'shell rail buttons must share one rule');
-    assert.match(shellButtons, /width:\s*var\(--maka-sidebar-topbar-button-size\)/);
-    assert.match(shellButtons, /height:\s*var\(--maka-sidebar-topbar-button-size\)/);
-  });
-
-  it('keeps expanded top chrome in the titlebar while drag strips avoid the icon hit boxes', async () => {
-    const css = await readRendererContractCss();
-
-    assert.doesNotMatch(
-      css,
-      /--maka-titlebar-interactive-safe-center-y/,
-      'do not move top chrome below the titlebar to dodge hit-test bugs; keep it on the titlebar baseline and carve drag regions away instead',
-    );
-    assert.match(
-      css,
-      /--maka-workspace-top-actions-top:\s*calc\(var\(--maka-titlebar-control-safe-top\)\s*-\s*17px\)/,
-      'workspace top actions should stay aligned to the titlebar control baseline',
-    );
-
-    const shellTokens = extractRuleBody(css, '.maka-shell-2col');
-    assert.ok(shellTokens, '.maka-shell-2col must define sidebar topbar geometry tokens');
-    assert.match(
-      shellTokens,
-      /--maka-sidebar-topbar-offset-y:\s*calc\(var\(--maka-titlebar-control-safe-top\)\s*-\s*18px\)/,
-      'sidebar topbar rail should stay aligned to the titlebar control baseline',
-    );
-
-    const sidebarHeader = extractRuleBody(css, '.maka-session-panel-header');
-    assert.ok(sidebarHeader, '.maka-session-panel-header rule must exist');
+    const sidebarHeader = ruleBody(css, '.maka-session-panel-header');
     assert.doesNotMatch(
       sidebarHeader,
       /-webkit-app-region:\s*drag/,
       'the full sidebar header covers the titlebar buttons; only the narrowed drag strip should be draggable',
     );
 
-    const sidebarDragStrip = extractRuleBody(css, '.maka-sidebar-drag-strip');
-    assert.ok(sidebarDragStrip, '.maka-sidebar-drag-strip rule must exist');
+    const sidebarDragStrip = ruleBody(css, '.maka-sidebar-drag-strip');
     assert.match(
       sidebarDragStrip,
-      /margin-left:\s*calc\(\s*var\(--maka-sidebar-topbar-offset-x\)\s*\+\s*var\(--maka-sidebar-topbar-button-size\)\s*\+\s*var\(--maka-sidebar-topbar-button-size\)\s*\+\s*var\(--maka-sidebar-topbar-gap\)\s*\+\s*8px\s*\)/,
-      'the sidebar drag strip should start to the right of the two titlebar buttons',
+      /margin-left:\s*calc\(/,
+      'the sidebar drag strip should leave a clickable titlebar action area before the draggable blank strip',
+    );
+    assert.match(
+      sidebarDragStrip,
+      /-webkit-app-region:\s*drag/,
+      'the narrowed sidebar drag strip should remain draggable',
     );
 
-    const chatHeader = extractRuleBody(css, '.maka-chat-header');
-    assert.ok(chatHeader, '.maka-chat-header rule must exist');
-    const collapsedChatHeader = extractRuleBody(
+    const chatHeader = ruleBody(css, '.maka-chat-header');
+    assert.match(
+      chatHeader,
+      /margin-right:\s*var\(--maka-workspace-top-actions-inset\)/,
+      'the chat header drag strip should end before the workspace top actions',
+    );
+    const collapsedChatHeader = ruleBody(
       css,
       '.maka-shell-2col[data-sidebar-state="collapsed"] .maka-chat-header',
     );
-    assert.ok(collapsedChatHeader, 'collapsed chat header rule must exist');
     assert.match(
       collapsedChatHeader,
       /margin-left:\s*var\(--maka-sidebar-collapsed-topbar-inset\)/,
@@ -138,55 +69,13 @@ describe('sidebar topbar rail geometry contract', () => {
   });
 });
 
-function extractRuleBody(css: string, selector: string | string[]): string | undefined {
-  const expected = Array.isArray(selector) ? selector : [selector];
-  for (const rule of iterateRules(css)) {
-    const selectors = rule.selector.split(',').map((part) => part.trim());
-    if (selectors.length === expected.length && expected.every((part) => selectors.includes(part))) {
-      return rule.body;
-    }
-  }
-  return undefined;
+function ruleBody(css: string, selector: string): string {
+  const body = optionalRuleBody(css, selector);
+  assert.ok(body, `${selector} rule must exist`);
+  return body;
 }
 
-function customPropertyValue(body: string, property: string): string {
-  const match = new RegExp(`${escapeRegExp(property)}:\\s*([\\s\\S]*?);`).exec(body);
-  assert.ok(match, `${property} must be declared`);
-  return match[1] ?? '';
-}
-
-function countMatches(value: string, pattern: RegExp): number {
-  return [...value.matchAll(pattern)].length;
-}
-
-function* iterateRules(css: string): Generator<{ selector: string; body: string }> {
-  let i = 0;
-  while (i < css.length) {
-    while (i < css.length && /\s/.test(css[i]!)) i += 1;
-    if (css.startsWith('/*', i)) {
-      const end = css.indexOf('*/', i + 2);
-      if (end === -1) return;
-      i = end + 2;
-      continue;
-    }
-    const braceIdx = css.indexOf('{', i);
-    if (braceIdx === -1) return;
-    const selector = css.slice(i, braceIdx).trim();
-    let depth = 1;
-    let j = braceIdx + 1;
-    while (j < css.length && depth > 0) {
-      const ch = css[j];
-      if (ch === '{') depth += 1;
-      if (ch === '}') depth -= 1;
-      j += 1;
-    }
-    if (selector && !selector.startsWith('@')) {
-      yield { selector, body: css.slice(braceIdx + 1, j - 1) };
-    }
-    i = j;
-  }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function optionalRuleBody(css: string, selector: string): string | undefined {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css)?.[1];
 }

--- a/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-topbar-rail-contract.test.ts
@@ -1,10 +1,28 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readRendererContractCss } from './contract-css-helpers.js';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { CONTRACT_REPO_ROOT, readRendererContractCss } from './contract-css-helpers.js';
+
+const SHELL_TOPBAR_CLEARANCE_PX = 8;
+
+async function shellTopbarButtonCount(): Promise<number> {
+  const source = await readFile(
+    join(CONTRACT_REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'app-shell-chrome-actions.tsx'),
+    'utf8',
+  );
+  const start = source.indexOf('export function AppShellTopbarActions');
+  const end = source.indexOf('export function AppShellWorkspaceTopActions');
+  assert.notEqual(start, -1, 'AppShellTopbarActions should exist');
+  assert.notEqual(end, -1, 'AppShellWorkspaceTopActions should exist');
+  const block = source.slice(start, end);
+  return [...block.matchAll(/className="maka-shell-topbar-button"/g)].length;
+}
 
 describe('sidebar topbar rail geometry contract', () => {
-  it('anchors expanded and collapsed shell controls to the same top-left geometry', async () => {
+  it('keeps expanded and collapsed shell controls on the shared titlebar geometry', async () => {
     const css = await readRendererContractCss();
+    const buttonCount = await shellTopbarButtonCount();
 
     const tokenRule = extractRuleBody(css, '.maka-shell-2col');
     assert.ok(tokenRule, '.maka-shell-2col must define the shared topbar geometry tokens');
@@ -13,9 +31,27 @@ describe('sidebar topbar rail geometry contract', () => {
       '--maka-sidebar-topbar-gap',
       '--maka-sidebar-topbar-offset-y',
       '--maka-sidebar-topbar-offset-x',
+      '--maka-sidebar-collapsed-topbar-inset',
     ]) {
       assert.match(tokenRule, new RegExp(`${escapeRegExp(token)}\\s*:`), `${token} must be defined once on the shell`);
     }
+    const insetValue = customPropertyValue(tokenRule, '--maka-sidebar-collapsed-topbar-inset');
+    assert.match(insetValue, /var\(--maka-sidebar-topbar-offset-x\)/);
+    assert.equal(
+      countMatches(insetValue, /var\(--maka-sidebar-topbar-button-size\)/g),
+      buttonCount,
+      'collapsed chat header drag strip must reserve the collapsed titlebar button footprint',
+    );
+    assert.equal(
+      countMatches(insetValue, /var\(--maka-sidebar-topbar-gap\)/g),
+      buttonCount - 1,
+      'collapsed chat header drag strip must include the gaps between titlebar buttons',
+    );
+    assert.match(
+      insetValue,
+      new RegExp(`${SHELL_TOPBAR_CLEARANCE_PX}px`),
+      'collapsed chat header drag strip must keep a small clearance after the titlebar buttons',
+    );
 
     const shellRail = extractRuleBody(css, '.maka-shell-topbar-rail');
     assert.ok(shellRail, '.maka-shell-topbar-rail rule must exist');
@@ -28,10 +64,77 @@ describe('sidebar topbar rail geometry contract', () => {
       'shell controls must not move horizontally when the sidebar width changes',
     );
 
+    const collapsedRail = extractRuleBody(css, '.maka-shell-topbar-rail.is-collapsed');
+    assert.doesNotMatch(css, /--maka-sidebar-collapsed-topbar-offset-y/, 'do not reintroduce a below-titlebar collapsed rail offset');
+    if (collapsedRail) {
+      assert.doesNotMatch(
+        collapsedRail,
+        /top\s*:/,
+        'collapsed shell controls must not get a special vertical offset; keep the rail visually in the titlebar and carve the drag strip instead',
+      );
+    }
+
     const shellButtons = extractRuleBody(css, '.maka-shell-topbar-button');
     assert.ok(shellButtons, 'shell rail buttons must share one rule');
     assert.match(shellButtons, /width:\s*var\(--maka-sidebar-topbar-button-size\)/);
     assert.match(shellButtons, /height:\s*var\(--maka-sidebar-topbar-button-size\)/);
+  });
+
+  it('keeps expanded top chrome in the titlebar while drag strips avoid the icon hit boxes', async () => {
+    const css = await readRendererContractCss();
+
+    assert.doesNotMatch(
+      css,
+      /--maka-titlebar-interactive-safe-center-y/,
+      'do not move top chrome below the titlebar to dodge hit-test bugs; keep it on the titlebar baseline and carve drag regions away instead',
+    );
+    assert.match(
+      css,
+      /--maka-workspace-top-actions-top:\s*calc\(var\(--maka-titlebar-control-safe-top\)\s*-\s*17px\)/,
+      'workspace top actions should stay aligned to the titlebar control baseline',
+    );
+
+    const shellTokens = extractRuleBody(css, '.maka-shell-2col');
+    assert.ok(shellTokens, '.maka-shell-2col must define sidebar topbar geometry tokens');
+    assert.match(
+      shellTokens,
+      /--maka-sidebar-topbar-offset-y:\s*calc\(var\(--maka-titlebar-control-safe-top\)\s*-\s*18px\)/,
+      'sidebar topbar rail should stay aligned to the titlebar control baseline',
+    );
+
+    const sidebarHeader = extractRuleBody(css, '.maka-session-panel-header');
+    assert.ok(sidebarHeader, '.maka-session-panel-header rule must exist');
+    assert.doesNotMatch(
+      sidebarHeader,
+      /-webkit-app-region:\s*drag/,
+      'the full sidebar header covers the titlebar buttons; only the narrowed drag strip should be draggable',
+    );
+
+    const sidebarDragStrip = extractRuleBody(css, '.maka-sidebar-drag-strip');
+    assert.ok(sidebarDragStrip, '.maka-sidebar-drag-strip rule must exist');
+    assert.match(
+      sidebarDragStrip,
+      /margin-left:\s*calc\(\s*var\(--maka-sidebar-topbar-offset-x\)\s*\+\s*var\(--maka-sidebar-topbar-button-size\)\s*\+\s*var\(--maka-sidebar-topbar-button-size\)\s*\+\s*var\(--maka-sidebar-topbar-gap\)\s*\+\s*8px\s*\)/,
+      'the sidebar drag strip should start to the right of the two titlebar buttons',
+    );
+
+    const chatHeader = extractRuleBody(css, '.maka-chat-header');
+    assert.ok(chatHeader, '.maka-chat-header rule must exist');
+    const collapsedChatHeader = extractRuleBody(
+      css,
+      '.maka-shell-2col[data-sidebar-state="collapsed"] .maka-chat-header',
+    );
+    assert.ok(collapsedChatHeader, 'collapsed chat header rule must exist');
+    assert.match(
+      collapsedChatHeader,
+      /margin-left:\s*var\(--maka-sidebar-collapsed-topbar-inset\)/,
+      'when the sidebar is collapsed, the chat header drag strip must start after the left titlebar buttons',
+    );
+    assert.match(
+      chatHeader,
+      /-webkit-app-region:\s*drag/,
+      'the chat header remains a narrow drag strip after reserving the toolbar hit box',
+    );
   });
 });
 
@@ -46,9 +149,26 @@ function extractRuleBody(css: string, selector: string | string[]): string | und
   return undefined;
 }
 
+function customPropertyValue(body: string, property: string): string {
+  const match = new RegExp(`${escapeRegExp(property)}:\\s*([\\s\\S]*?);`).exec(body);
+  assert.ok(match, `${property} must be declared`);
+  return match[1] ?? '';
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  return [...value.matchAll(pattern)].length;
+}
+
 function* iterateRules(css: string): Generator<{ selector: string; body: string }> {
   let i = 0;
   while (i < css.length) {
+    while (i < css.length && /\s/.test(css[i]!)) i += 1;
+    if (css.startsWith('/*', i)) {
+      const end = css.indexOf('*/', i + 2);
+      if (end === -1) return;
+      i = end + 2;
+      continue;
+    }
     const braceIdx = css.indexOf('{', i);
     if (braceIdx === -1) return;
     const selector = css.slice(i, braceIdx).trim();

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -309,9 +309,10 @@
      toolbar occupies in the top-right corner: its right offset + four 24px icon
      buttons with 6px gaps (114px) + a 12px clearance gap. Right-aligned
      chat-header content (model switcher, .maka-chat-header-mode-pill, memory
-     pill) reserves this as right padding so it does not render underneath the
-     toolbar. Companion to PR-CHAT-HEADER-STATUS-CLUSTER-0, which only relocated
-     the status cluster and left the in-header pills overlapping. */
+     pill) and the chat-header drag strip reserve this footprint so neither
+     content nor titlebar hit regions sit underneath the toolbar. Companion to
+     PR-CHAT-HEADER-STATUS-CLUSTER-0, which only relocated the status cluster and
+     left the in-header pills overlapping. */
   --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 126px);
 
   /* session list geometry */

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1945,14 +1945,19 @@
   display: flex;
   align-items: flex-end;
   gap: 4px;
-  /* Right padding reserves space for the absolutely-positioned
-     .maka-workspace-top-actions toolbar so right-aligned content
-     (.maka-chat-header-mode-pill, .maka-model-switcher, memory pill) stops
-     before the toolbar instead of rendering underneath it. */
-  padding: 0 var(--maka-workspace-top-actions-inset) 0 10px;
+  /* The header is also a drag strip, so its box must stop before the
+     absolutely-positioned .maka-workspace-top-actions toolbar instead of
+     merely padding content away from it. Otherwise the transparent drag
+     region covers the titlebar icon buttons. */
+  margin-right: var(--maka-workspace-top-actions-inset);
+  padding: 0 10px;
   background: transparent;
   border-bottom: 0;
   -webkit-app-region: drag;
+}
+
+.maka-shell-2col[data-sidebar-state="collapsed"] .maka-chat-header {
+  margin-left: var(--maka-sidebar-collapsed-topbar-inset);
 }
 
 /* PR-CHAT-HEADER-STATUS-CLUSTER-0: the session-status / connection /

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -24,6 +24,11 @@
   --maka-sidebar-topbar-gap: 8px;
   --maka-sidebar-topbar-offset-y: calc(var(--maka-titlebar-control-safe-top) - 18px);
   --maka-sidebar-topbar-offset-x: calc(var(--maka-titlebar-control-safe-left) - 10px);
+  --maka-sidebar-collapsed-topbar-inset: calc(
+    var(--maka-sidebar-topbar-offset-x) + var(--maka-sidebar-topbar-button-size) +
+      var(--maka-sidebar-topbar-button-size) + var(--maka-sidebar-topbar-button-size) +
+      var(--maka-sidebar-topbar-gap) + var(--maka-sidebar-topbar-gap) + 8px
+  );
   position: relative;
   display: grid;
   grid-template-columns:
@@ -491,11 +496,14 @@
   gap: 5px;
   padding: 6px 6px 7px;
   border-bottom: 0;
-  -webkit-app-region: drag;
 }
 
 .maka-sidebar-drag-strip {
   min-height: 34px;
+  margin-left: calc(
+    var(--maka-sidebar-topbar-offset-x) + var(--maka-sidebar-topbar-button-size) +
+      var(--maka-sidebar-topbar-button-size) + var(--maka-sidebar-topbar-gap) + 8px
+  );
   box-sizing: border-box;
   -webkit-app-region: drag;
 }


### PR DESCRIPTION
## Summary

Keep the collapsed sidebar topbar actions visually on the macOS titlebar baseline while making them clickable again.

## Why

In the collapsed sidebar state, Search, Expand sidebar, and New Task looked like titlebar controls but clicks were swallowed by the overlapping `.maka-chat-header` drag region. Moving the buttons below the titlebar fixed hit testing but introduced an unacceptable visual regression.

Closes #

None.

## Scope

Changed:
- Carve the chat-header drag box away from the left collapsed shell actions and the right workspace actions.
- Keep the shell topbar rail on the shared titlebar geometry instead of adding a collapsed vertical offset.
- Add a minimal CSS contract for the relevant hit-test geometry: chat-header margins, collapsed left inset, sidebar header drag hygiene, and narrowed draggable blank strips.
- Update the workspace top-actions inset comment to describe drag-region reservation, not padding-only spacing.

Not included:
- No Electron BrowserWindow chrome changes.
- No visual relocation of the titlebar buttons.
- No behavior changes to sidebar navigation, session creation, or search beyond restoring clickability.

## Verification

- `node --test dist/main/__tests__/sidebar-topbar-rail-contract.test.js dist/main/__tests__/chat-header-actions-inset-contract.test.js`
- `npm --workspace @maka/desktop test`
- Manual Electron check: clicked Search, New Task, and Expand while the buttons stayed in the titlebar row.

## User-facing impact

Collapsed titlebar actions stay in the expected titlebar position and are clickable again. No changelog, docs, breaking changes, or migrations.

## Reviewer notes

Fresh-eye review agreed the production CSS seam is the smallest correct fix: shrink the `drag` regions rather than moving buttons or changing window chrome. Follow-up cleanup keeps the regression contract focused on the CSS hit-test surface instead of deriving exact geometry from JSX or `calc()` formulas.
