### PR TITLE
fix(ui): polish settings controls

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -40,8 +40,8 @@ describe('Command palette accessibility and visible copy', () => {
     );
     assert.match(
       src,
-      /<InputGroup className="maka-palette-input-wrap" aria-label="命令面板搜索">[\s\S]*<InputGroupInput[\s\S]*aria-label="搜索命令、设置项或会话"[\s\S]*<InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">/,
-      'CommandPalette input shell must be shared primitive InputGroup with an accessible input label and trailing hint addon',
+      /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{[\s\S]*inputRef\.current\?\.focus\(\);[\s\S]*<InputGroupInput[\s\S]*aria-label="搜索命令、设置项或会话"[\s\S]*<InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">/,
+      'CommandPalette input shell must be shared primitive InputGroup with an accessible input label, whole-shell click focus, and trailing hint addon',
     );
     assert.doesNotMatch(
       src,
@@ -60,7 +60,7 @@ describe('Command palette accessibility and visible copy', () => {
     );
     assert.match(
       styles,
-      /@media \(max-width: 560px\) \{[\s\S]*\.maka-palette-input-hint-addon \{[\s\S]*display:\s*none;/,
+      /@media \(max-width: 720px\) \{[\s\S]*\.maka-palette-input-hint-addon \{[\s\S]*display:\s*none;/,
       'Palette trailing key hint must collapse on narrow widths instead of squeezing the input',
     );
   });

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -122,7 +122,7 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.doesNotMatch(source, /<input\b/, 'Command palette search must use shared Input');
     assert.doesNotMatch(source, /<button\b/, 'Command palette rows must use shared Button');
     assert.doesNotMatch(source, /<kbd\b/, 'Command palette shortcut glyphs must use shared primitive Kbd');
-    assert.match(source, /<InputGroup className="maka-palette-input-wrap" aria-label="命令面板搜索">/);
+    assert.match(source, /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{/);
     assert.match(source, /<InputGroupInput[\s\S]*className="maka-palette-input"/);
     assert.match(source, /<InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">/);
     assert.match(source, /<Button[\s\S]*role="option"[\s\S]*className="maka-palette-item"/);

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -41,6 +41,7 @@ describe('Settings coming-soon cleanup contract', () => {
     assert.doesNotMatch(providers, /即将推出|尚未实现|路线图/, 'ProvidersPanel must not show unavailable providers as visible roadmap copy');
     assert.doesNotMatch(providers, /providerComingSoon|未开放配置|聊天发送未开放|未进入配置入口/, 'ProvidersPanel must use product-state account copy instead of coming-soon configuration copy');
     assert.match(providers, /等待添加供应商/, 'ProvidersPanel empty state should frame setup as an add-provider action');
+    assert.doesNotMatch(providers, /onClick=\{\(\) => startAdd\('zai-coding-plan'\)\}[\s\S]*等待添加供应商/, 'ProvidersPanel empty state must stay passive instead of opening Z.AI by default');
     assert.doesNotMatch(providers, /还没有供应商/, 'ProvidersPanel empty state should not read like unfinished product setup');
     assert.doesNotMatch(providerCatalog, /catalogBadge:\s*'Soon'|future phase/, 'provider catalog metadata must not keep soon/future-phase copy');
     assert.doesNotMatch(styles, /ComingSoonPage|roadmap banner|providerComingSoon|providerCatalogSoon/, 'Settings CSS must not keep stale coming-soon/provider-roadmap naming');

--- a/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-usage-contract.test.ts
@@ -25,20 +25,21 @@ describe('Settings usage dashboard contract', () => {
     assert.match(usagePage![0], /status: 'all', modelFilter: ''/);
     assert.match(
       usagePage![0],
-      /\{usageDraft\.activeTab === 'requests' && \([\s\S]*?<div className="settingsUsageFilters" role="group" aria-label="请求记录筛选">/,
-      'Usage filters must live under the requests-only conditional block',
+      /\{showRequestDetails && \([\s\S]*?<div className="settingsUsageFilters" role="group" aria-label="请求记录筛选">/,
+      'Usage filters must render only when request details are visible',
     );
     assert.doesNotMatch(
       usagePage![0],
       /<div className="settingsUsageFilters">\s*\{usageDraft\.showDetails/,
       'Usage request filters must not regress to an anonymous control cluster',
     );
-    assert.match(
-      usagePage![0],
-      /\{usageDraft\.showDetails && \([\s\S]*?<Input value=\{usageDraft\.modelFilter\}/,
-      'model/status request filters must be hidden until detail records are enabled',
-    );
+    assert.match(usagePage![0], /<Input value=\{usageDraft\.modelFilter\}/);
     assert.match(usagePage![0], /按模型或工具筛选/);
+    assert.match(usagePage![0], /className="settingsUsageDetailToggle"/);
+    assert.match(usagePage![0], /className="settingsUsageRecordCount"/);
+    assert.match(usagePage![0], /className="settingsUsageClearFilter"/);
+    assert.match(usagePage![0], /disabled=\{!hasRequestFilters\}/);
+    assert.match(usagePage![0], /tabIndex=\{!hasRequestFilters \? -1 : undefined\}/);
     assert.match(usagePage![0], /log\.model\.toLowerCase\(\)\.includes\(normalizedModelFilter\)/);
     assert.match(usagePage![0], /\(log\.toolName \?\? ''\)\.toLowerCase\(\)\.includes\(normalizedModelFilter\)/);
   });

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -696,7 +696,16 @@ export function CommandPalette(props: {
         aria-label="命令面板"
         onClick={(event) => event.stopPropagation()}
       >
-        <InputGroup className="maka-palette-input-wrap" aria-label="命令面板搜索">
+        <InputGroup
+          className="maka-palette-input-wrap"
+          aria-label="命令面板搜索"
+          onMouseDown={(event) => {
+            const target = event.target as HTMLElement;
+            if (target.closest('input')) return;
+            event.preventDefault();
+            inputRef.current?.focus();
+          }}
+        >
           <InputGroupInput
             ref={inputRef}
             className="maka-palette-input"
@@ -713,7 +722,10 @@ export function CommandPalette(props: {
           />
           <InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">
             <span className="maka-palette-input-hint" aria-hidden="true">
-              <Kbd className="maka-shortcut-kbd">↵</Kbd> 执行 · <Kbd className="maka-shortcut-kbd">Esc</Kbd> 关闭
+              <Kbd className="maka-shortcut-kbd">↵</Kbd>
+              <span>执行</span>
+              <Kbd className="maka-shortcut-kbd">Esc</Kbd>
+              <span>关闭</span>
             </span>
           </InputGroupAddon>
         </InputGroup>

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -197,15 +197,15 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
             )}
           </div>
           {loadError ? (
-            <Button className="enabledEmptyChip" type="button" variant="ghost" onClick={() => void reload()}>
+            <Button className="enabledEmptyChip enabledEmptyAction" type="button" variant="ghost" onClick={() => void reload()}>
               <strong>模型连接载入失败</strong>
               <small>{loadError} · 点击重试。</small>
             </Button>
           ) : connections.length === 0 ? (
-            <Button className="enabledEmptyChip" type="button" variant="ghost" onClick={() => startAdd('zai-coding-plan')}>
+            <div className="enabledEmptyChip" role="note">
               <strong>等待添加供应商</strong>
               <small>从下面选择一个开始配置。</small>
-            </Button>
+            </div>
           ) : (
             <PrimitiveAccordion className="enabledAccordion" multiple defaultValue={defaultOpenGroups}>
               {providerGroups.map((group) => {

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -150,24 +150,20 @@ export function UsageSettingsPage(props: {
         onChange={(activeTab) => void updateUsage({ activeTab: activeTab as typeof usageDraft.activeTab })}
       />
 
-      {usageDraft.activeTab === 'requests' && (
+      {showRequestDetails && (
         <div className="settingsUsageFilters" role="group" aria-label="请求记录筛选">
-          {usageDraft.showDetails && (
-            <>
-              <Input value={usageDraft.modelFilter} onChange={(event) => void updateUsage({ modelFilter: event.currentTarget.value })} placeholder="按模型或工具筛选…" aria-label="按模型或工具筛选请求记录" />
-              <SettingsSelect
-                value={usageDraft.status}
-                ariaLabel="请求状态筛选"
-                options={[
-                  ['all', '全部状态'],
-                  ['success', '成功'],
-                  ['error', '错误'],
-                ] satisfies Array<readonly [typeof usageDraft.status, string]>}
-                onChange={(status) => void updateUsage({ status })}
-              />
-            </>
-          )}
-          <label>
+          <Input value={usageDraft.modelFilter} onChange={(event) => void updateUsage({ modelFilter: event.currentTarget.value })} placeholder="按模型或工具筛选…" aria-label="按模型或工具筛选请求记录" />
+          <SettingsSelect
+            value={usageDraft.status}
+            ariaLabel="请求状态筛选"
+            options={[
+              ['all', '全部状态'],
+              ['success', '成功'],
+              ['error', '错误'],
+            ] satisfies Array<readonly [typeof usageDraft.status, string]>}
+            onChange={(status) => void updateUsage({ status })}
+          />
+          <label className="settingsUsageDetailToggle">
             <span>详情记录</span>
             <Switch
               ariaLabel="显示使用统计详情记录"
@@ -175,12 +171,19 @@ export function UsageSettingsPage(props: {
               onChange={(showDetails) => void updateUsage({ showDetails })}
             />
           </label>
-          {usageDraft.showDetails && <small>共 {filteredLogs.length} 条记录</small>}
-          {usageDraft.showDetails && hasRequestFilters && (
-            <Button type="button" variant="ghost" size="sm" onClick={clearRequestFilters}>
-              清除筛选
-            </Button>
-          )}
+          <small className="settingsUsageRecordCount">共 {filteredLogs.length} 条记录</small>
+          <Button
+            className="settingsUsageClearFilter"
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!hasRequestFilters}
+            aria-hidden={!hasRequestFilters ? 'true' : undefined}
+            tabIndex={!hasRequestFilters ? -1 : undefined}
+            onClick={hasRequestFilters ? clearRequestFilters : undefined}
+          >
+            清除筛选
+          </Button>
         </div>
       )}
 

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -732,14 +732,38 @@
      surface, so it steps DOWN one level (slightly darker = "type into
      here"), not up. foreground-derived so dark mode adapts. */
   background: oklch(from var(--foreground) l c h / 0.03);
+  transition:
+    border-color var(--duration-fast) var(--ease-out-strong),
+    box-shadow var(--duration-fast) var(--ease-out-strong),
+    background var(--duration-fast) var(--ease-out-strong);
+}
+
+.maka-palette-input-wrap:has(input:focus) {
+  border-color: var(--ring);
+  background: oklch(from var(--foreground) l c h / 0.04);
+  box-shadow: none;
 }
 
 .maka-palette-input {
   color: var(--foreground);
   font-size: var(--font-size-ui);
   line-height: 1.4;
+  outline: none;
+  box-shadow: none;
   -webkit-user-select: text;
   user-select: text;
+}
+
+.maka-palette-input:focus,
+.maka-palette-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
+.maka-palette-input-wrap input:focus,
+.maka-palette-input-wrap input:focus-visible {
+  outline: none;
+  box-shadow: none !important;
 }
 
 .maka-palette-input::placeholder {
@@ -749,7 +773,8 @@
 .maka-palette-input-hint {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1-5);
+  gap: var(--space-1);
+  min-height: 24px;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   white-space: nowrap;
@@ -757,6 +782,7 @@
 
 .maka-palette-input-hint-addon {
   flex-shrink: 0;
+  padding-inline-end: var(--space-1-5);
 }
 
 .maka-shortcut-group {
@@ -782,9 +808,10 @@
 
 .maka-palette-input-hint .maka-shortcut-kbd {
   background: var(--foreground-5);
+  box-shadow: none;
 }
 
-@media (max-width: 560px) {
+@media (max-width: 720px) {
   .maka-palette-input-hint-addon {
     display: none;
   }

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -3,21 +3,29 @@
   align-content: start;
   gap: var(--space-1-5);
   border-right: 1px solid var(--border);
-  padding-right: var(--space-6);
+  padding-right: var(--space-4);
 }
 
 .settingsBotList button {
+  width: 100%;
   min-height: 44px;
   display: grid;
-  grid-template-columns: 30px minmax(0, 1fr) auto;
+  grid-template-columns: 30px minmax(0, 1fr) max-content;
   align-items: center;
-  gap: var(--space-2-5);
+  column-gap: var(--space-2);
   border: 0;
   border-radius: var(--radius-surface);
   background: transparent;
   color: var(--foreground-secondary);
-  padding: var(--space-1-5) var(--space-2-5);
+  padding: var(--space-1-5) var(--space-2);
   text-align: left;
+}
+
+.settingsBotList button > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settingsBotList button[data-active="true"] {
@@ -41,6 +49,7 @@
   font-size: var(--font-size-caption);
   font-style: normal;
   color: var(--muted-foreground);
+  white-space: nowrap;
 }
 
 .settingsBotList em[data-tone="info"] { color: var(--status-running); }
@@ -272,6 +281,54 @@
   align-items: center;
   flex-wrap: wrap;
   gap: var(--space-1-5);
+}
+
+.settingsUsageFilters {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) 148px 108px 92px 92px;
+  align-items: center;
+}
+
+.settingsUsageDetailToggle {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-1-5);
+  color: var(--foreground);
+  font-size: var(--font-size-ui);
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.settingsUsageRecordCount {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.settingsUsageClearFilter {
+  justify-self: start;
+  min-width: 86px;
+}
+
+.settingsUsageClearFilter[aria-hidden="true"] {
+  visibility: hidden;
+}
+
+@media (max-width: 900px) {
+  .settingsUsageFilters {
+    grid-template-columns: 1fr;
+  }
+
+  .settingsUsageDetailToggle {
+    justify-content: flex-start;
+  }
 }
 
 .settingsSegmented {

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -619,19 +619,28 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-0-5);
-  border: 1px dashed var(--border);
+  gap: var(--space-1-5);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-control);
-  background: var(--background);
+  background: var(--background-elevated);
   color: var(--foreground);
-  padding: var(--space-3) var(--space-3);
+  padding: var(--space-4) var(--space-4);
   text-align: left;
 }
 
-.enabledEmptyChip:hover {
+.enabledEmptyAction:hover {
   border-color: oklch(from var(--nav-active) l c h / 0.16);
   background: var(--background-elevated);
 }
 
-.enabledEmptyChip strong { font-size: var(--font-size-caption); font-weight: 700; }
-.enabledEmptyChip small { margin-top: var(--space-0-5); color: var(--muted-foreground); font-size: var(--font-size-ui); }
+.enabledEmptyChip strong {
+  font-size: var(--font-size-ui);
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.enabledEmptyChip small {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: 1.45;
+}

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -759,8 +759,7 @@
 .settingsBotLayout {
   min-height: 470px;
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr);
+  grid-template-columns: 210px minmax(0, 1fr);
   gap: var(--space-6);
 }
-
 

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -578,12 +578,16 @@
   resize: vertical;
   border: 1px solid var(--border);
   border-radius: var(--radius-surface);
-  padding: var(--space-2-5) var(--space-3);
+  padding: var(--space-4);
   background: var(--background-elevated, var(--background));
   color: var(--foreground);
-  font-family: var(--font-mono);
+  font-family: inherit;
   font-size: var(--font-size-ui);
-  line-height: 1.55;
+  line-height: 1.75;
+  letter-spacing: 0;
+  tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .settingsMemoryEditor textarea:focus-visible {


### PR DESCRIPTION
## Summary

  - Polish command palette search input focus behavior and shortcut hint layout.
  - Make the empty model-provider state passive so it no longer opens Z.AI configuration by default.
  - Improve Settings usage filters layout to prevent controls from shifting across filter states.
  - Refine bot platform list spacing and MEMORY.md editor readability.
  - Add/update contract tests for the adjusted UI behavior.

  ## Verification

  - `npm --workspace @maka/desktop run typecheck -- --pretty false`
  - `npm --workspace @maka/desktop run build:main`
  - `node --test dist/main/__tests__/command-palette-a11y-copy-contract.test.js`
  - `node --test dist/main/__tests__/renderer-utility-primitives-contract.test.js`
  - `node --test dist/main/__tests__/settings-roadmap-cleanup-contract.test.js`
  - `node --test dist/main/__tests__/settings-usage-contract.test.js`
  - `node --test dist/main/__tests__/local-memory-ui-contract.test.js`
  - `node --test dist/main/__tests__/settings-form-a11y-contract.test.js`
  - `node --test dist/main/__tests__/renderer-style-layer-cascade-contract.test.js`