### PR TITLE
Keep heavy-task workspace observation diagnostics neutral

### DIFF
--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -189,7 +189,7 @@ describe('heavy-task self-check gate', () => {
     assert.doesNotMatch(decision.reason, /fix|repair|rerun|submit a revised plan/i);
   });
 
-  test('machine workspace observation remains diagnostic after bounded repair in a single-file deliverable directory', () => {
+  test('machine workspace observation facts do not block an otherwise passing self-check', () => {
     const polyglotTask: Task = {
       id: 'polyglot-task',
       instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
@@ -212,16 +212,14 @@ describe('heavy-task self-check gate', () => {
           { path: '/app/polyglot/main.py', kind: 'symlink', symlinkTarget: 'main.py.c' },
         ]),
       ),
-      repairAttemptsUsed: 1,
+      repairAttemptsUsed: 0,
       maxRepairAttempts: 1,
     });
 
-    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
-    assert.match(decision.reason, /machine workspace observation found extra final paths/);
-    assert.match(decision.reason, /\/app\/polyglot\/main\.py/);
+    assert.equal(decision.action, 'allow_finalize');
   });
 
-  test('bounded repair records observed extra sibling diagnostic without local rejection', () => {
+  test('gate prompt includes neutral machine observation facts when blocked for a separate reason', () => {
     const polyglotTask: Task = {
       id: 'polyglot-task',
       instruction: 'Write me a single file in /app/polyglot/main.py.c which is a polyglot.',
@@ -235,6 +233,8 @@ describe('heavy-task self-check gate', () => {
       refs: ['/app/polyglot/main.py.c'],
       artifactPath: '/app/polyglot/main.py.c',
     });
+    selfCheckState.commandEvidence = [];
+    selfCheckState.artifactEvidence = [];
 
     const decision = evaluateHeavyTaskSelfCheckGate({
       task: polyglotTask,
@@ -247,13 +247,17 @@ describe('heavy-task self-check gate', () => {
           { path: '/app/polyglot/cmain', kind: 'file' },
         ]),
       ),
-      repairAttemptsUsed: 1,
+      repairAttemptsUsed: 0,
       maxRepairAttempts: 1,
     });
 
-    assert.equal(decision.action, 'allow_official_verifier_after_bounded_attempt');
-    assert.match(decision.reason, /expected only: \/app\/polyglot\/main\.py\.c/);
-    assert.match(decision.reason, /observed extras: \/app\/polyglot\/cmain/);
+    assert.equal(decision.action, 'repair_prompt');
+    assert.match(decision.reason, /lacks concrete command or artifact evidence/);
+    assert.match(decision.prompt, /Machine workspace observation facts/);
+    assert.match(decision.prompt, /file \/app\/polyglot\/main\.py\.c/);
+    assert.match(decision.prompt, /file \/app\/polyglot\/cmain/);
+    assert.doesNotMatch(decision.reason, /expected only|observed extras|single-file deliverable/);
+    assert.doesNotMatch(decision.prompt, /expected only|observed extras|single-file deliverable/);
   });
 
   test('weak pass without command or artifact evidence stays blocked', () => {

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -862,7 +862,7 @@ describe('runTaskOnce', () => {
     });
   });
 
-  test('bounded repair records machine-observed extra final path diagnostic before official verifier', async () => {
+  test('bounded repair records model-reported workspace side-effect diagnostic before official verifier', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const prompts: string[] = [];
       const config: Config = {
@@ -898,7 +898,7 @@ describe('runTaskOnce', () => {
       assert.equal(prompts.length, 2);
       assert.equal(result.projection.latestHeavyTaskSelfCheckGate?.action, 'allow_official_verifier_after_bounded_attempt');
       assert.match(result.projection.latestHeavyTaskSelfCheckGate?.reason ?? '', /\/app\/polyglot\/cmain/);
-      assert.match(result.projection.latestHeavyTaskSelfCheckGate?.reason ?? '', /unplanned_added_path|observed extras/);
+      assert.match(result.projection.latestHeavyTaskSelfCheckGate?.reason ?? '', /unplanned_added_path/);
       assert.equal(result.projection.latestVerifierResult?.passed, true);
       assert.equal(result.projection.latestScoreResult?.taxonomy, 'passed');
       assert.equal(result.resultRecord.status, 'completed');

--- a/packages/headless/src/heavy-task-self-check-gate.ts
+++ b/packages/headless/src/heavy-task-self-check-gate.ts
@@ -49,7 +49,6 @@ export function evaluateHeavyTaskSelfCheckGate(input: HeavyTaskSelfCheckGateInpu
   const reason = gateBlockerReason(
     selfCheck,
     input.projection.latestHeavyTaskSelfCheckPlan,
-    input.projection.latestHeavyTaskWorkspaceObservation,
     completion.semantic.reason,
     checklist,
   );
@@ -81,6 +80,7 @@ export function evaluateHeavyTaskSelfCheckGate(input: HeavyTaskSelfCheckGateInpu
       reason: blockedReason,
       checklist,
       selfCheck,
+      workspaceObservation: input.projection.latestHeavyTaskWorkspaceObservation,
       attempt: attemptsUsed + 1,
       maxAttempts,
     }),
@@ -189,6 +189,7 @@ export function renderHeavyTaskSelfCheckGatePrompt(input: {
   reason: string;
   checklist: readonly HeavyTaskAcceptanceCheck[];
   selfCheck?: HeavyTaskSemanticSelfCheckState;
+  workspaceObservation?: HeavyTaskWorkspaceObservationState;
   attempt: number;
   maxAttempts: number;
 }): string {
@@ -205,6 +206,7 @@ export function renderHeavyTaskSelfCheckGatePrompt(input: {
     }),
     '',
     latestSelfCheckSummary(input.selfCheck),
+    ...latestWorkspaceObservationSummary(input.workspaceObservation),
     '',
     'Required action: run public commands or artifact inspections in the current workspace or under /tmp/maka-self-check, repair only if those checks fail, then call self_check_submit with concrete command/artifact evidence, executionHygiene.sandbox, and executionHygiene.workspaceGuard.',
     'Constraints: do not inspect hidden, private, evaluator, official verifier, or scorer-only material. Keep scratch outputs under /tmp/maka-self-check/... and clean or report any workspace side effects.',
@@ -215,7 +217,6 @@ export function renderHeavyTaskSelfCheckGatePrompt(input: {
 function gateBlockerReason(
   selfCheck: HeavyTaskSemanticSelfCheckState | undefined,
   plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan'],
-  workspaceObservation: HeavyTaskWorkspaceObservationState | undefined,
   semanticReason: string,
   checklist: readonly HeavyTaskAcceptanceCheck[],
 ): string | undefined {
@@ -227,8 +228,6 @@ function gateBlockerReason(
   }
   const strongPassBlocker = heavyTaskSelfCheckStrongPassBlocker(selfCheck, plan);
   if (strongPassBlocker) return strongPassBlocker;
-  const workspaceObservationBlocker = machineWorkspaceObservationBlocker(plan, workspaceObservation);
-  if (workspaceObservationBlocker) return workspaceObservationBlocker;
   if (!selfCheckAddressesRequiredArtifacts(selfCheck, checklist)) {
     return 'latest self-check does not address visible required artifact contract';
   }
@@ -256,44 +255,6 @@ function selfCheckAddressesRequiredArtifacts(
     ...selfCheck.artifactEvidence.map((evidence) => evidence.path),
   ].join('\n').toLowerCase();
   return requiredPaths.some((path) => evidenceText.includes(path.toLowerCase()) || evidenceText.includes(basename(path).toLowerCase()));
-}
-
-function machineWorkspaceObservationBlocker(
-  plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan'],
-  observation: HeavyTaskWorkspaceObservationState | undefined,
-): string | undefined {
-  if (!observation || observation.status !== 'ok') return undefined;
-  for (const expectedPath of plannedSingleArtifactDirectoryPaths(plan)) {
-    const expectedDir = dirname(expectedPath);
-    const entries = observation.entries.filter((entry) => dirname(entry.path) === expectedDir);
-    if (entries.length === 0 || !entries.some((entry) => entry.path === expectedPath)) continue;
-    const extras = entries
-      .map((entry) => entry.path)
-      .filter((path) => path !== expectedPath);
-    if (extras.length > 0) {
-      return [
-        `machine workspace observation found extra final paths in single-file deliverable directory ${expectedDir}`,
-        `- expected only: ${expectedPath}`,
-        `- observed extras: ${extras.join(', ')}`,
-      ].join('\n');
-    }
-  }
-  return undefined;
-}
-
-function plannedSingleArtifactDirectoryPaths(plan: TaskRunProjection['latestHeavyTaskSelfCheckPlan']): string[] {
-  if (!plan) return [];
-  const byDir = new Map<string, string[]>();
-  for (const artifact of plan.finalArtifacts) {
-    if (!artifact.path.startsWith('/app/')) continue;
-    const dir = dirname(artifact.path);
-    byDir.set(dir, [...(byDir.get(dir) ?? []), artifact.path]);
-  }
-  const paths: string[] = [];
-  for (const artifacts of byDir.values()) {
-    if (artifacts.length === 1) paths.push(artifacts[0]!);
-  }
-  return paths;
 }
 
 function parseCheckForPath(
@@ -336,6 +297,29 @@ function latestSelfCheckSummary(selfCheck: HeavyTaskSemanticSelfCheckState | und
   ].join('\n');
 }
 
+function latestWorkspaceObservationSummary(observation: HeavyTaskWorkspaceObservationState | undefined): string[] {
+  if (!observation) return [];
+  if (observation.status !== 'ok') {
+    return [
+      '',
+      'Machine workspace observation facts: unavailable.',
+      `- roots: ${observation.roots.join(', ') || '(none)'}`,
+      `- error: ${cleanOneLine(observation.errorExcerpt ?? 'unknown observation error', 240)}`,
+    ];
+  }
+  const entries = observation.entries.slice(0, 40).map((entry) => {
+    const suffix = entry.kind === 'symlink' && entry.symlinkTarget ? ` -> ${entry.symlinkTarget}` : '';
+    return `- ${entry.kind} ${entry.path}${suffix}`;
+  });
+  return [
+    '',
+    'Machine workspace observation facts (directory listing only; compare with the task instructions and your accepted plan):',
+    `- roots: ${observation.roots.join(', ') || '(none)'}`,
+    ...entries,
+    ...(observation.entries.length > entries.length ? [`- ... ${observation.entries.length - entries.length} more entries omitted`] : []),
+  ];
+}
+
 function publicMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
   if (!metadata) return {};
   const output: Record<string, unknown> = {};
@@ -358,10 +342,4 @@ function shellQuote(value: string): string {
 function basename(path: string): string {
   const parts = path.split('/');
   return parts.at(-1) ?? path;
-}
-
-function dirname(path: string): string {
-  const index = path.lastIndexOf('/');
-  if (index <= 0) return '.';
-  return path.slice(0, index);
 }


### PR DESCRIPTION
## Summary
- remove the machine workspace observation blocker that inferred a single-file deliverable directory from one planned `/app` artifact
- keep machine workspace observations as neutral directory-listing facts instead of generating `expected only` / `observed extras` contract text
- downgrade self-check path/side-effect diagnostics (`unplanned_added_path`, `scratch_escape`, reported workspace side effects) from repair blockers into an explicit `advisory_prompt` gate action
- preserve hard repair blockers for missing/non-public self-checks, failed/inconclusive status, missing concrete evidence, missing sandbox evidence, missing workspace guard, and missing plan structure

## Context
DeepSeek V4 Pro failed `terminal-bench-sample` `sqlite-with-gcov` after the gate told the model that `/app/sqlite` was a single-file deliverable directory and expected only `/app/sqlite/sqlite3`. The model cleaned out gcov sidecars, but official `test_gcov_enabled` expects `.gcda` under `/app/sqlite` after running `sqlite3`.

A PR #495 sqlite-only rerun with DeepSeek V4 Pro passed official Harbor after the single-file observation wording was removed, but the trace still showed friction from plan consistency and workspace side-effect hygiene: `.gcno` / `.gcda` / `.gcov` paths were treated as repair-triggering path facts. Those should be facts shown to the model, not a local repair order, because coverage tasks may require these generated artifacts under `/app`.

## Verification
- `npm --workspace @maka/headless test` (97 suites; 685 tests; 684 pass, 1 skipped)
- `git diff --check`
- Prior PR #495 sqlite-only validation: `terminal-bench-smoke/jobs/maka-pr495-sqlite-v4pro-20260704e`, trial `sqlite-with-gcov__gPAQ8M5`, Harbor official reward `1.0`
