### PR TITLE
feat(storybook): add P1 UI primitive stories (Progress, Radio, Toggle, Badge, Menu, Accordion, Spinner, Empty, Kbd)

### DIFF
--- a/packages/ui/stories/accordion.stories.tsx
+++ b/packages/ui/stories/accordion.stories.tsx
@@ -20,6 +20,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+type AccItem = { value: string; title: string; body: string };
+
+const ITEMS: AccItem[] = [
+  { value: 'a', title: '第一项', body: '第一项的内容。单选模式下，同时只能展开一项。' },
+  { value: 'b', title: '第二项', body: '第二项的内容。' },
+  { value: 'c', title: '第三项', body: '第三项的内容。' },
+];
+
 function Trigger({ children }: { children: React.ReactNode }) {
   return (
     <span style={{ alignItems: 'center', display: 'flex', gap: 8, padding: '8px 4px', width: 320 }}>
@@ -29,109 +37,41 @@ function Trigger({ children }: { children: React.ReactNode }) {
   );
 }
 
-function Body({ children }: { children: React.ReactNode }) {
+function SampleAccordion({
+  multiple,
+  defaultValue,
+  items = ITEMS,
+}: {
+  multiple?: boolean;
+  defaultValue: string[];
+  items?: AccItem[];
+}) {
   return (
-    <div style={{ fontSize: 13, color: 'var(--muted-foreground)', padding: '0 4px 12px' }}>{children}</div>
+    <Accordion multiple={multiple} defaultValue={defaultValue} style={{ width: 320 }}>
+      {items.map((item) => (
+        <AccordionItem key={item.value} value={item.value}>
+          <AccordionHeader>
+            <AccordionTrigger>
+              <Trigger>{item.title}</Trigger>
+            </AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel>
+            <div style={{ fontSize: 13, color: 'var(--muted-foreground)', padding: '0 4px 12px' }}>{item.body}</div>
+          </AccordionPanel>
+        </AccordionItem>
+      ))}
+    </Accordion>
   );
 }
 
 export const SingleOpen: Story = {
-  render: () => (
-    <Accordion defaultValue={['item-1']} style={{ width: 320 }}>
-      <AccordionItem value="item-1">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>第一项（默认展开）</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>第一项的内容。单选模式下，同时只能展开一项。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-      <AccordionItem value="item-2">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>第二项</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>第二项的内容。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-      <AccordionItem value="item-3">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>第三项</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>第三项的内容。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
-  ),
+  render: () => <SampleAccordion defaultValue={['a']} />,
 };
 
 export const MultipleOpen: Story = {
-  render: () => (
-    <Accordion multiple defaultValue={['a', 'c']} style={{ width: 320 }}>
-      <AccordionItem value="a">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>A（默认展开）</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>A 内容。multiple 模式下可以同时展开多项。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-      <AccordionItem value="b">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>B</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>B 内容。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-      <AccordionItem value="c">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>C（默认展开）</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>C 内容。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
-  ),
+  render: () => <SampleAccordion multiple defaultValue={['a', 'c']} />,
 };
 
 export const AllCollapsed: Story = {
-  render: () => (
-    <Accordion style={{ width: 320 }}>
-      <AccordionItem value="x">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>收起态 X</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>X 内容（初始收起）。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-      <AccordionItem value="y">
-        <AccordionHeader>
-          <AccordionTrigger>
-            <Trigger>收起态 Y</Trigger>
-          </AccordionTrigger>
-        </AccordionHeader>
-        <AccordionPanel>
-          <Body>Y 内容。</Body>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
-  ),
+  render: () => <SampleAccordion defaultValue={[]} items={ITEMS.slice(0, 2)} />,
 };

--- a/packages/ui/stories/accordion.stories.tsx
+++ b/packages/ui/stories/accordion.stories.tsx
@@ -1,0 +1,137 @@
+import { ChevronRight } from '@maka/ui/icons';
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  AccordionTrigger,
+} from '../src/primitives/accordion.js';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Primitives/Accordion',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Trigger({ children }: { children: React.ReactNode }) {
+  return (
+    <span style={{ alignItems: 'center', display: 'flex', gap: 8, padding: '8px 4px', width: 320 }}>
+      <span style={{ flex: 1, fontSize: 13, fontWeight: 500 }}>{children}</span>
+      <ChevronRight size={14} strokeWidth={2} aria-hidden="true" style={{ transition: 'transform .15s' }} />
+    </span>
+  );
+}
+
+function Body({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ fontSize: 13, color: 'var(--muted-foreground)', padding: '0 4px 12px' }}>{children}</div>
+  );
+}
+
+export const SingleOpen: Story = {
+  render: () => (
+    <Accordion defaultValue="item-1" style={{ width: 320 }}>
+      <AccordionItem value="item-1">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>第一项（默认展开）</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>第一项的内容。单选模式下，同时只能展开一项。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>第二项</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>第二项的内容。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>第三项</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>第三项的内容。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+};
+
+export const MultipleOpen: Story = {
+  render: () => (
+    <Accordion multiple defaultValue={['a', 'c']} style={{ width: 320 }}>
+      <AccordionItem value="a">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>A（默认展开）</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>A 内容。multiple 模式下可以同时展开多项。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="b">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>B</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>B 内容。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="c">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>C（默认展开）</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>C 内容。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+};
+
+export const AllCollapsed: Story = {
+  render: () => (
+    <Accordion style={{ width: 320 }}>
+      <AccordionItem value="x">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>收起态 X</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>X 内容（初始收起）。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem value="y">
+        <AccordionHeader>
+          <AccordionTrigger>
+            <Trigger>收起态 Y</Trigger>
+          </AccordionTrigger>
+        </AccordionHeader>
+        <AccordionPanel>
+          <Body>Y 内容。</Body>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/packages/ui/stories/accordion.stories.tsx
+++ b/packages/ui/stories/accordion.stories.tsx
@@ -37,7 +37,7 @@ function Body({ children }: { children: React.ReactNode }) {
 
 export const SingleOpen: Story = {
   render: () => (
-    <Accordion defaultValue="item-1" style={{ width: 320 }}>
+    <Accordion defaultValue={['item-1']} style={{ width: 320 }}>
       <AccordionItem value="item-1">
         <AccordionHeader>
           <AccordionTrigger>

--- a/packages/ui/stories/badge.stories.tsx
+++ b/packages/ui/stories/badge.stories.tsx
@@ -13,25 +13,17 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-function Group({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div style={{ alignItems: 'center', display: 'flex', gap: 12, width: 480 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 80 }}>{label}</span>
-      <div style={{ alignItems: 'center', display: 'flex', gap: 8, flexWrap: 'wrap' }}>{children}</div>
-    </div>
-  );
-}
-
 const UI_VARIANTS = ['default', 'secondary', 'success', 'warning', 'destructive', 'muted'] as const;
 
 export const UiBadgeVariants: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 12, width: 480 }}>
       {UI_VARIANTS.map((variant) => (
-        <Group key={variant} label={variant}>
+        <div key={variant} style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+          <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 80 }}>{variant}</span>
           <Badge variant={variant}>{variant}</Badge>
           <Badge variant={variant}>{variant} 12</Badge>
-        </Group>
+        </div>
       ))}
     </div>
   ),
@@ -40,28 +32,23 @@ export const UiBadgeVariants: Story = {
 const PRIM_VARIANTS = ['default', 'destructive', 'error', 'info', 'outline', 'secondary', 'success', 'warning'] as const;
 const SIZES = ['sm', 'default', 'lg'] as const;
 
-export const PrimitiveBadgeVariants: Story = {
+export const PrimitiveBadgeMatrix: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 12, width: 560 }}>
-      {PRIM_VARIANTS.map((variant) => (
-        <Group key={variant} label={variant}>
-          <PrimitiveBadge variant={variant}>{variant}</PrimitiveBadge>
-          <PrimitiveBadge variant={variant}>{variant} 3</PrimitiveBadge>
-        </Group>
-      ))}
-    </div>
-  ),
-};
-
-export const PrimitiveBadgeSizes: Story = {
-  render: () => (
-    <div style={{ display: 'grid', gap: 12, width: 480 }}>
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div style={{ alignItems: 'center', display: 'flex', gap: 8, paddingLeft: 80 }}>
+        {PRIM_VARIANTS.map((v) => (
+          <span key={v} style={{ color: 'var(--muted-foreground)', fontSize: 11, width: 72 }}>{v}</span>
+        ))}
+      </div>
       {SIZES.map((size) => (
-        <Group key={size} label={`size=${size}`}>
-          <PrimitiveBadge size={size}>Aa</PrimitiveBadge>
-          <PrimitiveBadge size={size} variant="info">info</PrimitiveBadge>
-          <PrimitiveBadge size={size} variant="success">ok 12</PrimitiveBadge>
-        </Group>
+        <div key={size} style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+          <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 72 }}>{size}</span>
+          {PRIM_VARIANTS.map((variant) => (
+            <PrimitiveBadge key={variant} size={size} variant={variant} style={{ width: 72, justifyContent: 'center' }}>
+              {variant}
+            </PrimitiveBadge>
+          ))}
+        </div>
       ))}
     </div>
   ),

