### PR TITLE
fix(desktop): kill startup flash — prefetch onboarding snapshot before React mounts

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -32,6 +32,7 @@ import { useCommandPalette } from './command-palette';
 import { OnboardingHero } from './OnboardingHero';
 import { FirstRunChecklist } from './FirstRunChecklist';
 import { useOnboardingSnapshot } from './use-onboarding-snapshot';
+import type { OnboardingSnapshot } from '../global';
 import { ProviderLogo } from './settings/provider-display';
 import { ProviderBrandMark } from './settings/provider-brand-marks';
 // Artifact pane + embedded browser panel are only mounted for sessions
@@ -110,7 +111,12 @@ type ComposerImportOwner = {
   navSection: NavSelection['section'];
 };
 
-export function AppShell() {
+export function AppShell({
+  initialOnboardingSnapshot = null,
+}: {
+  /** Pre-mount snapshot prefetched by main.tsx — see prefetchOnboardingSnapshot. */
+  initialOnboardingSnapshot?: OnboardingSnapshot | null;
+} = {}) {
   const toastApi = useToast();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const sessionsRef = useRef<SessionSummary[]>([]);
@@ -633,7 +639,7 @@ export function AppShell() {
   // `sessions:changed` + `connections:event`. The hero renders only
   // when sessions.length === 0; any session (including archived /
   // aborted) takes over with the existing chat surface.
-  const onboarding = useOnboardingSnapshot();
+  const onboarding = useOnboardingSnapshot(initialOnboardingSnapshot);
   const [quickChatPending, setQuickChatPending] = useState(false);
   const quickChatPendingRef = useRef(false);
   const { handleQuickChatSubmit } = createAppShellQuickChatActions({

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -2,13 +2,19 @@ import { StrictMode } from 'react';
 import { ToastProvider } from '@maka/ui';
 import { AppShell } from './app-shell';
 import { ErrorBoundary } from './error-boundary';
+import type { OnboardingSnapshot } from '../global';
 
-export function App() {
+export function App({
+  initialOnboardingSnapshot = null,
+}: {
+  /** Pre-mount snapshot prefetched by main.tsx — see prefetchOnboardingSnapshot. */
+  initialOnboardingSnapshot?: OnboardingSnapshot | null;
+}) {
   return (
     <StrictMode>
       <ErrorBoundary>
         <ToastProvider>
-          <AppShell />
+          <AppShell initialOnboardingSnapshot={initialOnboardingSnapshot} />
         </ToastProvider>
       </ErrorBoundary>
     </StrictMode>

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,7 +1,42 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './app';
 import { applyCachedThemeBeforeMount } from './cached-theme-bootstrap';
+import type { OnboardingSnapshot } from '../global';
 import './styles.css';
 
 applyCachedThemeBeforeMount();
-createRoot(document.getElementById('root')!).render(<App />);
+
+/**
+ * Prefetch the onboarding snapshot BEFORE mounting React. The preload
+ * skeleton (index.html) stays on screen while this resolves, so the first
+ * React commit already has sessions + connections and paints the real
+ * chat surface directly — no intermediate loading card, no layout jump
+ * (the "配置页闪了一下" startup flash).
+ *
+ * Fail-open: one quick retry (the IPC handler may not be registered in
+ * the first milliseconds), then a hard timeout so a wedged main process
+ * can never block the renderer from mounting. On timeout/failure React
+ * mounts with `null` and the classic in-app loading path takes over.
+ */
+async function prefetchOnboardingSnapshot(): Promise<OnboardingSnapshot | null> {
+  const attempt = async (): Promise<OnboardingSnapshot | null> => {
+    try {
+      return await window.maka.onboarding.getSnapshot();
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      try {
+        return await window.maka.onboarding.getSnapshot();
+      } catch {
+        return null;
+      }
+    }
+  };
+  const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), 2500));
+  return Promise.race([attempt(), timeout]);
+}
+
+void prefetchOnboardingSnapshot().then((initialOnboardingSnapshot) => {
+  createRoot(document.getElementById('root')!).render(
+    <App initialOnboardingSnapshot={initialOnboardingSnapshot} />,
+  );
+});

--- a/apps/desktop/src/renderer/use-onboarding-snapshot.ts
+++ b/apps/desktop/src/renderer/use-onboarding-snapshot.ts
@@ -58,12 +58,15 @@ export interface UseOnboardingSnapshotDeps {
  * defense. Tests target the pure poller directly so they don't need
  * a DOM / React runtime.
  */
-export function useOnboardingSnapshotImpl(deps: UseOnboardingSnapshotDeps): UseOnboardingSnapshotResult {
-  const [snapshot, setSnapshot] = useState<OnboardingSnapshot | null>(null);
+export function useOnboardingSnapshotImpl(
+  deps: UseOnboardingSnapshotDeps,
+  initialSnapshot: OnboardingSnapshot | null = null,
+): UseOnboardingSnapshotResult {
+  const [snapshot, setSnapshot] = useState<OnboardingSnapshot | null>(initialSnapshot);
   const [error, setError] = useState<string | null>(null);
-  const sessionsRef = useRef<SessionSummary[] | null>(null);
-  const connectionsRef = useRef<LlmConnection[] | null>(null);
-  const defaultSlugRef = useRef<string | null>(null);
+  const sessionsRef = useRef<SessionSummary[] | null>(initialSnapshot?.sessions ?? null);
+  const connectionsRef = useRef<LlmConnection[] | null>(initialSnapshot?.connections ?? null);
+  const defaultSlugRef = useRef<string | null>(initialSnapshot?.defaultSlug ?? null);
   const pollerRef = useRef<OnboardingSnapshotPoller | null>(null);
 
   if (pollerRef.current === null) {
@@ -185,10 +188,14 @@ function onboardingSnapshotErrorMessage(error: unknown): string {
  * Callers that need a re-pull on a specific UI action (e.g. modal
  * close) should call `refresh()` from the returned object.
  */
-export function useOnboardingSnapshot(): UseOnboardingSnapshotResult {
+export function useOnboardingSnapshot(initialSnapshot: OnboardingSnapshot | null = null): UseOnboardingSnapshotResult {
   // Bind to the live IPC bridge. `deps` is memoized as a module-level
   // object so the effect deps stay stable across re-renders.
-  return useOnboardingSnapshotImpl(LIVE_DEPS);
+  // `initialSnapshot` comes from main.tsx's pre-mount prefetch: with it,
+  // the very first commit already has sessions + connections, so the
+  // startup path never shows the intermediate loading card ("配置页
+  // 闪了一下"). The mount effect still pulls a fresh snapshot.
+  return useOnboardingSnapshotImpl(LIVE_DEPS, initialSnapshot);
 }
 
 const LIVE_DEPS: UseOnboardingSnapshotDeps = {


### PR DESCRIPTION
## 问题
启动时会闪过'像配置页一样'的灰色卡片（用户反馈的启动闪屏）。

## 根因（CDP screencast 实测）
真实启动序列闪过 **三张不同的灰卡**：
1. 0–2.6s：index.html 的 preload 骨架卡（全窗口居中）
2. ~3.0s：React 挂载后换成 `.maka-onboarding-loading` 卡（位于内容面板内，几何位置不同 → 肉眼可见跳动）
3. ~3.3s：卡片再次移位
4. ~3.7s：聊天页才出现

## 修复
`main.tsx` 在 `createRoot().render()` 之前预取 `onboarding:getSnapshot`（失败重试一次 + 2.5s fail-open 超时）。preload 骨架保持到 React 首次 commit，而首次 commit 已带 sessions + connections，直接绘制真实聊天界面。

## 验证
- CDP screencast 复测：preload 骨架 → 聊天页，中间无任何卡片
- `npm --workspace @maka/desktop test`：1892/1892 通过
- typecheck 通过