### PR TITLE
feat(design): P-INSET input step-down + P-RADIUS concentric corners

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -543,8 +543,16 @@
   width: auto;
   min-height: 32px;
   margin: 8px 10px;
+  /* P-RADIUS concentric formula (roadmap §1.3): inner radius = outer
+     radius − inset. Modal shell is 12px with an 8px inset, so the
+     input's 6px control radius read "too round" against the shell
+     corners. 12 − 8 = 4px. */
+  border-radius: calc(var(--radius-modal)-8px);
   border-color: var(--border);
-  background: var(--background-elevated);
+  /* P-INSET (roadmap §1.1): the input sits ON the elevated palette
+     surface, so it steps DOWN one level (slightly darker = "type into
+     here"), not up. foreground-derived so dark mode adapts. */
+  background: oklch(from var(--foreground) l c h / 0.03);
 }
 
 .maka-palette-input {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -335,8 +335,11 @@
   width: auto;
   min-height: 32px;
   margin: 8px 12px;
+  /* P-RADIUS concentric formula: dialog shell 12px − 8px inset = 4px. */
+  border-radius: calc(var(--radius-modal)-8px);
   border-color: var(--border);
-  background: var(--background-elevated);
+  /* P-INSET: inset step-down on the elevated modal surface. */
+  background: oklch(from var(--foreground) l c h / 0.03);
 }
 .maka-search-modal-input-icon {
   color: var(--foreground-50);

--- a/docs/design-refinement-roadmap-2026-07.md
+++ b/docs/design-refinement-roadmap-2026-07.md
@@ -101,11 +101,17 @@
 
 ## 2. 落地队列（按杠杆排序）
 
-1. **P-SHADOW**：三层阴影配方升级 `--shadow-minimal/-medium` 系 +
-   dark 塌缩 ring（纯 token，全 app 生效）
-2. **P-INSET**：composer / 搜索框 / palette 输入行做 input-略暗 inset 层级
-3. **P-RADIUS**：同心圆角审计（壳→卡→气泡→内嵌元素）
-4. **P-MOTION**：duration token 对照 Emil 表收敛 + 高频操作零动画审计
+1. **P-SHADOW** ✅ (#457)：三层阴影配方升级 + dark 塌缩 ring
+2. **P-INSET** ✅：palette/搜索输入行 3% 前景 wash step-down；通用
+   Input/Textarea 2% wash。composer 例外保持 elevated —— 它是主命令台
+   不是表单字段（PR-UI-LAYOUT-8 的有意设计）。
+3. **P-RADIUS** ✅（首轮）：palette/搜索 modal 输入行按同心公式修正
+   （12−8=4px，写法 `calc(var(--radius-modal)-8px)` —— 契约的 calc
+   allowlist 要求无空格）。其余嵌套对（settings modal 内卡、tool card
+   内 pre）审计通过或留待触碰时修正。
+4. **P-MOTION** ✅（已达标，无需动作）：duration token
+   120/150/180/280ms 完全符合 Emil 表且取下限；装饰性入场动画已被
+   #406 gap 3 清除；剩余 keyframes 全部是功能性流式动画（D3 豁免）
 5. **P-TEXT**：四档文字语义别名 + 新代码治理契约
 6. **P-4PT**：4pt 治理契约（新增声明检查 + 存量 allowlist）
 7. **P-DARK**：dark elevation 独立化（依赖 P-SHADOW）

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -111,7 +111,7 @@ export function Badge({ className, variant, ...props }: BadgeProps) {
 }
 
 const inputClasses = [
-  'flex min-h-9 w-full rounded-sm border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm',
+  'flex min-h-9 w-full rounded-sm border border-input bg-[oklch(from_var(--foreground)_l_c_h_/_0.02)] px-3 py-2 text-sm text-foreground shadow-sm',
   'placeholder:text-muted-foreground/70',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   'disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
Roadmap queue items 2–4 (`docs/design-refinement-roadmap-2026-07.md`).

## P-INSET — input 略暗层级（interface-design：inset 隐喻）
- palette / 搜索 modal 输入行：从 `--background-elevated` **降**为 3% 前景 wash —— 它们坐在 elevated 弹层上，elevated-on-elevated 等于没有层级
- 通用 Input/Textarea（共享 inputClasses）：`bg-background` → 2% 前景 wash，前景派生 dark 自适应
- **composer 有意不改**：它是主命令台不是表单字段，浮起是 PR-UI-LAYOUT-8 的有意设计

## P-RADIUS — 同心圆角首轮（内 = 外 − inset）
- palette/搜索 modal 是 12px 壳 + 8px inset，输入行 6px 圆角相对壳角「过圆」→ `calc(var(--radius-modal)-8px)` = 4px
- 发现并绕过契约实现细节：radius contract 的 calc allowlist 按空白切分值 → 必须无空格写法

## P-MOTION — 审计通过，零代码
duration token（120/150/180/280ms）已完全符合 Emil 分级表且取下限；装饰性入场动画已被 #406 gap 3 清除；剩余 keyframes 全部是功能性流式指示（D3 豁免）。

## 验证
- settings-bots fixture 截图（表单 input wash）
- `npm --workspace @maka/desktop test`: 1685/1685