### PR TITLE
refactor(settings): migrate hand-rolled status badges onto SettingsBadge wrapper

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -42,8 +42,6 @@ describe('Settings form accessibility labels', () => {
   it('keeps Settings secondary surfaces close to reference implementation card geometry', async () => {
     const styles = await readRendererContractCss();
     const connectionRow = styles.match(/\.settingsConnectionRow\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const connectionBadge = styles.match(/\.settingsConnectionBadge\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const settingsBadge = styles.match(/\.settingsBadge\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const authContract = styles.match(/\.settingsAuthContract\s*\{[\s\S]*?\}/)?.[0] ?? '';
     // PR-DELETE-ORPHAN-CSS: `.providerEmpty` / `.providerCard` were
     // orphan classes (no TSX consumer); the comma-grouped rule
@@ -92,13 +90,27 @@ describe('Settings form accessibility labels', () => {
     assert.match(providerCatalogBadge, /border-radius:\s*var\(--radius-control\);/, 'Provider catalog badges (category / preview / login) should use compact squared target-layout style corners, not pills');
     assert.match(modelTableChip, /border-radius:\s*var\(--radius-control\);/, 'Settings model capability chips should use compact squared target-layout style corners, not pills');
     assert.match(modelTableDefaultBadge, /border-radius:\s*var\(--radius-control\);/, 'Settings model default badge should use compact squared target-layout style corners, not pills');
-    assert.match(connectionBadge, /border-radius:\s*var\(--radius-control\);/, 'Settings status badges should use compact squared target-layout style corners, not pills');
-    assert.match(settingsBadge, /border-radius:\s*var\(--radius-control\);/, 'Generic Settings badges should use compact squared target-layout style corners, not pills');
+    // PR-SETTINGS-BADGE-PRIMITIVE-0: `.settingsConnectionBadge` /
+    // `.settingsBadge` (and the earlier raw PrimitiveBadge call sites)
+    // migrated onto the SettingsBadge wrapper, which owns the settings
+    // decision that status chips use compact squared target-layout corners
+    // instead of the primitive's canonical pill.
+    const settingsBadgeWrapper = await readRepo('apps/desktop/src/renderer/settings/settings-badge.tsx');
+    assert.match(
+      settingsBadgeWrapper,
+      /rounded-\[var\(--radius-control\)\]/,
+      'SettingsBadge must square the primitive pill onto --radius-control corners',
+    );
+    const settingsSource = await readSettingsCombinedSource();
+    const providerSource = await readProviderSettingsCombinedSource();
+    assert.equal(
+      `${settingsSource}\n${providerSource}`.match(/<PrimitiveBadge\b/g),
+      null,
+      'Settings surfaces must render status chips through SettingsBadge (squared corners), never raw pill PrimitiveBadge',
+    );
     assert.doesNotMatch(providerCatalogBadge, /border-radius:\s*var\(--radius-pill\);/, 'Provider catalog badges must not regress to pill-shaped chrome');
     assert.doesNotMatch(modelTableChip, /border-radius:\s*var\(--radius-pill\);/, 'Settings model capability chips must not regress to pill-shaped chrome');
     assert.doesNotMatch(modelTableDefaultBadge, /border-radius:\s*var\(--radius-pill\);/, 'Settings model default badge must not regress to pill-shaped chrome');
-    assert.doesNotMatch(connectionBadge, /border-radius:\s*var\(--radius-pill\);/, 'Settings connection badges must not regress to pill-shaped chrome');
-    assert.doesNotMatch(settingsBadge, /border-radius:\s*var\(--radius-pill\);/, 'Generic Settings badges must not regress to pill-shaped chrome');
     assert.match(settingsRow, /display:\s*grid;/, 'Settings rows should use a stable label/value grid instead of flex auto sizing');
     assert.match(settingsRow, /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\);/, 'Settings rows need a protected label column and shrinkable value column');
     assert.match(settingsRowValue, /overflow-wrap:\s*anywhere;/, 'Long Settings values such as workspace paths should wrap in the value column');

--- a/apps/desktop/src/renderer/settings/account-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/account-settings-page.tsx
@@ -3,6 +3,8 @@ import type { ConnectionTestResult, LlmConnection } from '@maka/core';
 import { deriveProviderAuthContractFromConnection, generalizedErrorMessageChinese } from '@maka/core';
 import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { Button, RelativeTime, useToast } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
+import { statusBadgeVariant } from './settings-status-badge';
 import {
   deriveAccountAuthActions,
   presentAccountAuthState,
@@ -277,9 +279,9 @@ function AccountConnectionRow(props: {
           </div>
           <small>{subtitle}</small>
         </div>
-        <span className="settingsConnectionBadge" data-tone={presentation.tone}>
+        <SettingsBadge variant={statusBadgeVariant(presentation.tone)}>
           {presentation.label}
-        </span>
+        </SettingsBadge>
       </div>
       <p className="settingsConnectionDetail">{presentation.detail}</p>
       <div className="settingsAuthContract" data-state={authContractState}>

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -21,7 +21,6 @@ import {
   DialogContent,
   DialogRoot,
   Input,
-  PrimitiveBadge,
   RelativeTime,
   SettingsSelect,
   SettingsSwitch as Switch,

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -7,8 +7,9 @@ import type {
   HealthSnapshot,
 } from '@maka/core';
 import { HEALTH_SIGNAL_LAYERS } from '@maka/core';
-import { Button, PrimitiveBadge, RelativeTime } from '@maka/ui';
+import { Button, RelativeTime } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { SettingsBadge } from './settings-badge';
 import { statusBadgeVariant } from './settings-status-badge';
 
 /**
@@ -130,7 +131,7 @@ export function HealthCenterPage() {
           </p>
         </div>
         <div className="settingsHealthMeta">
-          <PrimitiveBadge variant="info">只读快照</PrimitiveBadge>
+          <SettingsBadge variant="info">只读快照</SettingsBadge>
           <small>
             最近一次读取：<RelativeTime ts={healthCheckedAtMs} className="settingsHelpInlineTime" />
           </small>
@@ -163,14 +164,14 @@ export function HealthCenterPage() {
       {(blocksSendCount > 0 || blocksCapabilityCount > 0) && (
         <div className="settingsHealthBlockers" role="status">
           {blocksSendCount > 0 && (
-            <PrimitiveBadge variant="destructive">
+            <SettingsBadge variant="destructive">
               {blocksSendCount} 条健康信号会阻塞发送
-            </PrimitiveBadge>
+            </SettingsBadge>
           )}
           {blocksCapabilityCount > 0 && (
-            <PrimitiveBadge variant="warning">
+            <SettingsBadge variant="warning">
               {blocksCapabilityCount} 条健康信号会阻塞能力
-            </PrimitiveBadge>
+            </SettingsBadge>
           )}
         </div>
       )}
@@ -225,7 +226,7 @@ function HealthSignalRow(props: { signal: HealthSignal }) {
           <strong>{signal.label}</strong>
           <small className="settingsHealthSignalScope">{HEALTH_SCOPE_LABEL[signal.scope]}</small>
         </div>
-        <PrimitiveBadge variant={statusBadgeVariant(statusCopy.tone)}>{statusCopy.label}</PrimitiveBadge>
+        <SettingsBadge variant={statusBadgeVariant(statusCopy.tone)}>{statusCopy.label}</SettingsBadge>
       </div>
       <p className="settingsHealthSignalMessage">{signal.message}</p>
       {signal.detail && <small className="settingsHealthSignalDetail">{signal.detail}</small>}

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -9,6 +9,8 @@ import {
   setLocalMemoryEntryStatusDraft,
 } from '@maka/core';
 import { Button, Input, RelativeTime, SettingsSwitch as Switch, Textarea, redactSecrets, useToast } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
+import { statusBadgeVariant } from './settings-status-badge';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
@@ -592,9 +594,9 @@ export function MemorySettingsPage(props: {
             <strong>本地 MEMORY.md</strong>
             <small>透明 Markdown 文件，保存在当前本机工作区。这里的内容不会自动从聊天里抽取。</small>
           </div>
-          <span className="settingsConnectionBadge" data-tone={memoryStatusTone(effective.status)}>
+          <SettingsBadge variant={statusBadgeVariant(memoryStatusTone(effective.status))}>
             {memoryStatusLabel(effective.status)}
-          </span>
+          </SettingsBadge>
           <Switch
             ariaLabel="启用本地 MEMORY.md"
             checked={effective.enabled}

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -18,8 +18,9 @@ import type {
   PermissionSnapshot,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, PrimitiveBadge, RelativeTime, useToast } from '@maka/ui';
+import { Button, RelativeTime, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
+import { SettingsBadge } from './settings-badge';
 import { statusBadgeVariant } from './settings-status-badge';
 
 /**
@@ -385,7 +386,7 @@ function CapabilityRow(props: { capability: CapabilitySnapshot }) {
           <strong>{capability.label}</strong>
           <small className="settingsCapabilityId">{prettyCapabilityId(capability.id)}</small>
         </div>
-        <PrimitiveBadge variant={statusBadgeVariant(readinessCopy.tone)}>{readinessCopy.label}</PrimitiveBadge>
+        <SettingsBadge variant={statusBadgeVariant(readinessCopy.tone)}>{readinessCopy.label}</SettingsBadge>
       </div>
       <p className="settingsCapabilityDetail">{readinessCopy.detail}</p>
       <dl className="settingsCapabilityLayers" aria-label={`${capability.label}能力状态明细`}>
@@ -514,7 +515,7 @@ function OsPermissionRow(props: {
       <div className="settingsOsPermissionBody">
         <div className="settingsOsPermissionHeading">
           <strong>{label}</strong>
-          <PrimitiveBadge variant={statusBadgeVariant(stateCopy.tone)}>{stateCopy.label}</PrimitiveBadge>
+          <SettingsBadge variant={statusBadgeVariant(stateCopy.tone)}>{stateCopy.label}</SettingsBadge>
         </div>
         <small className="settingsOsPermissionPurpose">{purpose}</small>
         {impact ? (

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '@maka/core';
 import { Button, Input } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
 import { providerDisplay } from './provider-display';
 import {
@@ -83,7 +84,7 @@ export function AddProviderForm(props: {
             : isExperimental ? '账号登录暂未接入聊天发送' : `添加 ${display.name}`}</h3>
           <p>{display.description}</p>
         </div>
-        <span className="settingsBadge">{categoryLabel(defaults.category)}</span>
+        <SettingsBadge variant="secondary">{categoryLabel(defaults.category)}</SettingsBadge>
       </header>
       {isExperimental && (
         <div className="providerUnavailableNotice">

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -16,6 +16,7 @@ import {
 } from '@maka/core';
 import { formatRelativeTimestamp } from '@maka/core';
 import { Button, FieldDescription, FieldRoot, Input, Label, useToast } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
 import { PasswordInput } from './password-input';
 import { buildCatalogModelChoices } from '../model-catalog-choices';
 import { providerDisplay } from './provider-display';
@@ -375,8 +376,8 @@ export function ConnectionDetail(props: {
           <p>{display.name}</p>
         </div>
         <span className="providerHeaderBadges">
-          {props.isDefault && <span className="settingsBadge">默认</span>}
-          <span className="settingsBadge">{categoryLabel(defaults.category)}</span>
+          {props.isDefault && <SettingsBadge variant="secondary">默认</SettingsBadge>}
+          <SettingsBadge variant="secondary">{categoryLabel(defaults.category)}</SettingsBadge>
         </span>
       </header>
       <FieldRoot className="grid gap-1.5">

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -19,6 +19,8 @@ import {
   useModalA11y,
   useToast,
 } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
+import { statusBadgeVariant, type StatusTone } from './settings-status-badge';
 import { ProviderLogo } from './provider-display';
 import { useProviderSheetBackgroundInert } from './provider-config-sheet';
 
@@ -707,7 +709,7 @@ function ClaudeSubscriptionCard() {
             </div>
             <small>无法确认 Claude OAuth 是否可用。没有登录动作会被执行。</small>
           </div>
-          <span className="settingsConnectionBadge" data-tone="destructive">读取失败</span>
+          <SettingsBadge variant="destructive">读取失败</SettingsBadge>
         </div>
         <small className="settingsErrorText" role="alert">
           Claude 登录开关读取失败：{experimentalGateError}
@@ -887,7 +889,9 @@ function ClaudeSubscriptionCard() {
   }
 
   // Closed-state render mapping per the runtime state enum.
-  const presentation = state ? presentSubscriptionState(state) : { label: '加载中…', tone: 'muted', detail: '' };
+  const presentation: SubscriptionStatePresentation = state
+    ? presentSubscriptionState(state)
+    : { label: '加载中…', tone: 'muted', detail: '' };
   const canStartClaudeLogin =
     state?.runtimeState === 'not_logged_in' ||
     state?.runtimeState === 'refresh_failed' ||
@@ -909,9 +913,9 @@ function ClaudeSubscriptionCard() {
             {state?.profile?.email ? ` · ${state.profile.email}` : ''}
           </small>
         </div>
-        <span className="settingsConnectionBadge" data-tone={presentation.tone}>
+        <SettingsBadge variant={statusBadgeVariant(presentation.tone)}>
           {presentation.label}
-        </span>
+        </SettingsBadge>
       </div>
       <p className="settingsConnectionDetail">{presentation.detail}</p>
       {pasteError && !authRequestId && (
@@ -1021,7 +1025,7 @@ type ClaudeSubscriptionPendingAction = 'login' | 'submit' | 'cancel' | 'logout' 
 
 interface SubscriptionStatePresentation {
   label: string;
-  tone: string;
+  tone: StatusTone;
   detail: string;
 }
 

--- a/apps/desktop/src/renderer/settings/settings-badge.tsx
+++ b/apps/desktop/src/renderer/settings/settings-badge.tsx
@@ -1,0 +1,18 @@
+import { cn, PrimitiveBadge, type PrimitiveBadgeProps } from '@maka/ui';
+
+/**
+ * Settings-scope status badge: the shared Badge primitive plus the
+ * settings design decision that status chips use compact squared
+ * target-layout corners, not pills (settings-form-a11y-contract). The
+ * primitive stays canonically pill-shaped; this wrapper owns the
+ * settings exception so call sites can't drift.
+ */
+export function SettingsBadge({ className, size = 'sm', ...props }: PrimitiveBadgeProps) {
+  return (
+    <PrimitiveBadge
+      size={size}
+      {...props}
+      className={cn('rounded-[var(--radius-control)]', className)}
+    />
+  );
+}

--- a/apps/desktop/src/renderer/settings/settings-status-badge.ts
+++ b/apps/desktop/src/renderer/settings/settings-status-badge.ts
@@ -1,11 +1,13 @@
-export type StatusTone = 'neutral' | 'info' | 'success' | 'warning' | 'destructive';
+export type StatusTone = 'neutral' | 'muted' | 'info' | 'success' | 'warning' | 'destructive';
 export function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'destructive' | 'info' | 'secondary' {
   switch (tone) {
     case 'success': return 'success';
     case 'warning': return 'warning';
     case 'destructive': return 'destructive';
     case 'info': return 'info';
-    case 'neutral': return 'secondary';
+    case 'neutral':
+    case 'muted':
+      return 'secondary';
   }
 }
 

--- a/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import type { AppSettings, UpdateAppSettingsResult, WebSearchCredentialStatus } from '@maka/core';
 import { normalizeSearchUrl, webSearchCredentialStatusFromResponse } from '@maka/core';
 import { Button, Input, RelativeTime, SettingsSwitch as Switch, redactSecrets, useToast } from '@maka/ui';
+import { SettingsBadge } from './settings-badge';
+import { statusBadgeVariant } from './settings-status-badge';
 import { PasswordInput } from './password-input';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
@@ -244,9 +246,9 @@ export function WebSearchSettingsPage(props: {
           </div>
           <div className="settingsWebSearchControlCluster">
             <div className="settingsWebSearchStatusCluster" role="group" aria-label="联网搜索凭据状态">
-              <span className="settingsConnectionBadge" data-tone={statusCopy.tone}>
+              <SettingsBadge variant={statusBadgeVariant(statusCopy.tone)}>
                 {statusCopy.label}
-              </span>
+              </SettingsBadge>
               {hasCheckedAt && (
                 <small>
                   最近测试 <RelativeTime ts={checkedAtMs} />

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -429,17 +429,6 @@
   transition: background var(--duration-base) var(--ease-out-strong);
 }
 
-.settingsBadge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 18px;
-  border-radius: var(--radius-control);
-  background: var(--foreground-5);
-  color: var(--foreground-secondary);
-  padding: 0 var(--space-1-5);
-  font-size: var(--font-size-caption);
-}
-
 /* PR-SETTINGS-GROUPED-CARD-0 (WAWQAQ msg `1abecd66`): same grouped-
    card pattern as `.settingsStructuredPage` — outer card + hairline
    dividers, no per-row chrome. */

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -126,37 +126,6 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
   }
-.settingsConnectionBadge {
-    display: inline-flex;
-    align-items: center;
-    min-height: 20px;
-    padding: var(--space-0-5) var(--space-2);
-    border-radius: var(--radius-control);
-    font-size: var(--font-size-caption);
-    font-weight: 600;
-    letter-spacing: 0;
-    background: var(--foreground-5);
-    color: var(--foreground-secondary);
-    white-space: nowrap;
-  }
-.settingsConnectionBadge[data-tone="success"] {
-    background: oklch(from var(--success) l c h / 0.12);
-    color: var(--success);
-  }
-.settingsConnectionBadge[data-tone="info"] {
-    background: oklch(from var(--info) l c h / 0.14);
-    color: var(--info-text);
-  }
-.settingsConnectionBadge[data-tone="warning"] {
-    background: oklch(from var(--info) l c h / 0.18);
-    color: var(--info-text);
-    font-weight: 700;
-  }
-.settingsConnectionBadge[data-tone="destructive"] {
-    background: oklch(from var(--destructive) l c h / 0.15);
-    color: var(--destructive);
-    font-weight: 700;
-  }
 .settingsConnectionDetail {
     margin: 0;
     color: var(--foreground-secondary);


### PR DESCRIPTION
## 内容
按「组件库优先」原则清理 settings 页面的手写徽章（`.settingsConnectionBadge` ×5 / `.settingsBadge` ×3），统一迁移到共享 Badge primitive，并删除对应 CSS（-42 行手写样式）。

## 设计决策的保留方式
- **方角契约**：`settings-form-a11y-contract` 锁定 settings 状态徽章用方角（radius-control）而非 pill。primitive 保持规范的 pill 形态，新增 `SettingsBadge` 包装组件承接 settings 例外——契约改为锁定包装组件 + 禁止 settings 源码出现裸 `<PrimitiveBadge`。
- **顺带修复存量不一致**：health/permission 页此前直接用 pill 形态的 PrimitiveBadge（违反方角设计意图），一并迁到 SettingsBadge。
- **统一 tone 词汇**：合并到已有的 `statusBadgeVariant` 映射器（补 'muted' tone），删除重复实现。

## 验证
- typecheck 0 错误
- check-dead-css 通过（强制保证删掉的 class 无残留）
- @maka/desktop 1892/1892 通过