### PR TITLE
feat(storybook): add P0 UI primitive stories (Button, Alert, Dialog, Select, Switch, Tabs, Checkbox, Form Controls, Toast)

### DIFF
--- a/packages/ui/stories/alert.stories.tsx
+++ b/packages/ui/stories/alert.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info } from '@maka/ui/icons';
+import { Alert, AlertAction, AlertDescription, AlertTitle } from '../src/primitives/alert.js';
+import { Button } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Alert',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const ICONS = {
+  default: <Info size={16} strokeWidth={1.75} aria-hidden="true" />,
+  error: <AlertCircle size={16} strokeWidth={1.75} aria-hidden="true" />,
+  info: <Info size={16} strokeWidth={1.75} aria-hidden="true" />,
+  success: <CheckCircle2 size={16} strokeWidth={1.75} aria-hidden="true" />,
+  warning: <AlertTriangle size={16} strokeWidth={1.75} aria-hidden="true" />,
+} as const;
+
+const VARIANTS = ['default', 'error', 'info', 'success', 'warning'] as const;
+
+export const TitleOnly: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 480 }}>
+      {VARIANTS.map((variant) => (
+        <Alert key={variant} variant={variant}>
+          {ICONS[variant]}
+          <AlertTitle>{variant} 标题</AlertTitle>
+        </Alert>
+      ))}
+    </div>
+  ),
+};
+
+export const TitleAndDescription: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 480 }}>
+      {VARIANTS.map((variant) => (
+        <Alert key={variant} variant={variant}>
+          {ICONS[variant]}
+          <AlertTitle>{variant} 标题</AlertTitle>
+          <AlertDescription>这条说明文字配合 {variant} 样式，验证图标、标题和描述的排版。</AlertDescription>
+        </Alert>
+      ))}
+    </div>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 480 }}>
+      {VARIANTS.map((variant) => (
+        <Alert key={variant} variant={variant}>
+          {ICONS[variant]}
+          <AlertTitle>{variant} 标题</AlertTitle>
+          <AlertDescription>带操作按钮的 alert，操作区在右侧。</AlertDescription>
+          <AlertAction>
+            <Button variant="ghost" size="sm">查看</Button>
+          </AlertAction>
+        </Alert>
+      ))}
+    </div>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, maxWidth: 480 }}>
+      <Alert variant="info">
+        <AlertTitle>无图标 info</AlertTitle>
+          <AlertDescription>验证 has-[&gt;svg] 选择器不影响无图标布局。</AlertDescription>
+      </Alert>
+      <Alert variant="warning">
+        <AlertTitle>无图标 warning</AlertTitle>
+        <AlertDescription>带操作按钮但无图标。</AlertDescription>
+        <AlertAction>
+          <Button variant="ghost" size="sm">忽略</Button>
+        </AlertAction>
+      </Alert>
+    </div>
+  ),
+};

--- a/packages/ui/stories/button.stories.tsx
+++ b/packages/ui/stories/button.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Plus, Search, Trash2 } from '@maka/ui/icons';
+import { Button } from '../src/ui.js';
+import { Spinner } from '../src/primitives/spinner.js';
+
+const meta = {
+  title: 'Primitives/Button',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['default', 'secondary', 'ghost', 'outline', 'destructive', 'quiet'] as const;
+const SIZES = ['sm', 'md', 'lg', 'icon', 'icon-sm', 'nav'] as const;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 72 }}>{label}</span>
+      <div style={{ alignItems: 'center', display: 'flex', gap: 8, flexWrap: 'wrap' }}>{children}</div>
+    </div>
+  );
+}
+
+export const VariantMatrix: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 560 }}>
+      {VARIANTS.map((variant) => (
+        <Row key={variant} label={variant}>
+          <Button variant={variant}>按钮</Button>
+          <Button variant={variant} disabled>disabled</Button>
+        </Row>
+      ))}
+    </div>
+  ),
+};
+
+export const SizeMatrix: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 560 }}>
+      {SIZES.map((size) => (
+        <Row key={size} label={size}>
+          <Button size={size}>Aa</Button>
+        </Row>
+      ))}
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <Button>
+        <Plus aria-hidden="true" />
+        新建
+      </Button>
+      <Button variant="secondary">
+        <Search aria-hidden="true" />
+        搜索
+      </Button>
+      <Button variant="destructive">
+        <Trash2 aria-hidden="true" />
+        删除
+      </Button>
+      <Button variant="outline" size="icon" aria-label="搜索">
+        <Search aria-hidden="true" />
+      </Button>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <Button disabled>
+        <Spinner style={{ height: 14, width: 14 }} />
+        提交中
+      </Button>
+      <Button variant="secondary" disabled>
+        <Spinner style={{ height: 14, width: 14 }} />
+        加载
+      </Button>
+      <Button variant="outline" size="icon-sm" disabled aria-label="加载中">
+        <Spinner style={{ height: 14, width: 14 }} />
+      </Button>
+    </div>
+  ),
+};
+
+export const NavSize: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 8 }}>
+      <Button size="nav" className="h-[30px] min-h-[30px] px-1.5 text-xs">
+        nav 行内
+      </Button>
+      <Button size="nav" variant="ghost" className="h-[30px] min-h-[30px] px-1.5 text-xs">
+        ghost nav
+      </Button>
+    </div>
+  ),
+};

