### PR TITLE
feat: enable activeToolResultPrune by default on desktop and headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,27 @@ Rive deep-read follow-up work.
 | 4 | Credential-store secret kind expansion | Extended encrypted credential-store support for bot tokens, bot app secrets, proxy passwords, gateway tokens, and Tavily API keys while preserving legacy API-key/OAuth-token key formats. |
 | 5 | Connection credential IPC input hardening | Added shared main-process validation for renderer-controlled connection slugs and API keys before store, credential, or provider side effects. |
 
+### Active tool-result pruning default-on
+
+`activeToolResultPrune` (current-turn large tool-result pruning) is now
+enabled by default on both desktop and headless. Tool results above the
+2048 estimated-token threshold are archived and replaced with a
+metadata-only placeholder (artifact id + content hash) in the next
+provider-visible request; the raw payload is preserved in the archive
+and is not lost. On desktop this runs before the already-default-on
+`semanticCompact` summary step. On headless the placeholder reaches the
+next provider step directly (no default compaction/retrieval), which
+benchmark A/B evidence in #340 showed is non-inferior within the 10pp
+margin while saving ~31.6% cost.
+
+Opt out with `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE=off` (both sides).
+Tune the threshold with `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS`
+and the start step with `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER`.
+
 ### Verification
 
+- Headless and desktop context-budget tests for activeToolResultPrune
+  default-on, opt-out, and env knobs.
 - Runtime package typecheck/build and full runtime test suite.
 - Desktop main build/typecheck.
 - Storage package build and AgentRun store tests.

--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import { buildContextBudgetPolicy } from '../context-budget-policy.js';
+
+const ACTIVE_PRUNE_ENV_KEYS = [
+  'MAKA_CONTEXT_BUDGET',
+  'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE',
+  'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS',
+  'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER',
+] as const;
+
+const savedEnv: Record<string, string | undefined> = {};
+
+function openaiConnection(): LlmConnection {
+  return { providerType: 'openai' } as unknown as LlmConnection;
+}
+
+describe('desktop activeToolResultPrune policy', () => {
+  beforeEach(() => {
+    for (const key of ACTIVE_PRUNE_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ACTIVE_PRUNE_ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  test('is enabled by default with the measured 2048-token threshold', () => {
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune?.enabled, true);
+    assert.equal(policy?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 2048);
+    assert.equal(policy?.activeToolResultPrune?.minStepNumber, 1);
+  });
+
+  test('can be disabled with explicit false', () => {
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE = 'false';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune, undefined);
+  });
+
+  test('can be disabled with explicit off', () => {
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE = 'off';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune, undefined);
+  });
+
+  test('respects max current result estimated tokens env', () => {
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS = '4096';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 4096);
+  });
+
+  test('respects the alias env for max current result estimated tokens', () => {
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS = '1024';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 1024);
+  });
+
+  test('respects min step number env', () => {
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER = '3';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy?.activeToolResultPrune?.minStepNumber, 3);
+  });
+
+  test('MAKA_CONTEXT_BUDGET=off disables the whole policy including activeToolResultPrune', () => {
+    process.env.MAKA_CONTEXT_BUDGET = 'off';
+    const policy = buildContextBudgetPolicy(openaiConnection());
+    assert.equal(policy, undefined);
+  });
+});

--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -7,7 +7,6 @@ const ACTIVE_PRUNE_ENV_KEYS = [
   'MAKA_CONTEXT_BUDGET',
   'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE',
   'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS',
-  'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS',
   'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER',
 ] as const;
 
