### PR TITLE
fix(storage): prevent write-queue memory leak

### DIFF
--- a/packages/storage/src/__tests__/write-queue.test.ts
+++ b/packages/storage/src/__tests__/write-queue.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { chainWrite } from '../write-queue.js';
+
+// Flush all pending microtasks (e.g. a .finally cleanup callback queued
+// after a chain settles) before asserting on Map state.
+const flushMicrotasks = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('chainWrite', () => {
+  it('evicts queue entries once the chain drains', async () => {
+    const queues = new Map<string, Promise<void>>();
+    for (let i = 0; i < 50; i++) {
+      await chainWrite(queues, `k${i}`, async () => {});
+    }
+    // Earlier keys' .finally cleanups run during the subsequent awaits;
+    // setImmediate drains the last key's residual microtask.
+    await flushMicrotasks();
+    assert.equal(queues.size, 0);
+  });
+
+  it('does not evict while a newer write is queued behind', async () => {
+    const queues = new Map<string, Promise<void>>();
+    let resolveOp1!: () => void;
+    let resolveOp2!: () => void;
+    const op1 = () => new Promise<void>((resolve) => { resolveOp1 = resolve; });
+    const op2 = () => new Promise<void>((resolve) => { resolveOp2 = resolve; });
+
+    const p1 = chainWrite(queues, 'k', op1);
+    const p2 = chainWrite(queues, 'k', op2); // queues behind op1; overwrites map entry
+
+    // Let op1's body run (it sets resolveOp1) without completing it.
+    // op2 stays queued behind op1's pending chain.
+    await flushMicrotasks();
+    resolveOp1();
+    await p1; // op1 drains; op2 starts running
+    await flushMicrotasks();
+    // op2 is now in flight — the identity guard must keep its entry
+    // alive (op1's .finally saw get(k) !== its own tracked promise).
+    assert.equal(queues.has('k'), true);
+
+    resolveOp2();
+    await p2;
+    await flushMicrotasks();
+    assert.equal(queues.has('k'), false);
+  });
+
+  it('does not evict when a successor is queued behind a failing write', async () => {
+    // Combines the two axes the tests above split: the in-flight write
+    // rejects *while* a successor is already queued behind it (rather than
+    // a successor queued after the rejection settles). Guards the identity
+    // check under rejection: op1's .finally must see get(k) !== its own
+    // tracked promise (op2 overwrote it) and leave the entry in place for
+    // the still-in-flight op2. Note: this does NOT guard the .catch(noop)
+    // swallow — op2's .then(op, op) already absorbs op1's rejection — that
+    // invariant is covered by the "keeps the chain alive" test below.
+    const queues = new Map<string, Promise<void>>();
+    let rejectOp1!: (e: Error) => void;
+    let resolveOp2!: () => void;
+    const p1 = chainWrite(queues, 'k', () => new Promise<void>((_, rej) => { rejectOp1 = rej; }));
+    const p2 = chainWrite(queues, 'k', () => new Promise<void>((res) => { resolveOp2 = res; }));
+
+    // op1's body runs and parks on rejectOp1; op2 stays queued behind it.
+    await flushMicrotasks();
+    rejectOp1(new Error('boom'));
+    await assert.rejects(p1, /boom/);
+    await flushMicrotasks();
+    // op2 is now in flight — the identity guard kept its entry alive.
+    assert.equal(queues.has('k'), true);
+
+    resolveOp2();
+    await p2;
+    await flushMicrotasks();
+    assert.equal(queues.size, 0);
+  });
+
+  it('serializes operations under the same key in call order', async () => {
+    const queues = new Map<string, Promise<void>>();
+    const order: number[] = [];
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < 5; i++) {
+      promises.push(chainWrite(queues, 'k', async () => { order.push(i); }));
+    }
+    await Promise.all(promises);
+    assert.deepEqual(order, [0, 1, 2, 3, 4]);
+  });
+
+  it('propagates rejection to the caller and keeps the chain alive', async () => {
+    const queues = new Map<string, Promise<void>>();
+    await assert.rejects(
+      chainWrite(queues, 'k', async () => { throw new Error('boom'); }),
+      /boom/,
+    );
+    // The Map-held chain swallowed the rejection; a subsequent write
+    // under the same key must still run.
+    let ran = false;
+    await chainWrite(queues, 'k', async () => { ran = true; });
+    assert.equal(ran, true);
+    await flushMicrotasks();
+    assert.equal(queues.size, 0);
+  });
+});

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { chainWrite } from './write-queue.js';
 import {
   AGENT_RUN_STATUSES,
   isPermissionMode,
@@ -150,16 +151,7 @@ class FileAgentRunStore implements AgentRunStore {
   private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    const key = `${sessionId}:${runId}`;
-    const previous = this.writeQueues.get(key) ?? Promise.resolve();
-    const next = previous.then(operation, operation);
-    this.writeQueues.set(
-      key,
-      next.catch(() => {
-        // Keep the chain alive after failures.
-      }),
-    );
-    return next;
+    return chainWrite(this.writeQueues, `${sessionId}:${runId}`, operation);
   }
 }
 
