### PR TITLE
fix(ui-css): clean renderer css hygiene

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -55,6 +55,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",
     "esbuild": "^0.27.7",
+    "postcss": "8.5.15",
     "storybook": "^10.4.6",
     "tailwindcss": "^4.3.1"
   }

--- a/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import postcss from 'postcss';
+import { REPO_ROOT, readCssTree } from './css-test-helpers.js';
+
+describe('renderer CSS parse contract', () => {
+  it('keeps every renderer CSS file parseable by a strict CSS parser', async () => {
+    const rendererRoot = `${REPO_ROOT}/apps/desktop/src/renderer`;
+    const styleFiles = [
+      `${rendererRoot}/styles.css`,
+      `${rendererRoot}/reference-shell.css`,
+      `${rendererRoot}/maka-tokens.css`,
+      ...(await readCssTree(`${rendererRoot}/styles`)),
+    ];
+
+    for (const file of styleFiles) {
+      postcss.parse(await readFile(file, 'utf8'), { from: file });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
@@ -29,7 +29,7 @@ describe('renderer CSS parse contract', () => {
     for (const { file, source } of await readRendererCssFiles()) {
       assert.doesNotMatch(
         stripCssComments(source),
-        /html\[data-theme=/,
+        /html\[\s*data-theme(?:\s*[~|^$*]?=|\s*\])/,
         `${file} must use .dark / [data-maka-theme], not retired html[data-theme] selectors`,
       );
     }
@@ -39,7 +39,7 @@ describe('renderer CSS parse contract', () => {
     for (const { file, source } of await readRendererCssFiles()) {
       assert.doesNotMatch(
         stripCssComments(source),
-        /--font-sans\s*:\s*var\(--font-sans\)\s*;|--font-mono\s*:\s*var\(--font-mono\)\s*;/,
+        /--font-(sans|mono)\s*:\s*var\(\s*--font-\1\s*\)\s*;/,
         `${file} must not declare self-referential --font-sans / --font-mono tokens`,
       );
     }

--- a/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts
@@ -1,20 +1,47 @@
+import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 import postcss from 'postcss';
-import { REPO_ROOT, readCssTree } from './css-test-helpers.js';
+import { REPO_ROOT, readCssTree, stripCssComments } from './css-test-helpers.js';
+
+type RendererCssFile = {
+  file: string;
+  source: string;
+};
+
+async function readRendererCssFiles(): Promise<RendererCssFile[]> {
+  const rendererRoot = `${REPO_ROOT}/apps/desktop/src/renderer`;
+  const styleFiles = await readCssTree(rendererRoot);
+  return Promise.all(styleFiles.map(async (file) => ({
+    file,
+    source: await readFile(file, 'utf8'),
+  })));
+}
 
 describe('renderer CSS parse contract', () => {
   it('keeps every renderer CSS file parseable by a strict CSS parser', async () => {
-    const rendererRoot = `${REPO_ROOT}/apps/desktop/src/renderer`;
-    const styleFiles = [
-      `${rendererRoot}/styles.css`,
-      `${rendererRoot}/reference-shell.css`,
-      `${rendererRoot}/maka-tokens.css`,
-      ...(await readCssTree(`${rendererRoot}/styles`)),
-    ];
+    for (const { file, source } of await readRendererCssFiles()) {
+      postcss.parse(source, { from: file });
+    }
+  });
 
-    for (const file of styleFiles) {
-      postcss.parse(await readFile(file, 'utf8'), { from: file });
+  it('does not reintroduce retired data-theme selectors', async () => {
+    for (const { file, source } of await readRendererCssFiles()) {
+      assert.doesNotMatch(
+        stripCssComments(source),
+        /html\[data-theme=/,
+        `${file} must use .dark / [data-maka-theme], not retired html[data-theme] selectors`,
+      );
+    }
+  });
+
+  it('does not reintroduce self-referential font token declarations', async () => {
+    for (const { file, source } of await readRendererCssFiles()) {
+      assert.doesNotMatch(
+        stripCssComments(source),
+        /--font-sans\s*:\s*var\(--font-sans\)\s*;|--font-mono\s*:\s*var\(--font-mono\)\s*;/,
+        `${file} must not declare self-referential --font-sans / --font-mono tokens`,
+      );
     }
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -737,9 +737,6 @@
   --color-hover: var(--hover);
   --color-active: var(--active);
   --color-user-message-bubble: var(--user-message-bubble);
-
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-mono);
 }
 
 /* =============================================================================

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -818,5 +818,3 @@
 .settingsField[data-orient="horizontal"] + .settingsField[data-orient="horizontal"] {
   border-top: 0;
 }
-
-   inputs inside settings rows were at 12px / 26px min-height with

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -202,36 +202,6 @@ html[data-os="darwin"] .maka-nav-row {
   }
 }
 
-@layer base {
-  /* §13.4 — `[data-parchment-brand-motion]` auto-tints any third-party brand
-     motion (Lottie / SVG / GIF) to match the current theme. Drop the attribute
-     on a brand-motion element and these filters do the per-theme tinting. */
-  html[data-theme="light-parchment"] [data-parchment-brand-motion],
-  html[data-theme="dark-parchment"] [data-parchment-brand-motion] {
-    filter: hue-rotate(-85deg) saturate(0.65);
-  }
-
-  html[data-theme="dark"] [data-parchment-brand-motion],
-  html[data-theme="dark-glass"] [data-parchment-brand-motion],
-  html[data-theme="classic-dark"] [data-parchment-brand-motion] {
-    filter: brightness(0.8);
-  }
-
-  /* §13.3 — Banner-style SVG color rewrite. Any banner / hero SVG that
-     wears `[data-banner-logo]` or `[data-skill-deco-cover]` gets its brand
-     strokes/fills auto-mapped to parchment-neutral tokens. We don't ship a
-     maka-specific mascot SVG yet, but the rule sits ready for when we do. */
-  html[data-theme="light-parchment"] [data-banner-logo] :is(path, circle)[fill*="accent"],
-  html[data-theme="dark-parchment"] [data-banner-logo] :is(path, circle)[fill*="accent"] {
-    fill: oklch(from var(--foreground) l c h / 0.08);
-  }
-
-  html[data-theme="light-parchment"] [data-banner-logo] :is(path, circle)[stroke*="accent"],
-  html[data-theme="dark-parchment"] [data-banner-logo] :is(path, circle)[stroke*="accent"] {
-    stroke: var(--card-border-color);
-  }
-}
-
 /* PR-FE-BUG-HUNT-8 (kenji aesthetic-audit reminder 9, finding #3):
    `[data-gradual-blur-layer]` block removed. Originally ported from
    atlas §15.2 as a generic linear-gradient mask + `backdrop-filter:

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,38 @@
         "@types/react-dom": "^19.2.3",
         "@types/ws": "^8.18.1",
         "esbuild": "^0.27.7",
+        "postcss": "8.5.15",
         "storybook": "^10.4.6",
         "tailwindcss": "^4.3.1"
+      }
+    },
+    "apps/desktop/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Summary

- Add a renderer CSS parse contract backed by an explicit `postcss` dev dependency.
- Make the contract scan all CSS under `apps/desktop/src/renderer`, so future sibling CSS files are covered automatically.
- Remove the dangling `nav-sidebar.css` text that strict CSS parsers reject.
- Remove dead `[data-theme]` selectors and ineffective font token self-references, with narrow regression guards for both patterns.

## Why

Part of #476. This is PR1 from the shared post-#430 cleanup roadmap and does not close #476.

The immediate bug is that `styles/settings/nav-sidebar.css` contains dangling plain text that Tailwind currently tolerates but a strict CSS parser rejects. The same hygiene pass also removes selectors and declarations that never affect runtime behavior, then pins those removals so the bad patterns do not return silently.

## Scope

Changed:

- `apps/desktop/src/main/__tests__/renderer-css-parse-contract.test.ts` adds a strict parse contract over every renderer CSS file and guards against retired `html[data-theme...]` selectors plus self-referential font tokens.
- `apps/desktop/src/renderer/styles/settings/nav-sidebar.css` removes the dangling partial text line.
- `apps/desktop/src/renderer/styles/theme-glass.css` removes unreachable `html[data-theme="..."]` rules.
- `apps/desktop/src/renderer/maka-tokens.css` removes `--font-sans` / `--font-mono` self-references.
- `apps/desktop/package.json` / `package-lock.json` declare `postcss@8.5.15` directly for the new contract.

Not included:

- No cascade `@layer` strategy changes.
- No `!important` / input ring-reset changes.
- No `module-pages.css` split.
- No visual redesign.

## Verification

- `npm run -w @maka/desktop build:main`
- `node --test apps/desktop/dist/main/__tests__/renderer-css-parse-contract.test.js` (red before fix: `nav-sidebar.css:822 Unknown word inputs`; final run: 3 tests pass)
- Temporary regression checks: re-adding `html[data-theme = "dark"]` failed the retired selector assertion; re-adding `--font-sans: var( --font-sans );` failed the self-reference assertion.
- `node --test apps/desktop/dist/main/__tests__/renderer-tailwind-compile-contract.test.js`
- `npm run -w @maka/desktop build:renderer` (passes; existing Vite chunk size warning remains)
- `npm run -w @maka/desktop test` (1706 tests pass)

## User-facing impact

None expected. This removes invalid dangling text, unreachable selectors, and no-op token declarations.

## Reviewer notes

Addressed review feedback by removing the hand-written CSS file list and adding regression assertions for the retired patterns, including CSS-equivalent spaced forms. GitHub Checks are still not providing CI evidence on this PR, so the verification above is local.
