### PR TITLE
Add heavy-task workspace observation gate

### DIFF
--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -256,42 +256,6 @@ describe('heavy-task self-check gate', () => {
     assert.match(decision.reason, /observed extras: \/app\/polyglot\/cmain/);
   });
 
-  test('package source directory observation is diagnostic after bounded repair, not a hard reject', () => {
-    const packageTask: Task = {
-      id: 'build-cython-task',
-      instruction: 'Build the pyknotid Cython extension in the existing package.',
-      workspaceDir: '/tmp/workspace',
-      verification: { command: 'true', protectedPaths: [] },
-    };
-    const extensionPath = '/app/pyknotid/pyknotid/cinvariants.cpython-313-x86_64-linux-gnu.so';
-    const selfCheckState = selfCheck('pass', {
-      command: `python -c "import pyknotid.cinvariants" && test -f ${extensionPath}`,
-      refs: [extensionPath],
-      artifactPath: extensionPath,
-    });
-    const decision = evaluateHeavyTaskSelfCheckGate({
-      task: packageTask,
-      heavyTaskMode,
-      projection: projection(
-        selfCheckState,
-        plan([extensionPath]),
-        workspaceObservation([
-          { path: extensionPath, kind: 'file' },
-          { path: '/app/pyknotid/pyknotid/__init__.py', kind: 'file' },
-          { path: '/app/pyknotid/pyknotid/utils.py', kind: 'file' },
-          { path: '/app/pyknotid/pyknotid/cinvariants.c', kind: 'file' },
-          { path: '/app/pyknotid/pyknotid/spacecurves', kind: 'directory' },
-        ]),
-      ),
-      repairAttemptsUsed: 1,
-      maxRepairAttempts: 1,
-    });
-
-    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
-    assert.match(decision.reason, /machine workspace observation found extra final paths/);
-    assert.match(decision.reason, /\/app\/pyknotid\/pyknotid\/utils\.py/);
-  });
-
   test('weak pass without command or artifact evidence stays blocked', () => {
     const weak = {
       ...selfCheck('pass', { command: 'test -f /app/move.txt', refs: ['/app/move.txt'] }),

--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -2,7 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { evaluateHeavyTaskSelfCheckGate } from '../heavy-task-self-check-gate.js';
 import type { Task } from '../contracts.js';
-import type { HeavyTaskModeFacts, HeavyTaskSelfCheckPlanState, HeavyTaskSemanticSelfCheckState, HeavyTaskTodoItem, TaskEvent } from '../task-contracts.js';
+import type {
+  HeavyTaskModeFacts,
+  HeavyTaskSelfCheckPlanState,
+  HeavyTaskSemanticSelfCheckState,
+  HeavyTaskTodoItem,
+  HeavyTaskWorkspaceObservationState,
+  TaskEvent,
+} from '../task-contracts.js';
 import { projectTaskRun } from '../task-run-store.js';
 
 const heavyTaskMode: HeavyTaskModeFacts = {
@@ -25,7 +32,7 @@ describe('heavy-task self-check gate', () => {
     const decision = evaluateHeavyTaskSelfCheckGate({
       task,
       heavyTaskMode,
-      projection: projection(),
+      projection: projection(undefined, plan(['/app/move.txt', '/app/report.jsonl'])),
     });
 
     assert.equal(decision.action, 'repair_prompt');
@@ -33,6 +40,23 @@ describe('heavy-task self-check gate', () => {
     assert.match(decision.action === 'repair_prompt' ? decision.prompt : '', /not accepted for heavy-task finalization/);
     assert.ok(decision.checklist.some((check) => check.path === '/app/move.txt'));
     assert.ok(decision.checklist.some((check) => check.path === '/app/report.jsonl' && check.kind === 'artifact_parse'));
+  });
+
+  test('does not derive required artifacts by parsing raw instruction text', () => {
+    const polyglotTask: Task = {
+      id: 'polyglot-task',
+      instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
+      workspaceDir: '/tmp/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    };
+    const decision = evaluateHeavyTaskSelfCheckGate({
+      task: polyglotTask,
+      heavyTaskMode,
+      projection: projection(),
+    });
+
+    assert.ok(!decision.checklist.some((check) => check.kind === 'required_artifact'));
+    assert.ok(!decision.checklist.some((check) => check.path === '/app/polyglot/main.py'));
   });
 
   test('fail and inconclusive self-checks return repair prompts', () => {
@@ -165,6 +189,38 @@ describe('heavy-task self-check gate', () => {
     assert.doesNotMatch(decision.reason, /fix|repair|rerun|submit a revised plan/i);
   });
 
+  test('machine workspace observation blocks extra sibling in a single-file deliverable directory', () => {
+    const polyglotTask: Task = {
+      id: 'polyglot-task',
+      instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
+      workspaceDir: '/tmp/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    };
+    const selfCheckState = selfCheck('pass', {
+      command: 'python3 /app/polyglot/main.py.c 10 && python3 /app/polyglot/main.py 10',
+      refs: ['/app/polyglot/main.py.c', '/app/polyglot/main.py'],
+      artifactPath: '/app/polyglot/main.py.c',
+    });
+    const decision = evaluateHeavyTaskSelfCheckGate({
+      task: polyglotTask,
+      heavyTaskMode,
+      projection: projection(
+        selfCheckState,
+        plan(['/app/polyglot/main.py.c']),
+        workspaceObservation([
+          { path: '/app/polyglot/main.py.c', kind: 'file' },
+          { path: '/app/polyglot/main.py', kind: 'symlink', symlinkTarget: 'main.py.c' },
+        ]),
+      ),
+      repairAttemptsUsed: 1,
+      maxRepairAttempts: 1,
+    });
+
+    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
+    assert.match(decision.reason, /machine workspace observation found extra final paths/);
+    assert.match(decision.reason, /\/app\/polyglot\/main\.py/);
+  });
+
   test('weak pass without command or artifact evidence stays blocked', () => {
     const weak = {
       ...selfCheck('pass', { command: 'test -f /app/move.txt', refs: ['/app/move.txt'] }),
@@ -210,7 +266,11 @@ describe('heavy-task self-check gate', () => {
   });
 });
 
-function projection(selfCheckState?: HeavyTaskSemanticSelfCheckState, planState?: HeavyTaskSelfCheckPlanState) {
+function projection(
+  selfCheckState?: HeavyTaskSemanticSelfCheckState,
+  planState?: HeavyTaskSelfCheckPlanState,
+  observation?: HeavyTaskWorkspaceObservationState,
+) {
   const taskRunId = 'run-gate';
   const events: TaskEvent[] = [
     { type: 'task_run_created', id: 'e1', taskRunId, ts: 1, taskId: task.id, configId: 'cfg' },
@@ -236,7 +296,24 @@ function projection(selfCheckState?: HeavyTaskSemanticSelfCheckState, planState?
   if (selfCheckState) {
     events.push({ type: 'heavy_task_self_check_recorded', id: 'e4', taskRunId, ts: 4, selfCheck: selfCheckState });
   }
+  if (observation) {
+    events.push({ type: 'heavy_task_workspace_observation_recorded', id: 'e5-observation', taskRunId, ts: 5, observation });
+  }
   return projectTaskRun(events, taskRunId);
+}
+
+function workspaceObservation(entries: HeavyTaskWorkspaceObservationState['entries']): HeavyTaskWorkspaceObservationState {
+  return {
+    schemaVersion: 1,
+    observationId: 'workspace-observation-1',
+    taskRunId: 'run-gate',
+    ts: 5,
+    roots: ['/app/polyglot'],
+    entries,
+    status: 'ok',
+    command: 'find /app/polyglot -mindepth 1 -maxdepth 1',
+    source: { kind: 'system', label: 'unit test' },
+  };
 }
 
 function plan(finalArtifacts: string[]): HeavyTaskSelfCheckPlanState {

--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -189,7 +189,7 @@ describe('heavy-task self-check gate', () => {
     assert.doesNotMatch(decision.reason, /fix|repair|rerun|submit a revised plan/i);
   });
 
-  test('machine workspace observation blocks extra sibling in a single-file deliverable directory', () => {
+  test('machine workspace observation remains diagnostic after bounded repair in a single-file deliverable directory', () => {
     const polyglotTask: Task = {
       id: 'polyglot-task',
       instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
@@ -219,6 +219,77 @@ describe('heavy-task self-check gate', () => {
     assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
     assert.match(decision.reason, /machine workspace observation found extra final paths/);
     assert.match(decision.reason, /\/app\/polyglot\/main\.py/);
+  });
+
+  test('bounded repair records observed extra sibling diagnostic without local rejection', () => {
+    const polyglotTask: Task = {
+      id: 'polyglot-task',
+      instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
+      workspaceDir: '/tmp/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    };
+    const revisedPlan = plan(['/app/polyglot/main.py.c']);
+    revisedPlan.workspaceGuardPlan.expectedGeneratedPathsOutsideScratch = ['/app/polyglot/cmain'];
+    const selfCheckState = selfCheck('pass', {
+      command: 'gcc /app/polyglot/main.py.c -o /tmp/maka-self-check/run-gate/cmain && /tmp/maka-self-check/run-gate/cmain 10',
+      refs: ['/app/polyglot/main.py.c'],
+      artifactPath: '/app/polyglot/main.py.c',
+    });
+
+    const decision = evaluateHeavyTaskSelfCheckGate({
+      task: polyglotTask,
+      heavyTaskMode,
+      projection: projection(
+        selfCheckState,
+        revisedPlan,
+        workspaceObservation([
+          { path: '/app/polyglot/main.py.c', kind: 'file' },
+          { path: '/app/polyglot/cmain', kind: 'file' },
+        ]),
+      ),
+      repairAttemptsUsed: 1,
+      maxRepairAttempts: 1,
+    });
+
+    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
+    assert.match(decision.reason, /expected only: \/app\/polyglot\/main\.py\.c/);
+    assert.match(decision.reason, /observed extras: \/app\/polyglot\/cmain/);
+  });
+
+  test('package source directory observation is diagnostic after bounded repair, not a hard reject', () => {
+    const packageTask: Task = {
+      id: 'build-cython-task',
+      instruction: 'Build the pyknotid Cython extension in the existing package.',
+      workspaceDir: '/tmp/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    };
+    const extensionPath = '/app/pyknotid/pyknotid/cinvariants.cpython-313-x86_64-linux-gnu.so';
+    const selfCheckState = selfCheck('pass', {
+      command: `python -c "import pyknotid.cinvariants" && test -f ${extensionPath}`,
+      refs: [extensionPath],
+      artifactPath: extensionPath,
+    });
+    const decision = evaluateHeavyTaskSelfCheckGate({
+      task: packageTask,
+      heavyTaskMode,
+      projection: projection(
+        selfCheckState,
+        plan([extensionPath]),
+        workspaceObservation([
+          { path: extensionPath, kind: 'file' },
+          { path: '/app/pyknotid/pyknotid/__init__.py', kind: 'file' },
+          { path: '/app/pyknotid/pyknotid/utils.py', kind: 'file' },
+          { path: '/app/pyknotid/pyknotid/cinvariants.c', kind: 'file' },
+          { path: '/app/pyknotid/pyknotid/spacecurves', kind: 'directory' },
+        ]),
+      ),
+      repairAttemptsUsed: 1,
+      maxRepairAttempts: 1,
+    });
+
+    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
+    assert.match(decision.reason, /machine workspace observation found extra final paths/);
+    assert.match(decision.reason, /\/app\/pyknotid\/pyknotid\/utils\.py/);
   });
 
   test('weak pass without command or artifact evidence stays blocked', () => {

--- a/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { Task } from '../contracts.js';
+import { observeHeavyTaskWorkspace } from '../heavy-task-workspace-observation.js';
+import type { IsolatedCommandInput, IsolatedToolExecutor } from '../isolation.js';
+import type { HeavyTaskSelfCheckPlanState, TaskEvent } from '../task-contracts.js';
+import { projectTaskRun } from '../task-run-store.js';
+
+describe('heavy-task workspace observation', () => {
+  test('records machine-observed one-level entries for task artifact directories', async () => {
+    const taskRunId = 'run-observe';
+    const task: Task = {
+      id: 'polyglot-task',
+      instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
+      workspaceDir: '/tmp/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    };
+    const plan: HeavyTaskSelfCheckPlanState = {
+      schemaVersion: 1,
+      planId: 'plan-1',
+      taskRunId,
+      ts: 2,
+      finalArtifacts: [{
+        path: '/app/polyglot/main.py.c',
+        purpose: 'final polyglot source file',
+        publicReason: 'accepted structured plan artifact',
+      }],
+      selfCheckScratch: {
+        root: '/tmp/maka-self-check/run-observe',
+        expectedGeneratedPaths: ['/tmp/maka-self-check/run-observe/cmain'],
+        publicReason: 'compile probes stay in scratch',
+      },
+      workspaceGuardPlan: {
+        checkedPaths: ['/app/polyglot'],
+        expectedAddedPaths: ['/app/polyglot/main.py.c'],
+        expectedGeneratedPathsOutsideScratch: [],
+        publicReason: 'observe the declared artifact directory',
+      },
+      publicReason: 'structured plan supplies artifact paths for observation',
+      guard: {
+        status: 'accepted',
+        checkedAt: 2,
+        categories: [],
+        publicReason: 'Accepted as public, task-derived advisory self-check plan.',
+      },
+      source: { kind: 'model_tool', toolCallId: 'tool-plan' },
+    };
+    const projection = projectTaskRun([
+      { type: 'task_run_created', id: 'e1', taskRunId, ts: 1, taskId: task.id, configId: 'cfg' },
+      { type: 'heavy_task_self_check_plan_recorded', id: 'e2', taskRunId, ts: 2, plan },
+    ] satisfies TaskEvent[], taskRunId);
+    const seenCommands: IsolatedCommandInput[] = [];
+    const executor: IsolatedToolExecutor = {
+      async exec(input) {
+        seenCommands.push(input);
+        return {
+          exitCode: 0,
+          stdout: [
+            'file\t/app/polyglot/main.py.c\t',
+            'symlink\t/app/polyglot/main.py\tmain.py.c',
+          ].join('\n'),
+          stderr: '',
+        };
+      },
+    };
+
+    const event = await observeHeavyTaskWorkspace({
+      taskRunId,
+      projection,
+      executor,
+      cwd: '/agent/workspace',
+      now: () => 10,
+      newId: (() => {
+        let next = 0;
+        return () => `id-${++next}`;
+      })(),
+    });
+
+    assert.ok(event);
+    assert.deepEqual(event.observation.roots, ['/app/polyglot']);
+    assert.equal(event.observation.status, 'ok');
+    assert.deepEqual(event.observation.entries, [
+      { path: '/app/polyglot/main.py.c', kind: 'file' },
+      { path: '/app/polyglot/main.py', kind: 'symlink', symlinkTarget: 'main.py.c' },
+    ]);
+    assert.equal(seenCommands[0]?.cwd, '/agent/workspace');
+    assert.equal(seenCommands[0]?.timeoutMs, 30_000);
+    assert.match(seenCommands[0]?.command ?? '', /\/app\/polyglot/);
+  });
+});

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -456,6 +456,116 @@ const registerGateRepairBackend = (
   }));
 };
 
+class GateLaunderBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(private readonly ctx: {
+    sessionId: string;
+    header: SessionHeader;
+    tools: ReturnType<typeof buildIsolatedHeadlessTools>;
+    prompts: string[];
+  }) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.ctx.prompts.push(input.text);
+    const ts = Date.now();
+    const turnNumber = this.ctx.prompts.length;
+    const selfCheckPlanSubmit = this.ctx.tools.find((tool) => tool.name === 'self_check_plan_submit');
+    const selfCheckSubmit = this.ctx.tools.find((tool) => tool.name === 'self_check_submit');
+    assert.ok(selfCheckPlanSubmit);
+    assert.ok(selfCheckSubmit);
+    const toolCtx = {
+      sessionId: this.sessionId,
+      turnId: input.turnId,
+      cwd: this.ctx.header.cwd,
+      toolCallId: `launder-tool-call-${turnNumber}`,
+      abortSignal: new AbortController().signal,
+      emitOutput: () => {},
+    };
+    await selfCheckPlanSubmit.impl({
+      finalArtifacts: [{
+        path: '/app/polyglot/main.py.c',
+        purpose: 'single-file polyglot source',
+        publicReason: 'visible task asks for this final file',
+      }],
+      selfCheckScratch: {
+        root: '/tmp/maka-self-check/polyglot',
+        expectedGeneratedPaths: ['/tmp/maka-self-check/polyglot/cmain'],
+        publicReason: 'compile checks should stay under scratch',
+      },
+      workspaceGuardPlan: {
+        checkedPaths: ['/app/polyglot'],
+        expectedAddedPaths: [],
+        expectedGeneratedPathsOutsideScratch: turnNumber === 1 ? [] : ['/app/polyglot/cmain'],
+        publicReason: turnNumber === 1
+          ? 'first plan only declares the final source file'
+          : 'repair attempt tries to launder the observed cmain path',
+      },
+      publicReason: 'public polyglot self-check plan',
+    }, toolCtx);
+    await selfCheckSubmit.impl({
+      status: 'pass',
+      publicReason: 'python and gcc checks passed, but cmain remains in /app/polyglot',
+      commandEvidence: [{
+        command: 'gcc /app/polyglot/main.py.c -o /app/polyglot/cmain && /app/polyglot/cmain 10',
+        exitCode: 0,
+        outputExcerpt: '55',
+        artifactRefs: ['/app/polyglot/main.py.c', '/app/polyglot/cmain'],
+      }],
+      artifactEvidence: [
+        { path: '/app/polyglot/main.py.c', kind: 'file', exists: true },
+        { path: '/app/polyglot/cmain', kind: 'file', exists: true },
+      ],
+      executionHygiene: {
+        sandbox: {
+          root: '/tmp/maka-self-check/polyglot',
+          strategy: 'copied_inputs',
+          commandCwd: '/tmp/maka-self-check/polyglot',
+          outputPolicy: 'scratch_only',
+        },
+        scratchUsed: true,
+        scratchPath: '/tmp/maka-self-check/polyglot',
+        cleanupPerformed: true,
+        workspaceSideEffects: 'present',
+        workspaceGuard: {
+          checked: true,
+          checkedPaths: ['/app/polyglot'],
+          beforeListingCommand: 'find /app/polyglot -maxdepth 1',
+          afterListingCommand: 'find /app/polyglot -maxdepth 1',
+          addedPaths: ['/app/polyglot/cmain'],
+          modifiedPaths: [],
+          removedPaths: [],
+        },
+      },
+    }, toolCtx);
+    yield { type: 'text_complete', id: `launder-text-${turnNumber}`, turnId: input.turnId, ts, messageId: `launder-message-${turnNumber}`, text: 'done' };
+    yield { type: 'complete', id: `launder-complete-${turnNumber}`, turnId: input.turnId, ts, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+const registerGateLaunderBackend = (
+  prompts: string[],
+) => (registry: BackendRegistry, context: HeadlessBackendContext): void => {
+  assert.ok(context.toolExecutor);
+  registry.register('ai-sdk', (ctx) => new GateLaunderBackend({
+    sessionId: ctx.sessionId,
+    header: ctx.header,
+    tools: buildIsolatedHeadlessTools(context.toolExecutor!, {
+      ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
+      ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
+      ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+    }),
+    prompts,
+  }));
+};
+
 async function withDirs<T>(fn: (fixtureDir: string, storageRoot: string) => Promise<T>): Promise<T> {
   const fixtureDir = await mkdtemp(join(tmpdir(), 'maka-task-controller-fx-'));
   const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-controller-store-'));
@@ -749,6 +859,51 @@ describe('runTaskOnce', () => {
         result.projection.events.filter((event) => event.type === 'heavy_task_self_check_gate_recorded').length,
         2,
       );
+    });
+  });
+
+  test('bounded repair records machine-observed extra final path diagnostic before official verifier', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const prompts: string[] = [];
+      const config: Config = {
+        ...fakeConfig,
+        backend: 'ai-sdk',
+        heavyTaskMode: true,
+      };
+      const task: Task = {
+        id: 'polyglot-launder-task',
+        instruction: 'Write a single file in /app/polyglot/main.py.c.',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(config, task, {
+        storageRoot,
+        registerBackends: registerGateLaunderBackend(prompts),
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return {
+                exitCode: 0,
+                stdout: 'file\t/app/polyglot/main.py.c\t\nfile\t/app/polyglot/cmain\t\n',
+                stderr: '',
+              };
+            },
+          },
+        },
+      });
+
+      assert.equal(prompts.length, 2);
+      assert.equal(result.projection.latestHeavyTaskSelfCheckGate?.action, 'allow_official_verifier_after_bounded_attempt');
+      assert.match(result.projection.latestHeavyTaskSelfCheckGate?.reason ?? '', /\/app\/polyglot\/cmain/);
+      assert.match(result.projection.latestHeavyTaskSelfCheckGate?.reason ?? '', /unplanned_added_path|observed extras/);
+      assert.equal(result.projection.latestVerifierResult?.passed, true);
+      assert.equal(result.projection.latestScoreResult?.taxonomy, 'passed');
+      assert.equal(result.resultRecord.status, 'completed');
+      assert.equal(result.resultRecord.passed, true);
+      assert.equal(result.projection.events.some((event) => event.type === 'task_run_verifying'), true);
     });
   });
 

--- a/packages/headless/src/heavy-task-self-check-gate.ts
+++ b/packages/headless/src/heavy-task-self-check-gate.ts
@@ -6,6 +6,7 @@ import type {
   HeavyTaskAcceptanceCheck,
   HeavyTaskSemanticSelfCheckState,
   HeavyTaskSelfCheckGateState,
+  HeavyTaskWorkspaceObservationState,
   HeavyTaskTodoItem,
 } from './task-contracts.js';
 import type { TaskRunProjection } from './task-run-store.js';
@@ -48,6 +49,7 @@ export function evaluateHeavyTaskSelfCheckGate(input: HeavyTaskSelfCheckGateInpu
   const reason = gateBlockerReason(
     selfCheck,
     input.projection.latestHeavyTaskSelfCheckPlan,
+    input.projection.latestHeavyTaskWorkspaceObservation,
     completion.semantic.reason,
     checklist,
   );
@@ -110,7 +112,7 @@ export function heavyTaskSelfCheckGateStateFromDecision(input: {
 
 export function deriveHeavyTaskAcceptanceChecks(
   task: Task,
-  projection: Pick<TaskRunProjection, 'latestHeavyTaskTodos'> = {},
+  projection: Pick<TaskRunProjection, 'latestHeavyTaskTodos' | 'latestHeavyTaskSelfCheckPlan'> = {},
 ): HeavyTaskAcceptanceCheck[] {
   const checks: HeavyTaskAcceptanceCheck[] = [];
   const seen = new Set<string>();
@@ -121,16 +123,17 @@ export function deriveHeavyTaskAcceptanceChecks(
     checks.push({ id: `check-${checks.length + 1}`, ...check });
   };
 
-  for (const path of publicPathsFromText(task.instruction)) {
+  for (const artifact of projection.latestHeavyTaskSelfCheckPlan?.finalArtifacts ?? []) {
+    const path = artifact.path;
     add({
       kind: 'required_artifact',
-      source: 'task_instruction',
-      description: `Visible task instruction requires artifact ${path}`,
+      source: 'self_check_plan',
+      description: `Accepted self_check_plan_submit declares final artifact ${path}`,
       evidenceRequired: 'command_or_artifact',
       path,
       commandHint: `test -e ${shellQuote(path)}`,
     });
-    const parseHint = parseCheckForPath(path);
+    const parseHint = parseCheckForPath(path, 'self_check_plan');
     if (parseHint) add(parseHint);
   }
 
@@ -212,6 +215,7 @@ export function renderHeavyTaskSelfCheckGatePrompt(input: {
 function gateBlockerReason(
   selfCheck: HeavyTaskSemanticSelfCheckState | undefined,
   plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan'],
+  workspaceObservation: HeavyTaskWorkspaceObservationState | undefined,
   semanticReason: string,
   checklist: readonly HeavyTaskAcceptanceCheck[],
 ): string | undefined {
@@ -223,6 +227,8 @@ function gateBlockerReason(
   }
   const strongPassBlocker = heavyTaskSelfCheckStrongPassBlocker(selfCheck, plan);
   if (strongPassBlocker) return strongPassBlocker;
+  const workspaceObservationBlocker = machineWorkspaceObservationBlocker(plan, workspaceObservation);
+  if (workspaceObservationBlocker) return workspaceObservationBlocker;
   if (!selfCheckAddressesRequiredArtifacts(selfCheck, checklist)) {
     return 'latest self-check does not address visible required artifact contract';
   }
@@ -252,31 +258,64 @@ function selfCheckAddressesRequiredArtifacts(
   return requiredPaths.some((path) => evidenceText.includes(path.toLowerCase()) || evidenceText.includes(basename(path).toLowerCase()));
 }
 
-function publicPathsFromText(text: string): string[] {
-  const matches = text.matchAll(/(?:^|[\s'"`(])((?:\/app\/|\.{0,2}\/)?[A-Za-z0-9._/-]+\.(?:jsonl|json|txt|csv|py|js|ts|mjs|cjs|md|html|xml|yaml|yml|toml|ini|log|out|bin|png|jpg|jpeg|bmp|gif|svg))(?:$|[\s'"`),.;:])/g);
-  return unique([...matches]
-    .map((match) => match[1])
-    .filter((path): path is string => Boolean(path))
-    .filter((path) => !/hidden|private|evaluator|official[-_ ]?verifier|scorer/i.test(path))
-    .map((path) => path.replace(/^\.\//, '')));
+function machineWorkspaceObservationBlocker(
+  plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan'],
+  observation: HeavyTaskWorkspaceObservationState | undefined,
+): string | undefined {
+  if (!observation || observation.status !== 'ok') return undefined;
+  for (const expectedPath of plannedSingleArtifactDirectoryPaths(plan)) {
+    const expectedDir = dirname(expectedPath);
+    const entries = observation.entries.filter((entry) => dirname(entry.path) === expectedDir);
+    if (entries.length === 0 || !entries.some((entry) => entry.path === expectedPath)) continue;
+    const extras = entries
+      .map((entry) => entry.path)
+      .filter((path) => path !== expectedPath);
+    if (extras.length > 0) {
+      return [
+        `machine workspace observation found extra final paths in single-file deliverable directory ${expectedDir}`,
+        `- expected only: ${expectedPath}`,
+        `- observed extras: ${extras.join(', ')}`,
+      ].join('\n');
+    }
+  }
+  return undefined;
 }
 
-function parseCheckForPath(path: string): Omit<HeavyTaskAcceptanceCheck, 'id'> | undefined {
-  if (/\.jsonl$/i.test(path)) {
+function plannedSingleArtifactDirectoryPaths(plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan']): string[] {
+  if (!plan) return [];
+  const byDir = new Map<string, string[]>();
+  for (const artifact of plan.finalArtifacts) {
+    if (!artifact.path.startsWith('/app/')) continue;
+    const dir = dirname(artifact.path);
+    byDir.set(dir, [...(byDir.get(dir) ?? []), artifact.path]);
+  }
+  const paths: string[] = [];
+  for (const artifacts of byDir.values()) {
+    if (artifacts.length === 1) paths.push(artifacts[0]!);
+  }
+  return paths;
+}
+
+function parseCheckForPath(
+  path: string,
+  source: HeavyTaskAcceptanceCheck['source'],
+): Omit<HeavyTaskAcceptanceCheck, 'id'> | undefined {
+  const lowerPath = path.toLowerCase();
+  if (lowerPath.endsWith('.jsonl')) {
     return {
       kind: 'artifact_parse',
-      source: 'task_instruction',
-      description: `Visible JSONL artifact ${path} should be parseable or line-inspected`,
+      source,
+      description: `Declared JSONL artifact ${path} should be parseable or line-inspected`,
       evidenceRequired: 'command_or_artifact',
       path,
       commandHint: `python - <<'PY'\nimport json\nfrom pathlib import Path\np=Path(${JSON.stringify(path)})\nfor line in p.read_text().splitlines(): json.loads(line)\nPY`,
     };
   }
-  if (/\.json$/i.test(path)) {
+  if (lowerPath.endsWith('.json')) {
     return {
       kind: 'artifact_parse',
-      source: 'task_instruction',
-      description: `Visible JSON artifact ${path} should be parseable`,
+      source,
+      description: `Declared JSON artifact ${path} should be parseable`,
       evidenceRequired: 'command_or_artifact',
       path,
       commandHint: `python -m json.tool ${shellQuote(path)} >/tmp/maka-self-check/json-parse.out`,
@@ -321,6 +360,8 @@ function basename(path: string): string {
   return parts.at(-1) ?? path;
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values)];
+function dirname(path: string): string {
+  const index = path.lastIndexOf('/');
+  if (index <= 0) return '.';
+  return path.slice(0, index);
 }

--- a/packages/headless/src/heavy-task-workspace-observation.ts
+++ b/packages/headless/src/heavy-task-workspace-observation.ts
@@ -1,0 +1,100 @@
+import { posix as pathPosix } from 'node:path';
+import type { IsolatedToolExecutor } from './isolation.js';
+import type { HeavyTaskWorkspaceObservationRecordedEvent } from './task-contracts.js';
+import type { TaskRunProjection } from './task-run-store.js';
+
+export async function observeHeavyTaskWorkspace(input: {
+  taskRunId: string;
+  projection: TaskRunProjection;
+  executor?: IsolatedToolExecutor;
+  cwd: string;
+  now: () => number;
+  newId: () => string;
+}): Promise<HeavyTaskWorkspaceObservationRecordedEvent | undefined> {
+  if (!input.executor) return undefined;
+  const roots = observationRoots(input.projection);
+  if (roots.length === 0) return undefined;
+  const command = workspaceObservationCommand(roots);
+  const result = await input.executor.exec({ command, cwd: input.cwd, timeoutMs: 30_000 });
+  return {
+    type: 'heavy_task_workspace_observation_recorded',
+    id: input.newId(),
+    taskRunId: input.taskRunId,
+    ts: input.now(),
+    observation: {
+      schemaVersion: 1,
+      observationId: input.newId(),
+      taskRunId: input.taskRunId,
+      ts: input.now(),
+      roots,
+      entries: result.exitCode === 0 ? parseWorkspaceObservation(result.stdout) : [],
+      status: result.exitCode === 0 ? 'ok' : 'error',
+      command,
+      ...(result.exitCode === 0 ? {} : { errorExcerpt: cleanOneLine(result.stderr || result.stdout, 500) }),
+      source: { kind: 'system', label: 'isolated workspace observation' },
+    },
+  };
+}
+
+function observationRoots(projection: TaskRunProjection): string[] {
+  const candidates = [
+    ...(projection.latestHeavyTaskSelfCheckPlan?.finalArtifacts ?? []).map((artifact) => parentDir(artifact.path)),
+    ...(projection.latestHeavyTaskSelfCheck?.executionHygiene?.workspaceGuard?.checkedPaths ?? []).map((path) => pathPosix.normalize(path)),
+  ];
+  return unique(candidates
+    .filter((root) => root.startsWith('/app/'))
+    .map((root) => root.replace(/\/+$/, '')))
+    .slice(0, 12);
+}
+
+function parentDir(path: string): string {
+  const dir = pathPosix.dirname(pathPosix.normalize(path));
+  return dir === '.' ? path : dir;
+}
+
+function workspaceObservationCommand(roots: readonly string[]): string {
+  const args = roots.map(shellQuote).join(' ');
+  return [
+    `for root in ${args}; do`,
+    '  if [ -e "$root" ]; then',
+    '    if [ -d "$root" ]; then find "$root" -mindepth 1 -maxdepth 1 -exec sh -c \'for p do if [ -L "$p" ]; then t=$(readlink "$p" 2>/dev/null || true); printf "symlink\\t%s\\t%s\\n" "$p" "$t"; elif [ -f "$p" ]; then printf "file\\t%s\\t\\n" "$p"; elif [ -d "$p" ]; then printf "directory\\t%s\\t\\n" "$p"; else printf "other\\t%s\\t\\n" "$p"; fi; done\' sh {} +;',
+    '    elif [ -L "$root" ]; then t=$(readlink "$root" 2>/dev/null || true); printf "symlink\\t%s\\t%s\\n" "$root" "$t";',
+    '    elif [ -f "$root" ]; then printf "file\\t%s\\t\\n" "$root";',
+    '    else printf "other\\t%s\\t\\n" "$root"; fi',
+    '  fi',
+    'done',
+  ].join('\n');
+}
+
+function parseWorkspaceObservation(stdout: string) {
+  return stdout.split(/\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const [kind, path, symlinkTarget] = line.split('\t');
+      if (!isObservationKind(kind) || !path) return undefined;
+      return {
+        path,
+        kind,
+        ...(kind === 'symlink' && symlinkTarget ? { symlinkTarget } : {}),
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+}
+
+function isObservationKind(value: string | undefined): value is 'file' | 'directory' | 'symlink' | 'other' {
+  return value === 'file' || value === 'directory' || value === 'symlink' || value === 'other';
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function cleanOneLine(value: string, limit: number): string {
+  const cleaned = value.replace(/\s+/g, ' ').trim();
+  return cleaned.length <= limit ? cleaned : `${cleaned.slice(0, limit - 3)}...`;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -49,6 +49,7 @@ import {
   evaluateHeavyTaskSelfCheckGate,
   heavyTaskSelfCheckGateStateFromDecision,
 } from './heavy-task-self-check-gate.js';
+import { observeHeavyTaskWorkspace } from './heavy-task-workspace-observation.js';
 import type { HeadlessBackendContext } from './isolation.js';
 import {
   ISOLATED_HEADLESS_TOOL_NAMES,
@@ -369,7 +370,17 @@ export async function runTaskOnce(
     let runtimeSummary = summarizeRuntime(invocation, deps.realBackendIsolation);
     await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, runtimeSummary);
     if (heavyTaskMode.enabled) {
-      const gateProjection = await taskRunStore.project(taskRunId);
+      let gateProjection = await taskRunStore.project(taskRunId);
+      await appendHeavyTaskWorkspaceObservation({
+        taskRunStore,
+        taskRunId,
+        projection: gateProjection,
+        executor: deps.realBackendIsolation?.toolExecutor,
+        cwd: agentWorkspaceDir,
+        now,
+        newId,
+      });
+      gateProjection = await taskRunStore.project(taskRunId);
       const gateDecision = evaluateHeavyTaskSelfCheckGate({
         task,
         heavyTaskMode,
@@ -445,7 +456,17 @@ export async function runTaskOnce(
         await appendRuntimeFeedback(taskRunStore, taskRunId, attemptId, now, newId, repairSummary);
         runtimeSummary = mergeRuntimeSummaries(runtimeSummary, repairSummary);
 
-        const boundedProjection = await taskRunStore.project(taskRunId);
+        let boundedProjection = await taskRunStore.project(taskRunId);
+        await appendHeavyTaskWorkspaceObservation({
+          taskRunStore,
+          taskRunId,
+          projection: boundedProjection,
+          executor: deps.realBackendIsolation?.toolExecutor,
+          cwd: agentWorkspaceDir,
+          now,
+          newId,
+        });
+        boundedProjection = await taskRunStore.project(taskRunId);
         const boundedDecision = evaluateHeavyTaskSelfCheckGate({
           task,
           heavyTaskMode,
@@ -611,6 +632,26 @@ export async function runTaskOnce(
   } finally {
     await workspace.cleanup();
   }
+}
+
+async function appendHeavyTaskWorkspaceObservation(input: {
+  taskRunStore: TaskRunStore;
+  taskRunId: string;
+  projection: TaskRunProjection;
+  executor?: NonNullable<RunTaskOnceDeps['realBackendIsolation']>['toolExecutor'];
+  cwd: string;
+  now: () => number;
+  newId: () => string;
+}): Promise<void> {
+  const event = await observeHeavyTaskWorkspace({
+    taskRunId: input.taskRunId,
+    projection: input.projection,
+    executor: input.executor,
+    cwd: input.cwd,
+    now: input.now,
+    newId: input.newId,
+  });
+  if (event) await appendTaskEvent(input.taskRunStore, input.taskRunId, event);
 }
 
 const DEFAULT_INTERVENTION_POLICY: TaskInterventionPolicy = { mode: 'fail_closed' };

--- a/packages/headless/src/task-contracts.ts
+++ b/packages/headless/src/task-contracts.ts
@@ -437,6 +437,25 @@ export interface HeavyTaskSelfCheckPlanAuditSummary {
   diagnostics: string[];
 }
 
+export interface HeavyTaskWorkspaceObservationEntry {
+  path: string;
+  kind: 'file' | 'directory' | 'symlink' | 'other';
+  symlinkTarget?: string;
+}
+
+export interface HeavyTaskWorkspaceObservationState {
+  schemaVersion: 1;
+  observationId: string;
+  taskRunId: string;
+  ts: number;
+  roots: string[];
+  entries: HeavyTaskWorkspaceObservationEntry[];
+  status: 'ok' | 'error';
+  command: string;
+  errorExcerpt?: string;
+  source: { kind: 'system'; label: string };
+}
+
 export interface HeavyTaskSemanticSelfCheckState {
   schemaVersion: 1;
   selfCheckId: string;
@@ -455,7 +474,7 @@ export interface HeavyTaskSemanticSelfCheckState {
 export interface HeavyTaskAcceptanceCheck {
   id: string;
   kind: 'required_artifact' | 'artifact_parse' | 'public_command' | 'fresh_context' | 'workspace_hygiene' | 'task_family_hint';
-  source: 'task_instruction' | 'task_metadata' | 'todo' | 'terminal_bench_hint' | 'generic_heavy_task';
+  source: 'task_instruction' | 'task_metadata' | 'todo' | 'self_check_plan' | 'terminal_bench_hint' | 'generic_heavy_task';
   description: string;
   evidenceRequired: 'command' | 'artifact' | 'command_or_artifact';
   path?: string;
@@ -789,6 +808,11 @@ export interface HeavyTaskSelfCheckGateRecordedEvent extends BaseTaskEvent {
   gate: HeavyTaskSelfCheckGateState;
 }
 
+export interface HeavyTaskWorkspaceObservationRecordedEvent extends BaseTaskEvent {
+  type: 'heavy_task_workspace_observation_recorded';
+  observation: HeavyTaskWorkspaceObservationState;
+}
+
 export interface HeavyTaskEvidenceRecordedEvent extends BaseTaskEvent {
   type: 'heavy_task_evidence_recorded';
   evidence: HeavyTaskCompactEvidenceEnvelope;
@@ -924,6 +948,7 @@ export type TaskEvent =
   | HeavyTaskSelfCheckPlanRecordedEvent
   | HeavyTaskSelfCheckRecordedEvent
   | HeavyTaskSelfCheckGateRecordedEvent
+  | HeavyTaskWorkspaceObservationRecordedEvent
   | HeavyTaskEvidenceRecordedEvent
   | IsolationPolicyRecordedEvent
   | WorkspaceLeaseRecordedEvent

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -10,6 +10,7 @@ import type {
   HeavyTaskCompactEvidenceEnvelope,
   HeavyTaskSelfCheckPlanState,
   HeavyTaskSelfCheckGateState,
+  HeavyTaskWorkspaceObservationState,
   EconomyTaskModeFacts,
   HeavyTaskInventoryState,
   TaskInboxItem,
@@ -61,6 +62,8 @@ export interface TaskRunProjection extends TaskRun {
   latestHeavyTaskSelfCheckPlan?: HeavyTaskSelfCheckPlanState;
   heavyTaskSelfCheckGates: HeavyTaskSelfCheckGateState[];
   latestHeavyTaskSelfCheckGate?: HeavyTaskSelfCheckGateState;
+  heavyTaskWorkspaceObservations: HeavyTaskWorkspaceObservationState[];
+  latestHeavyTaskWorkspaceObservation?: HeavyTaskWorkspaceObservationState;
   heavyTaskEvidence: HeavyTaskCompactEvidenceEnvelope[];
   latestHeavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope;
   heavyTaskCompletion?: HeavyTaskCompletionStatus;
@@ -109,6 +112,7 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
     heavyTaskSelfCheckPlans: [],
     heavyTaskSelfChecks: [],
     heavyTaskSelfCheckGates: [],
+    heavyTaskWorkspaceObservations: [],
     heavyTaskEvidence: [],
   };
   const attempts = new Map<string, TaskAttempt>();
@@ -222,6 +226,10 @@ export function projectTaskRun(events: readonly TaskEvent[], taskRunId?: string)
       case 'heavy_task_self_check_gate_recorded':
         projection.heavyTaskSelfCheckGates.push(event.gate);
         projection.latestHeavyTaskSelfCheckGate = event.gate;
+        break;
+      case 'heavy_task_workspace_observation_recorded':
+        projection.heavyTaskWorkspaceObservations.push(event.observation);
+        projection.latestHeavyTaskWorkspaceObservation = event.observation;
         break;
       case 'heavy_task_evidence_recorded':
         if (!appendCompactEvidence(projection, event.evidence)) {


### PR DESCRIPTION
## Summary
- add machine-backed heavy-task workspace observation before the self-check gate and after the bounded repair attempt
- surface observed final-workspace mismatches as gate diagnostics instead of relying on raw task-text path parsing
- keep engineering diagnostics advisory after one bounded repair attempt so official verifier/scorer authority remains final
- add generic regressions that observed extra final-workspace paths remain diagnostic and do not become local rejection

## Verification
- `npm --workspace @maka/headless run typecheck`
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/heavy-task-self-check-gate.test.js`
- `node --test packages/headless/dist/__tests__/task-agent-controller.test.js`
- `npm --workspace @maka/headless test` (97 suites, 686 tests, 685 pass, 1 skipped)
- `git diff --check`

## Benchmark context
- Full `terminal-bench-sample@2.0` rerun with DeepSeek V4 Flash on this branch completed 10 trials, 0 errors, mean `0.700` (7 pass / 3 fail).
- `polyglot-c-py` passed after the diagnostic prompted cleanup of `/app/polyglot/cmain` and scratch compilation.
- `build-cython-ext` exposed why observation diagnostics must not become a second local verifier: task-shaped heuristics should be shown to the model once and then left to official verification.
