### PR TITLE
fix(desktop): sync Electron's nativeTheme with the in-app theme preference

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -54,6 +54,7 @@ import type {
   WebSearchResponse,
   BrowserState,
   BrowserViewRect,
+  ThemePreference,
 } from '@maka/core';
 import type {
   PricingConfig,
@@ -394,7 +395,7 @@ declare global {
       appWindow: {
         subscribeOpenSettings(handler: () => void): () => void;
         setTitlebarControlsVisible(visible: boolean): Promise<void>;
-        setThemeSource(themeSource: 'system' | 'light' | 'dark'): Promise<void>;
+        setThemeSource(themePref: ThemePreference): Promise<void>;
       };
       app: {
         info(): Promise<{

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -394,6 +394,7 @@ declare global {
       appWindow: {
         subscribeOpenSettings(handler: () => void): () => void;
         setTitlebarControlsVisible(visible: boolean): Promise<void>;
+        setThemeSource(themeSource: 'system' | 'light' | 'dark'): Promise<void>;
       };
       app: {
         info(): Promise<{

--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Astro-Han review (#493) P2: a small regression test for the
+ * ThemePreference -> nativeTheme.themeSource bridge. The main-process side
+ * (setThemeSource IPC handler, createWindow startup sync) is Electron-coupled
+ * and covered by the main-window-safe-send-contract-style source checks;
+ * this test covers the pure mapping/validation logic directly.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { isThemePreference, toNativeThemeSource } from '../theme-source.js';
+
+// Anchored at the repo root, not relative to this test file's own location --
+// `npm test` runs the compiled dist/main/__tests__/*.test.js, so a plain
+// relative path would resolve into dist/ (no .ts sources there) instead of
+// the real src/ file. Same approach as main-process-contract-source-helpers.ts.
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const MAIN_WINDOW_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main-window.ts');
+
+describe('theme-source', () => {
+  describe('toNativeThemeSource', () => {
+    it('maps auto to system', () => {
+      assert.equal(toNativeThemeSource('auto'), 'system');
+    });
+
+    it('passes light and dark through unchanged', () => {
+      assert.equal(toNativeThemeSource('light'), 'light');
+      assert.equal(toNativeThemeSource('dark'), 'dark');
+    });
+  });
+
+  describe('isThemePreference', () => {
+    it('accepts the three valid preferences', () => {
+      assert.equal(isThemePreference('auto'), true);
+      assert.equal(isThemePreference('light'), true);
+      assert.equal(isThemePreference('dark'), true);
+    });
+
+    it('rejects the already-mapped nativeTheme.themeSource value ("system")', () => {
+      // Regression guard: the IPC contract now carries the app's own
+      // ThemePreference, not the Electron-native themeSource. A caller
+      // that still sends the old pre-mapped 'system' value must be
+      // rejected, not silently accepted as if it were a no-op 'auto'.
+      assert.equal(isThemePreference('system'), false);
+    });
+
+    it('rejects garbage / wrong-type values', () => {
+      assert.equal(isThemePreference('evil-unknown'), false);
+      assert.equal(isThemePreference(undefined), false);
+      assert.equal(isThemePreference(null), false);
+      assert.equal(isThemePreference(42), false);
+      assert.equal(isThemePreference({}), false);
+    });
+  });
+
+  describe('main-window.ts wiring', () => {
+    it('setThemeSource validates the sender is the main window and rejects invalid preferences', async () => {
+      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
+      const methodMatch = src.match(/setThemeSource\(sender, themePref\) \{([\s\S]*?)\n {4}\},/);
+      assert.ok(methodMatch, 'setThemeSource method must exist on the controller');
+      const body = methodMatch![1];
+      assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
+      assert.match(body, /isThemePreference\(themePref\)/, 'must reject values that are not a valid ThemePreference');
+      assert.match(body, /nativeTheme\.themeSource = toNativeThemeSource\(themePref\)/, 'must assign via the shared mapping helper');
+    });
+
+    it('createWindow syncs nativeTheme.themeSource before creating the BrowserWindow, not only via the later IPC call', async () => {
+      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
+      // Astro-Han review (#493) P2: on a cold start where the OS appearance
+      // disagrees with the persisted preference, the vibrancy material must
+      // already be on the right theme before the window is even created --
+      // syncing it only after the renderer's later setThemeSource() IPC call
+      // would let the first frame or two flash the *system* theme's tint.
+      const syncIndex = src.indexOf('nativeTheme.themeSource = toNativeThemeSource(themePref)');
+      const newWindowIndex = src.indexOf('new BrowserWindow({');
+      assert.notEqual(syncIndex, -1, 'createWindow must sync nativeTheme.themeSource from the resolved themePref');
+      assert.notEqual(newWindowIndex, -1, 'new BrowserWindow(...) call must exist');
+      assert.ok(syncIndex < newWindowIndex, 'the nativeTheme sync must happen before the BrowserWindow is constructed');
+    });
+  });
+});

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -17,6 +17,7 @@ export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
+  setThemeSource(sender: Electron.WebContents, themeSource: unknown): void;
   showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
   showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue>;
   capturePage(): Promise<Electron.NativeImage | null>;
@@ -273,6 +274,20 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       target.setWindowButtonPosition(
         shouldShow ? MAIN_WINDOW_TRAFFIC_LIGHT_POSITION : HIDDEN_TRAFFIC_LIGHT_POSITION,
       );
+    },
+    setThemeSource(sender, themeSource) {
+      const target = BrowserWindow.fromWebContents(sender);
+      if (!target || target !== mainWindow) return;
+      if (themeSource !== 'system' && themeSource !== 'light' && themeSource !== 'dark') return;
+      // The renderer's `.dark` class flip (theme.ts) only repaints the DOM.
+      // `nativeTheme.themeSource` is the separate Electron/OS-level switch
+      // that drives native chrome — on macOS this is what the window's
+      // `vibrancy: 'sidebar'` material (main-window.ts createWindow) reads
+      // its light/dark tint from. Without this, picking an in-app theme
+      // that disagrees with the OS appearance leaves the vibrancy-backed
+      // sidebar showing the *system* theme's tint while the rest of the
+      // (opaque) UI repaints to the chosen one.
+      nativeTheme.themeSource = themeSource;
     },
     showOpenDialog(options) {
       return mainWindow

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -8,6 +8,7 @@ import { readSavedBounds, writeSavedBounds, type SavedBounds } from './window-st
 import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { VisualSmokeFixture } from './visual-smoke-fixture.js';
+import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 
 type SettingsReader = {
   get(): Promise<AppSettings>;
@@ -17,7 +18,7 @@ export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
-  setThemeSource(sender: Electron.WebContents, themeSource: unknown): void;
+  setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
   showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
   showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue>;
   capturePage(): Promise<Electron.NativeImage | null>;
@@ -108,6 +109,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       themePref === 'dark' ||
       (themePref === 'auto' && nativeTheme.shouldUseDarkColors);
     const initialBg = isDark ? '#1c1d21' : '#f3f3f5';
+    // Astro-Han review (#493): sync nativeTheme here too, not only via the
+    // renderer's later setThemeSource() IPC call -- otherwise the vibrancy
+    // material behind the sidebar can still flash the *system* theme's tint
+    // for the first frame or two on a cold start where the OS appearance
+    // disagrees with the persisted in-app preference.
+    nativeTheme.themeSource = toNativeThemeSource(themePref);
 
     mainWindow = new BrowserWindow({
       width: bounds.width,
@@ -275,19 +282,11 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         shouldShow ? MAIN_WINDOW_TRAFFIC_LIGHT_POSITION : HIDDEN_TRAFFIC_LIGHT_POSITION,
       );
     },
-    setThemeSource(sender, themeSource) {
+    setThemeSource(sender, themePref) {
       const target = BrowserWindow.fromWebContents(sender);
       if (!target || target !== mainWindow) return;
-      if (themeSource !== 'system' && themeSource !== 'light' && themeSource !== 'dark') return;
-      // The renderer's `.dark` class flip (theme.ts) only repaints the DOM.
-      // `nativeTheme.themeSource` is the separate Electron/OS-level switch
-      // that drives native chrome — on macOS this is what the window's
-      // `vibrancy: 'sidebar'` material (main-window.ts createWindow) reads
-      // its light/dark tint from. Without this, picking an in-app theme
-      // that disagrees with the OS appearance leaves the vibrancy-backed
-      // sidebar showing the *system* theme's tint while the rest of the
-      // (opaque) UI repaints to the chosen one.
-      nativeTheme.themeSource = themeSource;
+      if (!isThemePreference(themePref)) return;
+      nativeTheme.themeSource = toNativeThemeSource(themePref);
     },
     showOpenDialog(options) {
       return mainWindow

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -775,6 +775,9 @@ function registerIpc(): void {
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
   });
+  ipcMain.handle('window:setThemeSource', (event, themeSource: unknown): void => {
+    mainWindowController.setThemeSource(event.sender, themeSource);
+  });
   ipcMain.handle('app:info', async () => {
     const projectPath = await currentProjectRoot();
     return {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -775,8 +775,8 @@ function registerIpc(): void {
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
   });
-  ipcMain.handle('window:setThemeSource', (event, themeSource: unknown): void => {
-    mainWindowController.setThemeSource(event.sender, themeSource);
+  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
+    mainWindowController.setThemeSource(event.sender, themePref);
   });
   ipcMain.handle('app:info', async () => {
     const projectPath = await currentProjectRoot();

--- a/apps/desktop/src/main/theme-source.ts
+++ b/apps/desktop/src/main/theme-source.ts
@@ -1,0 +1,24 @@
+import type { ThemePreference } from '@maka/core';
+
+export type NativeThemeSource = 'system' | 'light' | 'dark';
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'auto' || value === 'light' || value === 'dark';
+}
+
+/**
+ * The renderer's `.dark` class flip (renderer/theme.ts) only repaints the
+ * DOM. `nativeTheme.themeSource` is the separate Electron/OS-level switch
+ * that drives native chrome -- on macOS this is what the window's
+ * `vibrancy: 'sidebar'` material (main-window.ts createWindow) reads its
+ * light/dark tint from. Without keeping the two in sync, an in-app theme
+ * that disagrees with the OS appearance leaves the vibrancy-backed sidebar
+ * showing the *system* theme's tint while the rest of the (opaque) UI
+ * repaints to the chosen one. Single conversion point for both the
+ * createWindow() startup sync and the setThemeSource() IPC handler in
+ * main-window.ts, so the two call sites can't drift out of sync with
+ * each other.
+ */
+export function toNativeThemeSource(pref: ThemePreference): NativeThemeSource {
+  return pref === 'auto' ? 'system' : pref;
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -56,6 +56,7 @@ import type {
   WebSearchResponse,
   BrowserState,
   BrowserViewRect,
+  ThemePreference,
 } from '@maka/core';
 import type {
   PricingConfig,
@@ -718,8 +719,8 @@ contextBridge.exposeInMainWorld('maka', {
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },
-    setThemeSource(themeSource: 'system' | 'light' | 'dark'): Promise<void> {
-      return ipcRenderer.invoke('window:setThemeSource', themeSource);
+    setThemeSource(themePref: ThemePreference): Promise<void> {
+      return ipcRenderer.invoke('window:setThemeSource', themePref);
     },
   },
   app: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -718,6 +718,9 @@ contextBridge.exposeInMainWorld('maka', {
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },
+    setThemeSource(themeSource: 'system' | 'light' | 'dark'): Promise<void> {
+      return ipcRenderer.invoke('window:setThemeSource', themeSource);
+    },
   },
   app: {
     info(): Promise<{

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -29,17 +29,10 @@ export function applyTheme(pref: ThemePreference): () => void {
   // pre-React paint reapplies the auto → system-matchMedia branch itself.
   safeLocalStorageSet('maka-theme-v1', pref);
 
-  // This only flips the DOM (`.dark` + `color-scheme`) — it does not touch
-  // Electron's own native chrome. On macOS the window's `vibrancy: 'sidebar'`
-  // material (main-window.ts) reads its light/dark tint from
-  // `nativeTheme.themeSource`, which otherwise stays on its default
-  // ('system') regardless of what's picked here. Without this call, an
-  // in-app preference that disagrees with the OS appearance leaves the
-  // vibrancy-backed sidebar showing the *system* theme while the rest of
-  // the (opaque) UI repaints correctly.
-  void window.maka.appWindow
-    .setThemeSource(pref === 'auto' ? 'system' : pref)
-    .catch(() => {});
+  // Also syncs Electron's own native chrome (nativeTheme.themeSource) --
+  // see toNativeThemeSource() in main-window.ts for why this DOM-only flip
+  // isn't enough on its own.
+  void window.maka.appWindow.setThemeSource(pref).catch(() => {});
 
   if (pref === 'auto') {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -29,6 +29,18 @@ export function applyTheme(pref: ThemePreference): () => void {
   // pre-React paint reapplies the auto → system-matchMedia branch itself.
   safeLocalStorageSet('maka-theme-v1', pref);
 
+  // This only flips the DOM (`.dark` + `color-scheme`) — it does not touch
+  // Electron's own native chrome. On macOS the window's `vibrancy: 'sidebar'`
+  // material (main-window.ts) reads its light/dark tint from
+  // `nativeTheme.themeSource`, which otherwise stays on its default
+  // ('system') regardless of what's picked here. Without this call, an
+  // in-app preference that disagrees with the OS appearance leaves the
+  // vibrancy-backed sidebar showing the *system* theme while the rest of
+  // the (opaque) UI repaints correctly.
+  void window.maka.appWindow
+    .setThemeSource(pref === 'auto' ? 'system' : pref)
+    .catch(() => {});
+
   if (pref === 'auto') {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     setDarkClass(mq.matches);


### PR DESCRIPTION

<img width="1309" height="808" alt="image" src="https://github.com/user-attachments/assets/7d8b34c2-762b-41fc-9b0e-35e59ad05e0b" />



## Summary

Reported bug: switching the in-app theme from dark back to light left the left session-list sidebar stuck dark, while the rest of the UI repainted correctly to light.

- Theme switching (`apps/desktop/src/renderer/theme.ts`) only ever toggles a `.dark` class on `<html>` -- a pure renderer/DOM operation with zero IPC to the main process.
- On macOS the sidebar is deliberately transparent (`theme-glass.css`) so it can show through the window's native `vibrancy: 'sidebar'` material (set once at window creation in `main-window.ts`). That material's light/dark tint is controlled by Electron's own `nativeTheme.themeSource`, which stays on its default (`'system'`) forever -- nothing ever updated it.
- So when the OS appearance disagrees with the chosen in-app theme (OS is Dark, user picks Light in-app), the opaque main content repaints correctly (it uses CSS vars that flip with `.dark`), but the vibrancy-backed sidebar keeps showing the *system* theme's tint, since that's a native/OS-level material, not something CSS variables can reach.

## Fix

Added a `window:setThemeSource` IPC round-trip:
- `main-window.ts`: new `setThemeSource` method on `MainWindowController`, sets `nativeTheme.themeSource`.
- `main.ts`: registers the `window:setThemeSource` IPC handler.
- `preload.ts` / `global.d.ts`: exposes `window.maka.appWindow.setThemeSource(...)`.
- `theme.ts`: `applyTheme()` now calls this alongside the existing `.dark` class toggle, mapping the app's `'auto'|'light'|'dark'` preference to Electron's `'system'|'light'|'dark'` themeSource.

This keeps the vibrancy material (and any other Electron-native chrome) in sync with the in-app theme choice, instead of silently following the OS setting forever.

## Test plan

- [x] `npm --workspace @maka/desktop run typecheck`
- [x] Full desktop test suite: 1821/1821 passing
- [x] Manually verified: launched with OS in Dark mode, switched in-app theme to Light -- sidebar now repaints to light along with the rest of the UI

## Note

A related fix for duplicate app instances (adding `app.requestSingleInstanceLock()`) was developed alongside this one but is intentionally **not** included here -- it'll land in a separate follow-up PR.

Co-Authored-By: Claude <noreply@anthropic.com>