### PR TITLE
fix(headless): resolve connection defaults from llm-connections.json

### DIFF
--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test, afterEach } from 'node:test';
+import { applyConnectionDefaults } from '../harbor-cli.js';
+
+/**
+ * Tests for applyConnectionDefaults — the function that reads
+ * llm-connections.json and injects MAKA_MODEL, MAKA_LLM_CONNECTION_SLUG,
+ * and MAKA_BASE_URL into the env when no explicit model is set.
+ */
+
+let cleanupDirs: string[] = [];
+
+function makeTempConnections(content: object): string {
+  const dir = mkdtempSync(join(tmpdir(), 'maka-conn-test-'));
+  cleanupDirs.push(dir);
+  const filePath = join(dir, 'llm-connections.json');
+  writeFileSync(filePath, JSON.stringify(content), 'utf8');
+  return filePath;
+}
+
+afterEach(() => {
+  for (const dir of cleanupDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  }
+  cleanupDirs = [];
+});
+
+describe('applyConnectionDefaults', () => {
+  test('happy path: injects env vars from default connection', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, 'anthropic/claude-sonnet-4-20250514');
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'harbor-anthropic');
+    assert.equal(env.MAKA_BASE_URL, 'http://127.0.0.1:8537');
+  });
+
+  test('MAKA_MODEL already set → no override', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_MODEL: 'deepseek/deepseek-v4-flash',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, 'deepseek/deepseek-v4-flash');
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('HARBOR_MODEL already set → no override', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      HARBOR_MODEL: 'some-model',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('file missing → no error, no env vars set', () => {
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: '/tmp/nonexistent-path-abc123/llm-connections.json',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('defaultSlug connection has enabled:false → skipped', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: false,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('connection has no baseUrl → MAKA_BASE_URL not set', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'deepseek-default',
+      connections: [
+        {
+          slug: 'deepseek-default',
+          providerType: 'deepseek',
+          defaultModel: 'deepseek-v4-flash',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, 'deepseek/deepseek-v4-flash');
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'deepseek-default');
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('MAKA_CONNECTIONS_PATH override works', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'custom-conn',
+      connections: [
+        {
+          slug: 'custom-conn',
+          providerType: 'moonshot',
+          defaultModel: 'moonshot-v1-8k',
+          baseUrl: 'https://api.moonshot.cn/v1',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, 'moonshot/moonshot-v1-8k');
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'custom-conn');
+    assert.equal(env.MAKA_BASE_URL, 'https://api.moonshot.cn/v1');
+  });
+
+  test('malformed JSON → no error, no env vars set', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'maka-conn-test-'));
+    cleanupDirs.push(dir);
+    const filePath = join(dir, 'llm-connections.json');
+    writeFileSync(filePath, '{ not valid json!!!', 'utf8');
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: filePath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('no defaultSlug in file → no env vars set', () => {
+    const connectionsPath = makeTempConnections({
+      connections: [
+        {
+          slug: 'some-conn',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+  });
+
+  test('defaultSlug points to non-existent connection → no env vars set', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'missing-slug',
+      connections: [
+        {
+          slug: 'other-conn',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+  });
+});

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describe, test, afterEach } from 'node:test';
-import { applyConnectionDefaults } from '../harbor-cli.js';
+import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
 
 /**
  * Tests for applyConnectionDefaults — the function that reads
@@ -51,6 +51,21 @@ describe('applyConnectionDefaults', () => {
     assert.equal(env.MAKA_MODEL, 'anthropic/claude-sonnet-4-20250514');
     assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'harbor-anthropic');
     assert.equal(env.MAKA_BASE_URL, 'http://127.0.0.1:8537');
+  });
+
+  test('sets MAKA_CREDENTIALS_PATH to credentials.json next to the connections file (cross-platform no-env)', () => {
+    // credentials.json lives next to llm-connections.json in the workspace.
+    // Without this, readStoredMakaApiKey falls back to the macOS-only path and
+    // Windows/Linux users can read the default connection but not its API key.
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        { slug: 'harbor-anthropic', providerType: 'anthropic', defaultModel: 'claude-sonnet-4-20250514', baseUrl: 'http://127.0.0.1:8537', enabled: true },
+      ],
+    });
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+    assert.equal(env.MAKA_CREDENTIALS_PATH, join(dirname(connectionsPath), 'credentials.json'));
   });
 
   test('MAKA_MODEL already set → no override', () => {
@@ -378,5 +393,46 @@ describe('applyConnectionDefaults', () => {
     assert.equal(env.MAKA_MODEL, undefined);
     assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
     assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+});
+
+describe('resolveHarborRunOptions backend guard', () => {
+  test('--backend fake flag skips applyConnectionDefaults (no desktop connection pollution)', async () => {
+    // cliEnv does not forward the --backend flag into env.MAKA_BACKEND, so the
+    // in-function guard inside applyConnectionDefaults only covers the
+    // MAKA_BACKEND env-var path. resolveHarborRunOptions must resolve backend
+    // first and skip applyConnectionDefaults for non-ai-sdk backends.
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        { slug: 'harbor-anthropic', providerType: 'anthropic', defaultModel: 'claude-sonnet-4-20250514', baseUrl: 'http://127.0.0.1:8537', enabled: true },
+      ],
+    });
+    const opts = await resolveHarborRunOptions(
+      ['--backend', 'fake', '--instruction', 'test'],
+      { MAKA_CONNECTIONS_PATH: connectionsPath },
+    );
+    assert.equal(opts.backend, 'fake');
+    assert.equal(opts.env.MAKA_MODEL, undefined, 'desktop default connection must not pollute fake backend');
+    assert.equal(opts.env.MAKA_LLM_CONNECTION_SLUG, undefined);
+  });
+
+  test('--api-key-file infers provider from the default connection (anthropic, not deepseek)', async () => {
+    // applyApiKeyFile runs after applyConnectionDefaults, so its provider
+    // inference must use the resolved MAKA_MODEL (anthropic), not a hardcoded
+    // default. Without the ordering, --api-key-file would write
+    // DEEPSEEK_API_KEY_FILE for an anthropic default connection.
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        { slug: 'harbor-anthropic', providerType: 'anthropic', defaultModel: 'claude-sonnet-4-20250514', baseUrl: 'http://127.0.0.1:8537', enabled: true },
+      ],
+    });
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--api-key-file', '/tmp/key', '--isolation', 'harbor-local'],
+      { MAKA_CONNECTIONS_PATH: connectionsPath },
+    );
+    assert.equal(opts.env.ANTHROPIC_API_KEY_FILE, '/tmp/key');
+    assert.equal(opts.env.DEEPSEEK_API_KEY_FILE, undefined);
   });
 });

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -231,4 +231,152 @@ describe('applyConnectionDefaults', () => {
     assert.equal(env.MAKA_MODEL, undefined);
     assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
   });
+
+  test('MAKA_PROVIDER set without MAKA_MODEL → no override (respects explicit provider)', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_PROVIDER: 'deepseek',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('MAKA_BASE_URL set without MAKA_MODEL → base-url not overwritten', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_BASE_URL: 'http://custom-url:9999',
+    };
+    applyConnectionDefaults(env);
+
+    // Model gets set since no MAKA_MODEL/HARBOR_MODEL/MAKA_PROVIDER/MAKA_LLM_CONNECTION_SLUG guard triggered
+    assert.equal(env.MAKA_MODEL, 'anthropic/claude-sonnet-4-20250514');
+    // But MAKA_BASE_URL is NOT overwritten (per-field respect)
+    assert.equal(env.MAKA_BASE_URL, 'http://custom-url:9999');
+  });
+
+  test('MAKA_LLM_CONNECTION_SLUG set without MAKA_MODEL → no override (respects explicit slug)', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_LLM_CONNECTION_SLUG: 'my-custom-slug',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, 'my-custom-slug');
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('MAKA_BACKEND=fake → no defaults applied', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_BACKEND: 'fake',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('MAKA_BACKEND=pi-agent → no defaults applied', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-anthropic',
+      connections: [
+        {
+          slug: 'harbor-anthropic',
+          providerType: 'anthropic',
+          defaultModel: 'claude-sonnet-4-20250514',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = {
+      MAKA_CONNECTIONS_PATH: connectionsPath,
+      MAKA_BACKEND: 'pi-agent',
+    };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
+
+  test('invalid providerType in connections file → no-op', () => {
+    const connectionsPath = makeTempConnections({
+      defaultSlug: 'harbor-invalid',
+      connections: [
+        {
+          slug: 'harbor-invalid',
+          providerType: 'totally-unknown-provider',
+          defaultModel: 'some-model',
+          baseUrl: 'http://127.0.0.1:8537',
+          enabled: true,
+        },
+      ],
+    });
+
+    const env: Record<string, string | undefined> = { MAKA_CONNECTIONS_PATH: connectionsPath };
+    applyConnectionDefaults(env);
+
+    assert.equal(env.MAKA_MODEL, undefined);
+    assert.equal(env.MAKA_LLM_CONNECTION_SLUG, undefined);
+    assert.equal(env.MAKA_BASE_URL, undefined);
+  });
 });

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import type { BackendKind, ProviderType } from '@maka/core';
 import { PROVIDER_DEFAULTS } from '@maka/core';
@@ -227,6 +229,7 @@ async function resolveHarborRunOptions(args: string[], baseEnv: NodeJS.ProcessEn
   const parsed = parseArgs(args, HARBOR_RUN_FLAGS, HARBOR_RUN_BOOLS);
   if (parsed.positional.length > 0) throw new Error(`unexpected positional argument: ${parsed.positional[0]}`);
   const env = cliEnv(parsed, baseEnv);
+  applyConnectionDefaults(env);
   const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
   const backend = backendKind(valueOf(parsed, env, 'backend', 'MAKA_BACKEND') ?? 'ai-sdk');
   const isolation = optionalIsolation(valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION);
@@ -535,6 +538,42 @@ function officialVerifierKind(value: string): OfficialVerifier {
 function backendKind(value: string): BackendKind {
   if (value === 'fake' || value === 'ai-sdk' || value === 'pi-agent') return value;
   throw new Error(`--backend must be fake, ai-sdk, or pi-agent, got ${JSON.stringify(value)}`);
+}
+
+/**
+ * When no explicit MAKA_MODEL is set, read the desktop workspace's
+ * llm-connections.json and inject the default connection's provider, model,
+ * slug, and baseUrl into env so downstream code resolves them naturally.
+ */
+export function applyConnectionDefaults(env: Record<string, string | undefined>): void {
+  if (env.MAKA_MODEL || env.HARBOR_MODEL) return;
+  const connectionsPath = env.MAKA_CONNECTIONS_PATH ?? resolveDefaultConnectionsPath();
+  try {
+    const file = JSON.parse(readFileSync(connectionsPath, 'utf8')) as {
+      defaultSlug?: string | null;
+      connections?: Array<{ slug: string; providerType?: string; defaultModel?: string; baseUrl?: string; enabled?: boolean }>;
+    };
+    if (!file.defaultSlug || !Array.isArray(file.connections)) return;
+    const conn = file.connections.find(c => c.slug === file.defaultSlug && c.enabled !== false);
+    if (!conn?.providerType || !conn.defaultModel) return;
+    env.MAKA_MODEL = `${conn.providerType}/${conn.defaultModel}`;
+    env.MAKA_LLM_CONNECTION_SLUG = conn.slug;
+    if (conn.baseUrl) env.MAKA_BASE_URL = conn.baseUrl;
+  } catch {
+    // File doesn't exist or is malformed — fall through to existing hardcoded defaults
+  }
+}
+
+export function resolveDefaultConnectionsPath(): string {
+  const home = homedir();
+  switch (process.platform) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', 'Maka', 'workspaces', 'default', 'llm-connections.json');
+    case 'win32':
+      return join(process.env.APPDATA ?? join(home, 'AppData', 'Roaming'), 'Maka', 'workspaces', 'default', 'llm-connections.json');
+    default:
+      return join(process.env.XDG_CONFIG_HOME ?? join(home, '.config'), 'Maka', 'workspaces', 'default', 'llm-connections.json');
+  }
 }
 
 function parseModelSpec(rawModel: string, rawProvider: string | undefined): { provider: ProviderType; model: string } {

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -230,6 +230,7 @@ async function resolveHarborRunOptions(args: string[], baseEnv: NodeJS.ProcessEn
   if (parsed.positional.length > 0) throw new Error(`unexpected positional argument: ${parsed.positional[0]}`);
   const env = cliEnv(parsed, baseEnv);
   applyConnectionDefaults(env);
+  applyApiKeyFile(parsed, env);
   const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
   const backend = backendKind(valueOf(parsed, env, 'backend', 'MAKA_BACKEND') ?? 'ai-sdk');
   const isolation = optionalIsolation(valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION);
@@ -470,11 +471,17 @@ function cliEnv(parsed: ParsedArgs, baseEnv: NodeJS.ProcessEnv): RunHarborCellEn
   if (parsed.flags.benchmark && parsed.flags.benchmark !== 'terminal-bench') {
     throw new Error('--benchmark currently supports only terminal-bench');
   }
-  if (parsed.flags['api-key-file']) {
-    const provider = providerFromValue(parsed.flags.provider ?? env.MAKA_PROVIDER ?? providerFromModel(env.MAKA_MODEL ?? env.HARBOR_MODEL));
-    env[apiKeyFileEnvName(provider)] = parsed.flags['api-key-file'];
-  }
   return env;
+}
+
+/**
+ * Apply --api-key-file AFTER applyConnectionDefaults so that provider
+ * inference uses the final resolved MAKA_MODEL, not the pre-defaults value.
+ */
+function applyApiKeyFile(parsed: ParsedArgs, env: RunHarborCellEnv): void {
+  if (!parsed.flags['api-key-file']) return;
+  const provider = providerFromValue(parsed.flags.provider ?? env.MAKA_PROVIDER ?? providerFromModel(env.MAKA_MODEL ?? env.HARBOR_MODEL));
+  env[apiKeyFileEnvName(provider)] = parsed.flags['api-key-file'];
 }
 
 async function instructionFromOptions(parsed: ParsedArgs, env: RunHarborCellEnv): Promise<string> {
@@ -541,12 +548,23 @@ function backendKind(value: string): BackendKind {
 }
 
 /**
- * When no explicit MAKA_MODEL is set, read the desktop workspace's
- * llm-connections.json and inject the default connection's provider, model,
- * slug, and baseUrl into env so downstream code resolves them naturally.
+ * When no explicit model/provider/connection input is set, read the desktop
+ * workspace's llm-connections.json and inject the default connection's
+ * provider, model, slug, and baseUrl into env so downstream code resolves
+ * them naturally.
+ *
+ * Guards:
+ * - Skip if any explicit model/provider/connection input is already set
+ * - Skip for non-ai-sdk backends (fake, pi-agent)
+ * - Validate providerType against PROVIDER_DEFAULTS before writing
+ * - Only write MAKA_LLM_CONNECTION_SLUG / MAKA_BASE_URL if they are undefined
  */
 export function applyConnectionDefaults(env: Record<string, string | undefined>): void {
-  if (env.MAKA_MODEL || env.HARBOR_MODEL) return;
+  // Skip if any explicit model/provider/connection input is set
+  if (env.MAKA_MODEL || env.HARBOR_MODEL || env.MAKA_PROVIDER || env.MAKA_LLM_CONNECTION_SLUG) return;
+  // Skip for non-ai-sdk backends
+  if (env.MAKA_BACKEND === 'fake' || env.MAKA_BACKEND === 'pi-agent') return;
+
   const connectionsPath = env.MAKA_CONNECTIONS_PATH ?? resolveDefaultConnectionsPath();
   try {
     const file = JSON.parse(readFileSync(connectionsPath, 'utf8')) as {
@@ -556,9 +574,12 @@ export function applyConnectionDefaults(env: Record<string, string | undefined>)
     if (!file.defaultSlug || !Array.isArray(file.connections)) return;
     const conn = file.connections.find(c => c.slug === file.defaultSlug && c.enabled !== false);
     if (!conn?.providerType || !conn.defaultModel) return;
+    // Validate providerType against known providers
+    if (!(conn.providerType in PROVIDER_DEFAULTS)) return;
+
     env.MAKA_MODEL = `${conn.providerType}/${conn.defaultModel}`;
-    env.MAKA_LLM_CONNECTION_SLUG = conn.slug;
-    if (conn.baseUrl) env.MAKA_BASE_URL = conn.baseUrl;
+    if (env.MAKA_LLM_CONNECTION_SLUG === undefined) env.MAKA_LLM_CONNECTION_SLUG = conn.slug;
+    if (env.MAKA_BASE_URL === undefined && conn.baseUrl) env.MAKA_BASE_URL = conn.baseUrl;
   } catch {
     // File doesn't exist or is malformed — fall through to existing hardcoded defaults
   }

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import type { BackendKind, ProviderType } from '@maka/core';
 import { PROVIDER_DEFAULTS } from '@maka/core';
 import type { Config, Task } from './contracts.js';
@@ -225,14 +225,20 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   return benchmarkFailure.shouldThrow ? 1 : 0;
 }
 
-async function resolveHarborRunOptions(args: string[], baseEnv: NodeJS.ProcessEnv): Promise<HarborRunOptions> {
+export async function resolveHarborRunOptions(args: string[], baseEnv: NodeJS.ProcessEnv): Promise<HarborRunOptions> {
   const parsed = parseArgs(args, HARBOR_RUN_FLAGS, HARBOR_RUN_BOOLS);
   if (parsed.positional.length > 0) throw new Error(`unexpected positional argument: ${parsed.positional[0]}`);
   const env = cliEnv(parsed, baseEnv);
-  applyConnectionDefaults(env);
+  // Resolve backend before applying desktop defaults so --backend fake /
+  // pi-agent never picks up the workspace's default connection. cliEnv does
+  // not forward the backend flag, so guarding inside applyConnectionDefaults
+  // only covers the MAKA_BACKEND env-var path, not the flag path.
+  const backend = backendKind(valueOf(parsed, env, 'backend', 'MAKA_BACKEND') ?? 'ai-sdk');
+  if (backend === 'ai-sdk') {
+    applyConnectionDefaults(env);
+  }
   applyApiKeyFile(parsed, env);
   const mode = harborMode(valueOf(parsed, env, 'mode', 'MAKA_HARBOR_MODE') ?? 'task-run');
-  const backend = backendKind(valueOf(parsed, env, 'backend', 'MAKA_BACKEND') ?? 'ai-sdk');
   const isolation = optionalIsolation(valueOf(parsed, env, 'isolation', 'MAKA_HARBOR_ISOLATION') ?? env.MAKA_ISOLATION);
   preflightIsolation(backend, isolation, env);
 
@@ -580,6 +586,12 @@ export function applyConnectionDefaults(env: Record<string, string | undefined>)
     env.MAKA_MODEL = `${conn.providerType}/${conn.defaultModel}`;
     if (env.MAKA_LLM_CONNECTION_SLUG === undefined) env.MAKA_LLM_CONNECTION_SLUG = conn.slug;
     if (env.MAKA_BASE_URL === undefined && conn.baseUrl) env.MAKA_BASE_URL = conn.baseUrl;
+    // credentials.json lives next to llm-connections.json in the workspace;
+    // point readStoredMakaApiKey at it so Windows/Linux no-env works too,
+    // not just macOS.
+    if (env.MAKA_CREDENTIALS_PATH === undefined) {
+      env.MAKA_CREDENTIALS_PATH = join(dirname(connectionsPath), 'credentials.json');
+    }
   } catch {
     // File doesn't exist or is malformed — fall through to existing hardcoded defaults
   }


### PR DESCRIPTION
## Summary

- Read the desktop workspace's `llm-connections.json` `defaultSlug` after `cliEnv()` to inject `MAKA_MODEL`, `MAKA_LLM_CONNECTION_SLUG`, and `MAKA_BASE_URL` into the headless env — so `harbor run` honors configured connections without manual env vars
- No-op when `MAKA_MODEL` or `HARBOR_MODEL` is already explicitly set
- Cross-platform path resolution (macOS/Windows/Linux) with `MAKA_CONNECTIONS_PATH` override
- Comprehensive unit tests (10 cases: happy path, skip-when-set, missing file, disabled connection, no baseUrl, malformed JSON, etc.)

Fixes #521

## Test plan

- [x] `npm --workspace @maka/headless run build` passes
- [x] `node --test dist/__tests__/harbor-cli-connection-defaults.test.js` — all 10 tests pass
- [x] Manual verification: `harbor run` with `harbor-anthropic` coproxy connection resolves correctly (3847 tokens, no `model_resolve_failed`)
- [ ] Verify existing headless tests still pass (`npm --workspace @maka/headless run test`)