### PR TITLE
test(desktop): add behavior tests for the default permission-mode resolver

### DIFF
--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -26,7 +26,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import { readRendererShellSources } from './renderer-shell-source-helpers.js';
 import { readSettingsCombinedSource } from './settings-contract-source-helpers.js';
-import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
+import { readMainTsSource } from './main-process-contract-source-helpers.js';
 
 describe('default permission mode contract', () => {
   it('renderer omits permissionMode unless the user explicitly picked one', async () => {
@@ -50,7 +50,11 @@ describe('default permission mode contract', () => {
     // (see permission-mode-default.test.ts). main.ts must import it and route
     // EVERY permission-mode fallback through it by injecting settingsStore.get
     // — no inline definition and no unguarded inline settings read may remain.
-    const src = await readMainProcessCombinedSource();
+    // Read main.ts only (not the combined source): the resolver now lives in
+    // ./permission-mode-default.ts, which is part of the combined list, and
+    // its `export async function resolveDefaultPermissionMode` would falsely
+    // trip the no-inline assertion below.
+    const src = await readMainTsSource();
 
     assert.match(
       src,
@@ -79,7 +83,7 @@ describe('default permission mode contract', () => {
   });
 
   it('quick chat resolves the default in parallel with the connection check', async () => {
-    const src = await readMainProcessCombinedSource();
+    const src = await readMainTsSource();
     assert.match(
       src,
       /await Promise\.all\(\[\s*getReadyConnection\(input\.defaultConnectionSlug, input\.defaultModel\),\s*input\.mode === 'deep_research'/,

--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -44,26 +44,32 @@ describe('default permission mode contract', () => {
     );
   });
 
-  it('main.ts resolves the default through a hardened helper that can never reject', async () => {
+  it('main.ts routes every session-creation fallback through the extracted resolver (single authority)', async () => {
+    // The resolver lives in ./permission-mode-default.ts as an injected pure
+    // function so its never-rejects fallback is unit-testable in isolation
+    // (see permission-mode-default.test.ts). main.ts must import it and route
+    // EVERY permission-mode fallback through it by injecting settingsStore.get
+    // — no inline definition and no unguarded inline settings read may remain.
     const src = await readMainProcessCombinedSource();
 
-    const helperMatch = src.match(
-      /async function resolveDefaultPermissionMode\(\): Promise<PermissionMode> \{([\s\S]*?)\n\}/,
-    );
-    assert.ok(helperMatch, 'resolveDefaultPermissionMode() must exist in main.ts');
-    const helperBody = helperMatch![1];
     assert.match(
-      helperBody,
-      /try \{[\s\S]*settingsStore\.get\(\)[\s\S]*chatDefaults\.permissionMode[\s\S]*\} catch \{[\s\S]*return 'ask';/,
-      'the helper must read chatDefaults.permissionMode inside try/catch and fall back to \'ask\' -- session creation must never fail because settings.json is unreadable',
+      src,
+      /import \{ resolveDefaultPermissionMode \} from '\.\/permission-mode-default\.js';/,
+      'main.ts must import the extracted resolver',
+    );
+    assert.doesNotMatch(
+      src,
+      /async function resolveDefaultPermissionMode/,
+      'the resolver must live in ./permission-mode-default.ts, not inline in main.ts (so its never-rejects fallback is unit-testable)',
     );
 
-    // Both sessions:create branches + quick chat must use the helper, and no
-    // raw (unguarded) settings read for the permission mode may remain.
-    const helperUses = src.match(/resolveDefaultPermissionMode\(\)/g) ?? [];
+    // Both sessions:create branches (fake + ai-sdk) + quick chat must inject
+    // settingsStore.get into the resolver — proving they route through the
+    // single authority instead of reading settings inline.
+    const routedCalls = src.match(/resolveDefaultPermissionMode\(\(\) => settingsStore\.get\(\)\)/g) ?? [];
     assert.ok(
-      helperUses.length >= 4, // definition + fake branch + ai-sdk branch + quick chat
-      `all session-creation fallbacks must route through resolveDefaultPermissionMode() (found ${helperUses.length} references, expected >= 4)`,
+      routedCalls.length >= 3, // fake branch + ai-sdk branch + quick chat
+      `all session-creation fallbacks must route through resolveDefaultPermissionMode(() => settingsStore.get()) (found ${routedCalls.length}, expected >= 3)`,
     );
     assert.doesNotMatch(
       src,
@@ -86,8 +92,8 @@ describe('default permission mode contract', () => {
 
     assert.match(
       src,
-      /const \[defaultPermissionMode, setDefaultPermissionMode\] = useState<PermissionMode>\('ask'\);/,
-      'app-shell.tsx must track the configured default for composer-chip display',
+      /const \[defaultPermissionMode, setDefaultPermissionMode\] = useState<ChatDefaultPermissionMode>\('ask'\);/,
+      'app-shell.tsx must track the configured default for composer-chip display (typed as ChatDefaultPermissionMode — the configured default can never be explore)',
     );
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -15,6 +15,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/main-window.ts',
   'apps/desktop/src/main/memory-ipc-main.ts',
   'apps/desktop/src/main/oauth-model-connections-main.ts',
+  'apps/desktop/src/main/permission-mode-default.ts',
   'apps/desktop/src/main/plan-reminders-ipc-main.ts',
   'apps/desktop/src/main/plan-reminders-main.ts',
   'apps/desktop/src/main/subscription-model-fetch.ts',
@@ -38,4 +39,12 @@ export function readMainProcessCombinedSourceSync(): string {
   return MAIN_PROCESS_SOURCE_REPO_PATHS
     .map((sourcePath) => readFileSync(resolve(REPO_ROOT, sourcePath), 'utf8'))
     .join('\n');
+}
+
+/** Read just apps/desktop/src/main/main.ts. Use this for assertions that
+ *  target main.ts specifically and must not be matched by another main
+ *  module that the combined source folds in (e.g. the extracted resolver
+ *  module's own `export async function resolveDefaultPermissionMode`). */
+export async function readMainTsSource(): Promise<string> {
+  return readFile(resolve(REPO_ROOT, 'apps/desktop/src/main/main.ts'), 'utf8');
 }

--- a/apps/desktop/src/main/__tests__/permission-mode-default.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-mode-default.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Behavior tests for the chat-default permission-mode resolver. This is the
+ * SINGLE authority for a new session's starting permission mode: the renderer
+ * omits `permissionMode` unless the user explicitly picked one in the composer,
+ * so main.ts resolves the configured `chatDefaults.permissionMode` here at
+ * create time.
+ *
+ * The two guarantees pinned here (and previously only asserted as a source-grep
+ * contract on main.ts):
+ *   1. The configured default is returned verbatim (ask / execute / bypass).
+ *   2. Session creation never fails because settings.json is unreadable — the
+ *      store's get() rethrows anything but ENOENT, so a corrupted file must
+ *      fall back to the safest mode, not reject the create path.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { AppSettings } from '@maka/core';
+import { createDefaultSettings } from '@maka/core/settings';
+import { resolveDefaultPermissionMode } from '../permission-mode-default.js';
+
+describe('resolveDefaultPermissionMode', () => {
+  it('returns the configured chatDefaults.permissionMode', async () => {
+    const settings = createDefaultSettings();
+    settings.chatDefaults.permissionMode = 'execute';
+    const mode = await resolveDefaultPermissionMode(async () => settings);
+    assert.equal(mode, 'execute');
+  });
+
+  it('returns bypass when that is the configured default (no special-casing)', async () => {
+    const settings = createDefaultSettings();
+    settings.chatDefaults.permissionMode = 'bypass';
+    const mode = await resolveDefaultPermissionMode(async () => settings);
+    assert.equal(mode, 'bypass');
+  });
+
+  it('falls back to ask when the settings read rejects (corrupted settings.json)', async () => {
+    const readFailingSettings = async (): Promise<AppSettings> => {
+      throw new Error("simulated settingsStore.get() rethrow (non-ENOENT)");
+    };
+    const mode = await resolveDefaultPermissionMode(readFailingSettings);
+    assert.equal(mode, 'ask');
+  });
+
+  it('defaults to ask via createDefaultSettings when no value is configured', async () => {
+    const mode = await resolveDefaultPermissionMode(async () => createDefaultSettings());
+    assert.equal(mode, 'ask');
+  });
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -123,6 +123,7 @@ import {
 } from './workspace-instructions.js';
 import { buildCapabilitySnapshotCollection, buildPermissionSnapshot } from './capability-snapshot.js';
 import { openSystemPermissionPane, requestPermissionAccess } from './permissions-actions.js';
+import { resolveDefaultPermissionMode } from './permission-mode-default.js';
 import {
   getVisualSmokeState,
   resolveVisualSmokeFixture,
@@ -1023,7 +1024,7 @@ function registerIpc(): void {
         backend: 'fake',
         llmConnectionSlug: input.llmConnectionSlug ?? 'fake',
         model: input.model ?? 'fake-model',
-        permissionMode: input.permissionMode ?? (await resolveDefaultPermissionMode()),
+        permissionMode: input.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
         name: input.name ?? 'New Chat',
         labels: input.labels,
       });
@@ -1039,7 +1040,7 @@ function registerIpc(): void {
       backend: 'ai-sdk',
       llmConnectionSlug: connection.slug,
       model,
-      permissionMode: input?.permissionMode ?? (await resolveDefaultPermissionMode()),
+      permissionMode: input?.permissionMode ?? (await resolveDefaultPermissionMode(() => settingsStore.get())),
       name: input?.name ?? 'New Chat',
       labels: input?.labels,
     });
@@ -1541,23 +1542,6 @@ function getReadyConnection(slug: string | null | undefined, model?: string) {
 }
 
 /**
- * Settings → 通用 → 默认权限模式, hardened: session creation must never
- * fail because settings.json is unreadable/corrupted (settingsStore.get()
- * rethrows anything but ENOENT). Before this fallback existed the mode was
- * a synchronous `'ask'` literal with zero settings dependency — keep that
- * never-fails guarantee by falling back to the safest mode on any error.
- * This is the SINGLE authority for a new session's default: the renderer
- * intentionally omits permissionMode unless the user explicitly picked one.
- */
-async function resolveDefaultPermissionMode(): Promise<PermissionMode> {
-  try {
-    return (await settingsStore.get()).chatDefaults.permissionMode;
-  } catch {
-    return 'ask';
-  }
-}
-
-/**
  * PR110b: Quick Chat entry — thin adapter over the extracted helper.
  * The discriminated-union logic + readiness gating lives in
  * `./quick-chat.ts` so it can be unit-tested without spinning up an
@@ -1579,7 +1563,7 @@ async function handleQuickChatStart(rawInput: unknown): Promise<QuickChatResult>
         getReadyConnection(input.defaultConnectionSlug, input.defaultModel),
         input.mode === 'deep_research'
           ? Promise.resolve<PermissionMode>('explore')
-          : resolveDefaultPermissionMode(),
+          : resolveDefaultPermissionMode(() => settingsStore.get()),
       ]);
       return runtime.createSession({
         cwd: process.cwd(),

--- a/apps/desktop/src/main/permission-mode-default.ts
+++ b/apps/desktop/src/main/permission-mode-default.ts
@@ -1,0 +1,24 @@
+import type { AppSettings, PermissionMode } from '@maka/core';
+
+/**
+ * Reads the configured chat-default permission mode (Settings → 通用 →
+ * 默认权限模式). Hardened: session creation must never fail because
+ * settings.json is unreadable/corrupted — the store's `get()` rethrows
+ * anything but ENOENT, so a corrupted file would otherwise reject the
+ * whole create path. Falls back to the safest mode on any error.
+ *
+ * This is the SINGLE authority for a new session's default: the renderer
+ * intentionally omits `permissionMode` unless the user explicitly picked
+ * one, so this resolver reads the source of truth (settingsStore) at
+ * create time. Kept as an injected pure function so the never-rejects
+ * fallback can be unit-tested without a settings.json on disk.
+ */
+export async function resolveDefaultPermissionMode(
+  readSettings: () => Promise<AppSettings>,
+): Promise<PermissionMode> {
+  try {
+    return (await readSettings()).chatDefaults.permissionMode;
+  } catch {
+    return 'ask';
+  }
+}

--- a/apps/desktop/src/main/permission-mode-default.ts
+++ b/apps/desktop/src/main/permission-mode-default.ts
@@ -1,21 +1,11 @@
-import type { AppSettings, PermissionMode } from '@maka/core';
+import type { AppSettings, ChatDefaultPermissionMode } from '@maka/core';
 
-/**
- * Reads the configured chat-default permission mode (Settings → 通用 →
- * 默认权限模式). Hardened: session creation must never fail because
- * settings.json is unreadable/corrupted — the store's `get()` rethrows
- * anything but ENOENT, so a corrupted file would otherwise reject the
- * whole create path. Falls back to the safest mode on any error.
- *
- * This is the SINGLE authority for a new session's default: the renderer
- * intentionally omits `permissionMode` unless the user explicitly picked
- * one, so this resolver reads the source of truth (settingsStore) at
- * create time. Kept as an injected pure function so the never-rejects
- * fallback can be unit-tested without a settings.json on disk.
- */
+/** Read the configured chat-default permission mode; fall back to 'ask' if
+ *  settings cannot be read (so session creation never fails on a corrupted
+ *  settings.json). Injected so the fallback is unit-testable. */
 export async function resolveDefaultPermissionMode(
   readSettings: () => Promise<AppSettings>,
-): Promise<PermissionMode> {
+): Promise<ChatDefaultPermissionMode> {
   try {
     return (await readSettings()).chatDefaults.permissionMode;
   } catch {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import type {
+  ChatDefaultPermissionMode,
   ConnectionEvent,
   LlmConnection,
   PermissionMode,
@@ -193,7 +194,7 @@ export function AppShell() {
   // (the renderer omits permissionMode unless the user explicitly picked),
   // so a stale value here can briefly mislabel the chip but never changes
   // which mode a session is created with.
-  const [defaultPermissionMode, setDefaultPermissionMode] = useState<PermissionMode>('ask');
+  const [defaultPermissionMode, setDefaultPermissionMode] = useState<ChatDefaultPermissionMode>('ask');
   const [skills, setSkills] = useState<SkillEntry[]>([]);
   const [planReminders, setPlanReminders] = useState<PlanReminder[]>([]);
   const [appInfo, setAppInfo] = useState<RendererAppInfo | null>(null);


### PR DESCRIPTION
## Summary
Turn the "session creation never fails because settings.json is unreadable" guarantee — which #513 pinned only as a source-grep contract on main.ts — into a real runtime behavior test, by extracting the resolver into an injectable pure function.

## Why
Refs #513.

#513's `default-permission-mode-contract.test.ts` asserted the never-rejects fallback by grepping main.ts's inline function body. That breaks under any rename/reformat and, more importantly, proves the code *looks* right without proving it *behaves* right — a rejecting settings read that silently turned into a thrown session-create would still pass the grep.

## Scope
Changed:
- Extract `resolveDefaultPermissionMode` from main.ts into `apps/desktop/src/main/permission-mode-default.ts` as an injected pure function (a `readSettings` parameter).
- Add `permission-mode-default.test.ts` covering: configured ask/execute/bypass returned verbatim; a rejecting settings read (corrupted settings.json) falls back to 'ask'.
- main.ts imports the resolver and injects `settingsStore.get` at all three session-creation fallbacks (fake + ai-sdk branches + quick chat).
- Update `default-permission-mode-contract.test.ts` to assert the routing (import + injected calls) instead of grepping the inline body, and to forbid re-inlining.
- Narrow app-shell.tsx's display-only `defaultPermissionMode` mirror to `ChatDefaultPermissionMode` (the configured default can never be 'explore').

Not included:
- settings-surface ticket mechanism under cross-field concurrent updates (pre-existing; separate PR).
- DOM-level behavior test for the Settings focus-churn fix (needs a React/dom harness the repo lacks today).

## Verification
- typecheck clean across all workspaces.
- desktop 1886/1886 (incl. new resolver behavior tests + updated contract).

## User-facing impact
None. The renderer-omits / single-authority design from #513 is unchanged; this is a pure test-strengthening + extraction refactor.

## Reviewer notes
The contract-test changes are intentional: extraction moves the function out of main.ts, so the old "grep the inline body" assertion can no longer hold. It's replaced by a routing assertion (import + injected calls) plus behavior tests on the extracted module — strictly stronger.
