### PR TITLE
fix(runtime): normalize kimi send baseURL to /v1 like probe/model-fetch paths

### DIFF
--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -84,14 +84,21 @@ describe('Claude subscription runtime wiring', () => {
     }
   });
 
-  test('model factory gives API-key Anthropic the /v1 SDK base without changing Kimi', async () => {
-    const src = await readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8');
-    const anthropicCase = src.slice(src.indexOf("case 'anthropic'"), src.indexOf("case 'kimi-coding-plan'"));
-    const kimiCase = src.slice(src.indexOf("case 'kimi-coding-plan'"), src.indexOf("case 'claude-subscription'"));
+  test('anthropicV1BaseUrl normalizes base URLs to a single /v1 suffix', async () => {
+    const { anthropicV1BaseUrl } = await import('../subscription-auth.js');
+    assert.equal(anthropicV1BaseUrl('https://api.anthropic.com'), 'https://api.anthropic.com/v1', 'bare root gains /v1');
+    assert.equal(anthropicV1BaseUrl('https://api.anthropic.com/'), 'https://api.anthropic.com/v1', 'trailing slash is stripped before re-appending /v1');
+    assert.equal(anthropicV1BaseUrl('https://api.anthropic.com/v1'), 'https://api.anthropic.com/v1', 'already-versioned root is idempotent');
+    assert.equal(anthropicV1BaseUrl('https://api.kimi.com/coding/v1'), 'https://api.kimi.com/coding/v1', 'already-versioned override is idempotent');
+    assert.equal(anthropicV1BaseUrl('https://api.kimi.com/coding/'), 'https://api.kimi.com/coding/v1', 'override omitting /v1 gets it filled in');
+  });
 
-    assert.match(anthropicCase, /baseURL:\s*anthropicV1BaseUrl\(baseURL\)/, 'Anthropic API-key sends must use the SDK /v1 base URL');
-    assert.match(kimiCase, /baseURL,\s*[\s\S]*headers:/, 'Kimi Anthropic-compatible endpoint must keep its provider-specific base URL');
-    assert.doesNotMatch(kimiCase, /anthropicV1BaseUrl/, 'Kimi endpoint must not be blindly rewritten to /v1');
+  test('model factory routes Anthropic and Kimi sends through the /v1 base URL helper', async () => {
+    const src = await readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8');
+    // anthropic and kimi-coding-plan share one case body; slice the whole region
+    // up to the next distinct provider (MiniMax) so a shared case is not a failure.
+    const region = src.slice(src.indexOf("case 'anthropic'"), src.indexOf("case 'MiniMax'"));
+    assert.match(region, /baseURL:\s*anthropicV1BaseUrl\(baseURL\)/, 'Anthropic API-key and Kimi sends must use the SDK /v1 base URL');
   });
 
   test('model factory sends MiniMax over Bearer (authToken), not x-api-key', async () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -25,16 +25,14 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
 
   switch (connection.providerType) {
     case 'anthropic':
+    case 'kimi-coding-plan':
+      // Both send through the Anthropic SDK, normalizing the base URL to /v1
+      // (anthropicV1BaseUrl) so a baseUrl override omitting `/v1` sends to
+      // `<root>/v1/messages` instead of 404ing on `<root>/messages`, matching
+      // the probe/model-fetch paths.
       return createAnthropic({
         apiKey,
         baseURL: anthropicV1BaseUrl(baseURL),
-        headers: { 'anthropic-beta': ANTHROPIC_BETA },
-      }).chat(modelId);
-
-    case 'kimi-coding-plan':
-      return createAnthropic({
-        apiKey,
-        baseURL,
         headers: { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);
 


### PR DESCRIPTION
  ## Summary

  Kimi Coding Plan sends 404'd (resource_not_found on https://api.kimi.com/coding/messages) while
  the connection test reported verified, because the send path and the probe/model-fetch paths
  disagreed on /v1 normalization. This makes the send path use the same anthropicV1BaseUrl
  normalization the other two already use.

  ## Root cause

  getAIModel's kimi-coding-plan case passed the raw baseURL straight to createAnthropic, which
  appends /messages internally. testConnection (probeAnthropic) and fetchProviderModels both route
  through anthropicV1Url(...), which forces a /v1 segment.

  So when a connection baseUrl override omitted /v1 (repro: https://api.kimi.com/coding/):

| path | URL | result |
  | --- | --- | --- |
  | probe | `…/coding/v1/messages` | ✅ verified |
  | model-fetch | `…/coding/v1/models` | ✅ |
  | send | `…/coding/messages` | ❌ 404 |

  → "connection verified, every message fails."
  
   ## Not in this PR

  - read-model throwing on legacy non-terminal error rows (bricks old sessions on read) — separate,
    has a design tradeoff.

  - probe/send anthropic-beta header asymmetry — pre-existing.
  - anthropic/kimi case dedup — deferred (may diverge again per the header asymmetry above).