### PR TITLE
fix(ui): theme palette leaks — derive surfaces and CTA family from base tokens

### DIFF
--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -37,6 +37,19 @@ function parseOklch(value: string): [number, number, number] {
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+/**
+ * PALETTE-LEAK-0: --action/--control tokens derive hue + chroma from
+ * --accent (with a min() chroma cap) while keeping their WCAG-tuned
+ * lightness anchors literal. Resolve the derived form against the block's
+ * literal --accent so the contrast gates below keep checking real colors
+ * for the default palette.
+ */
+function resolveAccentDerived(value: string, accent: [number, number, number]): [number, number, number] {
+  const match = value.match(/^oklch\(from var\(--accent\) ([\d.]+) min\(c, ([\d.]+)\) h\)$/);
+  assert.ok(match, `${value} must be the accent-derived form oklch(from var(--accent) <l> min(c, <cap>) h)`);
+  return [Number(match[1]), Math.min(accent[1], Number(match[2])), accent[2]];
+}
+
 function oklchToSrgb([l, c, h]: [number, number, number]): [number, number, number] {
   const hue = h * Math.PI / 180;
   const a = c * Math.cos(hue);
@@ -141,6 +154,7 @@ describe('issue #406 design-system governance contract', () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
     const emphasisTokens = ['link', 'focus-ring', 'status-running', 'nav-active', 'toast-accent'];
     for (const selector of [':root', '.dark'] as const) {
+      const accent = parseOklch(readCssToken(tokens, selector, 'accent'));
       const action = readCssToken(tokens, selector, 'action');
       const actionForeground = readCssToken(tokens, selector, 'action-foreground');
       const control = readCssToken(tokens, selector, 'control');
@@ -148,11 +162,17 @@ describe('issue #406 design-system governance contract', () => {
 
       assert.notEqual(action, 'var(--accent)', `${selector} action must be independently tunable`);
       assert.notEqual(control, 'var(--accent)', `${selector} control must be independently tunable`);
-      // A's CTA is a pale-blue chip with deep-blue text (was dark-green + near-white).
-      assert.match(actionForeground, /^oklch\(0\.30 0\.06 250\)$/);
-      assert.match(controlForeground, /^oklch\(0\.985 0\.003 250\)$/);
+      // PALETTE-LEAK-0: the CTA family keeps its tuned lightness anchors but
+      // derives hue/chroma from --accent so palette switches reach the send
+      // button and checked controls (they used to stay hardcoded-blue). The
+      // anchors stay pinned inside the derived form.
+      assert.match(actionForeground, /^oklch\(from var\(--accent\) 0\.30 min\(c, 0\.06\) h\)$/);
+      assert.match(controlForeground, /^oklch\(from var\(--accent\) 0\.985 min\(c, 0\.003\) h\)$/);
       assert.ok(
-        contrastRatio(oklchToSrgb(parseOklch(action)), oklchToSrgb(parseOklch(actionForeground))) >= 4.5,
+        contrastRatio(
+          oklchToSrgb(resolveAccentDerived(action, accent)),
+          oklchToSrgb(resolveAccentDerived(actionForeground, accent)),
+        ) >= 4.5,
         `${selector} action/action-foreground contrast must clear 4.5:1`,
       );
       // control/foreground paints graphical objects (checkbox check, switch
@@ -160,7 +180,10 @@ describe('issue #406 design-system governance contract', () => {
       // non-text contrast bar (3:1) applies, not the 4.5:1 text bar used for
       // action above. --control is tuned (L0.65) to clear 3:1 with a small margin.
       assert.ok(
-        contrastRatio(oklchToSrgb(parseOklch(control)), oklchToSrgb(parseOklch(controlForeground))) >= 3.0,
+        contrastRatio(
+          oklchToSrgb(resolveAccentDerived(control, accent)),
+          oklchToSrgb(resolveAccentDerived(controlForeground, accent)),
+        ) >= 3.0,
         `${selector} control/control-foreground contrast must clear 3:1 (WCAG 1.4.11 non-text)`,
       );
       for (const token of emphasisTokens) {
@@ -322,6 +345,14 @@ describe('issue #406 design-system governance contract', () => {
       '--selection',
       '--accent',
       '--color-accent',
+      // PALETTE-LEAK-0: the CTA family derives hue/chroma from --accent
+      // (lightness anchors stay literal) so palette switches reach the send
+      // button and checked controls; --color-accent-foreground follows the
+      // same derivation in styles.css @theme; --system-alert-accent is the
+      // semantic alias component CSS (plan-reminders banner) consumes.
+      '--action', '--action-foreground', '--control', '--control-foreground',
+      '--color-accent-foreground',
+      '--system-alert-accent',
     ]);
 
     // Walk CSS source line-by-line, tracking the current selector stack via

--- a/apps/desktop/src/renderer/cached-theme-bootstrap.ts
+++ b/apps/desktop/src/renderer/cached-theme-bootstrap.ts
@@ -18,4 +18,14 @@ export function applyCachedThemeBeforeMount(): void {
   } else {
     document.documentElement.style.colorScheme = 'light';
   }
+  // PALETTE-LEAK-0: restore the cached palette too (persisted by
+  // applyThemePalette), not just light/dark — otherwise non-default-palette
+  // users get a first paint in the default zinc palette that visibly snaps
+  // once app-shell applies settings. An unknown/stale value is harmless
+  // (no [data-maka-theme=…] block matches → default palette), but keep the
+  // attribute within the safe charset anyway.
+  const cachedPalette = safeLocalStorageGet('maka-theme-palette-v1');
+  if (cachedPalette && cachedPalette !== 'default' && /^[a-z0-9-]{1,32}$/.test(cachedPalette)) {
+    document.documentElement.setAttribute('data-maka-theme', cachedPalette);
+  }
 }

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -63,7 +63,11 @@
   /* PR-UI-FRAME-4 (2026-06-22): pull back from the heavy gray plate.
      参考实现's sidebar is a light glass-like near-white gradient, with
      depth coming from translucent overlays and active rows, not a dark slab. */
-  --surface-canvas: oklch(0.976 0.002 286);
+  /* PALETTE-LEAK-0: derive from --background instead of hardcoding zinc
+     h286 — palettes never override this token, so the sidebar/shell plate
+     stayed zinc after a palette switch. Default background (l=1.0)
+     resolves to the same 0.976 plate. */
+  --surface-canvas: oklch(from var(--background) calc(l - 0.024) c h);
   /* PR-GRAY-CARD-LIFT-3 (WAWQAQ msg `053ca971`): in the new
      gray-plate / white-card hierarchy, "elevated" cards live on the
      same pure white as base content cards — the lift comes from the
@@ -94,10 +98,17 @@
      controls (--control) use a slightly deeper blue (L0.65, one step below
      the accent) so the near-white glyph clears WCAG 1.4.11 non-text contrast
      3:1 (3.09:1); the logo L0.70 only reaches 2.55:1. */
-  --action: oklch(0.85 0.08 250);
-  --action-foreground: oklch(0.30 0.06 250);
-  --control: oklch(0.65 0.135 250);
-  --control-foreground: oklch(0.985 0.003 250);
+  /* PALETTE-LEAK-0: derive hue/chroma from --accent instead of hardcoding
+     blue h250 — palettes only override the base tokens, so literals here
+     kept the send button, onboarding CTA and every checked control blue
+     after a palette switch (same bug --brand-deep already had and fixed).
+     Lightness anchors stay literal to preserve the WCAG 1.4.11 tuning;
+     min(c, …) keeps the default palette byte-identical while following
+     low-chroma palettes down. */
+  --action: oklch(from var(--accent) 0.85 min(c, 0.08) h);
+  --action-foreground: oklch(from var(--accent) 0.30 min(c, 0.06) h);
+  --control: oklch(from var(--accent) 0.65 min(c, 0.135) h);
+  --control-foreground: oklch(from var(--accent) 0.985 min(c, 0.003) h);
   --link: var(--accent);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
@@ -115,6 +126,11 @@
   --brand-deep: var(--accent);
   --brand-deep-hover: oklch(from var(--accent) calc(l - 0.06) c h);
   --bot-brand-default: var(--accent);
+  /* PALETTE-LEAK-0: semantic alias for informational system banners (the
+     plan-reminders 系统提醒 banner) — component CSS derives its tint family
+     from this instead of referencing var(--accent) directly (governance
+     contract #406 bans raw accent outside token blocks). */
+  --system-alert-accent: var(--accent);
 
   /* === text variants (mixed toward foreground for better contrast) === */
   --success-text: color-mix(in oklab, var(--success) 50%, var(--foreground));
@@ -546,7 +562,9 @@
    * (hue 0, no chroma) hierarchy. Lightness anchors keep existing
    * contrast tuning. */
   --background: oklch(0.205 0.004 286);
-  --surface-canvas: oklch(0.14 0.004 286);
+  /* PALETTE-LEAK-0: derived (see light-mode note) — default background
+     (l=0.205) resolves to the same 0.14 shell. */
+  --surface-canvas: oklch(from var(--background) calc(l - 0.065) c h);
   --background-elevated: color-mix(in srgb, var(--foreground) 2%, var(--background));
   --foreground: oklch(0.92 0.004 286);
 
@@ -555,10 +573,17 @@
      mode, so the "light, fresh button" reads consistently across themes;
      --control uses the same L0.65 blue as light so the white glyph clears
      WCAG 1.4.11 non-text contrast 3:1 (3.09:1) in both themes. */
-  --action: oklch(0.85 0.08 250);
-  --action-foreground: oklch(0.30 0.06 250);
-  --control: oklch(0.65 0.135 250);
-  --control-foreground: oklch(0.985 0.003 250);
+  /* PALETTE-LEAK-0: derive hue/chroma from --accent instead of hardcoding
+     blue h250 — palettes only override the base tokens, so literals here
+     kept the send button, onboarding CTA and every checked control blue
+     after a palette switch (same bug --brand-deep already had and fixed).
+     Lightness anchors stay literal to preserve the WCAG 1.4.11 tuning;
+     min(c, …) keeps the default palette byte-identical while following
+     low-chroma palettes down. */
+  --action: oklch(from var(--accent) 0.85 min(c, 0.08) h);
+  --action-foreground: oklch(from var(--accent) 0.30 min(c, 0.06) h);
+  --control: oklch(from var(--accent) 0.65 min(c, 0.135) h);
+  --control-foreground: oklch(from var(--accent) 0.985 min(c, 0.003) h);
   --link: var(--accent);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
@@ -595,7 +620,7 @@
      PR-DEFAULT-CANVAS-DEYELLOW-0: hue 250 to match the cool-neutral
      canvas in dark mode too. */
   --chat-user-bg: oklch(0.30 0.010 250);
-  --chat-user-foreground: oklch(0.96 0.004 250);
+  --chat-user-foreground: oklch(from var(--foreground) 0.96 min(c, 0.004) h);
   --user-message-bubble: var(--chat-user-bg);
 
   /* foreground-N variants re-derive automatically via color-mix(), so the

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -49,11 +49,11 @@
   --color-muted: var(--foreground-5);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
-  --color-accent-foreground: oklch(0.985 0.003 250);
+  --color-accent-foreground: oklch(from var(--accent) 0.985 min(c, 0.003) h);
   --color-control: var(--control);
   --color-control-foreground: var(--control-foreground);
   --color-destructive: var(--destructive);
-  --color-destructive-foreground: oklch(0.985 0.003 250);
+  --color-destructive-foreground: oklch(from var(--destructive) 0.985 min(c, 0.003) h);
   --color-info: var(--info);
   --color-info-foreground: var(--info-text);
   --color-success: var(--success);

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -56,7 +56,7 @@
     width: 62px;
     height: 62px;
     border: var(--border-width-accent) solid oklch(from var(--brand-deep) l c h / 0.12);
-    background: oklch(0.93 0.006 286);
+    background: var(--chat-user-bg);
     color: var(--foreground);
     font-size: 1.4667em;
     font-weight: var(--font-weight-bold);

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -323,15 +323,15 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  border-color: oklch(0.90 0.04 240);
+  border-color: oklch(from var(--system-alert-accent) 0.90 min(c, 0.04) h);
   border-radius: var(--radius-surface);
-  background: oklch(0.965 0.035 235);
-  color: oklch(0.50 0.13 245);
+  background: oklch(from var(--system-alert-accent) 0.965 min(c, 0.035) h);
+  color: oklch(from var(--system-alert-accent) 0.50 min(c, 0.13) h);
   padding: var(--space-3) var(--space-4);
 }
 
 .maka-plan-system-alert [class*="lucide"] {
-  color: oklch(0.42 0.095 245);
+  color: oklch(from var(--system-alert-accent) 0.42 min(c, 0.095) h);
 }
 
 .maka-plan-system-alert-main,
@@ -358,7 +358,7 @@
 
 .maka-plan-system-alert-switch {
   flex: 0 0 auto;
-  color: oklch(0.38 0.075 245);
+  color: oklch(from var(--system-alert-accent) 0.38 min(c, 0.075) h);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
@@ -371,21 +371,21 @@
   align-items: center;
   height: 20px;
   padding: 0 var(--space-2);
-  border: var(--border-width-hairline) solid oklch(0.56 0.08 245 / 0.4);
+  border: var(--border-width-hairline) solid oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.4);
   border-radius: var(--radius-pill);
-  background: oklch(0.56 0.08 245 / 0.10);
+  background: oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.10);
   font-weight: var(--font-weight-semibold);
 }
 
 .dark .maka-plan-system-alert {
-  border-color: oklch(0.56 0.08 245 / 0.44);
-  background: oklch(0.25 0.04 245 / 0.52);
-  color: oklch(0.84 0.07 245);
+  border-color: oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.44);
+  background: oklch(from var(--system-alert-accent) 0.25 min(c, 0.04) h / 0.52);
+  color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
 }
 
 .dark .maka-plan-system-alert [class*="lucide"],
 .dark .maka-plan-system-alert-switch {
-  color: oklch(0.84 0.07 245);
+  color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
 }
 
 .maka-plan-tabs {

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -252,7 +252,7 @@
   inset: 0;
   display: flex;
   justify-content: flex-end;
-  background: oklch(0.95 0.003 286 / 0.64);
+  background: oklch(from var(--background) calc(l - 0.05) c h / 0.64);
   backdrop-filter: blur(2px);
   border-radius: var(--radius-modal);
   padding: var(--space-3);

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -80,7 +80,12 @@ html[data-os="darwin"] {
      light-glass extraction was warm ivory (#fdfcfa/#faf9f6/#f5f3ee),
      which read beige against vibrancy blur. zinc-family equivalents
      keep the same lightness steps but zero warm cast. */
-  --color-bg-container: #fafafa;
+  /* PALETTE-LEAK-0: the zinc hex here (#fafafa) overrode reference-shell's
+     var(--background)-derived container for ALL of darwin, so the main
+     content pane ignored palette switches entirely. Re-anchor on
+     --background so hue/chroma follow the active palette; the default
+     palette (background l=1.0) resolves to the same value. */
+  --color-bg-container: oklch(from var(--background) calc(l - 0.015) c h);
   --color-text-quaternary: oklch(from var(--foreground) l c h / 0.45);
 }
 
@@ -89,7 +94,9 @@ html[data-os="darwin"] {
    sat under near-white foreground text and the parchment surfaces glowed
    against the dark shell, so the dark variants below re-tune lightness. */
 html[data-os="darwin"].dark {
-  --color-bg-container: oklch(0.24 0.004 286);
+  /* PALETTE-LEAK-0: same derivation as the light block — dark default
+     background (l=0.205) resolves to the previous 0.24 literal. */
+  --color-bg-container: oklch(from var(--background) calc(l + 0.035) c h);
 }
 
 


### PR DESCRIPTION
## 问题
用户反馈：换了主题色后很多地方漏改。根因是颜色系统的结构性缺口——palette（`[data-maka-theme]`）只覆盖 7 个基色 token，其余颜色理应从基色**派生**，但一批 token/规则写死了字面量，palette 切换根本触达不到：

| 泄漏点 | 影响面 |
|---|---|
| `--action`/`--control` CTA 四件套硬编码蓝 h250 | 发送按钮、onboarding CTA、**所有** checked 复选框/单选/开关在任何 palette 下都是蓝的 |
| theme-glass darwin block 的 `--color-bg-container` 等 4 个 zinc hex | **macOS 上整个内容面板**无视 palette |
| `--surface-canvas` 硬编码 zinc | 侧栏/shell 底板无视 palette |
| plan 页系统提醒 banner 11 处硬编码蓝 | 定时任务页 48px 全宽横幅恒为蓝 |
| providerConfigOverlay scrim 硬编码近白 + **无 dark 变体** | dark 模式下白纱罩在暗 UI 上（顺带修掉的独立 bug）|
| 其余：settings/QR scrim、hero 头像底、dark 气泡文字色、accent/destructive 前景 | 小面积 |

## 修法
统一改为从基色派生：lightness 锚点保持字面量（保住 WCAG 调优），hue/chroma 用 `oklch(from var(--accent) <L> min(c, <cap>) h)` 跟随 palette；表面阶梯用 `--background` 的 l 偏移。banner 走新的语义别名 `--system-alert-accent`（遵守 #406 治理契约：组件 CSS 禁用裸 `var(--accent)`）。

## 验证（CDP computed style 实测）
- 默认 palette **零回归**：内容面板仍解析为 `oklch(0.985 0 0)`
- coral → 全界面 hue 25；forest → hue 130（侧栏/内容区/composer/气泡全部跟随，附截图验证过）
- 治理契约测试更新：派生形式成为新的锁定格式，WCAG 4.5:1 / 3:1 门槛用默认 accent 解析后仍然实算
- typecheck 0 错误；@maka/desktop 1892/1892 通过；check-dead-css 通过