### PR TITLE
fix: Gemini /v1beta baseUrl + default baseUrl persistence

### DIFF
--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -42,7 +42,7 @@ describe('validateConnectionBaseUrl (PR-UI-IPC-1, @kenji msg 35260e29)', () => {
       const canonical = [
         'https://api.anthropic.com',
         'https://api.openai.com/v1',
-        'https://generativelanguage.googleapis.com',
+        'https://generativelanguage.googleapis.com/v1beta',
         'https://api.deepseek.com',
         'https://api.z.ai/api/coding/paas/v4',
         'https://api.kimi.com/coding/v1',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -16,6 +16,7 @@ import { describe, it } from 'node:test';
 import {
   PROVIDER_DEFAULTS,
   normalizeConnectionBaseUrl,
+  persistedBaseUrl,
   validateConnectionBaseUrl,
 } from '../llm-connections.js';
 
@@ -195,6 +196,58 @@ describe('provider URL defaults', () => {
     assert.equal(PROVIDER_DEFAULTS['kimi-coding-plan'].signupUrl, 'https://www.kimi.com/code/console');
     assert.equal(PROVIDER_DEFAULTS.moonshot.baseUrl, 'https://api.moonshot.cn/v1');
     assert.equal(PROVIDER_DEFAULTS.moonshot.signupUrl, 'https://platform.kimi.com/console/api-keys');
+  });
+});
+
+describe('persistedBaseUrl', () => {
+  // The store calls this on create / update / save to decide what `baseUrl`
+  // to persist. Only a real override is stored; the provider default collapses
+  // to undefined so the connection follows the live default.
+
+  it('returns undefined for undefined / null / empty / whitespace-only', () => {
+    assert.equal(persistedBaseUrl('openai', undefined), undefined);
+    assert.equal(persistedBaseUrl('openai', null), undefined);
+    assert.equal(persistedBaseUrl('openai', ''), undefined);
+    assert.equal(persistedBaseUrl('openai', '   '), undefined);
+    assert.equal(persistedBaseUrl('openai', '\t\n'), undefined);
+  });
+
+  it('returns undefined when the value equals the provider current default (no override to persist)', () => {
+    assert.equal(
+      persistedBaseUrl('openai', 'https://api.openai.com/v1'),
+      undefined,
+      'openai default must not be persisted as an override',
+    );
+    assert.equal(
+      persistedBaseUrl('google', 'https://generativelanguage.googleapis.com/v1beta'),
+      undefined,
+      'google default must not be persisted as an override',
+    );
+    assert.equal(
+      persistedBaseUrl('ollama', 'http://localhost:11434/v1'),
+      undefined,
+      'ollama default must not be persisted as an override',
+    );
+  });
+
+  it('returns undefined when the value equals the default modulo surrounding whitespace', () => {
+    assert.equal(persistedBaseUrl('openai', '  https://api.openai.com/v1  '), undefined);
+    assert.equal(persistedBaseUrl('openai', '\thttps://api.openai.com/v1\n'), undefined);
+  });
+
+  it('returns the trimmed value for a real custom override', () => {
+    const custom = 'https://my-openai-proxy.example.com/v1';
+    assert.equal(persistedBaseUrl('openai', custom), custom);
+    assert.equal(persistedBaseUrl('openai', `  ${custom}  `), custom, 'whitespace is trimmed');
+    assert.equal(persistedBaseUrl('google', 'https://my-gemini-proxy.example.com/v1beta'), 'https://my-gemini-proxy.example.com/v1beta');
+  });
+
+  it('persists a custom override for openai-compatible (whose default is the empty string)', () => {
+    // openai-compatible is the one provider with no canonical default — any
+    // non-empty value the user supplies is a real override and must persist.
+    const custom = 'https://my-gateway.example.com/v1';
+    assert.equal(persistedBaseUrl('openai-compatible', custom), custom);
+    assert.equal(persistedBaseUrl('openai-compatible', ''), undefined, 'empty still means no override');
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -586,6 +586,7 @@ export {
   effectiveBaseUrl,
   migrateConnectionV1ToV2,
   normalizeConnectionBaseUrl,
+  persistedBaseUrl,
   validateConnectionBaseUrl,
   validateSlug,
 } from './llm-connections.js';

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -161,7 +161,7 @@ export const PROVIDER_DEFAULTS: Record<ProviderType, ProviderDefaults> = {
   google: {
     label: 'Google Gemini',
     description: 'Gemini API key access from Google AI Studio.',
-    baseUrl: 'https://generativelanguage.googleapis.com',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
     authKind: 'api_key',
     backendKind: 'ai-sdk',
     fallbackModels: ['gemini-2.5-flash', 'gemini-2.0-flash', 'gemini-1.5-pro'],

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -339,6 +339,28 @@ export function effectiveBaseUrl(c: Pick<LlmConnection, 'providerType' | 'baseUr
   return PROVIDER_DEFAULTS[c.providerType].baseUrl;
 }
 
+/**
+ * Reduce a submitted connection `baseUrl` to the value that should be persisted,
+ * or `undefined` if nothing should be stored.
+ *
+ * The add-form and edit-form pre-fill `defaults.baseUrl` and submit it verbatim
+ * when the user does not customize the field. Storing that default as an
+ * explicit override would pin the connection to the current default —
+ * `effectiveBaseUrl` honors the explicit value first, so future default changes
+ * would not reach it. Only a real override (non-empty and differing from the
+ * current default) is persisted; the empty/whitespace and equals-default cases
+ * collapse to `undefined` so the connection reads back through the live default.
+ */
+export function persistedBaseUrl(
+  providerType: ProviderType,
+  baseUrl: string | undefined | null,
+): string | undefined {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed === PROVIDER_DEFAULTS[providerType].baseUrl) return undefined;
+  return trimmed;
+}
+
 export function validateSlug(slug: string): string | null {
   if (!slug.trim()) return 'Slug is required';
   if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug)) {

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -85,7 +85,7 @@ describe('Claude subscription runtime wiring', () => {
   });
 
   test('anthropicV1BaseUrl normalizes base URLs to a single /v1 suffix', async () => {
-    const { anthropicV1BaseUrl } = await import('../subscription-auth.js');
+    const { anthropicV1BaseUrl } = await import('../provider-urls.js');
     assert.equal(anthropicV1BaseUrl('https://api.anthropic.com'), 'https://api.anthropic.com/v1', 'bare root gains /v1');
     assert.equal(anthropicV1BaseUrl('https://api.anthropic.com/'), 'https://api.anthropic.com/v1', 'trailing slash is stripped before re-appending /v1');
     assert.equal(anthropicV1BaseUrl('https://api.anthropic.com/v1'), 'https://api.anthropic.com/v1', 'already-versioned root is idempotent');

--- a/packages/runtime/src/__tests__/google-base-url.test.ts
+++ b/packages/runtime/src/__tests__/google-base-url.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, test } from 'node:test';
-import { googleApiUrl, googleV1BetaBaseUrl } from '../subscription-auth.js';
+import { googleApiUrl, googleV1BetaBaseUrl } from '../provider-urls.js';
 
 describe('googleV1BetaBaseUrl', () => {
   // Force a single /v1beta suffix so a bare-root override self-heals and an

--- a/packages/runtime/src/__tests__/google-base-url.test.ts
+++ b/packages/runtime/src/__tests__/google-base-url.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, test } from 'node:test';
+import { googleApiUrl, googleV1BetaBaseUrl } from '../subscription-auth.js';
+
+describe('googleV1BetaBaseUrl', () => {
+  // Force a single /v1beta suffix so a bare-root override self-heals and an
+  // already-versioned root is idempotent.
+
+  test('normalizes bare-root / versioned / trailing-slash / custom-proxy inputs to a single /v1beta', () => {
+    const root = 'https://generativelanguage.googleapis.com';
+    assert.equal(googleV1BetaBaseUrl(root), `${root}/v1beta`, 'bare root gains /v1beta (self-heal)');
+    assert.equal(googleV1BetaBaseUrl(`${root}/v1beta`), `${root}/v1beta`, 'already-versioned root is idempotent');
+    assert.equal(googleV1BetaBaseUrl(`${root}/`), `${root}/v1beta`, 'trailing slash is stripped before re-appending /v1beta');
+    assert.equal(googleV1BetaBaseUrl(`${root}/v1beta/`), `${root}/v1beta`, 'trailing slash on a versioned root is stripped');
+    assert.equal(
+      googleV1BetaBaseUrl('https://my-gemini-proxy.example.com/v1beta'),
+      'https://my-gemini-proxy.example.com/v1beta',
+      'already-versioned custom override is idempotent',
+    );
+    assert.equal(
+      googleV1BetaBaseUrl('https://my-gemini-proxy.example.com/'),
+      'https://my-gemini-proxy.example.com/v1beta',
+      'custom override omitting /v1beta gets it filled in',
+    );
+  });
+
+  test('does not double /v1beta', () => {
+    assert.equal(
+      googleV1BetaBaseUrl('https://generativelanguage.googleapis.com/v1beta'),
+      'https://generativelanguage.googleapis.com/v1beta',
+      'a single /v1beta stays single',
+    );
+  });
+});
+
+describe('googleApiUrl', () => {
+  test('appends a path + ?key= to a /v1beta base URL without doubling the version segment', () => {
+    const root = 'https://generativelanguage.googleapis.com/v1beta';
+    assert.equal(googleApiUrl(root, '/models', 'k'), `${root}/models?key=k`, 'versioned root + path, no doubled /v1beta');
+    assert.equal(googleApiUrl(`${root}/`, '/models', 'k'), `${root}/models?key=k`, 'trailing slash on base URL is stripped');
+    assert.equal(googleApiUrl(root, 'models', 'k'), `${root}/models?key=k`, 'path without a leading slash gets one');
+    assert.equal(
+      googleApiUrl(root, '/models/gemini-2.5-flash:generateContent', 'k'),
+      `${root}/models/gemini-2.5-flash:generateContent?key=k`,
+      'generateContent probe path is preserved',
+    );
+    assert.equal(googleApiUrl(root, '/models', 'k ey+'), `${root}/models?key=k%20ey%2B`, 'api key is URL-encoded into the query string');
+  });
+
+  test('normalizes a bare-root base URL to /v1beta so a stale stored default self-heals', () => {
+    const bare = 'https://generativelanguage.googleapis.com';
+    assert.equal(
+      googleApiUrl(bare, '/models', 'k'),
+      'https://generativelanguage.googleapis.com/v1beta/models?key=k',
+      'bare root is normalized to /v1beta before the path is appended',
+    );
+  });
+});
+
+describe('model-factory Google chat wiring', () => {
+  test('routes the Google chat base URL through googleV1BetaBaseUrl, not raw effectiveBaseUrl', async () => {
+    const src = await readFile(new URL('../../src/model-factory.ts', import.meta.url), 'utf8');
+    const caseIdx = src.indexOf("case 'google'");
+    assert.notEqual(caseIdx, -1, 'Google case must exist in model-factory');
+    const caseRegion = src.slice(caseIdx, src.indexOf("case 'deepseek'", caseIdx));
+    assert.match(
+      caseRegion,
+      /baseURL:\s*googleV1BetaBaseUrl\(baseURL\)/,
+      'Google chat must pass the AI SDK a /v1beta-normalized base URL so a stale bare-root override self-heals',
+    );
+    assert.doesNotMatch(
+      caseRegion,
+      /createGoogleGenerativeAI\(\{\s*apiKey,\s*baseURL\s*\}\)/,
+      'Google chat must not pass the raw effectiveBaseUrl to createGoogleGenerativeAI',
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -97,6 +97,34 @@ describe('fetchProviderModels', () => {
     assert.deepEqual(models, [{ id: 'custom-live-model' }]);
   });
 
+  test('Google Gemini appends /models to a /v1beta base URL without doubling the version segment', async () => {
+    let observedPath = '';
+    let observedKey = '';
+    const server = await startJsonServer((request, response) => {
+      observedPath = request.url ?? '';
+      const url = new URL(request.url ?? '', 'http://test.local');
+      observedKey = url.searchParams.get('key') ?? '';
+      assert.equal(request.method, 'GET');
+      respondJson(response, 200, {
+        models: [
+          { name: 'models/gemini-2.5-flash' },
+          { name: 'models/gemini-2.0-flash' },
+        ],
+      });
+    });
+
+    const models = await fetchProviderModels(
+      { ...googleConnection(), baseUrl: `${server.url}/v1beta` },
+      'google-api-key',
+    );
+
+    // baseUrl already ends with /v1beta — the fetcher must append /models,
+    // not /v1beta/models (which would double the version segment and 404).
+    assert.equal(observedPath, '/v1beta/models?key=google-api-key');
+    assert.equal(observedKey, 'google-api-key');
+    assert.deepEqual(models, [{ id: 'gemini-2.5-flash' }, { id: 'gemini-2.0-flash' }]);
+  });
+
   test('Claude subscription model fetch uses OAuth bearer headers, not x-api-key', async () => {
     let observedAuth = '';
     let observedApiKey = '';
@@ -216,6 +244,18 @@ function zaiConnection(): LlmConnection {
     name: 'Z.ai',
     providerType: 'zai-coding-plan',
     defaultModel: 'glm-4.7',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function googleConnection(): LlmConnection {
+  return {
+    slug: 'google',
+    name: 'Google Gemini',
+    providerType: 'google',
+    defaultModel: 'gemini-2.5-flash',
     enabled: true,
     createdAt: 1,
     updatedAt: 1,

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -8,6 +8,7 @@ import {
   anthropicV1BaseUrl,
   claudeSubscriptionHeaders,
   codexSubscriptionHeaders,
+  googleV1BetaBaseUrl,
 } from './subscription-auth.js';
 
 export interface ModelFactoryInput {
@@ -73,7 +74,10 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
     }
 
     case 'google':
-      return createGoogleGenerativeAI({ apiKey, baseURL }).chat(modelId);
+      // Normalize the base URL to /v1beta (googleV1BetaBaseUrl) so a baseUrl
+      // override omitting `/v1beta` sends to `<root>/v1beta/models/{model}`
+      // instead of 404ing, matching the probe/model-fetch paths.
+      return createGoogleGenerativeAI({ apiKey, baseURL: googleV1BetaBaseUrl(baseURL) }).chat(modelId);
 
     case 'deepseek':
       return createOpenAICompatible({

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -4,11 +4,10 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { LanguageModelV3 } from '@ai-sdk/provider';
 import { effectiveBaseUrl, type LlmConnection } from '@maka/core/llm-connections';
+import { anthropicV1BaseUrl, googleV1BetaBaseUrl } from './provider-urls.js';
 import {
-  anthropicV1BaseUrl,
   claudeSubscriptionHeaders,
   codexSubscriptionHeaders,
-  googleV1BetaBaseUrl,
 } from './subscription-auth.js';
 
 export interface ModelFactoryInput {
@@ -74,9 +73,8 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV3 {
     }
 
     case 'google':
-      // Normalize the base URL to /v1beta (googleV1BetaBaseUrl) so a baseUrl
-      // override omitting `/v1beta` sends to `<root>/v1beta/models/{model}`
-      // instead of 404ing, matching the probe/model-fetch paths.
+      // Normalize to /v1beta so a baseUrl override omitting it still hits
+      // `<root>/v1beta/models/{model}` instead of 404ing.
       return createGoogleGenerativeAI({ apiKey, baseURL: googleV1BetaBaseUrl(baseURL) }).chat(modelId);
 
     case 'deepseek':

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -6,7 +6,7 @@ import {
 } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url, claudeSubscriptionHeaders } from './subscription-auth.js';
+import { anthropicV1Url, claudeSubscriptionHeaders, googleApiUrl } from './subscription-auth.js';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 
@@ -61,7 +61,7 @@ async function fetchProviderModelsStrict(
     }
     case 'google': {
       const r = await proxiedFetch(
-        `${stripTrailing(baseUrl)}/v1beta/models?key=${encodeURIComponent(apiKey)}`,
+        googleApiUrl(baseUrl, '/models', apiKey),
         { timeoutMs: MODEL_FETCH_TIMEOUT_MS },
       );
       if (!r.ok) throw new Error(`HTTP ${r.status}`);

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -6,7 +6,8 @@ import {
 } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url, claudeSubscriptionHeaders, googleApiUrl } from './subscription-auth.js';
+import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
+import { claudeSubscriptionHeaders } from './subscription-auth.js';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 

--- a/packages/runtime/src/provider-urls.ts
+++ b/packages/runtime/src/provider-urls.ts
@@ -1,0 +1,41 @@
+/**
+ * The Anthropic AI SDK expects a versioned API prefix and appends
+ * `/messages` internally. Maka's provider defaults are user-facing roots
+ * (`https://api.anthropic.com`) because our manual probes append `/v1/...`.
+ * Keep the translation centralized so OAuth/API-key sends and probes do not
+ * drift into `https://api.anthropic.com/messages` or `/v1/v1/...`.
+ */
+export function anthropicRootUrl(baseUrl: string): string {
+  return stripTrailing(baseUrl).replace(/\/v1$/i, '');
+}
+
+export function anthropicV1BaseUrl(baseUrl: string): string {
+  return `${anthropicRootUrl(baseUrl)}/v1`;
+}
+
+export function anthropicV1Url(baseUrl: string, path: string): string {
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  return `${anthropicV1BaseUrl(baseUrl)}${cleanPath}`;
+}
+
+/**
+ * Normalize a Google AI base URL to a single `/v1beta` suffix: a bare-root
+ * override self-heals to `/v1beta` instead of 404ing on
+ * `/models/{model}:generateContent`.
+ */
+export function googleV1BetaBaseUrl(baseUrl: string): string {
+  return `${stripTrailing(baseUrl).replace(/\/v1beta$/i, '')}/v1beta`;
+}
+
+/**
+ * The model-list fetcher and the connection probe route through here; the chat
+ * path uses `googleV1BetaBaseUrl` directly via `createGoogleGenerativeAI`.
+ */
+export function googleApiUrl(baseUrl: string, path: string, apiKey: string): string {
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  return `${googleV1BetaBaseUrl(baseUrl)}${cleanPath}?key=${encodeURIComponent(apiKey)}`;
+}
+
+function stripTrailing(u: string): string {
+  return u.replace(/\/+$/, '');
+}

--- a/packages/runtime/src/subscription-auth.ts
+++ b/packages/runtime/src/subscription-auth.ts
@@ -32,6 +32,24 @@ export function anthropicV1Url(baseUrl: string, path: string): string {
   return `${anthropicV1BaseUrl(baseUrl)}${cleanPath}`;
 }
 
+/**
+ * Normalize a Google AI base URL to a single `/v1beta` suffix: a bare-root
+ * override (e.g. a connection that stored the pre-fix default) self-heals to
+ * `/v1beta` instead of 404ing on `/models/{model}:generateContent`.
+ */
+export function googleV1BetaBaseUrl(baseUrl: string): string {
+  return `${stripTrailing(baseUrl).replace(/\/v1beta$/i, '')}/v1beta`;
+}
+
+/**
+ * The model-list fetcher and the connection probe route through here; the chat
+ * path uses `googleV1BetaBaseUrl` directly via `createGoogleGenerativeAI`.
+ */
+export function googleApiUrl(baseUrl: string, path: string, apiKey: string): string {
+  const cleanPath = path.startsWith('/') ? path : `/${path}`;
+  return `${googleV1BetaBaseUrl(baseUrl)}${cleanPath}?key=${encodeURIComponent(apiKey)}`;
+}
+
 export function codexSubscriptionHeaders(accessToken: string): Record<string, string> {
   const accountId = extractCodexAccountId(accessToken);
   return {

--- a/packages/runtime/src/subscription-auth.ts
+++ b/packages/runtime/src/subscription-auth.ts
@@ -12,44 +12,6 @@ export function claudeSubscriptionHeaders(): Record<string, string> {
   };
 }
 
-/**
- * The Anthropic AI SDK expects a versioned API prefix and appends
- * `/messages` internally. Maka's provider defaults are user-facing roots
- * (`https://api.anthropic.com`) because our manual probes append `/v1/...`.
- * Keep the translation centralized so OAuth/API-key sends and probes do not
- * drift into `https://api.anthropic.com/messages` or `/v1/v1/...`.
- */
-export function anthropicRootUrl(baseUrl: string): string {
-  return stripTrailing(baseUrl).replace(/\/v1$/i, '');
-}
-
-export function anthropicV1BaseUrl(baseUrl: string): string {
-  return `${anthropicRootUrl(baseUrl)}/v1`;
-}
-
-export function anthropicV1Url(baseUrl: string, path: string): string {
-  const cleanPath = path.startsWith('/') ? path : `/${path}`;
-  return `${anthropicV1BaseUrl(baseUrl)}${cleanPath}`;
-}
-
-/**
- * Normalize a Google AI base URL to a single `/v1beta` suffix: a bare-root
- * override (e.g. a connection that stored the pre-fix default) self-heals to
- * `/v1beta` instead of 404ing on `/models/{model}:generateContent`.
- */
-export function googleV1BetaBaseUrl(baseUrl: string): string {
-  return `${stripTrailing(baseUrl).replace(/\/v1beta$/i, '')}/v1beta`;
-}
-
-/**
- * The model-list fetcher and the connection probe route through here; the chat
- * path uses `googleV1BetaBaseUrl` directly via `createGoogleGenerativeAI`.
- */
-export function googleApiUrl(baseUrl: string, path: string, apiKey: string): string {
-  const cleanPath = path.startsWith('/') ? path : `/${path}`;
-  return `${googleV1BetaBaseUrl(baseUrl)}${cleanPath}?key=${encodeURIComponent(apiKey)}`;
-}
-
 export function codexSubscriptionHeaders(accessToken: string): Record<string, string> {
   const accountId = extractCodexAccountId(accessToken);
   return {
@@ -81,10 +43,6 @@ export function extractCodexAccountId(accessToken: string): string | null {
     }
   }
   return null;
-}
-
-function stripTrailing(u: string): string {
-  return u.replace(/\/+$/, '');
 }
 
 function decodeJwtPayload(token: string): Record<string, unknown> | null {

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -5,7 +5,7 @@ import {
   type LlmConnection,
 } from '@maka/core/llm-connections';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url, claudeSubscriptionHeaders } from './subscription-auth.js';
+import { anthropicV1Url, claudeSubscriptionHeaders, googleApiUrl } from './subscription-auth.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 
@@ -132,7 +132,7 @@ async function probeGoogle(
   t0: number,
 ): Promise<ConnectionTestResult> {
   const r = await proxiedFetch(
-    `${stripTrailing(baseUrl)}/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(apiKey)}`,
+    googleApiUrl(baseUrl, `/models/${encodeURIComponent(model)}:generateContent`, apiKey),
     {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -5,7 +5,8 @@ import {
   type LlmConnection,
 } from '@maka/core/llm-connections';
 import { proxiedFetch } from './bots/proxied-fetch.js';
-import { anthropicV1Url, claudeSubscriptionHeaders, googleApiUrl } from './subscription-auth.js';
+import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
+import { claudeSubscriptionHeaders } from './subscription-auth.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { createConnectionStore } from '../connection-store.js';
 
 describe('FileConnectionStore', () => {
@@ -294,6 +295,99 @@ describe('FileConnectionStore', () => {
         /connections must be an array/,
       );
       assert.equal(await readFile(filePath, 'utf8'), invalid);
+    });
+  });
+
+  test('does not persist the provider default baseUrl as an explicit override on create', async () => {
+    await withConnectionStore(async (store, dir) => {
+      // The add-form submits defaults.baseUrl verbatim when the field isn't
+      // customized; the store drops it so the connection follows the live default.
+      const created = await store.create({
+        slug: 'openai-default',
+        name: 'OpenAI',
+        providerType: 'openai',
+        baseUrl: PROVIDER_DEFAULTS.openai.baseUrl,
+        defaultModel: 'gpt-4o-mini',
+      });
+      assert.equal(created.baseUrl, undefined);
+
+      const onDisk = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8'));
+      assert.equal(onDisk.connections[0].baseUrl, undefined, 'default must not be written to disk as an override');
+    });
+  });
+
+  test('persists a custom baseUrl override on create and trims surrounding whitespace', async () => {
+    await withConnectionStore(async (store, dir) => {
+      const custom = 'https://my-openai-proxy.example.com/v1';
+      const created = await store.create({
+        slug: 'openai-proxy',
+        name: 'OpenAI Proxy',
+        providerType: 'openai',
+        baseUrl: `  ${custom}  `,
+        defaultModel: 'gpt-4o-mini',
+      });
+      assert.equal(created.baseUrl, custom);
+
+      const onDisk = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8'));
+      assert.equal(onDisk.connections[0].baseUrl, custom, 'custom override is persisted, trimmed');
+    });
+  });
+
+  test('update clears the override when the default is submitted and stores a custom override verbatim', async () => {
+    await withConnectionStore(async (store) => {
+      const created = await store.create({
+        slug: 'openai-main',
+        name: 'OpenAI',
+        providerType: 'openai',
+        baseUrl: 'https://my-openai-proxy.example.com/v1',
+        defaultModel: 'gpt-4o-mini',
+      });
+      assert.equal(created.baseUrl, 'https://my-openai-proxy.example.com/v1');
+
+      // Submitting the provider default clears the override (no pin).
+      const cleared = await store.update(created.slug, { baseUrl: PROVIDER_DEFAULTS.openai.baseUrl });
+      assert.equal(cleared.baseUrl, undefined);
+
+      // A custom override is stored.
+      const overridden = await store.update(created.slug, { baseUrl: 'https://other-proxy.example.com/v1' });
+      assert.equal(overridden.baseUrl, 'https://other-proxy.example.com/v1');
+
+      // An explicit clear (empty string) also clears the override.
+      const clearedAgain = await store.update(created.slug, { baseUrl: '' });
+      assert.equal(clearedAgain.baseUrl, undefined);
+    });
+  });
+
+  test('save drops the provider default baseUrl instead of persisting it as an override', async () => {
+    await withConnectionStore(async (store, dir) => {
+      // save()'s OAuth-sync caller constructs `{ baseUrl: defaults.baseUrl }`;
+      // without persistedBaseUrl that pins the connection to the current default.
+      const created = await store.create({
+        slug: 'claude-oauth',
+        name: 'Claude OAuth',
+        providerType: 'claude-subscription',
+        defaultModel: 'claude-sonnet-4-5-20250929',
+      });
+      assert.equal(created.baseUrl, undefined);
+
+      const saved = await store.save({
+        ...created,
+        baseUrl: PROVIDER_DEFAULTS['claude-subscription'].baseUrl,
+        updatedAt: Date.now(),
+      });
+      assert.equal(saved.baseUrl, undefined, 'save must not persist the provider default as an override');
+
+      const onDisk = JSON.parse(await readFile(join(dir, 'llm-connections.json'), 'utf8'));
+      assert.equal(onDisk.connections[0].baseUrl, undefined, 'default must not be written to disk by save');
+
+      // A custom override round-trips through save.
+      const custom = 'https://my-anthropic-proxy.example.com';
+      const overridden = await store.save({
+        ...created,
+        baseUrl: custom,
+        updatedAt: Date.now(),
+      });
+      assert.equal(overridden.baseUrl, custom);
     });
   });
 

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import {
   PROVIDER_DEFAULTS,
   migrateConnectionV1ToV2,
+  persistedBaseUrl,
   validateSlug,
   type CreateConnectionInput,
   type LlmConnection,
@@ -60,11 +61,12 @@ class FileConnectionStore implements ConnectionStore {
       }
       const defaults = PROVIDER_DEFAULTS[input.providerType];
       const now = Date.now();
+      const baseUrl = persistedBaseUrl(input.providerType, input.baseUrl);
       const next: LlmConnection = {
         slug: input.slug,
         name: input.name || defaults.label,
         providerType: input.providerType,
-        ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+        ...(baseUrl ? { baseUrl } : {}),
         defaultModel: input.defaultModel || defaults.fallbackModels[0] || '',
         enabled: true,
         createdAt: now,
@@ -111,7 +113,9 @@ class FileConnectionStore implements ConnectionStore {
       const next: LlmConnection = {
         ...current,
         name: patch.name ?? current.name,
-        baseUrl: patch.baseUrl !== undefined ? patch.baseUrl || undefined : current.baseUrl,
+        baseUrl: patch.baseUrl !== undefined
+          ? persistedBaseUrl(current.providerType, patch.baseUrl)
+          : current.baseUrl,
         defaultModel: patch.defaultModel ?? current.defaultModel,
         enabled: patch.enabled ?? current.enabled,
         models: updatesModelCache ? patch.models : (clearsModelCache ? undefined : current.models),
@@ -138,12 +142,19 @@ class FileConnectionStore implements ConnectionStore {
   }
 
   async save(connection: LlmConnection): Promise<LlmConnection> {
+    let saved: LlmConnection | null = null;
     await this.withQueue(async () => {
       const file = await this.readUnlocked();
       const index = file.connections.findIndex((item) => item.slug === connection.slug);
       const now = Date.now();
+      // save() is a full-replace write; route it through persistedBaseUrl too,
+      // or a caller handing back defaults.baseUrl (e.g. OAuth sync) pins the
+      // connection to the current default.
+      const baseUrl = persistedBaseUrl(connection.providerType, connection.baseUrl);
+      const { baseUrl: _omit, ...rest } = connection;
       const next: LlmConnection = {
-        ...connection,
+        ...rest,
+        ...(baseUrl ? { baseUrl } : {}),
         enabled: connection.enabled ?? true,
         createdAt: connection.createdAt ?? now,
         updatedAt: connection.updatedAt ?? now,
@@ -155,8 +166,10 @@ class FileConnectionStore implements ConnectionStore {
       }
       if (!file.defaultSlug && next.enabled !== false) file.defaultSlug = connection.slug;
       await this.write(file);
+      saved = next;
     });
-    return connection;
+    if (!saved) throw new Error(`Failed to save connection: ${connection.slug}`);
+    return saved;
   }
 
   async remove(slug: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `/v1beta` to the Google default `baseUrl` so Gemini chat stops 404ing (`@ai-sdk/google` appends `/models/{model}:generateContent` directly onto `baseURL`).
- Centralize Google URL construction in `googleApiUrl` and normalize all three consumers (chat, model-fetch, test-connection) through `googleV1BetaBaseUrl`, so a `baseUrl` override omitting `/v1beta` self-heals instead of 404ing.
- Fix the root cause: the add-form / edit-form submit the pre-filled `defaults.baseUrl` verbatim, which the store persisted as an explicit override, pinning connections to the current default. `persistedBaseUrl` drops the default (and empty/whitespace) on `create` / `update` / `save`, so uncustomized connections follow the live default.
- Move the provider URL helpers out of `subscription-auth.ts` into `provider-urls.ts` (name now matches content).

## Why

The Google default omitted the version segment while model-fetcher / test-connection hardcoded `/v1beta` to compensate — chat 404'd, and naively aligning the default would have doubled the segment elsewhere. Centralizing makes the default the single source of truth and matches the codebase convention (other providers carry the version path in the default).

`persistedBaseUrl` fixes the deeper pattern flagged in review: storing the pre-filled default as an override re-stales existing connections on every future default change. Dropping it on the write side avoids future migrations.

## Scope

Changed:

- Core: Google default `baseUrl` → `/v1beta`; `persistedBaseUrl` helper.
- Storage: `create` / `update` / `save` route `baseUrl` through `persistedBaseUrl` (save now returns the normalized record).
- Runtime: new `provider-urls.ts` (URL helpers moved from `subscription-auth.ts`); Google chat / fetch / test-connection normalize via `googleV1BetaBaseUrl` / `googleApiUrl`.
- Tests: `googleV1BetaBaseUrl` / `googleApiUrl` / chat wiring; `persistedBaseUrl` units; store create / update / save not persisting the default.

Not included:

- Load-path migration for existing bare-root overrides — no release yet; recreate/edit to clear. The `googleV1BetaBaseUrl` self-heal means stale bare-root overrides still work.

## Verification

- `@maka/core` — llm-connections: 53 pass / 0 fail.
- `@maka/storage` — connection-store: 16 pass / 0 fail.
- `@maka/runtime` — full suite: 643 pass / 1 pre-existing skip / 0 fail.

Co-Authored-By: Claude <noreply@anthropic.com>