### PR TITLE
fix(ui): revive dead darwin glass palette, fix token typos, dark mint contrast

### DIFF
--- a/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
+++ b/apps/desktop/src/main/__tests__/first-run-task-suggestions.test.ts
@@ -216,9 +216,17 @@ describe('FIRST_RUN_TASK_SUGGESTIONS', () => {
     assert.match(checklist, /onStartPlanReminder\?\(\): void/);
     assert.match(checklist, /id:\s*'plan-reminder'/);
     assert.match(checklist, /建一条本地计划提醒/);
+    // The old `props.onStartPlanReminder?.() ?? props.onOpenSidebarModule(...)`
+    // pattern was a bug: the callback returns void, so `?.()` always yields
+    // undefined and the "fallback" fired unconditionally. The contract now
+    // pins the explicit branch.
     assert.match(
       checklist,
-      /onClick:\s*\(\)\s*=>\s*props\.onStartPlanReminder\?\.\(\)\s*\?\?\s*props\.onOpenSidebarModule\('automations'\)/,
+      /if\s*\(props\.onStartPlanReminder\)\s*props\.onStartPlanReminder\(\);/,
+    );
+    assert.match(
+      checklist,
+      /else\s*props\.onOpenSidebarModule\('automations'\);/,
     );
     assert.match(main, /function\s+openPlanReminderForm\(\)/);
     assert.match(main, /<FirstRunChecklist[\s\S]*onStartPlanReminder=\{openPlanReminderForm\}/);

--- a/apps/desktop/src/renderer/FirstRunChecklist.tsx
+++ b/apps/desktop/src/renderer/FirstRunChecklist.tsx
@@ -169,7 +169,12 @@ export function FirstRunChecklist(props: FirstRunChecklistProps) {
           : '计划提醒状态暂时没刷新成功，打开计划页可查看。',
         done: hasPlanReminder,
         trackCompletion: planStatusKnown,
-        onClick: () => props.onStartPlanReminder?.() ?? props.onOpenSidebarModule('automations'),
+        // `onStartPlanReminder` returns void, so `?.() ?? fallback()` would
+        // ALWAYS also fire the fallback — explicit branch instead.
+        onClick: () => {
+          if (props.onStartPlanReminder) props.onStartPlanReminder();
+          else props.onOpenSidebarModule('automations');
+        },
       },
       {
         id: 'daily-review',

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -69,5 +69,5 @@
   --text-sm: var(--font-size-ui);
   --text-base: var(--font-size-base);
 
-  --shadow-maka-panel: 0 0 0 1px var(--border), 0 1px 2px rgba(15, 23, 42, 0.04), 0 14px 40px rgba(15, 23, 42, 0.08);
+  --shadow-maka-panel: 0 0 0 1px var(--border), 0 1px 2px oklch(from var(--foreground) l c h / 0.04), 0 14px 40px oklch(from var(--foreground) l c h / 0.08);
 }

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -544,7 +544,7 @@
   min-height: 32px;
   margin: 8px 10px;
   border-color: var(--border);
-  background: var(--surface);
+  background: var(--background-elevated);
 }
 
 .maka-palette-input {

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1266,21 +1266,21 @@
 
 .maka-skill-add-button {
   gap: 5px;
-  border-color: #151515;
+  border-color: oklch(0.19 0 0);
   border-radius: var(--radius-pill);
-  background: linear-gradient(#333, #151515);
+  background: linear-gradient(oklch(0.32 0 0), oklch(0.19 0 0));
   box-shadow:
-    inset 0 1px 0 #ffffff26,
-    0 1px 2px #0c0c0d1a;
-  color: #fff;
+    inset 0 1px 0 oklch(1 0 0 / 0.15),
+    0 1px 2px oklch(0.1 0 0 / 0.10);
+  color: oklch(1 0 0);
   font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .maka-skill-add-button:hover {
-  border-color: #1f1f1f;
-  background: linear-gradient(#3e3e3e, #1f1f1f);
-  color: #fff;
+  border-color: oklch(0.24 0 0);
+  background: linear-gradient(oklch(0.36 0 0), oklch(0.24 0 0));
+  color: oklch(1 0 0);
 }
 
 /* Phase 2 — atlas-driven rewrite (notes/reference-atlas.md §10). Skills page

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -370,13 +370,13 @@
   border: 1px solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--text);
+  color: var(--foreground);
   font-size: var(--font-size-base);
   line-height: 1;
 }
 
 .maka-browser-navbtn:hover:not(:disabled) {
-  background: var(--surface-hover, rgba(127, 127, 127, 0.12));
+  background: var(--foreground-8);
 }
 
 .maka-browser-navbtn:disabled {
@@ -392,7 +392,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--surface, var(--background));
-  color: var(--text);
+  color: var(--foreground);
   font-size: var(--font-size-ui);
 }
 
@@ -403,7 +403,7 @@
 }
 
 .maka-browser-empty {
-  color: var(--text-muted, #888);
+  color: var(--foreground-50);
 }
 
 .maka-browser-empty-hint {
@@ -734,7 +734,7 @@
   object-fit: contain;
   border-radius: var(--radius-control);
   border: 1px solid var(--border);
-  background: var(--surface);
+  background: var(--foreground-3);
 }
 
 /* PR-UI-RENDER-3a — Unsupported preview card. Shown when the

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -336,7 +336,7 @@
   min-height: 32px;
   margin: 8px 12px;
   border-color: var(--border);
-  background: var(--surface);
+  background: var(--background-elevated);
 }
 .maka-search-modal-input-icon {
   color: var(--foreground-50);

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -76,15 +76,33 @@
    prefixed `state` rather than `row` so it can be reused for chip /
    tab / nav selected states later (per @maka-审美专家 token-naming
    suggestion). */
-@layer base {
-  html[data-os="darwin"] {
-    --color-bg-layout: #fdfcfa;
-    --color-bg-highlight: #c9c4b8;
-    --color-bg-container: #faf9f6;
-    --color-bg-element: #f5f3ee;
-    --color-state-selected: #8ee5a1;
-    --color-text-quaternary: oklch(from var(--foreground) l c h / 0.45);
-  }
+/* UNLAYERED on purpose: reference-shell.css defines the same custom
+   properties in an unlayered :root block, and unlayered declarations
+   beat @layer ones regardless of specificity — inside @layer base this
+   entire warm glass palette was silently dead (the documented
+   "parchment glass" never shipped). html[data-os] (0,1,1) outranks
+   :root (0,1,0), so the darwin override now actually applies. */
+html[data-os="darwin"] {
+  --color-bg-layout: #fdfcfa;
+  --color-bg-highlight: #c9c4b8;
+  --color-bg-container: #faf9f6;
+  --color-bg-element: #f5f3ee;
+  --color-state-selected: #8ee5a1;
+  --color-text-quaternary: oklch(from var(--foreground) l c h / 0.45);
+}
+
+/* Dark-mode variants for the darwin glass palette. The light hexes above
+   are QoderWork light-glass extractions; reused verbatim in dark mode the
+   mint selected-row fill sat under near-white foreground text (unreadable)
+   and the parchment surfaces glowed against the dark shell. Deep sage keeps
+   the selected row's "color block IS the signal" behavior with ~7:1
+   contrast against the dark foreground. */
+html[data-os="darwin"].dark {
+  --color-bg-layout: oklch(0.22 0.006 96);
+  --color-bg-highlight: oklch(0.34 0.008 96);
+  --color-bg-container: oklch(0.24 0.006 96);
+  --color-bg-element: oklch(0.27 0.006 96);
+  --color-state-selected: oklch(0.42 0.075 152);
 }
 
 /* L3 — selected list-row uses the QoderWork mint state fill instead of

--- a/packages/ui/stories/form-controls.stories.tsx
+++ b/packages/ui/stories/form-controls.stories.tsx
@@ -31,16 +31,16 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export const InputStates: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
-      <Section title="default">
+      <Section title="默认">
         <Input placeholder="输入内容…" aria-label="默认输入" />
       </Section>
-      <Section title="with value">
+      <Section title="已填值">
         <Input defaultValue="已经填好的文本" aria-label="有值输入" />
       </Section>
-      <Section title="disabled">
+      <Section title="禁用">
         <Input defaultValue="禁用态" disabled aria-label="禁用输入" />
       </Section>
-      <Section title="aria-invalid (error)">
+      <Section title="错误态">
         <Input defaultValue="错误值" aria-invalid="true" aria-label="错误态输入" />
       </Section>
     </div>
@@ -50,10 +50,10 @@ export const InputStates: Story = {
 export const TextareaStates: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
-      <Section title="default">
+      <Section title="默认">
         <Textarea placeholder="多行输入…" aria-label="默认多行" />
       </Section>
-      <Section title="disabled">
+      <Section title="禁用">
         <Textarea defaultValue="禁用态多行文本" disabled aria-label="禁用多行" />
       </Section>
     </div>
@@ -70,7 +70,7 @@ export const Field: Story = {
           <FieldDescription>显示在侧栏和会话标题里。</FieldDescription>
         </FieldRoot>
       </Section>
-      <Section title="Field + Textarea">
+      <Section title="Field + Textarea 组合">
         <FieldRoot className="grid gap-1.5">
           <Label>项目说明</Label>
           <Textarea defaultValue="一个本地优先的 AI agent。" aria-label="项目说明" />
@@ -84,14 +84,14 @@ export const Field: Story = {
 export const SeparatorStates: Story = {
   render: () => (
     <div style={{ display: 'grid', gap: 20, maxWidth: 440 }}>
-      <Section title="horizontal">
+      <Section title="横向排列">
         <div style={{ display: 'grid', gap: 8 }}>
           <span style={{ fontSize: 13 }}>上方</span>
           <Separator />
           <span style={{ fontSize: 13 }}>下方</span>
         </div>
       </Section>
-      <Section title="vertical">
+      <Section title="纵向排列">
         <div style={{ alignItems: 'center', display: 'flex', gap: 12, height: 48 }}>
           <span style={{ fontSize: 13 }}>左</span>
           <Separator orientation="vertical" />


### PR DESCRIPTION
Landing the verified findings from a 3-way parallel deep code review (renderer / @maka/ui + settings / CSS system).

## Headline: the parchment-glass look never shipped (P1, dead rules)
`theme-glass.css` defines the darwin warm-glass palette inside `@layer base`, but `reference-shell.css` defines the same custom properties **unlayered** — unlayered beats layered regardless of specificity, so 4 of 5 overrides were silently dead and macOS users have been seeing the flat palette instead of the documented QoderWork glass extraction. Moved out of `@layer`; `html[data-os]` (0,1,1) outranks `:root` (0,1,0).

## Dark-mode mint contrast (P0)
`--color-state-selected: #8ee5a1` was the only live token of that block — and in dark mode it painted the active session row light-mint under near-white foreground text. Added dark variants for the whole palette; selected row deepens to `oklch(0.42 0.075 152)` (~7:1 against dark foreground).

## Undefined-token typos (P1 × 5 call sites)
`var(--surface)` / `var(--text)` / `var(--text-muted)` / `var(--surface-hover)` don't exist in the token system → background/text color silently dropped on: search-modal input row, ⌘K palette input, browser-panel nav/address/empty, artifact image matte. All now use real tokens.

## Also
- `--shadow-maka-panel` blur layers: navy rgba literals → `oklch(from var(--foreground))` (theme-tracking)
- `.maka-skill-add-button`: hex → oklch equivalents (same look, one token language)
- FirstRunChecklist `?.() ?? fallback()` void-bug (fallback always fired) + contract updated to pin the explicit branch
- 9 english storybook section labels → Chinese (check-a11y was red on main)

## Verification
- `npm --workspace @maka/desktop test`: 1685/1685
- `node scripts/check-a11y.mjs`: clean
