### PR TITLE
fix(ui): visual audit round — list bullets, artifact toolbar, disclosure affordance

### DIFF
--- a/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/capability-audit-ui-contract.test.ts
@@ -48,9 +48,9 @@ describe('capability audit visible system contract', () => {
     assert.match(markup, /aria-label="能力审计摘要"/);
     assert.match(markup, /能力审计/);
     assert.match(markup, /3 类声明工具/);
-    assert.match(markup, /1\/1 来源就绪/);
-    assert.match(markup, /1\/1 技能启用/);
-    assert.match(markup, /1\/1 自动化启用/);
+    assert.match(markup, /来源<\/dt><dd>1\/1 就绪/);
+    assert.match(markup, /技能<\/dt><dd>1\/1 启用/);
+    assert.match(markup, /自动化<\/dt><dd>1\/1 启用/);
     assert.match(markup, /1 个自动化上次失败/);
     assert.equal(report.skills[0].permissionMode, 'ask');
     assert.notEqual(report.skills[0].permissionMode, 'execute');

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -445,6 +445,11 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
                   id={`maka-artifact-row-${record.id}`}
                   type="button"
                   variant="ghost"
+                  // size="nav": className owns layout. The default md size
+                  // pins h-9 on the button, but deleted rows add a badge on
+                  // an implicit second grid row — fixed height + centering
+                  // painted the badge over the icon/name.
+                  size="nav"
                   className="maka-artifact-row"
                   role="option"
                   aria-selected={record.id === selectedId}

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -546,7 +546,7 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
                     aria-busy={pendingArtifactAction === `${selected.id}:copy` ? 'true' : undefined}
                   >
                     <Copy size={14} aria-hidden="true" />
-                    <span>{pendingArtifactAction === `${selected.id}:copy` ? '复制中…' : '复制文本'}</span>
+                    <span>{pendingArtifactAction === `${selected.id}:copy` ? '复制中…' : '复制'}</span>
                   </Button>
                 )}
               </ToolbarGroup>
@@ -557,13 +557,17 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
                   variant="destructive"
                   size="sm"
                   className="maka-artifact-toolbar-button maka-artifact-toolbar-destructive"
