### PR TITLE
feat(design): toast exit window + lucide stroke governance (D5/D6)

### DIFF
--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -83,6 +83,7 @@ describe('issue #406 design-system governance contract', () => {
       // guidance for new information) + composer streaming top sweep
       // (visible "working" status) — both functional, not decorative.
       'maka-toast-enter',
+      'maka-toast-exit',
       'maka-processing-sweep',
       'maka-cursor',
       'maka-list-row-streaming-pulse',

--- a/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-system-contract.test.ts
@@ -53,11 +53,23 @@ describe('icon system contract (single chrome size token)', () => {
     );
   });
 
+  it('unifies lucide stroke weight through one governed rule (D5)', async () => {
+    const styles = await readRendererContractCss();
+    const blanket = ruleBody(styles, 'svg.lucide');
+    assert.ok(blanket, 'the global svg.lucide stroke governance rule must exist');
+    assert.match(
+      blanket!,
+      /stroke-width:\s*1\.75/,
+      'all lucide glyphs render at one stroke weight (1.75) — call-site strokeWidth props are overridden by design',
+    );
+  });
+
   it('forbids a blanket svg.lucide size rule (no app-wide resize hammer)', async () => {
     const styles = await readRendererContractCss();
     const blanket = ruleBody(styles, 'svg.lucide');
     assert.ok(
-      !blanket || !/\b(width|height)\s*:/.test(blanket),
+      // (?<!-) so the governed `stroke-width` rule doesn't false-positive.
+      !blanket || !/(?<!-)\b(width|height)\s*:/.test(blanket),
       'a global `svg.lucide { width/height }` rule would silently resize every '
         + 'icon, including intentional 11-14px dense glyphs — it must not exist',
     );

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1860,6 +1860,22 @@
 }
 
 /* =============================================================================
+   Icon stroke governance (decision D5, roadmap §4.1): call sites had
+   accumulated EIGHT different strokeWidth values (1.5 → 2) across 143
+   usages, plus the lucide default of 2 wherever unspecified — the
+   classic "can't say why it looks unpolished" tell. One CSS rule beats
+   every SVG presentation attribute, so all lucide glyphs render at a
+   single weight without touching call sites. Width/height stay
+   per-call-site by contract (icon-system-contract forbids a global
+   size hammer). If a surface ever needs a heavier stroke, scope a more
+   specific selector with a comment.
+============================================================================= */
+svg.lucide {
+  stroke-width: 1.75;
+}
+
+
+/* =============================================================================
    REDUCED-MOTION
 
    Users with `prefers-reduced-motion: reduce` get instant transitions and

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -349,6 +349,18 @@
   animation: maka-toast-enter 240ms var(--ease-out-strong);
 }
 
+/* Exit = enter x 75% (roadmap §4.1), ease-in per the enter-out/exit-in
+   rule — the toast shrinks away instead of vanishing mid-glance. */
+@keyframes maka-toast-exit {
+  0%   { opacity: 1; transform: translateY(0) scale(1); }
+  100% { opacity: 0; transform: translateY(6px) scale(0.98); }
+}
+
+.maka-toast[data-exiting="true"] {
+  animation: maka-toast-exit 180ms var(--ease-in-out-strong) forwards;
+  pointer-events: none;
+}
+
 /* D6 spectrum #2 (Command Input processing): while the assistant is
    streaming, a slow top-edge light sweep on the composer shell keeps
    "working" visible at the exact place the user's attention returns

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -64,6 +64,8 @@ interface InternalToast extends Required<Pick<ToastInput, 'title' | 'variant' | 
   id: string;
   description?: string;
   action?: ToastAction;
+  /** Two-phase dismissal: exit animation plays, then the entry unmounts. */
+  exiting?: boolean;
 }
 
 interface PendingConfirm extends ConfirmInput {
@@ -81,8 +83,16 @@ export function ToastProvider(props: { children: ReactNode }) {
   const confirmQueueRef = useRef<PendingConfirm[]>([]);
   const idSeed = useRef(0);
 
+  const TOAST_EXIT_MS = 180; // exit = enter (240ms) x 75% per the motion roadmap
   const dismiss = useCallback((id: string) => {
-    setToasts((prev) => prev.filter((entry) => entry.id !== id));
+    // Two-phase dismissal (D6 spectrum): mark exiting so CSS can play a
+    // shrink/fade, then unmount after the exit window. Instant unmount
+    // (the old behavior) made toasts vanish mid-glance. Re-entrant calls
+    // for an already-exiting id are no-ops.
+    setToasts((prev) => prev.map((entry) => (entry.id === id ? { ...entry, exiting: true } : entry)));
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((entry) => entry.id !== id));
+    }, TOAST_EXIT_MS);
   }, []);
 
   const push = useCallback(
@@ -198,7 +208,7 @@ function ToastViewport(props: { toasts: InternalToast[]; onDismiss(id: string): 
         // browsers / AT pairings handle the live region announce
         // better when the live items themselves carry an alert
         // role rather than relying on the region inheritance.
-        <li key={entry.id} className="maka-toast" data-variant={entry.variant} role="alert">
+        <li key={entry.id} className="maka-toast" data-variant={entry.variant} data-exiting={entry.exiting ? 'true' : undefined} role="alert">
           <span className="maka-toast-icon" aria-hidden="true">{VARIANT_ICON[entry.variant]}</span>
           <div className="maka-toast-copy">
             <strong>{entry.title}</strong>


### PR DESCRIPTION
队列两项：

## Toast 退场窗口（补完 #471 的生命周期）
dismiss 改两阶段：标记 exiting → 180ms 收缩淡出（退场 = 进场 240ms × 75%，roadmap 动效规则）→ 卸载。toast 不再在注视中瞬间消失；退场中丢弃 pointer-events。

## Lucide stroke 治理（D5 兑现）
调用点累积了 **8 种 strokeWidth**（1.5→2）共 143 处 + 未指定处默认 2 —— 典型「说不清为什么不精致」。一行 `svg.lucide { stroke-width: 1.75 }` 覆盖全部 SVG presentation attribute，零调用点改动全量统一到分布主峰值。icon 契约加正向断言；顺修旧 size-hammer 断言的 `\bwidth` 误匹配 stroke-width。

## Markdown 缓存项评估后降级
MessageBody memo 已阻止已提交 turn 的重 parse；流式 turn 的重 parse 是本质工作。记录在案防止重提。

1697/1697（+1 契约）。