--- a/packages/ui/stories/badge.stories.tsx
+++ b/packages/ui/stories/badge.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge } from '../src/ui.js';
+import { Badge as PrimitiveBadge } from '../src/primitives/badge.js';
+
+const meta = {
+  title: 'Primitives/Badge',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Group({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12, width: 480 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 80 }}>{label}</span>
+      <div style={{ alignItems: 'center', display: 'flex', gap: 8, flexWrap: 'wrap' }}>{children}</div>
+    </div>
+  );
+}
+
+const UI_VARIANTS = ['default', 'secondary', 'success', 'warning', 'destructive', 'muted'] as const;
+
+export const UiBadgeVariants: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 480 }}>
+      {UI_VARIANTS.map((variant) => (
+        <Group key={variant} label={variant}>
+          <Badge variant={variant}>{variant}</Badge>
+          <Badge variant={variant}>{variant} 12</Badge>
+        </Group>
+      ))}
+    </div>
+  ),
+};
+
+const PRIM_VARIANTS = ['default', 'destructive', 'error', 'info', 'outline', 'secondary', 'success', 'warning'] as const;
+const SIZES = ['sm', 'default', 'lg'] as const;
+
+export const PrimitiveBadgeVariants: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 560 }}>
+      {PRIM_VARIANTS.map((variant) => (
+        <Group key={variant} label={variant}>
+          <PrimitiveBadge variant={variant}>{variant}</PrimitiveBadge>
+          <PrimitiveBadge variant={variant}>{variant} 3</PrimitiveBadge>
+        </Group>
+      ))}
+    </div>
+  ),
+};
+
+export const PrimitiveBadgeSizes: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 480 }}>
+      {SIZES.map((size) => (
+        <Group key={size} label={`size=${size}`}>
+          <PrimitiveBadge size={size}>Aa</PrimitiveBadge>
+          <PrimitiveBadge size={size} variant="info">info</PrimitiveBadge>
+          <PrimitiveBadge size={size} variant="success">ok 12</PrimitiveBadge>
+        </Group>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/stories/empty.stories.tsx
+++ b/packages/ui/stories/empty.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Search } from '@maka/ui/icons';
+import { Button } from '../src/ui.js';
+import { Spinner } from '../src/primitives/spinner.js';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '../src/primitives/empty.js';
+
+const meta = {
+  title: 'Primitives/Empty',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        background: 'var(--background)',
+        border: '1px dashed var(--border)',
+        borderRadius: 'var(--radius-xl)',
+        minHeight: 280,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export const IconOnly: Story = {
+  render: () => (
+    <Frame>
+      <Empty>
+        <EmptyMedia variant="icon">
+          <Search size={18} aria-hidden="true" />
+        </EmptyMedia>
+      </Empty>
+    </Frame>
+  ),
+};
+
+export const Title: Story = {
+  render: () => (
+    <Frame>
+      <Empty>
+        <EmptyHeader>
+          <EmptyTitle>暂无会话</EmptyTitle>
+        </EmptyHeader>
+      </Empty>
+    </Frame>
+  ),
+};
+
+export const TitleAndDescription: Story = {
+  render: () => (
+    <Frame>
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Search size={18} aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>没有匹配的结果</EmptyTitle>
+          <EmptyDescription>试试调整筛选条件，或清空搜索词查看全部会话。</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </Frame>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <Frame>
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Search size={18} aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>还没有会话</EmptyTitle>
+          <EmptyDescription>开始第一次对话吧。</EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button variant="outline" size="sm">新建会话</Button>
+        </EmptyContent>
+      </Empty>
+    </Frame>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <Frame>
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Spinner style={{ height: 16, width: 16 }} />
+          </EmptyMedia>
+          <EmptyTitle>加载中</EmptyTitle>
+          <EmptyDescription>正在读取会话列表…</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </Frame>
+  ),
+};

--- a/packages/ui/stories/kbd.stories.tsx
+++ b/packages/ui/stories/kbd.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Kbd, KbdGroup } from '../src/primitives/kbd.js';
+
+const meta = {
+  title: 'Primitives/Kbd',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12, width: 360 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 120 }}>{label}</span>
+      <div style={{ alignItems: 'center', display: 'flex', gap: 6 }}>{children}</div>
+    </div>
+  );
+}
+
+export const SingleKeys: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 360 }}>
+      <Row label="enter">
+        <Kbd>↵</Kbd>
+      </Row>
+      <Row label="escape">
+        <Kbd>Esc</Kbd>
+      </Row>
+      <Row label="tab">
+        <Kbd>Tab</Kbd>
+      </Row>
+      <Row label="space">
+        <Kbd>Space</Kbd>
+      </Row>
+    </div>
+  ),
+};
+
+export const Combos: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 360 }}>
+      <Row label="command palette">
+        <Kbd>⌘</Kbd>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>+</span>
+        <Kbd>K</Kbd>
+      </Row>
+      <Row label="shift+cmd+P">
+        <Kbd>⇧</Kbd>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>+</span>
+        <Kbd>⌘</Kbd>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>+</span>
+        <Kbd>P</Kbd>
+      </Row>
+      <Row label="undo">
+        <Kbd>⌘</Kbd>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>+</span>
+        <Kbd>Z</Kbd>
+      </Row>
+    </div>
+  ),
+};
+
+export const ArrowGroup: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 12, width: 360 }}>
+      <Row label="navigate">
+        <KbdGroup>
+          <Kbd>↑</Kbd>
+          <Kbd>↓</Kbd>
+        </KbdGroup>
+      </Row>
+      <Row label="navigate all">
+        <KbdGroup>
+          <Kbd>↑</Kbd>
+          <Kbd>↓</Kbd>
+          <Kbd>←</Kbd>
+          <Kbd>→</Kbd>
+        </KbdGroup>
+      </Row>
+    </div>
+  ),
+};

