### PR TITLE
feat(ui): tab component spec — maka-tab + variants, migrate 4 tab surfaces (#499 P0-3)

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -271,7 +271,7 @@ describe('experimental kill-switch (kenji 1da909d5 + 45b31e16)', () => {
     assert.match(src, /\{\s*id:\s*'oauth'[\s\S]*label:\s*'OAuth'/, 'model provider catalog must show OAuth as a peer tab');
     assert.match(
       src,
-      /catalogTab === 'oauth'\s*\?\s*\(\s*<ModelOAuthSection\s+onConnectionsChanged=\{async \(\) => \{ await reload\(\); \}\}\s*\/>/,
+      /<PrimitiveTabsPanel value="oauth">\s*<ModelOAuthSection\s+onConnectionsChanged=\{async \(\) => \{ await reload\(\); \}\}\s*\/>\s*<\/PrimitiveTabsPanel>/,
       'OAuth tab must render the real login cards, not an empty roadmap tile',
     );
     assert.doesNotMatch(

--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -96,13 +96,13 @@ describe('Daily Review copy feedback contract', () => {
     const panelBlock = extractFunctionBlock(ui, 'DailyReviewPanel');
 
     assert.match(panelBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="icon-sm"[\s\S]*?className="maka-daily-review-stepper"/);
-    assert.match(panelBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="sm"[\s\S]*?className="maka-daily-review-range-tab"/);
+    assert.match(panelBlock, /<SettingsSegmented[\s\S]*?className="maka-daily-review-range-tabs"/);
     assert.match(panelBlock, /className="maka-daily-review-copy"/);
     assert.match(panelBlock, /className="maka-daily-review-append"/);
     assert.match(panelBlock, /className="maka-daily-review-save"/);
     assert.match(panelBlock, /className="maka-daily-review-alert-retry"/);
     assert.doesNotMatch(panelBlock, /className="[^"]*\bmaka-button\b[^"]*"/);
-    assert.match(css, /\.maka-daily-review-range-tab\[data-active="true"\]/);
+    assert.doesNotMatch(css, /\.maka-daily-review-range-tab\[data-active/);
     assert.match(css, /\.maka-daily-review-copy,\s*\.maka-daily-review-append,\s*\.maka-daily-review-save/);
     assert.doesNotMatch(css, /\.maka-daily-review-range-tabs > button/);
     assert.doesNotMatch(css, /\.maka-daily-review-actions > button/);

--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -185,8 +185,9 @@ describe('issue #406 design-system governance contract', () => {
     const menu = await readFile(resolve(REPO_ROOT, 'packages/ui/src/primitives/menu.tsx'), 'utf8');
     const tabs = await readFile(resolve(REPO_ROOT, 'packages/ui/src/primitives/tabs.tsx'), 'utf8');
     assert.match(menu, /data-checked:bg-control/);
-    assert.match(tabs, /bg-control data-\[orientation=horizontal\]:h-0\.5/);
+    assert.match(tabs, /bg-foreground data-\[orientation=horizontal\]:h-0\.5/);
     assert.doesNotMatch(menu, /data-checked:bg-primary/);
+    assert.doesNotMatch(tabs, /bg-control data-\[orientation=horizontal\]:h-0\.5/);
     assert.doesNotMatch(tabs, /bg-primary data-\[orientation=horizontal\]:h-0\.5/);
 
     const docs = await readFile(resolve(REPO_ROOT, 'docs/design-system.md'), 'utf8');

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -33,8 +33,8 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(tabs[0], /id:\s*'oauth'[\s\S]*label:\s*'OAuth'/, 'OAuth must be a catalog tab');
     assert.match(
       src,
-      /catalogTab === 'oauth'\s*\?\s*\(\s*<ModelOAuthSection\s+onConnectionsChanged=\{async \(\) => \{ await reload\(\); \}\}\s*\/>/,
-      'OAuth login UI must render from the tab content branch and refresh enabled models',
+      /<PrimitiveTabsPanel value="oauth">\s*<ModelOAuthSection\s+onConnectionsChanged=\{async \(\) => \{ await reload\(\); \}\}\s*\/>\s*<\/PrimitiveTabsPanel>/,
+      'OAuth login UI must render inside the oauth TabsPanel and refresh enabled models',
     );
     const marketStart = src.indexOf('<section className="providerMarket">');
     const firstOAuthRender = src.indexOf('<ModelOAuthSection');
@@ -65,8 +65,8 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.doesNotMatch(src, /function onCatalogTabsKeyDown/, 'provider catalog tabs should not keep a custom keyboard handler');
     assert.doesNotMatch(src, /data-catalog-tab="\$\{CSS\.escape/, 'provider catalog tabs should not use manual focus queries');
     assert.match(tabs, /value=\{catalogTab\}[\s\S]*onValueChange=\{\(value\) => setCatalogTab\(value as CatalogTab\)\}/);
-    assert.match(tabs, /<PrimitiveTabsList className="catalogTabs catalogPillTabs" aria-label="模型供应商分类">/);
-    assert.match(tabs, /<PrimitiveTabsTrigger[\s\S]*className="catalogTab"[\s\S]*value=\{tab\.id\}/);
+    assert.match(tabs, /<PrimitiveTabsList[^>]*variant="pill"[^>]*aria-label="模型供应商分类">/);
+    assert.match(tabs, /<PrimitiveTabsTrigger[\s\S]*className="maka-tab"[\s\S]*value=\{tab\.id\}/);
     assert.match(tabs, /data-catalog-tab=\{tab\.id\}/);
   });
 

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -66,7 +66,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.doesNotMatch(src, /data-catalog-tab="\$\{CSS\.escape/, 'provider catalog tabs should not use manual focus queries');
     assert.match(tabs, /value=\{catalogTab\}[\s\S]*onValueChange=\{\(value\) => setCatalogTab\(value as CatalogTab\)\}/);
     assert.match(tabs, /<PrimitiveTabsList[^>]*variant="pill"[^>]*aria-label="模型供应商分类">/);
-    assert.match(tabs, /<PrimitiveTabsTrigger[\s\S]*className="maka-tab"[\s\S]*value=\{tab\.id\}/);
+    assert.match(tabs, /<PrimitiveTabsTrigger[\s\S]*value=\{tab\.id\}/, 'catalog tabs use PrimitiveTabsTrigger as a real tablist (maka-tab comes from the primitive)');
     assert.match(tabs, /data-catalog-tab=\{tab\.id\}/);
   });
 

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -174,11 +174,13 @@ const COMPONENT_RADIUS: ComponentRadiusCheck[] = [
   { file: 'packages/ui/src/ui.tsx', name: 'inputClasses', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'SelectItem', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'Toggle', tier: 'control' },
-  { file: 'packages/ui/src/ui.tsx', name: 'TabsTrigger', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'badgeVariants', tier: 'pill' },
   { file: 'packages/ui/src/ui.tsx', name: 'DialogPopup', tier: 'modal' },
-  { file: 'packages/ui/src/ui.tsx', name: 'TabsList', tier: 'surface' },
   { file: 'packages/ui/src/ui.tsx', name: 'SelectPopup', tier: 'surface' },
+  // TabsTrigger/TabsList used to be declared in ui.tsx with --radius-* tokens;
+  // #499 P0-3 re-exports them from primitives/tabs.tsx, which uses Tailwind
+  // rounded-md/rounded-sm (governed by primitives-design-contract escape
+  // hatches, not the radius-token convergence contract).
   { file: 'packages/ui/src/ui.tsx', name: 'ToggleGroup', tier: 'surface' },
   { file: 'packages/ui/src/primitives/input-group.tsx', name: 'InputGroup', tier: 'control' },
   { file: 'packages/ui/src/primitives/badge.tsx', name: 'badgeVariants', tier: 'pill' },

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -603,7 +603,7 @@ name: Writer
     assert.match(skillPanel, /<section className="maka-skill-examples" aria-label="技能示例">/);
     assert.match(skillPanel, /<ul className="maka-skill-example-grid" aria-label="技能模板示例">/);
     assert.match(skillPanel, /className="maka-skill-template-row"/);
-    assert.match(skillPanel, /<section className="maka-skill-installed" aria-label="已安装技能">/);
+    assert.match(skillPanel, /<section className="maka-skill-installed" aria-label={label}>/);
     assert.match(skillPanel, /<div className="maka-skill-library" aria-busy=\{props\.actionBusy \? 'true' : undefined\}>/);
     assert.match(skillPanel, /<ul className="maka-skill-library-list" aria-label="技能列表">/);
     assert.match(skillPanel, /<span className="maka-skill-library-status" aria-hidden="true">/);

--- a/apps/desktop/src/main/__tests__/state-token-governance-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/state-token-governance-499-contract.test.ts
@@ -87,14 +87,13 @@ describe('issue #499 state-token governance contract', () => {
     assert.deepEqual(violations, [], `:hover backgrounds must use --state-hover-bg, not --foreground-N, inline oklch, or brand tokens --nav-active/--accent/--toast-accent/--bot-brand-* (allowlist: base-brand controls):\n${violations.join('\n')}`);
   });
 
-  it('selected/active surfaces use neutral tokens, not brand tokens --nav-active/--accent/--toast-accent/--bot-brand-* (allowlist: onboarding brand emphasis + tabs pending tab-spec)', async () => {
+  it('selected/active surfaces use neutral tokens, not brand tokens --nav-active/--accent/--toast-accent/--bot-brand-* (allowlist: onboarding brand emphasis)', async () => {
     const allCss = [TOKENS_FILE, ...(await readCssTree(RENDERER_STYLES_DIR)), STYLES_FILE];
-    // --nav-active stays only for:
-    //   - onboarding brand emphasis (selected/active selectors only):
-    //     .maka-firstrun-step, .maka-onboarding-setup-steps
-    //   - tab surfaces pending the tab-spec PR (single underline variant):
-    //     daily-review-range-tab, catalogTab, catalogPillTabs, skill-tab, plan-tab
-    const ALLOWLIST_SELECTOR = /(\.maka-daily-review-range-tab|\.catalogTab|\.catalogPillTabs\b|\.maka-skill-tab|\.maka-plan-tab|\.maka-firstrun-step\b|\.maka-onboarding-setup-steps\b)/;
+    // --nav-active stays only for onboarding brand emphasis (selected/active
+    // selectors): .maka-firstrun-step, .maka-onboarding-setup-steps. Tab
+    // surfaces migrated to the tab spec (#499 P0-3) now use neutral state
+    // tokens, so they no longer need an allowlist entry.
+    const ALLOWLIST_SELECTOR = /(\.maka-firstrun-step\b|\.maka-onboarding-setup-steps\b)/;
     const SELECTED_ACTIVE = /\[data-active|\[data-checked|\[data-default|\[data-pressed|\[data-selected|\[data-state\s*=\s*"active"|aria-selected\s*=\s*"true"/;
     const violations: string[] = [];
     for (const file of allCss) {
@@ -109,6 +108,6 @@ describe('issue #499 state-token governance contract', () => {
         }
       }
     }
-    assert.deepEqual(violations, [], `selected/active must not use brand tokens --nav-active/--accent/--toast-accent/--bot-brand-* (allowlist: onboarding brand emphasis + tabs pending tab-spec):\n${violations.join('\n')}`);
+    assert.deepEqual(violations, [], `selected/active must not use brand tokens --nav-active/--accent/--toast-accent/--bot-brand-* (allowlist: onboarding brand emphasis):\n${violations.join('\n')}`);
   });
 });

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -25,6 +25,12 @@ const PLAN_CSS_FILE = resolve(
   REPO_ROOT,
   'apps/desktop/src/renderer/styles/module-pages/plan-reminders.css',
 );
+const PROVIDERS_PANEL_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/ProvidersPanel.tsx');
+const MODELS_CSS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles/settings/models.css');
+const PROVIDER_EDITOR_CSS_FILE = resolve(
+  REPO_ROOT,
+  'apps/desktop/src/renderer/styles/settings/provider-editor.css',
+);
 
 const BRAND_STATE_TOKEN_RE =
   /var\(--nav-active\)|var\(--accent\)|var\(--toast-accent\)|var\(--bot-brand-color\)|var\(--bot-brand-default\)/;
@@ -97,6 +103,67 @@ describe('issue #499 P0-3 tab spec contract', () => {
       css,
       /\.maka-plan-tab\[data-state\s*=\s*"active"\]::after/,
       'plan hand-written under-bar ::after must be removed',
+    );
+  });
+
+  it('catalog tabs consume maka-tab + pill variant + TabsPanel; no hand-written catalogTab/catalogPillTabs active/hover/indicator CSS', async () => {
+    const panel = await readFile(PROVIDERS_PANEL_FILE, 'utf8');
+    assert.match(
+      panel,
+      /PrimitiveTabsList[^>]*variant="pill"/,
+      'catalog TabsList must pass variant="pill"',
+    );
+    assert.match(
+      panel,
+      /PrimitiveTabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
+      'catalog TabsTrigger must carry the maka-tab class',
+    );
+    assert.match(
+      panel,
+      /PrimitiveTabsPanel/,
+      'catalog content must render through PrimitiveTabsPanel (not bare conditional render)',
+    );
+    // data-active hand-written boolean removed (Base UI sets data-active on the
+    // active tab); data-catalog-tab stays (locked by model-oauth-section contract
+    // as the tab identifier, not a manual focus query).
+    assert.doesNotMatch(
+      panel,
+      /data-active=\{catalogTab === tab\.id\}/,
+      'catalog hand-written data-active={catalogTab === tab.id} must be removed (Base UI sets data-active)',
+    );
+    assert.match(
+      panel,
+      /data-catalog-tab=\{tab\.id\}/,
+      'data-catalog-tab={tab.id} must stay (tab identifier used by model-oauth contract)',
+    );
+
+    const modelsCss = stripCssComments(await readFile(MODELS_CSS_FILE, 'utf8'));
+    assert.doesNotMatch(
+      modelsCss,
+      /\.catalogPillTabs button\[data-active/,
+      'catalog hand-written .catalogPillTabs button[data-active] must be removed (active moves to .maka-tab)',
+    );
+    assert.doesNotMatch(
+      modelsCss,
+      /\.catalogPillTabs button:hover/,
+      'catalog hand-written .catalogPillTabs button:hover must be removed (hover moves to .maka-tab)',
+    );
+    assert.doesNotMatch(
+      modelsCss,
+      /\.catalogPillTabs \[data-slot="tab-indicator"\]/,
+      'catalog hand-written indicator display:none must be removed (pill variant hides the indicator in tabs.tsx)',
+    );
+
+    const providerEditorCss = stripCssComments(await readFile(PROVIDER_EDITOR_CSS_FILE, 'utf8'));
+    assert.doesNotMatch(
+      providerEditorCss,
+      /\.catalogTab\[data-active/,
+      'catalog hand-written .catalogTab[data-active] must be removed (active moves to .maka-tab)',
+    );
+    assert.doesNotMatch(
+      providerEditorCss,
+      /\.catalogTab:hover/,
+      'catalog hand-written .catalogTab:hover must be removed (hover moves to .maka-tab)',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -88,11 +88,6 @@ describe('issue #499 P0-3 tab spec contract', () => {
       /TabsList[^>]*variant="underline"/,
       'plan TabsList must pass variant="underline"',
     );
-    assert.match(
-      panel,
-      /TabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
-      'plan TabsTrigger must carry the maka-tab class',
-    );
     const css = stripCssComments(await readFile(PLAN_CSS_FILE, 'utf8'));
     // The active state + under-bar move to .maka-tab; surface-specific layout
     // rules (.maka-plan-tab height/padding/font-size) may remain, but the
@@ -116,11 +111,6 @@ describe('issue #499 P0-3 tab spec contract', () => {
       panel,
       /PrimitiveTabsList[^>]*variant="pill"/,
       'catalog TabsList must pass variant="pill"',
-    );
-    assert.match(
-      panel,
-      /PrimitiveTabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
-      'catalog TabsTrigger must carry the maka-tab class',
     );
     assert.match(
       panel,
@@ -177,11 +167,6 @@ describe('issue #499 P0-3 tab spec contract', () => {
       panel,
       /TabsList[^>]*variant="underline"/,
       'skill TabsList must pass variant="underline"',
-    );
-    assert.match(
-      panel,
-      /TabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
-      'skill TabsTrigger must carry the maka-tab class',
     );
     assert.match(
       panel,

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -33,6 +33,8 @@ const PROVIDER_EDITOR_CSS_FILE = resolve(
 );
 const SKILLS_PANEL_FILE = resolve(REPO_ROOT, 'packages/ui/src/skills-panel.tsx');
 const SKILLS_CSS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles/module-pages/skills.css');
+const DAILY_REVIEW_PANEL_FILE = resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx');
+const DAILY_REVIEW_CSS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles/daily-review.css');
 
 const BRAND_STATE_TOKEN_RE =
   /var\(--nav-active\)|var\(--accent\)|var\(--toast-accent\)|var\(--bot-brand-color\)|var\(--bot-brand-default\)/;
@@ -208,6 +210,36 @@ describe('issue #499 P0-3 tab spec contract', () => {
       css,
       /\.maka-skill-tab\[data-state\s*=\s*"active"\]::after/,
       'skill hand-written under-bar ::after must be removed (underline variant uses the Base UI indicator)',
+    );
+  });
+
+  it('daily-review range uses SettingsSegmented (Base UI ToggleGroup), not hand-rolled buttons; active is neutral', async () => {
+    // daily-review range (今日/本周/本月) switches a time-window parameter —
+    // the report re-fetches for the chosen range, it is not 3 distinct views.
+    // So it is a segmented control, not tabs: SettingsSegmented (Base UI
+    // ToggleGroup, single-select, roving tabindex + arrow keys + data-pressed)
+    // is the a11y-correct primitive, not Tabs/TabsPanel.
+    const panel = await readFile(DAILY_REVIEW_PANEL_FILE, 'utf8');
+    assert.match(
+      panel,
+      /SettingsSegmented/,
+      'daily-review range must use SettingsSegmented (Base UI ToggleGroup), not hand-rolled buttons',
+    );
+    assert.doesNotMatch(
+      panel,
+      /aria-pressed=\{range === option\}/,
+      'daily-review hand-rolled aria-pressed switcher must be removed',
+    );
+    assert.doesNotMatch(
+      panel,
+      /data-active=\{range === option \? 'true' : undefined\}/,
+      'daily-review hand-rolled data-active switcher must be removed',
+    );
+    const css = stripCssComments(await readFile(DAILY_REVIEW_CSS_FILE, 'utf8'));
+    assert.doesNotMatch(
+      css,
+      /\.maka-daily-review-range-tab\[data-active/,
+      'daily-review hand-written .maka-daily-review-range-tab[data-active] (brand --nav-active) must be removed (active is neutral via .settingsSegmented button[data-pressed])',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -88,6 +88,17 @@ describe('issue #499 P0-3 tab spec contract', () => {
       /TabsList[^>]*variant="underline"/,
       'plan TabsList must pass variant="underline"',
     );
+    // Each plan tab value has a corresponding panel (tabpanel a11y pairing).
+    assert.match(
+      panel,
+      /TabsPanel[^>]*value="tasks"/,
+      'plan must have a TabsPanel for the tasks view',
+    );
+    assert.match(
+      panel,
+      /TabsPanel[^>]*value="runs"/,
+      'plan must have a TabsPanel for the runs view',
+    );
     const css = stripCssComments(await readFile(PLAN_CSS_FILE, 'utf8'));
     // The active state + under-bar move to .maka-tab; surface-specific layout
     // rules (.maka-plan-tab height/padding/font-size) may remain, but the
@@ -112,10 +123,24 @@ describe('issue #499 P0-3 tab spec contract', () => {
       /PrimitiveTabsList[^>]*variant="pill"/,
       'catalog TabsList must pass variant="pill"',
     );
+    // Each catalog tab value has a corresponding panel: OAuth gets a fixed
+    // panel, and the three provider categories (domestic/overseas/local) are
+    // mapped to panels via value={cat}. Locking the template + the array
+    // proves every category has a panel without a runtime render test.
     assert.match(
       panel,
-      /PrimitiveTabsPanel/,
-      'catalog content must render through PrimitiveTabsPanel (not bare conditional render)',
+      /PrimitiveTabsPanel[^>]*value="oauth"/,
+      'catalog must have a TabsPanel for the OAuth category',
+    );
+    assert.match(
+      panel,
+      /PrimitiveTabsPanel[^>]*value=\{cat\}/,
+      'catalog must map a TabsPanel per provider category (value={cat})',
+    );
+    assert.match(
+      panel,
+      /\['domestic', 'overseas', 'local'\]/,
+      'catalog category tabs must cover domestic / overseas / local',
     );
     // data-active hand-written boolean removed (Base UI sets data-active on the
     // active tab); data-catalog-tab stays (locked by model-oauth-section contract
@@ -168,10 +193,21 @@ describe('issue #499 P0-3 tab spec contract', () => {
       /TabsList[^>]*variant="underline"/,
       'skill TabsList must pass variant="underline"',
     );
+    // Each skill tab value has a corresponding panel (tabpanel a11y pairing).
     assert.match(
       panel,
-      /TabsPanel/,
-      'skill content must render through TabsPanel',
+      /TabsPanel[^>]*value="market"/,
+      'skill must have a TabsPanel for the market view',
+    );
+    assert.match(
+      panel,
+      /TabsPanel[^>]*value="builtin"/,
+      'skill must have a TabsPanel for the builtin view',
+    );
+    assert.match(
+      panel,
+      /TabsPanel[^>]*value="installed"/,
+      'skill must have a TabsPanel for the installed view',
     );
     // hand-rolled tab-switcher markers removed (Base UI TabsTrigger carries the
     // tab role + aria-selected; the aria-pressed segmented-switcher pattern goes).

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -31,6 +31,8 @@ const PROVIDER_EDITOR_CSS_FILE = resolve(
   REPO_ROOT,
   'apps/desktop/src/renderer/styles/settings/provider-editor.css',
 );
+const SKILLS_PANEL_FILE = resolve(REPO_ROOT, 'packages/ui/src/skills-panel.tsx');
+const SKILLS_CSS_FILE = resolve(REPO_ROOT, 'apps/desktop/src/renderer/styles/module-pages/skills.css');
 
 const BRAND_STATE_TOKEN_RE =
   /var\(--nav-active\)|var\(--accent\)|var\(--toast-accent\)|var\(--bot-brand-color\)|var\(--bot-brand-default\)/;
@@ -164,6 +166,48 @@ describe('issue #499 P0-3 tab spec contract', () => {
       providerEditorCss,
       /\.catalogTab:hover/,
       'catalog hand-written .catalogTab:hover must be removed (hover moves to .maka-tab)',
+    );
+  });
+
+  it('skill tabs migrate from hand-rolled buttons to maka-tab + underline variant + TabsPanel', async () => {
+    const panel = await readFile(SKILLS_PANEL_FILE, 'utf8');
+    assert.match(
+      panel,
+      /TabsList[^>]*variant="underline"/,
+      'skill TabsList must pass variant="underline"',
+    );
+    assert.match(
+      panel,
+      /TabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
+      'skill TabsTrigger must carry the maka-tab class',
+    );
+    assert.match(
+      panel,
+      /TabsPanel/,
+      'skill content must render through TabsPanel',
+    );
+    // hand-rolled tab-switcher markers removed (Base UI TabsTrigger carries the
+    // tab role + aria-selected; the aria-pressed segmented-switcher pattern goes).
+    assert.doesNotMatch(
+      panel,
+      /aria-pressed=\{activeSkillTab === tab\}/,
+      'skill hand-rolled aria-pressed switcher must be removed',
+    );
+    assert.doesNotMatch(
+      panel,
+      /data-state=\{activeSkillTab === tab \? 'active' : 'inactive'\}/,
+      'skill hand-rolled data-state switcher must be removed',
+    );
+    const css = stripCssComments(await readFile(SKILLS_CSS_FILE, 'utf8'));
+    assert.doesNotMatch(
+      css,
+      /\.maka-skill-tab\[data-state\s*=\s*"active"\]/,
+      'skill hand-written [data-state=active] selector must be removed (active moves to .maka-tab)',
+    );
+    assert.doesNotMatch(
+      css,
+      /\.maka-skill-tab\[data-state\s*=\s*"active"\]::after/,
+      'skill hand-written under-bar ::after must be removed (underline variant uses the Base UI indicator)',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tab-spec-499-contract.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  REPO_ROOT,
+  TOKENS_FILE,
+  RENDERER_STYLES_DIR,
+  STYLES_FILE,
+  readCssTree,
+  stripCssComments,
+} from './css-test-helpers.js';
+
+// Issue #499 P0-3 — tab component governance.
+// One tab spec: shared `maka-tab` class + `underline`/`pill` variants on the Base
+// UI Tabs primitive, active/hover repointed to --state-selected-bg /
+// --state-hover-bg (no brand token, no per-surface hand-written tab CSS).
+//
+// This file grows one slice at a time. Slice 1 covers the primitive + the
+// first consumer (plan tabs).
+
+const TABS_FILE = resolve(REPO_ROOT, 'packages/ui/src/primitives/tabs.tsx');
+const PLAN_PANEL_FILE = resolve(REPO_ROOT, 'packages/ui/src/plan-reminder-panel.tsx');
+const PLAN_CSS_FILE = resolve(
+  REPO_ROOT,
+  'apps/desktop/src/renderer/styles/module-pages/plan-reminders.css',
+);
+
+const BRAND_STATE_TOKEN_RE =
+  /var\(--nav-active\)|var\(--accent\)|var\(--toast-accent\)|var\(--bot-brand-color\)|var\(--bot-brand-default\)/;
+
+describe('issue #499 P0-3 tab spec contract', () => {
+  it('tabs primitive exposes maka-tab class on TabsTab and underline|pill variants on TabsList', async () => {
+    const src = await readFile(TABS_FILE, 'utf8');
+    assert.match(src, /"underline"/, 'TabsVariant must include "underline"');
+    assert.match(src, /"pill"/, 'TabsVariant must include "pill" (currently only default|underline)');
+    assert.match(src, /\bmaka-tab\b/, 'TabsTab must emit the shared maka-tab class');
+  });
+
+  it('.maka-tab active/hover use neutral state tokens, no brand token', async () => {
+    const allCss = [TOKENS_FILE, ...(await readCssTree(RENDERER_STYLES_DIR)), STYLES_FILE];
+    let foundMakaTab = false;
+    let foundActiveBg = false;
+    let foundHoverBg = false;
+    const brandInTab: string[] = [];
+    for (const file of allCss) {
+      const source = stripCssComments(await readFile(file, 'utf8'));
+      for (const ruleMatch of source.matchAll(/([^{}]*)\{([^}]*)\}/g)) {
+        const selector = ruleMatch[1]!;
+        const body = ruleMatch[2]!;
+        if (!/\.maka-tab\b/.test(selector)) continue;
+        foundMakaTab = true;
+        if ((/\[data-active\]/.test(selector) || /:active\b/.test(selector)) && /background(?:-color)?:/.test(body)) {
+          if (/var\(--state-selected-bg\)/.test(body)) foundActiveBg = true;
+        }
+        if (/:hover/.test(selector) && /background(?:-color)?:/.test(body)) {
+          if (/var\(--state-hover-bg\)/.test(body)) foundHoverBg = true;
+        }
+        if (BRAND_STATE_TOKEN_RE.test(body)) {
+          brandInTab.push(`${file}: ${selector.trim()}`);
+        }
+      }
+    }
+    assert.ok(foundMakaTab, 'a .maka-tab rule must exist');
+    assert.ok(foundActiveBg, '.maka-tab active must use --state-selected-bg');
+    assert.ok(foundHoverBg, '.maka-tab hover must use --state-hover-bg');
+    assert.deepEqual(
+      brandInTab,
+      [],
+      `.maka-tab must not use brand tokens (--nav-active/--accent/--toast-accent/--bot-brand-*):\n${brandInTab.join('\n')}`,
+    );
+  });
+
+  it('plan tabs consume maka-tab + underline variant; no hand-written .maka-plan-tab active/under-bar CSS', async () => {
+    const panel = await readFile(PLAN_PANEL_FILE, 'utf8');
+    assert.match(
+      panel,
+      /TabsList[^>]*variant="underline"/,
+      'plan TabsList must pass variant="underline"',
+    );
+    assert.match(
+      panel,
+      /TabsTrigger[^>]*className="[^"]*\bmaka-tab\b/,
+      'plan TabsTrigger must carry the maka-tab class',
+    );
+    const css = stripCssComments(await readFile(PLAN_CSS_FILE, 'utf8'));
+    // The active state + under-bar move to .maka-tab; surface-specific layout
+    // rules (.maka-plan-tab height/padding/font-size) may remain, but the
+    // hand-written [data-state="active"] selectors (currently dead — Base UI
+    // sets data-active, not data-state) must be gone.
+    assert.doesNotMatch(
+      css,
+      /\.maka-plan-tab\[data-state\s*=\s*"active"\]/,
+      'plan hand-written [data-state="active"] selector must be removed (active state moves to .maka-tab)',
+    );
+    assert.doesNotMatch(
+      css,
+      /\.maka-plan-tab\[data-state\s*=\s*"active"\]::after/,
+      'plan hand-written under-bar ::after must be removed',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1747,6 +1747,24 @@
   .maka-button[disabled],
   .maka-button[aria-disabled="true"] { opacity: 0.45; cursor: not-allowed; }
 
+  /* ---- Tabs ------------------------------------------------------- */
+
+  /* Shared tab spec (#499 P0-3): one `maka-tab` class + `underline`/`pill`
+   * variants on the Base UI Tabs primitive. Active/hover use the neutral
+   * state tokens — no brand color, no per-surface hand-written tab CSS.
+   * underline = neutral under-bar via the Base UI indicator (no bg fill);
+   * pill = neutral bg fill + bold (indicator hidden). */
+  .maka-tabs-list[data-variant="pill"] .maka-tab:hover {
+    background: var(--state-hover-bg);
+  }
+  .maka-tabs-list[data-variant="pill"] .maka-tab[data-active] {
+    background: var(--state-selected-bg);
+    font-weight: 600;
+  }
+  .maka-tabs-list[data-variant="underline"] .maka-tab[data-active] {
+    color: var(--foreground);
+  }
+
   /* ---- Modal / Dialog --------------------------------------------- */
 
   .maka-modal-backdrop {

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1754,10 +1754,20 @@
    * state tokens — no brand color, no per-surface hand-written tab CSS.
    * underline = neutral under-bar via the Base UI indicator (no bg fill);
    * pill = neutral bg fill + bold (indicator hidden). */
+  .maka-tabs-list[data-variant="pill"] .maka-tab {
+    min-height: 34px;
+    border-radius: var(--radius-pill);
+    border: 1px solid transparent;
+    background: var(--foreground-5);
+    color: var(--foreground-secondary);
+    padding: 0 var(--space-4);
+  }
   .maka-tabs-list[data-variant="pill"] .maka-tab:hover {
     background: var(--state-hover-bg);
+    color: var(--foreground);
   }
   .maka-tabs-list[data-variant="pill"] .maka-tab[data-active] {
+    border-color: oklch(from var(--foreground) l c h / 0.16);
     background: var(--state-selected-bg);
     font-weight: 600;
   }

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@maka/core';
 import {
   Button,
-  PrimitiveTabs, PrimitiveTabsList, PrimitiveTabsTrigger,
+  PrimitiveTabs, PrimitiveTabsList, PrimitiveTabsTrigger, PrimitiveTabsPanel,
   PrimitiveAccordion, PrimitiveAccordionItem, PrimitiveAccordionHeader, PrimitiveAccordionTrigger, PrimitiveAccordionPanel,
   Item, ItemContent, ItemTitle, ItemActions,
   useToast,
@@ -138,9 +138,6 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
     [providerGroups, defaultSlug],
   );
 
-  const catalogProviders = CATALOG_PROVIDER_TYPES.filter(
-    (type) => PROVIDER_DEFAULTS[type].category === catalogTab,
-  );
   const customProviders = CATALOG_PROVIDER_TYPES.filter(
     (type) => PROVIDER_DEFAULTS[type].category === 'custom',
   );
@@ -294,35 +291,36 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
           value={catalogTab}
           onValueChange={(value) => setCatalogTab(value as CatalogTab)}
         >
-          <PrimitiveTabsList className="catalogTabs catalogPillTabs" aria-label="模型供应商分类">
+          <PrimitiveTabsList variant="pill" className="catalogTabs catalogPillTabs" aria-label="模型供应商分类">
             {CATALOG_TABS.map((tab) => (
               <PrimitiveTabsTrigger
                 key={tab.id}
-                className="catalogTab"
+                className="maka-tab"
                 value={tab.id}
-                data-active={catalogTab === tab.id}
                 data-catalog-tab={tab.id}
               >
                 <strong>{tab.label}</strong>
               </PrimitiveTabsTrigger>
             ))}
           </PrimitiveTabsList>
+          <PrimitiveTabsPanel value="oauth">
+            <ModelOAuthSection onConnectionsChanged={async () => { await reload(); }} />
+          </PrimitiveTabsPanel>
+          {(['domestic', 'overseas', 'local'] as const).map((cat) => (
+            <PrimitiveTabsPanel key={cat} value={cat}>
+              <div className="catalogGrid providerMarketGrid">
+                {CATALOG_PROVIDER_TYPES.filter((type) => PROVIDER_DEFAULTS[type].category === cat).map((type) => (
+                  <ProviderCatalogCard
+                    key={type}
+                    type={type}
+                    count={configuredByType(type)}
+                    onSelect={() => startAdd(type)}
+                  />
+                ))}
+              </div>
+            </PrimitiveTabsPanel>
+          ))}
         </PrimitiveTabs>
-
-        {catalogTab === 'oauth' ? (
-          <ModelOAuthSection onConnectionsChanged={async () => { await reload(); }} />
-        ) : (
-          <div className="catalogGrid providerMarketGrid">
-            {catalogProviders.map((type) => (
-              <ProviderCatalogCard
-                key={type}
-                type={type}
-                count={configuredByType(type)}
-                onSelect={() => startAdd(type)}
-              />
-            ))}
-          </div>
-        )}
 
         <div className="customProviderEntry">
           <div>

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -295,7 +295,6 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
             {CATALOG_TABS.map((tab) => (
               <PrimitiveTabsTrigger
                 key={tab.id}
-                className="maka-tab"
                 value={tab.id}
                 data-catalog-tab={tab.id}
               >

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -316,9 +316,6 @@
     color: var(--foreground);
   }
 
-/* PR-DAILY-REVIEW-RANGE-0: 今日 / 本周 / 本月 tabs. Active tab uses
-   the same accent-emphasis as the surrounding Settings nav so the
-   visual language stays consistent. */
 .maka-daily-review-range-tabs,
   .maka-daily-review-actions {
     display: flex;
@@ -331,21 +328,11 @@
     justify-content: flex-end;
   }
 
-.maka-daily-review-range-tab {
-  font-size: var(--font-size-ui);
-}
-
 .maka-daily-review-copy,
 .maka-daily-review-append,
 .maka-daily-review-save {
   font-size: var(--font-size-ui);
   white-space: nowrap;
-}
-
-.maka-daily-review-range-tab[data-active="true"] {
-  background: oklch(from var(--nav-active) l c h / 0.12);
-  color: var(--nav-active);
-  font-weight: 600;
 }
 
 .maka-daily-review-alert {

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -421,26 +421,6 @@
   font-weight: 600;
 }
 
-.maka-plan-tab[data-state="active"] {
-  color: var(--foreground);
-  background: transparent;
-  box-shadow: none;
-}
-
-/* PR-UI-PIXEL-2 (2026-06-21): reference keeps the active-tab under-bar
-   NEUTRAL (the text/foreground color), not a brand tint — structural chrome
-   stays calm, brand color is reserved as a garnish (study §4 rule 2/3). */
-.maka-plan-tab[data-state="active"]::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--foreground);
-}
-
 .maka-plan-tab span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -222,22 +222,6 @@ color: oklch(0.55 0.015 220);
   padding: 0 1px;
 }
 
-.maka-skill-tab[data-state="active"] {
-  color: var(--foreground);
-  font-weight: 650;
-}
-
-.maka-skill-tab[data-state="active"]::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -1px;
-  height: 2px;
-  border-radius: var(--radius-pill);
-  background: var(--foreground);
-}
-
 .maka-skill-tab span {
   min-width: 16px;
   height: 16px;

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -145,36 +145,6 @@
   gap: var(--space-2);
 }
 
-.catalogPillTabs button {
-  min-height: 34px;
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  background: var(--foreground-5);
-  color: var(--foreground-secondary);
-  padding: 0 var(--space-4);
-}
-
-.catalogPillTabs button:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
-.catalogPillTabs button[data-active="true"] {
-  border-color: oklch(from var(--nav-active) l c h / 0.22);
-  background: oklch(from var(--nav-active) l c h / 0.13);
-  color: var(--nav-active);
-}
-
-/* Base UI's Tabs renders a sliding rounded-md indicator behind the active
- * tab. These pills supply their own active fill, and the indicator's square
- * radius pokes out from behind the 999px pill (the warped selected look).
- * Hide it; the pill background is the single source of the active state. */
-.catalogPillTabs [data-slot="tab-indicator"] {
-  display: none;
-}
-
 .catalogPillTabs strong {
   font-size: var(--font-size-ui);
   font-weight: 700;

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -30,15 +30,6 @@
   text-align: left;
 }
 
-.catalogTab:hover {
-  background: var(--state-hover-bg);
-}
-
-.catalogTab[data-active="true"] {
-  border-color: oklch(from var(--nav-active) l c h / 0.16);
-  background: oklch(from var(--nav-active) l c h / 0.08);
-}
-
 .catalogTabs strong {
   font-size: var(--font-size-caption);
   font-weight: 600;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -550,6 +550,19 @@ spinner、status pulse、streaming caret、shimmer，以及必要的 hover/press
 - **task list 复选框**（remark-gfm）：禁用态 `<input disabled>`；选中态用
   `--accent` 填充；`cursor: not-allowed`（markdown 是只读的）。
 
+### 3.13 Tabs（`packages/ui/src/primitives/tabs.tsx` + `maka-tab`）
+
+Tab spec 是“一个 primitive + 两个 variant + neutral state token”，不是每 surface 手写。
+
+- **primitive**：`packages/ui/src/primitives/tabs.tsx`（Base UI Tabs）。`TabsTab` 吐 `maka-tab` class；`TabsList` 接受 `variant="underline" | "pill"` 并设 `data-variant`。`ui.tsx` 的 `TabsRoot/TabsList/TabsTrigger/TabsPanel` re-export 这一套，不走第二套手写。
+- **variant**：
+  - `underline`：active = neutral under-bar（Base UI indicator，`--foreground`），无背景填充。用于切 view + 联动 panel 的真 tabs（plan / skill）。
+  - `pill`：active = `--state-selected-bg` 填充 + bold + neutral border，Base UI indicator 藏掉。用于 pill 风格的 view 切换（catalog 供应商分类）。
+- **token**：tab 不引入专属颜色 token，直接复用 `--state-hover-bg` / `--state-selected-bg`（§1.1）。under-bar 用 `--foreground`——structural chrome 保持中性，品牌色只做 garnish。
+- **不要**：手写 `[data-state=active]::after` under-bar、手写 `[data-active="true"]` brand 背景、per-surface 藏 Base UI indicator。active/hover 一律走 `.maka-tab`。
+- **segmented control（切参数，不是切 view）**：用 `SettingsSegmented`（Base UI ToggleGroup，`packages/ui/src/primitives/settings-segmented.tsx`），不是 Tabs。例如 daily-review range（今日/本周/本月切时间窗口，内容是同一个 report 按 range 重新 fetch，不是 3 个 view）。active 是 `.settingsSegmented button[data-pressed]`（neutral 白底 + 阴影）。
+- **contract**：`tab-spec-499-contract.test.ts` 锁每个 surface 用 `maka-tab` / `SettingsSegmented` + 无手写 active/hover CSS；`state-token-governance-499-contract.test.ts` 禁 selected/active 用 brand token（tab 不再是例外，无需 allowlist）。
+
 ---
 
 ## 4. 动效契约（Motion contract）

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -17,6 +17,7 @@ import {
   formatDailyReviewMarkdown,
 } from './daily-review-helpers.js';
 import { Button as UiButton } from './ui.js';
+import { SettingsSegmented } from './primitives/settings-segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { EmptyState } from './empty-state.js';
 import type { DailyReviewBridge, DailyReviewMarkdownActionInput } from './module-panel-types.js';
@@ -288,25 +289,16 @@ export function DailyReviewPanel(props: {
             ›
           </UiButton>
         </div>
-        <div className="maka-daily-review-range-tabs" role="group" aria-label="时间范围切换">
-          {([1, 7, 30] as const).map((option) => (
-            <UiButton
-              key={option}
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="maka-daily-review-range-tab"
-              data-active={range === option ? 'true' : undefined}
-              aria-pressed={range === option}
-              onClick={() => {
-                setRange(option);
-                setOffsetDays(0);
-              }}
-            >
-              {option === 1 ? '今日' : option === 7 ? '本周' : '本月'}
-            </UiButton>
-          ))}
-        </div>
+        <SettingsSegmented
+          value={String(range)}
+          options={[['1', '今日'], ['7', '本周'], ['30', '本月']]}
+          onChange={(v) => {
+            setRange(Number(v) as DailyReviewRange);
+            setOffsetDays(0);
+          }}
+          ariaLabel="时间范围切换"
+          className="maka-daily-review-range-tabs"
+        />
       </header>
       <section className="maka-daily-review-info" aria-label="每日回顾说明">
         <p className="maka-daily-review-info-hint">

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -395,11 +395,11 @@ export function PlanReminderPanel(props: {
         >
           <div className="maka-plan-tabs-bar">
             <TabsList variant="underline" className="maka-plan-tabs-list" aria-label="计划提醒视图">
-              <TabsTrigger className="maka-tab maka-plan-tab" value="tasks">
+              <TabsTrigger className="maka-plan-tab" value="tasks">
                 我的定时任务
                 <span>{props.reminders.length}</span>
               </TabsTrigger>
-              <TabsTrigger className="maka-tab maka-plan-tab" value="runs">
+              <TabsTrigger className="maka-plan-tab" value="runs">
                 执行记录
                 <span>{visibleRunEntries.length}</span>
               </TabsTrigger>

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -394,12 +394,12 @@ export function PlanReminderPanel(props: {
           }}
         >
           <div className="maka-plan-tabs-bar">
-            <TabsList className="maka-plan-tabs-list" aria-label="计划提醒视图">
-              <TabsTrigger className="maka-plan-tab" value="tasks">
+            <TabsList variant="underline" className="maka-plan-tabs-list" aria-label="计划提醒视图">
+              <TabsTrigger className="maka-tab maka-plan-tab" value="tasks">
                 我的定时任务
                 <span>{props.reminders.length}</span>
               </TabsTrigger>
-              <TabsTrigger className="maka-plan-tab" value="runs">
+              <TabsTrigger className="maka-tab maka-plan-tab" value="runs">
                 执行记录
                 <span>{visibleRunEntries.length}</span>
               </TabsTrigger>

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -4,7 +4,7 @@ import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "../utils.js";
 import type React from "react";
 
-export type TabsVariant = "default" | "underline";
+export type TabsVariant = "default" | "underline" | "pill";
 
 export function Tabs({
   className,
@@ -33,14 +33,15 @@ export function TabsList({
   return (
     <TabsPrimitive.List
       className={cn(
-        "relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-foreground-secondary",
+        "maka-tabs-list relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-foreground-secondary",
         "data-[orientation=vertical]:flex-col",
         variant === "default"
           ? "rounded-md bg-muted p-0.5 text-foreground-secondary/72"
-          : "data-[orientation=vertical]:px-1 data-[orientation=horizontal]:py-1 *:data-[slot=tabs-tab]:hover:bg-accent",
+          : "data-[orientation=vertical]:px-1 data-[orientation=horizontal]:py-1",
         className,
       )}
       data-slot="tabs-list"
+      data-variant={variant}
       {...props}
     >
       {children}
@@ -48,8 +49,10 @@ export function TabsList({
         className={cn(
           "absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) -translate-y-(--active-tab-bottom) transition-[width,translate] duration-200 ease-[var(--ease-in-out-strong)]",
           variant === "underline"
-            ? "z-10 bg-control data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
-            : "-z-1 rounded-md bg-background shadow-sm/5 dark:bg-input",
+            ? "z-10 bg-foreground data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=vertical]:-translate-x-px data-[orientation=horizontal]:translate-y-px"
+            : variant === "pill"
+              ? "hidden"
+              : "-z-1 rounded-md bg-background shadow-sm/5 dark:bg-input",
         )}
         data-slot="tab-indicator"
       />
@@ -64,7 +67,7 @@ export function TabsTab({
   return (
     <TabsPrimitive.Tab
       className={cn(
-        "relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent px-[calc(--spacing(2.5)-1px)] font-medium text-base outline-none transition-[color,background-color,box-shadow] hover:text-foreground-secondary focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 sm:h-8 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
+        "maka-tab relative flex h-9 shrink-0 grow cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent px-[calc(--spacing(2.5)-1px)] font-medium text-base outline-none transition-[color,background-color,box-shadow] hover:text-foreground-secondary focus-visible:ring-2 focus-visible:ring-ring data-disabled:pointer-events-none data-[orientation=vertical]:w-full data-[orientation=vertical]:justify-start data-active:text-foreground data-disabled:opacity-64 sm:h-8 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0",
         className,
       )}
       data-slot="tabs-tab"

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -11,7 +11,7 @@ import {
 } from './icons.js';
 import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
-import { Button as UiButton, Input } from './ui.js';
+import { Button as UiButton, Input, TabsRoot, TabsList, TabsTrigger, TabsPanel } from './ui.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
 import type { SkillEntry } from './module-panel-types.js';
@@ -38,6 +38,13 @@ function SkillLibraryPanel(props: {
     if (!normalizedSkillQuery) return true;
     return `${card.title} ${card.body} ${card.meta}`.toLowerCase().includes(normalizedSkillQuery);
   });
+  const skillListEmptyTitle = normalizedSkillQuery ? '没有匹配的 Skill' : '等待添加 Skill';
+  const skillListEmptyBody: ReactNode = normalizedSkillQuery ? '换一个关键词，或清空搜索查看全部本地技能。' : (
+    <>
+      把一个含 <code className="maka-empty-state-code">SKILL.md</code> 的文件夹放到工作区的
+      {' '}<code className="maka-empty-state-code">skills/</code> 目录下，刷新后会出现在这里。
+    </>
+  );
   const templates = (
     <section className="maka-skill-examples" aria-label="技能示例">
       <ul className="maka-skill-example-grid" aria-label="技能模板示例">
@@ -59,29 +66,22 @@ function SkillLibraryPanel(props: {
 
   const tabs = (
     <div className="maka-skill-tabs-bar">
-      {/* Not role=tablist: these are plain buttons without the ARIA tabs
-          keyboard contract (roving tabindex, arrow keys, linked panels).
-          aria-pressed states the truth — a segmented view switcher. */}
-      <div className="maka-skill-tabs" aria-label="技能视图">
+      <TabsList variant="underline" className="maka-skill-tabs" aria-label="技能视图">
         {([
           ['market', '市场', filteredMarketCards.length],
           ['builtin', '内置', filteredSkills.length],
           ['installed', '已安装', skillCount],
         ] as const).map(([tab, label, count]) => (
-          <UiButton
+          <TabsTrigger
             key={tab}
-            type="button"
-            variant="ghost"
-            aria-pressed={activeSkillTab === tab}
-            className="maka-skill-tab"
-            data-state={activeSkillTab === tab ? 'active' : 'inactive'}
-            onClick={() => setActiveSkillTab(tab)}
+            className="maka-tab maka-skill-tab"
+            value={tab}
           >
             {label}
             {tab === 'installed' && <span>{count}</span>}
-          </UiButton>
+          </TabsTrigger>
         ))}
-      </div>
+      </TabsList>
       {activeSkillTab === 'market' && (
         <div className="maka-skill-filter-actions" aria-label="技能筛选排序">
           {/* Static labels, not disabled buttons: filter/sort are not
@@ -162,8 +162,8 @@ function SkillLibraryPanel(props: {
     </section>
   );
 
-  const skillList = (list: SkillEntry[], emptyTitle: string, emptyBody: ReactNode) => (
-    <section className="maka-skill-installed" aria-label="已安装技能">
+  const skillList = (list: SkillEntry[], emptyTitle: string, emptyBody: ReactNode, label: string) => (
+    <section className="maka-skill-installed" aria-label={label}>
       {list.length === 0 ? (
         <EmptyState
           Icon={Sparkles}
@@ -184,7 +184,7 @@ function SkillLibraryPanel(props: {
       ) : (
         <>
           <div className="maka-skill-section-row">
-            <span className="maka-skill-section-label">{activeSkillTab === 'installed' ? '已安装技能' : '内置技能'}</span>
+            <span className="maka-skill-section-label">{label}</span>
             <small>{list.length} 个</small>
           </div>
           <ul className="maka-skill-library-list" aria-label="技能列表">
@@ -239,20 +239,12 @@ function SkillLibraryPanel(props: {
     return (
       <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
         {banner}
-        {tabs}
-        {activeSkillTab === 'market'
-          ? market
-          : skillList(
-            [],
-            normalizedSkillQuery ? '没有匹配的 Skill' : '等待添加 Skill',
-            normalizedSkillQuery ? '换一个关键词，或清空搜索查看全部本地技能。' : (
-              <>
-                把一个含 <code className="maka-empty-state-code">SKILL.md</code> 的文件夹放到工作区的
-                {' '}<code className="maka-empty-state-code">skills/</code> 目录下，刷新后会出现在这里。
-              </>
-            ),
-          )}
-        {activeSkillTab !== 'market' && templates}
+        <TabsRoot value={activeSkillTab} onValueChange={(v) => setActiveSkillTab(v as 'market' | 'builtin' | 'installed')}>
+          {tabs}
+          <TabsPanel value="market">{market}</TabsPanel>
+          <TabsPanel value="builtin">{skillList([], skillListEmptyTitle, skillListEmptyBody, '内置技能')}{templates}</TabsPanel>
+          <TabsPanel value="installed">{skillList([], skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
+        </TabsRoot>
       </div>
     );
   }
@@ -260,20 +252,12 @@ function SkillLibraryPanel(props: {
   return (
     <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
       {banner}
-      {tabs}
-      {activeSkillTab === 'market'
-        ? market
-        : skillList(
-          filteredSkills,
-          normalizedSkillQuery ? '没有匹配的 Skill' : '等待添加 Skill',
-          normalizedSkillQuery ? '换一个关键词，或清空搜索查看全部本地技能。' : (
-            <>
-              把一个含 <code className="maka-empty-state-code">SKILL.md</code> 的文件夹放到工作区的
-              {' '}<code className="maka-empty-state-code">skills/</code> 目录下，刷新后会出现在这里。
-            </>
-          ),
-        )}
-      {activeSkillTab !== 'market' && templates}
+      <TabsRoot value={activeSkillTab} onValueChange={(v) => setActiveSkillTab(v as 'market' | 'builtin' | 'installed')}>
+        {tabs}
+        <TabsPanel value="market">{market}</TabsPanel>
+        <TabsPanel value="builtin">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '内置技能')}{templates}</TabsPanel>
+        <TabsPanel value="installed">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
+      </TabsRoot>
       <span className="maka-skill-tool-summary-hidden" aria-hidden="true">
         {`${skillCount} 个 Skill · ${new Set((props.skills ?? []).flatMap((skill) => skill.declaredTools ?? [])).size} 类工具`}
       </span>

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -74,7 +74,7 @@ function SkillLibraryPanel(props: {
         ] as const).map(([tab, label, count]) => (
           <TabsTrigger
             key={tab}
-            className="maka-tab maka-skill-tab"
+            className="maka-skill-tab"
             value={tab}
           >
             {label}
@@ -235,20 +235,6 @@ function SkillLibraryPanel(props: {
     </section>
   );
 
-  if (!props.skills || props.skills.length === 0) {
-    return (
-      <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
-        {banner}
-        <TabsRoot value={activeSkillTab} onValueChange={(v) => setActiveSkillTab(v as 'market' | 'builtin' | 'installed')}>
-          {tabs}
-          <TabsPanel value="market">{market}</TabsPanel>
-          <TabsPanel value="builtin">{skillList([], skillListEmptyTitle, skillListEmptyBody, '内置技能')}{templates}</TabsPanel>
-          <TabsPanel value="installed">{skillList([], skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
-        </TabsRoot>
-      </div>
-    );
-  }
-
   return (
     <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
       {banner}
@@ -258,9 +244,11 @@ function SkillLibraryPanel(props: {
         <TabsPanel value="builtin">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '内置技能')}{templates}</TabsPanel>
         <TabsPanel value="installed">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
       </TabsRoot>
-      <span className="maka-skill-tool-summary-hidden" aria-hidden="true">
-        {`${skillCount} 个 Skill · ${new Set((props.skills ?? []).flatMap((skill) => skill.declaredTools ?? [])).size} 类工具`}
-      </span>
+      {props.skills && props.skills.length > 0 ? (
+        <span className="maka-skill-tool-summary-hidden" aria-hidden="true">
+          {`${skillCount} 个 Skill · ${new Set((props.skills ?? []).flatMap((skill) => skill.declaredTools ?? [])).size} 类工具`}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -7,7 +7,6 @@ import { Progress as BaseProgress } from '@base-ui/react/progress';
 import { Radio as BaseRadio } from '@base-ui/react/radio';
 import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group';
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
-import { Tabs as BaseTabs } from '@base-ui/react/tabs';
 import { Toggle as BaseToggle } from '@base-ui/react/toggle';
 import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
 import { Select as BaseSelect } from '@base-ui/react/select';
@@ -254,36 +253,14 @@ export const DialogContent = forwardRef<
   );
 });
 
-export const TabsRoot = BaseTabs.Root;
-export const TabsList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseTabs.List>>(function TabsList(
-  { className, ...props },
-  ref,
-) {
-  return <BaseTabs.List ref={ref} className={cn('inline-flex items-center rounded-md bg-muted p-1', className)} {...props} />;
-});
-
-export const TabsTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseTabs.Tab>>(function TabsTrigger(
-  { className, ...props },
-  ref,
-) {
-  return (
-    <BaseTabs.Tab
-      ref={ref}
-      className={cn(
-        'inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm font-medium text-foreground-secondary transition-colors data-[selected]:bg-background data-[selected]:text-foreground data-[selected]:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        className,
-      )}
-      {...props}
-    />
-  );
-});
-
-export const TabsPanel = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseTabs.Panel>>(function TabsPanel(
-  { className, ...props },
-  ref,
-) {
-  return <BaseTabs.Panel ref={ref} className={cn('focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring', className)} {...props} />;
-});
+// Tabs: re-export the shared tab spec primitive (#499 P0-3). The tab spec
+// (maka-tab class + underline/pill variants + neutral state tokens) lives in
+// primitives/tabs.tsx. ui.tsx used to carry a second hand-rolled set (Base UI
+// + bg-muted plate, no variant, dead data-[selected] active selectors — Base
+// UI sets data-active) which plan-reminder-panel consumed, bypassing the spec.
+// Re-exporting unifies on one primitive so every tab surface gets variant +
+// maka-tab + the correct data-active attribute.
+export { Tabs as TabsRoot, TabsList, TabsTab as TabsTrigger, TabsPanel } from './primitives/tabs.js';
 
 export const SelectRoot = BaseSelect.Root;
 export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Trigger>>(function SelectTrigger(


### PR DESCRIPTION
## Summary

Tab component governance for #499 P0-3: one tab spec primitive (`maka-tab` class + `underline`/`pill` variants on Base UI Tabs), migrate the 4 hand-written tab surfaces, retire per-surface hand-written tab CSS, and collapse the duplicate tab sets (#477 debt). Tab active/hover repoint to the neutral `--state-*` tokens from #503 — no dedicated tab color token.

## Why

#499 P0-3 — tabs had no spec; 4 hand-written implementations drifted: plan/skill underline with dead `[data-state]` selectors (Base UI sets `data-active`), catalog brand pill hiding the Base UI indicator, daily-review range hand-rolled `<button aria-pressed>`. Plus `packages/ui/src/ui.tsx` carried a **second** hand-rolled tab set (Base UI + bg-muted plate, no variant, dead `data-[selected]`) that plan-reminder-panel consumed, bypassing the existing `primitives/tabs.tsx`. Direction: structural chrome stays neutral (brand is garnish), one primitive, two intentional variants — and a segmented control for parameter switches (not Tabs).

Refs #499

## Scope

Changed:

- `primitives/tabs.tsx`: `TabsVariant` adds `"pill"`; `TabsList` sets `data-variant` + `maka-tabs-list`; pill hides the Base UI indicator; underline indicator recolored from brand `bg-control` to neutral `bg-foreground`. `TabsTab` emits the shared `maka-tab` class.
- `ui.tsx`: `TabsRoot/TabsList/TabsTrigger/TabsPanel` re-export from `primitives/tabs.tsx` (drops the second hand-rolled set + dead `data-[selected]` active selectors). One tab primitive, not two (#477 debt).
- `maka-tokens.css`: `.maka-tab` spec — pill base shape + `--state-selected-bg` active + `--state-hover-bg` hover + neutral border; underline active = `--foreground` text. Reuses #503 state tokens; no dedicated tab color token.
- `plan-reminder-panel.tsx`: `variant="underline"` + `maka-tab`; drops the dead `.maka-plan-tab[data-state="active"]::after` under-bar (Base UI sets `data-active`, not `data-state` — plan's active visual was actually the Base UI default sliding plate, not the hand-written under-bar).
- `ProvidersPanel.tsx`: catalog → `variant="pill"` + `maka-tab` + `TabsPanel` (oauth → ModelOAuthSection; domestic/overseas/local → filtered provider grid). Drops `data-active={catalogTab === tab.id}` (Base UI sets it) and the `catalogTab` hand-written class; keeps `data-catalog-tab`. Content moves from bare conditional render into panels.
- `skills-panel.tsx`: hand-rolled segmented switcher (`UiButton` + `aria-pressed` + `data-state`) → `Tabs/TabsList/TabsTrigger/TabsPanel` (market/builtin/installed each a panel). a11y upgrade: roving tabindex + arrow-key contract + linked tabpanels. `skillList` gains a `label` param (no longer depends on `activeSkillTab` — safe under default `keepMounted=false`).
- `daily-review-panel.tsx`: range (今日/本周/本月) → `SettingsSegmented` (Base UI ToggleGroup). It switches a time-window parameter, not views — segmented control is the a11y-correct primitive, not Tabs/TabsPanel. Active inherits the neutral `.settingsSegmented button[data-pressed]` chrome.
- CSS cleanup: drop `.catalogPillTabs button` base/hover/active + `[data-slot=tab-indicator] display:none` (models.css), `.catalogTab:hover/[data-active]` (provider-editor.css), `.maka-skill-tab[data-state=active]` + `::after` (skills.css), `.maka-daily-review-range-tab[data-active]` brand (daily-review.css), `.maka-plan-tab[data-state=active]` + `::after` (plan-reminders.css).
- `state-token-governance-499-contract.test.ts`: drop the 5 tab selectors from the selected/active brand-token allowlist (tabs no longer need the carve-out). Onboarding brand-emphasis allowlist stays.
- `design-system.md §3.13 Tabs`: documents the spec (primitive, variants, no dedicated color token, segmented-control rule).
- Contract tests updated: `tab-spec-499-contract.test.ts` (new, per-surface), `model-oauth-section-contract` + `claude-subscription-experimental-gate` (catalog conditional render → TabsPanel), `skills.test` (skillList aria-label dynamic), `daily-review-copy-feedback-contract` (range → SettingsSegmented), `radius-converge-contract` (drop stale TabsTrigger/TabsList ui.tsx entries), `design-system-governance-406-contract` (under-bar `bg-control` → `bg-foreground`).

Not included:

- #499 P0-1/P0-2/P2 (hover/selected/press state governance) — done in #503.
- #499 P1 (design-system.md color section) — done in #496.
- #476 cascade debt, #477 broader React debt.
- Storybook Tabs story (issue didn't require it; #503 added Interaction States).

## Verification

- `npm run -w @maka/desktop test`: 1888 pass / 0 fail (rebased onto main `85c81d9d`).
- `npm run typecheck`: clean (main + renderer + storybook).
- Visual: captured the 4 tab/segmented surfaces × {light, dark} = 8 default-state screenshots with the in-repo fixture harness and human-verified them. Command (from repo root, after `npm run build`):
  ```
  node scripts/capture-screenshots.mjs --scenario <scenario> --variant <light-1280-motion|dark-1280-motion>
  ```
  Scenarios: `provider-workspace` (catalog pill), `module-skills` (skill tabs), `module-daily-review` (daily-review range), `plan-reminders` (plan underline). Output: `apps/desktop/tests/screenshots/<scenario>/<variant>.png`. Conclusion: catalog pill active = neutral wash, skill/plan underline = neutral bar, daily-review range = neutral SettingsSegmented chrome — correct in both light and dark.
- Token / a11y (objective, not pixel-based): `tab-spec-499-contract` verifies `.maka-tab` active/hover use `--state-selected-bg` / `--state-hover-bg` (neutral) with no brand token; `design-system-governance-406` verifies the under-bar is `bg-foreground`; keyboard a11y (roving tabindex + arrow keys + tabpanel pairing) is guaranteed by Base UI Tabs (plan/catalog/skill) and Base UI ToggleGroup (daily-review range).
- Harness limit: `capture-screenshots.mjs` variants are theme × viewport × motion; it does not capture hover/active/keyboard state variants. Hover/active state correctness is covered by the token/static contract tests above (not by screenshots); keyboard behavior is covered by the Base UI primitive contract. A CDP-driven state-variant harness is a separate piece of work.
- Pre-existing note (not introduced here): 23 tests import `dist/renderer/settings/*.js` by path, but `build:renderer` is vite (chunks, not per-path). A fresh worktree lacks these by-path files; this PR was verified with `tsc -p tsconfig.renderer.json --outDir dist/renderer` to emit per-path dist. This is a test/build setup mismatch — CI may need the same workaround, or the test script should build renderer per-path.

## User-facing impact

- Catalog tabs (供应商分类) active: brand blue → neutral wash + bold.
- Skill tabs: same neutral underline visual, but now real tabs (arrow-key nav + tabpanel) instead of a segmented switcher.
- Daily-review range: brand blue active → neutral white-fill + shadow (SettingsSegmented chrome).
- Plan tabs: Base UI default sliding plate → neutral underline (the hand-written under-bar was dead CSS).

## Reviewer notes

- 8 commits: slice 1 primitive+plan, unify ui.tsx, slice 2 catalog, slice 3 skill, slice 4 daily-review, slice 5 close-out, review P3-2/4 (drop redundant maka-tab + merge skill double return), review P3 (tighten TabsPanel locks to per-value). Each independently builds/typechecks/tests; squash-merge recommended.
- The `ui.tsx` two-sets-of-tabs unification is the structural fix that makes slice 1's `variant="underline"` actually typecheck (plan imported `TabsList` from `ui.js`, which was the hand-rolled set without variant). It's the #477 duplicate-component debt P0-3 had to collapse.
- Biggest a11y change: skill (segmented switcher → real tabs). Biggest visual change: catalog + daily-review range (brand → neutral).
- Review round 2: dropped the redundant `maka-tab` class on tab triggers (primitive already emits it); merged the skills-panel empty/non-empty duplicate return; tightened the `TabsPanel` contract locks from `/TabsPanel/` (matched imports) to per-value (`TabsPanel value="tasks"`, `value="oauth"` + `value={cat}` + `['domestic','overseas','local']`, `value="market|builtin|installed"`). See Verification for the visual verification record.
