### PR TITLE
chore(ci): GitHub Actions pipeline — README pre-contribution gates on PR/push (#414)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+# CI
+#
+# Gates are the CI translation of README「贡献前检查」and GitHub issue #414:
+#   typecheck -> build -> check:stale -> git diff --check -> full test.
+# README's local guidance runs a *focused* test suite for the touched surface;
+# CI cannot know the change surface, so it converges on the full `npm test`.
+#
+# The officecli bundle check runs on macOS because
+# apps/desktop/bundled-tools.json ships no linux asset (only darwin/win32),
+# so `prepare:officecli` / `check:officecli-bundle` cannot pass on ubuntu.
+#
+# Candidate gates from #414 (lint, dead-css, storybook) are intentionally
+# left out here — they are still under discussion.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs for the same ref (e.g. a new push to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Typecheck, build & test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Tests are pure `node --test` against compiled dist; the electron binary
+      # is not needed and downloading it wastes minutes / can flake.
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so `git diff --check` can reach the PR merge-base.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Check dist is not stale
+        run: npm run check:stale
+
+      - name: Check diff for whitespace errors and conflict markers
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          else
+            git diff --check "HEAD~1..HEAD"
+          fi
+
+      - name: Test
+        run: npm test
+
+  officecli-bundle:
+    name: officecli bundle (macOS)
+    # macOS only: bundled-tools.json has no linux officecli asset, so the
+    # prepare/check steps below can only pass on darwin.
+    # No `npm ci` here: prepare-officecli.mjs / check-officecli-bundle.mjs
+    # import only node:* stdlib (plus each other), so node_modules is not
+    # needed — macOS minutes are ~10x ubuntu, keep this job lean.
+    runs-on: macos-14
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download officecli binary
+        run: npm run prepare:officecli
+
+      - name: Check officecli bundle
+        run: npm run check:officecli-bundle

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Maka
 
+[![CI](https://github.com/maka-agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/maka-agent/maka-agent/actions/workflows/ci.yml)
+
 Maka 是一个本地优先的桌面 AI 工作台。它把模型连接、会话、工具权限、文件读写、终端执行、搜索、机器人入口和运行恢复放在一个 Electron 应用里，目标是让用户在自己的电脑上跑一个可观察、可控、可持续恢复的 agent。
 
 这个仓库还在活跃开发中。README 先服务两类人：

--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -97,9 +97,12 @@ describe('Daily Review copy feedback contract', () => {
 
     assert.match(panelBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="icon-sm"[\s\S]*?className="maka-daily-review-stepper"/);
     assert.match(panelBlock, /<SettingsSegmented[\s\S]*?className="maka-daily-review-range-tabs"/);
-    assert.match(panelBlock, /className="maka-daily-review-copy"/);
-    assert.match(panelBlock, /className="maka-daily-review-append"/);
-    assert.match(panelBlock, /className="maka-daily-review-save"/);
+    // Allow trailing utility classes after the hook class (e.g. the min-w-*
+    // text-swap layout locks); the min-w values themselves are pinned by the
+    // text-swap contract, not here.
+    assert.match(panelBlock, /className="maka-daily-review-copy(?: [^"]*)?"/);
+    assert.match(panelBlock, /className="maka-daily-review-append(?: [^"]*)?"/);
+    assert.match(panelBlock, /className="maka-daily-review-save(?: [^"]*)?"/);
     assert.match(panelBlock, /className="maka-daily-review-alert-retry"/);
     assert.doesNotMatch(panelBlock, /className="[^"]*\bmaka-button\b[^"]*"/);
     assert.doesNotMatch(css, /\.maka-daily-review-range-tab\[data-active/);

--- a/apps/desktop/src/main/__tests__/renderer-error-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-boundary.test.ts
@@ -33,7 +33,10 @@ test('renderer error boundary exposes a redacted copyable diagnostic report', as
   assert.match(source, /disabled=\{copyPending\}/);
   assert.match(source, /aria-busy=\{copyPending \? 'true' : undefined\}/);
   assert.match(source, /data-copy-state=\{copyState\}/);
-  assert.match(source, /variant="outline"[\s\S]*className="maka-error-copy-action"/);
+  // Allow trailing utility classes after the hook class (e.g. the min-w-*
+  // text-swap layout lock); the min-w value is pinned by the text-swap
+  // contract, not here.
+  assert.match(source, /variant="outline"[\s\S]*className="maka-error-copy-action(?: [^"]*)?"/);
   assert.match(source, /<UiButton type="button" variant="secondary" onClick=\{this\.handleReset\}>/);
   assert.match(source, /<UiButton[\s\S]*variant="default"[\s\S]*onClick=\{this\.handleReload\}/);
   assert.doesNotMatch(source, /className="maka-button/);


### PR DESCRIPTION
Closes #414.

## 做了什么

新增 `.github/workflows/ci.yml`,把 README「贡献前检查」翻译成 PR/push 门禁,并同步两个已在 main 上红掉的 desktop 契约测试。

### CI workflow

**触发**:PR → main、push → main;同 ref 新 run 自动取消旧 run。

**Job `checks`**(ubuntu, node 22, npm cache):

| 步骤 | 命令 | 来源 |
|---|---|---|
| Typecheck | `npm run typecheck` | README 贡献前检查 |
| Build | `npm run build` | README 贡献前检查 |
| Stale dist | `npm run check:stale` | issue #414 core gate |
| Whitespace/冲突标记 | `git diff --check`(PR 用 `origin/<base>...HEAD`,push 用 `HEAD~1..HEAD`) | README `git diff --check` 的 CI 语境翻译 |
| Test | `npm test`(全量) | README focused-suite 策略在 CI 无法知道改动面,收敛为全量 |

**Job `officecli-bundle`**(macos-14,与 checks 并行):`prepare:officecli` + `check:officecli-bundle`。放 macOS 是因为 `bundled-tools.json` 只有 darwin/win32 资产,ubuntu 上必挂。两个脚本纯 node 标准库,不跑 `npm ci`。

**未纳入**:issue #414 的 candidate gates(lint、dead-css、storybook)标记为待讨论,本 PR 不引入。

### 契约测试同步(让 CI 第一天不红)

实现过程中发现 main 的测试套件本身是红的——这正是 #414 要解决的问题的实证:

- `@maka/desktop` 2 个失败:已合入的 #527(#520 PR3)给按钮 className 追加了 ` min-w-[Nrem]` 布局锁,但 `daily-review-copy-feedback-contract` 和 `renderer-error-boundary` 两个契约测试用精确匹配正则找旧 className。本 PR 放宽正则为「hook class 存在、允许尾随 class」(min-w 的值锁由 #527 的 text-swap 契约负责,不在这两个测试里重复锁)。
- `@maka/ui` 2 个失败:#448 spacing 收敛导致的 chat-primitives 契约漂移,**已有 open PR #532 修复,本 PR 不重复**。

## 顺序依赖

本 PR 的 `npm test` 门禁在 #532 合入前会因 @maka/ui 的已知失败而红。建议先合 #532,再 rebase/re-run 本 PR 的 CI。

## 验证

- 本地(darwin, node v22.17):`npm run typecheck` ✅、`npm run build` ✅、`npm run check:stale` ✅
- `npm --workspace @maka/desktop run test`:修复前 1933/1935(2 fail),修复后全绿
- YAML 语法经 pyyaml 校验
- workflow 本身由本 PR 的 CI run 实证(pull_request 事件使用 PR 分支上的 workflow 文件)

## 已知风险

- 测试套件此前从未在 Linux 上跑过;若有平台相关失败,会在本 PR 的 CI run 上暴露。
- push 路径的 `git diff --check HEAD~1..HEAD` 只查最新 commit;PR 路径(merge-base 全量)是主门禁。
- `npm test` 里每个 workspace 自带 clean+build,与前置 Build 步骤有重复编译;忠实于现有脚本语义,提速留作后续。
