### PR TITLE
test(desktop): sync copy-feedback contract to the --link semantic token

### DIFF
--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -516,7 +516,7 @@ describe('turn footer copy feedback contract', () => {
     );
     assert.match(
       src,
-      /data-\[copy-feedback=copied\]:text-\[color:var\(--accent\)\]/,
+      /data-\[copy-feedback=copied\]:text-\[color:var\(--link\)\]/,
       'Turn footer copied state should have a stable styling hook.',
     );
     assert.match(
@@ -584,7 +584,7 @@ describe('tool error copy feedback contract', () => {
     );
     assert.match(
       block,
-      /data-\[copy-feedback=copied\]:text-\[color:var\(--accent\)\] data-\[copy-feedback=copied\]:border-\[oklch\(from_var\(--accent\)_l_c_h_\/_0\.35\)\]/,
+      /data-\[copy-feedback=copied\]:text-\[color:var\(--link\)\] data-\[copy-feedback=copied\]:border-\[oklch\(from_var\(--link\)_l_c_h_\/_0\.35\)\]/,
       'Tool-error copied state should have a stable color + border styling hook.',
     );
     assert.match(


### PR DESCRIPTION
main is currently red (2 failures in `visible-copy-hygiene-contract`): #441 moved the copied-state feedback color to `var(--link)` at both call sites but the contract still asserts `var(--accent)`. This syncs the two assertions to the token actually in source.

`npm --workspace @maka/desktop test`: 1685/1685 after this fix (was 1679/2).