--- a/packages/ui/stories/checkbox.stories.tsx
+++ b/packages/ui/stories/checkbox.stories.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Checkbox } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Checkbox',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+      {children}
+      <span style={{ fontSize: 13 }}>{label}</span>
+    </label>
+  );
+}
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 14, width: 200 }}>
+      <Row label="unchecked">
+        <Checkbox checked={false} onCheckedChange={() => undefined} aria-label="未勾选" />
+      </Row>
+      <Row label="checked">
+        <Checkbox checked onCheckedChange={() => undefined} aria-label="已勾选" />
+      </Row>
+      <Row label="indeterminate">
+        <Checkbox indeterminate onCheckedChange={() => undefined} aria-label="半选" />
+      </Row>
+      <Row label="disabled unchecked">
+        <Checkbox checked={false} disabled onCheckedChange={() => undefined} aria-label="禁用未勾选" />
+      </Row>
+      <Row label="disabled checked">
+        <Checkbox checked disabled onCheckedChange={() => undefined} aria-label="禁用已勾选" />
+      </Row>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <Row label="点击切换">
+        <Checkbox checked={checked} onCheckedChange={setChecked} aria-label="受控勾选" />
+      </Row>
+    );
+  },
+};

--- a/packages/ui/stories/dialog.stories.tsx
+++ b/packages/ui/stories/dialog.stories.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DialogClose, DialogContent, DialogRoot, Button, Input, Label, Textarea } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Dialog',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function DialogShell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gap: 16, padding: 24, placeItems: 'center', minHeight: '100%' }}>
+      <p style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{title}</p>
+      {children}
+    </div>
+  );
+}
+
+function ControlledDialog({
+  triggerLabel,
+  showClose = true,
+  children,
+}: {
+  triggerLabel: string;
+  showClose?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>{triggerLabel}</Button>
+      <DialogRoot open={open} onOpenChange={setOpen}>
+        <DialogContent showClose={showClose}>{children}</DialogContent>
+      </DialogRoot>
+    </>
+  );
+}
+
+function Footer({ onClose }: { onClose: () => void }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+      <Button variant="ghost" onClick={onClose}>取消</Button>
+      <Button onClick={onClose}>确认</Button>
+    </div>
+  );
+}
+
+export const Basic: Story = {
+  render: () => (
+    <DialogShell title="点击按钮打开 dialog">
+      <ControlledDialog triggerLabel="打开 dialog">
+        <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 600 }}>基础 Dialog</h2>
+          <p style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
+            点击遮罩或右上角关闭按钮可关闭。DialogContent 默认带 showClose。
+          </p>
+        </div>
+      </ControlledDialog>
+    </DialogShell>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <DialogShell title="带底部操作按钮">
+      <ControlledDialogTriggerFooter />
+    </DialogShell>
+  ),
+};
+
+function ControlledDialogTriggerFooter() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>打开（带操作）</Button>
+      <DialogRoot open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600 }}>带操作按钮</h2>
+            <p style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
+              底部按钮通过 onOpenChange 关闭。
+            </p>
+            <Footer onClose={() => setOpen(false)} />
+          </div>
+        </DialogContent>
+      </DialogRoot>
+    </>
+  );
+}
+
+export const WithoutCloseButton: Story = {
+  render: () => (
+    <DialogShell title="showClose={false}，只能用底部按钮或 Esc 关闭">
+      <ControlledDialog triggerLabel="打开（无关闭按钮）" showClose={false}>
+        <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 600 }}>无关闭按钮</h2>
+          <p style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
+            showClose=false 时右上角不显示 X。
+          </p>
+        </div>
+      </ControlledDialog>
+    </DialogShell>
+  ),
+};
+
+export const WithDialogClose: Story = {
+  render: () => (
+    <DialogShell title="用 DialogClose 作为自定义关闭按钮">
+      <ControlledDialogClose />
+    </DialogShell>
+  ),
+};
+
+function ControlledDialogClose() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>打开（DialogClose 关闭）</Button>
+      <DialogRoot open={open} onOpenChange={setOpen}>
+        <DialogContent showClose={false}>
+          <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600 }}>DialogClose 示例</h2>
+            <p style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
+              DialogClose 包裹的按钮点击后会自动关闭 dialog。
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <DialogClose render={<Button variant="ghost" />}>关闭</DialogClose>
+            </div>
+          </div>
+        </DialogContent>
+      </DialogRoot>
+    </>
+  );
+}
+
+export const FormDialog: Story = {
+  render: () => (
+    <DialogShell title="表单 dialog，验证 Input/Label/Textarea 在 portal 内排版">
+      <ControlledDialogTriggerForm />
+    </DialogShell>
+  ),
+};
+
+function ControlledDialogTriggerForm() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>打开表单</Button>
+      <DialogRoot open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <div style={{ display: 'grid', gap: 14, padding: 24, width: 'min(92vw, 480px)' }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600 }}>编辑说明</h2>
+            <div style={{ display: 'grid', gap: 6 }}>
+              <Label htmlFor="dialog-title">标题</Label>
+              <Input id="dialog-title" defaultValue="项目周报" />
+            </div>
+            <div style={{ display: 'grid', gap: 6 }}>
+              <Label htmlFor="dialog-desc">描述</Label>
+              <Textarea id="dialog-desc" defaultValue="本周完成了 Storybook P0 组件覆盖。" />
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <Button variant="ghost" onClick={() => setOpen(false)}>取消</Button>
+              <Button onClick={() => setOpen(false)}>保存</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </DialogRoot>
+    </>
+  );
+}
+
+export const AlwaysOpen: Story = {
+  render: () => (
+    <DialogShell title="默认 open，验证 dialog 渲染（视觉回归快照）">
+      <DialogRoot open>
+        <DialogContent>
+          <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 600 }}>常驻 open</h2>
+            <p style={{ color: 'var(--muted-foreground)', fontSize: 14 }}>
+              DialogRoot open 固定为 true，用于视觉回归快照。
+            </p>
+          </div>
+        </DialogContent>
+      </DialogRoot>
+    </DialogShell>
+  ),
+};

