### PR TITLE
refactor(ui): converge anti-layout-shift specs — tabular-nums, min-w-0, text-swap (#520 PR3)

### DIFF
--- a/apps/desktop/src/main/__tests__/min-w-0-truncation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/min-w-0-truncation-contract.test.ts
@@ -1,0 +1,93 @@
+/**
+ * PR-ANTI-LAYOUT-SHIFT-MIN-W-0-0 (issue #520 PR3):
+ * flex/grid children that truncate text need `min-width: 0` to release the
+ * default `min-width: auto` (which equals min-content and stops ellipsis
+ * from triggering). Missing min-width:0 is a historic truncation-bug source.
+ *
+ * Invariant: every CSS rule that declares `text-overflow: ellipsis` +
+ * `white-space: nowrap` (the truncation intent) must, *for that selector*,
+ * also have `min-width: 0` somewhere — UNLESS the selector is on the
+ * truncation exception list:
+ *   - parent grid uses a `minmax(0, …)` track (column can shrink to 0
+ *     without the child needing min-width:0), or
+ *   - the ellipsis is dead code (e.g. `flex-shrink: 0` means the item never
+ *     shrinks so ellipsis can't fire — a separate dead-code cleanup, not a
+ *     min-w-0 gap).
+ *
+ * Adding a new truncation surface: give it min-width:0. If it sits in a
+ * grid with a minmax(0,…) track, or its ellipsis is dead for another
+ * reason, add it to TRUNCATION_EXCEPTIONS with a comment explaining why.
+ */
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import postcss from 'postcss';
+import { REPO_ROOT, readCssTree, stripCssComments } from './css-test-helpers.js';
+
+const RENDERER_ROOT = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
+
+// Selectors exempt from the min-width:0 requirement. Keep this short and
+// comment each entry with the reason it doesn't need min-width:0.
+const TRUNCATION_EXCEPTIONS = new Set<string>([
+  // parent .maka-palette-item: grid-template-columns: 18px minmax(0,1fr) auto
+  '.maka-palette-label',
+  // parent .maka-artifact-row: grid-template-columns: 16px minmax(0,1fr) auto
+  '.maka-artifact-row-name',
+  // flex-shrink:0 makes this meta non-shrinkable, so ellipsis never fires
+  // (dead code, not a min-w-0 gap). Tracked separately for dead-ellipsis cleanup.
+  '.maka-list-row-meta',
+]);
+
+type TruncationSite = { file: string; selector: string };
+
+async function scanTruncationSites(): Promise<{
+  minWidthSelectors: Set<string>;
+  truncation: TruncationSite[];
+}> {
+  const files = await readCssTree(RENDERER_ROOT);
+  const minWidthSelectors = new Set<string>();
+  const truncation: TruncationSite[] = [];
+  for (const file of files) {
+    const source = stripCssComments(await readFile(file, 'utf8'));
+    const root = postcss.parse(source, { from: file });
+    root.walkRules((rule) => {
+      const decls = rule.nodes.filter((n): n is postcss.Declaration => n.type === 'decl');
+      const hasMinWidth0 = decls.some(
+        (d) => d.prop === 'min-width' && /^0\b/.test(d.value.trim()),
+      );
+      const hasEllipsis = decls.some((d) => d.prop === 'text-overflow' && /ellipsis/.test(d.value));
+      const hasNowrap = decls.some((d) => d.prop === 'white-space' && /nowrap/.test(d.value));
+      for (const sel of rule.selectors) {
+        if (hasMinWidth0) minWidthSelectors.add(sel);
+        if (hasEllipsis && hasNowrap) truncation.push({ file, selector: sel });
+      }
+    });
+  }
+  return { minWidthSelectors, truncation };
+}
+
+describe('PR-ANTI-LAYOUT-SHIFT-MIN-W-0-0 contract', () => {
+  it('every ellipsis+nowrap truncation rule has min-width:0 (or is a listed exception)', async () => {
+    const { minWidthSelectors, truncation } = await scanTruncationSites();
+    const offenders = truncation
+      .filter((t) => !minWidthSelectors.has(t.selector) && !TRUNCATION_EXCEPTIONS.has(t.selector))
+      .map((t) => `${t.file.replace(RENDERER_ROOT + '/', '')}: ${t.selector}`);
+    assert.deepEqual(
+      offenders,
+      [],
+      `Truncation rules with ellipsis+nowrap but no min-width:0 (add min-width:0, or add to TRUNCATION_EXCEPTIONS with a reason):\n  ${offenders.join('\n  ')}`,
+    );
+  });
+
+  it('exception list only contains selectors that are actually truncation sites', async () => {
+    const { truncation } = await scanTruncationSites();
+    const truncationSelectors = new Set(truncation.map((t) => t.selector));
+    const stale = [...TRUNCATION_EXCEPTIONS].filter((s) => !truncationSelectors.has(s));
+    assert.deepEqual(
+      stale,
+      [],
+      `TRUNCATION_EXCEPTIONS has entries that are no longer ellipsis+nowrap truncation sites (remove them): ${stale.join(', ')}`,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tabular-nums-converge-contract.test.ts
@@ -1,0 +1,107 @@
+/**
+ * PR-ANTI-LAYOUT-SHIFT-TABULAR-NUMS-0 (issue #520 PR3):
+ * lock `tabular-nums` on every known numeric surface so digit columns
+ * stay aligned and numbers don't jitter layout as they change
+ * (token counts, timestamps, usage stats, progress, file sizes, costs).
+ *
+ * Two invariants:
+ *
+ * 1. Each whitelisted selector must appear in a renderer CSS rule that
+ *    *declares* `font-variant-numeric: tabular-nums` (directly, not only
+ *    via inheritance — inheritance is fine visually but can't be enforced
+ *    here, so the rule that owns the number surface carries the declaration).
+ *
+ * 2. The `RelativeTime` component renders `tabular-nums` on its `<small>`,
+ *    because it backs every self-refreshing timestamp across the app and
+ *    a single source beats chasing each call site's CSS.
+ *
+ * Adding a new numeric surface: give it `tabular-nums` AND add its
+ * selector here, so it can't silently regress.
+ */
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import postcss from 'postcss';
+import { REPO_ROOT, readCssTree, stripCssComments } from './css-test-helpers.js';
+
+const RENDERER_ROOT = resolve(REPO_ROOT, 'apps/desktop/src/renderer');
+const RELATIVE_TIME_SRC = resolve(REPO_ROOT, 'packages/ui/src/relative-time.tsx');
+
+// Selectors that own a "number that changes" surface and must declare
+// tabular-nums themselves. Kept as a flat list so a regression on any one
+// fails the test with a precise diff.
+const TABULAR_NUMS_SELECTORS = [
+  // timestamps / durations
+  '.maka-message-time-inline',
+  '.maka-plan-run-row time',
+  '.maka-daily-review-session-time',
+  '.maka-list-row-meta',
+  '.maka-daily-review-day',
+  // counts / totals badges
+  '.maka-artifact-pane-count',
+  '.maka-artifact-row-meta',
+  '.settingsRow > span',
+  '.maka-plan-tab span',
+  '.maka-daily-review-archive-count',
+  '.maka-daily-review-archive-row-meta',
+  '.maka-daily-review-totals-value',
+  '.maka-daily-review-top-meta',
+  '.settingsPermissionSummaryValue',
+  '.maka-nav-count',
+  '.maka-list-group-count',
+  '.maka-first-run-checklist-count',
+  '.settingsQuotaRow',
+  // settings numeric surfaces
+  '.settingsStatsTable th',
+  '.settingsStatsTable td',
+  '.settingsMetricCard',
+  '.settingsUsageRecordCount',
+  '.settingsHealthSummaryTile strong',
+  '.settingsMemoryEntryGroupHeader',
+  // skill counts
+  '.maka-skill-tab span',
+  '.maka-skill-section-row small',
+  // search result counts
+  '.maka-search-modal-result-summary',
+  // provider counts
+  '.enabledStripHeader span',
+  '.modelTableHeaderText small',
+  // plan search count
+  '.maka-plan-search-summary',
+];
+
+async function readTabularNumsCoveredSelectors(): Promise<Set<string>> {
+  const files = await readCssTree(RENDERER_ROOT);
+  const covered = new Set<string>();
+  for (const file of files) {
+    const source = stripCssComments(await readFile(file, 'utf8'));
+    const root = postcss.parse(source, { from: file });
+    root.walkRules((rule) => {
+      const hasTabular = rule.nodes.some(
+        (n) => n.type === 'decl' && n.prop === 'font-variant-numeric' && /tabular-nums/.test(n.value),
+      );
+      if (hasTabular) {
+        for (const sel of rule.selectors) covered.add(sel);
+      }
+    });
+  }
+  return covered;
+}
+
+describe('PR-ANTI-LAYOUT-SHIFT-TABULAR-NUMS-0 contract', () => {
+  it('every whitelisted numeric surface declares tabular-nums in renderer CSS', async () => {
+    const covered = await readTabularNumsCoveredSelectors();
+    const missing = TABULAR_NUMS_SELECTORS.filter((s) => !covered.has(s));
+    assert.deepEqual(missing, [], `Selectors missing a tabular-nums declaration:\n  ${missing.join('\n  ')}`);
+  });
+
+  it('RelativeTime renders tabular-nums (covers all self-refreshing timestamps)', async () => {
+    const src = await readFile(RELATIVE_TIME_SRC, 'utf8');
+    assert.match(
+      src,
+      /tabular-nums/,
+      'RelativeTime must add tabular-nums to its <small> so self-refreshing timestamps stay aligned as they tick',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -65,7 +65,7 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyBackupReference(backup)}', minW: '4rem', note: '复制中… ↔ 复制引用 (备份候选行)' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void reloadDraftFromDisk()}', minW: '4rem', note: '载入中… ↔ 重新载入 (settingsActionRow)' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void props.onCopyReference?.(entry)}', minW: '4rem', note: '复制中… ↔ 复制引用 (记忆条目行)' },
-  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void props.onStatusChange?.(entry', minW: '4rem', note: '归档切换 statusActionLabel (记忆条目行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void props.onStatusChange?.(entry', minW: '5rem', note: '归档到草稿/恢复到草稿 ↔ 归档/恢复 (draftDirty 5字最宽)' },
   // open-gateway-settings-page.tsx — settingsActionRow copy buttons
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyBaseUrl()}', minW: '4rem', note: '复制中… ↔ 复制地址' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOverviewCurl()}', minW: '8rem', note: '复制总览 curl' },
@@ -171,33 +171,61 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
     }
   });
 
-  it('no state-swap Button with a string-ternary child slips through without min-w-[Nrem] (scoped scan)', () => {
-    const missing: Array<{ file: string; line: number; snippet: string }> = [];
+  it('no state-swap Button with a string-ternary child slips through without min-w-[Nrem] + whitelist value pin', () => {
+    // Two failure modes, both must fail closed:
+    //  (a) no min-w-[Nrem] at all — the width lock is missing;
+    //  (b) has some min-w-[Nrem] but the button isn't in TEXT_SWAP_BUTTONS
+    //      (or EXCEPTIONS) — the value lock can be bypassed by setting
+    //      min-w-[1rem]. The scan finds the button; the whitelist pins the
+    //      exact value. Both must hold.
+    const WHITELIST_ANCHORS = TEXT_SWAP_BUTTONS.map((b) => b.onClick);
+    const EXCEPTION_ANCHORS: string[] = [
+      // (none — every state-swap button in the PR3 scope files is
+      // whitelisted. Add an onClick substring here only if a scanned button
+      // is intentionally not value-pinned, with a comment saying why.)
+    ];
+    const missingMinW: Array<{ file: string; line: number; snippet: string }> = [];
+    const notPinned: Array<{ file: string; line: number; snippet: string }> = [];
     for (const file of SCAN_FILES) {
       const src = readFileSync(resolve(REPO_ROOT, file), 'utf8');
       BUTTON_BLOCK_RE.lastIndex = 0;
       let m: RegExpExecArray | null;
       while ((m = BUTTON_BLOCK_RE.exec(src)) !== null) {
+        const block = m[0];
         const attrs = m[2];
         const children = m[3];
         if (!STRING_TERNARY_RE.test(children)) continue;
         const clsMatch = attrs.match(/className="([^"]*)"/);
-        if (!clsMatch || !MIN_W_REM_RE.test(clsMatch[1])) {
-          const line = src.slice(0, m.index).split('\n').length;
-          missing.push({
-            file,
-            line,
-            snippet: children.trim().replace(/\s+/g, ' ').slice(0, 80),
-          });
+        const hasMinW = clsMatch != null && MIN_W_REM_RE.test(clsMatch[1]);
+        const line = src.slice(0, m.index).split('\n').length;
+        const snippet = children.trim().replace(/\s+/g, ' ').slice(0, 80);
+        if (!hasMinW) {
+          missingMinW.push({ file, line, snippet });
+        }
+        // Even with a min-w, the button must be value-pinned by the
+        // whitelist (or an explicit exception) so a too-small min-w can't
+        // bypass the value lock.
+        const pinned =
+          WHITELIST_ANCHORS.some((oc) => block.includes(oc)) ||
+          EXCEPTION_ANCHORS.some((oc) => block.includes(oc));
+        if (!pinned) {
+          notPinned.push({ file, line, snippet });
         }
       }
     }
-    const msgs = missing.map((m) => `  ${m.file}:${m.line} — ${m.snippet}`);
+    const fmt = (arr: typeof missingMinW) =>
+      arr.map((m) => `  ${m.file}:${m.line} — ${m.snippet}`).join('\n');
     assert.equal(
-      missing.length,
+      missingMinW.length,
       0,
-      `Found ${missing.length} state-swap button(s) without min-w-[Nrem] in the PR3 scope files. Each <Button>/<UiButton> whose children contain a string ternary (? 'A' : 'B', the state-swap signal) must keep min-w-[Nrem] in its className. Add the lock sized to the widest state + a TEXT_SWAP_BUTTONS entry:\n` +
-        msgs.join('\n'),
+      `Found ${missingMinW.length} state-swap button(s) without min-w-[Nrem] in the PR3 scope files. Each <Button>/<UiButton> whose children contain a string ternary (? 'A' : 'B', the state-swap signal) must keep min-w-[Nrem] in its className:\n` +
+        fmt(missingMinW),
+    );
+    assert.equal(
+      notPinned.length,
+      0,
+      `Found ${notPinned.length} state-swap button(s) with a min-w but no TEXT_SWAP_BUTTONS value pin (and not in EXCEPTIONS). A too-small min-w-[1rem] would bypass the value lock. Add a TEXT_SWAP_BUTTONS entry (file + onClick anchor + min-w sized to the widest state):\n` +
+        fmt(notPinned),
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -35,7 +35,9 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void reset()}', minW: '5rem', note: '重置中… ↔ 重置并备份' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void restoreLatestBackup()}', minW: '5rem', note: '恢复中… ↔ 恢复上一版' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyLocalMemoryPromptPreview()}', minW: '5rem', note: 'settingsInlineTextButton: 复制中… ↔ 复制上下文' },
-  // open-gateway-settings-page.tsx — settingsActionRow curl copy buttons
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyPath()}', minW: '4rem', note: '复制中… ↔ 复制路径' },
+  // open-gateway-settings-page.tsx — settingsActionRow copy buttons
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyBaseUrl()}', minW: '4rem', note: '复制中… ↔ 复制地址' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOverviewCurl()}', minW: '8rem', note: '复制总览 curl' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOpenApiCurl()}', minW: '9rem', note: '复制接口说明 curl' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copySessionStateCurl()}', minW: '9.5rem', note: '复制单会话状态 curl' },
@@ -47,6 +49,7 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "triggerManualRun('deep')", minW: '6rem', note: '生成中… ↔ 生成深度分析' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('copy'", minW: '4rem', note: '复制中… ↔ 复制' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('save'", minW: '4rem', note: '保存中… ↔ 保存' },
+  { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('append'", minW: '5rem', note: '追加中… ↔ 粘到输入框' },
   // error-boundary.tsx — maka-error-copy-action
   { file: 'apps/desktop/src/renderer/error-boundary.tsx', onClick: 'onClick={this.handleCopyReport}', minW: '5.5rem', note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
 ];

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -2,22 +2,20 @@
  * PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 (issue #520 PR3):
  * lock `min-width` on state-swap surfaces so a button/label whose text
  * changes between states (复制 ↔ 已复制, 保存 ↔ 保存中…, token counts
- * 9 → 10 → 100) can't shrink and push its right-hand siblings, causing
- * layout shift.
+ * 9 → 10 → 100) can't shrink and push its right-hand siblings.
  *
- * Invariant: each known state-swap surface file keeps at least the count
- * of `min-w-[Nrem]` locks it was given. A regression that drops them
- * (removing the className, refactoring the button out, etc.) fails here
- * before it ships.
+ * Invariant (per-element pin, not a coarse file count): every known
+ * state-swap button keeps a `min-w-[Nrem]` in the className of the very
+ * `<Button>`/`<UiButton>` that owns the swapping onClick handler, and the
+ * chat summary-chip / stream-count variants keep their `min-w-[Nrem]`
+ * declarations. Dropping a lock from a real surface fails here; moving a
+ * lock onto an unrelated element (different handler / different variant
+ * string) also fails.
  *
- * Adding a new state-swap surface: give each swapping element
- * `min-w-[Nrem]` sized to its widest state, and add the file + expected
- * count here.
- *
- * Note: this is a coarse presence guard (count of min-w-[Nrem] per file),
- * not a per-element pin — the per-element pin lives in review + the audit
- * notes that produced this list. It stops the whole class of regressions
- * where a refactor silently drops the width locks.
+ * Adding a new state-swap surface: give the swapping element
+ * `min-w-[Nrem]` sized to its widest state, and add an entry to
+ * TEXT_SWAP_BUTTONS (file + a unique onClick substring + the min-w) or
+ * CHAT_VARIANT_LOCKS (the literal declaration substring).
  */
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
@@ -25,30 +23,97 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT } from './css-test-helpers.js';
 
-// file -> minimum number of `min-w-[Nrem]` locks that must remain.
-// Counts are the locks added by the PR3 text-swap audit for state-swap
-// buttons/chips in left-aligned multi-button rows (settingsActionRow,
-// maka-error-actions, maka-daily-review-actions) and summary chips whose
-// digit count can grow.
-const TEXT_SWAP_SURFACES: Array<{ file: string; minCount: number; note: string }> = [
-  { file: 'packages/ui/src/daily-review-panel.tsx', minCount: 4, note: '生成每日回顾/生成深度分析/复制/保存 state-swap buttons' },
-  { file: 'apps/desktop/src/renderer/error-boundary.tsx', minCount: 1, note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
-  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', minCount: 8, note: 'settingsActionRow: 保存/打开MEMORY.md/打开所在目录/打开上一版/复制上一版引用/重置并备份/恢复上一版 + 复制上下文' },
-  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', minCount: 6, note: 'settingsActionRow: 6 curl copy buttons (总览/接口说明/单会话状态/事件流/最近事件/最近请求)' },
-  { file: 'packages/ui/src/primitives/chat.tsx', minCount: 3, note: 'summary-chip data-[kind=tools]/[duration] min-w + streamVariants count min-w' },
+// State-swap buttons: file + a unique onClick substring that identifies the
+// exact button + the min-w-[Nrem] the button's className must keep.
+const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; note: string }> = [
+  // memory-settings-page.tsx — settingsActionRow + the inline 复制上下文 button
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void save()}', minW: '3.5rem', note: '保存 ↔ 保存中… ↔ 已保存' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void openFile()}', minW: '7.5rem', note: '打开中… ↔ 打开 MEMORY.md' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void openFolder()}', minW: '6rem', note: '打开中… ↔ 打开所在目录' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void openLatestBackup()}', minW: '5rem', note: '打开中… ↔ 打开上一版' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyLatestBackupReference()}', minW: '7rem', note: '复制中… ↔ 复制上一版引用' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void reset()}', minW: '5rem', note: '重置中… ↔ 重置并备份' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void restoreLatestBackup()}', minW: '5rem', note: '恢复中… ↔ 恢复上一版' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyLocalMemoryPromptPreview()}', minW: '5rem', note: 'settingsInlineTextButton: 复制中… ↔ 复制上下文' },
+  // open-gateway-settings-page.tsx — settingsActionRow curl copy buttons
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOverviewCurl()}', minW: '8rem', note: '复制总览 curl' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOpenApiCurl()}', minW: '9rem', note: '复制接口说明 curl' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copySessionStateCurl()}', minW: '9.5rem', note: '复制单会话状态 curl' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyEventStreamCurl()}', minW: '8.5rem', note: '复制事件流 curl' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyRecentEventsCurl()}', minW: '9rem', note: '复制最近事件 curl' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyRecentRequestsCurl()}', minW: '9rem', note: '复制最近请求 curl' },
+  // daily-review-panel.tsx — quick-run + 复制/保存 actions
+  { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "triggerManualRun('daily')", minW: '6rem', note: '生成中… ↔ 生成每日回顾' },
+  { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "triggerManualRun('deep')", minW: '6rem', note: '生成中… ↔ 生成深度分析' },
+  { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('copy'", minW: '4rem', note: '复制中… ↔ 复制' },
+  { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('save'", minW: '4rem', note: '保存中… ↔ 保存' },
+  // error-boundary.tsx — maka-error-copy-action
+  { file: 'apps/desktop/src/renderer/error-boundary.tsx', onClick: 'onClick={this.handleCopyReport}', minW: '5.5rem', note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
 ];
 
-const MIN_W_REM_RE = /min-w-\[\d+(?:\.\d+)?rem\]/g;
+// Chat summary-chip / stream-count variant locks: the min-w-[Nrem]
+// declaration lives in the variant definition (chat.tsx), not at the call
+// site, so we pin the literal declaration substrings.
+const CHAT_VARIANT_LOCKS: Array<{ file: string; substr: string; note: string }> = [
+  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'data-[kind=tools]:min-w-[5rem]', note: 'summary-chip tools count (N 个工具)' },
+  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'data-[kind=duration]:min-w-[4rem]', note: 'summary-chip duration (进行中 ↔ 时长)' },
+  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'min-w-[5rem] [font-variant-numeric:tabular-nums]', note: 'streamVariants count (stdout/stderr/已脱敏 N)' },
+];
+
+const BUTTON_OPEN_RE = /<(?:Ui)?Button\b/g;
 
 describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
-  it('every known state-swap surface keeps its min-w-[Nrem] width locks', async () => {
-    for (const { file, minCount, note } of TEXT_SWAP_SURFACES) {
+  it('every state-swap button keeps min-w-[Nrem] in its own className', async () => {
+    // Group by file so we read each file once.
+    const byFile = new Map<string, typeof TEXT_SWAP_BUTTONS>();
+    for (const b of TEXT_SWAP_BUTTONS) {
+      const arr = byFile.get(b.file) ?? [];
+      arr.push(b);
+      byFile.set(b.file, arr);
+    }
+    for (const [file, buttons] of byFile) {
       const src = await readFile(resolve(REPO_ROOT, file), 'utf8');
-      const count = (src.match(MIN_W_REM_RE) ?? []).length;
-      assert.ok(
-        count >= minCount,
-        `${file} has ${count} min-w-[Nrem] lock(s), expected >= ${minCount} (${note}). A state-swap button lost its width lock and will push siblings on state change.`,
-      );
+      for (const { onClick, minW, note } of buttons) {
+        const handlerIdx = src.indexOf(onClick);
+        assert.ok(handlerIdx >= 0, `${file}: onClick anchor "${onClick}" not found (${note})`);
+        // Find the nearest <Button / <UiButton opening tag at or before the
+        // handler — that is the element the handler belongs to.
+        let tagStart = -1;
+        BUTTON_OPEN_RE.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = BUTTON_OPEN_RE.exec(src)) !== null) {
+          if (m.index > handlerIdx) break;
+          tagStart = m.index;
+        }
+        assert.ok(tagStart >= 0, `${file}: no <Button>/<UiButton> opens before "${onClick}" (${note})`);
+        // Slice from the tag open to the handler; the className must sit in
+        // that span (className always precedes onClick in these tags).
+        const tagSpan = src.slice(tagStart, handlerIdx);
+        const clsMatch = tagSpan.match(/className="([^"]*)"/);
+        assert.ok(clsMatch, `${file}: button for "${onClick}" has no className (${note})`);
+        assert.ok(
+          clsMatch[1].includes(`min-w-[${minW}]`),
+          `${file}: button for "${onClick}" className="${clsMatch[1]}" is missing min-w-[${minW}] (${note})`,
+        );
+      }
+    }
+  });
+
+  it('chat summary-chip / stream-count variants keep their min-w declarations', async () => {
+    const byFile = new Map<string, typeof CHAT_VARIANT_LOCKS>();
+    for (const l of CHAT_VARIANT_LOCKS) {
+      const arr = byFile.get(l.file) ?? [];
+      arr.push(l);
+      byFile.set(l.file, arr);
+    }
+    for (const [file, locks] of byFile) {
+      const src = await readFile(resolve(REPO_ROOT, file), 'utf8');
+      for (const { substr, note } of locks) {
+        assert.ok(
+          src.includes(substr),
+          `${file}: missing variant declaration "${substr}" (${note})`,
+        );
+      }
     }
   });
 });

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -1,0 +1,54 @@
+/**
+ * PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 (issue #520 PR3):
+ * lock `min-width` on state-swap surfaces so a button/label whose text
+ * changes between states (复制 ↔ 已复制, 保存 ↔ 保存中…, token counts
+ * 9 → 10 → 100) can't shrink and push its right-hand siblings, causing
+ * layout shift.
+ *
+ * Invariant: each known state-swap surface file keeps at least the count
+ * of `min-w-[Nrem]` locks it was given. A regression that drops them
+ * (removing the className, refactoring the button out, etc.) fails here
+ * before it ships.
+ *
+ * Adding a new state-swap surface: give each swapping element
+ * `min-w-[Nrem]` sized to its widest state, and add the file + expected
+ * count here.
+ *
+ * Note: this is a coarse presence guard (count of min-w-[Nrem] per file),
+ * not a per-element pin — the per-element pin lives in review + the audit
+ * notes that produced this list. It stops the whole class of regressions
+ * where a refactor silently drops the width locks.
+ */
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+// file -> minimum number of `min-w-[Nrem]` locks that must remain.
+// Counts are the locks added by the PR3 text-swap audit for state-swap
+// buttons/chips in left-aligned multi-button rows (settingsActionRow,
+// maka-error-actions, maka-daily-review-actions) and summary chips whose
+// digit count can grow.
+const TEXT_SWAP_SURFACES: Array<{ file: string; minCount: number; note: string }> = [
+  { file: 'packages/ui/src/daily-review-panel.tsx', minCount: 4, note: '生成每日回顾/生成深度分析/复制/保存 state-swap buttons' },
+  { file: 'apps/desktop/src/renderer/error-boundary.tsx', minCount: 1, note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', minCount: 8, note: 'settingsActionRow: 保存/打开MEMORY.md/打开所在目录/打开上一版/复制上一版引用/重置并备份/恢复上一版 + 复制上下文' },
+  { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', minCount: 6, note: 'settingsActionRow: 6 curl copy buttons (总览/接口说明/单会话状态/事件流/最近事件/最近请求)' },
+  { file: 'packages/ui/src/primitives/chat.tsx', minCount: 3, note: 'summary-chip data-[kind=tools]/[duration] min-w + streamVariants count min-w' },
+];
+
+const MIN_W_REM_RE = /min-w-\[\d+(?:\.\d+)?rem\]/g;
+
+describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
+  it('every known state-swap surface keeps its min-w-[Nrem] width locks', async () => {
+    for (const { file, minCount, note } of TEXT_SWAP_SURFACES) {
+      const src = await readFile(resolve(REPO_ROOT, file), 'utf8');
+      const count = (src.match(MIN_W_REM_RE) ?? []).length;
+      assert.ok(
+        count >= minCount,
+        `${file} has ${count} min-w-[Nrem] lock(s), expected >= ${minCount} (${note}). A state-swap button lost its width lock and will push siblings on state change.`,
+      );
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -15,9 +15,15 @@
  *    stops a new state-swap button in those files from shipping without a
  *    lock: the test fails closed. A whitelist-only contract kept missing
  *    buttons nobody had audited by hand (reload, backup-candidate actions,
- *    instruction-file actions all slipped through); the scan makes "did we
- *    forget one in these files?" a question the test answers, not a
- *    question a reviewer has to keep answering.
+ *    instruction-file actions all slipped through). The scan closes that
+ *    gap for INLINE string ternaries (`? 'A' : 'B'` in children). It does
+ *    NOT cover COMPUTED-LABEL state-swap buttons (children is a variable
+ *    holding a ternary result, e.g. `{copyLabel}` / `{statusActionLabel}`)
+ *    — those have no inline ternary for the scan to find, so they MUST be
+ *    hand-pinned in TEXT_SWAP_BUTTONS (see the COMPUTED-LABEL note above
+ *    TEXT_SWAP_BUTTONS). So the claim is narrower than "no reviewer needed":
+ *    inline-ternary omissions in these files are auto-caught; computed-label
+ *    omissions are still on the whitelist author.
  *
  *    The scan is deliberately scoped to the PR3 files, not the whole
  *    renderer. `? 'A' : 'B'` is only the state-swap SIGNAL — it can't tell
@@ -32,9 +38,10 @@
  *
  * 2. Whitelist per-element pin (VALUE LOCK): each known state-swap button
  *    keeps a SPECIFIC `min-w-[Nrem]` sized to its widest state, located by
- *    its onClick handler. The scan only checks "has any min-w-[Nrem]";
- *    the whitelist stops a refactor from shrinking a real lock to the
- *    wrong value. Chat summary-chip / stream-count variant locks live in
+ *    its onClick handler. The scan also requires every discovered button to
+ *    be value-pinned here (or in EXCEPTIONS) so a too-small `min-w-[1rem]`
+ *    can't bypass the value lock; the whitelist pins the exact value so a
+ *    refactor can't shrink a real lock to the wrong value. Chat summary-chip / stream-count variant locks live in
  *    the variant definition, so they're pinned by their literal declaration
  *    substrings.
  */
@@ -47,6 +54,21 @@ import { REPO_ROOT } from './css-test-helpers.js';
 
 // State-swap buttons: file + a unique onClick substring that identifies the
 // exact button + the min-w-[Nrem] the button's className must keep.
+// COMPUTED-LABEL state-swap buttons (children is a variable holding a ternary
+// result, NOT an inline `? 'A' : 'B'`): the scan CANNOT discover these (no
+// inline ternary in children), so they MUST be hand-pinned in TEXT_SWAP_BUTTONS.
+// Known cases — keep this list in sync with the whitelist entries that pin
+// them:
+// - error-boundary copyLabel (onClick={this.handleCopyReport}): children is
+//   {copyLabel}; copyLabel = copyPending ? '复制中…' : copyState === 'copied'
+//   ? '已复制' : copyState === 'failed' ? '复制失败' : '复制诊断信息'.
+// - memory onStatusChange (onClick={() => void props.onStatusChange?.(...)}):
+//   children is {statusActionLabel}; statusActionLabel = draftDirty
+//   ? (archived ? '恢复到草稿' : '归档到草稿') : (archived ? '恢复' : '归档').
+//   NB: the scan happens to flag this one too because its onClick contains a
+//   `props.archived ? 'active' : 'archived'` ternary that BUTTON_BLOCK_RE
+//   leaks into children via the `=>` boundary — a regex artifact, not a real
+//   discovery; keep the whitelist pin regardless.
 const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; note: string }> = [
   // memory-settings-page.tsx — settingsActionRow + the inline 复制上下文 button
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void save()}', minW: '3.5rem', note: '保存 ↔ 保存中… ↔ 已保存' },
@@ -226,6 +248,27 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
       0,
       `Found ${notPinned.length} state-swap button(s) with a min-w but no TEXT_SWAP_BUTTONS value pin (and not in EXCEPTIONS). A too-small min-w-[1rem] would bypass the value lock. Add a TEXT_SWAP_BUTTONS entry (file + onClick anchor + min-w sized to the widest state):\n` +
         fmt(notPinned),
+    );
+  });
+
+  it('scan does NOT discover computed-label state-swap (children is a variable, not inline ternary)', () => {
+    // Computed-label buttons (children is {someVariable} holding a ternary
+    // result) are NOT auto-discovered: STRING_TERNARY_RE looks for
+    // ? 'A' : 'B' IN children, and {label} has none. These buttons MUST be
+    // hand-pinned in TEXT_SWAP_BUTTONS — see the COMPUTED-LABEL note above.
+    const computedLabelButton = [
+      '<Button type="button" className="min-w-[1rem]" onClick={() => void fn()}">',
+      '  {label}',
+      '</Button>',
+    ].join('\n');
+    BUTTON_BLOCK_RE.lastIndex = 0;
+    const blockMatch = BUTTON_BLOCK_RE.exec(computedLabelButton);
+    assert.ok(blockMatch, 'BUTTON_BLOCK_RE should match the button block');
+    const children = blockMatch[3];
+    assert.equal(
+      STRING_TERNARY_RE.test(children),
+      false,
+      'STRING_TERNARY_RE must NOT match a computed-label child ({label}); if it did, the scan would wrongly claim to cover computed-label buttons. They must stay hand-pinned in TEXT_SWAP_BUTTONS.',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -4,21 +4,43 @@
  * changes between states (复制 ↔ 已复制, 保存 ↔ 保存中…, token counts
  * 9 → 10 → 100) can't shrink and push its right-hand siblings.
  *
- * Invariant (per-element pin, not a coarse file count): every known
- * state-swap button keeps a `min-w-[Nrem]` in the className of the very
- * `<Button>`/`<UiButton>` that owns the swapping onClick handler, and the
- * chat summary-chip / stream-count variants keep their `min-w-[Nrem]`
- * declarations. Dropping a lock from a real surface fails here; moving a
- * lock onto an unrelated element (different handler / different variant
- * string) also fails.
+ * Two layers, complementary:
  *
- * Adding a new state-swap surface: give the swapping element
- * `min-w-[Nrem]` sized to its widest state, and add an entry to
- * TEXT_SWAP_BUTTONS (file + a unique onClick substring + the min-w) or
- * CHAT_VARIANT_LOCKS (the literal declaration substring).
+ * 1. Heuristic scan (DISCOVERY, scoped): every `<Button>`/`<UiButton>`
+ *    whose children contain a string-ternary (`? 'A' : 'B'` with
+ *    string/template branches — the state-swap signal) must keep
+ *    `min-w-[Nrem]` in its className. The scan runs over the PR3 text-swap
+ *    audit scope (the files #520 PR3 touched: memory/open-gateway settings
+ *    action rows, daily-review actions, error-boundary). This is what
+ *    stops a new state-swap button in those files from shipping without a
+ *    lock: the test fails closed. A whitelist-only contract kept missing
+ *    buttons nobody had audited by hand (reload, backup-candidate actions,
+ *    instruction-file actions all slipped through); the scan makes "did we
+ *    forget one in these files?" a question the test answers, not a
+ *    question a reviewer has to keep answering.
+ *
+ *    The scan is deliberately scoped to the PR3 files, not the whole
+ *    renderer. `? 'A' : 'B'` is only the state-swap SIGNAL — it can't tell
+ *    whether the button actually sits in a multi-element row where width
+ *    change pushes siblings (the real bug condition needs layout context,
+ *    unlike min-w-0's mechanical ellipsis+nowrap signal). A repo-wide scan
+ *    would flag ~77 buttons, most of them toggles/accordion headers/stand-
+ *    alone retry buttons with no right-hand sibling to push. Those are a
+ *    separate, broader text-swap convergence effort, not this contract.
+ *    Adding a state-swap button to one of the SCAN_FILES below: give it
+ *    min-w-[Nrem] or the scan fails.
+ *
+ * 2. Whitelist per-element pin (VALUE LOCK): each known state-swap button
+ *    keeps a SPECIFIC `min-w-[Nrem]` sized to its widest state, located by
+ *    its onClick handler. The scan only checks "has any min-w-[Nrem]";
+ *    the whitelist stops a refactor from shrinking a real lock to the
+ *    wrong value. Chat summary-chip / stream-count variant locks live in
+ *    the variant definition, so they're pinned by their literal declaration
+ *    substrings.
  */
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT } from './css-test-helpers.js';
@@ -36,6 +58,14 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void restoreLatestBackup()}', minW: '5rem', note: '恢复中… ↔ 恢复上一版' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyLocalMemoryPromptPreview()}', minW: '5rem', note: 'settingsInlineTextButton: 复制中… ↔ 复制上下文' },
   { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyPath()}', minW: '4rem', note: '复制中… ↔ 复制路径' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void openWorkspaceInstructionFile(file.file)}', minW: '4rem', note: '打开中… ↔ 打开 (项目指令文件行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void createWorkspaceInstructionFile(file.file)}', minW: '4rem', note: '创建中… ↔ 创建 (项目指令文件行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void openBackupCandidate(backup)}', minW: '4rem', note: '打开中… ↔ 打开 (备份候选行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void restoreBackupCandidate(backup)}', minW: '4rem', note: '恢复中… ↔ 恢复 (备份候选行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void copyBackupReference(backup)}', minW: '4rem', note: '复制中… ↔ 复制引用 (备份候选行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void reloadDraftFromDisk()}', minW: '4rem', note: '载入中… ↔ 重新载入 (settingsActionRow)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void props.onCopyReference?.(entry)}', minW: '4rem', note: '复制中… ↔ 复制引用 (记忆条目行)' },
