### PR TITLE
feat(design): converge foreground text tiers 5→3 (issue #430 PR4)

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -75,11 +75,11 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       'max-w-[var(--maka-chat-measure,680px)]',
       "[&:not(:first-child)]:before:content-['·']",
       '[&_code]:[font-family:var(--font-mono)]',
-      'data-[kind=model]:[&_code]:text-[color:var(--foreground-60)]',
+      'data-[kind=model]:[&_code]:text-[color:var(--foreground-secondary)]',
       // every chip `data-[kind]` conditional is pinned, not just `model`, so
       // dropping the tools tint / duration+tokens tabular-nums / tokens mono
       // fails the contract.
-      'data-[kind=tools]:text-[color:var(--foreground-50)]',
+      'data-[kind=tools]:text-[color:var(--muted-foreground)]',
       'data-[kind=duration]:[font-variant-numeric:tabular-nums]',
       'data-[kind=tokens]:[font-family:var(--font-mono)]',
       'data-[state=in-progress]:text-[color:var(--status-running)]',

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -206,12 +206,9 @@ const TEXT_PROP_NAMES = [
  *
  * Locates the property name (preceded by `{`, `,`, `<`, or whitespace
  * to avoid matching inside Tailwind class tokens), then extracts the
- * full value:
- *  - Quoted ("...' / '...' / `...`): scan until closing quote
- *  - Unquoted expression: scan with bracket depth tracking, stop at
- *    matching `}` (depth 0), `;`, or newline — so commas inside
- *    function calls (e.g. pick(base, "var(--foreground-5)")) are
- *    included.
+ * full value via readExpressionValue — a bracket/quote-depth-aware
+ * reader that stops at the real end of the current property/attribute,
+ * not at the first comma or newline.
  */
 function scanTextPropValue(src: string): string[] {
   const offenders: string[] = [];
@@ -219,32 +216,61 @@ function scanTextPropValue(src: string): string[] {
   const propRe = new RegExp(`(?:[{,]\\s*|^\\s*|\\s)(${namesAlt})\\s*[:=]\\s*`, 'gi');
   let m: RegExpExecArray | null;
   while ((m = propRe.exec(src)) !== null) {
-    let i = m.index + m[0].length;
-    let quote = '';
-    if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
-      quote = src[i]!;
-      i++;
-    }
-    let val = '';
-    if (quote) {
-      while (i < src.length && src[i] !== quote) { val += src[i]!; i++; }
-    } else {
-      let depth = 0;
-      while (i < src.length) {
-        const c = src[i]!;
-        if (c === '{' || c === '(') depth++;
-        else if (c === '}' && depth === 0) break;
-        else if (c === '}') depth--;
-        else if (c === ';' || c === '\n') break;
-        val += c; i++;
-      }
-    }
+    const val = readExpressionValue(src, m.index + m[0].length);
     for (const fm of val.matchAll(FG_IN_TOKEN_RE)) {
       const num = fm[1]!;
       offenders.push(`text-prop --foreground-${num}`);
     }
   }
   return offenders;
+}
+
+/**
+ * Read a single JS/CSS expression value starting at `start`, tracking
+ * quote, parenthesis, bracket, and brace depth. Stops at:
+ *  - Closing quote (if the value starts with one)
+ *  - Depth-0 comma (next property in an object/style declaration)
+ *  - Depth-0 semicolon (CSS declaration end)
+ *  - Depth-0 closing brace (style object end, or JSX expression end)
+ *
+ * Characters inside quotes do not affect depth, so commas/braces in
+ * string literals are ignored. Handles multi-line expressions.
+ * If the value starts with `{` (JSX expression), it is treated as a
+ * nested expression — the opening brace increments depth so the
+ * matching closing brace terminates the value.
+ */
+function readExpressionValue(src: string, start: number): string {
+  let i = start;
+  // Skip leading whitespace.
+  while (i < src.length && /\s/.test(src[i]!)) i++;
+  // Quoted value: read to closing quote.
+  const ch = src[i];
+  if (ch === '"' || ch === "'" || ch === '`') {
+    const end = src.indexOf(ch, i + 1);
+    return end < 0 ? src.slice(i) : src.slice(i, end + 1);
+  }
+  // Unquoted: track ()[]{} depth, stop at depth-0 , ; }
+  const out: string[] = [];
+  let depth = 0;
+  // JSX expression {value}: opening brace is part of the value.
+  if (ch === '{') { depth = 1; out.push(ch); i++; }
+  while (i < src.length) {
+    const c = src[i]!;
+    // Skip over string literals so their contents don't affect depth.
+    if (c === '"' || c === "'" || c === '`') {
+      const close = src.indexOf(c, i + 1);
+      const segEnd = close < 0 ? src.length : close + 1;
+      out.push(src.slice(i, segEnd));
+      i = segEnd;
+      continue;
+    }
+    if (c === '(' || c === '[' || c === '{') { depth++; out.push(c); i++; continue; }
+    if (c === ')' || c === ']') { depth--; out.push(c); i++; continue; }
+    if (c === '}') { depth--; out.push(c); i++; if (depth <= 0) break; continue; }
+    if ((c === ',' || c === ';') && depth <= 0) break;
+    out.push(c); i++;
+  }
+  return out.join('');
 }
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
@@ -783,5 +809,15 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts style={{ background: pick(base, "var(--foreground-5)") }} in TSX (bg expr)', () => {
     assert.deepEqual(scanTsxSnippet('style={{ background: pick(base, "var(--foreground-5)") }}'), []);
+  });
+
+  // P2: multi-line expression + depth-aware property boundary
+  it('rejects multi-line style={{ color: colorMix(...) }} in TSX', () => {
+    const snippet = 'style={{ color: colorMix(\n  base,\n  "var(--foreground-5)"\n) }}';
+    assert.ok(scanTsxSnippet(snippet).length > 0);
+  });
+
+  it('accepts style={{ color: semantic, background: "var(--foreground-5)" }} in TSX (surface after text prop)', () => {
+    assert.deepEqual(scanTsxSnippet('style={{ color: semantic, background: "var(--foreground-5)" }}'), []);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -81,26 +81,29 @@ function findCssTextOffenders(css: string, label: string): string[] {
 // --- TSX scanning -----------------------------------------------------------
 
 /**
- * Tailwind arbitrary value referencing a raw foreground mix stop.
- * Matches any utility (text, color, fill, stroke, bg, border, etc.)
- * with optional variant prefix (disabled:, hover:, etc.) and optional
- * `color:` inner prefix:
- *   text-[color:var(--foreground-60)]     ✓ caught
- *   text-[var(--foreground-60)]            ✓ caught
- *   disabled:text-[var(--foreground-40)]  ✓ caught
- *   bg-[var(--foreground-50)]             ✓ caught
+ * Scan TS/TSX source for any reference to banned raw foreground mix stops.
+ * Instead of matching Tailwind syntax shapes (which evolve and have many
+ * forms — arbitrary values, shorthand, variant prefixes, quoted strings,
+ * template literals, inline styles), we simply ban the raw token names
+ * from appearing in TS/TSX at all. The semantic aliases
+ * (--muted-foreground, --foreground-secondary) are the only sanctioned
+ * text-color tokens; the raw stops should never be referenced directly.
  *
- * Note: the utility name is followed by `-[` (e.g. `text-[`), not `[`
- * directly — the `-` is the Tailwind arbitrary value separator.
+ * RAW_STOP_RE catches every form that contains the CSS variable name:
+ *   className="text-[var(--foreground-60)]"     ✓
+ *   cn("text-[var(--foreground-60)]")            ✓
+ *   `text-[var(--foreground-60)]`               ✓
+ *   style={{ color: "var(--foreground-60)" }}    ✓
+ *   text-(--foreground-60)                      ✓ (Tailwind shorthand)
+ *   text-[color:var(--foreground-60)]           ✓
+ *
+ * UTILITY_CLASS_RE catches the Tailwind utility-class form that omits
+ * the `--` prefix (these don't contain a CSS var() reference):
+ *   text-foreground-60                          ✓
+ *   bg-foreground-50                            ✓
  */
-const TSX_ARBITRARY_RE = /(?:^|\s|:)(?:text|color|fill|stroke|bg|border|ring|from|to|via)-\[(?:color:)?var\(\s*(--foreground-\d+)\s*\)\]/g;
-
-/**
- * Tailwind utility-class form: text-foreground-40, bg-foreground-50, etc.
- * These should not exist once @theme stops exporting the raw stops,
- * but the regex catches them defensively if someone re-adds the export.
- */
-const TSX_UTILITY_RE = /(?:^|\s|:)(?:text|bg|border|fill|stroke|ring|from|to|via)-foreground-(\d+)\b/g;
+const RAW_STOP_RE = /--foreground-(40|50|60|70|80|90|95)\b/g;
+const UTILITY_CLASS_RE = /(?:text|bg|border|fill|stroke|ring|from|to|via)-foreground-(40|50|60|70|80|90|95)\b/g;
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
@@ -117,32 +120,11 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
       if (entry.name.includes('.test.')) continue;
       const src = await readFile(full, 'utf8');
       const label = full.replace(REPO_ROOT + '/', '');
-
-      // Tailwind arbitrary value: text-[color:var(--foreground-N)],
-      // text-[var(--foreground-N)], disabled:text-[var(--foreground-N)], etc.
-      for (const m of src.matchAll(TSX_ARBITRARY_RE)) {
-        const tok = m[1]!;
-        if (BANNED_TEXT_STOPS.includes(tok)) {
-          offenders.push(`${label}: ${m[0].trim()} [banned ${tok}]`);
-        }
+      for (const m of src.matchAll(RAW_STOP_RE)) {
+        offenders.push(`${label}: --foreground-${m[1]}`);
       }
-
-      // Tailwind utility class: text-foreground-40, bg-foreground-50, etc.
-      for (const m of src.matchAll(TSX_UTILITY_RE)) {
-        const num = m[1]!;
-        const tok = `--foreground-${num}`;
-        if (BANNED_TEXT_STOPS.includes(tok)) {
-          offenders.push(`${label}: ${m[0].trim()} [banned ${tok}]`);
-        }
-      }
-
-      // Inline style: { color: 'var(--foreground-N)' }
-      const styleRe = /(color|fill|stroke)\s*:\s*['"]var\(\s*(--foreground-\d+)\s*\)['"]/g;
-      for (const m of src.matchAll(styleRe)) {
-        const tok = m[2]!;
-        if (BANNED_TEXT_STOPS.includes(tok)) {
-          offenders.push(`${label}: inline style ${m[1]}: var(${tok})`);
-        }
+      for (const m of src.matchAll(UTILITY_CLASS_RE)) {
+        offenders.push(`${label}: ${m[0]}`);
       }
     }
   }
@@ -157,18 +139,11 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
 /** Scan a TSX source snippet for banned foreground references. */
 function scanTsxSnippet(src: string): string[] {
   const offenders: string[] = [];
-  for (const m of src.matchAll(TSX_ARBITRARY_RE)) {
-    const tok = m[1]!;
-    if (BANNED_TEXT_STOPS.includes(tok)) {
-      offenders.push(`${m[0].trim()} [banned ${tok}]`);
-    }
+  for (const m of src.matchAll(RAW_STOP_RE)) {
+    offenders.push(`--foreground-${m[1]}`);
   }
-  for (const m of src.matchAll(TSX_UTILITY_RE)) {
-    const num = m[1]!;
-    const tok = `--foreground-${num}`;
-    if (BANNED_TEXT_STOPS.includes(tok)) {
-      offenders.push(`${m[0].trim()} [banned ${tok}]`);
-    }
+  for (const m of src.matchAll(UTILITY_CLASS_RE)) {
+    offenders.push(m[0]);
   }
   return offenders;
 }
@@ -182,14 +157,13 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
 
   it('maka-tokens.css text-color props use semantic aliases', async () => {
     const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
-    // Strip the alias definition lines and @theme mirror lines — they
-    // legitimately reference the raw stops.
+    // Strip alias definition lines and @theme mirror lines — they
+    // legitimately reference --foreground (no number suffix).
     const stripped = tokens
-      .replace(/^\s*--muted-foreground:\s*var\(--foreground-50\)\s*;?\s*$/gm, '')
-      .replace(/^\s*--foreground-secondary:\s*var\(--foreground-80\)\s*;?\s*$/gm, '')
-      .replace(/^\s*--color-foreground-\d+:\s*var\(--foreground-\d+\)\s*;?\s*$/gm, '')
-      .replace(/^\s*--color-foreground-secondary:\s*var\(--foreground-secondary\)\s*;?\s*$/gm, '')
-      .replace(/^\s*--color-muted-foreground:\s*var\(--muted-foreground\)\s*;?\s*$/gm, '');
+      .replace(/^\s*--muted-foreground:\s*color-mix.*$/gm, '')
+      .replace(/^\s*--foreground-secondary:\s*color-mix.*$/gm, '')
+      .replace(/^\s*--color-foreground-secondary:.*$/gm, '')
+      .replace(/^\s*--color-muted-foreground:.*$/gm, '');
     const offenders = findCssTextOffenders(stripped, 'maka-tokens.css');
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
@@ -203,19 +177,20 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
-  it('--muted-foreground is defined and targets --foreground-50', async () => {
+  it('--muted-foreground is defined as 50% foreground mix', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--muted-foreground:\s*var\(--foreground-50\)/, '--muted-foreground must target --foreground-50');
+    assert.match(tokens, /--muted-foreground:\s*color-mix\(in oklch,\s*var\(--foreground\)\s*50%,\s*var\(--background\)\)/, '--muted-foreground must be 50% foreground mix');
   });
 
-  it('--foreground-secondary is defined and targets --foreground-80', async () => {
+  it('--foreground-secondary is defined as 80% foreground mix', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--foreground-secondary:\s*var\(--foreground-80\)/, '--foreground-secondary must target --foreground-80');
+    assert.match(tokens, /--foreground-secondary:\s*color-mix\(in oklch,\s*var\(--foreground\)\s*80%,\s*var\(--background\)\)/, '--foreground-secondary must be 80% foreground mix');
   });
 
-  it('--foreground-90 and --foreground-95 are not defined', async () => {
+  it('raw text mix stops --foreground-40/50/60/70/80/90/95 are not defined', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    for (const stop of DELETED_STOPS) {
+    const allBanned = [...BANNED_TEXT_STOPS, ...DELETED_STOPS];
+    for (const stop of allBanned) {
       const re = new RegExp(`^\\s*${stop}:`, 'm');
       assert.doesNotMatch(tokens, re, `${stop} must not be defined`);
     }
@@ -228,10 +203,10 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
   });
 
   it('@theme inline does not export raw text stops --foreground-40/50/60/70/80', async () => {
-    const tokens = await readFile(TOKENS_FILE, 'utf8');
-    for (const stop of BANNED_TEXT_STOPS) {
-      const re = new RegExp(`--color-${stop}:`);
-      assert.doesNotMatch(tokens, re, `@theme must not export ${stop} as a Tailwind color utility`);
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    for (const num of ['40', '50', '60', '70', '80']) {
+      const re = new RegExp(`--color-foreground-${num}\\s*:`);
+      assert.doesNotMatch(tokens, re, `@theme must not export --color-foreground-${num}`);
     }
   });
 });
@@ -259,32 +234,54 @@ describe('foreground-tier negative cases', () => {
   });
 
   it('rejects text-[color:var(--foreground-60)] in TSX', () => {
-    const offenders = scanTsxSnippet("text-[color:var(--foreground-60)]");
-    assert.ok(offenders.length > 0, 'text-[color:var(--foreground-60)] must fail');
+    assert.ok(scanTsxSnippet("text-[color:var(--foreground-60)]").length > 0);
   });
 
   it('rejects text-[var(--foreground-60)] in TSX', () => {
-    const offenders = scanTsxSnippet("text-[var(--foreground-60)]");
-    assert.ok(offenders.length > 0, 'text-[var(--foreground-60)] must fail');
+    assert.ok(scanTsxSnippet("text-[var(--foreground-60)]").length > 0);
   });
 
   it('rejects disabled:text-[var(--foreground-40)] in TSX', () => {
-    const offenders = scanTsxSnippet("disabled:text-[var(--foreground-40)]");
-    assert.ok(offenders.length > 0, 'disabled:text-[var(--foreground-40)] must fail');
+    assert.ok(scanTsxSnippet("disabled:text-[var(--foreground-40)]").length > 0);
   });
 
   it('rejects text-foreground-60 Tailwind utility in TSX', () => {
-    const offenders = scanTsxSnippet("text-foreground-60");
-    assert.ok(offenders.length > 0, 'text-foreground-60 must fail');
+    assert.ok(scanTsxSnippet("text-foreground-60").length > 0);
+  });
+
+  it('rejects className="text-[var(--foreground-60)]" (quoted string)', () => {
+    assert.ok(scanTsxSnippet('className="text-[var(--foreground-60)]"').length > 0);
+  });
+
+  it('rejects cn("text-[var(--foreground-60)]") (cn call)', () => {
+    assert.ok(scanTsxSnippet('cn("text-[var(--foreground-60)]")').length > 0);
+  });
+
+  it('rejects `text-[var(--foreground-60)]` (template literal)', () => {
+    assert.ok(scanTsxSnippet('`text-[var(--foreground-60)]`').length > 0);
+  });
+
+  it('rejects style={{ color: "var(--foreground-60)" }} (inline style)', () => {
+    assert.ok(scanTsxSnippet('style={{ color: "var(--foreground-60)" }}').length > 0);
+  });
+
+  it('rejects text-(--foreground-60) Tailwind shorthand', () => {
+    assert.ok(scanTsxSnippet("text-(--foreground-60)").length > 0);
+  });
+
+  it('rejects hover:text-(--foreground-60) variant + shorthand', () => {
+    assert.ok(scanTsxSnippet("hover:text-(--foreground-60)").length > 0);
+  });
+
+  it('rejects fill-(--foreground-50) fill shorthand', () => {
+    assert.ok(scanTsxSnippet("fill-(--foreground-50)").length > 0);
   });
 
   it('accepts text-[color:var(--foreground-secondary)] in TSX', () => {
-    const offenders = scanTsxSnippet("text-[color:var(--foreground-secondary)]");
-    assert.deepEqual(offenders, []);
+    assert.deepEqual(scanTsxSnippet("text-[color:var(--foreground-secondary)]"), []);
   });
 
   it('accepts text-[color:var(--muted-foreground)] in TSX', () => {
-    const offenders = scanTsxSnippet("text-[color:var(--muted-foreground)]");
-    assert.deepEqual(offenders, []);
+    assert.deepEqual(scanTsxSnippet("text-[color:var(--muted-foreground)]"), []);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -1,32 +1,29 @@
 /**
  * PR-FOREGROUND-TIER-CONVERGE-0 (issue #430 PR4, 2026-07-03):
  * lock the text-color vocabulary so individual PRs can't silently drift
- * back to the 5-step text ladder (40/50/60/70/80) or the deleted 90/95
- * stops. Text call sites must use the 3 semantic aliases:
+ * back to the old multi-step ladder. Text call sites must use the 3
+ * semantic aliases:
  *
  *   var(--foreground)            — primary text (100% ink)
  *   var(--foreground-secondary)  — secondary text (80% ink)
  *   var(--muted-foreground)      — muted text (50% ink)
  *
- * The underlying mix stops (--foreground-40..80) stay in maka-tokens.css
- * so the aliases can target them, and surface washes (-2/-3/-5/-8/-10)
- * are NOT text so they remain call-site addressable. -90/-95 had zero
- * call sites and were deleted.
+ * --foreground-40..95 are deleted and must not be re-introduced.
+ * Surface wash stops (-2/-3/-5/-8/-10) exist for backgrounds, borders,
+ * and other non-text surfaces; they must NOT be used as text color.
  *
- * Three invariants:
+ * Invariants:
  *
- * 1. CSS `color:` / `fill:` / `stroke:` properties must not reference
- *    --foreground-40/50/60/70/80 directly — they must use the semantic
- *    aliases. Background/border/etc. properties are out of scope (those
- *    use the surface-wash scale, not the text ladder).
+ * 1. CSS text-color props (color/fill/stroke/caret-color/...) must not
+ *    reference --foreground-2..95. Only --foreground, --foreground-
+ *    secondary, --muted-foreground are allowed as text color.
  *
- * 2. TSX inline styles and Tailwind arbitrary values must not reference
- *    the raw mix stops for text color. Tailwind utility aliases
- *    (text-muted-foreground, text-foreground-secondary) are OK.
+ * 2. TS/TSX files must not reference --foreground-40..95 at all (any
+ *    syntax form). Tailwind utility classes text-foreground-2..95 are
+ *    also banned as text color.
  *
- * 3. The aliases are defined in maka-tokens.css with pinned targets:
- *    --muted-foreground → --foreground-50, --foreground-secondary →
- *    --foreground-80. --foreground-90/95 must not be defined.
+ * 3. @theme must not export --color-foreground-40..95 as Tailwind
+ *    color utilities.
  */
 
 import { strict as assert } from 'node:assert';
@@ -35,30 +32,36 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
 
-// --- banned raw text stops --------------------------------------------------
+// --- banned foreground numbers ----------------------------------------------
 
-const BANNED_TEXT_STOPS = ['--foreground-40', '--foreground-50', '--foreground-60', '--foreground-70', '--foreground-80'];
-const DELETED_STOPS = ['--foreground-90', '--foreground-95'];
+/** All foreground mix-stop numbers that must never be used as text color. */
+const BANNED_TEXT_NUMS = ['40', '50', '60', '70', '80', '90', '95'];
+
+/** Surface-wash numbers — allowed in bg/border context, banned in text context. */
+const SURFACE_WASH_NUMS = ['2', '3', '5', '8', '10'];
+
+/** All banned numbers for TSX (text + surface, since TSX can't distinguish context). */
+const ALL_BANNED_NUMS = [...BANNED_TEXT_NUMS, ...SURFACE_WASH_NUMS];
 
 // Properties that set TEXT color (not background/border/shadow).
-// Border-color is excluded — borders use the surface-wash scale or
-// alpha overlays, not the text ladder; a separate contract can govern
-// border tokens if needed.
 const TEXT_PROP_RE = /^(color|fill|stroke|caret-color|text-decoration-color|column-rule-color)$/i;
 
-// CSS `var(--foreground-N)` reference (N = 2 digits).
+// CSS `var(--foreground-N)` reference (N = digits).
 const VAR_FOREGROUND_N_RE = /var\(\s*(--foreground-\d+)\s*\)/g;
 
 // --- CSS scanning -----------------------------------------------------------
 
 /**
  * Extract color property declarations and check they don't reference
- * the banned raw text stops. Background, border, box-shadow etc. are
- * out of scope — those use the surface-wash scale.
+ * any banned foreground stop as text color. Text props must only use
+ * the 3 semantic aliases (--foreground, --foreground-secondary,
+ * --muted-foreground). Surface wash stops are banned in text context
+ * but allowed in bg/border context.
  */
 function findCssTextOffenders(css: string, label: string): string[] {
   const stripped = stripCssComments(css);
   const offenders: string[] = [];
+  const bannedNumsSet = new Set(BANNED_TEXT_NUMS.concat(SURFACE_WASH_NUMS));
 
   const declRe = /([\w-]+)\s*:\s*([^;}\n]+?)\s*(?:[;}|\n]|$)/gi;
   for (const m of stripped.matchAll(declRe)) {
@@ -66,10 +69,10 @@ function findCssTextOffenders(css: string, label: string): string[] {
     const rawVal = m[2]!.trim();
     if (!TEXT_PROP_RE.test(prop)) continue;
 
-    // Scan for var(--foreground-N) references.
     for (const vm of rawVal.matchAll(VAR_FOREGROUND_N_RE)) {
       const tok = vm[1]!;
-      if (BANNED_TEXT_STOPS.includes(tok)) {
+      const num = tok.replace('--foreground-', '');
+      if (bannedNumsSet.has(num)) {
         offenders.push(`${label}: ${prop}: ${rawVal} [banned ${tok}]`);
       }
     }
@@ -81,32 +84,31 @@ function findCssTextOffenders(css: string, label: string): string[] {
 // --- TSX scanning -----------------------------------------------------------
 
 /**
- * Scan TS/TSX source for any reference to banned raw foreground mix stops.
- * Instead of matching Tailwind syntax shapes (which evolve and have many
- * forms — arbitrary values, shorthand, variant prefixes, quoted strings,
- * template literals, inline styles), we simply ban the raw token names
- * from appearing in TS/TSX at all. The semantic aliases
- * (--muted-foreground, --foreground-secondary) are the only sanctioned
- * text-color tokens; the raw stops should never be referenced directly.
+ * RAW_STOP_RE: bans --foreground-40..95 from TS/TSX entirely (any syntax
+ * form). These stops are deleted; the only valid text tokens are
+ * --foreground, --foreground-secondary, --muted-foreground.
  *
- * RAW_STOP_RE catches every form that contains the CSS variable name:
- *   className="text-[var(--foreground-60)]"     ✓
- *   cn("text-[var(--foreground-60)]")            ✓
- *   `text-[var(--foreground-60)]`               ✓
- *   style={{ color: "var(--foreground-60)" }}    ✓
- *   text-(--foreground-60)                      ✓ (Tailwind shorthand)
- *   text-[color:var(--foreground-60)]           ✓
+ * TEXT_UTILITY_RE: bans text-foreground-N (Tailwind utility class form)
+ * for ALL N (2..95). Surface wash stops (2/3/5/8/10) are allowed as
+ * bg-foreground-N / border-foreground-N but NOT as text-foreground-N.
  *
- * UTILITY_CLASS_RE catches the Tailwind utility-class form that omits
- * the `--` prefix (these don't contain a CSS var() reference):
- *   text-foreground-60                          ✓
- *   bg-foreground-50                            ✓
+ * TEXT_ARBITRARY_RE: bans surface wash stops (2/3/5/8/10) when used in
+ * a text-color Tailwind arbitrary value or shorthand —
+ *   text-[color:var(--foreground-5)]   ✓
+ *   text-[var(--foreground-5)]          ✓
+ *   text-(--foreground-5)               ✓ (Tailwind v4 shorthand)
+ * Inline styles (color: "var(--foreground-5)") are caught by
+ * TEXT_INLINE_RE.
  */
 const RAW_STOP_RE = /--foreground-(40|50|60|70|80|90|95)\b/g;
-const UTILITY_CLASS_RE = /(?:text|bg|border|fill|stroke|ring|from|to|via)-foreground-(40|50|60|70|80|90|95)\b/g;
+const TEXT_UTILITY_RE = /text-foreground-(\d+)\b/g;
+const TEXT_ARBITRARY_RE = /(?:text|fill|stroke)-\[(?:color:)?var\(\s*--foreground-(\d+)\s*\)\]/g;
+const TEXT_SHORTHAND_RE = /(?:text|fill|stroke)-\(\s*--foreground-(\d+)\s*\)/g;
+const TEXT_INLINE_RE = /(?:color|fill|stroke)\s*:\s*['"]var\(\s*--foreground-(\d+)\s*\)['"]/g;
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
+  const surfaceSet = new Set(SURFACE_WASH_NUMS);
   async function walk(dir: string): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
@@ -120,11 +122,32 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
       if (entry.name.includes('.test.')) continue;
       const src = await readFile(full, 'utf8');
       const label = full.replace(REPO_ROOT + '/', '');
+
+      // Deleted stops: banned in any context.
       for (const m of src.matchAll(RAW_STOP_RE)) {
         offenders.push(`${label}: --foreground-${m[1]}`);
       }
-      for (const m of src.matchAll(UTILITY_CLASS_RE)) {
-        offenders.push(`${label}: ${m[0]}`);
+      // text-foreground-N utility class: banned for all N (text context).
+      for (const m of src.matchAll(TEXT_UTILITY_RE)) {
+        offenders.push(`${label}: text-foreground-${m[1]}`);
+      }
+      // Surface wash in text arbitrary value: text-[var(--foreground-N)]
+      for (const m of src.matchAll(TEXT_ARBITRARY_RE)) {
+        if (surfaceSet.has(m[1]!)) {
+          offenders.push(`${label}: text-context --foreground-${m[1]}`);
+        }
+      }
+      // Surface wash in text shorthand: text-(--foreground-N)
+      for (const m of src.matchAll(TEXT_SHORTHAND_RE)) {
+        if (surfaceSet.has(m[1]!)) {
+          offenders.push(`${label}: text-context --foreground-${m[1]}`);
+        }
+      }
+      // Surface wash in inline style: color: "var(--foreground-N)"
+      for (const m of src.matchAll(TEXT_INLINE_RE)) {
+        if (surfaceSet.has(m[1]!)) {
+          offenders.push(`${label}: text-context --foreground-${m[1]}`);
+        }
       }
     }
   }
@@ -139,11 +162,27 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
 /** Scan a TSX source snippet for banned foreground references. */
 function scanTsxSnippet(src: string): string[] {
   const offenders: string[] = [];
+  const surfaceSet = new Set(SURFACE_WASH_NUMS);
   for (const m of src.matchAll(RAW_STOP_RE)) {
     offenders.push(`--foreground-${m[1]}`);
   }
-  for (const m of src.matchAll(UTILITY_CLASS_RE)) {
-    offenders.push(m[0]);
+  for (const m of src.matchAll(TEXT_UTILITY_RE)) {
+    offenders.push(`text-foreground-${m[1]}`);
+  }
+  for (const m of src.matchAll(TEXT_ARBITRARY_RE)) {
+    if (surfaceSet.has(m[1]!)) {
+      offenders.push(`text-context --foreground-${m[1]}`);
+    }
+  }
+  for (const m of src.matchAll(TEXT_SHORTHAND_RE)) {
+    if (surfaceSet.has(m[1]!)) {
+      offenders.push(`text-context --foreground-${m[1]}`);
+    }
+  }
+  for (const m of src.matchAll(TEXT_INLINE_RE)) {
+    if (surfaceSet.has(m[1]!)) {
+      offenders.push(`text-context --foreground-${m[1]}`);
+    }
   }
   return offenders;
 }
@@ -187,12 +226,11 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
     assert.match(tokens, /--foreground-secondary:\s*color-mix\(in oklch,\s*var\(--foreground\)\s*80%,\s*var\(--background\)\)/, '--foreground-secondary must be 80% foreground mix');
   });
 
-  it('raw text mix stops --foreground-40/50/60/70/80/90/95 are not defined', async () => {
+  it('raw text mix stops --foreground-40..95 are not defined', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    const allBanned = [...BANNED_TEXT_STOPS, ...DELETED_STOPS];
-    for (const stop of allBanned) {
-      const re = new RegExp(`^\\s*${stop}:`, 'm');
-      assert.doesNotMatch(tokens, re, `${stop} must not be defined`);
+    for (const num of BANNED_TEXT_NUMS) {
+      const re = new RegExp(`^\\s*--foreground-${num}:`, 'm');
+      assert.doesNotMatch(tokens, re, `--foreground-${num} must not be defined`);
     }
   });
 
@@ -202,9 +240,9 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
     assert.match(tokens, /--color-muted-foreground:\s*var\(--muted-foreground\)/, '@theme must export --color-muted-foreground');
   });
 
-  it('@theme inline does not export raw text stops --foreground-40/50/60/70/80', async () => {
+  it('@theme inline does not export raw text stops --foreground-40..95', async () => {
     const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
-    for (const num of ['40', '50', '60', '70', '80']) {
+    for (const num of BANNED_TEXT_NUMS) {
       const re = new RegExp(`--color-foreground-${num}\\s*:`);
       assert.doesNotMatch(tokens, re, `@theme must not export --color-foreground-${num}`);
     }
@@ -283,5 +321,57 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts text-[color:var(--muted-foreground)] in TSX', () => {
     assert.deepEqual(scanTsxSnippet("text-[color:var(--muted-foreground)]"), []);
+  });
+
+  // P2: CSS 90/95 must be banned in text props too
+  it('rejects color: var(--foreground-90) in CSS', () => {
+    assert.ok(findCssTextOffenders('color: var(--foreground-90)', 'test').length > 0);
+  });
+
+  it('rejects fill: var(--foreground-95) in CSS', () => {
+    assert.ok(findCssTextOffenders('fill: var(--foreground-95)', 'test').length > 0);
+  });
+
+  // P2: surface wash stops banned in text context
+  it('rejects text-foreground-5 (surface wash as text) in TSX', () => {
+    assert.ok(scanTsxSnippet("text-foreground-5").length > 0);
+  });
+
+  it('rejects text-[color:var(--foreground-5)] in TSX', () => {
+    assert.ok(scanTsxSnippet("text-[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects text-(--foreground-5) in TSX', () => {
+    assert.ok(scanTsxSnippet("text-(--foreground-5)").length > 0);
+  });
+
+  it('rejects color: var(--foreground-5) in CSS text prop', () => {
+    assert.ok(findCssTextOffenders('color: var(--foreground-5)', 'test').length > 0);
+  });
+
+  // P2: surface wash stops allowed in non-text context
+  it('accepts bg-foreground-5 in TSX (bg context)', () => {
+    assert.deepEqual(scanTsxSnippet("bg-foreground-5"), []);
+  });
+
+  it('accepts bg-[var(--foreground-5)] in TSX (bg context)', () => {
+    assert.deepEqual(scanTsxSnippet("bg-[var(--foreground-5)]"), []);
+  });
+
+  it('accepts background: var(--foreground-5) in CSS (bg context)', () => {
+    assert.deepEqual(findCssTextOffenders('background: var(--foreground-5)', 'test'), []);
+  });
+
+  it('accepts border-color: var(--foreground-10) in CSS (border context)', () => {
+    assert.deepEqual(findCssTextOffenders('border-color: var(--foreground-10)', 'test'), []);
+  });
+
+  // P2: @theme 90/95 export banned
+  it('@theme must not export --color-foreground-90/95', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    for (const num of ['90', '95']) {
+      const re = new RegExp(`--color-foreground-${num}\\s*:`);
+      assert.doesNotMatch(tokens, re, `@theme must not export --color-foreground-${num}`);
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -1,0 +1,198 @@
+/**
+ * PR-FOREGROUND-TIER-CONVERGE-0 (issue #430 PR4, 2026-07-03):
+ * lock the text-color vocabulary so individual PRs can't silently drift
+ * back to the 5-step text ladder (40/50/60/70/80) or the deleted 90/95
+ * stops. Text call sites must use the 3 semantic aliases:
+ *
+ *   var(--foreground)            — primary text (100% ink)
+ *   var(--foreground-secondary)  — secondary text (80% ink)
+ *   var(--muted-foreground)      — muted text (50% ink)
+ *
+ * The underlying mix stops (--foreground-40..80) stay in maka-tokens.css
+ * so the aliases can target them, and surface washes (-2/-3/-5/-8/-10)
+ * are NOT text so they remain call-site addressable. -90/-95 had zero
+ * call sites and were deleted.
+ *
+ * Three invariants:
+ *
+ * 1. CSS `color:` / `fill:` / `stroke:` properties must not reference
+ *    --foreground-40/50/60/70/80 directly — they must use the semantic
+ *    aliases. Background/border/etc. properties are out of scope (those
+ *    use the surface-wash scale, not the text ladder).
+ *
+ * 2. TSX inline styles and Tailwind arbitrary values must not reference
+ *    the raw mix stops for text color. Tailwind utility aliases
+ *    (text-muted-foreground, text-foreground-secondary) are OK.
+ *
+ * 3. The aliases are defined in maka-tokens.css with pinned targets:
+ *    --muted-foreground → --foreground-50, --foreground-secondary →
+ *    --foreground-80. --foreground-90/95 must not be defined.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+// --- banned raw text stops --------------------------------------------------
+
+const BANNED_TEXT_STOPS = ['--foreground-40', '--foreground-50', '--foreground-60', '--foreground-70', '--foreground-80'];
+const DELETED_STOPS = ['--foreground-90', '--foreground-95'];
+
+// Properties that set TEXT color (not background/border/shadow).
+// Border-color is excluded — borders use the surface-wash scale or
+// alpha overlays, not the text ladder; a separate contract can govern
+// border tokens if needed.
+const TEXT_PROP_RE = /^(color|fill|stroke|caret-color|text-decoration-color|column-rule-color)$/i;
+
+// CSS `var(--foreground-N)` reference (N = 2 digits).
+const VAR_FOREGROUND_N_RE = /var\(\s*(--foreground-\d+)\s*\)/g;
+
+// --- CSS scanning -----------------------------------------------------------
+
+/**
+ * Extract color property declarations and check they don't reference
+ * the banned raw text stops. Background, border, box-shadow etc. are
+ * out of scope — those use the surface-wash scale.
+ */
+function findCssTextOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+
+  const declRe = /([\w-]+)\s*:\s*([^;}\n]+?)\s*(?:[;}|\n]|$)/gi;
+  for (const m of stripped.matchAll(declRe)) {
+    const prop = m[1]!;
+    const rawVal = m[2]!.trim();
+    if (!TEXT_PROP_RE.test(prop)) continue;
+
+    // Scan for var(--foreground-N) references.
+    for (const vm of rawVal.matchAll(VAR_FOREGROUND_N_RE)) {
+      const tok = vm[1]!;
+      if (BANNED_TEXT_STOPS.includes(tok)) {
+        offenders.push(`${label}: ${prop}: ${rawVal} [banned ${tok}]`);
+      }
+    }
+  }
+
+  return offenders;
+}
+
+// --- TSX scanning -----------------------------------------------------------
+
+const TSX_TEXT_RE = /(?:text|color|fill|stroke)\[color:var\(\s*(--foreground-\d+)\s*\)\]/g;
+
+async function collectTsxOffenders(): Promise<string[]> {
+  const offenders: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      if (!/\.(tsx|ts)$/.test(entry.name)) continue;
+      if (entry.name.includes('.test.')) continue;
+      const src = await readFile(full, 'utf8');
+      const label = full.replace(REPO_ROOT + '/', '');
+
+      // Tailwind arbitrary value: text-[color:var(--foreground-N)] / color-[...]
+      for (const m of src.matchAll(TSX_TEXT_RE)) {
+        const tok = m[1]!;
+        if (BANNED_TEXT_STOPS.includes(tok)) {
+          offenders.push(`${label}: ${m[0]} [banned ${tok}]`);
+        }
+      }
+
+      // Inline style: { color: 'var(--foreground-N)' }
+      const styleRe = /(color|fill|stroke)\s*:\s*['"]var\(\s*(--foreground-\d+)\s*\)['"]/g;
+      for (const m of src.matchAll(styleRe)) {
+        const tok = m[2]!;
+        if (BANNED_TEXT_STOPS.includes(tok)) {
+          offenders.push(`${label}: inline style ${m[1]}: var(${tok})`);
+        }
+      }
+    }
+  }
+  await walk(resolve(REPO_ROOT, 'packages/ui/src'));
+  await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+  return offenders;
+}
+
+// === tests ==================================================================
+
+describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
+  it('CSS text-color props use semantic aliases, not raw --foreground-40..80', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssTextOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css text-color props use semantic aliases', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    // Strip the alias definition lines and @theme mirror lines — they
+    // legitimately reference the raw stops.
+    const stripped = tokens
+      .replace(/^\s*--muted-foreground:\s*var\(--foreground-50\)\s*;?\s*$/gm, '')
+      .replace(/^\s*--foreground-secondary:\s*var\(--foreground-80\)\s*;?\s*$/gm, '')
+      .replace(/^\s*--color-foreground-\d+:\s*var\(--foreground-\d+\)\s*;?\s*$/gm, '')
+      .replace(/^\s*--color-foreground-secondary:\s*var\(--foreground-secondary\)\s*;?\s*$/gm, '')
+      .replace(/^\s*--color-muted-foreground:\s*var\(--muted-foreground\)\s*;?\s*$/gm, '');
+    const offenders = findCssTextOffenders(stripped, 'maka-tokens.css');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('TSX text-color uses semantic aliases, not raw --foreground-40..80', async () => {
+    const offenders = await collectTsxOffenders();
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--muted-foreground is defined and targets --foreground-50', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--muted-foreground:\s*var\(--foreground-50\)/, '--muted-foreground must target --foreground-50');
+  });
+
+  it('--foreground-secondary is defined and targets --foreground-80', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--foreground-secondary:\s*var\(--foreground-80\)/, '--foreground-secondary must target --foreground-80');
+  });
+
+  it('--foreground-90 and --foreground-95 are not defined', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    for (const stop of DELETED_STOPS) {
+      const re = new RegExp(`^\\s*${stop}:`, 'm');
+      assert.doesNotMatch(tokens, re, `${stop} must not be defined`);
+    }
+  });
+
+  it('@theme inline exports the semantic aliases', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--color-foreground-secondary:\s*var\(--foreground-secondary\)/, '@theme must export --color-foreground-secondary');
+    assert.match(tokens, /--color-muted-foreground:\s*var\(--muted-foreground\)/, '@theme must export --color-muted-foreground');
+  });
+});
+
+describe('foreground-tier negative cases', () => {
+  it('rejects raw --foreground-60 in color props', () => {
+    assert.ok(findCssTextOffenders('color: var(--foreground-60)', 'test').length > 0, 'raw --foreground-60 in color must fail');
+  });
+
+  it('accepts --muted-foreground in color props', () => {
+    assert.deepEqual(findCssTextOffenders('color: var(--muted-foreground)', 'test'), []);
+  });
+
+  it('accepts --foreground-secondary in color props', () => {
+    assert.deepEqual(findCssTextOffenders('color: var(--foreground-secondary)', 'test'), []);
+  });
+
+  it('does not scan background/border props for text-stop violations', () => {
+    assert.deepEqual(findCssTextOffenders('background: var(--foreground-5)', 'test'), []);
+    assert.deepEqual(findCssTextOffenders('border-color: var(--foreground-10)', 'test'), []);
+  });
+
+  it('accepts --foreground (100% ink) in color props', () => {
+    assert.deepEqual(findCssTextOffenders('color: var(--foreground)', 'test'), []);
+  });
+});

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -46,8 +46,9 @@ const ALL_BANNED_NUMS = [...BANNED_TEXT_NUMS, ...SURFACE_WASH_NUMS];
 // Properties that set TEXT color (not background/border/shadow).
 const TEXT_PROP_RE = /^(color|fill|stroke|caret-color|text-decoration-color|column-rule-color)$/i;
 
-// CSS `var(--foreground-N)` reference (N = digits).
-const VAR_FOREGROUND_N_RE = /var\(\s*(--foreground-\d+)\s*\)/g;
+// CSS `--foreground-N` token reference (N = digits). Does NOT require
+// var() to be closed — catches `var(--foreground-5, currentColor)`.
+const FOREGROUND_TOKEN_RE = /--foreground-(\d+)\b/g;
 
 // --- CSS scanning -----------------------------------------------------------
 
@@ -69,11 +70,10 @@ function findCssTextOffenders(css: string, label: string): string[] {
     const rawVal = m[2]!.trim();
     if (!TEXT_PROP_RE.test(prop)) continue;
 
-    for (const vm of rawVal.matchAll(VAR_FOREGROUND_N_RE)) {
-      const tok = vm[1]!;
-      const num = tok.replace('--foreground-', '');
+    for (const vm of rawVal.matchAll(FOREGROUND_TOKEN_RE)) {
+      const num = vm[1]!;
       if (bannedNumsSet.has(num)) {
-        offenders.push(`${label}: ${prop}: ${rawVal} [banned ${tok}]`);
+        offenders.push(`${label}: ${prop}: ${rawVal} [banned --foreground-${num}]`);
       }
     }
   }
@@ -146,10 +146,18 @@ const TEXT_CONTEXT_RE = new RegExp(
   //    text-(color:--fg-N), fill-[...], stroke-(...)
   + '|(?:text|fill|stroke|caret|decoration)-[(\\[](?:color:)?(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
   // C) arbitrary property (no utility prefix): [color:var(--fg-N)]
-  //    Must start with [color: to distinguish from bg-[var(--fg-N)].
+  //    Must start with [color: to distinguish from bg-[var(--fg-N)]
+  //    and [border-color:...] / [background-color:...].
   + '|\\[color:(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
-  // D) inline style string: color: "var(--foreground-N...", color: var(--fg-N...
-  + '|(?:color|fill|stroke)\\s*:\\s*["\']?var\\(\\s*--foreground-(\\d+)'
+  // D) inline style: the property name must be exactly color/fill/stroke
+  //    (not border-color or background-color). Require the property
+  //    name to start at a declaration boundary (^, whitespace, ;, {, ").
+  //    Matches: color: var(--fg-N, color: "var(--fg-N
+  + '|(?:^|\\s|;\\s*|\\{\\s*|["\']\\s*)(?:color|fill|stroke)\\s*:\\s*["\']?var\\(\\s*--foreground-(\\d+)'
+  // E) arbitrary property for text-like CSS props: [caret-color:...],
+  //    [text-decoration-color:...]. These have hyphenated property names
+  //    that D won't catch.
+  + '|\\[(?:caret-color|text-decoration-color|column-rule-color):(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
   , 'g');
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
@@ -176,14 +184,14 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
       // Surface wash in text-like context, OR any text-foreground-N
       // utility class (all N banned as text, not just surface wash).
       for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
-        const num = m[1] || m[2] || m[3] || m[4];
+        const num = m[1] || m[2] || m[3] || m[4] || m[5];
         if (!num) continue;
         // Alternative A (utility class): ban all N — deleted stops
         // (40..95) and surface wash (2/3/5/8/10) alike.
         if (m[1]) {
           offenders.push(`${label}: text-foreground-${num}`);
         }
-        // Alternatives B/C/D: only surface wash banned in text context.
+        // Alternatives B/C/D/E: only surface wash banned in text context.
         else if (surfaceSet.has(num)) {
           offenders.push(`${label}: text-context --foreground-${num}`);
         }
@@ -206,7 +214,7 @@ function scanTsxSnippet(src: string): string[] {
     offenders.push(`--foreground-${m[1]}`);
   }
   for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
-    const num = m[1] || m[2] || m[3] || m[4];
+    const num = m[1] || m[2] || m[3] || m[4] || m[5];
     if (!num) continue;
     if (m[1]) {
       offenders.push(`text-foreground-${num}`);
@@ -441,6 +449,36 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts border-foreground-10 in TSX (border context)', () => {
     assert.deepEqual(scanTsxSnippet("border-foreground-10"), []);
+  });
+
+  // P3: surface arbitrary property must not be误杀
+  it('accepts [border-color:var(--foreground-10)] in TSX (border arbitrary property)', () => {
+    assert.deepEqual(scanTsxSnippet("[border-color:var(--foreground-10)]"), []);
+  });
+
+  it('accepts [background-color:var(--foreground-5)] in TSX (bg arbitrary property)', () => {
+    assert.deepEqual(scanTsxSnippet("[background-color:var(--foreground-5)]"), []);
+  });
+
+  it('rejects [caret-color:var(--foreground-5)] in TSX (text-like arbitrary property)', () => {
+    assert.ok(scanTsxSnippet("[caret-color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects [text-decoration-color:var(--foreground-5)] in TSX (text-like arbitrary property)', () => {
+    assert.ok(scanTsxSnippet("[text-decoration-color:var(--foreground-5)]").length > 0);
+  });
+
+  // P2: CSS var() fallback — text context must fail even with fallback
+  it('rejects color: var(--foreground-5, currentColor) in CSS (var with fallback)', () => {
+    assert.ok(findCssTextOffenders('color: var(--foreground-5, currentColor)', 'test').length > 0);
+  });
+
+  it('rejects fill: var(--foreground-95, currentColor) in CSS (var with fallback)', () => {
+    assert.ok(findCssTextOffenders('fill: var(--foreground-95, currentColor)', 'test').length > 0);
+  });
+
+  it('accepts background: var(--foreground-5, currentColor) in CSS (bg context with fallback)', () => {
+    assert.deepEqual(findCssTextOffenders('background: var(--foreground-5, currentColor)', 'test'), []);
   });
 
   // P2: @theme 90/95 export banned

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -43,9 +43,10 @@ const SURFACE_WASH_NUMS = ['2', '3', '5', '8', '10'];
 // Properties that set TEXT color (not background/border/shadow).
 const TEXT_PROP_RE = /^(color|fill|stroke|caret-color|text-decoration-color|column-rule-color)$/i;
 
-// CSS `--foreground-N` token reference (N = digits). Does NOT require
+// CSS foreground token reference — matches both --foreground-N and
+// --color-foreground-N (the @theme mirror form). Does NOT require
 // var() to be closed — catches `var(--foreground-5, currentColor)`.
-const FOREGROUND_TOKEN_RE = /--foreground-(\d+)\b/g;
+const FOREGROUND_TOKEN_RE = /--(?:color-)?foreground-(\d+)\b/g;
 
 // --- CSS scanning -----------------------------------------------------------
 
@@ -59,6 +60,8 @@ const FOREGROUND_TOKEN_RE = /--foreground-(\d+)\b/g;
  * Declaration values may span multiple lines (e.g. color-mix() with
  * line breaks). The value regex matches [^;}]+ so newlines are
  * included.
+ *
+ * Also scans @apply utility lists via findCssApplyOffenders.
  */
 function findCssTextOffenders(css: string, label: string): string[] {
   const stripped = stripCssComments(css);
@@ -83,31 +86,65 @@ function findCssTextOffenders(css: string, label: string): string[] {
   return offenders;
 }
 
+/**
+ * Scan @apply utility lists for text-like foreground classes.
+ * Reuses the TSX token classifier (isTextLikeClass / isBareTextProperty)
+ * to determine context. Surface utilities (bg-/border-/ring-) pass.
+ */
+function findCssApplyOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  const applyRe = /@apply\s+([^;]+);/gi;
+  for (const m of stripped.matchAll(applyRe)) {
+    const utilityList = m[1]!;
+    for (const tm of utilityList.matchAll(TOKEN_RE)) {
+      const tok = tm[0];
+      if (!tok.includes('foreground')) continue;
+      if (!isTextLikeClass(tok) && !isBareTextProperty(tok)) continue;
+      const um = stripVariant(tok).match(UTILITY_CLASS_RE);
+      if (um) {
+        offenders.push(`${label}: @apply text-foreground-${um[1]}`);
+      }
+      for (const fm of tok.matchAll(FG_IN_TOKEN_RE)) {
+        const num = fm[1]!;
+        if (SURFACE_WASH_NUMS.includes(num)) {
+          offenders.push(`${label}: @apply text-context --foreground-${num}`);
+        }
+      }
+    }
+  }
+  return offenders;
+}
+
 // --- TSX scanning -----------------------------------------------------------
 
 /**
  * Two-layer scan strategy:
  *
- * 1. RAW_STOP_RE: --foreground-40..95 are deleted; ban them from TS/TSX
- *    entirely (any syntax form, any context).
+ * 1. RAW_STOP_THEME_RE: --foreground-40..95 and --color-foreground-40..95
+ *    (the @theme mirror form) are deleted; ban them from TS/TSX entirely
+ *    (any syntax form, any context).
  *
  * 2. Token-based context scan: split source into class-like tokens, then
  *    classify each token as text-like or surface-like by its prefix.
  *    Text-like tokens (text/fill/stroke/caret/decoration prefix, or bare
- *    [color:...] arbitrary property) trigger a search for --foreground-N
- *    anywhere inside the token — not just right after the prefix. This
- *    catches complex arbitrary values like
+ *    [color:...] arbitrary property) trigger a search for
+ *    --(?:color-)?foreground-N anywhere inside the token — not just right
+ *    after the prefix. This catches complex arbitrary values like
  *    text-[color:color-mix(in_oklch,var(--foreground-5),...)].
  *
- *    Inline-style declarations (color:/fill:/stroke: followed by a value
- *    that may span whitespace) are scanned separately, since the
- *    property name and value can be split across tokens by whitespace.
+ * 3. Text-property value scan: inline-style declarations
+ *    (style={{ color: "..." }}) and JSX attributes (fill="...", stroke={...})
+ *    are scanned by locating the property name, then extracting the full
+ *    value (quoted or bare) and searching for foreground tokens inside.
+ *    Covers camelCase props (caretColor, textDecorationColor) and complex
+ *    values (color-mix(...)).
  *
  *    Surface-context prefixes (bg-, border-, ring-, from-, to-, via-,
  *    [background:, [border-color:) are NOT matched — surface wash stops
  *    remain addressable there.
  */
-const RAW_STOP_RE = /--foreground-(40|50|60|70|80|90|95)\b/g;
+const RAW_STOP_THEME_RE = /--(?:color-)?foreground-(40|50|60|70|80|90|95)\b/g;
 
 /** Utility prefixes that set TEXT color. */
 const TEXT_PREFIXES = new Set(['text', 'fill', 'stroke', 'caret', 'decoration']);
@@ -148,15 +185,49 @@ function isBareTextProperty(cls: string): boolean {
 /** Utility class form: text-foreground-N (no --). Captures N. */
 const UTILITY_CLASS_RE = /^(?:text|fill|stroke|caret|decoration)-foreground-(\d+)/;
 
-/** Inline-style declaration: color/fill/stroke: ... var(--foreground-N) ...
- *  Value may be quoted ("...", '...', `...`) or bare. */
-const INLINE_STYLE_RE = /(?:^|[\s;{])(?:color|fill|stroke)\s*:\s*["'`]?\s*var\(\s*--foreground-(\d+)/gi;
-
 /** Splits source into class-like tokens (non-whitespace, non-quote, non-brace). */
 const TOKEN_RE = /[^\s"'`;{}=]+/g;
 
-/** Find --foreground-N (any N) inside a token string. */
-const FG_IN_TOKEN_RE = /--foreground-(\d+)\b/g;
+/** Find --(?:color-)?foreground-N (any N) inside a token string. */
+const FG_IN_TOKEN_RE = /--(?:color-)?foreground-(\d+)\b/g;
+
+/** Text-like property names (kebab-case CSS + camelCase JS). */
+const TEXT_PROP_NAMES_RE = /\b(?:color|fill|stroke|caretColor|textDecorationColor|columnRuleColor|caret-color|text-decoration-color|column-rule-color)\b/i;
+
+/**
+ * Scan inline-style declarations and JSX attributes for text-like
+ * properties whose value references a foreground stop.
+ *
+ * Locates the property name (preceded by `{`, `,`, `<`, or whitespace
+ * to avoid matching inside Tailwind class tokens), then extracts the
+ * full value (quoted or bare) and searches for foreground tokens.
+ */
+function scanTextPropValue(src: string): string[] {
+  const offenders: string[] = [];
+  // Match prop name preceded by {, ,, <, whitespace (not inside [...])
+  // followed by : (inline style) or = (JSX attr)
+  const propRe = /(?:[{,]\s*|^\s*|\s)(color|fill|stroke|caretColor|textDecorationColor|columnRuleColor|caret-color|text-decoration-color|column-rule-color)\s*[:=]\s*/gi;
+  let m: RegExpExecArray | null;
+  while ((m = propRe.exec(src)) !== null) {
+    let i = m.index + m[0].length;
+    let quote = '';
+    if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
+      quote = src[i]!;
+      i++;
+    }
+    let val = '';
+    if (quote) {
+      while (i < src.length && src[i] !== quote) { val += src[i]!; i++; }
+    } else {
+      while (i < src.length && !/[\};,\n]/.test(src[i]!)) { val += src[i]!; i++; }
+    }
+    for (const fm of val.matchAll(FG_IN_TOKEN_RE)) {
+      const num = fm[1]!;
+      offenders.push(`text-prop --foreground-${num}`);
+    }
+  }
+  return offenders;
+}
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
@@ -188,13 +259,14 @@ function scanTsx(src: string): string[] {
   const offenders: string[] = [];
   const surfaceSet = new Set(SURFACE_WASH_NUMS);
 
-  // 1. Deleted stops: banned in any context.
-  for (const m of src.matchAll(RAW_STOP_RE)) {
+  // 1. Deleted stops (incl. --color-foreground-N mirror): banned anywhere.
+  for (const m of src.matchAll(RAW_STOP_THEME_RE)) {
     offenders.push(`--foreground-${m[1]}`);
   }
 
   // 2. Class-like tokens: check if text-like context, then search for
-  //    --foreground-N anywhere inside (handles complex arbitrary values).
+  //    --(?:color-)?foreground-N anywhere inside (handles complex
+  //    arbitrary values like color-mix() wrapping).
   for (const m of src.matchAll(TOKEN_RE)) {
     const tok = m[0];
     if (!tok.includes('foreground')) continue;
@@ -206,7 +278,7 @@ function scanTsx(src: string): string[] {
       offenders.push(`text-foreground-${um[1]}`);
     }
 
-    // CSS var form: --foreground-N anywhere in token — ban surface wash.
+    // CSS var form: --(?:color-)?foreground-N anywhere in token — ban surface wash.
     for (const fm of tok.matchAll(FG_IN_TOKEN_RE)) {
       const num = fm[1]!;
       if (surfaceSet.has(num)) {
@@ -215,15 +287,10 @@ function scanTsx(src: string): string[] {
     }
   }
 
-  // 3. Inline-style: color/fill/stroke: var(--foreground-N) — value may
-  //    span whitespace (e.g. "color: var(--foreground-5)").
-  INLINE_STYLE_RE.lastIndex = 0;
-  for (const m of src.matchAll(INLINE_STYLE_RE)) {
-    const num = m[1]!;
-    if (surfaceSet.has(num) || BANNED_TEXT_NUMS.includes(num)) {
-      offenders.push(`inline-style --foreground-${num}`);
-    }
-  }
+  // 3. Text-property values: inline style (style={{ color: "..." }})
+  //    and JSX attributes (fill="...", stroke={...}). Scans the full
+  //    value for foreground tokens, handles camelCase + complex values.
+  offenders.push(...scanTextPropValue(src));
 
   return offenders;
 }
@@ -258,7 +325,7 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
   it('renderer CSS has no deleted raw --foreground-40..95 (any context)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     const offenders: string[] = [];
-    for (const m of css.matchAll(RAW_STOP_RE)) {
+    for (const m of css.matchAll(RAW_STOP_THEME_RE)) {
       offenders.push(`renderer CSS: --foreground-${m[1]}`);
     }
     assert.deepEqual(offenders, [], `Deleted raw stops must not appear:\n  ${offenders.join('\n  ')}`);
@@ -267,7 +334,7 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
   it('maka-tokens.css has no deleted raw --foreground-40..95 (any context)', async () => {
     const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
     const offenders: string[] = [];
-    for (const m of tokens.matchAll(RAW_STOP_RE)) {
+    for (const m of tokens.matchAll(RAW_STOP_THEME_RE)) {
       offenders.push(`maka-tokens.css: --foreground-${m[1]}`);
     }
     assert.deepEqual(offenders, [], `Deleted raw stops must not appear:\n  ${offenders.join('\n  ')}`);
@@ -279,6 +346,12 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
       'packages/ui/stories',
       'apps/desktop/src/renderer',
     ]);
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('renderer CSS @apply does not use text-like foreground utilities', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssApplyOffenders(css, 'renderer CSS');
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
@@ -560,12 +633,11 @@ describe('foreground-tier negative cases', () => {
 
   // P2-a: global raw stop ban in CSS (non-text context)
   it('rejects background: var(--foreground-80) in renderer CSS (global raw ban)', async () => {
-    // Simulate by scanning a snippet with stripCssComments
-    assert.ok(stripCssComments('background: var(--foreground-80)').match(RAW_STOP_RE));
+    assert.ok(stripCssComments('background: var(--foreground-80)').match(RAW_STOP_THEME_RE));
   });
 
   it('rejects border-color: var(--foreground-60) in renderer CSS (global raw ban)', async () => {
-    assert.ok(stripCssComments('border-color: var(--foreground-60)').match(RAW_STOP_RE));
+    assert.ok(stripCssComments('border-color: var(--foreground-60)').match(RAW_STOP_THEME_RE));
   });
 
   // P2: complex Tailwind variants must be stripped correctly
@@ -604,5 +676,60 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts style={{ background: "var(--foreground-5)" }} in TSX (bg inline)', () => {
     assert.deepEqual(scanTsxSnippet('style={{ background: "var(--foreground-5)" }}'), []);
+  });
+
+  // P2-a: --color-foreground-N theme mirror must be caught as text color
+  it('rejects text-[color:var(--color-foreground-5)] in TSX (theme mirror)', () => {
+    assert.ok(scanTsxSnippet("text-[color:var(--color-foreground-5)]").length > 0);
+  });
+
+  it('rejects color: var(--color-foreground-5) in CSS (theme mirror text prop)', () => {
+    assert.ok(findCssTextOffenders('color: var(--color-foreground-5)', 'test').length > 0);
+  });
+
+  it('rejects style={{ color: "var(--color-foreground-5)" }} in TSX (theme mirror inline)', () => {
+    assert.ok(scanTsxSnippet('style={{ color: "var(--color-foreground-5)" }}').length > 0);
+  });
+
+  it('accepts background: var(--color-foreground-5) in CSS (theme mirror bg)', () => {
+    assert.deepEqual(findCssTextOffenders('background: var(--color-foreground-5)', 'test'), []);
+  });
+
+  it('accepts bg-[color:var(--color-foreground-5)] in TSX (theme mirror surface)', () => {
+    assert.deepEqual(scanTsxSnippet("bg-[color:var(--color-foreground-5)]"), []);
+  });
+
+  // P2-b: @apply with text-like foreground utility
+  it('rejects @apply text-foreground-5; in CSS', () => {
+    assert.ok(findCssApplyOffenders('@apply text-foreground-5;', 'test').length > 0);
+  });
+
+  it('rejects @apply fill-foreground-5; in CSS', () => {
+    assert.ok(findCssApplyOffenders('@apply fill-foreground-5;', 'test').length > 0);
+  });
+
+  it('rejects @apply text-[color:var(--foreground-5)]; in CSS', () => {
+    assert.ok(findCssApplyOffenders('@apply text-[color:var(--foreground-5)];', 'test').length > 0);
+  });
+
+  it('accepts @apply bg-foreground-5 border-foreground-10; in CSS (surface)', () => {
+    assert.deepEqual(findCssApplyOffenders('@apply bg-foreground-5 border-foreground-10;', 'test'), []);
+  });
+
+  // P2-c: complex inline style value + camelCase + SVG attrs
+  it('rejects style={{ color: `color-mix(in oklch, var(--foreground-5), var(--background))` }} in TSX', () => {
+    assert.ok(scanTsxSnippet('style={{ color: `color-mix(in oklch, var(--foreground-5), var(--background))` }}').length > 0);
+  });
+
+  it('rejects style={{ caretColor: "var(--foreground-5)" }} in TSX (camelCase)', () => {
+    assert.ok(scanTsxSnippet('style={{ caretColor: "var(--foreground-5)" }}').length > 0);
+  });
+
+  it('rejects <path fill="var(--foreground-5)" /> in TSX (SVG attr)', () => {
+    assert.ok(scanTsxSnippet('<path fill="var(--foreground-5)" />').length > 0);
+  });
+
+  it('rejects <path stroke={"var(--foreground-5)"} /> in TSX (SVG attr expression)', () => {
+    assert.ok(scanTsxSnippet('<path stroke={"var(--foreground-5)"} />').length > 0);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -40,9 +40,6 @@ const BANNED_TEXT_NUMS = ['40', '50', '60', '70', '80', '90', '95'];
 /** Surface-wash numbers — allowed in bg/border context, banned in text context. */
 const SURFACE_WASH_NUMS = ['2', '3', '5', '8', '10'];
 
-/** All banned numbers for TSX (text + surface, since TSX can't distinguish context). */
-const ALL_BANNED_NUMS = [...BANNED_TEXT_NUMS, ...SURFACE_WASH_NUMS];
-
 // Properties that set TEXT color (not background/border/shadow).
 const TEXT_PROP_RE = /^(color|fill|stroke|caret-color|text-decoration-color|column-rule-color)$/i;
 
@@ -58,13 +55,18 @@ const FOREGROUND_TOKEN_RE = /--foreground-(\d+)\b/g;
  * the 3 semantic aliases (--foreground, --foreground-secondary,
  * --muted-foreground). Surface wash stops are banned in text context
  * but allowed in bg/border context.
+ *
+ * Declaration values may span multiple lines (e.g. color-mix() with
+ * line breaks). The value regex matches [^;}]+ so newlines are
+ * included.
  */
 function findCssTextOffenders(css: string, label: string): string[] {
   const stripped = stripCssComments(css);
   const offenders: string[] = [];
   const bannedNumsSet = new Set(BANNED_TEXT_NUMS.concat(SURFACE_WASH_NUMS));
 
-  const declRe = /([\w-]+)\s*:\s*([^;}\n]+?)\s*(?:[;}|\n]|$)/gi;
+  // Value may span multiple lines — stop at ; or } (or EOF).
+  const declRe = /([\w-]+)\s*:\s*([^;}]+?)\s*(?:[;}]|$)/gi;
   for (const m of stripped.matchAll(declRe)) {
     const prop = m[1]!;
     const rawVal = m[2]!.trim();
@@ -89,76 +91,61 @@ function findCssTextOffenders(css: string, label: string): string[] {
  * 1. RAW_STOP_RE: --foreground-40..95 are deleted; ban them from TS/TSX
  *    entirely (any syntax form, any context).
  *
- * 2. TEXT_CONTEXT_RE: surface wash stops (2/3/5/8/10) are allowed in
- *    surface context (bg-/background/border-/ring-/from-/to-/via-) but
- *    banned in text-like context. We match any occurrence of
- *    --foreground-N preceded by a text-like utility prefix, regardless
- *    of the surrounding Tailwind syntax (arbitrary value, shorthand,
- *    inline style, var with fallback, etc.).
+ * 2. Token-based context scan: split source into class-like tokens, then
+ *    classify each token as text-like or surface-like by its prefix.
+ *    Text-like tokens (text/fill/stroke/caret/decoration prefix, or bare
+ *    [color:...] arbitrary property) trigger a search for --foreground-N
+ *    anywhere inside the token — not just right after the prefix. This
+ *    catches complex arbitrary values like
+ *    text-[color:color-mix(in_oklch,var(--foreground-5),...)].
  *
- *    Text-like prefixes: text-, fill-, stroke-, caret-, decoration-,
- *    color: (inline style), [color: (arbitrary property), and the
- *    Tailwind v4 shorthand type-hint form text-(color:...).
- *
- *    This approach does NOT depend on var() being properly closed,
- *    so `var(--foreground-5, currentColor)` is caught.
+ *    Inline-style declarations (color:/fill:/stroke: followed by a value
+ *    that may span whitespace) are scanned separately, since the
+ *    property name and value can be split across tokens by whitespace.
  *
  *    Surface-context prefixes (bg-, border-, ring-, from-, to-, via-,
- *    background:, [background:, [border:) are NOT matched — surface
- *    wash stops remain addressable there.
+ *    [background:, [border-color:) are NOT matched — surface wash stops
+ *    remain addressable there.
  */
 const RAW_STOP_RE = /--foreground-(40|50|60|70|80|90|95)\b/g;
 
+/** Utility prefixes that set TEXT color. */
+const TEXT_PREFIXES = new Set(['text', 'fill', 'stroke', 'caret', 'decoration']);
+
 /**
- * TEXT_CONTEXT_RE: matches surface wash stops (2/3/5/8/10) when preceded
- * by a text-like context. Matches the full sequence from prefix to token,
- * capturing N. Does NOT depend on var() being properly closed.
- *
- * Text-like prefixes matched:
- *   text-foreground-N          (utility class)
- *   text-[color:var(--fg-N)]   (arbitrary value)
- *   text-[var(--fg-N)]         (arbitrary value, no color:)
- *   text-(--fg-N)              (shorthand)
- *   text-(color:--fg-N)       (type-hint shorthand)
- *   fill/stroke/caret/decoration-foreground-N
- *   fill/stroke-[...var(--fg-N)]
- *   fill/stroke-(--fg-N)
- *   [color:var(--fg-N)]        (arbitrary property)
- *   color: var(--fg-N)         (inline style)
- *   color: var(--fg-N, ...)    (inline style w/ fallback)
- *
- * Surface prefixes NOT matched (allowed):
- *   bg-foreground-N, bg-[var(--fg-N)], border-foreground-N,
- *   background: var(--fg-N), [background:var(--fg-N)]
- *
- * The regex has three alternatives:
- * A) Utility class form: (text|fill|stroke|caret|decoration)-foreground-N
- * B) Arbitrary value / shorthand form with bracket or paren:
- *    (text|fill|stroke|caret|decoration)-[\( or \[](?:color:)?var?...--foreground-N
- *    Also covers bare [color:var(--fg-N)] (no utility prefix).
- * C) Inline style: color/fill/stroke: "...var(--fg-N"
+ * Strip Tailwind variant prefixes (hover:, sm:, disabled:, group-hover:,
+ * etc.) from a class token. Handles stacked variants.
  */
-const TEXT_CONTEXT_RE = new RegExp(
-  // A) utility class: text-foreground-5, fill-foreground-5, etc.
-  '(?:text|fill|stroke|caret|decoration)-foreground-(\\d+)'
-  // B) arbitrary value or shorthand with text-like utility prefix:
-  //    text-[color:var(--fg-N)], text-[var(--fg-N)], text-(--fg-N),
-  //    text-(color:--fg-N), fill-[...], stroke-(...)
-  + '|(?:text|fill|stroke|caret|decoration)-[(\\[](?:color:)?(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
-  // C) arbitrary property (no utility prefix): [color:var(--fg-N)]
-  //    Must start with [color: to distinguish from bg-[var(--fg-N)]
-  //    and [border-color:...] / [background-color:...].
-  + '|\\[color:(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
-  // D) inline style: the property name must be exactly color/fill/stroke
-  //    (not border-color or background-color). Require the property
-  //    name to start at a declaration boundary (^, whitespace, ;, {, ").
-  //    Matches: color: var(--fg-N, color: "var(--fg-N
-  + '|(?:^|\\s|;\\s*|\\{\\s*|["\']\\s*)(?:color|fill|stroke)\\s*:\\s*["\']?var\\(\\s*--foreground-(\\d+)'
-  // E) arbitrary property for text-like CSS props: [caret-color:...],
-  //    [text-decoration-color:...]. These have hyphenated property names
-  //    that D won't catch.
-  + '|\\[(?:caret-color|text-decoration-color|column-rule-color):(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
-  , 'g');
+function stripVariant(cls: string): string {
+  let s = cls;
+  while (/^[a-z][a-z-]*:/.test(s)) s = s.replace(/^[a-z][a-z-]*:/, '');
+  return s;
+}
+
+/** Does this class token have a text-like utility prefix? */
+function isTextLikeClass(cls: string): boolean {
+  const m = stripVariant(cls).match(/^([a-z]+)/);
+  return m !== null && TEXT_PREFIXES.has(m[1]!);
+}
+
+/** Bare arbitrary property setting text color: [color:...], [caret-color:...], etc. */
+const BARE_TEXT_PROP_RE = /^\[(color|caret-color|text-decoration-color|column-rule-color):/i;
+
+function isBareTextProperty(cls: string): boolean {
+  return BARE_TEXT_PROP_RE.test(stripVariant(cls));
+}
+
+/** Utility class form: text-foreground-N (no --). Captures N. */
+const UTILITY_CLASS_RE = /^(?:text|fill|stroke|caret|decoration)-foreground-(\d+)/;
+
+/** Inline-style declaration: color/fill/stroke: ... var(--foreground-N) ... */
+const INLINE_STYLE_RE = /(?:^|[\s;{])(?:color|fill|stroke)\s*:\s*var\(\s*--foreground-(\d+)/gi;
+
+/** Splits source into class-like tokens (non-whitespace, non-quote, non-brace). */
+const TOKEN_RE = /[^\s"'`;{}=]+/g;
+
+/** Find --foreground-N (any N) inside a token string. */
+const FG_IN_TOKEN_RE = /--foreground-(\d+)\b/g;
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
@@ -176,26 +163,7 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
       if (entry.name.includes('.test.')) continue;
       const src = await readFile(full, 'utf8');
       const label = full.replace(REPO_ROOT + '/', '');
-
-      // Deleted stops: banned in any context.
-      for (const m of src.matchAll(RAW_STOP_RE)) {
-        offenders.push(`${label}: --foreground-${m[1]}`);
-      }
-      // Surface wash in text-like context, OR any text-foreground-N
-      // utility class (all N banned as text, not just surface wash).
-      for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
-        const num = m[1] || m[2] || m[3] || m[4] || m[5];
-        if (!num) continue;
-        // Alternative A (utility class): ban all N — deleted stops
-        // (40..95) and surface wash (2/3/5/8/10) alike.
-        if (m[1]) {
-          offenders.push(`${label}: text-foreground-${num}`);
-        }
-        // Alternatives B/C/D/E: only surface wash banned in text context.
-        else if (surfaceSet.has(num)) {
-          offenders.push(`${label}: text-context --foreground-${num}`);
-        }
-      }
+      offenders.push(...scanTsx(src).map((o) => `${label}: ${o}`));
     }
   }
   for (const dir of dirs) {
@@ -204,25 +172,56 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   return offenders;
 }
 
+/** Scan TS/TSX source for banned foreground references. Returns offender strings. */
+function scanTsx(src: string): string[] {
+  const offenders: string[] = [];
+  const surfaceSet = new Set(SURFACE_WASH_NUMS);
+
+  // 1. Deleted stops: banned in any context.
+  for (const m of src.matchAll(RAW_STOP_RE)) {
+    offenders.push(`--foreground-${m[1]}`);
+  }
+
+  // 2. Class-like tokens: check if text-like context, then search for
+  //    --foreground-N anywhere inside (handles complex arbitrary values).
+  for (const m of src.matchAll(TOKEN_RE)) {
+    const tok = m[0];
+    if (!tok.includes('foreground')) continue;
+    if (!isTextLikeClass(tok) && !isBareTextProperty(tok)) continue;
+
+    // Utility class form: text-foreground-N (no -- prefix) — ban all N.
+    const um = stripVariant(tok).match(UTILITY_CLASS_RE);
+    if (um) {
+      offenders.push(`text-foreground-${um[1]}`);
+    }
+
+    // CSS var form: --foreground-N anywhere in token — ban surface wash.
+    for (const fm of tok.matchAll(FG_IN_TOKEN_RE)) {
+      const num = fm[1]!;
+      if (surfaceSet.has(num)) {
+        offenders.push(`text-context --foreground-${num}`);
+      }
+    }
+  }
+
+  // 3. Inline-style: color/fill/stroke: var(--foreground-N) — value may
+  //    span whitespace (e.g. "color: var(--foreground-5)").
+  INLINE_STYLE_RE.lastIndex = 0;
+  for (const m of src.matchAll(INLINE_STYLE_RE)) {
+    const num = m[1]!;
+    if (surfaceSet.has(num) || BANNED_TEXT_NUMS.includes(num)) {
+      offenders.push(`inline-style --foreground-${num}`);
+    }
+  }
+
+  return offenders;
+}
+
 // === tests ==================================================================
 
 /** Scan a TSX source snippet for banned foreground references. */
 function scanTsxSnippet(src: string): string[] {
-  const offenders: string[] = [];
-  const surfaceSet = new Set(SURFACE_WASH_NUMS);
-  for (const m of src.matchAll(RAW_STOP_RE)) {
-    offenders.push(`--foreground-${m[1]}`);
-  }
-  for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
-    const num = m[1] || m[2] || m[3] || m[4] || m[5];
-    if (!num) continue;
-    if (m[1]) {
-      offenders.push(`text-foreground-${num}`);
-    } else if (surfaceSet.has(num)) {
-      offenders.push(`text-context --foreground-${num}`);
-    }
-  }
-  return offenders;
+  return scanTsx(src);
 }
 
 describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
@@ -243,6 +242,24 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
       .replace(/^\s*--color-muted-foreground:.*$/gm, '');
     const offenders = findCssTextOffenders(stripped, 'maka-tokens.css');
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('renderer CSS has no deleted raw --foreground-40..95 (any context)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const offenders: string[] = [];
+    for (const m of css.matchAll(RAW_STOP_RE)) {
+      offenders.push(`renderer CSS: --foreground-${m[1]}`);
+    }
+    assert.deepEqual(offenders, [], `Deleted raw stops must not appear:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css has no deleted raw --foreground-40..95 (any context)', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const offenders: string[] = [];
+    for (const m of tokens.matchAll(RAW_STOP_RE)) {
+      offenders.push(`maka-tokens.css: --foreground-${m[1]}`);
+    }
+    assert.deepEqual(offenders, [], `Deleted raw stops must not appear:\n  ${offenders.join('\n  ')}`);
   });
 
   it('TSX text-color uses semantic aliases, not raw --foreground-40..80', async () => {
@@ -488,5 +505,55 @@ describe('foreground-tier negative cases', () => {
       const re = new RegExp(`--color-foreground-${num}\\s*:`);
       assert.doesNotMatch(tokens, re, `@theme must not export --color-foreground-${num}`);
     }
+  });
+
+  // P3-a: surface utility with [color:] type hint must pass
+  it('accepts border-[color:var(--foreground-10)] in TSX (border w/ color type hint)', () => {
+    assert.deepEqual(scanTsxSnippet("border-[color:var(--foreground-10)]"), []);
+  });
+
+  it('accepts bg-[color:var(--foreground-5)] in TSX (bg w/ color type hint)', () => {
+    assert.deepEqual(scanTsxSnippet("bg-[color:var(--foreground-5)]"), []);
+  });
+
+  it('accepts ring-[color:var(--foreground-5)] in TSX (ring w/ color type hint)', () => {
+    assert.deepEqual(scanTsxSnippet("ring-[color:var(--foreground-5)]"), []);
+  });
+
+  // P2-b: complex arbitrary value — token must be found anywhere in payload
+  it('rejects text-[color:color-mix(in_oklch,var(--foreground-5),var(--background))] in TSX', () => {
+    assert.ok(scanTsxSnippet("text-[color:color-mix(in_oklch,var(--foreground-5),var(--background))]").length > 0);
+  });
+
+  it('rejects text-[oklch(from_var(--foreground-5)_l_c_h)] in TSX', () => {
+    assert.ok(scanTsxSnippet("text-[oklch(from_var(--foreground-5)_l_c_h)]").length > 0);
+  });
+
+  // P2-b: CSS multi-line declaration value
+  it('rejects multi-line color: color-mix(...,var(--foreground-5),...) in CSS', () => {
+    const css = `color:
+  color-mix(in oklch,
+    var(--foreground-5),
+    var(--background));`;
+    assert.ok(findCssTextOffenders(css, 'test').length > 0);
+  });
+
+  it('rejects multi-line color: color-mix(...,var(--foreground-5) 50%,...) in CSS', () => {
+    const css = `color: color-mix(
+  in oklch,
+  var(--foreground-5) 50%,
+  var(--background)
+);`;
+    assert.ok(findCssTextOffenders(css, 'test').length > 0);
+  });
+
+  // P2-a: global raw stop ban in CSS (non-text context)
+  it('rejects background: var(--foreground-80) in renderer CSS (global raw ban)', async () => {
+    // Simulate by scanning a snippet with stripCssComments
+    assert.ok(stripCssComments('background: var(--foreground-80)').match(RAW_STOP_RE));
+  });
+
+  it('rejects border-color: var(--foreground-60) in renderer CSS (global raw ban)', async () => {
+    assert.ok(stripCssComments('border-color: var(--foreground-60)').match(RAW_STOP_RE));
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -175,8 +175,9 @@ function isTextLikeClass(cls: string): boolean {
   return m !== null && TEXT_PREFIXES.has(m[1]!);
 }
 
-/** Bare arbitrary property setting text color: [color:...], [caret-color:...], etc. */
-const BARE_TEXT_PROP_RE = /^\[(color|caret-color|text-decoration-color|column-rule-color):/i;
+/** Bare arbitrary property setting text color: [color:...], [fill:...],
+ *  [stroke:...], [caret-color:...], etc. */
+const BARE_TEXT_PROP_RE = /^\[(color|fill|stroke|caret-color|text-decoration-color|column-rule-color):/i;
 
 function isBareTextProperty(cls: string): boolean {
   return BARE_TEXT_PROP_RE.test(stripVariant(cls));
@@ -191,8 +192,13 @@ const TOKEN_RE = /[^\s"'`;{}=]+/g;
 /** Find --(?:color-)?foreground-N (any N) inside a token string. */
 const FG_IN_TOKEN_RE = /--(?:color-)?foreground-(\d+)\b/g;
 
-/** Text-like property names (kebab-case CSS + camelCase JS). */
-const TEXT_PROP_NAMES_RE = /\b(?:color|fill|stroke|caretColor|textDecorationColor|columnRuleColor|caret-color|text-decoration-color|column-rule-color)\b/i;
+/** Text-like property names (kebab-case CSS + camelCase JS + SVG attrs).
+ *  Shared by scanTextPropValue and BARE_TEXT_PROP_RE to avoid drift. */
+const TEXT_PROP_NAMES = [
+  'color', 'fill', 'stroke',
+  'caret-color', 'text-decoration-color', 'column-rule-color',
+  'caretColor', 'textDecorationColor', 'columnRuleColor',
+];
 
 /**
  * Scan inline-style declarations and JSX attributes for text-like
@@ -200,13 +206,17 @@ const TEXT_PROP_NAMES_RE = /\b(?:color|fill|stroke|caretColor|textDecorationColo
  *
  * Locates the property name (preceded by `{`, `,`, `<`, or whitespace
  * to avoid matching inside Tailwind class tokens), then extracts the
- * full value (quoted or bare) and searches for foreground tokens.
+ * full value:
+ *  - Quoted ("...' / '...' / `...`): scan until closing quote
+ *  - Unquoted expression: scan with bracket depth tracking, stop at
+ *    matching `}` (depth 0), `;`, or newline — so commas inside
+ *    function calls (e.g. pick(base, "var(--foreground-5)")) are
+ *    included.
  */
 function scanTextPropValue(src: string): string[] {
   const offenders: string[] = [];
-  // Match prop name preceded by {, ,, <, whitespace (not inside [...])
-  // followed by : (inline style) or = (JSX attr)
-  const propRe = /(?:[{,]\s*|^\s*|\s)(color|fill|stroke|caretColor|textDecorationColor|columnRuleColor|caret-color|text-decoration-color|column-rule-color)\s*[:=]\s*/gi;
+  const namesAlt = TEXT_PROP_NAMES.join('|');
+  const propRe = new RegExp(`(?:[{,]\\s*|^\\s*|\\s)(${namesAlt})\\s*[:=]\\s*`, 'gi');
   let m: RegExpExecArray | null;
   while ((m = propRe.exec(src)) !== null) {
     let i = m.index + m[0].length;
@@ -219,7 +229,15 @@ function scanTextPropValue(src: string): string[] {
     if (quote) {
       while (i < src.length && src[i] !== quote) { val += src[i]!; i++; }
     } else {
-      while (i < src.length && !/[\};,\n]/.test(src[i]!)) { val += src[i]!; i++; }
+      let depth = 0;
+      while (i < src.length) {
+        const c = src[i]!;
+        if (c === '{' || c === '(') depth++;
+        else if (c === '}' && depth === 0) break;
+        else if (c === '}') depth--;
+        else if (c === ';' || c === '\n') break;
+        val += c; i++;
+      }
     }
     for (const fm of val.matchAll(FG_IN_TOKEN_RE)) {
       const num = fm[1]!;
@@ -731,5 +749,39 @@ describe('foreground-tier negative cases', () => {
 
   it('rejects <path stroke={"var(--foreground-5)"} /> in TSX (SVG attr expression)', () => {
     assert.ok(scanTsxSnippet('<path stroke={"var(--foreground-5)"} />').length > 0);
+  });
+
+  // P2: bare arbitrary property [fill:] / [stroke:] must be caught
+  it('rejects [fill:var(--foreground-5)] in TSX (bare arbitrary property)', () => {
+    assert.ok(scanTsxSnippet("[fill:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects [stroke:var(--foreground-5)] in TSX (bare arbitrary property)', () => {
+    assert.ok(scanTsxSnippet("[stroke:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects hover:[fill:var(--color-foreground-5)] in TSX (variant + theme mirror)', () => {
+    assert.ok(scanTsxSnippet("hover:[fill:var(--color-foreground-5)]").length > 0);
+  });
+
+  it('accepts [background:var(--foreground-5)] in TSX (bg bare property)', () => {
+    assert.deepEqual(scanTsxSnippet("[background:var(--foreground-5)]"), []);
+  });
+
+  it('accepts [border-color:var(--foreground-10)] in TSX (border bare property)', () => {
+    assert.deepEqual(scanTsxSnippet("[border-color:var(--foreground-10)]"), []);
+  });
+
+  // P2: unquoted complex expression in inline style / JSX attr
+  it('rejects style={{ color: pick(base, "var(--foreground-5)") }} in TSX (unquoted expr)', () => {
+    assert.ok(scanTsxSnippet('style={{ color: pick(base, "var(--foreground-5)") }}').length > 0);
+  });
+
+  it('rejects <path fill={pick(base, "var(--foreground-5)")} /> in TSX (JSX expr)', () => {
+    assert.ok(scanTsxSnippet('<path fill={pick(base, "var(--foreground-5)")} />').length > 0);
+  });
+
+  it('accepts style={{ background: pick(base, "var(--foreground-5)") }} in TSX (bg expr)', () => {
+    assert.deepEqual(scanTsxSnippet('style={{ background: pick(base, "var(--foreground-5)") }}'), []);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -114,12 +114,22 @@ const TEXT_PREFIXES = new Set(['text', 'fill', 'stroke', 'caret', 'decoration'])
 
 /**
  * Strip Tailwind variant prefixes (hover:, sm:, disabled:, group-hover:,
- * etc.) from a class token. Handles stacked variants.
+ * data-[...]:, [&...]:, named-group /name, etc.) from a class token.
+ *
+ * Strategy: scan from right to left, tracking bracket/paren depth, and
+ * cut at the last `:` that is outside any `[]`/`()` nesting. This
+ * uniformly handles arbitrary variants like `data-[state=open]:` and
+ * `[&.is-dragging]:` without hand-writing a regex per variant form.
  */
 function stripVariant(cls: string): string {
-  let s = cls;
-  while (/^[a-z][a-z-]*:/.test(s)) s = s.replace(/^[a-z][a-z-]*:/, '');
-  return s;
+  let depth = 0;
+  for (let i = cls.length - 1; i >= 0; i--) {
+    const c = cls[i];
+    if (c === ']' || c === ')') depth++;
+    else if (c === '[' || c === '(') depth--;
+    else if (c === ':' && depth === 0) return cls.slice(i + 1);
+  }
+  return cls;
 }
 
 /** Does this class token have a text-like utility prefix? */
@@ -138,8 +148,9 @@ function isBareTextProperty(cls: string): boolean {
 /** Utility class form: text-foreground-N (no --). Captures N. */
 const UTILITY_CLASS_RE = /^(?:text|fill|stroke|caret|decoration)-foreground-(\d+)/;
 
-/** Inline-style declaration: color/fill/stroke: ... var(--foreground-N) ... */
-const INLINE_STYLE_RE = /(?:^|[\s;{])(?:color|fill|stroke)\s*:\s*var\(\s*--foreground-(\d+)/gi;
+/** Inline-style declaration: color/fill/stroke: ... var(--foreground-N) ...
+ *  Value may be quoted ("...", '...', `...`) or bare. */
+const INLINE_STYLE_RE = /(?:^|[\s;{])(?:color|fill|stroke)\s*:\s*["'`]?\s*var\(\s*--foreground-(\d+)/gi;
 
 /** Splits source into class-like tokens (non-whitespace, non-quote, non-brace). */
 const TOKEN_RE = /[^\s"'`;{}=]+/g;
@@ -555,5 +566,43 @@ describe('foreground-tier negative cases', () => {
 
   it('rejects border-color: var(--foreground-60) in renderer CSS (global raw ban)', async () => {
     assert.ok(stripCssComments('border-color: var(--foreground-60)').match(RAW_STOP_RE));
+  });
+
+  // P2: complex Tailwind variants must be stripped correctly
+  it('rejects data-[state=open]:text-[color:var(--foreground-5)] in TSX', () => {
+    assert.ok(scanTsxSnippet("data-[state=open]:text-[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects group-hover/item:text-[color:var(--foreground-5)] in TSX', () => {
+    assert.ok(scanTsxSnippet("group-hover/item:text-[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects [&.is-dragging]:text-[color:var(--foreground-5)] in TSX', () => {
+    assert.ok(scanTsxSnippet("[&.is-dragging]:text-[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('accepts data-[state=open]:bg-[color:var(--foreground-5)] in TSX (surface variant)', () => {
+    assert.deepEqual(scanTsxSnippet("data-[state=open]:bg-[color:var(--foreground-5)]"), []);
+  });
+
+  it('accepts data-[state=open]:border-[color:var(--foreground-10)] in TSX (surface variant)', () => {
+    assert.deepEqual(scanTsxSnippet("data-[state=open]:border-[color:var(--foreground-10)]"), []);
+  });
+
+  // P2: quoted inline style — surface wash as text color
+  it('rejects style={{ color: "var(--foreground-5)" }} in TSX (quoted inline)', () => {
+    assert.ok(scanTsxSnippet('style={{ color: "var(--foreground-5)" }}').length > 0);
+  });
+
+  it('rejects style={{ color: `var(--foreground-5)` }} in TSX (template literal inline)', () => {
+    assert.ok(scanTsxSnippet('style={{ color: `var(--foreground-5)` }}').length > 0);
+  });
+
+  it('rejects style={{ fill: \'var(--foreground-5)\' }} in TSX (single-quoted inline)', () => {
+    assert.ok(scanTsxSnippet("style={{ fill: 'var(--foreground-5)' }}").length > 0);
+  });
+
+  it('accepts style={{ background: "var(--foreground-5)" }} in TSX (bg inline)', () => {
+    assert.deepEqual(scanTsxSnippet('style={{ background: "var(--foreground-5)" }}'), []);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -80,9 +80,29 @@ function findCssTextOffenders(css: string, label: string): string[] {
 
 // --- TSX scanning -----------------------------------------------------------
 
-const TSX_TEXT_RE = /(?:text|color|fill|stroke)\[color:var\(\s*(--foreground-\d+)\s*\)\]/g;
+/**
+ * Tailwind arbitrary value referencing a raw foreground mix stop.
+ * Matches any utility (text, color, fill, stroke, bg, border, etc.)
+ * with optional variant prefix (disabled:, hover:, etc.) and optional
+ * `color:` inner prefix:
+ *   text-[color:var(--foreground-60)]     ✓ caught
+ *   text-[var(--foreground-60)]            ✓ caught
+ *   disabled:text-[var(--foreground-40)]  ✓ caught
+ *   bg-[var(--foreground-50)]             ✓ caught
+ *
+ * Note: the utility name is followed by `-[` (e.g. `text-[`), not `[`
+ * directly — the `-` is the Tailwind arbitrary value separator.
+ */
+const TSX_ARBITRARY_RE = /(?:^|\s|:)(?:text|color|fill|stroke|bg|border|ring|from|to|via)-\[(?:color:)?var\(\s*(--foreground-\d+)\s*\)\]/g;
 
-async function collectTsxOffenders(): Promise<string[]> {
+/**
+ * Tailwind utility-class form: text-foreground-40, bg-foreground-50, etc.
+ * These should not exist once @theme stops exporting the raw stops,
+ * but the regex catches them defensively if someone re-adds the export.
+ */
+const TSX_UTILITY_RE = /(?:^|\s|:)(?:text|bg|border|fill|stroke|ring|from|to|via)-foreground-(\d+)\b/g;
+
+async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
   async function walk(dir: string): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
@@ -98,11 +118,21 @@ async function collectTsxOffenders(): Promise<string[]> {
       const src = await readFile(full, 'utf8');
       const label = full.replace(REPO_ROOT + '/', '');
 
-      // Tailwind arbitrary value: text-[color:var(--foreground-N)] / color-[...]
-      for (const m of src.matchAll(TSX_TEXT_RE)) {
+      // Tailwind arbitrary value: text-[color:var(--foreground-N)],
+      // text-[var(--foreground-N)], disabled:text-[var(--foreground-N)], etc.
+      for (const m of src.matchAll(TSX_ARBITRARY_RE)) {
         const tok = m[1]!;
         if (BANNED_TEXT_STOPS.includes(tok)) {
-          offenders.push(`${label}: ${m[0]} [banned ${tok}]`);
+          offenders.push(`${label}: ${m[0].trim()} [banned ${tok}]`);
+        }
+      }
+
+      // Tailwind utility class: text-foreground-40, bg-foreground-50, etc.
+      for (const m of src.matchAll(TSX_UTILITY_RE)) {
+        const num = m[1]!;
+        const tok = `--foreground-${num}`;
+        if (BANNED_TEXT_STOPS.includes(tok)) {
+          offenders.push(`${label}: ${m[0].trim()} [banned ${tok}]`);
         }
       }
 
@@ -116,12 +146,32 @@ async function collectTsxOffenders(): Promise<string[]> {
       }
     }
   }
-  await walk(resolve(REPO_ROOT, 'packages/ui/src'));
-  await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+  for (const dir of dirs) {
+    await walk(resolve(REPO_ROOT, dir));
+  }
   return offenders;
 }
 
 // === tests ==================================================================
+
+/** Scan a TSX source snippet for banned foreground references. */
+function scanTsxSnippet(src: string): string[] {
+  const offenders: string[] = [];
+  for (const m of src.matchAll(TSX_ARBITRARY_RE)) {
+    const tok = m[1]!;
+    if (BANNED_TEXT_STOPS.includes(tok)) {
+      offenders.push(`${m[0].trim()} [banned ${tok}]`);
+    }
+  }
+  for (const m of src.matchAll(TSX_UTILITY_RE)) {
+    const num = m[1]!;
+    const tok = `--foreground-${num}`;
+    if (BANNED_TEXT_STOPS.includes(tok)) {
+      offenders.push(`${m[0].trim()} [banned ${tok}]`);
+    }
+  }
+  return offenders;
+}
 
 describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
   it('CSS text-color props use semantic aliases, not raw --foreground-40..80', async () => {
@@ -145,7 +195,11 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
   });
 
   it('TSX text-color uses semantic aliases, not raw --foreground-40..80', async () => {
-    const offenders = await collectTsxOffenders();
+    const offenders = await collectTsxOffenders([
+      'packages/ui/src',
+      'packages/ui/stories',
+      'apps/desktop/src/renderer',
+    ]);
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
@@ -172,6 +226,14 @@ describe('PR-FOREGROUND-TIER-CONVERGE-0 contract', () => {
     assert.match(tokens, /--color-foreground-secondary:\s*var\(--foreground-secondary\)/, '@theme must export --color-foreground-secondary');
     assert.match(tokens, /--color-muted-foreground:\s*var\(--muted-foreground\)/, '@theme must export --color-muted-foreground');
   });
+
+  it('@theme inline does not export raw text stops --foreground-40/50/60/70/80', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    for (const stop of BANNED_TEXT_STOPS) {
+      const re = new RegExp(`--color-${stop}:`);
+      assert.doesNotMatch(tokens, re, `@theme must not export ${stop} as a Tailwind color utility`);
+    }
+  });
 });
 
 describe('foreground-tier negative cases', () => {
@@ -194,5 +256,35 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts --foreground (100% ink) in color props', () => {
     assert.deepEqual(findCssTextOffenders('color: var(--foreground)', 'test'), []);
+  });
+
+  it('rejects text-[color:var(--foreground-60)] in TSX', () => {
+    const offenders = scanTsxSnippet("text-[color:var(--foreground-60)]");
+    assert.ok(offenders.length > 0, 'text-[color:var(--foreground-60)] must fail');
+  });
+
+  it('rejects text-[var(--foreground-60)] in TSX', () => {
+    const offenders = scanTsxSnippet("text-[var(--foreground-60)]");
+    assert.ok(offenders.length > 0, 'text-[var(--foreground-60)] must fail');
+  });
+
+  it('rejects disabled:text-[var(--foreground-40)] in TSX', () => {
+    const offenders = scanTsxSnippet("disabled:text-[var(--foreground-40)]");
+    assert.ok(offenders.length > 0, 'disabled:text-[var(--foreground-40)] must fail');
+  });
+
+  it('rejects text-foreground-60 Tailwind utility in TSX', () => {
+    const offenders = scanTsxSnippet("text-foreground-60");
+    assert.ok(offenders.length > 0, 'text-foreground-60 must fail');
+  });
+
+  it('accepts text-[color:var(--foreground-secondary)] in TSX', () => {
+    const offenders = scanTsxSnippet("text-[color:var(--foreground-secondary)]");
+    assert.deepEqual(offenders, []);
+  });
+
+  it('accepts text-[color:var(--muted-foreground)] in TSX', () => {
+    const offenders = scanTsxSnippet("text-[color:var(--muted-foreground)]");
+    assert.deepEqual(offenders, []);
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -84,27 +84,73 @@ function findCssTextOffenders(css: string, label: string): string[] {
 // --- TSX scanning -----------------------------------------------------------
 
 /**
- * RAW_STOP_RE: bans --foreground-40..95 from TS/TSX entirely (any syntax
- * form). These stops are deleted; the only valid text tokens are
- * --foreground, --foreground-secondary, --muted-foreground.
+ * Two-layer scan strategy:
  *
- * TEXT_UTILITY_RE: bans text-foreground-N (Tailwind utility class form)
- * for ALL N (2..95). Surface wash stops (2/3/5/8/10) are allowed as
- * bg-foreground-N / border-foreground-N but NOT as text-foreground-N.
+ * 1. RAW_STOP_RE: --foreground-40..95 are deleted; ban them from TS/TSX
+ *    entirely (any syntax form, any context).
  *
- * TEXT_ARBITRARY_RE: bans surface wash stops (2/3/5/8/10) when used in
- * a text-color Tailwind arbitrary value or shorthand —
- *   text-[color:var(--foreground-5)]   ✓
- *   text-[var(--foreground-5)]          ✓
- *   text-(--foreground-5)               ✓ (Tailwind v4 shorthand)
- * Inline styles (color: "var(--foreground-5)") are caught by
- * TEXT_INLINE_RE.
+ * 2. TEXT_CONTEXT_RE: surface wash stops (2/3/5/8/10) are allowed in
+ *    surface context (bg-/background/border-/ring-/from-/to-/via-) but
+ *    banned in text-like context. We match any occurrence of
+ *    --foreground-N preceded by a text-like utility prefix, regardless
+ *    of the surrounding Tailwind syntax (arbitrary value, shorthand,
+ *    inline style, var with fallback, etc.).
+ *
+ *    Text-like prefixes: text-, fill-, stroke-, caret-, decoration-,
+ *    color: (inline style), [color: (arbitrary property), and the
+ *    Tailwind v4 shorthand type-hint form text-(color:...).
+ *
+ *    This approach does NOT depend on var() being properly closed,
+ *    so `var(--foreground-5, currentColor)` is caught.
+ *
+ *    Surface-context prefixes (bg-, border-, ring-, from-, to-, via-,
+ *    background:, [background:, [border:) are NOT matched — surface
+ *    wash stops remain addressable there.
  */
 const RAW_STOP_RE = /--foreground-(40|50|60|70|80|90|95)\b/g;
-const TEXT_UTILITY_RE = /text-foreground-(\d+)\b/g;
-const TEXT_ARBITRARY_RE = /(?:text|fill|stroke)-\[(?:color:)?var\(\s*--foreground-(\d+)\s*\)\]/g;
-const TEXT_SHORTHAND_RE = /(?:text|fill|stroke)-\(\s*--foreground-(\d+)\s*\)/g;
-const TEXT_INLINE_RE = /(?:color|fill|stroke)\s*:\s*['"]var\(\s*--foreground-(\d+)\s*\)['"]/g;
+
+/**
+ * TEXT_CONTEXT_RE: matches surface wash stops (2/3/5/8/10) when preceded
+ * by a text-like context. Matches the full sequence from prefix to token,
+ * capturing N. Does NOT depend on var() being properly closed.
+ *
+ * Text-like prefixes matched:
+ *   text-foreground-N          (utility class)
+ *   text-[color:var(--fg-N)]   (arbitrary value)
+ *   text-[var(--fg-N)]         (arbitrary value, no color:)
+ *   text-(--fg-N)              (shorthand)
+ *   text-(color:--fg-N)       (type-hint shorthand)
+ *   fill/stroke/caret/decoration-foreground-N
+ *   fill/stroke-[...var(--fg-N)]
+ *   fill/stroke-(--fg-N)
+ *   [color:var(--fg-N)]        (arbitrary property)
+ *   color: var(--fg-N)         (inline style)
+ *   color: var(--fg-N, ...)    (inline style w/ fallback)
+ *
+ * Surface prefixes NOT matched (allowed):
+ *   bg-foreground-N, bg-[var(--fg-N)], border-foreground-N,
+ *   background: var(--fg-N), [background:var(--fg-N)]
+ *
+ * The regex has three alternatives:
+ * A) Utility class form: (text|fill|stroke|caret|decoration)-foreground-N
+ * B) Arbitrary value / shorthand form with bracket or paren:
+ *    (text|fill|stroke|caret|decoration)-[\( or \[](?:color:)?var?...--foreground-N
+ *    Also covers bare [color:var(--fg-N)] (no utility prefix).
+ * C) Inline style: color/fill/stroke: "...var(--fg-N"
+ */
+const TEXT_CONTEXT_RE = new RegExp(
+  // A) utility class: text-foreground-5, fill-foreground-5, etc.
+  '(?:text|fill|stroke|caret|decoration)-foreground-(\\d+)'
+  // B) arbitrary value or shorthand with text-like utility prefix:
+  //    text-[color:var(--fg-N)], text-[var(--fg-N)], text-(--fg-N),
+  //    text-(color:--fg-N), fill-[...], stroke-(...)
+  + '|(?:text|fill|stroke|caret|decoration)-[(\\[](?:color:)?(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
+  // C) arbitrary property (no utility prefix): [color:var(--fg-N)]
+  //    Must start with [color: to distinguish from bg-[var(--fg-N)].
+  + '|\\[color:(?:var\\()?(?:\\s*)?--foreground-(\\d+)'
+  // D) inline style string: color: "var(--foreground-N...", color: var(--fg-N...
+  + '|(?:color|fill|stroke)\\s*:\\s*["\']?var\\(\\s*--foreground-(\\d+)'
+  , 'g');
 
 async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
   const offenders: string[] = [];
@@ -127,26 +173,19 @@ async function collectTsxOffenders(dirs: string[]): Promise<string[]> {
       for (const m of src.matchAll(RAW_STOP_RE)) {
         offenders.push(`${label}: --foreground-${m[1]}`);
       }
-      // text-foreground-N utility class: banned for all N (text context).
-      for (const m of src.matchAll(TEXT_UTILITY_RE)) {
-        offenders.push(`${label}: text-foreground-${m[1]}`);
-      }
-      // Surface wash in text arbitrary value: text-[var(--foreground-N)]
-      for (const m of src.matchAll(TEXT_ARBITRARY_RE)) {
-        if (surfaceSet.has(m[1]!)) {
-          offenders.push(`${label}: text-context --foreground-${m[1]}`);
+      // Surface wash in text-like context, OR any text-foreground-N
+      // utility class (all N banned as text, not just surface wash).
+      for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
+        const num = m[1] || m[2] || m[3] || m[4];
+        if (!num) continue;
+        // Alternative A (utility class): ban all N — deleted stops
+        // (40..95) and surface wash (2/3/5/8/10) alike.
+        if (m[1]) {
+          offenders.push(`${label}: text-foreground-${num}`);
         }
-      }
-      // Surface wash in text shorthand: text-(--foreground-N)
-      for (const m of src.matchAll(TEXT_SHORTHAND_RE)) {
-        if (surfaceSet.has(m[1]!)) {
-          offenders.push(`${label}: text-context --foreground-${m[1]}`);
-        }
-      }
-      // Surface wash in inline style: color: "var(--foreground-N)"
-      for (const m of src.matchAll(TEXT_INLINE_RE)) {
-        if (surfaceSet.has(m[1]!)) {
-          offenders.push(`${label}: text-context --foreground-${m[1]}`);
+        // Alternatives B/C/D: only surface wash banned in text context.
+        else if (surfaceSet.has(num)) {
+          offenders.push(`${label}: text-context --foreground-${num}`);
         }
       }
     }
@@ -166,22 +205,13 @@ function scanTsxSnippet(src: string): string[] {
   for (const m of src.matchAll(RAW_STOP_RE)) {
     offenders.push(`--foreground-${m[1]}`);
   }
-  for (const m of src.matchAll(TEXT_UTILITY_RE)) {
-    offenders.push(`text-foreground-${m[1]}`);
-  }
-  for (const m of src.matchAll(TEXT_ARBITRARY_RE)) {
-    if (surfaceSet.has(m[1]!)) {
-      offenders.push(`text-context --foreground-${m[1]}`);
-    }
-  }
-  for (const m of src.matchAll(TEXT_SHORTHAND_RE)) {
-    if (surfaceSet.has(m[1]!)) {
-      offenders.push(`text-context --foreground-${m[1]}`);
-    }
-  }
-  for (const m of src.matchAll(TEXT_INLINE_RE)) {
-    if (surfaceSet.has(m[1]!)) {
-      offenders.push(`text-context --foreground-${m[1]}`);
+  for (const m of src.matchAll(TEXT_CONTEXT_RE)) {
+    const num = m[1] || m[2] || m[3] || m[4];
+    if (!num) continue;
+    if (m[1]) {
+      offenders.push(`text-foreground-${num}`);
+    } else if (surfaceSet.has(num)) {
+      offenders.push(`text-context --foreground-${num}`);
     }
   }
   return offenders;
@@ -364,6 +394,53 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts border-color: var(--foreground-10) in CSS (border context)', () => {
     assert.deepEqual(findCssTextOffenders('border-color: var(--foreground-10)', 'test'), []);
+  });
+
+  // P2: arbitrary property, type-hint shorthand, fill/stroke/caret/decoration utility
+  it('rejects [color:var(--foreground-5)] (arbitrary property) in TSX', () => {
+    assert.ok(scanTsxSnippet("[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects hover:[color:var(--foreground-5)] in TSX', () => {
+    assert.ok(scanTsxSnippet("hover:[color:var(--foreground-5)]").length > 0);
+  });
+
+  it('rejects text-(color:--foreground-5) (type-hint shorthand) in TSX', () => {
+    assert.ok(scanTsxSnippet("text-(color:--foreground-5)").length > 0);
+  });
+
+  it('rejects fill-foreground-5 in TSX', () => {
+    assert.ok(scanTsxSnippet("fill-foreground-5").length > 0);
+  });
+
+  it('rejects stroke-foreground-5 in TSX', () => {
+    assert.ok(scanTsxSnippet("stroke-foreground-5").length > 0);
+  });
+
+  it('rejects caret-foreground-5 in TSX', () => {
+    assert.ok(scanTsxSnippet("caret-foreground-5").length > 0);
+  });
+
+  it('rejects decoration-foreground-5 in TSX', () => {
+    assert.ok(scanTsxSnippet("decoration-foreground-5").length > 0);
+  });
+
+  // P2: var() with fallback — must not depend on closing paren
+  it('rejects color: var(--foreground-5, currentColor) (var with fallback) in TSX', () => {
+    assert.ok(scanTsxSnippet("color: var(--foreground-5, currentColor)").length > 0);
+  });
+
+  it('rejects text-[color:var(--foreground-5,currentColor)] in TSX', () => {
+    assert.ok(scanTsxSnippet("text-[color:var(--foreground-5,currentColor)]").length > 0);
+  });
+
+  // P2: surface context still allowed
+  it('accepts [background:var(--foreground-5)] in TSX (bg arbitrary property)', () => {
+    assert.deepEqual(scanTsxSnippet("[background:var(--foreground-5)]"), []);
+  });
+
+  it('accepts border-foreground-10 in TSX (border context)', () => {
+    assert.deepEqual(scanTsxSnippet("border-foreground-10"), []);
   });
 
   // P2: @theme 90/95 export banned

--- a/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-tier-contract.test.ts
@@ -231,6 +231,7 @@ function scanTextPropValue(src: string): string[] {
  *  - Closing quote (if the value starts with one)
  *  - Depth-0 comma (next property in an object/style declaration)
  *  - Depth-0 semicolon (CSS declaration end)
+ *  - Depth-0 opening brace (function/class body — not part of the value)
  *  - Depth-0 closing brace (style object end, or JSX expression end)
  *
  * Characters inside quotes do not affect depth, so commas/braces in
@@ -249,7 +250,7 @@ function readExpressionValue(src: string, start: number): string {
     const end = src.indexOf(ch, i + 1);
     return end < 0 ? src.slice(i) : src.slice(i, end + 1);
   }
-  // Unquoted: track ()[]{} depth, stop at depth-0 , ; }
+  // Unquoted: track ()[]{} depth, stop at depth-0 , ; { }
   const out: string[] = [];
   let depth = 0;
   // JSX expression {value}: opening brace is part of the value.
@@ -264,8 +265,10 @@ function readExpressionValue(src: string, start: number): string {
       i = segEnd;
       continue;
     }
-    if (c === '(' || c === '[' || c === '{') { depth++; out.push(c); i++; continue; }
+    if (c === '(' || c === '[') { depth++; out.push(c); i++; continue; }
     if (c === ')' || c === ']') { depth--; out.push(c); i++; continue; }
+    if (c === '{' && depth <= 0) break; // function/class body boundary
+    if (c === '{') { depth++; out.push(c); i++; continue; }
     if (c === '}') { depth--; out.push(c); i++; if (depth <= 0) break; continue; }
     if ((c === ',' || c === ';') && depth <= 0) break;
     out.push(c); i++;
@@ -819,5 +822,11 @@ describe('foreground-tier negative cases', () => {
 
   it('accepts style={{ color: semantic, background: "var(--foreground-5)" }} in TSX (surface after text prop)', () => {
     assert.deepEqual(scanTsxSnippet('style={{ color: semantic, background: "var(--foreground-5)" }}'), []);
+  });
+
+  // P3: TypeScript type annotation must not scan into function body
+  it('accepts function icon(fill: string) with bg-[var(--foreground-5)] in body', () => {
+    const snippet = 'function icon(fill: string) { return <div className="bg-[var(--foreground-5)]" /> }';
+    assert.deepEqual(scanTsxSnippet(snippet), []);
   });
 });

--- a/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/web-search-boundary.test.ts
@@ -355,7 +355,7 @@ describe('web-search renderer boundary (PR-WEB-SEARCH-TAVILY-0)', () => {
     );
     assert.match(styles, /\.settingsWebSearchKeyRow > \.settingsPasswordField/);
     assert.match(styles, /\.settingsWebSearchQueryIntroRow\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\);/);
-    assert.match(styles, /\.settingsWebSearchDisabledReason\s*\{[\s\S]*?color:\s*var\(--foreground-50\);/);
+    assert.match(styles, /\.settingsWebSearchDisabledReason\s*\{[\s\S]*?color:\s*var\(--muted-foreground\);/);
   });
 
   it('Settings credential badge uses waiting-state copy instead of raw missing configuration copy', async () => {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -131,25 +131,17 @@
   --foreground-5:  color-mix(in oklch, var(--foreground) 5%,  var(--background));
   --foreground-8:  color-mix(in oklch, var(--foreground) 8%,  var(--background));
   --foreground-10: color-mix(in oklch, var(--foreground) 10%, var(--background));
-  /* P-TEXT (roadmap §1.6): the -20/-30 text tiers were orphans (8 call
-     sites total) sitting between the surface washes (2..10) and the
-     real text ladder (40/50/60/70/80). Text uses moved to -40 (also a
-     contrast fix: 30% ink fails 4.5:1); decorative uses inlined their
-     color-mix. Fewer tiers = crisper hierarchy.
-     P-FOREGROUND-TIER-CONVERGE (issue #430 PR4, 2026-07-03): the 5-step
-     text ladder (40/50/60/70/80) collapsed to 3 semantic tiers —
-     primary (var(--foreground), 100% ink), secondary (--foreground-
-     secondary, 80% ink), muted (--muted-foreground, 50% ink). The 40/50
-     pair mapped to muted (both barely distinguishable to the eye); the
-     60/70/80 triple mapped to secondary (all "supporting text" that
-     must stay readable). -90/-95 had zero call sites and were deleted.
-     The underlying mix stops stay so the aliases can target them; text
-     call sites use the semantic aliases, never the raw stops. */
-  --foreground-40: color-mix(in oklch, var(--foreground) 40%, var(--background));
-  --foreground-50: color-mix(in oklch, var(--foreground) 50%, var(--background));
-  --foreground-60: color-mix(in oklch, var(--foreground) 60%, var(--background));
-  --foreground-70: color-mix(in oklch, var(--foreground) 70%, var(--background));
-  --foreground-80: color-mix(in oklch, var(--foreground) 80%, var(--background));
+   /* P-TEXT (roadmap §1.6): the -20/-30 text tiers were orphans (8 call
+      sites total) sitting between the surface washes (2..10) and the
+      real text ladder. Text uses moved to -40 (also a contrast fix:
+      30% ink fails 4.5:1); decorative uses inlined their color-mix.
+      Fewer tiers = crisper hierarchy.
+      P-FOREGROUND-TIER-CONVERGE (issue #430 PR4, 2026-07-03): the 5-step
+      text ladder (40/50/60/70/80) collapsed to 3 semantic tiers —
+      primary (var(--foreground), 100% ink), secondary (--foreground-
+      secondary, 80% ink), muted (--muted-foreground, 50% ink). The raw
+      mix stops are gone; the aliases ARE the definitions. Text call
+      sites use the semantic aliases only. */
 
   /* === alpha overlays via oklch(from ...) ===
      Use these when stacking on a tinted surface (e.g. a card on background-elevated).
@@ -160,8 +152,8 @@
   --border:        oklch(from var(--foreground) l c h / 0.10);
   --border-strong: oklch(from var(--foreground) l c h / 0.16);
   --muted:         oklch(from var(--foreground) l c h / 0.05);
-  --muted-foreground: var(--foreground-50);
-  --foreground-secondary: var(--foreground-80);
+  --muted-foreground: color-mix(in oklch, var(--foreground) 50%, var(--background));
+  --foreground-secondary: color-mix(in oklch, var(--foreground) 80%, var(--background));
   --ring:          oklch(from var(--foreground) l c h / 0.25);
   --hover:         oklch(from var(--foreground) l c h / 0.04);
   --active:        oklch(from var(--foreground) l c h / 0.08);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -731,11 +731,6 @@
   --color-foreground-5:  var(--foreground-5);
   --color-foreground-8:  var(--foreground-8);
   --color-foreground-10: var(--foreground-10);
-  --color-foreground-40: var(--foreground-40);
-  --color-foreground-50: var(--foreground-50);
-  --color-foreground-60: var(--foreground-60);
-  --color-foreground-70: var(--foreground-70);
-  --color-foreground-80: var(--foreground-80);
   --color-foreground-secondary: var(--foreground-secondary);
 
   --color-border: var(--border);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -124,8 +124,9 @@
 
   /* === foreground solid mix scale ===
      foreground-N = N% of foreground interpolated INTO background.
-     These are the SOLID gray tones used for body text, captions, dividers.
-     Prefer these over alpha overlays when stacking on a non-background surface. */
+     These are surface wash stops for backgrounds, borders, and other
+     non-text surfaces only. Text color uses --foreground (primary),
+     --foreground-secondary, or --muted-foreground — never these. */
   --foreground-2:  color-mix(in oklch, var(--foreground) 2%,  var(--background));
   --foreground-3:  color-mix(in oklch, var(--foreground) 3%,  var(--background));
   --foreground-5:  color-mix(in oklch, var(--foreground) 5%,  var(--background));

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -135,14 +135,21 @@
      sites total) sitting between the surface washes (2..10) and the
      real text ladder (40/50/60/70/80). Text uses moved to -40 (also a
      contrast fix: 30% ink fails 4.5:1); decorative uses inlined their
-     color-mix. Fewer tiers = crisper hierarchy. */
+     color-mix. Fewer tiers = crisper hierarchy.
+     P-FOREGROUND-TIER-CONVERGE (issue #430 PR4, 2026-07-03): the 5-step
+     text ladder (40/50/60/70/80) collapsed to 3 semantic tiers —
+     primary (var(--foreground), 100% ink), secondary (--foreground-
+     secondary, 80% ink), muted (--muted-foreground, 50% ink). The 40/50
+     pair mapped to muted (both barely distinguishable to the eye); the
+     60/70/80 triple mapped to secondary (all "supporting text" that
+     must stay readable). -90/-95 had zero call sites and were deleted.
+     The underlying mix stops stay so the aliases can target them; text
+     call sites use the semantic aliases, never the raw stops. */
   --foreground-40: color-mix(in oklch, var(--foreground) 40%, var(--background));
   --foreground-50: color-mix(in oklch, var(--foreground) 50%, var(--background));
   --foreground-60: color-mix(in oklch, var(--foreground) 60%, var(--background));
   --foreground-70: color-mix(in oklch, var(--foreground) 70%, var(--background));
   --foreground-80: color-mix(in oklch, var(--foreground) 80%, var(--background));
-  --foreground-90: color-mix(in oklch, var(--foreground) 90%, var(--background));
-  --foreground-95: color-mix(in oklch, var(--foreground) 95%, var(--background));
 
   /* === alpha overlays via oklch(from ...) ===
      Use these when stacking on a tinted surface (e.g. a card on background-elevated).
@@ -154,6 +161,7 @@
   --border-strong: oklch(from var(--foreground) l c h / 0.16);
   --muted:         oklch(from var(--foreground) l c h / 0.05);
   --muted-foreground: var(--foreground-50);
+  --foreground-secondary: var(--foreground-80);
   --ring:          oklch(from var(--foreground) l c h / 0.25);
   --hover:         oklch(from var(--foreground) l c h / 0.04);
   --active:        oklch(from var(--foreground) l c h / 0.08);
@@ -688,13 +696,14 @@
 /* =============================================================================
    TAILWIND v4 THEME INTEGRATION
    Make tokens addressable as Tailwind utilities:
-     bg-foreground-5       → background of subtle hover surface
-     text-foreground-60    → secondary text
-     bg-accent             → accent garnish fill
-     bg-action             → primary action fill
-     bg-control            → checked/on/progress fill
-     text-link             → link emphasis
-     border-border         → 1px subtle divider
+      bg-foreground-5       → background of subtle hover surface
+      text-muted-foreground → muted text (50% ink)
+      text-foreground-secondary → secondary text (80% ink)
+      bg-accent             → accent garnish fill
+      bg-action             → primary action fill
+      bg-control            → checked/on/progress fill
+      text-link             → link emphasis
+      border-border         → 1px subtle divider
    See https://tailwindcss.com/docs/v4-beta for @theme inline semantics.
 ============================================================================= */
 
@@ -727,8 +736,7 @@
   --color-foreground-60: var(--foreground-60);
   --color-foreground-70: var(--foreground-70);
   --color-foreground-80: var(--foreground-80);
-  --color-foreground-90: var(--foreground-90);
-  --color-foreground-95: var(--foreground-95);
+  --color-foreground-secondary: var(--foreground-secondary);
 
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
@@ -821,7 +829,7 @@
     background: var(--foreground-5);
     border: 1px solid var(--border-strong);
     box-shadow: inset 0 -1px 0 var(--border);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
   }
 }
 
@@ -861,7 +869,7 @@
     padding: var(--space-0-5) var(--space-2);
     font-size: var(--font-size-ui);
     font-weight: 500;
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     background: var(--foreground-5);
     border: 1px solid var(--border);
     border-radius: var(--radius-pill);
@@ -916,7 +924,7 @@
     font-size: var(--font-size-ui);
     letter-spacing: 0.02em;
     text-transform: uppercase;
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
   .maka-sidebar-section {
     padding: var(--space-2) var(--space-1-5);
@@ -927,7 +935,7 @@
     gap: var(--space-2);
     padding: var(--space-1-5) var(--space-2-5);
     border-radius: var(--radius-control);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.4;
     user-select: none;
@@ -953,7 +961,7 @@
     border: none;
     padding: var(--space-1) var(--space-2);
     border-radius: var(--radius-control);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
   }
   .maka-sidebar-button:hover { background: var(--hover); color: var(--foreground); }
@@ -974,7 +982,7 @@
     gap: var(--space-3);
     padding: 0 var(--space-4);
     font-size: var(--font-size-ui);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
   .maka-titlebar strong { color: var(--foreground); font-weight: 500; }
 
@@ -1062,7 +1070,7 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--focus-ring) l c h / 0.03);
     font-size: var(--font-size-ui);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
   .maka-turn-thinking summary {
@@ -1100,7 +1108,7 @@
     font-size: var(--font-size-caption);
     font-weight: 500;
     letter-spacing: 0.04em;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     text-transform: uppercase;
   }
 
@@ -1142,7 +1150,7 @@
     width: 14px;
     height: 14px;
     margin: 0 var(--space-2) 0 0;
-    border: 1.5px solid var(--foreground-40);
+    border: 1.5px solid var(--muted-foreground);
     border-radius: var(--radius-control);
     background: transparent;
     vertical-align: text-bottom;
@@ -1244,7 +1252,7 @@
   .maka-bubble-assistant h1 { font-size: 1.4667em; }
   .maka-bubble-assistant h2 { font-size: 1.2667em; }
   .maka-bubble-assistant h3 { font-size: 1.0667em; }
-  .maka-bubble-assistant h4 { font-size: 0.9333em; color: var(--foreground-80); }
+  .maka-bubble-assistant h4 { font-size: 0.9333em; color: var(--foreground-secondary); }
   .maka-bubble-assistant ul,
   .maka-bubble-assistant ol {
     margin: 0 0 var(--space-3);
@@ -1310,7 +1318,7 @@
     padding: var(--space-1) var(--space-2-5) var(--space-1) var(--space-3);
     border-bottom: 1px solid var(--border);
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
     letter-spacing: 0.02em;
@@ -1331,7 +1339,7 @@
      * would change the header height. */
     border-radius: var(--radius-control);
     background: transparent;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     transition: background 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
   .maka-code-block-copy:hover {
@@ -1377,7 +1385,7 @@
      in sync without per-theme overrides. */
   .hljs            { color: var(--foreground); }
   .hljs-comment,
-  .hljs-quote      { color: var(--foreground-50); font-style: italic; }
+  .hljs-quote      { color: var(--muted-foreground); font-style: italic; }
   .hljs-keyword,
   .hljs-selector-tag,
   .hljs-literal,
@@ -1421,7 +1429,7 @@
     border-left: 3px solid oklch(from var(--focus-ring) l c h / 0.28);
     background: var(--foreground-3);
     border-radius: 0 var(--radius-surface) var(--radius-surface) 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
   .maka-bubble-assistant table {
     width: 100%;
@@ -1449,7 +1457,7 @@
     border-bottom: 0;
   }
   .maka-bubble-assistant th {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-weight: 600;
     background: var(--foreground-3);
     /* PR-UI-LAYOUT-28: header tone slightly darker than body cell
@@ -1482,7 +1490,7 @@
     border: 0;
     border-radius: var(--radius-pill);
     background: oklch(from var(--background) l c h / 0.88);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     opacity: 0;
     /* PR-CHAT-COPY-BUTTON-POLISH-0 (WAWQAQ 10min loop): the copy
        button used to fade in on hover but never moved — felt like
@@ -1677,7 +1685,7 @@
     max-height: 240px;
   }
   .maka-composer textarea::placeholder {
-    color: var(--foreground-40);
+    color: var(--muted-foreground);
     /* PR-CHAT-COMPOSER-PLACEHOLDER-0 (WAWQAQ 10min loop):
        fade the placeholder slightly when the textarea is focused
        and not yet typed in, so the focus state reads as "we're
@@ -1694,7 +1702,7 @@
     align-items: center;
     justify-content: space-between;
     gap: var(--space-2);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
   }
 
@@ -1766,7 +1774,7 @@
   }
   .maka-modal-subtitle {
     font-size: var(--font-size-ui);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     margin-top: var(--space-0-5);
   }
   .maka-modal-body { padding: var(--space-4) var(--space-5); overflow-y: auto; flex: 1; }
@@ -1788,7 +1796,7 @@
   .maka-reason-text[data-reason="privileged"]       { color: var(--destructive-text); font-weight: 500; }
   .maka-reason-text[data-reason="network"]          { color: var(--info-text); }
   .maka-reason-text[data-reason="browser"]          { color: var(--info-text); }
-  .maka-reason-text[data-reason="custom"]           { color: var(--foreground-70); }
+  .maka-reason-text[data-reason="custom"]           { color: var(--foreground-secondary); }
 
   /* ---- Code blocks (used in args preview inside permission dialog) --- */
 

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -10,9 +10,9 @@
   --color-bg-spotlight: oklch(from var(--background) calc(l - 0.03) c h);
   --color-text-base: var(--foreground);
   --color-text: var(--foreground);
-  --color-text-secondary: var(--foreground-70);
-  --color-text-tertiary: var(--foreground-50);
-  --color-text-quaternary: var(--foreground-40);
+  --color-text-secondary: var(--foreground-secondary);
+  --color-text-tertiary: var(--muted-foreground);
+  --color-text-quaternary: var(--muted-foreground);
   --color-text-on-primary: #fff;
   --color-border: var(--border);
   --color-border-secondary: var(--border);

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -380,11 +380,11 @@ export function ConnectionDetail(props: {
         </span>
       </header>
       <FieldRoot className="grid gap-1.5">
-        <Label className="text-xs text-foreground-60">连接标识</Label>
+        <Label className="text-xs text-foreground-secondary">连接标识</Label>
         <Input value={connection.slug} disabled aria-label="模型连接标识" />
       </FieldRoot>
       <FieldRoot className="grid gap-1.5">
-        <Label className="text-xs text-foreground-60">服务地址</Label>
+        <Label className="text-xs text-foreground-secondary">服务地址</Label>
         {hasFixedOAuthBaseUrl && <FieldDescription>OAuth 固定</FieldDescription>}
         <Input
           value={hasFixedOAuthBaseUrl ? defaults.baseUrl : baseUrl}
@@ -398,7 +398,7 @@ export function ConnectionDetail(props: {
       </FieldRoot>
       {needsApiKey && (
         <FieldRoot className="grid gap-1.5">
-          <Label className="text-xs text-foreground-60">模型密钥</Label>
+          <Label className="text-xs text-foreground-secondary">模型密钥</Label>
           {hasSecret === true && <FieldDescription>已设置，粘贴新值可替换</FieldDescription>}
           {hasSecret === 'loading' && <FieldDescription>正在读取状态</FieldDescription>}
           {hasSecret === 'error' && <FieldDescription>凭据状态未知</FieldDescription>}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -46,7 +46,7 @@
   --color-secondary: var(--foreground-5);
   --color-secondary-foreground: var(--foreground);
   --color-muted: var(--foreground-5);
-  --color-muted-foreground: var(--foreground-60);
+  --color-muted-foreground: var(--foreground-secondary);
   --color-accent: var(--accent);
   --color-accent-foreground: oklch(0.985 0.003 250);
   --color-control: var(--control);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -46,7 +46,7 @@
   --color-secondary: var(--foreground-5);
   --color-secondary-foreground: var(--foreground);
   --color-muted: var(--foreground-5);
-  --color-muted-foreground: var(--foreground-secondary);
+  --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: oklch(0.985 0.003 250);
   --color-control: var(--control);

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -209,7 +209,7 @@
 
 .maka-chat-header-status[data-tone="muted"] {
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     border-color: var(--border);
   }
 
@@ -252,7 +252,7 @@
     border: 1px solid var(--border-strong);
     border-radius: var(--radius-pill);
     background: var(--background);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   box-shadow: var(--shadow-medium);
   opacity: 1;
   transition:
@@ -318,7 +318,7 @@
 
 .maka-error-copy p {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
     max-width: 56ch;
@@ -331,7 +331,7 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     overflow: auto;
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
@@ -520,7 +520,7 @@
 
 .maka-toast-icon {
   margin-top: var(--space-0-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 .maka-toast[data-variant="success"] .maka-toast-icon { color: var(--success-text); }
 .maka-toast[data-variant="warning"] .maka-toast-icon { color: var(--info-text); }
@@ -541,7 +541,7 @@
 }
 
 .maka-toast-copy small {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.4;
   text-wrap: pretty;
@@ -577,7 +577,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
     color var(--duration-base) var(--ease-out-strong),
@@ -630,7 +630,7 @@
   align-items: center;
   gap: var(--space-1);
   margin-bottom: var(--space-1);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
@@ -646,7 +646,7 @@
 
 .maka-help-section h3 {
   margin: 0 0 var(--space-1);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
@@ -665,7 +665,7 @@
 }
 
 .maka-help-section dt {
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.45;
 }
@@ -685,7 +685,7 @@
 }
 
 .maka-help-plus {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
 }
 
@@ -743,14 +743,14 @@
 }
 
 .maka-palette-input::placeholder {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 .maka-palette-input-hint {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   white-space: nowrap;
 }
@@ -773,7 +773,7 @@
   border: 1px solid var(--border);
   background: var(--foreground-5);
   box-shadow: inset 0 1px 0 oklch(from var(--background) l c h / 0.45);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   font-weight: 600;
@@ -802,7 +802,7 @@
 
 .maka-palette-group-label {
   padding: var(--space-1) var(--space-2) var(--space-0-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
@@ -866,7 +866,7 @@
 }
 
 .maka-palette-item[data-disabled="true"] {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   cursor: default;
   opacity: 0.72;
 }
@@ -881,7 +881,7 @@
   width: 18px;
   height: 18px;
   border-radius: var(--radius-control);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   transition:
     background-color 140ms var(--ease-out-strong),
     color 140ms var(--ease-out-strong);
@@ -902,7 +902,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
@@ -913,7 +913,7 @@
 }
 
 .maka-palette-empty {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .maka-palette-footer {
@@ -923,7 +923,7 @@
   padding: var(--space-0-5) var(--space-2);
   border-top: 1px solid var(--border);
   background: var(--foreground-2);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
 }
 

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -18,7 +18,7 @@
     min-height: 32px;
     border-radius: var(--radius-modal);
     background: var(--foreground-3);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-ui);
     font-weight: 600;
     line-height: 1;
@@ -91,7 +91,7 @@
 .maka-hero p {
     margin: 0;
     max-width: 54ch;
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.55;
     text-wrap: pretty;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -70,7 +70,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font: inherit;
   font-size: var(--font-size-caption);
   line-height: 1.25;
@@ -84,7 +84,7 @@
      background ≈ #f7f7f7) was indistinguishable from the gray plate
      (≈ #ebebeb). Alpha overlay reads consistently regardless of
      plate tone. */
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   background: oklch(from var(--foreground) l c h / 0.06);
 }
 
@@ -102,7 +102,7 @@
   min-width: 0;
   max-width: 180px;
   overflow: hidden;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -114,7 +114,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
 }
 
@@ -227,7 +227,7 @@
   align-items: center;
   gap: var(--space-1);
   margin-top: var(--space-2-5);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
 }
 
@@ -273,12 +273,12 @@
   padding: 0 var(--space-1);
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   border: 1px solid oklch(from var(--foreground) l c h / 0.03);
 }
 
 .maka-permission-age {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   white-space: nowrap;
 }
@@ -303,7 +303,7 @@
 
 .maka-permission-line {
   margin: 0;
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
 }
 
@@ -330,7 +330,7 @@
 
 .maka-permission-meta {
   margin: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
 }
 

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -38,7 +38,7 @@
     margin: 0;
     font-size: var(--font-size-ui);
     line-height: 1.55;
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
   }
 .maka-daily-review-info-body strong {
     font-weight: 600;
@@ -48,11 +48,11 @@
     margin: 0;
     font-size: var(--font-size-caption);
     line-height: 1.5;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 .maka-daily-review-info-hint strong {
     font-weight: 600;
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
   }
 
 .maka-daily-review-quick-runs {
@@ -100,7 +100,7 @@
 
 .maka-daily-review-archive-count {
     font-size: var(--font-size-caption);
-    color: var(--foreground-40);
+    color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
 
@@ -164,7 +164,7 @@
   }
 
 .maka-daily-review-archive-row-meta {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-variant-numeric: tabular-nums;
     overflow: hidden;
@@ -185,7 +185,7 @@
 
 .maka-daily-review-archive-body[data-empty="true"],
   .maka-daily-review-archive-empty {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-ui);
     line-height: 1.5;
   }
@@ -207,7 +207,7 @@
 
 .maka-daily-review-archive-body-header p {
     margin: var(--space-0-5) 0 0;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     line-height: 1.45;
     overflow-wrap: anywhere;
@@ -217,7 +217,7 @@
     flex: none;
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-pill);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     line-height: 1;
     padding: var(--space-1) var(--space-1-5);
@@ -254,7 +254,7 @@
 
 .maka-daily-review-archive-section h5 {
     margin: 0;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0;
@@ -262,7 +262,7 @@
 
 .maka-daily-review-archive-section p {
     margin: 0;
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.6;
     overflow-wrap: anywhere;
@@ -375,7 +375,7 @@
     font-size: var(--font-size-caption);
     text-transform: none;
     letter-spacing: 0;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 /* PR-DAILY-REVIEW-EYEBROW-RHYTHM-0 (WAWQAQ msg `7f0ec4a5`): granularity
@@ -402,7 +402,7 @@
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     margin: 0;
   }
 .maka-daily-review-section-title::before {
@@ -471,7 +471,7 @@
   }
 
 .maka-daily-review-session-time {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
@@ -479,7 +479,7 @@
 
 .maka-daily-review-session-preview {
     font-size: var(--font-size-ui);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -492,7 +492,7 @@
 
 .maka-daily-review-top-meta {
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
 

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -32,7 +32,7 @@
 
 .settingsHealthIntro p {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 60ch;
@@ -51,7 +51,7 @@
   }
 
 .settingsHealthMeta small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 
@@ -63,7 +63,7 @@
   background: var(--background);
   border-radius: var(--radius-control);
   padding: var(--space-1) var(--space-2-5);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
@@ -93,7 +93,7 @@
   }
 
 .settingsHealthError small {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
   }
 
@@ -135,7 +135,7 @@
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsHealthSummaryTile[data-empty="true"] {
@@ -175,7 +175,7 @@
   }
 
 .settingsHealthSummaryTile[data-tone="neutral"] strong {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 .settingsHealthBlockers {
@@ -198,7 +198,7 @@
   }
 
 .settingsHealthLayer > header small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 
@@ -253,20 +253,20 @@
 
 .settingsHealthSignalScope {
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     letter-spacing: 0.04em;
   }
 
 .settingsHealthSignalMessage {
     margin: 0;
     font-size: var(--font-size-ui);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     line-height: 1.5;
   }
 
 .settingsHealthSignalDetail {
     font-size: var(--font-size-caption);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     line-height: 1.45;
   }
 
@@ -276,7 +276,7 @@
     align-items: center;
     gap: var(--space-2-5);
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsHealthSignalMeta code {
@@ -284,7 +284,7 @@
     background: var(--foreground-5);
     border-radius: var(--radius-control);
     padding: 1px var(--space-1);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 .settingsHealthSignalBlocker {
@@ -312,7 +312,7 @@
     border: 1px dashed var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.55;
   }

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -71,7 +71,7 @@
   flex: 0 0 auto;
   font-size: var(--font-size-caption);
   font-weight: 650;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .maka-model-switcher-value {

--- a/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
+++ b/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
@@ -18,7 +18,7 @@
 }
 
 .maka-capability-audit-kicker {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 700;
   letter-spacing: 0;
@@ -33,7 +33,7 @@
 }
 
 .maka-capability-audit-copy small {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.45;
@@ -56,7 +56,7 @@
 }
 
 .maka-capability-audit-metrics dt {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 700;
   letter-spacing: 0;
@@ -65,7 +65,7 @@
 
 .maka-capability-audit-metrics dd {
   margin: 0;
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 700;
   line-height: 1.3;

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -48,7 +48,7 @@
 
 .maka-module-main-header p {
   margin: var(--space-1) 0 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.45;
 }

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -52,7 +52,7 @@
 
 .maka-plan-eyebrow {
   margin: 0;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
@@ -69,7 +69,7 @@
 
 .maka-plan-heading p:last-child {
   margin: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.45;
 }
@@ -128,7 +128,7 @@
 }
 
 .maka-plan-refresh-button {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-plan-template-strip {
@@ -188,7 +188,7 @@
   grid-column: 2;
   grid-row: 1;
   justify-self: end;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   letter-spacing: 1px;
   line-height: 20px;
@@ -202,7 +202,7 @@
   justify-content: center;
   border-radius: var(--radius-control);
   background: var(--foreground-3);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-icon {
@@ -258,7 +258,7 @@
 }
 
 .maka-plan-template-note {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -268,7 +268,7 @@
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-note {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   white-space: normal;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -285,7 +285,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--foreground-2);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
@@ -301,7 +301,7 @@
   border-top: 1px dashed var(--border);
   border-radius: 0;
   background: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: var(--space-3) 0 0;
 }
 
@@ -403,7 +403,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
 }
@@ -429,7 +429,7 @@
 }
 
 .maka-plan-tab span {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
 }
@@ -539,7 +539,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-plan-card-menu-trigger:hover {
@@ -590,7 +590,7 @@
 .maka-plan-field {
   display: grid;
   gap: var(--space-0-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -640,7 +640,7 @@
   border: 1px solid oklch(from var(--warning) l c h / 0.34);
   border-radius: var(--radius-control);
   background: oklch(from var(--warning) l c h / 0.08);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1.4;
@@ -655,7 +655,7 @@
 
 .maka-plan-delivery-help {
   margin: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 500;
   line-height: 1.4;
@@ -669,7 +669,7 @@
 .maka-plan-compact-select {
   display: grid;
   gap: var(--space-1);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -724,7 +724,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-1-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -788,7 +788,7 @@
   border: 0;
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   line-height: 1;
@@ -817,7 +817,7 @@
 /* PR-UI-PIXEL-1: note clamps to two lines (reference cards show a 2-line
    description), replacing the single-line ellipsis used by the old row layout. */
 .maka-plan-card-note {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.5;
   margin: 0;
@@ -843,7 +843,7 @@
 .maka-plan-run-status {
   border-radius: var(--radius-pill);
   background: var(--foreground-3);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   padding: var(--space-0-5) var(--space-1-5);
@@ -876,7 +876,7 @@
 
 .maka-plan-run-main span,
 .maka-plan-run-row time {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   line-height: 1.35;
 }

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -7,7 +7,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   padding: 0 var(--space-2-5);
 }
 
@@ -22,7 +22,7 @@
 }
 
 .maka-skill-search input::placeholder {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 .maka-skill-search:focus-within {
@@ -216,7 +216,7 @@ color: oklch(0.55 0.015 220);
   border: 0;
   border-radius: 0;
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 500;
   padding: 0 1px;
@@ -246,7 +246,7 @@ color: oklch(0.55 0.015 220);
   justify-content: center;
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.06);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 650;
   padding: 0 var(--space-1);
@@ -268,7 +268,7 @@ color: oklch(0.55 0.015 220);
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-weight: 600;
   padding: 0 var(--space-3);
@@ -288,7 +288,7 @@ color: oklch(0.55 0.015 220);
 }
 
 .maka-skill-section-row small {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -338,7 +338,7 @@ color: oklch(0.55 0.015 220);
 
 .maka-skill-market-card small,
 .maka-skill-market-card-foot span {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -346,7 +346,7 @@ color: oklch(0.55 0.015 220);
 .maka-skill-market-card p {
   min-height: 40px;
   margin: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.5;
   display: -webkit-box;
@@ -365,7 +365,7 @@ color: oklch(0.55 0.015 220);
   border: 1px solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.05);
 }
 
@@ -382,7 +382,7 @@ color: oklch(0.55 0.015 220);
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   cursor: not-allowed;
   font-size: var(--font-size-ui);
   font-weight: 650;
@@ -399,7 +399,7 @@ color: oklch(0.55 0.015 220);
 }
 
 .maka-skill-section-label {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -461,7 +461,7 @@ color: oklch(0.55 0.015 220);
 
 .maka-skill-template-copy span {
   min-width: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.45;
 }
@@ -472,7 +472,7 @@ color: oklch(0.55 0.015 220);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   line-height: 1.35;
 }
@@ -555,7 +555,7 @@ color: oklch(0.55 0.015 220);
   border: 1px solid var(--foreground-8);
   background: var(--background);
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
 }
 
@@ -590,7 +590,7 @@ color: oklch(0.55 0.015 220);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.45;
 }
@@ -600,7 +600,7 @@ color: oklch(0.55 0.015 220);
   justify-self: end;
   align-items: center;
   gap: var(--space-1-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   white-space: nowrap;
   min-width: 0;
@@ -617,7 +617,7 @@ color: oklch(0.55 0.015 220);
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: var(--font-size-caption);
   letter-spacing: -0.01em;
@@ -630,7 +630,7 @@ color: oklch(0.55 0.015 220);
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   text-align: center;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -407,7 +407,7 @@
    * family (same chrome as inline code badges). */
   border-radius: var(--radius-surface);
   background: var(--foreground-5, oklch(from var(--foreground) l c h / 0.06));
-  color: var(--foreground-80, oklch(from var(--foreground) l c h / 0.80));
+  color: var(--foreground-secondary);
 }
 
 /* Quick Chat composer (ready_empty branch). Looks similar to the

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -120,7 +120,7 @@
   margin: var(--space-2) 0 0;
   font-size: var(--font-size-ui);
   line-height: 1.5;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 /* --- compact stepper (numbered nodes + connectors) --- */
@@ -151,12 +151,12 @@
   font-size: var(--font-size-caption);
   font-weight: 650;
   border: 1.5px solid var(--border-strong);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .maka-firstrun-step-label {
   font-size: var(--font-size-ui);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   white-space: nowrap;
 }
 
@@ -176,7 +176,7 @@
 .maka-firstrun-step[data-state="done"] .maka-firstrun-step-dot {
   background: var(--foreground-8);
   border-color: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-firstrun-step[data-state="warning"] .maka-firstrun-step-dot {
@@ -207,7 +207,7 @@
 }
 .maka-firstrun-pick-hint {
   font-size: var(--font-size-ui);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 /* --- provider list panel (scrolls vertically as the list grows) --- */
@@ -302,7 +302,7 @@
   justify-content: center;
   border-radius: var(--radius-pill);
   background: var(--background-elevated);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
 }
@@ -331,7 +331,7 @@
 }
 
 .maka-onboarding-setup-step-copy small {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.3;
 }
@@ -341,7 +341,7 @@
   padding: var(--space-0-5) var(--space-1-5);
   border-radius: var(--radius-pill);
   background: var(--background-elevated);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   white-space: nowrap;
@@ -379,7 +379,7 @@
 }
 .maka-onboarding-setup header p {
   margin-top: var(--space-2);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   line-height: 1.55;
 }
 .maka-onboarding-setup[data-tone="warning"] header h1 {
@@ -488,7 +488,7 @@
   margin-top: 0;
   margin-bottom: 0;
   padding-inline: 0;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.4;
   font-style: italic;
@@ -569,7 +569,7 @@
 
 .maka-first-run-task-suggestions-header > strong {
   font-size: var(--font-size-ui);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-weight: 600;
 }
 
@@ -596,7 +596,7 @@
   border: 1px solid oklch(from var(--foreground) l c h / 0.08);
   border-radius: var(--radius-pill);
   background: oklch(from var(--background-elevated, var(--background)) l c h / 0.78);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   height: auto;
   min-height: 38px;
   padding: var(--space-2) var(--space-4);
@@ -728,7 +728,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 500;
   font-variant-numeric: tabular-nums;
@@ -800,7 +800,7 @@
   margin-right: var(--space-1);
   width: 14px;
   height: 14px;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 .maka-list-row-status-icon[data-tone="accent"] {
   color: var(--nav-active);
@@ -819,7 +819,7 @@
   color: var(--brand-deep);
 }
 .maka-list-row-status-icon[data-tone="muted"] {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 .maka-list-row-status-icon[data-status="running"] svg {
   animation: maka-status-spin 1.2s var(--ease-linear) infinite;
@@ -856,7 +856,7 @@
 }
 .maka-list-group-count {
   font-variant-numeric: tabular-nums;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 500;
 }
@@ -900,13 +900,13 @@
   justify-items: center;
   gap: var(--space-1-5);
   text-align: center;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-empty-state-icon {
   width: 32px;
   height: 32px;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   padding: 0;
 }
 
@@ -923,7 +923,7 @@
 
 .maka-empty-state-body {
   max-width: 30ch;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.4;
   text-wrap: pretty;
@@ -940,7 +940,7 @@
   background: transparent !important;
   box-shadow: none !important;
   padding: 0 !important;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-media {
@@ -948,14 +948,14 @@
 }
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-title {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
 }
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-body {
   max-width: 22ch;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
 }
 
@@ -965,7 +965,7 @@
   padding: 1px var(--space-1);
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 
 .maka-empty-state-actions {

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -31,7 +31,7 @@
 
 .settingsPermissionIntro p {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 52ch;
@@ -46,7 +46,7 @@
   }
 
 .settingsPermissionMeta small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 
@@ -58,7 +58,7 @@
   background: var(--background);
   border-radius: var(--radius-control);
   padding: var(--space-1) var(--space-2-5);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
@@ -88,7 +88,7 @@
   }
 
 .settingsPermissionError small {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
   }
 
@@ -110,7 +110,7 @@
   }
 
 .settingsPermissionSection > header small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 
@@ -171,13 +171,13 @@
 .settingsCapabilityId {
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsCapabilityDetail {
     margin: 0;
     font-size: var(--font-size-ui);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     line-height: 1.5;
   }
 
@@ -201,7 +201,7 @@
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     margin: 0;
   }
 
@@ -216,7 +216,7 @@
 
 .settingsCapabilityLayers dd small {
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsCapabilityLayers dd[data-tone="success"] { color: var(--success-text); }
@@ -227,7 +227,7 @@
 
 .settingsCapabilityLayers dd[data-tone="info"] { color: var(--info-text); }
 
-.settingsCapabilityLayers dd[data-tone="neutral"] { color: var(--foreground-70); }
+.settingsCapabilityLayers dd[data-tone="neutral"] { color: var(--foreground-secondary); }
 
 .settingsCapabilityOsPermissions {
     display: flex;
@@ -239,7 +239,7 @@
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsCapabilityOsPermissions ul {
@@ -260,7 +260,7 @@
     border-radius: var(--radius-pill);
     font-size: var(--font-size-caption);
     background: var(--background);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
   }
 
 .settingsCapabilityOsPermissions li em {
@@ -269,7 +269,7 @@
     padding: 1px var(--space-1-5);
     border-radius: var(--radius-pill);
     background: var(--foreground-5);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 .settingsCapabilityOsPermissions li em[data-tone="success"] {
@@ -303,13 +303,13 @@
 .settingsCapabilityGuidance > span {
     font-size: var(--font-size-caption);
     font-weight: 650;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 .settingsCapabilityGuidance ul {
     margin: 0;
     padding-left: var(--space-4);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.55;
   }
@@ -328,7 +328,7 @@
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--background);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     white-space: nowrap;
   }
@@ -341,7 +341,7 @@
   }
 
 .settingsCapabilityGuidanceActions a {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     text-decoration: none;
   }
@@ -356,7 +356,7 @@
   }
 
 .settingsCapabilityAuditSlot small {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
   }
 
@@ -365,7 +365,7 @@
     margin: 0;
     padding-left: var(--space-4);
     font-size: var(--font-size-caption);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 /* PR-PERMISSIONS-UNIFIED-CARD-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
@@ -422,7 +422,7 @@
     height: 36px;
     border-radius: var(--radius-surface);
     background: oklch(from var(--foreground) l c h / 0.05);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 /* Status-tinted icon: the denied tint lives here; the granted tint
@@ -456,7 +456,7 @@
   }
 
 .settingsOsPermissionPurpose {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.55;
   }
@@ -466,7 +466,7 @@
     align-items: center;
     gap: var(--space-1-5);
     font-size: var(--font-size-ui);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     line-height: 1.45;
   }
 
@@ -476,14 +476,14 @@
     padding: 1px var(--space-1-5);
     border-radius: var(--radius-pill);
     background: oklch(from var(--foreground) l c h / 0.05);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-weight: 600;
     letter-spacing: 0.04em;
   }
 
 .settingsOsPermissionReason {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-style: italic;
   }
@@ -574,7 +574,7 @@
 
 .settingsPermissionSummaryLabel {
     font-size: var(--font-size-caption);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     letter-spacing: 0.02em;
   }
 
@@ -613,7 +613,7 @@
     border: 1px dashed var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.55;
   }

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -94,7 +94,7 @@
 .maka-reasoning-panel-chevron {
     font-size: var(--font-size-ui);
     line-height: 1;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     transition: transform var(--duration-base) var(--ease-out-strong);
   }
 .maka-reasoning-panel[open] .maka-reasoning-panel-chevron {
@@ -105,7 +105,7 @@
     padding: var(--space-1-5) var(--space-2-5) var(--space-2);
     border-top: 1px solid oklch(from var(--info) l c h / 0.14);
     background: transparent;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
     line-height: 1.55;

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -15,7 +15,7 @@
   border: 0;
   border-radius: var(--radius-surface);
   background: transparent;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   padding: var(--space-1-5) var(--space-2-5);
   text-align: left;
 }
@@ -40,7 +40,7 @@
 .settingsBotList em {
   font-size: var(--font-size-caption);
   font-style: normal;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .settingsBotList em[data-tone="info"] { color: var(--status-running); }
@@ -65,7 +65,7 @@
   border: 1px solid var(--foreground-10);
   border-radius: var(--radius-pill);
   padding: 0 var(--space-1-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-style: normal;
   letter-spacing: 0.04em;
 }
@@ -171,14 +171,14 @@
   }
 .settingsBotHero small,
   .settingsHelpText {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 .settingsBotEnableHint {
     display: block;
     margin-top: var(--space-1);
-    color: var(--warning-text, var(--foreground-70));
+    color: var(--warning-text, var(--foreground-secondary));
   }
 .settingsBotConfigDocLink {
     color: var(--bot-brand-color, var(--bot-brand-default));
@@ -196,7 +196,7 @@
     padding: var(--space-0-5) var(--space-2) var(--space-0-5) var(--space-1-5);
     border-radius: var(--radius-pill);
     background: color-mix(in srgb, var(--foreground) 5%, transparent);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     font-weight: 500;
     letter-spacing: 0.01em;
@@ -205,7 +205,7 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--foreground-40);
+    background: var(--muted-foreground);
   }
 .settingsBotStatusPill[data-tone="info"] .settingsBotStatusPillDot { background: var(--status-running); }
 .settingsBotStatusPill[data-tone="success"] { color: var(--success-text); }
@@ -237,7 +237,7 @@
   }
 .settingsBotStatusGrid dt {
     margin-bottom: var(--space-1);
-    color: var(--foreground-40);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
   }
 .settingsBotStatusGrid dd {
@@ -248,7 +248,7 @@
   }
 .settingsBotReason {
     border-left: 2px solid var(--focus-ring);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.5;
     padding-left: var(--space-2-5);
@@ -290,7 +290,7 @@
   border: 0;
   border-radius: var(--radius-pill);
   background: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: 0 var(--space-2);
   font-size: var(--font-size-caption);
 }
@@ -319,7 +319,7 @@
 
 .settingsMetricCard small,
 .settingsMetricCard span {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
 }
 
@@ -339,13 +339,13 @@
 .settingsStatsTable th,
 .settingsStatsTable td {
   border-bottom: 1px solid var(--border);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: var(--space-1) var(--space-2);
   text-align: left;
 }
 
 .settingsStatsTable th {
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-weight: 600;
 }
 
@@ -357,7 +357,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   line-height: 1;
 }
 
@@ -390,7 +390,7 @@
   min-height: 18px;
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: 0 var(--space-1-5);
   font-size: var(--font-size-caption);
 }

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -122,7 +122,7 @@
     font-weight: 600;
   }
 .settingsConnectionRowText small {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
   }
@@ -136,7 +136,7 @@
     font-weight: 600;
     letter-spacing: 0;
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     white-space: nowrap;
   }
 .settingsConnectionBadge[data-tone="success"] {
@@ -159,7 +159,7 @@
   }
 .settingsConnectionDetail {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.45;
   }
@@ -185,7 +185,7 @@
     font-weight: 650;
   }
 .settingsAuthContractText span {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.45;
   }
@@ -202,7 +202,7 @@
 .settingsAuthContractBadge {
     padding: var(--space-0-5) var(--space-2);
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
 .settingsAuthContractBadge[data-tone="success"],
   .settingsAuthActionPill[data-tone="success"] {
@@ -228,7 +228,7 @@
     margin: 0;
     display: flex;
     gap: var(--space-3);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-family: var(--font-mono);
   }
@@ -258,7 +258,7 @@
 .settingsAuthActionPill {
     padding: var(--space-0-5) var(--space-2);
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
 .settingsAuthActionPill[data-kind="preview"] {
     border: 1px dashed oklch(from var(--info) l c h / 0.30);
@@ -278,7 +278,7 @@
 .settingsRow small {
     display: block;
     margin-top: var(--space-1);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-ui);
     line-height: 1.4;
   }

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -60,7 +60,7 @@
   align-items: center;
   gap: var(--space-1-5);
   padding: var(--space-1) var(--space-2-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -55,7 +55,7 @@
 }
 
 .enabledChevron {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   transition: transform 160ms var(--ease-out-strong);
 }
 
@@ -73,7 +73,7 @@
   gap: var(--space-1-5);
   font-size: var(--font-size-ui);
   white-space: nowrap;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .enabledStatusDot {
@@ -91,7 +91,7 @@
 .enabledRollup.is-err,
 .enabledConnStatus.is-error { color: var(--destructive); }
 .enabledRollup.is-idle,
-.enabledConnStatus.is-untested { color: var(--foreground-50); }
+.enabledConnStatus.is-untested { color: var(--muted-foreground); }
 
 .enabledProviderPanel {
   background: oklch(from var(--foreground) l c h / 0.02);
@@ -152,7 +152,7 @@
   border: 1px solid transparent;
   border-radius: var(--radius-pill);
   background: var(--foreground-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: 0 var(--space-4);
 }
 
@@ -403,7 +403,7 @@
 }
 
 .maka-browser-empty {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .maka-browser-empty-hint {
@@ -453,7 +453,7 @@
   justify-content: center;
   border: 0;
   background: transparent;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   border-radius: var(--radius-control);
   padding: 0;
   transition: background var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong), box-shadow var(--duration-quick) var(--ease-out-strong);
@@ -484,7 +484,7 @@
   padding: 0 var(--space-1);
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-variant-numeric: tabular-nums;
 }
 
@@ -515,7 +515,7 @@
 
 .maka-artifact-list-error p {
   margin: 0;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   overflow-wrap: anywhere;
 }
 
@@ -750,7 +750,7 @@
   border-radius: var(--radius-surface);
   border: 1px dashed oklch(from var(--info) l c h / 0.32);
   background: oklch(from var(--info) l c h / 0.06);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
 }
 
 .maka-artifact-preview-unsupported-title {
@@ -763,7 +763,7 @@
   margin: 0;
   font-size: var(--font-size-ui);
   line-height: 1.55;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 
 .maka-artifact-preview-unsupported-meta {
@@ -773,13 +773,13 @@
   margin: 0;
   padding: 0;
   font-size: var(--font-size-ui);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 .maka-artifact-preview-unsupported-meta > div {
   display: contents;
 }
 .maka-artifact-preview-unsupported-meta dt {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-weight: 500;
 }
 .maka-artifact-preview-unsupported-meta dd {

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -40,7 +40,7 @@
   padding: var(--space-1-5) var(--space-3);
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-weight: 500;
   text-align: left;
@@ -109,7 +109,7 @@
   font-weight: 500;
   letter-spacing: 0.05em;
   text-transform: none;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   padding: var(--space-4) var(--space-3) var(--space-1-5);
 }
 
@@ -135,7 +135,7 @@
   border-radius: var(--radius-control);
   background: transparent;
   box-shadow: none;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   margin-inline: var(--space-1);
   padding: var(--space-1-5) var(--space-3);
   text-align: left;
@@ -228,7 +228,7 @@
   height: 24px;
   display: grid;
   place-items: center;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .settingsNavGlyph svg {
@@ -262,7 +262,7 @@
   border: 1px dashed oklch(from var(--info) l c h / 0.32);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.06);
-  color: var(--foreground-80);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.5;
   width: fit-content;
@@ -312,7 +312,7 @@
 .settingsFeatureStatusHero p {
   margin: 0;
   max-width: 56ch;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.45;
 }
@@ -322,13 +322,13 @@
   padding: 0 0 0 var(--space-3);
   display: grid;
   gap: var(--space-1);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.45;
 }
 
 .settingsFeatureStatusList li::marker {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 .settingsFeatureStatusHeroHeading {
@@ -497,7 +497,7 @@
 .settingsPageHeaderDescription {
   margin: 0;
   max-width: 56ch;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.5;
   text-wrap: pretty;
@@ -569,7 +569,7 @@
    than a hairline. */
 .settingsSectionHeading {
   margin: var(--space-6) var(--space-0-5) var(--space-2-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -584,7 +584,7 @@
   min-height: 240px;
   display: grid;
   place-items: center;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
 }
 
@@ -730,7 +730,7 @@
 .settingsField small {
   display: block;
   margin-top: var(--space-1-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   /* Hint is the most-read body text on the page; use the base scale so
      it clears the 14px legibility floor. */
   font-size: var(--font-size-base);

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -7,7 +7,7 @@
 
 .providerEditor p {
   margin: 0;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.4;
 }
@@ -45,7 +45,7 @@
 }
 
 .catalogTabs small {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   line-height: 1.2;
 }
@@ -89,13 +89,13 @@
 
 .providerCatalogCount {
   margin-left: var(--space-2);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
 }
 
 .providerCatalogChevron {
   flex: 0 0 auto;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 /* category / preview / login badges — compact squared corners, never pills */
@@ -104,7 +104,7 @@
   width: fit-content;
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: var(--space-0-5) var(--space-1-5);
   font-size: var(--font-size-caption);
   font-style: normal;
@@ -151,7 +151,7 @@
 .providerEditor label {
   display: grid;
   gap: var(--space-1-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-weight: 500;
 }
@@ -263,7 +263,7 @@
 .modelTableHeaderText small {
   font-size: var(--font-size-caption);
   line-height: 1.5;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .modelTable[data-source="fetched"] .modelTableHeaderText small {
@@ -275,7 +275,7 @@
 }
 
 .modelTableHeaderText .modelTableStickyHint {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .modelTableSearch {
@@ -302,7 +302,7 @@
   padding: var(--space-4);
   border-radius: var(--radius-surface);
   background: var(--background);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.55;
   text-align: center;
@@ -389,7 +389,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  border: 1.5px solid var(--foreground-40);
+  border: 1.5px solid var(--muted-foreground);
   background: transparent;
   position: relative;
 }
@@ -424,7 +424,7 @@
   background: transparent;
   font-family: var(--font-mono);
   font-size: var(--font-size-ui);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -450,7 +450,7 @@
   padding: 1px var(--space-1-5);
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
   letter-spacing: 0;
@@ -487,7 +487,7 @@
      when stacked vertically. baseline-ui + /typeset both require this
      for any numeric data. */
   min-width: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-variant-numeric: tabular-nums;
   overflow-wrap: anywhere;
@@ -598,7 +598,7 @@
 .providerMarketHeader p,
 .customProviderEntry p {
   margin: 0;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   line-height: 1.35;
 }
@@ -623,4 +623,4 @@
 }
 
 .enabledEmptyChip strong { font-size: var(--font-size-caption); font-weight: 700; }
-.enabledEmptyChip small { margin-top: var(--space-0-5); color: var(--foreground-50); font-size: var(--font-size-ui); }
+.enabledEmptyChip small { margin-top: var(--space-0-5); color: var(--muted-foreground); font-size: var(--font-size-ui); }

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -55,7 +55,7 @@
 
 .settingsNotice[data-tone="passive"] {
   background: var(--foreground-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .settingsActionRow {
@@ -114,7 +114,7 @@
 .settingsAboutVersion {
   font-family: var(--font-mono);
   font-size: var(--font-size-ui);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
@@ -131,7 +131,7 @@
 
 .settingsAboutTagline {
   margin: 0;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.55;
 }
@@ -159,7 +159,7 @@
   padding: 0 0 0 var(--space-4);
   display: grid;
   gap: var(--space-1-5);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.55;
 }
@@ -359,7 +359,7 @@
   margin: 0;
   font-size: var(--font-size-caption);
   font-weight: 500;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   letter-spacing: 0;
 }
 
@@ -393,7 +393,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   transition: background var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
 }
 .settingsPasswordToggle:hover {
@@ -445,7 +445,7 @@
 .settingsFieldHint {
   font-style: normal;
   font-weight: 400;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   margin-left: var(--space-1-5);
 }
@@ -518,14 +518,14 @@
   border-radius: var(--radius-surface);
   background: var(--foreground-5);
   border: 1px dashed var(--border);
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: 1.6em;
 }
 .settingsBotScanLoginStatus {
   margin: 0;
   font-size: var(--font-size-caption);
   font-weight: 500;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 .settingsBotScanLoginStatus[data-status="confirmed"] { color: var(--success-text); }
 .settingsBotScanLoginStatus[data-status="error"] { color: var(--destructive-text); }
@@ -547,7 +547,7 @@
   appearance: none;
   border: 0;
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   padding: var(--space-1) 0;
   font-size: var(--font-size-ui);
   text-decoration: underline;
@@ -604,7 +604,7 @@
 .settingsWechatQrHeader p,
 .settingsWechatQrCaption {
   margin: 0;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.5;
 }
@@ -617,7 +617,7 @@
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .settingsWechatQrClose:hover {
@@ -666,7 +666,7 @@
   border: 1px dashed var(--border);
   border-radius: var(--radius-surface);
   background: var(--foreground-3);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   padding: var(--space-4);
   font-size: var(--font-size-ui);
   line-height: 1.5;
@@ -731,7 +731,7 @@
 }
 
 .settingsThemeLabel small {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.4;
   overflow-wrap: anywhere;
@@ -745,7 +745,7 @@
 
 .settingsSubheading {
   margin: 0;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -134,7 +134,7 @@
   width: var(--maka-sidebar-topbar-button-size);
   height: var(--maka-sidebar-topbar-button-size);
   border-radius: var(--radius-control);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 
 .maka-shell-topbar-button:hover {
@@ -247,7 +247,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1-5);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-panel-detail[data-agents-view="skills"] .maka-workspace-top-actions,
@@ -260,7 +260,7 @@
   width: 24px;
   height: 24px;
   border-radius: var(--radius-control);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-shell-topbar-button,
@@ -325,7 +325,7 @@
   height: 22px;
   border: 0;
   background: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: 1.0667em;
   line-height: 1;
   border-radius: var(--radius-control);
@@ -355,7 +355,7 @@
   background: oklch(from var(--foreground) l c h / 0.03);
 }
 .maka-search-modal-input-icon {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 .maka-search-modal-input {
   width: 100%;
@@ -364,7 +364,7 @@
   line-height: 1.4;
 }
 .maka-search-modal-input::placeholder {
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 .maka-search-modal-input::-webkit-search-cancel-button {
   display: none;
@@ -373,7 +373,7 @@
   width: 22px;
   height: 22px;
   border-radius: var(--radius-control);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 .maka-search-modal-clear:hover {
   background: oklch(from var(--foreground) l c h / 0.06);
@@ -396,7 +396,7 @@
 .maka-search-modal-placeholder {
   margin: var(--space-3) var(--space-2);
   font-size: var(--font-size-ui);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   text-align: center;
 }
 /* PR-UX-POLISH-1 commit 5: state cards for incognito / error.
@@ -422,7 +422,7 @@
 }
 .maka-search-modal-state .maka-search-modal-state-detail {
   font-size: var(--font-size-caption);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-search-modal-result-summary {
@@ -432,7 +432,7 @@
   gap: var(--space-3);
   padding: 0 var(--space-1-5) var(--space-1-5);
   font-size: var(--font-size-caption);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
 }
 
 .maka-search-modal-results {
@@ -483,14 +483,14 @@
 }
 .maka-search-modal-result-meta {
   font-size: var(--font-size-caption);
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .maka-search-modal-result-snippet {
   font-size: var(--font-size-caption);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   line-height: 1.45;
   /* Plain text snippet — backend redacts secrets + bounds to
    * SNIPPET_MAX_CODE_POINTS. We cap visual lines at 3 so very
@@ -592,7 +592,7 @@
 .maka-nav-icon {
   width: var(--icon-size);
   height: var(--icon-size);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   justify-self: center;
 }
 
@@ -694,7 +694,7 @@
   align-items: baseline;
   gap: var(--space-0-5);
   padding: 0 var(--space-1-5) var(--space-0-5);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
@@ -953,7 +953,7 @@
 }
 
 .maka-prompt-chip-hint {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.45;
   overflow: hidden;
@@ -990,7 +990,7 @@
 
 .maka-deep-research-workflow-body {
   display: block;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.45;
 }
@@ -1052,7 +1052,7 @@
 .maka-deep-research-evidence-body,
 .maka-deep-research-progress-body {
   min-width: 0;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   line-height: 1.45;
 }

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -4,7 +4,7 @@
    muted — and rides in the user turn's meta row beneath the block. */
 .maka-message-time-inline {
   display: inline-block;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 500;
   line-height: 1;
@@ -183,7 +183,7 @@
 .maka-composer-status-slot {
   min-width: 0;
   flex: 1 1 auto;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   text-align: center;
 }
@@ -198,7 +198,7 @@
   border-radius: var(--radius-pill);
   padding: 0 var(--space-2);
   background: oklch(from var(--background) l c h / 0.82);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 500;
   white-space: nowrap;
@@ -273,7 +273,7 @@
 }
 .maka-composer-mode-menu-hint {
   font-size: var(--font-size-caption);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   line-height: 1.4;
   white-space: normal;
 }
@@ -295,7 +295,7 @@
   padding: 0 var(--space-2);
   border-color: var(--color-border-tertiary);
   background: var(--background);
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
 }
 
 .maka-composer-right-controls .maka-model-switcher-trigger:hover:not(:disabled):not([data-disabled]) {
@@ -339,7 +339,7 @@
   border: 0;
   border-radius: var(--radius-pill);
   background: transparent;
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
     color var(--duration-base) var(--ease-out-strong),
@@ -386,6 +386,6 @@
 .maka-composer-tool-button.maka-composer-mic-button:disabled {
   border: 0;
   background: transparent;
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   opacity: 1;
 }

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -23,7 +23,7 @@
 }
 
 .settingsWebSearchStatusCluster small {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-family: var(--font-mono);
   white-space: nowrap;
@@ -44,7 +44,7 @@
 }
 
 .settingsWebSearchDisabledReason {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   line-height: 1.45;
   text-align: right;
@@ -73,7 +73,7 @@
     text-decoration: underline;
   }
 .settingsWebSearchResult small {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -81,7 +81,7 @@
 .settingsWebSearchResult p {
     margin: 0;
     font-size: var(--font-size-ui);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     line-height: 1.45;
     white-space: pre-wrap;
     word-break: break-word;
@@ -137,11 +137,11 @@
   }
 .settingsMemoryPreview small {
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 .settingsMemoryPreview p {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
     white-space: pre-wrap;
@@ -176,20 +176,20 @@
   }
 .settingsMemoryPromptPreviewHeader span {
     flex-shrink: 0;
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 .settingsMemoryPromptPreview[data-active="true"] .settingsMemoryPromptPreviewHeader span {
     color: var(--nav-active);
   }
 .settingsMemoryPromptPreview small {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
 .settingsMemoryPromptPreviewBudget {
     font-family: var(--font-mono);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
 .settingsMemoryPromptPreview pre {
     max-height: 220px;
@@ -199,7 +199,7 @@
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-control);
     background: var(--background);
-    color: var(--foreground-80);
+    color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
     line-height: 1.45;
@@ -208,7 +208,7 @@
   }
 .settingsMemoryPromptPreview p {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
   }
@@ -225,7 +225,7 @@
     font-size: var(--font-size-ui);
   }
 .settingsMemoryEntryPreviewNotice small {
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
@@ -242,18 +242,18 @@
     font-size: var(--font-size-ui);
   }
 .settingsMemorySaveSummary small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
   }
 .settingsMemorySaveSummaryTime {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
   }
 .settingsMemoryBackupState {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
 .settingsMemoryBackupState[data-empty="true"] {
-    color: var(--foreground-40);
+    color: var(--muted-foreground);
   }
 .settingsMemoryBackupList {
     display: grid;
@@ -285,7 +285,7 @@
     padding: 0;
   }
 .settingsMemoryBackupList small {
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
@@ -297,7 +297,7 @@
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-pill);
     background: var(--background);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
   }
 
@@ -321,7 +321,7 @@
     justify-content: space-between;
     gap: var(--space-3);
     font-size: var(--font-size-ui);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
   }
 
 .settingsMemoryEntryGroupHeader strong {
@@ -335,7 +335,7 @@
     border: 1px solid oklch(from var(--warning) l c h / 0.30);
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning) l c h / 0.08);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
   }
@@ -386,7 +386,7 @@
 
 .settingsMemoryEntryCard small {
     font-size: var(--font-size-caption);
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
   }
 
 .settingsMemoryEntryFacts {
@@ -406,7 +406,7 @@
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-control);
     background: var(--foreground-5);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
@@ -414,7 +414,7 @@
 .settingsMemoryPromptScope[data-active="true"] {
     border-color: oklch(from var(--success) l c h / 0.32);
     background: oklch(from var(--success) l c h / 0.08);
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
   }
 
 .settingsMemoryDirtyState[data-dirty="true"] {
@@ -425,7 +425,7 @@
 .settingsMemoryEntryCard p,
   .settingsMemoryEntryEmpty {
     margin: 0;
-    color: var(--foreground-70);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
     white-space: pre-wrap;
@@ -456,7 +456,7 @@
 }
 
 .settingsMemoryFilter small {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   white-space: nowrap;
 }
@@ -484,7 +484,7 @@
 
 .settingsMemoryFilterEmpty small,
   .settingsMemoryListEmpty small {
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: 1.45;
   }
@@ -509,7 +509,7 @@
 }
 
 .settingsMemoryManualAddHeader small {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   font-size: var(--font-size-caption);
 }
 
@@ -556,7 +556,7 @@
 }
 
 .settingsMemoryDraftWarning small {
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   line-height: 1.4;
 }
@@ -567,7 +567,7 @@
 }
 
 .settingsMemoryEditor > span {
-  color: var(--foreground-60);
+  color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
   font-weight: 600;
 }
@@ -632,7 +632,7 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    color: var(--foreground-60);
+    color: var(--foreground-secondary);
     padding: 0 var(--space-1) var(--space-0-5);
   }
 .maka-first-run-checklist-header strong {
@@ -643,7 +643,7 @@
     margin-left: auto;
     font-size: var(--font-size-caption);
     letter-spacing: 0.04em;
-    color: var(--foreground-50);
+    color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
 
@@ -712,7 +712,7 @@
   gap: var(--space-1-5);
   width: auto;
   text-align: left;
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.03);
 }
 
@@ -723,7 +723,7 @@
 }
 
 .maka-first-run-checklist-row[data-done="true"] > button {
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   cursor: default;
 }
 
@@ -739,7 +739,7 @@
   height: 20px;
   border-radius: 50%;
   background: var(--foreground-5);
-  color: var(--foreground-70);
+  color: var(--foreground-secondary);
 }
 
 .maka-first-run-checklist-row[data-done="true"] .maka-first-run-checklist-status {
@@ -761,13 +761,13 @@
 .maka-first-run-checklist-copy small {
   display: none;
   font-size: var(--font-size-ui);
-  color: var(--foreground-50);
+  color: var(--muted-foreground);
   line-height: 1.45;
 }
 
 .maka-first-run-checklist-arrow {
   display: none;
-  color: var(--foreground-40);
+  color: var(--muted-foreground);
 }
 
 .maka-first-run-checklist-row[data-done="true"] .maka-first-run-checklist-arrow {

--- a/docs/design-refinement-roadmap-2026-07.md
+++ b/docs/design-refinement-roadmap-2026-07.md
@@ -70,9 +70,12 @@
 
 ### 1.6 文字层级（收敛，而非增加）
 
-- 四档制：primary（600/full）/ secondary（500/70%）/ tertiary（50%）/
-  muted（40%）。`--foreground-N` 十几档是层级糊的来源，UI 新代码只从
-  四档语义别名取值。
+- 三档制：primary（`--foreground`，100% ink）/ secondary
+  （`--foreground-secondary`，80% ink）/ muted
+  （`--muted-foreground`，50% ink）。`--foreground-N` 十几档是
+  层级糊的来源，UI 新代码只从三档语义别名取值。40% 和 50% 肉眼
+  barely 可分，桌面工具场景不需要在"不重要"内部再分一档，所以
+  从原四档制进一步收敛到三档。
 - CJK 注意：Windows 中文字体缺中间字重 → color/opacity 杠杆权重高于
   weight；**禁收紧 CJK letter-spacing**（拉丁负 tracking 规则不适用）。
 - 数字全面 tabular-nums（token 数、时间戳、计数）——部分已 shipped，
@@ -137,9 +140,18 @@
 - #459 P-4PT ratchet 契约 + P-TEXT 孤儿档清理
 - 前置质感修复：#454（玻璃色板复活/token 卫生）、#452（blocked
   语义/时间戳/i18n）、#451（copy-feedback 契约同步）
+- P-FOREGROUND-TIER-CONVERGE（issue #430 PR4）：5 档文字梯
+  （40/50/60/70/80）收敛到 3 档语义别名 — `--foreground`
+  （100% ink）、`--foreground-secondary`（80% ink）、
+  `--muted-foreground`（50% ink）。-90/-95 零调用直接删。
+  444 处调用点全量替换，契约测试锁住文字用法不回退到裸
+  mix stops。
 
-下一轮候选（按杠杆）：文字档 60/80 的逐面归并（→四档制）、
-P-STATE 边缘面补齐、storybook Design System 页同步新阴影/层级规则。
+下一轮候选（按杠杆）：P-STATE 边缘面补齐、storybook Design
+System 页同步新阴影/层级规则。
+（原「文字档 60/80 的逐面归并」已由 P-FOREGROUND-TIER-CONVERGE
+解决，落地为 3 档制而非 4 档 — 50% 和 40% 肉眼 barely 可分，
+桌面工具场景不需要在"不重要"内部再分一档。）
 （原「module-pages 76 个 off-grid 值」已由 #448 全量收敛解决。）
 
 ## 4. 第二轮全量精读增补（2026-07-03，四源全覆盖）

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -94,8 +94,10 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 |---|---|---|
 | `--background` | 顶层背景、modal 体 | 不要用作"灰底卡片"——卡片用 `--background-elevated` |
 | `--background-elevated` | 卡片、Pill 内部填充 | 不要用作页面主背景 |
-| `--foreground` | 主文字、Active 行文字、modal title | 不要在 `--background-elevated` 上做"略低对比" — 用 `--foreground-80` |
-| `--foreground-dimmed` | 极少用 — 主要是 placeholder hover 时的过渡 | 一般用 `--foreground-50/60` 替代 |
+| `--foreground` | 主文字（primary, 100% ink）、Active 行文字、modal title | 不要在 `--background-elevated` 上做"略低对比" — 用 `--foreground-secondary` |
+| `--foreground-secondary` | 副文字（80% ink）：tool meta、titlebar、sidebar row、caption heading | 不要做大段正文或主文字 |
+| `--muted-foreground` | muted 文字（50% ink）：placeholder、disabled text、scrollbar hover、极弱标注 | 不要做 caption 或副文字 — 那是 `--foreground-secondary` |
+| `--foreground-dimmed` | 极少用 — 主要是 placeholder hover 时的过渡 | 一般用 `--muted-foreground` 替代 |
 | `--accent` | 链接、focus ring、active 状态、live/status dot、toast/sidebar accent 等 garnish | 不要做 primary CTA 或 checked 控件；用 `--action` / `--control` |
 | `--action` / `--action-foreground` | primary CTA、submit/send/apply/done 等实心动作按钮 | 不要做 checkbox/radio/switch/progress 的 selected 状态 |
 | `--control` / `--control-foreground` | checkbox/radio/switch/progress 等 checked/on/progress 状态 | 不要做 primary CTA |
@@ -104,15 +106,12 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 | `--destructive` | 红，error、denied、fs_destructive、git_destructive | 不要因为 hover/active 看起来更"突出"就升级到 destructive |
 | `--brand-deep` / `--brand-deep-hover` | 少数品牌强调位、reverse lineage 提示 | 不要做 CTA 或 checked 控件，不要新增调用 |
 | `--success-text` / `--info-text` / `--destructive-text` | 文字色（向 foreground 拉过） | 不要用作背景或边框 |
-| `--foreground-2 / 3 / 5` | 极淡填充：sidebar、code、tool 卡片 | 不要做正文 |
-| `--foreground-10 / 20 / 30` | 分割、shadow accent | 不要做正文 |
-| `--foreground-40 / 50 / 60` | placeholder / caption / muted heading | 不要做主文字 |
-| `--foreground-70 / 80` | 副文字、tool meta、titlebar | 不要做大段正文 |
-| `--foreground-90 / 95` | 极少用 — 几乎等同主文 | 用 `--foreground` 即可 |
+| `--foreground-2 / 3 / 5` | 极淡填充：sidebar、code、tool 卡片（表面 wash 档，非文字） | 不要做正文 |
+| `--foreground-8 / 10` | 分割、shadow accent、block bg（表面 wash 档，非文字） | 不要做正文 |
+| `--foreground-40 / 50 / 60 / 70 / 80` | 内部 mix stops，文字用法经语义别名访问（`--muted-foreground` = 50, `--foreground-secondary` = 80）；表面 wash 可直接引用 | 文字不要直接引用，用别名 |
 | `--border` | 1px 默认分割线 / 卡片外框 | 不要做 hover ring（那是 `--ring`） |
 | `--border-strong` | 选中态/active 卡片框 | 不要做默认外框 |
 | `--muted` | 与 border 同 α，语义上"作为背景而非分割" | 不要混用 |
-| `--muted-foreground` | scrollbar hover、disabled text 的最后一层 | 不要做 caption |
 | `--ring` | focus-visible 的 2px box-shadow | 不要做静态边框 |
 | `--hover` | sidebar row / button ghost hover 填充 | 不要用作 active（那是 `--active`） |
 | `--active` | sidebar row active / button :active | 不要做 hover（视觉会"提前"） |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -108,7 +108,6 @@ background / foreground / accent (purple) / info (amber) / success (green) / des
 | `--success-text` / `--info-text` / `--destructive-text` | 文字色（向 foreground 拉过） | 不要用作背景或边框 |
 | `--foreground-2 / 3 / 5` | 极淡填充：sidebar、code、tool 卡片（表面 wash 档，非文字） | 不要做正文 |
 | `--foreground-8 / 10` | 分割、shadow accent、block bg（表面 wash 档，非文字） | 不要做正文 |
-| `--foreground-40 / 50 / 60 / 70 / 80` | 内部 mix stops，文字用法经语义别名访问（`--muted-foreground` = 50, `--foreground-secondary` = 80）；表面 wash 可直接引用 | 文字不要直接引用，用别名 |
 | `--border` | 1px 默认分割线 / 卡片外框 | 不要做 hover ring（那是 `--ring`） |
 | `--border-strong` | 选中态/active 卡片框 | 不要做默认外框 |
 | `--muted` | 与 border 同 α，语义上"作为背景而非分割" | 不要混用 |

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -87,7 +87,7 @@ test('footer-action merge drops the UiButton base shell so the retired footer pi
     'px-[8px]',
     'py-[4px]',
     'rounded-[var(--radius-surface)]',
-    'text-[color:var(--foreground-50)]',
+    'text-[color:var(--muted-foreground)]',
     'text-[12px]',
   ]) {
     assert.ok(merged.includes(win), `footer pixel "${win}" must survive the merge`);
@@ -115,7 +115,7 @@ test('lineage-badge merge drops the UiButton base shell so the retired badge pix
     'px-[5px]',
     'py-[1px]',
     'rounded-[var(--radius-pill)]',
-    'text-[color:var(--foreground-50)]',
+    'text-[color:var(--muted-foreground)]',
     'text-[9px]',
   ]) {
     assert.ok(merged.includes(win), `lineage pixel "${win}" must survive the merge`);

--- a/packages/ui/src/primitives/alert.tsx
+++ b/packages/ui/src/primitives/alert.tsx
@@ -11,7 +11,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-transparent dark:bg-input/32 [&>svg]:text-muted-foreground",
+          "bg-transparent dark:bg-input/32 [&>svg]:text-foreground-secondary",
         error:
           "border-destructive/32 bg-destructive/4 [&>svg]:text-destructive",
         info: "border-info/32 bg-info/4 [&>svg]:text-info",
@@ -58,7 +58,7 @@ export function AlertDescription({
   return (
     <div
       className={cn(
-        "flex flex-col gap-2.5 text-muted-foreground [svg~&]:col-start-2",
+        "flex flex-col gap-2.5 text-foreground-secondary [svg~&]:col-start-2",
         className,
       )}
       data-slot="alert-description"

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -139,27 +139,27 @@ const markerVariants = cva("", {
       // `.maka-turn-summary` + the `tool-output.css` measure-column re-anchor:
       // one quiet caption line (model · tools · duration · tokens).
       summary:
-        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-1.5 mb-0.5 ml-0 mr-auto text-[color:var(--foreground-50)] [font-variant-numeric:tabular-nums]",
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-1.5 mb-0.5 ml-0 mr-auto text-[color:var(--muted-foreground)] [font-variant-numeric:tabular-nums]",
       // `.maka-turn-summary-chip` (+ `::before` middot, nested `code`, and the
       // `[data-kind]` / `[data-state]` / `[data-switched]` conditionals). The
       // call site keeps passing `data-kind` / `data-state` / `data-switched`,
       // which the literalized `data-[…]:` variants read.
       "summary-chip":
-        "inline-flex items-center gap-1 text-[color:var(--foreground-50)] text-[12px] font-medium leading-[1.4]"
-        + " [&:not(:first-child)]:before:content-['·'] [&:not(:first-child)]:before:mr-1 [&:not(:first-child)]:before:text-[color:var(--foreground-40)] [&:not(:first-child)]:before:font-normal"
+        "inline-flex items-center gap-1 text-[color:var(--muted-foreground)] text-[12px] font-medium leading-[1.4]"
+        + " [&:not(:first-child)]:before:content-['·'] [&:not(:first-child)]:before:mr-1 [&:not(:first-child)]:before:text-[color:var(--muted-foreground)] [&:not(:first-child)]:before:font-normal"
         + " [&_code]:bg-transparent [&_code]:text-[color:inherit] [&_code]:[font-family:var(--font-mono)] [&_code]:text-[12px]"
-        + " data-[kind=model]:[&_code]:text-[color:var(--foreground-60)] data-[kind=model]:[&_code]:font-semibold"
-        + " data-[kind=tools]:text-[color:var(--foreground-50)]"
+        + " data-[kind=model]:[&_code]:text-[color:var(--foreground-secondary)] data-[kind=model]:[&_code]:font-semibold"
+        + " data-[kind=tools]:text-[color:var(--muted-foreground)]"
         + " data-[kind=duration]:[font-variant-numeric:tabular-nums]"
         + " data-[kind=tokens]:[font-variant-numeric:tabular-nums] data-[kind=tokens]:[font-family:var(--font-mono)] data-[kind=tokens]:text-[12px]"
         + " data-[state=in-progress]:text-[color:var(--status-running)] data-[state=in-progress]:font-semibold"
-        + " data-[kind=model]:data-[switched=true]:[&_code]:text-[color:var(--foreground-60)]",
+        + " data-[kind=model]:data-[switched=true]:[&_code]:text-[color:var(--foreground-secondary)]",
       // `.maka-turn-summary-chip-switched` — the muted "切换" pill.
       "summary-switched":
-        "ml-1 px-1.5 py-[1px] rounded-[var(--radius-pill)] bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)] text-[color:var(--foreground-60)] text-[11px] font-semibold",
+        "ml-1 px-1.5 py-[1px] rounded-[var(--radius-pill)] bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)] text-[color:var(--foreground-secondary)] text-[11px] font-semibold",
       // `.maka-turn-aborted-marker` (+ its italic `em`) — dormant, muted.
       aborted:
-        "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-60)] text-[12px] italic [&_em]:italic",
+        "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[12px] italic [&_em]:italic",
       // `.maka-turn-failed-banner` — fault state, destructive tone.
       "failed-banner":
         "inline-flex w-fit flex-wrap items-center gap-1.5 mx-0 mt-0.5 mb-1.5 px-2 py-1 rounded-[var(--radius-control)] border border-[oklch(from_var(--destructive)_l_c_h_/_0.28)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] text-[color:var(--destructive)] text-[12px]",
@@ -183,7 +183,7 @@ const markerVariants = cva("", {
         // the 4/3 line-height (9px font × 4/3 = 12px) that `size="sm"`'s `h-8` /
         // `text-xs` used to supply implicitly on `main`, so geometry lives in
         // the marker shell.
-        "inline-flex items-center h-8 gap-0.5 px-1 py-[1px] rounded-[var(--radius-pill)] [border:0] bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--foreground-50)] text-[9px] leading-[12px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
+        "inline-flex items-center h-8 gap-0.5 px-1 py-[1px] rounded-[var(--radius-pill)] [border:0] bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--muted-foreground)] text-[9px] leading-[12px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
         + " hover:bg-[oklch(from_var(--foreground)_l_c_h_/_0.08)] hover:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " data-[direction=forward]:bg-[oklch(from_var(--info)_l_c_h_/_0.06)] data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]"
@@ -203,7 +203,7 @@ const markerVariants = cva("", {
         // line-height ratio over the 12px font (12 × 4/3 = 16px exactly).
         // Folding them in keeps the exact pixels while the marker shell owns its
         // geometry (verified equal to `main` by computed style, headless electron).
-        "inline-flex items-center gap-1.5 min-h-[28px] h-8 px-2 py-1 rounded-[var(--radius-surface)] [border:0] bg-transparent text-[color:var(--foreground-50)] text-[12px] leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
+        "inline-flex items-center gap-1.5 min-h-[28px] h-8 px-2 py-1 rounded-[var(--radius-surface)] [border:0] bg-transparent text-[color:var(--muted-foreground)] text-[12px] leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
         + " [&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not(:disabled)]:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " disabled:opacity-[0.45] disabled:cursor-not-allowed aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
@@ -288,7 +288,7 @@ const streamVariants = cva("", {
         + " data-[live=true]:border-[oklch(from_var(--status-running)_l_c_h_/_0.40)] data-[live=true]:[box-shadow:inset_0_0_0_1px_oklch(from_var(--status-running)_l_c_h_/_0.06)]",
       // `.maka-tool-output-stream-header`
       header:
-        "flex items-center justify-between gap-3 px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--foreground-3)] text-[0.72rem] uppercase tracking-[0.06em] text-[color:var(--foreground-50)]",
+        "flex items-center justify-between gap-3 px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--foreground-3)] text-[0.72rem] uppercase tracking-[0.06em] text-[color:var(--muted-foreground)]",
       // `.maka-tool-output-stream-label`
       label: "inline-flex items-center gap-1.5",
       // `.maka-tool-output-stream-counts`
@@ -308,7 +308,7 @@ const streamVariants = cva("", {
       // `word-break:break-word` stays an arbitrary literal (Tailwind's
       // `break-words` is `overflow-wrap`, a different property).
       body:
-        "m-0 max-h-[220px] overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-[0.78rem] leading-[1.5] bg-[var(--background)] text-[color:var(--foreground-80)] [scroll-behavior:auto]",
+        "m-0 max-h-[220px] overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-[0.78rem] leading-[1.5] bg-[var(--background)] text-[color:var(--foreground-secondary)] [scroll-behavior:auto]",
       // `.maka-tool-output-stream-chunk` (`display:contents`; recolors stderr,
       // dims redacted). The call site keeps `data-stream` / `data-redacted`.
       chunk:
@@ -423,10 +423,10 @@ const toolVariants = cva("", {
       container: "w-[min(680px,100%)] mx-auto mt-0.5 mb-0 px-4 py-0",
       // `.toolInline > header` — the quiet "工具调用" caption row.
       "container-header":
-        "flex items-center justify-between mb-0.5 text-[color:var(--foreground-50)] text-[10px]",
+        "flex items-center justify-between mb-0.5 text-[color:var(--muted-foreground)] text-[10px]",
       // `.maka-tool-count` — the call-count pill.
       count:
-        "inline-flex items-center justify-center min-w-[22px] h-[18px] px-1.5 py-0 rounded-[var(--radius-pill)] bg-[var(--foreground-5)] text-[color:var(--foreground-60)] text-[11px] [font-variant-numeric:tabular-nums]",
+        "inline-flex items-center justify-center min-w-[22px] h-[18px] px-1.5 py-0 rounded-[var(--radius-pill)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[11px] [font-variant-numeric:tabular-nums]",
       // `.maka-tool` (effective: the later `padding: 0` rule wins over `8px 12px`)
       // + `.toolItem` + the `[open]>summary` divider + the `[data-status]` border /
       // background / opacity swaps. `[border: …]` / `[border-color: …]` are arbitrary
@@ -434,7 +434,7 @@ const toolVariants = cva("", {
       // `<summary>` marker reset stays a residue keyed on `[data-slot="tool"]`
       // (see docstring).
       item:
-        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-80)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
+        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
         + " [&[open]>summary]:[border-bottom:1px_solid_var(--border)]"
         // `waiting_permission` border tint — see `WP_CARD_BORDER` above (String.raw).
         + " " + WP_CARD_BORDER
@@ -445,32 +445,32 @@ const toolVariants = cva("", {
       // `.maka-tool > summary` (list-style + padding) + `.maka-tool-header` (the
       // 8px · name · meta grid). Folded together since the summary IS the header.
       header:
-        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-70)]",
+        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-secondary)]",
       // `.maka-tool-status-dot` (+ the `[data-status]` color swaps; running adds
       // the box-shadow ring + `maka-tool-pulse` breath — keyframe stays in CSS).
       dot:
-        "w-[8px] h-[8px] rounded-[var(--radius-pill)] bg-[var(--foreground-40)] [flex:0_0_auto]"
+        "w-[8px] h-[8px] rounded-[var(--radius-pill)] bg-[var(--muted-foreground)] [flex:0_0_auto]"
         // `waiting_permission` dot tint — see `WP_DOT_BG` above (String.raw).
         + " " + WP_DOT_BG
         + " data-[status=running]:bg-[var(--status-running)] data-[status=running]:[box-shadow:0_0_0_3px_oklch(from_var(--status-running)_l_c_h_/_0.15)] data-[status=running]:[animation:maka-tool-pulse_1.5s_ease-in-out_infinite]"
         + " data-[status=completed]:bg-[var(--success)]"
         + " data-[status=errored]:bg-[var(--destructive)]"
-        + " data-[status=interrupted]:bg-[var(--foreground-40)]",
+        + " data-[status=interrupted]:bg-[var(--muted-foreground)]",
       // `.maka-tool-name` — the mono tool name, ellipsized.
       name:
         "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground)] font-medium [font-family:var(--font-mono)]",
       // `.maka-tool-meta` — duration + status-label cluster.
       meta:
-        "inline-flex items-center gap-2 text-[color:var(--foreground-50)] text-[11px]",
+        "inline-flex items-center gap-2 text-[color:var(--muted-foreground)] text-[11px]",
       // `.maka-tool-duration`
       duration: "[font-variant-numeric:tabular-nums]",
       // `.maka-tool-status-label`
-      "status-label": "text-[color:var(--foreground-60)]",
+      "status-label": "text-[color:var(--foreground-secondary)]",
       // `.maka-tool-body`
       body: "px-3 pt-2.5 pb-3",
       // `.maka-tool-intent`
       intent:
-        "mx-0 mt-0 mb-2 text-[color:var(--foreground-60)] [font-family:var(--font-default)] text-[12px] leading-[1.4]",
+        "mx-0 mt-0 mb-2 text-[color:var(--foreground-secondary)] [font-family:var(--font-default)] text-[12px] leading-[1.4]",
       // `.toolArgs` — the override layered over the shared `.maka-code` base
       // (`.maka-code` stays in CSS; the call site keeps the class).
       args: "m-0 max-h-[110px] overflow-auto",
@@ -549,7 +549,7 @@ const previewVariants = cva("", {
       // `.maka-tool-diff-paths` (+ its bare `code` children).
       "diff-paths":
         "flex flex-wrap gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-[10px]"
-        + " [&_code]:text-[color:var(--foreground-70)] [&_code]:bg-transparent",
+        + " [&_code]:text-[color:var(--foreground-secondary)] [&_code]:bg-transparent",
       // `.maka-tool-diff-body` — the scrolling mono `<pre>`.
       "diff-body":
         "m-0 px-0 py-1 max-h-[320px] overflow-auto [font-family:var(--font-mono)] text-[11.5px] leading-[1.45] [white-space:pre] [word-break:normal]",
@@ -558,9 +558,9 @@ const previewVariants = cva("", {
         "block px-2 py-0 [white-space:pre]"
         + " data-[line=add]:bg-[oklch(from_var(--success)_l_c_h_/_0.10)] data-[line=add]:text-[color:var(--success-text)]"
         + " data-[line=del]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] data-[line=del]:text-[color:var(--destructive)]"
-        + " data-[line=hunk]:bg-[oklch(from_var(--link)_l_c_h_/_0.08)] data-[line=hunk]:text-[color:var(--foreground-70)] data-[line=hunk]:font-semibold"
-        + " data-[line=meta]:text-[color:var(--foreground-50)]"
-        + " data-[line=ctx]:text-[color:var(--foreground-70)]",
+        + " data-[line=hunk]:bg-[oklch(from_var(--link)_l_c_h_/_0.08)] data-[line=hunk]:text-[color:var(--foreground-secondary)] data-[line=hunk]:font-semibold"
+        + " data-[line=meta]:text-[color:var(--muted-foreground)]"
+        + " data-[line=ctx]:text-[color:var(--foreground-secondary)]",
 
       // ── terminal ──────────────────────────────────────────────────────────
       // `.maka-tool-terminal` — same card shell as diff.
@@ -570,18 +570,18 @@ const previewVariants = cva("", {
       "terminal-head":
         "flex flex-wrap items-center gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-[10px]",
       // `.maka-tool-terminal-cwd`
-      "terminal-cwd": "text-[color:var(--foreground-50)] bg-transparent",
+      "terminal-cwd": "text-[color:var(--muted-foreground)] bg-transparent",
       // `.maka-tool-terminal-cmd` — the ellipsized command line.
       "terminal-cmd":
         "[flex:1_1_auto] min-w-0 text-[color:var(--foreground)] bg-transparent font-semibold whitespace-nowrap overflow-hidden text-ellipsis",
       // `.maka-tool-terminal-exit` (+ the `[data-ok]` success/failure badge).
       "terminal-exit":
-        "px-1.5 py-[1px] rounded-[var(--radius-pill)] text-[9px] font-bold tracking-[0.04em] bg-[var(--foreground-5)] text-[color:var(--foreground-60)]"
+        "px-1.5 py-[1px] rounded-[var(--radius-pill)] text-[9px] font-bold tracking-[0.04em] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)]"
         + " data-[ok=true]:bg-[oklch(from_var(--success)_l_c_h_/_0.14)] data-[ok=true]:text-[color:var(--success)]"
         + " data-[ok=false]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.14)] data-[ok=false]:text-[color:var(--destructive)]",
       // `.maka-tool-terminal-empty`
       "terminal-empty":
-        "m-0 p-2 text-[color:var(--foreground-50)] [font-family:var(--font-mono)] text-[11px] italic",
+        "m-0 p-2 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-[11px] italic",
       // `.maka-tool-terminal-stream` (+ the `[data-stream]` stdout/stderr tone).
       "terminal-stream":
         "m-0 px-2 py-1.5 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-[11.5px] [white-space:pre-wrap] [word-break:break-word]"
@@ -589,7 +589,7 @@ const previewVariants = cva("", {
         + " data-[stream=stderr]:[border-top:1px_solid_var(--border)] data-[stream=stderr]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)] data-[stream=stderr]:text-[color:var(--destructive)]",
       // `.maka-tool-terminal-truncated-note` (+ its `> span` min-width reset).
       "terminal-truncated-note":
-        "flex items-center justify-between gap-2 px-2 py-1.5 [border-top:1px_solid_var(--border)] bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] text-[color:var(--foreground-70)] text-[11px] leading-[1.5] [&>span]:min-w-0",
+        "flex items-center justify-between gap-2 px-2 py-1.5 [border-top:1px_solid_var(--border)] bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] text-[color:var(--foreground-secondary)] text-[11px] leading-[1.5] [&>span]:min-w-0",
       // `.maka-tool-terminal-copy` (UiButton) + the shared copy-state tints.
       "terminal-copy":
         "[flex:0_0_auto] data-[pending=true]:cursor-progress data-[copy-error=true]:text-[color:var(--destructive)] data-[copy-error=true]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.35)]",
@@ -602,17 +602,17 @@ const previewVariants = cva("", {
       "office-head":
         "grid gap-0.5 pb-1.5 [border-bottom:1px_solid_var(--foreground-10)]"
         + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-[13px] [&_strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--foreground-50)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-office-document-args`
       "office-args":
-        "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground-60)] bg-transparent text-[11px]",
+        "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground-secondary)] bg-transparent text-[11px]",
       // `.maka-office-document-message` (+ its `small` caption).
       "office-message":
         "grid gap-0.5 px-2.5 py-2 rounded-[var(--radius-control)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.07)] text-[color:var(--destructive)] [font-family:var(--font-sans)] text-[12px]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--foreground-50)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-office-document-empty`
       "office-empty":
-        "m-0 text-[color:var(--foreground-50)] [font-family:var(--font-mono)] text-[12px] italic",
+        "m-0 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-[12px] italic",
       // `.maka-office-document-stream` (+ the `[data-stream=stderr]` tone).
       "office-stream":
         "m-0 px-2.5 py-2 max-h-[200px] overflow-auto [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-control)] bg-[var(--background)] [font-family:var(--font-mono)] text-[12.5px] [white-space:pre-wrap] [word-break:break-word]"
@@ -632,7 +632,7 @@ const previewVariants = cva("", {
       "agent-head":
         "grid gap-0.5 pb-1.5 [border-bottom:1px_solid_var(--foreground-10)]"
         + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-[13px] [&_strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--foreground-50)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-explore-agent-summary-line` (+ its `small` ellipsis, layered over
       // the head's caption styling above).
       "agent-summary-line":
@@ -646,20 +646,20 @@ const previewVariants = cva("", {
       "agent-meta":
         "grid grid-cols-[repeat(2,minmax(0,1fr))] gap-2 m-0"
         + " [&>div]:min-w-0 [&>div]:grid [&>div]:gap-0.5"
-        + " [&_dt]:text-[11px] [&_dt]:text-[color:var(--foreground-50)] [&_dt]:uppercase [&_dt]:tracking-[0.04em]"
-        + " [&_dd]:min-w-0 [&_dd]:m-0 [&_dd]:overflow-hidden [&_dd]:text-ellipsis [&_dd]:whitespace-nowrap [&_dd]:text-[color:var(--foreground-70)] [&_dd]:text-[12px]",
+        + " [&_dt]:text-[11px] [&_dt]:text-[color:var(--muted-foreground)] [&_dt]:uppercase [&_dt]:tracking-[0.04em]"
+        + " [&_dd]:min-w-0 [&_dd]:m-0 [&_dd]:overflow-hidden [&_dd]:text-ellipsis [&_dd]:whitespace-nowrap [&_dd]:text-[color:var(--foreground-secondary)] [&_dd]:text-[12px]",
       // `.maka-explore-agent-section` (+ its direct `> strong`, list `ul`/`li`
       // rows, leading `li` reset, `code` / `small` / `p` / `span` leaves).
       "agent-section":
         "grid gap-1.5"
         + " [&>strong]:text-[12px] [&>strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--foreground-50)] [&_small]:uppercase [&_small]:tracking-[0.04em]"
+        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]"
         + " [&_ul]:list-none [&_ul]:m-0 [&_ul]:p-0 [&_ul]:grid [&_ul]:gap-1.5"
         + " [&_li]:min-w-0 [&_li]:grid [&_li]:gap-0.5 [&_li]:py-1.5 [&_li]:[border-top:1px_solid_var(--foreground-5)]"
         + " [&_li:first-child]:border-t-0 [&_li:first-child]:pt-0"
         + " [&_code]:min-w-0 [&_code]:overflow-hidden [&_code]:text-ellipsis [&_code]:whitespace-nowrap [&_code]:text-[color:var(--foreground)] [&_code]:bg-transparent [&_code]:[font-family:var(--font-mono)] [&_code]:text-[12px]"
-        + " [&_p]:m-0 [&_p]:text-[color:var(--foreground-70)] [&_p]:text-[12px] [&_p]:leading-[1.45] [&_p]:[white-space:pre-wrap] [&_p]:[word-break:break-word]"
-        + " [&_span]:m-0 [&_span]:text-[color:var(--foreground-70)] [&_span]:text-[12px] [&_span]:leading-[1.45] [&_span]:[white-space:pre-wrap] [&_span]:[word-break:break-word]",
+        + " [&_p]:m-0 [&_p]:text-[color:var(--foreground-secondary)] [&_p]:text-[12px] [&_p]:leading-[1.45] [&_p]:[white-space:pre-wrap] [&_p]:[word-break:break-word]"
+        + " [&_span]:m-0 [&_span]:text-[color:var(--foreground-secondary)] [&_span]:text-[12px] [&_span]:leading-[1.45] [&_span]:[white-space:pre-wrap] [&_span]:[word-break:break-word]",
       // `.maka-explore-agent-section-head` (+ its `> strong`).
       "agent-section-head":
         "flex items-center justify-between gap-2 min-w-0 [&>strong]:min-w-0 [&>strong]:text-[12px] [&>strong]:text-[color:var(--foreground)]",
@@ -677,13 +677,13 @@ const previewVariants = cva("", {
         "grid gap-2 px-3 py-2.5 [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-surface)] bg-[var(--foreground-3)]"
         + " [&>header]:flex [&>header]:flex-col [&>header]:gap-0.5 [&>header]:pb-1.5 [&>header]:[border-bottom:1px_solid_var(--foreground-10)]"
         + " [&>header_strong]:text-[13px] [&>header_strong]:text-[color:var(--foreground)] [&>header_strong]:font-semibold"
-        + " [&>header_small]:text-[11px] [&>header_small]:text-[color:var(--foreground-50)] [&>header_small]:uppercase [&>header_small]:tracking-[0.04em]"
+        + " [&>header_small]:text-[11px] [&>header_small]:text-[color:var(--muted-foreground)] [&>header_small]:uppercase [&>header_small]:tracking-[0.04em]"
         + " [&_ul]:list-none [&_ul]:m-0 [&_ul]:p-0 [&_ul]:grid [&_ul]:gap-2"
         + " [&_li]:grid [&_li]:gap-0.5 [&_li]:py-2 [&_li]:[border-top:1px_solid_var(--foreground-5)]"
         + " [&_li:first-child]:border-t-0 [&_li:first-child]:pt-0"
         + " [&_a]:font-semibold [&_a]:text-[color:var(--foreground)] [&_a]:no-underline [&_a:hover]:underline"
-        + " [&_li_small]:text-[11px] [&_li_small]:text-[color:var(--foreground-50)] [&_li_small]:uppercase [&_li_small]:tracking-[0.04em]"
-        + " [&_li_p]:m-0 [&_li_p]:text-[12px] [&_li_p]:text-[color:var(--foreground-70)] [&_li_p]:leading-[1.45] [&_li_p]:[white-space:pre-wrap] [&_li_p]:[word-break:break-word]",
+        + " [&_li_small]:text-[11px] [&_li_small]:text-[color:var(--muted-foreground)] [&_li_small]:uppercase [&_li_small]:tracking-[0.04em]"
+        + " [&_li_p]:m-0 [&_li_p]:text-[12px] [&_li_p]:text-[color:var(--foreground-secondary)] [&_li_p]:leading-[1.45] [&_li_p]:[white-space:pre-wrap] [&_li_p]:[word-break:break-word]",
       // `.maka-web-search-error` — the destructive container tint, layered over
       // the `web-search` part via `cn`. It MUST restate the FULL `[border: …]`
       // shorthand + `bg-[ …]` util — NOT a bare `[border-color: …]`/`[background: …]`
@@ -700,7 +700,7 @@ const previewVariants = cva("", {
         "m-0 text-[12px] leading-[1.45] [white-space:pre-wrap] [word-break:break-word] text-[color:var(--destructive-text)]",
       // `.maka-web-search-error-repair`
       "web-search-error-repair":
-        "m-0 text-[12px] leading-[1.45] [white-space:pre-wrap] [word-break:break-word] text-[color:var(--foreground-70)]",
+        "m-0 text-[12px] leading-[1.45] [white-space:pre-wrap] [word-break:break-word] text-[color:var(--foreground-secondary)]",
 
       // ── load-tool result card (separate base; not an overlay) ─────────────
       // `.maka-load-tool-preview` (+ its `p` margin reset).

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -709,11 +709,11 @@ const previewVariants = cva("", {
       // `.maka-load-tool-title`
       "load-tool-title": "font-semibold",
       // `.maka-load-tool-count`
-      "load-tool-count": "text-[color:var(--foreground-2)]",
+      "load-tool-count": "text-[color:var(--muted-foreground)]",
       // `.maka-load-tool-tools`
       "load-tool-tools": "[font-family:var(--font-mono)] [word-break:break-word]",
       // `.maka-load-tool-footer`
-      "load-tool-footer": "text-[color:var(--foreground-2)] text-[11px]",
+      "load-tool-footer": "text-[color:var(--muted-foreground)] text-[11px]",
     },
   },
 });

--- a/packages/ui/src/primitives/empty.tsx
+++ b/packages/ui/src/primitives/empty.tsx
@@ -108,7 +108,7 @@ export function EmptyDescription({
   return (
     <div
       className={cn(
-        "text-muted-foreground text-sm [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4 [[data-slot=empty-title]+&]:mt-1",
+        "text-foreground-secondary text-sm [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4 [[data-slot=empty-title]+&]:mt-1",
         className,
       )}
       data-slot="empty-description"

--- a/packages/ui/src/primitives/input-group.tsx
+++ b/packages/ui/src/primitives/input-group.tsx
@@ -82,7 +82,7 @@ export function InputGroupText({
   return (
     <span
       className={cn(
-        "line-clamp-1 flex items-center gap-2 whitespace-nowrap text-muted-foreground leading-none in-[[data-slot=input-group]:has([data-slot=input-control],[data-slot=textarea-control])]:[&_svg:not([class*='size-'])]:size-4.5 sm:in-[[data-slot=input-group]:has([data-slot=input-control],[data-slot=textarea-control])]:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5",
+        "line-clamp-1 flex items-center gap-2 whitespace-nowrap text-foreground-secondary leading-none in-[[data-slot=input-group]:has([data-slot=input-control],[data-slot=textarea-control])]:[&_svg:not([class*='size-'])]:size-4.5 sm:in-[[data-slot=input-group]:has([data-slot=input-control],[data-slot=textarea-control])]:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5",
         className,
       )}
       {...props}

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -29,7 +29,7 @@ export function Input({
     props.type === "search" &&
       "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
     props.type === "file" &&
-      "text-muted-foreground file:me-3 file:bg-transparent file:font-medium file:text-foreground file:text-sm",
+      "text-foreground-secondary file:me-3 file:bg-transparent file:font-medium file:text-foreground file:text-sm",
   );
 
   return (

--- a/packages/ui/src/primitives/item.tsx
+++ b/packages/ui/src/primitives/item.tsx
@@ -155,7 +155,7 @@ export function ItemDescription({
 }: useRender.ComponentProps<"span">): React.ReactElement {
   const defaultProps = {
     className: cn(
-      "line-clamp-2 text-xs leading-snug text-muted-foreground",
+      "line-clamp-2 text-xs leading-snug text-foreground-secondary",
       className,
     ),
     "data-slot": "item-description",
@@ -173,7 +173,7 @@ export function ItemActions({
   ...props
 }: useRender.ComponentProps<"span">): React.ReactElement {
   const defaultProps = {
-    className: cn("flex shrink-0 items-center gap-1 text-muted-foreground", className),
+    className: cn("flex shrink-0 items-center gap-1 text-foreground-secondary", className),
     "data-slot": "item-actions",
   };
   return useRender({

--- a/packages/ui/src/primitives/kbd.tsx
+++ b/packages/ui/src/primitives/kbd.tsx
@@ -8,7 +8,7 @@ export function Kbd({
   return (
     <kbd
       className={cn(
-        "pointer-events-none inline-flex h-5 min-w-5 select-none items-center justify-center gap-1 rounded-[var(--radius-control)] bg-muted px-1 font-medium font-sans text-muted-foreground text-xs [&_svg:not([class*='size-'])]:size-3",
+        "pointer-events-none inline-flex h-5 min-w-5 select-none items-center justify-center gap-1 rounded-[var(--radius-control)] bg-muted px-1 font-medium font-sans text-foreground-secondary text-xs [&_svg:not([class*='size-'])]:size-3",
         className,
       )}
       data-slot="kbd"

--- a/packages/ui/src/primitives/menu.tsx
+++ b/packages/ui/src/primitives/menu.tsx
@@ -236,7 +236,7 @@ export function MenuGroupLabel({
   return (
     <MenuPrimitive.GroupLabel
       className={cn(
-        "px-2 py-1.5 font-medium text-muted-foreground text-xs data-inset:ps-9 sm:data-inset:ps-8",
+        "px-2 py-1.5 font-medium text-foreground-secondary text-xs data-inset:ps-9 sm:data-inset:ps-8",
         className,
       )}
       data-inset={inset}

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -33,10 +33,10 @@ export function TabsList({
   return (
     <TabsPrimitive.List
       className={cn(
-        "relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-muted-foreground",
+        "relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-foreground-secondary",
         "data-[orientation=vertical]:flex-col",
         variant === "default"
-          ? "rounded-md bg-muted p-0.5 text-muted-foreground/72"
+          ? "rounded-md bg-muted p-0.5 text-foreground-secondary/72"
           : "data-[orientation=vertical]:px-1 data-[orientation=horizontal]:py-1 *:data-[slot=tabs-tab]:hover:bg-accent",
         className,
       )}
@@ -64,7 +64,7 @@ export function TabsTab({
   return (
     <TabsPrimitive.Tab
       className={cn(
-        "relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent px-[calc(--spacing(2.5)-1px)] font-medium text-base outline-none transition-[color,background-color,box-shadow] hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 sm:h-8 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
+        "relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent px-[calc(--spacing(2.5)-1px)] font-medium text-base outline-none transition-[color,background-color,box-shadow] hover:text-foreground-secondary focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 sm:h-8 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
         className,
       )}
       data-slot="tabs-tab"

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -38,12 +38,12 @@ import { cva, type VariantProps } from 'class-variance-authority';
 const navRowVariants = cva(
   [
     'min-h-[30px] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
-    'text-left text-sm leading-[1.43] text-[var(--foreground-80)]',
+    'text-left text-sm leading-[1.43] text-[var(--foreground-secondary)]',
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/6 hover:text-foreground',
     'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
     'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
-    '[&_.maka-nav-count]:bg-foreground/6 [&_.maka-nav-count]:text-[var(--foreground-40)]',
+    '[&_.maka-nav-count]:bg-foreground/6 [&_.maka-nav-count]:text-[var(--muted-foreground)]',
     'data-[active=true]:[&_.maka-nav-count]:bg-foreground/8 data-[active=true]:[&_.maka-nav-count]:text-foreground',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
     'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
@@ -52,7 +52,7 @@ const navRowVariants = cva(
     variants: {
       tone: {
         default: '',
-        newTask: 'text-foreground [&_.maka-nav-icon]:text-[var(--foreground-70)]',
+        newTask: 'text-foreground [&_.maka-nav-icon]:text-[var(--foreground-secondary)]',
       },
     },
     defaultVariants: {
@@ -65,19 +65,19 @@ type NavRowVariants = VariantProps<typeof navRowVariants>;
 
 const settingsButtonClass =
   'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-2 py-1.5 ' +
-  'text-left text-sm font-medium text-[var(--foreground-60)] ' +
+  'text-left text-sm font-medium text-[var(--foreground-secondary)] ' +
   'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
   'hover:bg-foreground/6 hover:text-foreground';
 
 const rowActionVariants = cva(
   [
     'grid h-[26px] w-[26px] place-items-center rounded-sm border-0 bg-transparent',
-    'text-[var(--foreground-60)]',
+    'text-[var(--foreground-secondary)]',
     'transition-[background-color,color,box-shadow] duration-[var(--duration-quick)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/5 hover:text-foreground',
     'focus-visible:outline-none focus-visible:bg-foreground/5 focus-visible:text-foreground focus-visible:ring-[3px] focus-visible:ring-accent/14',
-    'disabled:cursor-default disabled:bg-transparent disabled:text-[var(--foreground-40)] disabled:shadow-none',
-    'disabled:hover:bg-transparent disabled:hover:text-[var(--foreground-40)]',
+    'disabled:cursor-default disabled:bg-transparent disabled:text-[var(--muted-foreground)] disabled:shadow-none',
+    'disabled:hover:bg-transparent disabled:hover:text-[var(--muted-foreground)]',
     'data-[active=true]:text-accent',
     'data-[pending=true]:cursor-progress data-[pending=true]:bg-foreground/5 data-[pending=true]:text-foreground data-[pending=true]:opacity-78',
   ],

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -40,7 +40,7 @@ export const buttonVariants = cva(
         ghost: 'bg-transparent text-foreground hover:bg-muted',
         outline: 'border border-border bg-background text-foreground hover:bg-muted',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        quiet: 'bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground',
+        quiet: 'bg-transparent text-foreground-secondary hover:bg-muted hover:text-foreground',
       },
       size: {
         sm: 'h-8 rounded-sm px-2.5 text-xs',
@@ -93,7 +93,7 @@ export const badgeVariants = cva(
         success: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700',
         warning: 'border-amber-500/25 bg-amber-500/10 text-amber-800',
         destructive: 'border-destructive/25 bg-destructive/10 text-destructive',
-        muted: 'border-border bg-muted text-muted-foreground',
+        muted: 'border-border bg-muted text-foreground-secondary',
       },
     },
     defaultVariants: {
@@ -112,7 +112,7 @@ export function Badge({ className, variant, ...props }: BadgeProps) {
 
 const inputClasses = [
   'flex min-h-9 w-full rounded-sm border border-input bg-[oklch(from_var(--foreground)_l_c_h_/_0.02)] px-3 py-2 text-sm text-foreground shadow-sm',
-  'placeholder:text-muted-foreground/70',
+  'placeholder:text-foreground-secondary/70',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   'disabled:cursor-not-allowed disabled:opacity-50',
 ].join(' ');
@@ -270,7 +270,7 @@ export const TabsTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWit
     <BaseTabs.Tab
       ref={ref}
       className={cn(
-        'inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm font-medium text-muted-foreground transition-colors data-[selected]:bg-background data-[selected]:text-foreground data-[selected]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm font-medium text-foreground-secondary transition-colors data-[selected]:bg-background data-[selected]:text-foreground data-[selected]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         className,
       )}
       {...props}
@@ -336,7 +336,7 @@ export const SelectGroupLabel = forwardRef<HTMLDivElement, React.ComponentPropsW
   { className, ...props },
   ref,
 ) {
-  return <BaseSelect.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-muted-foreground', className)} {...props} />;
+  return <BaseSelect.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} {...props} />;
 });
 export const SelectSeparator = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Separator>>(function SelectSeparator(
   { className, ...props },
@@ -378,7 +378,7 @@ export const FieldDescription = forwardRef<HTMLParagraphElement, React.Component
   { className, ...props },
   ref,
 ) {
-  return <BaseField.Description ref={ref} className={cn('text-xs text-muted-foreground', className)} {...props} />;
+  return <BaseField.Description ref={ref} className={cn('text-xs text-foreground-secondary', className)} {...props} />;
 });
 export const Label = forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<typeof BaseField.Label>>(function Label(
   { className, ...props },

--- a/packages/ui/stories/animation-catalog.stories.tsx
+++ b/packages/ui/stories/animation-catalog.stories.tsx
@@ -15,7 +15,7 @@ export const RetainedFunctionalMotion: Story = {
     <div style={{ alignItems: 'end', display: 'grid', gap: 24, gridTemplateColumns: 'repeat(3, minmax(96px, 1fr))' }}>
       <div style={{ alignItems: 'center', display: 'grid', gap: 8, justifyItems: 'center' }}>
         <Spinner style={{ height: 20, width: 20 }} />
-        <span style={{ color: 'var(--foreground-70)', fontSize: 12, fontWeight: 600 }}>Spinner</span>
+        <span style={{ color: 'var(--foreground-secondary)', fontSize: 12, fontWeight: 600 }}>Spinner</span>
       </div>
       <div style={{ alignItems: 'center', display: 'grid', gap: 8, justifyItems: 'center' }}>
         <span
@@ -29,7 +29,7 @@ export const RetainedFunctionalMotion: Story = {
             width: 10,
           }}
         />
-        <span style={{ color: 'var(--foreground-70)', fontSize: 12, fontWeight: 600 }}>Status pulse</span>
+        <span style={{ color: 'var(--foreground-secondary)', fontSize: 12, fontWeight: 600 }}>Status pulse</span>
       </div>
       <div style={{ alignItems: 'center', display: 'grid', gap: 8, justifyItems: 'center' }}>
         <span
@@ -44,7 +44,7 @@ export const RetainedFunctionalMotion: Story = {
             width: 96,
           }}
         />
-        <span style={{ color: 'var(--foreground-70)', fontSize: 12, fontWeight: 600 }}>Shimmer</span>
+        <span style={{ color: 'var(--foreground-secondary)', fontSize: 12, fontWeight: 600 }}>Shimmer</span>
       </div>
     </div>
   ),
@@ -65,7 +65,7 @@ export const DurationScale: Story = {
       <section style={{ display: 'grid', gap: 24, maxWidth: 760 }}>
         <div style={{ display: 'grid', gap: 4 }}>
           <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Duration Scale</h2>
-          <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+          <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
             按意图选择时长,不凭感觉。token 之外的值需要注释说明。
           </p>
         </div>
@@ -74,8 +74,8 @@ export const DurationScale: Story = {
             <div key={name} style={{ display: 'grid', gap: 8 }}>
               <div style={{ display: 'flex', gap: 12, alignItems: 'baseline' }}>
                 <strong style={{ fontSize: 14, fontWeight: 650 }}>{name}</strong>
-                <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{token}</code>
-                <span style={{ fontSize: 11, color: 'var(--foreground-50)' }}>{value}</span>
+                <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{token}</code>
+                <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>{value}</span>
               </div>
               <div
                 style={{
@@ -101,7 +101,7 @@ export const DurationScale: Story = {
                   }}
                 />
               </div>
-              <span style={{ color: 'var(--foreground-60)', fontSize: 12 }}>{usage}</span>
+              <span style={{ color: 'var(--foreground-secondary)', fontSize: 12 }}>{usage}</span>
             </div>
           ))}
         </div>
@@ -125,7 +125,7 @@ export const EasingScale: Story = {
       <section style={{ display: 'grid', gap: 24, maxWidth: 760 }}>
         <div style={{ display: 'grid', gap: 4 }}>
           <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Easing Scale</h2>
-          <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+          <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
             自定义曲线,内置 CSS easing 太弱。--ease-out-strong 用于反馈,--ease-in-out-strong 用于移动,--ease-drawer 用于 sheet,--ease-linear 用于无限循环功能性动画。
           </p>
         </div>
@@ -134,8 +134,8 @@ export const EasingScale: Story = {
             <div key={name} style={{ display: 'grid', gap: 8 }}>
               <div style={{ display: 'flex', gap: 12, alignItems: 'baseline' }}>
                 <strong style={{ fontSize: 14, fontWeight: 650 }}>{name}</strong>
-                <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{token}</code>
-                <span style={{ fontSize: 11, color: 'var(--foreground-50)' }}>{value}</span>
+                <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{token}</code>
+                <span style={{ fontSize: 11, color: 'var(--muted-foreground)' }}>{value}</span>
               </div>
               <div
                 style={{
@@ -161,7 +161,7 @@ export const EasingScale: Story = {
                   }}
                 />
               </div>
-              <span style={{ color: 'var(--foreground-60)', fontSize: 12 }}>{usage}</span>
+              <span style={{ color: 'var(--foreground-secondary)', fontSize: 12 }}>{usage}</span>
             </div>
           ))}
         </div>

--- a/packages/ui/stories/design-tokens.stories.tsx
+++ b/packages/ui/stories/design-tokens.stories.tsx
@@ -35,11 +35,9 @@ const foregroundScale = [
   ['foreground-2', '--foreground-2'],
   ['foreground-5', '--foreground-5'],
   ['foreground-10', '--foreground-10'],
-  ['foreground-50', '--foreground-50'],
-  ['foreground-40', '--foreground-40'],
-  ['foreground-60', '--foreground-60'],
-  ['foreground-80', '--foreground-80'],
-  ['foreground-95', '--foreground-95'],
+  ['muted-foreground', '--muted-foreground'],
+  ['foreground-secondary', '--foreground-secondary'],
+  ['foreground', '--foreground'],
 ] as const;
 
 const radiusSamples = [
@@ -88,8 +86,8 @@ function SwatchTile({ name, token, fill, usage }: { name: string; token: string;
         </span>
       </div>
       <strong style={{ fontSize: 12, fontWeight: 600 }}>{name}</strong>
-      <code style={{ color: 'var(--foreground-60)', fontSize: 11, wordBreak: 'break-word' }}>{token}</code>
-      <span style={{ color: 'var(--foreground-50)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
+      <code style={{ color: 'var(--foreground-secondary)', fontSize: 11, wordBreak: 'break-word' }}>{token}</code>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
     </div>
   );
 }
@@ -105,7 +103,7 @@ function ScaleTile({ name, token }: { name: string; token: string }) {
           height: 32,
         }}
       />
-      <code style={{ color: 'var(--foreground-60)', fontSize: 10, wordBreak: 'break-word' }}>{name}</code>
+      <code style={{ color: 'var(--foreground-secondary)', fontSize: 10, wordBreak: 'break-word' }}>{name}</code>
     </div>
   );
 }
@@ -115,13 +113,13 @@ export const Colors: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 820 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Colors</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           六色哲学：其余派生色都是 foreground 的 alpha 叠加或 solid 混合。
         </p>
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>语义基色</h3>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>语义基色</h3>
         <div
           style={{
             display: 'grid',
@@ -136,7 +134,7 @@ export const Colors: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>强调色 alias</h3>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>强调色 alias</h3>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
           {emphasisAliases.map((token) => (
             <code
@@ -146,7 +144,7 @@ export const Colors: Story = {
                 background: 'var(--foreground-5)',
                 padding: '4px 8px',
                 fontSize: 11,
-                color: 'var(--foreground-80)',
+                color: 'var(--foreground-secondary)',
                 border: '1px solid var(--border)',
               }}
             >
@@ -157,7 +155,7 @@ export const Colors: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           前景色阶 (foreground-N)
         </h3>
         <div
@@ -196,8 +194,8 @@ export const Radius: Story = {
             <div style={{ display: 'grid', gap: 5, minWidth: 0 }}>
               <strong style={{ fontSize: 14, fontWeight: 650 }}>{name}</strong>
               <span style={{ fontSize: 28, fontWeight: 650, lineHeight: 1 }}>{value}</span>
-              <code style={{ color: 'var(--foreground-60)', fontSize: 11, wordBreak: 'break-word' }}>{token}</code>
-              <span style={{ color: 'var(--foreground-60)', fontSize: 12, lineHeight: 1.4 }}>{usage}</span>
+              <code style={{ color: 'var(--foreground-secondary)', fontSize: 11, wordBreak: 'break-word' }}>{token}</code>
+              <span style={{ color: 'var(--foreground-secondary)', fontSize: 12, lineHeight: 1.4 }}>{usage}</span>
             </div>
             <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
               <div
@@ -231,13 +229,13 @@ export const PrimaryActions: Story = {
     <section style={{ display: 'grid', gap: 20, maxWidth: 760 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Primary Actions</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           variant 落到 token 上的实际效果。
         </p>
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           variant
         </h3>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -251,7 +249,7 @@ export const PrimaryActions: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           disabled
         </h3>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -269,7 +267,7 @@ export const PrimaryActions: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           size + icon
         </h3>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -292,7 +290,7 @@ export const PrimaryActions: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           loading
         </h3>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -328,7 +326,7 @@ export const SemanticColors: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 820 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Semantic Color Roles</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           每个 semantic role 独立命名,即使当前多个 alias 指向同一值。PR5 将进一步分离 action/control。
         </p>
       </div>

--- a/packages/ui/stories/elevation.stories.tsx
+++ b/packages/ui/stories/elevation.stories.tsx
@@ -28,7 +28,7 @@ export const Elevation: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 820 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Elevation & Borders</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           4 个 shadow recipe 承载所有视觉层级。视觉边框走 shadow-ring,布局边框保留 border。
         </p>
       </div>
@@ -50,13 +50,13 @@ export const Elevation: Story = {
               }}
             />
             <strong style={{ fontSize: 12, fontWeight: 600 }}>{name}</strong>
-            <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{token}</code>
-            <span style={{ color: 'var(--foreground-50)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
+            <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{token}</code>
+            <span style={{ color: 'var(--muted-foreground)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
           </div>
         ))}
       </div>
       <div style={{ display: 'grid', gap: 8 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>Border tokens</h3>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>Border tokens</h3>
         <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
           {borderTokens.map(([name, token, usage]) => (
             <div key={name} style={{ display: 'grid', gap: 4, placeItems: 'center' }}>
@@ -68,8 +68,8 @@ export const Elevation: Story = {
                   width: 72,
                 }}
               />
-              <code style={{ color: 'var(--foreground-60)', fontSize: 10 }}>{token}</code>
-              <span style={{ color: 'var(--foreground-50)', fontSize: 10 }}>{usage}</span>
+              <code style={{ color: 'var(--foreground-secondary)', fontSize: 10 }}>{token}</code>
+              <span style={{ color: 'var(--muted-foreground)', fontSize: 10 }}>{usage}</span>
             </div>
           ))}
         </div>

--- a/packages/ui/stories/icons.stories.tsx
+++ b/packages/ui/stories/icons.stories.tsx
@@ -35,7 +35,7 @@ export const LucideIcons: Story = {
     <section style={{ display: 'grid', gap: 20, maxWidth: 920 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Lucide Icons</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           {LUCIDE_ICONS.length} 个通用 UI 图标,通过 icons.tsx 的 lucide-react re-export 自动追踪。业务代码仍只从 @maka/ui/icons 取图标。
         </p>
       </div>
@@ -60,7 +60,7 @@ export const LucideIcons: Story = {
             }}
           >
             <Comp size={20} />
-            <code style={{ color: 'var(--foreground-70)', fontSize: 10, wordBreak: 'break-word' }}>{name}</code>
+            <code style={{ color: 'var(--foreground-secondary)', fontSize: 10, wordBreak: 'break-word' }}>{name}</code>
           </div>
         ))}
       </div>
@@ -73,7 +73,7 @@ export const BotBrandIcons: Story = {
     <section style={{ display: 'grid', gap: 20, maxWidth: 760 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Bot Brand Icons</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           {BOT_BRAND_PROVIDERS.length} 个 IM 渠道品牌图标,本地 React SVG,零运行时 CDN 依赖。
         </p>
       </div>
@@ -92,7 +92,7 @@ export const BotBrandIcons: Story = {
             }}
           >
             <BotBrandLogo provider={provider} width={32} height={32} />
-            <code style={{ color: 'var(--foreground-70)', fontSize: 10 }}>{provider}</code>
+            <code style={{ color: 'var(--foreground-secondary)', fontSize: 10 }}>{provider}</code>
           </div>
         ))}
       </div>

--- a/packages/ui/stories/layering.stories.tsx
+++ b/packages/ui/stories/layering.stories.tsx
@@ -27,7 +27,7 @@ export const Layering: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 760 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Layering / Z-index</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           语义 z-index token,按值排序。值越大越在上层。裸 z-index 数字在 renderer CSS 中被 contract 禁止。
         </p>
       </div>
@@ -48,9 +48,9 @@ export const Layering: Story = {
           >
             <div style={{ display: 'grid', gap: 2, minWidth: 0 }}>
               <strong style={{ fontSize: 13, fontWeight: 600 }}>{name}</strong>
-              <span style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{usage}</span>
+              <span style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{usage}</span>
             </div>
-            <code style={{ color: 'var(--foreground-60)', fontSize: 11, textAlign: 'right' }}>{token}</code>
+            <code style={{ color: 'var(--foreground-secondary)', fontSize: 11, textAlign: 'right' }}>{token}</code>
             <span
               style={{
                 fontSize: 13,

--- a/packages/ui/stories/palette-matrix.stories.tsx
+++ b/packages/ui/stories/palette-matrix.stories.tsx
@@ -46,7 +46,7 @@ export const AllPalettes: Story = {
       <section style={{ display: 'grid', gap: 20, maxWidth: 920 }}>
         <div style={{ display: 'grid', gap: 4 }}>
           <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Palette Matrix</h2>
-          <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+          <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
             {THEME_PALETTES.length} 个 palette,用工具栏切 light/dark 查看另一组。每个块独立应用 data-maka-theme。
           </p>
         </div>

--- a/packages/ui/stories/spacing.stories.tsx
+++ b/packages/ui/stories/spacing.stories.tsx
@@ -41,13 +41,13 @@ export const Spacing: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 820 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Spacing</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           基础步长 --spacing: 4px。14 个 --space-* token 覆盖全部 padding/gap/margin。Tailwind 的 p-N/gap-N/m-N 通过 @theme inline 共用同一把尺子。1px 作为 hairline literal 保留，不进 scale。
         </p>
       </div>
 
       <div style={{ display: 'grid', gap: 8 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           --space-* scale
         </h3>
         <div
@@ -65,7 +65,7 @@ export const Spacing: Story = {
       </div>
 
       <div style={{ display: 'grid', gap: 8 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           Hairline
         </h3>
         <div
@@ -76,7 +76,7 @@ export const Spacing: Story = {
             alignItems: 'center',
           }}
         >
-          <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>1px literal</code>
+          <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>1px literal</code>
           <div
             style={{
               height: 1,
@@ -84,14 +84,14 @@ export const Spacing: Story = {
               width: '100%',
             }}
           />
-          <span style={{ color: 'var(--foreground-50)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ color: 'var(--muted-foreground)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
             1px
           </span>
         </div>
       </div>
 
       <div style={{ display: 'grid', gap: 8 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>
           布局几何
         </h3>
         <div
@@ -114,7 +114,7 @@ export const Spacing: Story = {
 function ScaleRow({ token, px, usage }: { token: string; px: number; usage: string }) {
   return (
     <>
-      <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{token}</code>
+      <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{token}</code>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
         <div
           style={{
@@ -126,11 +126,11 @@ function ScaleRow({ token, px, usage }: { token: string; px: number; usage: stri
             flexShrink: 0,
           }}
         />
-        <span style={{ color: 'var(--foreground-50)', fontSize: 10, lineHeight: 1.3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        <span style={{ color: 'var(--muted-foreground)', fontSize: 10, lineHeight: 1.3, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {usage}
         </span>
       </div>
-      <span style={{ color: 'var(--foreground-50)', fontSize: 11, fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 11, fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>
         {px === 0 ? '0' : `${px}px`}
       </span>
     </>
@@ -140,11 +140,11 @@ function ScaleRow({ token, px, usage }: { token: string; px: number; usage: stri
 function FragmentRow({ token, value, usage }: { token: string; value: string; usage: string }) {
   return (
     <>
-      <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>{token}</code>
-      <span style={{ color: 'var(--foreground-50)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
+      <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>{token}</code>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
         {value}
       </span>
-      <span style={{ color: 'var(--foreground-50)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 10, lineHeight: 1.3 }}>{usage}</span>
     </>
   );
 }

--- a/packages/ui/stories/typography.stories.tsx
+++ b/packages/ui/stories/typography.stories.tsx
@@ -14,26 +14,26 @@ export const TypeScale: Story = {
     <section style={{ display: 'grid', gap: 24, maxWidth: 760 }}>
       <div style={{ display: 'grid', gap: 4 }}>
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>Typography</h2>
-        <p style={{ color: 'var(--foreground-60)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        <p style={{ color: 'var(--foreground-secondary)', fontSize: 12, margin: 0, lineHeight: 1.5 }}>
           基础字号 15px。主字体走系统栈,CJK 回退到平台中文字体。Mono 用 Geist Mono。
         </p>
       </div>
       <div style={{ display: 'grid', gap: 14 }}>
         <div style={{ display: 'grid', gap: 4 }}>
-          <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>--font-sans</code>
+          <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>--font-sans</code>
           <div style={{ fontFamily: 'var(--font-sans)', fontSize: 15 }}>
             The quick brown fox jumps over the lazy dog. 中文排版示例:敏捷的棕色狐狸跳过了懒狗。
           </div>
         </div>
         <div style={{ display: 'grid', gap: 4 }}>
-          <code style={{ color: 'var(--foreground-60)', fontSize: 11 }}>--font-mono</code>
+          <code style={{ color: 'var(--foreground-secondary)', fontSize: 11 }}>--font-mono</code>
           <div style={{ fontFamily: 'var(--font-mono)', fontSize: 14 }}>
             const greeting = "Hello, 世界";
           </div>
         </div>
       </div>
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>Markdown 示例</h3>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>Markdown 示例</h3>
         <div style={{ fontFamily: 'var(--font-sans)', fontSize: 15, display: 'grid', gap: 8 }}>
           <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>Heading 1</h1>
           <h2 style={{ fontSize: 20, fontWeight: 600, margin: 0 }}>Heading 2</h2>
@@ -45,7 +45,7 @@ export const TypeScale: Story = {
         </div>
       </div>
       <div style={{ display: 'grid', gap: 10 }}>
-        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-70)' }}>Code block</h3>
+        <h3 style={{ fontSize: 13, fontWeight: 600, margin: 0, color: 'var(--foreground-secondary)' }}>Code block</h3>
         <pre
           style={{
             fontFamily: 'var(--font-mono)',


### PR DESCRIPTION
## Summary

Collapse the 7-step foreground text ladder (40/50/60/70/80/90/95) into 3 semantic tiers:
- `--foreground` — primary text (100% ink)
- `--foreground-secondary` — secondary text (80% ink, new alias)
- `--muted-foreground` — muted text (50% ink, existing alias)

`--foreground-90`/`--foreground-95` had zero call sites; deleted. `--foreground-40/50/60/70/80` are also fully deleted from `maka-tokens.css` — the aliases now compute directly via `color-mix(in oklch, var(--foreground) N%, var(--background))` instead of pointing at intermediate stops. Surface wash stops (`--foreground-2/3/5/8/10`) remain for non-text use only.

Closes #430 (PR4 — foreground tier converge).

## Why

The 7-step text ladder was the single biggest source of "layer hierarchy blur" in the UI. 40% and 50% are barely distinguishable to the eye; 60/70/80 are all "supporting text" that must stay readable. Industry research (WCAG, Material, Apple HIG) converges on 3 readable text tiers; a 4th (if any) is reserved for disabled/decorative. Desktop tools don't need fine granularity within "unimportant" — they need clear separation between primary, secondary, and muted.

## Scope

Changed:
- `maka-tokens.css`: new `--foreground-secondary` alias (80% color-mix) and updated `--muted-foreground` (50% color-mix); deleted all raw text stops `--foreground-40/50/60/70/80/90/95` (definitions + @theme mirror); surface wash stops (`--foreground-2/3/5/8/10`) kept for non-text use
- `styles.css`: shadcn `@theme` exports only surface wash + semantic aliases (`--color-foreground-secondary`, `--color-muted-foreground`); `--color-muted-foreground` maps to `--muted-foreground` (not retargeted to secondary)
- 444 text call sites replaced across 20 CSS files (styles/), 3 TSX files (packages/ui/src, provider-connection-detail.tsx), 8 storybook stories
- 4 existing test files updated to pin the new alias names
- New contract test `foreground-tier-contract.test.ts` (100 tests) bans:
  - Raw `--foreground-40..95` and `--color-foreground-40..95` (theme mirror) in renderer CSS, maka-tokens.css, and TS/TSX (any context, strip comments)
  - Surface wash `--foreground-2/3/5/8/10` (and `--color-foreground-N` mirror) used as text color in TS/TSX (token-based prefix classification, handles all Tailwind variants, complex arbitrary values, quoted inline styles, camelCase props, SVG attrs, `@apply` utility lists)
  - CSS text props (`color`/`fill`/`stroke`/`caret-color`/`text-decoration-color`/`column-rule-color`) referencing any `--foreground-N` (multi-line values supported)
  - Bare arbitrary properties `[fill:...]` / `[stroke:...]` / `[color:...]` in TS/TSX
  - Unquoted JS expressions in inline style / JSX attributes (bracket-depth-aware scanning)
- `docs/design-system.md` §1.1 color table updated (raw text stops row removed)
- `docs/design-refinement-roadmap-2026-07.md` §1.6 + §3 updated

Not included:
- Surface wash stops (-2/-3/-5/-8/-10) — 187 call sites untouched (they're backgrounds/borders, not text)
- `--foreground-dimmed` — kept as-is (1 @theme mirror, 0 call sites)
- Light mode secondary AA normal contrast (3.97:1) — structural issue (foreground oklch 0.17 too deep), deferred to a separate PR
- Pre-existing `chat-primitives.test.ts` failures (gap-[6px]/gap-[3px] pin mismatch) — unrelated to this change, fails on main too

## Verification

- `npm run typecheck` — all 6 workspaces pass
- `npm --workspace @maka/desktop test` — 1821 tests pass, 0 fail
- `npm --workspace @maka/ui test` — 13 pass, 2 fail (pre-existing, same on main)
- `npm run build` — succeeds
- Screenshot harness `turn-narrative` × 8 variants (light/dark × 1280/990 × motion/reduced) — all succeed
- New contract test `foreground-tier-contract.test.ts` — 100 tests pass

## User-facing impact

No visual regression. All text color changes go darker/clearer (40→50, 60→80, 70→80), never lighter. The 3-tier hierarchy reads crisper: primary, secondary, and muted are now clearly separable where the 7-step ladder had ambiguous neighbors.

## Reviewer notes

- The `--foreground-secondary` alias is new; `--muted-foreground` already existed and is now the canonical muted tier.
- `styles.css` `--color-muted-foreground` (shadcn mapping) maps to `--muted-foreground` (50% mix), not `--foreground-secondary`. shadcn components that need secondary text use `text-foreground-secondary` (17 call sites migrated in `packages/ui/src/ui.tsx`).
- Raw text stops (`--foreground-40..95`) are fully deleted from `maka-tokens.css`; the contract test ensures they cannot be re-introduced in CSS or TS/TSX.