### PR TITLE
fix(ui): stop showing healthy legacy sessions as 已阻塞; compact sidebar timestamps; localize bypass label

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-display-normalization.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-display-normalization.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Display normalization for non-actionable blocked sessions.
+ *
+ * Runtime keeps writing the strict lifecycle status (the #397/#410
+ * terminal-fact invariant): a run that closes without terminal evidence
+ * marks its session `blocked/unknown`. But session-level "已阻塞" in the
+ * sidebar/header is only worth the interruption when the user can ACT
+ * (configure a connection, re-login, confirm a permission). Legacy
+ * sessions repaired as `missing_terminal_event` are intact, retryable
+ * conversations — showing three healthy chats under an「已阻塞」group
+ * (real-world report, 2026-07-03) reads as data loss.
+ *
+ * `normalizeSessionSummaryForDisplay` is applied at the renderer state
+ * boundary (app-shell commitSessions / upsertSessionSummary), so the
+ * grouping, row icon, and chat-header badge all agree.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { SessionBlockedReason, SessionStatus, SessionSummary } from '@maka/core';
+import {
+  isActionableBlocked,
+  normalizeSessionSummaryForDisplay,
+} from '../../renderer/session-status-presentation.js';
+
+function session(status: SessionStatus, blockedReason?: SessionBlockedReason): SessionSummary {
+  return {
+    id: 'session-1',
+    name: '测试会话',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'zai-live',
+    model: 'glm-4.7',
+    permissionMode: 'ask',
+    status,
+    ...(blockedReason ? { blockedReason } : {}),
+  };
+}
+
+describe('normalizeSessionSummaryForDisplay', () => {
+  it('reads non-actionable blocked (missing terminal bookkeeping) as an ordinary resumable session', () => {
+    for (const reason of ['unknown', 'tool_failed'] as const) {
+      const out = normalizeSessionSummaryForDisplay(session('blocked', reason));
+      assert.equal(out.status, 'active', `blocked/${reason} should display as active`);
+      assert.equal(out.blockedReason, undefined, `blocked/${reason} should drop the stale reason`);
+    }
+  });
+
+  it('keeps actionable blocked states (user can fix something) as blocked', () => {
+    for (const reason of ['NO_REAL_CONNECTION', 'auth', 'permission_required'] as const) {
+      const out = normalizeSessionSummaryForDisplay(session('blocked', reason));
+      assert.equal(out.status, 'blocked', `blocked/${reason} must stay blocked`);
+      assert.equal(out.blockedReason, reason);
+      assert.equal(isActionableBlocked(reason), true);
+    }
+  });
+
+  it('treats blocked with a missing reason as non-actionable', () => {
+    const out = normalizeSessionSummaryForDisplay(session('blocked'));
+    assert.equal(out.status, 'active');
+  });
+
+  it('passes every non-blocked status through unchanged', () => {
+    for (const status of ['active', 'running', 'waiting_for_user', 'review', 'done', 'archived', 'aborted'] as const) {
+      const input = session(status);
+      assert.equal(normalizeSessionSummaryForDisplay(input), input, `${status} must be identity`);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/app-shell-session-settings-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-session-settings-actions.ts
@@ -71,7 +71,7 @@ export function createAppShellSessionSettingsActions(deps: {
         explore: '只读模式',
         ask: '询问权限',
         execute: '自动执行',
-        bypass: 'Bypass permissions',
+        bypass: '跳过确认',
       };
       if (activeIdRef.current === sessionId) toastApi.success(`已切到 ${labels[mode]}`, permissionModeDescriptions[mode]);
       await refreshSessions();

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -43,6 +43,7 @@ import { deriveChatHeaderAlert } from './chat-header-alert';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveSessionStatusGroups } from './session-status-grouping';
 import {
+  normalizeSessionSummaryForDisplay,
   presentSessionStatus,
   sessionStatusAriaLabel,
 } from './session-status-presentation';
@@ -111,8 +112,12 @@ export function AppShell() {
       readBoundaries: () => sessionReadBoundariesRef.current,
       currentSessions: () => sessionsRef.current,
       commitSessions: (next) => {
-        sessionsRef.current = next;
-        setSessions(next);
+        // Display normalization at the state boundary: non-actionable
+        // blocked (missing terminal bookkeeping) reads as an ordinary
+        // resumable session everywhere in the renderer.
+        const displayNext = next.map(normalizeSessionSummaryForDisplay);
+        sessionsRef.current = displayNext;
+        setSessions(displayNext);
       },
       onError: (error) => {
         toastApi.error('刷新会话列表失败', generalizedErrorMessageChinese(error, '刷新会话列表失败，请稍后重试。'));
@@ -946,7 +951,10 @@ export function AppShell() {
 
   function upsertSessionSummary(session: SessionSummary): void {
     setSessions((current) => {
-      const next = [session, ...current.filter((entry) => entry.id !== session.id)];
+      const next = [
+        normalizeSessionSummaryForDisplay(session),
+        ...current.filter((entry) => entry.id !== session.id),
+      ];
       sessionsRef.current = next;
       return next;
     });

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -475,7 +475,7 @@ export function buildCommandList(args: {
       { id: 'explore', label: '权限 · 只读', hintCopy: '读取和搜索直通，写入仍确认' },
       { id: 'ask', label: '权限 · 询问权限', hintCopy: '每条敏感工具都先确认（默认）' },
       { id: 'execute', label: '权限 · 自动执行', hintCopy: '常见工具直通，破坏性操作仍确认' },
-      { id: 'bypass', label: '权限 · Bypass permissions', hintCopy: '全部工具直通，不再弹权限确认' },
+      { id: 'bypass', label: '权限 · 跳过确认', hintCopy: '全部工具直通，不再弹权限确认' },
     ];
     for (const entry of modes) {
       cmds.push({

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -21,7 +21,41 @@
  *     vocabulary.
  */
 
-import type { SessionBlockedReason, SessionStatus } from '@maka/core';
+import type { SessionBlockedReason, SessionStatus, SessionSummary } from '@maka/core';
+
+/**
+ * Session-level "blocked" is only worth interrupting the user when
+ * they can ACT on it: configure a connection, re-login, or confirm a
+ * permission. `tool_failed` / `unknown` mean "the last run's bookkeeping
+ * didn't close cleanly" — the conversation itself is intact and
+ * retryable, and the failure detail already surfaces on the failed
+ * turn inside the chat. Runtime keeps writing the strict status (the
+ * #397/#410 terminal-fact invariant is untouched); this is a
+ * display-layer distinction only.
+ */
+const ACTIONABLE_BLOCKED_REASONS: ReadonlySet<SessionBlockedReason> = new Set([
+  'NO_REAL_CONNECTION',
+  'auth',
+  'permission_required',
+]);
+
+export function isActionableBlocked(reason: SessionBlockedReason | undefined): boolean {
+  return reason !== undefined && ACTIONABLE_BLOCKED_REASONS.has(reason);
+}
+
+/**
+ * Normalize a SessionSummary as it enters renderer state: non-actionable
+ * blocked sessions read as ordinary resumable sessions (`active`), so the
+ * sidebar grouping, row icon, and chat-header badge all agree without
+ * each consumer re-implementing the rule. Everything else passes through
+ * unchanged.
+ */
+export function normalizeSessionSummaryForDisplay(session: SessionSummary): SessionSummary {
+  if (session.status !== 'blocked' || isActionableBlocked(session.blockedReason)) return session;
+  const { blockedReason: _blockedReason, ...rest } = session;
+  void _blockedReason;
+  return { ...rest, status: 'active' };
+}
 
 /**
  * Status tone vocabulary — extends the chat-header-alert tone set

--- a/apps/desktop/src/renderer/settings/account-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/account-settings-page.tsx
@@ -156,7 +156,7 @@ export function AccountSettingsPage(props: {
       <SettingsRows>
         <SettingRow
           title="默认权限模式"
-          detail="新会话默认从询问权限开始；可在输入框左下角切到自动执行或 Bypass permissions。"
+          detail="新会话默认从询问权限开始；可在输入框左下角切到自动执行或跳过确认。"
           value="询问权限"
         />
         <SettingRow

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -769,6 +769,7 @@ export type {
 } from './usage-stats/types.js';
 
 export {
+  formatCompactTimestamp,
   formatRelativeTimestamp,
   nextRelativeRefreshDelay,
   resetRelativeTimeFormatters,

--- a/packages/core/src/relative-time.ts
+++ b/packages/core/src/relative-time.ts
@@ -92,6 +92,45 @@ export function formatRelativeTimestamp(ts: number, now: number = Date.now()): s
   return getRelativeFormat().format(-diffDays, 'day');
 }
 
+let cachedCompactSameYearFormat: Intl.DateTimeFormat | null = null;
+let cachedCompactOtherYearFormat: Intl.DateTimeFormat | null = null;
+let cachedCompactLocale: string | null = null;
+
+function getCompactFormats(): { sameYear: Intl.DateTimeFormat; otherYear: Intl.DateTimeFormat } {
+  const locale = resolveLocale();
+  if (!cachedCompactSameYearFormat || !cachedCompactOtherYearFormat || cachedCompactLocale !== locale) {
+    cachedCompactSameYearFormat = new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' });
+    cachedCompactOtherYearFormat = new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+    cachedCompactLocale = locale;
+  }
+  return { sameYear: cachedCompactSameYearFormat, otherYear: cachedCompactOtherYearFormat };
+}
+
+/**
+ * Compact variant for space-starved rows (sidebar session list): same
+ * relative buckets inside the 7-day horizon, then a DATE-ONLY label —
+ * "6月20日" within the current year, "2025年6月20日" across years.
+ * `formatRelativeTimestamp`'s medium-date + time fallback
+ * ("2026年6月20日 16:33") is right for wide surfaces but crushed the
+ * session title next to it to ~2 characters. Minute precision belongs
+ * in tooltips/detail surfaces, not scan-level list rows.
+ */
+export function formatCompactTimestamp(ts: number, now: number = Date.now()): string {
+  const diffMs = now - ts;
+  if (diffMs >= 0 && diffMs <= RELATIVE_HORIZON_MS) {
+    return formatRelativeTimestamp(ts, now);
+  }
+  if (diffMs < 0) return formatRelativeTimestamp(ts, now);
+  const { sameYear, otherYear } = getCompactFormats();
+  const date = new Date(ts);
+  const nowDate = new Date(now);
+  return date.getFullYear() === nowDate.getFullYear() ? sameYear.format(date) : otherYear.format(date);
+}
+
 /**
  * Reset the cached formatters. Used by `applyUiLocale()` so a language
  * change takes effect without a full reload — the next call will
@@ -101,6 +140,9 @@ export function resetRelativeTimeFormatters(): void {
   cachedRelativeFormat = null;
   cachedAbsoluteFormat = null;
   cachedLocale = null;
+  cachedCompactSameYearFormat = null;
+  cachedCompactOtherYearFormat = null;
+  cachedCompactLocale = null;
 }
 
 /**

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -65,7 +65,7 @@ const PERMISSION_MODE_META: Record<PermissionMode, PermissionModeMeta> = {
     tone: 'caution',
   },
   bypass: {
-    label: 'Bypass permissions',
+    label: '跳过确认',
     hint: '跳过全部工具确认，包括破坏性操作、特权操作和浏览器操作。只在完全信任本轮任务时使用。',
     tone: 'caution',
   },
@@ -190,7 +190,7 @@ export const Composer = forwardRef<
      * PR-MOVE-PERMISSION-MODE (WAWQAQ 47fe0d0e + a667cf6c): the
      * permission mode picker lives inside the composer left-controls
      * instead of the chat header. Composer renders a dropdown labelled
-     * by the current mode (询问权限 / 自动执行 / Bypass permissions);
+     * by the current mode (询问权限 / 自动执行 / 跳过确认);
      * selecting an option fires `onPermissionModeChange`. When the
      * active session is in the legacy `explore` mode the picker
      * collapses to display 询问权限 — explore is internal-only now and

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type FocusEvent, type KeyboardEvent, type MouseEvent } from 'react';
 import type { PlanReminder, SessionSummary } from '@maka/core';
-import { formatRelativeTimestamp } from '@maka/core';
+import { formatCompactTimestamp } from '@maka/core';
 import {
   Archive,
   ArchiveRestore,
@@ -1099,5 +1099,5 @@ function groupSessionsByTime(sessions: SessionSummary[]): SessionGroup[] {
 
 function formatSessionMeta(session: SessionSummary): string {
   if (!session.lastMessageAt) return noMessagesYet;
-  return formatRelativeTimestamp(session.lastMessageAt);
+  return formatCompactTimestamp(session.lastMessageAt);
 }


### PR DESCRIPTION
Driven by a real-app screenshot report (2026-07-03): three healthy chat sessions piled under an 已阻塞 sidebar group with shield icons, titles crushed to `?...`, and an English 'Bypass permissions' pill in an otherwise Chinese composer.

## 1. Blocked display semantics (the headline bug)
The #410 terminal-ledger invariant marks legacy sessions missing a terminal fact as `blocked/unknown`. The sidebar groups by raw status → intact, resumable conversations showed as 已阻塞 (header badge too), reading like data loss when nothing needed the user's attention.

**First-principles split:** session-level 已阻塞 is only worth the interruption when the user can ACT — configure a connection, re-login, confirm a permission. `tool_failed`/`unknown` mean "the last run's bookkeeping didn't close cleanly"; the failure detail already lives on the failed turn in the chat.

- `normalizeSessionSummaryForDisplay()` applied at the renderer state boundary (`commitSessions` / `upsertSessionSummary`) → grouping, row icon, and header badge all agree
- actionable reasons (`NO_REAL_CONNECTION`/`auth`/`permission_required`) keep the blocked presentation
- **runtime status writes untouched** (the #397/#410 invariant stays strict)
- regression: `session-status-display-normalization.test.ts` (4 cases)

## 2. Sidebar timestamps crushed titles
\>7-day sessions rendered `2026年6月20日 16:33` (~150px) next to the title. New `formatCompactTimestamp` in @maka/core: relative within 7 days, date-only beyond (`6月20日` same year, `2025年6月20日` across years). Sidebar-only; wide surfaces keep the existing formatter (artifact-pane dedup contract still satisfied — one shared implementation in core).

## 3. Bypass permissions → 跳过确认
询问权限 / 自动执行 / ~~Bypass permissions~~ 跳过确认 — consistent zh across composer, command palette, session settings, and account settings copy.

## Verification
- `npm --workspace @maka/desktop test`: **1685/1685**
- `npm run typecheck`: clean
- behavior spot-check: unknown/tool_failed → active (reason dropped); auth/NO_REAL_CONNECTION/permission_required → blocked kept; non-blocked statuses identity