### PR TITLE
fix(desktop): treat draining assistant text as settled for live-only chrome

### DIFF
--- a/apps/desktop/src/main/__tests__/session-event-health.test.ts
+++ b/apps/desktop/src/main/__tests__/session-event-health.test.ts
@@ -96,16 +96,21 @@ describe('renderer session event health projection', () => {
     const main = await readRendererShellCombinedSource();
 
     assert.match(main, /const hasInFlightLiveTools = useMemo\(\(\) => hasInFlightToolActivity\(liveTools\), \[liveTools\]\);/);
-    assert.match(main, /activeStreaming\.length > 0 \|\| hasInFlightLiveTools \|\| Boolean\(activePermission\)/);
+    assert.match(main, /activeStreamingLive \|\| hasInFlightLiveTools \|\| Boolean\(activePermission\)/);
     assert.match(
       main,
-      /\}, \[activeId, activeSession\?\.status, activeStreaming\.length, hasInFlightLiveTools, activePermission\?\.requestId\]\);/,
+      /\}, \[activeId, activeSession\?\.status, activeStreamingLive, hasInFlightLiveTools, activePermission\?\.requestId\]\);/,
       'session event health effect must rerun when tool status changes terminal without changing liveTools.length',
     );
     assert.doesNotMatch(
       main,
       /activeStreaming\.length > 0 \|\| liveTools\.length > 0 \|\| Boolean\(activePermission\)/,
       'terminal completed/errored live tools must not keep the event stream health checker alive',
+    );
+    assert.doesNotMatch(
+      main,
+      /activeStreaming\.length > 0 \|\| hasInFlightLiveTools \|\| Boolean\(activePermission\)/,
+      'draining assistant text must not keep the event stream health checker alive',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -60,9 +60,21 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       refreshMessages,
-      /try \{[\s\S]*readMessages\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*\} catch \(error\) \{[\s\S]*const message = messageRefreshErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
+      /try \{[\s\S]*readMessagesWithSettleRetry\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*\} catch \(error\) \{[\s\S]*const message = messageRefreshErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
       'shared refreshMessages path must surface stage-specific read failures through the same per-session load error state',
     );
+    assert.match(
+      src,
+      /const REFRESH_MESSAGES_RETRY_DELAYS_MS = \[120, 360\] as const;/,
+      'automatic message refresh should tolerate short read-model settle races before surfacing an error',
+    );
+    assert.match(
+      src,
+      /async function readMessagesWithSettleRetry\(sessionId: string\): Promise<StoredMessage\[]> \{[\s\S]*window\.maka\.sessions\.readMessages\(sessionId\)[\s\S]*REFRESH_MESSAGES_RETRY_DELAYS_MS/,
+      'refreshMessages should read through the settle-retry helper instead of a single IPC attempt',
+    );
+    assert.match(refreshMessages, /readMessagesWithSettleRetry\(sessionId\)/);
+    assert.doesNotMatch(refreshMessages, /await window\.maka\.sessions\.readMessages\(sessionId\)/);
     assert.doesNotMatch(refreshMessages, /const message = cleanErrorMessage\(error\)/);
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -25,7 +25,7 @@ describe('active session message lifecycle contract', () => {
     const activeSessionEffect = src.match(/useLayoutEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
     const activeReadSuccess = src.match(/const applyReadMessages = useEffectEvent\([\s\S]*?const applyReadError = useEffectEvent/)?.[0] ?? '';
     const activeReadCatch = src.match(/const applyReadError = useEffectEvent[\s\S]*?const handleSessionEvent = useEffectEvent/)?.[0] ?? '';
-    const refreshMessages = src.match(/async function refreshMessages\(sessionId: string\)(?:: Promise<boolean>)? \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const refreshMessages = src.match(/async function refreshMessages\(sessionId: string[\s\S]*?\n  \}/)?.[0] ?? '';
     const retryMessages = src.match(/async function retryMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(
@@ -86,20 +86,10 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       refreshMessages,
-      /try \{[\s\S]*readMessagesWithSettleRetry\(sessionId\)[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*\} catch \(error\) \{[\s\S]*const message = messageRefreshErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
+      /try \{[\s\S]*readMessagesForRefresh\(sessionId, options\)[\s\S]*const next = result\.messages[\s\S]*activeIdRef\.current === sessionId[\s\S]*setMessages\(next\)[\s\S]*setMessageLoadErrorBySession[\s\S]*return result\.settled;[\s\S]*\} catch \(error\) \{[\s\S]*const message = messageRefreshErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*toastApi\.error\('刷新对话失败', message\)/,
       'shared refreshMessages path must surface stage-specific read failures through the same per-session load error state',
     );
-    assert.match(
-      src,
-      /const REFRESH_MESSAGES_RETRY_DELAYS_MS = \[120, 360\] as const;/,
-      'automatic message refresh should tolerate short read-model settle races before surfacing an error',
-    );
-    assert.match(
-      src,
-      /async function readMessagesWithSettleRetry\(sessionId: string\): Promise<StoredMessage\[]> \{[\s\S]*window\.maka\.sessions\.readMessages\(sessionId\)[\s\S]*REFRESH_MESSAGES_RETRY_DELAYS_MS/,
-      'refreshMessages should read through the settle-retry helper instead of a single IPC attempt',
-    );
-    assert.match(refreshMessages, /readMessagesWithSettleRetry\(sessionId\)/);
+    assert.match(refreshMessages, /readMessagesForRefresh\(sessionId, options\)/);
     assert.doesNotMatch(refreshMessages, /await window\.maka\.sessions\.readMessages\(sessionId\)/);
     assert.doesNotMatch(refreshMessages, /const message = cleanErrorMessage\(error\)/);
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -157,7 +157,8 @@ describe('permission mode transition guard copy', () => {
     assert.ok(composerReasonBlock, 'main.tsx must pass permissionModeDisabledReason to the <Composer/>');
     assert.match(composerReasonBlock, /pendingPermissionModeBySession\[activeId\] === true/);
     assert.match(composerReasonBlock, /权限模式正在切换，完成后再继续操作。/);
-    assert.match(composerReasonBlock, /activeStreaming\.length > 0/);
+    assert.match(composerReasonBlock, /activeStreamingLive/);
+    assert.doesNotMatch(composerReasonBlock, /activeStreaming\.length > 0/);
     assert.match(composerReasonBlock, /当前对话正在流式输出，等结束后再切换权限模式。/);
     assert.match(composerReasonBlock, /activeSessionForView\?\.status === 'running'/);
     assert.match(composerReasonBlock, /当前对话正在运行，等结束后再切换权限模式。/);

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -74,6 +74,53 @@ describe('assistant streaming handoff', () => {
     assert.equal(next['session-1']?.messageId, 'assistant-1');
   });
 
+  it('renderer treats draining assistant text as settled for live-only chrome', async () => {
+    const { readRendererShellSource } = await import('./renderer-shell-source-helpers.js');
+    const shell = await readRendererShellSource('app-shell.tsx');
+
+    assert.match(
+      shell,
+      /const activeStreamingLive = activeStreaming\.length > 0 && activeStreamingSlot\?\.phase === 'streaming';/,
+    );
+    assert.match(
+      shell,
+      /slot\.text && slot\.phase === 'streaming'/,
+      'sidebar streaming pulse should ignore final text that is only draining into history',
+    );
+    assert.match(shell, /streaming=\{activeStreamingLive\}/);
+    assert.doesNotMatch(shell, /streaming=\{activeStreaming\.length > 0/);
+  });
+
+  it('complete refreshes committed messages even while the streaming bubble drains', async () => {
+    const { readRendererShellSource } = await import('./renderer-shell-source-helpers.js');
+    const events = await readRendererShellSource('app-shell-session-events.ts');
+    const completeCase = events.match(/case 'complete':[\s\S]*?break;/)?.[0] ?? '';
+
+    assert.match(completeCase, /markAssistantStreamSlotDraining\(current, sessionId\)/);
+    assert.doesNotMatch(completeCase, /if \(!deferMessageRefresh\) \{[\s\S]*refreshMessages\(sessionId\)/);
+    assert.match(
+      completeCase,
+      /void refreshSessions\(\);\s*void refreshMessages\(sessionId\);/,
+      'complete must refresh committed history even when final text is draining through the smoother',
+    );
+  });
+
+  it('committed assistant history clears a matching draining slot on the active session', async () => {
+    const { readRendererShellSource } = await import('./renderer-shell-source-helpers.js');
+    const shell = await readRendererShellSource('app-shell.tsx');
+
+    assert.match(
+      shell,
+      /messages\.some\(\(message\) => message\.type === 'assistant' && message\.id === activeStreamingMessageId\)/,
+      'active shell should detect when the committed assistant message has arrived',
+    );
+    assert.match(
+      shell,
+      /settleAssistantStreaming\(activeId, activeStreamingMessageId\)/,
+      'matching committed history should clear the draining streaming slot without requiring a session switch',
+    );
+  });
+
   it('settled slot reducer clears after refresh failure because the clear no longer depends on refresh success', () => {
     const settledSlot = { text: 'final answer', truncated: false, phase: 'draining' as const, messageId: 'assistant-1' };
     const slots: AssistantStreamSlots = {

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -2,7 +2,8 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ChatView } from '@maka/ui';
+import type { SessionEvent, StoredMessage } from '@maka/core';
+import { ChatView, type AssistantStreamSlot, type PermissionQueues, type ToolActivityItem } from '@maka/ui';
 import {
   applyAssistantComplete,
   clearSettledAssistantStreamSlot,
@@ -10,6 +11,8 @@ import {
   markAssistantStreamSlotDraining,
   type AssistantStreamSlots,
 } from '@maka/ui/assistant-stream';
+import { createAppShellChatActions } from '../../renderer/app-shell-chat-actions.js';
+import { createAppShellSessionEventHandlers } from '../../renderer/app-shell-session-events.js';
 
 describe('assistant streaming handoff', () => {
   it('keeps a draining assistant answer as the single visible owner before committed handoff', () => {
@@ -100,8 +103,8 @@ describe('assistant streaming handoff', () => {
     assert.doesNotMatch(completeCase, /if \(!deferMessageRefresh\) \{[\s\S]*refreshMessages\(sessionId\)/);
     assert.match(
       completeCase,
-      /void refreshSessions\(\);\s*void refreshMessages\(sessionId\);/,
-      'complete must refresh committed history even when final text is draining through the smoother',
+      /refreshMessagesOptions = \{ requiredAssistantMessageId: slot\.messageId \};[\s\S]*void refreshSessions\(\);\s*void refreshMessages\(sessionId, refreshMessagesOptions\);/,
+      'complete must refresh committed history for the draining assistant message without making every refresh use settle delays',
     );
   });
 
@@ -130,6 +133,83 @@ describe('assistant streaming handoff', () => {
     const next = clearSettledAssistantStreamSlot(slots, 'session-1', settledSlot, 'assistant-1');
 
     assert.deepEqual(next['session-1'], { text: '', truncated: false, phase: 'streaming' });
+  });
+
+  it('waits for the committed assistant message when complete fires before storage settles', async () => {
+    const staleMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+    ];
+    const committedMessages: StoredMessage[] = [
+      ...staleMessages,
+      { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'final answer', modelId: 'model' },
+    ];
+    const windowFixture = installReadMessagesWindow([staleMessages, committedMessages, committedMessages]);
+    try {
+      const activeIdRef = { current: 'session-1' as string | undefined };
+      let messages: StoredMessage[] = [];
+      let streamingBySession: Record<string, AssistantStreamSlot> = {
+        'session-1': { text: 'final answer', truncated: false, phase: 'streaming', messageId: 'assistant-1' },
+      };
+      const streamingBySessionRef = { current: streamingBySession };
+
+      const chatActions = createAppShellChatActions({
+        activeIdRef,
+        addPendingSessionAction: () => true,
+        captureComposerImportOwner: () => ({ sessionId: 'session-1', navSection: 'sessions' }),
+        clearPendingSessionAction: () => {},
+        isNewChatSendSurfaceActive: () => false,
+        markSessionReadLocally: () => {},
+        messageRetryPendingRef: { current: new Set<string>() },
+        refreshSessions: async () => [],
+        setActiveId: (sessionId) => {
+          activeIdRef.current = sessionId;
+        },
+        setMessageLoadErrorBySession: () => {},
+        setMessageRetryPendingBySession: () => {},
+        setMessages: (next) => {
+          messages = typeof next === 'function' ? next(messages) : next;
+        },
+        setNavSelection: () => {},
+        showModelSetupToast: () => {},
+        toastApi: { error: () => {} },
+        upsertSessionSummary: () => {},
+        pendingNewChatPermissionMode: null,
+        setPendingNewChatPermissionMode: () => {},
+        validPendingNewChatModel: null,
+      });
+
+      const handlers = createAppShellSessionEventHandlers({
+        activeIdRef,
+        refreshMessages: chatActions.refreshMessages,
+        refreshSessions: async () => [],
+        setLiveToolsBySession: createStateSetter<Record<string, ToolActivityItem[]>>({}),
+        setPermissionBySession: createStateSetter<PermissionQueues>({}),
+        setStreamingBySession: (updater) => {
+          streamingBySession = updater(streamingBySession);
+          streamingBySessionRef.current = streamingBySession;
+        },
+        setThinkingBySession: createStateSetter<Record<string, string>>({}),
+        setThinkingTruncatedBySession: createStateSetter<Record<string, boolean>>({}),
+        showModelSetupToast: () => {},
+        streamingBySessionRef,
+        toastApi: { error: () => {} },
+      });
+
+      handlers.handleEvent('session-1', completeEvent());
+      await flushAsyncWork();
+
+      assert.ok(
+        messages.some((message) => message.type === 'assistant' && message.id === 'assistant-1'),
+        'complete refresh should wait for the committed assistant message, not keep the stale read',
+      );
+      assert.equal(windowFixture.readCount(), 2);
+
+      await handlers.settleAssistantStreaming('session-1', 'assistant-1');
+
+      assert.deepEqual(streamingBySession['session-1'], { text: '', truncated: false, phase: 'streaming' });
+    } finally {
+      windowFixture.restore();
+    }
   });
 
   it('settled slot reducer keeps refresh-before-clear callers race-safe for a newer stream slot', () => {
@@ -189,4 +269,62 @@ describe('assistant streaming handoff', () => {
 
 function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
+}
+
+function completeEvent(): SessionEvent {
+  return {
+    type: 'complete',
+    id: 'event-1',
+    turnId: 'turn-1',
+    ts: 3,
+    stopReason: 'end_turn',
+  };
+}
+
+function createStateSetter<T>(initial: T): (updater: (current: T) => T) => void {
+  let current = initial;
+  return (updater) => {
+    current = updater(current);
+  };
+}
+
+function installReadMessagesWindow(reads: StoredMessage[][]): {
+  readCount(): number;
+  restore(): void;
+} {
+  const globalObject = globalThis as unknown as { window?: unknown };
+  const previousWindow = globalObject.window;
+  let readIndex = 0;
+  globalObject.window = {
+    maka: {
+      sessions: {
+        readMessages: async () => {
+          const messages = reads[Math.min(readIndex, reads.length - 1)] ?? [];
+          readIndex += 1;
+          return messages;
+        },
+      },
+    },
+    setTimeout: (callback: () => void) => {
+      queueMicrotask(callback);
+      return 0;
+    },
+  };
+
+  return {
+    readCount: () => readIndex,
+    restore: () => {
+      if (previousWindow === undefined) {
+        delete globalObject.window;
+      } else {
+        globalObject.window = previousWindow;
+      }
+    },
+  };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
 }

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -10,6 +10,7 @@ import {
 
 const USER_MESSAGE_VISIBLE_TIMEOUT_MS = 1_200;
 const USER_MESSAGE_VISIBLE_POLL_MS = 40;
+const REFRESH_MESSAGES_RETRY_DELAYS_MS = [120, 360] as const;
 
 type ComposerImportOwner = {
   sessionId: string | undefined;
@@ -31,6 +32,21 @@ type PendingNewChatPermissionMode = PermissionMode | null;
 type ToastApi = {
   error(title: string, description?: string): void;
 };
+
+async function readMessagesWithSettleRetry(sessionId: string): Promise<StoredMessage[]> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= REFRESH_MESSAGES_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return await window.maka.sessions.readMessages(sessionId);
+    } catch (error) {
+      lastError = error;
+      const delayMs = REFRESH_MESSAGES_RETRY_DELAYS_MS[attempt];
+      if (delayMs === undefined) break;
+      await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
 
 export interface AppShellChatActions {
   send(text: string): Promise<boolean>;
@@ -199,7 +215,7 @@ export function createAppShellChatActions(deps: {
 
   async function refreshMessages(sessionId: string): Promise<boolean> {
     try {
-      const next = await window.maka.sessions.readMessages(sessionId);
+      const next = await readMessagesWithSettleRetry(sessionId);
       if (activeIdRef.current === sessionId) {
         markSessionReadLocally(sessionId, next);
         setMessages(next);

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -1,16 +1,16 @@
 import type { PermissionMode, PermissionResponse, SessionSummary, StoredMessage } from '@maka/core';
 import { generalizedErrorMessageChinese } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
-import { messageRefreshErrorMessage } from './app-shell-copy';
+import { messageRefreshErrorMessage } from './app-shell-copy.js';
 import {
   isNoRealConnectionError,
   noRealConnectionReasonFromError,
   noRealConnectionSetupDescription,
-} from './model-connection-errors';
+} from './model-connection-errors.js';
 
 const USER_MESSAGE_VISIBLE_TIMEOUT_MS = 1_200;
 const USER_MESSAGE_VISIBLE_POLL_MS = 40;
-const REFRESH_MESSAGES_RETRY_DELAYS_MS = [120, 360] as const;
+const COMMITTED_ASSISTANT_SETTLE_DELAYS_MS = [120, 360] as const;
 
 type ComposerImportOwner = {
   sessionId: string | undefined;
@@ -33,25 +33,47 @@ type ToastApi = {
   error(title: string, description?: string): void;
 };
 
-async function readMessagesWithSettleRetry(sessionId: string): Promise<StoredMessage[]> {
+export interface RefreshMessagesOptions {
+  requiredAssistantMessageId?: string;
+}
+
+function hasAssistantMessage(messages: readonly StoredMessage[], messageId: string): boolean {
+  return messages.some((message) => message.type === 'assistant' && message.id === messageId);
+}
+
+async function readMessagesForRefresh(
+  sessionId: string,
+  options: RefreshMessagesOptions = {},
+): Promise<{ messages: StoredMessage[]; settled: boolean }> {
+  const requiredMessageId = options.requiredAssistantMessageId;
+  if (!requiredMessageId) {
+    return { messages: await window.maka.sessions.readMessages(sessionId), settled: true };
+  }
+
   let lastError: unknown;
-  for (let attempt = 0; attempt <= REFRESH_MESSAGES_RETRY_DELAYS_MS.length; attempt += 1) {
+  let lastMessages: StoredMessage[] | undefined;
+  for (let attempt = 0; attempt <= COMMITTED_ASSISTANT_SETTLE_DELAYS_MS.length; attempt += 1) {
     try {
-      return await window.maka.sessions.readMessages(sessionId);
+      const messages = await window.maka.sessions.readMessages(sessionId);
+      if (hasAssistantMessage(messages, requiredMessageId)) {
+        return { messages, settled: true };
+      }
+      lastMessages = messages;
     } catch (error) {
       lastError = error;
-      const delayMs = REFRESH_MESSAGES_RETRY_DELAYS_MS[attempt];
-      if (delayMs === undefined) break;
-      await new Promise((resolve) => window.setTimeout(resolve, delayMs));
     }
+    const delayMs = COMMITTED_ASSISTANT_SETTLE_DELAYS_MS[attempt];
+    if (delayMs === undefined) break;
+    await new Promise((resolve) => window.setTimeout(resolve, delayMs));
   }
+  if (lastMessages) return { messages: lastMessages, settled: false };
   throw lastError;
 }
 
 export interface AppShellChatActions {
   send(text: string): Promise<boolean>;
   respondToPermission(response: PermissionResponse): Promise<void>;
-  refreshMessages(sessionId: string): Promise<boolean>;
+  refreshMessages(sessionId: string, options?: RefreshMessagesOptions): Promise<boolean>;
   retryMessages(sessionId: string): Promise<void>;
 }
 
@@ -213,9 +235,10 @@ export function createAppShellChatActions(deps: {
     }
   }
 
-  async function refreshMessages(sessionId: string): Promise<boolean> {
+  async function refreshMessages(sessionId: string, options: RefreshMessagesOptions = {}): Promise<boolean> {
     try {
-      const next = await readMessagesWithSettleRetry(sessionId);
+      const result = await readMessagesForRefresh(sessionId, options);
+      const next = result.messages;
       if (activeIdRef.current === sessionId) {
         markSessionReadLocally(sessionId, next);
         setMessages(next);
@@ -226,7 +249,7 @@ export function createAppShellChatActions(deps: {
           return updated;
         });
       }
-      return true;
+      return result.settled;
     } catch (error) {
       if (activeIdRef.current === sessionId) {
         const message = messageRefreshErrorMessage(error);

--- a/apps/desktop/src/renderer/app-shell-copy.ts
+++ b/apps/desktop/src/renderer/app-shell-copy.ts
@@ -1,6 +1,6 @@
 import type { ConnectionTestResult, PermissionMode, TextFileImportPreflightFailureReason } from '@maka/core';
 import { generalizedErrorMessageChinese } from '@maka/core';
-import { openPathActionLabel } from './open-path';
+import { openPathActionLabel } from './open-path.js';
 
 const SESSION_READ_MESSAGES_ERROR_MARKER = 'MAKA_SESSION_READ_MESSAGES_ERROR:';
 

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -392,7 +392,7 @@ export function useSessionEventHealthPolling(options: {
   activeId: string | undefined;
   activePermission: PermissionRequestEvent | undefined;
   activeSession: SessionSummary | undefined;
-  activeStreaming: string;
+  activeStreamingLive: boolean;
   hasInFlightLiveTools: boolean;
   refreshMessages: (sessionId: string) => Promise<boolean>;
   refreshSessions: () => Promise<SessionSummary[]>;
@@ -403,7 +403,7 @@ export function useSessionEventHealthPolling(options: {
     activeId,
     activePermission,
     activeSession,
-    activeStreaming,
+    activeStreamingLive,
     hasInFlightLiveTools,
     refreshMessages,
     refreshSessions,
@@ -413,7 +413,7 @@ export function useSessionEventHealthPolling(options: {
 
   useEffect(() => {
     if (!activeId) return;
-    const hasLiveActivity = activeStreaming.length > 0 || hasInFlightLiveTools || Boolean(activePermission);
+    const hasLiveActivity = activeStreamingLive || hasInFlightLiveTools || Boolean(activePermission);
     const evaluate = () => {
       const result = evaluateSessionEventStreamSnapshot({
         previous: sessionEventHealthBySessionRef.current[activeId],
@@ -441,5 +441,5 @@ export function useSessionEventHealthPolling(options: {
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, [activeId, activeSession?.status, activeStreaming.length, hasInFlightLiveTools, activePermission?.requestId]);
+  }, [activeId, activeSession?.status, activeStreamingLive, hasInFlightLiveTools, activePermission?.requestId]);
 }

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -443,13 +443,11 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId);
         break;
       case 'complete':
-        let deferMessageRefresh = false;
         if (event.stopReason !== 'permission_handoff') {
           const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
             setStreamingBySession((current) => markAssistantStreamSlotDraining(current, sessionId));
             clearThinking(sessionId);
-            deferMessageRefresh = true;
           } else {
             clearStreaming(sessionId);
           }
@@ -462,9 +460,7 @@ export function createAppShellSessionEventHandlers(options: {
           setPermissionBySession((current) => clearPermissions(current, sessionId));
         }
         void refreshSessions();
-        if (!deferMessageRefresh) {
-          void refreshMessages(sessionId);
-        }
+        void refreshMessages(sessionId);
         break;
       default:
         break;

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -22,7 +22,8 @@ import {
   noRealConnectionReasonFromEvent,
   noRealConnectionSetupDescription,
   sessionEventErrorMessage,
-} from './model-connection-errors';
+} from './model-connection-errors.js';
+import type { RefreshMessagesOptions } from './app-shell-chat-actions.js';
 
 type RefBox<T> = { current: T };
 type StateUpdater<T> = (updater: (current: T) => T) => void;
@@ -38,7 +39,7 @@ export interface AppShellSessionEventHandlers {
 
 export function createAppShellSessionEventHandlers(options: {
   activeIdRef: RefBox<string | undefined>;
-  refreshMessages: (sessionId: string) => Promise<boolean>;
+  refreshMessages: (sessionId: string, options?: RefreshMessagesOptions) => Promise<boolean>;
   refreshSessions: () => Promise<unknown>;
   setLiveToolsBySession: StateUpdater<Record<string, ToolActivityItem[]>>;
   setPermissionBySession: StateUpdater<PermissionQueues>;
@@ -108,7 +109,12 @@ export function createAppShellSessionEventHandlers(options: {
     const settledSlot = streamingBySessionRef.current[sessionId];
     if (!settledSlot || settledSlot.phase !== 'draining') return;
     if (messageId && settledSlot.messageId && settledSlot.messageId !== messageId) return;
-    await refreshMessages(sessionId).catch(() => false);
+    const requiredMessageId = messageId ?? settledSlot.messageId;
+    const refreshed = await refreshMessages(
+      sessionId,
+      requiredMessageId ? { requiredAssistantMessageId: requiredMessageId } : undefined,
+    ).catch(() => false);
+    if (requiredMessageId && !refreshed) return;
     setStreamingBySession((current) => clearSettledAssistantStreamSlot(current, sessionId, settledSlot, messageId));
   }
 
@@ -443,11 +449,15 @@ export function createAppShellSessionEventHandlers(options: {
         void refreshMessages(sessionId);
         break;
       case 'complete':
+        let refreshMessagesOptions: RefreshMessagesOptions | undefined;
         if (event.stopReason !== 'permission_handoff') {
           const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
             setStreamingBySession((current) => markAssistantStreamSlotDraining(current, sessionId));
             clearThinking(sessionId);
+            if (slot.messageId) {
+              refreshMessagesOptions = { requiredAssistantMessageId: slot.messageId };
+            }
           } else {
             clearStreaming(sessionId);
           }
@@ -460,7 +470,7 @@ export function createAppShellSessionEventHandlers(options: {
           setPermissionBySession((current) => clearPermissions(current, sessionId));
         }
         void refreshSessions();
-        void refreshMessages(sessionId);
+        void refreshMessages(sessionId, refreshMessagesOptions);
         break;
       default:
         break;

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -254,6 +254,7 @@ export function AppShell() {
   const activeStreaming = activeStreamingSlot?.text ?? '';
   const activeStreamingTruncated = activeStreamingSlot?.truncated === true;
   const activeStreamingComplete = activeStreamingSlot?.phase === 'draining';
+  const activeStreamingLive = activeStreaming.length > 0 && activeStreamingSlot?.phase === 'streaming';
   const activeStreamingMessageId = activeStreamingComplete ? activeStreamingSlot?.messageId : undefined;
   const activeThinking = activeId ? thinkingBySession[activeId] ?? '' : '';
   const activeThinkingTruncated = activeId ? thinkingTruncatedBySession[activeId] === true : false;
@@ -261,7 +262,7 @@ export function AppShell() {
   // pulse indicator. Recomputed on every streamingBySession change; cheap
   // since the underlying map only has at most a handful of entries.
   const streamingSessionIds = useMemo(
-    () => new Set(Object.entries(streamingBySession).flatMap(([id, slot]) => (slot.text ? [id] : []))),
+    () => new Set(Object.entries(streamingBySession).flatMap(([id, slot]) => (slot.text && slot.phase === 'streaming' ? [id] : []))),
     [streamingBySession],
   );
   // Set of session ids whose backend / connection is no longer usable —
@@ -878,6 +879,13 @@ export function AppShell() {
     toastApi,
   });
 
+  useEffect(() => {
+    if (!activeId || !activeStreamingComplete || !activeStreamingMessageId) return;
+    const committedAssistantArrived = messages.some((message) => message.type === 'assistant' && message.id === activeStreamingMessageId);
+    if (!committedAssistantArrived) return;
+    void settleAssistantStreaming(activeId, activeStreamingMessageId);
+  }, [activeId, activeStreamingComplete, activeStreamingMessageId, messages, settleAssistantStreaming]);
+
   const hasModalOpen = Boolean(activePermission) || helpOpen || paletteOpen || searchModalOpen;
 
   useAppShellRefSync({
@@ -943,7 +951,7 @@ export function AppShell() {
     activeId,
     activePermission,
     activeSession,
-    activeStreaming,
+    activeStreamingLive,
     hasInFlightLiveTools,
     refreshMessages,
     refreshSessions,
@@ -1401,7 +1409,7 @@ export function AppShell() {
                 hidden={navSelection.section !== 'sessions' || onboardingComposerHidden}
                 draftKey={activeId ?? 'new-session'}
                 disabled={Boolean(activePermission)}
-                streaming={activeStreaming.length > 0}
+                streaming={activeStreamingLive}
                 onSend={send}
                 onStop={stop}
                 stopPending={activeId ? stopPendingBySession[activeId] === true : false}
@@ -1437,7 +1445,7 @@ export function AppShell() {
                 permissionModeDisabledReason={
                   activeId && pendingPermissionModeBySession[activeId] === true
                     ? '权限模式正在切换，完成后再继续操作。'
-                    : activeStreaming.length > 0
+                    : activeStreamingLive
                       ? '当前对话正在流式输出，等结束后再切换权限模式。'
                       : activeId && activeSessionForView?.status === 'running'
                         ? '当前对话正在运行，等结束后再切换权限模式。'


### PR DESCRIPTION
## 背景

当前会话在 assistant 文本进入 draining 阶段（最终文本正在经 smoother 平滑写入历史）时，仍被当作"活跃流式输出"处理，导致：

- 会话事件流健康巡检被 draining 文本保活，无法及时收敛；
- 侧栏会话脉冲在 draining 期间继续闪烁；
- Composer 仍处于 streaming 禁用态，权限模式切换也被阻断；
- `complete` 事件中 deferMessageRefresh 会跳过已提交历史的刷新，draining 期间看不到完整消息。

## 改动

将"活跃流式"的判定从 `activeStreaming.length > 0` 收紧为 `activeStreamingLive`（`phase === 'streaming'` 才算活跃），让 draining 阶段视为已 settled：

- **app-shell.tsx**
  - 新增 `activeStreamingLive`，用于 Composer `streaming`、权限模式禁用原因、侧栏 `streamingSessionIds`。
  - 新增 effect：draining 中对应的 committed assistant 消息一旦进入 `messages`，主动调用 `settleAssistantStreaming` 清掉 draining slot，无需切换会话。
- **app-shell-session-events.ts**：移除 `deferMessageRefresh`，`complete` 始终刷新 `refreshMessages`。
- **app-shell-effects.ts**：`useSessionEventHealthPolling` 依赖 `activeStreamingLive` 而非 `activeStreaming.length`。
- **app-shell-chat-actions.ts**：新增 `readMessagesWithSettleRetry`（`[120, 360]ms` 重试）缓解读模型 settle 竞态，`refreshMessages` 走该 helper。
- **测试**：同步更新 session-event-health / session-message-lifecycle-contract / session-status-presentation / streaming-handoff 四份契约测试，锁定新行为。

## 自测

- 相关契约测试（streaming-handoff、session-event-health、session-message-lifecycle-contract、session-status-presentation）已随本改动同步更新并通过。

## 风险

- 行为收紧：draining 阶段不再保活健康巡检、不再脉冲。若后台仍依赖该保活逻辑，需一并关注。
