### PR TITLE
refactor(ui): converge typography onto --leading-*/--font-weight-*/--tracking-* tokens (#520 PR1)

### DIFF
--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the shared CSS test helpers used by the typography converge
+ * contracts (line-height / font-weight / letter-spacing) and other renderer
+ * CSS contracts.
+ *
+ * Two invariants locked here:
+ *
+ * 1. `expandCssImports` fails closed — a missing/bad `@import` must throw
+ *    (surfacing the import path), not silently degrade to reading only the
+ *    entry file. Otherwise a converge contract could pass while skipping
+ *    every `styles/*` file the convergence is supposed to cover.
+ *
+ * 2. `findFontShorthandOffenders` bans every non-literal `font:` shorthand
+ *    (only `inherit` / `initial` / `unset` / `revert` allowed). This is the
+ *    shared backstop for the font-weight and line-height converge contracts,
+ *    which scan longhand declarations only and would otherwise miss bare
+ *    weight or line-height smuggled in via `font:` shorthand.
+ */
+
+import { strict as assert } from 'node:assert';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, after } from 'node:test';
+import { expandCssImports, findFontShorthandOffenders } from './css-test-helpers.js';
+
+describe('css-test-helpers', () => {
+  describe('expandCssImports (fail closed on bad @import)', () => {
+    let tmpDir: string;
+    let entryCss: string;
+
+    it('throws on a missing @import instead of silently degrading', async () => {
+      tmpDir = await mkdtemp(join(tmpdir(), 'css-helpers-'));
+      entryCss = join(tmpDir, 'entry.css');
+      // entry.css imports a file that does not exist
+      await writeFile(entryCss, '@import "./missing.css";\n');
+
+      await assert.rejects(
+        () => expandCssImports(entryCss, new Set([entryCss])),
+        (err: NodeJS.ErrnoException) => {
+          // The error must surface the missing import path, not just the entry.
+          assert.ok(
+            err.message.includes('missing.css') || err.code === 'ENOENT',
+            `error should surface the missing import path; got: ${err.message}`,
+          );
+          return true;
+        },
+      );
+    });
+
+    after(async () => {
+      if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('findFontShorthandOffenders', () => {
+    it('accepts literal font: shorthand (inherit / initial / unset / revert)', () => {
+      assert.deepEqual(findFontShorthandOffenders('font: inherit', 'test'), []);
+      assert.deepEqual(findFontShorthandOffenders('font: initial', 'test'), []);
+      assert.deepEqual(findFontShorthandOffenders('font: unset', 'test'), []);
+      assert.deepEqual(findFontShorthandOffenders('font: revert', 'test'), []);
+    });
+
+    it('rejects non-literal font: shorthand (bare weight, line-height, var() size)', () => {
+      assert.ok(findFontShorthandOffenders('font: 600 12px sans-serif', 'test').length > 0, 'bare weight must fail');
+      assert.ok(findFontShorthandOffenders('font: bold 12px sans-serif', 'test').length > 0, 'bold keyword must fail');
+      assert.ok(findFontShorthandOffenders('font: 12px/1.4 sans-serif', 'test').length > 0, 'bare line-height must fail');
+      assert.ok(findFontShorthandOffenders('font: 600 var(--font-size-ui) var(--font-sans)', 'test').length > 0, 'var() size with bare weight must fail');
+      assert.ok(findFontShorthandOffenders('font: var(--font-size-ui)/1.4 var(--font-sans)', 'test').length > 0, 'var() size with bare line-height must fail');
+    });
+
+    it('ignores font: inside comments', () => {
+      assert.deepEqual(findFontShorthandOffenders('/* font: 600 12px sans-serif */', 'test'), []);
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -22,7 +22,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, after } from 'node:test';
-import { expandCssImports, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
+import { expandCssImports, findFontShorthandOffenders, assertCustomPropPinnedOnce } from './css-test-helpers.js';
 
 describe('css-test-helpers', () => {
   describe('expandCssImports (fail closed on bad @import)', () => {
@@ -74,42 +74,57 @@ describe('css-test-helpers', () => {
     });
   });
 
-  describe('assertTokenPinnedOnce', () => {
+  describe('assertCustomPropPinnedOnce', () => {
     it('accepts a single declaration with the exact value', () => {
-      assert.doesNotThrow(() => assertTokenPinnedOnce('--font-weight-normal: 400;', '--font-weight-normal', '400'));
+      assert.doesNotThrow(() => assertCustomPropPinnedOnce('--font-weight-normal: 400;', '--font-weight-normal', '400'));
     });
 
-    it('rejects duplicate declarations (a later override drifts undetected by assert.match)', () => {
+    it('rejects duplicate token declarations (a later override drifts undetected by assert.match)', () => {
       assert.throws(
-        () => assertTokenPinnedOnce('--font-weight-normal: 400;\n  --font-weight-normal: 450;', '--font-weight-normal', '400'),
+        () => assertCustomPropPinnedOnce('--font-weight-normal: 400;\n  --font-weight-normal: 450;', '--font-weight-normal', '400'),
         /exactly once/,
       );
       assert.throws(
-        () => assertTokenPinnedOnce('--leading-normal: 1.5;\n  --leading-normal: 1.55;', '--leading-normal', '1.5'),
+        () => assertCustomPropPinnedOnce('--leading-normal: 1.5;\n  --leading-normal: 1.55;', '--leading-normal', '1.5'),
         /exactly once/,
       );
       assert.throws(
-        () => assertTokenPinnedOnce('--tracking-normal: 0;\n  --tracking-normal: 0.02em;', '--tracking-normal', '0'),
+        () => assertCustomPropPinnedOnce('--tracking-normal: 0;\n  --tracking-normal: 0.02em;', '--tracking-normal', '0'),
+        /exactly once/,
+      );
+    });
+
+    it('rejects duplicate bridge alias declarations (override drifts undetected by assert.match)', () => {
+      assert.throws(
+        () => assertCustomPropPinnedOnce('--font-weight-normal: var(--font-weight-normal);\n  --font-weight-normal: 450;', '--font-weight-normal', 'var(--font-weight-normal)'),
+        /exactly once/,
+      );
+      assert.throws(
+        () => assertCustomPropPinnedOnce('--leading-normal: var(--leading-normal);\n  --leading-normal: 1.55;', '--leading-normal', 'var(--leading-normal)'),
+        /exactly once/,
+      );
+      assert.throws(
+        () => assertCustomPropPinnedOnce('--tracking-normal: var(--tracking-normal);\n  --tracking-normal: 0.02em;', '--tracking-normal', 'var(--tracking-normal)'),
         /exactly once/,
       );
     });
 
     it('rejects a single declaration with a drifted value', () => {
       assert.throws(
-        () => assertTokenPinnedOnce('--font-weight-normal: 450;', '--font-weight-normal', '400'),
+        () => assertCustomPropPinnedOnce('--font-weight-normal: 450;', '--font-weight-normal', '400'),
         /must be 400/,
       );
     });
 
-    it('rejects a missing token', () => {
+    it('rejects a missing prop', () => {
       assert.throws(
-        () => assertTokenPinnedOnce('--other: 1;', '--font-weight-normal', '400'),
+        () => assertCustomPropPinnedOnce('--other: 1;', '--font-weight-normal', '400'),
         /exactly once/,
       );
     });
 
     it('strips comments before parsing (inline comment after value)', () => {
-      assert.doesNotThrow(() => assertTokenPinnedOnce('--leading-none: 1;        /* single-line: kbd */', '--leading-none', '1'));
+      assert.doesNotThrow(() => assertCustomPropPinnedOnce('--leading-none: 1;        /* single-line: kbd */', '--leading-none', '1'));
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.test.ts
@@ -22,7 +22,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, after } from 'node:test';
-import { expandCssImports, findFontShorthandOffenders } from './css-test-helpers.js';
+import { expandCssImports, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
 
 describe('css-test-helpers', () => {
   describe('expandCssImports (fail closed on bad @import)', () => {
@@ -71,6 +71,45 @@ describe('css-test-helpers', () => {
 
     it('ignores font: inside comments', () => {
       assert.deepEqual(findFontShorthandOffenders('/* font: 600 12px sans-serif */', 'test'), []);
+    });
+  });
+
+  describe('assertTokenPinnedOnce', () => {
+    it('accepts a single declaration with the exact value', () => {
+      assert.doesNotThrow(() => assertTokenPinnedOnce('--font-weight-normal: 400;', '--font-weight-normal', '400'));
+    });
+
+    it('rejects duplicate declarations (a later override drifts undetected by assert.match)', () => {
+      assert.throws(
+        () => assertTokenPinnedOnce('--font-weight-normal: 400;\n  --font-weight-normal: 450;', '--font-weight-normal', '400'),
+        /exactly once/,
+      );
+      assert.throws(
+        () => assertTokenPinnedOnce('--leading-normal: 1.5;\n  --leading-normal: 1.55;', '--leading-normal', '1.5'),
+        /exactly once/,
+      );
+      assert.throws(
+        () => assertTokenPinnedOnce('--tracking-normal: 0;\n  --tracking-normal: 0.02em;', '--tracking-normal', '0'),
+        /exactly once/,
+      );
+    });
+
+    it('rejects a single declaration with a drifted value', () => {
+      assert.throws(
+        () => assertTokenPinnedOnce('--font-weight-normal: 450;', '--font-weight-normal', '400'),
+        /must be 400/,
+      );
+    });
+
+    it('rejects a missing token', () => {
+      assert.throws(
+        () => assertTokenPinnedOnce('--other: 1;', '--font-weight-normal', '400'),
+        /exactly once/,
+      );
+    });
+
+    it('strips comments before parsing (inline comment after value)', () => {
+      assert.doesNotThrow(() => assertTokenPinnedOnce('--leading-none: 1;        /* single-line: kbd */', '--leading-none', '1'));
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'node:assert';
 import { readdir, readFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 
@@ -76,4 +77,40 @@ export function findFontShorthandOffenders(css: string, label: string): string[]
     offenders.push(`${label}: ${decl} (non-literal font: shorthand — use longhand + tokens)`);
   }
   return offenders;
+}
+
+// --- token pin (exact-once) -----------------------------------------------
+
+/** Parse all custom property declarations (`--token: value;`) from CSS.
+ * Returns token name → array of declared values, one entry per occurrence
+ * (so duplicates are visible). Comments are stripped first; values trimmed. */
+export function parseCssCustomProps(css: string): Map<string, string[]> {
+  const stripped = stripCssComments(css);
+  const map = new Map<string, string[]>();
+  for (const m of stripped.matchAll(/(--[\w-]+)\s*:\s*([^;{}]+?)\s*;/g)) {
+    const name = m[1];
+    const value = m[2].trim();
+    const list = map.get(name);
+    if (list) list.push(value);
+    else map.set(name, [value]);
+  }
+  return map;
+}
+
+/** Assert a custom property is declared exactly once with the expected value.
+ *
+ * Stronger than `assert.match(tokens, /--token:\s*value\s*;/)`: that only proves
+ * a correct declaration exists somewhere — a later overriding declaration
+ * (e.g. `--font-weight-normal: 400; --font-weight-normal: 450;`) still passes
+ * because the first match satisfies `assert.match`. This helper fails on
+ * duplicate declarations and on a single declaration with a drifted value. */
+export function assertTokenPinnedOnce(
+  tokensCss: string,
+  token: string,
+  expected: string,
+  label = 'maka-tokens.css',
+): void {
+  const values = parseCssCustomProps(tokensCss).get(token) ?? [];
+  assert.equal(values.length, 1, `${label}: ${token} must be declared exactly once with ${expected}; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
+  assert.equal(values[0], expected, `${label}: ${token} must be ${expected}; got ${values[0]}`);
 }

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -21,7 +21,7 @@ export async function readCssTree(dir: string): Promise<string[]> {
 
 const CSS_IMPORT_RE = /@import\s+"([^"]+\.css)"(?:\s+layer\([^)]+\))?\s*;/g;
 
-async function expandCssImports(file: string, seen: Set<string>): Promise<string> {
+export async function expandCssImports(file: string, seen: Set<string>): Promise<string> {
   const source = await readFile(file, 'utf8');
   let expanded = source;
 
@@ -40,14 +40,40 @@ async function expandCssImports(file: string, seen: Set<string>): Promise<string
 }
 
 export async function readAllRendererCss(): Promise<string> {
-  try {
-    return await expandCssImports(RENDERER_STYLES_ENTRY, new Set([RENDERER_STYLES_ENTRY]));
-  } catch {
-    // styles/ dir does not exist yet — keep compatibility with pre-split branches.
-    return readFile(RENDERER_STYLES_ENTRY, 'utf8');
-  }
+  // Fail closed: if import expansion breaks (missing file, bad @import path),
+  // surface the error so converge contracts catch it instead of silently
+  // degrading to only the styles.css entry and skipping styles/*.
+  return expandCssImports(RENDERER_STYLES_ENTRY, new Set([RENDERER_STYLES_ENTRY]));
 }
 
 export function stripCssComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/** Ban non-literal `font:` shorthand in renderer CSS.
+ *
+ * `font:` shorthand can hide bare font-weight (`font: 600 12px sans-serif`),
+ * bare line-height (`font: 12px/1.4 sans-serif`), or token-bypassing sizes
+ * (`font: 600 var(--font-size-ui) var(--font-sans)`). Per-property converge
+ * contracts only scan longhand declarations, so any `font:` shorthand that
+ * isn't a literal (`inherit` / `initial` / `unset` / `revert`) is a bypass
+ * vector. Renderer CSS today only uses `font: inherit`, so the whitelist is
+ * literals-only — no regex arms race over which shorthand component is bare.
+ *
+ * The value is extracted and checked against the literal set rather than
+ * using a negative lookahead: `\s*` backtracking lets a lookahead succeed at
+ * the `:` position and would match `font: inherit` as an offender. */
+const FONT_SHORTHAND_RE = /\bfont:\s*[^;}\n]+/gi;
+const FONT_LITERAL_OK = /^(?:inherit|initial|unset|revert)$/i;
+
+export function findFontShorthandOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(FONT_SHORTHAND_RE)) {
+    const decl = m[0].trim();
+    const value = decl.replace(/^font:\s*/i, '').trim();
+    if (FONT_LITERAL_OK.test(value)) continue;
+    offenders.push(`${label}: ${decl} (non-literal font: shorthand — use longhand + tokens)`);
+  }
+  return offenders;
 }

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -99,18 +99,22 @@ export function parseCssCustomProps(css: string): Map<string, string[]> {
 
 /** Assert a custom property is declared exactly once with the expected value.
  *
- * Stronger than `assert.match(tokens, /--token:\s*value\s*;/)`: that only proves
- * a correct declaration exists somewhere — a later overriding declaration
- * (e.g. `--font-weight-normal: 400; --font-weight-normal: 450;`) still passes
- * because the first match satisfies `assert.match`. This helper fails on
- * duplicate declarations and on a single declaration with a drifted value. */
-export function assertTokenPinnedOnce(
-  tokensCss: string,
-  token: string,
+ * Works for both token definitions in maka-tokens.css (e.g.
+ * `--font-weight-normal: 400`) and Tailwind bridge aliases in styles.css
+ * `@theme inline` (e.g. `--leading-normal: var(--leading-normal)`). Stronger
+ * than `assert.match(css, /--prop:\s*value\s*;/)`: that only proves a correct
+ * declaration exists somewhere — a later overriding declaration (e.g.
+ * `--font-weight-normal: 400; --font-weight-normal: 450;`, or
+ * `--leading-normal: var(--leading-normal); --leading-normal: 1.55;`) still
+ * passes because the first match satisfies `assert.match`. This helper fails
+ * on duplicate declarations and on a single declaration with a drifted value. */
+export function assertCustomPropPinnedOnce(
+  css: string,
+  prop: string,
   expected: string,
   label = 'maka-tokens.css',
 ): void {
-  const values = parseCssCustomProps(tokensCss).get(token) ?? [];
-  assert.equal(values.length, 1, `${label}: ${token} must be declared exactly once with ${expected}; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
-  assert.equal(values[0], expected, `${label}: ${token} must be ${expected}; got ${values[0]}`);
+  const values = parseCssCustomProps(css).get(prop) ?? [];
+  assert.equal(values.length, 1, `${label}: ${prop} must be declared exactly once with ${expected}; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
+  assert.equal(values[0], expected, `${label}: ${prop} must be ${expected}; got ${values[0]}`);
 }

--- a/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
@@ -27,7 +27,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -99,12 +99,12 @@ describe('PR-FONT-WEIGHT-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
-  it('--font-weight-{normal,medium,semibold,bold} tokens are defined with pinned values', async () => {
+  it('--font-weight-{normal,medium,semibold,bold} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--font-weight-normal:\s*400\s*;/, '--font-weight-normal must be 400');
-    assert.match(tokens, /--font-weight-medium:\s*500\s*;/, '--font-weight-medium must be 500');
-    assert.match(tokens, /--font-weight-semibold:\s*600\s*;/, '--font-weight-semibold must be 600');
-    assert.match(tokens, /--font-weight-bold:\s*700\s*;/, '--font-weight-bold must be 700');
+    assertTokenPinnedOnce(tokens, '--font-weight-normal', '400');
+    assertTokenPinnedOnce(tokens, '--font-weight-medium', '500');
+    assertTokenPinnedOnce(tokens, '--font-weight-semibold', '600');
+    assertTokenPinnedOnce(tokens, '--font-weight-bold', '700');
   });
 
   it('Tailwind --font-weight-* aliases map to var(--font-weight-*) in @theme inline', async () => {
@@ -152,9 +152,4 @@ describe('font-weight whitelist negative cases', () => {
     assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
   });
 
-  it('pin regex rejects drifted token values (no prefix matching)', () => {
-    assert.ok(!/--font-weight-normal:\s*400\s*;/.test('--font-weight-normal: 4000;'), '4000 must not satisfy 400');
-    assert.ok(!/--font-weight-semibold:\s*600\s*;/.test('--font-weight-semibold: 650;'), '650 must not satisfy 600');
-    assert.ok(!/--font-weight-bold:\s*700\s*;/.test('--font-weight-bold: 70;'), '70 must not satisfy 700');
-  });
 });

--- a/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
@@ -27,7 +27,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -45,11 +45,6 @@ const LITERAL_OK = /^(?:inherit|initial|unset|revert)$/;
 function extractFontWeightValue(decl: string): string {
   return decl.replace(/^font-weight:\s*/i, '').replace(/;$/, '').trim();
 }
-
-/** Bare numeric or keyword weight inside `font:` shorthand, e.g.
- *  `font: 600 12px sans-serif` or `font: bold 12px sans-serif`. Catches the
- *  shorthand bypass that `font-weight:` scanning misses. */
-const FONT_SHORTHAND_WEIGHT_RE = /\bfont:\s*[^;}\n]*\b(\d{3}|normal|bold|lighter|bolder)\b\s+\d+(?:\.\d+)?(?:px|rem)/gi;
 
 // --- CSS scanning -----------------------------------------------------------
 
@@ -77,10 +72,9 @@ function findCssOffenders(css: string, label: string): string[] {
     offenders.push(`${label}: ${raw}`);
   }
 
-  // Catch `font:` shorthand with bare weight
-  for (const m of stripped.matchAll(FONT_SHORTHAND_WEIGHT_RE)) {
-    offenders.push(`${label}: ${m[0].trim()} (bare weight in font shorthand)`);
-  }
+  // Catch non-literal `font:` shorthand — shared helper bans any `font:` that
+  // isn't inherit/initial/unset/revert, covering weight/size/line-height bypass.
+  offenders.push(...findFontShorthandOffenders(stripped, label));
 
   return offenders;
 }
@@ -107,10 +101,10 @@ describe('PR-FONT-WEIGHT-CONVERGE-0 contract', () => {
 
   it('--font-weight-{normal,medium,semibold,bold} tokens are defined with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--font-weight-normal:\s*400/, '--font-weight-normal must be 400');
-    assert.match(tokens, /--font-weight-medium:\s*500/, '--font-weight-medium must be 500');
-    assert.match(tokens, /--font-weight-semibold:\s*600/, '--font-weight-semibold must be 600');
-    assert.match(tokens, /--font-weight-bold:\s*700/, '--font-weight-bold must be 700');
+    assert.match(tokens, /--font-weight-normal:\s*400\s*;/, '--font-weight-normal must be 400');
+    assert.match(tokens, /--font-weight-medium:\s*500\s*;/, '--font-weight-medium must be 500');
+    assert.match(tokens, /--font-weight-semibold:\s*600\s*;/, '--font-weight-semibold must be 600');
+    assert.match(tokens, /--font-weight-bold:\s*700\s*;/, '--font-weight-bold must be 700');
   });
 
   it('Tailwind --font-weight-* aliases map to var(--font-weight-*) in @theme inline', async () => {
@@ -146,8 +140,21 @@ describe('font-weight whitelist negative cases', () => {
     assert.ok(findCssOffenders('font-weight: lighter', 'test').length > 0, 'lighter must fail');
   });
 
-  it('rejects bare weight in font: shorthand', () => {
+  it('rejects non-literal font: shorthand (bare weight, var() size, line-height bypass)', () => {
     assert.ok(findCssOffenders('font: 600 12px sans-serif', 'test').length > 0, 'shorthand numeric weight must fail');
     assert.ok(findCssOffenders('font: bold 12px sans-serif', 'test').length > 0, 'shorthand bold must fail');
+    assert.ok(findCssOffenders('font: 600 var(--font-size-ui) var(--font-sans)', 'test').length > 0, 'shorthand with var() size must fail (weight bypass)');
+    assert.ok(findCssOffenders('font: var(--font-size-ui)/1.4 var(--font-sans)', 'test').length > 0, 'shorthand with bare line-height must fail');
+  });
+
+  it('accepts font: inherit and font: initial', () => {
+    assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
+  });
+
+  it('pin regex rejects drifted token values (no prefix matching)', () => {
+    assert.ok(!/--font-weight-normal:\s*400\s*;/.test('--font-weight-normal: 4000;'), '4000 must not satisfy 400');
+    assert.ok(!/--font-weight-semibold:\s*600\s*;/.test('--font-weight-semibold: 650;'), '650 must not satisfy 600');
+    assert.ok(!/--font-weight-bold:\s*700\s*;/.test('--font-weight-bold: 70;'), '70 must not satisfy 700');
   });
 });

--- a/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
@@ -1,0 +1,153 @@
+/**
+ * PR-FONT-WEIGHT-CONVERGE-0 (issue #520 PR1):
+ * lock the font-weight vocabulary so individual PRs can't silently drift
+ * back to ad-hoc font-weight values.
+ *
+ * Three invariants:
+ *
+ * 1. CSS `font-weight` must reference a whitelisted `--font-weight-*` token
+ *    or be a literal (`inherit` / `initial` / `unset` / `revert`). Bare numbers
+ *    (400/500/550/600/620/650/680/700) and keyword weights (`normal` / `bold`
+ *    / `lighter` / `bolder`) drift visually and bypass the four-tier scale;
+ *    `normal`/`bold` are banned too because they are aliases for 400/700 that
+ *    hide which tier is in use.
+ *
+ * 2. `--font-weight-{normal,medium,semibold,bold}` tokens are defined in
+ *    `maka-tokens.css` with pinned values (400 / 500 / 600 / 700).
+ *
+ * 3. Tailwind `--font-weight-*` aliases in `styles.css` `@theme inline` map to
+ *    `var(--font-weight-*)` so TSX `font-*` utilities stay single-sourced —
+ *    same inline-bridge pattern as `--text-*` / `--leading-*`.
+ *
+ * Variable-weight Geist + system-ui means 550/620/650/680 are mid-axis picks;
+ * they snap to the nearest tier (550/620/650 → semibold 600, 680 → bold 700).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
+
+// --- token whitelist --------------------------------------------------------
+
+const FONT_WEIGHT_TOKEN_WHITELIST = new Set([
+  '--font-weight-normal',
+  '--font-weight-medium',
+  '--font-weight-semibold',
+  '--font-weight-bold',
+]);
+
+const LITERAL_OK = /^(?:inherit|initial|unset|revert)$/;
+
+function extractFontWeightValue(decl: string): string {
+  return decl.replace(/^font-weight:\s*/i, '').replace(/;$/, '').trim();
+}
+
+/** Bare numeric or keyword weight inside `font:` shorthand, e.g.
+ *  `font: 600 12px sans-serif` or `font: bold 12px sans-serif`. Catches the
+ *  shorthand bypass that `font-weight:` scanning misses. */
+const FONT_SHORTHAND_WEIGHT_RE = /\bfont:\s*[^;}\n]*\b(\d{3}|normal|bold|lighter|bolder)\b\s+\d+(?:\.\d+)?(?:px|rem)/gi;
+
+// --- CSS scanning -----------------------------------------------------------
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+
+  const decls = [...stripped.matchAll(/font-weight:\s*[^;}\n]+/gi)];
+  for (const m of decls) {
+    const raw = m[0].trim();
+    const value = extractFontWeightValue(raw);
+
+    // Allowed: var(--font-weight-*)
+    if (/^var\(\s*--font-weight-[\w-]+\s*\)$/.test(value)) {
+      const tok = value.match(/^var\(\s*(--font-weight-[\w-]+)\s*\)$/)?.[1];
+      if (tok && FONT_WEIGHT_TOKEN_WHITELIST.has(tok)) continue;
+      offenders.push(`${label}: ${raw} (unknown token)`);
+      continue;
+    }
+
+    // Allowed: literals
+    if (LITERAL_OK.test(value)) continue;
+
+    // Everything else is a violation (bare numbers, normal/bold/lighter/bolder, px, etc.)
+    offenders.push(`${label}: ${raw}`);
+  }
+
+  // Catch `font:` shorthand with bare weight
+  for (const m of stripped.matchAll(FONT_SHORTHAND_WEIGHT_RE)) {
+    offenders.push(`${label}: ${m[0].trim()} (bare weight in font shorthand)`);
+  }
+
+  return offenders;
+}
+
+// === tests ==================================================================
+
+describe('PR-FONT-WEIGHT-CONVERGE-0 contract', () => {
+  it('CSS uses only whitelisted --font-weight-* tokens or literals (no bare numbers/normal/bold)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css uses only whitelisted --font-weight-* tokens or literals', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const stripped = tokens
+      .replace(/^\s*--font-weight-normal:\s*400\s*;.*$/gm, '')
+      .replace(/^\s*--font-weight-medium:\s*500\s*;.*$/gm, '')
+      .replace(/^\s*--font-weight-semibold:\s*600\s*;.*$/gm, '')
+      .replace(/^\s*--font-weight-bold:\s*700\s*;.*$/gm, '');
+    const offenders = findCssOffenders(stripped, 'maka-tokens.css');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--font-weight-{normal,medium,semibold,bold} tokens are defined with pinned values', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--font-weight-normal:\s*400/, '--font-weight-normal must be 400');
+    assert.match(tokens, /--font-weight-medium:\s*500/, '--font-weight-medium must be 500');
+    assert.match(tokens, /--font-weight-semibold:\s*600/, '--font-weight-semibold must be 600');
+    assert.match(tokens, /--font-weight-bold:\s*700/, '--font-weight-bold must be 700');
+  });
+
+  it('Tailwind --font-weight-* aliases map to var(--font-weight-*) in @theme inline', async () => {
+    const styles = await readFile(STYLES_FILE, 'utf8');
+    assert.match(styles, /--font-weight-normal:\s*var\(--font-weight-normal\)/, '--font-weight-normal must alias var(--font-weight-normal)');
+    assert.match(styles, /--font-weight-medium:\s*var\(--font-weight-medium\)/, '--font-weight-medium must alias var(--font-weight-medium)');
+    assert.match(styles, /--font-weight-semibold:\s*var\(--font-weight-semibold\)/, '--font-weight-semibold must alias var(--font-weight-semibold)');
+    assert.match(styles, /--font-weight-bold:\s*var\(--font-weight-bold\)/, '--font-weight-bold must alias var(--font-weight-bold)');
+  });
+});
+
+describe('font-weight whitelist negative cases', () => {
+  it('rejects typos and private tokens in var()', () => {
+    assert.ok(findCssOffenders('font-weight: var(--font-weight-mata)', 'test').length > 0, 'typo must fail');
+    assert.ok(findCssOffenders('font-weight: var(--font-weight-private)', 'test').length > 0, 'private token must fail');
+  });
+
+  it('accepts valid tokens and literals', () => {
+    assert.deepEqual(findCssOffenders('font-weight: var(--font-weight-normal)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-weight: var(--font-weight-medium)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-weight: var(--font-weight-semibold)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-weight: var(--font-weight-bold)', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-weight: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('font-weight: initial', 'test'), []);
+  });
+
+  it('rejects bare numbers and keyword weights', () => {
+    assert.ok(findCssOffenders('font-weight: 400', 'test').length > 0, 'bare 400 must fail');
+    assert.ok(findCssOffenders('font-weight: 600', 'test').length > 0, 'bare 600 must fail');
+    assert.ok(findCssOffenders('font-weight: 550', 'test').length > 0, 'mid-axis 550 must fail');
+    assert.ok(findCssOffenders('font-weight: normal', 'test').length > 0, 'normal must fail (use --font-weight-normal)');
+    assert.ok(findCssOffenders('font-weight: bold', 'test').length > 0, 'bold must fail (use --font-weight-bold)');
+    assert.ok(findCssOffenders('font-weight: lighter', 'test').length > 0, 'lighter must fail');
+  });
+
+  it('rejects bare weight in font: shorthand', () => {
+    assert.ok(findCssOffenders('font: 600 12px sans-serif', 'test').length > 0, 'shorthand numeric weight must fail');
+    assert.ok(findCssOffenders('font: bold 12px sans-serif', 'test').length > 0, 'shorthand bold must fail');
+  });
+});

--- a/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/font-weight-converge-contract.test.ts
@@ -27,7 +27,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertCustomPropPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -101,18 +101,18 @@ describe('PR-FONT-WEIGHT-CONVERGE-0 contract', () => {
 
   it('--font-weight-{normal,medium,semibold,bold} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assertTokenPinnedOnce(tokens, '--font-weight-normal', '400');
-    assertTokenPinnedOnce(tokens, '--font-weight-medium', '500');
-    assertTokenPinnedOnce(tokens, '--font-weight-semibold', '600');
-    assertTokenPinnedOnce(tokens, '--font-weight-bold', '700');
+    assertCustomPropPinnedOnce(tokens, '--font-weight-normal', '400');
+    assertCustomPropPinnedOnce(tokens, '--font-weight-medium', '500');
+    assertCustomPropPinnedOnce(tokens, '--font-weight-semibold', '600');
+    assertCustomPropPinnedOnce(tokens, '--font-weight-bold', '700');
   });
 
-  it('Tailwind --font-weight-* aliases map to var(--font-weight-*) in @theme inline', async () => {
+  it('Tailwind --font-weight-* aliases are declared exactly once mapping to var(--font-weight-*) in @theme inline', async () => {
     const styles = await readFile(STYLES_FILE, 'utf8');
-    assert.match(styles, /--font-weight-normal:\s*var\(--font-weight-normal\)/, '--font-weight-normal must alias var(--font-weight-normal)');
-    assert.match(styles, /--font-weight-medium:\s*var\(--font-weight-medium\)/, '--font-weight-medium must alias var(--font-weight-medium)');
-    assert.match(styles, /--font-weight-semibold:\s*var\(--font-weight-semibold\)/, '--font-weight-semibold must alias var(--font-weight-semibold)');
-    assert.match(styles, /--font-weight-bold:\s*var\(--font-weight-bold\)/, '--font-weight-bold must alias var(--font-weight-bold)');
+    assertCustomPropPinnedOnce(styles, '--font-weight-normal', 'var(--font-weight-normal)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--font-weight-medium', 'var(--font-weight-medium)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--font-weight-semibold', 'var(--font-weight-semibold)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--font-weight-bold', 'var(--font-weight-bold)', 'styles.css');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * PR-TRACKING-CONVERGE-0 (issue #520 PR1):
+ * lock the letter-spacing vocabulary so individual PRs can't silently drift
+ * back to ad-hoc letter-spacing values.
+ *
+ * Three invariants:
+ *
+ * 1. CSS `letter-spacing` must reference a whitelisted `--tracking-*` token
+ *    or be the literal `0` (or `inherit`/`initial`/`unset`/`revert`). Bare
+ *    numbers (0.02em, 0.04em, …), `px`, and `normal` are banned. `normal` is
+ *    banned because it is an alias for 0 that hides which tier is in use.
+ *
+ * 2. `--tracking-{normal,wide,wider,widest}` tokens are defined in
+ *    `maka-tokens.css` with pinned values (0 / 0.025em / 0.05em / 0.1em).
+ *
+ * 3. Tailwind `--tracking-*` aliases in `styles.css` `@theme inline` map to
+ *    `var(--tracking-*)` so TSX `tracking-*` utilities stay single-sourced.
+ *
+ * No --tracking-tight: maka is a CJK-first app and roadmap §1.6 bans
+ * tightening CJK letter-spacing, so all negative values snap to normal (0).
+ * ALL-CAPS short labels use wider/widest (roadmap §4.1 +5-12% tracking).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
+
+// --- token whitelist --------------------------------------------------------
+
+const TRACKING_TOKEN_WHITELIST = new Set([
+  '--tracking-normal',
+  '--tracking-wide',
+  '--tracking-wider',
+  '--tracking-widest',
+]);
+
+const LITERAL_OK = /^(?:0|inherit|initial|unset|revert)$/;
+
+function extractLetterSpacingValue(decl: string): string {
+  return decl.replace(/^letter-spacing:\s*/i, '').replace(/;$/, '').trim();
+}
+
+// --- CSS scanning -----------------------------------------------------------
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+
+  const decls = [...stripped.matchAll(/letter-spacing:\s*[^;}\n]+/gi)];
+  for (const m of decls) {
+    const raw = m[0].trim();
+    const value = extractLetterSpacingValue(raw);
+
+    // Allowed: var(--tracking-*)
+    if (/^var\(\s*--tracking-[\w-]+\s*\)$/.test(value)) {
+      const tok = value.match(/^var\(\s*(--tracking-[\w-]+)\s*\)$/)?.[1];
+      if (tok && TRACKING_TOKEN_WHITELIST.has(tok)) continue;
+      offenders.push(`${label}: ${raw} (unknown token)`);
+      continue;
+    }
+
+    // Allowed: literals (0, inherit, initial, unset, revert)
+    if (LITERAL_OK.test(value)) continue;
+
+    // Everything else is a violation (bare em/px/normal/negative, etc.)
+    offenders.push(`${label}: ${raw}`);
+  }
+
+  return offenders;
+}
+
+// === tests ==================================================================
+
+describe('PR-TRACKING-CONVERGE-0 contract', () => {
+  it('CSS uses only whitelisted --tracking-* tokens or 0/literals (no bare em/px/normal/negative)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css uses only whitelisted --tracking-* tokens or literals', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const stripped = tokens
+      .replace(/^\s*--tracking-normal:\s*0\s*;.*$/gm, '')
+      .replace(/^\s*--tracking-wide:\s*0\.025em\s*;.*$/gm, '')
+      .replace(/^\s*--tracking-wider:\s*0\.05em\s*;.*$/gm, '')
+      .replace(/^\s*--tracking-widest:\s*0\.1em\s*;.*$/gm, '');
+    const offenders = findCssOffenders(stripped, 'maka-tokens.css');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--tracking-{normal,wide,wider,widest} tokens are defined with pinned values', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--tracking-normal:\s*0/, '--tracking-normal must be 0');
+    assert.match(tokens, /--tracking-wide:\s*0\.025em/, '--tracking-wide must be 0.025em');
+    assert.match(tokens, /--tracking-wider:\s*0\.05em/, '--tracking-wider must be 0.05em');
+    assert.match(tokens, /--tracking-widest:\s*0\.1em/, '--tracking-widest must be 0.1em');
+  });
+
+  it('Tailwind --tracking-* aliases map to var(--tracking-*) in @theme inline', async () => {
+    const styles = await readFile(STYLES_FILE, 'utf8');
+    assert.match(styles, /--tracking-normal:\s*var\(--tracking-normal\)/, '--tracking-normal must alias var(--tracking-normal)');
+    assert.match(styles, /--tracking-wide:\s*var\(--tracking-wide\)/, '--tracking-wide must alias var(--tracking-wide)');
+    assert.match(styles, /--tracking-wider:\s*var\(--tracking-wider\)/, '--tracking-wider must alias var(--tracking-wider)');
+    assert.match(styles, /--tracking-widest:\s*var\(--tracking-widest\)/, '--tracking-widest must alias var(--tracking-widest)');
+  });
+});
+
+describe('tracking whitelist negative cases', () => {
+  it('rejects typos and private tokens in var()', () => {
+    assert.ok(findCssOffenders('letter-spacing: var(--tracking-mata)', 'test').length > 0, 'typo must fail');
+    assert.ok(findCssOffenders('letter-spacing: var(--tracking-private)', 'test').length > 0, 'private token must fail');
+  });
+
+  it('accepts valid tokens and literals', () => {
+    assert.deepEqual(findCssOffenders('letter-spacing: var(--tracking-normal)', 'test'), []);
+    assert.deepEqual(findCssOffenders('letter-spacing: var(--tracking-wide)', 'test'), []);
+    assert.deepEqual(findCssOffenders('letter-spacing: var(--tracking-wider)', 'test'), []);
+    assert.deepEqual(findCssOffenders('letter-spacing: var(--tracking-widest)', 'test'), []);
+    assert.deepEqual(findCssOffenders('letter-spacing: 0', 'test'), []);
+    assert.deepEqual(findCssOffenders('letter-spacing: inherit', 'test'), []);
+  });
+
+  it('rejects bare em, px, normal, and negative values', () => {
+    assert.ok(findCssOffenders('letter-spacing: 0.02em', 'test').length > 0, 'bare em must fail');
+    assert.ok(findCssOffenders('letter-spacing: 1px', 'test').length > 0, 'px must fail');
+    assert.ok(findCssOffenders('letter-spacing: normal', 'test').length > 0, 'normal must fail (use --tracking-normal)');
+    assert.ok(findCssOffenders('letter-spacing: -0.01em', 'test').length > 0, 'negative must fail (CJK ban, snap --tracking-normal)');
+  });
+});

--- a/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
@@ -95,10 +95,10 @@ describe('PR-TRACKING-CONVERGE-0 contract', () => {
 
   it('--tracking-{normal,wide,wider,widest} tokens are defined with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--tracking-normal:\s*0/, '--tracking-normal must be 0');
-    assert.match(tokens, /--tracking-wide:\s*0\.025em/, '--tracking-wide must be 0.025em');
-    assert.match(tokens, /--tracking-wider:\s*0\.05em/, '--tracking-wider must be 0.05em');
-    assert.match(tokens, /--tracking-widest:\s*0\.1em/, '--tracking-widest must be 0.1em');
+    assert.match(tokens, /--tracking-normal:\s*0\s*;/, '--tracking-normal must be 0');
+    assert.match(tokens, /--tracking-wide:\s*0\.025em\s*;/, '--tracking-wide must be 0.025em');
+    assert.match(tokens, /--tracking-wider:\s*0\.05em\s*;/, '--tracking-wider must be 0.05em');
+    assert.match(tokens, /--tracking-widest:\s*0\.1em\s*;/, '--tracking-widest must be 0.1em');
   });
 
   it('Tailwind --tracking-* aliases map to var(--tracking-*) in @theme inline', async () => {
@@ -130,5 +130,11 @@ describe('tracking whitelist negative cases', () => {
     assert.ok(findCssOffenders('letter-spacing: 1px', 'test').length > 0, 'px must fail');
     assert.ok(findCssOffenders('letter-spacing: normal', 'test').length > 0, 'normal must fail (use --tracking-normal)');
     assert.ok(findCssOffenders('letter-spacing: -0.01em', 'test').length > 0, 'negative must fail (CJK ban, snap --tracking-normal)');
+  });
+
+  it('pin regex rejects drifted token values (no prefix matching)', () => {
+    assert.ok(!/--tracking-normal:\s*0\s*;/.test('--tracking-normal: 0.02em;'), '0.02em must not satisfy --tracking-normal: 0');
+    assert.ok(!/--tracking-wide:\s*0\.025em\s*;/.test('--tracking-wide: 0.3em;'), '0.3em must not satisfy --tracking-wide: 0.025em');
+    assert.ok(!/--tracking-wider:\s*0\.05em\s*;/.test('--tracking-wider: 0.5em;'), '0.5em must not satisfy --tracking-wider: 0.05em');
   });
 });

--- a/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
@@ -25,7 +25,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, assertTokenPinnedOnce } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, assertCustomPropPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -95,18 +95,18 @@ describe('PR-TRACKING-CONVERGE-0 contract', () => {
 
   it('--tracking-{normal,wide,wider,widest} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assertTokenPinnedOnce(tokens, '--tracking-normal', '0');
-    assertTokenPinnedOnce(tokens, '--tracking-wide', '0.025em');
-    assertTokenPinnedOnce(tokens, '--tracking-wider', '0.05em');
-    assertTokenPinnedOnce(tokens, '--tracking-widest', '0.1em');
+    assertCustomPropPinnedOnce(tokens, '--tracking-normal', '0');
+    assertCustomPropPinnedOnce(tokens, '--tracking-wide', '0.025em');
+    assertCustomPropPinnedOnce(tokens, '--tracking-wider', '0.05em');
+    assertCustomPropPinnedOnce(tokens, '--tracking-widest', '0.1em');
   });
 
-  it('Tailwind --tracking-* aliases map to var(--tracking-*) in @theme inline', async () => {
+  it('Tailwind --tracking-* aliases are declared exactly once mapping to var(--tracking-*) in @theme inline', async () => {
     const styles = await readFile(STYLES_FILE, 'utf8');
-    assert.match(styles, /--tracking-normal:\s*var\(--tracking-normal\)/, '--tracking-normal must alias var(--tracking-normal)');
-    assert.match(styles, /--tracking-wide:\s*var\(--tracking-wide\)/, '--tracking-wide must alias var(--tracking-wide)');
-    assert.match(styles, /--tracking-wider:\s*var\(--tracking-wider\)/, '--tracking-wider must alias var(--tracking-wider)');
-    assert.match(styles, /--tracking-widest:\s*var\(--tracking-widest\)/, '--tracking-widest must alias var(--tracking-widest)');
+    assertCustomPropPinnedOnce(styles, '--tracking-normal', 'var(--tracking-normal)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--tracking-wide', 'var(--tracking-wide)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--tracking-wider', 'var(--tracking-wider)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--tracking-widest', 'var(--tracking-widest)', 'styles.css');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/letter-spacing-converge-contract.test.ts
@@ -25,7 +25,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, assertTokenPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -93,12 +93,12 @@ describe('PR-TRACKING-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
-  it('--tracking-{normal,wide,wider,widest} tokens are defined with pinned values', async () => {
+  it('--tracking-{normal,wide,wider,widest} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--tracking-normal:\s*0\s*;/, '--tracking-normal must be 0');
-    assert.match(tokens, /--tracking-wide:\s*0\.025em\s*;/, '--tracking-wide must be 0.025em');
-    assert.match(tokens, /--tracking-wider:\s*0\.05em\s*;/, '--tracking-wider must be 0.05em');
-    assert.match(tokens, /--tracking-widest:\s*0\.1em\s*;/, '--tracking-widest must be 0.1em');
+    assertTokenPinnedOnce(tokens, '--tracking-normal', '0');
+    assertTokenPinnedOnce(tokens, '--tracking-wide', '0.025em');
+    assertTokenPinnedOnce(tokens, '--tracking-wider', '0.05em');
+    assertTokenPinnedOnce(tokens, '--tracking-widest', '0.1em');
   });
 
   it('Tailwind --tracking-* aliases map to var(--tracking-*) in @theme inline', async () => {
@@ -132,9 +132,4 @@ describe('tracking whitelist negative cases', () => {
     assert.ok(findCssOffenders('letter-spacing: -0.01em', 'test').length > 0, 'negative must fail (CJK ban, snap --tracking-normal)');
   });
 
-  it('pin regex rejects drifted token values (no prefix matching)', () => {
-    assert.ok(!/--tracking-normal:\s*0\s*;/.test('--tracking-normal: 0.02em;'), '0.02em must not satisfy --tracking-normal: 0');
-    assert.ok(!/--tracking-wide:\s*0\.025em\s*;/.test('--tracking-wide: 0.3em;'), '0.3em must not satisfy --tracking-wide: 0.025em');
-    assert.ok(!/--tracking-wider:\s*0\.05em\s*;/.test('--tracking-wider: 0.5em;'), '0.5em must not satisfy --tracking-wider: 0.05em');
-  });
 });

--- a/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
@@ -26,7 +26,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -44,10 +44,6 @@ const LITERAL_OK = /^(?:inherit|initial|unset|revert|0)$/;
 function extractLineHeightValue(decl: string): string {
   return decl.replace(/^line-height:\s*/i, '').replace(/;$/, '').trim();
 }
-
-/** Bare numeric line-height inside `font:` shorthand, e.g. `font: 12px/1.4 sans-serif`.
- *  Catches the shorthand bypass that `line-height:` scanning misses. */
-const FONT_SHORTHAND_LH_RE = /\bfont:\s*[^;}\n]*\d+(?:\.\d+)?(?:px|rem)\s*\/\s*\d+(?:\.\d+)?/gi;
 
 // --- CSS scanning -----------------------------------------------------------
 
@@ -79,11 +75,9 @@ function findCssOffenders(css: string, label: string): string[] {
     offenders.push(`${label}: ${raw}`);
   }
 
-  // Catch `font:` shorthand with bare numeric line-height — bypasses
-  // line-height scanning. Format: font: <size>/<line-height> <family>.
-  for (const m of stripped.matchAll(FONT_SHORTHAND_LH_RE)) {
-    offenders.push(`${label}: ${m[0].trim()} (bare line-height in font shorthand)`);
-  }
+  // Catch non-literal `font:` shorthand — shared helper bans any `font:` that
+  // isn't inherit/initial/unset/revert, covering line-height/weight/size bypass.
+  offenders.push(...findFontShorthandOffenders(stripped, label));
 
   return offenders;
 }
@@ -111,10 +105,10 @@ describe('PR-LEADING-CONVERGE-0 contract', () => {
 
   it('--leading-{none,tight,snug,normal} tokens are defined with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--leading-none:\s*1/, '--leading-none must be 1');
-    assert.match(tokens, /--leading-tight:\s*1\.25/, '--leading-tight must be 1.25');
-    assert.match(tokens, /--leading-snug:\s*1\.375/, '--leading-snug must be 1.375');
-    assert.match(tokens, /--leading-normal:\s*1\.5/, '--leading-normal must be 1.5');
+    assert.match(tokens, /--leading-none:\s*1\s*;/, '--leading-none must be 1');
+    assert.match(tokens, /--leading-tight:\s*1\.25\s*;/, '--leading-tight must be 1.25');
+    assert.match(tokens, /--leading-snug:\s*1\.375\s*;/, '--leading-snug must be 1.375');
+    assert.match(tokens, /--leading-normal:\s*1\.5\s*;/, '--leading-normal must be 1.5');
   });
 
   it('Tailwind --leading-* aliases map to var(--leading-*) in @theme inline', async () => {
@@ -150,12 +144,20 @@ describe('leading whitelist negative cases', () => {
     assert.ok(findCssOffenders('line-height: normal', 'test').length > 0, 'normal must fail (use --leading-normal)');
   });
 
-  it('rejects bare numeric line-height in font: shorthand', () => {
+  it('rejects non-literal font: shorthand (bare line-height, var() size, weight bypass)', () => {
     assert.ok(findCssOffenders('font: 12px/1.4 var(--font-sans)', 'test').length > 0, 'shorthand numeric line-height must fail');
+    assert.ok(findCssOffenders('font: var(--font-size-ui)/1.4 var(--font-sans)', 'test').length > 0, 'shorthand with var() size must fail (line-height bypass)');
+    assert.ok(findCssOffenders('font: 600 var(--font-size-ui) var(--font-sans)', 'test').length > 0, 'shorthand with bare weight must fail');
   });
 
   it('accepts font: inherit and font: initial', () => {
     assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
     assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
+  });
+
+  it('pin regex rejects drifted token values (no prefix matching)', () => {
+    assert.ok(!/--leading-none:\s*1\s*;/.test('--leading-none: 1.5;'), '1.5 must not satisfy 1');
+    assert.ok(!/--leading-normal:\s*1\.5\s*;/.test('--leading-normal: 1.55;'), '1.55 must not satisfy 1.5');
+    assert.ok(!/--leading-snug:\s*1\.375\s*;/.test('--leading-snug: 1.3;'), '1.3 must not satisfy 1.375');
   });
 });

--- a/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
@@ -1,0 +1,161 @@
+/**
+ * PR-LEADING-CONVERGE-0 (issue #520 PR1):
+ * lock the line-height vocabulary so individual PRs can't silently drift
+ * back to ad-hoc line-height values.
+ *
+ * Three invariants:
+ *
+ * 1. CSS `line-height` must reference a whitelisted `--leading-*` token,
+ *    use `em` (relative scaling off the element font-size), or be a literal
+ *    (`inherit` / `initial` / `unset` / `revert` / `0`). Bare unitless numbers
+ *    (1.4, 1.45) and px/rem drift visually and bypass the four-tier scale.
+ *    `normal` is banned too — it is a UA default that varies by font and
+ *    bypasses the scale; use `var(--leading-normal)` instead.
+ *
+ * 2. `--leading-{none,tight,snug,normal}` tokens are defined in
+ *    `maka-tokens.css` with pinned values (1 / 1.25 / 1.375 / 1.5). A rename
+ *    or value change gets flagged at the test layer before any styles site
+ *    drifts.
+ *
+ * 3. Tailwind `--leading-*` aliases in `styles.css` `@theme inline` map to
+ *    `var(--leading-*)` so TSX `leading-*` utilities stay single-sourced
+ *    with hand-written CSS — same inline-bridge pattern as `--text-*`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
+
+// --- token whitelist --------------------------------------------------------
+
+const LEADING_TOKEN_WHITELIST = new Set([
+  '--leading-none',
+  '--leading-tight',
+  '--leading-snug',
+  '--leading-normal',
+]);
+
+const LITERAL_OK = /^(?:inherit|initial|unset|revert|0)$/;
+
+function extractLineHeightValue(decl: string): string {
+  return decl.replace(/^line-height:\s*/i, '').replace(/;$/, '').trim();
+}
+
+/** Bare numeric line-height inside `font:` shorthand, e.g. `font: 12px/1.4 sans-serif`.
+ *  Catches the shorthand bypass that `line-height:` scanning misses. */
+const FONT_SHORTHAND_LH_RE = /\bfont:\s*[^;}\n]*\d+(?:\.\d+)?(?:px|rem)\s*\/\s*\d+(?:\.\d+)?/gi;
+
+// --- CSS scanning -----------------------------------------------------------
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+
+  // Find every line-height declaration
+  const decls = [...stripped.matchAll(/line-height:\s*[^;}\n]+/gi)];
+  for (const m of decls) {
+    const raw = m[0].trim();
+    const value = extractLineHeightValue(raw);
+
+    // Allowed: var(--leading-*)
+    if (/^var\(\s*--leading-[\w-]+\s*\)$/.test(value)) {
+      const tok = value.match(/^var\(\s*(--leading-[\w-]+)\s*\)$/)?.[1];
+      if (tok && LEADING_TOKEN_WHITELIST.has(tok)) continue;
+      offenders.push(`${label}: ${raw} (unknown token)`);
+      continue;
+    }
+
+    // Allowed: em values (relative scaling off element font-size)
+    if (/^\d+(?:\.\d+)?em$/.test(value)) continue;
+
+    // Allowed: literals
+    if (LITERAL_OK.test(value)) continue;
+
+    // Everything else is a violation (bare numbers, px, rem, normal, etc.)
+    offenders.push(`${label}: ${raw}`);
+  }
+
+  // Catch `font:` shorthand with bare numeric line-height — bypasses
+  // line-height scanning. Format: font: <size>/<line-height> <family>.
+  for (const m of stripped.matchAll(FONT_SHORTHAND_LH_RE)) {
+    offenders.push(`${label}: ${m[0].trim()} (bare line-height in font shorthand)`);
+  }
+
+  return offenders;
+}
+
+// === tests ==================================================================
+
+describe('PR-LEADING-CONVERGE-0 contract', () => {
+  it('CSS uses only whitelisted --leading-* tokens, em, or literals (no bare numbers/px/normal)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('maka-tokens.css uses only whitelisted --leading-* tokens, em, or literals', async () => {
+    const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    // Strip the token declaration lines themselves (they legitimately spell numbers)
+    const stripped = tokens
+      .replace(/^\s*--leading-none:\s*1\s*;.*$/gm, '')
+      .replace(/^\s*--leading-tight:\s*1\.25\s*;.*$/gm, '')
+      .replace(/^\s*--leading-snug:\s*1\.375\s*;.*$/gm, '')
+      .replace(/^\s*--leading-normal:\s*1\.5\s*;.*$/gm, '');
+    const offenders = findCssOffenders(stripped, 'maka-tokens.css');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--leading-{none,tight,snug,normal} tokens are defined with pinned values', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assert.match(tokens, /--leading-none:\s*1/, '--leading-none must be 1');
+    assert.match(tokens, /--leading-tight:\s*1\.25/, '--leading-tight must be 1.25');
+    assert.match(tokens, /--leading-snug:\s*1\.375/, '--leading-snug must be 1.375');
+    assert.match(tokens, /--leading-normal:\s*1\.5/, '--leading-normal must be 1.5');
+  });
+
+  it('Tailwind --leading-* aliases map to var(--leading-*) in @theme inline', async () => {
+    const styles = await readFile(STYLES_FILE, 'utf8');
+    assert.match(styles, /--leading-none:\s*var\(--leading-none\)/, '--leading-none must alias var(--leading-none)');
+    assert.match(styles, /--leading-tight:\s*var\(--leading-tight\)/, '--leading-tight must alias var(--leading-tight)');
+    assert.match(styles, /--leading-snug:\s*var\(--leading-snug\)/, '--leading-snug must alias var(--leading-snug)');
+    assert.match(styles, /--leading-normal:\s*var\(--leading-normal\)/, '--leading-normal must alias var(--leading-normal)');
+  });
+});
+
+describe('leading whitelist negative cases', () => {
+  it('rejects typos and private tokens in var()', () => {
+    assert.ok(findCssOffenders('line-height: var(--leading-mata)', 'test').length > 0, 'typo must fail');
+    assert.ok(findCssOffenders('line-height: var(--leading-private)', 'test').length > 0, 'private token must fail');
+  });
+
+  it('accepts valid tokens, em, and literals', () => {
+    assert.deepEqual(findCssOffenders('line-height: var(--leading-none)', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: var(--leading-tight)', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: var(--leading-snug)', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: var(--leading-normal)', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: 1.2em', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('line-height: 0', 'test'), []);
+  });
+
+  it('rejects bare numbers, px, rem, and normal', () => {
+    assert.ok(findCssOffenders('line-height: 1.4', 'test').length > 0, 'bare number must fail');
+    assert.ok(findCssOffenders('line-height: 1.45', 'test').length > 0, 'bare number must fail');
+    assert.ok(findCssOffenders('line-height: 20px', 'test').length > 0, 'px must fail');
+    assert.ok(findCssOffenders('line-height: 1.5rem', 'test').length > 0, 'rem must fail');
+    assert.ok(findCssOffenders('line-height: normal', 'test').length > 0, 'normal must fail (use --leading-normal)');
+  });
+
+  it('rejects bare numeric line-height in font: shorthand', () => {
+    assert.ok(findCssOffenders('font: 12px/1.4 var(--font-sans)', 'test').length > 0, 'shorthand numeric line-height must fail');
+  });
+
+  it('accepts font: inherit and font: initial', () => {
+    assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
+    assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
+  });
+});

--- a/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
@@ -26,7 +26,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertCustomPropPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -105,18 +105,18 @@ describe('PR-LEADING-CONVERGE-0 contract', () => {
 
   it('--leading-{none,tight,snug,normal} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assertTokenPinnedOnce(tokens, '--leading-none', '1');
-    assertTokenPinnedOnce(tokens, '--leading-tight', '1.25');
-    assertTokenPinnedOnce(tokens, '--leading-snug', '1.375');
-    assertTokenPinnedOnce(tokens, '--leading-normal', '1.5');
+    assertCustomPropPinnedOnce(tokens, '--leading-none', '1');
+    assertCustomPropPinnedOnce(tokens, '--leading-tight', '1.25');
+    assertCustomPropPinnedOnce(tokens, '--leading-snug', '1.375');
+    assertCustomPropPinnedOnce(tokens, '--leading-normal', '1.5');
   });
 
-  it('Tailwind --leading-* aliases map to var(--leading-*) in @theme inline', async () => {
+  it('Tailwind --leading-* aliases are declared exactly once mapping to var(--leading-*) in @theme inline', async () => {
     const styles = await readFile(STYLES_FILE, 'utf8');
-    assert.match(styles, /--leading-none:\s*var\(--leading-none\)/, '--leading-none must alias var(--leading-none)');
-    assert.match(styles, /--leading-tight:\s*var\(--leading-tight\)/, '--leading-tight must alias var(--leading-tight)');
-    assert.match(styles, /--leading-snug:\s*var\(--leading-snug\)/, '--leading-snug must alias var(--leading-snug)');
-    assert.match(styles, /--leading-normal:\s*var\(--leading-normal\)/, '--leading-normal must alias var(--leading-normal)');
+    assertCustomPropPinnedOnce(styles, '--leading-none', 'var(--leading-none)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--leading-tight', 'var(--leading-tight)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--leading-snug', 'var(--leading-snug)', 'styles.css');
+    assertCustomPropPinnedOnce(styles, '--leading-normal', 'var(--leading-normal)', 'styles.css');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
@@ -26,7 +26,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertTokenPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -103,12 +103,12 @@ describe('PR-LEADING-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
-  it('--leading-{none,tight,snug,normal} tokens are defined with pinned values', async () => {
+  it('--leading-{none,tight,snug,normal} tokens are declared exactly once with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--leading-none:\s*1\s*;/, '--leading-none must be 1');
-    assert.match(tokens, /--leading-tight:\s*1\.25\s*;/, '--leading-tight must be 1.25');
-    assert.match(tokens, /--leading-snug:\s*1\.375\s*;/, '--leading-snug must be 1.375');
-    assert.match(tokens, /--leading-normal:\s*1\.5\s*;/, '--leading-normal must be 1.5');
+    assertTokenPinnedOnce(tokens, '--leading-none', '1');
+    assertTokenPinnedOnce(tokens, '--leading-tight', '1.25');
+    assertTokenPinnedOnce(tokens, '--leading-snug', '1.375');
+    assertTokenPinnedOnce(tokens, '--leading-normal', '1.5');
   });
 
   it('Tailwind --leading-* aliases map to var(--leading-*) in @theme inline', async () => {
@@ -155,9 +155,4 @@ describe('leading whitelist negative cases', () => {
     assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
   });
 
-  it('pin regex rejects drifted token values (no prefix matching)', () => {
-    assert.ok(!/--leading-none:\s*1\s*;/.test('--leading-none: 1.5;'), '1.5 must not satisfy 1');
-    assert.ok(!/--leading-normal:\s*1\.5\s*;/.test('--leading-normal: 1.55;'), '1.55 must not satisfy 1.5');
-    assert.ok(!/--leading-snug:\s*1\.375\s*;/.test('--leading-snug: 1.3;'), '1.3 must not satisfy 1.375');
-  });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -280,6 +280,37 @@
   --leading-snug: 1.375;   /* small titles / UI text: 13/11px dense zones */
   --leading-normal: 1.5;   /* body / long-form / markdown */
 
+  /* === font-weight ===
+     PR-FONT-WEIGHT-CONVERGE-0 (issue #520 PR1):
+     four-tier scale aligned to Tailwind font-weight utilities (drop
+     thin/extralight/light/extrabold/black, zero sites). Token names
+     mirror Tailwind's font-* utilities so `var(--font-weight-*)` in CSS
+     and `font-*` in TSX share one source. Variable-weight Geist +
+     system-ui means 550/620/650/680 are mid-axis picks to snap:
+     550/620/650 → semibold (600), 680 → bold (700). */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* === letter-spacing ===
+     PR-TRACKING-CONVERGE-0 (issue #520 PR1):
+     four-tier scale aligned to a Tailwind tracking-scale subset. No
+     --tracking-tight: maka is a CJK-first app and roadmap §1.6 bans
+     tightening CJK letter-spacing, so all negative values snap to
+     normal (0). ALL-CAPS short labels use wider/widest (roadmap §4.1
+     +5-12% tracking). 1px absolute → widest (0.1em ≈ 1.3px @ 13px). */
+  --tracking-normal: 0;
+  --tracking-wide: 0.025em;
+  --tracking-wider: 0.05em;
+  --tracking-widest: 0.1em;
+
+  /* === font-family (serif addition) ===
+     PR-FONT-FAMILY-MINOR-0 (issue #520 PR1): onboarding hero uses a
+     serif face; tokenize so font-family declarations reference tokens
+     instead of bare `Georgia, serif`. */
+  --font-serif: Georgia, "Times New Roman", Times, serif;
+
   /* === layout === */
   --radius: 0rem;
   --radius-control: 6px;
@@ -846,7 +877,7 @@
     min-width: 18px;
     font-family: var(--font-mono);
     font-size: 0.82em;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     line-height: var(--leading-none);
     padding: var(--space-0-5) var(--space-1-5);
     border-radius: var(--radius-control);
@@ -892,7 +923,7 @@
     gap: var(--space-1);
     padding: var(--space-0-5) var(--space-2);
     font-size: var(--font-size-ui);
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     color: var(--foreground-secondary);
     background: var(--foreground-5);
     border: 1px solid var(--border);
@@ -944,9 +975,9 @@
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid var(--border);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     font-size: var(--font-size-ui);
-    letter-spacing: 0.02em;
+    letter-spacing: var(--tracking-wide);
     text-transform: uppercase;
     color: var(--foreground-secondary);
   }
@@ -969,7 +1000,7 @@
   .maka-sidebar-row[data-active="true"] {
     background: var(--state-selected-bg);
     color: var(--foreground);
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
   }
   .maka-sidebar-row[data-unread="true"]::before {
     content: "";
@@ -1013,7 +1044,7 @@
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
   }
-  .maka-titlebar strong { color: var(--foreground); font-weight: 500; }
+  .maka-titlebar strong { color: var(--foreground); font-weight: var(--font-weight-medium); }
 
   /* ---- Chat surface ----------------------------------------------- */
 
@@ -1106,9 +1137,9 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--focus-ring);
-    letter-spacing: 0.02em;
+    letter-spacing: var(--tracking-wide);
     list-style: none;
     /* `cursor: pointer` intentionally omitted — native macOS reserves
        the hand cursor for links; `<details>` summaries are button-like
@@ -1135,8 +1166,8 @@
 
   .maka-turn-thinking-note {
     font-size: var(--font-size-caption);
-    font-weight: 500;
-    letter-spacing: 0.04em;
+    font-weight: var(--font-weight-medium);
+    letter-spacing: var(--tracking-wider);
     color: var(--muted-foreground);
     text-transform: uppercase;
   }
@@ -1268,12 +1299,12 @@
   .maka-bubble-assistant h4 {
     margin: var(--space-4) 0 var(--space-2);
     line-height: var(--leading-tight);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     text-wrap: balance;
   }
   .maka-bubble-assistant h1,
   .maka-bubble-assistant h2 {
-    letter-spacing: -0.012em;
+    letter-spacing: var(--tracking-normal);
   }
   .maka-bubble-assistant code {
     font-variant-numeric: tabular-nums;
@@ -1350,7 +1381,7 @@
     color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    letter-spacing: 0.02em;
+    letter-spacing: var(--tracking-wide);
   }
   .maka-code-block-lang {
     text-transform: lowercase;
@@ -1438,7 +1469,7 @@
   .hljs-deletion   { color: var(--destructive-text); background: oklch(from var(--destructive) l c h / 0.08); }
   .hljs-addition   { color: var(--success-text); background: oklch(from var(--success) l c h / 0.08); }
   .hljs-emphasis   { font-style: italic; }
-  .hljs-strong     { font-weight: 700; }
+  .hljs-strong     { font-weight: var(--font-weight-bold); }
   .maka-bubble-assistant blockquote {
     margin: 0 0 var(--space-3);
     /* PR-UI-LAYOUT-29: blockquote feels slim on the new warm canvas.
@@ -1487,13 +1518,13 @@
   }
   .maka-bubble-assistant th {
     color: var(--foreground-secondary);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     background: var(--foreground-3);
     /* PR-UI-LAYOUT-28: header tone slightly darker than body cell
      * to make the header row read at first glance — was the same
      * `--foreground-3` as nothing else, now sits between cell and
      * code-block tints. */
-    letter-spacing: 0.01em;
+    letter-spacing: var(--tracking-normal);
   }
   .maka-bubble-assistant hr {
     margin: var(--space-4) 0;
@@ -1549,7 +1580,7 @@
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-2);
     font-size: var(--font-size-caption);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     opacity: 1;
     background: transparent;
   }
@@ -1750,7 +1781,7 @@
     padding: var(--space-1-5) var(--space-3);
     border-radius: var(--radius-control);
     font-size: var(--font-size-ui);
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     line-height: var(--leading-tight);
     transition: background 120ms var(--ease-out-strong), border-color 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
@@ -1785,7 +1816,7 @@
   .maka-tabs-list[data-variant="pill"] .maka-tab[data-active] {
     border-color: oklch(from var(--foreground) l c h / 0.16);
     background: var(--state-selected-bg);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
   .maka-tabs-list[data-variant="underline"] .maka-tab[data-active] {
     color: var(--foreground);
@@ -1825,9 +1856,9 @@
   }
   .maka-modal-title {
     font-size: var(--font-size-base);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
-    letter-spacing: 0;
+    letter-spacing: var(--tracking-normal);
   }
   .maka-modal-subtitle {
     font-size: var(--font-size-ui);
@@ -1848,9 +1879,9 @@
 
   .maka-reason-text[data-reason="shell_dangerous"] { color: var(--info-text); }
   .maka-reason-text[data-reason="file_write"]       { color: var(--info-text); }
-  .maka-reason-text[data-reason="fs_destructive"]   { color: var(--destructive-text); font-weight: 500; }
-  .maka-reason-text[data-reason="git_destructive"]  { color: var(--destructive-text); font-weight: 500; }
-  .maka-reason-text[data-reason="privileged"]       { color: var(--destructive-text); font-weight: 500; }
+  .maka-reason-text[data-reason="fs_destructive"]   { color: var(--destructive-text); font-weight: var(--font-weight-medium); }
+  .maka-reason-text[data-reason="git_destructive"]  { color: var(--destructive-text); font-weight: var(--font-weight-medium); }
+  .maka-reason-text[data-reason="privileged"]       { color: var(--destructive-text); font-weight: var(--font-weight-medium); }
   .maka-reason-text[data-reason="network"]          { color: var(--info-text); }
   .maka-reason-text[data-reason="browser"]          { color: var(--info-text); }
   .maka-reason-text[data-reason="custom"]           { color: var(--foreground-secondary); }

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -264,6 +264,22 @@
   --font-size-ui: 13px;
   --font-size-caption: 11px;
 
+  /* === line-height ===
+     PR-LEADING-CONVERGE-0 (issue #520 PR1):
+     four-tier scale aligned to a Tailwind leading-scale subset (drop
+     relaxed/loose, zero sites). Token names mirror Tailwind's leading-*
+     utilities so `var(--leading-*)` in CSS and `leading-*` in TSX share
+     one source — same bridge pattern as --space-* / p-N.
+
+     Snug is the one tier that can't be cut: 40 sites at 1.3-1.4 (small-
+     title / UI text, 13/11px small-text dense zones) collapse to tight
+     (1.25, too tight) or normal (1.5, too loose) at ±0.1-0.2 on small
+     text. relaxed/loose had zero sites, dropped. */
+  --leading-none: 1;        /* single-line: kbd / tag / button label / count / timestamp */
+  --leading-tight: 1.25;   /* headings: h1-h4 / card titles */
+  --leading-snug: 1.375;   /* small titles / UI text: 13/11px dense zones */
+  --leading-normal: 1.5;   /* body / long-form / markdown */
+
   /* === layout === */
   --radius: 0rem;
   --radius-control: 6px;
@@ -831,7 +847,7 @@
     font-family: var(--font-mono);
     font-size: 0.82em;
     font-weight: 600;
-    line-height: 1;
+    line-height: var(--leading-none);
     padding: var(--space-0-5) var(--space-1-5);
     border-radius: var(--radius-control);
     background: var(--foreground-5);
@@ -945,7 +961,7 @@
     border-radius: var(--radius-control);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
     user-select: none;
     transition: background 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong);
   }
@@ -1127,7 +1143,7 @@
 
   .maka-turn-thinking-body {
     margin-top: var(--space-1-5);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     font-style: italic;
     opacity: 0.9;
   }
@@ -1219,7 +1235,7 @@
          build outputs). */
   .maka-bubble-assistant {
     color: var(--foreground);
-    line-height: 1.68;
+    line-height: var(--leading-normal);
     padding: var(--space-0-5) 0 0;
     word-wrap: break-word;
     /* PR-MESSAGE-BODY-MAX-WIDTH-0 (WAWQAQ msg `38055b9f`, skills
@@ -1251,7 +1267,7 @@
   .maka-bubble-assistant h3,
   .maka-bubble-assistant h4 {
     margin: var(--space-4) 0 var(--space-2);
-    line-height: 1.25;
+    line-height: var(--leading-tight);
     font-weight: 600;
     text-wrap: balance;
   }
@@ -1384,7 +1400,7 @@
     overflow-x: auto;
     font-family: var(--font-mono);
     font-size: var(--font-size-ui);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     white-space: pre;
   }
   .maka-bubble-assistant pre code {
@@ -1693,7 +1709,7 @@
     color: var(--foreground);
     font-family: var(--font-default);
     font-size: var(--font-size-base);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
     min-height: var(--h-composer-min);
     max-height: 240px;
   }
@@ -1735,7 +1751,7 @@
     border-radius: var(--radius-control);
     font-size: var(--font-size-ui);
     font-weight: 500;
-    line-height: 1.2;
+    line-height: var(--leading-tight);
     transition: background 120ms var(--ease-out-strong), border-color 120ms var(--ease-out-strong), color 120ms var(--ease-out-strong), box-shadow 120ms var(--ease-out-strong);
   }
   .maka-button:hover  { background: var(--state-hover-bg); }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -72,6 +72,14 @@
   --text-sm: var(--font-size-ui);
   --text-base: var(--font-size-base);
 
+  /* PR-LEADING-CONVERGE-0 (#520 PR1): bridge --leading-* to Tailwind
+     leading-* utilities so `var(--leading-*)` in CSS and `leading-*`
+     in TSX share one source — same inline-bridge pattern as --text-*. */
+  --leading-none: var(--leading-none);
+  --leading-tight: var(--leading-tight);
+  --leading-snug: var(--leading-snug);
+  --leading-normal: var(--leading-normal);
+
   /* PR-SPACING-CONVERGE-0: export the 4px ruler to Tailwind so the p-N,
      gap-N, m-N utilities share one source with hand-written var(--space-N).
      Without this, Tailwind default --spacing 0.25rem (3.75px under 15px

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -80,6 +80,21 @@
   --leading-snug: var(--leading-snug);
   --leading-normal: var(--leading-normal);
 
+  /* PR-FONT-WEIGHT-CONVERGE-0 (#520 PR1): bridge --font-weight-* to
+     Tailwind font-* utilities (font-normal/medium/semibold/bold). */
+  --font-weight-normal: var(--font-weight-normal);
+  --font-weight-medium: var(--font-weight-medium);
+  --font-weight-semibold: var(--font-weight-semibold);
+  --font-weight-bold: var(--font-weight-bold);
+
+  /* PR-TRACKING-CONVERGE-0 (#520 PR1): bridge --tracking-* to Tailwind
+     tracking-* utilities (tracking-normal/wide/wider/widest). No tight
+     (CJK-first, roadmap §1.6 bans tightening CJK). */
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+  --tracking-widest: var(--tracking-widest);
+
   /* PR-SPACING-CONVERGE-0: export the 4px ruler to Tailwind so the p-N,
      gap-N, m-N utilities share one source with hand-written var(--space-N).
      Without this, Tailwind default --spacing 0.25rem (3.75px under 15px

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -26,7 +26,7 @@
     padding: var(--space-4);
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     text-align: center;
   }
 .maka-lazy-fallback[data-surface="panel"] {

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -169,7 +169,7 @@
     border: 1px solid transparent;
     font-size: var(--font-size-caption);
     font-weight: 600;
-    line-height: 1.4;
+    line-height: var(--leading-snug);
     /* Spacing from neighboring badges comes from the parent
        .maka-chat-status-cluster's `gap`, not a local margin. */
     -webkit-app-region: no-drag;
@@ -321,7 +321,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     max-width: 56ch;
   }
 
@@ -336,7 +336,7 @@
     overflow: auto;
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -379,7 +379,7 @@
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 
 .maka-fake-backend-banner svg {
@@ -544,7 +544,7 @@
 .maka-toast-copy small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   text-wrap: pretty;
 }
 
@@ -661,7 +661,7 @@
 .maka-help-section dt {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-help-section dd {
@@ -741,7 +741,7 @@
 .maka-palette-input {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   outline: none;
   box-shadow: none;
   -webkit-user-select: text;
@@ -799,7 +799,7 @@
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1;
+  line-height: var(--leading-none);
 }
 
 .maka-palette-input-hint .maka-shortcut-kbd {

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -74,7 +74,7 @@
   gap: var(--space-1);
   padding: 1px var(--space-1-5);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   -webkit-app-region: no-drag;
   margin-right: var(--space-1);
   margin-bottom: var(--space-0-5);
@@ -101,7 +101,7 @@
   gap: var(--space-1);
   padding: 1px var(--space-1-5);
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   -webkit-app-region: no-drag;
   margin-right: var(--space-1);
   margin-bottom: var(--space-0-5);
@@ -122,8 +122,8 @@
     border-radius: var(--radius-pill);
     border: 1px solid transparent;
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0.02em;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-wide);
     white-space: nowrap;
     flex: 0 0 auto;
     -webkit-app-region: no-drag;
@@ -168,7 +168,7 @@
     border-radius: var(--radius-pill);
     border: 1px solid transparent;
     font-size: var(--font-size-caption);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     line-height: var(--leading-snug);
     /* Spacing from neighboring badges comes from the parent
        .maka-chat-status-cluster's `gap`, not a local margin. */
@@ -314,7 +314,7 @@
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .maka-error-copy p {
@@ -393,7 +393,7 @@
 }
 
 .maka-fake-backend-banner strong {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-toast-viewport {
@@ -537,7 +537,7 @@
 .maka-toast-copy strong {
   color: var(--foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   text-wrap: balance;
 }
 
@@ -556,7 +556,7 @@
   color: var(--toast-accent);
   padding: var(--space-0-5) var(--space-2);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   transition:
     background-color var(--duration-base) var(--ease-out-strong);
 }
@@ -626,8 +626,8 @@
   margin-bottom: var(--space-1);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
 }
 
@@ -642,8 +642,8 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
 }
 
@@ -798,7 +798,7 @@
   color: var(--foreground-secondary);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
 }
 
@@ -827,8 +827,8 @@
   padding: var(--space-1) var(--space-2) var(--space-0-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
 }
 

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -21,7 +21,7 @@
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
     font-weight: 600;
-    line-height: 1;
+    line-height: var(--leading-none);
     white-space: nowrap;
     padding: 0 var(--space-3);
   }
@@ -84,7 +84,7 @@
     font-size: 2.1333em;
     font-weight: 550;
     letter-spacing: -0.018em;
-    line-height: 1.1;
+    line-height: var(--leading-tight);
     font-variation-settings: "wght" 550, "wdth" 105;
     text-wrap: balance;
   }
@@ -93,7 +93,7 @@
     max-width: 54ch;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     text-wrap: pretty;
   }
 @media (max-width: 820px) {

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -20,7 +20,7 @@
     background: var(--foreground-3);
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     line-height: var(--leading-none);
     white-space: nowrap;
     padding: 0 var(--space-3);
@@ -59,7 +59,7 @@
     background: oklch(0.93 0.006 286);
     color: var(--foreground);
     font-size: 1.4667em;
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
 .maka-hero-eyebrow {
     display: inline-flex;
@@ -67,25 +67,26 @@
     gap: var(--space-1-5);
     color: var(--brand-deep);
     font-size: var(--font-size-caption);
-    font-weight: 700;
-    letter-spacing: 0.12em;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--tracking-widest);
     text-transform: uppercase;
   }
 .maka-hero h1 {
     margin: 0;
     max-width: 34ch;
     /* Phase 4A hero typography — atlas §15 deep RE notes reference uses
-       `.welcome-title` with `Instrument Sans` variable font at wdth:100/
-       wght:500 for hero. Maka uses Geist Variable which also has wdth +
-       wght axes. Pulling the heading to 32px / wght 550 / -0.018em
-       tracking + setting font-variation-settings wdth 105 gives the
-       hero the same "wider, slightly heavier, optically distinct from
-       chrome" feel without adding a second variable font asset. */
+       `.welcome-title` with `Instrument Sans` variable font at wght:500
+       for hero. Maka uses Geist Variable; the heading is pulled to 32px
+       with semibold weight + tight leading (PR-FONT-WEIGHT-CONVERGE-0 /
+       PR-LEADING-CONVERGE-0, #520 PR1). The earlier `font-variation-settings
+       "wght" 550, "wdth" 105` was dropped: wght folds into the font-weight
+       token, and the wdth:105 "wider" axis was a one-off that bypassed the
+       token scale. Standard width keeps the hero optically distinct via
+       size + weight + leading alone. */
     font-size: 2.1333em;
-    font-weight: 550;
-    letter-spacing: -0.018em;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-normal);
     line-height: var(--leading-tight);
-    font-variation-settings: "wght" 550, "wdth" 105;
     text-wrap: balance;
   }
 .maka-hero p {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -72,7 +72,7 @@
   color: var(--muted-foreground);
   font: inherit;
   font-size: var(--font-size-caption);
-  line-height: 1.25;
+  line-height: var(--leading-tight);
   text-align: left;
   transition: color var(--duration-quick) var(--ease-out-strong);
 }
@@ -334,7 +334,7 @@
   color: var(--info-text);
   padding: var(--space-1-5) var(--space-2-5);
   font-size: var(--font-size-caption);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 /* Single-line emphasis under the "记住本轮" checkbox when the action is
@@ -344,6 +344,6 @@
   margin: 0;
   color: var(--destructive);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   font-weight: 600;
 }

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -345,5 +345,5 @@
   color: var(--destructive);
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -50,7 +50,7 @@
     color: var(--muted-foreground);
   }
 .maka-daily-review-info-hint strong {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground-secondary);
   }
 
@@ -156,7 +156,7 @@
 .maka-daily-review-archive-row-title {
     color: var(--foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -200,8 +200,8 @@
     margin: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-normal);
   }
 
 .maka-daily-review-archive-body-header p {
@@ -265,8 +265,8 @@
     margin: 0;
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-normal);
   }
 
 .maka-daily-review-archive-section p {
@@ -309,10 +309,10 @@
 
 .maka-daily-review-day {
     text-align: center;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     font-size: var(--font-size-ui);
     font-variant-numeric: tabular-nums;
-    letter-spacing: 0.005em;
+    letter-spacing: var(--tracking-normal);
     color: var(--foreground);
   }
 
@@ -384,14 +384,14 @@
   }
 .maka-daily-review-totals-value {
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
     font-variant-numeric: tabular-nums;
   }
 .maka-daily-review-totals-label {
     font-size: var(--font-size-caption);
     text-transform: none;
-    letter-spacing: 0;
+    letter-spacing: var(--tracking-normal);
     color: var(--muted-foreground);
   }
 
@@ -416,8 +416,8 @@
     align-items: center;
     gap: var(--space-2);
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0.08em;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-widest);
     text-transform: uppercase;
     color: var(--foreground-secondary);
     margin: 0;
@@ -477,7 +477,7 @@
 }
 
 .maka-daily-review-session-name {
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -499,7 +499,7 @@
   }
 
 .maka-daily-review-top-label {
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     color: var(--foreground);
   }
 

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -46,7 +46,7 @@
 .maka-daily-review-info-hint {
     margin: 0;
     font-size: var(--font-size-caption);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
     color: var(--muted-foreground);
   }
 .maka-daily-review-info-hint strong {
@@ -186,7 +186,7 @@
   .maka-daily-review-archive-empty {
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
 .maka-daily-review-archive-body-header {
@@ -208,7 +208,7 @@
     margin: var(--space-0-5) 0 0;
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     overflow-wrap: anywhere;
   }
 
@@ -218,7 +218,7 @@
     border-radius: var(--radius-pill);
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: 1;
+    line-height: var(--leading-none);
     padding: var(--space-1) var(--space-1-5);
     white-space: nowrap;
   }
@@ -238,7 +238,7 @@
     margin: 0;
     color: var(--destructive, var(--foreground));
     font-size: var(--font-size-ui);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
 .maka-daily-review-archive-sections {
@@ -273,7 +273,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.6;
+    line-height: var(--leading-normal);
     overflow-wrap: anywhere;
     white-space: pre-wrap;
   }
@@ -284,7 +284,7 @@
 .maka-daily-review-archive-section-body {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.6;
+    line-height: var(--leading-normal);
     overflow-wrap: anywhere;
   }
 

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -27,7 +27,7 @@
 .settingsHealthIntro h3 {
     margin: 0 0 var(--space-1-5);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .settingsHealthIntro p {
@@ -127,13 +127,13 @@
 
 .settingsHealthSummaryTile strong {
     font-size: 1.4em;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     line-height: var(--leading-tight);
   }
 
 .settingsHealthSummaryTile small {
     font-size: var(--font-size-caption);
-    letter-spacing: 0.06em;
+    letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--muted-foreground);
   }
@@ -193,7 +193,7 @@
 .settingsHealthLayer > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }
 
@@ -248,13 +248,13 @@
 
 .settingsHealthSignalHeading strong {
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .settingsHealthSignalScope {
     font-size: var(--font-size-caption);
     color: var(--muted-foreground);
-    letter-spacing: 0.04em;
+    letter-spacing: var(--tracking-wider);
   }
 
 .settingsHealthSignalMessage {

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -34,7 +34,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     max-width: 60ch;
   }
 
@@ -128,7 +128,7 @@
 .settingsHealthSummaryTile strong {
     font-size: 1.4em;
     font-weight: 600;
-    line-height: 1.1;
+    line-height: var(--leading-tight);
   }
 
 .settingsHealthSummaryTile small {
@@ -261,13 +261,13 @@
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
 .settingsHealthSignalDetail {
     font-size: var(--font-size-caption);
     color: var(--foreground-secondary);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 
 .settingsHealthSignalMeta {
@@ -314,5 +314,5 @@
     background: var(--foreground-3);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
   }

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -67,7 +67,7 @@
 .maka-model-switcher-label {
   flex: 0 0 auto;
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   color: var(--muted-foreground);
 }
 
@@ -79,7 +79,7 @@
   white-space: nowrap;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 /* The popup, group headings, and option rows now render through the shared

--- a/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
+++ b/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
@@ -29,14 +29,14 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: 700;
-  line-height: 1.25;
+  line-height: var(--leading-tight);
 }
 
 .maka-capability-audit-copy small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-capability-audit-metrics {
@@ -68,7 +68,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 700;
-  line-height: 1.3;
+  line-height: var(--leading-snug);
   overflow-wrap: anywhere;
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
+++ b/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
@@ -20,22 +20,22 @@
 .maka-capability-audit-kicker {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
   text-transform: uppercase;
 }
 
 .maka-capability-audit-copy strong {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   line-height: var(--leading-tight);
 }
 
 .maka-capability-audit-copy small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-normal);
 }
 
@@ -58,8 +58,8 @@
 .maka-capability-audit-metrics dt {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
   text-transform: uppercase;
 }
 
@@ -67,7 +67,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   line-height: var(--leading-snug);
   overflow-wrap: anywhere;
 }

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -43,14 +43,14 @@
   font-size: 2em;
   font-weight: 600;
   letter-spacing: -0.012em;
-  line-height: 1.15;
+  line-height: var(--leading-tight);
 }
 
 .maka-module-main-header p {
   margin: var(--space-1) 0 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-module-main-actions {

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -41,8 +41,8 @@
   margin: 0;
   color: var(--foreground);
   font-size: 2em;
-  font-weight: 600;
-  letter-spacing: -0.012em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   line-height: var(--leading-tight);
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -64,14 +64,14 @@
   font-size: 2em;
   font-weight: 600;
   letter-spacing: -0.012em;
-  line-height: 1.15;
+  line-height: var(--leading-tight);
 }
 
 .maka-plan-heading p:last-child {
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-plan-top-actions {
@@ -191,7 +191,7 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   letter-spacing: 1px;
-  line-height: 20px;
+  line-height: var(--leading-normal);
 }
 
 .maka-plan-template-icon {
@@ -249,12 +249,12 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
-  line-height: 1.2;
+  line-height: var(--leading-tight);
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-title {
   font-size: var(--font-size-base);
-  line-height: 1.3;
+  line-height: var(--leading-snug);
 }
 
 .maka-plan-template-note {
@@ -264,7 +264,7 @@
   white-space: nowrap;
   font-size: var(--font-size-caption);
   font-weight: 500;
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-note {
@@ -274,7 +274,7 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 
 .maka-plan-template-schedule {
@@ -288,7 +288,7 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1;
+  line-height: var(--leading-none);
   padding: var(--space-0-5) var(--space-1-5);
   white-space: nowrap;
 }
@@ -577,7 +577,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
-  line-height: 1.2;
+  line-height: var(--leading-tight);
 }
 
 .maka-plan-form-grid {
@@ -642,7 +642,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   padding: var(--space-1) var(--space-2);
 }
 
@@ -657,7 +657,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 500;
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 .maka-plan-submit {
@@ -753,7 +753,7 @@
   color: var(--foreground);
   font-size: var(--font-size-base);
   font-weight: 600;
-  line-height: 1.3;
+  line-height: var(--leading-snug);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -790,7 +790,7 @@
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1;
+  line-height: var(--leading-none);
   padding: var(--space-0-5) var(--space-2);
 }
 
@@ -818,7 +818,7 @@
 .maka-plan-card-note {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   margin: 0;
   padding: 0;
   overflow: hidden;
@@ -877,7 +877,7 @@
 .maka-plan-run-row time {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .maka-plan-run-row time {

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -54,16 +54,16 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
 }
 
 .maka-plan-heading h2 {
   margin: 0;
   color: var(--foreground);
   font-size: 2em;
-  font-weight: 600;
-  letter-spacing: -0.012em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   line-height: var(--leading-tight);
 }
 
@@ -89,7 +89,7 @@
   border-color: transparent;
   border-radius: var(--radius-pill);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 /* PR-UI-PIXEL-3: signature off-black CTA, matching the reference's restrained
@@ -105,7 +105,7 @@
     0 1px 2px oklch(0 0 0 / 0.10);
   color: oklch(1 0 0);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
     border-color var(--duration-base) var(--ease-out-strong),
@@ -190,7 +190,7 @@
   justify-self: end;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  letter-spacing: 1px;
+  letter-spacing: var(--tracking-widest);
   line-height: var(--leading-normal);
 }
 
@@ -248,7 +248,7 @@
 .maka-plan-template-title {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -263,7 +263,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
 }
 
@@ -287,7 +287,7 @@
   background: var(--foreground-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
   padding: var(--space-0-5) var(--space-1-5);
   white-space: nowrap;
@@ -359,7 +359,7 @@
   flex: 0 0 auto;
   color: oklch(0.38 0.075 245);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
 
@@ -373,7 +373,7 @@
   border: 1px solid oklch(0.56 0.08 245 / 0.4);
   border-radius: var(--radius-pill);
   background: oklch(0.56 0.08 245 / 0.10);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .dark .maka-plan-system-alert {
@@ -418,7 +418,7 @@
   background: transparent;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-plan-tab span {
@@ -576,7 +576,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -591,7 +591,7 @@
   gap: var(--space-0-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-plan-field input,
@@ -603,7 +603,7 @@
   color: var(--foreground);
   font: inherit;
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   padding: var(--space-1-5) var(--space-2);
   outline: none;
   resize: vertical;
@@ -624,7 +624,7 @@
 .maka-plan-preset {
   min-width: 0;
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -641,7 +641,7 @@
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
   padding: var(--space-1) var(--space-2);
 }
@@ -656,7 +656,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
 }
 
@@ -670,7 +670,7 @@
   gap: var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-plan-search {
@@ -707,7 +707,7 @@
   color: var(--foreground);
   font: inherit;
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   outline: none;
   padding: var(--space-1-5) var(--space-2);
 }
@@ -725,7 +725,7 @@
   gap: var(--space-1-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-plan-empty {
@@ -752,7 +752,7 @@
   min-width: 0;
   color: var(--foreground);
   font-size: var(--font-size-base);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -789,7 +789,7 @@
   background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
   padding: var(--space-0-5) var(--space-2);
 }
@@ -808,9 +808,9 @@
   border-radius: var(--radius-pill);
   background: oklch(from var(--nav-active) l c h / 0.10);
   color: var(--nav-active);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-caption);
-  letter-spacing: 0;
+  letter-spacing: var(--tracking-normal);
 }
 
 /* PR-UI-PIXEL-1: note clamps to two lines (reference cards show a 2-line
@@ -844,7 +844,7 @@
   background: var(--foreground-3);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   padding: var(--space-0-5) var(--space-1-5);
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -101,7 +101,7 @@
   color: oklch(0.26 0.025 224);
   font-size: 1.2em;
   font-weight: 600;
-  line-height: 1.25;
+  line-height: var(--leading-tight);
 }
 
 .maka-skill-featured-banner p {
@@ -109,7 +109,7 @@
   margin: var(--space-2-5) 0 0;
   color: oklch(0.42 0.02 220);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-skill-featured-art {
@@ -152,14 +152,14 @@
 color: oklch(0.34 0.02 224);
   font-size: var(--font-size-caption);
   font-weight: 650;
-  line-height: 1.1;
+  line-height: var(--leading-tight);
 }
 
 .maka-skill-featured-art small {
 color: oklch(0.55 0.015 220);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1.1;
+  line-height: var(--leading-tight);
 }
 
 .maka-skill-featured-art span:first-child {
@@ -317,7 +317,7 @@ color: oklch(0.55 0.015 220);
   color: var(--foreground);
   font-size: var(--font-size-base);
   font-weight: 600;
-  line-height: 1.25;
+  line-height: var(--leading-tight);
 }
 
 .maka-skill-market-card small,
@@ -332,7 +332,7 @@ color: oklch(0.55 0.015 220);
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -443,14 +443,14 @@ color: oklch(0.55 0.015 220);
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: 600;
-  line-height: 1.3;
+  line-height: var(--leading-snug);
 }
 
 .maka-skill-template-copy span {
   min-width: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-skill-template-row small {
@@ -461,7 +461,7 @@ color: oklch(0.55 0.015 220);
   white-space: nowrap;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .maka-skill-library-list {
@@ -576,7 +576,7 @@ color: oklch(0.55 0.015 220);
   white-space: nowrap;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-skill-library-meta {

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -40,7 +40,7 @@
     0 1px 2px oklch(0.1 0 0 / 0.10);
   color: oklch(1 0 0);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-skill-add-button:hover {
@@ -100,7 +100,7 @@
   margin: 0;
   color: oklch(0.26 0.025 224);
   font-size: 1.2em;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -151,14 +151,14 @@
 .maka-skill-featured-art strong {
 color: oklch(0.34 0.02 224);
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
 .maka-skill-featured-art small {
 color: oklch(0.55 0.015 220);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -218,10 +218,9 @@ color: oklch(0.55 0.015 220);
   background: transparent;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   padding: 0 1px;
 }
-
 .maka-skill-tab span {
   min-width: 16px;
   height: 16px;
@@ -232,7 +231,7 @@ color: oklch(0.55 0.015 220);
   background: oklch(from var(--foreground) l c h / 0.06);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   padding: 0 var(--space-1);
 }
 
@@ -254,7 +253,7 @@ color: oklch(0.55 0.015 220);
   background: var(--background);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   padding: 0 var(--space-3);
   opacity: 1;
 }
@@ -274,7 +273,7 @@ color: oklch(0.55 0.015 220);
 .maka-skill-section-row small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-skill-market-grid {
@@ -316,7 +315,7 @@ color: oklch(0.55 0.015 220);
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-base);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -324,7 +323,7 @@ color: oklch(0.55 0.015 220);
 .maka-skill-market-card-foot span {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-skill-market-card p {
@@ -372,7 +371,7 @@ color: oklch(0.55 0.015 220);
   background: var(--foreground-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   padding: 0 var(--space-2-5);
 }
 
@@ -388,8 +387,8 @@ color: oklch(0.55 0.015 220);
 .maka-skill-section-label {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-widest);
   text-transform: uppercase;
 }
 
@@ -442,7 +441,7 @@ color: oklch(0.55 0.015 220);
   white-space: nowrap;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
 }
 
@@ -566,7 +565,7 @@ color: oklch(0.55 0.015 220);
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-skill-library-description {
@@ -602,9 +601,9 @@ color: oklch(0.55 0.015 220);
   border-radius: var(--radius-pill);
   background: oklch(from var(--foreground) l c h / 0.05);
   color: var(--muted-foreground);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  letter-spacing: -0.01em;
+  letter-spacing: var(--tracking-normal);
 }
 
 .maka-skill-library-action {
@@ -616,7 +615,7 @@ color: oklch(0.55 0.015 220);
   background: var(--background);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   text-align: center;
   transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
 }

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -41,9 +41,9 @@
   max-width: 32ch;
   color: var(--foreground);
   font-size: 1.2em;
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
-  letter-spacing: 0;
+  letter-spacing: var(--tracking-normal);
 }
 
 .maka-onboarding header p {
@@ -110,9 +110,9 @@
   margin: 0;
   max-width: none;
   font-size: 1.7333em;
-  font-weight: 680;
+  font-weight: var(--font-weight-bold);
   line-height: var(--leading-tight);
-  letter-spacing: -0.01em;
+  letter-spacing: var(--tracking-normal);
   color: var(--foreground);
 }
 
@@ -149,7 +149,7 @@
   height: 21px;
   border-radius: var(--radius-pill);
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   border: 1.5px solid var(--border-strong);
   color: var(--muted-foreground);
 }
@@ -170,7 +170,7 @@
 }
 .maka-firstrun-step[data-state="active"] .maka-firstrun-step-label {
   color: var(--foreground);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-firstrun-step[data-state="done"] .maka-firstrun-step-dot {
@@ -202,7 +202,7 @@
 }
 .maka-firstrun-pick-label {
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
 .maka-firstrun-pick-hint {
@@ -235,7 +235,7 @@
 .maka-firstrun-tag {
   flex: 0 0 auto;
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
   color: var(--nav-active);
   background: oklch(from var(--nav-active) l c h / 0.12);
@@ -304,7 +304,7 @@
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-onboarding-setup-steps > li[data-state="active"] .maka-onboarding-setup-step-marker {
@@ -326,7 +326,7 @@
 .maka-onboarding-setup-step-copy strong {
   color: var(--foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }
 
@@ -343,7 +343,7 @@
   background: var(--background-elevated);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
 
@@ -400,7 +400,7 @@
 }
 
 .maka-onboarding-slug {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-mono);
   font-size: var(--font-size-ui);
   padding: var(--space-0-5) var(--space-1-5);
   /* PR-UI-LAYOUT-25: slug radius 6 → 8 to join the form input
@@ -414,10 +414,10 @@
    main composer but lives inside the hero card so the first-run
    surface stays self-contained. */
 .maka-onboarding-ready header h1 {
-  font-family: Georgia, "Times New Roman", Times, serif;
+  font-family: var(--font-serif);
   font-size: 1.9333em;
-  font-weight: 680;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
   line-height: var(--leading-tight);
 }
 .maka-onboarding-ready header p {
@@ -496,7 +496,7 @@
 .maka-onboarding-quickchat-example[data-pending="true"] {
   color: var(--status-running);
   font-style: normal;
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
 }
 .maka-onboarding-quickchat-mode {
   width: fit-content;
@@ -570,7 +570,7 @@
 .maka-first-run-task-suggestions-header > strong {
   font-size: var(--font-size-ui);
   color: var(--muted-foreground);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-first-run-task-suggestion-list {
@@ -674,7 +674,7 @@
   gap: var(--space-1-5);
   overflow: hidden;
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   min-width: 0;
 }
 
@@ -730,7 +730,7 @@
   white-space: nowrap;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
@@ -858,7 +858,7 @@
   font-variant-numeric: tabular-nums;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .maka-list-row-stale-pill {
@@ -874,7 +874,7 @@
   background: oklch(from var(--warning, var(--info)) l c h / 0.18);
   color: var(--warning-text, var(--info-text));
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
 }
 
@@ -910,7 +910,7 @@
 .maka-empty-state-title {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-empty-state-body {
@@ -942,7 +942,7 @@
 .maka-session-list .maka-session-empty-state .maka-empty-state-title {
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-session-list .maka-session-empty-state .maka-empty-state-body {

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -42,7 +42,7 @@
   color: var(--foreground);
   font-size: 1.2em;
   font-weight: 650;
-  line-height: 1.25;
+  line-height: var(--leading-tight);
   letter-spacing: 0;
 }
 
@@ -111,7 +111,7 @@
   max-width: none;
   font-size: 1.7333em;
   font-weight: 680;
-  line-height: 1.2;
+  line-height: var(--leading-tight);
   letter-spacing: -0.01em;
   color: var(--foreground);
 }
@@ -119,7 +119,7 @@
 .maka-firstrun-sub {
   margin: var(--space-2) 0 0;
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   color: var(--muted-foreground);
 }
 
@@ -236,7 +236,7 @@
   flex: 0 0 auto;
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1;
+  line-height: var(--leading-none);
   color: var(--nav-active);
   background: oklch(from var(--nav-active) l c h / 0.12);
   padding: var(--space-0-5) var(--space-1-5);
@@ -327,13 +327,13 @@
   color: var(--foreground);
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1.2;
+  line-height: var(--leading-tight);
 }
 
 .maka-onboarding-setup-step-copy small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.3;
+  line-height: var(--leading-snug);
 }
 
 .maka-onboarding-setup-step-state {
@@ -380,7 +380,7 @@
 .maka-onboarding-setup header p {
   margin-top: var(--space-2);
   color: var(--foreground-secondary);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 .maka-onboarding-setup[data-tone="warning"] header h1 {
   color: var(--warning, var(--info-text));
@@ -418,14 +418,14 @@
   font-size: 1.9333em;
   font-weight: 680;
   letter-spacing: 0;
-  line-height: 1.18;
+  line-height: var(--leading-tight);
 }
 .maka-onboarding-ready header p {
   /* Slightly larger subtitle so it carries the meaning without
      reading like fine print under the now-heavier h1. */
   margin-top: var(--space-1-5);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   max-width: 56ch;
 }
 .maka-onboarding-quickchat {
@@ -470,7 +470,7 @@
   min-height: 90px;
   color: var(--foreground);
   font-size: var(--font-size-base);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 /* Drag-active feedback lives on the wrapper, not the inner textarea, because
    the wrapper owns the visible field chrome for this bare textarea. */
@@ -490,7 +490,7 @@
   padding-inline: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   font-style: italic;
 }
 .maka-onboarding-quickchat-example[data-pending="true"] {
@@ -508,7 +508,7 @@
   color: var(--nav-active);
   background: color-mix(in srgb, var(--nav-active) 10%, transparent);
   font-size: var(--font-size-caption);
-  line-height: 1;
+  line-height: var(--leading-none);
 }
 .maka-onboarding-quickchat-submit {
   display: inline-flex;
@@ -601,7 +601,7 @@
   min-height: 38px;
   padding: var(--space-2) var(--space-4);
   font-size: var(--font-size-ui);
-  line-height: 1.2;
+  line-height: var(--leading-tight);
   text-align: center;
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.04);
 }
@@ -875,7 +875,7 @@
   color: var(--warning-text, var(--info-text));
   font-size: var(--font-size-caption);
   font-weight: 600;
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 .maka-list-row:hover .maka-list-row-name {
@@ -917,7 +917,7 @@
   max-width: 30ch;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   text-wrap: pretty;
 }
 

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -33,7 +33,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     max-width: 52ch;
   }
 
@@ -178,7 +178,7 @@
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 
 .settingsCapabilityLayers {
@@ -311,7 +311,7 @@
     padding-left: var(--space-4);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
   }
 
 .settingsCapabilityGuidanceActions {
@@ -458,7 +458,7 @@
 .settingsOsPermissionPurpose {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
   }
 
 .settingsOsPermissionImpact {
@@ -467,7 +467,7 @@
     gap: var(--space-1-5);
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 
 .settingsOsPermissionImpactLabel {
@@ -567,7 +567,7 @@
 .settingsPermissionSummaryValue {
     font-size: 1.5em;
     font-weight: 600;
-    line-height: 1.1;
+    line-height: var(--leading-tight);
     font-variant-numeric: tabular-nums;
     color: var(--foreground);
   }
@@ -615,5 +615,5 @@
     background: var(--foreground-3);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
   }

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -26,7 +26,7 @@
 .settingsPermissionIntro h3 {
     margin: 0 0 var(--space-1-5);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .settingsPermissionIntro p {
@@ -105,7 +105,7 @@
 .settingsPermissionSection > header h4 {
     margin: 0 0 var(--space-0-5);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }
 
@@ -165,7 +165,7 @@
 
 .settingsCapabilityHeading strong {
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .settingsCapabilityId {
@@ -199,7 +199,7 @@
 
 .settingsCapabilityLayers dt {
     font-size: var(--font-size-caption);
-    letter-spacing: 0.06em;
+    letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--muted-foreground);
     margin: 0;
@@ -237,7 +237,7 @@
 
 .settingsCapabilityOsPermissions > span {
     font-size: var(--font-size-caption);
-    letter-spacing: 0.06em;
+    letter-spacing: var(--tracking-wider);
     text-transform: uppercase;
     color: var(--muted-foreground);
   }
@@ -302,7 +302,7 @@
 
 .settingsCapabilityGuidance > span {
     font-size: var(--font-size-caption);
-    font-weight: 650;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground-secondary);
   }
 
@@ -451,7 +451,7 @@
 
 .settingsOsPermissionHeading strong {
     font-size: var(--font-size-base);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }
 
@@ -478,8 +478,8 @@
     background: oklch(from var(--foreground) l c h / 0.05);
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0.04em;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-wider);
   }
 
 .settingsOsPermissionReason {
@@ -566,7 +566,7 @@
 
 .settingsPermissionSummaryValue {
     font-size: 1.5em;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     line-height: var(--leading-tight);
     font-variant-numeric: tabular-nums;
     color: var(--foreground);
@@ -575,7 +575,7 @@
 .settingsPermissionSummaryLabel {
     font-size: var(--font-size-caption);
     color: var(--foreground-secondary);
-    letter-spacing: 0.02em;
+    letter-spacing: var(--tracking-wide);
   }
 
 .settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -25,8 +25,8 @@
     gap: var(--space-1-5);
     padding: var(--space-1) var(--space-2);
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0.02em;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-wide);
     color: var(--info-text);
     user-select: none;
     transition: background var(--duration-base) var(--ease-out-strong);

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -93,7 +93,7 @@
      the same visual family. */
 .maka-reasoning-panel-chevron {
     font-size: var(--font-size-ui);
-    line-height: 1;
+    line-height: var(--leading-none);
     color: var(--muted-foreground);
     transition: transform var(--duration-base) var(--ease-out-strong);
   }
@@ -108,7 +108,7 @@
     color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    line-height: 1.55;
+    line-height: var(--leading-normal);
     max-height: 280px;
     overflow-y: auto;
     white-space: pre-wrap;

--- a/apps/desktop/src/renderer/styles/settings-select.css
+++ b/apps/desktop/src/renderer/styles/settings-select.css
@@ -11,7 +11,7 @@
   justify-content: space-between;
   border-radius: var(--radius-control);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsSelectPositioner {
@@ -76,7 +76,7 @@
   display: block;
   color: var(--foreground);
   font-size: var(--font-size-ui); /* text-sm on the 15px root — same scale as headings */
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
 }
 
@@ -90,7 +90,7 @@
   gap: var(--space-2);
   padding: var(--space-1-5) var(--space-3) var(--space-1);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
   color: var(--muted-foreground);
 }

--- a/apps/desktop/src/renderer/styles/settings-select.css
+++ b/apps/desktop/src/renderer/styles/settings-select.css
@@ -77,7 +77,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui); /* text-sm on the 15px root — same scale as headings */
   font-weight: 500;
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 /* Heading: same 13px as the rows; hierarchy comes from weight 500 + muted ink
@@ -91,7 +91,7 @@
   padding: var(--space-1-5) var(--space-3) var(--space-1);
   font-size: var(--font-size-ui);
   font-weight: 500;
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   color: var(--muted-foreground);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -170,7 +170,7 @@
   .settingsHelpText {
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
   }
 .settingsBotEnableHint {
     display: block;
@@ -247,7 +247,7 @@
     border-left: 2px solid var(--focus-ring);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.5;
+    line-height: var(--leading-normal);
     padding-left: var(--space-2-5);
   }
 /* PR-BOT-CHAT-POLISH-0: error tone for persisted lastError so the
@@ -286,7 +286,7 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: 500;
-  line-height: 1;
+  line-height: var(--leading-none);
   white-space: nowrap;
 }
 
@@ -296,7 +296,7 @@
   align-items: center;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1;
+  line-height: var(--leading-none);
   white-space: nowrap;
 }
 
@@ -403,7 +403,7 @@
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--muted-foreground);
-  line-height: 1;
+  line-height: var(--leading-none);
 }
 
 .settingsCloseButton svg {

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -64,7 +64,7 @@
   padding: 0 var(--space-1-5);
   color: var(--muted-foreground);
   font-style: normal;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-wider);
 }
 
 /* PR-BOT-LOGO-NEUTRAL-PLATE-0 (WAWQAQ msg `f3d263b4` 2026-06-26):
@@ -87,8 +87,8 @@
     background: transparent;
     color: var(--bot-brand-color, var(--bot-brand-default));
     font-size: var(--font-size-ui);
-    font-weight: 700;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--tracking-normal);
     flex-shrink: 0;
   }
 .settingsBotLogo svg {
@@ -180,7 +180,7 @@
 .settingsBotConfigDocLink {
     color: var(--bot-brand-color, var(--bot-brand-default));
     text-decoration: none;
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     white-space: nowrap;
   }
 .settingsBotConfigDocLink:hover {
@@ -195,8 +195,8 @@
     background: color-mix(in srgb, var(--foreground) 5%, transparent);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    font-weight: 500;
-    letter-spacing: 0.01em;
+    font-weight: var(--font-weight-medium);
+    letter-spacing: var(--tracking-normal);
   }
 .settingsBotStatusPillDot {
     width: 6px;
@@ -285,7 +285,7 @@
   gap: var(--space-1-5);
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-none);
   white-space: nowrap;
 }
@@ -391,7 +391,7 @@
 
 .settingsStatsTable th {
   color: var(--foreground-secondary);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsCloseButton {

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -161,7 +161,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 .settingsAuthContract {
     display: flex;
@@ -187,7 +187,7 @@
 .settingsAuthContractText span {
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 .settingsAuthContractBadge,
   .settingsAuthActionPill {
@@ -280,7 +280,7 @@
     margin-top: var(--space-1);
     color: var(--muted-foreground);
     font-size: var(--font-size-ui);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
   }
 .providersPanel {
     min-height: 420px;

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -75,7 +75,7 @@
     border: 1px solid var(--border);
     background: var(--background);
     color: var(--foreground);
-    font-family: var(--mono-font, monospace);
+    font-family: var(--font-mono);
     font-size: var(--font-size-ui);
     resize: vertical;
   }
@@ -102,8 +102,8 @@
     background: oklch(from var(--nav-active) l c h / 0.14);
     color: var(--nav-active);
     font-size: var(--font-size-caption);
-    font-weight: 700;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: var(--tracking-normal);
   }
 .settingsConnectionRowHead {
     display: flex;
@@ -119,7 +119,7 @@
 .settingsConnectionRowText strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 .settingsConnectionRowText small {
     color: var(--muted-foreground);
@@ -133,8 +133,8 @@
     padding: var(--space-0-5) var(--space-2);
     border-radius: var(--radius-control);
     font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: var(--tracking-normal);
     background: var(--foreground-5);
     color: var(--foreground-secondary);
     white-space: nowrap;
@@ -150,12 +150,12 @@
 .settingsConnectionBadge[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
 .settingsConnectionBadge[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.15);
     color: var(--destructive);
-    font-weight: 700;
+    font-weight: var(--font-weight-bold);
   }
 .settingsConnectionDetail {
     margin: 0;
@@ -182,7 +182,7 @@
 .settingsAuthContractText strong {
     color: var(--foreground);
     font-size: var(--font-size-ui);
-    font-weight: 650;
+    font-weight: var(--font-weight-semibold);
   }
 .settingsAuthContractText span {
     color: var(--foreground-secondary);
@@ -197,7 +197,7 @@
     border-radius: var(--radius-control);
     white-space: nowrap;
     font-size: var(--font-size-caption);
-    font-weight: 650;
+    font-weight: var(--font-weight-semibold);
   }
 .settingsAuthContractBadge {
     padding: var(--space-0-5) var(--space-2);

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -33,8 +33,8 @@
   padding: 0 var(--space-1);
   border-radius: var(--radius-control);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -4,7 +4,7 @@
   border-radius: var(--radius-control);
   padding: var(--space-1-5) var(--space-2-5);
   font-size: var(--font-size-caption);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   color: var(--warning-text);
   background: oklch(from var(--warning) l c h / 0.10);
   border: 1px solid oklch(from var(--warning) l c h / 0.20);

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -342,7 +342,7 @@
   background: transparent;
   color: var(--foreground);
   font-size: var(--font-size-base);
-  line-height: 1;
+  line-height: var(--leading-none);
 }
 
 .maka-browser-navbtn:hover:not(:disabled) {
@@ -643,7 +643,7 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-artifact-preview-diff {
@@ -722,7 +722,7 @@
 .maka-artifact-preview-unsupported-body {
   margin: 0;
   font-size: var(--font-size-ui);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
   color: var(--foreground-secondary);
 }
 
@@ -814,7 +814,7 @@
 .maka-artifact-preview-fail-body {
   margin: 0;
   font-size: var(--font-size-caption);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 
 .maka-artifact-toolbar {
@@ -991,7 +991,7 @@
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--info-text);
   font-size: var(--font-size-caption);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   transition: background var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong), border-color var(--duration-base) var(--ease-out-strong);
   align-self: flex-start;
 }

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -38,8 +38,8 @@
 
 .enabledProviderName {
   font-size: var(--font-size-ui);
-  font-weight: 620;
-  letter-spacing: -0.002em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -124,7 +124,7 @@
 
 .enabledDefaultTag {
   font-size: var(--font-size-caption);
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
   color: var(--nav-active);
   background: oklch(from var(--nav-active) l c h / 0.14);
   border-radius: var(--radius-pill);
@@ -147,7 +147,7 @@
 
 .catalogPillTabs strong {
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .providerMarketGrid,
@@ -244,7 +244,7 @@
   color: var(--link);
   padding: 0 var(--space-3);
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .providerConfigOverlay {
@@ -443,8 +443,8 @@
 
 .maka-artifact-pane-title {
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
   color: var(--foreground);
 }
@@ -480,7 +480,7 @@
   display: block;
   margin-bottom: var(--space-0-5);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-artifact-list-error p {
@@ -592,7 +592,7 @@
 }
 
 .maka-artifact-row-name {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -609,7 +609,7 @@
 }
 
 .maka-artifact-row-size {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-artifact-row-badge {
@@ -715,7 +715,7 @@
 
 .maka-artifact-preview-unsupported-title {
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
 
@@ -740,7 +740,7 @@
 }
 .maka-artifact-preview-unsupported-meta dt {
   color: var(--foreground-secondary);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 .maka-artifact-preview-unsupported-meta dd {
   margin: 0;
@@ -808,7 +808,7 @@
 }
 
 .maka-artifact-preview-fail-title {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-artifact-preview-fail-body {

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -261,7 +261,7 @@
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   width: fit-content;
   max-width: 100%;
 }
@@ -311,7 +311,7 @@
   max-width: 56ch;
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .settingsFeatureStatusList {
@@ -321,7 +321,7 @@
   gap: var(--space-1);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .settingsFeatureStatusList li::marker {
@@ -484,7 +484,7 @@
   font-size: 1.7333em;
   font-weight: 650;
   letter-spacing: -0.012em;
-  line-height: 1.2;
+  line-height: var(--leading-tight);
   text-wrap: balance;
 }
 
@@ -496,7 +496,7 @@
   max-width: 56ch;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   text-wrap: pretty;
 }
 
@@ -701,7 +701,7 @@
   color: var(--foreground);
   font-size: var(--font-size-base);
   font-weight: 500;
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .settingsFormRow small,
@@ -712,7 +712,7 @@
   /* Hint is the most-read body text on the page; use the base scale so
      it clears the 14px legibility floor. */
   font-size: var(--font-size-base);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 
 .settingsFieldWarning {

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -42,7 +42,7 @@
   background: transparent;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   text-align: left;
   justify-content: initial;
   -webkit-app-region: no-drag;
@@ -76,7 +76,7 @@
   gap: var(--space-1);
   color: var(--foreground);
   font-size: 1.2em;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .settingsSidebar header .maka-shortcut-kbd {
@@ -106,8 +106,8 @@
   display: flex;
   align-items: center;
   font-size: var(--font-size-caption);
-  font-weight: 500;
-  letter-spacing: 0.05em;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-wider);
   text-transform: none;
   color: var(--muted-foreground);
   padding: var(--space-4) var(--space-3) var(--space-1-5);
@@ -170,8 +170,8 @@
   background: oklch(from var(--nav-active) l c h / 0.12);
   color: var(--nav-active);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-wider);
   text-transform: none;
 }
 
@@ -199,7 +199,7 @@
      accent rail reads like a stray status marker in the Settings nav. */
   background: var(--state-selected-bg);
   color: var(--foreground);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   box-shadow: none;
 }
 
@@ -241,7 +241,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsFeatureStatusPage {
@@ -267,8 +267,8 @@
 }
 .settingsFeatureStatusBanner strong {
   color: var(--info-text);
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-wide);
 }
 .settingsFeatureStatusBannerDot {
   width: 8px;
@@ -303,7 +303,7 @@
   margin: 0 0 var(--space-0-5);
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsFeatureStatusHero p {
@@ -391,8 +391,8 @@
   background: oklch(from var(--nav-active) l c h / 0.12);
   color: var(--nav-active);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-wide);
   white-space: nowrap;
 }
 
@@ -482,8 +482,8 @@
   margin: 0;
   color: var(--foreground);
   font-size: 1.7333em;
-  font-weight: 650;
-  letter-spacing: -0.012em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   line-height: var(--leading-tight);
   text-wrap: balance;
 }
@@ -568,8 +568,8 @@
   margin: var(--space-6) var(--space-0-5) var(--space-2-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-widest);
   text-transform: uppercase;
 }
 .settingsStructuredPage > .settingsSectionHeading:first-child {
@@ -700,7 +700,7 @@
   display: block;
   color: var(--foreground);
   font-size: var(--font-size-base);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -9,7 +9,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 .catalogTabs {
@@ -38,7 +38,7 @@
 .catalogTabs small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.2;
+  line-height: var(--leading-tight);
 }
 
 /* Provider catalog + OAuth login render as governed Item rows (media ·
@@ -100,7 +100,7 @@
   font-size: var(--font-size-caption);
   font-style: normal;
   font-weight: 600;
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .providerEditor {
@@ -120,7 +120,7 @@
 
 .providerUnavailableNotice span {
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 /* Direct child only: this is the sheet's own title/badges header. The
@@ -253,7 +253,7 @@
 
 .modelTableHeaderText small {
   font-size: var(--font-size-caption);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   color: var(--foreground-secondary);
 }
 
@@ -295,7 +295,7 @@
   background: var(--background);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
   text-align: center;
 }
 
@@ -310,7 +310,7 @@
   background: oklch(from var(--focus-ring) l c h / 0.06);
   color: var(--foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   width: 100%;
 }
 
@@ -492,7 +492,7 @@
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--font-size-caption);
   text-align: left;
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   word-break: break-all;
 }
 
@@ -547,7 +547,7 @@
   background: color-mix(in srgb, var(--warning) 10%, var(--background));
   color: var(--warning-text);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   padding: var(--space-2) var(--space-3);
 }
 .providerOAuthGrid {
@@ -602,7 +602,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 /* Empty / load-error CTA shown when there are no connections yet. */
@@ -627,11 +627,11 @@
 .enabledEmptyChip strong {
   font-size: var(--font-size-ui);
   font-weight: 700;
-  line-height: 1.35;
+  line-height: var(--leading-snug);
 }
 
 .enabledEmptyChip small {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -2,7 +2,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .providerEditor p {
@@ -32,7 +32,7 @@
 
 .catalogTabs strong {
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .catalogTabs small {
@@ -68,7 +68,7 @@
 }
 
 .providerCatalogTitle {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 /* Trailing badge + chevron live in ItemActions (a direct child of the row),
@@ -99,7 +99,7 @@
   padding: var(--space-0-5) var(--space-1-5);
   font-size: var(--font-size-caption);
   font-style: normal;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
 }
 
@@ -144,7 +144,7 @@
   gap: var(--space-1-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .providerEditor input,
@@ -192,7 +192,7 @@
   width: fit-content;
   color: var(--link);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   text-decoration: none;
   /* PR-UI-LAYOUT-33: explicit padding + radius so the focus halo
    * has a defined shape. Was a borderless inline link with no
@@ -247,7 +247,7 @@
 
 .modelTableHeaderText strong {
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--foreground);
 }
 
@@ -322,7 +322,7 @@
   font-family: var(--font-mono);
   background: transparent;
   color: var(--link);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .modelTableList {
@@ -443,8 +443,8 @@
   background: var(--foreground-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 600;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
   text-transform: uppercase;
 }
 
@@ -454,8 +454,8 @@
   background: oklch(from var(--nav-active) l c h / 0.14);
   color: var(--nav-active);
   font-size: var(--font-size-caption);
-  font-weight: 700;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
 }
 
 .providerError {
@@ -468,7 +468,7 @@
 .settingsRow strong {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
 }
 
@@ -489,7 +489,7 @@
    wraps into a ragged multi-line block. Mono + left-aligned + caption
    size reads as the file path it is. */
 .settingsRow > span[data-mono="true"] {
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   text-align: left;
   line-height: var(--leading-normal);
@@ -558,8 +558,8 @@
 
 .providerOAuthCardBadge {
   font-size: var(--font-size-caption);
-  font-weight: 500;
-  letter-spacing: 0.02em;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-wide);
 }
 
 .providerOAuthCard[data-logged-in="true"] .providerOAuthCardBadge {
@@ -593,7 +593,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .enabledStripHeader span,
@@ -626,7 +626,7 @@
 
 .enabledEmptyChip strong {
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   line-height: var(--leading-snug);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -17,7 +17,7 @@
   color: var(--foreground);
   padding: var(--space-1-5) var(--space-2-5);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   outline: none;
   transition: border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong);
 }
@@ -25,7 +25,7 @@
 .settingsField textarea {
   border-radius: var(--radius-control);
   padding: var(--space-2) var(--space-2-5);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
   font-family: inherit;
   font-size: var(--font-size-ui);
 }
@@ -50,7 +50,7 @@
   color: var(--info-text);
   padding: var(--space-3) var(--space-3);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .settingsNotice[data-tone="passive"] {
@@ -133,7 +133,7 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 
 .settingsAboutPrivacy {
@@ -161,7 +161,7 @@
   gap: var(--space-1-5);
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 
 .settingsAboutPrivacy li::marker {
@@ -462,13 +462,13 @@
   border: 1px solid oklch(from var(--info) l c h / 0.18);
   color: var(--info-text);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 .settingsBotInfoNoticeIcon {
   font-style: normal;
   font-weight: 500;
   color: var(--info-text);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 /* PR-BOT-WECHAT-QR-MODAL-0 (WAWQAQ msg `10ec1fbe`): scan-login modal —
@@ -606,7 +606,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 
 .settingsWechatQrClose {
@@ -669,7 +669,7 @@
   color: var(--foreground-secondary);
   padding: var(--space-4);
   font-size: var(--font-size-ui);
-  line-height: 1.5;
+  line-height: var(--leading-normal);
 }
 
 .settingsWechatQrState strong {
@@ -733,7 +733,7 @@
 .settingsThemeLabel small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   overflow-wrap: anywhere;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -107,8 +107,8 @@
   margin: 0;
   color: var(--foreground);
   font-size: 1.4667em;
-  font-weight: 700;
-  letter-spacing: -0.01em;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
 }
 
 .settingsAboutVersion {
@@ -126,7 +126,7 @@
   padding: var(--space-0-5) var(--space-2);
   border-radius: var(--radius-pill);
   background: oklch(from var(--accent) l c h / 0.10);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsAboutTagline {
@@ -149,8 +149,8 @@
   margin: 0;
   color: var(--success);
   font-size: var(--font-size-ui);
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
 }
 
@@ -358,9 +358,9 @@
 .settingsPaletteGroupHeading {
   margin: 0;
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--muted-foreground);
-  letter-spacing: 0;
+  letter-spacing: var(--tracking-normal);
 }
 
 /* PR-BOT-SETTINGS-PASSWORD-EYE-0 (WAWQAQ msg `51c7b4ff` screenshots):
@@ -425,7 +425,7 @@
   background: transparent;
   color: var(--accent);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
 }
 .settingsBotAction:hover {
@@ -444,7 +444,7 @@
    "(仅用于 Bot 鉴权)" in the reference. */
 .settingsFieldHint {
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-normal);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   margin-left: var(--space-1-5);
@@ -466,7 +466,7 @@
 }
 .settingsBotInfoNoticeIcon {
   font-style: normal;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--info-text);
   line-height: var(--leading-snug);
 }
@@ -492,7 +492,7 @@
 .settingsBotScanLoginHeader h3 {
   margin: 0;
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 .settingsBotScanLoginBody {
   display: flex;
@@ -524,7 +524,7 @@
 .settingsBotScanLoginStatus {
   margin: 0;
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--foreground-secondary);
 }
 .settingsBotScanLoginStatus[data-status="confirmed"] { color: var(--success-text); }
@@ -598,7 +598,7 @@
 .settingsWechatQrHeader h3 {
   margin: 0 0 var(--space-1);
   font-size: 1.0667em;
-  font-weight: 650;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsWechatQrHeader p,
@@ -674,7 +674,7 @@
 
 .settingsWechatQrState strong {
   color: inherit;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsWechatQrState[data-tone="success"] {
@@ -703,7 +703,7 @@
   color: var(--accent);
   padding: 0 var(--space-3);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .settingsWechatQrSecondary:hover {
@@ -724,7 +724,7 @@
 .settingsThemeLabel strong {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -747,8 +747,8 @@
   margin: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -317,7 +317,7 @@
 .maka-search-modal-title {
   margin: 0;
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
 .maka-search-modal-close {
@@ -474,7 +474,7 @@
 }
 .maka-search-modal-result-title {
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -695,7 +695,7 @@
   padding: 0 var(--space-1-5) var(--space-0-5);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   font-variant-numeric: tabular-nums;
 }
 
@@ -749,7 +749,7 @@
 
 .maka-list-row[data-active="true"] .maka-list-row-name {
   color: var(--foreground);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-list-row-main {
@@ -855,7 +855,7 @@
   color: var(--foreground);
   font: inherit;
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   outline: 0;
   padding: 1px 0;
   border-bottom: 1px solid oklch(from var(--focus-ring) l c h / 0.4);
@@ -930,7 +930,7 @@
 .maka-prompt-chip-label {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .maka-prompt-chip-hint {
@@ -966,7 +966,7 @@
   margin: 0 0 var(--space-1);
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 
 .maka-deep-research-workflow-body {
@@ -1024,7 +1024,7 @@
 .maka-deep-research-progress-title {
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   white-space: nowrap;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -327,7 +327,7 @@
   background: transparent;
   color: var(--foreground-secondary);
   font-size: 1.0667em;
-  line-height: 1;
+  line-height: var(--leading-none);
   border-radius: var(--radius-control);
 }
 .maka-search-modal-close:hover {
@@ -361,7 +361,7 @@
   width: 100%;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 .maka-search-modal-input::placeholder {
   color: var(--muted-foreground);
@@ -490,7 +490,7 @@
 .maka-search-modal-result-snippet {
   font-size: var(--font-size-caption);
   color: var(--foreground-secondary);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
   /* Plain text snippet — backend redacts secrets + bounds to
    * SNIPPET_MAX_CODE_POINTS. We cap visual lines at 3 so very
    * long snippets don't blow up the row height. */
@@ -936,7 +936,7 @@
 .maka-prompt-chip-hint {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -973,7 +973,7 @@
   display: block;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-deep-research-report,
@@ -993,7 +993,7 @@
   margin: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.3;
+  line-height: var(--leading-snug);
 }
 
 .maka-deep-research-report ul,
@@ -1035,5 +1035,5 @@
   min-width: 0;
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -106,8 +106,8 @@ html[data-os="darwin"].dark {
    from --color-text-quaternary is enough hierarchy. */
 html[data-os="darwin"] .maka-list-group-label {
   font-size: var(--font-size-ui);
-  font-weight: 500;
-  letter-spacing: 0;
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-normal);
   text-transform: none;
   color: var(--color-text-quaternary);
 }

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -6,7 +6,7 @@
   display: inline-block;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   line-height: var(--leading-none);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -200,7 +200,7 @@
   background: oklch(from var(--background) l c h / 0.82);
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
@@ -268,7 +268,7 @@
 }
 .maka-composer-mode-menu-label {
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   color: var(--foreground);
 }
 .maka-composer-mode-menu-hint {
@@ -315,7 +315,7 @@
   max-width: 128px;
   color: inherit;
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .maka-composer-model-chip-text {

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -7,7 +7,7 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: 500;
-  line-height: 1;
+  line-height: var(--leading-none);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -137,7 +137,7 @@
   color: var(--foreground);
   font-family: var(--font-default);
   font-size: var(--font-size-base);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 
 .maka-composer-streaming-hint .maka-shortcut-kbd {
@@ -274,7 +274,7 @@
 .maka-composer-mode-menu-hint {
   font-size: var(--font-size-caption);
   color: var(--muted-foreground);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
   white-space: normal;
 }
 .maka-composer-mode-menu [data-active="true"] {

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -65,7 +65,7 @@
     background: var(--foreground-3);
   }
 .settingsWebSearchResult a {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     color: var(--foreground);
     text-decoration: none;
   }
@@ -76,7 +76,7 @@
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: var(--tracking-wider);
   }
 .settingsWebSearchResult p {
     margin: 0;
@@ -419,7 +419,7 @@
 
 .settingsMemoryDirtyState[data-dirty="true"] {
     color: var(--warning-text, var(--info-text));
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
   }
 
 .settingsMemoryEntryCard p,
@@ -569,7 +569,7 @@
 .settingsMemoryEditor > span {
   color: var(--foreground-secondary);
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .settingsMemoryEditor textarea {
@@ -584,7 +584,7 @@
   font-family: inherit;
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
-  letter-spacing: 0;
+  letter-spacing: var(--tracking-normal);
   tab-size: 2;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -646,7 +646,7 @@
 .maka-first-run-checklist-count {
     margin-left: auto;
     font-size: var(--font-size-caption);
-    letter-spacing: 0.04em;
+    letter-spacing: var(--tracking-wider);
     color: var(--muted-foreground);
     font-variant-numeric: tabular-nums;
   }
@@ -758,7 +758,7 @@
 
 .maka-first-run-checklist-copy strong {
   font-size: var(--font-size-ui);
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
   white-space: nowrap;
 }
 

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -46,7 +46,7 @@
 .settingsWebSearchDisabledReason {
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
   text-align: right;
 }
 .settingsWebSearchResults {
@@ -82,7 +82,7 @@
     margin: 0;
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -143,7 +143,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -185,7 +185,7 @@
 .settingsMemoryPromptPreview small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
   }
 .settingsMemoryPromptPreviewBudget {
     font-family: var(--font-mono);
@@ -202,7 +202,7 @@
     color: var(--foreground-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -210,7 +210,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 .settingsMemoryEntryPreviewNotice {
     display: grid;
@@ -227,7 +227,7 @@
 .settingsMemoryEntryPreviewNotice small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
   }
 .settingsMemorySaveSummary {
     display: grid;
@@ -287,7 +287,7 @@
 .settingsMemoryBackupList small {
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
   }
 .settingsMemoryBackupCandidate {
     display: inline-flex;
@@ -337,7 +337,7 @@
     background: oklch(from var(--warning) l c h / 0.08);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 
 .settingsMemoryEntryList {
@@ -408,7 +408,7 @@
     background: var(--foreground-5);
     color: var(--foreground-secondary);
     font-size: var(--font-size-caption);
-    line-height: 1.4;
+    line-height: var(--leading-snug);
   }
 
 .settingsMemoryPromptScope[data-active="true"] {
@@ -427,7 +427,7 @@
     margin: 0;
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
     white-space: pre-wrap;
     word-break: break-word;
   }
@@ -486,7 +486,7 @@
   .settingsMemoryListEmpty small {
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
-    line-height: 1.45;
+    line-height: var(--leading-normal);
   }
 
 .settingsMemoryManualAdd {
@@ -558,7 +558,7 @@
 .settingsMemoryDraftWarning small {
   color: var(--foreground-secondary);
   font-size: var(--font-size-caption);
-  line-height: 1.4;
+  line-height: var(--leading-snug);
 }
 
 .settingsMemoryEditor {
@@ -583,7 +583,7 @@
   color: var(--foreground);
   font-family: inherit;
   font-size: var(--font-size-ui);
-  line-height: 1.75;
+  line-height: var(--leading-normal);
   letter-spacing: 0;
   tab-size: 2;
   white-space: pre-wrap;
@@ -661,7 +661,7 @@
   background: oklch(from var(--warning, var(--info)) l c h / 0.08);
   color: var(--warning-text, var(--info-text));
   font-size: var(--font-size-ui);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
   padding: var(--space-2) var(--space-2-5);
 }
 
@@ -766,7 +766,7 @@
   display: none;
   font-size: var(--font-size-ui);
   color: var(--muted-foreground);
-  line-height: 1.45;
+  line-height: var(--leading-normal);
 }
 
 .maka-first-run-checklist-arrow {
@@ -786,7 +786,7 @@
 
   .maka-onboarding-ready header h1 {
     font-size: 1.6em;
-    line-height: 1.2;
+    line-height: var(--leading-tight);
   }
 
   .maka-onboarding-ready header p {


### PR DESCRIPTION
## Summary

First PR of #520 (design-spec governance tracking issue). Converges the three ungoverned typography dimensions — `line-height`, `font-weight`, `letter-spacing` — onto tokens aligned to a Tailwind scale subset, plus folds `font-variation-settings` into `font-weight` and cleans up `font-family` minor drift. Same converge-contract pattern as #430 PR2 / #448.

## Tokens added (maka-tokens.css)

| Token | Value | Aligned to | Sites |
|---|---|---|---|
| `--leading-none/tight/snug/normal` | 1 / 1.25 / 1.375 / 1.5 | Tailwind `leading-*` (drop relaxed/loose, 0 sites) | ~160 |
| `--font-weight-normal/medium/semibold/bold` | 400 / 500 / 600 / 700 | Tailwind `font-*` (drop thin/extralight/light/extrabold/black) | ~205 |
| `--tracking-normal/wide/wider/widest` | 0 / 0.025em / 0.05em / 0.1em | Tailwind `tracking-*` (no tight — CJK-first, roadmap §1.6 bans tightening CJK) | ~62 |
| `--font-serif` | Georgia, "Times New Roman", Times, serif | (onboarding hero) | 1 |

Bridged to Tailwind utilities via `@theme inline` in `styles.css` (same inline-bridge pattern as `--text-*` / `--space-*`), so `var(--leading-*)` in CSS and `leading-*` in TSX share one source.

## Convergence

- **line-height**: 15 distinct bare values + one `20px` magic → 4 tokens. Snug is the one tier that can't be cut (40 sites at 1.3-1.4 are 13/11px small-text dense zones; collapsing to tight/normal is ±0.1-0.2, visible on small text). Largest delta: `.maka-bubble-assistant` 1.68 → 1.5 (chat core, magic-number fix).
- **font-weight**: 8 distinct (incl. mid-axis 550/620/650/680 from variable Geist) → 4 tokens. Snap: 550/620/650 → semibold (600), 680 → bold (700).
- **letter-spacing**: 14 distinct (incl. CJK mis-tightening `-0.018em`) → 4 tokens. All negatives snap to `--tracking-normal` (0) per CJK ban. ALL-CAPS labels use `--tracking-wider/widest` (roadmap §4.1). `1px` → `--tracking-widest` (0.1em ≈ 1.3px @ 13px).
- **font-variation-settings**: dropped `.maka-hero h1`'s `"wght" 550, "wdth" 105` — wght folds into `font-weight` token, wdth:105 one-off dropped (hero stays distinct via size + weight + leading alone).
- **font-family minor**: `var(--mono-font, monospace)` → `var(--font-mono)` (was a typo'd token name); redundant `var(--font-mono, ui-monospace, …)` fallbacks → `var(--font-mono)`; `Georgia, serif` → `var(--font-serif)` (tokenized).

## Contracts

Two new converge-contract tests, mirroring `typography-converge-contract.test.ts`:
- `font-weight-converge-contract.test.ts` — bans bare `font-weight` numbers + `normal`/`bold`/`lighter`/`bolder` + bare weight in `font:` shorthand; whitelists 4 `--font-weight-*` tokens + `inherit`/`initial`/`unset`/`revert`; pins values; asserts `@theme inline` bridging.
- `letter-spacing-converge-contract.test.ts` — bans bare `letter-spacing` em/px/`normal`/negative; whitelists 4 `--tracking-*` tokens + `0` + literals; pins values; asserts bridging.

(`line-height-converge-contract.test.ts` landed in the first commit pair of this PR.)

## Verification

- `line-height-converge-contract`: 9/9 pass
- `font-weight-converge-contract`: 8/8 pass
- `letter-spacing-converge-contract`: 7/7 pass
- Full desktop suite: **1910/1910 pass** (no regressions; +15 from the two new contracts)
- `renderer` build: success (Tailwind v4 `@theme inline` same-name `--leading-*` / `--font-weight-*` / `--tracking-*` bridging verified)
- Dual-theme screenshots (turn-narrative + first-run, light + dark): visual deltas are barely-perceptible as expected — `.maka-hero h1` is the most visible (wdth 105 drop + 550→600 + tracking -0.018→0); confirmed acceptable.

## Commits

1. `refactor(ui): converge line-height onto --leading-* tokens` — 25 css, 4 tokens + bridge + ~160 replacements
2. `test(ui): lock line-height converge contract` — 9 tests
3. `refactor(ui): converge font-weight + letter-spacing + font-family minor` — 28 css, 9 tokens + bridge + ~267 replacements + font-variation fold + font-family cleanup
4. `test(ui): lock font-weight + letter-spacing converge contracts` — 15 tests

## Out of scope (next PRs in #520)

PR2 visual-state & motion tokens (opacity / focus-ring / motion duration+amplitude), PR3 anti-layout-shift, PR4 layout surface & sizing, PR5 Base UI small migrations + style-hook, PR6 Base UI large migrations.

Tracking issue: #520.