### PR TITLE
feat(cli): make TUI controls usable

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -123,6 +123,36 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(visibleLines.includes('maka'));
     assert.ok(!visibleLines.includes('Assistant'));
   });
+
+  test('surfaces pending permission requests with terminal decision hints', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'permission_request',
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+      hint: 'Run tests before editing.',
+    }));
+
+    const visibleLines = renderMakaPiTranscript(state, {
+      title: 'Maka',
+      cwd: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+    }, 100).map(stripAnsi);
+
+    assert.equal(state.pendingPermission?.requestId, 'permission-1');
+    assert.ok(visibleLines.some((line) => line.includes('Permission required')));
+    assert.ok(visibleLines.some((line) => line.includes('Bash')));
+    assert.ok(visibleLines.some((line) => line.includes('npm test')));
+    assert.ok(visibleLines.some((line) => line.includes('y/Enter allow')));
+    assert.ok(visibleLines.some((line) => line.includes('n/Esc deny')));
+  });
 });
 
 class RecordingDriver {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -2,11 +2,13 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import type { SessionEvent } from '@maka/core/events';
+import type { StoredMessage } from '@maka/core/session';
 import {
   appendUserPrompt,
   applyMakaSessionEventToTranscript,
   createMakaPiTranscriptState,
   renderMakaPiTranscript,
+  replaceTranscriptWithStoredMessages,
   submitPromptToTranscript,
   toggleLatestToolExpansion,
 } from '../pi-transcript.js';
@@ -82,6 +84,53 @@ describe('Maka Pi TUI transcript', () => {
     assert.equal(state.entries[0]?.kind === 'user' ? state.entries[0].text : '', 'hi');
     assert.equal(state.entries[1]?.kind === 'assistant' ? state.entries[1].text : '', 'Hello from Maka');
     assert.ok(changes >= 2);
+  });
+
+  test('rebuilds transcript from stored session messages', () => {
+    const state = createMakaPiTranscriptState();
+
+    replaceTranscriptWithStoredMessages(state, [
+      {
+        type: 'user',
+        id: 'user-1',
+        turnId: 'turn-1',
+        ts: 1,
+        text: 'What did we decide?',
+      },
+      {
+        type: 'assistant',
+        id: 'assistant-1',
+        turnId: 'turn-1',
+        ts: 2,
+        text: 'We decided to keep the TUI small.',
+        modelId: 'deepseek-v4-flash',
+      },
+      {
+        type: 'tool_call',
+        id: 'tool-1',
+        turnId: 'turn-1',
+        ts: 3,
+        toolName: 'Read',
+        args: { path: 'README.md' },
+      },
+      {
+        type: 'tool_result',
+        id: 'tool-result-1',
+        turnId: 'turn-1',
+        ts: 4,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: { kind: 'text', text: 'README contents' },
+      },
+    ] satisfies StoredMessage[]);
+
+    assert.deepEqual(state.entries.map((entry) => entry.kind), ['user', 'assistant', 'tool']);
+    assert.equal(state.entries[0]?.kind === 'user' ? state.entries[0].text : '', 'What did we decide?');
+    assert.equal(
+      state.entries[1]?.kind === 'assistant' ? state.entries[1].text : '',
+      'We decided to keep the TUI small.',
+    );
+    assert.equal(state.entries[2]?.kind === 'tool' ? state.entries[2].output : '', 'README contents');
   });
 
   test('renders every transcript line within the terminal width', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -8,6 +8,7 @@ import {
   createMakaPiTranscriptState,
   renderMakaPiTranscript,
   submitPromptToTranscript,
+  toggleLatestToolExpansion,
 } from '../pi-transcript.js';
 
 describe('Maka Pi TUI transcript', () => {
@@ -152,6 +153,55 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(visibleLines.some((line) => line.includes('npm test')));
     assert.ok(visibleLines.some((line) => line.includes('y/Enter allow')));
     assert.ok(visibleLines.some((line) => line.includes('n/Esc deny')));
+  });
+
+  test('keeps tool cards compact until the latest tool is expanded', () => {
+    const state = createMakaPiTranscriptState();
+    const longStdout = `${'x'.repeat(900)}\nexpanded-tail`;
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      isError: false,
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'npm test',
+        exitCode: 0,
+        stdout: longStdout,
+        stderr: '',
+      },
+    }));
+
+    const compact = renderMakaPiTranscript(state, {
+      title: 'Maka',
+      cwd: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+    }, 100).map(stripAnsi).join('\n');
+
+    assert.match(compact, /Tool Bash done/);
+    assert.match(compact, /command: npm test/);
+    assert.match(compact, /Ctrl\+O expand/);
+    assert.doesNotMatch(compact, /expanded-tail/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, {
+      title: 'Maka',
+      cwd: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+    }, 100).map(stripAnsi).join('\n');
+
+    assert.match(expanded, /expanded-tail/);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -125,6 +125,26 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(!visibleLines.includes('Assistant'));
   });
 
