### PR TITLE
feat(providers): add MiniMax M-series (Global + China)

### DIFF
--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -92,6 +92,7 @@ const FEATURED: Array<{ type: ProviderType; tag: string; recommended?: boolean }
   { type: 'anthropic', tag: 'Claude · Anthropic', recommended: true },
   { type: 'openai', tag: 'OpenAI' },
   { type: 'zai-coding-plan', tag: 'GLM Coding Plan · Z.ai' },
+  { type: 'MiniMax', tag: 'MiniMax M-series' },
   { type: 'kimi-coding-plan', tag: 'Kimi · Moonshot' },
   { type: 'deepseek', tag: 'DeepSeek' },
   { type: 'ollama', tag: 'Ollama' },

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -103,6 +103,17 @@ function ZAI(): ReactElement {
   );
 }
 
+// MiniMax ships no vendored logo in `@lobehub/icons-static-svg`, so we render
+// a neutral monochrome "M" glyph (currentColor) as an identifying placeholder
+// rather than misusing a trademarked asset. Swap in the official mark later.
+function MiniMaxMark(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" role="img" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+      <path d="M4 18V6l5 8 5-8v12M20 6v12" />
+    </svg>
+  );
+}
+
 function Ollama(): ReactElement {
   return (
     <svg viewBox="0 0 24 24" role="img" fill="currentColor" fillRule="evenodd" xmlns="http://www.w3.org/2000/svg">
@@ -134,6 +145,9 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
       return <Moonshot />;
     case 'zai-coding-plan':
       return <ZAI />;
+    case 'MiniMax':
+    case 'MiniMax-cn':
+      return <MiniMaxMark />;
     case 'ollama':
       return <Ollama />;
   }

--- a/apps/desktop/src/renderer/settings/provider-display.tsx
+++ b/apps/desktop/src/renderer/settings/provider-display.tsx
@@ -34,6 +34,10 @@ export function providerDisplay(type: ProviderType): { name: string; description
       return { name: 'Moonshot', description: 'Moonshot 官方接入', badge: 'API' };
     case 'zai-coding-plan':
       return { name: 'Z.AI Coding Plan', description: '智谱 · OpenAI 兼容', badge: 'Coding' };
+    case 'MiniMax':
+      return { name: 'MiniMax', description: 'MiniMax · Anthropic 兼容', badge: 'API' };
+    case 'MiniMax-cn':
+      return { name: 'MiniMax 中国站', description: 'MiniMax 中国站 · Anthropic 兼容', badge: 'API' };
     case 'ollama':
       return { name: 'Ollama', description: '本机运行 · 离线可用', badge: 'Local' };
     case 'openai-compatible':

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -17,6 +17,8 @@ export type ProviderType =
   | 'deepseek'
   | 'moonshot'
   | 'zai-coding-plan'
+  | 'MiniMax'
+  | 'MiniMax-cn'
   | 'ollama'
   | 'openai-compatible'
   | 'claude-subscription'
@@ -208,6 +210,32 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
     catalogBadge: 'Coding',
     signupUrl: 'https://bigmodel.cn/usercenter/proj-mgmt/apikeys',
   },
+  MiniMax: {
+    label: 'MiniMax',
+    description: 'MiniMax M-series over Anthropic-compatible protocol.',
+    baseUrl: 'https://api.minimax.io/anthropic/v1',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: ['MiniMax-M3'],
+    status: 'ready',
+    protocol: 'anthropic',
+    category: 'overseas',
+    catalogBadge: 'API',
+    signupUrl: 'https://platform.minimax.io/user-center/basic-information/interface-key',
+  },
+  'MiniMax-cn': {
+    label: 'MiniMax 中国站',
+    description: 'MiniMax M-series (China) over Anthropic-compatible protocol.',
+    baseUrl: 'https://api.minimaxi.com/anthropic/v1',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: ['MiniMax-M3'],
+    status: 'ready',
+    protocol: 'anthropic',
+    category: 'domestic',
+    catalogBadge: 'API',
+    signupUrl: 'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+  },
   ollama: {
     label: 'Ollama',
     description: 'Local models from Ollama on localhost.',
@@ -281,6 +309,8 @@ export const READY_PROVIDER_TYPES: ProviderType[] = [
   'deepseek',
   'moonshot',
   'zai-coding-plan',
+  'MiniMax',
+  'MiniMax-cn',
   'ollama',
   'kimi-coding-plan',
   'openai-compatible',
@@ -291,6 +321,8 @@ export const CATALOG_PROVIDER_TYPES: ProviderType[] = [
   'deepseek',
   'moonshot',
   'zai-coding-plan',
+  'MiniMax',
+  'MiniMax-cn',
   'anthropic',
   'openai',
   'google',

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -69,6 +69,10 @@ const OPENAI_OAUTH_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
   'gpt-5.3-codex-spark': OPENAI_MODELS_DEV_METADATA['gpt-5.3-codex-spark']!,
 };
 
+const MINIMAX_MODELS_DEV_METADATA: Record<string, ModelMetadata> = {
+  'MiniMax-M3': { displayName: 'MiniMax-M3', lifecycle: 'active', docsUrl: 'https://platform.minimax.io/docs/guides/text-generation', contextWindow: 1_000_000, maxOutputTokens: 128_000, capabilities: REASONING_FUNCTION_CALLING },
+};
+
 // Provider/access-path-specific static facts. Keep limits unset unless the
 // source is authoritative for that provider path; request routing keeps raw ids.
 const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMetadata>>> = {
@@ -92,6 +96,8 @@ const MODELS_DEV_METADATA: Partial<Record<ProviderType, Record<string, ModelMeta
     'glm-4.7': { displayName: 'GLM-4.7', lifecycle: 'active', docsUrl: 'https://docs.z.ai', contextWindow: 204_800, maxOutputTokens: 131_072, capabilities: REASONING_FUNCTION_CALLING },
     'glm-4.5-air': { displayName: 'GLM-4.5-Air', lifecycle: 'deprecated', docsUrl: 'https://docs.z.ai', contextWindow: 131_072, maxOutputTokens: 98_304, capabilities: REASONING_FUNCTION_CALLING },
   },
+  MiniMax: MINIMAX_MODELS_DEV_METADATA,
+  'MiniMax-cn': MINIMAX_MODELS_DEV_METADATA,
 };
 
 function displayMetadataOnly(source: Record<string, ModelMetadata>): Record<string, ModelMetadata> {
@@ -122,4 +128,6 @@ const CURATED_CATALOG_FALLBACK_MODELS: Partial<Record<ProviderType, readonly str
   google: ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
   'gemini-cli': ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
   'zai-coding-plan': ['glm-5.2', 'glm-5.1', 'glm-5-turbo', 'glm-4.7', 'glm-4.5-air'],
+  MiniMax: ['MiniMax-M3'],
+  'MiniMax-cn': ['MiniMax-M3'],
 };

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -2008,3 +2008,40 @@ async function withDirs<T>(
     await rm(storageRoot, { recursive: true, force: true });
   }
 }
+
+describe('Harbor pi CLI env passthrough for MiniMax', () => {
+  test('MINIMAX_* rule matches the lowercased provider name', async () => {
+    const src = await readFile(new URL('../../src/harbor-cell.ts', import.meta.url), 'utf8');
+
+    // buildPiCliEnv lowercases the provider before matching against the rule's
+    // `includes` values, so any rule value with uppercase letters can never
+    // match. Guard the MiniMax rule specifically against that regression.
+    const ruleMatch = src.match(/\{\s*includes:\s*\[([^\]]*)\][^}]*MINIMAX_API_KEY[^}]*\}/);
+    assert.notEqual(ruleMatch, null, 'MiniMax MINIMAX_* env rule must exist');
+    const includeValues = ruleMatch![1]
+      .split(',')
+      .map((raw) => raw.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean);
+    assert.ok(includeValues.length > 0, 'MiniMax env rule must list at least one include token');
+    for (const value of includeValues) {
+      assert.equal(value, value.toLowerCase(), `env rule include "${value}" must be lowercase to match normalized provider`);
+    }
+    // The normalized provider names ('minimax' / 'minimax-cn') must actually hit the rule.
+    const normalized = ['minimax', 'minimax-cn'];
+    for (const provider of normalized) {
+      assert.ok(
+        includeValues.some((value) => provider.includes(value)),
+        `normalized provider "${provider}" must match the MiniMax env rule`,
+      );
+    }
+  });
+
+  test('buildPiCliEnv lowercases the provider before matching', async () => {
+    const src = await readFile(new URL('../../src/harbor-cell.ts', import.meta.url), 'utf8');
+    const fnIdx = src.indexOf('function buildPiCliEnv');
+    assert.notEqual(fnIdx, -1, 'buildPiCliEnv must exist');
+    const fnRegion = src.slice(fnIdx, src.indexOf('\n}', fnIdx));
+    assert.match(fnRegion, /provider\?\.toLowerCase\(\)/, 'buildPiCliEnv must normalize provider to lowercase');
+    assert.match(fnRegion, /normalizedProvider\.includes\(value\)/, 'buildPiCliEnv must match rule values against the normalized provider');
+  });
+});

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -246,7 +246,7 @@ const PI_PROVIDER_ENV_RULES = [
     includes: ['zai'],
     keys: ['ZAI_API_KEY', 'ZAI_API_KEY_FILE', 'ZAI_CODING_CN_API_KEY', 'ZAI_CODING_CN_API_KEY_FILE', 'ZAI_BASE_URL'],
   },
