### PR TITLE
refactor(ui-css): settle cascade and important resets

### DIFF
--- a/apps/desktop/src/main/__tests__/bare-field-chrome-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/bare-field-chrome-contract.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Input, Textarea } from '@maka/ui';
+
+const BARE_FIELD_RESET_CLASSES = [
+  'appearance-none',
+  'rounded-none',
+  'border-0',
+  'bg-transparent',
+  'p-0',
+  'text-inherit',
+  'shadow-none',
+  'outline-none',
+  '[font:inherit]',
+  'focus-visible:outline-none',
+  'focus-visible:ring-0',
+  'focus-visible:ring-offset-0',
+  'disabled:cursor-not-allowed',
+  'disabled:opacity-60',
+];
+
+function classAttribute(markup: string): string {
+  const match = markup.match(/\bclass="([^"]*)"/);
+  assert.ok(match, `expected rendered markup to include a class attribute: ${markup}`);
+  return match[1] ?? '';
+}
+
+function assertBareField(markup: string): void {
+  assert.match(markup, /\bdata-maka-field-chrome="none"/);
+  const className = classAttribute(markup);
+  for (const token of BARE_FIELD_RESET_CLASSES) {
+    assert.match(className, new RegExp(`(?:^|\\s)${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s|$)`));
+  }
+  assert.doesNotMatch(className, /(?:^|\s)focus-visible:ring-2(?:\s|$)/);
+  assert.doesNotMatch(className, /(?:^|\s)border-input(?:\s|$)/);
+}
+
+describe('bare field chrome contract', () => {
+  it('renders unstyled Input as a real bare input', () => {
+    const markup = renderToStaticMarkup(createElement(Input, { unstyled: true, 'aria-label': 'Search skills' }));
+
+    assert.match(markup, /^<input\b/);
+    assertBareField(markup);
+  });
+
+  it('renders unstyled Textarea as a real bare textarea', () => {
+    const markup = renderToStaticMarkup(createElement(Textarea, { unstyled: true, 'aria-label': 'Prompt' }));
+
+    assert.match(markup, /^<textarea\b/);
+    assertBareField(markup);
+  });
+
+  it('keeps default field chrome on styled fields', () => {
+    const markup = renderToStaticMarkup(createElement(Input, { 'aria-label': 'Named field' }));
+    const className = classAttribute(markup);
+
+    assert.doesNotMatch(markup, /\bdata-maka-field-chrome=/);
+    assert.match(className, /(?:^|\s)border-input(?:\s|$)/);
+    assert.match(className, /(?:^|\s)focus-visible:ring-2(?:\s|$)/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
+import postcss from 'postcss';
 import { REPO_ROOT, readCssTree, stripCssComments } from './css-test-helpers.js';
 
 type ImportantAllowance = {
@@ -87,24 +88,6 @@ const RETIRED_RING_RESET_BLOCKS = [
   },
 ];
 
-const BARE_FIELD_CALLS = [
-  {
-    fileSuffix: 'packages/ui/src/skills-panel.tsx',
-    pattern: /<Input\s+unstyled[\s\S]*placeholder="搜索技能"/,
-    label: 'skill search Input',
-  },
-  {
-    fileSuffix: 'packages/ui/src/composer.tsx',
-    pattern: /<UiTextarea\s+[^>]*unstyled[\s\S]*className="maka-composer-textarea\b/,
-    label: 'composer textarea',
-  },
-  {
-    fileSuffix: 'apps/desktop/src/renderer/OnboardingHero.tsx',
-    pattern: /<Textarea\s+[^>]*unstyled[\s\S]*className="maka-onboarding-quickchat-input\b/,
-    label: 'onboarding quickchat textarea',
-  },
-];
-
 function isAllowed(file: string, source: string): boolean {
   return ALLOWLIST.some((entry) => file.endsWith(entry.fileSuffix) && source.includes(entry.anchor));
 }
@@ -137,6 +120,17 @@ function readRuleBody(source: string, anchor: string): string | null {
   }
 
   return null;
+}
+
+function findFieldFocusSelector(source: string): string | null {
+  const root = postcss.parse(source);
+  let selector: string | null = null;
+  root.walkRules((rule) => {
+    if (rule.selector.includes('data-maka-field-chrome') && rule.selector.includes(':focus')) {
+      selector = rule.selector;
+    }
+  });
+  return selector;
 }
 
 describe('renderer !important audit contract', () => {
@@ -174,16 +168,12 @@ describe('renderer !important audit contract', () => {
 
   it('keeps embedded bare fields off page-level important ring resets', async () => {
     const modulePages = stripCssComments(await readFile(`${REPO_ROOT}/apps/desktop/src/renderer/styles/module-pages.css`, 'utf8'));
-    assert.match(
-      modulePages,
-      /:where\(input, select, textarea\):focus:not\(\[data-maka-field-chrome="none"\]\)/,
-      'the global renderer field focus rule must skip explicit bare fields',
+    const fieldFocusSelector = findFieldFocusSelector(modulePages);
+    assert.equal(
+      fieldFocusSelector,
+      ':where(input, select, textarea):focus:not(:where([data-maka-field-chrome="none"]))',
+      'the global renderer field focus rule must skip explicit bare fields without increasing selector specificity',
     );
-
-    for (const entry of BARE_FIELD_CALLS) {
-      const source = await readFile(`${REPO_ROOT}/${entry.fileSuffix}`, 'utf8');
-      assert.match(source, entry.pattern, `${entry.label} must pass unstyled to opt into the explicit bare field path`);
-    }
 
     for (const entry of RETIRED_RING_RESET_BLOCKS) {
       const file = `${REPO_ROOT}/${entry.fileSuffix}`;

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, readCssTree } from './css-test-helpers.js';
+import { REPO_ROOT, readCssTree, stripCssComments } from './css-test-helpers.js';
 
 type ImportantAllowance = {
   fileSuffix: string;
@@ -56,21 +56,6 @@ const ALLOWLIST: ImportantAllowance[] = [
     reason: 'shared field ring shadow override',
   },
   {
-    fileSuffix: 'apps/desktop/src/renderer/styles/module-pages.css',
-    anchor: '.maka-skill-search input',
-    reason: 'shared input ring reset inside wrapper-owned surface, defensive against the global focus rule above being scoped away',
-  },
-  {
-    fileSuffix: 'apps/desktop/src/renderer/styles/onboarding.css',
-    anchor: '.maka-onboarding-quickchat-input',
-    reason: 'shared textarea chrome reset inside wrapper-owned surface',
-  },
-  {
-    fileSuffix: 'apps/desktop/src/renderer/styles/onboarding.css',
-    anchor: '.maka-onboarding-quickchat-input:focus-visible',
-    reason: 'shared textarea ring reset inside wrapper-owned surface',
-  },
-  {
     fileSuffix: 'apps/desktop/src/renderer/styles/onboarding.css',
     anchor: '.maka-session-list .maka-session-empty-state',
     reason: 'shared empty-state card reset in sidebar surface',
@@ -85,20 +70,38 @@ const ALLOWLIST: ImportantAllowance[] = [
     anchor: '.maka-session-panel[data-collapsed="true"] .maka-list-stack',
     reason: 'shared list/empty-state collapse override',
   },
+];
+
+const RETIRED_RING_RESET_BLOCKS = [
+  {
+    fileSuffix: 'apps/desktop/src/renderer/styles/module-pages.css',
+    anchor: '.maka-skill-search input',
+  },
+  {
+    fileSuffix: 'apps/desktop/src/renderer/styles/onboarding.css',
+    anchor: '.maka-onboarding-quickchat .maka-onboarding-quickchat-input',
+  },
   {
     fileSuffix: 'apps/desktop/src/renderer/styles/tool-output.css',
     anchor: '.composer .maka-composer-textarea',
-    reason: 'shared textarea chrome reset inside composer wrapper',
+  },
+];
+
+const BARE_FIELD_CALLS = [
+  {
+    fileSuffix: 'packages/ui/src/skills-panel.tsx',
+    pattern: /<Input\s+unstyled[\s\S]*placeholder="搜索技能"/,
+    label: 'skill search Input',
   },
   {
-    fileSuffix: 'apps/desktop/src/renderer/styles/tool-output.css',
-    anchor: '.composer textarea:focus',
-    reason: 'shared textarea ring reset inside composer wrapper',
+    fileSuffix: 'packages/ui/src/composer.tsx',
+    pattern: /<UiTextarea\s+[^>]*unstyled[\s\S]*className="maka-composer-textarea\b/,
+    label: 'composer textarea',
   },
   {
-    fileSuffix: 'apps/desktop/src/renderer/styles/tool-output.css',
-    anchor: '.composer textarea:focus-visible',
-    reason: 'shared textarea ring reset inside composer wrapper',
+    fileSuffix: 'apps/desktop/src/renderer/OnboardingHero.tsx',
+    pattern: /<Textarea\s+[^>]*unstyled[\s\S]*className="maka-onboarding-quickchat-input\b/,
+    label: 'onboarding quickchat textarea',
   },
 ];
 
@@ -112,6 +115,28 @@ function isA11yOnlyFile(file: string): boolean {
     file.endsWith('apps/desktop/src/renderer/maka-tokens.css') ||
     file.endsWith('apps/desktop/src/renderer/styles/settings/nav-sidebar.css')
   );
+}
+
+function readRuleBody(source: string, anchor: string): string | null {
+  const start = source.indexOf(anchor);
+  if (start === -1) return null;
+
+  const open = source.indexOf('{', start);
+  if (open === -1) return null;
+
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    const ch = source[index];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(open + 1, index);
+      }
+    }
+  }
+
+  return null;
 }
 
 describe('renderer !important audit contract', () => {
@@ -145,5 +170,31 @@ describe('renderer !important audit contract', () => {
       [],
       'Non-a11y `!important` usage must be explicitly justified in-file and tracked in renderer-important-audit-contract.test.ts.',
     );
+  });
+
+  it('keeps embedded bare fields off page-level important ring resets', async () => {
+    const modulePages = stripCssComments(await readFile(`${REPO_ROOT}/apps/desktop/src/renderer/styles/module-pages.css`, 'utf8'));
+    assert.match(
+      modulePages,
+      /:where\(input, select, textarea\):focus:not\(\[data-maka-field-chrome="none"\]\)/,
+      'the global renderer field focus rule must skip explicit bare fields',
+    );
+
+    for (const entry of BARE_FIELD_CALLS) {
+      const source = await readFile(`${REPO_ROOT}/${entry.fileSuffix}`, 'utf8');
+      assert.match(source, entry.pattern, `${entry.label} must pass unstyled to opt into the explicit bare field path`);
+    }
+
+    for (const entry of RETIRED_RING_RESET_BLOCKS) {
+      const file = `${REPO_ROOT}/${entry.fileSuffix}`;
+      const source = stripCssComments(await readFile(file, 'utf8'));
+      const body = readRuleBody(source, entry.anchor);
+      assert.notEqual(body, null, `${entry.anchor} rule not found in ${entry.fileSuffix}`);
+      assert.doesNotMatch(
+        body ?? '',
+        /!important|--tw-ring-(?:offset-)?shadow/,
+        `${entry.anchor} must route through the explicit bare field path instead of resetting primitive ring chrome in page CSS.`,
+      );
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
-import { readAllRendererCss } from './css-test-helpers.js';
+import { readAllRendererCss, readCssTree, RENDERER_STYLES_DIR, stripCssComments } from './css-test-helpers.js';
 
 /**
  * Returns the number of `@layer` blocks enclosing the first occurrence of
@@ -35,6 +36,22 @@ function enclosingLayerCount(styles: string, selectorLine: string): number {
 }
 
 describe('renderer style layer cascade contract', () => {
+  it('keeps feature stylesheets unlayered so renderer author CSS has one cascade model', async () => {
+    const layeredFiles: string[] = [];
+    for (const file of await readCssTree(RENDERER_STYLES_DIR)) {
+      const source = stripCssComments(await readFile(file, 'utf8'));
+      if (/@layer\b/.test(source)) {
+        layeredFiles.push(file);
+      }
+    }
+
+    assert.deepEqual(
+      layeredFiles,
+      [],
+      'Feature stylesheets under apps/desktop/src/renderer/styles must stay unlayered. Keep Tailwind layer integration in maka-tokens.css instead of mixing local @layer blocks with unlayered override rules.',
+    );
+  });
+
   /**
    * Regression guard for #257 / #253 Round A.
    *

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -735,7 +735,7 @@ function ReadyEmptyHero(props: {
           <Textarea
             ref={inputRef}
             unstyled
-            className="maka-onboarding-quickchat-input border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            className="maka-onboarding-quickchat-input"
             placeholder={copy.quickChatPlaceholder}
             rows={3}
             value={draft}

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -734,6 +734,7 @@ function ReadyEmptyHero(props: {
         <div className="maka-onboarding-quickchat-field">
           <Textarea
             ref={inputRef}
+            unstyled
             className="maka-onboarding-quickchat-input border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
             placeholder={copy.quickChatPlaceholder}
             rows={3}

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -1,23 +1,19 @@
-@layer base {
+
   body {
     margin: 0;
   }
-
-  .maka-overlay-scrollarea {
+.maka-overlay-scrollarea {
     min-width: 0;
     min-height: 0;
   }
-
-  .maka-overlay-scrollarea-viewport {
+.maka-overlay-scrollarea-viewport {
     min-width: 0;
     min-height: 0;
   }
-
-  .maka-overlay-scrollarea-content {
+.maka-overlay-scrollarea-content {
     min-width: 0;
   }
-
-  .os-theme-maka {
+.os-theme-maka {
     /* local: OverlayScrollbars theme overrides */
     --os-size: 8px;
     --os-padding-perpendicular: 1px;
@@ -34,28 +30,23 @@
     --os-handle-min-size: 40px;
     box-sizing: border-box;
   }
-
-  .os-theme-maka.os-scrollbar-vertical {
+.os-theme-maka.os-scrollbar-vertical {
     width: var(--os-size);
   }
-
-  .os-theme-maka.os-scrollbar-horizontal {
+.os-theme-maka.os-scrollbar-horizontal {
     height: var(--os-size);
   }
-
-  .maka-overlay-scrollarea-viewport:focus-visible {
+.maka-overlay-scrollarea-viewport:focus-visible {
     outline: none;
     box-shadow: none;
   }
-
-  button,
+button,
   textarea,
   input,
   select {
     font: inherit;
   }
-
-  .maka-visually-hidden {
+.maka-visually-hidden {
     position: absolute !important;
     width: 1px !important;
     height: 1px !important;
@@ -66,26 +57,22 @@
     white-space: nowrap !important;
     border: 0 !important;
   }
-
-  button {
+button {
     transition:
       background var(--duration-base) var(--ease-out-strong),
       border-color var(--duration-base) var(--ease-out-strong),
       color var(--duration-base) var(--ease-out-strong),
       transform var(--duration-base) var(--ease-out-strong);
   }
-
-  button:active {
+button:active {
     transform: scale(0.97);
   }
-
-  @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     button:active {
       transform: none;
     }
   }
-
-  /* PR-IR-04: Test-fixture-driven reduced-motion variant (per
+/* PR-IR-04: Test-fixture-driven reduced-motion variant (per
      docs/ui-quality-plan.md §5). Mirrors `prefers-reduced-motion: reduce`
      via an attribute on `<html>` so visual smoke fixtures can capture a
      "reduced motion" screenshot variant without depending on the host OS
@@ -94,7 +81,7 @@
      The `data-maka-reduced-motion="true"` attribute is applied by the
      renderer when `MAKA_VISUAL_SMOKE_REDUCED_MOTION=1` is set in the env.
      Real users still get motion as configured by their OS. */
-  [data-maka-reduced-motion="true"] *,
+[data-maka-reduced-motion="true"] *,
   [data-maka-reduced-motion="true"] *::before,
   [data-maka-reduced-motion="true"] *::after {
     animation-duration: 0.01ms !important;
@@ -103,20 +90,17 @@
     /* Scroll behavior + view transition durations also collapse */
     scroll-behavior: auto !important;
   }
-
-  [data-maka-reduced-motion="true"] button:active {
+[data-maka-reduced-motion="true"] button:active {
     transform: none;
   }
-
-  /* Visual smoke captures must be deterministic. We still exercise the
+/* Visual smoke captures must be deterministic. We still exercise the
      normal DOM for every scenario, but pause purely decorative animation,
      transitions, and caret blink so screenshot hashes don't depend on the
      exact millisecond when Electron captures the page. */
-  [data-maka-visual-smoke="true"] *,
+[data-maka-visual-smoke="true"] *,
   [data-maka-visual-smoke="true"] *::before,
   [data-maka-visual-smoke="true"] *::after {
     animation-play-state: paused !important;
     transition-duration: 0.01ms !important;
     caret-color: transparent !important;
   }
-}

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -1,4 +1,4 @@
-@layer components {
+
   .maka-chat-header-alert {
     display: inline-flex;
     align-items: center;
@@ -15,30 +15,35 @@
     -webkit-app-region: no-drag;
     transition: transform 0.12s var(--ease-out-strong);
   }
-  .maka-chat-header-alert:hover {
+
+.maka-chat-header-alert:hover {
     transform: translateY(-1px);
   }
-  .maka-chat-header-alert:focus-visible {
+
+.maka-chat-header-alert:focus-visible {
     outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
   }
-  .maka-chat-header-alert[data-tone="info"] {
+
+.maka-chat-header-alert[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);
     color: var(--info-text);
     border-color: oklch(from var(--info) l c h / 0.20);
   }
-  .maka-chat-header-alert[data-tone="warning"] {
+
+.maka-chat-header-alert[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
     border-color: oklch(from var(--info) l c h / 0.30);
   }
-  .maka-chat-header-alert[data-tone="destructive"] {
+
+.maka-chat-header-alert[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.14);
     color: var(--destructive);
     border-color: oklch(from var(--destructive) l c h / 0.28);
   }
 
-  .maka-chat-header-status {
+.maka-chat-header-status {
     display: inline-flex;
     align-items: center;
     /* PR-CHAT-HEADER-BADGE-SCALE-0: matches .maka-chat-header-alert's
@@ -57,56 +62,62 @@
     white-space: nowrap;
     flex: 0 0 auto;
   }
-  .maka-chat-header-status[data-tone="accent"] {
+
+.maka-chat-header-status[data-tone="accent"] {
     background: oklch(from var(--nav-active) l c h / 0.14);
     color: var(--nav-active);
     border-color: oklch(from var(--nav-active) l c h / 0.24);
   }
-  .maka-chat-header-status[data-tone="warning"] {
+
+.maka-chat-header-status[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
     border-color: oklch(from var(--info) l c h / 0.30);
   }
-  .maka-chat-header-status[data-tone="destructive"] {
+
+.maka-chat-header-status[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.14);
     color: var(--destructive);
     border-color: oklch(from var(--destructive) l c h / 0.28);
   }
-  .maka-chat-header-status[data-tone="info"] {
+
+.maka-chat-header-status[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);
     color: var(--info-text);
     border-color: oklch(from var(--info) l c h / 0.20);
   }
-  .maka-chat-header-status[data-tone="success"] {
+
+.maka-chat-header-status[data-tone="success"] {
     background: oklch(from var(--brand-deep) l c h / 0.14);
     color: var(--brand-deep);
     border-color: oklch(from var(--brand-deep) l c h / 0.28);
   }
-  .maka-chat-header-status[data-tone="muted"] {
+
+.maka-chat-header-status[data-tone="muted"] {
     background: var(--foreground-5);
     color: var(--foreground-60);
     border-color: var(--border);
   }
 
-  .messages {
+.messages {
     position: relative;
     flex: 1;
     min-height: 0;
     overflow: hidden;
   }
 
-  .maka-chatViewport {
+.maka-chatViewport {
     height: 100%;
     overscroll-behavior: contain;
   }
 
-  .maka-chatContent {
+.maka-chatContent {
     position: relative;
     min-height: 100%;
     padding-inline: clamp(var(--space-6), 4vw, var(--space-10));
   }
 
-  .maka-chat-shell {
+.maka-chat-shell {
     position: relative;
     min-height: 0;
     display: flex;
@@ -114,10 +125,8 @@
     flex: 1;
     overflow: hidden;
   }
-}
 
-@layer components {
-  .maka-chat-jump-bottom {
+.maka-chat-jump-bottom {
     position: absolute;
     bottom: 10px;
     left: 50%;
@@ -138,20 +147,17 @@
     background 120ms var(--ease-out-strong);
   }
 
-  .maka-chat-jump-bottom:hover {
+.maka-chat-jump-bottom:hover {
     color: var(--foreground);
     background: var(--foreground-3);
     transform: translateX(-50%) translateY(-2px);
   }
 
-  .maka-chat-jump-bottom:active {
+.maka-chat-jump-bottom:active {
     transform: translateX(-50%) scale(0.97);
   }
 
-}
-
-@layer components {
-  .maka-error-surface {
+.maka-error-surface {
     position: fixed;
     inset: 0;
     z-index: var(--z-overlay);
@@ -161,7 +167,7 @@
     background: var(--background);
   }
 
-  .maka-error-card {
+.maka-error-card {
     display: grid;
     grid-template-columns: 32px minmax(0, 1fr);
     align-items: start;
@@ -174,7 +180,7 @@
     box-shadow: var(--shadow-modal);
   }
 
-  .maka-error-icon {
+.maka-error-icon {
     width: 32px;
     height: 32px;
     display: grid;
@@ -184,19 +190,19 @@
     color: var(--destructive-text);
   }
 
-  .maka-error-copy {
+.maka-error-copy {
     display: grid;
     gap: var(--space-1-5);
   }
 
-  .maka-error-copy h2 {
+.maka-error-copy h2 {
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
 
-  .maka-error-copy p {
+.maka-error-copy p {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
@@ -204,7 +210,7 @@
     max-width: 56ch;
   }
 
-  .maka-error-stack {
+.maka-error-stack {
     margin: var(--space-1) 0 0;
     max-height: 220px;
     padding: var(--space-2-5) var(--space-3);
@@ -220,26 +226,25 @@
     word-break: break-word;
   }
 
-  .maka-error-actions {
+.maka-error-actions {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     margin-top: var(--space-1-5);
   }
 
-  .maka-error-copy-action[data-copy-state="pending"] {
+.maka-error-copy-action[data-copy-state="pending"] {
     cursor: progress;
   }
 
-  .maka-error-copy-action[data-copy-state="failed"] {
+.maka-error-copy-action[data-copy-state="failed"] {
     color: var(--destructive);
     border-color: oklch(from var(--destructive) l c h / 0.35);
   }
 
-  .maka-error-copy-status {
+.maka-error-copy-status {
     color: var(--destructive-text);
   }
-}
 
 .maka-fake-backend-banner {
   display: flex;

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -1,19 +1,17 @@
-@layer components {
+
   .maka-hero header,
   .maka-hero-empty-chat header {
     display: grid;
     gap: var(--space-2-5);
     justify-items: center;
   }
-
-  .maka-hero-visual {
+.maka-hero-visual {
     position: relative;
     width: min(520px, 62vw);
     height: 130px;
     margin-bottom: var(--space-1);
   }
-
-  .maka-hero-bubble {
+.maka-hero-bubble {
     position: absolute;
     display: inline-flex;
     align-items: center;
@@ -27,28 +25,24 @@
     white-space: nowrap;
     padding: 0 var(--space-3);
   }
-
-  .maka-hero-bubble-primary {
+.maka-hero-bubble-primary {
     left: 38px;
     top: 16px;
     background: oklch(from var(--brand-deep) l c h / 0.10);
     color: var(--brand-deep);
   }
-
-  .maka-hero-bubble-secondary {
+.maka-hero-bubble-secondary {
     right: 22px;
     top: 42px;
   }
-
-  .maka-hero-avatar {
+.maka-hero-avatar {
     position: absolute;
     display: inline-grid;
     place-items: center;
     border-radius: var(--radius-pill);
     box-shadow: 0 6px 18px -14px oklch(from var(--foreground) l c h / 0.32);
   }
-
-  .maka-hero-avatar-maka {
+.maka-hero-avatar-maka {
     left: calc(50% - 48px);
     top: 42px;
     width: 66px;
@@ -56,8 +50,7 @@
     background: oklch(from var(--brand-deep) l c h / 0.18);
     color: var(--brand-deep);
   }
-
-  .maka-hero-avatar-user {
+.maka-hero-avatar-user {
     left: calc(50% + 4px);
     top: 52px;
     width: 62px;
@@ -68,8 +61,7 @@
     font-size: 1.4667em;
     font-weight: 700;
   }
-
-  .maka-hero-eyebrow {
+.maka-hero-eyebrow {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -79,8 +71,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
   }
-
-  .maka-hero h1 {
+.maka-hero h1 {
     margin: 0;
     max-width: 34ch;
     /* Phase 4A hero typography — atlas §15 deep RE notes reference uses
@@ -97,8 +88,7 @@
     font-variation-settings: "wght" 550, "wdth" 105;
     text-wrap: balance;
   }
-
-  .maka-hero p {
+.maka-hero p {
     margin: 0;
     max-width: 54ch;
     color: var(--foreground-60);
@@ -106,8 +96,7 @@
     line-height: 1.55;
     text-wrap: pretty;
   }
-
-  @media (max-width: 820px) {
+@media (max-width: 820px) {
     .maka-hero-visual {
       width: min(420px, 84vw);
       height: 112px;
@@ -126,4 +115,3 @@
       right: 0;
     }
   }
-}

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -2,8 +2,7 @@
    Skills + Plan shells (1px hairline border + 6px radius + 4% lift + inner
    highlight). Was flat (transparent) which felt orphaned next to the other
    module pages. */
-@layer components {
-  .maka-module-main .maka-daily-review-panel {
+.maka-module-main .maka-daily-review-panel {
     max-width: 980px;
     width: 100%;
     margin-inline: auto;
@@ -14,8 +13,7 @@
       var(--card-shadow),
       var(--card-highlight);
   }
-
-  .maka-daily-review-header {
+.maka-daily-review-header {
     display: grid;
     grid-template-columns: 24px 1fr 24px;
     align-items: center;
@@ -23,13 +21,11 @@
     padding: var(--space-0-5) var(--space-0-5) var(--space-1-5);
     border-bottom: 1px solid var(--foreground-10);
   }
-}
 
 /* PR-DAILY-REVIEW-FULL-0: info banner explaining the feature, plus a
    manual-trigger row. Banner uses the page-card recipe with a softer
    tint so it reads as supporting context, not a primary surface. */
-@layer components {
-  .maka-daily-review-info {
+.maka-daily-review-info {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
@@ -38,31 +34,26 @@
     background: oklch(from var(--foreground) l c h / 0.03);
     box-shadow: var(--card-highlight);
   }
-
-  .maka-daily-review-info-body {
+.maka-daily-review-info-body {
     margin: 0;
     font-size: var(--font-size-ui);
     line-height: 1.55;
     color: var(--foreground-80);
   }
-
-  .maka-daily-review-info-body strong {
+.maka-daily-review-info-body strong {
     font-weight: 600;
     color: var(--foreground);
   }
-
-  .maka-daily-review-info-hint {
+.maka-daily-review-info-hint {
     margin: 0;
     font-size: var(--font-size-caption);
     line-height: 1.5;
     color: var(--foreground-50);
   }
-
-  .maka-daily-review-info-hint strong {
+.maka-daily-review-info-hint strong {
     font-weight: 600;
     color: var(--foreground-80);
   }
-}
 
 .maka-daily-review-quick-runs {
   /* WAWQAQ msg `3871e56b` 2026-06-25: "按钮的位置也不对。按道理一般都
@@ -93,35 +84,34 @@
   opacity: 0.7;
 }
 
-@layer components {
-  .maka-daily-review-archives {
+.maka-daily-review-archives {
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) 0 var(--space-2-5);
     border-bottom: 1px solid var(--foreground-10);
   }
 
-  .maka-daily-review-archives-header {
+.maka-daily-review-archives-header {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     gap: var(--space-2);
   }
 
-  .maka-daily-review-archive-count {
+.maka-daily-review-archive-count {
     font-size: var(--font-size-caption);
     color: var(--foreground-40);
     font-variant-numeric: tabular-nums;
   }
 
-  .maka-daily-review-archive-layout {
+.maka-daily-review-archive-layout {
     display: grid;
     grid-template-columns: minmax(180px, 0.34fr) minmax(0, 1fr);
     gap: var(--space-2);
     align-items: start;
   }
 
-  .maka-daily-review-archive-list {
+.maka-daily-review-archive-list {
     /* PR-DAILYREVIEW-ARCHIVE-ROW-A11Y-0 (round 7/30): changed
        from `<div role="list">` to semantic `<ul>`. Reset the
        UA's default list bullet + padding-left so the visual
@@ -134,11 +124,10 @@
     min-width: 0;
   }
 
-  .maka-daily-review-archive-list > li {
+.maka-daily-review-archive-list > li {
     margin: 0;
     padding: 0;
   }
-}
 
 .maka-daily-review-archive-row {
   appearance: none;
@@ -165,8 +154,7 @@
   border-color: oklch(from var(--nav-active) l c h / 0.18);
 }
 
-@layer components {
-  .maka-daily-review-archive-row-title {
+.maka-daily-review-archive-row-title {
     color: var(--foreground);
     font-size: var(--font-size-ui);
     font-weight: 600;
@@ -175,7 +163,7 @@
     white-space: nowrap;
   }
 
-  .maka-daily-review-archive-row-meta {
+.maka-daily-review-archive-row-meta {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     font-variant-numeric: tabular-nums;
@@ -184,7 +172,7 @@
     white-space: nowrap;
   }
 
-  .maka-daily-review-archive-body {
+.maka-daily-review-archive-body {
     display: grid;
     gap: var(--space-2);
     min-width: 0;
@@ -195,21 +183,21 @@
     box-shadow: var(--card-highlight);
   }
 
-  .maka-daily-review-archive-body[data-empty="true"],
+.maka-daily-review-archive-body[data-empty="true"],
   .maka-daily-review-archive-empty {
     color: var(--foreground-50);
     font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 
-  .maka-daily-review-archive-body-header {
+.maka-daily-review-archive-body-header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     gap: var(--space-2-5);
   }
 
-  .maka-daily-review-archive-body-header h4 {
+.maka-daily-review-archive-body-header h4 {
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
@@ -217,7 +205,7 @@
     letter-spacing: 0;
   }
 
-  .maka-daily-review-archive-body-header p {
+.maka-daily-review-archive-body-header p {
     margin: var(--space-0-5) 0 0;
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
@@ -225,7 +213,7 @@
     overflow-wrap: anywhere;
   }
 
-  .maka-daily-review-archive-status {
+.maka-daily-review-archive-status {
     flex: none;
     border: 1px solid var(--foreground-10);
     border-radius: var(--radius-pill);
@@ -236,35 +224,35 @@
     white-space: nowrap;
   }
 
-  .maka-daily-review-archive-status[data-status="ok"] {
+.maka-daily-review-archive-status[data-status="ok"] {
     border-color: oklch(from var(--success, var(--status-running)) l c h / 0.26);
     color: var(--success, var(--status-running));
   }
 
-  .maka-daily-review-archive-status[data-status="failed"],
+.maka-daily-review-archive-status[data-status="failed"],
   .maka-daily-review-archive-status[data-status="no_model"] {
     border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.30);
     color: var(--destructive, var(--warning, var(--foreground)));
   }
 
-  .maka-daily-review-archive-error {
+.maka-daily-review-archive-error {
     margin: 0;
     color: var(--destructive, var(--foreground));
     font-size: var(--font-size-ui);
     line-height: 1.5;
   }
 
-  .maka-daily-review-archive-sections {
+.maka-daily-review-archive-sections {
     display: grid;
     gap: var(--space-2);
   }
 
-  .maka-daily-review-archive-section {
+.maka-daily-review-archive-section {
     display: grid;
     gap: var(--space-0-5);
   }
 
-  .maka-daily-review-archive-section h5 {
+.maka-daily-review-archive-section h5 {
     margin: 0;
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
@@ -272,7 +260,7 @@
     letter-spacing: 0;
   }
 
-  .maka-daily-review-archive-section p {
+.maka-daily-review-archive-section p {
     margin: 0;
     color: var(--foreground-80);
     font-size: var(--font-size-ui);
@@ -281,7 +269,7 @@
     white-space: pre-wrap;
   }
 
-  .maka-daily-review-day {
+.maka-daily-review-day {
     text-align: center;
     font-weight: 600;
     font-size: var(--font-size-ui);
@@ -289,13 +277,11 @@
     letter-spacing: 0.005em;
     color: var(--foreground);
   }
-}
 
 /* PR-DAILY-REVIEW-RANGE-0: 今日 / 本周 / 本月 tabs. Active tab uses
    the same accent-emphasis as the surrounding Settings nav so the
    visual language stays consistent. */
-@layer components {
-  .maka-daily-review-range {
+.maka-daily-review-range {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
@@ -303,14 +289,12 @@
     padding: var(--space-0-5) 0 var(--space-1-5);
     border-bottom: 1px solid var(--foreground-10);
   }
-
-  .maka-daily-review-range-tabs,
+.maka-daily-review-range-tabs,
   .maka-daily-review-actions {
     display: flex;
     gap: var(--space-1);
     min-width: 0;
   }
-}
 
 .maka-daily-review-range-tab {
   flex: 1;
@@ -330,8 +314,7 @@
   font-weight: 600;
 }
 
-@layer components {
-  .maka-daily-review-alert {
+.maka-daily-review-alert {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -344,10 +327,9 @@
     font-size: var(--font-size-ui);
   }
 
-  .maka-daily-review-alert > span {
+.maka-daily-review-alert > span {
     min-width: 0;
   }
-}
 
 .maka-daily-review-alert-retry {
   flex: none;
@@ -355,7 +337,6 @@
 }
 
 @media (max-width: 720px) {
-  @layer components {
     .maka-daily-review-range {
       grid-template-columns: 1fr;
     }
@@ -363,20 +344,16 @@
     .maka-daily-review-archive-layout {
       grid-template-columns: 1fr;
     }
-  }
 }
-@layer components {
-  .maka-daily-review-totals {
+.maka-daily-review-totals {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
     gap: var(--space-1);
   }
-
-  .maka-module-main .maka-daily-review-totals {
+.maka-module-main .maka-daily-review-totals {
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
-
-  .maka-daily-review-totals-cell {
+.maka-daily-review-totals-cell {
     display: grid;
     gap: 1px;
     padding: var(--space-1) var(--space-2);
@@ -384,26 +361,22 @@
     border-radius: var(--radius-control);
     background: oklch(from var(--foreground) l c h / 0.04);
   }
-
-  .maka-daily-review-totals-cell[data-tone="error"] {
+.maka-daily-review-totals-cell[data-tone="error"] {
     border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.35);
     background: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.06);
   }
-
-  .maka-daily-review-totals-value {
+.maka-daily-review-totals-value {
     font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
     font-variant-numeric: tabular-nums;
   }
-
-  .maka-daily-review-totals-label {
+.maka-daily-review-totals-label {
     font-size: var(--font-size-caption);
     text-transform: none;
     letter-spacing: 0;
     color: var(--foreground-50);
   }
-}
 
 /* PR-DAILY-REVIEW-EYEBROW-RHYTHM-0 (WAWQAQ msg `7f0ec4a5`): granularity
    bump. Each section now starts with a prominent eyebrow badge above
@@ -411,20 +384,17 @@
    "minimalist-ui §5 keystroke badges" + "design-taste-frontend §3
    eyebrow + accent bar" rules from the skills audit. Visible every time
    the user opens Daily Review. */
-@layer components {
-  .maka-daily-review-section {
+.maka-daily-review-section {
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3) 0 0;
     border-top: 1px solid oklch(from var(--foreground) l c h / 0.07);
   }
-
-  .maka-daily-review-section:first-of-type {
+.maka-daily-review-section:first-of-type {
     border-top: 0;
     padding-top: var(--space-1);
   }
-
-  .maka-daily-review-section-title {
+.maka-daily-review-section-title {
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
@@ -435,8 +405,7 @@
     color: var(--foreground-60);
     margin: 0;
   }
-
-  .maka-daily-review-section-title::before {
+.maka-daily-review-section-title::before {
     content: '';
     display: inline-block;
     width: 3px;
@@ -445,16 +414,14 @@
     background: oklch(from var(--status-running) l c h / 0.85);
     flex-shrink: 0;
   }
-
-  .maka-daily-review-list {
+.maka-daily-review-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
     gap: var(--space-1);
   }
-
-  .maka-daily-review-list-item {
+.maka-daily-review-list-item {
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-1-5) var(--space-2-5);
@@ -463,16 +430,13 @@
     transition: background 140ms var(--ease-out-strong),
                 transform var(--duration-quick) var(--ease-out-strong);
   }
-
-  .maka-daily-review-list-item:hover {
+.maka-daily-review-list-item:hover {
     background: oklch(from var(--foreground) l c h / 0.045);
   }
-
-  .maka-daily-review-list-item:active:not(:has(button:disabled)) {
+.maka-daily-review-list-item:active:not(:has(button:disabled)) {
     transform: scale(0.99);
   }
-
-  @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     .maka-daily-review-list-item {
       transition: background 0ms;
     }
@@ -480,7 +444,6 @@
       transform: none;
     }
   }
-}
 
 .maka-daily-review-session-button {
   appearance: none;
@@ -500,22 +463,21 @@
   cursor: default;
 }
 
-@layer components {
-  .maka-daily-review-session-name {
+.maka-daily-review-session-name {
     font-weight: 500;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .maka-daily-review-session-time {
+.maka-daily-review-session-time {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     white-space: nowrap;
     font-variant-numeric: tabular-nums;
   }
 
-  .maka-daily-review-session-preview {
+.maka-daily-review-session-preview {
     font-size: var(--font-size-ui);
     color: var(--foreground-50);
     overflow: hidden;
@@ -523,23 +485,22 @@
     white-space: nowrap;
   }
 
-  .maka-daily-review-top-label {
+.maka-daily-review-top-label {
     font-weight: 500;
     color: var(--foreground);
   }
 
-  .maka-daily-review-top-meta {
+.maka-daily-review-top-meta {
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
     font-variant-numeric: tabular-nums;
   }
 
-  .maka-daily-review-loading {
+.maka-daily-review-loading {
     display: grid;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-1);
   }
-}
 
 /* Unlayered on purpose: the shared `.maka-empty-state` base
    (onboarding.css) is unlayered `position: absolute` centering, and

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -7,14 +7,13 @@
    diagnostic detail.
 ============================================================================= */
 
-@layer components {
-  .settingsHealthPage {
+.settingsHealthPage {
     display: flex;
     flex-direction: column;
     gap: var(--space-5);
   }
 
-  .settingsHealthIntro {
+.settingsHealthIntro {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
@@ -24,33 +23,37 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-  .settingsHealthIntro h3 {
+
+.settingsHealthIntro h3 {
     margin: 0 0 var(--space-1-5);
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
-  .settingsHealthIntro p {
+
+.settingsHealthIntro p {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 60ch;
   }
-  .settingsHealthIntro p strong {
+
+.settingsHealthIntro p strong {
     color: var(--foreground);
   }
-  .settingsHealthMeta {
+
+.settingsHealthMeta {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     gap: var(--space-1-5);
     flex-shrink: 0;
   }
-  .settingsHealthMeta small {
+
+.settingsHealthMeta small {
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
-}
 
 /* Unlayered on purpose: this class customizes a shared `Button
    variant="secondary"` and must outrank the Tailwind utility classes baked
@@ -74,8 +77,7 @@
   outline-offset: 2px;
 }
 
-@layer components {
-  .settingsHealthError {
+.settingsHealthError {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -85,18 +87,21 @@
     border-radius: var(--radius-surface);
     color: var(--destructive-text);
   }
-  .settingsHealthError strong {
+
+.settingsHealthError strong {
     font-size: var(--font-size-ui);
   }
-  .settingsHealthError small {
+
+.settingsHealthError small {
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
   }
-  .settingsHealthError button {
+
+.settingsHealthError button {
     align-self: flex-start;
   }
 
-  .settingsHealthSummary {
+.settingsHealthSummary {
     /* PR-HEALTH-SUMMARY-LIST-A11Y-0 (round 19/30): switched from
        `<section role="list">` to semantic `<ul>`. Reset the UA's
        default bullet + 40px padding-left so the 5-column grid
@@ -108,7 +113,8 @@
     grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: var(--space-2-5);
   }
-  .settingsHealthSummaryTile {
+
+.settingsHealthSummaryTile {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -118,71 +124,85 @@
     border-radius: var(--radius-surface);
     background: var(--background);
   }
-  .settingsHealthSummaryTile strong {
+
+.settingsHealthSummaryTile strong {
     font-size: 1.4em;
     font-weight: 600;
     line-height: 1.1;
   }
-  .settingsHealthSummaryTile small {
+
+.settingsHealthSummaryTile small {
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
   }
-  .settingsHealthSummaryTile[data-empty="true"] {
+
+.settingsHealthSummaryTile[data-empty="true"] {
     opacity: 0.55;
   }
-  .settingsHealthSummaryTile[data-tone="success"] {
+
+.settingsHealthSummaryTile[data-tone="success"] {
     border-color: oklch(from var(--success) l c h / 0.24);
   }
-  .settingsHealthSummaryTile[data-tone="success"] strong {
+
+.settingsHealthSummaryTile[data-tone="success"] strong {
     color: var(--success-text);
   }
-  .settingsHealthSummaryTile[data-tone="info"] {
+
+.settingsHealthSummaryTile[data-tone="info"] {
     border-color: oklch(from var(--info) l c h / 0.24);
   }
-  .settingsHealthSummaryTile[data-tone="info"] strong {
+
+.settingsHealthSummaryTile[data-tone="info"] strong {
     color: var(--info-text);
   }
-  .settingsHealthSummaryTile[data-tone="warning"] {
+
+.settingsHealthSummaryTile[data-tone="warning"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
   }
-  .settingsHealthSummaryTile[data-tone="warning"] strong {
+
+.settingsHealthSummaryTile[data-tone="warning"] strong {
     color: var(--warning-text, var(--info-text));
   }
-  .settingsHealthSummaryTile[data-tone="destructive"] {
+
+.settingsHealthSummaryTile[data-tone="destructive"] {
     border-color: oklch(from var(--destructive) l c h / 0.30);
   }
-  .settingsHealthSummaryTile[data-tone="destructive"] strong {
+
+.settingsHealthSummaryTile[data-tone="destructive"] strong {
     color: var(--destructive-text);
   }
-  .settingsHealthSummaryTile[data-tone="neutral"] strong {
+
+.settingsHealthSummaryTile[data-tone="neutral"] strong {
     color: var(--foreground-70);
   }
 
-  .settingsHealthBlockers {
+.settingsHealthBlockers {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
   }
 
-  .settingsHealthLayer {
+.settingsHealthLayer {
     display: flex;
     flex-direction: column;
     gap: var(--space-2-5);
   }
-  .settingsHealthLayer > header h4 {
+
+.settingsHealthLayer > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
   }
-  .settingsHealthLayer > header small {
+
+.settingsHealthLayer > header small {
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
 
-  .settingsHealthSignalList {
+.settingsHealthSignalList {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -190,7 +210,7 @@
     gap: var(--space-2);
   }
 
-  .settingsHealthSignalRow {
+.settingsHealthSignalRow {
     display: flex;
     flex-direction: column;
     gap: var(--space-1-5);
@@ -200,50 +220,57 @@
     background: var(--background);
     transition: border-color var(--duration-base) var(--ease-out-strong);
   }
-  .settingsHealthSignalRow[data-status="ok"] {
+
+.settingsHealthSignalRow[data-status="ok"] {
     border-color: oklch(from var(--success) l c h / 0.24);
   }
-  .settingsHealthSignalRow[data-status="warning"] {
+
+.settingsHealthSignalRow[data-status="warning"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
   }
-  .settingsHealthSignalRow[data-status="error"] {
+
+.settingsHealthSignalRow[data-status="error"] {
     border-color: oklch(from var(--destructive) l c h / 0.30);
   }
 
-  .settingsHealthSignalHeader {
+.settingsHealthSignalHeader {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: var(--space-3);
   }
-  .settingsHealthSignalHeading {
+
+.settingsHealthSignalHeading {
     display: flex;
     flex-direction: column;
     gap: var(--space-0-5);
   }
-  .settingsHealthSignalHeading strong {
+
+.settingsHealthSignalHeading strong {
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
-  .settingsHealthSignalScope {
+
+.settingsHealthSignalScope {
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
     letter-spacing: 0.04em;
   }
 
-  .settingsHealthSignalMessage {
+.settingsHealthSignalMessage {
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-80);
     line-height: 1.5;
   }
-  .settingsHealthSignalDetail {
+
+.settingsHealthSignalDetail {
     font-size: var(--font-size-caption);
     color: var(--foreground-60);
     line-height: 1.45;
   }
 
-  .settingsHealthSignalMeta {
+.settingsHealthSignalMeta {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -251,31 +278,35 @@
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
-  .settingsHealthSignalMeta code {
+
+.settingsHealthSignalMeta code {
     font-family: var(--font-mono);
     background: var(--foreground-5);
     border-radius: var(--radius-control);
     padding: 1px var(--space-1);
     color: var(--foreground-70);
   }
-  .settingsHealthSignalBlocker {
+
+.settingsHealthSignalBlocker {
     font-size: var(--font-size-caption);
     padding: 1px var(--space-2);
     border-radius: var(--radius-pill);
     border: 1px solid var(--border);
   }
-  .settingsHealthSignalBlocker[data-tone="destructive"] {
+
+.settingsHealthSignalBlocker[data-tone="destructive"] {
     color: var(--destructive-text);
     background: oklch(from var(--destructive) l c h / 0.08);
     border-color: oklch(from var(--destructive) l c h / 0.22);
   }
-  .settingsHealthSignalBlocker[data-tone="warning"] {
+
+.settingsHealthSignalBlocker[data-tone="warning"] {
     color: var(--warning-text, var(--info-text));
     background: oklch(from var(--warning, var(--info)) l c h / 0.10);
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.22);
   }
 
-  .settingsHealthFootnote {
+.settingsHealthFootnote {
     margin: 0;
     padding: var(--space-3) var(--space-3);
     border: 1px dashed var(--border);
@@ -285,4 +316,3 @@
     font-size: var(--font-size-caption);
     line-height: 1.55;
   }
-}

--- a/apps/desktop/src/renderer/styles/markdown-link.css
+++ b/apps/desktop/src/renderer/styles/markdown-link.css
@@ -1,4 +1,4 @@
-@layer components {
+
   /* =============================================================================
      PR-UI-RENDER-2 — Markdown link router visual states
 
@@ -16,14 +16,12 @@
      variant uses a dashed destructive underline so users can tell it
      isn't actionable.
   ============================================================================= */
-
-  .maka-markdown-link {
+.maka-markdown-link {
     text-underline-offset: 2px;
     text-decoration-thickness: 1px;
     border-radius: var(--radius-control);
   }
-
-  .maka-markdown-link-internal {
+.maka-markdown-link-internal {
     /* Reset native <button> chrome so it visually flows with prose. */
     appearance: none;
     background: transparent;
@@ -35,28 +33,25 @@
     text-decoration: underline solid color-mix(in oklch, var(--link) 50%, var(--background));
     cursor: pointer;
   }
-  .maka-markdown-link-internal:hover {
+.maka-markdown-link-internal:hover {
     text-decoration-color: var(--link);
   }
-  .maka-markdown-link-internal:focus-visible {
+.maka-markdown-link-internal:focus-visible {
     outline: 2px solid oklch(from var(--focus-ring) l c h / 0.42);
     outline-offset: 2px;
   }
-  .maka-markdown-link-internal:active {
+.maka-markdown-link-internal:active {
     transform: translateY(0.5px);
   }
-
-  .maka-markdown-link-external {
+.maka-markdown-link-external {
     color: var(--link);
     text-decoration: underline solid color-mix(in oklch, var(--link) 50%, var(--background));
   }
-  .maka-markdown-link-external:hover {
+.maka-markdown-link-external:hover {
     text-decoration-color: var(--link);
   }
-
-  .maka-markdown-link-broken {
+.maka-markdown-link-broken {
     color: var(--destructive);
     text-decoration: underline dashed oklch(from var(--destructive) l c h / 0.55);
     cursor: not-allowed;
   }
-}

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1223,23 +1223,9 @@
 }
 
 .maka-skill-search input {
-  /* PR-SKILL-SEARCH-DOUBLE-BOX-0 (WAWQAQ msg `703f2167` + screenshot
-     `d6218b43`): the `<Input>` primitive carries Tailwind utilities
-     `rounded-md border border-input bg-background shadow-sm` from
-     `@maka/ui inputClasses`. The per-page overrides killed
-     `border` + `background`, but `border-radius`, `box-shadow`, and
-     `min-height` (via `min-h-9` = 36px) leaked through and painted
-     a second visible rounded card INSIDE the outer
-     `.maka-skill-search` label — reading as two stacked search
-     bars. The fix zeroes every visual property the primitive can
-     paint, so the inner `<input>` reads as a bare text field and
-     the outer label is the only box.
-     Correction (double-border textarea sweep, verified live via CDP):
-     `box-shadow`/ring-var reset need `!important` to beat the global
-     `:where(input, select, textarea):focus` rule below on focus — see
-     `.composer .maka-composer-textarea` in tool-output.css for why.
-     `border-radius`/`background` don't need it (nothing else sets them
-     on focus). */
+  /* The visible search chrome belongs to `.maka-skill-search`; the inner
+     `Input` uses the explicit bare field path so no primitive chrome or
+     page-level focus ring has to be reset here. */
   min-width: 0;
   width: 100%;
   height: 30px;
@@ -1247,12 +1233,9 @@
   border: 0;
   border-radius: 0;
   background: transparent;
-  box-shadow: none !important;
   outline: none;
   padding: 0;
   font-size: var(--font-size-ui);
-  --tw-ring-shadow: 0 0 #0000 !important;
-  --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
 
 .maka-skill-search input::placeholder {
@@ -1950,9 +1933,9 @@ color: oklch(0.55 0.015 220);
 
 /* Justified: renderer form fields and input-group wrappers ship their own
    focus ring shadow. This global chrome rule collapses that into the
-   converged inset accent line, so the shadow reset must outrank primitive
-   ring utilities. */
-:where(input, select, textarea):focus {
+   converged inset accent line, while explicit bare fields opt out through
+   `data-maka-field-chrome="none"`. */
+:where(input, select, textarea):focus:not([data-maka-field-chrome="none"]) {
   outline: none;
   border-color: oklch(from var(--focus-ring) l c h / 0.48);
   box-shadow: inset 0 0 0 1px oklch(from var(--focus-ring) l c h / 0.22) !important;

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1224,17 +1224,11 @@
 
 .maka-skill-search input {
   /* The visible search chrome belongs to `.maka-skill-search`; the inner
-     `Input` uses the explicit bare field path so no primitive chrome or
-     page-level focus ring has to be reset here. */
+     `Input` owns bare field reset through the shared UI component. */
   min-width: 0;
   width: 100%;
   height: 30px;
   min-height: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  outline: none;
-  padding: 0;
   font-size: var(--font-size-ui);
 }
 
@@ -1935,7 +1929,7 @@ color: oklch(0.55 0.015 220);
    focus ring shadow. This global chrome rule collapses that into the
    converged inset accent line, while explicit bare fields opt out through
    `data-maka-field-chrome="none"`. */
-:where(input, select, textarea):focus:not([data-maka-field-chrome="none"]) {
+:where(input, select, textarea):focus:not(:where([data-maka-field-chrome="none"])) {
   outline: none;
   border-color: oklch(from var(--focus-ring) l c h / 0.48);
   box-shadow: inset 0 0 0 1px oklch(from var(--focus-ring) l c h / 0.22) !important;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -462,19 +462,15 @@
     0 1px 0 oklch(from var(--foreground) 1 0 h / 0.75) inset;
 }
 /* The visible quick-chat chrome belongs to `.maka-onboarding-quickchat`;
-   the textarea uses the explicit bare field path so no primitive ring
-   chrome has to be reset in page CSS. */
+   the textarea owns bare field reset through the shared UI component. */
 .maka-onboarding-quickchat .maka-onboarding-quickchat-input {
-  appearance: none;
   box-sizing: border-box;
   width: 100%;
   resize: none;
   min-height: 90px;
   color: var(--foreground);
-  font: inherit;
   font-size: var(--font-size-base);
   line-height: 1.5;
-  outline: none;
 }
 /* Drag-active feedback lives on the wrapper, not the inner textarea, because
    the wrapper owns the visible field chrome for this bare textarea. */
@@ -484,13 +480,6 @@
   box-shadow:
     0 0 0 1px oklch(from var(--focus-ring) l c h / 0.22),
     0 0 0 4px oklch(from var(--focus-ring) l c h / 0.08);
-}
-.maka-onboarding-quickchat-input:focus-visible {
-  outline: none;
-}
-.maka-onboarding-quickchat-input:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 /* PR-UI-15 (@yuejing 2026-05-22): small example hint shown below the
  * quickChat textarea so first-run users still see an example of what

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -461,18 +461,9 @@
     0 0 0 4px oklch(from var(--focus-ring) l c h / 0.08),
     0 1px 0 oklch(from var(--foreground) 1 0 h / 0.75) inset;
 }
-/* Justified: bare-textarea chrome reset — see `.composer .maka-composer-
-   textarea` in tool-output.css for the full rationale (Tailwind's
-   `border-0 shadow-none focus-visible:ring-0` classes don't clear the
-   underlying `--tw-ring-shadow` custom properties, which re-composite
-   into `box-shadow` on focus).
-   Scoped to `.maka-onboarding-quickchat .maka-onboarding-quickchat-input`
-   (not the bare class) so this rule's specificity (0,2,0) beats the
-   global `:where(input, select, textarea):focus` rule in module-pages.css
-   (0,1,0) outright — `!important` alone isn't enough when both sides are
-   `!important` and this file loads *before* module-pages.css, since the
-   later rule then wins ties on source order. Same reasoning as
-   `.maka-skill-search input`'s extra type selector there. */
+/* The visible quick-chat chrome belongs to `.maka-onboarding-quickchat`;
+   the textarea uses the explicit bare field path so no primitive ring
+   chrome has to be reset in page CSS. */
 .maka-onboarding-quickchat .maka-onboarding-quickchat-input {
   appearance: none;
   box-sizing: border-box;
@@ -484,16 +475,9 @@
   font-size: var(--font-size-base);
   line-height: 1.5;
   outline: none;
-  border: none !important;
-  box-shadow: none !important;
-  --tw-ring-shadow: 0 0 #0000 !important;
-  --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
-/* Drag-active feedback lives on the wrapper, not the inner textarea: the
-   textarea's own `border`/`box-shadow` are hard-reset to `none !important`
-   above, which unconditionally wins over a non-`!important` declaration
-   regardless of selector specificity — so painting this on the textarea
-   was always dead code. */
+/* Drag-active feedback lives on the wrapper, not the inner textarea, because
+   the wrapper owns the visible field chrome for this bare textarea. */
 .maka-onboarding-quickchat[data-drag-active="true"] {
   border-color: oklch(from var(--focus-ring) l c h / 0.46);
   background: oklch(from var(--focus-ring) 0.98 calc(c * 0.20) h / 0.35);

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -6,14 +6,13 @@
    buttons here — that lands in PR-CU-0/1.
 ============================================================================= */
 
-@layer components {
-  .settingsPermissionPage {
+.settingsPermissionPage {
     display: flex;
     flex-direction: column;
     gap: var(--space-5);
   }
 
-  .settingsPermissionIntro {
+.settingsPermissionIntro {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
@@ -23,30 +22,33 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-  .settingsPermissionIntro h3 {
+
+.settingsPermissionIntro h3 {
     margin: 0 0 var(--space-1-5);
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
-  .settingsPermissionIntro p {
+
+.settingsPermissionIntro p {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
     line-height: 1.55;
     max-width: 52ch;
   }
-  .settingsPermissionMeta {
+
+.settingsPermissionMeta {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     gap: var(--space-1-5);
     flex-shrink: 0;
   }
-  .settingsPermissionMeta small {
+
+.settingsPermissionMeta small {
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
-}
 
 /* Unlayered on purpose: this class customizes a shared `Button
    variant="secondary"` and must outrank the Tailwind utility classes baked
@@ -70,8 +72,7 @@
   outline-offset: 2px;
 }
 
-@layer components {
-  .settingsPermissionError {
+.settingsPermissionError {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -81,34 +82,39 @@
     border-radius: var(--radius-surface);
     color: var(--destructive-text);
   }
-  .settingsPermissionError strong {
+
+.settingsPermissionError strong {
     font-size: var(--font-size-ui);
   }
-  .settingsPermissionError small {
+
+.settingsPermissionError small {
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
   }
-  .settingsPermissionError button {
+
+.settingsPermissionError button {
     align-self: flex-start;
   }
 
-  .settingsPermissionSection {
+.settingsPermissionSection {
     display: flex;
     flex-direction: column;
     gap: var(--space-2-5);
   }
-  .settingsPermissionSection > header h4 {
+
+.settingsPermissionSection > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
     font-weight: 600;
     color: var(--foreground);
   }
-  .settingsPermissionSection > header small {
+
+.settingsPermissionSection > header small {
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
 
-  .settingsCapabilityList {
+.settingsCapabilityList {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -116,7 +122,7 @@
     gap: var(--space-2-5);
   }
 
-  .settingsCapabilityRow {
+.settingsCapabilityRow {
     border: 1px solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
@@ -126,48 +132,56 @@
     gap: var(--space-2-5);
     transition: border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
   }
-  .settingsCapabilityRow:hover {
+
+.settingsCapabilityRow:hover {
     border-color: var(--border-strong);
     box-shadow: 0 1px 0 0 oklch(from var(--foreground) l c h / 0.03);
   }
-  .settingsCapabilityRow[data-readiness="denied"] {
+
+.settingsCapabilityRow[data-readiness="denied"] {
     border-color: oklch(from var(--destructive) l c h / 0.28);
   }
-  .settingsCapabilityRow[data-readiness="degraded"] {
+
+.settingsCapabilityRow[data-readiness="degraded"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
   }
-  .settingsCapabilityRow[data-readiness="enabled"] {
+
+.settingsCapabilityRow[data-readiness="enabled"] {
     border-color: oklch(from var(--success) l c h / 0.24);
   }
 
-  .settingsCapabilityHeader {
+.settingsCapabilityHeader {
     display: flex;
     justify-content: space-between;
     align-items: center;
     gap: var(--space-3);
   }
-  .settingsCapabilityHeading {
+
+.settingsCapabilityHeading {
     display: flex;
     flex-direction: column;
     gap: var(--space-0-5);
   }
-  .settingsCapabilityHeading strong {
+
+.settingsCapabilityHeading strong {
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
-  .settingsCapabilityId {
+
+.settingsCapabilityId {
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
-  .settingsCapabilityDetail {
+
+.settingsCapabilityDetail {
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-70);
     line-height: 1.5;
   }
 
-  .settingsCapabilityLayers {
+.settingsCapabilityLayers {
     margin: 0;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -176,19 +190,22 @@
     background: var(--foreground-3);
     border-radius: var(--radius-surface);
   }
-  .settingsCapabilityLayers > div {
+
+.settingsCapabilityLayers > div {
     display: flex;
     flex-direction: column;
     gap: var(--space-0-5);
   }
-  .settingsCapabilityLayers dt {
+
+.settingsCapabilityLayers dt {
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
     margin: 0;
   }
-  .settingsCapabilityLayers dd {
+
+.settingsCapabilityLayers dd {
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground);
@@ -196,28 +213,36 @@
     flex-direction: column;
     gap: var(--space-0-5);
   }
-  .settingsCapabilityLayers dd small {
+
+.settingsCapabilityLayers dd small {
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
-  .settingsCapabilityLayers dd[data-tone="success"] { color: var(--success-text); }
-  .settingsCapabilityLayers dd[data-tone="warning"] { color: var(--warning-text, var(--info-text)); }
-  .settingsCapabilityLayers dd[data-tone="destructive"] { color: var(--destructive-text); }
-  .settingsCapabilityLayers dd[data-tone="info"] { color: var(--info-text); }
-  .settingsCapabilityLayers dd[data-tone="neutral"] { color: var(--foreground-70); }
 
-  .settingsCapabilityOsPermissions {
+.settingsCapabilityLayers dd[data-tone="success"] { color: var(--success-text); }
+
+.settingsCapabilityLayers dd[data-tone="warning"] { color: var(--warning-text, var(--info-text)); }
+
+.settingsCapabilityLayers dd[data-tone="destructive"] { color: var(--destructive-text); }
+
+.settingsCapabilityLayers dd[data-tone="info"] { color: var(--info-text); }
+
+.settingsCapabilityLayers dd[data-tone="neutral"] { color: var(--foreground-70); }
+
+.settingsCapabilityOsPermissions {
     display: flex;
     flex-direction: column;
     gap: var(--space-1-5);
   }
-  .settingsCapabilityOsPermissions > span {
+
+.settingsCapabilityOsPermissions > span {
     font-size: var(--font-size-caption);
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--foreground-50);
   }
-  .settingsCapabilityOsPermissions ul {
+
+.settingsCapabilityOsPermissions ul {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -225,7 +250,8 @@
     flex-wrap: wrap;
     gap: var(--space-1-5);
   }
-  .settingsCapabilityOsPermissions li {
+
+.settingsCapabilityOsPermissions li {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -236,7 +262,8 @@
     background: var(--background);
     color: var(--foreground-80);
   }
-  .settingsCapabilityOsPermissions li em {
+
+.settingsCapabilityOsPermissions li em {
     font-style: normal;
     font-size: var(--font-size-caption);
     padding: 1px var(--space-1-5);
@@ -244,36 +271,42 @@
     background: var(--foreground-5);
     color: var(--foreground-70);
   }
-  .settingsCapabilityOsPermissions li em[data-tone="success"] {
+
+.settingsCapabilityOsPermissions li em[data-tone="success"] {
     color: var(--success-text);
     background: oklch(from var(--success) l c h / 0.10);
   }
-  .settingsCapabilityOsPermissions li em[data-tone="warning"] {
+
+.settingsCapabilityOsPermissions li em[data-tone="warning"] {
     color: var(--warning-text, var(--info-text));
     background: oklch(from var(--warning, var(--info)) l c h / 0.10);
   }
-  .settingsCapabilityOsPermissions li em[data-tone="destructive"] {
+
+.settingsCapabilityOsPermissions li em[data-tone="destructive"] {
     color: var(--destructive-text);
     background: oklch(from var(--destructive) l c h / 0.10);
   }
-  .settingsCapabilityOsPermissions li em[data-tone="info"] {
+
+.settingsCapabilityOsPermissions li em[data-tone="info"] {
     color: var(--info-text);
     background: oklch(from var(--info) l c h / 0.10);
   }
 
-  .settingsCapabilityGuidance {
+.settingsCapabilityGuidance {
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
     border: 1px solid var(--border);
     background: var(--foreground-3);
   }
-  .settingsCapabilityGuidance > span {
+
+.settingsCapabilityGuidance > span {
     font-size: var(--font-size-caption);
     font-weight: 650;
     color: var(--foreground-70);
   }
-  .settingsCapabilityGuidance ul {
+
+.settingsCapabilityGuidance ul {
     margin: 0;
     padding-left: var(--space-4);
     color: var(--foreground-60);
@@ -281,13 +314,13 @@
     line-height: 1.55;
   }
 
-  .settingsCapabilityGuidanceActions {
+.settingsCapabilityGuidanceActions {
     display: grid;
     gap: var(--space-2);
     padding-top: var(--space-0-5);
   }
 
-  .settingsCapabilityGuidanceActions code {
+.settingsCapabilityGuidanceActions code {
     display: block;
     max-width: 100%;
     overflow: auto;
@@ -300,32 +333,34 @@
     white-space: nowrap;
   }
 
-  .settingsCapabilityGuidanceActions > div {
+.settingsCapabilityGuidanceActions > div {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
     align-items: center;
   }
 
-  .settingsCapabilityGuidanceActions a {
+.settingsCapabilityGuidanceActions a {
     color: var(--foreground-70);
     font-size: var(--font-size-caption);
     text-decoration: none;
   }
 
-  .settingsCapabilityGuidanceActions a:hover {
+.settingsCapabilityGuidanceActions a:hover {
     text-decoration: underline;
   }
 
-  .settingsCapabilityAuditSlot {
+.settingsCapabilityAuditSlot {
     border-top: 1px dashed var(--border);
     padding-top: var(--space-2);
   }
-  .settingsCapabilityAuditSlot small {
+
+.settingsCapabilityAuditSlot small {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
   }
-  .settingsCapabilityAuditSlot ul {
+
+.settingsCapabilityAuditSlot ul {
     list-style: disc;
     margin: 0;
     padding-left: var(--space-4);
@@ -333,7 +368,7 @@
     color: var(--foreground-70);
   }
 
-  /* PR-PERMISSIONS-UNIFIED-CARD-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
+/* PR-PERMISSIONS-UNIFIED-CARD-0 (WAWQAQ msg `d3ea9a33` 2026-06-26):
      "权限与能力，里面的权限部分都是应该并在一块的，现在不是一个单独
      的权限组件，和其他的组件不一样". The OS-permission rows used to
      each render as their own bordered card with a 12px gap between
@@ -342,7 +377,8 @@
      radius + background) and have each row contribute just a bottom
      hairline divider — same shape as `.settingsRows` on the General /
      Bot Chat / Daily Review pages. */
-  .settingsOsPermissionList {
+
+.settingsOsPermissionList {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -354,18 +390,20 @@
     overflow: hidden;
   }
 
-  /* Per-row hairline divider — last child drops it so the outer card
+/* Per-row hairline divider — last child drops it so the outer card
      border closes cleanly. */
-  .settingsOsPermissionRow + .settingsOsPermissionRow {
+
+.settingsOsPermissionRow + .settingsOsPermissionRow {
     border-top: 1px solid oklch(from var(--foreground) l c h / 0.06);
   }
 
-  /* PR-PERMISSION-PAGE-REDESIGN: icon + body + actions row layout.
+/* PR-PERMISSION-PAGE-REDESIGN: icon + body + actions row layout.
      PR-PERMISSIONS-UNIFIED-CARD-0: dropped the per-row border + radius
      + shadow that ran against the outer grouped card. The status-tinted
      border now lives as a left-edge accent stripe (see status rules
      below) so denied / granted / not_determined still read at a glance. */
-  .settingsOsPermissionRow {
+
+.settingsOsPermissionRow {
     position: relative;
     display: grid;
     grid-template-columns: 36px minmax(0, 1fr) auto;
@@ -376,7 +414,7 @@
     transition: background 160ms var(--ease-out-strong);
   }
 
-  .settingsOsPermissionIcon {
+.settingsOsPermissionIcon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -387,41 +425,43 @@
     color: var(--foreground-70);
   }
 
-  /* Status-tinted icon: the denied tint lives here; the granted tint
+/* Status-tinted icon: the denied tint lives here; the granted tint
      was consolidated next to the granted border rule below (was dup'd
      twice, second instance won by cascade — kept the one near its
      border sibling). */
-  .settingsOsPermissionRow[data-state="denied"] .settingsOsPermissionIcon {
+
+.settingsOsPermissionRow[data-state="denied"] .settingsOsPermissionIcon {
     background: oklch(from var(--destructive) l c h / 0.10);
     color: var(--destructive);
   }
 
-  .settingsOsPermissionBody {
+.settingsOsPermissionBody {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
     min-width: 0;
   }
 
-  .settingsOsPermissionHeading {
+.settingsOsPermissionHeading {
     display: flex;
     align-items: center;
     gap: var(--space-2-5);
     flex-wrap: wrap;
   }
-  .settingsOsPermissionHeading strong {
+
+.settingsOsPermissionHeading strong {
     font-size: var(--font-size-base);
     font-weight: 600;
     color: var(--foreground);
   }
 
-  .settingsOsPermissionPurpose {
+.settingsOsPermissionPurpose {
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
     line-height: 1.55;
   }
 
-  .settingsOsPermissionImpact {
+.settingsOsPermissionImpact {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -429,7 +469,8 @@
     color: var(--foreground-60);
     line-height: 1.45;
   }
-  .settingsOsPermissionImpactLabel {
+
+.settingsOsPermissionImpactLabel {
     display: inline-flex;
     align-items: center;
     padding: 1px var(--space-1-5);
@@ -441,13 +482,13 @@
     letter-spacing: 0.04em;
   }
 
-  .settingsOsPermissionReason {
+.settingsOsPermissionReason {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     font-style: italic;
   }
 
-  /* PR-PERMISSIONS-UNIFIED-CARD-0: action buttons used to stack
+/* PR-PERMISSIONS-UNIFIED-CARD-0: action buttons used to stack
      vertically (column / align-items: flex-end / 6px gap), which read
      as "two separate options" rather than a primary + secondary pair.
      Lay them out horizontally with the primary "请求授权" on the right
@@ -456,7 +497,8 @@
      so the row height stays flush; the secondary "前往系统设置" uses
      `variant="ghost"` (less competing chrome) so the primary visibly
      anchors the row. */
-  .settingsOsPermissionActions {
+
+.settingsOsPermissionActions {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
@@ -466,11 +508,12 @@
     flex-shrink: 0;
   }
 
-  /* PR-PERMISSIONS-UNIFIED-CARD-0: status accents live as left-edge
+/* PR-PERMISSIONS-UNIFIED-CARD-0: status accents live as left-edge
      stripes on the outer grouped card so denied / not_determined /
      granted are visible at a glance without re-introducing per-row
      borders that fight the unified card. */
-  .settingsOsPermissionRow[data-state="denied"]::before,
+
+.settingsOsPermissionRow[data-state="denied"]::before,
   .settingsOsPermissionRow[data-state="not_determined"]::before,
   .settingsOsPermissionRow[data-state="granted"]::before {
     content: "";
@@ -480,29 +523,35 @@
     bottom: 0;
     width: 3px;
   }
-  .settingsOsPermissionRow[data-state="denied"]::before {
+
+.settingsOsPermissionRow[data-state="denied"]::before {
     background: oklch(from var(--destructive) l c h / 0.55);
   }
-  .settingsOsPermissionRow[data-state="not_determined"]::before {
+
+.settingsOsPermissionRow[data-state="not_determined"]::before {
     background: oklch(from var(--warning, var(--info)) l c h / 0.55);
   }
-  .settingsOsPermissionRow[data-state="granted"]::before {
+
+.settingsOsPermissionRow[data-state="granted"]::before {
     background: oklch(from var(--success) l c h / 0.45);
   }
-  .settingsOsPermissionRow[data-state="granted"] .settingsOsPermissionIcon {
+
+.settingsOsPermissionRow[data-state="granted"] .settingsOsPermissionIcon {
     background: oklch(from var(--success) l c h / 0.08);
     color: oklch(from var(--success) l c h);
   }
 
-  /* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
+/* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
      Quick read of overall posture (X granted / Y waiting / Z denied /
      W other) so users see what's configured at a glance. */
-  .settingsPermissionSummary {
+
+.settingsPermissionSummary {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-2);
   }
-  .settingsPermissionSummaryTile {
+
+.settingsPermissionSummaryTile {
     display: flex;
     flex-direction: column;
     gap: var(--space-0-5);
@@ -514,44 +563,51 @@
       var(--card-shadow, none),
       var(--card-highlight, none);
   }
-  .settingsPermissionSummaryValue {
+
+.settingsPermissionSummaryValue {
     font-size: 1.5em;
     font-weight: 600;
     line-height: 1.1;
     font-variant-numeric: tabular-nums;
     color: var(--foreground);
   }
-  .settingsPermissionSummaryLabel {
+
+.settingsPermissionSummaryLabel {
     font-size: var(--font-size-caption);
     color: var(--foreground-60);
     letter-spacing: 0.02em;
   }
-  .settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {
+
+.settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {
     color: oklch(from var(--success) l c h);
   }
-  .settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
+
+.settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
     color: oklch(from var(--warning, var(--info)) l c h);
   }
-  .settingsPermissionSummaryTile[data-tone="destructive"] .settingsPermissionSummaryValue {
+
+.settingsPermissionSummaryTile[data-tone="destructive"] .settingsPermissionSummaryValue {
     color: oklch(from var(--destructive) l c h);
   }
 
-  /* Diagnostic 5-column capability detail collapsed by default so the
+/* Diagnostic 5-column capability detail collapsed by default so the
      page reads as "system permissions" first. Expand on click. */
-  .settingsPermissionSectionHeader {
+
+.settingsPermissionSectionHeader {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
     gap: var(--space-3);
   }
-  .settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityLayers,
+
+.settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityLayers,
   .settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityGuidance,
   .settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityAuditSlot,
   .settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityOsPermissions {
     display: none;
   }
 
-  .settingsPermissionFootnote {
+.settingsPermissionFootnote {
     margin: 0;
     padding: var(--space-3) var(--space-3);
     border: 1px dashed var(--border);
@@ -561,4 +617,3 @@
     font-size: var(--font-size-caption);
     line-height: 1.55;
   }
-}

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -1,4 +1,4 @@
-@layer components {
+
   /* =============================================================================
      PR-UI-LAYOUT-42 — Reasoning panel (Anthropic extended thinking)
 
@@ -8,20 +8,17 @@
      a11y. Default-open so users see the live reasoning; clicking the
      header collapses.
   ============================================================================= */
-
-  .maka-reasoning-panel {
+.maka-reasoning-panel {
     margin: var(--space-1) 0 var(--space-2);
     border: 1px solid oklch(from var(--info) l c h / 0.22);
     border-radius: var(--radius-surface);
     background: oklch(from var(--info) l c h / 0.04);
     overflow: hidden;
   }
-
-  .maka-reasoning-panel[data-live="true"] {
+.maka-reasoning-panel[data-live="true"] {
     border-color: oklch(from var(--info) l c h / 0.32);
   }
-
-  .maka-reasoning-panel-header {
+.maka-reasoning-panel-header {
     list-style: none;
     display: flex;
     align-items: center;
@@ -34,22 +31,21 @@
     user-select: none;
     transition: background var(--duration-base) var(--ease-out-strong);
   }
-  .maka-reasoning-panel-header::-webkit-details-marker {
+.maka-reasoning-panel-header::-webkit-details-marker {
     display: none;
   }
-  .maka-reasoning-panel-header::marker {
+.maka-reasoning-panel-header::marker {
     content: '';
   }
-  .maka-reasoning-panel-header:hover {
+.maka-reasoning-panel-header:hover {
     background: oklch(from var(--info) l c h / 0.08);
   }
-  .maka-reasoning-panel-header:focus-visible {
+.maka-reasoning-panel-header:focus-visible {
     outline: none;
     background: oklch(from var(--info) l c h / 0.10);
     box-shadow: 0 0 0 3px oklch(from var(--info) l c h / 0.18);
   }
-
-  .maka-reasoning-panel-dot {
+.maka-reasoning-panel-dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
@@ -57,8 +53,7 @@
     /* Live pulse — collapses under prefers-reduced-motion via the rule below. */
     animation: maka-reasoning-panel-pulse 1.4s var(--ease-in-out-strong) infinite;
   }
-
-  @keyframes maka-reasoning-panel-pulse {
+@keyframes maka-reasoning-panel-pulse {
     0%, 100% { opacity: 0.6; transform: scale(1); }
     /* PR-FE-BUG-HUNT-6 (kenji aesthetic audit reminder 9, finding #5):
        standardize live-dot pulse amplitude across the three streaming
@@ -69,24 +64,21 @@
        a turn is streaming and the larger pulses read as agitated. */
     50% { opacity: 1; transform: scale(1.1); }
   }
-
-  @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     .maka-reasoning-panel-dot {
       animation: none;
       opacity: 0.8;
     }
   }
-
-  .maka-reasoning-panel-label {
+.maka-reasoning-panel-label {
     flex: 1;
     min-width: 0;
   }
-
-  /* PR-UI-C0 review fixup (@kenji msg 7885a347) — "已截断" pill
+/* PR-UI-C0 review fixup (@kenji msg 7885a347) — "已截断" pill
      fires when `applyThinkingDelta` / `applyThinkingComplete`
      dropped content. Same family as the A3 tool-output truncated
      pill: warning tone, rounded rect, cursor:help. */
-  .maka-reasoning-panel-truncated[data-truncated="true"] {
+.maka-reasoning-panel-truncated[data-truncated="true"] {
     font-size: var(--font-size-caption);
     color: var(--warning-text, var(--info-text));
     border: 1px solid oklch(from var(--warning) l c h / 0.24);
@@ -95,24 +87,20 @@
     padding: 0 var(--space-1);
     cursor: help;
   }
-
-  /* The streaming "已截断" pill (PR-UI-Cx, @kenji msg cd09bcac) moved onto the
+/* The streaming "已截断" pill (PR-UI-Cx, @kenji msg cd09bcac) moved onto the
      `Bubble variant="assistant"` chat primitive as inline utilities (issue
      #332 PR1); its sibling `.maka-reasoning-panel-truncated` pill below keeps
      the same visual family. */
-
-  .maka-reasoning-panel-chevron {
+.maka-reasoning-panel-chevron {
     font-size: var(--font-size-ui);
     line-height: 1;
     color: var(--foreground-50);
     transition: transform var(--duration-base) var(--ease-out-strong);
   }
-
-  .maka-reasoning-panel[open] .maka-reasoning-panel-chevron {
+.maka-reasoning-panel[open] .maka-reasoning-panel-chevron {
     transform: rotate(90deg);
   }
-
-  .maka-reasoning-panel-body {
+.maka-reasoning-panel-body {
     margin: 0;
     padding: var(--space-1-5) var(--space-2-5) var(--space-2);
     border-top: 1px solid oklch(from var(--info) l c h / 0.14);
@@ -126,4 +114,3 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
-}

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -81,8 +81,7 @@
    `BotBrandLogo` for the status-dot tint and Hero brand wash. The
    glyph fallback (`微` / `企` / `飞` / `钉` / `T` / `D` / `Q`)
    renders centered in the brand color when an SVG fails to load. */
-@layer components {
-  .settingsBotLogo {
+.settingsBotLogo {
     position: relative;
     width: 28px;
     height: 28px;
@@ -95,19 +94,17 @@
     letter-spacing: 0;
     flex-shrink: 0;
   }
-  .settingsBotLogo svg {
+.settingsBotLogo svg {
     width: 100%;
     height: 100%;
     display: block;
   }
-
-  .settingsBotLogo[data-large="true"] {
+.settingsBotLogo[data-large="true"] {
     width: 44px;
     height: 44px;
     font-size: 1.3333em;
   }
-
-  .settingsBotLogoStatusDot {
+.settingsBotLogoStatusDot {
     position: absolute;
     right: -2px;
     bottom: -2px;
@@ -117,29 +114,27 @@
     background: color-mix(in oklch, var(--foreground) 30%, var(--background));
     box-shadow: 0 0 0 2px var(--background);
   }
-  .settingsBotLogo[data-large="true"] .settingsBotLogoStatusDot {
+.settingsBotLogo[data-large="true"] .settingsBotLogoStatusDot {
     width: 11px;
     height: 11px;
     right: -3px;
     bottom: -3px;
     box-shadow: 0 0 0 2.5px var(--background);
   }
-  .settingsBotLogoStatusDot[data-tone="info"] { background: var(--status-running); }
-  .settingsBotLogoStatusDot[data-tone="success"] { background: var(--success); }
-  .settingsBotLogoStatusDot[data-tone="warning"] { background: var(--info); }
-  .settingsBotLogoStatusDot[data-tone="destructive"] { background: var(--destructive); }
-
-  .settingsBotDetail {
+.settingsBotLogoStatusDot[data-tone="info"] { background: var(--status-running); }
+.settingsBotLogoStatusDot[data-tone="success"] { background: var(--success); }
+.settingsBotLogoStatusDot[data-tone="warning"] { background: var(--info); }
+.settingsBotLogoStatusDot[data-tone="destructive"] { background: var(--destructive); }
+.settingsBotDetail {
     display: grid;
     align-content: start;
     gap: var(--space-3);
   }
-
-  /* PR-BOT-SETTINGS-UI-0 (WAWQAQ msg `51c7b4ff`): brand-tinted hero
+/* PR-BOT-SETTINGS-UI-0 (WAWQAQ msg `51c7b4ff`): brand-tinted hero
      card. Background uses the brand color at ~7% so the platform
      identity is visible without overpowering the form. Telegram-style
      light blue, WeChat green, Discord purple, etc. */
-  .settingsBotHero {
+.settingsBotHero {
     min-height: 76px;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
@@ -150,27 +145,23 @@
     border: 1px solid color-mix(in srgb, var(--bot-brand-color, var(--bot-brand-default)) 14%, transparent);
     padding: var(--space-4) var(--space-4);
   }
-
-  .settingsBotHero[data-support="planned"] {
+.settingsBotHero[data-support="planned"] {
     background: var(--foreground-5);
     border-color: var(--border);
   }
-
-  /* Re-export the brand color on the hero card so child logo + accents
+/* Re-export the brand color on the hero card so child logo + accents
      pick up the right CSS var without needing a second prop pass. */
-  .settingsBotHero[data-provider="telegram"] { --bot-brand-color: #229ED9; }
-  .settingsBotHero[data-provider="feishu"]   { --bot-brand-color: #00C6B7; }
-  .settingsBotHero[data-provider="wecom"]    { --bot-brand-color: #0089FF; }
-  .settingsBotHero[data-provider="wechat"]   { --bot-brand-color: #07C160; }
-  .settingsBotHero[data-provider="discord"]  { --bot-brand-color: #5865F2; }
-  .settingsBotHero[data-provider="dingtalk"] { --bot-brand-color: #1372FB; }
-  .settingsBotHero[data-provider="qq"]       { --bot-brand-color: #12B7F5; }
-
-  .settingsBotHeroBody {
+.settingsBotHero[data-provider="telegram"] { --bot-brand-color: #229ED9; }
+.settingsBotHero[data-provider="feishu"]   { --bot-brand-color: #00C6B7; }
+.settingsBotHero[data-provider="wecom"]    { --bot-brand-color: #0089FF; }
+.settingsBotHero[data-provider="wechat"]   { --bot-brand-color: #07C160; }
+.settingsBotHero[data-provider="discord"]  { --bot-brand-color: #5865F2; }
+.settingsBotHero[data-provider="dingtalk"] { --bot-brand-color: #1372FB; }
+.settingsBotHero[data-provider="qq"]       { --bot-brand-color: #12B7F5; }
+.settingsBotHeroBody {
     min-width: 0;
   }
-
-  .settingsBotHero h3 {
+.settingsBotHero h3 {
     margin: 0 0 var(--space-1);
     font-size: 1.0667em;
     display: flex;
@@ -178,31 +169,27 @@
     gap: var(--space-2-5);
     flex-wrap: wrap;
   }
-
-  .settingsBotHero small,
+.settingsBotHero small,
   .settingsHelpText {
     color: var(--foreground-50);
     font-size: var(--font-size-ui);
     line-height: 1.5;
   }
-
-  .settingsBotEnableHint {
+.settingsBotEnableHint {
     display: block;
     margin-top: var(--space-1);
     color: var(--warning-text, var(--foreground-70));
   }
-
-  .settingsBotConfigDocLink {
+.settingsBotConfigDocLink {
     color: var(--bot-brand-color, var(--bot-brand-default));
     text-decoration: none;
     font-weight: 500;
     white-space: nowrap;
   }
-  .settingsBotConfigDocLink:hover {
+.settingsBotConfigDocLink:hover {
     text-decoration: underline;
   }
-
-  .settingsBotStatusPill {
+.settingsBotStatusPill {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
@@ -214,74 +201,64 @@
     font-weight: 500;
     letter-spacing: 0.01em;
   }
-
-  .settingsBotStatusPillDot {
+.settingsBotStatusPillDot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
     background: var(--foreground-40);
   }
-  .settingsBotStatusPill[data-tone="info"] .settingsBotStatusPillDot { background: var(--status-running); }
-  .settingsBotStatusPill[data-tone="success"] { color: var(--success-text); }
-  .settingsBotStatusPill[data-tone="success"] .settingsBotStatusPillDot { background: var(--success); }
-  .settingsBotStatusPill[data-tone="warning"] { color: var(--info-text); }
-  .settingsBotStatusPill[data-tone="warning"] .settingsBotStatusPillDot { background: var(--info); }
-  .settingsBotStatusPill[data-tone="destructive"] { color: var(--destructive-text); }
-  .settingsBotStatusPill[data-tone="destructive"] .settingsBotStatusPillDot { background: var(--destructive); }
-
-  .settingsHelpText {
+.settingsBotStatusPill[data-tone="info"] .settingsBotStatusPillDot { background: var(--status-running); }
+.settingsBotStatusPill[data-tone="success"] { color: var(--success-text); }
+.settingsBotStatusPill[data-tone="success"] .settingsBotStatusPillDot { background: var(--success); }
+.settingsBotStatusPill[data-tone="warning"] { color: var(--info-text); }
+.settingsBotStatusPill[data-tone="warning"] .settingsBotStatusPillDot { background: var(--info); }
+.settingsBotStatusPill[data-tone="destructive"] { color: var(--destructive-text); }
+.settingsBotStatusPill[data-tone="destructive"] .settingsBotStatusPillDot { background: var(--destructive); }
+.settingsHelpText {
     margin: 0;
   }
-
-  .settingsBotStatusGrid {
+.settingsBotStatusGrid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-2);
     margin: 0;
   }
-
-  .settingsBotStatusGrid div {
+.settingsBotStatusGrid div {
     min-height: 52px;
     border: 1px solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     padding: var(--space-2-5) var(--space-3);
   }
-
-  @media (max-width: 1100px) {
+@media (max-width: 1100px) {
     .settingsBotStatusGrid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
-
-  .settingsBotStatusGrid dt {
+.settingsBotStatusGrid dt {
     margin-bottom: var(--space-1);
     color: var(--foreground-40);
     font-size: var(--font-size-caption);
   }
-
-  .settingsBotStatusGrid dd {
+.settingsBotStatusGrid dd {
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
     word-break: break-word;
   }
-
-  .settingsBotReason {
+.settingsBotReason {
     border-left: 2px solid var(--focus-ring);
     color: var(--foreground-60);
     font-size: var(--font-size-ui);
     line-height: 1.5;
     padding-left: var(--space-2-5);
   }
-
-  /* PR-BOT-CHAT-POLISH-0: error tone for persisted lastError so the
+/* PR-BOT-CHAT-POLISH-0: error tone for persisted lastError so the
      user can spot a failed test past the toast lifetime. */
-  .settingsBotReason[data-tone="error"] {
+.settingsBotReason[data-tone="error"] {
     border-left-color: var(--destructive, var(--warning));
     color: var(--destructive-text, var(--info-text));
   }
-}
 
 .settingsUsagePage {
   display: grid;

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -1,4 +1,4 @@
-@layer components {
+
   .settingsConnectionRow {
     display: grid;
     gap: var(--space-1-5);
@@ -8,63 +8,59 @@
     background: var(--foreground-2);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
   }
-
-  .settingsConnectionRow[data-status="verified"] {
+.settingsConnectionRow[data-status="verified"] {
     border-color: oklch(from var(--success) l c h / 0.24);
     background: oklch(from var(--success) l c h / 0.04);
   }
-  .settingsConnectionRow[data-status="needs_reauth"] {
+.settingsConnectionRow[data-status="needs_reauth"] {
     border-color: oklch(from var(--info) l c h / 0.30);
     background: oklch(from var(--info) l c h / 0.06);
   }
-  .settingsConnectionRow[data-status="error"] {
+.settingsConnectionRow[data-status="error"] {
     border-color: oklch(from var(--destructive) l c h / 0.30);
     background: oklch(from var(--destructive) l c h / 0.05);
   }
-  .settingsConnectionRow[data-status="not_configured"] {
+.settingsConnectionRow[data-status="not_configured"] {
     border-color: oklch(from var(--info) l c h / 0.20);
     background: oklch(from var(--info) l c h / 0.03);
   }
-
-  /* PR-OAUTH-SUBSCRIPTION-0: Claude subscription card states. */
-  .settingsConnectionRow[data-status="not_logged_in"] {
+/* PR-OAUTH-SUBSCRIPTION-0: Claude subscription card states. */
+.settingsConnectionRow[data-status="not_logged_in"] {
     border-color: var(--border);
     background: var(--foreground-2);
   }
-  .settingsConnectionRow[data-status="authorizing"],
+.settingsConnectionRow[data-status="authorizing"],
   .settingsConnectionRow[data-status="refreshing"] {
     border-color: oklch(from var(--info) l c h / 0.30);
     background: oklch(from var(--info) l c h / 0.04);
   }
-  .settingsConnectionRow[data-status="authenticated"] {
+.settingsConnectionRow[data-status="authenticated"] {
     border-color: oklch(from var(--success) l c h / 0.24);
     background: oklch(from var(--success) l c h / 0.04);
   }
-  .settingsConnectionRow[data-status="refresh_failed"],
+.settingsConnectionRow[data-status="refresh_failed"],
   .settingsConnectionRow[data-status="quota_unavailable"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.30);
     background: oklch(from var(--warning, var(--info)) l c h / 0.05);
   }
-  .settingsConnectionRow[data-status="provider_rejected"] {
+.settingsConnectionRow[data-status="provider_rejected"] {
     border-color: oklch(from var(--destructive) l c h / 0.30);
     background: oklch(from var(--destructive) l c h / 0.05);
   }
-
-  .settingsQuotaSection {
+.settingsQuotaSection {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2) var(--space-2-5);
     border-radius: var(--radius-surface);
     background: oklch(from var(--foreground) l c h / 0.03);
   }
-  .settingsQuotaRow {
+.settingsQuotaRow {
     display: flex;
     justify-content: space-between;
     font-size: var(--font-size-ui);
     font-variant-numeric: tabular-nums;
   }
-
-  .settingsOauthPastePanel {
+.settingsOauthPastePanel {
     display: grid;
     gap: var(--space-2);
     margin-top: var(--space-1);
@@ -72,7 +68,7 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--foreground) l c h / 0.04);
   }
-  .settingsOauthPastePanel textarea {
+.settingsOauthPastePanel textarea {
     width: 100%;
     padding: var(--space-2);
     border-radius: var(--radius-control);
@@ -83,25 +79,22 @@
     font-size: var(--font-size-ui);
     resize: vertical;
   }
-  .settingsErrorText {
+.settingsErrorText {
     color: var(--destructive-text, var(--destructive, red));
   }
-  .settingsConnectionRow[data-status="disabled"] {
+.settingsConnectionRow[data-status="disabled"] {
     opacity: 0.72;
   }
-
-  .settingsConnectionRow[data-default="true"] {
+.settingsConnectionRow[data-default="true"] {
     box-shadow: 0 0 0 2px oklch(from var(--control) l c h / 0.12);
   }
-
-  .settingsConnectionRowName {
+.settingsConnectionRowName {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     min-width: 0;
   }
-
-  .settingsConnectionDefaultBadge {
+.settingsConnectionDefaultBadge {
     display: inline-flex;
     align-items: center;
     padding: 1px var(--space-1-5);
@@ -112,33 +105,28 @@
     font-weight: 700;
     letter-spacing: 0;
   }
-
-  .settingsConnectionRowHead {
+.settingsConnectionRowHead {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--space-3);
   }
-
-  .settingsConnectionRowText {
+.settingsConnectionRowText {
     display: grid;
     gap: var(--space-0-5);
     min-width: 0;
   }
-
-  .settingsConnectionRowText strong {
+.settingsConnectionRowText strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
     font-weight: 600;
   }
-
-  .settingsConnectionRowText small {
+.settingsConnectionRowText small {
     color: var(--foreground-50);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
   }
-
-  .settingsConnectionBadge {
+.settingsConnectionBadge {
     display: inline-flex;
     align-items: center;
     min-height: 20px;
@@ -151,34 +139,31 @@
     color: var(--foreground-60);
     white-space: nowrap;
   }
-
-  .settingsConnectionBadge[data-tone="success"] {
+.settingsConnectionBadge[data-tone="success"] {
     background: oklch(from var(--success) l c h / 0.12);
     color: var(--success);
   }
-  .settingsConnectionBadge[data-tone="info"] {
+.settingsConnectionBadge[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);
     color: var(--info-text);
   }
-  .settingsConnectionBadge[data-tone="warning"] {
+.settingsConnectionBadge[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
     font-weight: 700;
   }
-  .settingsConnectionBadge[data-tone="destructive"] {
+.settingsConnectionBadge[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.15);
     color: var(--destructive);
     font-weight: 700;
   }
-
-  .settingsConnectionDetail {
+.settingsConnectionDetail {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-caption);
     line-height: 1.45;
   }
-
-  .settingsAuthContract {
+.settingsAuthContract {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
@@ -189,26 +174,22 @@
     background: var(--foreground-3);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
   }
-
-  .settingsAuthContractText {
+.settingsAuthContractText {
     display: grid;
     gap: var(--space-0-5);
     min-width: 0;
   }
-
-  .settingsAuthContractText strong {
+.settingsAuthContractText strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
     font-weight: 650;
   }
-
-  .settingsAuthContractText span {
+.settingsAuthContractText span {
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
     line-height: 1.45;
   }
-
-  .settingsAuthContractBadge,
+.settingsAuthContractBadge,
   .settingsAuthActionPill {
     display: inline-flex;
     align-items: center;
@@ -218,38 +199,32 @@
     font-size: var(--font-size-caption);
     font-weight: 650;
   }
-
-  .settingsAuthContractBadge {
+.settingsAuthContractBadge {
     padding: var(--space-0-5) var(--space-2);
     background: var(--foreground-5);
     color: var(--foreground-60);
   }
-
-  .settingsAuthContractBadge[data-tone="success"],
+.settingsAuthContractBadge[data-tone="success"],
   .settingsAuthActionPill[data-tone="success"] {
     background: oklch(from var(--success) l c h / 0.12);
     color: var(--success);
   }
-
-  .settingsAuthContractBadge[data-tone="info"],
+.settingsAuthContractBadge[data-tone="info"],
   .settingsAuthActionPill[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);
     color: var(--info-text);
   }
-
-  .settingsAuthContractBadge[data-tone="warning"],
+.settingsAuthContractBadge[data-tone="warning"],
   .settingsAuthActionPill[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
   }
-
-  .settingsAuthContractBadge[data-tone="destructive"],
+.settingsAuthContractBadge[data-tone="destructive"],
   .settingsAuthActionPill[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.14);
     color: var(--destructive);
   }
-
-  .settingsConnectionMeta {
+.settingsConnectionMeta {
     margin: 0;
     display: flex;
     gap: var(--space-3);
@@ -257,26 +232,22 @@
     font-size: var(--font-size-caption);
     font-family: var(--font-mono);
   }
-
-  .settingsInlineFileState {
+.settingsInlineFileState {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1-5);
   }
-
-  .settingsInlineTextButton {
+.settingsInlineTextButton {
     border: 0;
     padding: 0;
     background: transparent;
     color: var(--link);
     font: inherit;
   }
-
-  .settingsInlineTextButton:hover {
+.settingsInlineTextButton:hover {
     text-decoration: underline;
   }
-
-  .settingsConnectionActions {
+.settingsConnectionActions {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
@@ -284,64 +255,53 @@
     gap: var(--space-2);
     margin-top: var(--space-1);
   }
-
-  .settingsAuthActionPill {
+.settingsAuthActionPill {
     padding: var(--space-0-5) var(--space-2);
     background: var(--foreground-5);
     color: var(--foreground-60);
   }
-
-  .settingsAuthActionPill[data-kind="preview"] {
+.settingsAuthActionPill[data-kind="preview"] {
     border: 1px dashed oklch(from var(--info) l c h / 0.30);
   }
-
-  /* PR-SETTINGS-GROUPED-CARD-0: rows flush inside outer card, hairline
+/* PR-SETTINGS-GROUPED-CARD-0: rows flush inside outer card, hairline
      divider, last-child no border. Matches the reference grouped-list
      pattern. */
-
-  .settingsRow:last-child {
+.settingsRow:last-child {
     border-bottom: 0;
   }
-
-  .settingsRow:hover {
+.settingsRow:hover {
     background: oklch(from var(--foreground) l c h / 0.025);
   }
-
-  .settingsRow > div {
+.settingsRow > div {
     min-width: 0;
   }
-
-  .settingsRow small {
+.settingsRow small {
     display: block;
     margin-top: var(--space-1);
     color: var(--foreground-50);
     font-size: var(--font-size-ui);
     line-height: 1.4;
   }
-
-  .providersPanel {
+.providersPanel {
     min-height: 420px;
     display: grid;
     grid-template-columns: minmax(190px, 0.82fr) minmax(0, 1.5fr);
     gap: var(--space-3);
   }
-
-  .settingsSurface[data-modal="true"] .providersPanel {
+.settingsSurface[data-modal="true"] .providersPanel {
     min-height: 480px;
     grid-template-columns: minmax(190px, 0.7fr) minmax(250px, 1fr);
   }
-
-  /* Memory page meta row: the absolute MEMORY.md path used to render
+/* Memory page meta row: the absolute MEMORY.md path used to render
      full-width mono text that shoved the sibling status words into a
      cramped vertical stack. Give the path its own full row with
      head-side ellipsis (RTL trick keeps the meaningful .../MEMORY.md
      tail visible; title= carries the full path on hover). */
-  .settingsMemoryMeta {
+.settingsMemoryMeta {
     flex-wrap: wrap;
     row-gap: var(--space-1);
   }
-
-  .settingsMemoryPath {
+.settingsMemoryPath {
     /* The component already shortens the path for display
        (displayMemoryPath); this is just the safety net so an
        unexpectedly long tail can never shove the status words into a
@@ -352,4 +312,3 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
-}

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -11,15 +11,12 @@
    opaque chrome since vibrancy is a no-op there.
 ============================================================================= */
 
-@layer base {
-  html[data-os="darwin"],
+html[data-os="darwin"],
   html[data-os="darwin"] body {
     background: transparent;
   }
-}
 
-@layer components {
-  /* PR-SIDEBAR-GLASS-VIBRANCY-0 (WAWQAQ msg `6c0b8a7c` 2026-06-27):
+/* PR-SIDEBAR-GLASS-VIBRANCY-0 (WAWQAQ msg `6c0b8a7c` 2026-06-27):
      `vibrancy: 'sidebar'` was being set on the BrowserWindow and the
      shell-level `background: transparent` rule was already here, BUT
      the parent `.appFrame` was still painting solid `--surface-canvas`
@@ -28,15 +25,16 @@
      the native blur substrate actually shows through. This is the
      reference-atlas `light-glass` / `dark-glass` mode that we documented
      but never wired all the way through. */
-  html[data-os="darwin"] .appFrame {
+
+html[data-os="darwin"] .appFrame {
     background: transparent;
   }
 
-  html[data-os="darwin"] .maka-shell-2col {
+html[data-os="darwin"] .maka-shell-2col {
     background: transparent;
   }
 
-  html[data-os="darwin"] .maka-session-panel {
+html[data-os="darwin"] .maka-session-panel {
     /* PR-CHAT-CHROME-FIX-1 (WAWQAQ msg `4a1b8c13`): the previous 172deg
        gradient + 1px border-right reintroduced exactly the
        "上面灰下面白" + visible seam that WAWQAQ called out in
@@ -49,7 +47,6 @@
     backdrop-filter: saturate(140%) blur(8px);
     -webkit-backdrop-filter: saturate(140%) blur(8px);
   }
-}
 
 /* =============================================================================
    PR-QODERWORK-GLASS-RESHIP-L3-L6-L7 (WAWQAQ msg `c71b4dcb` thread,
@@ -143,13 +140,11 @@ html[data-os="darwin"] .maka-list-group-label {
    (audit finding §6). The wash + 50% base provide enough contrast for
    foreground @ full alpha; nav rows / list rows / settings button all
    inherit. */
-@layer components {
-  html[data-os="darwin"] .maka-session-panel-header,
+html[data-os="darwin"] .maka-session-panel-header,
   html[data-os="darwin"] .maka-session-list,
   html[data-os="darwin"] .maka-list-row {
     color: var(--foreground);
   }
-}
 
 /* Unlayered on purpose: `.maka-nav-row` is a shared `UiButton size="nav"`
    surface, so this darwin glass override must outrank the primitive's quiet
@@ -158,8 +153,7 @@ html[data-os="darwin"] .maka-nav-row {
   color: var(--foreground);
 }
 
-@layer components {
-  html[data-os="darwin"] .maka-session-panel-footer {
+html[data-os="darwin"] .maka-session-panel-footer {
     /* PR-FE-BUG-HUNT-8 (kenji aesthetic-audit reminder 9, finding #2):
        drop the 180deg footer linear-gradient. Even though it was a
        subtle transparent→30% surface-canvas fade, it's exactly the
@@ -171,23 +165,25 @@ html[data-os="darwin"] .maka-nav-row {
     background: oklch(from var(--surface-canvas) l c h / 0.15);
   }
 
-  /* The main content column stays on its existing solid `var(--background)` so
+/* The main content column stays on its existing solid `var(--background)` so
      chat text and cards remain legible. Without this, the page card would also
      go translucent and hurt readability. */
-  html[data-os="darwin"] .maka-panel-detail {
+
+html[data-os="darwin"] .maka-panel-detail {
     background: var(--background);
   }
 
-  /* =============================================================================
+/* =============================================================================
      Phase 3 quick-wins — atlas §13.7 + §14.6
      Pure CSS, no JSX surgery, all gated on theme/attribute selectors.
   ============================================================================= */
 
-  /* §14.4 — chrome surfaces opt out of text selection. Selectable text is
+/* §14.4 — chrome surfaces opt out of text selection. Selectable text is
      restricted to actual content (Markdown body, composer textarea, readonly
      pre/code). This prevents accidental "click-drag on nav row starts text
      selection" footgun and makes click+drag-to-resize feel native. */
-  .maka-session-panel,
+
+.maka-session-panel,
   .maka-session-panel-header,
   .maka-session-panel-footer,
   .maka-nav-row,
@@ -200,7 +196,6 @@ html[data-os="darwin"] .maka-nav-row {
     -webkit-user-select: none;
     user-select: none;
   }
-}
 
 /* PR-FE-BUG-HUNT-8 (kenji aesthetic-audit reminder 9, finding #3):
    `[data-gradual-blur-layer]` block removed. Originally ported from

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -129,10 +129,8 @@
 }
 
 /* The composer wrapper owns the visible field chrome. The textarea uses
-   the explicit bare field path, so primitive and page-level focus rings do
-   not need to be reset here. */
+   bare field reset from the shared UI component. */
 .composer .maka-composer-textarea {
-  appearance: none;
   display: block;
   width: 100%;
   min-height: var(--h-composer-min, 56px);
@@ -140,15 +138,6 @@
   font-family: var(--font-default);
   font-size: var(--font-size-base);
   line-height: 1.55;
-}
-
-.composer textarea:focus {
-  outline: 0;
-}
-
-.composer textarea:focus-visible,
-.composer .maka-composer-textarea:focus-visible {
-  outline: 0;
 }
 
 .maka-composer-streaming-hint .maka-shortcut-kbd {

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -128,20 +128,9 @@
   overflow-y: auto;
 }
 
-/* Justified: the composer wrapper owns the visible field chrome, so the
-   textarea stays bare and keeps only the scoped ring-shadow reset here.
-   The JSX `border-0 shadow-none focus-visible:ring-0` override classes
-   only remove those utility classes from the className string — they
-   don't clear the base Textarea's `focus-visible:ring-2` custom
-   properties (`--tw-ring-shadow` / `--tw-ring-offset-shadow`), which
-   otherwise re-composite into `box-shadow` on focus and render as a
-   second "framed" border nested inside the composer's own border.
-   `border`/`box-shadow` must be `!important`: the global
-   `:where(input, select, textarea):focus` rule in module-pages.css sets
-   an `!important` inset box-shadow on every focused field, and without
-   matching `!important` here it wins over this rule regardless of this
-   selector's specificity, repainting the exact nested-border bug this
-   file exists to fix — but only while the field is focused. */
+/* The composer wrapper owns the visible field chrome. The textarea uses
+   the explicit bare field path, so primitive and page-level focus rings do
+   not need to be reset here. */
 .composer .maka-composer-textarea {
   appearance: none;
   display: block;
@@ -151,11 +140,6 @@
   font-family: var(--font-default);
   font-size: var(--font-size-base);
   line-height: 1.55;
-  border: none !important;
-  box-shadow: none !important;
-  /* local: suppress tailwind ring shadow on this element */
-  --tw-ring-shadow: 0 0 #0000 !important;
-  --tw-ring-offset-shadow: 0 0 #0000 !important;
 }
 
 .composer textarea:focus {

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -49,16 +49,14 @@
   line-height: 1.45;
   text-align: right;
 }
-@layer components {
-  .settingsWebSearchResults {
+.settingsWebSearchResults {
     list-style: none;
     margin: var(--space-3) 0 0;
     padding: 0;
     display: grid;
     gap: var(--space-2-5);
   }
-
-  .settingsWebSearchResult {
+.settingsWebSearchResult {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
@@ -66,25 +64,21 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-
-  .settingsWebSearchResult a {
+.settingsWebSearchResult a {
     font-weight: 600;
     color: var(--foreground);
     text-decoration: none;
   }
-
-  .settingsWebSearchResult a:hover {
+.settingsWebSearchResult a:hover {
     text-decoration: underline;
   }
-
-  .settingsWebSearchResult small {
+.settingsWebSearchResult small {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     text-transform: uppercase;
     letter-spacing: 0.04em;
   }
-
-  .settingsWebSearchResult p {
+.settingsWebSearchResult p {
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-70);
@@ -92,7 +86,6 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
-}
 
 @media (max-width: 720px) {
   .settingsWebSearchEnableRow,
@@ -130,8 +123,7 @@
    Transparent local MEMORY.md surface. Editor is intentionally plain
    textarea chrome; no rich text, no hidden extraction.
    ──────────────────────────────────────────────────────────────── */
-@layer components {
-  .settingsMemoryPreview {
+.settingsMemoryPreview {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
@@ -139,18 +131,15 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-
-  .settingsMemoryPreview strong {
+.settingsMemoryPreview strong {
     font-size: var(--font-size-ui);
     color: var(--foreground);
   }
-
-  .settingsMemoryPreview small {
+.settingsMemoryPreview small {
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
-
-  .settingsMemoryPreview p {
+.settingsMemoryPreview p {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
@@ -158,8 +147,7 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
-
-  .settingsMemoryPromptPreview {
+.settingsMemoryPromptPreview {
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3);
@@ -167,52 +155,43 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-
-  .settingsMemoryPromptPreview[data-active="true"] {
+.settingsMemoryPromptPreview[data-active="true"] {
     border-color: oklch(from var(--nav-active) l c h / 0.35);
     background: oklch(from var(--nav-active) l c h / 0.06);
   }
-
-  .settingsMemoryPromptPreviewHeader {
+.settingsMemoryPromptPreviewHeader {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--space-3);
   }
-
-  .settingsMemoryPromptPreviewHeader strong {
+.settingsMemoryPromptPreviewHeader strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
-
-  .settingsMemoryPromptPreviewHeader div {
+.settingsMemoryPromptPreviewHeader div {
     display: inline-flex;
     align-items: center;
     gap: var(--space-2-5);
   }
-
-  .settingsMemoryPromptPreviewHeader span {
+.settingsMemoryPromptPreviewHeader span {
     flex-shrink: 0;
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
-
-  .settingsMemoryPromptPreview[data-active="true"] .settingsMemoryPromptPreviewHeader span {
+.settingsMemoryPromptPreview[data-active="true"] .settingsMemoryPromptPreviewHeader span {
     color: var(--nav-active);
   }
-
-  .settingsMemoryPromptPreview small {
+.settingsMemoryPromptPreview small {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
-
-  .settingsMemoryPromptPreviewBudget {
+.settingsMemoryPromptPreviewBudget {
     font-family: var(--font-mono);
     color: var(--foreground-60);
   }
-
-  .settingsMemoryPromptPreview pre {
+.settingsMemoryPromptPreview pre {
     max-height: 220px;
     margin: 0;
     padding: var(--space-2-5);
@@ -227,15 +206,13 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
-
-  .settingsMemoryPromptPreview p {
+.settingsMemoryPromptPreview p {
     margin: 0;
     color: var(--foreground-70);
     font-size: var(--font-size-ui);
     line-height: 1.45;
   }
-
-  .settingsMemoryEntryPreviewNotice {
+.settingsMemoryEntryPreviewNotice {
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
@@ -243,19 +220,16 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning) l c h / 0.08);
   }
-
-  .settingsMemoryEntryPreviewNotice strong {
+.settingsMemoryEntryPreviewNotice strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
-
-  .settingsMemoryEntryPreviewNotice small {
+.settingsMemoryEntryPreviewNotice small {
     color: var(--foreground-70);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
-
-  .settingsMemorySaveSummary {
+.settingsMemorySaveSummary {
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-2-5);
@@ -263,31 +237,25 @@
     border-radius: var(--radius-surface);
     background: oklch(from var(--success) l c h / 0.08);
   }
-
-  .settingsMemorySaveSummary strong {
+.settingsMemorySaveSummary strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
-
-  .settingsMemorySaveSummary small {
+.settingsMemorySaveSummary small {
     color: var(--foreground-60);
     font-size: var(--font-size-ui);
   }
-
-  .settingsMemorySaveSummaryTime {
+.settingsMemorySaveSummaryTime {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
   }
-
-  .settingsMemoryBackupState {
+.settingsMemoryBackupState {
     color: var(--foreground-60);
   }
-
-  .settingsMemoryBackupState[data-empty="true"] {
+.settingsMemoryBackupState[data-empty="true"] {
     color: var(--foreground-40);
   }
-
-  .settingsMemoryBackupList {
+.settingsMemoryBackupList {
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
@@ -295,18 +263,16 @@
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
-
-  .settingsMemoryBackupList strong {
+.settingsMemoryBackupList strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
-
-  /* PR-MEMORY-BACKUP-LIST-A11Y-0 (round 16/30): selector
+/* PR-MEMORY-BACKUP-LIST-A11Y-0 (round 16/30): selector
      targeted the old `<div role="list">`. Container is now a
      semantic `<ul>` (`.settingsMemoryBackupCandidates`); reset
      the UA's bullet + padding-left so the flex-wrap layout stays
      the same as before. */
-  .settingsMemoryBackupCandidates {
+.settingsMemoryBackupCandidates {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -314,19 +280,16 @@
     flex-wrap: wrap;
     gap: var(--space-1-5);
   }
-
-  .settingsMemoryBackupCandidates > li {
+.settingsMemoryBackupCandidates > li {
     margin: 0;
     padding: 0;
   }
-
-  .settingsMemoryBackupList small {
+.settingsMemoryBackupList small {
     color: var(--foreground-50);
     font-size: var(--font-size-caption);
     line-height: 1.4;
   }
-
-  .settingsMemoryBackupCandidate {
+.settingsMemoryBackupCandidate {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -337,24 +300,22 @@
     color: var(--foreground-60);
     font-size: var(--font-size-caption);
   }
-}
 
-@layer components {
-  .settingsMemoryEntryGroups {
+.settingsMemoryEntryGroups {
     display: grid;
     gap: var(--space-3);
   }
 
-  .settingsMemoryEntryGroup {
+.settingsMemoryEntryGroup {
     display: grid;
     gap: var(--space-2);
   }
 
-  .settingsMemoryEntryGroup[data-archived="true"] {
+.settingsMemoryEntryGroup[data-archived="true"] {
     opacity: 0.82;
   }
 
-  .settingsMemoryEntryGroupHeader {
+.settingsMemoryEntryGroupHeader {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -363,12 +324,12 @@
     color: var(--foreground-60);
   }
 
-  .settingsMemoryEntryGroupHeader strong {
+.settingsMemoryEntryGroupHeader strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
 
-  .settingsMemoryEntryDraftNotice {
+.settingsMemoryEntryDraftNotice {
     margin: 0;
     padding: var(--space-1-5) var(--space-2);
     border: 1px solid oklch(from var(--warning) l c h / 0.30);
@@ -379,7 +340,7 @@
     line-height: 1.45;
   }
 
-  .settingsMemoryEntryList {
+.settingsMemoryEntryList {
     /* PR-MEMORY-ENTRY-LIST-A11Y-0 (round 18/30): switched from
        `<div role="list">` to semantic `<ul>`. Reset the UA's
        bullet + padding-left so the grouped-card border + radius
@@ -395,49 +356,50 @@
     background: var(--foreground-2);
   }
 
-  .settingsMemoryEntryList > li {
+.settingsMemoryEntryList > li {
     margin: 0;
     padding: 0;
   }
 
-  .settingsMemoryEntryCard {
+.settingsMemoryEntryCard {
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-3);
     border-bottom: 1px solid var(--foreground-8);
   }
 
-  /* PR-MEMORY-ENTRY-DIVIDER-FIX-0 (WAWQAQ msg `610c0e5a`): after
+/* PR-MEMORY-ENTRY-DIVIDER-FIX-0 (WAWQAQ msg `610c0e5a`): after
      PR-MEMORY-ENTRY-LIST-A11Y-0 wrapped each card in `<li>`, the
      prior `.settingsMemoryEntryCard:last-child` selector matched
      EVERY card (each is the sole child of its `<li>`), so every
      between-card divider disappeared. Target the last `<li>` in
      the list instead. */
-  .settingsMemoryEntryList > li:last-child .settingsMemoryEntryCard {
+
+.settingsMemoryEntryList > li:last-child .settingsMemoryEntryCard {
     border-bottom: 0;
   }
 
-  .settingsMemoryEntryCard strong {
+.settingsMemoryEntryCard strong {
     font-size: var(--font-size-ui);
     color: var(--foreground);
   }
 
-  .settingsMemoryEntryCard small {
+.settingsMemoryEntryCard small {
     font-size: var(--font-size-caption);
     color: var(--foreground-50);
   }
 
-  .settingsMemoryEntryFacts {
+.settingsMemoryEntryFacts {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-1) var(--space-2-5);
   }
 
-  .settingsMemoryEntryFacts span {
+.settingsMemoryEntryFacts span {
     min-width: 0;
   }
 
-  .settingsMemoryPromptScope {
+.settingsMemoryPromptScope {
     width: max-content;
     max-width: 100%;
     padding: var(--space-0-5) var(--space-1-5);
@@ -449,18 +411,18 @@
     line-height: 1.4;
   }
 
-  .settingsMemoryPromptScope[data-active="true"] {
+.settingsMemoryPromptScope[data-active="true"] {
     border-color: oklch(from var(--success) l c h / 0.32);
     background: oklch(from var(--success) l c h / 0.08);
     color: var(--foreground-70);
   }
 
-  .settingsMemoryDirtyState[data-dirty="true"] {
+.settingsMemoryDirtyState[data-dirty="true"] {
     color: var(--warning);
     font-weight: 600;
   }
 
-  .settingsMemoryEntryCard p,
+.settingsMemoryEntryCard p,
   .settingsMemoryEntryEmpty {
     margin: 0;
     color: var(--foreground-70);
@@ -469,7 +431,6 @@
     white-space: pre-wrap;
     word-break: break-word;
   }
-}
 
 .settingsMemoryEntryActions {
   display: flex;
@@ -505,8 +466,7 @@
   outline-offset: 2px;
 }
 
-@layer components {
-  .settingsMemoryFilterEmpty,
+.settingsMemoryFilterEmpty,
   .settingsMemoryListEmpty {
     display: grid;
     gap: var(--space-1);
@@ -516,19 +476,18 @@
     background: var(--foreground-3);
   }
 
-  .settingsMemoryFilterEmpty strong,
+.settingsMemoryFilterEmpty strong,
   .settingsMemoryListEmpty strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
 
-  .settingsMemoryFilterEmpty small,
+.settingsMemoryFilterEmpty small,
   .settingsMemoryListEmpty small {
     color: var(--foreground-60);
     font-size: var(--font-size-ui);
     line-height: 1.45;
   }
-}
 
 .settingsMemoryManualAdd {
   display: grid;
@@ -642,8 +601,7 @@
    Rendered below OnboardingHero ready_empty hero. Each row is a
    real jumpable affordance; done rows mute.
    ──────────────────────────────────────────────────────────────── */
-@layer components {
-  .maka-onboarding-stack {
+.maka-onboarding-stack {
     display: grid;
     gap: var(--space-6);
     align-content: start;
@@ -652,18 +610,15 @@
     min-height: calc(100dvh - 84px);
     padding: clamp(var(--space-10), 7vh, 76px) var(--space-6) var(--space-12);
   }
-
-  .maka-onboarding-stack > .maka-onboarding-ready {
+.maka-onboarding-stack > .maka-onboarding-ready {
     margin: 0;
   }
-
-  .maka-onboarding-ready {
+.maka-onboarding-ready {
     width: min(760px, 100%);
     padding: 0;
     gap: 0;
   }
-
-  .maka-first-run-checklist {
+.maka-first-run-checklist {
     width: min(760px, 100%);
     border: 1px solid oklch(from var(--foreground) l c h / 0.07);
     border-radius: var(--radius-surface);
@@ -673,28 +628,24 @@
     gap: var(--space-3);
     box-shadow: 0 10px 30px oklch(from var(--foreground) l c h / 0.04);
   }
-
-  .maka-first-run-checklist-header {
+.maka-first-run-checklist-header {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     color: var(--foreground-60);
     padding: 0 var(--space-1) var(--space-0-5);
   }
-
-  .maka-first-run-checklist-header strong {
+.maka-first-run-checklist-header strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
   }
-
-  .maka-first-run-checklist-count {
+.maka-first-run-checklist-count {
     margin-left: auto;
     font-size: var(--font-size-caption);
     letter-spacing: 0.04em;
     color: var(--foreground-50);
     font-variant-numeric: tabular-nums;
   }
-}
 
 .maka-first-run-checklist-error {
   display: flex;
@@ -738,8 +689,7 @@
   background: var(--background);
 }
 
-@layer components {
-  .maka-first-run-checklist-list {
+.maka-first-run-checklist-list {
     list-style: none;
     margin: 0;
     padding: 0;
@@ -748,7 +698,6 @@
     justify-content: center;
     gap: var(--space-2);
   }
-}
 
 .maka-first-run-checklist-row > button {
   height: auto;
@@ -826,12 +775,10 @@
 }
 
 @media (max-width: 760px) {
-  @layer components {
     .maka-onboarding-stack {
       gap: var(--space-6);
       padding: var(--space-6) var(--space-4) var(--space-8);
     }
-  }
 
   .maka-onboarding-ready header h1 {
     font-size: 1.6em;
@@ -866,8 +813,6 @@
   .maka-first-run-task-suggestions-header {
     justify-content: center;
   }
-
-  @layer components {
     .maka-first-run-checklist-list {
       justify-content: center;
     }
@@ -875,7 +820,6 @@
     .maka-first-run-checklist {
       padding: var(--space-3);
     }
-  }
 }
 
 /* ────────────────────────────────────────────────────────────────

--- a/packages/ui/src/__tests__/field-chrome.test.ts
+++ b/packages/ui/src/__tests__/field-chrome.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { InputGroup, InputGroupInput, InputGroupTextarea } from '../primitives/input-group.js';
+import { Input as PrimitiveInput } from '../primitives/input.js';
+import { Textarea as PrimitiveTextarea } from '../primitives/textarea.js';
+
+test('primitive unstyled Input does not imply the field chrome opt-out', () => {
+  const markup = renderToStaticMarkup(createElement(PrimitiveInput, {
+    unstyled: true,
+    nativeInput: true,
+    'aria-label': 'Primitive input',
+  }));
+
+  assert.doesNotMatch(markup, /\bdata-maka-field-chrome=/);
+  assert.match(markup, /data-slot="input"/);
+  assert.match(markup, /\bh-8\.5\b/);
+  assert.match(markup, /\bpx-\[calc\(--spacing\(3\)-1px\)\]/);
+});
+
+test('primitive unstyled Textarea does not imply the field chrome opt-out', () => {
+  const markup = renderToStaticMarkup(createElement(PrimitiveTextarea, {
+    unstyled: true,
+    'aria-label': 'Primitive textarea',
+  }));
+
+  assert.doesNotMatch(markup, /\bdata-maka-field-chrome=/);
+  assert.match(markup, /data-slot="textarea"/);
+  assert.match(markup, /\bfield-sizing-content\b/);
+  assert.match(markup, /\bpx-\[calc\(--spacing\(3\)-1px\)\]/);
+});
+
+test('InputGroup adapters explicitly opt their inner fields out of global chrome', () => {
+  const inputMarkup = renderToStaticMarkup(
+    createElement(InputGroup, { 'aria-label': 'Grouped input' },
+      createElement(InputGroupInput, { nativeInput: true, 'aria-label': 'Grouped input field' }),
+    ),
+  );
+  const textareaMarkup = renderToStaticMarkup(
+    createElement(InputGroup, { 'aria-label': 'Grouped textarea' },
+      createElement(InputGroupTextarea, { 'aria-label': 'Grouped textarea field' }),
+    ),
+  );
+
+  assert.match(inputMarkup, /\bdata-maka-field-chrome="none"/);
+  assert.match(inputMarkup, /\bh-8\.5\b/);
+  assert.match(inputMarkup, /\bpx-\[calc\(--spacing\(3\)-1px\)\]/);
+  assert.match(textareaMarkup, /\bdata-maka-field-chrome="none"/);
+  assert.match(textareaMarkup, /\bfield-sizing-content\b/);
+  assert.match(textareaMarkup, /\bpx-\[calc\(--spacing\(3\)-1px\)\]/);
+});

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -518,7 +518,7 @@ export const Composer = forwardRef<
           ref={textareaRef}
           unstyled
           name="text"
-          className="maka-composer-textarea min-h-[44px] resize-none border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+          className="maka-composer-textarea min-h-[44px] resize-none"
           placeholder={copy.placeholder}
           aria-label={copy.textareaAriaLabel}
           disabled={props.disabled}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -516,6 +516,7 @@ export const Composer = forwardRef<
       >
         <UiTextarea
           ref={textareaRef}
+          unstyled
           name="text"
           className="maka-composer-textarea min-h-[44px] resize-none border-0 bg-transparent px-0 py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
           placeholder={copy.placeholder}

--- a/packages/ui/src/primitives/input-group.tsx
+++ b/packages/ui/src/primitives/input-group.tsx
@@ -94,12 +94,12 @@ export function InputGroupInput({
   className,
   ...props
 }: InputProps): React.ReactElement {
-  return <Input className={className} unstyled {...props} />;
+  return <Input className={className} unstyled {...props} data-maka-field-chrome="none" />;
 }
 
 export function InputGroupTextarea({
   className,
   ...props
 }: TextareaProps): React.ReactElement {
-  return <Textarea className={className} unstyled {...props} />;
+  return <Textarea className={className} unstyled {...props} data-maka-field-chrome="none" />;
 }

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -51,6 +51,7 @@ export function Input({
           size={typeof size === "number" ? size : undefined}
           style={typeof style === "function" ? undefined : style}
           {...props}
+          data-maka-field-chrome={unstyled ? "none" : undefined}
         />
       ) : (
         <InputPrimitive
@@ -59,6 +60,7 @@ export function Input({
           size={typeof size === "number" ? size : undefined}
           style={style}
           {...props}
+          data-maka-field-chrome={unstyled ? "none" : undefined}
         />
       )}
     </span>

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -51,7 +51,6 @@ export function Input({
           size={typeof size === "number" ? size : undefined}
           style={typeof style === "function" ? undefined : style}
           {...props}
-          data-maka-field-chrome={unstyled ? "none" : undefined}
         />
       ) : (
         <InputPrimitive
@@ -60,7 +59,6 @@ export function Input({
           size={typeof size === "number" ? size : undefined}
           style={style}
           {...props}
-          data-maka-field-chrome={unstyled ? "none" : undefined}
         />
       )}
     </span>

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -48,7 +48,6 @@ export function Textarea({
             )}
             data-slot="textarea"
             {...mergeProps(defaultProps, props)}
-            data-maka-field-chrome={unstyled ? "none" : undefined}
           />
         )}
       />

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -48,6 +48,7 @@ export function Textarea({
             )}
             data-slot="textarea"
             {...mergeProps(defaultProps, props)}
+            data-maka-field-chrome={unstyled ? "none" : undefined}
           />
         )}
       />

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -424,6 +424,7 @@ export function SkillsModuleMain(props: {
           <label className="maka-skill-search" aria-label="搜索技能">
             <Search size={15} strokeWidth={1.75} aria-hidden="true" />
             <Input
+              unstyled
               value={skillSearchQuery}
               onChange={(event) => setSkillSearchQuery(event.currentTarget.value)}
               maxLength={120}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -117,18 +117,26 @@ const inputClasses = [
   'disabled:cursor-not-allowed disabled:opacity-50',
 ].join(' ');
 
-export const Input = forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(function Input(
-  { className, ...props },
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  unstyled?: boolean;
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, unstyled = false, ...props },
   ref,
 ) {
-  return <input ref={ref} className={cn(inputClasses, className)} {...props} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
+  return <input ref={ref} className={cn(!unstyled && inputClasses, className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
 });
 
-export const Textarea = forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(function Textarea(
-  { className, ...props },
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  unstyled?: boolean;
+};
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, unstyled = false, ...props },
   ref,
 ) {
-  return <textarea ref={ref} className={cn(inputClasses, 'min-h-24 resize-y leading-6', className)} {...props} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
+  return <textarea ref={ref} className={cn(!unstyled && inputClasses, !unstyled && 'min-h-24 resize-y leading-6', className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
 });
 
 export const Separator = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSeparator>>(function Separator(

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -117,6 +117,12 @@ const inputClasses = [
   'disabled:cursor-not-allowed disabled:opacity-50',
 ].join(' ');
 
+const bareFieldClasses = [
+  'appearance-none rounded-none border-0 bg-transparent p-0 text-inherit shadow-none outline-none [font:inherit]',
+  'focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0',
+  'disabled:cursor-not-allowed disabled:opacity-60',
+].join(' ');
+
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   unstyled?: boolean;
 };
@@ -125,7 +131,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   { className, unstyled = false, ...props },
   ref,
 ) {
-  return <input ref={ref} className={cn(!unstyled && inputClasses, className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
+  return <input ref={ref} className={cn(unstyled ? bareFieldClasses : inputClasses, className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
 });
 
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -136,7 +142,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function 
   { className, unstyled = false, ...props },
   ref,
 ) {
-  return <textarea ref={ref} className={cn(!unstyled && inputClasses, !unstyled && 'min-h-24 resize-y leading-6', className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
+  return <textarea ref={ref} className={cn(unstyled ? bareFieldClasses : [inputClasses, 'min-h-24 resize-y leading-6'], className)} {...props} data-maka-field-chrome={unstyled ? 'none' : undefined} />; // a11y-allow: generic wrapper; callers must provide label or aria-label
 });
 
 export const Separator = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSeparator>>(function Separator(


### PR DESCRIPTION
## Summary

- Remove local `@layer` wrappers from renderer feature stylesheets and add a contract that keeps `apps/desktop/src/renderer/styles/**` unlayered.
- Route embedded bare legacy `Input` / `Textarea` fields through an explicit chrome-less path instead of resetting primitive focus rings with page-level `!important` CSS.
- Centralize legacy `Input` / `Textarea` bare reset in `@maka/ui`, so call sites keep only business sizing/layout classes.
- Decouple primitive `unstyled` from field chrome opt-out; `InputGroup` adapters now opt out explicitly because their wrapper owns chrome.
- Narrow the renderer `!important` audit around the retired skill search, onboarding quickchat, and composer textarea ring-reset sites, and add render-level bare-field contracts.

## Why

Refs #476.

PR1 made renderer CSS parseable. This PR settles the next CSS hygiene layer: feature stylesheets now use one cascade model, and embedded fields no longer need local `!important` ring-shadow resets to avoid double chrome.

## Scope

Changed:

- `apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts` now rejects `@layer` inside renderer feature stylesheets.
- Renderer feature CSS under `apps/desktop/src/renderer/styles/**` has local `@layer` wrappers mechanically removed while preserving rule order.
- `packages/ui/src/ui.tsx` gives legacy `Input` / `Textarea` an `unstyled` path that owns the bare field reset and `data-maka-field-chrome="none"`.
- `packages/ui/src/primitives/input.tsx` and `packages/ui/src/primitives/textarea.tsx` no longer treat primitive `unstyled` as field chrome opt-out.
- `packages/ui/src/primitives/input-group.tsx` marks its inner `Input` / `Textarea` with `data-maka-field-chrome="none"` at the adapter layer.
- `packages/ui/src/__tests__/field-chrome.test.ts` pins the primitive-vs-InputGroup `unstyled` contract.
- Skill search, onboarding quickchat, and composer textarea pass legacy `unstyled` and no longer carry repeated `border-0` / `shadow-none` / `focus-visible:ring-*` reset classes.
- Page CSS for skill search, onboarding quickchat, and composer textarea now owns layout/typography only; primitive/bare reset lives in the UI component.
- `apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts` guards the retired ring-reset patterns and parses the field focus selector semantically.
- `apps/desktop/src/main/__tests__/bare-field-chrome-contract.test.ts` renders `@maka/ui` fields and verifies the actual legacy `unstyled` DOM contract.

Not included:

- No visual redesign or new focus-ring design.
- No `module-pages.css` domain split.
- No broader `!important` cleanup outside the three ring-reset sites.
- No React architecture cleanup from #477.

## Verification

- RED: `renderer-style-layer-cascade-contract.test.js` failed on existing `@layer` feature stylesheets before unwrapping.
- RED: `renderer-important-audit-contract.test.js` failed on `.maka-skill-search input` before the bare-field route and ring-reset cleanup.
- RED: `bare-field-chrome-contract.test.js` failed before `unstyled` owned the shared bare reset.
- RED: `field-chrome.test.js` failed before primitive `unstyled` stopped emitting `data-maka-field-chrome="none"`.
- `npm run build`
- `npm run -w @maka/ui build`
- `npm run -w @maka/ui build && node --test packages/ui/dist/__tests__/field-chrome.test.js`
- `npm run -w @maka/desktop build:main`
- `node --test apps/desktop/dist/main/__tests__/bare-field-chrome-contract.test.js apps/desktop/dist/main/__tests__/renderer-important-audit-contract.test.js`
- `node --test apps/desktop/dist/main/__tests__/renderer-css-parse-contract.test.js apps/desktop/dist/main/__tests__/renderer-tailwind-compile-contract.test.js apps/desktop/dist/main/__tests__/renderer-important-audit-contract.test.js apps/desktop/dist/main/__tests__/bare-field-chrome-contract.test.js`
- `node --test apps/desktop/dist/main/__tests__/renderer-style-layer-cascade-contract.test.js`
- `npm run -w @maka/desktop build:renderer` (passes; existing Vite chunk-size warning remains)
- Visual screenshots from latest renderer build:
  - `node ../../scripts/capture-screenshots.mjs --scenario module-skills --variant light-1280-motion`
  - `node ../../scripts/capture-screenshots.mjs --scenario first-run --variant light-1280-motion`
  - `node ../../scripts/capture-screenshots.mjs --scenario provider-workspace --variant light-1280-motion`
  - `node ../../scripts/capture-screenshots.mjs --scenario module-daily-review --variant light-1280-motion`
  - `node ../../scripts/capture-screenshots.mjs --scenario command-palette-open --variant light-1280-motion`
  - `node ../../scripts/capture-screenshots.mjs --scenario sidebar-search-modal-open --variant light-1280-motion`
- Temporary Electron computed-style focus smoke against the built renderer CSS: ordinary field, skill search, composer textarea, and onboarding quickchat all passed focus/blur checks. Ordinary fields get the visible inner focus chrome; bare fields keep inner chrome invisible and move visible focus chrome to their wrappers.
- `node --test apps/desktop/dist/main/__tests__/rive-workflow-tool.test.js` (rerun after one unrelated transient full-suite timeout)
- `npm run -w @maka/desktop test` (1716 tests pass)

Known existing failure:

- `npm run -w @maka/ui test` still fails on `chat-primitives.test` footer-action / lineage-badge merge assertions. The same command fails the same way on current `main`, so this PR does not introduce that failure.

## User-facing impact

No visual redesign intended. This PR does touch focus chrome plumbing and cascade boundaries, so the latest screenshots plus the computed-style focus smoke above cover the affected surfaces.

## Reviewer notes

The commits are intentionally split by rollback reason:

- `refactor(ui-css): unlayer renderer feature styles` only settles feature stylesheet cascade.
- `fix(ui-css): route bare fields around focus chrome` introduces the explicit bare-field route and removes the original important resets.
- `fix(ui-css): centralize bare field focus chrome` addresses review feedback: lower-specificity focus opt-out, behavior-level bare-field contract, and UI-owned bare reset.
- `fix(ui-css): decouple primitive unstyled chrome` addresses review feedback: primitive `unstyled` no longer means bare field chrome opt-out; `InputGroup` opts out explicitly at its adapter boundary.
