### PR TITLE
feat(desktop): hide Windows titlebar and overlay min/max/close buttons in top-right corner

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -395,10 +395,10 @@ declare global {
       appWindow: {
         subscribeOpenSettings(handler: () => void): () => void;
         setTitlebarControlsVisible(visible: boolean): Promise<void>;
-	        setThemeSource(themePref: ThemePreference): Promise<void>;
-	        // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
-	        // color/symbolColor to the current app theme. No-op on non-Windows.
-	        setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
+        setThemeSource(themePref: ThemePreference): Promise<void>;
+        // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
+        // color/symbolColor to the current app theme. No-op on non-Windows.
+        setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
       };
       app: {
         info(): Promise<{

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -395,7 +395,10 @@ declare global {
       appWindow: {
         subscribeOpenSettings(handler: () => void): () => void;
         setTitlebarControlsVisible(visible: boolean): Promise<void>;
-        setThemeSource(themePref: ThemePreference): Promise<void>;
+	        setThemeSource(themePref: ThemePreference): Promise<void>;
+	        // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
+	        // color/symbolColor to the current app theme. No-op on non-Windows.
+	        setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
       };
       app: {
         info(): Promise<{

--- a/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
@@ -72,6 +72,28 @@ describe('chat header actions inset contract', () => {
     );
   });
 
+  it('uses Electron titlebar safe-area env vars for native Windows overlay avoidance', async () => {
+    const css = await readRendererContractCss();
+    assert.doesNotMatch(
+      css,
+      /\[data-platform=["']win32["']\]/,
+      'Windows titlebar avoidance should not depend on a renderer platform attribute',
+    );
+    assert.doesNotMatch(
+      css,
+      /\b138px\b/,
+      'Windows titlebar avoidance should not hard-code the native control width',
+    );
+    assert.match(css, /--maka-titlebar-area-x:\s*env\(titlebar-area-x,\s*0px\)\s*;/);
+    assert.match(css, /--maka-titlebar-area-width:\s*env\(titlebar-area-width,\s*100vw\)\s*;/);
+    assert.match(css, /--maka-titlebar-area-height:\s*env\(titlebar-area-height,\s*var\(--h-titlebar\)\)\s*;/);
+    assert.match(
+      css,
+      /--maka-titlebar-overlay-right-width:\s*max\(\s*0px,\s*calc\(100vw - var\(--maka-titlebar-area-x\) - var\(--maka-titlebar-area-width\)\s*\)\s*\)\s*;/,
+      'right-side native control width should be derived from the titlebar safe-area x/width pair',
+    );
+  });
+
   it('sizes the inset from the toolbar buttons, gaps, and clearance', async () => {
     const css = await readRendererContractCss();
     const buttonCount = await workspaceTopActionButtonCount();

--- a/apps/desktop/src/main/__tests__/theme-source.test.ts
+++ b/apps/desktop/src/main/__tests__/theme-source.test.ts
@@ -17,6 +17,7 @@ import { isThemePreference, toNativeThemeSource } from '../theme-source.js';
 // relative path would resolve into dist/ (no .ts sources there) instead of
 // the real src/ file. Same approach as main-process-contract-source-helpers.ts.
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const MAIN_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts');
 const MAIN_WINDOW_TS = resolve(REPO_ROOT, 'apps/desktop/src/main/main-window.ts');
 
 describe('theme-source', () => {
@@ -78,6 +79,41 @@ describe('theme-source', () => {
       assert.notEqual(syncIndex, -1, 'createWindow must sync nativeTheme.themeSource from the resolved themePref');
       assert.notEqual(newWindowIndex, -1, 'new BrowserWindow(...) call must exist');
       assert.ok(syncIndex < newWindowIndex, 'the nativeTheme sync must happen before the BrowserWindow is constructed');
+    });
+
+    it('keeps Windows titleBarOverlay height stable at window creation and runtime theme sync', async () => {
+      const src = await readFile(MAIN_WINDOW_TS, 'utf8');
+
+      assert.match(
+        src,
+        /const titleBarOverlayOptions = \(isDark: boolean\): \{ color: string; symbolColor: string; height: number \} => \(\{[\s\S]*height: TITLEBAR_OVERLAY_HEIGHT,[\s\S]*\}\);/,
+        'one helper should include color, symbolColor, and height',
+      );
+      assert.match(
+        src,
+        /titleBarOverlay:\s*titleBarOverlayOptions\(isDark\)/,
+        'window creation should use the shared titleBarOverlay options helper',
+      );
+
+      const methodMatch = src.match(/setTitleBarOverlayTheme\(sender, isDark\) \{([\s\S]*?)\n {4}\},/);
+      assert.ok(methodMatch, 'setTitleBarOverlayTheme method must exist on the controller');
+      const body = methodMatch![1];
+      assert.match(body, /target !== mainWindow/, 'must reject senders that are not the tracked main window');
+      assert.match(body, /typeof isDark !== 'boolean'/, 'must reject non-boolean theme values');
+      assert.match(
+        body,
+        /mainWindow\.setTitleBarOverlay\(titleBarOverlayOptions\(isDark\)\)/,
+        'runtime theme sync should preserve the same overlay height as window creation',
+      );
+    });
+
+    it('window:setTitleBarOverlayTheme forwards the sender to the guarded main-window controller', async () => {
+      const src = await readFile(MAIN_TS, 'utf8');
+      assert.match(
+        src,
+        /ipcMain\.handle\('window:setTitleBarOverlayTheme', \(event, isDark: unknown\): void => \{\s*mainWindowController\.setTitleBarOverlayTheme\(event\.sender, isDark\);\s*\}\);/,
+        'the IPC handler should let main-window.ts validate both sender and payload',
+      );
     });
   });
 });

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -18,14 +18,8 @@ export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
-	  setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
-	  /**
-	   * Re-sync the native titleBarOverlay color/symbolColor to the current
-	   * app theme. Called from the renderer whenever the resolved light/dark
-	   * mode changes so the Windows control strip doesn't drift from the app
-	   * theme at runtime. No-op on non-Windows platforms (no overlay there).
-	   */
-	  setTitleBarOverlayTheme(isDark: boolean): void;
+  setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
+  setTitleBarOverlayTheme(sender: Electron.WebContents, isDark: unknown): void;
   showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
   showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue>;
   capturePage(): Promise<Electron.NativeImage | null>;
@@ -73,9 +67,10 @@ const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 // window `backgroundColor`) and on runtime theme changes via
 // `setTitleBarOverlayTheme`.
 const TITLEBAR_OVERLAY_HEIGHT = 36;
-const titleBarOverlayColors = (isDark: boolean): { color: string; symbolColor: string } => ({
+const titleBarOverlayOptions = (isDark: boolean): { color: string; symbolColor: string; height: number } => ({
   color: isDark ? '#1c1d21' : '#f3f3f5',
   symbolColor: isDark ? '#e6e6e8' : '#1c1d21',
+  height: TITLEBAR_OVERLAY_HEIGHT,
 });
 
 export function createMainWindowController(deps: MainWindowControllerDeps): MainWindowController {
@@ -165,10 +160,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         : process.platform === 'win32'
           ? {
               titleBarStyle: 'hidden' as const,
-              titleBarOverlay: {
-                ...titleBarOverlayColors(isDark),
-                height: TITLEBAR_OVERLAY_HEIGHT,
-              },
+              titleBarOverlay: titleBarOverlayOptions(isDark),
             }
           : {}),
       // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5 (WAWQAQ msg `5b85fdb1`,
@@ -323,19 +315,17 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         shouldShow ? MAIN_WINDOW_TRAFFIC_LIGHT_POSITION : HIDDEN_TRAFFIC_LIGHT_POSITION,
       );
     },
-	    setThemeSource(sender, themePref) {
-	      const target = BrowserWindow.fromWebContents(sender);
-	      if (!target || target !== mainWindow) return;
-	      if (!isThemePreference(themePref)) return;
-	      nativeTheme.themeSource = toNativeThemeSource(themePref);
-	    },
-	    setTitleBarOverlayTheme(isDark) {
-	      // PR-WINDOW-TITLEBAR-0: keep the Windows titleBarOverlay color in sync
-	      // with the app theme when the user switches light/dark at runtime.
-	      // `setTitleBarOverlay` is a no-op on platforms without an overlay, so
-	      // the platform guard is mainly defensive.
-	      if (!mainWindow || mainWindow.isDestroyed() || process.platform !== 'win32') return;
-	      mainWindow.setTitleBarOverlay(titleBarOverlayColors(isDark));
+    setThemeSource(sender, themePref) {
+      const target = BrowserWindow.fromWebContents(sender);
+      if (!target || target !== mainWindow) return;
+      if (!isThemePreference(themePref)) return;
+      nativeTheme.themeSource = toNativeThemeSource(themePref);
+    },
+    setTitleBarOverlayTheme(sender, isDark) {
+      const target = BrowserWindow.fromWebContents(sender);
+      if (!target || target !== mainWindow || process.platform !== 'win32') return;
+      if (typeof isDark !== 'boolean') return;
+      mainWindow.setTitleBarOverlay(titleBarOverlayOptions(isDark));
     },
     showOpenDialog(options) {
       return mainWindow

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -18,7 +18,14 @@ export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
-  setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
+	  setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
+	  /**
+	   * Re-sync the native titleBarOverlay color/symbolColor to the current
+	   * app theme. Called from the renderer whenever the resolved light/dark
+	   * mode changes so the Windows control strip doesn't drift from the app
+	   * theme at runtime. No-op on non-Windows platforms (no overlay there).
+	   */
+	  setTitleBarOverlayTheme(isDark: boolean): void;
   showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue>;
   showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue>;
   capturePage(): Promise<Electron.NativeImage | null>;
@@ -58,6 +65,18 @@ export function safeSendToRenderer(channel: string, ...args: unknown[]): void {
 
 const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 14, y: 14 } as const;
 const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
+
+// PR-WINDOW-TITLEBAR-0: the Windows titleBarOverlay height matches the
+// renderer `--h-titlebar: 36px` token so the native control strip and the
+// in-app top chrome share a baseline. The overlay color/symbolColor are
+// reused both at window creation (to avoid a first-frame flash against the
+// window `backgroundColor`) and on runtime theme changes via
+// `setTitleBarOverlayTheme`.
+const TITLEBAR_OVERLAY_HEIGHT = 36;
+const titleBarOverlayColors = (isDark: boolean): { color: string; symbolColor: string } => ({
+  color: isDark ? '#1c1d21' : '#f3f3f5',
+  symbolColor: isDark ? '#e6e6e8' : '#1c1d21',
+});
 
 export function createMainWindowController(deps: MainWindowControllerDeps): MainWindowController {
   const { workspaceRoot, visualSmokeFixture, settingsStore } = deps;
@@ -129,8 +148,29 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // installer build pass. The asset path resolves from the built
       // dist/main/main.js (two levels up to apps/desktop, then assets).
       icon: join(import.meta.dirname, '..', '..', 'assets', 'icon.png'),
-      titleBarStyle: 'hiddenInset',
-      trafficLightPosition: MAIN_WINDOW_TRAFFIC_LIGHT_POSITION,
+      // PR-WINDOW-TITLEBAR-0: hide the native title bar so the renderer
+      // chrome can extend to the top edge on every platform. macOS keeps
+      // `hiddenInset` + traffic-light buttons (top-left); Windows uses
+      // `hidden` + `titleBarOverlay` so the OS draws native min/max/close
+      // buttons flush against the top-right corner. The overlay color is
+      // seeded from the initial window background to avoid a first-frame
+      // flash; `setTitleBarOverlayTheme` re-syncs it when the theme
+      // changes at runtime. Linux falls back to the default frame (no
+      // overlay support is wired up yet).
+      ...(process.platform === 'darwin'
+        ? {
+            titleBarStyle: 'hiddenInset' as const,
+            trafficLightPosition: MAIN_WINDOW_TRAFFIC_LIGHT_POSITION,
+          }
+        : process.platform === 'win32'
+          ? {
+              titleBarStyle: 'hidden' as const,
+              titleBarOverlay: {
+                ...titleBarOverlayColors(isDark),
+                height: TITLEBAR_OVERLAY_HEIGHT,
+              },
+            }
+          : {}),
       // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v5 (WAWQAQ msg `5b85fdb1`,
       // xuan `eea556cd`): explicit `resizable: true` so a future
       // patch can't silently disable window edge resize. Default is
@@ -283,11 +323,19 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         shouldShow ? MAIN_WINDOW_TRAFFIC_LIGHT_POSITION : HIDDEN_TRAFFIC_LIGHT_POSITION,
       );
     },
-    setThemeSource(sender, themePref) {
-      const target = BrowserWindow.fromWebContents(sender);
-      if (!target || target !== mainWindow) return;
-      if (!isThemePreference(themePref)) return;
-      nativeTheme.themeSource = toNativeThemeSource(themePref);
+	    setThemeSource(sender, themePref) {
+	      const target = BrowserWindow.fromWebContents(sender);
+	      if (!target || target !== mainWindow) return;
+	      if (!isThemePreference(themePref)) return;
+	      nativeTheme.themeSource = toNativeThemeSource(themePref);
+	    },
+	    setTitleBarOverlayTheme(isDark) {
+	      // PR-WINDOW-TITLEBAR-0: keep the Windows titleBarOverlay color in sync
+	      // with the app theme when the user switches light/dark at runtime.
+	      // `setTitleBarOverlay` is a no-op on platforms without an overlay, so
+	      // the platform guard is mainly defensive.
+	      if (!mainWindow || mainWindow.isDestroyed() || process.platform !== 'win32') return;
+	      mainWindow.setTitleBarOverlay(titleBarOverlayColors(isDark));
     },
     showOpenDialog(options) {
       return mainWindow

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -798,14 +798,14 @@ function registerIpc(): void {
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
   });
-	  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
-	    mainWindowController.setThemeSource(event.sender, themePref);
-	  });
-	  // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
-	  // renderer resolves a new light/dark theme (user toggle or `auto` following
-	  // the system). No-op outside Windows.
-	  ipcMain.handle('window:setTitleBarOverlayTheme', (_event, isDark: unknown): void => {
-	    if (typeof isDark === 'boolean') mainWindowController.setTitleBarOverlayTheme(isDark);
+  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
+    mainWindowController.setThemeSource(event.sender, themePref);
+  });
+  // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
+  // renderer resolves a new light/dark theme (user toggle or `auto` following
+  // the system). No-op outside Windows.
+  ipcMain.handle('window:setTitleBarOverlayTheme', (event, isDark: unknown): void => {
+    mainWindowController.setTitleBarOverlayTheme(event.sender, isDark);
   });
   ipcMain.handle('app:info', async () => {
     const projectPath = await currentProjectRoot();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -798,8 +798,14 @@ function registerIpc(): void {
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
   });
-  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
-    mainWindowController.setThemeSource(event.sender, themePref);
+	  ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
+	    mainWindowController.setThemeSource(event.sender, themePref);
+	  });
+	  // PR-WINDOW-TITLEBAR-0: re-sync the native titleBarOverlay color when the
+	  // renderer resolves a new light/dark theme (user toggle or `auto` following
+	  // the system). No-op outside Windows.
+	  ipcMain.handle('window:setTitleBarOverlayTheme', (_event, isDark: unknown): void => {
+	    if (typeof isDark === 'boolean') mainWindowController.setTitleBarOverlayTheme(isDark);
   });
   ipcMain.handle('app:info', async () => {
     const projectPath = await currentProjectRoot();

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -719,13 +719,13 @@ contextBridge.exposeInMainWorld('maka', {
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },
-	    setThemeSource(themePref: ThemePreference): Promise<void> {
-	      return ipcRenderer.invoke('window:setThemeSource', themePref);
-	    },
-	    // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
-	    // color/symbolColor to the current app theme. No-op on non-Windows.
-	    setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
-	      return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
+    setThemeSource(themePref: ThemePreference): Promise<void> {
+      return ipcRenderer.invoke('window:setThemeSource', themePref);
+    },
+    // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
+    // color/symbolColor to the current app theme. No-op on non-Windows.
+    setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
+      return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
     },
   },
   app: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -719,8 +719,13 @@ contextBridge.exposeInMainWorld('maka', {
     setTitlebarControlsVisible(visible: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitlebarControlsVisible', visible);
     },
-    setThemeSource(themePref: ThemePreference): Promise<void> {
-      return ipcRenderer.invoke('window:setThemeSource', themePref);
+	    setThemeSource(themePref: ThemePreference): Promise<void> {
+	      return ipcRenderer.invoke('window:setThemeSource', themePref);
+	    },
+	    // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
+	    // color/symbolColor to the current app theme. No-op on non-Windows.
+	    setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
+	      return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
     },
   },
   app: {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -379,6 +379,20 @@
      left the in-header pills overlapping. */
   --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 126px);
 
+  /* PR-WINDOW-TITLEBAR-0: Electron exposes the titlebar safe area through
+     `titlebar-area-*` CSS env vars. The safe area is the usable titlebar
+     rectangle next to the native controls, so the right-side control overlay is
+     the viewport width minus the safe-area x/width pair. `env()` fallbacks keep
+     the overlay inset at 0px on platforms/windows without titleBarOverlay. */
+  --maka-titlebar-area-x: env(titlebar-area-x, 0px);
+  --maka-titlebar-area-width: env(titlebar-area-width, 100vw);
+  --maka-titlebar-area-height: env(titlebar-area-height, var(--h-titlebar));
+  --maka-titlebar-overlay-right-width: max(
+    0px,
+    calc(100vw - var(--maka-titlebar-area-x) - var(--maka-titlebar-area-width))
+  );
+  --maka-workspace-top-actions-right: calc(24px + var(--maka-titlebar-overlay-right-width));
+
   /* session list geometry */
   --w-sessionlist: 240px;
   --h-list-header: 52px;

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -67,6 +67,12 @@ function setDarkClass(isDark: boolean): void {
   // Lets native form controls and scrollbars pick up the right base colors per
   // the Vercel Web Interface Guidelines dark-mode rule.
   root.style.colorScheme = isDark ? 'dark' : 'light';
+  // PR-WINDOW-TITLEBAR-0: keep the native Windows titleBarOverlay color in
+  // sync with the resolved theme. The IPC handler is a no-op on non-Windows,
+  // and `window.maka` is only defined in the Electron renderer, so guard for
+  // both. Swallowed errors (window torn down mid-toggle, etc.) never block
+  // the in-app `.dark` toggle above.
+  void window.maka?.appWindow?.setTitleBarOverlayTheme?.(isDark).catch(() => {});
 }
 
 /**


### PR DESCRIPTION
## Summary

On Windows, the app currently shows the full native title bar because `titleBarStyle: 'hiddenInset'` is a macOS-only option that is a no-op on Windows. This PR hides the native title bar on Windows and lets the OS draw the minimize / maximize / close buttons as a native `titleBarOverlay` flush against the top-right corner of the window, so the renderer chrome can extend to the top edge while keeping standard window controls.

## Changes

- **`apps/desktop/src/main/main-window.ts`** — Branch the BrowserWindow titlebar config by platform:
  - macOS: keeps `hiddenInset` + `trafficLightPosition` (unchanged).
  - Windows: uses `hidden` + `titleBarOverlay`. The overlay `color` is set to the initial window `backgroundColor` (computed from the persisted theme + system preference) to avoid a first-frame color flash; `symbolColor` is the contrasting foreground; `height: 36` aligns with the existing `--h-titlebar: 36px` token.
  - Linux: falls back to the default frame (no overlay wired up yet).

- **`apps/desktop/src/preload/preload.ts`** — Synchronously write `process.platform` to `document.documentElement.dataset.platform` so CSS can gate on `[data-platform="win32"]` before React mounts. `process.platform` is available in sandboxed preloads.

- **`apps/desktop/src/renderer/maka-tokens.css`** — Add `--maka-titlebar-overlay-width` (default `0` on macOS/Linux, `138px` on Windows = three 46px controls). On `[data-platform="win32"]` shift `--maka-workspace-top-actions-right` past the overlay strip so the top-right workspace toolbar and the chat-header drag strip clear the native controls. The derived `--maka-workspace-top-actions-inset` follows automatically, so `.maka-chat-header`\'s `margin-right` reservation needs no separate change.

## Platform scope

- Windows: behavior changes as described.
- macOS: completely unchanged.
- Linux: unchanged (default frame).

## Verification

- `tsc -p tsconfig.main.json --noEmit` — pass
- `tsc -p tsconfig.renderer.json --noEmit` — pass
- Contract tests (`renderer-css-parse-contract`, `renderer-tailwind-compile-contract`, `chat-header-actions-inset-contract`, `app-region-hygiene-contract`, `sidebar-topbar-rail-contract`): 20/20 pass
- Full desktop contract suite: 22 failures before and after this change (`diff` empty) — no regressions introduced; all pre-existing failures are unrelated.

## Notes / follow-ups

- The overlay color is set from the initial theme at window creation. If the user toggles light/dark at runtime, the overlay color will not update until a restart. A follow-up could listen for the theme-change IPC and call `BrowserWindow.setTitleBarOverlay()` dynamically.