--- a/packages/ui/stories/menu.stories.tsx
+++ b/packages/ui/stories/menu.stories.tsx
@@ -30,10 +30,9 @@ type Story = StoryObj<typeof meta>;
 
 function OpenMenuCell({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div style={{ minHeight: 220, minWidth: 180, position: 'relative' }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 11, position: 'absolute', top: 0, left: 0 }}>{label}</span>
+    <div style={{ minHeight: 220, minWidth: 180 }}>
       <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} style={{ marginTop: 20 }} />
+        <MenuTrigger render={<Button variant="outline" size="sm" />}>{label}</MenuTrigger>
         <MenuPopup>{children}</MenuPopup>
       </Menu>
     </div>

--- a/packages/ui/stories/menu.stories.tsx
+++ b/packages/ui/stories/menu.stories.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Plus, Trash2 } from '@maka/ui/icons';
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuShortcut,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from '../src/primitives/menu.js';
+import { Button } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Menu',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>打开菜单</MenuTrigger>
+      <MenuPopup>
+        <MenuItem>新建文件</MenuItem>
+        <MenuItem>打开…</MenuItem>
+        <MenuItem>保存</MenuItem>
+        <MenuSeparator />
+        <MenuItem variant="destructive">删除</MenuItem>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const WithShortcuts: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>带快捷键</MenuTrigger>
+      <MenuPopup>
+        <MenuItem>
+          新建
+          <MenuShortcut>⌘N</MenuShortcut>
+        </MenuItem>
+        <MenuItem>
+          打开
+          <MenuShortcut>⌘O</MenuShortcut>
+        </MenuItem>
+        <MenuItem>
+          保存
+          <MenuShortcut>⌘S</MenuShortcut>
+        </MenuItem>
+        <MenuSeparator />
+        <MenuItem variant="destructive">
+          删除
+          <MenuShortcut>⌫</MenuShortcut>
+        </MenuItem>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const CheckboxItems: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>勾选项</MenuTrigger>
+      <MenuPopup>
+        <MenuCheckboxItem checked>显示行号</MenuCheckboxItem>
+        <MenuCheckboxItem checked={false}>自动换行</MenuCheckboxItem>
+        <MenuSeparator />
+        <MenuGroup>
+          <MenuGroupLabel>视图</MenuGroupLabel>
+          <MenuCheckboxItem checked>侧栏</MenuCheckboxItem>
+          <MenuCheckboxItem checked={false}>小地图</MenuCheckboxItem>
+        </MenuGroup>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const RadioItems: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>单选项</MenuTrigger>
+      <MenuPopup>
+        <MenuGroupLabel>主题</MenuGroupLabel>
+        <MenuRadioGroup defaultValue="system">
+          <MenuRadioItem value="light">浅色</MenuRadioItem>
+          <MenuRadioItem value="dark">深色</MenuRadioItem>
+          <MenuRadioItem value="system">跟随系统</MenuRadioItem>
+        </MenuRadioGroup>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const Submenu: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>子菜单</MenuTrigger>
+      <MenuPopup>
+        <MenuItem>新建</MenuItem>
+        <MenuSub>
+          <MenuSubTrigger>导出为…</MenuSubTrigger>
+          <MenuSubPopup>
+            <MenuItem>PDF</MenuItem>
+            <MenuItem>Markdown</MenuItem>
+            <MenuItem>HTML</MenuItem>
+          </MenuSubPopup>
+        </MenuSub>
+        <MenuSeparator />
+        <MenuItem variant="destructive">关闭项目</MenuItem>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <Menu>
+      <MenuTrigger render={<Button variant="outline" />}>带图标</MenuTrigger>
+      <MenuPopup>
+        <MenuItem>
+          <Plus size={14} aria-hidden="true" />
+          新建
+        </MenuItem>
+        <MenuItem variant="destructive">
+          <Trash2 size={14} aria-hidden="true" />
+          删除
+        </MenuItem>
+      </MenuPopup>
+    </Menu>
+  ),
+};
+
+export const OpenSnapshot: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, padding: 24, width: 320 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>popup 常驻 open（快照用）</span>
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuItem>新建文件</MenuItem>
+          <MenuItem>打开…</MenuItem>
+          <MenuItem>
+            保存
+            <MenuShortcut>⌘S</MenuShortcut>
+          </MenuItem>
+          <MenuSeparator />
+          <MenuItem variant="destructive">删除</MenuItem>
+        </MenuPopup>
+      </Menu>
+    </div>
+  ),
+};