+  { file: 'apps/desktop/src/renderer/settings/memory-settings-page.tsx', onClick: 'onClick={() => void props.onStatusChange?.(entry', minW: '4rem', note: '归档切换 statusActionLabel (记忆条目行)' },
   // open-gateway-settings-page.tsx — settingsActionRow copy buttons
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyBaseUrl()}', minW: '4rem', note: '复制中… ↔ 复制地址' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyOverviewCurl()}', minW: '8rem', note: '复制总览 curl' },
@@ -44,13 +74,15 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyEventStreamCurl()}', minW: '8.5rem', note: '复制事件流 curl' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyRecentEventsCurl()}', minW: '9rem', note: '复制最近事件 curl' },
   { file: 'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx', onClick: 'onClick={() => void copyRecentRequestsCurl()}', minW: '9rem', note: '复制最近请求 curl' },
-  // daily-review-panel.tsx — quick-run + 复制/保存 actions
+  // daily-review-panel.tsx — quick-run + 复制/保存/粘到输入框 actions
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "triggerManualRun('daily')", minW: '6rem', note: '生成中… ↔ 生成每日回顾' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "triggerManualRun('deep')", minW: '6rem', note: '生成中… ↔ 生成深度分析' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('copy'", minW: '4rem', note: '复制中… ↔ 复制' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('save'", minW: '4rem', note: '保存中… ↔ 保存' },
   { file: 'packages/ui/src/daily-review-panel.tsx', onClick: "runDailyReviewAction('append'", minW: '5rem', note: '追加中… ↔ 粘到输入框' },
