### PR TITLE
fix(desktop): enforce single-instance lock, focus existing window

### DIFF
--- a/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const MAIN_TS = resolve(import.meta.dirname, '../../../../../apps/desktop/src/main/main.ts');
+
+describe('single-instance lock contract', () => {
+  it('requests the lock before any workspace/store setup, and exits the losing process immediately', async () => {
+    const src = await readFile(MAIN_TS, 'utf8');
+
+    const lockIndex = src.indexOf('app.requestSingleInstanceLock()');
+    assert.notEqual(lockIndex, -1, 'requestSingleInstanceLock() call must exist');
+
+    const workspaceRootIndex = src.indexOf('const workspaceRoot =');
+    assert.notEqual(workspaceRootIndex, -1, 'workspaceRoot declaration must exist');
+    assert.ok(
+      lockIndex < workspaceRootIndex,
+      'requestSingleInstanceLock() must run before workspaceRoot/store setup, so a losing second process never touches shared state',
+    );
+
+    // Astro-Han review (#494): app.exit(0) for the losing instance -- an
+    // immediate exit, not app.quit() + process.exit(0) (which routes through
+    // the normal event-based quit sequence before force-exiting).
+    assert.match(
+      src,
+      /if \(!app\.requestSingleInstanceLock\(\)\) \{\s*app\.exit\(0\);\s*\}/,
+      'the losing instance must call app.exit(0) immediately',
+    );
+  });
+
+  it('second-instance shares behavior with activate: focus an existing window, or create one if none exists', async () => {
+    const src = await readFile(MAIN_TS, 'utf8');
+
+    // Regression guard for Astro-Han review (#494) P1: a second launch
+    // attempt after all windows were closed (app still alive, e.g. macOS
+    // dock) must not be a silent no-op. `focus()` alone is a no-op with no
+    // window -- the handler must fall back to createWindow().
+    const helperMatch = src.match(
+      /function focusOrCreateMainWindow\(\): void \{([\s\S]*?)\n\}/,
+    );
+    assert.ok(helperMatch, 'a focusOrCreateMainWindow (or equivalently named) helper must exist');
+    const helperBody = helperMatch![1];
+    assert.match(helperBody, /hasOpenWindows\(\)/, 'helper must branch on whether a window currently exists');
+    assert.match(helperBody, /mainWindowController\.focus\(\)/, 'helper must focus the existing window when one exists');
+    assert.match(helperBody, /mainWindowController\.createWindow\(\)/, 'helper must create a window when none exists');
+
+    assert.match(
+      src,
+      /app\.on\('second-instance', focusOrCreateMainWindow\)/,
+      'second-instance must be wired to the shared focus-or-create helper, not a bare focus() call',
+    );
+    assert.match(
+      src,
+      /app\.on\('activate', focusOrCreateMainWindow\)/,
+      'activate should share the exact same behavior as second-instance',
+    );
+  });
+});

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -23,6 +23,7 @@ export interface MainWindowController {
   getBrowserViews(): BrowserViewManager<BrowserViewController>;
   disposeBrowserViews(): Promise<void>;
   hasOpenWindows(): boolean;
+  focus(): void;
 }
 
 interface MainWindowControllerDeps {
@@ -292,6 +293,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     disposeBrowserViews,
     hasOpenWindows() {
       return BrowserWindow.getAllWindows().length > 0;
+    },
+    focus() {
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.show();
+      mainWindow.focus();
     },
   };
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -176,19 +176,12 @@ import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
 
-// Electron does not enforce single-instance by default — without this, every
-// separate launch (a second `npm run dev`, a user double-clicking the dock
-// icon, etc.) spawns a fully independent process with its own window, and
-// none of them know about each other. Two instances sharing the same
-// `workspaceRoot`/settings/session-store files concurrently risks file-lock
-// contention and lost writes, on top of the confusing "why are there two
-// windows" UX. `requestSingleInstanceLock()` must run before any workspace
-// setup below — a losing second process quits immediately rather than
-// touching shared state at all. The 'second-instance' listener (registered
-// once `mainWindowController` exists) focuses the existing window instead.
+// Electron does not enforce single-instance by default. Must run before any
+// workspace/store setup below -- a losing second process exits immediately,
+// before touching shared state. See the 'second-instance' listener below for
+// what the surviving process does about it.
 if (!app.requestSingleInstanceLock()) {
-  app.quit();
-  process.exit(0);
+  app.exit(0);
 }
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
@@ -320,12 +313,17 @@ const mainWindowController = createMainWindowController({
   visualSmokeFixture,
   settingsStore,
 });