--- a/packages/ui/stories/menu.stories.tsx
+++ b/packages/ui/stories/menu.stories.tsx
@@ -3,7 +3,6 @@ import { Plus, Trash2 } from '@maka/ui/icons';
 import {
   Menu,
   MenuCheckboxItem,
-  MenuGroup,
   MenuGroupLabel,
   MenuItem,
   MenuPopup,
@@ -29,6 +28,18 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+function OpenMenuCell({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ minHeight: 220, minWidth: 180, position: 'relative' }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 11, position: 'absolute', top: 0, left: 0 }}>{label}</span>
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} style={{ marginTop: 20 }} />
+        <MenuPopup>{children}</MenuPopup>
+      </Menu>
+    </div>
+  );
+}
+
 export const Basic: Story = {
   render: () => (
     <Menu>
@@ -49,84 +60,66 @@ export const Basic: Story = {
 
 export const OpenMatrix: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 32, padding: 24, gridTemplateColumns: 'repeat(3, auto)' }}>
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuGroupLabel>文件</MenuGroupLabel>
-          <MenuItem>新建文件</MenuItem>
-          <MenuItem>打开…</MenuItem>
-          <MenuSeparator />
-          <MenuItem variant="destructive">删除</MenuItem>
-        </MenuPopup>
-      </Menu>
+    <div style={{ display: 'grid', gap: 48, padding: 40, gridTemplateColumns: 'repeat(3, 200px)' }}>
+      <OpenMenuCell label="basic">
+        <MenuGroupLabel>文件</MenuGroupLabel>
+        <MenuItem>新建文件</MenuItem>
+        <MenuItem>打开…</MenuItem>
+        <MenuSeparator />
+        <MenuItem variant="destructive">删除</MenuItem>
+      </OpenMenuCell>
 
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuItem>
-            新建
-            <MenuShortcut>⌘N</MenuShortcut>
-          </MenuItem>
-          <MenuItem>
-            打开
-            <MenuShortcut>⌘O</MenuShortcut>
-          </MenuItem>
-          <MenuItem>
-            保存
-            <MenuShortcut>⌘S</MenuShortcut>
-          </MenuItem>
-        </MenuPopup>
-      </Menu>
+      <OpenMenuCell label="shortcuts">
+        <MenuItem>
+          新建
+          <MenuShortcut>⌘N</MenuShortcut>
+        </MenuItem>
+        <MenuItem>
+          打开
+          <MenuShortcut>⌘O</MenuShortcut>
+        </MenuItem>
+        <MenuItem>
+          保存
+          <MenuShortcut>⌘S</MenuShortcut>
+        </MenuItem>
+      </OpenMenuCell>
 
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuCheckboxItem checked>显示行号</MenuCheckboxItem>
-          <MenuCheckboxItem checked={false}>自动换行</MenuCheckboxItem>
-        </MenuPopup>
-      </Menu>
+      <OpenMenuCell label="checkbox">
+        <MenuCheckboxItem checked>显示行号</MenuCheckboxItem>
+        <MenuCheckboxItem checked={false}>自动换行</MenuCheckboxItem>
+      </OpenMenuCell>
 
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuGroupLabel>主题</MenuGroupLabel>
-          <MenuRadioGroup defaultValue="system">
-            <MenuRadioItem value="light">浅色</MenuRadioItem>
-            <MenuRadioItem value="dark">深色</MenuRadioItem>
-            <MenuRadioItem value="system">跟随系统</MenuRadioItem>
-          </MenuRadioGroup>
-        </MenuPopup>
-      </Menu>
+      <OpenMenuCell label="radio">
+        <MenuGroupLabel>主题</MenuGroupLabel>
+        <MenuRadioGroup defaultValue="system">
+          <MenuRadioItem value="light">浅色</MenuRadioItem>
+          <MenuRadioItem value="dark">深色</MenuRadioItem>
+          <MenuRadioItem value="system">跟随系统</MenuRadioItem>
+        </MenuRadioGroup>
+      </OpenMenuCell>
 
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuItem>新建</MenuItem>
-          <MenuSub>
-            <MenuSubTrigger>导出为…</MenuSubTrigger>
-            <MenuSubPopup>
-              <MenuItem>PDF</MenuItem>
-              <MenuItem>Markdown</MenuItem>
-              <MenuItem>HTML</MenuItem>
-            </MenuSubPopup>
-          </MenuSub>
-        </MenuPopup>
-      </Menu>
+      <OpenMenuCell label="submenu">
+        <MenuItem>新建</MenuItem>
+        <MenuSub open>
+          <MenuSubTrigger>导出为…</MenuSubTrigger>
+          <MenuSubPopup>
+            <MenuItem>PDF</MenuItem>
+            <MenuItem>Markdown</MenuItem>
+            <MenuItem>HTML</MenuItem>
+          </MenuSubPopup>
+        </MenuSub>
+      </OpenMenuCell>
 
-      <Menu open>
-        <MenuTrigger render={<Button variant="outline" />} />
-        <MenuPopup>
-          <MenuItem>
-            <Plus size={14} aria-hidden="true" />
-            新建
-          </MenuItem>
-          <MenuItem variant="destructive">
-            <Trash2 size={14} aria-hidden="true" />
-            删除
-          </MenuItem>
-        </MenuPopup>
-      </Menu>
+      <OpenMenuCell label="icons">
+        <MenuItem>
+          <Plus size={14} aria-hidden="true" />
+          新建
+        </MenuItem>
+        <MenuItem variant="destructive">
+          <Trash2 size={14} aria-hidden="true" />
+          删除
+        </MenuItem>
+      </OpenMenuCell>
     </div>
   ),
 };

