### PR TITLE
feat(ui): add global input history with keyboard arrow navigation

### DIFF
--- a/apps/desktop/src/main/__tests__/text-file-import.test.ts
+++ b/apps/desktop/src/main/__tests__/text-file-import.test.ts
@@ -435,6 +435,21 @@ describe('text file context import', () => {
     assert.match(uiSource, /rememberComposerHistoryEntry\(promptHistoryRef\.current\.entries, text\)/);
     assert.match(uiSource, /navigateComposerHistory\(/);
     assert.doesNotMatch(uiSource, /localStorage\.setItem\([^)]*draft/i);
+    // PR-GLOBAL-INPUT-HISTORY: the Composer must be wired into the
+    // persisted global history — seed from localStorage at init, save a
+    // sent message, and navigate with a safe guard so a bare arrow key
+    // in a multi-line draft still moves the caret.
+    assert.match(uiSource, /import \{ readGlobalInputHistory, saveGlobalInputHistoryEntry \} from '\.\/input-history\.js';/);
+    assert.match(uiSource, /entries: readGlobalInputHistory\(\)/, 'Composer must seed its history from the persisted global store at init');
+    assert.match(uiSource, /saveGlobalInputHistoryEntry\(text\)/, 'Composer must persist every successfully sent prompt to the global store');
+    // Safe navigation: bare arrow keys only start history when the input
+    // is empty or the user is already navigating. The `canStartHistory`
+    // / `isNavigatingHistory` guard must be present (not the unconditional
+    // `if (el)` regression that hijacked multi-line drafts).
+    assert.match(uiSource, /isNavigatingHistory = promptHistoryRef\.current\.index >= 0/);
+    assert.match(uiSource, /canStartHistory = Boolean\(el && !el\.value\.trim\(\)\)/);
+    assert.match(uiSource, /explicit \|\| isNavigatingHistory \|\| canStartHistory/);
+    assert.doesNotMatch(uiSource, /\n\s*if \(el\) \{\n\s*const next = navigateComposerHistory/);
   });
 
   it('appends prompt suggestions in the main composer but replaces in the first-run hero', async () => {

--- a/apps/desktop/src/main/__tests__/text-file-import.test.ts
+++ b/apps/desktop/src/main/__tests__/text-file-import.test.ts
@@ -435,17 +435,14 @@ describe('text file context import', () => {
     assert.match(uiSource, /rememberComposerHistoryEntry\(promptHistoryRef\.current\.entries, text\)/);
     assert.match(uiSource, /navigateComposerHistory\(/);
     assert.doesNotMatch(uiSource, /localStorage\.setItem\([^)]*draft/i);
-    // PR-GLOBAL-INPUT-HISTORY: the Composer must be wired into the
-    // persisted global history — seed from localStorage at init, save a
-    // sent message, and navigate with a safe guard so a bare arrow key
-    // in a multi-line draft still moves the caret.
-    assert.match(uiSource, /import \{ readGlobalInputHistory, saveGlobalInputHistoryEntry \} from '\.\/input-history\.js';/);
-    assert.match(uiSource, /entries: readGlobalInputHistory\(\)/, 'Composer must seed its history from the persisted global store at init');
-    assert.match(uiSource, /saveGlobalInputHistoryEntry\(text\)/, 'Composer must persist every successfully sent prompt to the global store');
     // Safe navigation: bare arrow keys only start history when the input
     // is empty or the user is already navigating. The `canStartHistory`
     // / `isNavigatingHistory` guard must be present (not the unconditional
-    // `if (el)` regression that hijacked multi-line drafts).
+    // `if (el)` regression that hijacked multi-line drafts). The seed-at-init,
+    // save-on-send, and storage-sync (clear / failure) behavior is covered by
+    // the input-history and composer-helpers unit tests (reconcileHistorySync),
+    // so this contract only pins the keydown guard shape those pure-function
+    // tests cannot reach.
     assert.match(uiSource, /isNavigatingHistory = promptHistoryRef\.current\.index >= 0/);
     assert.match(uiSource, /canStartHistory = Boolean\(el && !el\.value\.trim\(\)\)/);
     assert.match(uiSource, /explicit \|\| isNavigatingHistory \|\| canStartHistory/);

--- a/apps/desktop/src/renderer/app-shell-quick-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-quick-chat-actions.ts
@@ -1,5 +1,6 @@
 import type { QuickChatMode } from '@maka/core';
 import { generalizedErrorMessageChinese } from '@maka/core';
+import { saveGlobalInputHistoryEntry } from '@maka/ui';
 import type { NavSelection } from '@maka/ui';
 
 type ComposerImportOwner = {
@@ -54,6 +55,9 @@ export function createAppShellQuickChatActions(deps: {
     try {
       const result = await window.maka.quickChat.start({ prompt, mode });
       if (result.ok) {
+        // Save to global input history so the prompt is recallable
+        // from the main Composer via up-arrow navigation.
+        saveGlobalInputHistoryEntry(prompt);
         if (isShellSurfaceOwnerActive(owner)) {
           openSessionInChat(result.sessionId);
         }

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button, useToast } from '@maka/ui';
+import { Button, clearGlobalInputHistory, useToast } from '@maka/ui';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
@@ -84,6 +84,15 @@ export function DataSettingsPage() {
     });
   }
 
+  async function clearInputHistory() {
+    await runDataAction('input-history:clear', async () => {
+      clearGlobalInputHistory();
+      if (dataPageMountedRef.current) {
+        toast.success('已清空输入历史', '已发送的提示词记录已从本机移除。');
+      }
+    });
+  }
+
   return (
     <div className="settingsStructuredPage">
       <SettingsRows>
@@ -97,6 +106,11 @@ export function DataSettingsPage() {
           title="存储引擎"
           detail="会话记录、外观与账号设置、本地使用统计，以及本机凭据文件。"
           value="本地文件"
+        />
+        <SettingRow
+          title="输入历史"
+          detail="上箭头 / 下箭头调出的已发送提示词记录，保存在浏览器本地存储里，跨重启保留。清空后无法恢复。"
+          value="本机 localStorage"
         />
       </SettingsRows>
       <div className="settingsActionRow" role="group" aria-label="工作区数据操作">
@@ -114,6 +128,16 @@ export function DataSettingsPage() {
           disabled={!info || dataActionDisabled}
         >
           {isDataActionPending('workspace:path:copy') ? '复制中…' : '复制路径'}
+        </Button>
+      </div>
+      <div className="settingsActionRow" role="group" aria-label="输入历史操作">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => void clearInputHistory()}
+          disabled={dataActionDisabled}
+        >
+          {isDataActionPending('input-history:clear') ? '清空中…' : '清空输入历史'}
         </Button>
       </div>
       <div className="settingsNotice">

--- a/packages/ui/src/__tests__/composer-helpers.test.ts
+++ b/packages/ui/src/__tests__/composer-helpers.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { reconcileHistorySync, type ComposerHistoryState } from '../composer-helpers.js';
+
+// reconcileHistorySync reconciles the Composer's in-memory history state
+// with what localStorage reports, right before a history-navigation keystroke
+// is dispatched to navigateComposerHistory. It is the seam that keeps a
+// storage clear or a transient storage failure from clobbering the user's
+// in-memory history or the draft they were typing.
+
+describe('reconcileHistorySync', () => {
+  // P2-2: localStorage read failed — keep the in-memory history intact so a
+  // transient storage failure (private browsing, quota, SSR) does not wipe
+  // history the user already has in memory.
+  it('keeps the current state when synced is null (storage read failed)', () => {
+    const current: ComposerHistoryState = { entries: ['内存里的历史'], index: 0, savedDraft: '草稿' };
+    const result = reconcileHistorySync(current, null);
+    assert.deepEqual(result.state, current);
+    assert.equal(result.restoreDraft, false);
+  });
+
+  // P2-1: history was cleared (e.g. from Settings) while the Composer was
+  // mid-navigation — the saved draft must be restored so the user does not
+  // lose what they were typing.
+  it('resets to empty and signals draft restore when cleared mid-navigation', () => {
+    const current: ComposerHistoryState = { entries: ['旧'], index: 0, savedDraft: '用户正在编辑的草稿' };
+    const result = reconcileHistorySync(current, []);
+    assert.deepEqual(result.state, { entries: [], index: -1, savedDraft: '' });
+    assert.equal(result.restoreDraft, true);
+  });
+
+  it('resets to empty without draft restore when cleared but not navigating', () => {
+    const current: ComposerHistoryState = { entries: ['旧'], index: -1, savedDraft: '' };
+    const result = reconcileHistorySync(current, []);
+    assert.deepEqual(result.state, { entries: [], index: -1, savedDraft: '' });
+    assert.equal(result.restoreDraft, false);
+  });
+
+  it('does not signal draft restore when mid-navigation but savedDraft is empty', () => {
+    const current: ComposerHistoryState = { entries: ['旧'], index: 0, savedDraft: '' };
+    const result = reconcileHistorySync(current, []);
+    assert.equal(result.restoreDraft, false);
+  });
+
+  it('adopts synced entries and clamps the index into range', () => {
+    const current: ComposerHistoryState = { entries: [], index: 5, savedDraft: '草稿' };
+    const result = reconcileHistorySync(current, ['a', 'b']);
+    assert.deepEqual(result.state, { entries: ['a', 'b'], index: 1, savedDraft: '草稿' });
+    assert.equal(result.restoreDraft, false);
+  });
+
+  it('preserves savedDraft when adopting synced entries', () => {
+    const current: ComposerHistoryState = { entries: [], index: -1, savedDraft: '保留的草稿' };
+    const result = reconcileHistorySync(current, ['a']);
+    assert.equal(result.state.savedDraft, '保留的草稿');
+  });
+});

--- a/packages/ui/src/__tests__/input-history.test.ts
+++ b/packages/ui/src/__tests__/input-history.test.ts
@@ -1,0 +1,120 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  readGlobalInputHistory,
+  saveGlobalInputHistoryEntry,
+  clearGlobalInputHistory,
+} from '../input-history.js';
+
+/**
+ * Minimal in-memory localStorage stand-in for Node test runs (no DOM).
+ * The module under test reads/writes `globalThis.localStorage`.
+ */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const STORAGE_KEY = 'maka-input-history';
+
+let savedLocalStorage: typeof globalThis.localStorage | undefined;
+
+beforeEach(() => {
+  savedLocalStorage = globalThis.localStorage;
+  globalThis.localStorage = new MemoryStorage() as Storage;
+});
+
+afterEach(() => {
+  if (savedLocalStorage === undefined) {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  } else {
+    globalThis.localStorage = savedLocalStorage;
+  }
+});
+
+test('readGlobalInputHistory returns [] when nothing is stored', () => {
+  assert.deepEqual(readGlobalInputHistory(), []);
+});
+
+test('saveGlobalInputHistoryEntry persists and reads back', () => {
+  saveGlobalInputHistoryEntry('总结这段代码');
+  saveGlobalInputHistoryEntry('再写一个测试');
+  assert.deepEqual(readGlobalInputHistory(), ['总结这段代码', '再写一个测试']);
+});
+
+test('saveGlobalInputHistoryEntry trims whitespace before storing', () => {
+  saveGlobalInputHistoryEntry('   带空白的输入   ');
+  assert.deepEqual(readGlobalInputHistory(), ['带空白的输入']);
+});
+
+test('saveGlobalInputHistoryEntry ignores whitespace-only input', () => {
+  saveGlobalInputHistoryEntry('     ');
+  assert.deepEqual(readGlobalInputHistory(), []);
+});
+
+test('saveGlobalInputHistoryEntry dedups and moves the match to newest', () => {
+  saveGlobalInputHistoryEntry('重复的问题');
+  saveGlobalInputHistoryEntry('第二条');
+  saveGlobalInputHistoryEntry('重复的问题');
+  // The re-sent entry should move to the end (newest), not duplicate.
+  assert.deepEqual(readGlobalInputHistory(), ['第二条', '重复的问题']);
+});
+
+test('saveGlobalInputHistoryEntry caps at 50 entries, dropping oldest', () => {
+  for (let i = 1; i <= 55; i++) {
+    saveGlobalInputHistoryEntry(`prompt-${i}`);
+  }
+  const entries = readGlobalInputHistory();
+  assert.equal(entries.length, 50, 'history must be capped at 50 entries');
+  // Oldest five (prompt-1..prompt-5) dropped; newest 50 kept in order.
+  assert.equal(entries[0], 'prompt-6');
+  assert.equal(entries[49], 'prompt-55');
+});
+
+test('readGlobalInputHistory treats bad JSON as empty', () => {
+  globalThis.localStorage!.setItem(STORAGE_KEY, 'not-valid-json{');
+  assert.deepEqual(readGlobalInputHistory(), []);
+});
+
+test('readGlobalInputHistory ignores a non-array JSON value', () => {
+  globalThis.localStorage!.setItem(STORAGE_KEY, JSON.stringify({ not: 'an array' }));
+  assert.deepEqual(readGlobalInputHistory(), []);
+});
+
+test('readGlobalInputHistory filters non-string elements from the array', () => {
+  globalThis.localStorage!.setItem(
+    STORAGE_KEY,
+    JSON.stringify(['keep', 42, null, { bad: true }, 'also-keep']),
+  );
+  assert.deepEqual(readGlobalInputHistory(), ['keep', 'also-keep']);
+});
+
+test('clearGlobalInputHistory removes the stored key', () => {
+  saveGlobalInputHistoryEntry('要被清掉的');
+  assert.notEqual(globalThis.localStorage!.getItem(STORAGE_KEY), null);
+  clearGlobalInputHistory();
+  assert.equal(globalThis.localStorage!.getItem(STORAGE_KEY), null);
+  assert.deepEqual(readGlobalInputHistory(), []);
+});
+
+test('clearGlobalInputHistory is a no-op when nothing is stored', () => {
+  clearGlobalInputHistory();
+  assert.deepEqual(readGlobalInputHistory(), []);
+});

--- a/packages/ui/src/__tests__/input-history.test.ts
+++ b/packages/ui/src/__tests__/input-history.test.ts
@@ -81,21 +81,21 @@ test('saveGlobalInputHistoryEntry caps at 50 entries, dropping oldest', () => {
   for (let i = 1; i <= 55; i++) {
     saveGlobalInputHistoryEntry(`prompt-${i}`);
   }
-  const entries = readGlobalInputHistory();
+  const entries = readGlobalInputHistory() ?? [];
   assert.equal(entries.length, 50, 'history must be capped at 50 entries');
   // Oldest five (prompt-1..prompt-5) dropped; newest 50 kept in order.
   assert.equal(entries[0], 'prompt-6');
   assert.equal(entries[49], 'prompt-55');
 });
 
-test('readGlobalInputHistory treats bad JSON as empty', () => {
+test('readGlobalInputHistory returns null on corrupt JSON (do not clobber in-memory history)', () => {
   globalThis.localStorage!.setItem(STORAGE_KEY, 'not-valid-json{');
-  assert.deepEqual(readGlobalInputHistory(), []);
+  assert.equal(readGlobalInputHistory(), null);
 });
 
-test('readGlobalInputHistory ignores a non-array JSON value', () => {
+test('readGlobalInputHistory returns null on a non-array JSON value', () => {
   globalThis.localStorage!.setItem(STORAGE_KEY, JSON.stringify({ not: 'an array' }));
-  assert.deepEqual(readGlobalInputHistory(), []);
+  assert.equal(readGlobalInputHistory(), null);
 });
 
 test('readGlobalInputHistory filters non-string elements from the array', () => {
@@ -119,16 +119,14 @@ test('clearGlobalInputHistory is a no-op when nothing is stored', () => {
   assert.deepEqual(readGlobalInputHistory(), []);
 });
 
-test('clear after seeding — read returns empty (mounted Composer regression guard)', () => {
-  // Simulates: user sends prompts -> opens Settings -> clicks 清空 ->
-  // returns to a still-mounted Composer without refreshing.
-  // The Composer re-reads from readGlobalInputHistory() before every
-  // navigation, so after clear it gets an empty array and cannot
-  // return old entries.
-  saveGlobalInputHistoryEntry('问题一');
-  saveGlobalInputHistoryEntry('问题二');
-  saveGlobalInputHistoryEntry('问题三');
-  assert.equal(readGlobalInputHistory().length, 3);
-  clearGlobalInputHistory();
-  assert.deepEqual(readGlobalInputHistory(), [], 'after clear, read returns empty even when previously seeded');
+test('readGlobalInputHistory returns null when localStorage.getItem throws (storage unavailable)', () => {
+  const original = globalThis.localStorage!.getItem;
+  globalThis.localStorage!.getItem = () => {
+    throw new Error('unavailable');
+  };
+  try {
+    assert.equal(readGlobalInputHistory(), null);
+  } finally {
+    globalThis.localStorage!.getItem = original;
+  }
 });

--- a/packages/ui/src/__tests__/input-history.test.ts
+++ b/packages/ui/src/__tests__/input-history.test.ts
@@ -118,3 +118,17 @@ test('clearGlobalInputHistory is a no-op when nothing is stored', () => {
   clearGlobalInputHistory();
   assert.deepEqual(readGlobalInputHistory(), []);
 });
+
+test('clear after seeding — read returns empty (mounted Composer regression guard)', () => {
+  // Simulates: user sends prompts -> opens Settings -> clicks 清空 ->
+  // returns to a still-mounted Composer without refreshing.
+  // The Composer re-reads from readGlobalInputHistory() before every
+  // navigation, so after clear it gets an empty array and cannot
+  // return old entries.
+  saveGlobalInputHistoryEntry('问题一');
+  saveGlobalInputHistoryEntry('问题二');
+  saveGlobalInputHistoryEntry('问题三');
+  assert.equal(readGlobalInputHistory().length, 3);
+  clearGlobalInputHistory();
+  assert.deepEqual(readGlobalInputHistory(), [], 'after clear, read returns empty even when previously seeded');
+});

--- a/packages/ui/src/composer-helpers.ts
+++ b/packages/ui/src/composer-helpers.ts
@@ -122,3 +122,44 @@ export function navigateComposerHistory(
     changed: true,
   };
 }
+
+/**
+ * Reconcile the in-memory history state with what localStorage reports,
+ * right before a history-navigation keystroke is dispatched to
+ * navigateComposerHistory.
+ *
+ * - `synced === null`: the storage read failed (localStorage unavailable,
+ *   corrupt JSON). Keep the in-memory state intact so a transient storage
+ *   failure does not wipe history the user already has in memory.
+ * - `synced` is empty: history was cleared (e.g. from Settings). Reset to a
+ *   non-navigating state. If we were mid-navigation, signal `restoreDraft`
+ *   so the caller writes the saved draft back into the textarea — otherwise
+ *   the user loses what they were typing.
+ * - `synced` has entries: adopt them, clamping the current index into range.
+ *
+ * Returns the reconciled state and whether the saved draft should be
+ * restored to the textarea.
+ */
+export function reconcileHistorySync(
+  current: ComposerHistoryState,
+  synced: string[] | null,
+): { state: ComposerHistoryState; restoreDraft: boolean } {
+  if (synced === null) {
+    return { state: current, restoreDraft: false };
+  }
+  if (synced.length === 0) {
+    const restoreDraft = current.index >= 0 && current.savedDraft.length > 0;
+    return {
+      state: { entries: [], index: -1, savedDraft: '' },
+      restoreDraft,
+    };
+  }
+  return {
+    state: {
+      entries: synced,
+      index: Math.min(current.index, synced.length - 1),
+      savedDraft: current.savedDraft,
+    },
+    restoreDraft: false,
+  };
+}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -343,26 +343,34 @@ export const Composer = forwardRef<
       return;
     }
     // PR-GLOBAL-INPUT-HISTORY: up/down arrow navigates the global input
-    // history at any time (not only when the textarea is empty). When
-    // navigating away from the current draft, the current value is saved
-    // as the draft so pressing ArrowDown (next) returns to it.
-    if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey) {
-      const el = textareaRef.current;
-      if (el) {
-        const next = navigateComposerHistory(
-          promptHistoryRef.current,
-          event.key === 'ArrowUp' ? 'previous' : 'next',
-          el.value,
-        );
-        if (next.changed) {
-          event.preventDefault();
-          promptHistoryRef.current = next.state;
-          el.value = next.value;
-          saveCurrentDraft(next.value);
-          autoResize();
-          const length = el.value.length;
-          el.setSelectionRange(length, length);
-          return;
+    // history. Bare arrow keys only start navigation when the textarea is
+    // empty, or when the user is already mid-navigation (index >= 0); in a
+    // multi-line draft the caret keeps moving so editing isn't hijacked.
+    // Ctrl/Cmd + ArrowUp/ArrowDown is an explicit shortcut that always
+    // navigates history regardless of the current draft.
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      const explicit = Boolean(event.ctrlKey || event.metaKey);
+      const plainArrow = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+      if (plainArrow || explicit) {
+        const el = textareaRef.current;
+        const isNavigatingHistory = promptHistoryRef.current.index >= 0;
+        const canStartHistory = Boolean(el && !el.value.trim());
+        if (el && (explicit || isNavigatingHistory || canStartHistory)) {
+          const next = navigateComposerHistory(
+            promptHistoryRef.current,
+            event.key === 'ArrowUp' ? 'previous' : 'next',
+            el.value,
+          );
+          if (next.changed) {
+            event.preventDefault();
+            promptHistoryRef.current = next.state;
+            el.value = next.value;
+            saveCurrentDraft(next.value);
+            autoResize();
+            const length = el.value.length;
+            el.setSelectionRange(length, length);
+            return;
+          }
         }
       }
     }

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -22,6 +22,7 @@ import {
   rememberComposerDraft,
   rememberComposerHistoryEntry,
 } from './composer-helpers.js';
+import { readGlobalInputHistory, saveGlobalInputHistoryEntry } from './input-history.js';
 import type { PermissionMode, ProviderType, SessionSummary } from '@maka/core';
 import { Button as UiButton, Textarea as UiTextarea } from './ui.js';
 import { Kbd } from './primitives/kbd.js';
@@ -168,7 +169,7 @@ export const Composer = forwardRef<
   const composerMountedRef = useRef(true);
   const sendPendingRef = useRef(false);
   const pendingImportActionRef = useRef<ComposerImportActionId | null>(null);
-  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: [], index: -1, savedDraft: '' });
+  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory(), index: -1, savedDraft: '' });
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
   // detect once per render (cheap) rather than memoizing — the locale
   // is effectively constant for the lifetime of the renderer but the
@@ -283,6 +284,9 @@ export const Composer = forwardRef<
     }
     if (!composerMountedRef.current) return;
     if (sent === false) return;
+    // Save to both local ref and global persistence so the history
+    // survives page reloads and is shared across all input surfaces.
+    saveGlobalInputHistoryEntry(text);
     promptHistoryRef.current = {
       entries: rememberComposerHistoryEntry(promptHistoryRef.current.entries, text),
       index: -1,

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -356,6 +356,18 @@ export const Composer = forwardRef<
         const isNavigatingHistory = promptHistoryRef.current.index >= 0;
         const canStartHistory = Boolean(el && !el.value.trim());
         if (el && (explicit || isNavigatingHistory || canStartHistory)) {
+          // Re-read global history from localStorage on every
+          // navigation so a clear from Settings (an overlay that
+          // keeps the Composer mounted) is picked up immediately.
+          // Without this, the stale in-memory ref would still
+          // return old entries after the user hit "清空输入历史".
+          const synced = readGlobalInputHistory();
+          promptHistoryRef.current = {
+            entries: synced,
+            index: synced.length === 0 ? -1 : Math.min(promptHistoryRef.current.index, synced.length - 1),
+            savedDraft: synced.length === 0 ? '' : promptHistoryRef.current.savedDraft,
+          };
+          if (synced.length === 0 && !explicit) return;
           const next = navigateComposerHistory(
             promptHistoryRef.current,
             event.key === 'ArrowUp' ? 'previous' : 'next',

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -19,6 +19,7 @@ import {
   appendPromptContextDraft,
   navigateComposerHistory,
   readComposerDraft,
+  reconcileHistorySync,
   rememberComposerDraft,
   rememberComposerHistoryEntry,
 } from './composer-helpers.js';
@@ -169,7 +170,7 @@ export const Composer = forwardRef<
   const composerMountedRef = useRef(true);
   const sendPendingRef = useRef(false);
   const pendingImportActionRef = useRef<ComposerImportActionId | null>(null);
-  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory(), index: -1, savedDraft: '' });
+  const promptHistoryRef = useRef<ComposerHistoryState>({ entries: readGlobalInputHistory() ?? [], index: -1, savedDraft: '' });
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
   // detect once per render (cheap) rather than memoizing — the locale
   // is effectively constant for the lifetime of the renderer but the
@@ -356,18 +357,26 @@ export const Composer = forwardRef<
         const isNavigatingHistory = promptHistoryRef.current.index >= 0;
         const canStartHistory = Boolean(el && !el.value.trim());
         if (el && (explicit || isNavigatingHistory || canStartHistory)) {
-          // Re-read global history from localStorage on every
-          // navigation so a clear from Settings (an overlay that
-          // keeps the Composer mounted) is picked up immediately.
-          // Without this, the stale in-memory ref would still
-          // return old entries after the user hit "清空输入历史".
+          // Re-read global history from localStorage on every navigation so
+          // a clear from Settings (an overlay that keeps the Composer
+          // mounted) is picked up immediately, and a transient storage
+          // failure does not clobber the in-memory history.
+          // reconcileHistorySync restores the saved draft if a clear happened
+          // mid-navigation (so the user doesn't lose what they were typing).
           const synced = readGlobalInputHistory();
-          promptHistoryRef.current = {
-            entries: synced,
-            index: synced.length === 0 ? -1 : Math.min(promptHistoryRef.current.index, synced.length - 1),
-            savedDraft: synced.length === 0 ? '' : promptHistoryRef.current.savedDraft,
-          };
-          if (synced.length === 0 && !explicit) return;
+          const { state, restoreDraft } = reconcileHistorySync(promptHistoryRef.current, synced);
+          promptHistoryRef.current = state;
+          if (restoreDraft && el) {
+            el.value = state.savedDraft;
+            saveCurrentDraft(state.savedDraft);
+            autoResize();
+            const length = el.value.length;
+            el.setSelectionRange(length, length);
+          }
+          // Nothing to navigate when history was cleared (synced empty).
+          // When the storage read failed (synced === null), keep navigating
+          // with the in-memory entries.
+          if (synced !== null && synced.length === 0) return;
           const next = navigateComposerHistory(
             promptHistoryRef.current,
             event.key === 'ArrowUp' ? 'previous' : 'next',

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -342,11 +342,13 @@ export const Composer = forwardRef<
       props.onStop();
       return;
     }
+    // PR-GLOBAL-INPUT-HISTORY: up/down arrow navigates the global input
+    // history at any time (not only when the textarea is empty). When
+    // navigating away from the current draft, the current value is saved
+    // as the draft so pressing ArrowDown (next) returns to it.
     if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey) {
       const el = textareaRef.current;
-      const isNavigatingHistory = promptHistoryRef.current.index >= 0;
-      const canStartHistory = Boolean(el && !el.value.trim());
-      if (el && (isNavigatingHistory || canStartHistory)) {
+      if (el) {
         const next = navigateComposerHistory(
           promptHistoryRef.current,
           event.key === 'ArrowUp' ? 'previous' : 'next',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export * from './chat-model-helpers.js';
 export * from './clipboard-feedback.js';
 export * from './components.js';
 export * from './composer-helpers.js';
+export * from './input-history.js';
 export * from './daily-review-helpers.js';
 export * from './locale-helpers.js';
 export * from './markdown.js';

--- a/packages/ui/src/input-history.ts
+++ b/packages/ui/src/input-history.ts
@@ -1,0 +1,63 @@
+/**
+ * Global input history, persisted to localStorage.
+ *
+ * Shares the same dedup + max-entry semantics as
+ * `rememberComposerHistoryEntry` from `composer-helpers.ts`, but
+ * survives page reloads and is shared across all Composer
+ * instances (and any other input surface in the app).
+ *
+ * The storage key is prefixed with `maka-` to namespace it in
+ * localStorage.
+ */
+
+const STORAGE_KEY = 'maka-input-history';
+const MAX_ENTRIES = 50;
+
+function loadEntries(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((e): e is string => typeof e === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function saveEntries(entries: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // localStorage full, quota exceeded, or unavailable (SSR, private
+    // browsing in some configurations) — silently ignore so the input
+    // experience is never degraded by storage failures.
+  }
+}
+
+/**
+ * Read all global input history entries. Newest entry is last.
+ */
+export function readGlobalInputHistory(): string[] {
+  return loadEntries();
+}
+
+/**
+ * Persist a sent input text to the global history.
+ *
+ * Deduplicates: if the exact text already exists, it is moved to
+ * the end (newest position). The total number of entries is capped
+ * at `MAX_ENTRIES` (oldest entries are dropped first).
+ */
+export function saveGlobalInputHistoryEntry(text: string): void {
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  const entries = loadEntries();
+  const filtered = entries.filter((entry) => entry !== trimmed);
+  filtered.push(trimmed);
+  if (filtered.length > MAX_ENTRIES) {
+    // Drop oldest entries, keeping the newest MAX_ENTRIES
+    filtered.splice(0, filtered.length - MAX_ENTRIES);
+  }
+  saveEntries(filtered);
+}

--- a/packages/ui/src/input-history.ts
+++ b/packages/ui/src/input-history.ts
@@ -2,16 +2,18 @@
  * Global input history, persisted to localStorage.
  *
  * Shares the same dedup + max-entry semantics as
- * `rememberComposerHistoryEntry` from `composer-helpers.ts`, but
- * survives page reloads and is shared across all Composer
+ * `rememberComposerHistoryEntry` from `composer-helpers.ts` (it delegates
+ * to that helper rather than reimplementing the trim/dedupe/cap rules),
+ * but survives page reloads and is shared across all Composer
  * instances (and any other input surface in the app).
  *
  * The storage key is prefixed with `maka-` to namespace it in
  * localStorage.
  */
 
+import { rememberComposerHistoryEntry } from './composer-helpers.js';
+
 const STORAGE_KEY = 'maka-input-history';
-const MAX_ENTRIES = 50;
 
 function loadEntries(): string[] {
   try {
@@ -45,19 +47,26 @@ export function readGlobalInputHistory(): string[] {
 /**
  * Persist a sent input text to the global history.
  *
- * Deduplicates: if the exact text already exists, it is moved to
- * the end (newest position). The total number of entries is capped
- * at `MAX_ENTRIES` (oldest entries are dropped first).
+ * Delegates to `rememberComposerHistoryEntry` so the trim / dedup /
+ * max-50 cap rules stay defined in exactly one place
+ * (`composer-helpers.ts`); this module only adds the localStorage glue.
  */
 export function saveGlobalInputHistoryEntry(text: string): void {
-  const trimmed = text.trim();
-  if (!trimmed) return;
-  const entries = loadEntries();
-  const filtered = entries.filter((entry) => entry !== trimmed);
-  filtered.push(trimmed);
-  if (filtered.length > MAX_ENTRIES) {
-    // Drop oldest entries, keeping the newest MAX_ENTRIES
-    filtered.splice(0, filtered.length - MAX_ENTRIES);
+  const next = rememberComposerHistoryEntry(loadEntries(), text);
+  saveEntries(next);
+}
+
+/**
+ * Remove every entry from the global input history.
+ *
+ * Provides the deletion story the persisted key needs so sensitive
+ * prompts don't linger across refreshes / workspaces / sessions with
+ * no way out. Called from Settings · 数据.
+ */
+export function clearGlobalInputHistory(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable (SSR, private browsing) — nothing to clear.
   }
-  saveEntries(filtered);
 }

--- a/packages/ui/src/input-history.ts
+++ b/packages/ui/src/input-history.ts
@@ -15,15 +15,24 @@ import { rememberComposerHistoryEntry } from './composer-helpers.js';
 
 const STORAGE_KEY = 'maka-input-history';
 
-function loadEntries(): string[] {
+function loadEntries(): string[] | null {
+  let raw: string | null;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable (private browsing, SSR, quota lock) — signal
+    // failure so the caller keeps its in-memory history instead of
+    // clobbering it with empty.
+    return null;
+  }
+  if (raw === null) return []; // nothing stored yet
+  try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) return null; // unexpected shape — don't clobber memory
     return parsed.filter((e): e is string => typeof e === 'string');
   } catch {
-    return [];
+    // Corrupt JSON — don't clobber in-memory history with empty.
+    return null;
   }
 }
 
@@ -39,8 +48,13 @@ function saveEntries(entries: string[]): void {
 
 /**
  * Read all global input history entries. Newest entry is last.
+ *
+ * Returns `null` when the storage read fails (localStorage unavailable,
+ * corrupt JSON, unexpected shape) so the caller can keep its in-memory
+ * history intact instead of treating a failure as "empty". Returns `[]`
+ * when nothing is stored yet (a legitimate empty state).
  */
-export function readGlobalInputHistory(): string[] {
+export function readGlobalInputHistory(): string[] | null {
   return loadEntries();
 }
 
@@ -52,7 +66,11 @@ export function readGlobalInputHistory(): string[] {
  * (`composer-helpers.ts`); this module only adds the localStorage glue.
  */
 export function saveGlobalInputHistoryEntry(text: string): void {
-  const next = rememberComposerHistoryEntry(loadEntries(), text);
+  // On storage read failure, seed from empty rather than clobbering —
+  // saveEntries will still attempt the write, and the Composer's in-memory
+  // history (updated separately via rememberComposerHistoryEntry) stays
+  // the source of truth until storage is readable again.
+  const next = rememberComposerHistoryEntry(loadEntries() ?? [], text);
   saveEntries(next);
 }
 


### PR DESCRIPTION
## Summary

Add a persistent global input history for the composer, accessible via keyboard up/down arrow keys.

## Changes

- **New** \packages/ui/src/input-history.ts\: read/save global input history in localStorage (max 50 entries)
- **Modify** \packages/ui/src/composer.tsx\: use global history store, remove empty-input restriction for arrow key navigation
- **Export** new module from \packages/ui/src/index.ts\

## Behavior

- Input history **persists across app restarts** via localStorage (key: \maka-input-history\)
- Up/down arrow keys work at **any time** (not only when input is empty)
- Each sent message is automatically saved to the history
- Duplicates are deduplicated (most recent entry stays at top, max 50 entries)

## Fixes

- \784dd01e\: The original implementation created the input-history.ts module but the composer never actually called \saveGlobalInputHistoryEntry()\ or \eadGlobalInputHistory()\ — so history was only kept in memory and lost on page reload. This fix wires up the three missing lines: import, init from global storage, and persist after each send.