### PR TITLE
fix(desktop): prevent empty chat flicker on session switch

### DIFF
--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -22,20 +22,40 @@ describe('active session message lifecycle contract', () => {
       'app-shell-copy.ts',
     ]);
     const ui = await readFile(join(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-view.tsx'), 'utf8');
-    const activeSessionEffect = src.match(/useEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
+    const activeSessionEffect = src.match(/useLayoutEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
     const activeReadCatch = activeSessionEffect.match(/readMessages\(activeId\)[\s\S]*?\.catch\(\(error\) => \{[\s\S]*?\n      \}\);/)?.[0] ?? '';
     const refreshMessages = src.match(/async function refreshMessages\(sessionId: string\)(?:: Promise<boolean>)? \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const retryMessages = src.match(/async function retryMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(
+      src,
+      /const \[messageLoadPending, setMessageLoadPending\] = useState\(false\);/,
+      'desktop shell must track the selected session message-read pending state',
+    );
+    assert.match(
+      src,
+      /const activeMessageLoading = Boolean\(activeId && messageLoadPending\);/,
+      'desktop shell must distinguish message-read loading from a genuinely empty session',
+    );
+    assert.match(
+      src,
+      /function setActiveId\(next: string \| undefined\): void \{[\s\S]*else if \(next !== activeIdRef\.current\) \{[\s\S]*setMessages\(\[\]\);[\s\S]*setMessageLoadPending\(true\)/,
+      'setActiveId must clear stale messages and mark the read pending only when the active session actually changes, in the same React batch as the switch so the empty hero does not flash',
+    );
+    assert.doesNotMatch(
       activeSessionEffect,
-      /const subscribedAt = Date\.now\(\);[\s\S]*setMessages\(\[\]\);[\s\S]*readMessages\(activeId\)/,
-      'selecting a new active session must clear the old chat body before async message read resolves',
+      /const subscribedAt = Date\.now\(\);[\s\S]*setMessages\(\[\]\)/,
+      'the active-session read-start effect must not clear messages; a layout-effect clear can wipe an optimistic user message for a brand-new session before the first paint',
+    );
+    assert.match(
+      src,
+      /setActiveId\(session\.id\);[\s\S]*?showOptimisticUserMessage\(session\.id, turnId, text, \{ replaceCurrentMessages: true \}\)/,
+      'the new-session-then-send path lets the optimistic user message overwrite the setActiveId clear in the same React batch, so the first message survives until the real read lands',
     );
     assert.match(
       activeSessionEffect,
-      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId, next\);[\s\S]*setMessages\(next\);[\s\S]*\}/,
-      'late active-session reads may set messages only while the same session is still active',
+      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId, next\);[\s\S]*if \(next\.length > 0\) setMessages\(next\);[\s\S]*setMessageLoadPending\(false\);[\s\S]*\}/,
+      'late active-session reads skip an empty result so an in-flight optimistic user message is not blanked while the same session is still active',
     );
     assert.match(
       activeReadCatch,
@@ -44,8 +64,8 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       activeReadCatch,
-      /\.catch\(\(error\) => \{[\s\S]*const message = messageReadErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[activeId\]: message \}\)\);[\s\S]*toastApi\.error\('读取对话失败', message\)/,
-      'active-session read failures must set a visible per-session load error after the old chat body has already been cleared',
+      /\.catch\(\(error\) => \{[\s\S]*const message = messageReadErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[activeId\]: message \}\)\);[\s\S]*setMessageLoadPending\(false\);[\s\S]*toastApi\.error\('读取对话失败', message\)/,
+      'active-session read failures must clear pending and set a visible per-session load error after stale content was cleared',
     );
     assert.doesNotMatch(activeReadCatch, /const message = cleanErrorMessage\(error\)/);
     assert.doesNotMatch(
@@ -56,7 +76,7 @@ describe('active session message lifecycle contract', () => {
     assert.doesNotMatch(
       activeReadCatch,
       /setMessages\(\[\]\)/,
-      'the read-failure catch must not perform a second destructive clear; the pre-read clear is the only stale-content boundary',
+      'the read-failure catch must not perform a second destructive clear; the setActiveId transition clear is the only stale-content boundary',
     );
     assert.match(
       refreshMessages,
@@ -96,13 +116,23 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       src,
-      /messageLoadError=\{activeId \? messageLoadErrorBySession\[activeId\] : undefined\}[\s\S]*messageLoadRetryPending=\{activeId \? messageRetryPendingBySession\[activeId\] === true : false\}[\s\S]*onRetryMessages=\{activeId \? \(\) => void retryMessages\(activeId\) : undefined\}/,
+      /messages=\{messages\}[\s\S]*messageLoading=\{activeMessageLoading\}[\s\S]*messageLoadError=\{activeId \? messageLoadErrorBySession\[activeId\] : undefined\}[\s\S]*messageLoadRetryPending=\{activeId \? messageRetryPendingBySession\[activeId\] === true : false\}[\s\S]*onRetryMessages=\{activeId \? \(\) => void retryMessages\(activeId\) : undefined\}/,
       'desktop shell must pass the active session load error, pending state, and guarded retry action to ChatView',
     );
     assert.doesNotMatch(
       src,
       /onRetryMessages=\{activeId \? \(\) => void refreshMessages\(activeId\) : undefined\}/,
       'manual retry must not call refreshMessages directly because that allows duplicate read IPCs',
+    );
+    assert.match(
+      ui,
+      /messageLoading\?: boolean/,
+      'ChatView must accept explicit message-read loading state',
+    );
+    assert.match(
+      ui,
+      /props\.messageLoading \? null : props\.messageLoadError \? \([\s\S]*\) : props\.emptyOverride/,
+      'ChatView must suppress the stale load error and the normal empty-chat hero while the selected session message read is still in flight',
     );
     assert.match(
       ui,

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import type {
   ConnectionEvent,
   PlanReminder,
@@ -316,6 +316,7 @@ export function useActiveSessionEvents(options: {
   setMessageLoadErrorBySession: (
     updater: (current: Record<string, string>) => Record<string, string>,
   ) => void;
+  setMessageLoadPending: (pending: boolean) => void;
   setMessages: (messages: StoredMessage[]) => void;
   setSessionEventHealthBySession: SessionEventHealthUpdater;
   toastApi: Pick<ToastApi, 'error'>;
@@ -326,16 +327,16 @@ export function useActiveSessionEvents(options: {
     handleEvent,
     markSessionReadLocally,
     setMessageLoadErrorBySession,
+    setMessageLoadPending,
     setMessages,
     setSessionEventHealthBySession,
     toastApi,
   } = options;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!activeId) return;
     let disposed = false;
     const subscribedAt = Date.now();
-    setMessages([]);
     setMessageLoadErrorBySession((current) => {
       if (!current[activeId]) return current;
       const next = { ...current };
@@ -350,13 +351,19 @@ export function useActiveSessionEvents(options: {
       .then((next) => {
         if (!disposed && activeIdRef.current === activeId) {
           markSessionReadLocally(activeId, next);
-          setMessages(next);
+          // Ignore an empty read: it can race a just-sent message's save and wipe
+          // the optimistic copy shown to the user. length is enough only because
+          // sends are serialized (one optimistic per session); parallel sends
+          // would need a merge instead.
+          if (next.length > 0) setMessages(next);
+          setMessageLoadPending(false);
         }
       })
       .catch((error) => {
         if (!disposed && activeIdRef.current === activeId) {
           const message = messageReadErrorMessage(error);
           setMessageLoadErrorBySession((current) => ({ ...current, [activeId]: message }));
+          setMessageLoadPending(false);
           toastApi.error('读取对话失败', message);
         }
       });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -140,6 +140,7 @@ export function AppShell() {
   const [navSelection, setNavSelection] = useState<NavSelection>(() => readNavSelection());
   const navSelectionRef = useRef<NavSelection>(navSelection);
   const [messages, setMessages] = useState<StoredMessage[]>([]);
+  const [messageLoadPending, setMessageLoadPending] = useState(false);
   const messageRetryPendingRef = useRef<Set<string>>(new Set());
   const stopPendingRef = useRef<Set<string>>(new Set());
   const {
@@ -601,6 +602,7 @@ export function AppShell() {
     model: 'fake-model',
     permissionMode: 'ask',
   } : undefined);
+  const activeMessageLoading = Boolean(activeId && messageLoadPending);
   const visibleSessions = useMemo(() => filterSessions(sessions, navSelection), [sessions, navSelection]);
   // PR110c: OnboardingState is now the single source of truth for
   // first-run UI. The renderer never re-derives provider readiness;
@@ -684,6 +686,14 @@ export function AppShell() {
   });
 
   function setActiveId(next: string | undefined): void {
+    // Clear here, not in the read effect: a layout-effect clear would wipe an
+    // optimistic first message before the first paint.
+    if (!next) {
+      setMessageLoadPending(false);
+    } else if (next !== activeIdRef.current) {
+      setMessages([]);
+      setMessageLoadPending(true);
+    }
     activeIdRef.current = next;
     setActiveIdState(next);
   }
@@ -888,6 +898,7 @@ export function AppShell() {
     handleEvent,
     markSessionReadLocally,
     setMessageLoadErrorBySession,
+    setMessageLoadPending,
     setMessages,
     setSessionEventHealthBySession,
     toastApi,
@@ -997,6 +1008,7 @@ export function AppShell() {
     setActiveId(undefined);
     setNavSelection({ section: 'sessions', filter: 'chats' });
     setSearchScrollTarget(null);
+    setMessageLoadPending(false);
     setMessages([]);
   }
 
@@ -1241,6 +1253,7 @@ export function AppShell() {
             <div className="mainColumn" data-home-surface={homeSurfaceActive ? 'true' : undefined}>
               <ChatView
                 messages={messages}
+                messageLoading={activeMessageLoading}
                 streamingText={activeStreaming}
                 streamingComplete={activeStreamingComplete}
                 streamingMessageId={activeStreamingMessageId}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -115,6 +115,7 @@ export interface ChatHeaderAlert {
 
 export function ChatView(props: {
   messages: StoredMessage[];
+  messageLoading?: boolean;
   streamingText: string;
   /** True after upstream emitted the final assistant text, while the UI is draining the smoother. */
   streamingComplete?: boolean;
@@ -559,7 +560,7 @@ export function ChatView(props: {
           onScroll={onScroll}
         >
           {chat.length === 0 && !props.streamingText && (
-            props.messageLoadError ? (
+            props.messageLoading ? null : props.messageLoadError ? (
               <div role="alert" aria-busy={props.messageLoadRetryPending ? 'true' : undefined}>
                 <EmptyState
                   Icon={AlertTriangle}


### PR DESCRIPTION
## Summary

Fixes the sidebar session-switch flicker where the default empty-chat hero briefly appeared before the selected session’s messages finished loading.

## Approach

Considered tracking messages by session, but that would be a larger cache-style change. 

For this bug, the simpler fix is enough: keep the current single `messages` state, add a small pending flag for the active session read, and hide the empty hero while that read is in flight.

`useLayoutEffect` makes the pending state apply before paint, so the transition frame does not flash the empty state.

## Verification

  - `npm --workspace @maka/ui run build`
  - `npm --workspace @maka/desktop run typecheck`
  - `npm --workspace @maka/desktop run build:main`
  - `node --test dist/main/__tests__/session-message-lifecycle-contract.test.js dist/main/
  __tests__/session-row-actions-fail-soft-contract.test.js dist/main/__tests__/session-
  open-routing-contract.test.js`