-  // error-boundary.tsx — maka-error-copy-action
+  // error-boundary.tsx — maka-error-copy-action (children is {copyLabel}, a
+  // variable holding the ternary result, so the scan won't catch it; the
+  // whitelist does.)
   { file: 'apps/desktop/src/renderer/error-boundary.tsx', onClick: 'onClick={this.handleCopyReport}', minW: '5.5rem', note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
 ];
 
@@ -65,9 +97,32 @@ const CHAT_VARIANT_LOCKS: Array<{ file: string; substr: string; note: string }> 
 
 const BUTTON_OPEN_RE = /<(?:Ui)?Button\b/g;
 
+// --- Heuristic scan (DISCOVERY, scoped to PR3 files) ------------------------
+// Files this contract governs: the surfaces #520 PR3 touched. A new
+// state-swap button in any of these is caught by the scan and must get a
+// min-w-[Nrem] (or the test fails). State-swap buttons in other files
+// (other settings pages, onboarding, etc.) are a separate, broader
+// text-swap convergence effort — not this contract's scope — so they
+// aren't scanned here and won't false-positive.
+const SCAN_FILES = [
+  'apps/desktop/src/renderer/settings/memory-settings-page.tsx',
+  'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx',
+  'apps/desktop/src/renderer/error-boundary.tsx',
+  'packages/ui/src/daily-review-panel.tsx',
+];
+// Match a full <Button>/<UiButton> element (opening attrs + children +
+// closing tag). `[^>]*` is fine here because these tags never put a `>`
+// inside an attribute; nested <Button> is handled by the non-greedy
+// children matching the nearest close.
+const BUTTON_BLOCK_RE = /<(Ui)?Button\b([^>]*)>([\s\S]*?)<\/\1Button>/g;
+// A string-ternary child: `? 'A' : 'B'` / `? "A" : "B"` / `? `A` : `B``
+// (template literals allowed). This is the state-swap signal: the button's
+// text depends on runtime state, so its width can change between states.
+const STRING_TERNARY_RE = /\?\s*['"`][^'"`]+['"`]\s*:\s*['"`][^'"`]+['"`]/;
+const MIN_W_REM_RE = /min-w-\[\d+(?:\.\d+)?rem\]/;
+
 describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
-  it('every state-swap button keeps min-w-[Nrem] in its own className', async () => {
-    // Group by file so we read each file once.
+  it('every whitelisted state-swap button keeps its exact min-w-[Nrem]', async () => {
     const byFile = new Map<string, typeof TEXT_SWAP_BUTTONS>();
     for (const b of TEXT_SWAP_BUTTONS) {
       const arr = byFile.get(b.file) ?? [];
@@ -79,8 +134,6 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
       for (const { onClick, minW, note } of buttons) {
         const handlerIdx = src.indexOf(onClick);
         assert.ok(handlerIdx >= 0, `${file}: onClick anchor "${onClick}" not found (${note})`);
-        // Find the nearest <Button / <UiButton opening tag at or before the
-        // handler — that is the element the handler belongs to.
         let tagStart = -1;
         BUTTON_OPEN_RE.lastIndex = 0;
         let m: RegExpExecArray | null;
@@ -89,8 +142,6 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
           tagStart = m.index;
         }
         assert.ok(tagStart >= 0, `${file}: no <Button>/<UiButton> opens before "${onClick}" (${note})`);
-        // Slice from the tag open to the handler; the className must sit in
-        // that span (className always precedes onClick in these tags).
         const tagSpan = src.slice(tagStart, handlerIdx);
         const clsMatch = tagSpan.match(/className="([^"]*)"/);
         assert.ok(clsMatch, `${file}: button for "${onClick}" has no className (${note})`);
@@ -118,5 +169,35 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
         );
       }
     }
+  });
+
+  it('no state-swap Button with a string-ternary child slips through without min-w-[Nrem] (scoped scan)', () => {
+    const missing: Array<{ file: string; line: number; snippet: string }> = [];
+    for (const file of SCAN_FILES) {
+      const src = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+      BUTTON_BLOCK_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = BUTTON_BLOCK_RE.exec(src)) !== null) {
+        const attrs = m[2];
+        const children = m[3];
+        if (!STRING_TERNARY_RE.test(children)) continue;
+        const clsMatch = attrs.match(/className="([^"]*)"/);
+        if (!clsMatch || !MIN_W_REM_RE.test(clsMatch[1])) {
+          const line = src.slice(0, m.index).split('\n').length;
+          missing.push({
+            file,
+            line,
+            snippet: children.trim().replace(/\s+/g, ' ').slice(0, 80),
+          });
+        }
+      }
+    }
+    const msgs = missing.map((m) => `  ${m.file}:${m.line} — ${m.snippet}`);
+    assert.equal(
+      missing.length,
+      0,
+      `Found ${missing.length} state-swap button(s) without min-w-[Nrem] in the PR3 scope files. Each <Button>/<UiButton> whose children contain a string ternary (? 'A' : 'B', the state-swap signal) must keep min-w-[Nrem] in its className. Add the lock sized to the widest state + a TEXT_SWAP_BUTTONS entry:\n` +
+        msgs.join('\n'),
+    );
   });
 });