--- a/packages/ui/stories/menu.stories.tsx
+++ b/packages/ui/stories/menu.stories.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Plus, Trash2 } from '@maka/ui/icons';
 import {
@@ -37,7 +36,10 @@ export const Basic: Story = {
       <MenuPopup>
         <MenuItem>新建文件</MenuItem>
         <MenuItem>打开…</MenuItem>
-        <MenuItem>保存</MenuItem>
+        <MenuItem>
+          保存
+          <MenuShortcut>⌘S</MenuShortcut>
+        </MenuItem>
         <MenuSeparator />
         <MenuItem variant="destructive">删除</MenuItem>
       </MenuPopup>
@@ -45,121 +47,84 @@ export const Basic: Story = {
   ),
 };
 
-export const WithShortcuts: Story = {
+export const OpenMatrix: Story = {
   render: () => (
-    <Menu>
-      <MenuTrigger render={<Button variant="outline" />}>带快捷键</MenuTrigger>
-      <MenuPopup>
-        <MenuItem>
-          新建
-          <MenuShortcut>⌘N</MenuShortcut>
-        </MenuItem>
-        <MenuItem>
-          打开
-          <MenuShortcut>⌘O</MenuShortcut>
-        </MenuItem>
-        <MenuItem>
-          保存
-          <MenuShortcut>⌘S</MenuShortcut>
-        </MenuItem>
-        <MenuSeparator />
-        <MenuItem variant="destructive">
-          删除
-          <MenuShortcut>⌫</MenuShortcut>
-        </MenuItem>
-      </MenuPopup>
-    </Menu>
-  ),
-};
-
-export const CheckboxItems: Story = {
-  render: () => (
-    <Menu>
-      <MenuTrigger render={<Button variant="outline" />}>勾选项</MenuTrigger>
-      <MenuPopup>
-        <MenuCheckboxItem checked>显示行号</MenuCheckboxItem>
-        <MenuCheckboxItem checked={false}>自动换行</MenuCheckboxItem>
-        <MenuSeparator />
-        <MenuGroup>
-          <MenuGroupLabel>视图</MenuGroupLabel>
-          <MenuCheckboxItem checked>侧栏</MenuCheckboxItem>
-          <MenuCheckboxItem checked={false}>小地图</MenuCheckboxItem>
-        </MenuGroup>
-      </MenuPopup>
-    </Menu>
-  ),
-};
-
-export const RadioItems: Story = {
-  render: () => (
-    <Menu>
-      <MenuTrigger render={<Button variant="outline" />}>单选项</MenuTrigger>
-      <MenuPopup>
-        <MenuGroupLabel>主题</MenuGroupLabel>
-        <MenuRadioGroup defaultValue="system">
-          <MenuRadioItem value="light">浅色</MenuRadioItem>
-          <MenuRadioItem value="dark">深色</MenuRadioItem>
-          <MenuRadioItem value="system">跟随系统</MenuRadioItem>
-        </MenuRadioGroup>
-      </MenuPopup>
-    </Menu>
-  ),
-};
-
-export const Submenu: Story = {
-  render: () => (
-    <Menu>
-      <MenuTrigger render={<Button variant="outline" />}>子菜单</MenuTrigger>
-      <MenuPopup>
-        <MenuItem>新建</MenuItem>
-        <MenuSub>
-          <MenuSubTrigger>导出为…</MenuSubTrigger>
-          <MenuSubPopup>
-            <MenuItem>PDF</MenuItem>
-            <MenuItem>Markdown</MenuItem>
-            <MenuItem>HTML</MenuItem>
-          </MenuSubPopup>
-        </MenuSub>
-        <MenuSeparator />
-        <MenuItem variant="destructive">关闭项目</MenuItem>
-      </MenuPopup>
-    </Menu>
-  ),
-};
-
-export const WithIcons: Story = {
-  render: () => (
-    <Menu>
-      <MenuTrigger render={<Button variant="outline" />}>带图标</MenuTrigger>
-      <MenuPopup>
-        <MenuItem>
-          <Plus size={14} aria-hidden="true" />
-          新建
-        </MenuItem>
-        <MenuItem variant="destructive">
-          <Trash2 size={14} aria-hidden="true" />
-          删除
-        </MenuItem>
-      </MenuPopup>
-    </Menu>
-  ),
-};
-
-export const OpenSnapshot: Story = {
-  render: () => (
-    <div style={{ display: 'grid', gap: 16, padding: 24, width: 320 }}>
-      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>popup 常驻 open（快照用）</span>
+    <div style={{ display: 'grid', gap: 32, padding: 24, gridTemplateColumns: 'repeat(3, auto)' }}>
       <Menu open>
         <MenuTrigger render={<Button variant="outline" />} />
         <MenuPopup>
+          <MenuGroupLabel>文件</MenuGroupLabel>
           <MenuItem>新建文件</MenuItem>
           <MenuItem>打开…</MenuItem>
+          <MenuSeparator />
+          <MenuItem variant="destructive">删除</MenuItem>
+        </MenuPopup>
+      </Menu>
+
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuItem>
+            新建
+            <MenuShortcut>⌘N</MenuShortcut>
+          </MenuItem>
+          <MenuItem>
+            打开
+            <MenuShortcut>⌘O</MenuShortcut>
+          </MenuItem>
           <MenuItem>
             保存
             <MenuShortcut>⌘S</MenuShortcut>
           </MenuItem>
-          <MenuSeparator />
-          <MenuItem variant="destructive">删除</MenuItem>
+        </MenuPopup>
+      </Menu>
+
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuCheckboxItem checked>显示行号</MenuCheckboxItem>
+          <MenuCheckboxItem checked={false}>自动换行</MenuCheckboxItem>
+        </MenuPopup>
+      </Menu>
+
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuGroupLabel>主题</MenuGroupLabel>
+          <MenuRadioGroup defaultValue="system">
+            <MenuRadioItem value="light">浅色</MenuRadioItem>
+            <MenuRadioItem value="dark">深色</MenuRadioItem>
+            <MenuRadioItem value="system">跟随系统</MenuRadioItem>
+          </MenuRadioGroup>
+        </MenuPopup>
+      </Menu>
+
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuItem>新建</MenuItem>
+          <MenuSub>
+            <MenuSubTrigger>导出为…</MenuSubTrigger>
+            <MenuSubPopup>
+              <MenuItem>PDF</MenuItem>
+              <MenuItem>Markdown</MenuItem>
+              <MenuItem>HTML</MenuItem>
+            </MenuSubPopup>
+          </MenuSub>
+        </MenuPopup>
+      </Menu>
+
+      <Menu open>
+        <MenuTrigger render={<Button variant="outline" />} />
+        <MenuPopup>
+          <MenuItem>
+            <Plus size={14} aria-hidden="true" />
+            新建
+          </MenuItem>
+          <MenuItem variant="destructive">
+            <Trash2 size={14} aria-hidden="true" />
+            删除
+          </MenuItem>
         </MenuPopup>
       </Menu>
     </div>

--- a/packages/ui/stories/progress.stories.tsx
+++ b/packages/ui/stories/progress.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Progress } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Progress',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12, width: 360 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 96 }}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export const Values: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 14, width: 360 }}>
+      <Row label="0%">
+        <Progress value={0} />
+      </Row>
+      <Row label="30%">
+        <Progress value={30} />
+      </Row>
+      <Row label="70%">
+        <Progress value={70} />
+      </Row>
+      <Row label="100%">
+        <Progress value={100} />
+      </Row>
+      <Row label="indeterminate">
+        <Progress value={null} />
+      </Row>
+    </div>
+  ),
+};

--- a/packages/ui/stories/radio.stories.tsx
+++ b/packages/ui/stories/radio.stories.tsx
@@ -13,10 +13,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-function Option({ value, children }: { value: string; children: React.ReactNode }) {
+function Option({ value, disabled, children }: { value: string; disabled?: boolean; children: React.ReactNode }) {
   return (
-    <label style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
-      <Radio value={value} />
+    <label style={{ alignItems: 'center', display: 'flex', gap: 8, opacity: disabled ? 0.5 : 1 }}>
+      <Radio value={value} disabled={disabled} />
       <span style={{ fontSize: 13 }}>{children}</span>
     </label>
   );
@@ -39,7 +39,7 @@ export const Horizontal: Story = {
   render: () => {
     const [value, setValue] = useState('a');
     return (
-      <RadioGroup value={value} onValueChange={(v) => setValue(v as string)} style={{ flexDirection: 'row', gap: 16 }}>
+      <RadioGroup value={value} onValueChange={(v) => setValue(v as string)} style={{ display: 'flex', flexDirection: 'row', gap: 16 }}>
         <Option value="a">A</Option>
         <Option value="b">B</Option>
         <Option value="c">C</Option>
@@ -52,8 +52,7 @@ export const Disabled: Story = {
   render: () => (
     <RadioGroup defaultValue="a">
       <Option value="a">可选</Option>
-      <Option value="b">禁用项</Option>
-      <Radio value="b" disabled />
+      <Option value="b" disabled>禁用项</Option>
       <Option value="c">可选</Option>
     </RadioGroup>
   ),

--- a/packages/ui/stories/radio.stories.tsx
+++ b/packages/ui/stories/radio.stories.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Radio, RadioGroup } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Radio',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Option({ value, children }: { value: string; children: React.ReactNode }) {
+  return (
+    <label style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+      <Radio value={value} />
+      <span style={{ fontSize: 13 }}>{children}</span>
+    </label>
+  );
+}
+
+export const Vertical: Story = {
+  render: () => {
+    const [value, setValue] = useState('a');
+    return (
+      <RadioGroup value={value} onValueChange={(v) => setValue(v as string)}>
+        <Option value="a">选项 A</Option>
+        <Option value="b">选项 B</Option>
+        <Option value="c">选项 C</Option>
+      </RadioGroup>
+    );
+  },
+};
+
+export const Horizontal: Story = {
+  render: () => {
+    const [value, setValue] = useState('a');
+    return (
+      <RadioGroup value={value} onValueChange={(v) => setValue(v as string)} style={{ flexDirection: 'row', gap: 16 }}>
+        <Option value="a">A</Option>
+        <Option value="b">B</Option>
+        <Option value="c">C</Option>
+      </RadioGroup>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <RadioGroup defaultValue="a">
+      <Option value="a">可选</Option>
+      <Option value="b">禁用项</Option>
+      <Radio value="b" disabled />
+      <Option value="c">可选</Option>
+    </RadioGroup>
+  ),
+};
+
+export const DefaultUncontrolled: Story = {
+  render: () => (
+    <RadioGroup defaultValue="b">
+      <Option value="a">选项 A</Option>
+      <Option value="b">选项 B（默认选中）</Option>
+      <Option value="c">选项 C</Option>
+    </RadioGroup>
+  ),
+};

--- a/packages/ui/stories/spinner.stories.tsx
+++ b/packages/ui/stories/spinner.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Spinner } from '../src/primitives/spinner.js';
+
+const meta = {
+  title: 'Primitives/Spinner',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const SIZES = [16, 20, 24, 32] as const;
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 20 }}>
+      {SIZES.map((size) => (
+        <div key={size} style={{ alignItems: 'center', display: 'flex', gap: 8 }}>
+          <Spinner style={{ height: size, width: size }} />
+          <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{size}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/stories/toggle.stories.tsx
+++ b/packages/ui/stories/toggle.stories.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Toggle, ToggleGroup } from '../src/ui.js';
+
+const meta = {
+  title: 'Primitives/Toggle',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ alignItems: 'center', display: 'flex', gap: 12, width: 360 }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12, width: 80 }}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export const ToggleStates: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 14, width: 360 }}>
+      <Row label="off">
+        <Toggle>未按下</Toggle>
+      </Row>
+      <Row label="on">
+        <Toggle defaultPressed>已按下</Toggle>
+      </Row>
+      <Row label="disabled">
+        <Toggle disabled>禁用</Toggle>
+      </Row>
+      <Row label="disabled on">
+        <Toggle disabled defaultPressed>禁用按下</Toggle>
+      </Row>
+      <Row label="controlled">
+        <ControlledToggle />
+      </Row>
+    </div>
+  ),
+};
+
+function ControlledToggle() {
+  const [pressed, setPressed] = useState(false);
+  return <Toggle pressed={pressed} onPressedChange={setPressed}>点击切换</Toggle>;
+}
+
+export const SingleSelect: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | null>('bold');
+    return (
+      <div style={{ display: 'grid', gap: 12, width: 360 }}>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>单选（toggleMultiple=false，value 为单值）</span>
+        <ToggleGroup value={value ? [value] : []} onValueChange={(v) => setValue(v[0] ?? null)}>
+          <Toggle value="bold" aria-label="加粗">B</Toggle>
+          <Toggle value="italic" aria-label="斜体">I</Toggle>
+          <Toggle value="underline" aria-label="下划线">U</Toggle>
+        </ToggleGroup>
+      </div>
+    );
+  },
+};
+
+export const MultiSelect: Story = {
+  render: () => {
+    const [value, setValue] = useState<string[]>(['bold', 'underline']);
+    return (
+      <div style={{ display: 'grid', gap: 12, width: 360 }}>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>多选（toggleMultiple，value 为数组）</span>
+        <ToggleGroup toggleMultiple value={value} onValueChange={setValue}>
+          <Toggle value="bold" aria-label="加粗">B</Toggle>
+          <Toggle value="italic" aria-label="斜体">I</Toggle>
+          <Toggle value="underline" aria-label="下划线">U</Toggle>
+          <Toggle value="strike" aria-label="删除线">S</Toggle>
+        </ToggleGroup>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
## Summary

Add independent Storybook stories for the 9 P1 UI primitive components in `packages/ui`, one commit per component. Covers all variants and key states for visual regression and component documentation.

## Why

Follow-up to PR #447 (P0 primitives). These P1 components are medium-frequency primitives used across the app; without independent stories, variant changes had no visual regression protection.

## Scope

Changed:
- `packages/ui/stories/progress.stories.tsx` — 0% / 30% / 70% / 100% / indeterminate (`value={null}`)
- `packages/ui/stories/radio.stories.tsx` — vertical / horizontal / disabled / uncontrolled (`defaultValue`)
- `packages/ui/stories/toggle.stories.tsx` — Toggle states (off/on/disabled/controlled) + ToggleGroup single-select / multi-select (`toggleMultiple`)
- `packages/ui/stories/badge.stories.tsx` — `ui.tsx` Badge (6 variant) + `primitives/badge.tsx` PrimitiveBadge (8 variant × 3 size sm/default/lg)
- `packages/ui/stories/menu.stories.tsx` — basic items / shortcuts / checkbox items / radio items / submenu / destructive / with icons + `open` snapshot
- `packages/ui/stories/accordion.stories.tsx` — single-open (`defaultValue`) / multiple-open (`multiple` + array `defaultValue`) / all-collapsed
- `packages/ui/stories/spinner.stories.tsx` — sizes 16/20/24/32px
- `packages/ui/stories/empty.stories.tsx` — icon-only / title / title+description / with-action / loading (Spinner media)
- `packages/ui/stories/kbd.stories.tsx` — single keys / combos (⌘K, ⇧⌘P) / arrow group (KbdGroup)

Not included:
- P2 components (ChoiceCard, SettingsSegmented, SettingsSelect, SettingsSwitch, InputGroup, Toolbar, standalone Separator, OverlayScrollArea, ScrollArea) — deferred to a follow-up PR
- No changes to existing source code, components, or build config

## Verification

- `npm run -w @maka/desktop build-storybook` — green (verified after each story, plus a final full run)
- All stories use the `Primitives/<Component>` namespace and reuse the `withMakaRoot` decorator from preview.tsx (colorScheme + palette switching)
- Menu `open` snapshot added per P0 review feedback (Select/Toast open-snapshot pattern); Accordion uses `defaultValue` for deterministic initial open state

## Reviewer notes

- Badge covers both exports: the simple `Badge` from `ui.tsx` (6 variants) and `PrimitiveBadge` from `primitives/badge.tsx` (8 variants × 3 sizes with `useRender` polymorphism), since both are used in the codebase
- Toggle single-select uses `value` as an array (`[value]`) and reads `v[0]` from `onValueChange`, matching Base UI ToggleGroup's array-based contract
- Accordion trigger/content use inline layout (chevron + label) to avoid coupling to settings CSS (`enabledProvider*` classes)
- Menu `MenuTrigger` uses `render={<Button variant="outline" />}` to compose the trigger button, matching `plan-reminder-panel.tsx` usage