--- a/packages/ui/stories/form-controls.stories.tsx
+++ b/packages/ui/stories/form-controls.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  FieldDescription,
+  FieldRoot,
+  Input,
+  Label,
+  Separator,
+  Textarea,
+} from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Form Controls',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gap: 8, maxWidth: 420 }}>
+      <h3 style={{ color: 'var(--muted-foreground)', fontSize: 12, fontWeight: 600, margin: 0 }}>{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+export const InputStates: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
+      <Section title="default">
+        <Input placeholder="输入内容…" aria-label="默认输入" />
+      </Section>
+      <Section title="with value">
+        <Input defaultValue="已经填好的文本" aria-label="有值输入" />
+      </Section>
+      <Section title="disabled">
+        <Input defaultValue="禁用态" disabled aria-label="禁用输入" />
+      </Section>
+      <Section title="aria-invalid (error)">
+        <Input defaultValue="错误值" aria-invalid="true" aria-label="错误态输入" />
+      </Section>
+    </div>
+  ),
+};
+
+export const TextareaStates: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
+      <Section title="default">
+        <Textarea placeholder="多行输入…" aria-label="默认多行" />
+      </Section>
+      <Section title="disabled">
+        <Textarea defaultValue="禁用态多行文本" disabled aria-label="禁用多行" />
+      </Section>
+    </div>
+  ),
+};
+
+export const Field: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
+      <Section title="完整 Field（Label + Input + Description）">
+        <FieldRoot className="grid gap-1.5">
+          <Label>项目名称</Label>
+          <Input defaultValue="maka-agent" aria-label="项目名称" />
+          <FieldDescription>显示在侧栏和会话标题里。</FieldDescription>
+        </FieldRoot>
+      </Section>
+      <Section title="Field + Textarea">
+        <FieldRoot className="grid gap-1.5">
+          <Label>项目说明</Label>
+          <Textarea defaultValue="一个本地优先的 AI agent。" aria-label="项目说明" />
+          <FieldDescription>支持 Markdown，最多 500 字。</FieldDescription>
+        </FieldRoot>
+      </Section>
+    </div>
+  ),
+};
+
+export const SeparatorStates: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
+      <Section title="horizontal">
+        <div style={{ display: 'grid', gap: 8 }}>
+          <span style={{ fontSize: 13 }}>上方</span>
+          <Separator />
+          <span style={{ fontSize: 13 }}>下方</span>
+        </div>
+      </Section>
+      <Section title="vertical">
+        <div style={{ alignItems: 'center', display: 'flex', gap: 12, height: 48 }}>
+          <span style={{ fontSize: 13 }}>左</span>
+          <Separator orientation="vertical" />
+          <span style={{ fontSize: 13 }}>右</span>
+        </div>
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/select.stories.tsx
+++ b/packages/ui/stories/select.stories.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Search } from '@maka/ui/icons';
+import {
+  SelectGroup,
+  SelectGroupLabel,
+  SelectItem,
+  SelectList,
+  SelectPortal,
+  SelectPositioner,
+  SelectPopup,
+  SelectRoot,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Select',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+type Option = { value: string; label: string };
+
+const FRUITS: Option[] = [
+  { value: 'apple', label: '苹果' },
+  { value: 'banana', label: '香蕉' },
+  { value: 'cherry', label: '樱桃' },
+  { value: 'durian', label: '榴莲' },
+];
+
+const GROUPED: { label: string; options: Option[] }[] = [
+  {
+    label: '柑橘类',
+    options: [
+      { value: 'orange', label: '橙子' },
+      { value: 'lemon', label: '柠檬' },
+      { value: 'grapefruit', label: '柚子' },
+    ],
+  },
+  {
+    label: '浆果类',
+    options: [
+      { value: 'strawberry', label: '草莓' },
+      { value: 'blueberry', label: '蓝莓' },
+      { value: 'raspberry', label: '树莓' },
+    ],
+  },
+];
+
+function BasicSelect() {
+  const [value, setValue] = useState('apple');
+  return (
+    <SelectRoot
+      items={FRUITS}
+      value={value}
+      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
+    >
+      <SelectTrigger style={{ width: 200 }} aria-label="选择水果">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
+          <SelectPopup>
+            <SelectList>
+              {FRUITS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
+  );
+}
+
+function GroupedSelect() {
+  const [value, setValue] = useState('orange');
+  const flat = GROUPED.flatMap((g) => g.options);
+  return (
+    <SelectRoot
+      items={flat}
+      value={value}
+      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
+    >
+      <SelectTrigger style={{ width: 200 }} aria-label="选择水果（分组）">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
+          <SelectPopup>
+            <SelectList>
+              {GROUPED.map((group, index) => (
+                <div key={group.label}>
+                  {index > 0 && <SelectSeparator />}
+                  <SelectGroup>
+                    <SelectGroupLabel>{group.label}</SelectGroupLabel>
+                    {group.options.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </div>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
+  );
+}
+
+function DisabledSelect() {
+  return (
+    <SelectRoot items={FRUITS} value="apple" disabled>
+      <SelectTrigger style={{ width: 200 }} aria-label="禁用选择器">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
+          <SelectPopup>
+            <SelectList>
+              {FRUITS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
+  );
+}
+
+function SelectWithLeadingIcon() {
+  const [value, setValue] = useState('apple');
+  return (
+    <SelectRoot
+      items={FRUITS}
+      value={value}
+      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
+    >
+      <SelectTrigger style={{ width: 220 }} aria-label="带前缀图标的选择器">
+        <Search size={14} strokeWidth={1.75} aria-hidden="true" style={{ marginRight: 4 }} />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
+          <SelectPopup>
+            <SelectList>
+              {FRUITS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectList>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
+  );
+}
+
+export const Basic: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>单选，点击触发</span>
+      <BasicSelect />
+    </div>
+  ),
+};
+
+export const Grouped: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>分组 + 分隔线</span>
+      <GroupedSelect />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>禁用态</span>
+      <DisabledSelect />
+    </div>
+  ),
+};
+
+export const WithLeadingIcon: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, padding: 24, width: 260 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>trigger 带前缀图标</span>
+      <SelectWithLeadingIcon />
+    </div>
+  ),
+};

--- a/packages/ui/stories/select.stories.tsx
+++ b/packages/ui/stories/select.stories.tsx
@@ -35,174 +35,143 @@ const FRUITS: Option[] = [
   { value: 'durian', label: '榴莲' },
 ];
 
-const GROUPED: { label: string; options: Option[] }[] = [
-  {
-    label: '柑橘类',
-    options: [
-      { value: 'orange', label: '橙子' },
-      { value: 'lemon', label: '柠檬' },
-      { value: 'grapefruit', label: '柚子' },
-    ],
-  },
-  {
-    label: '浆果类',
-    options: [
-      { value: 'strawberry', label: '草莓' },
-      { value: 'blueberry', label: '蓝莓' },
-      { value: 'raspberry', label: '树莓' },
-    ],
-  },
+const GROUPS: { label: string; options: Option[] }[] = [
+  { label: '柑橘类', options: [
+    { value: 'orange', label: '橙子' },
+    { value: 'lemon', label: '柠檬' },
+    { value: 'grapefruit', label: '柚子' },
+  ]},
+  { label: '浆果类', options: [
+    { value: 'strawberry', label: '草莓' },
+    { value: 'blueberry', label: '蓝莓' },
+    { value: 'raspberry', label: '树莓' },
+  ]},
 ];
 
-function BasicSelect() {
-  const [value, setValue] = useState('apple');
+function SelectPopupFrame({ children }: { children: React.ReactNode }) {
   return (
-    <SelectRoot
-      items={FRUITS}
-      value={value}
-      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
-    >
-      <SelectTrigger style={{ width: 200 }} aria-label="选择水果">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
-          <SelectPopup>
-            <SelectList>
-              {FRUITS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectList>
-          </SelectPopup>
-        </SelectPositioner>
-      </SelectPortal>
-    </SelectRoot>
+    <SelectPortal>
+      <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
+        <SelectPopup>
+          <SelectList>{children}</SelectList>
+        </SelectPopup>
+      </SelectPositioner>
+    </SelectPortal>
   );
 }
 
-function GroupedSelect() {
-  const [value, setValue] = useState('orange');
-  const flat = GROUPED.flatMap((g) => g.options);
+function FruitItems() {
   return (
-    <SelectRoot
-      items={flat}
-      value={value}
-      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
-    >
-      <SelectTrigger style={{ width: 200 }} aria-label="选择水果（分组）">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
-          <SelectPopup>
-            <SelectList>
-              {GROUPED.map((group, index) => (
-                <div key={group.label}>
-                  {index > 0 && <SelectSeparator />}
-                  <SelectGroup>
-                    <SelectGroupLabel>{group.label}</SelectGroupLabel>
-                    {group.options.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </div>
-              ))}
-            </SelectList>
-          </SelectPopup>
-        </SelectPositioner>
-      </SelectPortal>
-    </SelectRoot>
+    <>
+      {FRUITS.map((opt) => (
+        <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+      ))}
+    </>
   );
 }
 
-function DisabledSelect() {
+function GroupedItems() {
   return (
-    <SelectRoot items={FRUITS} value="apple" disabled>
-      <SelectTrigger style={{ width: 200 }} aria-label="禁用选择器">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
-          <SelectPopup>
-            <SelectList>
-              {FRUITS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectList>
-          </SelectPopup>
-        </SelectPositioner>
-      </SelectPortal>
-    </SelectRoot>
+    <>
+      {GROUPS.map((group, index) => (
+        <div key={group.label}>
+          {index > 0 && <SelectSeparator />}
+          <SelectGroup>
+            <SelectGroupLabel>{group.label}</SelectGroupLabel>
+            {group.options.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+            ))}
+          </SelectGroup>
+        </div>
+      ))}
+    </>
   );
 }
 
-function SelectWithLeadingIcon() {
-  const [value, setValue] = useState('apple');
-  return (
-    <SelectRoot
-      items={FRUITS}
-      value={value}
-      onValueChange={(v) => { if (v !== null) setValue(v as string); }}
-    >
-      <SelectTrigger style={{ width: 220 }} aria-label="带前缀图标的选择器">
-        <Search size={14} strokeWidth={1.75} aria-hidden="true" style={{ marginRight: 4 }} />
-        <SelectValue />
-      </SelectTrigger>
-      <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
-          <SelectPopup>
-            <SelectList>
-              {FRUITS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectList>
-          </SelectPopup>
-        </SelectPositioner>
-      </SelectPortal>
-    </SelectRoot>
-  );
+function useFruitSelect(initial: string) {
+  const [value, setValue] = useState(initial);
+  const onChange = (v: unknown) => { if (v !== null) setValue(v as string); };
+  return { value, onChange };
 }
 
 export const Basic: Story = {
-  render: () => (
-    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>单选，点击触发</span>
-      <BasicSelect />
-    </div>
-  ),
+  render: () => {
+    const sel = useFruitSelect('apple');
+    return (
+      <SelectRoot items={FRUITS} value={sel.value} onValueChange={sel.onChange}>
+        <SelectTrigger style={{ width: 200 }} aria-label="选择水果">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopupFrame><FruitItems /></SelectPopupFrame>
+      </SelectRoot>
+    );
+  },
 };
 
 export const Grouped: Story = {
-  render: () => (
-    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>分组 + 分隔线</span>
-      <GroupedSelect />
-    </div>
-  ),
+  render: () => {
+    const sel = useFruitSelect('orange');
+    return (
+      <SelectRoot items={GROUPS.flatMap((g) => g.options)} value={sel.value} onValueChange={sel.onChange}>
+        <SelectTrigger style={{ width: 200 }} aria-label="选择水果（分组）">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopupFrame><GroupedItems /></SelectPopupFrame>
+      </SelectRoot>
+    );
+  },
 };
 
 export const Disabled: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 16, padding: 24, width: 240 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>禁用态</span>
-      <DisabledSelect />
-    </div>
+    <SelectRoot items={FRUITS} value="apple" disabled>
+      <SelectTrigger style={{ width: 200 }} aria-label="禁用选择器">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPopupFrame><FruitItems /></SelectPopupFrame>
+    </SelectRoot>
   ),
 };
 
 export const WithLeadingIcon: Story = {
+  render: () => {
+    const sel = useFruitSelect('apple');
+    return (
+      <SelectRoot items={FRUITS} value={sel.value} onValueChange={sel.onChange}>
+        <SelectTrigger style={{ width: 220 }} aria-label="带前缀图标的选择器">
+          <Search size={14} strokeWidth={1.75} aria-hidden="true" style={{ marginRight: 4 }} />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopupFrame><FruitItems /></SelectPopupFrame>
+      </SelectRoot>
+    );
+  },
+};
+
+export const OpenSnapshot: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 16, padding: 24, width: 260 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>trigger 带前缀图标</span>
-      <SelectWithLeadingIcon />
+    <div style={{ display: 'grid', gap: 24, padding: 24, width: 240 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>popup 常驻 open（快照用）</span>
+      <SelectRoot items={FRUITS} value="banana" open>
+        <SelectTrigger style={{ width: 200 }} aria-label="快照选择器">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopupFrame><FruitItems /></SelectPopupFrame>
+      </SelectRoot>
+    </div>
+  ),
+};
+
+export const GroupedOpenSnapshot: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 24, padding: 24, width: 240 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>分组 popup 常驻 open（快照用）</span>
+      <SelectRoot items={GROUPS.flatMap((g) => g.options)} value="strawberry" open>
+        <SelectTrigger style={{ width: 200 }} aria-label="分组快照选择器">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectPopupFrame><GroupedItems /></SelectPopupFrame>
+      </SelectRoot>
     </div>
   ),
 };

--- a/packages/ui/stories/switch.stories.tsx
+++ b/packages/ui/stories/switch.stories.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Switch } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Switch',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 80 }}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function ControlledSwitch({ initial = false }: { initial?: boolean }) {
+  const [checked, setChecked] = useState(initial);
+  return <Switch checked={checked} onChange={setChecked} aria-label="受控开关" />;
+}
+
+export const OnOff: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 14, width: 240 }}>
+      <Row label="off">
+        <Switch checked={false} onChange={() => undefined} aria-label="关闭态" />
+      </Row>
+      <Row label="on">
+        <Switch checked onChange={() => undefined} aria-label="开启态" />
+      </Row>
+      <Row label="controlled">
+        <ControlledSwitch />
+      </Row>
+      <Row label="controlled on">
+        <ControlledSwitch initial />
+      </Row>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 14, width: 240 }}>
+      <Row label="disabled off">
+        <Switch checked={false} disabled onChange={() => undefined} aria-label="禁用关闭" />
+      </Row>
+      <Row label="disabled on">
+        <Switch checked disabled onChange={() => undefined} aria-label="禁用开启" />
+      </Row>
+    </div>
+  ),
+};

