### PR TITLE
refactor(ui-react): stabilize app shell effect callbacks

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -1,94 +1,371 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, it } from 'node:test';
+import type { ConnectionEvent, SessionEvent, StoredMessage } from '@maka/core';
+import { build } from 'esbuild';
+import { act, createElement, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type * as AppShellEffects from '../../renderer/app-shell-effects.js';
 import { readRendererShellSource } from './renderer-shell-source-helpers.js';
 
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+type RefBox<T> = { current: T };
+type RendererWindow = Window & typeof globalThis & { maka: RendererMakaStub };
+type AppShellEffectsModule = Pick<
+  typeof AppShellEffects,
+  'useActiveSessionEvents' | 'useAppShellBootstrapSubscriptions'
+>;
+type CapturedSubscriptions = {
+  activeSessionEvent?: (event: SessionEvent) => void;
+  activeSessionSubscribeCount: number;
+  connectionEvent?: (event: ConnectionEvent) => void;
+  connectionSubscribeCount: number;
+};
+type RendererMakaStub = {
+  appWindow: {
+    subscribeOpenSettings(callback: () => void): () => void;
+  };
+  connections: {
+    subscribeEvents(callback: (event: ConnectionEvent) => void): () => void;
+  };
+  plans: {
+    subscribeChanges(callback: () => void): () => void;
+    subscribeDue(callback: (reminder: never) => void): () => void;
+  };
+  sessions: {
+    readMessages(sessionId: string): Promise<StoredMessage[]>;
+    subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number }) => void): () => void;
+    subscribeEvents(sessionId: string, callback: (event: SessionEvent) => void): () => void;
+  };
+};
+
+const cleanupTasks: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanupTasks.length > 0) {
+    cleanupTasks.pop()?.();
+  }
+});
+
 describe('AppShell effect stability contract', () => {
-  it('keeps long-lived subscriptions on latest options instead of render-time callback closures', async () => {
+  it('keeps bootstrap subscriptions stable while invoking the latest connection handler', async () => {
+    const effects = await importAppShellEffects();
+    const refs = createBootstrapRefs();
+    const captured: CapturedSubscriptions = {
+      activeSessionSubscribeCount: 0,
+      connectionSubscribeCount: 0,
+    };
+    const root = installReactRenderer(captured);
+    const calls: string[] = [];
+    const event = { provider: 'sentinel' } as unknown as ConnectionEvent;
+
+    await render(root, createElement(BootstrapSubscriptionProbe, {
+      effects,
+      onConnectionEvent: () => calls.push('first'),
+      refs,
+    }));
+    assert.equal(captured.connectionSubscribeCount, 1);
+
+    await render(root, createElement(BootstrapSubscriptionProbe, {
+      effects,
+      onConnectionEvent: () => calls.push('second'),
+      refs,
+    }));
+    assert.equal(captured.connectionSubscribeCount, 1, 'rerendering with a new handler must not resubscribe');
+
+    await act(async () => {
+      captured.connectionEvent?.(event);
+    });
+
+    assert.deepEqual(calls, ['second']);
+  });
+
+  it('keeps active-session subscriptions stable while invoking the latest event handler', async () => {
+    const effects = await importAppShellEffects();
+    const captured: CapturedSubscriptions = {
+      activeSessionSubscribeCount: 0,
+      connectionSubscribeCount: 0,
+    };
+    const root = installReactRenderer(captured);
+    const refs = { activeIdRef: { current: 'session-1' } };
+    const calls: string[] = [];
+    const event = { type: 'sentinel' } as unknown as SessionEvent;
+
+    await render(root, createElement(ActiveSessionEventProbe, {
+      effects,
+      onSessionEvent: () => calls.push('first'),
+      refs,
+    }));
+    assert.equal(captured.activeSessionSubscribeCount, 1);
+
+    await render(root, createElement(ActiveSessionEventProbe, {
+      effects,
+      onSessionEvent: () => calls.push('second'),
+      refs,
+    }));
+    assert.equal(captured.activeSessionSubscribeCount, 1, 'rerendering with a new handler must not resubscribe');
+
+    await act(async () => {
+      captured.activeSessionEvent?.(event);
+    });
+
+    assert.deepEqual(calls, ['second']);
+  });
+
+  it('uses React effect events instead of a local latest-ref helper', async () => {
     const src = await readRendererShellSource('app-shell-effects.ts');
-    const bootstrapHook = extractFunction(src, 'useAppShellBootstrapSubscriptions');
-    const activeSessionHook = extractFunction(src, 'useActiveSessionEvents');
 
-    assert.match(
-      src,
-      /function useLatestRef<T>\(value: T\): RefBox<T> \{/,
-      'AppShell effect hooks need a single latest-ref helper for long-lived subscriptions',
-    );
-
-    assert.match(
-      bootstrapHook,
-      /const latestOptionsRef = useLatestRef\(options\);/,
-      'bootstrap subscriptions must read callbacks through a latest options ref',
-    );
-    assert.doesNotMatch(
-      bootstrapHook,
-      /const\s*\{[\s\S]*\}\s*=\s*options;/,
-      'bootstrap subscriptions must not close over a hook-scope options destructure',
-    );
-    assert.match(
-      extractUseEffect(bootstrapHook, '[]'),
-      /latestOptionsRef\.current/,
-      'the one-shot bootstrap effect must dereference latest options inside the mounted subscription boundary',
-    );
-
-    assert.match(
-      activeSessionHook,
-      /const latestOptionsRef = useLatestRef\(options\);/,
-      'active-session subscriptions must read callbacks through a latest options ref',
-    );
-    assert.doesNotMatch(
-      activeSessionHook,
-      /const\s*\{[\s\S]*\b(?:handleEvent|markSessionReadLocally|setMessages|setMessageLoadErrorBySession|setSessionEventHealthBySession|toastApi)\b[\s\S]*\}\s*=\s*options;/,
-      'active-session event effects may depend on activeId, but callbacks and setters must stay behind the latest options ref',
-    );
-    assert.match(
-      extractUseEffect(activeSessionHook, '[activeId]'),
-      /latestOptionsRef\.current/,
-      'the active-session effect must resubscribe by activeId while reading current callbacks from latest options',
-    );
+    assert.match(src, /\buseEffectEvent\(/);
+    assert.doesNotMatch(src, /\buseLatestRef\b|\blatestOptionsRef\b/);
   });
 });
 
-function extractFunction(src: string, functionName: string): string {
-  const signatureIndex = src.indexOf(`function ${functionName}`);
-  assert.notEqual(signatureIndex, -1, `${functionName} must exist`);
-  const paramsStart = src.indexOf('(', signatureIndex);
-  assert.notEqual(paramsStart, -1, `${functionName} must have params`);
-  const paramsEnd = findMatchingPair(src, paramsStart, '(', ')');
-  const bodyStart = src.indexOf('{', paramsEnd);
-  assert.notEqual(bodyStart, -1, `${functionName} must have a body`);
-  const bodyEnd = findMatchingBrace(src, bodyStart);
-  return src.slice(signatureIndex, bodyEnd + 1);
+function BootstrapSubscriptionProbe(props: {
+  effects: AppShellEffectsModule;
+  onConnectionEvent(event: ConnectionEvent): void;
+  refs: ReturnType<typeof createBootstrapRefs>;
+}) {
+  props.effects.useAppShellBootstrapSubscriptions({
+    activeIdRef: props.refs.activeIdRef,
+    applyVisualSmokeFixture: async () => {},
+    bootstrapSessions: async () => {},
+    clearPendingTurnActionsForSession: () => {},
+    clearSessionRendererState: () => {},
+    handleConnectionEvent: props.onConnectionEvent,
+    openSettings: () => {},
+    pendingPermissionModeChangesRef: props.refs.pendingPermissionModeChangesRef,
+    pendingSessionModelChangesRef: props.refs.pendingSessionModelChangesRef,
+    pendingTurnActionTimersRef: props.refs.pendingTurnActionTimersRef,
+    pendingTurnActionsRef: props.refs.pendingTurnActionsRef,
+    projectPickerPendingRef: props.refs.projectPickerPendingRef,
+    projectPickerRequestRef: props.refs.projectPickerRequestRef,
+    refreshAppInfo: async () => {},
+    refreshConnections: async () => {},
+    refreshMemoryActive: async () => {},
+    refreshMessages: async () => true,
+    refreshPlanReminders: async () => {},
+    refreshShellSettings: async () => {},
+    refreshSkills: async () => {},
+    refreshSessions: async () => [],
+    rendererMountedRef: props.refs.rendererMountedRef,
+    setActiveId: () => {},
+    setMessages: () => {},
+    setNavSelection: () => {},
+    setSessionEventHealthBySession: () => {},
+    toastApi: {
+      error: () => {},
+      info: () => {},
+      toast: () => {},
+    },
+  });
+  return null;
 }
 
-function extractUseEffect(src: string, deps: string): string {
-  const marker = 'useEffect(() => {';
-  let searchFrom = 0;
-  while (true) {
-    const effectIndex = src.indexOf(marker, searchFrom);
-    assert.notEqual(effectIndex, -1, `expected a useEffect with deps ${deps}`);
-    const bodyStart = src.indexOf('{', effectIndex);
-    const bodyEnd = findMatchingBrace(src, bodyStart);
-    const afterBody = src.slice(bodyEnd, src.indexOf(');', bodyEnd) + 2);
-    if (afterBody.includes(`}, ${deps});`)) {
-      return src.slice(effectIndex, bodyEnd + 1);
-    }
-    searchFrom = bodyEnd + 1;
+function ActiveSessionEventProbe(props: {
+  effects: AppShellEffectsModule;
+  onSessionEvent(sessionId: string, event: SessionEvent): void;
+  refs: { activeIdRef: RefBox<string | undefined> };
+}) {
+  props.effects.useActiveSessionEvents({
+    activeId: 'session-1',
+    activeIdRef: props.refs.activeIdRef,
+    handleEvent: props.onSessionEvent,
+    markSessionReadLocally: () => {},
+    setMessageLoadErrorBySession: () => {},
+    setMessages: () => {},
+    setSessionEventHealthBySession: () => {},
+    toastApi: {
+      error: () => {},
+    },
+  });
+  return null;
+}
+
+async function importAppShellEffects(): Promise<AppShellEffectsModule> {
+  const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/app-shell-effects-'));
+  const outfile = resolve(outdir, 'app-shell-effects.mjs');
+  await mkdir(dirname(outfile), { recursive: true });
+  await build({
+    entryPoints: [resolve(REPO_ROOT, 'apps/desktop/src/renderer/app-shell-effects.ts')],
+    outfile,
+    bundle: true,
+    external: ['react'],
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    logLevel: 'silent',
+  });
+  return await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as AppShellEffectsModule;
+}
+
+function createBootstrapRefs() {
+  return {
+    activeIdRef: { current: 'session-1' as string | undefined },
+    pendingPermissionModeChangesRef: { current: new Set<string>() },
+    pendingSessionModelChangesRef: { current: new Set<string>() },
+    pendingTurnActionTimersRef: { current: new Map<string, ReturnType<typeof setTimeout>>() },
+    pendingTurnActionsRef: { current: new Set<string>() },
+    projectPickerPendingRef: { current: false },
+    projectPickerRequestRef: { current: 0 },
+    rendererMountedRef: { current: false },
+  };
+}
+
+function installReactRenderer(captured: CapturedSubscriptions): Root {
+  installFakeDom();
+  installFakeMaka(captured);
+  const container = new FakeElement('div', document);
+  const root = createRoot(container as unknown as Element);
+  cleanupTasks.push(() => {
+    act(() => {
+      root.unmount();
+    });
+  });
+  return root;
+}
+
+async function render(root: Root, element: ReactElement): Promise<void> {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function installFakeMaka(captured: CapturedSubscriptions): void {
+  window.maka = {
+    appWindow: {
+      subscribeOpenSettings: () => noop,
+    },
+    connections: {
+      subscribeEvents(callback: (event: ConnectionEvent) => void) {
+        captured.connectionSubscribeCount += 1;
+        captured.connectionEvent = callback;
+        return noop;
+      },
+    },
+    plans: {
+      subscribeChanges: () => noop,
+      subscribeDue: () => noop,
+    },
+    sessions: {
+      readMessages: async () => [],
+      subscribeChanges: () => noop,
+      subscribeEvents(_sessionId: string, callback: (event: SessionEvent) => void) {
+        captured.activeSessionSubscribeCount += 1;
+        captured.activeSessionEvent = callback;
+        return noop;
+      },
+    },
+  } as unknown as RendererWindow['maka'];
+}
+
+function installFakeDom(): void {
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const previousActEnvironment = (globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }).IS_REACT_ACT_ENVIRONMENT;
+  const fakeDocument = createFakeDocument();
+  const fakeWindow = {
+    document: fakeDocument,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    HTMLElement: class HTMLElement {},
+    HTMLIFrameElement: class HTMLIFrameElement {},
+  } as unknown as RendererWindow;
+  Object.defineProperty(fakeDocument, 'defaultView', { value: fakeWindow });
+  globalThis.document = fakeDocument;
+  globalThis.window = fakeWindow;
+  globalThis.requestAnimationFrame = (callback) => {
+    callback(0);
+    return 0;
+  };
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  cleanupTasks.push(() => {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+    globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      previousActEnvironment;
+  });
+}
+
+function createFakeDocument(): Document {
+  const fakeDocument = {
+    nodeType: 9,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    createElement(tagName: string) {
+      return new FakeElement(tagName, fakeDocument as unknown as Document);
+    },
+    createElementNS(_namespace: string, tagName: string) {
+      return new FakeElement(tagName, fakeDocument as unknown as Document);
+    },
+    createTextNode(text: string) {
+      return new FakeText(text, fakeDocument as unknown as Document);
+    },
+  };
+  Object.defineProperty(fakeDocument, 'documentElement', {
+    value: new FakeElement('html', fakeDocument as unknown as Document),
+  });
+  return fakeDocument as unknown as Document;
+}
+
+class FakeElement {
+  readonly childNodes: Array<FakeElement | FakeText> = [];
+  readonly namespaceURI = 'http://www.w3.org/1999/xhtml';
+  readonly nodeName: string;
+  readonly nodeType = 1;
+  readonly tagName: string;
+  parentNode: FakeElement | null = null;
+  textContent = '';
+
+  constructor(tagName: string, readonly ownerDocument: Document) {
+    this.tagName = tagName.toUpperCase();
+    this.nodeName = this.tagName;
   }
-}
 
-function findMatchingBrace(src: string, openIndex: number): number {
-  return findMatchingPair(src, openIndex, '{', '}');
-}
+  addEventListener(): void {}
 
-function findMatchingPair(src: string, openIndex: number, open: string, close: string): number {
-  let depth = 0;
-  for (let index = openIndex; index < src.length; index += 1) {
-    const char = src[index];
-    if (char === open) depth += 1;
-    if (char === close) {
-      depth -= 1;
-      if (depth === 0) return index;
-    }
+  appendChild<T extends FakeElement | FakeText>(node: T): T {
+    this.childNodes.push(node);
+    node.parentNode = this;
+    return node;
   }
-  assert.fail(`missing matching ${close}`);
+
+  insertBefore<T extends FakeElement | FakeText>(node: T, before: FakeElement | FakeText | null): T {
+    const index = before ? this.childNodes.indexOf(before) : -1;
+    if (index < 0) return this.appendChild(node);
+    this.childNodes.splice(index, 0, node);
+    node.parentNode = this;
+    return node;
+  }
+
+  removeAttribute(): void {}
+
+  removeChild<T extends FakeElement | FakeText>(node: T): T {
+    const index = this.childNodes.indexOf(node);
+    if (index >= 0) {
+      this.childNodes.splice(index, 1);
+    }
+    node.parentNode = null;
+    return node;
+  }
+
+  removeEventListener(): void {}
+
+  setAttribute(): void {}
 }
+
+class FakeText {
+  readonly nodeName = '#text';
+  readonly nodeType = 3;
+  parentNode: FakeElement | null = null;
+
+  constructor(readonly nodeValue: string, readonly ownerDocument: Document) {}
+}
+
+function noop(): void {}

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readRendererShellSource } from './renderer-shell-source-helpers.js';
+
+describe('AppShell effect stability contract', () => {
+  it('keeps long-lived subscriptions on latest options instead of render-time callback closures', async () => {
+    const src = await readRendererShellSource('app-shell-effects.ts');
+    const bootstrapHook = extractFunction(src, 'useAppShellBootstrapSubscriptions');
+    const activeSessionHook = extractFunction(src, 'useActiveSessionEvents');
+
+    assert.match(
+      src,
+      /function useLatestRef<T>\(value: T\): RefBox<T> \{/,
+      'AppShell effect hooks need a single latest-ref helper for long-lived subscriptions',
+    );
+
+    assert.match(
+      bootstrapHook,
+      /const latestOptionsRef = useLatestRef\(options\);/,
+      'bootstrap subscriptions must read callbacks through a latest options ref',
+    );
+    assert.doesNotMatch(
+      bootstrapHook,
+      /const\s*\{[\s\S]*\}\s*=\s*options;/,
+      'bootstrap subscriptions must not close over a hook-scope options destructure',
+    );
+    assert.match(
+      extractUseEffect(bootstrapHook, '[]'),
+      /latestOptionsRef\.current/,
+      'the one-shot bootstrap effect must dereference latest options inside the mounted subscription boundary',
+    );
+
+    assert.match(
+      activeSessionHook,
+      /const latestOptionsRef = useLatestRef\(options\);/,
+      'active-session subscriptions must read callbacks through a latest options ref',
+    );
+    assert.doesNotMatch(
+      activeSessionHook,
+      /const\s*\{[\s\S]*\b(?:handleEvent|markSessionReadLocally|setMessages|setMessageLoadErrorBySession|setSessionEventHealthBySession|toastApi)\b[\s\S]*\}\s*=\s*options;/,
+      'active-session event effects may depend on activeId, but callbacks and setters must stay behind the latest options ref',
+    );
+    assert.match(
+      extractUseEffect(activeSessionHook, '[activeId]'),
+      /latestOptionsRef\.current/,
+      'the active-session effect must resubscribe by activeId while reading current callbacks from latest options',
+    );
+  });
+});
+
+function extractFunction(src: string, functionName: string): string {
+  const signatureIndex = src.indexOf(`function ${functionName}`);
+  assert.notEqual(signatureIndex, -1, `${functionName} must exist`);
+  const paramsStart = src.indexOf('(', signatureIndex);
+  assert.notEqual(paramsStart, -1, `${functionName} must have params`);
+  const paramsEnd = findMatchingPair(src, paramsStart, '(', ')');
+  const bodyStart = src.indexOf('{', paramsEnd);
+  assert.notEqual(bodyStart, -1, `${functionName} must have a body`);
+  const bodyEnd = findMatchingBrace(src, bodyStart);
+  return src.slice(signatureIndex, bodyEnd + 1);
+}
+
+function extractUseEffect(src: string, deps: string): string {
+  const marker = 'useEffect(() => {';
+  let searchFrom = 0;
+  while (true) {
+    const effectIndex = src.indexOf(marker, searchFrom);
+    assert.notEqual(effectIndex, -1, `expected a useEffect with deps ${deps}`);
+    const bodyStart = src.indexOf('{', effectIndex);
+    const bodyEnd = findMatchingBrace(src, bodyStart);
+    const afterBody = src.slice(bodyEnd, src.indexOf(');', bodyEnd) + 2);
+    if (afterBody.includes(`}, ${deps});`)) {
+      return src.slice(effectIndex, bodyEnd + 1);
+    }
+    searchFrom = bodyEnd + 1;
+  }
+}
+
+function findMatchingBrace(src: string, openIndex: number): number {
+  return findMatchingPair(src, openIndex, '{', '}');
+}
+
+function findMatchingPair(src: string, openIndex: number, open: string, close: string): number {
+  let depth = 0;
+  for (let index = openIndex; index < src.length; index += 1) {
+    const char = src[index];
+    if (char === open) depth += 1;
+    if (char === close) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  assert.fail(`missing matching ${close}`);
+}

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
-import type { ConnectionEvent, SessionEvent, StoredMessage } from '@maka/core';
+import type { ConnectionEvent, PlanReminder, SessionEvent, StoredMessage } from '@maka/core';
 import { build } from 'esbuild';
 import { act, createElement, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -23,6 +23,8 @@ type CapturedSubscriptions = {
   activeSessionSubscribeCount: number;
   connectionEvent?: (event: ConnectionEvent) => void;
   connectionSubscribeCount: number;
+  planDue?: (reminder: PlanReminder) => void;
+  planDueSubscribeCount: number;
 };
 type RendererMakaStub = {
   appWindow: {
@@ -57,6 +59,7 @@ describe('AppShell effect stability contract', () => {
     const captured: CapturedSubscriptions = {
       activeSessionSubscribeCount: 0,
       connectionSubscribeCount: 0,
+      planDueSubscribeCount: 0,
     };
     const root = installReactRenderer(captured);
     const calls: string[] = [];
@@ -88,6 +91,7 @@ describe('AppShell effect stability contract', () => {
     const captured: CapturedSubscriptions = {
       activeSessionSubscribeCount: 0,
       connectionSubscribeCount: 0,
+      planDueSubscribeCount: 0,
     };
     const root = installReactRenderer(captured);
     const refs = { activeIdRef: { current: 'session-1' } };
@@ -115,6 +119,52 @@ describe('AppShell effect stability contract', () => {
     assert.deepEqual(calls, ['second']);
   });
 
+  it('keeps plan reminder toast actions on the latest navigation handler', async () => {
+    const effects = await importAppShellEffects();
+    const refs = createBootstrapRefs();
+    const captured: CapturedSubscriptions = {
+      activeSessionSubscribeCount: 0,
+      connectionSubscribeCount: 0,
+      planDueSubscribeCount: 0,
+    };
+    const root = installReactRenderer(captured);
+    const navSections: string[] = [];
+    let toastAction: (() => void) | undefined;
+
+    await render(root, createElement(BootstrapSubscriptionProbe, {
+      effects,
+      onConnectionEvent: () => {},
+      onNavSelection: () => navSections.push('first'),
+      onToastAction: (action) => {
+        toastAction = action;
+      },
+      refs,
+    }));
+    assert.equal(captured.planDueSubscribeCount, 1);
+
+    await render(root, createElement(BootstrapSubscriptionProbe, {
+      effects,
+      onConnectionEvent: () => {},
+      onNavSelection: (selection) => navSections.push(selection.section),
+      onToastAction: (action) => {
+        toastAction = action;
+      },
+      refs,
+    }));
+    assert.equal(captured.planDueSubscribeCount, 1, 'rerendering with a new handler must not resubscribe');
+
+    await act(async () => {
+      captured.planDue?.(createPlanReminder());
+    });
+    assert.ok(toastAction, 'plan reminder toast must expose a navigation action');
+
+    await act(async () => {
+      toastAction?.();
+    });
+
+    assert.deepEqual(navSections, ['automations']);
+  });
+
   it('uses React effect events instead of a local latest-ref helper', async () => {
     const src = await readRendererShellSource('app-shell-effects.ts');
 
@@ -126,6 +176,8 @@ describe('AppShell effect stability contract', () => {
 function BootstrapSubscriptionProbe(props: {
   effects: AppShellEffectsModule;
   onConnectionEvent(event: ConnectionEvent): void;
+  onNavSelection?(selection: { section: string }): void;
+  onToastAction?(onClick: (() => void) | undefined): void;
   refs: ReturnType<typeof createBootstrapRefs>;
 }) {
   props.effects.useAppShellBootstrapSubscriptions({
@@ -153,12 +205,16 @@ function BootstrapSubscriptionProbe(props: {
     rendererMountedRef: props.refs.rendererMountedRef,
     setActiveId: () => {},
     setMessages: () => {},
-    setNavSelection: () => {},
+    setNavSelection: (selection) => {
+      props.onNavSelection?.(selection);
+    },
     setSessionEventHealthBySession: () => {},
     toastApi: {
       error: () => {},
       info: () => {},
-      toast: () => {},
+      toast: (payload) => {
+        props.onToastAction?.(payload.action?.onClick);
+      },
     },
   });
   return null;
@@ -214,6 +270,22 @@ function createBootstrapRefs() {
   };
 }
 
+function createPlanReminder(): PlanReminder {
+  return {
+    id: 'reminder-1',
+    title: 'Review automations',
+    note: '',
+    schedule: { kind: 'once', runAt: 1 },
+    delivery: { channel: 'local' },
+    status: 'scheduled',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+    runs: [],
+    runCount: 0,
+  };
+}
+
 function installReactRenderer(captured: CapturedSubscriptions): Root {
   installFakeDom();
   installFakeMaka(captured);
@@ -247,7 +319,11 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
     },
     plans: {
       subscribeChanges: () => noop,
-      subscribeDue: () => noop,
+      subscribeDue(callback: (reminder: PlanReminder) => void) {
+        captured.planDueSubscribeCount += 1;
+        captured.planDue = callback;
+        return noop;
+      },
     },
     sessions: {
       readMessages: async () => [],

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -260,7 +260,7 @@ describe('permission response IPC boundary', () => {
     // doesn't rot when the implementation tweaks the guard shape.
     assert.match(
       renderer,
-      /event\.reason === 'message-appended'[\s\S]{0,120}?(?:event\.sessionId|changedSessionId) === (?:latest\.)?activeIdRef\.current[\s\S]*?(?:latest\.)?refreshMessages\((?:event\.sessionId|changedSessionId)\)/,
+      /event\.reason === 'message-appended'[\s\S]{0,160}?(?:event\.sessionId|changedSessionId) === (?:options\.|latest\.)?activeIdRef\.current[\s\S]*?(?:options\.|latest\.)?refreshMessages\((?:event\.sessionId|changedSessionId)\)/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -260,7 +260,7 @@ describe('permission response IPC boundary', () => {
     // doesn't rot when the implementation tweaks the guard shape.
     assert.match(
       renderer,
-      /event\.reason === 'message-appended'[\s\S]{0,80}?(?:event\.sessionId|changedSessionId) === activeIdRef\.current[\s\S]*?refreshMessages\((?:event\.sessionId|changedSessionId)\)/,
+      /event\.reason === 'message-appended'[\s\S]{0,120}?(?:event\.sessionId|changedSessionId) === (?:latest\.)?activeIdRef\.current[\s\S]*?(?:latest\.)?refreshMessages\((?:event\.sessionId|changedSessionId)\)/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -1,12 +1,13 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
+import { readRendererShellCombinedSource, readRendererShellSource } from './renderer-shell-source-helpers.js';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
 
 describe('renderer startup fail-soft contract', () => {
   it('catches fire-and-forget app shell settings probes', async () => {
     const main = await readRendererShellCombinedSource();
-    const mountEffect = main.match(/useEffect\(\(\) => \{[\s\S]*?const unsubscribeConnections =/)?.[0] ?? '';
+    const effects = await readRendererShellSource('app-shell-effects.ts');
+    const mountEffect = effects.match(/export function useAppShellBootstrapSubscriptions[\s\S]*?useEffect\(\(\) => \{[\s\S]*?const unsubscribeConnections =/)?.[0] ?? '';
     const refreshConnections = main.match(/async function refreshConnections\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const refreshAppInfo = main.match(/async function refreshAppInfo\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const refreshPlanReminders = main.match(/async function refreshPlanReminders\([\s\S]*?\n  \}/)?.[0] ?? '';
@@ -14,7 +15,7 @@ describe('renderer startup fail-soft contract', () => {
     const refreshMemoryActive = main.match(/async function refreshMemoryActive[\s\S]*?\n  \}/)?.[0] ?? '';
     const refreshShellSettings = main.match(/async function refreshShellSettings\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(mountEffect, /void refreshAppInfo\(\)/);
+    assert.match(mountEffect, /void (?:latest\.)?refreshAppInfo\(\)/);
     assert.match(
       refreshAppInfo,
       /try \{[\s\S]*window\.maka\.app\.info\(\)[\s\S]*setAppInfo\(\{ projectPath: next\.projectPath, projectGit: next\.projectGit \}\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('读取项目路径失败', generalizedErrorMessageChinese\(error, '项目路径暂时无法读取，请稍后重试。'\)\)/,
@@ -26,7 +27,7 @@ describe('renderer startup fail-soft contract', () => {
       /setAppInfo\(null\)/,
       'app-info refresh failure must not silently hide the existing project badge',
     );
-    assert.match(mountEffect, /void refreshMemoryActive\('载入本地记忆状态失败'\)/);
+    assert.match(mountEffect, /void (?:latest\.)?refreshMemoryActive\('载入本地记忆状态失败'\)/);
     assert.match(
       refreshMemoryActive,
       /try \{[\s\S]*window\.maka\.memory\.getState\(\)[\s\S]*setMemoryActive\(next\.agentReadEnabled && next\.status === 'ok' && next\.content\.trim\(\)\.length > 0\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(failureTitle, generalizedErrorMessageChinese\(error, '本地记忆状态暂时无法刷新，请稍后重试。'\)\)/,
@@ -38,7 +39,7 @@ describe('renderer startup fail-soft contract', () => {
       /catch\(\(\) => setMemoryActive\(false\)\)|catch \(error\) \{[\s\S]*setMemoryActive\(false\)/,
       'memory-active refresh failures must not silently hide the existing memory pill',
     );
-    assert.match(mountEffect, /void refreshShellSettings\(\)/);
+    assert.match(mountEffect, /void (?:latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
       /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,

--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -15,7 +15,7 @@ describe('renderer startup fail-soft contract', () => {
     const refreshMemoryActive = main.match(/async function refreshMemoryActive[\s\S]*?\n  \}/)?.[0] ?? '';
     const refreshShellSettings = main.match(/async function refreshShellSettings\(\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
-    assert.match(mountEffect, /void (?:latest\.)?refreshAppInfo\(\)/);
+    assert.match(mountEffect, /void (?:options\.|latest\.)?refreshAppInfo\(\)/);
     assert.match(
       refreshAppInfo,
       /try \{[\s\S]*window\.maka\.app\.info\(\)[\s\S]*setAppInfo\(\{ projectPath: next\.projectPath, projectGit: next\.projectGit \}\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('读取项目路径失败', generalizedErrorMessageChinese\(error, '项目路径暂时无法读取，请稍后重试。'\)\)/,
@@ -27,7 +27,7 @@ describe('renderer startup fail-soft contract', () => {
       /setAppInfo\(null\)/,
       'app-info refresh failure must not silently hide the existing project badge',
     );
-    assert.match(mountEffect, /void (?:latest\.)?refreshMemoryActive\('载入本地记忆状态失败'\)/);
+    assert.match(mountEffect, /void (?:options\.|latest\.)?refreshMemoryActive\('载入本地记忆状态失败'\)/);
     assert.match(
       refreshMemoryActive,
       /try \{[\s\S]*window\.maka\.memory\.getState\(\)[\s\S]*setMemoryActive\(next\.agentReadEnabled && next\.status === 'ok' && next\.content\.trim\(\)\.length > 0\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\(failureTitle, generalizedErrorMessageChinese\(error, '本地记忆状态暂时无法刷新，请稍后重试。'\)\)/,
@@ -39,7 +39,7 @@ describe('renderer startup fail-soft contract', () => {
       /catch\(\(\) => setMemoryActive\(false\)\)|catch \(error\) \{[\s\S]*setMemoryActive\(false\)/,
       'memory-active refresh failures must not silently hide the existing memory pill',
     );
-    assert.match(mountEffect, /void (?:latest\.)?refreshShellSettings\(\)/);
+    assert.match(mountEffect, /void (?:options\.|latest\.)?refreshShellSettings\(\)/);
     assert.match(
       refreshShellSettings,
       /try \{[\s\S]*window\.maka\.settings\.get\(\)[\s\S]*applyUiLocale\(uiLocale\)[\s\S]*applyTheme\(pref\)[\s\S]*applyThemePalette\(palette\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('载入外观设置失败', generalizedErrorMessageChinese\(error, '外观设置暂时无法载入，请稍后重试。'\)\)/,

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -23,7 +23,8 @@ describe('active session message lifecycle contract', () => {
     ]);
     const ui = await readFile(join(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-view.tsx'), 'utf8');
     const activeSessionEffect = src.match(/useEffect\(\(\) => \{\s*if \(!activeId\) return;[\s\S]*?readMessages\(activeId\)[\s\S]*?\}, \[activeId\]\);/)?.[0] ?? '';
-    const activeReadCatch = activeSessionEffect.match(/readMessages\(activeId\)[\s\S]*?\.catch\(\(error\) => \{[\s\S]*?\n      \}\);/)?.[0] ?? '';
+    const activeReadSuccess = src.match(/const applyReadMessages = useEffectEvent\([\s\S]*?const applyReadError = useEffectEvent/)?.[0] ?? '';
+    const activeReadCatch = src.match(/const applyReadError = useEffectEvent[\s\S]*?const handleSessionEvent = useEffectEvent/)?.[0] ?? '';
     const refreshMessages = src.match(/async function refreshMessages\(sessionId: string\)(?:: Promise<boolean>)? \{[\s\S]*?\n  \}/)?.[0] ?? '';
     const retryMessages = src.match(/async function retryMessages\(sessionId: string\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
@@ -33,9 +34,14 @@ describe('active session message lifecycle contract', () => {
       'selecting a new active session must clear the old chat body before async message read resolves',
     );
     assert.match(
-      activeSessionEffect,
-      /if \(!disposed && activeIdRef\.current === activeId\) \{[\s\S]*markSessionReadLocally\(activeId, next\);[\s\S]*setMessages\(next\);[\s\S]*\}/,
+      activeReadSuccess,
+      /if \(!isDisposed\(\) && options\.activeIdRef\.current === sessionId\) \{[\s\S]*options\.markSessionReadLocally\(sessionId, next\);[\s\S]*options\.setMessages\(next\);[\s\S]*\}/,
       'late active-session reads may set messages only while the same session is still active',
+    );
+    assert.match(
+      activeSessionEffect,
+      /applyReadMessages\(activeId, next, \(\) => disposed\)/,
+      'active-session reads must pass the current disposed guard into the late-read effect event',
     );
     assert.match(
       activeReadCatch,
@@ -44,7 +50,7 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       activeReadCatch,
-      /\.catch\(\(error\) => \{[\s\S]*const message = messageReadErrorMessage\(error\);[\s\S]*setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[activeId\]: message \}\)\);[\s\S]*toastApi\.error\('读取对话失败', message\)/,
+      /const message = messageReadErrorMessage\(error\);[\s\S]*options\.setMessageLoadErrorBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: message \}\)\);[\s\S]*options\.toastApi\.error\('读取对话失败', message\)/,
       'active-session read failures must set a visible per-session load error after the old chat body has already been cleared',
     );
     assert.doesNotMatch(activeReadCatch, /const message = cleanErrorMessage\(error\)/);

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -232,9 +232,6 @@ export function useAppShellBootstrapSubscriptions(options: {
   const handlePlanChange = useEffectEvent(() => {
     void options.refreshPlanReminders();
   });
-  const openAutomations = useEffectEvent(() => {
-    options.setNavSelection({ section: 'automations' });
-  });
   const handlePlanDue = useEffectEvent((reminder: PlanReminder) => {
     void options.refreshPlanReminders();
     options.toastApi.toast({
@@ -244,7 +241,7 @@ export function useAppShellBootstrapSubscriptions(options: {
       duration: 8000,
       action: {
         label: '查看定时任务',
-        onClick: openAutomations,
+        onClick: () => options.setNavSelection({ section: 'automations' }),
       },
     });
   });

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 import type {
   ConnectionEvent,
   PlanReminder,
@@ -38,14 +38,6 @@ type ToastApi = {
     action?: { label: string; onClick: () => void };
   }): void;
 };
-
-// Long-lived subscriptions below mount once; their callbacks read this ref so
-// AppShell handlers can change across renders without resubscribing.
-function useLatestRef<T>(value: T): RefBox<T> {
-  const ref = useRef(value);
-  ref.current = value;
-  return ref;
-}
 
 export function useAppShellRefSync(options: {
   activeId: string | undefined;
@@ -191,108 +183,117 @@ export function useAppShellBootstrapSubscriptions(options: {
   setSessionEventHealthBySession: SessionEventHealthUpdater;
   toastApi: ToastApi;
 }) {
-  const latestOptionsRef = useLatestRef(options);
+  const runDeferredStartupRefreshes = useEffectEvent(() => {
+    void options.refreshAppInfo();
+    void options.refreshMemoryActive('载入本地记忆状态失败');
+    void options.refreshSkills();
+    void options.refreshPlanReminders();
+    void options.applyVisualSmokeFixture();
+  });
+  const handleConnectionSubscriptionEvent = useEffectEvent((event: ConnectionEvent) => {
+    options.handleConnectionEvent(event);
+  });
+  const handleSessionChange = useEffectEvent((event: { reason: string; sessionId?: string; ts: number; modelId?: string }) => {
+    void options.refreshSessions();
+    if (event.sessionId) {
+      options.setSessionEventHealthBySession((current) => {
+        const previous = current[event.sessionId!];
+        if (!previous) return current;
+        return {
+          ...current,
+          [event.sessionId!]: recordSessionEventStreamChange(previous, event.ts),
+        };
+      });
+    }
+    if (
+      event.sessionId &&
+      (event.reason === 'turn-status-change' || event.reason === 'message-appended' || event.reason === 'deleted')
+    ) {
+      options.clearPendingTurnActionsForSession(event.sessionId);
+    }
+    const changedSessionId = event.sessionId;
+    if (event.reason === 'message-appended' && changedSessionId && changedSessionId === options.activeIdRef.current) {
+      void options.refreshMessages(changedSessionId);
+    }
+    if (event.reason === 'rebound') {
+      const modelSuffix = event.modelId ? ` · ${event.modelId}` : '';
+      options.toastApi.info('已切换到默认模型', `原会话使用的连接已不可用${modelSuffix}`);
+    }
+    if (event.reason === 'deleted' && event.sessionId && event.sessionId === options.activeIdRef.current) {
+      const deletedSessionId = event.sessionId;
+      options.setActiveId(undefined);
+      options.setMessages([]);
+      options.clearSessionRendererState(deletedSessionId);
+    }
+  });
+  const handleOpenSettings = useEffectEvent(() => {
+    options.openSettings();
+  });
+  const handlePlanChange = useEffectEvent(() => {
+    void options.refreshPlanReminders();
+  });
+  const openAutomations = useEffectEvent(() => {
+    options.setNavSelection({ section: 'automations' });
+  });
+  const handlePlanDue = useEffectEvent((reminder: PlanReminder) => {
+    void options.refreshPlanReminders();
+    options.toastApi.toast({
+      title: '计划提醒',
+      description: reminder.title,
+      variant: 'info',
+      duration: 8000,
+      action: {
+        label: '查看定时任务',
+        onClick: openAutomations,
+      },
+    });
+  });
+  const handleKeyDown = useEffectEvent((event: globalThis.KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === ',') {
+      event.preventDefault();
+      options.openSettings();
+    }
+  });
+  const markRendererMounted = useEffectEvent(() => {
+    options.rendererMountedRef.current = true;
+  });
+  const cleanupPendingRefs = useEffectEvent(() => {
+    options.rendererMountedRef.current = false;
+    options.projectPickerRequestRef.current += 1;
+    options.projectPickerPendingRef.current = false;
+    for (const timeoutHandle of options.pendingTurnActionTimersRef.current.values()) {
+      clearTimeout(timeoutHandle);
+    }
+    options.pendingTurnActionTimersRef.current.clear();
+    options.pendingTurnActionsRef.current.clear();
+    options.pendingPermissionModeChangesRef.current.clear();
+    options.pendingSessionModelChangesRef.current.clear();
+  });
 
   useEffect(() => {
-    const latest = latestOptionsRef.current;
     // Critical data: sessions + connections are seeded from the onboarding
     // snapshot (see AppShell useEffect above).  `refreshShellSettings` is
     // waited because it drives theme + locale before first paint settles.
     // Everything else is fire-and-forget on a rAF to keep the critical
     // render path as short as possible.
-    void latest.refreshShellSettings();
+    void options.refreshShellSettings();
     // Non-critical: defer to next frame so the first paint isn't blocked.
-    requestAnimationFrame(() => {
-      const latest = latestOptionsRef.current;
-      void latest.refreshAppInfo();
-      void latest.refreshMemoryActive('载入本地记忆状态失败');
-      void latest.refreshSkills();
-      void latest.refreshPlanReminders();
-      void latest.applyVisualSmokeFixture();
-    });
-    const unsubscribeConnections = window.maka.connections.subscribeEvents((event) => {
-      latestOptionsRef.current.handleConnectionEvent(event);
-    });
-    const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges((event) => {
-      const latest = latestOptionsRef.current;
-      void latest.refreshSessions();
-      if (event.sessionId) {
-        latest.setSessionEventHealthBySession((current) => {
-          const previous = current[event.sessionId!];
-          if (!previous) return current;
-          return {
-            ...current,
-            [event.sessionId!]: recordSessionEventStreamChange(previous, event.ts),
-          };
-        });
-      }
-      if (
-        event.sessionId &&
-        (event.reason === 'turn-status-change' || event.reason === 'message-appended' || event.reason === 'deleted')
-      ) {
-        latest.clearPendingTurnActionsForSession(event.sessionId);
-      }
-      const changedSessionId = event.sessionId;
-      if (event.reason === 'message-appended' && changedSessionId && changedSessionId === latest.activeIdRef.current) {
-        void latest.refreshMessages(changedSessionId);
-      }
-      if (event.reason === 'rebound') {
-        const modelSuffix = event.modelId ? ` · ${event.modelId}` : '';
-        latest.toastApi.info('已切换到默认模型', `原会话使用的连接已不可用${modelSuffix}`);
-      }
-      if (event.reason === 'deleted' && event.sessionId && event.sessionId === latest.activeIdRef.current) {
-        const deletedSessionId = event.sessionId;
-        latest.setActiveId(undefined);
-        latest.setMessages([]);
-        latest.clearSessionRendererState(deletedSessionId);
-      }
-    });
-    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(() => {
-      latestOptionsRef.current.openSettings();
-    });
-    const unsubscribePlanChanges = window.maka.plans.subscribeChanges(() => {
-      void latestOptionsRef.current.refreshPlanReminders();
-    });
-    const unsubscribePlanDue = window.maka.plans.subscribeDue((reminder: PlanReminder) => {
-      const latest = latestOptionsRef.current;
-      void latest.refreshPlanReminders();
-      latest.toastApi.toast({
-        title: '计划提醒',
-        description: reminder.title,
-        variant: 'info',
-        duration: 8000,
-        action: {
-          label: '查看定时任务',
-          onClick: () => latestOptionsRef.current.setNavSelection({ section: 'automations' }),
-        },
-      });
-    });
-    function onKeyDown(event: globalThis.KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key === ',') {
-        event.preventDefault();
-        latestOptionsRef.current.openSettings();
-      }
-    }
-    latest.rendererMountedRef.current = true;
-    window.addEventListener('keydown', onKeyDown);
+    requestAnimationFrame(runDeferredStartupRefreshes);
+    const unsubscribeConnections = window.maka.connections.subscribeEvents(handleConnectionSubscriptionEvent);
+    const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges(handleSessionChange);
+    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(handleOpenSettings);
+    const unsubscribePlanChanges = window.maka.plans.subscribeChanges(handlePlanChange);
+    const unsubscribePlanDue = window.maka.plans.subscribeDue(handlePlanDue);
+    markRendererMounted();
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
-      const latest = latestOptionsRef.current;
-      latest.rendererMountedRef.current = false;
-      latest.projectPickerRequestRef.current += 1;
-      latest.projectPickerPendingRef.current = false;
+      cleanupPendingRefs();
       unsubscribeConnections();
       unsubscribeSessionChanges();
       unsubscribeOpenSettings();
       unsubscribePlanChanges();
       unsubscribePlanDue();
-      for (const timeoutHandle of latest.pendingTurnActionTimersRef.current.values()) {
-        clearTimeout(timeoutHandle);
-      }
-      latest.pendingTurnActionTimersRef.current.clear();
-      latest.pendingTurnActionsRef.current.clear();
-      latest.pendingPermissionModeChangesRef.current.clear();
-      latest.pendingSessionModelChangesRef.current.clear();
-      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
 }
@@ -309,72 +310,77 @@ export function useActiveSessionEvents(options: {
   setSessionEventHealthBySession: SessionEventHealthUpdater;
   toastApi: Pick<ToastApi, 'error'>;
 }) {
-  const latestOptionsRef = useLatestRef(options);
   const activeId = options.activeId;
+  const applyReadMessages = useEffectEvent((
+    sessionId: string,
+    next: StoredMessage[],
+    isDisposed: () => boolean,
+  ) => {
+    if (!isDisposed() && options.activeIdRef.current === sessionId) {
+      options.markSessionReadLocally(sessionId, next);
+      options.setMessages(next);
+    }
+  });
+  const applyReadError = useEffectEvent((sessionId: string, error: unknown, isDisposed: () => boolean) => {
+    if (!isDisposed() && options.activeIdRef.current === sessionId) {
+      const message = messageReadErrorMessage(error);
+      options.setMessageLoadErrorBySession((current) => ({ ...current, [sessionId]: message }));
+      options.toastApi.error('读取对话失败', message);
+    }
+  });
+  const handleSessionEvent = useEffectEvent((sessionId: string, event: SessionEvent) => {
+    options.setSessionEventHealthBySession((current) => {
+      const previous = current[sessionId];
+      if (!previous) return current;
+      return { ...current, [sessionId]: recordSessionEventStreamEvent(previous, Date.now()) };
+    });
+    options.handleEvent(sessionId, event);
+  });
+  const markSessionEventStreamClosed = useEffectEvent((sessionId: string) => {
+    options.setSessionEventHealthBySession((current) => {
+      const previous = current[sessionId];
+      if (!previous) return current;
+      return {
+        ...current,
+        [sessionId]: {
+          ...previous,
+          status: 'closed',
+          checkedAt: Date.now(),
+          staleSince: undefined,
+        },
+      };
+    });
+  });
 
   useEffect(() => {
     if (!activeId) return;
     let disposed = false;
     const subscribedAt = Date.now();
-    const latest = latestOptionsRef.current;
-    const {
-      setMessageLoadErrorBySession,
-      setMessages,
-      setSessionEventHealthBySession,
-    } = latest;
-    setMessages([]);
-    setMessageLoadErrorBySession((current) => {
+    options.setMessages([]);
+    options.setMessageLoadErrorBySession((current) => {
       if (!current[activeId]) return current;
       const next = { ...current };
       delete next[activeId];
       return next;
     });
-    setSessionEventHealthBySession((current) => ({
+    options.setSessionEventHealthBySession((current) => ({
       ...current,
       [activeId]: createSessionEventStreamSubscription({ sessionId: activeId, now: subscribedAt }),
     }));
     void window.maka.sessions.readMessages(activeId)
       .then((next) => {
-        const { activeIdRef, markSessionReadLocally, setMessages } = latestOptionsRef.current;
-        if (!disposed && activeIdRef.current === activeId) {
-          markSessionReadLocally(activeId, next);
-          setMessages(next);
-        }
+        applyReadMessages(activeId, next, () => disposed);
       })
       .catch((error) => {
-        const { activeIdRef, setMessageLoadErrorBySession, toastApi } = latestOptionsRef.current;
-        if (!disposed && activeIdRef.current === activeId) {
-          const message = messageReadErrorMessage(error);
-          setMessageLoadErrorBySession((current) => ({ ...current, [activeId]: message }));
-          toastApi.error('读取对话失败', message);
-        }
+        applyReadError(activeId, error, () => disposed);
       });
     const unsubscribe = window.maka.sessions.subscribeEvents(activeId, (event) => {
-      const { handleEvent, setSessionEventHealthBySession } = latestOptionsRef.current;
-      setSessionEventHealthBySession((current) => {
-        const previous = current[activeId];
-        if (!previous) return current;
-        return { ...current, [activeId]: recordSessionEventStreamEvent(previous, Date.now()) };
-      });
-      handleEvent(activeId, event);
+      handleSessionEvent(activeId, event);
     });
     return () => {
       disposed = true;
       unsubscribe();
-      const { setSessionEventHealthBySession } = latestOptionsRef.current;
-      setSessionEventHealthBySession((current) => {
-        const previous = current[activeId];
-        if (!previous) return current;
-        return {
-          ...current,
-          [activeId]: {
-            ...previous,
-            status: 'closed',
-            checkedAt: Date.now(),
-            staleSince: undefined,
-          },
-        };
-      });
+      markSessionEventStreamClosed(activeId);
     };
   }, [activeId]);
 }

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type {
   ConnectionEvent,
   PlanReminder,
@@ -38,6 +38,14 @@ type ToastApi = {
     action?: { label: string; onClick: () => void };
   }): void;
 };
+
+// Long-lived subscriptions below mount once; their callbacks read this ref so
+// AppShell handlers can change across renders without resubscribing.
+function useLatestRef<T>(value: T): RefBox<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
 
 export function useAppShellRefSync(options: {
   activeId: string | undefined;
@@ -183,56 +191,33 @@ export function useAppShellBootstrapSubscriptions(options: {
   setSessionEventHealthBySession: SessionEventHealthUpdater;
   toastApi: ToastApi;
 }) {
-  const {
-    activeIdRef,
-    applyVisualSmokeFixture,
-    bootstrapSessions,
-    clearPendingTurnActionsForSession,
-    clearSessionRendererState,
-    handleConnectionEvent,
-    openSettings,
-    pendingPermissionModeChangesRef,
-    pendingSessionModelChangesRef,
-    pendingTurnActionTimersRef,
-    pendingTurnActionsRef,
-    projectPickerPendingRef,
-    projectPickerRequestRef,
-    refreshAppInfo,
-    refreshConnections,
-    refreshMemoryActive,
-    refreshMessages,
-    refreshPlanReminders,
-    refreshShellSettings,
-    refreshSkills,
-    refreshSessions,
-    rendererMountedRef,
-    setActiveId,
-    setMessages,
-    setNavSelection,
-    setSessionEventHealthBySession,
-    toastApi,
-  } = options;
+  const latestOptionsRef = useLatestRef(options);
 
   useEffect(() => {
+    const latest = latestOptionsRef.current;
     // Critical data: sessions + connections are seeded from the onboarding
     // snapshot (see AppShell useEffect above).  `refreshShellSettings` is
     // waited because it drives theme + locale before first paint settles.
     // Everything else is fire-and-forget on a rAF to keep the critical
     // render path as short as possible.
-    void refreshShellSettings();
+    void latest.refreshShellSettings();
     // Non-critical: defer to next frame so the first paint isn't blocked.
     requestAnimationFrame(() => {
-      void refreshAppInfo();
-      void refreshMemoryActive('载入本地记忆状态失败');
-      void refreshSkills();
-      void refreshPlanReminders();
-      void applyVisualSmokeFixture();
+      const latest = latestOptionsRef.current;
+      void latest.refreshAppInfo();
+      void latest.refreshMemoryActive('载入本地记忆状态失败');
+      void latest.refreshSkills();
+      void latest.refreshPlanReminders();
+      void latest.applyVisualSmokeFixture();
     });
-    const unsubscribeConnections = window.maka.connections.subscribeEvents(handleConnectionEvent);
+    const unsubscribeConnections = window.maka.connections.subscribeEvents((event) => {
+      latestOptionsRef.current.handleConnectionEvent(event);
+    });
     const unsubscribeSessionChanges = window.maka.sessions.subscribeChanges((event) => {
-      void refreshSessions();
+      const latest = latestOptionsRef.current;
+      void latest.refreshSessions();
       if (event.sessionId) {
-        setSessionEventHealthBySession((current) => {
+        latest.setSessionEventHealthBySession((current) => {
           const previous = current[event.sessionId!];
           if (!previous) return current;
           return {
@@ -245,64 +230,68 @@ export function useAppShellBootstrapSubscriptions(options: {
         event.sessionId &&
         (event.reason === 'turn-status-change' || event.reason === 'message-appended' || event.reason === 'deleted')
       ) {
-        clearPendingTurnActionsForSession(event.sessionId);
+        latest.clearPendingTurnActionsForSession(event.sessionId);
       }
       const changedSessionId = event.sessionId;
-      if (event.reason === 'message-appended' && changedSessionId && changedSessionId === activeIdRef.current) {
-        void refreshMessages(changedSessionId);
+      if (event.reason === 'message-appended' && changedSessionId && changedSessionId === latest.activeIdRef.current) {
+        void latest.refreshMessages(changedSessionId);
       }
       if (event.reason === 'rebound') {
         const modelSuffix = event.modelId ? ` · ${event.modelId}` : '';
-        toastApi.info('已切换到默认模型', `原会话使用的连接已不可用${modelSuffix}`);
+        latest.toastApi.info('已切换到默认模型', `原会话使用的连接已不可用${modelSuffix}`);
       }
-      if (event.reason === 'deleted' && event.sessionId && event.sessionId === activeIdRef.current) {
+      if (event.reason === 'deleted' && event.sessionId && event.sessionId === latest.activeIdRef.current) {
         const deletedSessionId = event.sessionId;
-        setActiveId(undefined);
-        setMessages([]);
-        clearSessionRendererState(deletedSessionId);
+        latest.setActiveId(undefined);
+        latest.setMessages([]);
+        latest.clearSessionRendererState(deletedSessionId);
       }
     });
-    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(openSettings);
+    const unsubscribeOpenSettings = window.maka.appWindow.subscribeOpenSettings(() => {
+      latestOptionsRef.current.openSettings();
+    });
     const unsubscribePlanChanges = window.maka.plans.subscribeChanges(() => {
-      void refreshPlanReminders();
+      void latestOptionsRef.current.refreshPlanReminders();
     });
     const unsubscribePlanDue = window.maka.plans.subscribeDue((reminder: PlanReminder) => {
-      void refreshPlanReminders();
-      toastApi.toast({
+      const latest = latestOptionsRef.current;
+      void latest.refreshPlanReminders();
+      latest.toastApi.toast({
         title: '计划提醒',
         description: reminder.title,
         variant: 'info',
         duration: 8000,
         action: {
           label: '查看定时任务',
-          onClick: () => setNavSelection({ section: 'automations' }),
+          onClick: () => latestOptionsRef.current.setNavSelection({ section: 'automations' }),
         },
       });
     });
     function onKeyDown(event: globalThis.KeyboardEvent) {
       if ((event.metaKey || event.ctrlKey) && event.key === ',') {
         event.preventDefault();
-        openSettings();
+        latestOptionsRef.current.openSettings();
       }
     }
-    rendererMountedRef.current = true;
+    latest.rendererMountedRef.current = true;
     window.addEventListener('keydown', onKeyDown);
     return () => {
-      rendererMountedRef.current = false;
-      projectPickerRequestRef.current += 1;
-      projectPickerPendingRef.current = false;
+      const latest = latestOptionsRef.current;
+      latest.rendererMountedRef.current = false;
+      latest.projectPickerRequestRef.current += 1;
+      latest.projectPickerPendingRef.current = false;
       unsubscribeConnections();
       unsubscribeSessionChanges();
       unsubscribeOpenSettings();
       unsubscribePlanChanges();
       unsubscribePlanDue();
-      for (const timeoutHandle of pendingTurnActionTimersRef.current.values()) {
+      for (const timeoutHandle of latest.pendingTurnActionTimersRef.current.values()) {
         clearTimeout(timeoutHandle);
       }
-      pendingTurnActionTimersRef.current.clear();
-      pendingTurnActionsRef.current.clear();
-      pendingPermissionModeChangesRef.current.clear();
-      pendingSessionModelChangesRef.current.clear();
+      latest.pendingTurnActionTimersRef.current.clear();
+      latest.pendingTurnActionsRef.current.clear();
+      latest.pendingPermissionModeChangesRef.current.clear();
+      latest.pendingSessionModelChangesRef.current.clear();
       window.removeEventListener('keydown', onKeyDown);
     };
   }, []);
@@ -320,21 +309,19 @@ export function useActiveSessionEvents(options: {
   setSessionEventHealthBySession: SessionEventHealthUpdater;
   toastApi: Pick<ToastApi, 'error'>;
 }) {
-  const {
-    activeId,
-    activeIdRef,
-    handleEvent,
-    markSessionReadLocally,
-    setMessageLoadErrorBySession,
-    setMessages,
-    setSessionEventHealthBySession,
-    toastApi,
-  } = options;
+  const latestOptionsRef = useLatestRef(options);
+  const activeId = options.activeId;
 
   useEffect(() => {
     if (!activeId) return;
     let disposed = false;
     const subscribedAt = Date.now();
+    const latest = latestOptionsRef.current;
+    const {
+      setMessageLoadErrorBySession,
+      setMessages,
+      setSessionEventHealthBySession,
+    } = latest;
     setMessages([]);
     setMessageLoadErrorBySession((current) => {
       if (!current[activeId]) return current;
@@ -348,12 +335,14 @@ export function useActiveSessionEvents(options: {
     }));
     void window.maka.sessions.readMessages(activeId)
       .then((next) => {
+        const { activeIdRef, markSessionReadLocally, setMessages } = latestOptionsRef.current;
         if (!disposed && activeIdRef.current === activeId) {
           markSessionReadLocally(activeId, next);
           setMessages(next);
         }
       })
       .catch((error) => {
+        const { activeIdRef, setMessageLoadErrorBySession, toastApi } = latestOptionsRef.current;
         if (!disposed && activeIdRef.current === activeId) {
           const message = messageReadErrorMessage(error);
           setMessageLoadErrorBySession((current) => ({ ...current, [activeId]: message }));
@@ -361,6 +350,7 @@ export function useActiveSessionEvents(options: {
         }
       });
     const unsubscribe = window.maka.sessions.subscribeEvents(activeId, (event) => {
+      const { handleEvent, setSessionEventHealthBySession } = latestOptionsRef.current;
       setSessionEventHealthBySession((current) => {
         const previous = current[activeId];
         if (!previous) return current;
@@ -371,6 +361,7 @@ export function useActiveSessionEvents(options: {
     return () => {
       disposed = true;
       unsubscribe();
+      const { setSessionEventHealthBySession } = latestOptionsRef.current;
       setSessionEventHealthBySession((current) => {
         const previous = current[activeId];
         if (!previous) return current;


### PR DESCRIPTION
## Summary

- Replace the local latest-ref pattern in AppShell effect hooks with React `useEffectEvent`.
- Keep bootstrap subscriptions mounted once and active-session subscriptions keyed by `activeId`, while long-lived callbacks invoke the latest handlers.
- Keep the plan reminder toast action as a plain UI callback while preserving latest navigation behavior.
- Replace source-shape stability checks with behavior tests that rerender handler props, trigger captured old subscription callbacks, and assert no resubscribe plus latest-handler dispatch.
- Keep startup fail-soft, permission boundary, and active-session lifecycle contracts aligned with the effect-event shape.

## Why

Refs #477

AppShell subscription effects intentionally avoid resubscribing on every render, but they previously closed over many callback props. React 19's `useEffectEvent` is the smaller boundary for subscription, timer, and listener callbacks: subscription lifetime stays stable, callback bodies stay fresh, and ordinary UI callbacks stay outside the effect-event boundary.

## Scope

Changed:

- `useAppShellBootstrapSubscriptions()` now wraps subscription, timer, keydown, and cleanup callbacks with `useEffectEvent` while preserving the mount-once effect boundary.
- `useActiveSessionEvents()` still resubscribes by `activeId`, and its async read / session-event callbacks now use effect events for latest setters and handlers.
- Plan reminder due notifications still refresh reminders and show the same toast action, but the action click itself is a normal inline callback.
- AppShell effect stability coverage now proves old captured callbacks call the latest handler without a resubscribe, including the plan reminder toast action path.
- Existing startup fail-soft, permission boundary, and active-session lifecycle contracts were updated to match the effect-event owner path.

Not included:

- No visual redesign.
- No targeted memo work.
- No `ChatView` or AppShell component-size split.
- No change to subscription timing or user-visible copy.

## Verification

- GREEN: `npm run -w @maka/desktop build:main && (cd apps/desktop && node --test dist/main/__tests__/app-shell-effect-stability-contract.test.js dist/main/__tests__/session-message-lifecycle-contract.test.js dist/main/__tests__/permission-response-ipc-boundary.test.js dist/main/__tests__/renderer-startup-fail-soft-contract.test.js)` (26 passed)
- GREEN: `npm run -w @maka/desktop build:renderer` (passes; existing Vite large chunk warning remains)
- GREEN: `npm run -w @maka/desktop test` (1863 passed)

## User-facing impact

None expected. This is an AppShell effect-boundary refactor; UI layout, copy, and interaction timing should stay the same.

## Reviewer notes

The PR topic commits are rollback-sized:

- `refactor(ui-react): stabilize app shell effect callbacks`
- `test(ui-react): lock app shell effect stability contracts`
- `refactor(ui-react): use effect events for app shell subscriptions`
- `refactor(ui-react): keep plan toast actions outside effect events`

A final merge commit syncs `origin/main` so the PR is mergeable after the Windows titlebar change landed.