-  { includes: ['MiniMax'], keys: ['MINIMAX_API_KEY', 'MINIMAX_API_KEY_FILE', 'MINIMAX_BASE_URL'] },
+  { includes: ['minimax'], keys: ['MINIMAX_API_KEY', 'MINIMAX_API_KEY_FILE', 'MINIMAX_BASE_URL'] },
 ] satisfies Array<{ includes: string[]; keys?: string[]; prefixes?: string[] }>;
 
 export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarborCellResult> {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -246,6 +246,7 @@ const PI_PROVIDER_ENV_RULES = [
     includes: ['zai'],
     keys: ['ZAI_API_KEY', 'ZAI_API_KEY_FILE', 'ZAI_CODING_CN_API_KEY', 'ZAI_CODING_CN_API_KEY_FILE', 'ZAI_BASE_URL'],
   },
+  { includes: ['MiniMax'], keys: ['MINIMAX_API_KEY', 'MINIMAX_API_KEY_FILE', 'MINIMAX_BASE_URL'] },
 ] satisfies Array<{ includes: string[]; keys?: string[]; prefixes?: string[] }>;
 
 export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarborCellResult> {
@@ -1485,6 +1486,9 @@ function providerBaseUrl(provider: ProviderType, env: RunHarborCellEnv): string 
       return env.MOONSHOT_BASE_URL;
     case 'zai-coding-plan':
       return env.ZAI_BASE_URL;
+    case 'MiniMax':
+    case 'MiniMax-cn':
+      return env.MINIMAX_BASE_URL;
     default:
       return undefined;
   }