@@ -55,12 +54,6 @@ describe('desktop activeToolResultPrune policy', () => {
     process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS = '4096';
     const policy = buildContextBudgetPolicy(openaiConnection());
     assert.equal(policy?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 4096);
-  });
-
-  test('respects the alias env for max current result estimated tokens', () => {
-    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS = '1024';
-    const policy = buildContextBudgetPolicy(openaiConnection());
-    assert.equal(policy?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 1024);
   });
 
   test('respects min step number env', () => {

--- a/apps/desktop/src/main/context-budget-policy.ts
+++ b/apps/desktop/src/main/context-budget-policy.ts
@@ -15,6 +15,7 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
   const historyCompact = buildHistoryCompactPolicy();
   const historyRewrite = buildHistoryRewriteGatePolicy();
   const semanticCompact = buildSemanticCompactPolicy();
+  const activeToolResultPrune = buildActiveToolResultPrunePolicy();
   if (
     maxHistoryEstimatedTokens === undefined &&
     maxHistoryTurns === undefined &&
@@ -24,7 +25,8 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
     synthesisCache === undefined &&
     historyCompact === undefined &&
     semanticCompact === undefined &&
-    historyRewrite === undefined
+    historyRewrite === undefined &&
+    activeToolResultPrune === undefined
   ) {
     return undefined;
   }
@@ -38,6 +40,7 @@ export function buildContextBudgetPolicy(connection: LlmConnection): ContextBudg
     ...(synthesisCache !== undefined ? { synthesisCache } : {}),
     ...(historyCompact !== undefined ? { historyCompact } : {}),
     ...(semanticCompact !== undefined ? { semanticCompact } : {}),
+    ...(activeToolResultPrune !== undefined ? { activeToolResultPrune } : {}),
     ...(historyRewrite !== undefined ? { historyRewrite } : {}),
     minRecentTurns,
   };
@@ -55,6 +58,23 @@ function buildStaleToolResultPrunePolicy(): NonNullable<ContextBudgetPolicy['sta
       process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS,
       parsePositiveInt(process.env.MAKA_CONTEXT_MIN_RECENT_TURNS, 2),
     ),
+  };
+}
+
+function buildActiveToolResultPrunePolicy(): NonNullable<ContextBudgetPolicy['activeToolResultPrune']> | undefined {
+  const enabled = parseOptionalBoolean(
+    process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE,
+    'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE',
+  );
+  if (enabled === false) return undefined;
+  return {
+    enabled: true,
+    maxCurrentResultEstimatedTokens: parsePositiveInt(
+      process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS ??
+        process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS,
+      2048,
+    ),
+    minStepNumber: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER) ?? 1,
   };
 }
 

--- a/apps/desktop/src/main/context-budget-policy.ts
+++ b/apps/desktop/src/main/context-budget-policy.ts
@@ -70,8 +70,7 @@ function buildActiveToolResultPrunePolicy(): NonNullable<ContextBudgetPolicy['ac
   return {
     enabled: true,
     maxCurrentResultEstimatedTokens: parsePositiveInt(
-      process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS ??
-        process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE_MAX_ESTIMATED_TOKENS,
+      process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MAX_ESTIMATED_TOKENS,
       2048,
     ),
     minStepNumber: parseOptionalNonNegativeInt(process.env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_MIN_STEP_NUMBER) ?? 1,

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1320,13 +1320,15 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor context budget env treats explicit false-like booleans as disabled', () => {
-    assert.equal(
-      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'false' }).contextBudget,
-      undefined,
+    // stale and archive default off; activeToolResultPrune defaults on, so disabling
+    // stale/archive alone still leaves an enabled activeToolResultPrune policy.
+    assert.deepEqual(
+      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'false' }).contextBudget?.activeToolResultPrune,
+      { enabled: true },
     );