--- a/packages/ui/stories/switch.stories.tsx
+++ b/packages/ui/stories/switch.stories.tsx
@@ -22,22 +22,17 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   );
 }
 
-function ControlledSwitch({ initial = false }: { initial?: boolean }) {
-  const [checked, setChecked] = useState(initial);
-  return <Switch checked={checked} onChange={setChecked} aria-label="受控开关" />;
-}
-
 export const OnOff: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 14, width: 240 }}>
       <Row label="off">
-        <Switch checked={false} onChange={() => undefined} aria-label="关闭态" />
+        <Switch defaultChecked={false} aria-label="关闭态" />
       </Row>
       <Row label="on">
-        <Switch checked onChange={() => undefined} aria-label="开启态" />
+        <Switch defaultChecked aria-label="开启态" />
       </Row>
       <Row label="controlled">
-        <ControlledSwitch />
+        <ControlledSwitch initial={false} />
       </Row>
       <Row label="controlled on">
         <ControlledSwitch initial />
@@ -50,11 +45,16 @@ export const Disabled: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 14, width: 240 }}>
       <Row label="disabled off">
-        <Switch checked={false} disabled onChange={() => undefined} aria-label="禁用关闭" />
+        <Switch defaultChecked={false} disabled aria-label="禁用关闭" />
       </Row>
       <Row label="disabled on">
