### PR TITLE
fix(ui): clear the outstanding UI-review P0s and follow-ups

### DIFF
--- a/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/motion-token-converge-contract.test.ts
@@ -183,7 +183,15 @@ describe('PR-MOTION-TOKEN-CONVERGE-0 contract', () => {
         const full = resolve(dir, entry.name);
         if (entry.isDirectory()) await walk(full);
         else if (entry.isFile() && /\.(tsx|ts)$/.test(entry.name)) {
-          offenders.push(...scanBareTimingKeywords(await readFile(full, 'utf8'), full.replace(REPO_ROOT + '/', '')));
+          // Strip //-line and /*-block comments before scanning so a
+          // prose word like "ease" or "linear" in a doc comment can't
+          // false-positive (the CSS path already strips comments —
+          // this closes the asymmetry noted in #431 review).
+          const raw = await readFile(full, 'utf8');
+          const withoutComments = raw
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+          offenders.push(...scanBareTimingKeywords(withoutComments, full.replace(REPO_ROOT + '/', '')));
         }
       }
     }

--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -265,7 +265,7 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
     );
     assert.match(
       searchModal,
-      /useModalA11y\(dialogRef,\s*props\.onClose,\s*inputRef\)/,
+      /useModalA11y\(dialogRef,\s*props\.onClose,\s*inputRef,\s*\{\s*suppressFocusRestoreRef\s*\}\)/,
       'SearchModal must give initial modal focus to the search input, not the close button',
     );
     assert.match(
@@ -431,7 +431,7 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
 
     assert.match(
       hook,
-      /queueMicrotask\(\(\) => \{\s*if \(document\.contains\(container\)\) return;\s*if \(previouslyFocused && document\.contains\(previouslyFocused\)\)/m,
+      /queueMicrotask\(\(\) => \{\s*if \(suppressFocusRestoreRef\?\.current\) return;\s*if \(document\.contains\(container\)\) return;\s*if \(previouslyFocused && document\.contains\(previouslyFocused\)\)/m,
       'StrictMode effect cleanup must not restore focus to the opener while the modal container is still mounted',
     );
   });

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -866,6 +866,11 @@ export function BotChatSettingsPage(props: {
               data-support={providerSupport}
               aria-current={selected === provider ? 'page' : undefined}
               disabled={botActionBusy}
+              /* Locked by contract: platform switching is blocked while a
+                 provider-owned action runs. The original gap (UI review
+                 P0) was that all seven rows froze with NO explanation —
+                 the title tells the user why and when it unlocks. */
+              title={botActionBusy ? '当前操作进行中，完成后可切换平台' : undefined}
               style={{ ['--bot-brand-color' as string]: BOT_BRAND[provider].color }}
               onClick={() => {
                 setSelected(provider);

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1490,6 +1490,10 @@ color: oklch(0.55 0.015 220);
 }
 
 .maka-skill-filter-pill {
+  /* Rendered as a static <span> since the filter/sort controls are not
+     wired yet (was a disabled UiButton that promised interactivity). */
+  display: inline-flex;
+  align-items: center;
   height: 28px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);

--- a/packages/ui/src/modal-a11y.ts
+++ b/packages/ui/src/modal-a11y.ts
@@ -17,7 +17,18 @@ export function useModalA11y(
   containerRef: RefObject<HTMLElement | null>,
   onEscape?: () => void,
   initialFocusRef?: RefObject<HTMLElement | null>,
+  options?: {
+    /**
+     * When the ref's current value is true at unmount, skip restoring
+     * focus to the pre-modal element. Needed by flows that CLOSE the
+     * modal by navigating somewhere else (e.g. search -> jump to a chat
+     * turn): unconditionally yanking focus back to the trigger button
+     * would fight the destination's own focus management.
+     */
+    suppressFocusRestoreRef?: RefObject<boolean>;
+  },
 ): void {
+  const suppressFocusRestoreRef = options?.suppressFocusRestoreRef;
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -67,13 +78,14 @@ export function useModalA11y(
       // Defer restoration so any in-flight focus changes (e.g. clicking a
       // button that unmounts the modal) settle before we yank focus back.
       queueMicrotask(() => {
+        if (suppressFocusRestoreRef?.current) return;
         if (document.contains(container)) return;
         if (previouslyFocused && document.contains(previouslyFocused)) {
           previouslyFocused.focus?.({ preventScroll: true });
         }
       });
     };
-  }, [containerRef, onEscape, initialFocusRef]);
+  }, [containerRef, onEscape, initialFocusRef, suppressFocusRestoreRef]);
 }
 
 const FOCUSABLE_SELECTOR =

--- a/packages/ui/src/search-modal.tsx
+++ b/packages/ui/src/search-modal.tsx
@@ -108,7 +108,8 @@ export function SearchModal(props: {
   const searchMountedRef = useRef(true);
   const keyboardSelectionHandledRef = useRef(false);
   const searchThread = props.deps?.searchThread;
-  useModalA11y(dialogRef, props.onClose, inputRef);
+  const suppressFocusRestoreRef = useRef(false);
+  useModalA11y(dialogRef, props.onClose, inputRef, { suppressFocusRestoreRef });
 
   useEffect(() => {
     searchMountedRef.current = true;
@@ -178,6 +179,9 @@ export function SearchModal(props: {
     if (!props.onNavigateToSession) return;
     if (result.target?.kind !== 'thread') return;
     props.onNavigateToSession(result.target.sessionId, result.target.turnId);
+    // Navigating away owns focus now — stop the a11y hook's unmount
+    // cleanup from yanking focus back to the sidebar search trigger.
+    suppressFocusRestoreRef.current = true;
     props.onClose({ restoreFocus: false });
   }
 

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -59,7 +59,10 @@ function SkillLibraryPanel(props: {
 
   const tabs = (
     <div className="maka-skill-tabs-bar">
-      <div className="maka-skill-tabs" role="tablist" aria-label="技能视图">
+      {/* Not role=tablist: these are plain buttons without the ARIA tabs
+          keyboard contract (roving tabindex, arrow keys, linked panels).
+          aria-pressed states the truth — a segmented view switcher. */}
+      <div className="maka-skill-tabs" aria-label="技能视图">
         {([
           ['market', '市场', filteredMarketCards.length],
           ['builtin', '内置', filteredSkills.length],
@@ -69,8 +72,7 @@ function SkillLibraryPanel(props: {
             key={tab}
             type="button"
             variant="ghost"
-            role="tab"
-            aria-selected={activeSkillTab === tab}
+            aria-pressed={activeSkillTab === tab}
             className="maka-skill-tab"
             data-state={activeSkillTab === tab ? 'active' : 'inactive'}
             onClick={() => setActiveSkillTab(tab)}
@@ -82,12 +84,11 @@ function SkillLibraryPanel(props: {
       </div>
       {activeSkillTab === 'market' && (
         <div className="maka-skill-filter-actions" aria-label="技能筛选排序">
-          <UiButton type="button" variant="secondary" className="maka-skill-filter-pill" disabled aria-disabled="true">
-            全部
-          </UiButton>
-          <UiButton type="button" variant="secondary" className="maka-skill-filter-pill" disabled aria-disabled="true">
-            排序：热门
-          </UiButton>
+          {/* Static labels, not disabled buttons: filter/sort are not
+              wired yet, and a styled-but-dead button visually promises
+              interactivity it can't deliver. */}
+          <span className="maka-skill-filter-pill" data-static="true">全部</span>
+          <span className="maka-skill-filter-pill" data-static="true">排序：热门</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
把 2026-07-03 三路 code review 在案未修的项**全部清掉**（不留给别人）：

## P0 × 3
1. **搜索选结果后焦点被拽回侧栏**：`useModalA11y` 卸载时无条件恢复焦点，无视调用方 `restoreFocus:false` 的意图。hook 新增可选 `suppressFocusRestoreRef`；SearchModal 在导航接管焦点时置位。lifecycle 契约同步（StrictMode still-mounted 保护原样，只是后移一行）。
2. **技能页视图切换器 ARIA 违约**：`role=tablist/tab` 承诺了从未实现的 tabs 键盘契约（roving tabindex/方向键/panel 关联）→ 改为诚实的 `aria-pressed` 分段按钮。
3. **bot 平台导航七行冻结无解释**：契约有意锁定操作期间的平台切换 —— 保留锁，补上缺失的 `title`（「当前操作进行中，完成后可切换平台」），修的是"无解释"这半个缺陷。

## 跟进 × 2
- 假筛选按钮（全部/排序：热门）→ 静态 span（不再视觉承诺可交互；CSS 补 inline-flex 保持 28px 胶囊几何）
- #431 review 遗留：motion 契约 TSX 扫描先剥离注释，闭合 CSS/TSX 不对称

## 验证
`npm --workspace @maka/desktop test`: **1696/1696**