@@ -1513,6 +1517,10 @@ function apiKeyFromEnv(provider: ProviderType, env: RunHarborCellEnv, connection
     case 'kimi-coding-plan':
     case 'claude-subscription':
       names.push('ANTHROPIC_API_KEY');
+      break;
+    case 'MiniMax':
+    case 'MiniMax-cn':
+      names.push('MINIMAX_API_KEY');
       break;
     default:
       names.push('OPENAI_API_KEY');

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -575,6 +575,9 @@ function apiKeyFileEnvName(provider: ProviderType): string {
       return 'ANTHROPIC_API_KEY_FILE';
     case 'zai-coding-plan':
       return 'ZAI_API_KEY_FILE';
+    case 'MiniMax':
+    case 'MiniMax-cn':
+      return 'MINIMAX_API_KEY_FILE';
     case 'openai':
     case 'openai-compatible':
     default:

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -94,6 +94,25 @@ describe('Claude subscription runtime wiring', () => {
     assert.doesNotMatch(kimiCase, /anthropicV1BaseUrl/, 'Kimi endpoint must not be blindly rewritten to /v1');
   });
 
+  test('model factory sends MiniMax over Bearer (authToken), not x-api-key', async () => {
+    const src = await readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8');
+    const caseIdx = src.indexOf("case 'MiniMax'");
+    assert.notEqual(caseIdx, -1, 'MiniMax case must exist');
+    const caseRegion = src.slice(caseIdx, src.indexOf("case 'claude-subscription'", caseIdx));
+    assert.match(
+      caseRegion,
+      /createAnthropic\(\{[\s\S]*authToken:\s*apiKey/,
+      'MiniMax must pass the key as authToken so the request uses Authorization: Bearer (MiniMax-recommended auth)',
+    );
+    assert.doesNotMatch(
+      caseRegion,
+      /\n\s*apiKey,/,
+      'MiniMax must not send the key as x-api-key via the bare apiKey shorthand',
+    );
+    assert.match(caseRegion, /baseURL,/, 'MiniMax must keep its provider-specific Anthropic-compatible base URL');
+    assert.doesNotMatch(caseRegion, /anthropicV1BaseUrl/, 'MiniMax base URL must not be rewritten to /v1');
+  });
+
   test('model factory wires codex-subscription to OpenAI Responses with account-scoped fetch/header shape', async () => {
     const src = await readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8');
     const caseIdx = src.indexOf("case 'codex-subscription'");

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -38,6 +38,14 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
         headers: { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);
 
+    case 'MiniMax':
+    case 'MiniMax-cn':
+      return createAnthropic({
+        apiKey,
+        baseURL,
+        headers: { 'anthropic-beta': ANTHROPIC_BETA },
+      }).chat(modelId);
+
     case 'claude-subscription':
       return createAnthropic({
         authToken: apiKey,
@@ -113,6 +121,8 @@ export function buildProviderOptions(
   switch (connection.providerType) {
     case 'anthropic':
     case 'kimi-coding-plan':
+    case 'MiniMax':
+    case 'MiniMax-cn':
     case 'claude-subscription':
       return { anthropic: {} };
     case 'codex-subscription':

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -40,8 +40,11 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
 
     case 'MiniMax':
     case 'MiniMax-cn':
+      // MiniMax's Anthropic-compatible API accepts both x-api-key and Bearer,
+      // but documents Bearer as recommended (and it takes precedence when both
+      // are sent), so pass the key as authToken to emit `Authorization: Bearer`.
       return createAnthropic({
-        apiKey,
+        authToken: apiKey,
         baseURL,
         headers: { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);

--- a/packages/runtime/src/telemetry/builtin-pricing.ts
+++ b/packages/runtime/src/telemetry/builtin-pricing.ts
@@ -17,6 +17,8 @@ export const BUILTIN_PRICING: readonly PricingConfig[] = [
   { modelKey: 'zai-coding-plan:glm-4.7', inputUsdPer1M: 0.6, outputUsdPer1M: 2.2 },
   { modelKey: 'zai-coding-plan:glm-4.6', inputUsdPer1M: 0.6, outputUsdPer1M: 2.2 },
   { modelKey: 'zai-coding-plan:glm-4.5-air', inputUsdPer1M: 0.2, outputUsdPer1M: 0.8 },
+  { modelKey: 'MiniMax:MiniMax-M3', inputUsdPer1M: 0.3, outputUsdPer1M: 1.2, cacheReadUsdPer1M: 0.06 },
+  { modelKey: 'MiniMax-cn:MiniMax-M3', inputUsdPer1M: 0.3, outputUsdPer1M: 1.2, cacheReadUsdPer1M: 0.06 },
 ];
 
 const byKey = new Map(BUILTIN_PRICING.map((pricing) => [pricing.modelKey, pricing]));

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -48,6 +48,8 @@ const PROVIDER_SHORT_LABEL = {
   ollama: 'Ollama',
   'kimi-coding-plan': 'Kimi',
   'zai-coding-plan': 'Z.AI',
+  MiniMax: 'MiniMax',
+  'MiniMax-cn': 'MiniMax 中国站',
   'openai-compatible': '自定义',
   'claude-subscription': 'Claude 订阅',
   'codex-subscription': 'OpenAI OAuth',


### PR DESCRIPTION
## Summary

Adds **MiniMax** as a first-class model provider, with the **MiniMax-M3** model. It's wired over the **Anthropic-compatible protocol** — the same path this repo already uses for `kimi-coding-plan` — so it needs no new SDK dependency (`@ai-sdk/anthropic` is already present).

Two access entries, mirroring how the repo splits other providers by region/access:
- **`MiniMax`** — Global, `https://api.minimax.io/anthropic/v1` (category: overseas)
- **`MiniMax-cn`** — China, `https://api.minimaxi.com/anthropic/v1` (category: domestic)

## Model facts & provenance

`MiniMax-M3`: context **1,000,000**, max output **128,000**, pricing **$0.30 / $1.20** per 1M (input/output), cache-read **$0.06**.

All facts are taken from **[models.dev](https://models.dev)** — the same registry this repo's `model-metadata.ts` already tracks — not hand-entered. Happy to adjust display name / limits if you prefer a different source of truth.

## What changed

| Area | File | Change |
|---|---|---|
| Types + defaults | `packages/core/src/llm-connections.ts` | `ProviderType` union, `PROVIDER_DEFAULTS`, `READY_/CATALOG_PROVIDER_TYPES` |
| Model facts | `packages/core/src/model-metadata.ts` | M3 static metadata + curated fallback |
| Routing | `packages/runtime/src/model-factory.ts` | `createAnthropic` routing + `buildProviderOptions` |
| Headless harbor | `packages/headless/src/harbor-cell.ts`, `harbor-cli.ts` | `MINIMAX_*` env base-url/key wiring + key-file mapping |
| Pricing | `packages/runtime/src/telemetry/builtin-pricing.ts` | builtin M3 pricing |
| Desktop UI | `provider-display.tsx`, `provider-brand-marks.tsx`, `OnboardingHero.tsx`, `chat-model-helpers.ts` | display name, brand mark, onboarding entry, short label |

## A note on the brand mark

MiniMax isn't in the vendored `@lobehub/icons-static-svg` set, so `provider-brand-marks.tsx` currently renders a **neutral monochrome placeholder glyph** (currentColor, no trademarked asset). Glad to swap in the official mark if you can point me to a preferred source.

## Verification

- `npm run build` — ✅ all 6 workspaces + desktop renderer
- `npm run typecheck` — ✅ clean (exhaustive `Record<ProviderType>` / switches all satisfied)
- `npm --workspace @maka/core test` — ✅ 671/671
- `npm --workspace @maka/runtime test` — ✅ 806/806
- Runtime smoke: `getAIModel` resolves both entries to `anthropic.messages` with `modelId=MiniMax-M3` and `providerOptions={anthropic:{}}`

## Test plan

- [ ] Add an MiniMax connection in Settings · 模型 with an API key, run a chat turn
- [ ] Confirm the model appears in onboarding + catalog
- [ ] (China) repeat with `MiniMax 中国站`