-        <Switch checked disabled onChange={() => undefined} aria-label="禁用开启" />
+        <Switch defaultChecked disabled aria-label="禁用开启" />
       </Row>
     </div>
   ),
 };
+
+function ControlledSwitch({ initial }: { initial: boolean }) {
+  const [checked, setChecked] = useState(initial);
+  return <Switch checked={checked} onCheckedChange={setChecked} aria-label="受控开关" />;
+}

--- a/packages/ui/stories/tabs.stories.tsx
+++ b/packages/ui/stories/tabs.stories.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TabsList, TabsPanel, TabsRoot, TabsTrigger } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Tabs',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: 'var(--background)', border: '1px solid var(--border)', borderRadius: 'var(--radius-sm)', padding: 16 }}>
+      {children}
+    </div>
+  );
+}
+
+export const ThreeTabs: Story = {
+  render: () => {
+    const [value, setValue] = useState('overview');
+    return (
+      <div style={{ maxWidth: 480 }}>
+        <TabsRoot value={value} onValueChange={setValue}>
+          <TabsList aria-label="概览标签">
+            <TabsTrigger value="overview">概览</TabsTrigger>
+            <TabsTrigger value="activity">活动</TabsTrigger>
+            <TabsTrigger value="settings">设置</TabsTrigger>
+          </TabsList>
+          <TabsPanel value="overview">
+            <Panel>概览内容：这里是会话的整体摘要。</Panel>
+          </TabsPanel>
+          <TabsPanel value="activity">
+            <Panel>活动内容：最近的事件流。</Panel>
+          </TabsPanel>
+          <TabsPanel value="settings">
+            <Panel>设置内容：配置项。</Panel>
+          </TabsPanel>
+        </TabsRoot>
+      </div>
+    );
+  },
+};
+
+export const DisabledTab: Story = {
+  render: () => {
+    const [value, setValue] = useState('general');
+    return (
+      <div style={{ maxWidth: 480 }}>
+        <TabsRoot value={value} onValueChange={setValue}>
+          <TabsList aria-label="带禁用项">
+            <TabsTrigger value="general">通用</TabsTrigger>
+            <TabsTrigger value="advanced" disabled>高级</TabsTrigger>
+            <TabsTrigger value="about">关于</TabsTrigger>
+          </TabsList>
+          <TabsPanel value="general">
+            <Panel>通用设置。</Panel>
+          </TabsPanel>
+          <TabsPanel value="advanced">
+            <Panel>高级设置（禁用，不可切到此页）。</Panel>
+          </TabsPanel>
+          <TabsPanel value="about">
+            <Panel>关于信息。</Panel>
+          </TabsPanel>
+        </TabsRoot>
+      </div>
+    );
+  },
+};
+
+export const OverflowTabs: Story = {
+  render: () => {
+    const [value, setValue] = useState('tab-1');
+    const labels = Array.from({ length: 12 }, (_, i) => `标签 ${i + 1}`);
+    return (
+      <div style={{ maxWidth: 480 }}>
+        <TabsRoot value={value} onValueChange={setValue}>
+          <TabsList aria-label="溢出标签" style={{ overflowX: 'auto' }}>
+            {labels.map((label, i) => (
+              <TabsTrigger key={i} value={`tab-${i + 1}`}>{label}</TabsTrigger>
+            ))}
+          </TabsList>
+          {labels.map((_, i) => (
+            <TabsPanel key={i} value={`tab-${i + 1}`}>
+              <Panel>{labels[i]} 的内容。</Panel>
+            </TabsPanel>
+          ))}
+        </TabsRoot>
+      </div>
+    );
+  },
+};

