### PR TITLE
perf(ui): content-visibility on committed turns for long-session first render

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1011,6 +1011,20 @@
     margin: 0 auto;
     width: 100%;
     box-sizing: border-box;
+    /* Long-conversation first render: skip layout/paint for off-screen
+       turns (vercel react-best-practices rendering-content-visibility —
+       ~10x initial-render win on long sessions, keeps native Cmd+F and
+       text selection, no virtualization library). `auto 250px` keeps a
+       placeholder estimate until first render, then the remembered
+       actual size prevents scrollbar jumps. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 250px;
+  }
+
+  /* The streaming turn must never be skipped: it grows every frame and
+     anchors the auto-scroll-to-bottom behavior. */
+  .maka-turn-streaming {
+    content-visibility: visible;
   }
 
   .maka-turn-tools {


### PR DESCRIPTION
四源 skill 全量二轮精读的第一个落地项（vercel react-best-practices `rendering-content-visibility`，全仓此前 0 处使用）。

- 屏外已提交 turn 跳过 layout/paint：长会话首渲染 ~10x 收益，零依赖，保留原生 Cmd+F 与文本选择
- `contain-intrinsic-size: auto 250px`：首渲染前占位估值，之后记住实际尺寸防滚动条跳动
- **流式 turn 钉死 `visible`**：它每帧增长且锚定 auto-scroll，绝不能被跳过

1696/1696 测试全绿；turn-narrative / turn-control-history 截图无回归。