@@ -230,16 +222,7 @@ class FileRuntimeEventStore implements RuntimeEventStore {
   private withQueue(sessionId: string, runId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    const key = `${sessionId}:${runId}`;
-    const previous = this.writeQueues.get(key) ?? Promise.resolve();
-    const next = previous.then(operation, operation);
-    this.writeQueues.set(
-      key,
-      next.catch(() => {
-        // Keep the chain alive after failures.
-      }),
-    );
-    return next;
+    return chainWrite(this.writeQueues, `${sessionId}:${runId}`, operation);
   }
 }
 

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { chainWrite } from './write-queue.js';
 import { deriveTurnRecords, isPermissionMode, isSessionBlockedReason, isSessionStatus, normalizeUserSessionName } from '@maka/core';
 import type {
   CreateSessionInput,
@@ -362,15 +363,7 @@ class FileSessionStore implements SessionStore {
 
   private withQueue(sessionId: string, operation: () => Promise<void>): Promise<void> {
     assertSafeSessionId(sessionId);
-    const previous = this.writeQueues.get(sessionId) ?? Promise.resolve();
-    const next = previous.then(operation, operation);
-    this.writeQueues.set(
-      sessionId,
-      next.catch(() => {
-        // Keep the chain alive after failures.
-      }),
-    );
-    return next;
+    return chainWrite(this.writeQueues, sessionId, operation);
   }
 }
 

--- a/packages/storage/src/write-queue.ts
+++ b/packages/storage/src/write-queue.ts
@@ -1,0 +1,26 @@
+/**
+ * Serialize a write operation under `key` against a per-key promise
+ * chain held in `queueMap`. Once the chain for a key drains with no
+ * newer write queued behind it, the entry self-evicts so the Map
+ * does not accumulate one settled Promise per key forever.
+ *
+ * The returned promise rejects on operation failure so callers can
+ * observe errors; the Map-held chain swallows rejections only to keep
+ * the chain alive for subsequent writes.
+ */
+export function chainWrite(
+  queueMap: Map<string, Promise<void>>,
+  key: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  const previous = queueMap.get(key) ?? Promise.resolve();
+  const next = previous.then(operation, operation);
+  const stored = next.catch(() => {
+    // Keep the chain alive after failures.
+  });
+  const tracked = stored.finally(() => {
+    if (queueMap.get(key) === tracked) queueMap.delete(key);
+  });
+  queueMap.set(key, tracked);
+  return next;
+}


### PR DESCRIPTION
## Summary

  - Three persistence stores held per-key write-serialization Maps whose entries were never removed, leaking ~200 bytes per deleted session / per run over the process lifetime.

  - Extract a shared chainWrite helper that removes an entry once its write chain drains, guarded against deleting an entry a newer write replaced.

- The three withQueue methods delegate to it; behavior is otherwise unchanged.
  
- Added chainWrite unit tests (cleanup, identity guard, serialization order, error propagation)

- Verified the cleanup tests fail when the `.finally` is removed (50 !== 0) while serialization stays green.