--- a/packages/ui/stories/toast.stories.tsx
+++ b/packages/ui/stories/toast.stories.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ToastProvider, useToast, type ToastVariant } from '../src/toast.js';
+import { Button } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Toast',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS: ToastVariant[] = ['info', 'success', 'warning', 'error'];
+
+function ToastGrid() {
+  const toast = useToast();
+  return (
+    <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>点击触发 toast（4 秒自动消失）</span>
+      <div style={{ display: 'grid', gap: 8 }}>
+        {VARIANTS.map((variant) => (
+          <Button
+            key={variant}
+            variant="outline"
+            onClick={() => toast.toast({ title: `${variant} 标题`, description: `${variant} 说明文字`, variant })}
+          >
+            {variant}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ShortcutButtons({ methods }: { methods: { label: string; fn: () => void }[] }) {
+  return (
+    <div style={{ display: 'grid', gap: 8, padding: 24, width: 360 }}>
+      {methods.map((m) => (
+        <Button key={m.label} variant="outline" onClick={m.fn}>
+          {m.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export const Variants: Story = {
+  render: () => <ToastGrid />,
+};
+
+export const Shortcuts: Story = {
+  render: () => {
+    const toast = useToast();
+    return (
+      <ShortcutButtons
+        methods={[
+          { label: 'success()', fn: () => toast.success('保存成功', 'MEMORY.md 已写入。') },
+          { label: 'error()', fn: () => toast.error('连接失败', '请检查 API key 后重试。') },
+          { label: 'info()', fn: () => toast.info('提示', '新版本已可用。') },
+          { label: 'warning()', fn: () => toast.warning('存储空间不足', '剩余空间低于 1 GB。') },
+        ]}
+      />
+    );
+  },
+};
+
+export const WithAction: Story = {
+  render: () => {
+    const toast = useToast();
+    return (
+      <div style={{ display: 'grid', gap: 8, padding: 24, width: 360 }}>
+        <Button
+          variant="outline"
+          onClick={() =>
+            toast.toast({
+              title: '已删除会话',
+              description: '“本周周报”已移到回收站。',
+              variant: 'info',
+              action: { label: '撤销', onClick: () => window.setTimeout(() => undefined, 0) },
+            })
+          }
+        >
+          删除会话（带撤销）
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            toast.toast({
+              title: '已保存',
+              variant: 'success',
+              duration: 0,
+              action: { label: '查看', onClick: () => undefined },
+            })
+          }
+        >
+          保存（不自动消失）
+        </Button>
+      </div>
+    );
+  },
+};
+
+export const Confirm: Story = {
+  render: () => {
+    const toast = useToast();
+    const [result, setResult] = useState<string>('（未触发）');
+    return (
+      <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>结果：{result}</span>
+        <Button
+          variant="outline"
+          onClick={async () => {
+            const ok = await toast.confirm({ title: '删除项目？', description: '此操作不可撤销。', confirmLabel: '删除', destructive: true });
+            setResult(ok ? '已确认' : '已取消');
+          }}
+        >
+          destructive confirm
+        </Button>
+        <Button
+          variant="outline"
+          onClick={async () => {
+            const ok = await toast.confirm({ title: '保存修改？', confirmLabel: '保存' });
+            setResult(ok ? '已确认' : '已取消');
+          }}
+        >
+          普通 confirm
+        </Button>
+      </div>
+    );
+  },
+};

--- a/packages/ui/stories/toast.stories.tsx
+++ b/packages/ui/stories/toast.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ToastProvider, useToast, type ToastVariant } from '../src/toast.js';
 import { Button } from '../src/ui.js';
@@ -23,12 +23,11 @@ type Story = StoryObj<typeof meta>;
 
 const VARIANTS: ToastVariant[] = ['info', 'success', 'warning', 'error'];
 
-function ToastGrid() {
-  const toast = useToast();
-  return (
-    <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>点击触发 toast（4 秒自动消失）</span>
-      <div style={{ display: 'grid', gap: 8 }}>
+export const Interactive: Story = {
+  render: () => {
+    const toast = useToast();
+    return (
+      <div style={{ display: 'grid', gap: 8, padding: 24, width: 360 }}>
         {VARIANTS.map((variant) => (
           <Button
             key={variant}
@@ -38,48 +37,6 @@ function ToastGrid() {
             {variant}
           </Button>
         ))}
-      </div>
-    </div>
-  );
-}
-
-function ShortcutButtons({ methods }: { methods: { label: string; fn: () => void }[] }) {
-  return (
-    <div style={{ display: 'grid', gap: 8, padding: 24, width: 360 }}>
-      {methods.map((m) => (
-        <Button key={m.label} variant="outline" onClick={m.fn}>
-          {m.label}
-        </Button>
-      ))}
-    </div>
-  );
-}
-
-export const Variants: Story = {
-  render: () => <ToastGrid />,
-};
-
-export const Shortcuts: Story = {
-  render: () => {
-    const toast = useToast();
-    return (
-      <ShortcutButtons
-        methods={[
-          { label: 'success()', fn: () => toast.success('保存成功', 'MEMORY.md 已写入。') },
-          { label: 'error()', fn: () => toast.error('连接失败', '请检查 API key 后重试。') },
-          { label: 'info()', fn: () => toast.info('提示', '新版本已可用。') },
-          { label: 'warning()', fn: () => toast.warning('存储空间不足', '剩余空间低于 1 GB。') },
-        ]}
-      />
-    );
-  },
-};
-
-export const WithAction: Story = {
-  render: () => {
-    const toast = useToast();
-    return (
-      <div style={{ display: 'grid', gap: 8, padding: 24, width: 360 }}>
         <Button
           variant="outline"
           onClick={() =>
@@ -87,46 +44,62 @@ export const WithAction: Story = {
               title: '已删除会话',
               description: '“本周周报”已移到回收站。',
               variant: 'info',
-              action: { label: '撤销', onClick: () => window.setTimeout(() => undefined, 0) },
+              action: { label: '撤销', onClick: () => undefined },
             })
           }
         >
-          删除会话（带撤销）
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() =>
-            toast.toast({
-              title: '已保存',
-              variant: 'success',
-              duration: 0,
-              action: { label: '查看', onClick: () => undefined },
-            })
-          }
-        >
-          保存（不自动消失）
+          with action
         </Button>
       </div>
     );
   },
 };
 
-export const Confirm: Story = {
+export const Seeded: Story = {
+  render: () => {
+    const toast = useToast();
+    useEffect(() => {
+      for (const variant of VARIANTS) {
+        toast.toast({ title: `${variant} 标题`, description: `${variant} 说明文字`, variant, duration: 0 });
+      }
+    }, [toast]);
+    return <div style={{ minHeight: 360 }} />;
+  },
+};
+
+export const WithActionSeeded: Story = {
+  render: () => {
+    const toast = useToast();
+    useEffect(() => {
+      toast.toast({
+        title: '已删除会话',
+        description: '“本周周报”已移到回收站。',
+        variant: 'info',
+        duration: 0,
+        action: { label: '撤销', onClick: () => undefined },
+      });
+    }, [toast]);
+    return <div style={{ minHeight: 120 }} />;
+  },
+};
+
+export const ConfirmSeeded: Story = {
+  render: () => {
+    const toast = useToast();
+    useEffect(() => {
+      void toast.confirm({ title: '删除项目？', description: '此操作不可撤销。', confirmLabel: '删除', destructive: true });
+    }, [toast]);
+    return <div style={{ minHeight: 200 }} />;
+  },
+};
+
+export const ConfirmPlain: Story = {
   render: () => {
     const toast = useToast();
     const [result, setResult] = useState<string>('（未触发）');
     return (
       <div style={{ display: 'grid', gap: 12, padding: 24, width: 360 }}>
         <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>结果：{result}</span>
-        <Button
-          variant="outline"
-          onClick={async () => {
-            const ok = await toast.confirm({ title: '删除项目？', description: '此操作不可撤销。', confirmLabel: '删除', destructive: true });
-            setResult(ok ? '已确认' : '已取消');
-          }}
-        >
-          destructive confirm
-        </Button>
         <Button
           variant="outline"
           onClick={async () => {


### PR DESCRIPTION
## Summary

Add independent Storybook stories for the 9 P0 UI primitive components in `packages/ui`. Covers all variants and key states for visual regression and component documentation.

## Why

PR #446 covered business surfaces and product-layer stories, but the base UI component layer (form controls + layout primitives) was essentially empty — `storybook-baseline` only smoke-tested Button + Alert + Empty + Spinner. These P0 components are high-frequency form controls and overlay components; without independent stories, variant changes had no visual regression protection.

## Scope

Changed:
- `packages/ui/stories/button.stories.tsx` — 6 variant × 6 size matrix + disabled + icon + loading (Spinner inline) + nav size
- `packages/ui/stories/alert.stories.tsx` — 5 variant × {title-only, title+desc, with-action} + no-icon layout
- `packages/ui/stories/dialog.stories.tsx` — controlled open/close + footer + showClose=false + DialogClose + form dialog + always-open (snapshot)
- `packages/ui/stories/select.stories.tsx` — basic / grouped + separator / disabled / leading icon + open snapshots (extracted `SelectPopupFrame` helper to dedupe portal scaffolding)
- `packages/ui/stories/switch.stories.tsx` — on/off + controlled + disabled (uses `onCheckedChange` + `defaultChecked` per Base UI contract)
- `packages/ui/stories/tabs.stories.tsx` — 3-tab / disabled tab / 12-tab overflow
- `packages/ui/stories/checkbox.stories.tsx` — unchecked / checked / indeterminate / disabled / controlled
- `packages/ui/stories/form-controls.stories.tsx` — Input / Textarea / Label / Field (Root+Description) / Separator (horizontal + vertical)
- `packages/ui/stories/toast.stories.tsx` — interactive trigger + seeded snapshots (4 variants, with-action, confirm) via `useEffect`

Not included:
- P1 components (Progress, Radio, Toggle, Badge, Menu, Accordion, Spinner, Empty, Kbd) — deferred to a follow-up PR
- P2 components (ChoiceCard, SettingsSegmented, SettingsSelect, SettingsSwitch, InputGroup, Toolbar, standalone Separator, OverlayScrollArea) — deferred to a follow-up PR
- `storybook-baseline.stories.tsx` left as-is; complements the new stories

## Verification

- `npm run -w @maka/desktop build-storybook` — green (verified after each story and each review fix, plus a final full run)
- All stories use the `Primitives/<Component>` namespace and reuse the `withMakaRoot` decorator from preview.tsx (colorScheme + palette switching)
- Dialog / Select / Toast use portals and render correctly inside the Storybook iframe (consistent with existing permission-dialog story)
- Switch controlled state verified against Base UI `SwitchRootProps`: `onChange` is Omit'd from the base, only `onCheckedChange(checked, eventDetails)` is the contract

## Reviewer notes

- Button has no `loading` prop; the loading state is simulated with an inline `<Spinner>` + `disabled`, matching existing product usage
- Select story follows the `items=` + `<SelectPortal>` + `<SelectPositioner>` pattern from `chat-model-switcher.tsx`; `SelectPopupFrame` helper dedupes the portal/positioner/popup/list nesting
- Toast seeded snapshots use `useEffect` to push toasts with `duration: 0` (no auto-dismiss) on mount, so visual regression can capture the rendered toast/confirm without interaction
- Known pitfall avoided: the `>` in `has-[>svg]` text inside the Alert story is escaped as `&gt;` to avoid JSX parsing errors