### PR TITLE
feat(desktop): selective config import/export (backup bundle)

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -70,6 +70,7 @@ import type { Result } from '@maka/core/settings/result';
 import type { CreateSessionInput } from '@maka/core';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
 import type { SkillEntry } from '@maka/ui';
+import type { ConfigCategory } from '@maka/storage';
 import type {
   OnboardingMilestone,
   OnboardingMilestoneId,
@@ -402,6 +403,25 @@ declare global {
         // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
         // color/symbolColor to the current app theme. No-op on non-Windows.
         setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
+      };
+      config: {
+        export(input: { categories: ConfigCategory[] }): Promise<
+          | { ok: false; reason: 'no_categories' | 'canceled' }
+          | { ok: true; path: string; includedData: ConfigCategory[] }
+        >;
+        import(input: { strategy: 'skip' | 'overwrite' }): Promise<
+          | { ok: false; reason: 'canceled' | 'not_json' | 'malformed' | 'unsupported_version'; message?: string }
+          | {
+              ok: true;
+              includedData: ConfigCategory[];
+              result: {
+                connections?: { created: number; overwritten: number; skipped: number };
+                settings?: { applied: boolean };
+                credentials?: { applied: number };
+                memory?: { applied: boolean };
+              };
+            }
+        >;
       };
       app: {
         info(): Promise<{

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -417,7 +417,7 @@ declare global {
               result: {
                 connections?: { created: number; overwritten: number; skipped: number };
                 settings?: { applied: boolean };
-                credentials?: { applied: number };
+                credentials?: { applied: number; skipped: number };
                 memory?: { applied: boolean };
               };
             }

--- a/apps/desktop/src/main/__tests__/config-transfer-service.test.ts
+++ b/apps/desktop/src/main/__tests__/config-transfer-service.test.ts
@@ -1,0 +1,127 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { AppSettings } from '@maka/core';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import type { CredentialKind } from '@maka/storage';
+import { applyConfigImport, gatherConfigExport, type ConfigTransferDeps } from '../config-transfer-service.js';
+
+function conn(slug: string): LlmConnection {
+  return {
+    slug,
+    name: slug,
+    providerType: 'deepseek',
+    defaultModel: 'deepseek-v4-pro',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function settingsWithSecrets(): AppSettings {
+  return {
+    theme: 'dark',
+    network: { proxy: { password: 'proxy-secret' } },
+    botChat: { channels: { telegram: { token: 'bot-secret', appSecret: 'app-secret' } } },
+    openGateway: { token: 'gw-secret' },
+    webSearch: { providers: { tavily: { apiKey: 'tavily-secret' } } },
+  } as unknown as AppSettings;
+}
+
+function makeDeps(overrides: Partial<ConfigTransferDeps> = {}): {
+  deps: ConfigTransferDeps;
+  saved: LlmConnection[];
+  updatedSettings: unknown[];
+  setCreds: Array<{ slug: string; kind: CredentialKind; value: string }>;
+  writtenMemory: string[];
+} {
+  const saved: LlmConnection[] = [];
+  const updatedSettings: unknown[] = [];
+  const setCreds: Array<{ slug: string; kind: CredentialKind; value: string }> = [];
+  const writtenMemory: string[] = [];
+  const secretsBySlugKind = new Map<string, string>([['deepseek-main::api_key', 'sk-real-key']]);
+  const deps: ConfigTransferDeps = {
+    appVersion: '0.1.0',
+    connectionStore: {
+      list: async () => [conn('deepseek-main')],
+      save: async (c) => {
+        saved.push(c);
+        return c;
+      },
+    },
+    settingsStore: {
+      get: async () => settingsWithSecrets(),
+      update: async (patch) => {
+        updatedSettings.push(patch);
+        return patch as unknown as AppSettings;
+      },
+    },
+    credentialStore: {
+      getSecret: async (slug, kind) => secretsBySlugKind.get(`${slug}::${kind}`) ?? null,
+      setSecret: async (slug, kind, value) => {
+        setCreds.push({ slug, kind, value });
+      },
+    },
+    readMemory: async () => '# MEMORY\n- note',
+    writeMemory: async (content) => {
+      writtenMemory.push(content);
+    },
+    ...overrides,
+  };
+  return { deps, saved, updatedSettings, setCreds, writtenMemory };
+}
+
+describe('config-transfer-service', () => {
+  it('exports only selected categories', async () => {
+    const { deps } = makeDeps();
+    const bundle = await gatherConfigExport(['connections'], deps);
+    assert.deepEqual(bundle.includedData, ['connections']);
+    assert.equal(bundle.data.settings, undefined);
+    assert.equal(bundle.data.credentials, undefined);
+  });
+
+  it('strips settings secrets when credentials are NOT included', async () => {
+    const { deps } = makeDeps();
+    const bundle = await gatherConfigExport(['settings'], deps);
+    const s = bundle.data.settings as Record<string, any>;
+    assert.equal(s.network.proxy.password, '');
+    assert.equal(s.botChat.channels.telegram.token, '');
+    assert.equal(s.openGateway.token, '');
+    assert.equal(s.webSearch.providers.tavily.apiKey, '');
+    assert.equal(s.theme, 'dark', 'non-secret fields pass through');
+  });
+
+  it('keeps settings secrets and enumerates credentials when credentials ARE included', async () => {
+    const { deps } = makeDeps();
+    const bundle = await gatherConfigExport(['settings', 'credentials'], deps);
+    const s = bundle.data.settings as Record<string, any>;
+    assert.equal(s.network.proxy.password, 'proxy-secret', 'secrets retained alongside credentials');
+    assert.deepEqual(bundle.data.credentials, [
+      { slug: 'deepseek-main', kind: 'api_key', value: 'sk-real-key' },
+    ]);
+  });
+
+  it('applies an imported bundle to the stores and summarizes', async () => {
+    const { deps, saved, updatedSettings, setCreds, writtenMemory } = makeDeps();
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt: '',
+      appVersion: '0.1.0',
+      includedData: ['connections', 'settings', 'credentials', 'memory'] as const,
+      data: {
+        connections: [conn('deepseek-main'), conn('brand-new')],
+        settings: { theme: 'light' },
+        credentials: [{ slug: 'brand-new', kind: 'api_key', value: 'sk-imported' }],
+        memory: '# imported memory',
+      },
+    };
+    const result = await applyConfigImport(bundle as any, 'skip', deps);
+    // deepseek-main exists -> skipped; brand-new -> created
+    assert.deepEqual(result.connections, { created: 1, overwritten: 0, skipped: 1 });
+    assert.deepEqual(saved.map((c) => c.slug), ['brand-new']);
+    assert.equal(result.settings?.applied, true);
+    assert.equal(updatedSettings.length, 1);
+    assert.deepEqual(setCreds, [{ slug: 'brand-new', kind: 'api_key', value: 'sk-imported' }]);
+    assert.equal(result.credentials?.applied, 1);
+    assert.deepEqual(writtenMemory, ['# imported memory']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/config-transfer-service.test.ts
+++ b/apps/desktop/src/main/__tests__/config-transfer-service.test.ts
@@ -20,9 +20,9 @@ function conn(slug: string): LlmConnection {
 function settingsWithSecrets(): AppSettings {
   return {
     theme: 'dark',
-    network: { proxy: { password: 'proxy-secret' } },
-    botChat: { channels: { telegram: { token: 'bot-secret', appSecret: 'app-secret' } } },
-    openGateway: { token: 'gw-secret' },
+    network: { proxy: { host: '127.0.0.1', password: 'proxy-secret' } },
+    botChat: { channels: { telegram: { chatId: '42', token: 'bot-secret', appSecret: 'app-secret' } } },
+    openGateway: { port: 8848, token: 'gw-secret' },
     webSearch: { providers: { tavily: { apiKey: 'tavily-secret' } } },
   } as unknown as AppSettings;
 }
@@ -79,15 +79,23 @@ describe('config-transfer-service', () => {
     assert.equal(bundle.data.credentials, undefined);
   });
 
-  it('strips settings secrets when credentials are NOT included', async () => {
+  it('omits (does not blank) settings secrets when credentials are NOT included', async () => {
+    // Secret keys must be ABSENT, not '' — mergeSettings deep-merges to the
+    // leaf, so an absent key preserves the target machine's existing secret on
+    // import, whereas '' would overwrite and wipe it.
     const { deps } = makeDeps();
     const bundle = await gatherConfigExport(['settings'], deps);
     const s = bundle.data.settings as Record<string, any>;
-    assert.equal(s.network.proxy.password, '');
-    assert.equal(s.botChat.channels.telegram.token, '');
-    assert.equal(s.openGateway.token, '');
-    assert.equal(s.webSearch.providers.tavily.apiKey, '');
-    assert.equal(s.theme, 'dark', 'non-secret fields pass through');
+    assert.equal('password' in s.network.proxy, false, 'proxy password key omitted');
+    assert.equal('token' in s.botChat.channels.telegram, false, 'bot token key omitted');
+    assert.equal('appSecret' in s.botChat.channels.telegram, false, 'bot appSecret key omitted');
+    assert.equal('token' in s.openGateway, false, 'gateway token key omitted');
+    assert.equal('apiKey' in s.webSearch.providers.tavily, false, 'tavily apiKey key omitted');
+    // Non-secret fields at every level pass through untouched.
+    assert.equal(s.theme, 'dark');
+    assert.equal(s.network.proxy.host, '127.0.0.1');
+    assert.equal(s.botChat.channels.telegram.chatId, '42');
+    assert.equal(s.openGateway.port, 8848);
   });
 
   it('keeps settings secrets and enumerates credentials when credentials ARE included', async () => {
@@ -121,7 +129,44 @@ describe('config-transfer-service', () => {
     assert.equal(result.settings?.applied, true);
     assert.equal(updatedSettings.length, 1);
     assert.deepEqual(setCreds, [{ slug: 'brand-new', kind: 'api_key', value: 'sk-imported' }]);
-    assert.equal(result.credentials?.applied, 1);
+    assert.deepEqual(result.credentials, { applied: 1, skipped: 0 });
     assert.deepEqual(writtenMemory, ['# imported memory']);
+  });
+
+  it('does NOT write credentials for a connection the user skipped', async () => {
+    // `deepseek-main` already exists on the target; with strategy=skip the
+    // connection is not written, so its stored secret must stay untouched.
+    const { deps, saved, setCreds } = makeDeps();
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt: '',
+      appVersion: '0.1.0',
+      includedData: ['connections', 'credentials'] as const,
+      data: {
+        connections: [conn('deepseek-main')],
+        credentials: [{ slug: 'deepseek-main', kind: 'api_key', value: 'sk-should-not-write' }],
+      },
+    };
+    const result = await applyConfigImport(bundle as any, 'skip', deps);
+    assert.equal(saved.length, 0, 'existing connection is skipped');
+    assert.deepEqual(setCreds, [], 'skipped connection keeps its existing secret');
+    assert.deepEqual(result.credentials, { applied: 0, skipped: 1 });
+  });
+
+  it('writes credentials for a connection that was overwritten', async () => {
+    const { deps, setCreds } = makeDeps();
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt: '',
+      appVersion: '0.1.0',
+      includedData: ['connections', 'credentials'] as const,
+      data: {
+        connections: [conn('deepseek-main')],
+        credentials: [{ slug: 'deepseek-main', kind: 'api_key', value: 'sk-new' }],
+      },
+    };
+    const result = await applyConfigImport(bundle as any, 'overwrite', deps);
+    assert.deepEqual(setCreds, [{ slug: 'deepseek-main', kind: 'api_key', value: 'sk-new' }]);
+    assert.deepEqual(result.credentials, { applied: 1, skipped: 0 });
   });
 });

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -8,6 +8,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/main.ts',
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
+  'apps/desktop/src/main/config-ipc-main.ts',
   'apps/desktop/src/main/connections-ipc-main.ts',
   'apps/desktop/src/main/context-budget-policy.ts',
   'apps/desktop/src/main/daily-review-ipc-main.ts',

--- a/apps/desktop/src/main/config-ipc-main.ts
+++ b/apps/desktop/src/main/config-ipc-main.ts
@@ -1,0 +1,90 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { app, dialog, ipcMain } from 'electron';
+import type { ConnectionStore, CredentialStore, SettingsStore } from '@maka/storage';
+import {
+  type ConfigCategory,
+  type ConnectionConflictStrategy,
+  isConfigCategory,
+  parseConfigBundle,
+  serializeConfigBundle,
+} from '@maka/storage';
+import {
+  applyConfigImport,
+  gatherConfigExport,
+  type ConfigTransferDeps,
+} from './config-transfer-service.js';
+
+export interface ConfigIpcDeps {
+  connectionStore: ConnectionStore;
+  settingsStore: SettingsStore;
+  credentialStore: CredentialStore;
+  workspaceRoot: string;
+}
+
+function sanitizeCategories(value: unknown): ConfigCategory[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter(isConfigCategory))];
+}
+
+function sanitizeStrategy(value: unknown): ConnectionConflictStrategy {
+  return value === 'overwrite' ? 'overwrite' : 'skip';
+}
+
+export function registerConfigIpc(deps: ConfigIpcDeps): void {
+  const memoryPath = join(deps.workspaceRoot, 'MEMORY.md');
+  const transferDeps: ConfigTransferDeps = {
+    connectionStore: deps.connectionStore,
+    settingsStore: deps.settingsStore,
+    credentialStore: deps.credentialStore,
+    readMemory: async () => {
+      try {
+        return await readFile(memoryPath, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+    writeMemory: async (content) => {
+      await writeFile(memoryPath, content, 'utf8');
+    },
+    appVersion: app.getVersion(),
+  };
+
+  ipcMain.handle('config:export', async (_event, input: { categories?: unknown } = {}) => {
+    const categories = sanitizeCategories(input?.categories);
+    if (categories.length === 0) {
+      return { ok: false as const, reason: 'no_categories' as const };
+    }
+    const bundle = await gatherConfigExport(categories, transferDeps);
+    const today = new Date().toISOString().slice(0, 10);
+    const { canceled, filePath } = await dialog.showSaveDialog({
+      title: '导出 Maka 配置',
+      defaultPath: `maka-config-${today}.json`,
+      filters: [{ name: 'Maka Config', extensions: ['json'] }],
+    });
+    if (canceled || !filePath) {
+      return { ok: false as const, reason: 'canceled' as const };
+    }
+    await writeFile(filePath, serializeConfigBundle(bundle), 'utf8');
+    return { ok: true as const, path: filePath, includedData: bundle.includedData };
+  });
+
+  ipcMain.handle('config:import', async (_event, input: { strategy?: unknown } = {}) => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      title: '导入 Maka 配置',
+      properties: ['openFile'],
+      filters: [{ name: 'Maka Config', extensions: ['json'] }],
+    });
+    const filePath = filePaths?.[0];
+    if (canceled || !filePath) {
+      return { ok: false as const, reason: 'canceled' as const };
+    }
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = parseConfigBundle(raw);
+    if (!parsed.ok) {
+      return { ok: false as const, reason: parsed.reason, message: parsed.message };
+    }
+    const result = await applyConfigImport(parsed.bundle, sanitizeStrategy(input?.strategy), transferDeps);
+    return { ok: true as const, includedData: parsed.bundle.includedData, result };
+  });
+}

--- a/apps/desktop/src/main/config-transfer-service.ts
+++ b/apps/desktop/src/main/config-transfer-service.ts
@@ -94,7 +94,7 @@ export async function gatherConfigExport(
 export interface ConfigImportResult {
   connections?: { created: number; overwritten: number; skipped: number };
   settings?: { applied: boolean };
-  credentials?: { applied: number };
+  credentials?: { applied: number; skipped: number };
   memory?: { applied: boolean };
 }
 
@@ -104,6 +104,10 @@ export async function applyConfigImport(
   deps: ConfigTransferDeps,
 ): Promise<ConfigImportResult> {
   const result: ConfigImportResult = {};
+  // Credentials are only applied for connections actually written this import
+  // (created or overwritten). A slug the user chose to skip must not have its
+  // stored secret silently overwritten.
+  const appliedConnectionSlugs = new Set<string>();
 
   if (Array.isArray(bundle.data.connections)) {
     const incoming = bundle.data.connections as LlmConnection[];
@@ -111,6 +115,7 @@ export async function applyConfigImport(
     const plan = planConnectionMerge(existing, incoming, strategy);
     for (const connection of [...plan.create, ...plan.overwrite]) {
       await deps.connectionStore.save(connection);
+      appliedConnectionSlugs.add(connection.slug);
     }
     result.connections = {
       created: plan.create.length,
@@ -126,19 +131,26 @@ export async function applyConfigImport(
 
   if (Array.isArray(bundle.data.credentials)) {
     let applied = 0;
+    let skipped = 0;
     for (const entry of bundle.data.credentials as ExportedCredential[]) {
-      if (
+      const valid =
         entry &&
         typeof entry.slug === 'string' &&
         typeof entry.value === 'string' &&
         entry.value.length > 0 &&
-        VALID_CREDENTIAL_KINDS.has(entry.kind)
-      ) {
-        await deps.credentialStore.setSecret(entry.slug, entry.kind, entry.value);
-        applied += 1;
+        VALID_CREDENTIAL_KINDS.has(entry.kind);
+      if (!valid) continue;
+      // Only write a secret for a connection that was created or overwritten
+      // in this import. Skipped (or not-imported) slugs keep their existing
+      // stored secret untouched.
+      if (!appliedConnectionSlugs.has(entry.slug)) {
+        skipped += 1;
+        continue;
       }
+      await deps.credentialStore.setSecret(entry.slug, entry.kind, entry.value);
+      applied += 1;
     }
-    result.credentials = { applied };
+    result.credentials = { applied, skipped };
   }
 
   if (typeof bundle.data.memory === 'string') {

--- a/apps/desktop/src/main/config-transfer-service.ts
+++ b/apps/desktop/src/main/config-transfer-service.ts
@@ -1,0 +1,150 @@
+import type { AppSettings, UpdateAppSettingsInput } from '@maka/core';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import {
+  type ConfigBundle,
+  type ConfigCategory,
+  type ConfigData,
+  type ConnectionConflictStrategy,
+  type CredentialKind,
+  buildConfigBundle,
+  planConnectionMerge,
+} from '@maka/storage';
+import { stripSettingsSecretsForExport } from './settings-ipc-helpers.js';
+
+/**
+ * Desktop-side orchestration for config import/export. Kept store-injected and
+ * Electron-free so it is unit-testable; the IPC handlers in main.ts are thin
+ * wrappers that supply the real stores + file dialogs.
+ *
+ * The credential category (opt-in, plaintext) is gathered by walking the
+ * connection list and reading each slug's `api_key` / `oauth_token` — the
+ * credential store exposes no bulk-list, so enumeration is the only path.
+ */
+
+export interface ExportedCredential {
+  slug: string;
+  kind: CredentialKind;
+  value: string;
+}
+
+const CONNECTION_CREDENTIAL_KINDS: readonly CredentialKind[] = ['api_key', 'oauth_token'];
+const VALID_CREDENTIAL_KINDS: ReadonlySet<string> = new Set<CredentialKind>([
+  'api_key',
+  'oauth_token',
+  'bot_token',
+  'app_secret',
+  'proxy_password',
+  'gateway_token',
+  'tavily_api_key',
+]);
+
+export interface ConfigTransferDeps {
+  connectionStore: { list(): Promise<LlmConnection[]>; save(c: LlmConnection): Promise<LlmConnection> };
+  settingsStore: { get(): Promise<AppSettings>; update(patch: UpdateAppSettingsInput): Promise<AppSettings> };
+  credentialStore: {
+    getSecret(slug: string, kind: CredentialKind): Promise<string | null>;
+    setSecret(slug: string, kind: CredentialKind, value: string): Promise<void>;
+  };
+  readMemory(): Promise<string | null>;
+  writeMemory(content: string): Promise<void>;
+  appVersion: string;
+}
+
+export async function gatherConfigExport(
+  categories: readonly ConfigCategory[],
+  deps: ConfigTransferDeps,
+): Promise<ConfigBundle> {
+  const selected = new Set(categories);
+  const data: ConfigData = {};
+
+  const connections = selected.has('connections') || selected.has('credentials')
+    ? await deps.connectionStore.list()
+    : [];
+
+  if (selected.has('connections')) {
+    data.connections = connections;
+  }
+
+  if (selected.has('settings')) {
+    const settings = await deps.settingsStore.get();
+    // When credentials are included, settings keeps its embedded secrets
+    // (proxy password, bot tokens, gateway token, Tavily key); otherwise strip.
+    data.settings = selected.has('credentials') ? settings : stripSettingsSecretsForExport(settings);
+  }
+
+  if (selected.has('credentials')) {
+    const creds: ExportedCredential[] = [];
+    for (const connection of connections) {
+      for (const kind of CONNECTION_CREDENTIAL_KINDS) {
+        const value = await deps.credentialStore.getSecret(connection.slug, kind);
+        if (value) creds.push({ slug: connection.slug, kind, value });
+      }
+    }
+    data.credentials = creds;
+  }
+
+  if (selected.has('memory')) {
+    const memory = await deps.readMemory();
+    if (memory !== null) data.memory = memory;
+  }
+
+  return buildConfigBundle({ appVersion: deps.appVersion, data });
+}
+
+export interface ConfigImportResult {
+  connections?: { created: number; overwritten: number; skipped: number };
+  settings?: { applied: boolean };
+  credentials?: { applied: number };
+  memory?: { applied: boolean };
+}
+
+export async function applyConfigImport(
+  bundle: ConfigBundle,
+  strategy: ConnectionConflictStrategy,
+  deps: ConfigTransferDeps,
+): Promise<ConfigImportResult> {
+  const result: ConfigImportResult = {};
+
+  if (Array.isArray(bundle.data.connections)) {
+    const incoming = bundle.data.connections as LlmConnection[];
+    const existing = await deps.connectionStore.list();
+    const plan = planConnectionMerge(existing, incoming, strategy);
+    for (const connection of [...plan.create, ...plan.overwrite]) {
+      await deps.connectionStore.save(connection);
+    }
+    result.connections = {
+      created: plan.create.length,
+      overwritten: plan.overwrite.length,
+      skipped: plan.skipped.length,
+    };
+  }
+
+  if (bundle.data.settings && typeof bundle.data.settings === 'object') {
+    await deps.settingsStore.update(bundle.data.settings as unknown as UpdateAppSettingsInput);
+    result.settings = { applied: true };
+  }
+
+  if (Array.isArray(bundle.data.credentials)) {
+    let applied = 0;
+    for (const entry of bundle.data.credentials as ExportedCredential[]) {
+      if (
+        entry &&
+        typeof entry.slug === 'string' &&
+        typeof entry.value === 'string' &&
+        entry.value.length > 0 &&
+        VALID_CREDENTIAL_KINDS.has(entry.kind)
+      ) {
+        await deps.credentialStore.setSecret(entry.slug, entry.kind, entry.value);
+        applied += 1;
+      }
+    }
+    result.credentials = { applied };
+  }
+
+  if (typeof bundle.data.memory === 'string') {
+    await deps.writeMemory(bundle.data.memory);
+    result.memory = { applied: true };
+  }
+
+  return result;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -181,6 +181,7 @@ import { registerMemoryIpc } from './memory-ipc-main.js';
 import { registerSubscriptionIpc } from './subscription-ipc-main.js';
 import { registerBrowserIpc } from './browser-ipc-main.js';
 import { registerConnectionsIpc } from './connections-ipc-main.js';
+import { registerConfigIpc } from './config-ipc-main.js';
 import { registerPlanReminderIpc } from './plan-reminders-ipc-main.js';
 import { registerWorkspaceResourcesIpc } from './workspace-resources-ipc-main.js';
 import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
@@ -972,6 +973,7 @@ function registerIpc(): void {
     },
   );
   registerMemoryIpc({ localMemory });
+  registerConfigIpc({ connectionStore, settingsStore, credentialStore, workspaceRoot });
   ipcMain.handle('workspaceInstructions:getState', async () => getWorkspaceInstructionsState(await currentProjectRoot()));
   ipcMain.handle(
     'workspaceInstructions:openFile',

--- a/apps/desktop/src/main/settings-ipc-helpers.ts
+++ b/apps/desktop/src/main/settings-ipc-helpers.ts
@@ -115,6 +115,39 @@ export function maskAppSettings(settings: AppSettings, revealPatch: UpdateAppSet
   };
 }
 
+/**
+ * Empty every secret field in settings for a config export that does NOT
+ * include the `credentials` category. Unlike `maskAppSettings` (which returns
+ * a masked sentinel for display), this returns '' so a re-imported bundle
+ * carries no secret material at all — it must not round-trip a masked value as
+ * if it were real. Keep the field list in sync with `maskAppSettings`.
+ */
+export function stripSettingsSecretsForExport(settings: AppSettings): AppSettings {
+  return {
+    ...settings,
+    network: {
+      ...settings.network,
+      proxy: { ...settings.network.proxy, password: '' },
+    },
+    botChat: {
+      ...settings.botChat,
+      channels: Object.fromEntries(
+        Object.entries(settings.botChat.channels).map(([provider, channel]) => [
+          provider,
+          { ...channel, token: '', appSecret: '' },
+        ]),
+      ) as AppSettings['botChat']['channels'],
+    },
+    openGateway: { ...settings.openGateway, token: '' },
+    webSearch: {
+      ...settings.webSearch,
+      providers: {
+        tavily: { ...settings.webSearch.providers.tavily, apiKey: '' },
+      },
+    },
+  };
+}
+
 export function buildSettingsUpdateResult(
   settings: AppSettings,
   patch: UpdateAppSettingsInput,

--- a/apps/desktop/src/main/settings-ipc-helpers.ts
+++ b/apps/desktop/src/main/settings-ipc-helpers.ts
@@ -116,35 +116,37 @@ export function maskAppSettings(settings: AppSettings, revealPatch: UpdateAppSet
 }
 
 /**
- * Empty every secret field in settings for a config export that does NOT
- * include the `credentials` category. Unlike `maskAppSettings` (which returns
- * a masked sentinel for display), this returns '' so a re-imported bundle
- * carries no secret material at all — it must not round-trip a masked value as
- * if it were real. Keep the field list in sync with `maskAppSettings`.
+ * Return a copy of settings with every secret field OMITTED, for a config
+ * export that does NOT include the `credentials` category. The keys are
+ * removed (not blanked to '') on purpose: `mergeSettings` deep-merges to the
+ * leaf, so an absent key preserves the target machine's existing value on
+ * import, whereas a '' would overwrite and wipe a working proxy/bot/gateway/
+ * search secret. Keep the field list in sync with `maskAppSettings`.
  */
-export function stripSettingsSecretsForExport(settings: AppSettings): AppSettings {
+export function stripSettingsSecretsForExport(settings: AppSettings): Record<string, unknown> {
+  const proxy = { ...settings.network.proxy } as Record<string, unknown>;
+  delete proxy.password;
+
+  const channels: Record<string, unknown> = {};
+  for (const [provider, channel] of Object.entries(settings.botChat.channels)) {
+    const next = { ...channel } as Record<string, unknown>;
+    delete next.token;
+    delete next.appSecret;
+    channels[provider] = next;
+  }
+
+  const openGateway = { ...settings.openGateway } as Record<string, unknown>;
+  delete openGateway.token;
+
+  const tavily = { ...settings.webSearch.providers.tavily } as Record<string, unknown>;
+  delete tavily.apiKey;
+
   return {
     ...settings,
-    network: {
-      ...settings.network,
-      proxy: { ...settings.network.proxy, password: '' },
-    },
-    botChat: {
-      ...settings.botChat,
-      channels: Object.fromEntries(
-        Object.entries(settings.botChat.channels).map(([provider, channel]) => [
-          provider,
-          { ...channel, token: '', appSecret: '' },
-        ]),
-      ) as AppSettings['botChat']['channels'],
-    },
-    openGateway: { ...settings.openGateway, token: '' },
-    webSearch: {
-      ...settings.webSearch,
-      providers: {
-        tavily: { ...settings.webSearch.providers.tavily, apiKey: '' },
-      },
-    },
+    network: { ...settings.network, proxy },
+    botChat: { ...settings.botChat, channels },
+    openGateway,
+    webSearch: { ...settings.webSearch, providers: { ...settings.webSearch.providers, tavily } },
   };
 }
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -753,7 +753,7 @@ contextBridge.exposeInMainWorld('maka', {
           result: {
             connections?: { created: number; overwritten: number; skipped: number };
             settings?: { applied: boolean };
-            credentials?: { applied: number };
+            credentials?: { applied: number; skipped: number };
             memory?: { applied: boolean };
           };
         }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -69,6 +69,7 @@ import type {
 } from '@maka/core/usage-stats/types';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
 import type { SkillEntry } from '@maka/ui';
+import type { ConfigCategory } from '@maka/storage';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/settings/result';
 import type { CreateSessionInput } from '@maka/core';
@@ -735,6 +736,29 @@ contextBridge.exposeInMainWorld('maka', {
     // color/symbolColor to the current app theme. No-op on non-Windows.
     setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
+    },
+  },
+  config: {
+    export(input: { categories: ConfigCategory[] }): Promise<
+      | { ok: false; reason: 'no_categories' | 'canceled' }
+      | { ok: true; path: string; includedData: ConfigCategory[] }
+    > {
+      return ipcRenderer.invoke('config:export', input);
+    },
+    import(input: { strategy: 'skip' | 'overwrite' }): Promise<
+      | { ok: false; reason: 'canceled' | 'not_json' | 'malformed' | 'unsupported_version'; message?: string }
+      | {
+          ok: true;
+          includedData: ConfigCategory[];
+          result: {
+            connections?: { created: number; overwritten: number; skipped: number };
+            settings?: { applied: boolean };
+            credentials?: { applied: number };
+            memory?: { applied: boolean };
+          };
+        }
+    > {
+      return ipcRenderer.invoke('config:import', input);
     },
   },
   app: {

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -32,7 +32,10 @@ function summarizeImportResult(result: ConfigImportResult): string {
   const conn = result.connections;
   if (conn) parts.push(`连接 新增${conn.created}·覆盖${conn.overwritten}·跳过${conn.skipped}`);
   if (result.settings?.applied) parts.push('设置已应用');
-  if (result.credentials) parts.push(`凭据 ${result.credentials.applied}`);
+  if (result.credentials) {
+    const cred = result.credentials;
+    parts.push(cred.skipped > 0 ? `凭据 ${cred.applied}（跳过 ${cred.skipped}）` : `凭据 ${cred.applied}`);
+  }
   if (result.memory?.applied) parts.push('记忆已应用');
   return parts.join(' · ') || '文件不含可导入的内容';
 }

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -1,8 +1,41 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button, clearGlobalInputHistory, useToast } from '@maka/ui';
+import type { ConfigCategory } from '@maka/storage';
+import { Button, SettingsSelect, SettingsSwitch as Switch, clearGlobalInputHistory, useToast } from '@maka/ui';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
+
+const CONFIG_CATEGORY_OPTIONS: ReadonlyArray<{
+  id: ConfigCategory;
+  label: string;
+  detail: string;
+  sensitive?: boolean;
+}> = [
+  { id: 'connections', label: '模型连接', detail: '供应商连接与默认模型（不含密钥）' },
+  { id: 'settings', label: '应用设置', detail: '常规、搜索、机器人、代理等设置' },
+  { id: 'memory', label: '本地记忆', detail: '本机 MEMORY.md 的内容' },
+  {
+    id: 'credentials',
+    label: '凭据（API 密钥、令牌）',
+    detail: '模型密钥与订阅令牌等敏感信息',
+    sensitive: true,
+  },
+];
+
+type ConfigImportResult = Extract<
+  Awaited<ReturnType<typeof window.maka.config.import>>,
+  { ok: true }
+>['result'];
+
+function summarizeImportResult(result: ConfigImportResult): string {
+  const parts: string[] = [];
+  const conn = result.connections;
+  if (conn) parts.push(`连接 新增${conn.created}·覆盖${conn.overwritten}·跳过${conn.skipped}`);
+  if (result.settings?.applied) parts.push('设置已应用');
+  if (result.credentials) parts.push(`凭据 ${result.credentials.applied}`);
+  if (result.memory?.applied) parts.push('记忆已应用');
+  return parts.join(' · ') || '文件不含可导入的内容';
+}
 
 export function DataSettingsPage() {
   const [info, setInfo] = useState<Awaited<ReturnType<typeof window.maka.app.info>> | null>(null);
@@ -11,6 +44,11 @@ export function DataSettingsPage() {
   const pendingDataActionRef = useRef<string | null>(null);
   const dataPageMountedRef = useRef(false);
   const toast = useToast();
+  const [selectedCategories, setSelectedCategories] = useState<Set<ConfigCategory>>(
+    () => new Set<ConfigCategory>(['connections', 'settings']),
+  );
+  const [importStrategy, setImportStrategy] = useState<'skip' | 'overwrite'>('skip');
+  const [configBusy, setConfigBusy] = useState<null | 'export' | 'import'>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,6 +131,54 @@ export function DataSettingsPage() {
     });
   }
 
+  function toggleCategory(id: ConfigCategory) {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function exportConfig() {
+    if (configBusy) return;
+    const categories = [...selectedCategories];
+    if (categories.length === 0) {
+      toast.error('请至少选择一个类别');
+      return;
+    }
+    setConfigBusy('export');
+    try {
+      const res = await window.maka.config.export({ categories });
+      if (res.ok) {
+        toast.success('已导出配置', `包含：${res.includedData.join('、')}`);
+      } else if (res.reason !== 'canceled') {
+        toast.error('导出失败', res.reason === 'no_categories' ? '未选择任何类别' : '请稍后重试');
+      }
+    } catch (error) {
+      toast.error('导出失败', settingsActionErrorMessage(error));
+    } finally {
+      setConfigBusy(null);
+    }
+  }
+
+  async function importConfig() {
+    if (configBusy) return;
+    setConfigBusy('import');
+    try {
+      const res = await window.maka.config.import({ strategy: importStrategy });
+      if (res.ok) {
+        toast.success('已导入配置', summarizeImportResult(res.result));
+      } else if (res.reason !== 'canceled') {
+        toast.error('导入失败', res.message ?? '文件无效或版本不受支持。');
+      }
+    } catch (error) {
+      toast.error('导入失败', settingsActionErrorMessage(error));
+    } finally {
+      setConfigBusy(null);
+    }
+  }
+
   return (
     <div className="settingsStructuredPage">
       <SettingsRows>
@@ -149,6 +235,56 @@ export function DataSettingsPage() {
           无法载入工作区路径：{infoError}
         </div>
       )}
+
+      <section className="settingsAboutPrivacy" aria-label="配置导入导出">
+        <h3>配置导入导出</h3>
+        <p className="settingsHelpText">
+          勾选要导出的内容，生成一个 JSON 备份文件；换机或重装时可再导入。默认不含密钥。
+        </p>
+        <div role="group" aria-label="选择导出内容" className="settingsConfigCategoryList">
+          {CONFIG_CATEGORY_OPTIONS.map((option) => {
+            const checked = selectedCategories.has(option.id);
+            return (
+              <div key={option.id} className="settingsConfigCategoryItem">
+                <Switch
+                  ariaLabel={`导出${option.label}`}
+                  checked={checked}
+                  onChange={() => toggleCategory(option.id)}
+                />
+                <span>
+                  <strong>{option.label}</strong>
+                  <small>{option.detail}</small>
+                  {option.sensitive && checked ? (
+                    <small role="alert" data-tone="destructive">
+                      ⚠️ 密钥将以明文写入导出文件。任何拿到该文件的人都能使用这些密钥，请妥善保管、不要分享。
+                    </small>
+                  ) : null}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="settingsConfigStrategy">
+          <span className="settingsHelpText">导入时同名连接：</span>
+          <SettingsSelect
+            value={importStrategy}
+            ariaLabel="导入时同名连接的处理方式"
+            options={[
+              ['skip', '跳过'],
+              ['overwrite', '覆盖'],
+            ] satisfies Array<readonly [typeof importStrategy, string]>}
+            onChange={(strategy) => setImportStrategy(strategy)}
+          />
+        </div>
+        <div className="settingsActionRow">
+          <Button type="button" disabled={configBusy !== null} onClick={() => void exportConfig()}>
+            {configBusy === 'export' ? '导出中…' : '导出配置…'}
+          </Button>
+          <Button type="button" disabled={configBusy !== null} onClick={() => void importConfig()}>
+            {configBusy === 'import' ? '导入中…' : '导入配置…'}
+          </Button>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -154,6 +154,39 @@
   text-transform: uppercase;
 }
 
+.settingsConfigCategoryList {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.settingsConfigCategoryItem {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.settingsConfigCategoryItem small {
+  display: block;
+  color: var(--muted-foreground);
+}
+
+.settingsConfigCategoryItem small[data-tone="destructive"] {
+  margin-top: var(--space-1);
+  color: var(--destructive);
+}
+
+.settingsConfigStrategy {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2-5);
+}
+
+.settingsConfigStrategy > .settingsHelpText {
+  white-space: nowrap;
+}
+
 .settingsAboutPrivacy ul {
   margin: 0;
   padding: 0 0 0 var(--space-4);

--- a/packages/storage/src/__tests__/config-transfer.test.ts
+++ b/packages/storage/src/__tests__/config-transfer.test.ts
@@ -1,0 +1,118 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import {
+  CONFIG_TRANSFER_SCHEMA_VERSION,
+  buildConfigBundle,
+  parseConfigBundle,
+  planConnectionMerge,
+  serializeConfigBundle,
+} from '../config-transfer.js';
+
+function conn(slug: string, extra: Partial<LlmConnection> = {}): LlmConnection {
+  return {
+    slug,
+    name: slug,
+    providerType: 'deepseek',
+    defaultModel: 'deepseek-v4-pro',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+    ...extra,
+  };
+}
+
+describe('config-transfer', () => {
+  it('records only the selected categories in includedData and round-trips', () => {
+    const bundle = buildConfigBundle({
+      appVersion: '0.1.0',
+      data: {
+        connections: [conn('deepseek-main')],
+        settings: { theme: 'dark' },
+      },
+      now: () => new Date('2026-07-02T00:00:00.000Z'),
+    });
+    assert.equal(bundle.schemaVersion, CONFIG_TRANSFER_SCHEMA_VERSION);
+    assert.deepEqual(bundle.includedData, ['connections', 'settings']);
+    assert.equal(bundle.exportedAt, '2026-07-02T00:00:00.000Z');
+
+    const parsed = parseConfigBundle(serializeConfigBundle(bundle));
+    assert.ok(parsed.ok);
+    assert.deepEqual(parsed.bundle.includedData, ['connections', 'settings']);
+    assert.deepEqual(parsed.bundle.data.connections, [conn('deepseek-main')]);
+    assert.deepEqual(parsed.bundle.data.settings, { theme: 'dark' });
+    assert.equal(parsed.bundle.data.memory, undefined);
+  });
+
+  it('carries credentials only when the user opted into that category', () => {
+    const withCreds = buildConfigBundle({
+      appVersion: '0.1.0',
+      data: { credentials: [{ slug: 'deepseek-main', kind: 'api_key', value: 'sk-real' }] },
+    });
+    assert.deepEqual(withCreds.includedData, ['credentials']);
+    const parsed = parseConfigBundle(serializeConfigBundle(withCreds));
+    assert.ok(parsed.ok);
+    assert.deepEqual(parsed.bundle.data.credentials, [
+      { slug: 'deepseek-main', kind: 'api_key', value: 'sk-real' },
+    ]);
+  });
+
+  it('drops a credentials payload that is not declared in includedData', () => {
+    // Hand-edited / mislabeled file: data has credentials but manifest omits it.
+    const raw = JSON.stringify({
+      schemaVersion: 1,
+      includedData: ['connections'],
+      data: {
+        connections: [conn('deepseek-main')],
+        credentials: [{ slug: 'x', kind: 'api_key', value: 'sk-should-not-import' }],
+      },
+    });
+    const parsed = parseConfigBundle(raw);
+    assert.ok(parsed.ok);
+    assert.equal(parsed.bundle.data.credentials, undefined);
+    assert.ok(!parsed.bundle.includedData.includes('credentials'));
+    assert.ok(!serializeConfigBundle(parsed.bundle).includes('sk-should-not-import'));
+  });
+
+  it('fails closed on an unknown schema version', () => {
+    const raw = JSON.stringify({ schemaVersion: 999, includedData: [], data: {} });
+    const parsed = parseConfigBundle(raw);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.ok === false && parsed.reason, 'unsupported_version');
+  });
+
+  it('rejects non-JSON and malformed payloads', () => {
+    assert.equal((parseConfigBundle('not json') as { reason: string }).reason, 'not_json');
+    assert.equal(
+      (parseConfigBundle(JSON.stringify({ schemaVersion: 1, data: {} })) as { reason: string }).reason,
+      'malformed',
+      'missing includedData is malformed',
+    );
+    assert.equal(
+      (parseConfigBundle(JSON.stringify({ schemaVersion: 1, includedData: ['bogus'], data: {} })) as { reason: string })
+        .reason,
+      'malformed',
+      'unknown category in includedData is malformed',
+    );
+  });
+
+  it('plans connection merges with skip vs overwrite conflict strategies', () => {
+    const existing = [conn('a'), conn('b')];
+    const incoming = [conn('a', { name: 'A-new' }), conn('c')];
+
+    const skip = planConnectionMerge(existing, incoming, 'skip');
+    assert.deepEqual(skip.skipped, [{ slug: 'a', reason: 'exists' }]);
+    assert.deepEqual(skip.create.map((c) => c.slug), ['c']);
+    assert.equal(skip.overwrite.length, 0);
+
+    const overwrite = planConnectionMerge(existing, incoming, 'overwrite');
+    assert.deepEqual(overwrite.overwrite.map((c) => c.slug), ['a']);
+    assert.deepEqual(overwrite.create.map((c) => c.slug), ['c']);
+    assert.equal(overwrite.skipped.length, 0);
+  });
+
+  it('de-dupes repeated slugs within the imported set', () => {
+    const plan = planConnectionMerge([], [conn('x'), conn('x'), conn('y')], 'skip');
+    assert.deepEqual(plan.create.map((c) => c.slug), ['x', 'y']);
+  });
+});

--- a/packages/storage/src/config-transfer.ts
+++ b/packages/storage/src/config-transfer.ts
@@ -1,0 +1,168 @@
+import type { LlmConnection } from '@maka/core/llm-connections';
+
+/**
+ * Config import / export — Alma-style selective bundle.
+ *
+ * A single JSON bundle carries a manifest (`includedData`) plus a `data` map
+ * keyed by category. The user chooses which categories to export; the manifest
+ * records exactly what is present, and import applies only those categories.
+ *
+ * This module is category-agnostic on purpose: each category payload is opaque
+ * (`unknown`) here. The desktop layer owns what goes into each one — including
+ * the sensitive parts (deciding whether to gather credentials, and stripping
+ * secret fields out of `settings` when credentials are NOT included). Keeping
+ * that knowledge out of this module means the pure transfer logic never has to
+ * understand the AppSettings/credential shapes.
+ *
+ * `credentials` is an opt-in category that carries plaintext secrets. It is
+ * never implied: if it is not listed in `includedData`, any `data.credentials`
+ * payload is dropped on read so a hand-edited or mislabeled file cannot sneak
+ * secrets past a config-only import. The UI must warn before selecting it.
+ *
+ * Reads fail closed on unknown schema versions (mirrors credential-store).
+ */
+
+export const CONFIG_TRANSFER_SCHEMA_VERSION = 1;
+
+export const CONFIG_CATEGORIES = [
+  'connections',
+  'settings',
+  'credentials',
+  'memory',
+] as const;
+export type ConfigCategory = (typeof CONFIG_CATEGORIES)[number];
+
+/** Categories that carry plaintext secrets and must be explicitly opted into. */
+export const SENSITIVE_CATEGORIES: ReadonlySet<ConfigCategory> = new Set(['credentials']);
+
+export type ConfigData = Partial<Record<ConfigCategory, unknown>>;
+
+export interface ConfigBundle {
+  schemaVersion: number;
+  exportedAt: string;
+  appVersion: string;
+  includedData: ConfigCategory[];
+  data: ConfigData;
+}
+
+export interface BuildConfigBundleInput {
+  appVersion: string;
+  /** Only the categories the user selected; presence here == inclusion. */
+  data: ConfigData;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+}
+
+export function buildConfigBundle(input: BuildConfigBundleInput): ConfigBundle {
+  const now = input.now ?? (() => new Date());
+  const includedData = CONFIG_CATEGORIES.filter((c) => input.data[c] !== undefined);
+  const data: ConfigData = {};
+  for (const category of includedData) {
+    data[category] = cloneJson(input.data[category]);
+  }
+  return {
+    schemaVersion: CONFIG_TRANSFER_SCHEMA_VERSION,
+    exportedAt: now().toISOString(),
+    appVersion: input.appVersion,
+    includedData,
+    data,
+  };
+}
+
+export function serializeConfigBundle(bundle: ConfigBundle): string {
+  return `${JSON.stringify(bundle, null, 2)}\n`;
+}
+
+export type ConfigParseFailure = {
+  ok: false;
+  reason: 'not_json' | 'malformed' | 'unsupported_version';
+  message: string;
+};
+
+export type ConfigParseResult = { ok: true; bundle: ConfigBundle } | ConfigParseFailure;
+
+export function parseConfigBundle(raw: string): ConfigParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, reason: 'not_json', message: 'File is not valid JSON.' };
+  }
+  if (!isJsonObject(parsed)) {
+    return { ok: false, reason: 'malformed', message: 'Config bundle must be a JSON object.' };
+  }
+  const version = parsed.schemaVersion;
+  if (typeof version !== 'number') {
+    return { ok: false, reason: 'malformed', message: 'Config bundle is missing a numeric schemaVersion.' };
+  }
+  if (version !== CONFIG_TRANSFER_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      reason: 'unsupported_version',
+      message: `Unsupported config schemaVersion ${version} (this build reads ${CONFIG_TRANSFER_SCHEMA_VERSION}).`,
+    };
+  }
+  if (!Array.isArray(parsed.includedData) || !parsed.includedData.every(isConfigCategory)) {
+    return { ok: false, reason: 'malformed', message: 'includedData must be an array of known categories.' };
+  }
+  const rawData = isJsonObject(parsed.data) ? parsed.data : {};
+  const includedData = [...new Set(parsed.includedData as ConfigCategory[])];
+  const data: ConfigData = {};
+  // Only surface categories that are BOTH declared in the manifest AND present
+  // in `data`. A category listed but absent, or present but not listed, is
+  // ignored — never guessed. This is what drops an unlisted `credentials`.
+  for (const category of includedData) {
+    if (rawData[category] !== undefined) data[category] = rawData[category];
+  }
+  const bundle: ConfigBundle = {
+    schemaVersion: CONFIG_TRANSFER_SCHEMA_VERSION,
+    exportedAt: typeof parsed.exportedAt === 'string' ? parsed.exportedAt : '',
+    appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : '',
+    includedData: includedData.filter((c) => data[c] !== undefined),
+    data,
+  };
+  return { ok: true, bundle };
+}
+
+// --- connection merge planning (import applies this against the live store) ---
+
+export type ConnectionConflictStrategy = 'skip' | 'overwrite';
+
+export interface ConnectionMergePlan {
+  create: LlmConnection[];
+  overwrite: LlmConnection[];
+  skipped: Array<{ slug: string; reason: 'exists' }>;
+}
+
+export function planConnectionMerge(
+  existing: readonly LlmConnection[],
+  incoming: readonly LlmConnection[],
+  strategy: ConnectionConflictStrategy,
+): ConnectionMergePlan {
+  const existingSlugs = new Set(existing.map((c) => c.slug));
+  const plan: ConnectionMergePlan = { create: [], overwrite: [], skipped: [] };
+  const seen = new Set<string>();
+  for (const conn of incoming) {
+    if (seen.has(conn.slug)) continue; // de-dupe within the imported set
+    seen.add(conn.slug);
+    if (existingSlugs.has(conn.slug)) {
+      if (strategy === 'overwrite') plan.overwrite.push(cloneJson(conn));
+      else plan.skipped.push({ slug: conn.slug, reason: 'exists' });
+    } else {
+      plan.create.push(cloneJson(conn));
+    }
+  }
+  return plan;
+}
+
+export function isConfigCategory(value: unknown): value is ConfigCategory {
+  return typeof value === 'string' && (CONFIG_CATEGORIES as readonly string[]).includes(value);
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -19,3 +19,4 @@ export * from './telemetry-repo.js';
 export * from './artifact-store.js';
 export * from './plan-reminder-store.js';
 export * from './task-ledger-store.js';
+export * from './config-transfer.js';


### PR DESCRIPTION
Implements #449 (selective config import/export). Design rationale and the credential-handling decision live in that issue.

## What

A **selective** config export/import on the Data settings page (数据), directly under the existing workspace-backup notice — semantically the backup/restore home.

- The user picks which categories to include; a manifest (`includedData`) records exactly what the file contains.
- Categories: `connections` (provider connection metadata), `settings`, `credentials`, `memory` (`MEMORY.md`).
- Output is a single versioned JSON bundle: `{ schemaVersion, exportedAt, appVersion, includedData, data }`.
- Import fails closed on an unknown `schemaVersion` (mirrors the credential-store read policy) and merges connections by `slug` with a skip / overwrite strategy.

## Credentials (per #449)

`credentials` is an **explicit opt-in** category that carries plaintext secrets. It is off by default and the selection UI shows a prominent cleartext warning before it can be included. A `credentials` payload not declared in `includedData` is dropped on read (anti-smuggle). When credentials are *not* selected, `settings` is exported with its secret fields (proxy password, bot tokens, gateway token, Tavily key) stripped.

## Structure

- `packages/storage/config-transfer.ts` — pure, category-agnostic bundle build / parse / merge (7 tests).
- `apps/desktop/src/main/config-transfer-service.ts` — store-injected export/import orchestration; credentials enumerated by connection slug since the credential store exposes no bulk-list (4 tests).
- `config-ipc-main.ts` + preload + `global.d.ts` — `config:export` / `config:import`, paired per the IPC-surface contract.
- `data-settings-page.tsx` — category toggles + credentials warning + conflict strategy, on shared `SettingsSwitch` / `SettingsSelect` primitives.

## Testing

11 unit tests; a11y, IPC-surface, and Chinese-copy contracts pass; typecheck + build + dead-CSS clean; verified visually in the running app.

Not a zip: the repo has no zip dependency, so V1 is a single dependency-free JSON bundle. Large session history (which would justify a zip-of-files layout) is intentionally out of V1 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
