### PR TITLE
feat(design): waiting-state spectrum 1 — toast overshoot + streaming sweep (D6)

### DIFF
--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -79,6 +79,11 @@ describe('issue #406 design-system governance contract', () => {
       'animate-spin',
       'maka-composer-permission-pulse',
       'maka-composer-stream-bounce',
+      // D6 waiting-state spectrum: toast arrival overshoot (attention
+      // guidance for new information) + composer streaming top sweep
+      // (visible "working" status) — both functional, not decorative.
+      'maka-toast-enter',
+      'maka-processing-sweep',
       'maka-cursor',
       'maka-list-row-streaming-pulse',
       'maka-pulse',

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -334,6 +334,54 @@
   transition: background 120ms var(--ease-out-strong);
 }
 
+/* D6 waiting-state spectrum #1 (taste v1 §9 Live Status): toasts used
+   to POP into existence with zero motion. A 240ms overshoot entrance
+   (rise + slight over-scale, then settle) reads as "something arrived"
+   without slowing anyone down — Emil's toast tier is 200-300ms and the
+   global reduced-motion block clamps it to a single 0.01ms frame. */
+@keyframes maka-toast-enter {
+  0%   { opacity: 0; transform: translateY(12px) scale(0.97); }
+  70%  { opacity: 1; transform: translateY(-2px) scale(1.005); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.maka-toast {
+  animation: maka-toast-enter 240ms var(--ease-out-strong);
+}
+
+/* D6 spectrum #2 (Command Input processing): while the assistant is
+   streaming, a slow top-edge light sweep on the composer shell keeps
+   "working" visible at the exact place the user's attention returns
+   to. 1px line, foreground-derived, infinite = functional status. */
+.maka-composer-inner[data-streaming="true"] {
+  position: relative;
+  overflow: hidden;
+}
+
+.maka-composer-inner[data-streaming="true"]::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    oklch(from var(--status-running) l c h / 0.55) 50%,
+    transparent
+  );
+  background-size: 200% 100%;
+  animation: maka-processing-sweep 2.2s var(--ease-in-out-strong) infinite;
+  pointer-events: none;
+}
+
+@keyframes maka-processing-sweep {
+  0%   { background-position: 180% 0; }
+  100% { background-position: -80% 0; }
+}
+
 .maka-toast[data-variant="success"] { border-left: 3px solid var(--success); }
 .maka-toast[data-variant="warning"] { border-left: 3px solid var(--info); }
 .maka-toast[data-variant="error"]   { border-left: 3px solid var(--destructive); }

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -510,7 +510,10 @@ export const Composer = forwardRef<
       onDrop={onComposerDrop}
       onSubmit={submit}
     >
-      <div className="maka-composer-inner composerInner agents-parchment-paper-surface">
+      <div
+        className="maka-composer-inner composerInner agents-parchment-paper-surface"
+        data-streaming={props.streaming ? 'true' : undefined}
+      >
         <UiTextarea
           ref={textareaRef}
           name="text"


### PR DESCRIPTION
D6「等待感全谱」第一批（taste v1 §9 谱系）：

1. **Toast 到达 overshoot**：toast 此前零动画瞬间出现 → 240ms 上升+轻微过冲回落（Emil toast 档 200-300ms；reduced-motion 全局钳制生效）。退场动画需要 toast.tsx 的 dismissal 窗口（现在是瞬间卸载）—— 留组件级批次
2. **Composer 流式扫光**：生成中 composer 壳顶边 1px status-running 流光（2.2s 循环）——「在干活」始终可见于用户注意力回归处
3. 两个动画名进 #406 functionalMotion 白名单（带理由注释）

1696/1696；streaming-answer fixture 验证。