--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -123,7 +123,7 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
               <UiButton
                 type="button"
                 variant="outline"
-                className="maka-error-copy-action"
+                className="maka-error-copy-action min-w-[5.5rem]"
                 data-copy-state={copyState}
                 disabled={copyPending}
                 aria-busy={copyPending ? 'true' : undefined}

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -647,7 +647,7 @@ export function MemorySettingsPage(props: {
                     type="button"
                     variant="quiet"
                     size="sm"
-                    className="settingsInlineTextButton"
+                    className="settingsInlineTextButton min-w-[4rem]"
                     aria-label={`打开项目指令文件 ${file.file}`}
                     disabled={memoryControlsDisabled || isMemoryActionPending(`instruction:${file.file}:open`)}
                     onClick={() => void openWorkspaceInstructionFile(file.file)}
@@ -660,7 +660,7 @@ export function MemorySettingsPage(props: {
                     type="button"
                     variant="quiet"
                     size="sm"
-                    className="settingsInlineTextButton"
+                    className="settingsInlineTextButton min-w-[4rem]"
                     aria-label={`创建项目指令文件 ${file.file}`}
                     disabled={memoryControlsDisabled || isMemoryActionPending(`instruction:${file.file}:create`)}
                     onClick={() => void createWorkspaceInstructionFile(file.file)}
@@ -721,7 +721,7 @@ export function MemorySettingsPage(props: {
                     type="button"
                     variant="quiet"
                     size="sm"
-                    className="settingsInlineTextButton"
+                    className="settingsInlineTextButton min-w-[4rem]"
                     aria-label={`打开备份候选 ${backupCandidateLabel}`}
                     disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending(`backup:${backup.kind}:open`)}
                     onClick={() => void openBackupCandidate(backup)}
@@ -732,7 +732,7 @@ export function MemorySettingsPage(props: {
                     type="button"
                     variant="quiet"
                     size="sm"
-                    className="settingsInlineTextButton"
+                    className="settingsInlineTextButton min-w-[4rem]"
                     aria-label={`恢复备份候选 ${backupCandidateLabel}`}
                     disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending(`backup:${backup.kind}:restore`)}
                     onClick={() => void restoreBackupCandidate(backup)}
@@ -743,7 +743,7 @@ export function MemorySettingsPage(props: {
                     type="button"
                     variant="quiet"
                     size="sm"
-                    className="settingsInlineTextButton"
+                    className="settingsInlineTextButton min-w-[4rem]"
                     aria-label={`复制备份候选引用 ${backupCandidateLabel}`}
                     disabled={isMemoryActionPending(`backup:${backup.kind}:copy`)}
                     onClick={() => void copyBackupReference(backup)}
@@ -952,7 +952,7 @@ export function MemorySettingsPage(props: {
         <Button type="button" variant="ghost" className="min-w-[6rem]" disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending('memory:folder:open')} onClick={() => void openFolder()}>
           {isMemoryActionPending('memory:folder:open') ? '打开中…' : '打开所在目录'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled} onClick={() => void reloadDraftFromDisk()}>
+        <Button type="button" variant="ghost" className="min-w-[4rem]" disabled={memoryControlsDisabled || !effective.enabled} onClick={() => void reloadDraftFromDisk()}>
           {pendingMemoryWriteAction === 'reload' ? '载入中…' : '重新载入'}
         </Button>
         <Button type="button" variant="ghost" className="min-w-[5rem]" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:open')} onClick={() => void openLatestBackup()}>
@@ -1053,7 +1053,7 @@ function MemoryEntryList(props: {
                         type="button"
                         variant="quiet"
                         size="sm"
-                        className="settingsInlineTextButton"
+                        className="settingsInlineTextButton min-w-[4rem]"
                         disabled={copyPending}
                         onClick={() => void props.onCopyReference?.(entry)}
                       >
@@ -1076,7 +1076,7 @@ function MemoryEntryList(props: {
                         type="button"
                         variant="quiet"
                         size="sm"
-                        className="settingsInlineTextButton"
+                        className="settingsInlineTextButton min-w-[4rem]"
                         aria-label={statusActionAriaLabel}
                         disabled={props.busy}
                         onClick={() => void props.onStatusChange?.(entry, props.archived ? 'active' : 'archived')}

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -785,7 +785,7 @@ export function MemorySettingsPage(props: {
               variant="quiet"
               size="sm"
               className="settingsInlineTextButton min-w-[5rem]"
-              disabled={!localMemoryPromptPreview || isMemoryActionPending('memory:prompt-preview:copy')
+              disabled={!localMemoryPromptPreview || isMemoryActionPending('memory:prompt-preview:copy')}
               onClick={() => void copyLocalMemoryPromptPreview()}
             >
               {isMemoryActionPending('memory:prompt-preview:copy') ? '复制中…' : '复制上下文'}

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -784,8 +784,8 @@ export function MemorySettingsPage(props: {
               type="button"
               variant="quiet"
               size="sm"
-              className="settingsInlineTextButton"
-              disabled={!localMemoryPromptPreview || isMemoryActionPending('memory:prompt-preview:copy')}
+              className="settingsInlineTextButton min-w-[5rem]"
+              disabled={!localMemoryPromptPreview || isMemoryActionPending('memory:prompt-preview:copy')
               onClick={() => void copyLocalMemoryPromptPreview()}
             >
               {isMemoryActionPending('memory:prompt-preview:copy') ? '复制中…' : '复制上下文'}
@@ -943,31 +943,31 @@ export function MemorySettingsPage(props: {
       )}
 
       <div className="settingsActionRow" role="group" aria-label="MEMORY.md 文件操作">
-        <Button type="button" disabled={memoryControlsDisabled || !effective.enabled || !memoryDraftDirty} onClick={() => void save()}>
+        <Button type="button" className="min-w-[3.5rem]" disabled={memoryControlsDisabled || !effective.enabled || !memoryDraftDirty} onClick={() => void save()}>
           {pendingMemoryWriteAction === 'save' ? '保存中…' : memoryDraftDirty ? '保存' : '已保存'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending('memory:file:open')} onClick={() => void openFile()}>
+        <Button type="button" variant="ghost" className="min-w-[7.5rem]" disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending('memory:file:open')} onClick={() => void openFile()}>
           {isMemoryActionPending('memory:file:open') ? '打开中…' : '打开 MEMORY.md'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending('memory:folder:open')} onClick={() => void openFolder()}>
+        <Button type="button" variant="ghost" className="min-w-[6rem]" disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending('memory:folder:open')} onClick={() => void openFolder()}>
           {isMemoryActionPending('memory:folder:open') ? '打开中…' : '打开所在目录'}
         </Button>
         <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled} onClick={() => void reloadDraftFromDisk()}>
           {pendingMemoryWriteAction === 'reload' ? '载入中…' : '重新载入'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:open')} onClick={() => void openLatestBackup()}>
+        <Button type="button" variant="ghost" className="min-w-[5rem]" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:open')} onClick={() => void openLatestBackup()}>
           {isMemoryActionPending('backup:latest:open') ? '打开中…' : '打开上一版'}
         </Button>
         <Button type="button" variant="ghost" disabled={!effective.path || isMemoryActionPending('memory:path:copy')} onClick={() => void copyPath()}>
           {isMemoryActionPending('memory:path:copy') ? '复制中…' : '复制路径'}
         </Button>
-        <Button type="button" variant="ghost" disabled={!effective.latestBackup || (effective.latestBackup ? isMemoryActionPending(`backup:${effective.latestBackup.kind}:copy`) : false)} onClick={() => void copyLatestBackupReference()}>
+        <Button type="button" variant="ghost" className="min-w-[7rem]" disabled={!effective.latestBackup || (effective.latestBackup ? isMemoryActionPending(`backup:${effective.latestBackup.kind}:copy`) : false)} onClick={() => void copyLatestBackupReference()}>
           {effective.latestBackup && isMemoryActionPending(`backup:${effective.latestBackup.kind}:copy`) ? '复制中…' : '复制上一版引用'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled} onClick={() => void reset()}>
+        <Button type="button" variant="ghost" className="min-w-[5rem]" disabled={memoryControlsDisabled || !effective.enabled} onClick={() => void reset()}>
           {pendingMemoryWriteAction === 'reset' ? '重置中…' : '重置并备份'}
         </Button>
-        <Button type="button" variant="ghost" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:restore')} onClick={() => void restoreLatestBackup()}>
+        <Button type="button" variant="ghost" className="min-w-[5rem]" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:restore')} onClick={() => void restoreLatestBackup()}>
           {isMemoryActionPending('backup:latest:restore') ? '恢复中…' : '恢复上一版'}
         </Button>
       </div>

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -1076,7 +1076,7 @@ function MemoryEntryList(props: {
                         type="button"
                         variant="quiet"
                         size="sm"
-                        className="settingsInlineTextButton min-w-[4rem]"
+                        className="settingsInlineTextButton min-w-[5rem]"
                         aria-label={statusActionAriaLabel}
                         disabled={props.busy}
                         onClick={() => void props.onStatusChange?.(entry, props.archived ? 'active' : 'archived')}

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -958,7 +958,7 @@ export function MemorySettingsPage(props: {
         <Button type="button" variant="ghost" className="min-w-[5rem]" disabled={memoryControlsDisabled || !effective.enabled || !effective.latestBackup || isMemoryActionPending('backup:latest:open')} onClick={() => void openLatestBackup()}>
           {isMemoryActionPending('backup:latest:open') ? '打开中…' : '打开上一版'}
         </Button>
-        <Button type="button" variant="ghost" disabled={!effective.path || isMemoryActionPending('memory:path:copy')} onClick={() => void copyPath()}>
+        <Button type="button" variant="ghost" className="min-w-[4rem]" disabled={!effective.path || isMemoryActionPending('memory:path:copy')} onClick={() => void copyPath()}>
           {isMemoryActionPending('memory:path:copy') ? '复制中…' : '复制路径'}
         </Button>
         <Button type="button" variant="ghost" className="min-w-[7rem]" disabled={!effective.latestBackup || (effective.latestBackup ? isMemoryActionPending(`backup:${effective.latestBackup.kind}:copy`) : false)} onClick={() => void copyLatestBackupReference()}>

--- a/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
@@ -285,22 +285,22 @@ export function OpenGatewaySettingsPage(props: {
         <Button variant="secondary" type="button" disabled={gatewayCopyDisabled} onClick={() => void copyBaseUrl()}>
           {isCopyingGatewayAction('base-url') ? '复制中…' : '复制地址'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyOverviewCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[8rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyOverviewCurl()}>
           {isCopyingGatewayAction('overview-curl') ? '复制中…' : '复制总览 curl'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyOpenApiCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[9rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyOpenApiCurl()}>
           {isCopyingGatewayAction('openapi-curl') ? '复制中…' : '复制接口说明 curl'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copySessionStateCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[9.5rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copySessionStateCurl()}>
           {isCopyingGatewayAction('session-state-curl') ? '复制中…' : '复制单会话状态 curl'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyEventStreamCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[8.5rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyEventStreamCurl()}>
           {isCopyingGatewayAction('event-stream-curl') ? '复制中…' : '复制事件流 curl'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyRecentEventsCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[9rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyRecentEventsCurl()}>
           {isCopyingGatewayAction('recent-events-curl') ? '复制中…' : '复制最近事件 curl'}
         </Button>
-        <Button variant="secondary" type="button" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyRecentRequestsCurl()}>
+        <Button variant="secondary" type="button" className="min-w-[9rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyRecentRequestsCurl()}>
           {isCopyingGatewayAction('recent-requests-curl') ? '复制中…' : '复制最近请求 curl'}
         </Button>
       </div>

--- a/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
@@ -282,7 +282,7 @@ export function OpenGatewaySettingsPage(props: {
         <Button variant="secondary" type="button" disabled={!gatewayDraft.token || saving} onClick={() => void saveToken('')}>
           清空 token
         </Button>
-        <Button variant="secondary" type="button" disabled={gatewayCopyDisabled} onClick={() => void copyBaseUrl()}>
+        <Button variant="secondary" type="button" className="min-w-[4rem]" disabled={gatewayCopyDisabled} onClick={() => void copyBaseUrl()}>
           {isCopyingGatewayAction('base-url') ? '复制中…' : '复制地址'}
         </Button>
         <Button variant="secondary" type="button" className="min-w-[8rem]" disabled={!gatewayDraft.token || gatewayCopyDisabled} onClick={() => void copyOverviewCurl()}>

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -154,6 +154,7 @@
 }
 
 .maka-daily-review-archive-row-title {
+    min-width: 0;
     color: var(--foreground);
     font-size: var(--font-size-ui);
     font-weight: var(--font-weight-semibold);
@@ -163,6 +164,7 @@
   }
 
 .maka-daily-review-archive-row-meta {
+    min-width: 0;
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
     font-variant-numeric: tabular-nums;
@@ -477,6 +479,7 @@
 }
 
 .maka-daily-review-session-name {
+    min-width: 0;
     font-weight: var(--font-weight-medium);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -491,6 +494,7 @@
   }
 
 .maka-daily-review-session-preview {
+    min-width: 0;
     font-size: var(--font-size-ui);
     color: var(--muted-foreground);
     overflow: hidden;

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -126,6 +126,7 @@
   }
 
 .settingsHealthSummaryTile strong {
+    font-variant-numeric: tabular-nums;
     font-size: 1.4em;
     font-weight: var(--font-weight-semibold);
     line-height: var(--leading-tight);

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -718,6 +718,7 @@
 }
 
 .maka-plan-search-summary {
+  font-variant-numeric: tabular-nums;
   display: flex;
   min-width: 0;
   align-items: center;

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -258,6 +258,7 @@
 }
 
 .maka-plan-template-note {
+  min-width: 0;
   color: var(--muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -867,6 +868,7 @@
 }
 
 .maka-plan-run-main strong {
+  min-width: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -596,6 +596,7 @@ color: oklch(0.55 0.015 220);
    (reference treats ids/counts/sources as filled fill-tertiary pills, §4 rule 8)
    instead of loose gray text. */
 .maka-skill-library-meta > span:first-child {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -222,6 +222,7 @@ color: oklch(0.55 0.015 220);
   padding: 0 1px;
 }
 .maka-skill-tab span {
+  font-variant-numeric: tabular-nums;
   min-width: 16px;
   height: 16px;
   display: inline-flex;
@@ -271,6 +272,7 @@ color: oklch(0.55 0.015 220);
 }
 
 .maka-skill-section-row small {
+  font-variant-numeric: tabular-nums;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -291,6 +291,7 @@
 }
 
 .settingsUsageRecordCount {
+  font-variant-numeric: tabular-nums;
   min-height: 34px;
   display: inline-flex;
   align-items: center;
@@ -353,6 +354,7 @@
 }
 
 .settingsMetricCard {
+  font-variant-numeric: tabular-nums;
   min-height: 52px;
   display: grid;
   align-content: center;
@@ -383,6 +385,7 @@
 
 .settingsStatsTable th,
 .settingsStatsTable td {
+  font-variant-numeric: tabular-nums;
   border-bottom: 1px solid var(--border);
   color: var(--foreground-secondary);
   padding: var(--space-1) var(--space-2);

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -237,6 +237,7 @@
  * glyph is overridden above to `--foreground` for selection visibility. */
 
 .settingsNavItem strong {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -413,6 +413,7 @@
 }
 
 .modelTableRowId {
+  min-width: 0;
   background: transparent;
   font-family: var(--font-mono);
   font-size: var(--font-size-ui);

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -252,6 +252,7 @@
 }
 
 .modelTableHeaderText small {
+  font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);
   line-height: var(--leading-normal);
   color: var(--foreground-secondary);
@@ -599,6 +600,7 @@
 .enabledStripHeader span,
 .providerMarketHeader p,
 .customProviderEntry p {
+  font-variant-numeric: tabular-nums;
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -722,6 +722,7 @@
 }
 
 .settingsThemeLabel strong {
+  min-width: 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -426,6 +426,7 @@
 }
 
 .maka-search-modal-result-summary {
+  font-variant-numeric: tabular-nums;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -474,6 +474,7 @@
   opacity: 0.7;
 }
 .maka-search-modal-result-title {
+  min-width: 0;
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
   color: var(--foreground);
@@ -482,6 +483,7 @@
   white-space: nowrap;
 }
 .maka-search-modal-result-meta {
+  min-width: 0;
   font-size: var(--font-size-caption);
   color: var(--muted-foreground);
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -316,6 +316,7 @@
   }
 
 .settingsMemoryEntryGroupHeader {
+    font-variant-numeric: tabular-nums;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -435,7 +435,7 @@ export function DailyReviewPanel(props: {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="maka-daily-review-append"
+                className="maka-daily-review-append min-w-[5rem]"
                 onClick={() => void runDailyReviewAction('append', async () => {
                   const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
                   await props.onAppendMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -322,7 +322,7 @@ export function DailyReviewPanel(props: {
             type="button"
             variant="default"
             size="sm"
-            className="maka-daily-review-quick-run"
+            className="maka-daily-review-quick-run min-w-[6rem]"
             onClick={() => void triggerManualRun('daily')}
             disabled={dailyReviewActionBusy}
             data-pending={pendingDailyReviewAction === 'run:daily' ? 'true' : undefined}
@@ -334,7 +334,7 @@ export function DailyReviewPanel(props: {
             type="button"
             variant="outline"
             size="sm"
-            className="maka-daily-review-quick-run"
+            className="maka-daily-review-quick-run min-w-[6rem]"
             onClick={() => void triggerManualRun('deep')}
             disabled={dailyReviewActionBusy}
             data-pending={pendingDailyReviewAction === 'run:deep' ? 'true' : undefined}
@@ -417,7 +417,7 @@ export function DailyReviewPanel(props: {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="maka-daily-review-copy"
+                className="maka-daily-review-copy min-w-[4rem]"
                 onClick={() => void runDailyReviewAction('copy', async () => {
                   const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
                   await props.onCopyMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });
@@ -453,7 +453,7 @@ export function DailyReviewPanel(props: {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="maka-daily-review-save"
+                className="maka-daily-review-save min-w-[4rem]"
                 onClick={() => void runDailyReviewAction('save', async () => {
                   const md = formatDailyReviewMarkdown(visibleSummary, dayLabel);
                   await props.onSaveMarkdown?.({ markdown: md, label: dayLabel, summary: visibleSummary });

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -151,6 +151,7 @@ const markerVariants = cva("", {
         + " data-[kind=model]:[&_code]:text-[color:var(--foreground-secondary)] data-[kind=model]:[&_code]:font-semibold"
         + " data-[kind=tools]:text-[color:var(--muted-foreground)]"
         + " data-[kind=duration]:[font-variant-numeric:tabular-nums]"
+        + " data-[kind=tools]:min-w-[5rem] data-[kind=duration]:min-w-[4rem]"
         + " data-[kind=tokens]:[font-variant-numeric:tabular-nums] data-[kind=tokens]:[font-family:var(--font-mono)] data-[kind=tokens]:text-[12px]"
         + " data-[state=in-progress]:text-[color:var(--status-running)] data-[state=in-progress]:font-semibold"
         + " data-[kind=model]:data-[switched=true]:[&_code]:text-[color:var(--foreground-secondary)]",
@@ -300,7 +301,7 @@ const streamVariants = cva("", {
       // `.maka-tool-output-stream-truncated-tag` class (no rule of its own) is
       // dropped.
       count:
-        "[font-variant-numeric:tabular-nums]"
+        "min-w-[5rem] [font-variant-numeric:tabular-nums]"
         + " data-[stream=stderr]:text-[color:var(--destructive-text)]"
         + " data-[redacted=true]:text-[color:var(--warning-text,var(--info-text))]"
         + " data-[truncated=true]:rounded-[var(--radius-control)] data-[truncated=true]:border data-[truncated=true]:border-[oklch(from_var(--warning)_l_c_h_/_0.30)] data-[truncated=true]:bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] data-[truncated=true]:px-1 data-[truncated=true]:text-[color:var(--warning-text,var(--info-text))] data-[truncated=true]:cursor-help",

--- a/packages/ui/src/relative-time.tsx
+++ b/packages/ui/src/relative-time.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { formatAbsoluteTimestamp } from './chat-display-helpers.js';
 import { formatRelativeTimestamp, nextRelativeRefreshDelay } from '@maka/core';
+import { cn } from './utils.js';
 
 /**
  * PR-RELATIVE-TIME-0: a self-refreshing relative-time label. Sidebar +
@@ -20,7 +21,7 @@ export function RelativeTime(props: { ts: number; className?: string; suppressTi
   });
   return (
     <small
-      className={props.className ?? 'maka-message-time'}
+      className={cn('tabular-nums', props.className ?? 'maka-message-time')}
       aria-hidden="true"
       title={props.suppressTitle ? undefined : formatAbsoluteTimestamp(props.ts)}
     >


### PR DESCRIPTION
## Summary

Converge the three anti-layout-shift dimensions in #520 PR3 — tabular-nums on numeric surfaces, min-w-0 on truncation surfaces, min-width on state-swap surfaces. Each dimension adds a presence contract so its class of bug can't regress. Same converge-contract pattern as #430 / #448 / #499.

## Why

Refs #520 (PR3). The roadmap calls out all three as fill + contract governance sweeps: §1.6 (tabular-nums fill per numeric surface), §4.1 (text-swap min-width is the chat layout-shift root cause), and missing min-w-0 is a historic truncation-bug source.

## Scope

Three dimensions, one contract each:

**tabular-nums** — 12 numeric surfaces found missing tabular-nums (10 self-refreshing timestamps fixed in one shot on `RelativeTime`, plus usage stats table, metric cards, health/skill/search/provider/plan counts). Contract: whitelist presence guard locking 31 known numeric surfaces + `RelativeTime`.

**min-w-0** — 12 flex/grid truncation children missing `min-width: 0` (daily-review session/archive/preview, plan template/run, model-table id, search result title/meta, theme label, skill id, settingsNavItem strong). Without it the default `min-width: auto` stops ellipsis from firing. Contract: heuristic scan of every `ellipsis + nowrap` rule (grid-minmax + dead-ellipsis exceptions).

**text-swap min-width** — 30 state-swap surfaces across memory/open-gateway/daily-review/error-boundary (复制↔已复制, 保存↔保存中…, token counts 9→100, 归档↔归档到草稿, etc.). Contract is three layers:
1. **scoped discovery** — scan the PR3 scope files for every `<Button>`/`<UiButton>` whose children contain a string-ternary (`? 'A' : 'B'`, the state-swap signal); each must keep `min-w-[Nrem]` AND be value-pinned (or in EXCEPTIONS). This catches omissions the whitelist hasn't listed (reload, backup-candidate, instruction-file, memory-entry actions all slipped through earlier review rounds). Inline-ternary omissions in these files are auto-caught.
2. **exact value pin** — each known button keeps a SPECIFIC `min-w-[Nrem]` sized to its widest state, located by its onClick handler; stops a refactor from shrinking a real lock. Chat summary-chip / stream-count variant locks are pinned by their literal declaration substrings.
3. **computed-label boundary** — buttons whose children is a variable holding a ternary result (`{copyLabel}` / `{statusActionLabel}`) have no inline ternary for the scan to find, so they MUST be hand-pinned in `TEXT_SWAP_BUTTONS`. The contract has a COMPUTED-LABEL note + a test asserting the scan does NOT discover these, so the "scan covers it" claim can't overstate its reach.

The scan is scoped to the PR3 files, not the whole renderer — `? 'A' : 'B'` is only the state-swap signal; it can't tell whether the button sits in a multi-element row where width change pushes siblings (the real bug needs layout context, unlike min-w-0's mechanical ellipsis+nowrap signal). A repo-wide scan flags ~77 buttons, most toggles / stand-alone retry buttons with no right sibling. Those are a separate, broader text-swap convergence effort, not this contract.

Changed files: `packages/ui/src/relative-time.tsx`, `primitives/chat.tsx`, `daily-review-panel.tsx`; `apps/desktop/src/renderer/styles/*.css`; `apps/desktop/src/renderer/{error-boundary,settings/memory-settings-page,settings/open-gateway-settings-page}.tsx`; 3 new contract tests.

Not included: scroll-area (locked to OverlayScrollbars by `overlay-scrollbars-contract.test.ts`; #520 explicitly out of scope); other settings pages' state-swap buttons (about/bot-chat/data/general/permission — separate broader text-swap effort, not PR3's 5-file scope); screenshot / manual verification (value-changing, needs app run).

## Verification

- `@maka/ui` typecheck + `@maka/desktop` typecheck (main + renderer + storybook): pass
- desktop `build:main`: pass
- 3 new contracts: pass (tabular-nums 2/2, min-w-0 2/2, text-swap 4/4)
- `renderer-css-parse-contract` + `chat-primitive-cascade-contract`: pass (CSS still parseable, chat variant changes don't break chat contracts)
- Negative tests: text-swap value-lock (openBackupCandidate 4rem→1rem fails the exact-value pin); scan notPinned (openBackupCandidate anchor not matched fails the scan value-pin); scan computed-label boundary (a `{label}` child is NOT flagged as discovered). All restore green.
- Not verified: screenshot / manual state-swap visual (value-changing; run `npm run screenshots` + trigger copy/save/token-count/归档 state swaps before merge).

## User-facing impact

None beyond reduced layout jitter: digits stay aligned as they change, truncated text actually truncates, state-swap buttons stop pushing right-hand siblings. No CHANGELOG / docs / breaking changes / migrations.

## Reviewer notes

- text-swap contract reached its stable three-layer form over several review rounds; the commit history shows the progression (whitelist-only → +scoped discovery → +notPinned value-pin → +computed-label boundary). The final contract is what's described above; the intermediate "coarse count guard" framing in early commit messages is superseded — the contract is now scoped discovery + exact value pin + chat variant literal assertion, with a computed-label boundary test.
- `min-w-0` contract heuristic scan: three exceptions (grid-minmax parents + one dead-ellipsis), each commented in the contract.
- `text-swap` `min-w-[Nrem]` values are estimates sized to the widest state (偏宽防抖). Screenshot verification may want to tune them.