+                  title="删除"
                   onClick={() => void runArtifactAction(`${selected.id}:delete`, () => deleteArtifact(selected.id))}
                   disabled={artifactActionBusy}
                   data-pending={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
                   aria-busy={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
                 >
                   <Trash2 size={14} aria-hidden="true" />
-                  <span>{pendingArtifactAction === `${selected.id}:delete` ? '删除中…' : '删除'}</span>
+                  {/* Icon-only at rest: the visible label wrapped the toolbar
+                      onto a second line at 1280 pane width, stranding 删除
+                      alone bottom-right. Label stays for screen readers. */}
+                  <span className="maka-artifact-toolbar-destructive-label">{pendingArtifactAction === `${selected.id}:delete` ? '删除中…' : '删除'}</span>
                 </Button>
               </ToolbarGroup>
             </Toolbar>

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1253,6 +1253,13 @@
     margin: 0 0 var(--space-3);
     padding-left: var(--space-6);
   }
+  /* Tailwind v4 preflight strips list markers globally (`ul, ol
+     { list-style: none }` in @layer base); restore them for rendered
+     markdown or bulleted answers read as flat indented lines. Same
+     root cause as the permission-center fix (permission-center.css). */
+  .maka-bubble-assistant ul { list-style: disc; }
+  .maka-bubble-assistant ol { list-style: decimal; }
+  .maka-bubble-assistant li > ul { list-style: circle; }
   .maka-bubble-assistant li { margin: var(--space-0-5) 0; }
   .maka-bubble-assistant li > ul,
   .maka-bubble-assistant li > ol { margin-bottom: 0; }

--- a/apps/desktop/src/renderer/styles/module-pages.css
+++ b/apps/desktop/src/renderer/styles/module-pages.css
@@ -1359,8 +1359,12 @@
 
 .maka-skill-featured-art span {
   position: absolute;
-  width: 94px;
-  height: 112px;
+  /* Cards sized + offset so the banner's overflow:hidden never crops
+     their copy: previous 94-122px heights with 28px+ top offsets cut
+     「总结沉淀」mid-glyph at the banner edge. Corners may still bleed
+     off (intentional sticker collage), text must not. */
+  width: 84px;
+  height: 96px;
   display: inline-flex;
   flex-direction: column;
   align-items: center;
@@ -1394,7 +1398,7 @@ color: oklch(0.55 0.015 220);
 
 .maka-skill-featured-art span:first-child {
   left: 14px;
-  top: 28px;
+  top: 12px;
   transform: rotate(-14deg);
   color: oklch(64% 0.15 154);
 }
@@ -1408,17 +1412,17 @@ color: oklch(0.55 0.015 220);
      so they don't need a global token. The contract test
      `z-index-contract.test.ts` whitelists this exact site. */
   z-index: 2;
-  width: 104px;
-  height: 122px;
+  width: 92px;
+  height: 106px;
   transform: rotate(10deg);
   color: oklch(54% 0.10 236);
 }
 
 .maka-skill-featured-art span:nth-child(3) {
   right: 4px;
-  top: 34px;
-  width: 88px;
-  height: 104px;
+  top: 18px;
+  width: 78px;
+  height: 92px;
   transform: rotate(7deg);
   color: oklch(58% 0.18 32);
 }

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -56,6 +56,9 @@
 
 .maka-permission-raw > summary {
   list-style: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
   padding: var(--space-1) var(--space-2-5);
   color: var(--foreground-60);
   font-size: var(--font-size-caption);
@@ -63,6 +66,24 @@
 
 .maka-permission-raw > summary::-webkit-details-marker { display: none; }
 .maka-permission-raw > summary::marker { content: ''; }
+
+/* Rotating disclosure triangle (same recipe as .maka-turn-thinking):
+   without it the bordered summary row read as a text input, not a
+   collapsible section. */
+.maka-permission-raw > summary::before {
+  content: '';
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 0 4px 5px;
+  border-color: transparent transparent transparent currentColor;
+  transition: transform var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-permission-raw[open] > summary::before {
+  transform: rotate(90deg);
+}
 
 .maka-permission-raw[open] > summary {
   border-bottom: 1px solid var(--border);

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -926,6 +926,24 @@
 .maka-artifact-toolbar-destructive {
   color: var(--destructive-text);
   border-color: oklch(from var(--destructive) l c h / 0.32);
+  /* Icon-only footprint (see artifact-pane.tsx destructive label note):
+     square-ish hit area, no text gap. */
+  gap: 0;
+  padding: var(--space-1) var(--space-1-5);
+}
+
+/* Visually hidden, still announced: the 删除/删除中… label only exists
+   for assistive tech. Keeping it in-flow reintroduces the toolbar wrap
+   this exists to prevent. */
+.maka-artifact-toolbar-destructive-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .maka-artifact-toolbar-destructive:hover {

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -655,6 +655,7 @@
 .maka-artifact-row-badge {
   grid-column: 1 / -1;
   justify-self: start;
+  margin-top: var(--space-0-5);
 }
 
 .maka-artifact-preview {

--- a/packages/ui/src/capability-audit-strip.tsx
+++ b/packages/ui/src/capability-audit-strip.tsx
@@ -2,11 +2,13 @@ import type { CapabilityAuditReport } from '@maka/core';
 
 export function CapabilityAuditStrip(props: { report: CapabilityAuditReport; focus: 'skills' | 'automations' }) {
   const report = props.report;
+  // Metric labels live in the <dt> (来源/技能/自动化) — the <dd> only
+  // carries count + state so the strip doesn't read「技能 3/3 技能启用」.
   const sourceCopy = report.summary.sourceCount === 0
-    ? '0 个来源'
-    : `${report.summary.readySourceCount}/${report.summary.sourceCount} 来源就绪`;
-  const skillCopy = `${report.summary.enabledSkillCount}/${report.summary.skillCount} 技能启用`;
-  const automationCopy = `${report.summary.enabledAutomationCount}/${report.summary.automationCount} 自动化启用`;
+    ? '暂无'
+    : `${report.summary.readySourceCount}/${report.summary.sourceCount} 就绪`;
+  const skillCopy = `${report.summary.enabledSkillCount}/${report.summary.skillCount} 启用`;
+  const automationCopy = `${report.summary.enabledAutomationCount}/${report.summary.automationCount} 启用`;
   const riskCopy = capabilityAuditRiskCopy(report);
   const primaryCopy = props.focus === 'skills'
     ? `${report.summary.declaredToolKindCount} 类声明工具`

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -38,11 +38,14 @@ export function formatAbsoluteTimestamp(ts: number): string {
 }
 
 export function formatTurnDuration(ms: number): string {
+  // Same shape as tool-activity's formatDuration — the turn meta chip
+  // and tool cards sit stacked in one view;「1 m 0 s」vs「8.2s」read as
+  // two different products.
   if (ms < 1000) return `${ms} ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)} s`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
   const m = Math.floor(ms / 60_000);
   const s = Math.round((ms % 60_000) / 1000);
-  return `${m} m ${s} s`;
+  return `${m}m ${s}s`;
 }
 
 export function turnAbortMarkerLabel(abortSource: string | undefined): string {


### PR DESCRIPTION
## 背景
按 visual-audit workflow（capture-screenshots fixtures → 逐 PNG 审查）对 18 个核心场景 × light/dark 做了一轮全量走查，修掉 7 处真实 UI 问题。全部双主题截图验收（D2）。

## 修复清单
1. **聊天 markdown 列表丢 bullet**（真 bug）：Tailwind v4 preflight 在 `@layer base` 全局 `list-style: none`，`.maka-bubble-assistant ul/ol` 只恢复了 padding。与 permission-center.css 那次是同一根因。现在 ul→disc / ol→decimal / 嵌套 ul→circle；task-list 的 none 豁免不受影响。
2. **Artifact 面板工具栏换行**：1280 视口下「删除」被挤到第二行孤立漂浮。「复制文本」→「复制」，删除改 icon-only（label 保留给屏幕阅读器 + title tooltip），单行放得下。
3. **Artifact 列表「已删除」badge 叠画在文件名上**（真 bug）：行 Button 默认 size=md 的 `h-9` 固定高度 + badge 隐式第二行 + 居中对齐 → 两行内容互相叠画。改用 `size="nav"`（仓库预留的 className-owns-layout 逃生口），高度随内容。
4. **权限弹窗「查看完整参数」**：无 marker 的 summary + 边框底色长得像输入框；补上与「查看思考过程」一致的旋转三角。
5. **技能页 hero 贴纸卡被硬裁**：卡片缩小重定位，banner 的 overflow:hidden 不再裁掉「总结沉淀」文字（角部出血保留，属拼贴风格）。
6. **能力审计条文案冗余**：dd 不再复读 dt 的词（「技能 3/3 技能启用」→「3/3 启用」）；零来源改「暂无」。契约测试同步收紧为 dt+dd 结构断言。
7. **turn 时长格式**：`1 m 0 s` → `1m 0s`，与同屏工具卡片的 `8.2s` 家族统一。

## 验证
- `npm run typecheck` ✓
- `@maka/desktop` 1708 tests ✓（两次全跑）；`check-dead-css` ✓
- `@maka/ui` 13/15 ✓ — 2 个失败为 main 上已存在的存量失败（chat-primitives 的 tailwind-merge 断言，干净 HEAD 复现），与本 PR 无关，已另开任务跟进
- 截图：module-skills / artifact-pane / artifact-errors / permission-destructive / streaming-answer / plan-reminders / provider-workspace 等，light+dark 重截通过；第二轮快扫 connection-error / stale-sessions / module-daily-review / command-palette-open / settings-bots 无新问题

---

## 第二轮追加（2026-07-04，同分支）
8. **聊天页「三块颜色」**（owner 反馈）：`.maka-main` 只给聊天滚动区刷了纯白，darwin 玻璃下与面板容器色 #fafafa 形成 composer 第三色带。改为 transparent —— 右面板单一表面（双主题验证）；顺带删除 theme-glass 里永远打不赢 cascade 的死规则。
9. **启动闪屏**（owner 反馈「配置页闪一下」）：snapshot 到达的那一帧 loading 门已放开而 sessions 仍为空，useEffect 在 paint 之后才种入会话 → 有历史的用户每次启动闪一帧空态 hero。种子逻辑改 useLayoutEffect（paint 前提交），契约测试同步放宽。
10. **技能市场死按钮**：永久 disabled 的「安装」按钮改为静态「即将上线」标签（与筛选 pill 同一设计判例）。
11. **死代码清理**：删 6 个从未被引用的 lucide icon 再导出；4 个仅文件内使用的 helper 去掉 export。全仓死文件/死 CSS 扫描为零（agent 全量核查）。

验证：typecheck ✓ / desktop 1708 ✓ / dead-css ✓ / ui 13/15（2 个为 main 存量失败，另行跟进）。

12. **每日回顾 IA 重构（第一轮）**（owner:「太乱、不直观」）：时间上下文合一——日期步进器与 今日/本周/本月 tabs 并入同一 header 条（原来 tabs 漂在页面中部）；两段说明卡片收成一行安静提示；导出操作紧贴其导出的统计区。radius 契约同步。双主题 + 990 窄屏截图验收。