+  test('uses logo blue instead of green for assistant headings', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta',
+      messageId: 'message-1',
+      text: 'hello',
+    }));
+
+    const rawOutput = renderMakaPiTranscript(state, {
+      title: 'Maka',
+      cwd: '/tmp/project',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'bypass',
+    }, 80).join('\n');
+
+    assert.match(rawOutput, /\x1b\[38;2;87;163;239mmaka\x1b\[39m/);
+    assert.doesNotMatch(rawOutput, /\x1b\[32mmaka/);
+  });
+
   test('surfaces pending permission requests with terminal decision hints', () => {
     const state = createMakaPiTranscriptState();
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -185,6 +185,7 @@ class RejectingStopDriver implements MakaSessionDriver {
   }
 
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
 
   getSessionId(): string {
@@ -239,6 +240,7 @@ class PermissionPromptDriver implements MakaSessionDriver {
     this.permissionResponses.push(response);
     this.continueAfterPermission?.();
   }
+  async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
 
   getSessionId(): string {
@@ -284,6 +286,7 @@ class ToolOutputDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   getSessionId(): string {
     return 'session-1';
@@ -307,6 +310,7 @@ class SlashCommandDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setModel(): Promise<void> {}
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4,7 +4,7 @@ import { describe, test } from 'node:test';
 import { visibleWidth, type Terminal } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage } from '@maka/core';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from '../session-driver.js';
-import { runMakaPiTui } from '../pi-tui-runner.js';
+import { arrangeAutocompleteAboveEditor, runMakaPiTui } from '../pi-tui-runner.js';
 
 describe('Maka Pi TUI runner', () => {
   test('restores the terminal when driver stop rejects during close', async () => {
@@ -404,6 +404,83 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close after Ctrl-C');
       }),
     ]);
+  });
+
+  test('keeps slash autocomplete filtering pinned to the bottom after scrollback', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new LongTranscriptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('fill');
+    terminal.input('\r');
+
+    await waitFor(() => driver.prompts.length === 1);
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('filler line 40'));
+
+    terminal.input('/');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
+    const beforeLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const beforeRows = inputSurfaceRows(beforeLines);
+
+    terminal.input('s');
+
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/s'));
+    const afterLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const afterRows = inputSurfaceRows(afterLines);
+    const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
+
+    assert.deepEqual(afterRows, beforeRows);
+    assert.equal(afterRows[1], terminal.rows - 2);
+    assert.equal(afterSessionRow, afterRows[0] - 1);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('bottom-aligns filtered autocomplete inside a stable slot', () => {
+    const expanded = arrangeAutocompleteAboveEditor({
+      lines: [
+        '────────',
+        '/ ',
+        '────────',
+        '→ /exit',
+        '  /model',
+        '  /permissions',
+        '  /session',
+      ],
+      autocompleteShowing: true,
+      autocompleteSlotRows: 0,
+    });
+
+    const filtered = arrangeAutocompleteAboveEditor({
+      lines: [
+        '────────',
+        '/s ',
+        '────────',
+        '→ /session',
+      ],
+      autocompleteShowing: true,
+      autocompleteSlotRows: expanded.autocompleteSlotRows,
+    });
+
+    assert.equal(filtered.lines.length, expanded.lines.length);
+    assert.deepEqual(filtered.lines.slice(0, 4), ['', '', '', '→ /session']);
+    assert.deepEqual(filtered.lines.slice(4), ['────────', '/s ', '────────']);
   });
 
   test('handles /exit without sending a prompt', async () => {
@@ -940,6 +1017,27 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
 }
 
+class LongTranscriptDriver extends SlashCommandDriver {
+  override async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    yield {
+      type: 'text_complete',
+      id: 'event-text-complete',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: Array.from({ length: 40 }, (_, index) => `filler line ${index + 1}`).join('\n'),
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 2,
+      stopReason: 'end_turn',
+    };
+  }
+}
+
 function switchResult(summary: SessionSummary, messages: StoredMessage[] = []): MakaSessionSwitchResult {
   return { summary, messages };
 }
@@ -1131,7 +1229,7 @@ function renderTerminalScreen(writes: readonly string[], rows: number): string {
   }
 
   while (screen.length < rows) screen.push('');
-  return screen.slice(0, rows).join('\n');
+  return screen.slice(Math.max(0, screen.length - rows)).join('\n');
 }
 
 interface ScreenEscapeActions {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -237,6 +237,45 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('selects a model from /model', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      models: ['deepseek-v4-flash', 'gpt-5.3-codex-spark'],
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/model');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Select Model'));
+    await waitFor(() => terminal.output().includes('gpt-5.3-codex-spark'));
+    const titleLine = latestPlainLineContaining(terminal.output(), 'Select Model');
+    assert.equal(titleLine.startsWith('Select Model'), true);
+    assert.equal(visibleWidth(titleLine), terminal.columns);
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+    await waitFor(() => terminal.output().includes('Model: gpt-5.3-codex-spark'));
+
+    assert.deepEqual(driver.models, ['gpt-5.3-codex-spark']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /session without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/other-repo')]);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -206,7 +206,7 @@ describe('Maka Pi TUI runner', () => {
 
   test('handles /session without sending a prompt', async () => {
     const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver();
+    const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/other-repo')]);
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -222,6 +222,7 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => driver.sessionIds.length === 1);
     await waitFor(() => terminal.output().includes('Session: session-2'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/other-repo'));
 
     assert.deepEqual(driver.sessionIds, ['session-2']);
     assert.deepEqual(driver.prompts, []);
@@ -482,7 +483,8 @@ class SlashCommandDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<SessionSummary> {
     this.sessionIds.push(sessionId);
     this.sessionId = sessionId;
-    return fakeSessionSummary(sessionId);
+    const summary = this.sessions.find((session) => session.id === sessionId);
+    return summary ?? fakeSessionSummary(sessionId);
   }
   getSessionId(): string {
     return this.sessionId;

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1,10 +1,19 @@
 import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
-import { visibleWidth, type Terminal } from '@earendil-works/pi-tui';
+import { visibleWidth } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage } from '@maka/core';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from '../session-driver.js';
-import { arrangeAutocompleteAboveEditor, runMakaPiTui } from '../pi-tui-runner.js';
+import { runMakaPiTui } from '../pi-tui-runner.js';
+import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
+import {
+  assertBottomPickerPlacement,
+  FakeTerminal,
+  inputSurfaceRows,
+  latestPlainLineContaining,
+  plainTerminalOutput,
+  waitFor,
+} from './tui-terminal-mock.js';
 
 describe('Maka Pi TUI runner', () => {
   test('restores the terminal when driver stop rejects during close', async () => {
@@ -685,7 +694,7 @@ describe('Maka Pi TUI runner', () => {
 
   test('handles /session without sending a prompt', async () => {
     const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/other-repo')]);
+    const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/repo')]);
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -701,7 +710,6 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => driver.sessionIds.length === 1);
     await waitFor(() => terminal.output().includes('Resumed session "Existing chat"'));
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/other-repo'));
 
     assert.deepEqual(driver.sessionIds, ['session-2']);
     assert.deepEqual(driver.prompts, []);
@@ -819,6 +827,139 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(output.includes('session-other'), false);
 
     terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('blocks prompt submission while a control command is in flight', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredControlDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/model claude-opus-4-1');
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+
+    // While the model switch is in flight, typing + Enter must not send a prompt.
+    terminal.input('blocked');
+    terminal.input('\r');
+    await delay(20);
+    assert.deepEqual(driver.prompts, []);
+
+    // After the switch completes, the previously typed prompt goes through.
+    driver.releaseSetModel();
+    await delay(20);
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    assert.deepEqual(driver.prompts, ['blocked']);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('rejects /session for a session in a different folder', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([fakeSessionSummary('session-other', '/elsewhere')]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session session-other');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('different folder'));
+
+    assert.deepEqual(driver.sessionIds, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('rejects /session for a session on a different connection', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      { ...fakeSessionSummary('session-conn', '/repo'), llmConnectionSlug: 'other-connection' },
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session session-conn');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('different connection'));
+
+    assert.deepEqual(driver.sessionIds, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('keeps the permission prompt visible when responding rejects', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RejectingPermissionDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Permission required'));
+
+    terminal.input('y');
+    await waitFor(() => driver.responses.length === 1);
+    await delay(20);
+
+    // Response rejected: error shows, but the permission prompt stays and can be retried.
+    assert.ok(plainTerminalOutput(terminal.output()).includes('Permission required'));
+
+    terminal.input('n');
+    await waitFor(() => driver.responses.length === 2);
+
     terminal.input('\x03');
     await Promise.race([
       run,
@@ -1038,6 +1179,93 @@ class LongTranscriptDriver extends SlashCommandDriver {
   }
 }
 
+class DeferredControlDriver implements MakaSessionDriver {
+  readonly prompts: string[] = [];
+  readonly models: string[] = [];
+  private resolveSetModel: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 1,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+
+  async setModel(model: string): Promise<void> {
+    this.models.push(model);
+    await new Promise<void>((resolve) => {
+      this.resolveSetModel = resolve;
+    });
+  }
+
+  releaseSetModel(): void {
+    this.resolveSetModel?.();
+    this.resolveSetModel = null;
+  }
+
+  async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class RejectingPermissionDriver implements MakaSessionDriver {
+  readonly responses: PermissionResponse[] = [];
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'permission_request',
+      id: 'event-permission',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+    };
+    // The turn stays parked while the permission is unresolved.
+    await new Promise<void>(() => {});
+  }
+
+  async stop(): Promise<void> {}
+
+  async respondToPermission(response: PermissionResponse): Promise<void> {
+    this.responses.push(response);
+    throw new Error('permission response rejected');
+  }
+
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
 function switchResult(summary: SessionSummary, messages: StoredMessage[] = []): MakaSessionSwitchResult {
   return { summary, messages };
 }
@@ -1080,222 +1308,3 @@ function storedAssistantMessage(id: string, turnId: string, text: string): Store
   };
 }
 
-function latestPlainLineContaining(output: string, text: string): string {
-  const line = plainTerminalOutput(output)
-    .split(/\r?\n/)
-    .reverse()
-    .find((candidate) => candidate.includes(text));
-  assert.ok(line, `Expected terminal output to contain ${text}`);
-  return line;
-}
-
-function plainTerminalOutput(output: string): string {
-  return output
-    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
-    .replace(/\x1b_pi:c\x07/g, '')
-    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
-}
-
-function inputSurfaceRows(lines: readonly string[]): [number, number] {
-  const editorBorderIndexes = lines
-    .map((line, index) => (/^─+$/.test(line) ? index : -1))
-    .filter((index) => index >= 0);
-  assert.ok(editorBorderIndexes.length >= 2);
-  return [
-    editorBorderIndexes[editorBorderIndexes.length - 2]!,
-    editorBorderIndexes[editorBorderIndexes.length - 1]!,
-  ];
-}
-
-function assertBottomPickerPlacement(terminal: FakeTerminal, title: string, statusText: string): void {
-  const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-  const titleIndex = lines.findIndex((line) => line.includes(title));
-  const statusLineIndex = lines.findIndex((line) => line.includes(statusText));
-  const [topEditorBorderIndex, bottomEditorBorderIndex] = inputSurfaceRows(lines);
-
-  assert.ok(titleIndex > 0);
-  assert.ok(titleIndex < topEditorBorderIndex);
-  assert.equal(bottomEditorBorderIndex, terminal.rows - 2);
-  assert.equal(statusLineIndex, terminal.rows - 1);
-}
-
-class FakeTerminal implements Terminal {
-  readonly columns = 80;
-  readonly rows = 24;
-  readonly kittyProtocolActive = false;
-  readonly progressStates: boolean[] = [];
-  readonly writes: string[] = [];
-  stopCalls = 0;
-  private onInput: ((data: string) => void) | null = null;
-
-  start(onInput: (data: string) => void, _onResize: () => void): void {
-    this.onInput = onInput;
-  }
-
-  stop(): void {
-    this.stopCalls += 1;
-  }
-
-  drainInput(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  write(data: string): void {
-    this.writes.push(data);
-  }
-  moveBy(_lines: number): void {}
-  hideCursor(): void {}
-  showCursor(): void {}
-  clearLine(): void {}
-  clearFromCursor(): void {}
-  clearScreen(): void {}
-  setTitle(_title: string): void {}
-
-  setProgress(active: boolean): void {
-    this.progressStates.push(active);
-  }
-
-  input(data: string): void {
-    this.onInput?.(data);
-  }
-
-  output(): string {
-    return this.writes.join('');
-  }
-
-  screenOutput(): string {
-    return renderTerminalScreen(this.writes, this.rows);
-  }
-}
-
-function renderTerminalScreen(writes: readonly string[], rows: number): string {
-  const screen: string[] = [];
-  let row = 0;
-  let col = 0;
-
-  const ensureRow = () => {
-    while (screen.length <= row) screen.push('');
-  };
-
-  const writeText = (text: string) => {
-    ensureRow();
-    const line = screen[row] ?? '';
-    screen[row] = `${line.slice(0, col)}${text}${line.slice(col + text.length)}`;
-    col += text.length;
-  };
-
-  for (const write of writes) {
-    for (let index = 0; index < write.length;) {
-      const char = write[index]!;
-      if (char === '\x1b') {
-        index = consumeEscapeSequence(write, index, {
-          clearScreen: () => {
-            screen.length = 0;
-            row = 0;
-            col = 0;
-          },
-          clearLine: () => {
-            ensureRow();
-            screen[row] = '';
-          },
-          moveTo: (nextRow, nextCol) => {
-            row = Math.max(0, nextRow);
-            col = Math.max(0, nextCol);
-          },
-          moveBy: (rowDelta, colDelta) => {
-            row = Math.max(0, row + rowDelta);
-            col = Math.max(0, col + colDelta);
-          },
-          moveCol: (nextCol) => {
-            col = Math.max(0, nextCol);
-          },
-        });
-        continue;
-      }
-      if (char === '\r') {
-        col = 0;
-        index += 1;
-        continue;
-      }
-      if (char === '\n') {
-        row += 1;
-        col = 0;
-        index += 1;
-        continue;
-      }
-      writeText(char);
-      index += 1;
-    }
-  }
-
-  while (screen.length < rows) screen.push('');
-  return screen.slice(Math.max(0, screen.length - rows)).join('\n');
-}
-
-interface ScreenEscapeActions {
-  clearScreen(): void;
-  clearLine(): void;
-  moveTo(row: number, col: number): void;
-  moveBy(rowDelta: number, colDelta: number): void;
-  moveCol(col: number): void;
-}
-
-function consumeEscapeSequence(input: string, index: number, actions: ScreenEscapeActions): number {
-  const kind = input[index + 1];
-  if (kind === '[') {
-    const finalIndex = findCsiFinalIndex(input, index + 2);
-    if (finalIndex < 0) return input.length;
-    const params = input.slice(index + 2, finalIndex);
-    applyCsiSequence(params, input[finalIndex]!, actions);
-    return finalIndex + 1;
-  }
-  if (kind === ']') return skipUntilTerminator(input, index + 2);
-  if (kind === '_' || kind === 'P') return skipUntilTerminator(input, index + 2);
-  return index + 2;
-}
-
-function findCsiFinalIndex(input: string, start: number): number {
-  for (let index = start; index < input.length; index += 1) {
-    const code = input.charCodeAt(index);
-    if (code >= 0x40 && code <= 0x7e) return index;
-  }
-  return -1;
-}
-
-function skipUntilTerminator(input: string, start: number): number {
-  for (let index = start; index < input.length; index += 1) {
-    if (input[index] === '\x07') return index + 1;
-    if (input[index] === '\x1b' && input[index + 1] === '\\') return index + 2;
-  }
-  return input.length;
-}
-
-function applyCsiSequence(params: string, final: string, actions: ScreenEscapeActions): void {
-  const values = parseCsiValues(params);
-  const first = values[0] ?? 1;
-  if (final === 'A') actions.moveBy(-first, 0);
-  if (final === 'B') actions.moveBy(first, 0);
-  if (final === 'C') actions.moveBy(0, first);
-  if (final === 'D') actions.moveBy(0, -first);
-  if (final === 'G') actions.moveCol(first - 1);
-  if (final === 'H' || final === 'f') actions.moveTo((values[0] ?? 1) - 1, (values[1] ?? 1) - 1);
-  if (final === 'J' && (values[0] === 2 || values[0] === 3)) actions.clearScreen();
-  if (final === 'K' && (values[0] ?? 0) === 2) actions.clearLine();
-}
-
-function parseCsiValues(params: string): number[] {
-  return params
-    .replace(/^\?/, '')
-    .split(';')
-    .filter((part) => /^\d+$/.test(part))
-    .map((part) => Number(part));
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 250;
-  while (Date.now() < deadline) {
-    if (predicate()) return;
-    await delay(5);
-  }
-  assert.equal(predicate(), true);
-}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -363,6 +363,51 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('keeps slash autocomplete filtering from collapsing the input area', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/');
+
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/session'));
+    const beforeLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const beforeRows = inputSurfaceRows(beforeLines);
+    const beforeFirstSuggestionRow = beforeLines.findIndex((line) => line.includes('/exit'));
+    const beforeSessionRow = beforeLines.findIndex((line) => line.includes('/session'));
+
+    terminal.input('s');
+
+    await waitFor(() => {
+      const output = plainTerminalOutput(terminal.screenOutput());
+      return output.includes('/session') && !output.includes('/model');
+    });
+    const afterLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const afterRows = inputSurfaceRows(afterLines);
+    const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
+
+    assert.ok(beforeFirstSuggestionRow >= 0);
+    assert.ok(beforeSessionRow >= 0);
+    assert.deepEqual(afterRows, beforeRows);
+    assert.equal(afterSessionRow, beforeFirstSuggestionRow);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /exit without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -910,6 +955,17 @@ function plainTerminalOutput(output: string): string {
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
+function inputSurfaceRows(lines: readonly string[]): [number, number] {
+  const editorBorderIndexes = lines
+    .map((line, index) => (/^─+$/.test(line) ? index : -1))
+    .filter((index) => index >= 0);
+  assert.ok(editorBorderIndexes.length >= 2);
+  return [
+    editorBorderIndexes[editorBorderIndexes.length - 2]!,
+    editorBorderIndexes[editorBorderIndexes.length - 1]!,
+  ];
+}
+
 class FakeTerminal implements Terminal {
   readonly columns = 80;
   readonly rows = 24;
@@ -953,6 +1009,133 @@ class FakeTerminal implements Terminal {
   output(): string {
     return this.writes.join('');
   }
+
+  screenOutput(): string {
+    return renderTerminalScreen(this.writes, this.rows);
+  }
+}
+
+function renderTerminalScreen(writes: readonly string[], rows: number): string {
+  const screen: string[] = [];
+  let row = 0;
+  let col = 0;
+
+  const ensureRow = () => {
+    while (screen.length <= row) screen.push('');
+  };
+
+  const writeText = (text: string) => {
+    ensureRow();
+    const line = screen[row] ?? '';
+    screen[row] = `${line.slice(0, col)}${text}${line.slice(col + text.length)}`;
+    col += text.length;
+  };
+
+  for (const write of writes) {
+    for (let index = 0; index < write.length;) {
+      const char = write[index]!;
+      if (char === '\x1b') {
+        index = consumeEscapeSequence(write, index, {
+          clearScreen: () => {
+            screen.length = 0;
+            row = 0;
+            col = 0;
+          },
+          clearLine: () => {
+            ensureRow();
+            screen[row] = '';
+          },
+          moveTo: (nextRow, nextCol) => {
+            row = Math.max(0, nextRow);
+            col = Math.max(0, nextCol);
+          },
+          moveBy: (rowDelta, colDelta) => {
+            row = Math.max(0, row + rowDelta);
+            col = Math.max(0, col + colDelta);
+          },
+          moveCol: (nextCol) => {
+            col = Math.max(0, nextCol);
+          },
+        });
+        continue;
+      }
+      if (char === '\r') {
+        col = 0;
+        index += 1;
+        continue;
+      }
+      if (char === '\n') {
+        row += 1;
+        col = 0;
+        index += 1;
+        continue;
+      }
+      writeText(char);
+      index += 1;
+    }
+  }
+
+  while (screen.length < rows) screen.push('');
+  return screen.slice(0, rows).join('\n');
+}
+
+interface ScreenEscapeActions {
+  clearScreen(): void;
+  clearLine(): void;
+  moveTo(row: number, col: number): void;
+  moveBy(rowDelta: number, colDelta: number): void;
+  moveCol(col: number): void;
+}
+
+function consumeEscapeSequence(input: string, index: number, actions: ScreenEscapeActions): number {
+  const kind = input[index + 1];
+  if (kind === '[') {
+    const finalIndex = findCsiFinalIndex(input, index + 2);
+    if (finalIndex < 0) return input.length;
+    const params = input.slice(index + 2, finalIndex);
+    applyCsiSequence(params, input[finalIndex]!, actions);
+    return finalIndex + 1;
+  }
+  if (kind === ']') return skipUntilTerminator(input, index + 2);
+  if (kind === '_' || kind === 'P') return skipUntilTerminator(input, index + 2);
+  return index + 2;
+}
+
+function findCsiFinalIndex(input: string, start: number): number {
+  for (let index = start; index < input.length; index += 1) {
+    const code = input.charCodeAt(index);
+    if (code >= 0x40 && code <= 0x7e) return index;
+  }
+  return -1;
+}
+
+function skipUntilTerminator(input: string, start: number): number {
+  for (let index = start; index < input.length; index += 1) {
+    if (input[index] === '\x07') return index + 1;
+    if (input[index] === '\x1b' && input[index + 1] === '\\') return index + 2;
+  }
+  return input.length;
+}
+
+function applyCsiSequence(params: string, final: string, actions: ScreenEscapeActions): void {
+  const values = parseCsiValues(params);
+  const first = values[0] ?? 1;
+  if (final === 'A') actions.moveBy(-first, 0);
+  if (final === 'B') actions.moveBy(first, 0);
+  if (final === 'C') actions.moveBy(0, first);
+  if (final === 'D') actions.moveBy(0, -first);
+  if (final === 'G') actions.moveCol(first - 1);
+  if (final === 'H' || final === 'f') actions.moveTo((values[0] ?? 1) - 1, (values[1] ?? 1) - 1);
+  if (final === 'J' && (values[0] === 2 || values[0] === 3)) actions.clearScreen();
+  if (final === 'K' && (values[0] ?? 0) === 2) actions.clearLine();
+}
+
+function parseCsiValues(params: string): number[] {
+  return params
+    .replace(/^\?/, '')
+    .split(';')
+    .filter((part) => /^\d+$/.test(part))
+    .map((part) => Number(part));
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -154,6 +154,7 @@ class RejectingStopDriver implements MakaSessionDriver {
   }
 
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
 
   getSessionId(): string {
     return 'session-1';
@@ -207,6 +208,7 @@ class PermissionPromptDriver implements MakaSessionDriver {
     this.permissionResponses.push(response);
     this.continueAfterPermission?.();
   }
+  async setPermissionMode(): Promise<void> {}
 
   getSessionId(): string {
     return 'session-1';
@@ -251,6 +253,7 @@ class ToolOutputDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
   getSessionId(): string {
     return 'session-1';
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -172,6 +172,37 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
+  test('handles /model without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/model claude-opus-4-1');
+    terminal.input('\r');
+
+    await waitFor(() => driver.models.length === 1);
+    await waitFor(() => terminal.output().includes('Model: claude-opus-4-1'));
+
+    assert.deepEqual(driver.models, ['claude-opus-4-1']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -295,6 +326,7 @@ class ToolOutputDriver implements MakaSessionDriver {
 
 class SlashCommandDriver implements MakaSessionDriver {
   readonly prompts: string[] = [];
+  readonly models: string[] = [];
   readonly permissionModes: PermissionMode[] = [];
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
@@ -310,7 +342,9 @@ class SlashCommandDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
-  async setModel(): Promise<void> {}
+  async setModel(model: string): Promise<void> {
+    this.models.push(model);
+  }
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -234,6 +234,59 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('does not close the main TUI on Escape', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+
+    terminal.input('\x1b');
+    await delay(30);
+
+    assert.equal(terminal.stopCalls, 0);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('closes the main TUI on Ctrl-D', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('\x04');
+
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-D');
+      }),
+    ]);
+    assert.equal(terminal.stopCalls, 1);
+  });
+
   test('shows slash commands alphabetically when typing /', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -251,13 +304,16 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
     const output = plainTerminalOutput(terminal.output());
+    const exitIndex = output.indexOf('/exit');
     const modelIndex = output.indexOf('/model');
     const permissionsIndex = output.indexOf('/permissions');
     const sessionIndex = output.indexOf('/session');
 
+    assert.ok(exitIndex >= 0);
     assert.ok(modelIndex >= 0);
     assert.ok(permissionsIndex >= 0);
     assert.ok(sessionIndex >= 0);
+    assert.ok(exitIndex < modelIndex);
     assert.ok(modelIndex < permissionsIndex);
     assert.ok(permissionsIndex < sessionIndex);
 
@@ -307,6 +363,33 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('handles /exit without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/exit');
+    terminal.input('\r');
+
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after /exit');
+      }),
+    ]);
+
+    assert.deepEqual(driver.prompts, []);
+    assert.equal(terminal.stopCalls, 1);
+  });
+
   test('applies the selected slash command from autocomplete', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -321,9 +404,9 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    terminal.input('/');
+    terminal.input('/m');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/model'));
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Select Model'));
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -272,6 +272,39 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows only current-cwd sessions in the session picker', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('session-current', '/repo'),
+      fakeSessionSummary('session-other', '/elsewhere'),
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('session-current'));
+    const output = plainTerminalOutput(terminal.output());
+    assert.equal(output.includes('session-other'), false);
+
+    terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -421,8 +454,10 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly sessionIds: string[] = [];
   private sessionId = 'session-1';
 
+  constructor(private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')]) {}
+
   async listSessions(): Promise<SessionSummary[]> {
-    return [fakeSessionSummary('session-2')];
+    return this.sessions;
   }
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
@@ -454,9 +489,10 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
 }
 
-function fakeSessionSummary(sessionId: string): SessionSummary {
+function fakeSessionSummary(sessionId: string, cwd = '/repo'): SessionSummary {
   return {
     id: sessionId,
+    cwd,
     name: 'Existing chat',
     isFlagged: false,
     isArchived: false,

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import type { Terminal } from '@earendil-works/pi-tui';
+import type { PermissionResponse } from '@maka/core';
 import type { MakaSessionDriver } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 
@@ -43,6 +44,8 @@ class RejectingStopDriver implements MakaSessionDriver {
     this.stopCalls += 1;
     throw new Error('stop failed');
   }
+
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
 
   getSessionId(): string {
     return 'session-1';

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import type { Terminal } from '@earendil-works/pi-tui';
-import type { PermissionResponse, SessionEvent } from '@maka/core';
+import type { PermissionMode, PermissionResponse, SessionEvent } from '@maka/core';
 import type { MakaSessionDriver } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 
@@ -141,6 +141,37 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
+  test('handles /permissions without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/permissions execute');
+    terminal.input('\r');
+
+    await waitFor(() => driver.permissionModes.length === 1);
+    await waitFor(() => terminal.output().includes('Permission mode: execute'));
+
+    assert.deepEqual(driver.permissionModes, ['execute']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -254,6 +285,31 @@ class ToolOutputDriver implements MakaSessionDriver {
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class SlashCommandDriver implements MakaSessionDriver {
+  readonly prompts: string[] = [];
+  readonly permissionModes: PermissionMode[] = [];
+
+  async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 1,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async setPermissionMode(mode: PermissionMode): Promise<void> {
+    this.permissionModes.push(mode);
+  }
   getSessionId(): string {
     return 'session-1';
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -175,6 +175,32 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('uses logo blue for TUI accent chrome', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => terminal.output().includes('\x1b[38;2;87;163;239m'));
+
+    assert.doesNotMatch(terminal.output(), /\x1b\[36m─/);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps the input editor and statusline at the terminal bottom', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import { visibleWidth, type Terminal } from '@earendil-works/pi-tui';
-import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary } from '@maka/core';
-import type { MakaSessionDriver } from '../session-driver.js';
+import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage } from '@maka/core';
+import type { MakaSessionDriver, MakaSessionSwitchResult } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 
 describe('Maka Pi TUI runner', () => {
@@ -540,7 +540,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => driver.sessionIds.length === 1);
-    await waitFor(() => terminal.output().includes('Session: session-2'));
+    await waitFor(() => terminal.output().includes('Resumed session "Existing chat"'));
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('/other-repo'));
 
     assert.deepEqual(driver.sessionIds, ['session-2']);
@@ -578,10 +578,48 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(visibleWidth(titleLine), terminal.columns);
     terminal.input('\r');
     await waitFor(() => driver.sessionIds.length === 1);
-    await waitFor(() => terminal.output().includes('Session: session-2'));
+    await waitFor(() => terminal.output().includes('Resumed session "Existing chat"'));
 
     assert.deepEqual(driver.sessionIds, ['session-2']);
     assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('renders switched session history instead of a session id note', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver(
+      [fakeSessionSummary('session-2', '/repo')],
+      new Map([
+        ['session-2', [
+          storedUserMessage('user-1', 'turn-1', 'previous question'),
+          storedAssistantMessage('assistant-1', 'turn-1', 'previous answer'),
+        ]],
+      ]),
+    );
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session session-2');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('previous question'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('previous answer'));
+    const output = plainTerminalOutput(terminal.output());
+    assert.equal(output.includes('Session: session-2'), false);
 
     terminal.input('\x03');
     await Promise.race([
@@ -644,8 +682,8 @@ class RejectingStopDriver implements MakaSessionDriver {
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
-  async switchSession(sessionId: string): Promise<SessionSummary> {
-    return fakeSessionSummary(sessionId);
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
   }
 
   getSessionId(): string {
@@ -706,8 +744,8 @@ class PermissionPromptDriver implements MakaSessionDriver {
   }
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
-  async switchSession(sessionId: string): Promise<SessionSummary> {
-    return fakeSessionSummary(sessionId);
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
   }
 
   getSessionId(): string {
@@ -759,8 +797,8 @@ class ToolOutputDriver implements MakaSessionDriver {
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
-  async switchSession(sessionId: string): Promise<SessionSummary> {
-    return fakeSessionSummary(sessionId);
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
   }
   getSessionId(): string {
     return 'session-1';
@@ -774,7 +812,10 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly sessionIds: string[] = [];
   private sessionId = 'session-1';
 
-  constructor(private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')]) {}
+  constructor(
+    private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')],
+    private readonly sessionMessages: ReadonlyMap<string, readonly StoredMessage[]> = new Map(),
+  ) {}
 
   async listSessions(): Promise<SessionSummary[]> {
     return this.sessions;
@@ -799,15 +840,20 @@ class SlashCommandDriver implements MakaSessionDriver {
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
   }
-  async switchSession(sessionId: string): Promise<SessionSummary> {
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     this.sessionIds.push(sessionId);
     this.sessionId = sessionId;
     const summary = this.sessions.find((session) => session.id === sessionId);
-    return summary ?? fakeSessionSummary(sessionId);
+    const nextSummary = summary ?? fakeSessionSummary(sessionId);
+    return switchResult(nextSummary, [...(this.sessionMessages.get(nextSummary.id) ?? [])]);
   }
   getSessionId(): string {
     return this.sessionId;
   }
+}
+
+function switchResult(summary: SessionSummary, messages: StoredMessage[] = []): MakaSessionSwitchResult {
+  return { summary, messages };
 }
 
 function fakeSessionSummary(sessionId: string, cwd = '/repo'): SessionSummary {
@@ -824,6 +870,27 @@ function fakeSessionSummary(sessionId: string, cwd = '/repo'): SessionSummary {
     llmConnectionSlug: 'claude-subscription',
     model: 'claude-sonnet-4-5',
     permissionMode: 'ask',
+  };
+}
+
+function storedUserMessage(id: string, turnId: string, text: string): StoredMessage {
+  return {
+    type: 'user',
+    id,
+    turnId,
+    ts: 1,
+    text,
+  };
+}
+
+function storedAssistantMessage(id: string, turnId: string, text: string): StoredMessage {
+  return {
+    type: 'assistant',
+    id,
+    turnId,
+    ts: 2,
+    text,
+    modelId: 'claude-sonnet-4-5',
   };
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -175,6 +175,39 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('keeps the input editor and statusline at the terminal bottom', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+
+    const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const editorBorderIndexes = lines
+      .map((line, index) => (/^─+$/.test(line) ? index : -1))
+      .filter((index) => index >= 0);
+
+    assert.equal(statusLineIndex, terminal.rows - 1);
+    assert.equal(editorBorderIndexes[editorBorderIndexes.length - 1], terminal.rows - 2);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /permissions without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -969,6 +969,107 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('blocks prompts while the session list is loading', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredListSessionsDriver([fakeSessionSummary('session-2')]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => driver.listCalls === 1);
+
+    // While the list is still loading, a submitted prompt must not go through.
+    terminal.input('hello');
+    terminal.input('\r');
+    await delay(20);
+    assert.deepEqual(driver.prompts, []);
+
+    driver.releaseList();
+    await delay(30);
+
+    terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('refuses to switch when the driver returns a mismatched folder', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new InconsistentSwitchDriver([fakeSessionSummary('session-2', '/repo')]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session session-2');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('no longer matches'));
+
+    assert.deepEqual(driver.sessionIds, ['session-2']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('clears the permission prompt when the turn errors', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionThenErrorDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Permission required'));
+    driver.continueToError();
+    await waitFor(() => terminal.output().includes('turn failed'));
+
+    // The turn errored: the permission prompt must be gone from the screen.
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Permission required'), false);
+
+    // y must not trigger a response for the now-dead request.
+    terminal.input('y');
+    await delay(20);
+    assert.equal(driver.respondCalls, 0);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -1253,6 +1354,87 @@ class RejectingPermissionDriver implements MakaSessionDriver {
   async respondToPermission(response: PermissionResponse): Promise<void> {
     this.responses.push(response);
     throw new Error('permission response rejected');
+  }
+
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class DeferredListSessionsDriver extends SlashCommandDriver {
+  listCalls = 0;
+  private resolveList: (() => void) | null = null;
+
+  override async listSessions(): Promise<SessionSummary[]> {
+    this.listCalls += 1;
+    await new Promise<void>((resolve) => {
+      this.resolveList = resolve;
+    });
+    return super.listSessions();
+  }
+
+  releaseList(): void {
+    this.resolveList?.();
+    this.resolveList = null;
+  }
+}
+
+class InconsistentSwitchDriver extends SlashCommandDriver {
+  override async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    const result = await super.switchSession(sessionId);
+    return { summary: { ...result.summary, cwd: '/unexpected' }, messages: result.messages };
+  }
+}
+
+class PermissionThenErrorDriver implements MakaSessionDriver {
+  respondCalls = 0;
+  private resolveContinue: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'permission_request',
+      id: 'event-permission',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+    };
+    await new Promise<void>((resolve) => {
+      this.resolveContinue = resolve;
+    });
+    yield {
+      type: 'error',
+      id: 'event-error',
+      turnId: 'turn-1',
+      ts: 2,
+      message: 'turn failed',
+      recoverable: false,
+    };
+  }
+
+  continueToError(): void {
+    this.resolveContinue?.();
+    this.resolveContinue = null;
+  }
+
+  async stop(): Promise<void> {}
+
+  async respondToPermission(_response: PermissionResponse): Promise<void> {
+    this.respondCalls += 1;
   }
 
   async setModel(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import type { Terminal } from '@earendil-works/pi-tui';
-import type { PermissionResponse } from '@maka/core';
+import type { PermissionResponse, SessionEvent } from '@maka/core';
 import type { MakaSessionDriver } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 
@@ -33,6 +33,81 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(terminal.stopCalls, 1);
     assert.equal(terminal.progressStates.at(-1), false);
   });
+
+  test('allows a pending permission request from the terminal', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('u');
+    terminal.input('n');
+    terminal.input('\r');
+
+    await waitFor(() => driver.permissionRequests === 1);
+    await delay(20);
+    terminal.input('y');
+    await waitFor(() => driver.permissionResponses.length === 1);
+
+    assert.deepEqual(driver.permissionResponses, [{
+      requestId: 'permission-1',
+      decision: 'allow',
+      rememberForTurn: true,
+    }]);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('denies a pending permission request from the terminal', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('u');
+    terminal.input('n');
+    terminal.input('\r');
+
+    await waitFor(() => driver.permissionRequests === 1);
+    await delay(20);
+    terminal.input('n');
+    await waitFor(() => driver.permissionResponses.length === 1);
+
+    assert.deepEqual(driver.permissionResponses, [{
+      requestId: 'permission-1',
+      decision: 'deny',
+    }]);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -46,6 +121,59 @@ class RejectingStopDriver implements MakaSessionDriver {
   }
 
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class PermissionPromptDriver implements MakaSessionDriver {
+  readonly permissionResponses: PermissionResponse[] = [];
+  permissionRequests = 0;
+  private continueAfterPermission: (() => void) | null = null;
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    this.permissionRequests += 1;
+    yield {
+      type: 'permission_request',
+      id: 'event-permission',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+    };
+    await new Promise<void>((resolve) => {
+      this.continueAfterPermission = resolve;
+    });
+    yield {
+      type: 'permission_decision_ack',
+      id: 'event-decision',
+      turnId: 'turn-1',
+      ts: 2,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      decision: 'allow',
+      rememberForTurn: true,
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 3,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+
+  async respondToPermission(response: PermissionResponse): Promise<void> {
+    this.permissionResponses.push(response);
+    this.continueAfterPermission?.();
+  }
 
   getSessionId(): string {
     return 'session-1';
@@ -88,4 +216,13 @@ class FakeTerminal implements Terminal {
   input(data: string): void {
     this.onInput?.(data);
   }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 250;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  assert.equal(predicate(), true);
 }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import type { Terminal } from '@earendil-works/pi-tui';
-import type { PermissionMode, PermissionResponse, SessionEvent } from '@maka/core';
+import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary } from '@maka/core';
 import type { MakaSessionDriver } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 
@@ -218,6 +218,9 @@ class RejectingStopDriver implements MakaSessionDriver {
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<SessionSummary> {
+    return fakeSessionSummary(sessionId);
+  }
 
   getSessionId(): string {
     return 'session-1';
@@ -273,6 +276,9 @@ class PermissionPromptDriver implements MakaSessionDriver {
   }
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<SessionSummary> {
+    return fakeSessionSummary(sessionId);
+  }
 
   getSessionId(): string {
     return 'session-1';
@@ -319,6 +325,9 @@ class ToolOutputDriver implements MakaSessionDriver {
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<SessionSummary> {
+    return fakeSessionSummary(sessionId);
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -348,9 +357,28 @@ class SlashCommandDriver implements MakaSessionDriver {
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
   }
+  async switchSession(sessionId: string): Promise<SessionSummary> {
+    return fakeSessionSummary(sessionId);
+  }
   getSessionId(): string {
     return 'session-1';
   }
+}
+
+function fakeSessionSummary(sessionId: string): SessionSummary {
+  return {
+    id: sessionId,
+    name: 'Existing chat',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'claude-subscription',
+    model: 'claude-sonnet-4-5',
+    permissionMode: 'ask',
+  };
 }
 
 class FakeTerminal implements Terminal {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -875,64 +875,6 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('rejects /session for a session in a different folder', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver([fakeSessionSummary('session-other', '/elsewhere')]);
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/session session-other');
-    terminal.input('\r');
-    await waitFor(() => terminal.output().includes('different folder'));
-
-    assert.deepEqual(driver.sessionIds, []);
-
-    terminal.input('\x03');
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close after Ctrl-C');
-      }),
-    ]);
-  });
-
-  test('rejects /session for a session on a different connection', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new SlashCommandDriver([
-      { ...fakeSessionSummary('session-conn', '/repo'), llmConnectionSlug: 'other-connection' },
-    ]);
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/session session-conn');
-    terminal.input('\r');
-    await waitFor(() => terminal.output().includes('different connection'));
-
-    assert.deepEqual(driver.sessionIds, []);
-
-    terminal.input('\x03');
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close after Ctrl-C');
-      }),
-    ]);
-  });
-
   test('keeps the permission prompt visible when responding rejects', async () => {
     const terminal = new FakeTerminal();
     const driver = new RejectingPermissionDriver();
@@ -996,35 +938,6 @@ describe('Maka Pi TUI runner', () => {
     await delay(30);
 
     terminal.input('\x1b');
-    terminal.input('\x03');
-    await Promise.race([
-      run,
-      delay(50).then(() => {
-        throw new Error('TUI did not close after Ctrl-C');
-      }),
-    ]);
-  });
-
-  test('refuses to switch when the driver returns a mismatched folder', async () => {
-    const terminal = new FakeTerminal();
-    const driver = new InconsistentSwitchDriver([fakeSessionSummary('session-2', '/repo')]);
-    const run = runMakaPiTui({
-      title: 'Maka',
-      driver,
-      cwd: '/repo',
-      model: 'claude-sonnet-4-5',
-      connectionSlug: 'claude-subscription',
-      permissionMode: 'ask',
-      terminal,
-    });
-
-    terminal.input('/session session-2');
-    terminal.input('\r');
-    await waitFor(() => terminal.output().includes('no longer matches'));
-
-    assert.deepEqual(driver.sessionIds, ['session-2']);
-    assert.deepEqual(driver.prompts, []);
-
     terminal.input('\x03');
     await Promise.race([
       run,
@@ -1382,13 +1295,6 @@ class DeferredListSessionsDriver extends SlashCommandDriver {
   releaseList(): void {
     this.resolveList?.();
     this.resolveList = null;
-  }
-}
-
-class InconsistentSwitchDriver extends SlashCommandDriver {
-  override async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
-    const result = await super.switchSession(sessionId);
-    return { summary: { ...result.summary, cwd: '/unexpected' }, messages: result.messages };
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -270,6 +270,43 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('renders slash autocomplete above the input editor', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
+    const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
+    const suggestionIndex = lines.findIndex((line) => line.includes('/model'));
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const editorBorderIndexes = lines
+      .map((line, index) => (/^─+$/.test(line) ? index : -1))
+      .filter((index) => index >= 0);
+
+    assert.ok(suggestionIndex >= 0);
+    assert.ok(editorBorderIndexes.length >= 2);
+    assert.ok(suggestionIndex < editorBorderIndexes[editorBorderIndexes.length - 2]!);
+    assert.equal(editorBorderIndexes[editorBorderIndexes.length - 1], statusLineIndex - 1);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('applies the selected slash command from autocomplete', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -203,6 +203,37 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
+  test('handles /session without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session session-2');
+    terminal.input('\r');
+
+    await waitFor(() => driver.sessionIds.length === 1);
+    await waitFor(() => terminal.output().includes('Session: session-2'));
+
+    assert.deepEqual(driver.sessionIds, ['session-2']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -337,6 +368,8 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly prompts: string[] = [];
   readonly models: string[] = [];
   readonly permissionModes: PermissionMode[] = [];
+  readonly sessionIds: string[] = [];
+  private sessionId = 'session-1';
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
     this.prompts.push(prompt);
@@ -358,10 +391,12 @@ class SlashCommandDriver implements MakaSessionDriver {
     this.permissionModes.push(mode);
   }
   async switchSession(sessionId: string): Promise<SessionSummary> {
+    this.sessionIds.push(sessionId);
+    this.sessionId = sessionId;
     return fakeSessionSummary(sessionId);
   }
   getSessionId(): string {
-    return 'session-1';
+    return this.sessionId;
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -239,6 +239,10 @@ describe('Maka Pi TUI runner', () => {
 class RejectingStopDriver implements MakaSessionDriver {
   stopCalls = 0;
 
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
   async *sendPrompt(_prompt: string): AsyncIterable<never> {}
 
   async stop(): Promise<void> {
@@ -262,6 +266,10 @@ class PermissionPromptDriver implements MakaSessionDriver {
   readonly permissionResponses: PermissionResponse[] = [];
   permissionRequests = 0;
   private continueAfterPermission: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
 
   async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
     this.permissionRequests += 1;
@@ -317,6 +325,10 @@ class PermissionPromptDriver implements MakaSessionDriver {
 }
 
 class ToolOutputDriver implements MakaSessionDriver {
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
   async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
     yield {
       type: 'tool_start',
@@ -370,6 +382,10 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly permissionModes: PermissionMode[] = [];
   readonly sessionIds: string[] = [];
   private sessionId = 'session-1';
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [fakeSessionSummary('session-2')];
+  }
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
     this.prompts.push(prompt);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -235,7 +235,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('lists sessions for /session without an id', async () => {
+  test('selects a session from /session', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
     const run = runMakaPiTui({
@@ -251,10 +251,12 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Recent sessions'));
     await waitFor(() => terminal.output().includes('session-2'));
+    terminal.input('\r');
+    await waitFor(() => driver.sessionIds.length === 1);
+    await waitFor(() => terminal.output().includes('Session: session-2'));
 
-    assert.deepEqual(driver.sessionIds, []);
+    assert.deepEqual(driver.sessionIds, ['session-2']);
     assert.deepEqual(driver.prompts, []);
 
     terminal.input('\x03');

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -498,6 +498,45 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('selects a permission mode from /permissions', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/permissions');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Select Permission Mode'));
+    assertBottomPickerPlacement(
+      terminal,
+      'Select Permission Mode',
+      'Maka claude-sonnet-4-5 claude-subscription ask /repo',
+    );
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => driver.permissionModes.length === 1);
+    await waitFor(() => terminal.output().includes('Permission mode: execute'));
+
+    assert.deepEqual(driver.permissionModes, ['execute']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /model without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -551,6 +551,7 @@ describe('Maka Pi TUI runner', () => {
     const titleLine = latestPlainLineContaining(terminal.output(), 'Select Model');
     assert.equal(titleLine.startsWith('Select Model'), true);
     assert.equal(visibleWidth(titleLine), terminal.columns);
+    assertBottomPickerPlacement(terminal, 'Select Model', 'Maka deepseek-v4-flash deepseek ask /repo');
     terminal.input('\x1b[B');
     terminal.input('\r');
     await waitFor(() => driver.models.length === 1);
@@ -621,6 +622,11 @@ describe('Maka Pi TUI runner', () => {
     const titleLine = latestPlainLineContaining(terminal.output(), 'Resume Session (Current Folder)');
     assert.equal(titleLine.startsWith('Resume Session (Current Folder)'), true);
     assert.equal(visibleWidth(titleLine), terminal.columns);
+    assertBottomPickerPlacement(
+      terminal,
+      'Resume Session (Current Folder)',
+      'Maka claude-sonnet-4-5 claude-subscription ask /repo',
+    );
     terminal.input('\r');
     await waitFor(() => driver.sessionIds.length === 1);
     await waitFor(() => terminal.output().includes('Resumed session "Existing chat"'));
@@ -964,6 +970,18 @@ function inputSurfaceRows(lines: readonly string[]): [number, number] {
     editorBorderIndexes[editorBorderIndexes.length - 2]!,
     editorBorderIndexes[editorBorderIndexes.length - 1]!,
   ];
+}
+
+function assertBottomPickerPlacement(terminal: FakeTerminal, title: string, statusText: string): void {
+  const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+  const titleIndex = lines.findIndex((line) => line.includes(title));
+  const statusLineIndex = lines.findIndex((line) => line.includes(statusText));
+  const [topEditorBorderIndex, bottomEditorBorderIndex] = inputSurfaceRows(lines);
+
+  assert.ok(titleIndex > 0);
+  assert.ok(titleIndex < topEditorBorderIndex);
+  assert.equal(bottomEditorBorderIndex, terminal.rows - 2);
+  assert.equal(statusLineIndex, terminal.rows - 1);
 }
 
 class FakeTerminal implements Terminal {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
-import type { Terminal } from '@earendil-works/pi-tui';
+import { visibleWidth, type Terminal } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary } from '@maka/core';
 import type { MakaSessionDriver } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
@@ -251,8 +251,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Select session'));
+    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
     await waitFor(() => terminal.output().includes('session-2'));
+    const titleLine = latestPlainLineContaining(terminal.output(), 'Resume Session (Current Folder)');
+    assert.equal(titleLine.startsWith('Resume Session (Current Folder)'), true);
+    assert.equal(visibleWidth(titleLine), terminal.columns);
     terminal.input('\r');
     await waitFor(() => driver.sessionIds.length === 1);
     await waitFor(() => terminal.output().includes('Session: session-2'));
@@ -268,6 +271,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -464,6 +468,19 @@ function fakeSessionSummary(sessionId: string): SessionSummary {
     model: 'claude-sonnet-4-5',
     permissionMode: 'ask',
   };
+}
+
+function latestPlainLineContaining(output: string, text: string): string {
+  const line = plainTerminalOutput(output)
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.includes(text));
+  assert.ok(line, `Expected terminal output to contain ${text}`);
+  return line;
+}
+
+function plainTerminalOutput(output: string): string {
+  return output.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
 class FakeTerminal implements Terminal {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -208,6 +208,74 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows slash commands alphabetically when typing /', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
+    const output = plainTerminalOutput(terminal.output());
+    const modelIndex = output.indexOf('/model');
+    const permissionsIndex = output.indexOf('/permissions');
+    const sessionIndex = output.indexOf('/session');
+
+    assert.ok(modelIndex >= 0);
+    assert.ok(permissionsIndex >= 0);
+    assert.ok(sessionIndex >= 0);
+    assert.ok(modelIndex < permissionsIndex);
+    assert.ok(permissionsIndex < sessionIndex);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('applies the selected slash command from autocomplete', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      models: ['deepseek-v4-flash', 'gpt-5.3-codex-spark'],
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('/session'));
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /permissions without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -234,6 +234,37 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
+  test('lists sessions for /session without an id', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Recent sessions'));
+    await waitFor(() => terminal.output().includes('session-2'));
+
+    assert.deepEqual(driver.sessionIds, []);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -108,6 +108,39 @@ describe('Maka Pi TUI runner', () => {
       }),
     ]);
   });
+
+  test('toggles the latest tool detail with Ctrl-O', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ToolOutputDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('u');
+    terminal.input('n');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Ctrl+O expand'));
+    assert.equal(terminal.output().includes('expanded-tail'), false);
+
+    terminal.input('\x0f');
+    await waitFor(() => terminal.output().includes('expanded-tail'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
 });
 
 class RejectingStopDriver implements MakaSessionDriver {
@@ -180,11 +213,55 @@ class PermissionPromptDriver implements MakaSessionDriver {
   }
 }
 
+class ToolOutputDriver implements MakaSessionDriver {
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'tool_start',
+      id: 'event-tool-start',
+      turnId: 'turn-1',
+      ts: 1,
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'npm test' },
+    };
+    yield {
+      type: 'tool_result',
+      id: 'event-tool-result',
+      turnId: 'turn-1',
+      ts: 2,
+      toolUseId: 'tool-1',
+      isError: false,
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'npm test',
+        exitCode: 0,
+        stdout: `${'x'.repeat(900)}\nexpanded-tail`,
+        stderr: '',
+      },
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 3,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
 class FakeTerminal implements Terminal {
   readonly columns = 80;
   readonly rows = 24;
   readonly kittyProtocolActive = false;
   readonly progressStates: boolean[] = [];
+  readonly writes: string[] = [];
   stopCalls = 0;
   private onInput: ((data: string) => void) | null = null;
 
@@ -200,7 +277,9 @@ class FakeTerminal implements Terminal {
     return Promise.resolve();
   }
 
-  write(_data: string): void {}
+  write(data: string): void {
+    this.writes.push(data);
+  }
   moveBy(_lines: number): void {}
   hideCursor(): void {}
   showCursor(): void {}
@@ -215,6 +294,10 @@ class FakeTerminal implements Terminal {
 
   input(data: string): void {
     this.onInput?.(data);
+  }
+
+  output(): string {
+    return this.writes.join('');
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -251,6 +251,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
+    await waitFor(() => terminal.output().includes('Select session'));
     await waitFor(() => terminal.output().includes('session-2'));
     terminal.input('\r');
     await waitFor(() => driver.sessionIds.length === 1);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -363,7 +363,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('keeps slash autocomplete filtering from collapsing the input area', async () => {
+  test('keeps slash autocomplete filtering anchored to the input editor', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
     const run = runMakaPiTui({
@@ -381,7 +381,6 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/session'));
     const beforeLines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
     const beforeRows = inputSurfaceRows(beforeLines);
-    const beforeFirstSuggestionRow = beforeLines.findIndex((line) => line.includes('/exit'));
     const beforeSessionRow = beforeLines.findIndex((line) => line.includes('/session'));
 
     terminal.input('s');
@@ -394,10 +393,9 @@ describe('Maka Pi TUI runner', () => {
     const afterRows = inputSurfaceRows(afterLines);
     const afterSessionRow = afterLines.findIndex((line) => line.includes('/session'));
 
-    assert.ok(beforeFirstSuggestionRow >= 0);
     assert.ok(beforeSessionRow >= 0);
     assert.deepEqual(afterRows, beforeRows);
-    assert.equal(afterSessionRow, beforeFirstSuggestionRow);
+    assert.equal(afterSessionRow, afterRows[0] - 1);
 
     terminal.input('\x03');
     await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -142,6 +142,39 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('renders the statusline below the input editor', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka deepseek-v4-flash deepseek ask /repo'));
+
+    const lines = plainTerminalOutput(terminal.output()).split(/\r?\n/);
+    const statusLineIndex = lines.findIndex((line) => line.includes('Maka deepseek-v4-flash deepseek ask /repo'));
+    const editorBorderIndexes = lines
+      .map((line, index) => (/^─+$/.test(line) ? index : -1))
+      .filter((index) => index >= 0);
+
+    assert.ok(editorBorderIndexes.length >= 2);
+    assert.ok(statusLineIndex > editorBorderIndexes[editorBorderIndexes.length - 1]!);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /permissions without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -518,7 +551,10 @@ function latestPlainLineContaining(output: string, text: string): string {
 }
 
 function plainTerminalOutput(output: string): string {
-  return output.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '').replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+  return output
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b_pi:c\x07/g, '')
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
 class FakeTerminal implements Terminal {

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -43,6 +43,30 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('registers Edit in the TUI runtime toolset and still requires permission', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local',
+        name: 'Local Ollama',
+        providerType: 'ollama',
+        defaultModel: 'llama3.2',
+      });
+
+      const context = await createMakaCliRuntimeContext({
+        workspaceRoot,
+        cwd: '/repo',
+      });
+
+      const edit = context.tools.find((tool) => tool.name === 'Edit');
+      assert.ok(
+        edit,
+        'Edit must be registered (regression: it was once filtered out of the TUI runtime)',
+      );
+      assert.equal(edit?.permissionRequired, true);
+    });
+  });
+
   test('keeps Claude subscription cloaking enabled unless the emergency opt-out is set', () => {
     assert.equal(isMakaClaudeSubscriptionCloakEnabled({}), true);
     assert.equal(isMakaClaudeSubscriptionCloakEnabled({ MAKA_CLAUDE_SUBSCRIPTION_CLOAK: '1' }), true);

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -114,6 +114,36 @@ describe('Maka session driver', () => {
     }]);
   });
 
+  test('switches to an existing session for the next prompt', async () => {
+    const runtime = new RecordingRuntime();
+    runtime.sessionSummaries = [{
+      id: 'session-2',
+      name: 'Existing chat',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      status: 'active',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-opus-4-1',
+      permissionMode: 'execute',
+    }];
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    const summary = await driver.switchSession('session-2');
+    await collect(driver.sendPrompt('continue'));
+
+    assert.equal(summary.id, 'session-2');
+    assert.deepEqual(runtime.created, []);
+    assert.equal(runtime.sent[0]?.sessionId, 'session-2');
+  });
+
   test('uses the default turn id generator when one is not injected', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -162,6 +192,7 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
   readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string } }> = [];
+  sessionSummaries: SessionSummary[] = [];
 
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     this.created.push(input);
@@ -237,6 +268,10 @@ class RecordingRuntime {
       model: patch.model ?? 'claude-sonnet-4-5',
       permissionMode: 'ask',
     };
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return this.sessionSummaries;
   }
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -144,6 +144,29 @@ describe('Maka session driver', () => {
     assert.equal(runtime.sent[0]?.sessionId, 'session-2');
   });
 
+  test('lists current-cwd sessions before other recent sessions', async () => {
+    const runtime = new RecordingRuntime();
+    runtime.sessionSummaries = [
+      sessionSummary({ id: 'other-newer', cwd: '/other', lastMessageAt: 30 }),
+      sessionSummary({ id: 'cwd-newer', cwd: '/repo', lastMessageAt: 20 }),
+      sessionSummary({ id: 'cwd-older', cwd: '/repo', lastMessageAt: 10 }),
+    ];
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    const sessions = await driver.listSessions();
+
+    assert.deepEqual(sessions.map((session) => session.id), [
+      'cwd-newer',
+      'cwd-older',
+      'other-newer',
+    ]);
+  });
+
   test('uses the default turn id generator when one is not injected', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -278,6 +301,24 @@ class RecordingRuntime {
 function nextId(prefix: string): () => string {
   let count = 0;
   return () => `${prefix}-${++count}`;
+}
+
+function sessionSummary(overrides: Partial<SessionSummary>): SessionSummary {
+  return {
+    id: 'session',
+    cwd: '/repo',
+    name: 'Existing chat',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    permissionMode: 'ask',
+    ...overrides,
+  };
 }
 
 async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -4,7 +4,7 @@ import type { CreateSessionInput, SessionEvent, SessionSummary, UserMessageInput
 import { createMakaSessionDriver } from '../session-driver.js';
 
 describe('Maka session driver', () => {
-  test('creates a bypass session from the first prompt and streams the turn', async () => {
+  test('creates an ask-permission session from the first prompt and streams the turn', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
       runtime,
@@ -23,13 +23,29 @@ describe('Maka session driver', () => {
       backend: 'ai-sdk',
       llmConnectionSlug: 'anthropic',
       model: 'claude-sonnet-4-5',
-      permissionMode: 'bypass',
+      permissionMode: 'ask',
     }]);
     assert.deepEqual(runtime.sent, [{
       sessionId: 'session-1',
       input: { turnId: 'turn-1', text: 'please inspect this workspace' },
     }]);
     assert.deepEqual(events.map((event) => event.type), ['text_delta', 'complete']);
+  });
+
+  test('can still create a bypass session when explicitly requested', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      permissionMode: 'bypass',
+      newId: nextId('turn'),
+    });
+
+    await collect(driver.sendPrompt('ship fast'));
+
+    assert.equal(runtime.created[0]?.permissionMode, 'bypass');
   });
 
   test('uses the default turn id generator when one is not injected', async () => {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -181,6 +181,64 @@ describe('Maka session driver', () => {
     assert.equal(driver.getSessionId(), null);
   });
 
+  test('refuses to switch across folders and leaves the active session unchanged', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-active-cwd-'));
+    const elsewhere = await mkdtemp(join(tmpdir(), 'maka-other-cwd-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [sessionSummary({ id: 'other-folder', cwd: elsewhere })];
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+      await collect(driver.sendPrompt('hi'));
+
+      await assert.rejects(
+        driver.switchSession('other-folder'),
+        /Session belongs to a different folder/,
+      );
+
+      // The rejected switch must not move the active session: the next prompt
+      // still lands on the original session.
+      await collect(driver.sendPrompt('again'));
+      assert.equal(runtime.sent[0]?.sessionId, 'session-1');
+      assert.equal(runtime.sent[1]?.sessionId, 'session-1');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+      await rm(elsewhere, { recursive: true, force: true });
+    }
+  });
+
+  test('refuses to switch across connections and leaves the active session unchanged', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-active-cwd-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [
+        sessionSummary({ id: 'other-conn', cwd: repo, llmConnectionSlug: 'other-connection' }),
+      ];
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+      await collect(driver.sendPrompt('hi'));
+
+      await assert.rejects(
+        driver.switchSession('other-conn'),
+        /Session uses a different connection/,
+      );
+
+      await collect(driver.sendPrompt('again'));
+      assert.equal(runtime.sent[0]?.sessionId, 'session-1');
+      assert.equal(runtime.sent[1]?.sessionId, 'session-1');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   test('lists current-cwd sessions before other recent sessions', async () => {
     const runtime = new RecordingRuntime();
     runtime.sessionSummaries = [

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
+import type { CreateSessionInput, PermissionResponse, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
 import { createMakaSessionDriver } from '../session-driver.js';
 
 describe('Maka session driver', () => {
@@ -61,11 +61,39 @@ describe('Maka session driver', () => {
 
     assert.match(runtime.sent[0]?.input.turnId ?? '', /^[0-9a-f-]{36}$/);
   });
+
+  test('routes permission responses to the active session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      newId: nextId('turn'),
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.respondToPermission({
+      requestId: 'permission-1',
+      decision: 'allow',
+      rememberForTurn: true,
+    });
+
+    assert.deepEqual(runtime.permissionResponses, [{
+      sessionId: 'session-1',
+      response: {
+        requestId: 'permission-1',
+        decision: 'allow',
+        rememberForTurn: true,
+      },
+    }]);
+  });
 });
 
 class RecordingRuntime {
   readonly created: CreateSessionInput[] = [];
   readonly sent: Array<{ sessionId: string; input: UserMessageInput }> = [];
+  readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
 
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     this.created.push(input);
@@ -104,6 +132,10 @@ class RecordingRuntime {
   }
 
   async stopSession(_sessionId: string): Promise<void> {}
+
+  async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {
+    this.permissionResponses.push({ sessionId, response });
+  }
 }
 
 function nextId(prefix: string): () => string {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput, PermissionMode, PermissionResponse, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
 import { createMakaSessionDriver } from '../session-driver.js';
@@ -142,6 +145,27 @@ describe('Maka session driver', () => {
     assert.equal(summary.id, 'session-2');
     assert.deepEqual(runtime.created, []);
     assert.equal(runtime.sent[0]?.sessionId, 'session-2');
+  });
+
+  test('rejects switching to a session whose cwd no longer exists', async () => {
+    const missingCwd = await mkdtemp(join(tmpdir(), 'maka-missing-session-cwd-'));
+    await rm(missingCwd, { recursive: true, force: true });
+    const runtime = new RecordingRuntime();
+    runtime.sessionSummaries = [
+      sessionSummary({ id: 'deleted-worktree', cwd: missingCwd }),
+    ];
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await assert.rejects(
+      driver.switchSession('deleted-worktree'),
+      new RegExp(`Session cwd no longer exists: ${escapeRegExp(missingCwd)}`),
+    );
+    assert.equal(driver.getSessionId(), null);
   });
 
   test('lists current-cwd sessions before other recent sessions', async () => {
@@ -319,6 +343,10 @@ function sessionSummary(overrides: Partial<SessionSummary>): SessionSummary {
     permissionMode: 'ask',
     ...overrides,
   };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -3,7 +3,15 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput, PermissionMode, PermissionResponse, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
+import type {
+  CreateSessionInput,
+  PermissionMode,
+  PermissionResponse,
+  SessionEvent,
+  SessionSummary,
+  StoredMessage,
+  UserMessageInput,
+} from '@maka/core';
 import { createMakaSessionDriver } from '../session-driver.js';
 
 describe('Maka session driver', () => {
@@ -132,6 +140,10 @@ describe('Maka session driver', () => {
       model: 'claude-opus-4-1',
       permissionMode: 'execute',
     }];
+    runtime.sessionMessages.set('session-2', [
+      storedUserMessage('user-1', 'turn-1', 'previous question'),
+      storedAssistantMessage('assistant-1', 'turn-1', 'previous answer'),
+    ]);
     const driver = createMakaSessionDriver({
       runtime,
       cwd: '/repo',
@@ -142,7 +154,8 @@ describe('Maka session driver', () => {
     const summary = await driver.switchSession('session-2');
     await collect(driver.sendPrompt('continue'));
 
-    assert.equal(summary.id, 'session-2');
+    assert.equal(summary.summary.id, 'session-2');
+    assert.deepEqual(summary.messages.map((message) => message.id), ['user-1', 'assistant-1']);
     assert.deepEqual(runtime.created, []);
     assert.equal(runtime.sent[0]?.sessionId, 'session-2');
   });
@@ -239,6 +252,7 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
   readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string } }> = [];
+  readonly sessionMessages = new Map<string, StoredMessage[]>();
   sessionSummaries: SessionSummary[] = [];
 
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
@@ -320,6 +334,10 @@ class RecordingRuntime {
   async listSessions(): Promise<SessionSummary[]> {
     return this.sessionSummaries;
   }
+
+  async getMessages(sessionId: string): Promise<StoredMessage[]> {
+    return this.sessionMessages.get(sessionId) ?? [];
+  }
 }
 
 function nextId(prefix: string): () => string {
@@ -342,6 +360,27 @@ function sessionSummary(overrides: Partial<SessionSummary>): SessionSummary {
     model: 'claude-sonnet-4-5',
     permissionMode: 'ask',
     ...overrides,
+  };
+}
+
+function storedUserMessage(id: string, turnId: string, text: string): StoredMessage {
+  return {
+    type: 'user',
+    id,
+    turnId,
+    ts: 1,
+    text,
+  };
+}
+
+function storedAssistantMessage(id: string, turnId: string, text: string): StoredMessage {
+  return {
+    type: 'assistant',
+    id,
+    turnId,
+    ts: 2,
+    text,
+    modelId: 'claude-sonnet-4-5',
   };
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -126,38 +126,70 @@ describe('Maka session driver', () => {
   });
 
   test('switches to an existing session for the next prompt', async () => {
-    const runtime = new RecordingRuntime();
-    runtime.sessionSummaries = [{
-      id: 'session-2',
-      name: 'Existing chat',
-      isFlagged: false,
-      isArchived: false,
-      labels: [],
-      hasUnread: false,
-      status: 'active',
-      backend: 'ai-sdk',
-      llmConnectionSlug: 'anthropic',
-      model: 'claude-opus-4-1',
-      permissionMode: 'execute',
-    }];
-    runtime.sessionMessages.set('session-2', [
-      storedUserMessage('user-1', 'turn-1', 'previous question'),
-      storedAssistantMessage('assistant-1', 'turn-1', 'previous answer'),
-    ]);
-    const driver = createMakaSessionDriver({
-      runtime,
-      cwd: '/repo',
-      llmConnectionSlug: 'anthropic',
-      model: 'claude-sonnet-4-5',
-    });
+    const repo = await mkdtemp(join(tmpdir(), 'maka-switch-cwd-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [{
+        id: 'session-2',
+        cwd: repo,
+        name: 'Existing chat',
+        isFlagged: false,
+        isArchived: false,
+        labels: [],
+        hasUnread: false,
+        status: 'active',
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-opus-4-1',
+        permissionMode: 'execute',
+      }];
+      runtime.sessionMessages.set('session-2', [
+        storedUserMessage('user-1', 'turn-1', 'previous question'),
+        storedAssistantMessage('assistant-1', 'turn-1', 'previous answer'),
+      ]);
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
 
-    const summary = await driver.switchSession('session-2');
-    await collect(driver.sendPrompt('continue'));
+      const summary = await driver.switchSession('session-2');
+      await collect(driver.sendPrompt('continue'));
 
-    assert.equal(summary.summary.id, 'session-2');
-    assert.deepEqual(summary.messages.map((message) => message.id), ['user-1', 'assistant-1']);
-    assert.deepEqual(runtime.created, []);
-    assert.equal(runtime.sent[0]?.sessionId, 'session-2');
+      assert.equal(summary.summary.id, 'session-2');
+      assert.deepEqual(summary.messages.map((message) => message.id), ['user-1', 'assistant-1']);
+      assert.deepEqual(runtime.created, []);
+      assert.equal(runtime.sent[0]?.sessionId, 'session-2');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a session summary without a cwd and leaves the active session unchanged', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-active-cwd-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [{ ...sessionSummary({ id: 'no-cwd' }), cwd: undefined }];
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+      await collect(driver.sendPrompt('hi'));
+
+      await assert.rejects(
+        driver.switchSession('no-cwd'),
+        /Session belongs to a different folder/,
+      );
+
+      await collect(driver.sendPrompt('again'));
+      assert.equal(runtime.sent[0]?.sessionId, 'session-1');
+      assert.equal(runtime.sent[1]?.sessionId, 'session-1');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   test('rejects switching to a session whose cwd no longer exists', async () => {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput, PermissionResponse, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
+import type { CreateSessionInput, PermissionMode, PermissionResponse, SessionEvent, SessionSummary, UserMessageInput } from '@maka/core';
 import { createMakaSessionDriver } from '../session-driver.js';
 
 describe('Maka session driver', () => {
@@ -46,6 +46,39 @@ describe('Maka session driver', () => {
     await collect(driver.sendPrompt('ship fast'));
 
     assert.equal(runtime.created[0]?.permissionMode, 'bypass');
+  });
+
+  test('uses an updated permission mode for a new session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await driver.setPermissionMode('execute');
+    await collect(driver.sendPrompt('run tests'));
+
+    assert.equal(runtime.created[0]?.permissionMode, 'execute');
+  });
+
+  test('updates permission mode on an active session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.setPermissionMode('execute');
+
+    assert.deepEqual(runtime.permissionModes, [{
+      sessionId: 'session-1',
+      mode: 'execute',
+    }]);
   });
 
   test('uses the default turn id generator when one is not injected', async () => {
@@ -94,6 +127,7 @@ class RecordingRuntime {
   readonly created: CreateSessionInput[] = [];
   readonly sent: Array<{ sessionId: string; input: UserMessageInput }> = [];
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
+  readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
 
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     this.created.push(input);
@@ -135,6 +169,23 @@ class RecordingRuntime {
 
   async respondToPermission(sessionId: string, response: PermissionResponse): Promise<void> {
     this.permissionResponses.push({ sessionId, response });
+  }
+
+  async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {
+    this.permissionModes.push({ sessionId, mode });
+    return {
+      id: sessionId,
+      name: 'New Chat',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      status: 'active',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      permissionMode: mode,
+    };
   }
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -81,6 +81,39 @@ describe('Maka session driver', () => {
     }]);
   });
 
+  test('uses an updated model for a new session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await driver.setModel('claude-opus-4-1');
+    await collect(driver.sendPrompt('run tests'));
+
+    assert.equal(runtime.created[0]?.model, 'claude-opus-4-1');
+  });
+
+  test('updates model on an active session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.setModel('claude-opus-4-1');
+
+    assert.deepEqual(runtime.sessionUpdates, [{
+      sessionId: 'session-1',
+      patch: { model: 'claude-opus-4-1' },
+    }]);
+  });
+
   test('uses the default turn id generator when one is not injected', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -128,6 +161,7 @@ class RecordingRuntime {
   readonly sent: Array<{ sessionId: string; input: UserMessageInput }> = [];
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
+  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string } }> = [];
 
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     this.created.push(input);
@@ -185,6 +219,23 @@ class RecordingRuntime {
       llmConnectionSlug: 'anthropic',
       model: 'claude-sonnet-4-5',
       permissionMode: mode,
+    };
+  }
+
+  async updateSession(sessionId: string, patch: { model?: string }): Promise<SessionSummary> {
+    this.sessionUpdates.push({ sessionId, patch });
+    return {
+      id: sessionId,
+      name: 'New Chat',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      status: 'active',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'anthropic',
+      model: patch.model ?? 'claude-sonnet-4-5',
+      permissionMode: 'ask',
     };
   }
 }

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
+import type { Terminal } from '@earendil-works/pi-tui';
+
+export class FakeTerminal implements Terminal {
+  readonly columns = 80;
+  readonly rows = 24;
+  readonly kittyProtocolActive = false;
+  readonly progressStates: boolean[] = [];
+  readonly writes: string[] = [];
+  stopCalls = 0;
+  private onInput: ((data: string) => void) | null = null;
+
+  start(onInput: (data: string) => void, _onResize: () => void): void {
+    this.onInput = onInput;
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+  }
+
+  drainInput(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  write(data: string): void {
+    this.writes.push(data);
+  }
+  moveBy(_lines: number): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(_title: string): void {}
+
+  setProgress(active: boolean): void {
+    this.progressStates.push(active);
+  }
+
+  input(data: string): void {
+    this.onInput?.(data);
+  }
+
+  output(): string {
+    return this.writes.join('');
+  }
+
+  screenOutput(): string {
+    return renderTerminalScreen(this.writes, this.rows);
+  }
+}
+
+export function plainTerminalOutput(output: string): string {
+  return output
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b_pi:c\x07/g, '')
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+}
+
+export function inputSurfaceRows(lines: readonly string[]): [number, number] {
+  const editorBorderIndexes = lines
+    .map((line, index) => (/^─+$/.test(line) ? index : -1))
+    .filter((index) => index >= 0);
+  assert.ok(editorBorderIndexes.length >= 2);
+  return [
+    editorBorderIndexes[editorBorderIndexes.length - 2]!,
+    editorBorderIndexes[editorBorderIndexes.length - 1]!,
+  ];
+}
+
+export function assertBottomPickerPlacement(
+  terminal: FakeTerminal,
+  title: string,
+  statusText: string,
+): void {
+  const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+  const titleIndex = lines.findIndex((line) => line.includes(title));
+  const statusLineIndex = lines.findIndex((line) => line.includes(statusText));
+  const [topEditorBorderIndex, bottomEditorBorderIndex] = inputSurfaceRows(lines);
+
+  assert.ok(titleIndex > 0);
+  assert.ok(titleIndex < topEditorBorderIndex);
+  assert.equal(bottomEditorBorderIndex, terminal.rows - 2);
+  assert.equal(statusLineIndex, terminal.rows - 1);
+}
+
+export function latestPlainLineContaining(output: string, text: string): string {
+  const line = plainTerminalOutput(output)
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.includes(text));
+  assert.ok(line, `Expected terminal output to contain ${text}`);
+  return line;
+}
+
+export async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 250;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  assert.equal(predicate(), true);
+}
+
+function renderTerminalScreen(writes: readonly string[], rows: number): string {
+  const screen: string[] = [];
+  let row = 0;
+  let col = 0;
+
+  const ensureRow = () => {
+    while (screen.length <= row) screen.push('');
+  };
+
+  const writeText = (text: string) => {
+    ensureRow();
+    const line = screen[row] ?? '';
+    screen[row] = `${line.slice(0, col)}${text}${line.slice(col + text.length)}`;
+    col += text.length;
+  };
+
+  for (const write of writes) {
+    for (let index = 0; index < write.length;) {
+      const char = write[index]!;
+      if (char === '\x1b') {
+        index = consumeEscapeSequence(write, index, {
+          clearScreen: () => {
+            screen.length = 0;
+            row = 0;
+            col = 0;
+          },
+          clearLine: () => {
+            ensureRow();
+            screen[row] = '';
+          },
+          moveTo: (nextRow, nextCol) => {
+            row = Math.max(0, nextRow);
+            col = Math.max(0, nextCol);
+          },
+          moveBy: (rowDelta, colDelta) => {
+            row = Math.max(0, row + rowDelta);
+            col = Math.max(0, col + colDelta);
+          },
+          moveCol: (nextCol) => {
+            col = Math.max(0, nextCol);
+          },
+        });
+        continue;
+      }
+      if (char === '\r') {
+        col = 0;
+        index += 1;
+        continue;
+      }
+      if (char === '\n') {
+        row += 1;
+        col = 0;
+        index += 1;
+        continue;
+      }
+      writeText(char);
+      index += 1;
+    }
+  }
+
+  while (screen.length < rows) screen.push('');
+  return screen.slice(Math.max(0, screen.length - rows)).join('\n');
+}
+
+interface ScreenEscapeActions {
+  clearScreen(): void;
+  clearLine(): void;
+  moveTo(row: number, col: number): void;
+  moveBy(rowDelta: number, colDelta: number): void;
+  moveCol(col: number): void;
+}
+
+function consumeEscapeSequence(input: string, index: number, actions: ScreenEscapeActions): number {
+  const kind = input[index + 1];
+  if (kind === '[') {
+    const finalIndex = findCsiFinalIndex(input, index + 2);
+    if (finalIndex < 0) return input.length;
+    const params = input.slice(index + 2, finalIndex);
+    applyCsiSequence(params, input[finalIndex]!, actions);
+    return finalIndex + 1;
+  }
+  if (kind === ']') return skipUntilTerminator(input, index + 2);
+  if (kind === '_' || kind === 'P') return skipUntilTerminator(input, index + 2);
+  return index + 2;
+}
+
+function findCsiFinalIndex(input: string, start: number): number {
+  for (let index = start; index < input.length; index += 1) {
+    const code = input.charCodeAt(index);
+    if (code >= 0x40 && code <= 0x7e) return index;
+  }
+  return -1;
+}
+
+function skipUntilTerminator(input: string, start: number): number {
+  for (let index = start; index < input.length; index += 1) {
+    if (input[index] === '\x07') return index + 1;
+    if (input[index] === '\x1b' && input[index + 1] === '\\') return index + 2;
+  }
+  return input.length;
+}
+
+function applyCsiSequence(params: string, final: string, actions: ScreenEscapeActions): void {
+  const values = parseCsiValues(params);
+  const first = values[0] ?? 1;
+  if (final === 'A') actions.moveBy(-first, 0);
+  if (final === 'B') actions.moveBy(first, 0);
+  if (final === 'C') actions.moveBy(0, first);
+  if (final === 'D') actions.moveBy(0, -first);
+  if (final === 'G') actions.moveCol(first - 1);
+  if (final === 'H' || final === 'f') actions.moveTo((values[0] ?? 1) - 1, (values[1] ?? 1) - 1);
+  if (final === 'J' && (values[0] === 2 || values[0] === 3)) actions.clearScreen();
+  if (final === 'K' && (values[0] ?? 0) === 2) actions.clearLine();
+}
+
+function parseCsiValues(params: string): number[] {
+  return params
+    .replace(/^\?/, '')
+    .split(';')
+    .filter((part) => /^\d+$/.test(part))
+    .map((part) => Number(part));
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -65,6 +65,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
         cwd: context.cwd,
         llmConnectionSlug: context.target.connection.slug,
         model: context.target.model,
+        permissionMode: 'ask',
       });
       await runMakaPiTui({
         driver,
@@ -72,7 +73,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
         cwd: context.cwd,
         model: context.target.model,
         connectionSlug: context.target.connection.slug,
-        permissionMode: 'bypass',
+        permissionMode: 'ask',
       });
       return 0;
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createMakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
+import { selectableModelIdsForTarget } from './connection-target.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 import { runMakaPiTui } from './pi-tui-runner.js';
 
@@ -72,6 +73,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
         title: 'Maka',
         cwd: context.cwd,
         model: context.target.model,
+        models: selectableModelIdsForTarget(context.target),
         connectionSlug: context.target.connection.slug,
         permissionMode: 'ask',
       });

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -11,6 +11,24 @@ export interface ReadySessionTarget {
   oauthTokens?: OAuthSubscriptionTokens;
 }
 
+export function selectableModelIdsForTarget(target: Pick<ReadySessionTarget, 'connection' | 'model'>): string[] {
+  const defaults = PROVIDER_DEFAULTS[target.connection.providerType];
+  const candidates = [
+    target.model,
+    target.connection.defaultModel,
+    ...(target.connection.models?.map((model) => model.id) ?? defaults?.fallbackModels ?? []),
+  ];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const id = candidate.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
 export interface ResolveDefaultSessionTargetInput {
   connectionStore: Pick<ConnectionStore, 'get' | 'getDefault'>;
   credentialStore: Pick<CredentialStore, 'getSecret'> & Partial<Pick<CredentialStore, 'setSecret'>>;

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -5,12 +5,13 @@ import {
   wrapTextWithAnsi,
   type MarkdownTheme,
 } from '@earendil-works/pi-tui';
-import type { SessionEvent, ToolResultContent } from '@maka/core/events';
+import type { PermissionRequestEvent, SessionEvent, ToolResultContent } from '@maka/core/events';
 import type { MakaSessionDriver } from './session-driver.js';
 
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
   sawTextDeltaMessageIds: Set<string>;
+  pendingPermission?: PermissionRequestEvent;
 }
 
 export type MakaPiTranscriptEntry =
@@ -140,11 +141,19 @@ export function applyMakaSessionEventToTranscript(
     }
 
     case 'permission_request':
-      state.entries.push({
-        kind: 'notice',
-        level: 'info',
-        text: `Permission requested for ${event.toolName}: ${event.hint ?? event.reason}`,
-      });
+      state.pendingPermission = event;
+      break;
+
+    case 'permission_decision_ack':
+      if (state.pendingPermission?.requestId === event.requestId) {
+        const toolName = state.pendingPermission.toolName;
+        state.pendingPermission = undefined;
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: `Permission ${event.decision}ed for ${toolName}`,
+        });
+      }
       break;
 
     case 'plan_submitted':
@@ -214,6 +223,11 @@ export function renderMakaPiTranscript(
     }
   }
 
+  if (state.pendingPermission) {
+    lines.push('');
+    lines.push(...renderPermissionPrompt(state.pendingPermission, safeWidth));
+  }
+
   return lines.length > 0 ? lines : [''];
 }
 
@@ -276,6 +290,30 @@ function renderToolBlock(entry: MakaPiToolEntry, width: number): string[] {
 function renderNotice(entry: MakaPiNoticeEntry, width: number): string[] {
   const label = entry.level === 'error' ? ansi.red('Error') : ansi.dim('Note');
   return renderIndented(`${label}: ${entry.text}`, width, 0).map((line) => fitLine(line, width));
+}
+
+function renderPermissionPrompt(request: PermissionRequestEvent, width: number): string[] {
+  const lines = [
+    fitLine(`${ansi.yellow('Permission required')} ${ansi.bold(request.toolName)} ${ansi.dim(request.category)}`, width),
+  ];
+  const summary = permissionRequestSummary(request);
+  if (summary) lines.push(...renderIndented(summary, width, 2));
+  if (request.hint) lines.push(...renderIndented(request.hint, width, 2).map(ansi.dim));
+  lines.push(fitLine(ansi.dim('y/Enter allow  n/Esc deny'), width));
+  return lines;
+}
+
+function permissionRequestSummary(request: PermissionRequestEvent): string {
+  const args = request.args;
+  if (request.toolName === 'Bash' && args !== null && typeof args === 'object') {
+    const command = (args as { command?: unknown }).command;
+    if (typeof command === 'string' && command.trim()) return `$ ${command}`;
+  }
+  if ((request.toolName === 'Write' || request.toolName === 'Edit') && args !== null && typeof args === 'object') {
+    const path = (args as { path?: unknown }).path;
+    if (typeof path === 'string' && path.trim()) return path;
+  }
+  return limitText(formatUnknown(request.args), 600);
 }
 
 function renderIndented(text: string, width: number, indent: number): string[] {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -197,6 +197,7 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'error':
+      state.pendingPermission = undefined;
       state.entries.push({
         kind: 'notice',
         level: 'error',
@@ -205,6 +206,7 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'abort':
+      state.pendingPermission = undefined;
       state.entries.push({
         kind: 'notice',
         level: 'info',
@@ -213,6 +215,8 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'complete':
+      // The turn is over; any unresolved permission request is no longer actionable.
+      state.pendingPermission = undefined;
       if (event.stopReason === 'max_tokens') {
         state.entries.push({
           kind: 'notice',

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -9,6 +9,7 @@ import type { PermissionRequestEvent, SessionEvent, ToolResultContent } from '@m
 import type { StoredMessage, SystemNoteMessage } from '@maka/core/session';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
+import { ansi } from './tui-ansi.js';
 
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
@@ -518,29 +519,6 @@ function formatUnknown(value: unknown): string {
 function limitText(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
   return `${text.slice(0, maxChars)}\n... ${text.length - maxChars} chars truncated`;
-}
-
-// PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
-const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
-
-const ansi = {
-  bold: style(1, 22),
-  dim: style(2, 22),
-  italic: style(3, 23),
-  underline: style(4, 24),
-  strikethrough: style(9, 29),
-  red: style(31, 39),
-  green: style(32, 39),
-  yellow: style(33, 39),
-  accent: rgb(...MAKA_LOGO_BLUE_RGB),
-};
-
-function style(open: number, close: number): (text: string) => string {
-  return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
-}
-
-function rgb(red: number, green: number, blue: number): (text: string) => string {
-  return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
 }
 
 const markdownTheme: MarkdownTheme = {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -206,16 +206,11 @@ export function applyMakaSessionEventToTranscript(
 
 export function renderMakaPiTranscript(
   state: MakaPiTranscriptState,
-  metadata: MakaPiTranscriptMetadata,
+  _metadata: MakaPiTranscriptMetadata,
   width: number,
 ): string[] {
   const safeWidth = Math.max(1, width);
-  const lines: string[] = [
-    fitLine(`${ansi.bold(metadata.title)} ${ansi.dim(metadata.model)} ${ansi.dim(metadata.connectionSlug)} ${ansi.dim(metadata.permissionMode)} ${ansi.dim(metadata.cwd)}`, safeWidth),
-    ansi.dim('-'.repeat(safeWidth)),
-  ];
-  const sessionId = metadata.sessionId ? `session ${metadata.sessionId}` : 'new session';
-  lines.push(fitLine(ansi.dim(metadata.busy ? `${sessionId} running` : `${sessionId} ready`), safeWidth));
+  const lines: string[] = [];
 
   for (const entry of state.entries) {
     lines.push('');
@@ -240,7 +235,15 @@ export function renderMakaPiTranscript(
     lines.push(...renderPermissionPrompt(state.pendingPermission, safeWidth));
   }
 
-  return lines.length > 0 ? lines : [''];
+  return lines;
+}
+
+export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width: number): string {
+  const safeWidth = Math.max(1, width);
+  return fitLine(
+    `${ansi.bold(metadata.title)} ${ansi.dim(metadata.model)} ${ansi.dim(metadata.connectionSlug)} ${ansi.dim(metadata.permissionMode)} ${ansi.dim(metadata.cwd)}`,
+    safeWidth,
+  );
 }
 
 function appendAssistantText(state: MakaPiTranscriptState, messageId: string, text: string): void {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -12,6 +12,7 @@ export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
   sawTextDeltaMessageIds: Set<string>;
   pendingPermission?: PermissionRequestEvent;
+  expandedToolUseId?: string;
 }
 
 export type MakaPiTranscriptEntry =
@@ -49,6 +50,17 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
 
 export function appendUserPrompt(state: MakaPiTranscriptState, text: string): void {
   state.entries.push({ kind: 'user', text });
+}
+
+export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean {
+  const latestTool = [...state.entries]
+    .reverse()
+    .find((entry): entry is MakaPiToolEntry => entry.kind === 'tool');
+  if (!latestTool) return false;
+  state.expandedToolUseId = state.expandedToolUseId === latestTool.toolUseId
+    ? undefined
+    : latestTool.toolUseId;
+  return true;
 }
 
 export async function submitPromptToTranscript(input: {
@@ -215,7 +227,7 @@ export function renderMakaPiTranscript(
         lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.green }));
         break;
       case 'tool':
-        lines.push(...renderToolBlock(entry, safeWidth));
+        lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseId === entry.toolUseId));
         break;
       case 'notice':
         lines.push(...renderNotice(entry, safeWidth));
@@ -265,7 +277,7 @@ function renderTextBlock(
   return lines;
 }
 
-function renderToolBlock(entry: MakaPiToolEntry, width: number): string[] {
+function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded: boolean): string[] {
   const status = entry.status === 'running'
     ? ansi.yellow('running')
     : entry.status === 'error'
@@ -275,16 +287,41 @@ function renderToolBlock(entry: MakaPiToolEntry, width: number): string[] {
   const lines = [
     fitLine(`${ansi.yellow('Tool')} ${entry.title ?? entry.toolName} ${status}${duration}`, width),
   ];
-  if (entry.input !== undefined) {
-    lines.push(...renderIndented(`input: ${formatUnknown(entry.input)}`, width, 2).map(ansi.dim));
-  }
+  const inputSummary = toolInputSummary(entry);
+  if (inputSummary) lines.push(...renderIndented(inputSummary, width, 2).map(ansi.dim));
   if (entry.progress.length > 0) {
-    lines.push(...renderIndented(limitText(entry.progress.join(''), 1200), width, 2).map(ansi.dim));
+    lines.push(...renderToolText(entry.progress.join(''), width, expanded).map(ansi.dim));
   }
   if (entry.output) {
-    lines.push(...renderIndented(limitText(entry.output, 4000), width, 2));
+    lines.push(...renderToolText(entry.output, width, expanded));
+  }
+  if (!expanded && toolHasHiddenDetail(entry)) {
+    lines.push(fitLine(ansi.dim('Ctrl+O expand'), width));
   }
   return lines.map((line) => fitLine(line, width));
+}
+
+function renderToolText(text: string, width: number, expanded: boolean): string[] {
+  const limit = expanded ? 12_000 : 600;
+  return renderIndented(limitText(text, limit), width, 2);
+}
+
+function toolHasHiddenDetail(entry: MakaPiToolEntry): boolean {
+  return entry.progress.join('').length > 600 || (entry.output?.length ?? 0) > 600;
+}
+
+function toolInputSummary(entry: MakaPiToolEntry): string {
+  const input = entry.input;
+  if (entry.toolName === 'Bash' && input !== null && typeof input === 'object') {
+    const command = (input as { command?: unknown }).command;
+    if (typeof command === 'string' && command.trim()) return `command: ${command}`;
+  }
+  if ((entry.toolName === 'Write' || entry.toolName === 'Edit') && input !== null && typeof input === 'object') {
+    const path = (input as { path?: unknown }).path;
+    if (typeof path === 'string' && path.trim()) return `path: ${path}`;
+  }
+  if (input === undefined) return '';
+  return `input: ${limitText(formatUnknown(input), 600)}`;
 }
 
 function renderNotice(entry: MakaPiNoticeEntry, width: number): string[] {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -216,10 +216,10 @@ export function renderMakaPiTranscript(
     lines.push('');
     switch (entry.kind) {
       case 'user':
-        lines.push(...renderTextBlock('User', entry.text, safeWidth, { markdown: false, heading: ansi.cyan }));
+        lines.push(...renderTextBlock('User', entry.text, safeWidth, { markdown: false, heading: ansi.accent }));
         break;
       case 'assistant':
-        lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.green }));
+        lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.accent }));
         break;
       case 'tool':
         lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseId === entry.toolUseId));
@@ -429,6 +429,9 @@ function limitText(text: string, maxChars: number): string {
   return `${text.slice(0, maxChars)}\n... ${text.length - maxChars} chars truncated`;
 }
 
+// PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
+const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
+
 const ansi = {
   bold: style(1, 22),
   dim: style(2, 22),
@@ -438,15 +441,19 @@ const ansi = {
   red: style(31, 39),
   green: style(32, 39),
   yellow: style(33, 39),
-  cyan: style(36, 39),
+  accent: rgb(...MAKA_LOGO_BLUE_RGB),
 };
 
 function style(open: number, close: number): (text: string) => string {
   return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
 }
 
+function rgb(red: number, green: number, blue: number): (text: string) => string {
+  return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
+}
+
 const markdownTheme: MarkdownTheme = {
-  heading: ansi.cyan,
+  heading: ansi.accent,
   link: ansi.underline,
   linkUrl: ansi.dim,
   code: ansi.yellow,
@@ -455,7 +462,7 @@ const markdownTheme: MarkdownTheme = {
   quote: ansi.dim,
   quoteBorder: ansi.dim,
   hr: ansi.dim,
-  listBullet: ansi.cyan,
+  listBullet: ansi.accent,
   bold: ansi.bold,
   italic: ansi.italic,
   strikethrough: ansi.strikethrough,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -6,6 +6,8 @@ import {
   type MarkdownTheme,
 } from '@earendil-works/pi-tui';
 import type { PermissionRequestEvent, SessionEvent, ToolResultContent } from '@maka/core/events';
+import type { StoredMessage, SystemNoteMessage } from '@maka/core/session';
+import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
 
 export interface MakaPiTranscriptState {
@@ -50,6 +52,23 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
 
 export function appendUserPrompt(state: MakaPiTranscriptState, text: string): void {
   state.entries.push({ kind: 'user', text });
+}
+
+export function replaceTranscriptWithStoredMessages(
+  state: MakaPiTranscriptState,
+  messages: readonly StoredMessage[],
+): void {
+  const view = materializeSession(messages);
+  state.entries = view.items
+    .map(chatItemToTranscriptEntry)
+    .filter((entry): entry is MakaPiTranscriptEntry => entry !== undefined);
+  state.sawTextDeltaMessageIds = new Set(
+    state.entries
+      .filter((entry): entry is Extract<MakaPiTranscriptEntry, { kind: 'assistant' }> => entry.kind === 'assistant')
+      .map((entry) => entry.messageId),
+  );
+  state.pendingPermission = undefined;
+  state.expandedToolUseId = undefined;
 }
 
 export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean {
@@ -201,6 +220,78 @@ export function applyMakaSessionEventToTranscript(
         });
       }
       break;
+  }
+}
+
+function chatItemToTranscriptEntry(item: ChatItem): MakaPiTranscriptEntry | undefined {
+  switch (item.kind) {
+    case 'user':
+      return { kind: 'user', text: item.message.text };
+    case 'assistant':
+      return { kind: 'assistant', messageId: item.message.id, text: item.message.text };
+    case 'tool':
+      return toolActivityToTranscriptEntry(item.item);
+    case 'system_note':
+      return systemNoteToTranscriptEntry(item.message);
+  }
+}
+
+function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiTranscriptEntry {
+  const output = item.result
+    ? formatToolResultContent(item.result)
+    : item.status === 'interrupted'
+      ? 'Interrupted before the tool returned a result.'
+      : undefined;
+  return {
+    kind: 'tool',
+    toolUseId: item.toolUseId,
+    toolName: item.toolName,
+    ...(item.displayName ? { title: item.displayName } : {}),
+    input: item.args,
+    progress: [],
+    ...(output ? { output } : {}),
+    ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
+    status: transcriptToolStatus(item.status),
+  };
+}
+
+function transcriptToolStatus(status: ToolActivityItem['status']): MakaPiToolEntry['status'] {
+  switch (status) {
+    case 'completed':
+      return 'done';
+    case 'errored':
+    case 'interrupted':
+      return 'error';
+    case 'pending':
+    case 'waiting_permission':
+    case 'running':
+      return 'running';
+  }
+}
+
+function systemNoteToTranscriptEntry(message: SystemNoteMessage): MakaPiTranscriptEntry | undefined {
+  const text = systemNoteText(message);
+  if (!text) return undefined;
+  return {
+    kind: 'notice',
+    level: message.kind === 'error' ? 'error' : 'info',
+    text,
+  };
+}
+
+function systemNoteText(message: SystemNoteMessage): string | undefined {
+  switch (message.kind) {
+    case 'session_start':
+    case 'session_resume':
+      return undefined;
+    case 'mode_change':
+      return 'Permission mode changed.';
+    case 'model_change':
+      return 'Model changed.';
+    case 'error':
+      return 'Session recorded an error.';
+    case 'abort':
+      return 'Session was stopped.';
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -6,6 +6,8 @@ import {
   SelectList,
   TUI,
   matchesKey,
+  truncateToWidth,
+  visibleWidth,
   type Component,
   type EditorTheme,
   type OverlayHandle,
@@ -176,6 +178,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       minPrimaryColumnWidth: 24,
       maxPrimaryColumnWidth: 40,
     });
+    const picker = new SessionPickerOverlay(list);
     let overlay: OverlayHandle | undefined;
     list.onSelect = (item) => {
       overlay?.hide();
@@ -191,11 +194,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     list.onCancel = () => {
       overlay?.hide();
     };
-    overlay = tui.showOverlay(list, {
-      anchor: 'bottom-center',
+    overlay = tui.showOverlay(picker, {
+      anchor: 'top-center',
+      row: 5,
       width: '80%',
-      maxHeight: 10,
-      offsetY: -3,
+      maxHeight: 12,
     });
   };
 
@@ -332,6 +335,39 @@ class MakaTranscriptComponent implements Component {
   render(width: number): string[] {
     return renderMakaPiTranscript(this.state, this.metadata(), width);
   }
+}
+
+class SessionPickerOverlay implements Component {
+  constructor(private readonly list: SelectList) {}
+
+  invalidate(): void {
+    this.list.invalidate();
+  }
+
+  handleInput(data: string): void {
+    this.list.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const safeWidth = Math.max(12, width);
+    const innerWidth = Math.max(1, safeWidth - 4);
+    const border = `+${'-'.repeat(safeWidth - 2)}+`;
+    const lines = [
+      border,
+      framedLine('Select session', safeWidth),
+      framedLine('', safeWidth),
+      ...this.list.render(innerWidth).map((line) => framedLine(line, safeWidth)),
+      border,
+    ];
+    return lines;
+  }
+}
+
+function framedLine(text: string, width: number): string {
+  const innerWidth = Math.max(1, width - 4);
+  const trimmed = visibleWidth(text) > innerWidth ? truncateToWidth(text, innerWidth, '') : text;
+  const padding = Math.max(0, innerWidth - visibleWidth(trimmed));
+  return `| ${trimmed}${' '.repeat(padding)} |`;
 }
 
 function editorTheme(): EditorTheme {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -494,6 +494,8 @@ class MakaPiLayoutComponent extends Container {
 }
 
 class MakaAutocompleteAboveEditorComponent implements Component {
+  private autocompleteSlotRows = 0;
+
   constructor(private readonly editor: Editor) {}
 
   get focused(): boolean {
@@ -514,13 +516,52 @@ class MakaAutocompleteAboveEditorComponent implements Component {
 
   render(width: number): string[] {
     const lines = this.editor.render(width);
-    if (!this.editor.isShowingAutocomplete()) return lines;
-    const sections = splitTrailingAutocomplete(lines);
-    return [
+    const result = arrangeAutocompleteAboveEditor({
+      lines,
+      autocompleteShowing: this.editor.isShowingAutocomplete(),
+      autocompleteSlotRows: this.autocompleteSlotRows,
+    });
+    this.autocompleteSlotRows = result.autocompleteSlotRows;
+    return result.lines;
+  }
+}
+
+export interface MakaAutocompleteArrangementInput {
+  lines: string[];
+  autocompleteShowing: boolean;
+  autocompleteSlotRows: number;
+}
+
+export interface MakaAutocompleteArrangementResult {
+  lines: string[];
+  autocompleteSlotRows: number;
+}
+
+export function arrangeAutocompleteAboveEditor(
+  input: MakaAutocompleteArrangementInput,
+): MakaAutocompleteArrangementResult {
+  if (!input.autocompleteShowing) {
+    return { lines: input.lines, autocompleteSlotRows: 0 };
+  }
+  const sections = splitTrailingAutocomplete(input.lines);
+  if (sections.autocompleteLines.length === 0) {
+    return { lines: sections.editorLines, autocompleteSlotRows: 0 };
+  }
+  const autocompleteSlotRows = Math.max(
+    input.autocompleteSlotRows,
+    sections.autocompleteLines.length,
+  );
+  return {
+    lines: [
+      ...Array.from(
+        { length: autocompleteSlotRows - sections.autocompleteLines.length },
+        () => '',
+      ),
       ...sections.autocompleteLines,
       ...sections.editorLines,
-    ];
-  }
+    ],
+    autocompleteSlotRows,
+  };
 }
 
 interface MakaAutocompleteSections {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -494,8 +494,6 @@ class MakaPiLayoutComponent extends Container {
 }
 
 class MakaAutocompleteAboveEditorComponent implements Component {
-  private autocompleteSlotRows = 0;
-
   constructor(private readonly editor: Editor) {}
 
   get focused(): boolean {
@@ -516,19 +514,10 @@ class MakaAutocompleteAboveEditorComponent implements Component {
 
   render(width: number): string[] {
     const lines = this.editor.render(width);
-    if (!this.editor.isShowingAutocomplete()) {
-      this.autocompleteSlotRows = 0;
-      return lines;
-    }
+    if (!this.editor.isShowingAutocomplete()) return lines;
     const sections = splitTrailingAutocomplete(lines);
-    if (sections.autocompleteLines.length === 0) {
-      this.autocompleteSlotRows = 0;
-      return sections.editorLines;
-    }
-    this.autocompleteSlotRows = Math.max(this.autocompleteSlotRows, sections.autocompleteLines.length);
     return [
       ...sections.autocompleteLines,
-      ...Array.from({ length: this.autocompleteSlotRows - sections.autocompleteLines.length }, () => ''),
       ...sections.editorLines,
     ];
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -40,6 +40,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const terminal = input.terminal ?? new ProcessTerminal();
   const tui = new TUI(terminal);
   const state = createMakaPiTranscriptState();
+  let cwd = input.cwd;
   let model = input.model;
   let connectionSlug = input.connectionSlug;
   let permissionMode = input.permissionMode;
@@ -52,7 +53,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const metadata = (): MakaPiTranscriptMetadata => ({
     title: input.title,
-    cwd: input.cwd,
+    cwd,
     model,
     connectionSlug,
     permissionMode,
@@ -146,6 +147,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const switchSession = async (sessionId: string) => {
     const summary = await input.driver.switchSession(sessionId);
+    cwd = summary.cwd ?? cwd;
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;
@@ -159,7 +161,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    const currentCwdSessions = sessions.filter((session) => session.cwd === input.cwd);
+    const currentCwdSessions = sessions.filter((session) => session.cwd === cwd);
     if (currentCwdSessions.length === 0) {
       state.entries.push({
         kind: 'notice',

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -71,7 +71,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const statusLine = new MakaStatusLineComponent(metadata);
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
   const layout = new MakaPiLayoutComponent(transcript, editor, statusLine, terminal);
-  editor.setAutocompleteProvider(new MakaAutocompleteProvider(input.cwd));
 
   const requestRender = () => {
     transcript.invalidate();
@@ -262,93 +261,112 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const slashCommands: MakaSlashCommand[] = [
+    {
+      name: 'model',
+      description: 'Select model',
+      run: (parts: string[]) => {
+        if (parts.length === 1) {
+          void showModelList().catch((error) => {
+            state.entries.push({
+              kind: 'notice',
+              level: 'error',
+              text: error instanceof Error ? error.message : String(error),
+            });
+            requestRender();
+          });
+          return;
+        }
+        const nextModel = parts.length === 2 ? parts[1] : undefined;
+        if (!nextModel) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Usage: /model <model-id>',
+          });
+          requestRender();
+          return;
+        }
+        void setModel(nextModel).catch((error) => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: error instanceof Error ? error.message : String(error),
+          });
+          requestRender();
+        });
+      },
+    },
+    {
+      name: 'permissions',
+      description: 'Set permission mode',
+      run: (parts: string[]) => {
+        const mode = parts.length === 2 ? parts[1] : undefined;
+        if (!isPermissionMode(mode)) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: `Usage: /permissions ${PERMISSION_MODES.join('|')}`,
+          });
+          requestRender();
+          return;
+        }
+        void setPermissionMode(mode).catch((error) => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: error instanceof Error ? error.message : String(error),
+          });
+          requestRender();
+        });
+      },
+    },
+    {
+      name: 'session',
+      description: 'Resume session',
+      run: (parts: string[]) => {
+        if (parts.length === 1) {
+          void showSessionList().catch((error) => {
+            state.entries.push({
+              kind: 'notice',
+              level: 'error',
+              text: error instanceof Error ? error.message : String(error),
+            });
+            requestRender();
+          });
+          return;
+        }
+        const sessionId = parts.length === 2 ? parts[1] : undefined;
+        if (!sessionId) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Usage: /session <session-id>',
+          });
+          requestRender();
+          return;
+        }
+        void switchSession(sessionId).catch((error) => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: error instanceof Error ? error.message : String(error),
+          });
+          requestRender();
+        });
+      },
+    },
+  ].sort((left, right) => left.name.localeCompare(right.name));
+
   const handleSlashCommand = (prompt: string): boolean => {
     const parts = prompt.trim().split(/\s+/);
-    if (parts[0] === '/model') {
-      if (parts.length === 1) {
-        void showModelList().catch((error) => {
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: error instanceof Error ? error.message : String(error),
-          });
-          requestRender();
-        });
-        return true;
-      }
-      const nextModel = parts.length === 2 ? parts[1] : undefined;
-      if (!nextModel) {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: 'Usage: /model <model-id>',
-        });
-        requestRender();
-        return true;
-      }
-      void setModel(nextModel).catch((error) => {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: error instanceof Error ? error.message : String(error),
-        });
-        requestRender();
-      });
-      return true;
-    }
-    if (parts[0] === '/session') {
-      if (parts.length === 1) {
-        void showSessionList().catch((error) => {
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: error instanceof Error ? error.message : String(error),
-          });
-          requestRender();
-        });
-        return true;
-      }
-      const sessionId = parts.length === 2 ? parts[1] : undefined;
-      if (!sessionId) {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: 'Usage: /session <session-id>',
-        });
-        requestRender();
-        return true;
-      }
-      void switchSession(sessionId).catch((error) => {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: error instanceof Error ? error.message : String(error),
-        });
-        requestRender();
-      });
-      return true;
-    }
-    if (parts[0] !== '/permissions') return false;
-    const mode = parts.length === 2 ? parts[1] : undefined;
-    if (!isPermissionMode(mode)) {
-      state.entries.push({
-        kind: 'notice',
-        level: 'error',
-        text: `Usage: /permissions ${PERMISSION_MODES.join('|')}`,
-      });
-      requestRender();
-      return true;
-    }
-    void setPermissionMode(mode).catch((error) => {
-      state.entries.push({
-        kind: 'notice',
-        level: 'error',
-        text: error instanceof Error ? error.message : String(error),
-      });
-      requestRender();
-    });
+    const command = slashCommands.find((candidate) => `/${candidate.name}` === parts[0]);
+    if (!command) return false;
+    command.run(parts);
     return true;
   };
+
+  editor.setAutocompleteProvider(new MakaAutocompleteProvider(input.cwd, slashCommands));
 
   tui.addInputListener((data) => {
     if (tui.hasOverlay()) return undefined;
@@ -436,10 +454,11 @@ class MakaPiLayoutComponent extends Container {
 
 class MakaAutocompleteProvider implements AutocompleteProvider {
   private readonly fileProvider: CombinedAutocompleteProvider;
-  private readonly slashCommands = MAKA_SLASH_COMMANDS;
+  private readonly slashCommands: readonly MakaSlashCommandMetadata[];
 
-  constructor(basePath: string) {
+  constructor(basePath: string, slashCommands: readonly MakaSlashCommandMetadata[]) {
     this.fileProvider = new CombinedAutocompleteProvider([], basePath);
+    this.slashCommands = slashCommands;
   }
 
   async getSuggestions(
@@ -487,6 +506,15 @@ class MakaAutocompleteProvider implements AutocompleteProvider {
   shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
     return this.fileProvider.shouldTriggerFileCompletion(lines, cursorLine, cursorCol);
   }
+}
+
+interface MakaSlashCommandMetadata {
+  name: string;
+  description: string;
+}
+
+interface MakaSlashCommand extends MakaSlashCommandMetadata {
+  run(parts: string[]): void;
 }
 
 function slashCommandPrefix(lines: string[], cursorLine: number, cursorCol: number): string | null {
@@ -592,12 +620,6 @@ const ansi = {
   accent: rgb(...MAKA_LOGO_BLUE_RGB),
   reverse: style(7, 27),
 };
-
-const MAKA_SLASH_COMMANDS = [
-  { name: 'model', description: 'Select model' },
-  { name: 'permissions', description: 'Set permission mode' },
-  { name: 'session', description: 'Resume session' },
-] as const;
 
 const PICKER_SURFACE_ROWS = 200;
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -261,6 +261,36 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const showPermissionModeList = () => {
+    const items = permissionModePickerItems(permissionMode);
+    const list = new SelectList(items, 10, selectListTheme(), {
+      minPrimaryColumnWidth: 16,
+      maxPrimaryColumnWidth: 24,
+    });
+    list.setSelectedIndex(items.findIndex((item) => item.value === permissionMode));
+    const picker = new PickerOverlay(list, {
+      title: 'Select Permission Mode',
+      rightLabel: permissionMode,
+    });
+    let overlay: OverlayHandle | undefined;
+    list.onSelect = (item) => {
+      overlay?.hide();
+      if (!isPermissionMode(item.value)) return;
+      void setPermissionMode(item.value).catch((error) => {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: error instanceof Error ? error.message : String(error),
+        });
+        requestRender();
+      });
+    };
+    list.onCancel = () => {
+      overlay?.hide();
+    };
+    overlay = showBottomPicker(picker);
+  };
+
   const slashCommands: MakaSlashCommand[] = [
     {
       name: 'exit',
@@ -308,6 +338,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       name: 'permissions',
       description: 'Set permission mode',
       run: (parts: string[]) => {
+        if (parts.length === 1) {
+          showPermissionModeList();
+          return;
+        }
         const mode = parts.length === 2 ? parts[1] : undefined;
         if (!isPermissionMode(mode)) {
           state.entries.push({
@@ -641,6 +675,14 @@ function modelPickerItems(currentModel: string, models: readonly string[] | unde
     value: id,
     label: id,
     ...(id === currentModel ? { description: 'current' } : {}),
+  }));
+}
+
+function permissionModePickerItems(currentMode: PermissionMode): SelectItem[] {
+  return PERMISSION_MODES.map((mode) => ({
+    value: mode,
+    label: mode,
+    ...(mode === currentMode ? { description: 'current' } : {}),
   }));
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -25,6 +25,7 @@ import {
   createMakaPiTranscriptState,
   renderMakaPiStatusLine,
   renderMakaPiTranscript,
+  replaceTranscriptWithStoredMessages,
   submitPromptToTranscript,
   toggleLatestToolExpansion,
   type MakaPiTranscriptMetadata,
@@ -154,16 +155,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   const switchSession = async (sessionId: string) => {
-    const summary = await input.driver.switchSession(sessionId);
+    const { summary, messages } = await input.driver.switchSession(sessionId);
     cwd = summary.cwd ?? cwd;
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: `Session: ${summary.id}`,
-    });
+    replaceTranscriptWithStoredMessages(state, messages);
+    if (messages.length === 0) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: `Resumed session "${summary.name}"`,
+      });
+    }
     requestRender();
   };
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -15,6 +15,7 @@ import {
   createMakaPiTranscriptState,
   renderMakaPiTranscript,
   submitPromptToTranscript,
+  toggleLatestToolExpansion,
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
 } from './pi-transcript.js';
@@ -123,6 +124,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   tui.addInputListener((data) => {
+    if (matchesKey(data, Key.ctrl('o'))) {
+      if (toggleLatestToolExpansion(state)) {
+        requestRender();
+        return { consume: true };
+      }
+    }
     if (state.pendingPermission) {
       if (matchesKey(data, 'y') || matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
         respondToPendingPermission('allow');

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -35,6 +35,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const terminal = input.terminal ?? new ProcessTerminal();
   const tui = new TUI(terminal);
   const state = createMakaPiTranscriptState();
+  let model = input.model;
   let permissionMode = input.permissionMode;
   let busy = false;
   let closed = false;
@@ -46,7 +47,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const metadata = (): MakaPiTranscriptMetadata => ({
     title: input.title,
     cwd: input.cwd,
-    model: input.model,
+    model,
     connectionSlug: input.connectionSlug,
     permissionMode,
     sessionId: input.driver.getSessionId(),
@@ -126,6 +127,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     });
   };
 
+  const setModel = async (nextModel: string) => {
+    await input.driver.setModel(nextModel);
+    model = nextModel;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Model: ${nextModel}`,
+    });
+    requestRender();
+  };
+
   const setPermissionMode = async (mode: PermissionMode) => {
     await input.driver.setPermissionMode(mode);
     permissionMode = mode;
@@ -139,6 +151,27 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const handleSlashCommand = (prompt: string): boolean => {
     const parts = prompt.trim().split(/\s+/);
+    if (parts[0] === '/model') {
+      const nextModel = parts.length === 2 ? parts[1] : undefined;
+      if (!nextModel) {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: 'Usage: /model <model-id>',
+        });
+        requestRender();
+        return true;
+      }
+      void setModel(nextModel).catch((error) => {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: error instanceof Error ? error.message : String(error),
+        });
+        requestRender();
+      });
+      return true;
+    }
     if (parts[0] !== '/permissions') return false;
     const mode = parts.length === 2 ? parts[1] : undefined;
     if (!isPermissionMode(mode)) {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -264,6 +264,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const slashCommands: MakaSlashCommand[] = [
     {
+      name: 'exit',
+      description: 'Exit Maka',
+      run: () => {
+        void close();
+      },
+    },
+    {
       name: 'model',
       description: 'Select model',
       run: (parts: string[]) => {
@@ -387,7 +394,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return { consume: true };
       }
     }
-    if (matchesKey(data, Key.ctrl('c')) || matchesKey(data, Key.escape)) {
+    if (matchesKey(data, Key.ctrl('c')) || matchesKey(data, Key.ctrl('d'))) {
       void close();
       return { consume: true };
     }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -194,29 +194,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
-  // The TUI is bound to one folder and one connection (its autocomplete base
-  // path and model candidates come from the startup target). Refuse to resume
-  // a session from another folder/connection rather than silently desyncing.
-  const assertSwitchable = async (sessionId: string) => {
-    const sessions = await input.driver.listSessions();
-    const target = sessions.find((session) => session.id === sessionId);
-    if (!target) throw new Error(`Session not found: ${sessionId}`);
-    if (target.cwd !== cwd) {
-      throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
-    }
-    if (target.llmConnectionSlug !== connectionSlug) {
-      throw new Error('Session uses a different connection; run Maka with that connection to resume it.');
-    }
-  };
-
+  // Folder/connection safety is enforced inside driver.switchSession(),
+  // before it commits any internal state, so a rejected switch leaves the
+  // active session untouched and the next prompt still lands on the old one.
   const switchSession = async (sessionId: string) => {
-    await assertSwitchable(sessionId);
     const { summary, messages } = await input.driver.switchSession(sessionId);
-    // Re-check against the driver's authoritative summary: the list snapshot we
-    // validated in assertSwitchable can be stale by the time the switch returns.
-    if (summary.cwd !== cwd || summary.llmConnectionSlug !== connectionSlug) {
-      throw new Error('Session no longer matches the current folder or connection.');
-    }
     cwd = summary.cwd ?? cwd;
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -36,6 +36,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const tui = new TUI(terminal);
   const state = createMakaPiTranscriptState();
   let model = input.model;
+  let connectionSlug = input.connectionSlug;
   let permissionMode = input.permissionMode;
   let busy = false;
   let closed = false;
@@ -48,7 +49,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     title: input.title,
     cwd: input.cwd,
     model,
-    connectionSlug: input.connectionSlug,
+    connectionSlug,
     permissionMode,
     sessionId: input.driver.getSessionId(),
     busy,
@@ -138,6 +139,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const switchSession = async (sessionId: string) => {
+    const summary = await input.driver.switchSession(sessionId);
+    model = summary.model;
+    connectionSlug = summary.llmConnectionSlug;
+    permissionMode = summary.permissionMode;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Session: ${summary.id}`,
+    });
+    requestRender();
+  };
+
   const setPermissionMode = async (mode: PermissionMode) => {
     await input.driver.setPermissionMode(mode);
     permissionMode = mode;
@@ -163,6 +177,27 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return true;
       }
       void setModel(nextModel).catch((error) => {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: error instanceof Error ? error.message : String(error),
+        });
+        requestRender();
+      });
+      return true;
+    }
+    if (parts[0] === '/session') {
+      const sessionId = parts.length === 2 ? parts[1] : undefined;
+      if (!sessionId) {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: 'Usage: /session <session-id>',
+        });
+        requestRender();
+        return true;
+      }
+      void switchSession(sessionId).catch((error) => {
         state.entries.push({
           kind: 'notice',
           level: 'error',

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -70,7 +70,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const transcript = new MakaTranscriptComponent(state, metadata);
   const statusLine = new MakaStatusLineComponent(metadata);
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
-  const layout = new MakaPiLayoutComponent(transcript, editor, statusLine, terminal);
+  const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
+  const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
 
   const requestRender = () => {
     transcript.invalidate();
@@ -395,7 +396,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   terminal.setTitle(input.title);
   tui.addChild(layout);
-  tui.setFocus(editor);
+  tui.setFocus(editorSurface);
   tui.start();
 
   return closedPromise;
@@ -450,6 +451,56 @@ class MakaPiLayoutComponent extends Container {
       ...statusLines,
     ];
   }
+}
+
+class MakaAutocompleteAboveEditorComponent implements Component {
+  constructor(private readonly editor: Editor) {}
+
+  get focused(): boolean {
+    return this.editor.focused;
+  }
+
+  set focused(value: boolean) {
+    this.editor.focused = value;
+  }
+
+  invalidate(): void {
+    this.editor.invalidate();
+  }
+
+  handleInput(data: string): void {
+    this.editor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const lines = this.editor.render(width);
+    if (!this.editor.isShowingAutocomplete()) return lines;
+    return moveTrailingAutocompleteAboveEditor(lines);
+  }
+}
+
+function moveTrailingAutocompleteAboveEditor(lines: string[]): string[] {
+  const bottomBorderIndex = findLastIndex(lines, isEditorChromeLine);
+  if (bottomBorderIndex < 1 || bottomBorderIndex === lines.length - 1) return lines;
+  const topBorderIndex = findLastIndex(lines.slice(0, bottomBorderIndex), isEditorChromeLine);
+  if (topBorderIndex < 0) return lines;
+
+  return [
+    ...lines.slice(bottomBorderIndex + 1),
+    ...lines.slice(0, bottomBorderIndex + 1),
+  ];
+}
+
+function isEditorChromeLine(line: string): boolean {
+  const text = stripAnsi(line);
+  return /^─+$/.test(text) || /^─── [↑↓] \d+ more ─*$/.test(text);
+}
+
+function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index]!)) return index;
+  }
+  return -1;
 }
 
 class MakaAutocompleteProvider implements AutocompleteProvider {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -465,6 +465,8 @@ class MakaPiLayoutComponent extends Container {
 }
 
 class MakaAutocompleteAboveEditorComponent implements Component {
+  private autocompleteSlotRows = 0;
+
   constructor(private readonly editor: Editor) {}
 
   get focused(): boolean {
@@ -485,21 +487,41 @@ class MakaAutocompleteAboveEditorComponent implements Component {
 
   render(width: number): string[] {
     const lines = this.editor.render(width);
-    if (!this.editor.isShowingAutocomplete()) return lines;
-    return moveTrailingAutocompleteAboveEditor(lines);
+    if (!this.editor.isShowingAutocomplete()) {
+      this.autocompleteSlotRows = 0;
+      return lines;
+    }
+    const sections = splitTrailingAutocomplete(lines);
+    if (sections.autocompleteLines.length === 0) {
+      this.autocompleteSlotRows = 0;
+      return sections.editorLines;
+    }
+    this.autocompleteSlotRows = Math.max(this.autocompleteSlotRows, sections.autocompleteLines.length);
+    return [
+      ...sections.autocompleteLines,
+      ...Array.from({ length: this.autocompleteSlotRows - sections.autocompleteLines.length }, () => ''),
+      ...sections.editorLines,
+    ];
   }
 }
 
-function moveTrailingAutocompleteAboveEditor(lines: string[]): string[] {
-  const bottomBorderIndex = findLastIndex(lines, isEditorChromeLine);
-  if (bottomBorderIndex < 1 || bottomBorderIndex === lines.length - 1) return lines;
-  const topBorderIndex = findLastIndex(lines.slice(0, bottomBorderIndex), isEditorChromeLine);
-  if (topBorderIndex < 0) return lines;
+interface MakaAutocompleteSections {
+  autocompleteLines: string[];
+  editorLines: string[];
+}
 
-  return [
-    ...lines.slice(bottomBorderIndex + 1),
-    ...lines.slice(0, bottomBorderIndex + 1),
-  ];
+function splitTrailingAutocomplete(lines: string[]): MakaAutocompleteSections {
+  const bottomBorderIndex = findLastIndex(lines, isEditorChromeLine);
+  if (bottomBorderIndex < 1 || bottomBorderIndex === lines.length - 1) {
+    return { autocompleteLines: [], editorLines: lines };
+  }
+  const topBorderIndex = findLastIndex(lines.slice(0, bottomBorderIndex), isEditorChromeLine);
+  if (topBorderIndex < 0) return { autocompleteLines: [], editorLines: lines };
+
+  return {
+    autocompleteLines: lines.slice(bottomBorderIndex + 1),
+    editorLines: lines.slice(0, bottomBorderIndex + 1),
+  };
 }
 
 function isEditorChromeLine(line: string): boolean {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -171,6 +171,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const showBottomPicker = (picker: Component): OverlayHandle => tui.showOverlay(picker, {
+    anchor: 'bottom-left',
+    width: '100%',
+    maxHeight: Math.max(1, terminal.rows - BOTTOM_PICKER_MARGIN_ROWS),
+    margin: { bottom: BOTTOM_PICKER_MARGIN_ROWS },
+  });
+
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
     const currentCwdSessions = sessions.filter((session) => session.cwd === cwd);
@@ -212,13 +219,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     list.onCancel = () => {
       overlay?.hide();
     };
-    overlay = tui.showOverlay(picker, {
-      anchor: 'top-left',
-      row: 0,
-      col: 0,
-      width: '100%',
-      maxHeight: '100%',
-    });
+    overlay = showBottomPicker(picker);
   };
 
   const showModelList = async () => {
@@ -246,13 +247,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     list.onCancel = () => {
       overlay?.hide();
     };
-    overlay = tui.showOverlay(picker, {
-      anchor: 'top-left',
-      row: 0,
-      col: 0,
-      width: '100%',
-      maxHeight: '100%',
-    });
+    overlay = showBottomPicker(picker);
   };
 
   const setPermissionMode = async (mode: PermissionMode) => {
@@ -623,17 +618,13 @@ class PickerOverlay implements Component {
 
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
-    const lines = [
+    return [
       alignColumns(this.input.title, ansi.accent(this.input.rightLabel), safeWidth),
       padLine(ansi.dim('enter select / esc close'), safeWidth),
       padLine('', safeWidth),
       ...this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth)),
       padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
     ];
-    while (lines.length < PICKER_SURFACE_ROWS) {
-      lines.push(' '.repeat(safeWidth));
-    }
-    return lines;
   }
 }
 
@@ -705,7 +696,7 @@ const ansi = {
   reverse: style(7, 27),
 };
 
-const PICKER_SURFACE_ROWS = 200;
+const BOTTOM_PICKER_MARGIN_ROWS = 4;
 
 function style(open: number, close: number): (text: string) => string {
   return (text) => `\x1b[${open}m${text}\x1b[${close}m`;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -73,6 +73,31 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     resolveClosed();
   };
 
+  const respondToPendingPermission = (decision: 'allow' | 'deny'): boolean => {
+    const request = state.pendingPermission;
+    if (!request) return false;
+    state.pendingPermission = undefined;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Permission ${decision}ed for ${request.toolName}`,
+    });
+    requestRender();
+    void input.driver.respondToPermission({
+      requestId: request.requestId,
+      decision,
+      ...(decision === 'allow' ? { rememberForTurn: true } : {}),
+    }).catch((error) => {
+      state.entries.push({
+        kind: 'notice',
+        level: 'error',
+        text: error instanceof Error ? error.message : String(error),
+      });
+      requestRender();
+    });
+    return true;
+  };
+
   editor.onSubmit = (prompt) => {
     if (busy || !prompt.trim()) {
       requestRender();
@@ -98,6 +123,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   tui.addInputListener((data) => {
+    if (state.pendingPermission) {
+      if (matchesKey(data, 'y') || matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
+        respondToPendingPermission('allow');
+        return { consume: true };
+      }
+      if (matchesKey(data, 'n') || matchesKey(data, Key.escape)) {
+        respondToPendingPermission('deny');
+        return { consume: true };
+      }
+    }
     if (matchesKey(data, Key.ctrl('c')) || matchesKey(data, Key.escape)) {
       void close();
       return { consume: true };

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -19,6 +19,7 @@ import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/c
 import type { MakaSessionDriver } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
+  renderMakaPiStatusLine,
   renderMakaPiTranscript,
   submitPromptToTranscript,
   toggleLatestToolExpansion,
@@ -62,6 +63,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   });
 
   const transcript = new MakaTranscriptComponent(state, metadata);
+  const statusLine = new MakaStatusLineComponent(metadata);
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
   editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], input.cwd));
 
@@ -322,6 +324,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   terminal.setTitle(input.title);
   tui.addChild(transcript);
   tui.addChild(editor);
+  tui.addChild(statusLine);
   tui.setFocus(editor);
   tui.start();
 
@@ -338,6 +341,16 @@ class MakaTranscriptComponent implements Component {
 
   render(width: number): string[] {
     return renderMakaPiTranscript(this.state, this.metadata(), width);
+  }
+}
+
+class MakaStatusLineComponent implements Component {
+  constructor(private readonly metadata: () => MakaPiTranscriptMetadata) {}
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    return [renderMakaPiStatusLine(this.metadata(), width)];
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -93,6 +93,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Run them through a single serial lock so a prompt submitted mid-switch can
   // not race the switch and land on the old session/model/permission mode.
   const runControl = async (action: () => Promise<void>): Promise<void> => {
+    // Refuse nested control actions: an overlay onSelect bypasses editor.onSubmit,
+    // so without this guard a switch could start while a prompt is still running.
+    if (busy) return;
     busy = true;
     editor.disableSubmit = true;
     terminal.setProgress(true);
@@ -136,6 +139,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     })
       .then(() => {
         permissionInFlight = false;
+        // The turn may have ended (error/abort/complete) and cleared the pending
+        // prompt while this response was in flight; only record success if the
+        // request is still the active one.
+        if (state.pendingPermission?.requestId !== request.requestId) return;
         state.pendingPermission = undefined;
         state.entries.push({
           kind: 'notice',
@@ -205,6 +212,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const switchSession = async (sessionId: string) => {
     await assertSwitchable(sessionId);
     const { summary, messages } = await input.driver.switchSession(sessionId);
+    // Re-check against the driver's authoritative summary: the list snapshot we
+    // validated in assertSwitchable can be stale by the time the switch returns.
+    if (summary.cwd !== cwd || summary.llmConnectionSlug !== connectionSlug) {
+      throw new Error('Session no longer matches the current folder or connection.');
+    }
     cwd = summary.cwd ?? cwd;
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
@@ -379,7 +391,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       description: 'Resume session',
       run: (parts: string[]) => {
         if (parts.length === 1) {
-          void showSessionList().catch(reportError);
+          void runControl(showSessionList);
           return;
         }
         const sessionId = parts.length === 2 ? parts[1] : undefined;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -512,11 +512,11 @@ class PickerOverlay implements Component {
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
     const lines = [
-      alignColumns(this.input.title, ansi.cyan(this.input.rightLabel), safeWidth),
+      alignColumns(this.input.title, ansi.accent(this.input.rightLabel), safeWidth),
       padLine(ansi.dim('enter select / esc close'), safeWidth),
       padLine('', safeWidth),
       ...this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth)),
-      padLine(ansi.cyan('-'.repeat(safeWidth)), safeWidth),
+      padLine(ansi.accent('-'.repeat(safeWidth)), safeWidth),
     ];
     while (lines.length < PICKER_SURFACE_ROWS) {
       lines.push(' '.repeat(safeWidth));
@@ -568,14 +568,14 @@ function stripAnsi(text: string): string {
 
 function editorTheme(): EditorTheme {
   return {
-    borderColor: ansi.cyan,
+    borderColor: ansi.accent,
     selectList: selectListTheme(),
   };
 }
 
 function selectListTheme(): SelectListTheme {
   return {
-    selectedPrefix: ansi.cyan,
+    selectedPrefix: ansi.accent,
     selectedText: ansi.bold,
     description: ansi.dim,
     scrollInfo: ansi.dim,
@@ -583,10 +583,13 @@ function selectListTheme(): SelectListTheme {
   };
 }
 
+// PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
+const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
+
 const ansi = {
   bold: style(1, 22),
   dim: style(2, 22),
-  cyan: style(36, 39),
+  accent: rgb(...MAKA_LOGO_BLUE_RGB),
   reverse: style(7, 27),
 };
 
@@ -600,4 +603,8 @@ const PICKER_SURFACE_ROWS = 200;
 
 function style(open: number, close: number): (text: string) => string {
   return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
+}
+
+function rgb(red: number, green: number, blue: number): (text: string) => string {
+  return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
 }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -152,6 +152,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const showSessionList = async () => {
+    const sessions = await input.driver.listSessions();
+    const items = sessions.slice(0, 10).map((session) => {
+      const marker = session.cwd === input.cwd ? '*' : ' ';
+      return `${marker} ${session.id} ${session.name} ${session.model}`;
+    });
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: ['Recent sessions:', ...(items.length > 0 ? items : ['No sessions found.'])].join('\n'),
+    });
+    requestRender();
+  };
+
   const setPermissionMode = async (mode: PermissionMode) => {
     await input.driver.setPermissionMode(mode);
     permissionMode = mode;
@@ -187,6 +201,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return true;
     }
     if (parts[0] === '/session') {
+      if (parts.length === 1) {
+        void showSessionList().catch((error) => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: error instanceof Error ? error.message : String(error),
+          });
+          requestRender();
+        });
+        return true;
+      }
       const sessionId = parts.length === 2 ? parts[1] : undefined;
       if (!sessionId) {
         state.entries.push({

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -13,10 +13,8 @@ import {
   type AutocompleteProvider,
   type AutocompleteSuggestions,
   type Component,
-  type EditorTheme,
   type OverlayHandle,
   type SelectItem,
-  type SelectListTheme,
   type Terminal,
 } from '@earendil-works/pi-tui';
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
@@ -31,6 +29,8 @@ import {
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
 } from './pi-transcript.js';
+import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
+import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
 
 export interface MakaPiTuiInput {
   title: string;
@@ -53,6 +53,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let permissionMode = input.permissionMode;
   let busy = false;
   let closed = false;
+  let permissionInFlight = false;
   let resolveClosed: () => void;
   const closedPromise = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -79,6 +80,35 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     tui.requestRender();
   };
 
+  const reportError = (error: unknown) => {
+    state.entries.push({
+      kind: 'notice',
+      level: 'error',
+      text: error instanceof Error ? error.message : String(error),
+    });
+    requestRender();
+  };
+
+  // Control commands (model/session/permission switches) mutate session state.
+  // Run them through a single serial lock so a prompt submitted mid-switch can
+  // not race the switch and land on the old session/model/permission mode.
+  const runControl = async (action: () => Promise<void>): Promise<void> => {
+    busy = true;
+    editor.disableSubmit = true;
+    terminal.setProgress(true);
+    requestRender();
+    try {
+      await action();
+    } catch (error) {
+      reportError(error);
+    } finally {
+      busy = false;
+      editor.disableSubmit = false;
+      terminal.setProgress(false);
+      requestRender();
+    }
+  };
+
   const close = async () => {
     if (closed) return;
     closed = true;
@@ -95,26 +125,29 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const respondToPendingPermission = (decision: 'allow' | 'deny'): boolean => {
     const request = state.pendingPermission;
-    if (!request) return false;
-    state.pendingPermission = undefined;
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: `Permission ${decision}ed for ${request.toolName}`,
-    });
-    requestRender();
+    if (!request || permissionInFlight) return false;
+    permissionInFlight = true;
+    // Keep the prompt visible until the driver accepts the response. If it
+    // rejects, the user can retry with y/n instead of being stuck.
     void input.driver.respondToPermission({
       requestId: request.requestId,
       decision,
       ...(decision === 'allow' ? { rememberForTurn: true } : {}),
-    }).catch((error) => {
-      state.entries.push({
-        kind: 'notice',
-        level: 'error',
-        text: error instanceof Error ? error.message : String(error),
+    })
+      .then(() => {
+        permissionInFlight = false;
+        state.pendingPermission = undefined;
+        state.entries.push({
+          kind: 'notice',
+          level: 'info',
+          text: `Permission ${decision}ed for ${request.toolName}`,
+        });
+        requestRender();
+      })
+      .catch((error) => {
+        permissionInFlight = false;
+        reportError(error);
       });
-      requestRender();
-    });
     return true;
   };
 
@@ -154,7 +187,23 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  // The TUI is bound to one folder and one connection (its autocomplete base
+  // path and model candidates come from the startup target). Refuse to resume
+  // a session from another folder/connection rather than silently desyncing.
+  const assertSwitchable = async (sessionId: string) => {
+    const sessions = await input.driver.listSessions();
+    const target = sessions.find((session) => session.id === sessionId);
+    if (!target) throw new Error(`Session not found: ${sessionId}`);
+    if (target.cwd !== cwd) {
+      throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
+    }
+    if (target.llmConnectionSlug !== connectionSlug) {
+      throw new Error('Session uses a different connection; run Maka with that connection to resume it.');
+    }
+  };
+
   const switchSession = async (sessionId: string) => {
+    await assertSwitchable(sessionId);
     const { summary, messages } = await input.driver.switchSession(sessionId);
     cwd = summary.cwd ?? cwd;
     model = summary.model;
@@ -178,10 +227,36 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     margin: { bottom: BOTTOM_PICKER_MARGIN_ROWS },
   });
 
+  const showSelectPicker = (
+    title: string,
+    rightLabel: string,
+    items: SelectItem[],
+    onSelect: (item: SelectItem) => void,
+    options: { minPrimaryColumnWidth: number; maxPrimaryColumnWidth: number; selectedIndex?: number },
+  ): void => {
+    const list = new SelectList(items, 10, selectListTheme(), {
+      minPrimaryColumnWidth: options.minPrimaryColumnWidth,
+      maxPrimaryColumnWidth: options.maxPrimaryColumnWidth,
+    });
+    if (options.selectedIndex !== undefined) list.setSelectedIndex(options.selectedIndex);
+    const picker = new PickerOverlay(list, { title, rightLabel });
+    let overlay: OverlayHandle | undefined;
+    list.onSelect = (item) => {
+      overlay?.hide();
+      onSelect(item);
+    };
+    list.onCancel = () => {
+      overlay?.hide();
+    };
+    overlay = showBottomPicker(picker);
+  };
+
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    const currentCwdSessions = sessions.filter((session) => session.cwd === cwd);
-    if (currentCwdSessions.length === 0) {
+    const currentSessions = sessions.filter(
+      (session) => session.cwd === cwd && session.llmConnectionSlug === connectionSlug,
+    );
+    if (currentSessions.length === 0) {
       state.entries.push({
         kind: 'notice',
         level: 'info',
@@ -191,63 +266,32 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
 
-    const items: SelectItem[] = currentCwdSessions.slice(0, 10).map((session) => ({
+    const items: SelectItem[] = currentSessions.slice(0, 10).map((session) => ({
       value: session.id,
       label: session.id,
       description: `${session.name} ${session.model}`,
     }));
-    const list = new SelectList(items, 10, selectListTheme(), {
-      minPrimaryColumnWidth: 24,
-      maxPrimaryColumnWidth: 40,
-    });
-    const picker = new PickerOverlay(list, {
-      title: 'Resume Session (Current Folder)',
-      rightLabel: 'Current Folder',
-    });
-    let overlay: OverlayHandle | undefined;
-    list.onSelect = (item) => {
-      overlay?.hide();
-      void switchSession(item.value).catch((error) => {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: error instanceof Error ? error.message : String(error),
-        });
-        requestRender();
-      });
-    };
-    list.onCancel = () => {
-      overlay?.hide();
-    };
-    overlay = showBottomPicker(picker);
+    showSelectPicker(
+      'Resume Session (Current Folder)',
+      'Current Folder',
+      items,
+      (item) => {
+        void runControl(() => switchSession(item.value));
+      },
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 40 },
+    );
   };
 
-  const showModelList = async () => {
-    const items = modelPickerItems(model, input.models);
-    const list = new SelectList(items, 10, selectListTheme(), {
-      minPrimaryColumnWidth: 24,
-      maxPrimaryColumnWidth: 48,
-    });
-    const picker = new PickerOverlay(list, {
-      title: 'Select Model',
-      rightLabel: connectionSlug,
-    });
-    let overlay: OverlayHandle | undefined;
-    list.onSelect = (item) => {
-      overlay?.hide();
-      void setModel(item.value).catch((error) => {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: error instanceof Error ? error.message : String(error),
-        });
-        requestRender();
-      });
-    };
-    list.onCancel = () => {
-      overlay?.hide();
-    };
-    overlay = showBottomPicker(picker);
+  const showModelList = () => {
+    showSelectPicker(
+      'Select Model',
+      connectionSlug,
+      modelPickerItems(model, input.models),
+      (item) => {
+        void runControl(() => setModel(item.value));
+      },
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48 },
+    );
   };
 
   const setPermissionMode = async (mode: PermissionMode) => {
@@ -263,32 +307,21 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showPermissionModeList = () => {
     const items = permissionModePickerItems(permissionMode);
-    const list = new SelectList(items, 10, selectListTheme(), {
-      minPrimaryColumnWidth: 16,
-      maxPrimaryColumnWidth: 24,
-    });
-    list.setSelectedIndex(items.findIndex((item) => item.value === permissionMode));
-    const picker = new PickerOverlay(list, {
-      title: 'Select Permission Mode',
-      rightLabel: permissionMode,
-    });
-    let overlay: OverlayHandle | undefined;
-    list.onSelect = (item) => {
-      overlay?.hide();
-      if (!isPermissionMode(item.value)) return;
-      void setPermissionMode(item.value).catch((error) => {
-        state.entries.push({
-          kind: 'notice',
-          level: 'error',
-          text: error instanceof Error ? error.message : String(error),
-        });
-        requestRender();
-      });
-    };
-    list.onCancel = () => {
-      overlay?.hide();
-    };
-    overlay = showBottomPicker(picker);
+    showSelectPicker(
+      'Select Permission Mode',
+      permissionMode,
+      items,
+      (item) => {
+        if (!isPermissionMode(item.value)) return;
+        const mode = item.value;
+        void runControl(() => setPermissionMode(mode));
+      },
+      {
+        minPrimaryColumnWidth: 16,
+        maxPrimaryColumnWidth: 24,
+        selectedIndex: items.findIndex((item) => item.value === permissionMode),
+      },
+    );
   };
 
   const slashCommands: MakaSlashCommand[] = [
@@ -304,14 +337,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       description: 'Select model',
       run: (parts: string[]) => {
         if (parts.length === 1) {
-          void showModelList().catch((error) => {
-            state.entries.push({
-              kind: 'notice',
-              level: 'error',
-              text: error instanceof Error ? error.message : String(error),
-            });
-            requestRender();
-          });
+          showModelList();
           return;
         }
         const nextModel = parts.length === 2 ? parts[1] : undefined;
@@ -324,14 +350,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        void setModel(nextModel).catch((error) => {
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: error instanceof Error ? error.message : String(error),
-          });
-          requestRender();
-        });
+        void runControl(() => setModel(nextModel));
       },
     },
     {
@@ -352,14 +371,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        void setPermissionMode(mode).catch((error) => {
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: error instanceof Error ? error.message : String(error),
-          });
-          requestRender();
-        });
+        void runControl(() => setPermissionMode(mode));
       },
     },
     {
@@ -367,14 +379,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       description: 'Resume session',
       run: (parts: string[]) => {
         if (parts.length === 1) {
-          void showSessionList().catch((error) => {
-            state.entries.push({
-              kind: 'notice',
-              level: 'error',
-              text: error instanceof Error ? error.message : String(error),
-            });
-            requestRender();
-          });
+          void showSessionList().catch(reportError);
           return;
         }
         const sessionId = parts.length === 2 ? parts[1] : undefined;
@@ -387,14 +392,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           requestRender();
           return;
         }
-        void switchSession(sessionId).catch((error) => {
-          state.entries.push({
-            kind: 'notice',
-            level: 'error',
-            text: error instanceof Error ? error.message : String(error),
-          });
-          requestRender();
-        });
+        void runControl(() => switchSession(sessionId));
       },
     },
   ].sort((left, right) => left.name.localeCompare(right.name));
@@ -491,108 +489,6 @@ class MakaPiLayoutComponent extends Container {
       ...statusLines,
     ];
   }
-}
-
-class MakaAutocompleteAboveEditorComponent implements Component {
-  private autocompleteSlotRows = 0;
-
-  constructor(private readonly editor: Editor) {}
-
-  get focused(): boolean {
-    return this.editor.focused;
-  }
-
-  set focused(value: boolean) {
-    this.editor.focused = value;
-  }
-
-  invalidate(): void {
-    this.editor.invalidate();
-  }
-
-  handleInput(data: string): void {
-    this.editor.handleInput(data);
-  }
-
-  render(width: number): string[] {
-    const lines = this.editor.render(width);
-    const result = arrangeAutocompleteAboveEditor({
-      lines,
-      autocompleteShowing: this.editor.isShowingAutocomplete(),
-      autocompleteSlotRows: this.autocompleteSlotRows,
-    });
-    this.autocompleteSlotRows = result.autocompleteSlotRows;
-    return result.lines;
-  }
-}
-
-export interface MakaAutocompleteArrangementInput {
-  lines: string[];
-  autocompleteShowing: boolean;
-  autocompleteSlotRows: number;
-}
-
-export interface MakaAutocompleteArrangementResult {
-  lines: string[];
-  autocompleteSlotRows: number;
-}
-
-export function arrangeAutocompleteAboveEditor(
-  input: MakaAutocompleteArrangementInput,
-): MakaAutocompleteArrangementResult {
-  if (!input.autocompleteShowing) {
-    return { lines: input.lines, autocompleteSlotRows: 0 };
-  }
-  const sections = splitTrailingAutocomplete(input.lines);
-  if (sections.autocompleteLines.length === 0) {
-    return { lines: sections.editorLines, autocompleteSlotRows: 0 };
-  }
-  const autocompleteSlotRows = Math.max(
-    input.autocompleteSlotRows,
-    sections.autocompleteLines.length,
-  );
-  return {
-    lines: [
-      ...Array.from(
-        { length: autocompleteSlotRows - sections.autocompleteLines.length },
-        () => '',
-      ),
-      ...sections.autocompleteLines,
-      ...sections.editorLines,
-    ],
-    autocompleteSlotRows,
-  };
-}
-
-interface MakaAutocompleteSections {
-  autocompleteLines: string[];
-  editorLines: string[];
-}
-
-function splitTrailingAutocomplete(lines: string[]): MakaAutocompleteSections {
-  const bottomBorderIndex = findLastIndex(lines, isEditorChromeLine);
-  if (bottomBorderIndex < 1 || bottomBorderIndex === lines.length - 1) {
-    return { autocompleteLines: [], editorLines: lines };
-  }
-  const topBorderIndex = findLastIndex(lines.slice(0, bottomBorderIndex), isEditorChromeLine);
-  if (topBorderIndex < 0) return { autocompleteLines: [], editorLines: lines };
-
-  return {
-    autocompleteLines: lines.slice(bottomBorderIndex + 1),
-    editorLines: lines.slice(0, bottomBorderIndex + 1),
-  };
-}
-
-function isEditorChromeLine(line: string): boolean {
-  const text = stripAnsi(line);
-  return /^─+$/.test(text) || /^─── [↑↓] \d+ more ─*$/.test(text);
-}
-
-function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    if (predicate(items[index]!)) return index;
-  }
-  return -1;
 }
 
 class MakaAutocompleteProvider implements AutocompleteProvider {
@@ -737,43 +633,4 @@ function padLine(text: string, width: number): string {
   return `${trimmed}${' '.repeat(Math.max(0, safeWidth - visibleWidth(trimmed)))}`;
 }
 
-function stripAnsi(text: string): string {
-  return text.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
-}
-
-function editorTheme(): EditorTheme {
-  return {
-    borderColor: ansi.accent,
-    selectList: selectListTheme(),
-  };
-}
-
-function selectListTheme(): SelectListTheme {
-  return {
-    selectedPrefix: ansi.accent,
-    selectedText: ansi.bold,
-    description: ansi.dim,
-    scrollInfo: ansi.dim,
-    noMatch: ansi.dim,
-  };
-}
-
-// PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
-const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
-
-const ansi = {
-  bold: style(1, 22),
-  dim: style(2, 22),
-  accent: rgb(...MAKA_LOGO_BLUE_RGB),
-  reverse: style(7, 27),
-};
-
 const BOTTOM_PICKER_MARGIN_ROWS = 4;
-
-function style(open: number, close: number): (text: string) => string {
-  return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
-}
-
-function rgb(red: number, green: number, blue: number): (text: string) => string {
-  return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
-}

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1,5 +1,6 @@
 import {
   CombinedAutocompleteProvider,
+  Container,
   Editor,
   Key,
   ProcessTerminal,
@@ -66,6 +67,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const transcript = new MakaTranscriptComponent(state, metadata);
   const statusLine = new MakaStatusLineComponent(metadata);
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
+  const layout = new MakaPiLayoutComponent(transcript, editor, statusLine, terminal);
   editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], input.cwd));
 
   const requestRender = () => {
@@ -371,9 +373,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   });
 
   terminal.setTitle(input.title);
-  tui.addChild(transcript);
-  tui.addChild(editor);
-  tui.addChild(statusLine);
+  tui.addChild(layout);
   tui.setFocus(editor);
   tui.start();
 
@@ -400,6 +400,34 @@ class MakaStatusLineComponent implements Component {
 
   render(width: number): string[] {
     return [renderMakaPiStatusLine(this.metadata(), width)];
+  }
+}
+
+class MakaPiLayoutComponent extends Container {
+  constructor(
+    private readonly transcript: Component,
+    private readonly editor: Component,
+    private readonly statusLine: Component,
+    private readonly terminal: Terminal,
+  ) {
+    super();
+    this.addChild(transcript);
+    this.addChild(editor);
+    this.addChild(statusLine);
+  }
+
+  render(width: number): string[] {
+    const transcriptLines = this.transcript.render(width);
+    const editorLines = this.editor.render(width);
+    const statusLines = this.statusLine.render(width);
+    const transcriptRows = Math.max(0, this.terminal.rows - editorLines.length - statusLines.length);
+    const paddingRows = Math.max(0, transcriptRows - transcriptLines.length);
+    return [
+      ...transcriptLines,
+      ...Array.from({ length: paddingRows }, () => ''),
+      ...editorLines,
+      ...statusLines,
+    ];
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -32,6 +32,7 @@ export interface MakaPiTuiInput {
   driver: MakaSessionDriver;
   cwd: string;
   model: string;
+  models?: readonly string[];
   connectionSlug: string;
   permissionMode: PermissionMode;
   terminal?: Terminal;
@@ -183,11 +184,48 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       minPrimaryColumnWidth: 24,
       maxPrimaryColumnWidth: 40,
     });
-    const picker = new SessionPickerOverlay(list);
+    const picker = new PickerOverlay(list, {
+      title: 'Resume Session (Current Folder)',
+      rightLabel: 'Current Folder',
+    });
     let overlay: OverlayHandle | undefined;
     list.onSelect = (item) => {
       overlay?.hide();
       void switchSession(item.value).catch((error) => {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: error instanceof Error ? error.message : String(error),
+        });
+        requestRender();
+      });
+    };
+    list.onCancel = () => {
+      overlay?.hide();
+    };
+    overlay = tui.showOverlay(picker, {
+      anchor: 'top-left',
+      row: 0,
+      col: 0,
+      width: '100%',
+      maxHeight: '100%',
+    });
+  };
+
+  const showModelList = async () => {
+    const items = modelPickerItems(model, input.models);
+    const list = new SelectList(items, 10, selectListTheme(), {
+      minPrimaryColumnWidth: 24,
+      maxPrimaryColumnWidth: 48,
+    });
+    const picker = new PickerOverlay(list, {
+      title: 'Select Model',
+      rightLabel: connectionSlug,
+    });
+    let overlay: OverlayHandle | undefined;
+    list.onSelect = (item) => {
+      overlay?.hide();
+      void setModel(item.value).catch((error) => {
         state.entries.push({
           kind: 'notice',
           level: 'error',
@@ -222,6 +260,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const handleSlashCommand = (prompt: string): boolean => {
     const parts = prompt.trim().split(/\s+/);
     if (parts[0] === '/model') {
+      if (parts.length === 1) {
+        void showModelList().catch((error) => {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: error instanceof Error ? error.message : String(error),
+          });
+          requestRender();
+        });
+        return true;
+      }
       const nextModel = parts.length === 2 ? parts[1] : undefined;
       if (!nextModel) {
         state.entries.push({
@@ -354,8 +403,11 @@ class MakaStatusLineComponent implements Component {
   }
 }
 
-class SessionPickerOverlay implements Component {
-  constructor(private readonly list: SelectList) {}
+class PickerOverlay implements Component {
+  constructor(
+    private readonly list: SelectList,
+    private readonly input: { title: string; rightLabel: string },
+  ) {}
 
   invalidate(): void {
     this.list.invalidate();
@@ -368,17 +420,33 @@ class SessionPickerOverlay implements Component {
   render(width: number): string[] {
     const safeWidth = Math.max(1, width);
     const lines = [
-      alignColumns('Resume Session (Current Folder)', ansi.cyan('Current Folder'), safeWidth),
+      alignColumns(this.input.title, ansi.cyan(this.input.rightLabel), safeWidth),
       padLine(ansi.dim('enter select / esc close'), safeWidth),
       padLine('', safeWidth),
       ...this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth)),
       padLine(ansi.cyan('-'.repeat(safeWidth)), safeWidth),
     ];
-    while (lines.length < SESSION_PICKER_SURFACE_ROWS) {
+    while (lines.length < PICKER_SURFACE_ROWS) {
       lines.push(' '.repeat(safeWidth));
     }
     return lines;
   }
+}
+
+function modelPickerItems(currentModel: string, models: readonly string[] | undefined): SelectItem[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of [currentModel, ...(models ?? [])]) {
+    const id = candidate.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids.map((id) => ({
+    value: id,
+    label: id,
+    ...(id === currentModel ? { description: 'current' } : {}),
+  }));
 }
 
 function alignColumns(left: string, right: string, width: number): string {
@@ -430,7 +498,7 @@ const ansi = {
   reverse: style(7, 27),
 };
 
-const SESSION_PICKER_SURFACE_ROWS = 200;
+const PICKER_SURFACE_ROWS = 200;
 
 function style(open: number, close: number): (text: string) => string {
   return (text) => `\x1b[${open}m${text}\x1b[${close}m`;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -195,10 +195,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       overlay?.hide();
     };
     overlay = tui.showOverlay(picker, {
-      anchor: 'top-center',
-      row: 5,
-      width: '80%',
-      maxHeight: 12,
+      anchor: 'top-left',
+      row: 0,
+      col: 0,
+      width: '100%',
+      maxHeight: '100%',
     });
   };
 
@@ -349,25 +350,44 @@ class SessionPickerOverlay implements Component {
   }
 
   render(width: number): string[] {
-    const safeWidth = Math.max(12, width);
-    const innerWidth = Math.max(1, safeWidth - 4);
-    const border = `+${'-'.repeat(safeWidth - 2)}+`;
+    const safeWidth = Math.max(1, width);
     const lines = [
-      border,
-      framedLine('Select session', safeWidth),
-      framedLine('', safeWidth),
-      ...this.list.render(innerWidth).map((line) => framedLine(line, safeWidth)),
-      border,
+      alignColumns('Resume Session (Current Folder)', ansi.cyan('Current Folder'), safeWidth),
+      padLine(ansi.dim('enter select / esc close'), safeWidth),
+      padLine('', safeWidth),
+      ...this.list.render(safeWidth).map((line) => formatPickerItemLine(line, safeWidth)),
+      padLine(ansi.cyan('-'.repeat(safeWidth)), safeWidth),
     ];
+    while (lines.length < SESSION_PICKER_SURFACE_ROWS) {
+      lines.push(' '.repeat(safeWidth));
+    }
     return lines;
   }
 }
 
-function framedLine(text: string, width: number): string {
-  const innerWidth = Math.max(1, width - 4);
-  const trimmed = visibleWidth(text) > innerWidth ? truncateToWidth(text, innerWidth, '') : text;
-  const padding = Math.max(0, innerWidth - visibleWidth(trimmed));
-  return `| ${trimmed}${' '.repeat(padding)} |`;
+function alignColumns(left: string, right: string, width: number): string {
+  const safeWidth = Math.max(1, width);
+  const rightWidth = visibleWidth(right);
+  if (rightWidth + 1 >= safeWidth) return padLine(left, safeWidth);
+  const leftMaxWidth = Math.max(1, safeWidth - rightWidth - 1);
+  const clippedLeft = visibleWidth(left) > leftMaxWidth ? truncateToWidth(left, leftMaxWidth, '') : left;
+  const gap = Math.max(1, safeWidth - visibleWidth(clippedLeft) - rightWidth);
+  return `${clippedLeft}${' '.repeat(gap)}${right}`;
+}
+
+function formatPickerItemLine(line: string, width: number): string {
+  const padded = padLine(line, width);
+  return stripAnsi(line).startsWith('→ ') ? ansi.reverse(padded) : padded;
+}
+
+function padLine(text: string, width: number): string {
+  const safeWidth = Math.max(1, width);
+  const trimmed = visibleWidth(text) > safeWidth ? truncateToWidth(text, safeWidth, '') : text;
+  return `${trimmed}${' '.repeat(Math.max(0, safeWidth - visibleWidth(trimmed)))}`;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
 function editorTheme(): EditorTheme {
@@ -391,7 +411,10 @@ const ansi = {
   bold: style(1, 22),
   dim: style(2, 22),
   cyan: style(36, 39),
+  reverse: style(7, 27),
 };
+
+const SESSION_PICKER_SURFACE_ROWS = 200;
 
 function style(open: number, close: number): (text: string) => string {
   return (text) => `\x1b[${open}m${text}\x1b[${close}m`;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -159,19 +159,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    if (sessions.length === 0) {
+    const currentCwdSessions = sessions.filter((session) => session.cwd === input.cwd);
+    if (currentCwdSessions.length === 0) {
       state.entries.push({
         kind: 'notice',
         level: 'info',
-        text: 'No sessions found.',
+        text: 'No sessions found for this folder.',
       });
       requestRender();
       return;
     }
 
-    const items: SelectItem[] = sessions.slice(0, 10).map((session) => ({
+    const items: SelectItem[] = currentCwdSessions.slice(0, 10).map((session) => ({
       value: session.id,
-      label: `${session.cwd === input.cwd ? '* ' : ''}${session.id}`,
+      label: session.id,
       description: `${session.name} ${session.model}`,
     }));
     const list = new SelectList(items, 10, selectListTheme(), {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -3,10 +3,13 @@ import {
   Editor,
   Key,
   ProcessTerminal,
+  SelectList,
   TUI,
   matchesKey,
   type Component,
   type EditorTheme,
+  type OverlayHandle,
+  type SelectItem,
   type SelectListTheme,
   type Terminal,
 } from '@earendil-works/pi-tui';
@@ -154,16 +157,46 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    const items = sessions.slice(0, 10).map((session) => {
-      const marker = session.cwd === input.cwd ? '*' : ' ';
-      return `${marker} ${session.id} ${session.name} ${session.model}`;
+    if (sessions.length === 0) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: 'No sessions found.',
+      });
+      requestRender();
+      return;
+    }
+
+    const items: SelectItem[] = sessions.slice(0, 10).map((session) => ({
+      value: session.id,
+      label: `${session.cwd === input.cwd ? '* ' : ''}${session.id}`,
+      description: `${session.name} ${session.model}`,
+    }));
+    const list = new SelectList(items, 10, selectListTheme(), {
+      minPrimaryColumnWidth: 24,
+      maxPrimaryColumnWidth: 40,
     });
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: ['Recent sessions:', ...(items.length > 0 ? items : ['No sessions found.'])].join('\n'),
+    let overlay: OverlayHandle | undefined;
+    list.onSelect = (item) => {
+      overlay?.hide();
+      void switchSession(item.value).catch((error) => {
+        state.entries.push({
+          kind: 'notice',
+          level: 'error',
+          text: error instanceof Error ? error.message : String(error),
+        });
+        requestRender();
+      });
+    };
+    list.onCancel = () => {
+      overlay?.hide();
+    };
+    overlay = tui.showOverlay(list, {
+      anchor: 'bottom-center',
+      width: '80%',
+      maxHeight: 10,
+      offsetY: -3,
     });
-    requestRender();
   };
 
   const setPermissionMode = async (mode: PermissionMode) => {
@@ -255,6 +288,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   tui.addInputListener((data) => {
+    if (tui.hasOverlay()) return undefined;
     if (matchesKey(data, Key.ctrl('o'))) {
       if (toggleLatestToolExpansion(state)) {
         requestRender();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -10,6 +10,7 @@ import {
   type SelectListTheme,
   type Terminal,
 } from '@earendil-works/pi-tui';
+import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import type { MakaSessionDriver } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
@@ -26,7 +27,7 @@ export interface MakaPiTuiInput {
   cwd: string;
   model: string;
   connectionSlug: string;
-  permissionMode: string;
+  permissionMode: PermissionMode;
   terminal?: Terminal;
 }
 
@@ -34,6 +35,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const terminal = input.terminal ?? new ProcessTerminal();
   const tui = new TUI(terminal);
   const state = createMakaPiTranscriptState();
+  let permissionMode = input.permissionMode;
   let busy = false;
   let closed = false;
   let resolveClosed: () => void;
@@ -46,7 +48,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     cwd: input.cwd,
     model: input.model,
     connectionSlug: input.connectionSlug,
-    permissionMode: input.permissionMode,
+    permissionMode,
     sessionId: input.driver.getSessionId(),
     busy,
   });
@@ -104,6 +106,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
       return;
     }
+    if (handleSlashCommand(prompt)) return;
 
     busy = true;
     editor.disableSubmit = true;
@@ -121,6 +124,41 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       terminal.setProgress(false);
       requestRender();
     });
+  };
+
+  const setPermissionMode = async (mode: PermissionMode) => {
+    await input.driver.setPermissionMode(mode);
+    permissionMode = mode;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Permission mode: ${mode}`,
+    });
+    requestRender();
+  };
+
+  const handleSlashCommand = (prompt: string): boolean => {
+    const parts = prompt.trim().split(/\s+/);
+    if (parts[0] !== '/permissions') return false;
+    const mode = parts.length === 2 ? parts[1] : undefined;
+    if (!isPermissionMode(mode)) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'error',
+        text: `Usage: /permissions ${PERMISSION_MODES.join('|')}`,
+      });
+      requestRender();
+      return true;
+    }
+    void setPermissionMode(mode).catch((error) => {
+      state.entries.push({
+        kind: 'notice',
+        level: 'error',
+        text: error instanceof Error ? error.message : String(error),
+      });
+      requestRender();
+    });
+    return true;
   };
 
   tui.addInputListener((data) => {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -199,7 +199,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // active session untouched and the next prompt still lands on the old one.
   const switchSession = async (sessionId: string) => {
     const { summary, messages } = await input.driver.switchSession(sessionId);
-    cwd = summary.cwd ?? cwd;
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -9,6 +9,9 @@ import {
   matchesKey,
   truncateToWidth,
   visibleWidth,
+  type AutocompleteItem,
+  type AutocompleteProvider,
+  type AutocompleteSuggestions,
   type Component,
   type EditorTheme,
   type OverlayHandle,
@@ -68,7 +71,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const statusLine = new MakaStatusLineComponent(metadata);
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
   const layout = new MakaPiLayoutComponent(transcript, editor, statusLine, terminal);
-  editor.setAutocompleteProvider(new CombinedAutocompleteProvider([], input.cwd));
+  editor.setAutocompleteProvider(new MakaAutocompleteProvider(input.cwd));
 
   const requestRender = () => {
     transcript.invalidate();
@@ -431,6 +434,67 @@ class MakaPiLayoutComponent extends Container {
   }
 }
 
+class MakaAutocompleteProvider implements AutocompleteProvider {
+  private readonly fileProvider: CombinedAutocompleteProvider;
+  private readonly slashCommands = MAKA_SLASH_COMMANDS;
+
+  constructor(basePath: string) {
+    this.fileProvider = new CombinedAutocompleteProvider([], basePath);
+  }
+
+  async getSuggestions(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    options: { signal: AbortSignal; force?: boolean },
+  ): Promise<AutocompleteSuggestions | null> {
+    const slashPrefix = slashCommandPrefix(lines, cursorLine, cursorCol);
+    if (slashPrefix !== null && !options.force) {
+      const query = slashPrefix.slice(1).toLowerCase();
+      const items = this.slashCommands
+        .filter((command) => command.name.startsWith(query))
+        .map((command) => ({
+          value: command.name,
+          label: `/${command.name}`,
+          description: command.description,
+        }));
+      return items.length > 0 ? { items, prefix: slashPrefix } : null;
+    }
+    return this.fileProvider.getSuggestions(lines, cursorLine, cursorCol, options);
+  }
+
+  applyCompletion(
+    lines: string[],
+    cursorLine: number,
+    cursorCol: number,
+    item: AutocompleteItem,
+    prefix: string,
+  ): { lines: string[]; cursorLine: number; cursorCol: number } {
+    const currentLine = lines[cursorLine] || '';
+    const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
+    if (prefix.startsWith('/') && beforePrefix.trim() === '') {
+      const nextLines = [...lines];
+      nextLines[cursorLine] = `${beforePrefix}/${item.value} ${currentLine.slice(cursorCol)}`;
+      return {
+        lines: nextLines,
+        cursorLine,
+        cursorCol: beforePrefix.length + item.value.length + 2,
+      };
+    }
+    return this.fileProvider.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+  }
+
+  shouldTriggerFileCompletion(lines: string[], cursorLine: number, cursorCol: number): boolean {
+    return this.fileProvider.shouldTriggerFileCompletion(lines, cursorLine, cursorCol);
+  }
+}
+
+function slashCommandPrefix(lines: string[], cursorLine: number, cursorCol: number): string | null {
+  const currentLine = lines[cursorLine] || '';
+  const textBeforeCursor = currentLine.slice(0, cursorCol);
+  return textBeforeCursor.startsWith('/') && !textBeforeCursor.includes(' ') ? textBeforeCursor : null;
+}
+
 class PickerOverlay implements Component {
   constructor(
     private readonly list: SelectList,
@@ -525,6 +589,12 @@ const ansi = {
   cyan: style(36, 39),
   reverse: style(7, 27),
 };
+
+const MAKA_SLASH_COMMANDS = [
+  { name: 'model', description: 'Select model' },
+  { name: 'permissions', description: 'Set permission mode' },
+  { name: 'session', description: 'Resume session' },
+] as const;
 
 const PICKER_SURFACE_ROWS = 200;
 

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -59,7 +59,7 @@ export async function createMakaCliRuntimeContext(
   });
   const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
   const backends = new BackendRegistry();
-  const tools = buildBuiltinTools().filter((tool) => tool.name !== 'Edit');
+  const tools = buildBuiltinTools();
 
   backends.register('ai-sdk', async (ctx) => {
     const ready = await resolveDefaultSessionTarget({

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -26,6 +26,7 @@ export interface MakaCliRuntimeContext {
   cwd: string;
   runtime: SessionManager;
   target: ReadySessionTarget;
+  tools: ReturnType<typeof buildBuiltinTools>;
 }
 
 export interface CreateMakaCliRuntimeContextInput {
@@ -109,6 +110,7 @@ export async function createMakaCliRuntimeContext(
     cwd: input.cwd,
     runtime,
     target,
+    tools,
   };
 }
 

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -109,7 +109,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     if (summary.cwd) await assertSessionCwdExists(summary.cwd);
     // Enforce folder/connection before reading messages or committing any
     // internal state, so a rejected switch leaves the active session untouched.
-    if (summary.cwd && summary.cwd !== this.input.cwd) {
+    if (summary.cwd !== this.input.cwd) {
       throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
     }
     if (summary.llmConnectionSlug !== this.input.llmConnectionSlug) {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -107,6 +107,14 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
     if (summary.cwd) await assertSessionCwdExists(summary.cwd);
+    // Enforce folder/connection before reading messages or committing any
+    // internal state, so a rejected switch leaves the active session untouched.
+    if (summary.cwd && summary.cwd !== this.input.cwd) {
+      throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
+    }
+    if (summary.llmConnectionSlug !== this.input.llmConnectionSlug) {
+      throw new Error('Session uses a different connection; run Maka with that connection to resume it.');
+    }
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
     this.model = summary.model;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -3,11 +3,12 @@ import { realpath } from 'node:fs/promises';
 import type { SessionEvent } from '@maka/core/events';
 import type { PermissionMode, PermissionResponse } from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
-import type { SessionSummary } from '@maka/core/session';
+import type { SessionSummary, StoredMessage } from '@maka/core/session';
 
 export interface MakaSessionRuntime {
   createSession(input: CreateSessionInput): Promise<SessionSummary>;
   listSessions(): Promise<SessionSummary[]>;
+  getMessages(sessionId: string): Promise<StoredMessage[]>;
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
@@ -24,13 +25,18 @@ export interface MakaSessionDriverInput {
   newId?: () => string;
 }
 
+export interface MakaSessionSwitchResult {
+  summary: SessionSummary;
+  messages: StoredMessage[];
+}
+
 export interface MakaSessionDriver {
   listSessions(): Promise<SessionSummary[]>;
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
   setModel(model: string): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
-  switchSession(sessionId: string): Promise<SessionSummary>;
+  switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -97,14 +103,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.permissionMode = mode;
   }
 
-  async switchSession(sessionId: string): Promise<SessionSummary> {
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
     if (summary.cwd) await assertSessionCwdExists(summary.cwd);
+    const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
     this.model = summary.model;
     this.permissionMode = summary.permissionMode;
-    return summary;
+    return { summary, messages };
   }
 
   getSessionId(): string | null {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { SessionEvent } from '@maka/core/events';
-import type { PermissionMode } from '@maka/core/permission';
+import type { PermissionMode, PermissionResponse } from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionSummary } from '@maka/core/session';
 
@@ -8,6 +8,7 @@ export interface MakaSessionRuntime {
   createSession(input: CreateSessionInput): Promise<SessionSummary>;
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
+  respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
 }
 
 export interface MakaSessionDriverInput {
@@ -21,6 +22,7 @@ export interface MakaSessionDriverInput {
 
 export interface MakaSessionDriver {
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
+  respondToPermission(response: PermissionResponse): Promise<void>;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -48,6 +50,11 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async stop(): Promise<void> {
     if (!this.sessionId) return;
     await this.input.runtime.stopSession(this.sessionId, { source: 'stop_button' });
+  }
+
+  async respondToPermission(response: PermissionResponse): Promise<void> {
+    if (!this.sessionId) throw new Error('Cannot respond to permission before a session starts.');
+    await this.input.runtime.respondToPermission(this.sessionId, response);
   }
 
   getSessionId(): string | null {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -9,6 +9,7 @@ export interface MakaSessionRuntime {
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
+  setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
 }
 
 export interface MakaSessionDriverInput {
@@ -23,6 +24,7 @@ export interface MakaSessionDriverInput {
 export interface MakaSessionDriver {
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
+  setPermissionMode(mode: PermissionMode): Promise<void>;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -33,10 +35,12 @@ export function createMakaSessionDriver(input: MakaSessionDriverInput): MakaSess
 
 class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private sessionId: string | null = null;
+  private permissionMode: PermissionMode;
   private readonly newId: () => string;
 
   constructor(private readonly input: MakaSessionDriverInput) {
     this.newId = input.newId ?? randomUUID;
+    this.permissionMode = input.permissionMode ?? 'ask';
   }
 
   async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
@@ -57,6 +61,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     await this.input.runtime.respondToPermission(this.sessionId, response);
   }
 
+  async setPermissionMode(mode: PermissionMode): Promise<void> {
+    if (this.sessionId) {
+      const summary = await this.input.runtime.setPermissionMode(this.sessionId, mode);
+      this.permissionMode = summary.permissionMode;
+      return;
+    }
+    this.permissionMode = mode;
+  }
+
   getSessionId(): string | null {
     return this.sessionId;
   }
@@ -69,7 +82,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       backend: 'ai-sdk',
       llmConnectionSlug: this.input.llmConnectionSlug,
       model: this.input.model,
-      permissionMode: this.input.permissionMode ?? 'ask',
+      permissionMode: this.permissionMode,
     });
     this.sessionId = session.id;
     return session.id;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -10,6 +10,7 @@ export interface MakaSessionRuntime {
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
+  updateSession(sessionId: string, patch: { model: string }): Promise<SessionSummary>;
 }
 
 export interface MakaSessionDriverInput {
@@ -24,6 +25,7 @@ export interface MakaSessionDriverInput {
 export interface MakaSessionDriver {
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
+  setModel(model: string): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
   stop(): Promise<void>;
   getSessionId(): string | null;
@@ -35,11 +37,13 @@ export function createMakaSessionDriver(input: MakaSessionDriverInput): MakaSess
 
 class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private sessionId: string | null = null;
+  private model: string;
   private permissionMode: PermissionMode;
   private readonly newId: () => string;
 
   constructor(private readonly input: MakaSessionDriverInput) {
     this.newId = input.newId ?? randomUUID;
+    this.model = input.model;
     this.permissionMode = input.permissionMode ?? 'ask';
   }
 
@@ -59,6 +63,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async respondToPermission(response: PermissionResponse): Promise<void> {
     if (!this.sessionId) throw new Error('Cannot respond to permission before a session starts.');
     await this.input.runtime.respondToPermission(this.sessionId, response);
+  }
+
+  async setModel(model: string): Promise<void> {
+    if (this.sessionId) {
+      const summary = await this.input.runtime.updateSession(this.sessionId, { model });
+      this.model = summary.model;
+      return;
+    }
+    this.model = model;
   }
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
@@ -81,7 +94,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       name: prompt.slice(0, 42) || '新建对话',
       backend: 'ai-sdk',
       llmConnectionSlug: this.input.llmConnectionSlug,
-      model: this.input.model,
+      model: this.model,
       permissionMode: this.permissionMode,
     });
     this.sessionId = session.id;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -24,6 +24,7 @@ export interface MakaSessionDriverInput {
 }
 
 export interface MakaSessionDriver {
+  listSessions(): Promise<SessionSummary[]>;
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
   setModel(model: string): Promise<void>;
@@ -57,6 +58,16 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     });
   }
 
+  async listSessions(): Promise<SessionSummary[]> {
+    return (await this.input.runtime.listSessions())
+      .map((session, index) => ({ session, index }))
+      .sort((left, right) => {
+        const cwdDelta = cwdRank(left.session, this.input.cwd) - cwdRank(right.session, this.input.cwd);
+        return cwdDelta !== 0 ? cwdDelta : left.index - right.index;
+      })
+      .map(({ session }) => session);
+  }
+
   async stop(): Promise<void> {
     if (!this.sessionId) return;
     await this.input.runtime.stopSession(this.sessionId, { source: 'stop_button' });
@@ -86,7 +97,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   }
 
   async switchSession(sessionId: string): Promise<SessionSummary> {
-    const summary = (await this.input.runtime.listSessions()).find((session) => session.id === sessionId);
+    const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
     this.sessionId = summary.id;
     this.model = summary.model;
@@ -111,4 +122,8 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     this.sessionId = session.id;
     return session.id;
   }
+}
+
+function cwdRank(session: SessionSummary, cwd: string): number {
+  return session.cwd === cwd ? 0 : 1;
 }

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
 import type { SessionEvent } from '@maka/core/events';
 import type { PermissionMode, PermissionResponse } from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
@@ -99,6 +100,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<SessionSummary> {
     const summary = (await this.listSessions()).find((session) => session.id === sessionId);
     if (!summary) throw new Error(`Session not found: ${sessionId}`);
+    if (summary.cwd) await assertSessionCwdExists(summary.cwd);
     this.sessionId = summary.id;
     this.model = summary.model;
     this.permissionMode = summary.permissionMode;
@@ -126,4 +128,16 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
 
 function cwdRank(session: SessionSummary, cwd: string): number {
   return session.cwd === cwd ? 0 : 1;
+}
+
+async function assertSessionCwdExists(cwd: string): Promise<void> {
+  try {
+    await realpath(cwd);
+  } catch (error) {
+    const code = (error as { code?: unknown }).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      throw new Error(`Session cwd no longer exists: ${cwd}`);
+    }
+    throw error;
+  }
 }

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { SessionEvent } from '@maka/core/events';
+import type { PermissionMode } from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionSummary } from '@maka/core/session';
 
@@ -14,6 +15,7 @@ export interface MakaSessionDriverInput {
   cwd: string;
   llmConnectionSlug: string;
   model: string;
+  permissionMode?: PermissionMode;
   newId?: () => string;
 }
 
@@ -60,7 +62,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       backend: 'ai-sdk',
       llmConnectionSlug: this.input.llmConnectionSlug,
       model: this.input.model,
-      permissionMode: 'bypass',
+      permissionMode: this.input.permissionMode ?? 'ask',
     });
     this.sessionId = session.id;
     return session.id;

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -6,6 +6,7 @@ import type { SessionSummary } from '@maka/core/session';
 
 export interface MakaSessionRuntime {
   createSession(input: CreateSessionInput): Promise<SessionSummary>;
+  listSessions(): Promise<SessionSummary[]>;
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
@@ -27,6 +28,7 @@ export interface MakaSessionDriver {
   respondToPermission(response: PermissionResponse): Promise<void>;
   setModel(model: string): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
+  switchSession(sessionId: string): Promise<SessionSummary>;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -81,6 +83,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       return;
     }
     this.permissionMode = mode;
+  }
+
+  async switchSession(sessionId: string): Promise<SessionSummary> {
+    const summary = (await this.input.runtime.listSessions()).find((session) => session.id === sessionId);
+    if (!summary) throw new Error(`Session not found: ${sessionId}`);
+    this.sessionId = summary.id;
+    this.model = summary.model;
+    this.permissionMode = summary.permissionMode;
+    return summary;
   }
 
   getSessionId(): string | null {

--- a/packages/cli/src/tui-ansi.ts
+++ b/packages/cli/src/tui-ansi.ts
@@ -1,0 +1,46 @@
+import type { EditorTheme, SelectListTheme } from '@earendil-works/pi-tui';
+
+// PR #496: desktop --accent = oklch(0.70 0.135 250), rendered here as truecolor ANSI.
+const MAKA_LOGO_BLUE_RGB = [87, 163, 239] as const;
+
+export const ansi = {
+  bold: style(1, 22),
+  dim: style(2, 22),
+  italic: style(3, 23),
+  underline: style(4, 24),
+  strikethrough: style(9, 29),
+  red: style(31, 39),
+  green: style(32, 39),
+  yellow: style(33, 39),
+  accent: rgb(...MAKA_LOGO_BLUE_RGB),
+  reverse: style(7, 27),
+};
+
+export function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
+}
+
+export function editorTheme(): EditorTheme {
+  return {
+    borderColor: ansi.accent,
+    selectList: selectListTheme(),
+  };
+}
+
+export function selectListTheme(): SelectListTheme {
+  return {
+    selectedPrefix: ansi.accent,
+    selectedText: ansi.bold,
+    description: ansi.dim,
+    scrollInfo: ansi.dim,
+    noMatch: ansi.dim,
+  };
+}
+
+function style(open: number, close: number): (text: string) => string {
+  return (text) => `\x1b[${open}m${text}\x1b[${close}m`;
+}
+
+function rgb(red: number, green: number, blue: number): (text: string) => string {
+  return (text) => `\x1b[38;2;${red};${green};${blue}m${text}\x1b[39m`;
+}

--- a/packages/cli/src/tui-autocomplete-layout.ts
+++ b/packages/cli/src/tui-autocomplete-layout.ts
@@ -1,0 +1,117 @@
+import type { Component, Editor } from '@earendil-works/pi-tui';
+import { stripAnsi } from './tui-ansi.js';
+
+// The pi-tui Editor renders its autocomplete menu at the tail of its render
+// output, i.e. below the input box. The Maka TUI pins the input at the bottom
+// of the screen, so those suggestions must appear *above* the editor instead.
+//
+// Editor exposes no way to render the menu on its own (only isShowingAutocomplete()),
+// so this module post-processes the lines Editor.render() returns: it locates the
+// editor's chrome borders and moves the trailing suggestion block above them.
+//
+// Fragile by necessity: isEditorChromeLine pattern-matches the editor's border
+// lines (all-dash) and scroll hint ("--- UP/DOWN N more ---"). If pi-tui changes
+// those shapes, this split silently misfires (suggestions vanish or land wrong)
+// with no compile error. Re-verify these patterns whenever pi-tui is upgraded.
+
+export interface MakaAutocompleteArrangementInput {
+  lines: string[];
+  autocompleteShowing: boolean;
+  autocompleteSlotRows: number;
+}
+
+export interface MakaAutocompleteArrangementResult {
+  lines: string[];
+  autocompleteSlotRows: number;
+}
+
+export function arrangeAutocompleteAboveEditor(
+  input: MakaAutocompleteArrangementInput,
+): MakaAutocompleteArrangementResult {
+  if (!input.autocompleteShowing) {
+    return { lines: input.lines, autocompleteSlotRows: 0 };
+  }
+  const sections = splitTrailingAutocomplete(input.lines);
+  if (sections.autocompleteLines.length === 0) {
+    return { lines: sections.editorLines, autocompleteSlotRows: 0 };
+  }
+  const autocompleteSlotRows = Math.max(
+    input.autocompleteSlotRows,
+    sections.autocompleteLines.length,
+  );
+  return {
+    lines: [
+      ...Array.from(
+        { length: autocompleteSlotRows - sections.autocompleteLines.length },
+        () => '',
+      ),
+      ...sections.autocompleteLines,
+      ...sections.editorLines,
+    ],
+    autocompleteSlotRows,
+  };
+}
+
+export class MakaAutocompleteAboveEditorComponent implements Component {
+  private autocompleteSlotRows = 0;
+
+  constructor(private readonly editor: Editor) {}
+
+  get focused(): boolean {
+    return this.editor.focused;
+  }
+
+  set focused(value: boolean) {
+    this.editor.focused = value;
+  }
+
+  invalidate(): void {
+    this.editor.invalidate();
+  }
+
+  handleInput(data: string): void {
+    this.editor.handleInput(data);
+  }
+
+  render(width: number): string[] {
+    const lines = this.editor.render(width);
+    const result = arrangeAutocompleteAboveEditor({
+      lines,
+      autocompleteShowing: this.editor.isShowingAutocomplete(),
+      autocompleteSlotRows: this.autocompleteSlotRows,
+    });
+    this.autocompleteSlotRows = result.autocompleteSlotRows;
+    return result.lines;
+  }
+}
+
+interface MakaAutocompleteSections {
+  autocompleteLines: string[];
+  editorLines: string[];
+}
+
+function splitTrailingAutocomplete(lines: string[]): MakaAutocompleteSections {
+  const bottomBorderIndex = findLastIndex(lines, isEditorChromeLine);
+  if (bottomBorderIndex < 1 || bottomBorderIndex === lines.length - 1) {
+    return { autocompleteLines: [], editorLines: lines };
+  }
+  const topBorderIndex = findLastIndex(lines.slice(0, bottomBorderIndex), isEditorChromeLine);
+  if (topBorderIndex < 0) return { autocompleteLines: [], editorLines: lines };
+
+  return {
+    autocompleteLines: lines.slice(bottomBorderIndex + 1),
+    editorLines: lines.slice(0, bottomBorderIndex + 1),
+  };
+}
+
+function isEditorChromeLine(line: string): boolean {
+  const text = stripAnsi(line);
+  return /^─+$/.test(text) || /^─── [↑↓] \d+ more ─*$/.test(text);
+}
+
+function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index]!)) return index;
+  }
+  return -1;
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -111,6 +111,7 @@ export type BackendKind = 'ai-sdk' | 'fake' | 'pi-agent';
 
 export interface SessionSummary {
   id: string;
+  cwd?: string;
   name: string;
   isFlagged: boolean;
   isArchived: boolean;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -986,6 +986,7 @@ export class SessionManager {
 export function headerToSummary(h: SessionHeader): SessionSummary {
   const summary: SessionSummary = {
     id: h.id,
+    cwd: h.cwd,
     name: h.name === 'New Session' ? 'New Chat' : h.name,
     isFlagged: h.isFlagged,
     isArchived: h.isArchived,

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -35,6 +35,7 @@ describe('FileSessionStore CRUD', () => {
       assert.equal(summary?.status, 'active');
       assert.equal(summary?.statusUpdatedAt, header.statusUpdatedAt);
       assert.equal(summary?.model, 'fake-model');
+      assert.equal(summary?.cwd, '/tmp/cwd');
     });
   });
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -488,6 +488,7 @@ function toSummary(header: SessionHeader, messages: StoredMessage[] = []): Sessi
   const lastMessageAt = maxTimestamp(header.lastMessageAt, derivedLastMessageAt);
   return {
     id: header.id,
+    cwd: header.cwd,
     name: normalizeSessionName(header.name),
     isFlagged: header.isFlagged,
     isArchived: header.isArchived,


### PR DESCRIPTION
## Summary

- make the Pi TUI usable for model, permission, and session switching through slash commands and pickers
- keep the input/statusline anchored at the bottom, with slash autocomplete and full-screen pickers rendering above it
- improve session behavior by scoping session choices to cwd, rejecting missing cwd sessions, and restoring resumed transcript history
- polish the transcript with compact tool cards, interactive permission prompts, and the Maka logo accent color

## Why

Refs #499. This moves the TUI from a raw prompt surface toward a usable Maka development interface: users can switch model, permission mode, and session from inside the TUI without hand-typing ids, while keeping the input area visually stable.

## Scope

Changed:

- TUI slash commands and pickers for `/model`, `/permissions`, `/session`, `/exit`, and `/quit`
- bottom-anchored input/statusline layout and above-input autocomplete/picker rendering
- session summaries now include `cwd`, and the TUI filters/resumes sessions for the current workspace
- transcript rendering for resumed history, tool cards, permission prompts, and Maka accent color

Not included:

- production permission UI hardening beyond the current dev/test TUI path
- non-CLI desktop UI changes

## Verification

- `npm run -w maka-agent test`

## User-facing impact

The Maka TUI can now drive common session workflows directly from slash commands, and resumed sessions render their previous transcript instead of a raw session id note.

## Reviewer notes

The diff is test-heavy: 12 files changed, 2612 insertions(+), 50 deletions(-). The largest files are `packages/cli/src/__tests__/pi-tui-runner.test.ts` and `packages/cli/src/pi-tui-runner.ts`.