### PR TITLE
perf(ui-react): memoize stable session rows

### DIFF
--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -27,9 +27,11 @@ describe('session row actions fail soft', () => {
     assert.match(main, /const sessionPrefix = `\$\{sessionId\}:`;/);
     assert.match(main, /Array\.from\(pendingSessionRowActionsRef\.current\)\.some\(\(key\) => key\.startsWith\(sessionPrefix\)\)/);
     assert.match(main, /pendingSessionRowActionsRef\.current\.add\(key\);[\s\S]*catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\)[\s\S]*finally \{[\s\S]*pendingSessionRowActionsRef\.current\.delete\(key\);/);
-    assert.match(main, /rowActions=\{\{[\s\S]*onToggleFlag: \(sessionId, next\) => flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => deleteSession\(sessionId\),/);
-    assert.doesNotMatch(main, /onDelete: \(sessionId\) => void deleteSession\(sessionId\)/);
-    assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void flagSession\(sessionId, next\)/);
+    assert.match(main, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\([\s\S]*onToggleFlag: \(sessionId, next\) => sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => sessionRowActionHandlersRef\.current\.renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\),/);
+    assert.match(main, /rowActions=\{sessionRowActions\}/);
+    assert.doesNotMatch(main, /rowActions=\{\{/);
+    assert.doesNotMatch(main, /onDelete: \(sessionId\) => void sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\)/);
+    assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\)/);
   });
 
   it('cleans active session renderer state consistently after archive or delete', async () => {

--- a/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts
@@ -22,6 +22,7 @@ describe('session row actions fail soft', () => {
 
   it('gates duplicate sidebar row actions before IPC or confirm dialogs can double-fire', async () => {
     const main = await readRendererShellCombinedSource();
+    const sessionListBlock = main.match(/<SessionListPanel[\s\S]*?\/>/)?.[0] ?? '';
 
     assert.match(main, /const pendingSessionRowActionsRef = useRef<Set<string>>\(new Set\(\)\);/);
     assert.match(main, /const sessionPrefix = `\$\{sessionId\}:`;/);
@@ -29,7 +30,10 @@ describe('session row actions fail soft', () => {
     assert.match(main, /pendingSessionRowActionsRef\.current\.add\(key\);[\s\S]*catch \(error\) \{[\s\S]*toastApi\.error\(errorTitle, generalizedErrorMessageChinese\(error, '会话操作失败，请稍后重试。'\)\)[\s\S]*finally \{[\s\S]*pendingSessionRowActionsRef\.current\.delete\(key\);/);
     assert.match(main, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\([\s\S]*onToggleFlag: \(sessionId, next\) => sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\),[\s\S]*onArchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.archiveSession\(sessionId\),[\s\S]*onUnarchive: \(sessionId\) => sessionRowActionHandlersRef\.current\.unarchiveSession\(sessionId\),[\s\S]*onRename: \(sessionId, name\) => sessionRowActionHandlersRef\.current\.renameSession\(sessionId, name\),[\s\S]*onDelete: \(sessionId\) => sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\),/);
     assert.match(main, /rowActions=\{sessionRowActions\}/);
-    assert.doesNotMatch(main, /rowActions=\{\{/);
+    assert.match(sessionListBlock, /onSelectSession=\{[^}]+\}/);
+    assert.match(sessionListBlock, /rowActions=\{[^}]+\}/);
+    assert.doesNotMatch(sessionListBlock, /onSelectSession=\{\(sessionId\)/);
+    assert.doesNotMatch(sessionListBlock, /rowActions=\{\{/);
     assert.doesNotMatch(main, /onDelete: \(sessionId\) => void sessionRowActionHandlersRef\.current\.deleteSession\(sessionId\)/);
     assert.doesNotMatch(main, /onToggleFlag: \(sessionId, next\) => void sessionRowActionHandlersRef\.current\.flagSession\(sessionId, next\)/);
   });

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { readFile, mkdir, mkdtemp } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
@@ -18,11 +18,18 @@ type SessionHistoryModule = {
     streamingSessionIds?: Set<string>;
     staleSessionIds?: Set<string>;
     onSelectSession(sessionId: string): void;
+    rowActions?: {
+      onToggleFlag(sessionId: string, next: boolean): void | Promise<void>;
+      onArchive(sessionId: string): void | Promise<void>;
+      onUnarchive(sessionId: string): void | Promise<void>;
+      onRename(sessionId: string, name: string): void | Promise<void>;
+      onDelete(sessionId: string): void | Promise<void>;
+    };
   }): ReactElement | null;
 };
 type RendererWindow = Window & typeof globalThis;
-type RenderProbeGlobal = typeof globalThis & {
-  __makaSessionRowRenderProbe?: (sessionId: string) => void;
+type MemoTestGlobal = typeof globalThis & {
+  __makaFormatCompactTimestampCount?: number;
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 
@@ -35,50 +42,73 @@ afterEach(() => {
 });
 
 describe('UI render memo boundary contract', () => {
-  it('keeps sidebar session rows from rendering on unrelated parent updates', async () => {
-    const { SessionHistoryList } = await importInstrumentedSessionHistoryList();
+  it('keeps AppShell sidebar row props stable enough for SessionRow memo', async () => {
+    const source = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/app-shell.tsx'), 'utf8');
+    const sessionListBlock = source.match(/<SessionListPanel[\s\S]*?\/>/)?.[0] ?? '';
+
+    assert.match(source, /const sessionListSelectSession = useCallback\(\(sessionId: string\) => \{[\s\S]*openSessionInChatRef\.current\(sessionId\);[\s\S]*\}, \[\]\);/);
+    assert.match(source, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\s*\(/);
+    assert.match(sessionListBlock, /onSelectSession=\{sessionListSelectSession\}/);
+    assert.match(sessionListBlock, /rowActions=\{sessionRowActions\}/);
+    assert.doesNotMatch(sessionListBlock, /onSelectSession=\{\(sessionId\)/);
+    assert.doesNotMatch(sessionListBlock, /rowActions=\{\{/);
+  });
+
+  it('keeps sidebar session rows from rendering on unrelated parent updates with row actions present', async () => {
+    const { SessionHistoryList } = await importSessionHistoryListWithCountedTimestamps();
     const root = installReactRenderer();
-    const rowRenderCount = new Map<string, number>();
     const sessions = [
       createSession('session-a', 'Alpha'),
       createSession('session-b', 'Beta'),
     ];
     const streamingSessionIds = new Set<string>();
     const staleSessionIds = new Set<string>();
+    const rowActions = createRowActions();
     const onSelectSession = () => {};
-    (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe = (sessionId) => {
-      rowRenderCount.set(sessionId, (rowRenderCount.get(sessionId) ?? 0) + 1);
-    };
+    (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount = 0;
 
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
       label: 'first parent render',
       onSelectSession,
+      rowActions,
       sessions,
       staleSessionIds,
       streamingSessionIds,
     }));
-    assert.deepEqual(Object.fromEntries(rowRenderCount), {
-      'session-a': 1,
-      'session-b': 1,
-    });
+    assert.equal((globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount, 2);
 
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
       label: 'unrelated parent render',
       onSelectSession,
+      rowActions,
       sessions,
       staleSessionIds,
       streamingSessionIds,
     }));
 
-    assert.deepEqual(
-      Object.fromEntries(rowRenderCount),
-      {
-        'session-a': 1,
-        'session-b': 1,
-      },
-      'stable session row props should not re-render when only sibling parent content changes',
+    assert.equal(
+      (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount,
+      2,
+      'stable session rows should not recompute row meta when only sibling parent content changes',
+    );
+
+    const nextStreamingSessionIds = new Set<string>(['session-a']);
+    await render(root, createElement(RenderHost, {
+      SessionHistoryList,
+      label: 'streaming session update',
+      onSelectSession,
+      rowActions,
+      sessions,
+      staleSessionIds,
+      streamingSessionIds: nextStreamingSessionIds,
+    }));
+
+    assert.equal(
+      (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount,
+      3,
+      'streaming updates should only recompute the row whose streaming flag changed',
     );
   });
 });
@@ -87,6 +117,7 @@ function RenderHost(props: {
   SessionHistoryList: SessionHistoryModule['SessionHistoryList'];
   label: string;
   onSelectSession(sessionId: string): void;
+  rowActions: NonNullable<Parameters<SessionHistoryModule['SessionHistoryList']>[0]['rowActions']>;
   sessions: SessionSummary[];
   staleSessionIds: Set<string>;
   streamingSessionIds: Set<string>;
@@ -101,6 +132,7 @@ function RenderHost(props: {
       streamingSessionIds: props.streamingSessionIds,
       staleSessionIds: props.staleSessionIds,
       onSelectSession: props.onSelectSession,
+      rowActions: props.rowActions,
     }),
   );
 }
@@ -122,7 +154,17 @@ function createSession(id: string, name: string): SessionSummary {
   };
 }
 
-async function importInstrumentedSessionHistoryList(): Promise<SessionHistoryModule> {
+function createRowActions(): NonNullable<Parameters<SessionHistoryModule['SessionHistoryList']>[0]['rowActions']> {
+  return {
+    onToggleFlag() {},
+    onArchive() {},
+    onUnarchive() {},
+    onRename() {},
+    onDelete() {},
+  };
+}
+
+async function importSessionHistoryListWithCountedTimestamps(): Promise<SessionHistoryModule> {
   const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/session-history-memo-'));
   const outfile = resolve(outdir, 'session-history-list.mjs');
   await mkdir(dirname(outfile), { recursive: true });
@@ -135,27 +177,28 @@ async function importInstrumentedSessionHistoryList(): Promise<SessionHistoryMod
     format: 'esm',
     target: 'node20',
     logLevel: 'silent',
-    plugins: [instrumentSessionRow(), mockOverlayScrollbars()],
+    plugins: [mockCoreTimestampFormatter(), mockOverlayScrollbars()],
   });
   return await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as SessionHistoryModule;
 }
 
-function instrumentSessionRow(): Plugin {
+function mockCoreTimestampFormatter(): Plugin {
   return {
-    name: 'instrument-session-row',
+    name: 'mock-core-timestamp-formatter',
     setup(buildApi) {
-      buildApi.onLoad({ filter: /packages\/ui\/src\/session-history-list\.tsx$/ }, async (args) => {
-        const source = await readFile(args.path, 'utf8');
-        const target = /(function SessionRow\(props: \{[\s\S]*?\n\}\) \{\n)/;
-        assert.match(source, target, 'test instrumentation must find the private SessionRow render boundary');
-        return {
-          loader: 'tsx',
-          contents: source.replace(
-            target,
-            `$1  (globalThis as typeof globalThis & { __makaSessionRowRenderProbe?: (sessionId: string) => void }).__makaSessionRowRenderProbe?.(props.session.id);\n`,
-          ),
-        };
-      });
+      buildApi.onResolve({ filter: /^@maka\/core$/ }, () => ({
+        path: 'maka-core-mock',
+        namespace: 'memo-test',
+      }));
+      buildApi.onLoad({ filter: /^maka-core-mock$/, namespace: 'memo-test' }, () => ({
+        loader: 'js',
+        contents: [
+          'export function formatCompactTimestamp() {',
+          '  globalThis.__makaFormatCompactTimestampCount = (globalThis.__makaFormatCompactTimestampCount ?? 0) + 1;',
+          '  return "just now";',
+          '}',
+        ].join('\n'),
+      }));
     },
   };
 }
@@ -200,8 +243,8 @@ function installFakeDom(): void {
   const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
   const previousHTMLElement = globalThis.HTMLElement;
   const previousHTMLIFrameElement = globalThis.HTMLIFrameElement;
-  const previousProbe = (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe;
-  const previousActEnvironment = (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT;
+  const previousCount = (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount;
+  const previousActEnvironment = (globalThis as MemoTestGlobal).IS_REACT_ACT_ENVIRONMENT;
   const fakeDocument = createFakeDocument();
   const fakeWindow = {
     document: fakeDocument,
@@ -219,15 +262,15 @@ function installFakeDom(): void {
     callback(0);
     return 0;
   };
-  (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  (globalThis as MemoTestGlobal).IS_REACT_ACT_ENVIRONMENT = true;
   cleanupTasks.push(() => {
     globalThis.document = previousDocument;
     globalThis.window = previousWindow;
     globalThis.requestAnimationFrame = previousRequestAnimationFrame;
     globalThis.HTMLElement = previousHTMLElement;
     globalThis.HTMLIFrameElement = previousHTMLIFrameElement;
-    (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe = previousProbe;
-    (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount = previousCount;
+    (globalThis as MemoTestGlobal).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
   });
 }
 

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'node:assert';
-import { mkdir, mkdtemp, readFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, it } from 'node:test';
 import type { SessionSummary } from '@maka/core';
@@ -29,9 +28,9 @@ type SessionHistoryModule = {
 };
 type RendererWindow = Window & typeof globalThis;
 type MemoTestGlobal = typeof globalThis & {
-  __makaFormatCompactTimestampCount?: number;
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
+type ResettableTimestamp = number & { reset(): void };
 
 const cleanupTasks: Array<() => void> = [];
 
@@ -42,31 +41,24 @@ afterEach(() => {
 });
 
 describe('UI render memo boundary contract', () => {
-  it('keeps AppShell sidebar row props stable enough for SessionRow memo', async () => {
-    const source = await readFile(resolve(REPO_ROOT, 'apps/desktop/src/renderer/app-shell.tsx'), 'utf8');
-    const sessionListBlock = source.match(/<SessionListPanel[\s\S]*?\/>/)?.[0] ?? '';
-
-    assert.match(source, /const sessionListSelectSession = useCallback\(\(sessionId: string\) => \{[\s\S]*openSessionInChatRef\.current\(sessionId\);[\s\S]*\}, \[\]\);/);
-    assert.match(source, /const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>\[0\]\['rowActions'\]>>\s*\(/);
-    assert.match(sessionListBlock, /onSelectSession=\{sessionListSelectSession\}/);
-    assert.match(sessionListBlock, /rowActions=\{sessionRowActions\}/);
-    assert.doesNotMatch(sessionListBlock, /onSelectSession=\{\(sessionId\)/);
-    assert.doesNotMatch(sessionListBlock, /rowActions=\{\{/);
-  });
-
   it('keeps sidebar session rows from rendering on unrelated parent updates with row actions present', async () => {
-    const { SessionHistoryList } = await importSessionHistoryListWithCountedTimestamps();
+    const { SessionHistoryList } = await importSessionHistoryList();
     const root = installReactRenderer();
+    let rowRenderCount = 0;
     const sessions = [
-      createSession('session-a', 'Alpha'),
-      createSession('session-b', 'Beta'),
+      createSession('session-a', 'Alpha', () => {
+        rowRenderCount += 1;
+      }),
+      createSession('session-b', 'Beta', () => {
+        rowRenderCount += 1;
+      }),
     ];
     const streamingSessionIds = new Set<string>();
     const staleSessionIds = new Set<string>();
     const rowActions = createRowActions();
     const onSelectSession = () => {};
-    (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount = 0;
 
+    resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
       label: 'first parent render',
@@ -76,8 +68,9 @@ describe('UI render memo boundary contract', () => {
       staleSessionIds,
       streamingSessionIds,
     }));
-    assert.equal((globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount, 2);
+    assert.equal(rowRenderCount, 2);
 
+    resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
       label: 'unrelated parent render',
@@ -89,12 +82,13 @@ describe('UI render memo boundary contract', () => {
     }));
 
     assert.equal(
-      (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount,
+      rowRenderCount,
       2,
       'stable session rows should not recompute row meta when only sibling parent content changes',
     );
 
     const nextStreamingSessionIds = new Set<string>(['session-a']);
+    resetTimestampCounters(sessions);
     await render(root, createElement(RenderHost, {
       SessionHistoryList,
       label: 'streaming session update',
@@ -106,7 +100,7 @@ describe('UI render memo boundary contract', () => {
     }));
 
     assert.equal(
-      (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount,
+      rowRenderCount,
       3,
       'streaming updates should only recompute the row whose streaming flag changed',
     );
@@ -137,7 +131,7 @@ function RenderHost(props: {
   );
 }
 
-function createSession(id: string, name: string): SessionSummary {
+function createSession(id: string, name: string, onRender: () => void): SessionSummary {
   return {
     id,
     name,
@@ -145,13 +139,40 @@ function createSession(id: string, name: string): SessionSummary {
     isArchived: false,
     labels: [],
     hasUnread: false,
-    lastMessageAt: 1_700_000_000_000,
+    lastMessageAt: createCountedTimestamp(1_700_000_000_000, onRender) as unknown as number,
     status: 'active',
     backend: 'fake',
     llmConnectionSlug: 'fake',
     model: 'fake-model',
     permissionMode: 'ask',
   };
+}
+
+function createCountedTimestamp(value: number, onRender: () => void): ResettableTimestamp {
+  let counted = false;
+  return {
+    reset() {
+      counted = false;
+    },
+    valueOf() {
+      // The parent also reads lastMessageAt for bucketing; only row rendering
+      // calls the compact timestamp formatter.
+      if (!counted && new Error().stack?.includes('formatCompactTimestamp')) {
+        counted = true;
+        onRender();
+      }
+      return value;
+    },
+    [Symbol.toPrimitive]() {
+      return this.valueOf();
+    },
+  } as unknown as ResettableTimestamp;
+}
+
+function resetTimestampCounters(sessions: SessionSummary[]): void {
+  for (const session of sessions) {
+    (session.lastMessageAt as ResettableTimestamp).reset();
+  }
 }
 
 function createRowActions(): NonNullable<Parameters<SessionHistoryModule['SessionHistoryList']>[0]['rowActions']> {
@@ -164,43 +185,20 @@ function createRowActions(): NonNullable<Parameters<SessionHistoryModule['Sessio
   };
 }
 
-async function importSessionHistoryListWithCountedTimestamps(): Promise<SessionHistoryModule> {
-  const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/session-history-memo-'));
-  const outfile = resolve(outdir, 'session-history-list.mjs');
-  await mkdir(dirname(outfile), { recursive: true });
+async function importSessionHistoryList(): Promise<SessionHistoryModule> {
+  const outfile = resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/session-history-list.memo-bundle.mjs');
   await build({
-    entryPoints: [resolve(REPO_ROOT, 'packages/ui/src/session-history-list.tsx')],
+    entryPoints: [resolve(REPO_ROOT, 'packages/ui/dist/session-history-list.js')],
     outfile,
     bundle: true,
-    external: ['@base-ui/react', LUCIDE_REACT_PACKAGE, 'react', 'react-dom', 'react-dom/*', 'react/jsx-runtime'],
+    external: ['@base-ui/react', '@maka/core', LUCIDE_REACT_PACKAGE, 'react', 'react-dom', 'react-dom/*', 'react/jsx-runtime'],
     platform: 'node',
     format: 'esm',
     target: 'node20',
     logLevel: 'silent',
-    plugins: [mockCoreTimestampFormatter(), mockOverlayScrollbars()],
+    plugins: [mockOverlayScrollbars()],
   });
   return await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as SessionHistoryModule;
-}
-
-function mockCoreTimestampFormatter(): Plugin {
-  return {
-    name: 'mock-core-timestamp-formatter',
-    setup(buildApi) {
-      buildApi.onResolve({ filter: /^@maka\/core$/ }, () => ({
-        path: 'maka-core-mock',
-        namespace: 'memo-test',
-      }));
-      buildApi.onLoad({ filter: /^maka-core-mock$/, namespace: 'memo-test' }, () => ({
-        loader: 'js',
-        contents: [
-          'export function formatCompactTimestamp() {',
-          '  globalThis.__makaFormatCompactTimestampCount = (globalThis.__makaFormatCompactTimestampCount ?? 0) + 1;',
-          '  return "just now";',
-          '}',
-        ].join('\n'),
-      }));
-    },
-  };
 }
 
 function mockOverlayScrollbars(): Plugin {
@@ -243,7 +241,6 @@ function installFakeDom(): void {
   const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
   const previousHTMLElement = globalThis.HTMLElement;
   const previousHTMLIFrameElement = globalThis.HTMLIFrameElement;
-  const previousCount = (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount;
   const previousActEnvironment = (globalThis as MemoTestGlobal).IS_REACT_ACT_ENVIRONMENT;
   const fakeDocument = createFakeDocument();
   const fakeWindow = {
@@ -269,7 +266,6 @@ function installFakeDom(): void {
     globalThis.requestAnimationFrame = previousRequestAnimationFrame;
     globalThis.HTMLElement = previousHTMLElement;
     globalThis.HTMLIFrameElement = previousHTMLIFrameElement;
-    (globalThis as MemoTestGlobal).__makaFormatCompactTimestampCount = previousCount;
     (globalThis as MemoTestGlobal).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
   });
 }

--- a/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts
@@ -1,0 +1,316 @@
+import { strict as assert } from 'node:assert';
+import { readFile, mkdir, mkdtemp } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, it } from 'node:test';
+import type { SessionSummary } from '@maka/core';
+import { build, type Plugin } from 'esbuild';
+import { act, createElement, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const LUCIDE_REACT_PACKAGE = ['lucide', 'react'].join('-');
+
+type SessionHistoryModule = {
+  SessionHistoryList(props: {
+    sessions: SessionSummary[];
+    activeId?: string;
+    streamingSessionIds?: Set<string>;
+    staleSessionIds?: Set<string>;
+    onSelectSession(sessionId: string): void;
+  }): ReactElement | null;
+};
+type RendererWindow = Window & typeof globalThis;
+type RenderProbeGlobal = typeof globalThis & {
+  __makaSessionRowRenderProbe?: (sessionId: string) => void;
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const cleanupTasks: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanupTasks.length > 0) {
+    cleanupTasks.pop()?.();
+  }
+});
+
+describe('UI render memo boundary contract', () => {
+  it('keeps sidebar session rows from rendering on unrelated parent updates', async () => {
+    const { SessionHistoryList } = await importInstrumentedSessionHistoryList();
+    const root = installReactRenderer();
+    const rowRenderCount = new Map<string, number>();
+    const sessions = [
+      createSession('session-a', 'Alpha'),
+      createSession('session-b', 'Beta'),
+    ];
+    const streamingSessionIds = new Set<string>();
+    const staleSessionIds = new Set<string>();
+    const onSelectSession = () => {};
+    (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe = (sessionId) => {
+      rowRenderCount.set(sessionId, (rowRenderCount.get(sessionId) ?? 0) + 1);
+    };
+
+    await render(root, createElement(RenderHost, {
+      SessionHistoryList,
+      label: 'first parent render',
+      onSelectSession,
+      sessions,
+      staleSessionIds,
+      streamingSessionIds,
+    }));
+    assert.deepEqual(Object.fromEntries(rowRenderCount), {
+      'session-a': 1,
+      'session-b': 1,
+    });
+
+    await render(root, createElement(RenderHost, {
+      SessionHistoryList,
+      label: 'unrelated parent render',
+      onSelectSession,
+      sessions,
+      staleSessionIds,
+      streamingSessionIds,
+    }));
+
+    assert.deepEqual(
+      Object.fromEntries(rowRenderCount),
+      {
+        'session-a': 1,
+        'session-b': 1,
+      },
+      'stable session row props should not re-render when only sibling parent content changes',
+    );
+  });
+});
+
+function RenderHost(props: {
+  SessionHistoryList: SessionHistoryModule['SessionHistoryList'];
+  label: string;
+  onSelectSession(sessionId: string): void;
+  sessions: SessionSummary[];
+  staleSessionIds: Set<string>;
+  streamingSessionIds: Set<string>;
+}) {
+  return createElement(
+    'div',
+    null,
+    createElement('p', null, props.label),
+    createElement(props.SessionHistoryList, {
+      sessions: props.sessions,
+      activeId: 'session-a',
+      streamingSessionIds: props.streamingSessionIds,
+      staleSessionIds: props.staleSessionIds,
+      onSelectSession: props.onSelectSession,
+    }),
+  );
+}
+
+function createSession(id: string, name: string): SessionSummary {
+  return {
+    id,
+    name,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    lastMessageAt: 1_700_000_000_000,
+    status: 'active',
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+  };
+}
+
+async function importInstrumentedSessionHistoryList(): Promise<SessionHistoryModule> {
+  const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/session-history-memo-'));
+  const outfile = resolve(outdir, 'session-history-list.mjs');
+  await mkdir(dirname(outfile), { recursive: true });
+  await build({
+    entryPoints: [resolve(REPO_ROOT, 'packages/ui/src/session-history-list.tsx')],
+    outfile,
+    bundle: true,
+    external: ['@base-ui/react', LUCIDE_REACT_PACKAGE, 'react', 'react-dom', 'react-dom/*', 'react/jsx-runtime'],
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    logLevel: 'silent',
+    plugins: [instrumentSessionRow(), mockOverlayScrollbars()],
+  });
+  return await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as SessionHistoryModule;
+}
+
+function instrumentSessionRow(): Plugin {
+  return {
+    name: 'instrument-session-row',
+    setup(buildApi) {
+      buildApi.onLoad({ filter: /packages\/ui\/src\/session-history-list\.tsx$/ }, async (args) => {
+        const source = await readFile(args.path, 'utf8');
+        const target = /(function SessionRow\(props: \{[\s\S]*?\n\}\) \{\n)/;
+        assert.match(source, target, 'test instrumentation must find the private SessionRow render boundary');
+        return {
+          loader: 'tsx',
+          contents: source.replace(
+            target,
+            `$1  (globalThis as typeof globalThis & { __makaSessionRowRenderProbe?: (sessionId: string) => void }).__makaSessionRowRenderProbe?.(props.session.id);\n`,
+          ),
+        };
+      });
+    },
+  };
+}
+
+function mockOverlayScrollbars(): Plugin {
+  return {
+    name: 'mock-overlayscrollbars',
+    setup(buildApi) {
+      buildApi.onResolve({ filter: /^overlayscrollbars$/ }, () => ({
+        path: 'overlayscrollbars-mock',
+        namespace: 'memo-test',
+      }));
+      buildApi.onLoad({ filter: /^overlayscrollbars-mock$/, namespace: 'memo-test' }, () => ({
+        loader: 'js',
+        contents: 'export function OverlayScrollbars() { return { destroy() {}, options() {} }; }',
+      }));
+    },
+  };
+}
+
+function installReactRenderer(): Root {
+  installFakeDom();
+  const container = new FakeElement('div', document);
+  const root = createRoot(container as unknown as Element);
+  cleanupTasks.push(() => {
+    act(() => {
+      root.unmount();
+    });
+  });
+  return root;
+}
+
+async function render(root: Root, element: ReactElement): Promise<void> {
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+function installFakeDom(): void {
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const previousHTMLElement = globalThis.HTMLElement;
+  const previousHTMLIFrameElement = globalThis.HTMLIFrameElement;
+  const previousProbe = (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe;
+  const previousActEnvironment = (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT;
+  const fakeDocument = createFakeDocument();
+  const fakeWindow = {
+    document: fakeDocument,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    HTMLElement: FakeElement,
+    HTMLIFrameElement: class HTMLIFrameElement {},
+  } as unknown as RendererWindow;
+  Object.defineProperty(fakeDocument, 'defaultView', { value: fakeWindow });
+  globalThis.document = fakeDocument;
+  globalThis.window = fakeWindow;
+  globalThis.HTMLElement = FakeElement as unknown as typeof HTMLElement;
+  globalThis.HTMLIFrameElement = fakeWindow.HTMLIFrameElement;
+  globalThis.requestAnimationFrame = (callback) => {
+    callback(0);
+    return 0;
+  };
+  (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT = true;
+  cleanupTasks.push(() => {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+    globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+    globalThis.HTMLElement = previousHTMLElement;
+    globalThis.HTMLIFrameElement = previousHTMLIFrameElement;
+    (globalThis as RenderProbeGlobal).__makaSessionRowRenderProbe = previousProbe;
+    (globalThis as RenderProbeGlobal).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  });
+}
+
+function createFakeDocument(): Document {
+  const fakeDocument = {
+    nodeType: 9,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    createElement(tagName: string) {
+      return new FakeElement(tagName, fakeDocument as unknown as Document);
+    },
+    createElementNS(_namespace: string, tagName: string) {
+      return new FakeElement(tagName, fakeDocument as unknown as Document);
+    },
+    createTextNode(text: string) {
+      return new FakeText(text, fakeDocument as unknown as Document);
+    },
+  };
+  Object.defineProperty(fakeDocument, 'documentElement', {
+    value: new FakeElement('html', fakeDocument as unknown as Document),
+  });
+  return fakeDocument as unknown as Document;
+}
+
+class FakeElement {
+  readonly attributes = new Map<string, string>();
+  readonly childNodes: Array<FakeElement | FakeText> = [];
+  readonly namespaceURI = 'http://www.w3.org/1999/xhtml';
+  readonly nodeName: string;
+  readonly nodeType = 1;
+  readonly tagName: string;
+  parentNode: FakeElement | null = null;
+  textContent = '';
+
+  constructor(tagName: string, readonly ownerDocument: Document) {
+    this.tagName = tagName.toUpperCase();
+    this.nodeName = this.tagName;
+  }
+
+  addEventListener(): void {}
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  appendChild<T extends FakeElement | FakeText>(node: T): T {
+    this.childNodes.push(node);
+    node.parentNode = this;
+    return node;
+  }
+
+  insertBefore<T extends FakeElement | FakeText>(node: T, before: FakeElement | FakeText | null): T {
+    const index = before ? this.childNodes.indexOf(before) : -1;
+    if (index < 0) return this.appendChild(node);
+    this.childNodes.splice(index, 0, node);
+    node.parentNode = this;
+    return node;
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  removeChild<T extends FakeElement | FakeText>(node: T): T {
+    const index = this.childNodes.indexOf(node);
+    if (index >= 0) {
+      this.childNodes.splice(index, 1);
+    }
+    node.parentNode = null;
+    return node;
+  }
+
+  removeEventListener(): void {}
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeText {
+  readonly nodeName = '#text';
+  readonly nodeType = 3;
+  parentNode: FakeElement | null = null;
+
+  constructor(readonly nodeValue: string, readonly ownerDocument: Document) {}
+}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -438,13 +438,7 @@ export function AppShell() {
     clearSessionUiState(sessionId);
   }
 
-  const {
-    flagSession,
-    archiveSession,
-    unarchiveSession,
-    renameSession,
-    deleteSession,
-  } = createAppShellSessionRowActions({
+  const sessionRowActionHandlers = createAppShellSessionRowActions({
     activeIdRef,
     clearSessionRendererState,
     pendingSessionRowActionsRef,
@@ -454,6 +448,18 @@ export function AppShell() {
     setMessages,
     toastApi,
   });
+  const sessionRowActionHandlersRef = useRef(sessionRowActionHandlers);
+  sessionRowActionHandlersRef.current = sessionRowActionHandlers;
+  const sessionRowActions = useMemo<NonNullable<Parameters<typeof SessionListPanel>[0]['rowActions']>>(
+    () => ({
+      onToggleFlag: (sessionId, next) => sessionRowActionHandlersRef.current.flagSession(sessionId, next),
+      onArchive: (sessionId) => sessionRowActionHandlersRef.current.archiveSession(sessionId),
+      onUnarchive: (sessionId) => sessionRowActionHandlersRef.current.unarchiveSession(sessionId),
+      onRename: (sessionId, name) => sessionRowActionHandlersRef.current.renameSession(sessionId, name),
+      onDelete: (sessionId) => sessionRowActionHandlersRef.current.deleteSession(sessionId),
+    }),
+    [],
+  );
 
   const {
     setPermissionMode,
@@ -545,6 +551,9 @@ export function AppShell() {
   }, []);
   const paletteOnSelectSession = useCallback((sessionId: string, turnId?: string) => {
     openSessionInChatRef.current(sessionId, turnId);
+  }, []);
+  const sessionListSelectSession = useCallback((sessionId: string) => {
+    openSessionInChatRef.current(sessionId);
   }, []);
 
   // PR109b: chat header lifecycle status badge. Hidden for `active`
@@ -1193,18 +1202,10 @@ export function AppShell() {
             staleSessionIds={staleSessionIds}
             statusGroups={sessionStatusGroups}
             onSelect={setNavSelection}
-            onSelectSession={(sessionId) => {
-              openSessionInChat(sessionId);
-            }}
+            onSelectSession={sessionListSelectSession}
             onOpenSettings={openSettings}
             onNew={createSession}
-            rowActions={{
-              onToggleFlag: (sessionId, next) => flagSession(sessionId, next),
-              onArchive: (sessionId) => archiveSession(sessionId),
-              onUnarchive: (sessionId) => unarchiveSession(sessionId),
-              onRename: (sessionId, name) => renameSession(sessionId, name),
-              onDelete: (sessionId) => deleteSession(sessionId),
-            }}
+            rowActions={sessionRowActions}
             sidebarCollapsed={sessionListCollapsed}
           />
         </div>

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FocusEvent, type KeyboardEvent, type MouseEvent } from 'react';
+import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent, type MouseEvent } from 'react';
 import type { SessionSummary } from '@maka/core';
 import { formatCompactTimestamp } from '@maka/core';
 import {
@@ -444,7 +444,7 @@ const BLOCKED_REASON_TOOLTIP = {
   unknown: '运行中断，可重试',
 } as const;
 
-function SessionRow(props: {
+const SessionRow = memo(function SessionRow(props: {
   session: SessionSummary;
   active: boolean;
   /** This session has a live streaming delta in flight. */
@@ -785,7 +785,7 @@ function SessionRow(props: {
       )}
     </div>
   );
-}
+});
 
 interface SessionGroup {
   label: string;


### PR DESCRIPTION
## Summary

- Memoize the private `SessionRow` render boundary inside `SessionHistoryList`.
- Stabilize the real `AppShell -> SessionListPanel` sidebar inputs so `onSelectSession` and `rowActions` no longer churn on unrelated AppShell renders.
- Keep the render-count contract on the public `SessionHistoryList` path with `rowActions` present, unrelated parent updates, and a single-row streaming update.

## Why

Refs #477

PR9 is the evidence-based memo pass after the React cleanup series. `SessionRow` has local hover/edit/pending state and sits under a sidebar owner that can rerender for unrelated parent state. The first pass memoized the row, but review found the real AppShell owner still passed a fresh select handler and fresh row action object every render, which would defeat the memo boundary on the hot sidebar path. This update makes those owner props stable while still dispatching to the latest action handlers through refs.

## Scope

Changed:

- `packages/ui/src/session-history-list.tsx`: wrap private `SessionRow` with React `memo`.
- `apps/desktop/src/renderer/app-shell.tsx`: pass stable `sessionListSelectSession` and stable `sessionRowActions` into `SessionListPanel`.
- `apps/desktop/src/main/__tests__/ui-render-memo-boundary-contract.test.ts`: keep only the public `SessionHistoryList` render-count contract; it no longer source-scans AppShell, regex-injects `SessionRow`, or mocks `@maka/core`.
- `apps/desktop/src/main/__tests__/session-row-actions-fail-soft-contract.test.ts`: keep owner no-inline and fail-soft row action wiring checks in the existing AppShell wiring contract.

Not included:

- No visual redesign.
- No `ToolActivity` memo boundary without render evidence.
- No `ChatView` or AppShell split.
- No public API changes.

## Verification

- RED: before the AppShell fix, `ui-render-memo-boundary-contract` failed because `sessionListSelectSession` / `sessionRowActions` did not exist and `SessionListPanel` still received inline props.
- GREEN: `npm run -w @maka/ui build`
- GREEN: `npm run -w @maka/desktop build:main && node --test apps/desktop/dist/main/__tests__/ui-render-memo-boundary-contract.test.js apps/desktop/dist/main/__tests__/session-row-actions-fail-soft-contract.test.js` (5 passed)
- GREEN: `npm run -w @maka/desktop build:renderer` (passes; existing Vite large chunk warning remains)
- GREEN: `npm run -w @maka/desktop test` (1864 passed)
- KNOWN BASELINE FAIL: `npm run -w @maka/ui test` still fails on the pre-existing `chat-primitives.test` footer/lineage merge assertions (`gap-[6px]`, `gap-[3px]`); this PR does not touch those files or classes.

## User-facing impact

No behavior or visual change intended. Sidebar session rows should do less React work when parent/sidebar state changes without changing the row props.

## Reviewer notes

Review fix commits:

- `5e8e2028 perf(ui-react): stabilize sidebar row inputs`
- `654bb91d test(ui-react): slim sidebar memo contract`

The render-count test still bundles the built UI file so React client rendering can run inside the Node desktop test environment without adding a DOM test dependency, but the temporary bundle now only replaces OverlayScrollbars' browser-only side effect. It uses the real `@maka/core` formatter and the built `packages/ui/dist/session-history-list.js` output. Owner no-inline coverage moved to the existing AppShell row-action wiring contract, where re-inlining `onSelectSession` or `rowActions` fails the test.