-    assert.equal(
-      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ARCHIVE_RETRIEVAL: 'off' }).contextBudget,
-      undefined,
+    assert.deepEqual(
+      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ARCHIVE_RETRIEVAL: 'off' }).contextBudget?.activeToolResultPrune,
+      { enabled: true },
     );
     assert.deepEqual(
       buildHarborCellContextBudgetBackendOptions({
@@ -1344,6 +1346,29 @@ describe('runHarborCell', () => {
     assert.equal(snapshot?.enabled, true);
     if (!snapshot?.enabled) throw new Error('expected context budget snapshot to be enabled');
     assert.equal(snapshot.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 2048);
+  });
+
+  test('Harbor active tool result prune is enabled by default without any env', () => {
+    const backend = buildHarborCellContextBudgetBackendOptions({});
+    assert.equal(backend.contextBudget?.activeToolResultPrune?.enabled, true);
+    assert.deepEqual(backend.contextBudget?.activeToolResultPrune, { enabled: true });
+
+    const snapshot = buildHarborCellContextBudgetPolicySnapshot({});
+    assert.equal(snapshot?.enabled, true);
+    assert.equal(snapshot?.activeToolResultPrune?.enabled, true);
+    assert.equal(snapshot?.activeToolResultPrune?.maxCurrentResultEstimatedTokens, 2048);
+    assert.equal(snapshot?.activeToolResultPrune?.minStepNumber, 1);
+  });
+
+  test('Harbor active tool result prune can be disabled with explicit off', () => {
+    assert.equal(
+      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' }).contextBudget,
+      undefined,
+    );
+    assert.equal(
+      buildHarborCellContextBudgetPolicySnapshot({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' }),
+      undefined,
+    );
   });
 
   test('Harbor parses semantic compact policy for headless runs', () => {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -673,7 +673,7 @@ export function buildHarborCellContextBudgetBackendOptions(
     env.MAKA_HARBOR_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE ??
     env.MAKA_ACTIVE_TOOL_RESULT_PRUNE,
     'MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE',
-  ) ?? false;
+  ) ?? true;
   const archiveRetrievalEnabled = booleanEnv(
     env.MAKA_CONTEXT_ARCHIVE_RETRIEVAL ??
     env.MAKA_HARBOR_CONTEXT_ARCHIVE_RETRIEVAL,


### PR DESCRIPTION
## Summary

Enable `activeToolResultPrune` (current-turn large tool-result pruning) by default on both desktop and headless. This wires the prune step that runs before `semanticCompact`, forming a "archive oversized current-turn tool result -> LLM summary compact" pipeline for the active turn.

## Why

Desktop already had `semanticCompact` default-on but lacked the preceding `activeToolResultPrune` step, so oversized current-turn tool results reached the summarizer un-pruned. Headless had the prune builder but required explicit `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE=on` to use it. Both sides can still opt out via explicit `off`/`false`.

No associated issue.

## Scope

Changed:
- desktop `context-budget-policy.ts`: new `buildActiveToolResultPrunePolicy()`, aligned with headless env names (`MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE` + aliases), default-on with 2048-token threshold, `minStepNumber=1`
- headless `harbor-cell.ts`: `activePruneEnabled` default `?? false` -> `?? true`
- headless `harbor-cell.test.ts`: adjusted `explicit false-like booleans as disabled` test (stale/archive off no longer implies empty context budget), added default-on and explicit-off coverage
- new desktop `__tests__/context-budget-policy.test.ts`: 7 tests covering default-on, opt-out (`false`/`off`), `MAX_ESTIMATED_TOKENS`, alias env, `MIN_STEP_NUMBER`, top-level `MAKA_CONTEXT_BUDGET=off`

Not included:
- `activeFullCompact` (deterministic full compact) — still headless-only; it is `??`-mutually-exclusive with `semanticCompact` (default-on for desktop), so wiring it on desktop would be a no-op without also changing semanticCompact defaults. Out of scope.
- the pre-existing `foreground-tier-contract` CSS test failures (see Reviewer notes)

## Verification

- `npm run -w @maka/headless test`: 686 pass / 0 fail / 1 skipped
- desktop new suite `context-budget-policy.test.ts`: 7/7 pass
- `npm run -w @maka/desktop test`: 1832 pass / 2 fail — the 2 failures are pre-existing `foreground-tier-contract` CSS token tests unrelated to this change. Verified: `apps/desktop/src/renderer/styles/base.css` on `main` already contains `var(--foreground-50)`; this PR only touches TS files (`git status` confirms 4 TS files, no CSS).

## User-facing impact

- Desktop: conversations now prune oversized (default 2048 estimated tokens) current-turn tool results before the next provider step, archiving via the existing `archiveToolResult`/`readToolResultArchive` wiring (`main.ts:577`). Reduces context growth in long tool-heavy turns.
- Headless: all harbor cells / benchmark runs now default to current-turn tool-result pruning. Existing runs that did not set `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE` will see a behavior change. Set `MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE=off` to restore the previous default.

No `CHANGELOG.md`, docs, migrations, or breaking schema changes.

## Reviewer notes

- Two atomic commits, one per rollback dimension:
  1. `feat(desktop): enable activeToolResultPrune by default` — desktop gains the builder + tests
  2. `feat(headless): default activeToolResultPrune on` — headless flips the default + tests
- Desktop `semanticCompact` remains default-on; `activeFullCompact` is intentionally left headless-only (mutual-exclusion with semanticCompact via `??`).
- Pre-existing CSS failures flagged so reviewers don't attribute them to this PR.