-// A second launch quit itself immediately (see requestSingleInstanceLock
-// above) without ever creating a window — focus the surviving instance's
-// window instead of silently doing nothing.
-app.on('second-instance', () => {
-  mainWindowController.focus();
-});
+// Shared by 'second-instance' and 'activate': focus the existing window, or
+// create one if all windows were closed while the app (macOS: still in the
+// dock) stayed running -- a second launch attempt must not be a silent no-op.
+function focusOrCreateMainWindow(): void {
+  if (mainWindowController.hasOpenWindows()) {
+    mainWindowController.focus();
+  } else {
+    void mainWindowController.createWindow();
+  }
+}
+app.on('second-instance', focusOrCreateMainWindow);
 const safeSendToRenderer = mainWindowController.send;
 const openGateway = new OpenGatewayService({
   getSettings: () => settingsStore.get(),
@@ -1754,6 +1752,4 @@ app.on('before-quit', () => {
   void mainWindowController.disposeBrowserViews();
 });
 
-app.on('activate', () => {
-  if (!mainWindowController.hasOpenWindows()) void mainWindowController.createWindow();
-});
+app.on('activate', focusOrCreateMainWindow);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -176,6 +176,21 @@ import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
 
+// Electron does not enforce single-instance by default — without this, every
+// separate launch (a second `npm run dev`, a user double-clicking the dock
+// icon, etc.) spawns a fully independent process with its own window, and
+// none of them know about each other. Two instances sharing the same
+// `workspaceRoot`/settings/session-store files concurrently risks file-lock
+// contention and lost writes, on top of the confusing "why are there two
+// windows" UX. `requestSingleInstanceLock()` must run before any workspace
+// setup below — a losing second process quits immediately rather than
+// touching shared state at all. The 'second-instance' listener (registered
+// once `mainWindowController` exists) focuses the existing window instead.
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+  process.exit(0);
+}
+
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 
 // PR-VISUAL-SMOKE-HEADLESS: resolve the fixture defensively. An unknown
@@ -304,6 +319,12 @@ const mainWindowController = createMainWindowController({
   workspaceRoot,
   visualSmokeFixture,
   settingsStore,
+});
+// A second launch quit itself immediately (see requestSingleInstanceLock
+// above) without ever creating a window — focus the surviving instance's
+// window instead of silently doing nothing.
+app.on('second-instance', () => {
+  mainWindowController.focus();
 });
 const safeSendToRenderer = mainWindowController.send;
 const openGateway = new OpenGatewayService({


### PR DESCRIPTION
## Summary

Electron does not prevent multiple instances by default -- you have to explicitly opt in. Without a `requestSingleInstanceLock()` call, every separate launch (a second `npm run dev`, a user double-clicking the dock icon, etc.) spawns a fully independent process with its own window, and none of them know about each other.

Beyond the confusing "why are there two windows" UX, this is a real correctness risk: two instances sharing the same `workspaceRoot`/settings/session-store files concurrently can hit file-lock contention and lost writes.

## Fix

- `main.ts`: added `app.requestSingleInstanceLock()` as the very first executable statement in the module (before any workspace/store setup) -- a losing second process calls `app.quit()` + `process.exit(0)` immediately, without touching any shared state.
- `main.ts` / `main-window.ts`: added a `'second-instance'` listener + a new `focus()` method on `MainWindowController` so a rejected second launch focuses the existing window (restoring it if minimized) instead of silently doing nothing.

## Test plan

- [x] `npm --workspace @maka/desktop run typecheck`
- [x] Full desktop test suite: 1821/1821 passing
- [x] Manually verified: launched the app, then attempted a second launch two different ways (`npm run dev` again, and a raw second `electron .` against the built dist) -- both times the second process quit immediately with no duplicate window, and the original instance kept running undisturbed

Co-Authored-By: Claude <noreply@anthropic.com>