### PR TITLE
refactor(ui): converge layout-surface & sizing tokens (#520 PR4)

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-pane-layout.test.ts
@@ -21,7 +21,7 @@ describe('ArtifactPane narrow layout CSS contract', () => {
     );
     assert.match(
       css,
-      /@media\s*\(max-width:\s*990px\)\s*\{[\s\S]*?\.maka-artifact-pane\s*\{[\s\S]*?width:\s*100%[\s\S]*?max-height:\s*min\(42dvh,\s*360px\)[\s\S]*?border-top:\s*1px solid var\(--border\)/,
+      /@media\s*\(max-width:\s*990px\)\s*\{[\s\S]*?\.maka-artifact-pane\s*\{[\s\S]*?width:\s*100%[\s\S]*?max-height:\s*min\(42dvh,\s*360px\)[\s\S]*?border-top:\s*var\(--border-width-hairline\) solid var\(--border\)/,
       'expected ArtifactPane narrow mode to become a bounded full-width bottom sheet',
     );
   });

--- a/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
@@ -1,0 +1,213 @@
+/**
+ * PR-BORDER-WIDTH-CONVERGE-0 (issue #520 PR4 item 14, 2026-07-05):
+ * lock the border-stroke width vocabulary so individual PRs can't drift
+ * back to bare Npx in `border:` / `border-{side}:` shorthand.
+ *
+ * Border COLOR was already tokenized (--border / --border-strong); the
+ * WIDTH was bare px in every `border: 1px solid var(--border)` shorthand
+ * plus a handful of `border-left: 3px solid …` status strips. Three
+ * semantic weights cover the whole app:
+ *
+ *   --border-width-hairline  1px  the universal divider (210+ sites)
+ *   --border-width-thick     2px  a heavier divider / selected outline
+ *   --border-width-accent    3px  a status / decorative strip (toast
+ *                                 variant color bars, avatar rings)
+ *
+ * The rare 1.5px hairlines snap to hairline; the one 4px avatar ring snaps
+ * to accent. Border-STYLE (solid / dashed) stays a literal keyword — it is
+ * a named value, not a magic number, so tokenizing it adds indirection
+ * with no governance benefit. CSS-triangle carets (`border-width: 4px 0
+ * 4px 5px`) are multi-value geometry, not border strokes, so the contract
+ * only flags a SINGLE bare-px width.
+ *
+ * Four invariants:
+ *
+ * 1. `border:` / `border-{side}:` shorthand must reference a
+ *    `--border-width-*` token for its width (the only bare-px slot in a
+ *    border shorthand — color is in var()/oklch(), style is a keyword).
+ *    Bare `Npx` drifts visually and bypasses the scale.
+ *
+ * 2. `border-width:` / `border-{side}-width:` longhand, when it is a
+ *    SINGLE bare-px value, must reference a token. Multi-value geometry
+ *    (CSS-triangle carets like `4px 0 4px 5px`) is allowed — it is not a
+ *    border stroke.
+ *
+ * 3. `border-style:` / `border-{side}-style:` must be a literal keyword
+ *    (solid / dashed / dotted / double / groove / ridge / inset / outset
+ *    / none / hidden / inherit / initial / revert / unset). No bare px
+ *    belongs in a style declaration.
+ *
+ * 4. TSX has no arbitrary `border-[Npx]` / `border-{side}-[Npx]` widths —
+ *    use the Tailwind border-width scale (`border` = 1px = hairline,
+ *    `border-2` = thick, `border-4`) so TSX and CSS share the same weights.
+ *    Tailwind `border` defaults to 1px, which matches the pinned hairline;
+ *    the CSS token and the Tailwind utility agree on the value.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  REPO_ROOT,
+  TOKENS_FILE,
+  readAllRendererCss,
+  stripCssComments,
+  assertCustomPropPinnedOnce,
+} from './css-test-helpers.js';
+
+// --- helpers ---------------------------------------------------------------
+
+/** Remove balanced fn(...) substrings for color/calc/token functions so a
+ *  bare-px scan only sees px that are NOT inside var()/calc()/oklch()/
+ *  color-mix()/rgb()/rgba()/hsl()/hsla(). Repeats so nested calls collapse. */
+function stripFnValues(value: string): string {
+  const FN_RE = /\b(?:oklch|var|calc|color-mix|rgb|rgba|hsl|hsla|env|clamp|min|max)\s*\((?:[^()]+|\([^()]*\))*\)/g;
+  let prev = value;
+  let cur = value.replace(FN_RE, '');
+  while (cur !== prev) {
+    prev = cur;
+    cur = cur.replace(FN_RE, '');
+  }
+  return cur;
+}
+
+const BARE_PX_RE = /(?<![\w-])-?\d+(?:\.\d+)?px(?![\w-])/;
+const SINGLE_BARE_PX_RE = /^-?\d+(?:\.\d+)?px$/;
+
+const BORDER_STYLE_KEYWORDS = new Set([
+  'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset',
+  'none', 'hidden', 'inherit', 'initial', 'revert', 'unset',
+]);
+
+// Properties the contract scopes to.
+const BORDER_SHORTHAND_RE = /^\s*border(?:-(?:top|right|bottom|left|inline|block|inline-start|inline-end|block-start|block-end))?\s*:/i;
+const BORDER_WIDTH_LONGHAND_RE = /^\s*border(?:-(?:top|right|bottom|left|inline-start|inline-end|block-start|block-end|inline|block))?-width\s*:/i;
+const BORDER_STYLE_LONGHAND_RE = /^\s*border(?:-(?:top|right|bottom|left|inline-start|inline-end|block-start|block-end|inline|block))?-style\s*:/i;
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const line of stripped.split('\n')) {
+    if (BORDER_SHORTHAND_RE.test(line)) {
+      // border / border-{side} shorthand: width is the only bare-px slot.
+      const decl = line.replace(BORDER_SHORTHAND_RE, '').trim().replace(/!\s*important$/, '').replace(/[;}]+$/, '').trim();
+      const cleaned = stripFnValues(decl);
+      if (BARE_PX_RE.test(cleaned)) {
+        offenders.push(`${label}: ${line.trim()} [bare px width — use var(--border-width-*)]`);
+      }
+      continue;
+    }
+    if (BORDER_WIDTH_LONGHAND_RE.test(line)) {
+      // border-{side}-width longhand: a SINGLE bare-px value is a border
+      // stroke (must use a token); multi-value is triangle geometry (OK).
+      const decl = line.replace(BORDER_WIDTH_LONGHAND_RE, '').trim().replace(/!\s*important$/, '').replace(/[;}]+$/, '').trim();
+      const cleaned = stripFnValues(decl).trim();
+      if (SINGLE_BARE_PX_RE.test(cleaned)) {
+        offenders.push(`${label}: ${line.trim()} [bare px width — use var(--border-width-*)]`);
+      }
+      continue;
+    }
+    if (BORDER_STYLE_LONGHAND_RE.test(line)) {
+      const decl = line.replace(BORDER_STYLE_LONGHAND_RE, '').trim().replace(/!\s*important$/, '').replace(/[;}]+$/, '').trim();
+      const kw = decl.split(/\s+/)[0] ?? '';
+      if (!BORDER_STYLE_KEYWORDS.has(kw.toLowerCase())) {
+        offenders.push(`${label}: ${line.trim()} [border-style must be a keyword literal, got ${kw}]`);
+      }
+      continue;
+    }
+  }
+  return offenders;
+}
+
+// --- TSX scanning ----------------------------------------------------------
+
+const TSX_BORDER_ARBITRARY_RE = /\bborder(?:-(?:top|right|bottom|left|inline-start|inline-end|block-start|block-end|inline|block))?-\[-?\d+(?:\.\d+)?px\]/g;
+
+async function collectTsxOffenders(): Promise<string[]> {
+  const offenders: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      if (!/\.(tsx|ts)$/.test(entry.name)) continue;
+      const src = await readFile(full, 'utf8');
+      const label = full.replace(REPO_ROOT + '/', '');
+      for (const m of src.matchAll(TSX_BORDER_ARBITRARY_RE)) {
+        offenders.push(`${label}: ${m[0]}`);
+      }
+    }
+  }
+  await walk(resolve(REPO_ROOT, 'packages/ui/src'));
+  await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+  return offenders;
+}
+
+// === tests =================================================================
+
+describe('PR-BORDER-WIDTH-CONVERGE-0 contract', () => {
+  it('--border-width-* tokens are pinned exactly-once (hairline=1px, thick=2px, accent=3px)', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assertCustomPropPinnedOnce(tokens, '--border-width-hairline', '1px', 'maka-tokens.css');
+    assertCustomPropPinnedOnce(tokens, '--border-width-thick', '2px', 'maka-tokens.css');
+    assertCustomPropPinnedOnce(tokens, '--border-width-accent', '3px', 'maka-tokens.css');
+  });
+
+  it('CSS border: / border-{side}: shorthand references --border-width-* (no bare px width)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('TSX has no arbitrary border-[Npx] / border-{side}-[Npx] widths (use the Tailwind border scale)', async () => {
+    const offenders = await collectTsxOffenders();
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+});
+
+describe('border-width whitelist negative cases', () => {
+  it('stripFnValues removes var()/calc()/oklch() so px inside them is not bare', () => {
+    assert.equal(stripFnValues('var(--border-width-hairline) solid var(--border)').includes('px'), false, 'token width must not leave bare px');
+    assert.equal(stripFnValues('1px solid var(--border)').includes('1px'), true, 'bare 1px must remain');
+    assert.equal(stripFnValues('var(--border-width-accent) solid oklch(from var(--brand-deep) l c h / 0.12)').includes('px'), false, 'oklch color must not leave bare px');
+  });
+
+  it('findCssOffenders flags a bare-px border shorthand and spares a token / triangle / 0', () => {
+    assert.ok(findCssOffenders('border: 1px solid var(--border);', 't').length > 0, 'bare 1px must fail');
+    assert.deepEqual(findCssOffenders('border: var(--border-width-hairline) solid var(--border);', 't'), [], 'token width must pass');
+    assert.deepEqual(findCssOffenders('border: 0;', 't'), [], 'border: 0 must pass');
+    assert.deepEqual(findCssOffenders('border: none;', 't'), [], 'border: none must pass');
+    assert.ok(findCssOffenders('border-left: 3px solid var(--success);', 't').length > 0, 'bare 3px directional must fail');
+  });
+
+  it('findCssOffenders allows triangle caret geometry but flags single bare-px border-width', () => {
+    assert.deepEqual(findCssOffenders('border-width: 4px 0 4px 5px;', 't'), [], 'triangle multi-value must pass');
+    assert.deepEqual(findCssOffenders('border-width: 0 2px 2px 0;', 't'), [], 'triangle multi-value must pass');
+    assert.ok(findCssOffenders('border-width: 1px;', 't').length > 0, 'single bare-px border-width must fail');
+    assert.deepEqual(findCssOffenders('border-width: var(--border-width-hairline);', 't'), [], 'token border-width must pass');
+    assert.deepEqual(findCssOffenders('border-width: 0;', 't'), [], 'border-width: 0 must pass');
+  });
+
+  it('findCssOffenders accepts keyword border-style literals and rejects bare px in style', () => {
+    assert.deepEqual(findCssOffenders('border-style: dashed;', 't'), [], 'dashed keyword must pass');
+    assert.deepEqual(findCssOffenders('border-style: solid;', 't'), [], 'solid keyword must pass');
+    assert.ok(findCssOffenders('border-style: 1px;', 't').length > 0, 'bare px in style must fail');
+  });
+
+  it('does not scan border-radius / outline / box-shadow (out of scope)', () => {
+    assert.deepEqual(findCssOffenders('border-radius: 6px;', 't'), [], 'border-radius must not be flagged');
+    assert.deepEqual(findCssOffenders('outline: 2px solid var(--focus-ring);', 't'), [], 'outline must not be flagged');
+    assert.deepEqual(findCssOffenders('box-shadow: 0 1px 2px oklch(0 0 0 / 0.06);', 't'), [], 'box-shadow must not be flagged');
+  });
+
+  it('TSX scanner catches border-[1px] / border-left-[2px] arbitrary but spares Tailwind border / border-2', () => {
+    const fixture = 'className="border border-2 border-4 border-0 border-[1px] border-left-[2px]"';
+    const matches = [...fixture.matchAll(TSX_BORDER_ARBITRARY_RE)].map((m) => m[0]);
+    assert.deepEqual(matches, ['border-[1px]', 'border-left-[2px]']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
@@ -27,10 +27,12 @@
  *    border shorthand — color is in var()/oklch(), style is a keyword).
  *    Bare `Npx` drifts visually and bypasses the scale.
  *
- * 2. `border-width:` / `border-{side}-width:` longhand, when it is a
- *    SINGLE bare-px value, must reference a token. Multi-value geometry
- *    (CSS-triangle carets like `4px 0 4px 5px`) is allowed — it is not a
- *    border stroke.
+ * 2. `border-width:` / `border-{side}-width:` longhand must not carry a
+ *    bare px value (single OR multi-value like `1px 2px`) unless the
+ *    current selector is a known triangle/caret (allowlisted in
+ *    TRIANGLE_CARET_SELECTORS) whose multi-value is geometry, not a
+ *    stroke. A value-shape heuristic that spared ALL multi-value would
+ *    miss a `1px 2px` stroke drift; the selector allowlist is precise.
  *
  * 3. `border-style:` / `border-{side}-style:` must be a literal keyword
  *    (solid / dashed / dotted / double / groove / ridge / inset / outset
@@ -73,7 +75,17 @@ function stripFnValues(value: string): string {
 }
 
 const BARE_PX_RE = /(?<![\w-])-?\d+(?:\.\d+)?px(?![\w-])/;
-const SINGLE_BARE_PX_RE = /^-?\d+(?:\.\d+)?px$/;
+
+/** Selectors whose `border-width:` longhand is CSS-triangle caret geometry
+ *  (a disclosure arrow / a checkbox checkmark), not a border stroke. They
+ *  are allowlisted by SELECTOR so a new `border-width: 1px 2px` drift on
+ *  any other selector is still caught — add a new caret here only after
+ *  confirming it is geometry, not a stroke. */
+const TRIANGLE_CARET_SELECTORS = new Set([
+  '.maka-turn-thinking summary::before',
+  '.maka-bubble-assistant li.task-list-item > input[type="checkbox"]:checked::after',
+  '.maka-permission-raw > summary::before',
+]);
 
 const BORDER_STYLE_KEYWORDS = new Set([
   'solid', 'dashed', 'dotted', 'double', 'groove', 'ridge', 'inset', 'outset',
@@ -88,7 +100,16 @@ const BORDER_STYLE_LONGHAND_RE = /^\s*border(?:-(?:top|right|bottom|left|inline-
 function findCssOffenders(css: string, label: string): string[] {
   const stripped = stripCssComments(css);
   const offenders: string[] = [];
+  // Track the current selector (text before `{` on the most recent line that
+  // opens a rule) so `border-width:` longhand can be allowlisted by selector
+  // for the known triangle/caret geometries. Flat enough for maka's CSS;
+  // nested @media update currentSelector to the inner selector.
+  let currentSelector = '';
   for (const line of stripped.split('\n')) {
+    const braceIdx = line.indexOf('{');
+    if (braceIdx !== -1) {
+      currentSelector = line.slice(0, braceIdx).trim().replace(/\s+/g, ' ');
+    }
     if (BORDER_SHORTHAND_RE.test(line)) {
       // border / border-{side} shorthand: width is the only bare-px slot.
       const decl = line.replace(BORDER_SHORTHAND_RE, '').trim().replace(/!\s*important$/, '').replace(/[;}]+$/, '').trim();
@@ -99,12 +120,14 @@ function findCssOffenders(css: string, label: string): string[] {
       continue;
     }
     if (BORDER_WIDTH_LONGHAND_RE.test(line)) {
-      // border-{side}-width longhand: a SINGLE bare-px value is a border
-      // stroke (must use a token); multi-value is triangle geometry (OK).
+      // border-{side}-width longhand: ANY bare px is a stroke drift (single
+      // OR multi-value like `1px 2px`), UNLESS the current selector is a
+      // known triangle/caret (allowlisted above) whose multi-value is
+      // geometry, not a stroke.
       const decl = line.replace(BORDER_WIDTH_LONGHAND_RE, '').trim().replace(/!\s*important$/, '').replace(/[;}]+$/, '').trim();
       const cleaned = stripFnValues(decl).trim();
-      if (SINGLE_BARE_PX_RE.test(cleaned)) {
-        offenders.push(`${label}: ${line.trim()} [bare px width — use var(--border-width-*)]`);
+      if (BARE_PX_RE.test(cleaned) && !TRIANGLE_CARET_SELECTORS.has(currentSelector)) {
+        offenders.push(`${label}: ${line.trim()} [bare px border-width — use var(--border-width-*), or add the selector to TRIANGLE_CARET_SELECTORS if it is caret geometry]`);
       }
       continue;
     }
@@ -185,12 +208,17 @@ describe('border-width whitelist negative cases', () => {
     assert.ok(findCssOffenders('border-left: 3px solid var(--success);', 't').length > 0, 'bare 3px directional must fail');
   });
 
-  it('findCssOffenders allows triangle caret geometry but flags single bare-px border-width', () => {
-    assert.deepEqual(findCssOffenders('border-width: 4px 0 4px 5px;', 't'), [], 'triangle multi-value must pass');
-    assert.deepEqual(findCssOffenders('border-width: 0 2px 2px 0;', 't'), [], 'triangle multi-value must pass');
-    assert.ok(findCssOffenders('border-width: 1px;', 't').length > 0, 'single bare-px border-width must fail');
-    assert.deepEqual(findCssOffenders('border-width: var(--border-width-hairline);', 't'), [], 'token border-width must pass');
-    assert.deepEqual(findCssOffenders('border-width: 0;', 't'), [], 'border-width: 0 must pass');
+  it('findCssOffenders allows triangle caret geometry on allowlisted selectors, flags multi-value and single bare-px elsewhere', () => {
+    // Known caret selectors: multi-value geometry is allowed.
+    assert.deepEqual(findCssOffenders('.maka-turn-thinking summary::before {\n  border-width: 4px 0 4px 5px;\n}', 't'), [], 'allowlisted caret: 4px 0 4px 5px must pass');
+    assert.deepEqual(findCssOffenders('.maka-bubble-assistant li.task-list-item > input[type="checkbox"]:checked::after {\n  border-width: 0 2px 2px 0;\n}', 't'), [], 'allowlisted caret: 0 2px 2px 0 must pass');
+    // Non-allowlisted selector: a multi-value bare px is a stroke drift, not
+    // triangle geometry — a heuristic that spared ALL multi-value would miss it.
+    assert.ok(findCssOffenders('.foo {\n  border-width: 1px 2px;\n}', 't').length > 0, 'non-allowlisted multi-value bare px must fail');
+    assert.ok(findCssOffenders('.foo {\n  border-width: 1px;\n}', 't').length > 0, 'single bare-px border-width must fail');
+    // Token / 0 pass on any selector.
+    assert.deepEqual(findCssOffenders('.foo {\n  border-width: var(--border-width-hairline);\n}', 't'), [], 'token border-width must pass');
+    assert.deepEqual(findCssOffenders('.foo {\n  border-width: 0;\n}', 't'), [], 'border-width: 0 must pass');
   });
 
   it('findCssOffenders accepts keyword border-style literals and rejects bare px in style', () => {

--- a/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
@@ -18,7 +18,8 @@
  * a named value, not a magic number, so tokenizing it adds indirection
  * with no governance benefit. CSS-triangle carets (`border-width: 4px 0
  * 4px 5px`) are multi-value geometry, not border strokes, so the contract
- * only flags a SINGLE bare-px width.
+ * allows them only on allowlisted caret selectors (TRIANGLE_CARET_SELECTORS)
+ * and flags any bare px — single OR multi-value — elsewhere.
  *
  * Four invariants:
  *

--- a/apps/desktop/src/main/__tests__/box-shadow-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/box-shadow-converge-contract.test.ts
@@ -1,0 +1,114 @@
+/**
+ * PR-BOX-SHADOW-CONVERGE-0 (issue #520 PR4 item 13, 2026-07-05):
+ * box-shadow color must derive from --foreground (P-SHADOW, roadmap §1.2),
+ * not pure black. A pure-black rgba()/oklch() shadow on maka's warm shell
+ * reads as a dirty smudge — the design system's shadow recipe comments spell
+ * the rule: "blur layers were pure-black rgba — on a light warm-gray shell
+ * a pure black shadow reads as a dirty smudge. Every layer now derives from
+ * the warm foreground so shadow, border ring, and ink share one light
+ * source."
+ *
+ * Item 13 converges the bare pure-black box-shadow usages onto the
+ * foreground-derived form (keeping each shadow's geometry — offset, blur,
+ * spread — intact, only swapping the color). This is the safe P-SHADOW win:
+ * it warms the dirty black shadows without adding the design-system
+ * recipe's 1px border ring to every surface (a broader recipe-converge that
+ * would change the visual weight of ~20 already-compliant foreground-
+ * derived elevation shadows, deferred as a separate design review).
+ *
+ * The dark-mode shadow recipe overrides in maka-tokens.css (--shadow-medium
+ * / --shadow-modal for dark mode) intentionally use pure-black
+ * oklch(0 0 0 / 0.5|0.6) — on a dark canvas a pure-black shadow is correct
+ * (the comment: "dark mode shadows collapse to a single ring; modal keeps
+ * one deep drop"). Those are TOKEN DEFINITIONS (--shadow-*:), not box-shadow
+ * usages, so this contract scopes to `box-shadow:` declarations and does not
+ * flag them. Recipe var refs (var(--shadow-*)) carry no literal pure-black,
+ * so they are not flagged either.
+ *
+ * ring shadows (0 0 0 Npx color) and inset shadows are out of scope — they
+ * are the focus-ring / inset-highlight track (PR2 / a future ring token), not
+ * elevation. A pure-black RING would still be caught here (the contract
+ * checks the whole box-shadow value for a pure-black color, regardless of
+ * the layer shape), which is desirable — a pure-black ring on the warm
+ * shell has the same smudge problem.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import {
+  TOKENS_FILE,
+  readAllRendererCss,
+  stripCssComments,
+} from './css-test-helpers.js';
+
+/** Pure-black color in a box-shadow value — the P-SHADOW violation. Matches
+ *  oklch(0 0 0 / <alpha>) and rgba(0, 0, 0, <alpha>) with a NON-ZERO alpha
+ *  (the rgba(0,0,0,0) transparent placeholder in the recipe definitions is
+ *  alpha 0 and not a shadow color), plus solid #000 / black. */
+const PURE_BLACK_RE = /(?:oklch\(\s*0\s+0\s+0\s*\/\s*0?\.\d+|rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.\d+|#000(?:000)?\b|\bblack\b)/i;
+
+/** A box-shadow declaration value, spanning newlines up to ; or }. The
+ *  char class [^;}] matches newlines, so multi-line box-shadow layers are
+ *  captured as one value. Token definitions (--shadow-*:) are NOT
+ *  `box-shadow:` so they are not matched. */
+const BOX_SHADOW_DECL_RE = /box-shadow\s*:\s*([^;}\n]+(?:\n[^;}\n]+)*)/gi;
+
+function findCssOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(BOX_SHADOW_DECL_RE)) {
+    const value = m[1];
+    if (value.trim() === 'none') continue;
+    if (PURE_BLACK_RE.test(value)) {
+      offenders.push(`${label}: box-shadow: ${value.trim().replace(/\s+/g, ' ').slice(0, 100)} [pure-black color — derive from var(--foreground) per P-SHADOW, or use a var(--shadow-*) recipe]`);
+    }
+  }
+  return offenders;
+}
+
+// === tests =================================================================
+
+describe('PR-BOX-SHADOW-CONVERGE-0 contract', () => {
+  it('box-shadow color derives from --foreground (no pure-black oklch/rgba/#000/black)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findCssOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('the shadow recipes are defined in maka-tokens.css (--shadow-minimal/medium/modal, --card-shadow, --card-highlight)', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    for (const token of ['--shadow-minimal', '--shadow-medium', '--shadow-modal', '--card-shadow', '--card-highlight']) {
+      assert.match(tokens, new RegExp(`${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*:`), `${token} must be defined in maka-tokens.css`);
+    }
+  });
+});
+
+describe('box-shadow pure-black negative cases', () => {
+  it('flags pure-black oklch / rgba / #000 / black in a box-shadow', () => {
+    assert.ok(findCssOffenders('box-shadow: 0 1px 2px oklch(0 0 0 / 0.08);', 't').length > 0, 'oklch(0 0 0 / 0.08) must fail');
+    assert.ok(findCssOffenders('box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);', 't').length > 0, 'rgba(0,0,0,0.03) must fail');
+    assert.ok(findCssOffenders('box-shadow: 0 4px 12px #000;', 't').length > 0, '#000 must fail');
+    assert.ok(findCssOffenders('box-shadow: 0 2px 8px black;', 't').length > 0, 'black must fail');
+  });
+
+  it('spares foreground-derived color, recipe var refs, none, and the rgba(0,0,0,0) transparent placeholder', () => {
+    assert.deepEqual(findCssOffenders('box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.08);', 't'), [], 'foreground-derived must pass');
+    assert.deepEqual(findCssOffenders('box-shadow: var(--shadow-minimal);', 't'), [], 'recipe var ref must pass');
+    assert.deepEqual(findCssOffenders('box-shadow: none;', 't'), [], 'none must pass');
+    assert.deepEqual(findCssOffenders('box-shadow: 0 0 0 1px var(--border);', 't'), [], 'ring with token color must pass');
+    // The recipe placeholder rgba(0,0,0,0) is alpha-0 transparent — not a shadow
+    // color, so it is not flagged even if it appeared in a box-shadow value.
+    assert.deepEqual(findCssOffenders('box-shadow: rgba(0,0,0,0) 0 0 0 0, 0 1px 2px oklch(from var(--foreground) l c h / 0.06);', 't'), [], 'alpha-0 placeholder + foreground-derived layer must pass');
+  });
+
+  it('captures a multi-line box-shadow value (pure-black on a continuation line is flagged)', () => {
+    const css = 'box-shadow:\n    0 0 0 1px var(--border),\n    0 4px 12px -6px oklch(0 0 0 / 0.5);';
+    assert.ok(findCssOffenders(css, 't').length > 0, 'pure-black on a continuation line must be caught');
+  });
+
+  it('does not scan --shadow-*: token definitions (dark-mode recipes intentionally use pure-black)', () => {
+    const css = '--shadow-modal:\n    0 0 0 1px oklch(1 0 0 / 0.10),\n    0 12px 32px -8px oklch(0 0 0 / 0.6);';
+    assert.deepEqual(findCssOffenders(css, 't'), [], 'token definitions are not box-shadow usages');
+  });
+});

--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -72,7 +72,7 @@ describe('Command palette accessibility and visible copy', () => {
     const rowStyle = styles.match(/\.maka-palette-item\s*\{[\s\S]*?\}/)?.[0] ?? '';
 
     assert.match(modalStyle, /width:\s*min\(584px, calc\(100vw - 32px\)\);/);
-    assert.match(modalStyle, /border:\s*1px solid var\(--border\);/);
+    assert.match(modalStyle, /border:\s*var\(--border-width-hairline\) solid var\(--border\);/);
     assert.match(modalStyle, /border-radius:\s*var\(--radius-modal\);/);
     assert.match(
       styles,

--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -44,6 +44,7 @@ import {
   readAllRendererCss,
   stripCssComments,
   assertCustomPropPinnedOnce,
+  assertCustomPropRefsDefined,
 } from './css-test-helpers.js';
 
 // --- token whitelist --------------------------------------------------------
@@ -57,13 +58,16 @@ const CONTROL_HEIGHT_TOKENS = new Set([
   '--h-control-2xl',
 ]);
 
-/** Expected var(--h-control-*) pin value per token (the spacing-ruler tier). */
+/** Expected var(--h-control-*) pin value per token (the spacing-ruler tier).
+ *  md (28) and xl (36) use calc(var(--spacing) * 7/9) directly — maka's
+ *  discrete --space-* scale skips 7 and 9, and control-only tiers must not
+ *  expand it (that would invite p-7 / gap-7 drift). */
 const CONTROL_HEIGHT_PIN: Array<[string, string]> = [
   ['--h-control-xs', 'var(--space-5)'],
   ['--h-control-sm', 'var(--space-6)'],
-  ['--h-control-md', 'var(--space-7)'],
+  ['--h-control-md', 'calc(var(--spacing) * 7)'],
   ['--h-control-lg', 'var(--space-8)'],
-  ['--h-control-xl', 'var(--space-9)'],
+  ['--h-control-xl', 'calc(var(--spacing) * 9)'],
   ['--h-control-2xl', 'var(--space-10)'],
 ];
 
@@ -106,27 +110,25 @@ const CONTROL_HEIGHT: ControlHeightCheck[] = [
 /** Values that are always allowed (not a control-height beat). `100%`
  *  is the common "fill parent" height on control wrappers. */
 const LITERAL_OK = /^(?:0(?:px|%)?|100%|auto|inherit|initial|unset|revert|none)$/;
-/** Other size tokens that legitimately size a control (layout chrome, the
- *  sidebar topbar button footprint, env()/calc() geometry). */
-const OTHER_SIZE_TOKEN_RE = /^var\(\s*(?:--h-titlebar|--h-toolbar|--h-composer-min|--h-list-header|--maka-sidebar-topbar-button-size|--maka-resize-handle-width)\s*(?:,[^)]*)?\)$/;
 
 function extractControlToken(expr: string): string | null {
   const m = expr.trim().match(/^var\(\s*(--h-control-[\w-]+)\s*\)$/);
   return m ? m[1] : null;
 }
 
+/** A mapped control selector's height / min-height / width must reference its
+ *  EXPECTED --h-control-* tier (or a neutral literal like 0 / auto / 100%).
+ *  Direct var(--space-N), calc(var(--spacing) * N), and layout-chrome tokens
+ *  (--h-titlebar / --maka-sidebar-topbar-button-size / …) are REJECTED —
+ *  they bypass the semantic scale, and a mapped control reaching for a
+ *  chrome token is a semantic mismatch, not height convergence. Unmapped
+ *  controls are added to CONTROL_HEIGHT rather than allowed to slip via a
+ *  space token. */
 function isAllowedControlHeight(expr: string, expected: string): boolean {
   const v = expr.trim().replace(/!\s*important$/, '').trim();
   if (LITERAL_OK.test(v)) return true;
-  if (OTHER_SIZE_TOKEN_RE.test(v)) return true;
   const tok = extractControlToken(v);
-  if (tok !== null) return tok === expected;
-  // calc(var(--spacing) * N) — ruler multiple, allowed for control heights
-  // that haven't been mapped to a semantic tier yet.
-  if (/^calc\(\s*var\(\s*--spacing\s*\)\s*\*[\s\d.+-]+\)$/.test(v)) return true;
-  // var(--space-N) — direct ruler reference, allowed.
-  if (/^var\(\s*--space-[\w-]+\s*\)$/.test(v)) return true;
-  return false;
+  return tok === expected;
 }
 
 // --- CSS scanning ----------------------------------------------------------
@@ -230,6 +232,13 @@ describe('PR-CONTROL-HEIGHT-CONVERGE-0 contract', () => {
     }
   });
 
+  it('--h-control-* reference chain is closed — every var(--xxx) in a tier value is a defined custom prop (guards the --space-7/--space-9 collapse bug)', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    for (const [prop] of CONTROL_HEIGHT_PIN) {
+      assertCustomPropRefsDefined(tokens, prop, 'maka-tokens.css');
+    }
+  });
+
   it('control selectors reference their expected --h-control-* tier (no bare px height/min-height)', async () => {
     const css = stripCssComments(await readAllRendererCss());
     const offenders: string[] = [];
@@ -246,6 +255,17 @@ describe('PR-CONTROL-HEIGHT-CONVERGE-0 contract', () => {
 });
 
 describe('control-height whitelist negative cases', () => {
+  it('assertCustomPropRefsDefined catches a token that references an undefined custom prop (the --space-7 collapse bug)', () => {
+    // The P1 bug: --h-control-md: var(--space-7) where --space-7 is not in
+    // maka's discrete spacing scale. A pin-only check (declared with
+    // var(--space-7)) passes while the token is broken; the ref-chain check
+    // must fail so the collapse is caught before any site follows the token.
+    const broken = ':root { --space-5: 20px; --space-6: 24px; --h-control-xs: var(--space-5); --h-control-sm: var(--space-6); --h-control-md: var(--space-7); }';
+    assert.throws(() => assertCustomPropRefsDefined(broken, '--h-control-md', 'test'), /references undefined --space-7/);
+    // A closed chain does not throw.
+    assert.doesNotThrow(() => assertCustomPropRefsDefined(broken, '--h-control-xs', 'test'));
+  });
+
   it('extractControlToken parses --h-control-* and rejects typos / non-var', () => {
     for (const tok of CONTROL_HEIGHT_TOKENS) {
       assert.equal(extractControlToken(`var(${tok})`), tok, `${tok} must parse`);
@@ -259,15 +279,19 @@ describe('control-height whitelist negative cases', () => {
     assert.equal(extractControlToken('34px'), null, 'bare px must not parse');
   });
 
-  it('isAllowedControlHeight accepts the expected tier + literals + other size tokens, rejects bare px / wrong tier', () => {
+  it('isAllowedControlHeight accepts only the expected --h-control-* tier + neutral literals; rejects space tokens, ruler calc, chrome tokens, bare px, wrong tier', () => {
     assert.ok(isAllowedControlHeight('var(--h-control-lg)', '--h-control-lg'), 'expected tier must pass');
     assert.ok(isAllowedControlHeight('var(--h-control-lg)', '--h-control-xl') === false, 'wrong tier must fail');
     assert.ok(isAllowedControlHeight('34px', '--h-control-lg') === false, 'bare px must fail');
     assert.ok(isAllowedControlHeight('auto', '--h-control-lg'), 'auto must pass');
     assert.ok(isAllowedControlHeight('100%', '--h-control-lg'), '100% must pass');
-    assert.ok(isAllowedControlHeight('var(--h-titlebar)', '--h-control-lg'), 'layout chrome token must pass');
-    assert.ok(isAllowedControlHeight('calc(var(--spacing) * 8)', '--h-control-lg'), 'ruler calc must pass');
-    assert.ok(isAllowedControlHeight('var(--space-8)', '--h-control-lg'), 'direct space token must pass');
+    // Mapped selectors must use the semantic --h-control-* tier — direct
+    // space tokens, ruler calc, and layout-chrome tokens bypass the scale
+    // and are rejected. A mapped control reaching for var(--h-titlebar) is
+    // a semantic mismatch, not height convergence.
+    assert.ok(isAllowedControlHeight('var(--space-8)', '--h-control-lg') === false, 'direct space token must fail on a mapped selector');
+    assert.ok(isAllowedControlHeight('calc(var(--spacing) * 8)', '--h-control-lg') === false, 'ruler calc must fail on a mapped selector');
+    assert.ok(isAllowedControlHeight('var(--h-titlebar)', '--h-control-lg') === false, 'chrome token must fail on a mapped selector');
   });
 
   it('TSX scanner flags a new arbitrary height and spares the whitelist', async () => {

--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -258,15 +258,18 @@ describe('PR-CONTROL-HEIGHT-CONVERGE-0 contract', () => {
 });
 
 describe('control-height whitelist negative cases', () => {
-  it('assertCustomPropRefsDefined catches a token that references an undefined custom prop (the --space-7 collapse bug)', () => {
-    // The P1 bug: --h-control-md: var(--space-7) where --space-7 is not in
-    // maka's discrete spacing scale. A pin-only check (declared with
-    // var(--space-7)) passes while the token is broken; the ref-chain check
-    // must fail so the collapse is caught before any site follows the token.
+  it('assertCustomPropRefsDefined catches a direct undefined ref, an undefined ref 2 hops down, and a cycle', () => {
+    // Direct undefined ref (the P1 bug: --h-control-md → --space-7, undefined).
     const broken = ':root { --space-5: 20px; --space-6: 24px; --h-control-xs: var(--space-5); --h-control-sm: var(--space-6); --h-control-md: var(--space-7); }';
     assert.throws(() => assertCustomPropRefsDefined(broken, '--h-control-md', 'test'), /references undefined --space-7/);
-    // A closed chain does not throw.
     assert.doesNotThrow(() => assertCustomPropRefsDefined(broken, '--h-control-xs', 'test'));
+    // Undefined 2 hops down: --h-control-xs → --space-5 → --missing. A
+    // single-level check (only --space-5 is defined) would miss --missing.
+    const twoHop = ':root { --h-control-xs: var(--space-5); --space-5: var(--missing); }';
+    assert.throws(() => assertCustomPropRefsDefined(twoHop, '--h-control-xs', 'test'), /references undefined --missing/);
+    // Cycle: --a → --b → --a.
+    const cycle = ':root { --a: var(--b); --b: var(--a); }';
+    assert.throws(() => assertCustomPropRefsDefined(cycle, '--a', 'test'), /circular custom-prop reference/);
   });
 
   it('extractControlToken parses --h-control-* and rejects typos / non-var', () => {

--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -1,0 +1,283 @@
+/**
+ * PR-CONTROL-HEIGHT-CONVERGE-0 (issue #520 PR4 item 15, 2026-07-05):
+ * lock the control-height vocabulary so the sidebar / 会话 / 设置 rows,
+ * triggers, and icon buttons can't drift back to off-ruler bare px.
+ *
+ * The historic "碍眼" was that interactive control heights were scattered
+ * across off-ruler px (22 / 26 / 30 / 34 / 38) while the TSX side used the
+ * 4px spacing ruler via Tailwind h-N (h-7=28, h-8=32, h-9=36). The two
+ * scales never aligned, so a sidebar nav row at 34px next to a session row
+ * at 30px next to a settings nav at 38px read as three different systems.
+ *
+ * Three invariants:
+ *
+ * 1. The --h-control-* scale lives on the 4px spacing ruler (var(--space-N))
+ *    so CSS var(--h-control-*) and Tailwind h-N share ONE scale. The six
+ *    tiers (xs/sm/md/lg/xl/2xl = 20/24/28/32/36/40) are pinned exactly-once;
+ *    a rename or value drift gets flagged here before any site follows.
+ *
+ * 2. A curated set of control-row / trigger / square-button selectors must
+ *    reference their expected --h-control-* tier for height (and width on
+ *    square icon controls). This is the radius-contract SELECTOR_TIER
+ *    pattern: height has no single anchor the way border-radius does
+ *    (content heights, icon sizes, and chrome bars are all legitimate bare
+ *    px), so the contract scopes to control selectors, not every height.
+ *    App-chrome bars (--h-titlebar / --h-toolbar / --h-composer-min /
+ *    --h-list-header) and content min/max heights stay bare — they are
+ *    structure / content, not controls.
+ *
+ * 3. TSX has no arbitrary h-[Npx] / min-h-[Npx] / max-h-[Npx] utilities —
+ *    use the Tailwind ruler scale (h-N / min-h-N / max-h-N, which compile
+ *    to calc(var(--spacing) * N)) so TSX and CSS share the same 4px ruler.
+ *    A tiny whitelist covers genuinely non-ruler heights that are not
+ *    control heights: the 6px / 8px decorator dots, the 18px count badge,
+ *    and one off-ruler 110px content scroll limit.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import {
+  REPO_ROOT,
+  TOKENS_FILE,
+  readAllRendererCss,
+  stripCssComments,
+  assertCustomPropPinnedOnce,
+} from './css-test-helpers.js';
+
+// --- token whitelist --------------------------------------------------------
+
+const CONTROL_HEIGHT_TOKENS = new Set([
+  '--h-control-xs',
+  '--h-control-sm',
+  '--h-control-md',
+  '--h-control-lg',
+  '--h-control-xl',
+  '--h-control-2xl',
+]);
+
+/** Expected var(--h-control-*) pin value per token (the spacing-ruler tier). */
+const CONTROL_HEIGHT_PIN: Array<[string, string]> = [
+  ['--h-control-xs', 'var(--space-5)'],
+  ['--h-control-sm', 'var(--space-6)'],
+  ['--h-control-md', 'var(--space-7)'],
+  ['--h-control-lg', 'var(--space-8)'],
+  ['--h-control-xl', 'var(--space-9)'],
+  ['--h-control-2xl', 'var(--space-10)'],
+];
+
+// --- curated control selectors → expected tier ------------------------------
+
+interface ControlHeightCheck {
+  selector: string;
+  /** Properties the contract verifies against the expected token. Height +
+   *  min-height for row/trigger controls; also width for square controls
+   *  whose footprint equals the control size. */
+  props: ('height' | 'min-height' | 'width')[];
+  token: string;
+}
+
+/** Each entry maps a control selector to the --h-control-* tier its height
+ *  (and width, for square icon controls) must reference. Add new control
+ *  rows here as they land on the scale. */
+const CONTROL_HEIGHT: ControlHeightCheck[] = [
+  // sidebar / 会话 rows
+  { selector: '.maka-list-row', props: ['min-height'], token: '--h-control-lg' },
+  { selector: '.maka-search-modal-close', props: ['width', 'height'], token: '--h-control-sm' },
+  { selector: '.maka-search-modal-clear', props: ['width', 'height'], token: '--h-control-sm' },
+  // 设置 nav / triggers
+  { selector: '.settingsBackButton', props: ['height', 'min-height'], token: '--h-control-xl' },
+  { selector: '.settingsNavItem', props: ['height', 'min-height'], token: '--h-control-xl' },
+  { selector: '.settingsSelectTrigger', props: ['height'], token: '--h-control-lg' },
+  { selector: '.settingsSelectMenuPopup [role="option"]', props: ['min-height'], token: '--h-control-lg' },
+  { selector: '.maka-model-switcher-trigger', props: ['height'], token: '--h-control-sm' },
+  // chat-header / palette controls
+  { selector: '.maka-chat-jump-bottom', props: ['width', 'height'], token: '--h-control-md' },
+  { selector: '.maka-palette-input-wrap', props: ['min-height'], token: '--h-control-lg' },
+  // first-run checklist rows
+  { selector: '.maka-first-run-checklist-error-action', props: ['min-height'], token: '--h-control-sm' },
+  { selector: '.maka-first-run-checklist-row > button', props: ['min-height'], token: '--h-control-xl' },
+  // composer controls
+  { selector: '.maka-composer-send-button', props: ['width', 'height'], token: '--h-control-lg' },
+  { selector: '.maka-composer-workspace-picker', props: ['min-height'], token: '--h-control-sm' },
+];
+
+/** Values that are always allowed (not a control-height beat). `100%`
+ *  is the common "fill parent" height on control wrappers. */
+const LITERAL_OK = /^(?:0(?:px|%)?|100%|auto|inherit|initial|unset|revert|none)$/;
+/** Other size tokens that legitimately size a control (layout chrome, the
+ *  sidebar topbar button footprint, env()/calc() geometry). */
+const OTHER_SIZE_TOKEN_RE = /^var\(\s*(?:--h-titlebar|--h-toolbar|--h-composer-min|--h-list-header|--maka-sidebar-topbar-button-size|--maka-resize-handle-width)\s*(?:,[^)]*)?\)$/;
+
+function extractControlToken(expr: string): string | null {
+  const m = expr.trim().match(/^var\(\s*(--h-control-[\w-]+)\s*\)$/);
+  return m ? m[1] : null;
+}
+
+function isAllowedControlHeight(expr: string, expected: string): boolean {
+  const v = expr.trim().replace(/!\s*important$/, '').trim();
+  if (LITERAL_OK.test(v)) return true;
+  if (OTHER_SIZE_TOKEN_RE.test(v)) return true;
+  const tok = extractControlToken(v);
+  if (tok !== null) return tok === expected;
+  // calc(var(--spacing) * N) — ruler multiple, allowed for control heights
+  // that haven't been mapped to a semantic tier yet.
+  if (/^calc\(\s*var\(\s*--spacing\s*\)\s*\*[\s\d.+-]+\)$/.test(v)) return true;
+  // var(--space-N) — direct ruler reference, allowed.
+  if (/^var\(\s*--space-[\w-]+\s*\)$/.test(v)) return true;
+  return false;
+}
+
+// --- CSS scanning ----------------------------------------------------------
+
+function checkSelectorTier(css: string, check: ControlHeightCheck): string[] {
+  const offenders: string[] = [];
+  const escaped = check.selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\s/g, '\\s+');
+  // Normalize: insert newlines after `{` and before `}` so a selector block
+  // can be matched even when several rules share one line.
+  const normalized = css.replace(/\{/g, '{\n').replace(/\}/g, '\n}');
+  const blockRe = new RegExp(`(?:^|\\n)\\s*${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  const blocks = [...normalized.matchAll(blockRe)];
+  if (blocks.length === 0) {
+    offenders.push(`${check.selector} not found in CSS — stale contract entry or renamed selector`);
+    return offenders;
+  }
+  // `checkedAny` is tracked across ALL matched blocks (a selector may have
+  // a base rule plus @media / :state variants); a variant that only overrides
+  // transition should not reset the "found a height" flag. Every height /
+  // min-height / width declaration that DOES appear must still reference the
+  // expected tier — including overrides inside @media.
+  let checkedAny = false;
+  for (const block of blocks) {
+    const body = block[1];
+    for (const prop of check.props) {
+      const propRe = new RegExp(`(?:^|\\n)\\s*${prop}\\s*:\\s*([^;}\\n]+)`, 'g');
+      for (const m of body.matchAll(propRe)) {
+        checkedAny = true;
+        const raw = m[1].trim();
+        if (!isAllowedControlHeight(raw, check.token)) {
+          offenders.push(`${check.selector} ${prop}: ${raw} [must use ${check.token}]`);
+        }
+      }
+    }
+  }
+  if (!checkedAny) {
+    offenders.push(`${check.selector} has no ${check.props.join('/')} declaration`);
+  }
+  return offenders;
+}
+
+// --- TSX scanning ----------------------------------------------------------
+
+/** Arbitrary h-[Npx] / min-h-[Npx] / max-h-[Npx] with a BARE numeric value —
+ *  banned except a small whitelist. Computed/token/viewport forms
+ *  (h-[calc(...)], h-[var(...)], max-h-[85dvh]) are NOT drift: they reference
+ *  a token or the viewport, so this regex only matches bare Npx. Widths
+ *  (w-/min-w-/max-w-) are out of scope — width is governed by the
+ *  responsive / measure track, not control height. */
+const TSX_ARBITRARY_HEIGHT_RE = /\b(min-h|max-h|h)-\[-?\d+(?:\.\d+)?px\]/g;
+
+/** Exact arbitrary-height strings that are NOT control heights and stay as
+ *  arbitrary values. The 6px / 8px decorator dots and the 18px count badge
+ *  are not control sizes; max-h-[110px] is one off-ruler content scroll cap.
+ *  min-h-[28px] and max-h-[180px] are pinned as arbitrary literals by the
+ *  #332 chat-marker / preview cascade contracts (a deliberate "literalize
+ *  vehicle" immune to scale re-tuning) — those contracts govern them, so
+ *  this contract defers and whitelists them here. */
+const TSX_HEIGHT_WHITELIST = new Set([
+  'h-[6px]',
+  'h-[8px]',
+  'h-[18px]',
+  'max-h-[110px]',
+  'min-h-[28px]',
+  'max-h-[180px]',
+]);
+
+async function collectTsxHeightOffenders(): Promise<string[]> {
+  const offenders: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '__tests__') continue;
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      if (!/\.(tsx|ts)$/.test(entry.name)) continue;
+      const src = await readFile(full, 'utf8');
+      const label = full.replace(REPO_ROOT + '/', '');
+      for (const m of src.matchAll(TSX_ARBITRARY_HEIGHT_RE)) {
+        const whole = m[0];
+        if (TSX_HEIGHT_WHITELIST.has(whole)) continue;
+        offenders.push(`${label}: ${whole}`);
+      }
+    }
+  }
+  await walk(resolve(REPO_ROOT, 'packages/ui/src'));
+  await walk(resolve(REPO_ROOT, 'apps/desktop/src/renderer'));
+  return offenders;
+}
+
+// === tests =================================================================
+
+describe('PR-CONTROL-HEIGHT-CONVERGE-0 contract', () => {
+  it('--h-control-* tokens are pinned exactly-once to their spacing-ruler tier', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    for (const [prop, expected] of CONTROL_HEIGHT_PIN) {
+      assertCustomPropPinnedOnce(tokens, prop, expected, 'maka-tokens.css');
+    }
+  });
+
+  it('control selectors reference their expected --h-control-* tier (no bare px height/min-height)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const offenders: string[] = [];
+    for (const check of CONTROL_HEIGHT) {
+      offenders.push(...checkSelectorTier(css, check));
+    }
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('TSX has no arbitrary h-[Npx] / min-h-[Npx] / max-h-[Npx] (use the ruler h-N / min-h-N / max-h-N)', async () => {
+    const offenders = await collectTsxHeightOffenders();
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+});
+
+describe('control-height whitelist negative cases', () => {
+  it('extractControlToken parses --h-control-* and rejects typos / non-var', () => {
+    for (const tok of CONTROL_HEIGHT_TOKENS) {
+      assert.equal(extractControlToken(`var(${tok})`), tok, `${tok} must parse`);
+    }
+    // The parser accepts any --h-control-* name; whitelisting is a separate
+    // concern (CONTROL_HEIGHT_TOKENS). A private --h-control-prv parses but
+    // is not in the whitelist.
+    assert.equal(extractControlToken('var(--h-control-prv)'), '--h-control-prv', 'parser accepts any --h-control-* (whitelist is separate)');
+    assert.ok(!CONTROL_HEIGHT_TOKENS.has('--h-control-prv'), 'private token is not whitelisted');
+    assert.equal(extractControlToken('var(--h-controll-lg)'), null, 'typo (extra letter before -) must not parse');
+    assert.equal(extractControlToken('34px'), null, 'bare px must not parse');
+  });
+
+  it('isAllowedControlHeight accepts the expected tier + literals + other size tokens, rejects bare px / wrong tier', () => {
+    assert.ok(isAllowedControlHeight('var(--h-control-lg)', '--h-control-lg'), 'expected tier must pass');
+    assert.ok(isAllowedControlHeight('var(--h-control-lg)', '--h-control-xl') === false, 'wrong tier must fail');
+    assert.ok(isAllowedControlHeight('34px', '--h-control-lg') === false, 'bare px must fail');
+    assert.ok(isAllowedControlHeight('auto', '--h-control-lg'), 'auto must pass');
+    assert.ok(isAllowedControlHeight('100%', '--h-control-lg'), '100% must pass');
+    assert.ok(isAllowedControlHeight('var(--h-titlebar)', '--h-control-lg'), 'layout chrome token must pass');
+    assert.ok(isAllowedControlHeight('calc(var(--spacing) * 8)', '--h-control-lg'), 'ruler calc must pass');
+    assert.ok(isAllowedControlHeight('var(--space-8)', '--h-control-lg'), 'direct space token must pass');
+  });
+
+  it('TSX scanner flags a new arbitrary height and spares the whitelist', async () => {
+    const whitelist = TSX_HEIGHT_WHITELIST;
+    assert.ok(whitelist.has('h-[18px]'), 'badge whitelist present');
+    assert.ok(!whitelist.has('h-[40px]'), 'h-[40px] is not whitelisted (a control would be flagged)');
+    // The regex catches bare-numeric h/min-h/max-h variants but spares
+    // computed / token / viewport forms (those are not drift).
+    const fixture = 'className="h-[40px] min-h-[22px] max-h-[110px] h-[6px] h-[calc(var(--x)+2px)] max-h-[85dvh]"';
+    const matches = [...fixture.matchAll(TSX_ARBITRARY_HEIGHT_RE)].map((m) => m[0]);
+    assert.deepEqual(matches, ['h-[40px]', 'min-h-[22px]', 'max-h-[110px]', 'h-[6px]']);
+  });
+});

--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -145,18 +145,19 @@ function checkSelectorTier(css: string, check: ControlHeightCheck): string[] {
     offenders.push(`${check.selector} not found in CSS — stale contract entry or renamed selector`);
     return offenders;
   }
-  // `checkedAny` is tracked across ALL matched blocks (a selector may have
-  // a base rule plus @media / :state variants); a variant that only overrides
-  // transition should not reset the "found a height" flag. Every height /
-  // min-height / width declaration that DOES appear must still reference the
-  // expected tier — including overrides inside @media.
-  let checkedAny = false;
+  // Each prop in check.props is a REQUIRED size on this control (a square
+  // control needs both width AND height; a settings row needs height AND
+  // min-height). Track which props appeared across ALL matched blocks (a
+  // selector may have a base rule plus @media / :state variants); a missing
+  // required prop is a regression. Every declaration that DOES appear must
+  // still reference the expected tier — including overrides inside @media.
+  const seenProps = new Set<string>();
   for (const block of blocks) {
     const body = block[1];
     for (const prop of check.props) {
       const propRe = new RegExp(`(?:^|\\n)\\s*${prop}\\s*:\\s*([^;}\\n]+)`, 'g');
       for (const m of body.matchAll(propRe)) {
-        checkedAny = true;
+        seenProps.add(prop);
         const raw = m[1].trim();
         if (!isAllowedControlHeight(raw, check.token)) {
           offenders.push(`${check.selector} ${prop}: ${raw} [must use ${check.token}]`);
@@ -164,8 +165,10 @@ function checkSelectorTier(css: string, check: ControlHeightCheck): string[] {
       }
     }
   }
-  if (!checkedAny) {
-    offenders.push(`${check.selector} has no ${check.props.join('/')} declaration`);
+  for (const prop of check.props) {
+    if (!seenProps.has(prop)) {
+      offenders.push(`${check.selector} is missing required ${prop} declaration (expected ${check.token})`);
+    }
   }
   return offenders;
 }
@@ -292,6 +295,23 @@ describe('control-height whitelist negative cases', () => {
     assert.ok(isAllowedControlHeight('var(--space-8)', '--h-control-lg') === false, 'direct space token must fail on a mapped selector');
     assert.ok(isAllowedControlHeight('calc(var(--spacing) * 8)', '--h-control-lg') === false, 'ruler calc must fail on a mapped selector');
     assert.ok(isAllowedControlHeight('var(--h-titlebar)', '--h-control-lg') === false, 'chrome token must fail on a mapped selector');
+  });
+
+  it('checkSelectorTier flags a missing required prop on a multi-prop selector (width+height square / height+min-height row)', () => {
+    // .maka-chat-jump-bottom is mapped with props: ['width', 'height'] — both
+    // are required (a square FAB whose footprint = control size). A fixture
+    // with only height must flag the missing width; the old single-checkedAny
+    // logic let this pass (any one prop set checkedAny=true).
+    const jbCheck: ControlHeightCheck = { selector: '.maka-chat-jump-bottom', props: ['width', 'height'], token: '--h-control-md' };
+    const offendersJb = checkSelectorTier('.maka-chat-jump-bottom {\n  height: var(--h-control-md);\n}', jbCheck);
+    assert.ok(offendersJb.some((o) => o.includes('missing required width')), `missing width must be flagged: ${offendersJb}`);
+    // .settingsNavItem is mapped with props: ['height', 'min-height'] — both
+    // required. Deleting either one must flag.
+    const navCheck: ControlHeightCheck = { selector: '.settingsNavItem', props: ['height', 'min-height'], token: '--h-control-xl' };
+    assert.ok(checkSelectorTier('.settingsNavItem {\n  min-height: var(--h-control-xl);\n}', navCheck).some((o) => o.includes('missing required height')), 'missing height must be flagged');
+    assert.ok(checkSelectorTier('.settingsNavItem {\n  height: var(--h-control-xl);\n}', navCheck).some((o) => o.includes('missing required min-height')), 'missing min-height must be flagged');
+    // A complete fixture (both props present, correct tier) passes.
+    assert.deepEqual(checkSelectorTier('.maka-chat-jump-bottom {\n  width: var(--h-control-md);\n  height: var(--h-control-md);\n}', jbCheck), [], 'complete square control must pass');
   });
 
   it('TSX scanner flags a new arbitrary height and spares the whitelist', async () => {

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -118,3 +118,30 @@ export function assertCustomPropPinnedOnce(
   assert.equal(values.length, 1, `${label}: ${prop} must be declared exactly once with ${expected}; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
   assert.equal(values[0], expected, `${label}: ${prop} must be ${expected}; got ${values[0]}`);
 }
+
+/** Assert every `var(--xxx)` reference in `prop`'s value is itself a defined
+ *  custom property somewhere in `css` (token :root, `@theme inline`, or a
+ *  bridge alias).
+ *
+ *  Catches the bug where a token points at an undefined custom prop — e.g.
+ *  `--h-control-md: var(--space-7)` when maka's discrete spacing scale skips
+ *  7. The declaration is invalid at computed-value time, so the sized
+ *  element collapses to its initial/inherited value (width/height → auto,
+ *  min-height → 0) instead of the intended 28px. A pin-only contract that
+ *  just checks `--h-control-md` is declared with `var(--space-7)` passes
+ *  while the token is broken — this helper walks the reference chain. */
+export function assertCustomPropRefsDefined(
+  css: string,
+  prop: string,
+  label = 'maka-tokens.css',
+): void {
+  const props = parseCssCustomProps(css);
+  const defined = new Set(props.keys());
+  const values = props.get(prop) ?? [];
+  assert.equal(values.length, 1, `${label}: ${prop} must be declared exactly once; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
+  const value = values[0];
+  const refs = [...value.matchAll(/var\(\s*(--[\w-]+)\s*(?:,[^)]*)?\)/g)].map((m) => m[1]);
+  for (const ref of refs) {
+    assert.ok(defined.has(ref), `${label}: ${prop} references undefined ${ref} (value: ${value}) — the declaration would collapse to its initial/inherited value at computed-value time`);
+  }
+}

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -119,9 +119,8 @@ export function assertCustomPropPinnedOnce(
   assert.equal(values[0], expected, `${label}: ${prop} must be ${expected}; got ${values[0]}`);
 }
 
-/** Assert every `var(--xxx)` reference in `prop`'s value is itself a defined
- *  custom property somewhere in `css` (token :root, `@theme inline`, or a
- *  bridge alias).
+/** Assert every `var(--xxx)` reference reachable from `prop` resolves to a
+ *  defined custom property — recursively, with cycle detection.
  *
  *  Catches the bug where a token points at an undefined custom prop — e.g.
  *  `--h-control-md: var(--space-7)` when maka's discrete spacing scale skips
@@ -129,19 +128,41 @@ export function assertCustomPropPinnedOnce(
  *  element collapses to its initial/inherited value (width/height → auto,
  *  min-height → 0) instead of the intended 28px. A pin-only contract that
  *  just checks `--h-control-md` is declared with `var(--space-7)` passes
- *  while the token is broken — this helper walks the reference chain. */
+ *  while the token is broken — this helper walks the reference chain.
+ *
+ *  Recurses through the whole chain, not just the first hop: a chain like
+ *  `--h-control-xs → --space-5 → --missing` (undefined two hops out) is
+ *  caught, and a cycle like `--a → --b → --a` is caught via a `visiting`
+ *  set. Each node must also be declared exactly once. */
 export function assertCustomPropRefsDefined(
   css: string,
   prop: string,
   label = 'maka-tokens.css',
 ): void {
   const props = parseCssCustomProps(css);
-  const defined = new Set(props.keys());
-  const values = props.get(prop) ?? [];
-  assert.equal(values.length, 1, `${label}: ${prop} must be declared exactly once; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
-  const value = values[0];
-  const refs = [...value.matchAll(/var\(\s*(--[\w-]+)\s*(?:,[^)]*)?\)/g)].map((m) => m[1]);
-  for (const ref of refs) {
-    assert.ok(defined.has(ref), `${label}: ${prop} references undefined ${ref} (value: ${value}) — the declaration would collapse to its initial/inherited value at computed-value time`);
-  }
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const errors: string[] = [];
+  const dfs = (name: string, path: string[]): void => {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      errors.push(`${label}: circular custom-prop reference: ${[...path, name].join(' → ')}`);
+      return;
+    }
+    visiting.add(name);
+    const values = props.get(name);
+    if (values === undefined) {
+      const via = path.length ? ` (via ${path.join(' → ')})` : '';
+      errors.push(`${label}: ${prop} references undefined ${name}${via} — the declaration would collapse to its initial/inherited value at computed-value time`);
+    } else if (values.length !== 1) {
+      errors.push(`${label}: ${name} must be declared exactly once; got ${values.length} declaration(s): ${JSON.stringify(values)}`);
+    } else {
+      const refs = [...values[0].matchAll(/var\(\s*(--[\w-]+)\s*(?:,[^)]*)?\)/g)].map((m) => m[1]);
+      for (const ref of refs) dfs(ref, [...path, name]);
+    }
+    visiting.delete(name);
+    visited.add(name);
+  };
+  dfs(prop, []);
+  assert.ok(errors.length === 0, errors.join('\n'));
 }

--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -97,10 +97,14 @@ describe('Daily Review copy feedback contract', () => {
 
     assert.match(panelBlock, /<UiButton[\s\S]*?variant="ghost"[\s\S]*?size="icon-sm"[\s\S]*?className="maka-daily-review-stepper"/);
     assert.match(panelBlock, /<SettingsSegmented[\s\S]*?className="maka-daily-review-range-tabs"/);
-    assert.match(panelBlock, /className="maka-daily-review-copy"/);
-    assert.match(panelBlock, /className="maka-daily-review-append"/);
-    assert.match(panelBlock, /className="maka-daily-review-save"/);
-    assert.match(panelBlock, /className="maka-daily-review-alert-retry"/);
+    // PR3 (#527) added min-w-[Nrem] utilities to the copy/append/save buttons
+    // (text-swap width lock for 复制/已复制 feedback). Match each semantic
+    // class as a whole word in the class list — same form as the negative
+    // maka-button check on the next line.
+    assert.match(panelBlock, /className="[^"]*\bmaka-daily-review-copy\b[^"]*"/);
+    assert.match(panelBlock, /className="[^"]*\bmaka-daily-review-append\b[^"]*"/);
+    assert.match(panelBlock, /className="[^"]*\bmaka-daily-review-save\b[^"]*"/);
+    assert.match(panelBlock, /className="[^"]*\bmaka-daily-review-alert-retry\b[^"]*"/);
     assert.doesNotMatch(panelBlock, /className="[^"]*\bmaka-button\b[^"]*"/);
     assert.doesNotMatch(css, /\.maka-daily-review-range-tab\[data-active/);
     assert.match(css, /\.maka-daily-review-copy,\s*\.maka-daily-review-append,\s*\.maka-daily-review-save/);

--- a/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
@@ -29,7 +29,7 @@ describe('PR-PERMISSIONS-UNIFIED-CARD-0 contract (#309)', () => {
     assert.ok(body, '.settingsOsPermissionList rule must exist');
 
     // Grouped card chrome lives on the outer container.
-    assert.match(body, /\bborder:\s*1px\s+solid\s+var\(--border\)/, 'list must own the outer border');
+    assert.match(body, /\bborder:\s*var\(--border-width-hairline\)\s+solid\s+var\(--border\)/, 'list must own the outer border');
     assert.match(body, /\bborder-radius:\s*var\(--radius-surface\)/, 'list must own the 8px outer radius (surface tier)');
     assert.match(body, /\bbackground:\s*var\(--background\)/, 'list must own the outer background');
     assert.match(body, /\boverflow:\s*hidden\b/, 'list must clip rows so divider corners stay clean');
@@ -55,7 +55,7 @@ describe('PR-PERMISSIONS-UNIFIED-CARD-0 contract (#309)', () => {
     // Adjacency selector provides a 6% foreground hairline between rows.
     assert.match(
       css,
-      /\.settingsOsPermissionRow\s*\+\s*\.settingsOsPermissionRow\s*\{[^}]*border-top:\s*1px solid oklch\(from var\(--foreground\) l c h \/ 0\.06\)/,
+      /\.settingsOsPermissionRow\s*\+\s*\.settingsOsPermissionRow\s*\{[^}]*border-top:\s*var\(--border-width-hairline\) solid oklch\(from var\(--foreground\) l c h \/ 0\.06\)/,
       'adjacent rows must share a 6% foreground hairline divider',
     );
   });

--- a/apps/desktop/src/main/__tests__/project-context-badge.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-badge.test.ts
@@ -149,7 +149,7 @@ describe('project context workspace picker', () => {
     // Workspace picker must track the shared chat/composer measure token,
     // not a bespoke hard-coded width, so future measure updates keep the
     // row aligned with the composer card automatically.
-    assert.match(styles, /\.maka-composer-workspace-row\s*\{[\s\S]*?width:\s*min\(var\(--maka-chat-measure,\s*680px\),\s*100%\)/);
+    assert.match(styles, /\.maka-composer-workspace-row\s*\{[\s\S]*?width:\s*min\(var\(--maka-chat-measure\),\s*100%\)/);
     assert.match(styles, /\.maka-composer-workspace-picker\s*\{/);
     assert.match(styles, /-webkit-app-region:\s*no-drag/);
     assert.match(renderer, /basenameFromPath\(appInfo\.projectPath\)/);

--- a/apps/desktop/src/main/__tests__/radius-nesting-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-nesting-contract.test.ts
@@ -1,0 +1,79 @@
+/**
+ * PR-RADIUS-NESTING-0 (issue #520 PR4 item 12, 2026-07-05):
+ * pin the concentric-radius nesting convention so the two calc-nested
+ * input sites don't silently regress to a hardcoded tier.
+ *
+ * Roadmap §1.3 / P-RADIUS: when a rounded surface sits inside another
+ * rounded surface with padding between them, the inner radius =
+ * outer radius − padding so the two curves share a center and read as
+ * one machined shell. Two forms (documented on the radius tokens in
+ * maka-tokens.css):
+ *
+ *   1. If outer − padding lands on a tier, pick that tier directly —
+ *      e.g. a settings card (8px surface) inside a 12px modal with 4px
+ *      padding: 12 − 4 = 8 = --radius-surface. The radius-converge
+ *      contract's SELECTOR_TIER already pins this, so this contract does
+ *      not re-check it.
+ *
+ *   2. If outer − padding does NOT land on a tier, use
+ *      `calc(var(--radius-*) - Npx)` — the radius-converge contract's
+ *      calc allowlist permits only this shrink form. Two sites today
+ *      use it: an input inside a 12px modal shell with an 8px inset
+ *      (12 − 8 = 4px, not a tier):
+ *        .maka-search-modal-input-row  (sidebar.css)
+ *        .maka-palette-input-wrap       (chat-header.css)
+ *      This contract pins both so a later "cleanup" can't drop the calc
+ *      and revert to a hardcoded --radius-control (6px) that would read
+ *      as too round against the shell corners.
+ *
+ * The settings-modal inner cards (audited) use the surface/control tier
+ * inside the modal shell — that is form (1), already governed by the
+ * radius-converge SELECTOR_TIER, so no calc is needed there. The seven
+ * settings inner surfaces that use --radius-modal are peer sub-modals
+ * (login modal, scan modal, select popup), not nested cards, so they
+ * legitimately keep the modal tier.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/** Extract the body of a CSS rule for an exact selector (first match),
+ *  matching the radius-converge SELECTOR_TIER block extraction. */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\s/g, '\\s+');
+  const normalized = css.replace(/\{/g, '{\n').replace(/\}/g, '\n}');
+  const re = new RegExp(`(?:^|\\n)\\s*${escaped}\\s*\\{([^}]*)\\}`, 'g');
+  const m = re.exec(normalized);
+  return m ? m[1] : null;
+}
+
+describe('PR-RADIUS-NESTING-0 contract', () => {
+  it('the two modal-inset input sites use calc(var(--radius-modal) - 8px) (12 − 8 = 4px, not a tier)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const sites: Array<[string, string]> = [
+      ['.maka-search-modal-input-row', 'sidebar.css'],
+      ['.maka-palette-input-wrap', 'chat-header.css'],
+    ];
+    for (const [selector, label] of sites) {
+      const body = ruleBody(css, selector);
+      assert.ok(body, `${selector} rule must exist (${label}) — stale contract entry or renamed selector`);
+      assert.match(
+        body,
+        /border-radius:\s*calc\(var\(--radius-modal\)\s*-\s*8px\)/,
+        `${selector} (${label}) must keep the concentric nesting calc(var(--radius-modal) - 8px) — dropping it to a hardcoded tier would make the input read too round against the 12px modal shell`,
+      );
+    }
+  });
+
+  it('the nesting calc uses the shrink form only (the radius-converge calc allowlist enforces this, restated here for the nesting sites)', async () => {
+    // No site should ADD to the modal radius (that would break concentricity).
+    const css = stripCssComments(await readAllRendererCss());
+    const additionSites = [...css.matchAll(/calc\(var\(--radius-[\w-]+\)\s*\+\s*\d+px\)/g)];
+    assert.equal(
+      additionSites.length,
+      0,
+      `radius nesting must only SHRINK (calc(var(--radius-*) - Npx)); addition breaks concentricity. Found ${additionSites.length} addition site(s): ${additionSites.map((m) => m[0]).join(', ')}`,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/renderer-error-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-boundary.test.ts
@@ -33,7 +33,11 @@ test('renderer error boundary exposes a redacted copyable diagnostic report', as
   assert.match(source, /disabled=\{copyPending\}/);
   assert.match(source, /aria-busy=\{copyPending \? 'true' : undefined\}/);
   assert.match(source, /data-copy-state=\{copyState\}/);
-  assert.match(source, /variant="outline"[\s\S]*className="maka-error-copy-action"/);
+  // PR3 (#527) added a min-w utility to the copy button (text-swap width
+  // lock for 复制中…/已复制 feedback). Match the class as a whole word in the
+  // class list instead of an exact className="…", same form as the negative
+  // maka-button check below.
+  assert.match(source, /variant="outline"[\s\S]*className="[^"]*\bmaka-error-copy-action\b[^"]*"/);
   assert.match(source, /<UiButton type="button" variant="secondary" onClick=\{this\.handleReset\}>/);
   assert.match(source, /<UiButton[\s\S]*variant="default"[\s\S]*onClick=\{this\.handleReload\}/);
   assert.doesNotMatch(source, /className="maka-button/);

--- a/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
@@ -1,0 +1,132 @@
+/**
+ * PR-RESPONSIVE-BREAKPOINT-CONVERGE-0 (issue #520 PR4 item 16, 2026-07-05):
+ * govern the responsive seams — @media breakpoints and the shared chat
+ * content measure — so individual PRs can't drift to ad-hoc values.
+ *
+ * Two tracks:
+ *
+ * 1. @media breakpoints. CSS @media queries are evaluated at parse time,
+ *    before custom properties resolve, so `@media (max-width: var(--bp))`
+ *    is INVALID — breakpoints cannot be tokenized with var(). Instead the
+ *    contract whitelists the eight max/min-width pixel values the app
+ *    actually uses (620 / 720 / 760 / 820 / 900 / 980 / 990 / 1100) and
+ *    bans any other bare `@media (max-width: Npx)`. A new breakpoint must
+ *    be added to the whitelist here, which forces a conscious decision
+ *    instead of a silent drift. (prefers-reduced-motion /
+ *    prefers-color-scheme are not width breakpoints and are out of scope.)
+ *
+ * 2. The chat content measure (--maka-chat-measure: 680px). This IS a
+ *    regular property value, so it can be tokenized. It was a local token
+ *    on .mainColumn with a `680px` fallback at every call site; item 16
+ *    promotes it to :root in maka-tokens.css so it is canonical and the
+ *    fallbacks are redundant. The contract pins it exactly-once in the
+ *    token file, bans a local re-declaration in styles/, and bans a bare
+ *    `680px` in any width / max-width / min-width declaration so the chat
+ *    column, tool output, composer, and onboarding hero all share one
+ *    measure. (A 680px HEIGHT cap on the settings form modal is a different
+ *    semantic and stays bare — the contract scopes to width.)
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import {
+  TOKENS_FILE,
+  readAllRendererCss,
+  stripCssComments,
+  assertCustomPropPinnedOnce,
+} from './css-test-helpers.js';
+
+/** The eight max/min-width pixel values the app gates layout on. A new
+ *  breakpoint must be added here (and the value used in the CSS). */
+const ALLOWED_BREAKPOINT_PX = new Set([620, 720, 760, 820, 900, 980, 990, 1100]);
+
+// --- @media breakpoint whitelist ------------------------------------------
+
+/** Match `@media (max-width: Npx)` / `@media (min-width: Npx)` and capture N.
+ *  Does NOT match prefers-* queries (those are not width breakpoints). */
+const MEDIA_WIDTH_RE = /@media\s*\(\s*(max|min)-width\s*:\s*(\d+(?:\.\d+)?)px\s*\)/g;
+
+function findBreakpointOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(MEDIA_WIDTH_RE)) {
+    const px = Number(m[2]);
+    if (!ALLOWED_BREAKPOINT_PX.has(px)) {
+      offenders.push(`${label}: ${m[0]} [${px}px not in the breakpoint whitelist ${[...ALLOWED_BREAKPOINT_PX].join('/')}px]`);
+    }
+  }
+  return offenders;
+}
+
+// --- chat content measure --------------------------------------------------
+
+/** Bare `680px` in a width / max-width / min-width declaration — must use
+ *  var(--maka-chat-measure) so the chat column shares one measure. A 680px
+ *  HEIGHT cap (e.g. the settings form modal) is a different semantic and
+ *  is not flagged. */
+const WIDTH_DECL_RE = /(?:^|\n)\s*(?:width|max-width|min-width|inline-size|max-inline-size|min-inline-size)\s*:\s*([^;}\n]+)/gi;
+
+function findChatMeasureOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(WIDTH_DECL_RE)) {
+    const val = m[1];
+    // bare 680px not inside var()/calc()/min()/max()/clamp()
+    if (/\b680px\b/.test(val) && !/var\(--maka-chat-measure/.test(val)) {
+      offenders.push(`${label}: ${m[0].replace(/\s+/g, ' ').trim()} [bare 680px width — use var(--maka-chat-measure)]`);
+    }
+  }
+  return offenders;
+}
+
+// === tests =================================================================
+
+describe('PR-RESPONSIVE-BREAKPOINT-CONVERGE-0 contract', () => {
+  it('@media (max/min-width: Npx) uses only the whitelisted breakpoints (no ad-hoc Npx)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findBreakpointOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('--maka-chat-measure is pinned to 680px exactly-once in maka-tokens.css', async () => {
+    const tokens = await readFile(TOKENS_FILE, 'utf8');
+    assertCustomPropPinnedOnce(tokens, '--maka-chat-measure', '680px', 'maka-tokens.css');
+  });
+
+  it('--maka-chat-measure is not redeclared in styles/ (canonical in maka-tokens.css only)', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    // readAllRendererCss includes maka-tokens.css; count declarations of the
+    // token and require exactly one (the :root pin). A local re-declaration
+    // in styles/ would be a second declaration.
+    const decls = [...css.matchAll(/^\s*--maka-chat-measure\s*:\s*([^;}\n]+)/gm)];
+    assert.equal(decls.length, 1, `--maka-chat-measure must be declared exactly once (in maka-tokens.css :root); got ${decls.length}: ${decls.map((d) => d[0].trim()).join(' | ')}`);
+  });
+
+  it('no bare 680px in width / max-width / min-width declarations (use var(--maka-chat-measure))', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findChatMeasureOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+});
+
+describe('responsive breakpoint whitelist negative cases', () => {
+  it('findBreakpointOffenders flags a value outside the whitelist and spares the eight allowed', () => {
+    const ok = '@media (max-width: 820px) { … } @media (min-width: 990px) { … } @media (max-width: 620px) { … }';
+    assert.deepEqual(findBreakpointOffenders(ok, 't'), [], 'the eight whitelisted values must pass');
+    const bad = '@media (max-width: 850px) { … } @media (min-width: 1200px) { … }';
+    assert.ok(findBreakpointOffenders(bad, 't').length === 2, '850px and 1200px must fail (not whitelisted)');
+  });
+
+  it('does not flag prefers-reduced-motion / prefers-color-scheme (not width breakpoints)', () => {
+    const css = '@media (prefers-reduced-motion: reduce) { … } @media (prefers-color-scheme: dark) { … }';
+    assert.deepEqual(findBreakpointOffenders(css, 't'), [], 'prefers-* queries are out of scope');
+  });
+
+  it('findChatMeasureOffenders flags a bare 680px width but spares var(--maka-chat-measure) and a 680px height', () => {
+    assert.ok(findChatMeasureOffenders('width: min(680px, 100%);', 't').length > 0, 'bare 680px width must fail');
+    assert.deepEqual(findChatMeasureOffenders('width: min(var(--maka-chat-measure), 100%);', 't'), [], 'token width must pass');
+    assert.deepEqual(findChatMeasureOffenders('max-width: var(--maka-chat-measure);', 't'), [], 'token max-width must pass');
+    assert.deepEqual(findChatMeasureOffenders('height: min(76vh, 680px);', 't'), [], '680px height (form modal cap) is out of scope');
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -74,9 +74,9 @@ describe('Settings form accessibility labels', () => {
     const settingsRowTitle = styles.match(/\.settingsRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
 
     assert.match(connectionRow, /border-radius:\s*var\(--radius-surface\);/, 'Settings connection cards should use reference implementation rounded-lg geometry');
-    assert.match(connectionRow, /box-shadow:\s*0 1px 3px rgba\(0, 0, 0, 0\.03\);/, 'Settings connection cards should use reference implementation near-flat card shadow');
+    assert.match(connectionRow, /box-shadow:\s*0 1px 3px oklch\(from var\(--foreground\) l c h \/ 0\.03\);/, 'Settings connection cards should use the near-flat card shadow (P-SHADOW: foreground-derived, not pure-black)');
     assert.match(authContract, /border-radius:\s*var\(--radius-surface\);/, 'Nested auth contract cards should stay on the same 8px radius');
-    assert.match(authContract, /box-shadow:\s*0 1px 3px rgba\(0, 0, 0, 0\.03\);/, 'Nested auth contract cards should keep the same near-flat shadow');
+    assert.match(authContract, /box-shadow:\s*0 1px 3px oklch\(from var\(--foreground\) l c h \/ 0\.03\);/, 'Nested auth contract cards should keep the same near-flat shadow');
     // PR-DELETE-ORPHAN-CSS: `.providerEmpty` / `.providerCard` were
     // orphan; only `.settingsRow` remains in the live rule. The
     // border-radius / shadow geometry still applies via the same
@@ -86,7 +86,7 @@ describe('Settings form accessibility labels', () => {
     assert.ok(providerCatalogRow, 'Settings provider catalog rows should be governed by the shared .providerCatalogRow (Item) class');
     // PR-DELETE-ORPHAN-CSS: providerIcon assertion removed (orphan).
     assert.match(modelTable, /border-radius:\s*var\(--radius-surface\);/, 'Settings model table should use the same 8px secondary-surface radius');
-    assert.match(modelTable, /box-shadow:\s*0 1px 3px rgba\(0, 0, 0, 0\.03\);/, 'Settings model table should stay near-flat instead of returning to legacy panel shadows');
+    assert.match(modelTable, /box-shadow:\s*0 1px 3px oklch\(from var\(--foreground\) l c h \/ 0\.03\);/, 'Settings model table should stay near-flat instead of returning to legacy panel shadows');
     assert.match(modelTableRow, /border-radius:\s*var\(--radius-surface\);/, 'Settings model rows should use compact 8px row geometry');
     assert.match(modelTableEmpty, /border-radius:\s*var\(--radius-surface\);/, 'Settings model table empty state should align with the same 8px geometry');
     assert.match(providerCatalogBadge, /border-radius:\s*var\(--radius-control\);/, 'Provider catalog badges (category / preview / login) should use compact squared target-layout style corners, not pills');

--- a/apps/desktop/src/main/__tests__/startup-loading-shell-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/startup-loading-shell-contract.test.ts
@@ -10,7 +10,7 @@ test('startup onboarding loading slot paints visible skeleton chrome', () => {
   const block = css.match(/\.maka-onboarding-loading\s*\{[\s\S]*?\n\}/)?.[0] ?? '';
 
   assert.match(block, /background:\s*var\(--foreground-5\)/);
-  assert.match(block, /border:\s*1px solid var\(--border-strong\)/);
+  assert.match(block, /border:\s*var\(--border-width-hairline\) solid var\(--border-strong\)/);
   assert.match(block, /box-shadow:/);
   assert.match(css, /var\(--foreground-8\)/);
   assert.match(css, /\.maka-onboarding-loading::before\s*\{/);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -490,6 +490,14 @@
                                       nav row, first-run checklist row    */
   --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 
+  /* === content measure (#520 PR4 item 16) ================================
+     The chat content max-width — the column the conversation, tool output,
+     composer, and onboarding hero share so prose + controls line up at one
+     measure. Previously a local token on .mainColumn with a 680px fallback
+     at every call site; promoted to :root so the token is canonical and the
+     fallbacks are redundant. */
+  --maka-chat-measure: 680px;
+
 }
 
 /* =============================================================================
@@ -1105,7 +1113,7 @@
     gap: var(--space-6);
   }
   .maka-message-row {
-    max-width: var(--maka-chat-measure, 680px);
+    max-width: var(--maka-chat-measure);
     margin: 0 auto;
     width: 100%;
     opacity: 1;
@@ -1123,7 +1131,7 @@
        internal rhythm while still reading as one unit against the 24px
        between-turn gap. */
     gap: var(--space-2);
-    max-width: var(--maka-chat-measure, 680px);
+    max-width: var(--maka-chat-measure);
     margin: 0 auto;
     width: 100%;
     box-sizing: border-box;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -324,7 +324,20 @@
      instead of bare `Georgia, serif`. */
   --font-serif: Georgia, "Times New Roman", Times, serif;
 
-  /* === layout === */
+  /* === layout ===
+     P-RADIUS concentric nesting (#520 PR4 item 12, roadmap §1.3):
+     when a rounded surface sits inside another rounded surface with padding
+     between them, the inner radius = outer radius − padding so the two
+     curves share a center and read as one machined shell. Two forms:
+       1. If outer − padding lands on a tier, pick that tier directly —
+          e.g. a settings card (8px surface) inside a 12px modal with 4px
+          padding: 12 − 4 = 8 = --radius-surface. The radius-converge
+          contract's SELECTOR_TIER already pins this.
+       2. If outer − padding does NOT land on a tier, use
+          `calc(var(--radius-*) - Npx)` — e.g. an input inside a 12px modal
+          with 8px inset: 12 − 8 = 4px (not a tier), so
+          `border-radius: calc(var(--radius-modal) - 8px)`. The radius
+          contract's calc allowlist permits only this shrink form. */
   --radius: 0rem;
   --radius-control: 6px;
   --radius-surface: 8px;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -478,15 +478,18 @@
      (22/26/30/34/38); this scale converges them. Square icon controls use
      the same token for width and height (their footprint = control size).
      App-chrome bars (--h-titlebar/--h-toolbar/--h-composer-min/--h-list-header)
-     stay as their own semantic tokens — they are structure, not controls. */
+     stay as their own semantic tokens — they are structure, not controls.
+     md (28) and xl (36) use calc(var(--spacing) * 7/9) directly because maka's
+     discrete spacing scale skips 7 and 9 — control-only tiers must not expand
+     the general --space-* scale (that would invite p-7 / gap-7 drift). */
   --h-control-xs:  var(--space-5);  /* 20px — kbd, dot, tiny chip / close  */
   --h-control-sm:  var(--space-6);  /* 24px — small button, chip, sidebar
                                       topbar button, model switcher       */
-  --h-control-md:  var(--space-7);  /* 28px — compact menu item, sm tab,
+  --h-control-md:  calc(var(--spacing) * 7);  /* 28px — compact menu item, sm tab,
                                       round FAB (jump-to-bottom)          */
   --h-control-lg:  var(--space-8);  /* 32px — default button, input, tab,
                                       sidebar nav row, session row, select */
-  --h-control-xl:  var(--space-9);  /* 36px — prominent button, settings
+  --h-control-xl:  calc(var(--spacing) * 9);  /* 36px — prominent button, settings
                                       nav row, first-run checklist row    */
   --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -155,8 +155,21 @@
   /* PR-UI-ALIGN-0: visible hairline borders (≈#e6e6e6) like the reference's
      card/container outlines — maka's 5% was nearly invisible, which flattened
      the floating-card hierarchy. */
-  --border:        oklch(from var(--foreground) l c h / 0.10);
+--border:        oklch(from var(--foreground) l c h / 0.10);
   --border-strong: oklch(from var(--foreground) l c h / 0.16);
+  /* === border stroke width (#520 PR4 item 14) ============================
+     Border color was already tokenized; the width was bare px in every
+     `border:` / `border-{side}:` shorthand. Three semantic weights cover
+     the whole app: hairline (the universal divider, 1px), thick (a heavier
+     divider / selected outline, 2px), and accent (a status / decorative
+     strip — toast variant color bars and avatar rings, 3px). The rare
+     1.5px hairlines snap to hairline; the one 4px avatar ring snaps to
+     accent. Border-style (solid / dashed) stays a literal keyword — it is
+     a named value, not a magic number, so tokenizing it adds indirection
+     with no governance benefit. */
+  --border-width-hairline: 1px;
+  --border-width-thick:    2px;
+  --border-width-accent:   3px;
   --muted:         oklch(from var(--foreground) l c h / 0.05);
   --muted-foreground: color-mix(in oklch, var(--foreground) 50%, var(--background));
   --foreground-secondary: color-mix(in oklch, var(--foreground) 80%, var(--background));
@@ -902,7 +915,7 @@
     padding: var(--space-0-5) var(--space-1-5);
     border-radius: var(--radius-control);
     background: var(--foreground-5);
-    border: 1px solid var(--border-strong);
+    border: var(--border-width-hairline) solid var(--border-strong);
     box-shadow: inset 0 -1px 0 var(--border);
     color: var(--foreground-secondary);
   }
@@ -946,7 +959,7 @@
     font-weight: var(--font-weight-medium);
     color: var(--foreground-secondary);
     background: var(--foreground-5);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-pill);
   }
   .pill[data-tone="accent"]      { background: oklch(from var(--accent) l c h / 0.08); color: var(--accent); border-color: oklch(from var(--accent) l c h / 0.15); }
@@ -983,7 +996,7 @@
 
   .maka-sidebar {
     background: var(--foreground-2);            /* subtle 2% wash */
-    border-right: 1px solid var(--border);
+    border-right: var(--border-width-hairline) solid var(--border);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -994,7 +1007,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-bottom: 1px solid var(--border);
+    border-bottom: var(--border-width-hairline) solid var(--border);
     font-weight: var(--font-weight-semibold);
     font-size: var(--font-size-ui);
     letter-spacing: var(--tracking-wide);
@@ -1056,7 +1069,7 @@
   }
   .maka-titlebar {
     height: var(--h-titlebar);
-    border-bottom: 1px solid var(--border);
+    border-bottom: var(--border-width-hairline) solid var(--border);
     display: flex;
     align-items: center;
     gap: var(--space-3);
@@ -1146,7 +1159,7 @@
   .maka-turn-thinking {
     margin: 0 0 var(--space-2);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px dashed oklch(from var(--focus-ring) l c h / 0.25);
+    border: var(--border-width-hairline) dashed oklch(from var(--focus-ring) l c h / 0.25);
     border-radius: var(--radius-surface);
     background: oklch(from var(--focus-ring) l c h / 0.03);
     font-size: var(--font-size-ui);
@@ -1230,7 +1243,7 @@
     width: 14px;
     height: 14px;
     margin: 0 var(--space-2) 0 0;
-    border: 1.5px solid var(--muted-foreground);
+    border: var(--border-width-hairline) solid var(--muted-foreground);
     border-radius: var(--radius-control);
     background: transparent;
     vertical-align: text-bottom;
@@ -1351,7 +1364,7 @@
   .maka-bubble-assistant a {
     color: var(--link);
     text-decoration: none;
-    border-bottom: 1px solid oklch(from var(--link) l c h / 0.4);
+    border-bottom: var(--border-width-hairline) solid oklch(from var(--link) l c h / 0.4);
     /* PR-UI-LAYOUT-34: explicit transition so focus state animates
      * smoothly. Also: explicit padding-inline + negative margin so
      * the focus halo has hit area without pushing inline content
@@ -1378,7 +1391,7 @@
      * pill rhythm that matches the rest of the warm-canvas chrome. */
     border-radius: var(--radius-control);
     background: var(--foreground-5);
-    border: 1px solid oklch(from var(--foreground) l c h / 0.03);
+    border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.03);
   }
   /* Block code goes inside a maka-code-block wrapper that adds a language
      pill + copy button on top of the pre. Pre keeps its monospace styling
@@ -1386,7 +1399,7 @@
      as part of the same surface. */
   .maka-bubble-assistant .maka-code-block {
     margin: 0 0 var(--space-3);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     overflow: hidden;
     background: var(--foreground-3);
@@ -1396,7 +1409,7 @@
     align-items: center;
     justify-content: space-between;
     padding: var(--space-1) var(--space-2-5) var(--space-1) var(--space-3);
-    border-bottom: 1px solid var(--border);
+    border-bottom: var(--border-width-hairline) solid var(--border);
     background: var(--foreground-5);
     color: var(--foreground-secondary);
     font-family: var(--font-mono);
@@ -1506,7 +1519,7 @@
      * icon + border + saturated tone pattern. The left rule keeps
      * the accent tie so quotes still feel branded, not generic. */
     padding: var(--space-2) var(--space-4);
-    border-left: 3px solid oklch(from var(--focus-ring) l c h / 0.28);
+    border-left: var(--border-width-accent) solid oklch(from var(--focus-ring) l c h / 0.28);
     background: var(--foreground-3);
     border-radius: 0 var(--radius-surface) var(--radius-surface) 0;
     color: var(--foreground-secondary);
@@ -1522,12 +1535,12 @@
      * edge against the warm panel. Without the border the rounded
      * corners would clip nothing visible. */
     border-radius: var(--radius-surface);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
   }
   .maka-bubble-assistant th,
   .maka-bubble-assistant td {
     padding: var(--space-2) var(--space-3);
-    border-bottom: 1px solid var(--border);
+    border-bottom: var(--border-width-hairline) solid var(--border);
     text-align: left;
   }
   /* PR-UI-LAYOUT-28: drop the trailing border on the last row so the
@@ -1549,7 +1562,7 @@
   .maka-bubble-assistant hr {
     margin: var(--space-4) 0;
     border: 0;
-    border-top: 1px solid var(--border);
+    border-top: var(--border-width-hairline) solid var(--border);
   }
 
   /* Hover-revealed copy button on assistant messages. The wrapper is
@@ -1726,7 +1739,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2-5);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     transition: border-color 160ms var(--ease-out-strong), box-shadow 160ms var(--ease-out-strong), background 160ms var(--ease-out-strong);
   }
 
@@ -1795,7 +1808,7 @@
      * - Focus ring added (was missing — only browser default outline). */
     appearance: none;
     min-height: 32px;
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     background: var(--background);
     color: var(--foreground);
     padding: var(--space-1-5) var(--space-3);
@@ -1824,7 +1837,7 @@
   .maka-tabs-list[data-variant="pill"] .maka-tab {
     min-height: 34px;
     border-radius: var(--radius-pill);
-    border: 1px solid transparent;
+    border: var(--border-width-hairline) solid transparent;
     background: var(--foreground-5);
     color: var(--foreground-secondary);
     padding: 0 var(--space-4);
@@ -1872,7 +1885,7 @@
   }
   .maka-modal-header {
     padding: var(--space-4) var(--space-5) var(--space-2) var(--space-5);
-    border-bottom: 1px solid var(--border);
+    border-bottom: var(--border-width-hairline) solid var(--border);
   }
   .maka-modal-title {
     font-size: var(--font-size-base);
@@ -1888,7 +1901,7 @@
   .maka-modal-body { padding: var(--space-4) var(--space-5); overflow-y: auto; flex: 1; }
   .maka-modal-footer {
     padding: var(--space-3) var(--space-5);
-    border-top: 1px solid var(--border);
+    border-top: var(--border-width-hairline) solid var(--border);
     display: flex;
     align-items: center;
     justify-content: flex-end;
@@ -1912,7 +1925,7 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-ui);
     background: var(--foreground-3);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     padding: var(--space-2) var(--space-2-5);
     color: var(--foreground);

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -444,6 +444,26 @@
   --w-sessionlist: 240px;
   --h-list-header: 52px;
 
+  /* === control-height scale (component sizing, #520 PR4 item 15) =========
+     Interactive controls (button / input / select / tab / nav row / badge /
+     kbd) live on the 4px spacing ruler so CSS var(--h-control-*) and Tailwind
+     h-N share one scale (h-5=20, h-6=24, h-7=28, h-8=32, h-9=36, h-10=40).
+     The historic sidebar/会话/设置 height drift came from off-ruler bare px
+     (22/26/30/34/38); this scale converges them. Square icon controls use
+     the same token for width and height (their footprint = control size).
+     App-chrome bars (--h-titlebar/--h-toolbar/--h-composer-min/--h-list-header)
+     stay as their own semantic tokens — they are structure, not controls. */
+  --h-control-xs:  var(--space-5);  /* 20px — kbd, dot, tiny chip / close  */
+  --h-control-sm:  var(--space-6);  /* 24px — small button, chip, sidebar
+                                      topbar button, model switcher       */
+  --h-control-md:  var(--space-7);  /* 28px — compact menu item, sm tab,
+                                      round FAB (jump-to-bottom)          */
+  --h-control-lg:  var(--space-8);  /* 32px — default button, input, tab,
+                                      sidebar nav row, session row, select */
+  --h-control-xl:  var(--space-9);  /* 36px — prominent button, settings
+                                      nav row, first-run checklist row    */
+  --h-control-2xl: var(--space-10); /* 40px — toolbar, large touch target  */
+
 }
 
 /* =============================================================================

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -124,14 +124,14 @@
   background-color: var(--agents-content-area-bg);
   box-shadow:
     0 0 0 1px oklch(from var(--foreground) l c h / 0.035),
-    0 1px 3px rgba(0, 0, 0, 0.025);
+    0 1px 3px oklch(from var(--foreground) l c h / 0.025);
 }
 
 .composer .maka-composer-inner.agents-parchment-paper-surface:focus-within {
   border-color: var(--color-border-tertiary);
   box-shadow:
     0 0 0 1px oklch(from var(--foreground) l c h / 0.07),
-    0 2px 8px -6px rgba(0, 0, 0, 0.16);
+    0 2px 8px -6px oklch(from var(--foreground) l c h / 0.16);
 }
 
 .agents-chat-panel {

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -120,7 +120,7 @@
 }
 
 .composer .maka-composer-inner.agents-parchment-paper-surface {
-  border: 1px solid var(--color-border-tertiary);
+  border: var(--border-width-hairline) solid var(--color-border-tertiary);
   background-color: var(--agents-content-area-bg);
   box-shadow:
     0 0 0 1px oklch(from var(--foreground) l c h / 0.035),

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -178,7 +178,7 @@ function PersonalizationSettingsPage(props: {
           spellCheck={false}
           disabled={saving}
           aria-label="助手语气偏好"
-          className="min-h-[84px]"
+          className="min-h-21"
         />
         <small>
           以低优先级用户偏好拼到 system prompt，500 字符内。Runtime 仍按权限策略和工具规则

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -245,8 +245,8 @@
     bottom: 10px;
     left: 50%;
     transform: translateX(-50%);
-    width: 26px;
-    height: 26px;
+    width: var(--h-control-md);
+    height: var(--h-control-md);
     display: grid;
     place-items: center;
     border: 1px solid var(--border-strong);
@@ -714,7 +714,7 @@
 
 .maka-palette-input-wrap {
   width: auto;
-  min-height: 32px;
+  min-height: var(--h-control-lg);
   margin: var(--space-2) var(--space-2-5);
   /* P-RADIUS concentric formula (roadmap §1.3): inner radius = outer
      radius − inset. Modal shell is 12px with an 8px inset, so the

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -66,7 +66,7 @@
 .maka-chat-header-memory-pill {
   appearance: none;
   background: oklch(from var(--nav-active) l c h / 0.10);
-  border: 1px solid oklch(from var(--nav-active) l c h / 0.25);
+  border: var(--border-width-hairline) solid oklch(from var(--nav-active) l c h / 0.25);
   color: var(--nav-active);
   border-radius: var(--radius-pill);
   display: inline-flex;
@@ -92,7 +92,7 @@
 }
 
 .maka-chat-header-mode-pill {
-  border: 1px solid oklch(from var(--info) l c h / 0.32);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.32);
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
   border-radius: var(--radius-pill);
@@ -120,7 +120,7 @@
     padding: 1px var(--space-1-5);
     margin-bottom: var(--space-0-5);
     border-radius: var(--radius-pill);
-    border: 1px solid transparent;
+    border: var(--border-width-hairline) solid transparent;
     font-size: var(--font-size-caption);
     font-weight: var(--font-weight-semibold);
     letter-spacing: var(--tracking-wide);
@@ -166,7 +166,7 @@
        towering over them. */
     padding: 1px var(--space-1-5);
     border-radius: var(--radius-pill);
-    border: 1px solid transparent;
+    border: var(--border-width-hairline) solid transparent;
     font-size: var(--font-size-caption);
     font-weight: var(--font-weight-semibold);
     line-height: var(--leading-snug);
@@ -249,7 +249,7 @@
     height: var(--h-control-md);
     display: grid;
     place-items: center;
-    border: 1px solid var(--border-strong);
+    border: var(--border-width-hairline) solid var(--border-strong);
     border-radius: var(--radius-pill);
     background: var(--background);
     color: var(--foreground-secondary);
@@ -289,7 +289,7 @@
     gap: var(--space-3);
     max-width: 520px;
     padding: var(--space-3) var(--space-4);
-    border: 1px solid oklch(from var(--destructive) l c h / 0.3);
+    border: var(--border-width-hairline) solid oklch(from var(--destructive) l c h / 0.3);
     border-radius: var(--radius-surface);
     background: var(--background-elevated);
     box-shadow: var(--shadow-modal);
@@ -329,7 +329,7 @@
     margin: var(--space-1) 0 0;
     max-height: 220px;
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     color: var(--foreground-secondary);
@@ -374,7 +374,7 @@
   gap: var(--space-2);
   margin: var(--space-2) var(--space-3) 0;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid oklch(from var(--info) l c h / 0.3);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.3);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
@@ -440,7 +440,7 @@
   grid-template-columns: 14px minmax(0, 1fr) auto auto;
   align-items: start;
   gap: var(--space-2);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   box-shadow:
@@ -514,10 +514,10 @@
   100% { background-position: -80% 0; }
 }
 
-.maka-toast[data-variant="success"] { border-left: 3px solid var(--success); }
-.maka-toast[data-variant="warning"] { border-left: 3px solid var(--info); }
-.maka-toast[data-variant="error"]   { border-left: 3px solid var(--destructive); }
-.maka-toast[data-variant="info"]    { border-left: 3px solid var(--toast-accent); }
+.maka-toast[data-variant="success"] { border-left: var(--border-width-accent) solid var(--success); }
+.maka-toast[data-variant="warning"] { border-left: var(--border-width-accent) solid var(--info); }
+.maka-toast[data-variant="error"]   { border-left: var(--border-width-accent) solid var(--destructive); }
+.maka-toast[data-variant="info"]    { border-left: var(--border-width-accent) solid var(--toast-accent); }
 
 .maka-toast-icon {
   margin-top: var(--space-0-5);
@@ -550,7 +550,7 @@
 
 .maka-toast-action {
   align-self: center;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--toast-accent);
@@ -694,7 +694,7 @@
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-modal);
   box-shadow:
     0 1px 2px oklch(from var(--foreground) l c h / 0.05),
@@ -792,7 +792,7 @@
   min-width: 16px;
   padding: 0 var(--space-1);
   border-radius: var(--radius-control);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   background: var(--foreground-5);
   box-shadow: inset 0 1px 0 oklch(from var(--background) l c h / 0.45);
   color: var(--foreground-secondary);
@@ -814,7 +814,7 @@
 }
 
 .maka-palette-list {
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
   overflow-y: auto;
   padding: var(--space-1) var(--space-1-5) var(--space-1-5);
 }
@@ -927,7 +927,7 @@
   align-items: center;
   gap: var(--space-1-5);
   padding: var(--space-0-5) var(--space-2);
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
   background: var(--foreground-2);
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -55,7 +55,7 @@
     top: 52px;
     width: 62px;
     height: 62px;
-    border: 4px solid oklch(from var(--brand-deep) l c h / 0.12);
+    border: var(--border-width-accent) solid oklch(from var(--brand-deep) l c h / 0.12);
     background: oklch(0.93 0.006 286);
     color: var(--foreground);
     font-size: 1.4667em;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -50,7 +50,7 @@
   /* PR-PARCHMENT-HOME-2: must share the new composer card measure
      (620px) so the "选择工作目录 ▾" pill stays aligned with the card
      left edge above it. */
-  width: min(var(--maka-chat-measure, 680px), 100%);
+  width: min(var(--maka-chat-measure), 100%);
   display: flex;
   justify-content: flex-start;
   box-sizing: border-box;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -258,7 +258,7 @@
 }
 
 .permissionDialog[data-tone="destructive"] {
-  border: 1px solid oklch(from var(--destructive) l c h / 0.32);
+  border: var(--border-width-hairline) solid oklch(from var(--destructive) l c h / 0.32);
 }
 
 .maka-permission-tool {
@@ -268,7 +268,7 @@
   border-radius: var(--radius-control);
   background: var(--foreground-5);
   color: var(--foreground-secondary);
-  border: 1px solid oklch(from var(--foreground) l c h / 0.03);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.03);
 }
 
 .maka-permission-age {
@@ -312,7 +312,7 @@
   border-radius: var(--radius-control);
   background: var(--foreground-5);
   color: var(--foreground);
-  border: 1px solid oklch(from var(--foreground) l c h / 0.03);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.03);
 }
 
 .maka-permission-command,

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -3,8 +3,8 @@
    per design-taste rules). Uses oklch off-black (charcoal) so the button
    reads as premium machined hardware. */
 .maka-composer-send-button {
-  width: 30px;
-  height: 30px;
+  width: var(--h-control-lg);
+  height: var(--h-control-lg);
   border-radius: var(--radius-pill);
   background: linear-gradient(
     oklch(from var(--action) calc(l - 0.10) c h),
@@ -61,7 +61,7 @@
   -webkit-app-region: no-drag;
   appearance: none;
   min-width: 0;
-  min-height: 24px;
+  min-height: var(--h-control-sm);
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -7,7 +7,7 @@
     width: 100%;
     margin-inline: auto;
     background: var(--card-bg);
-    border: 1px solid var(--card-border-color);
+    border: var(--border-width-hairline) solid var(--card-border-color);
     border-radius: var(--radius-surface);
     box-shadow:
       var(--card-shadow),
@@ -23,7 +23,7 @@
     flex-wrap: wrap;
     gap: var(--space-2);
     padding: var(--space-0-5) var(--space-0-5) var(--space-1-5);
-    border-bottom: 1px solid var(--foreground-10);
+    border-bottom: var(--border-width-hairline) solid var(--foreground-10);
   }
 
 .maka-daily-review-header-time {
@@ -67,7 +67,7 @@
   justify-content: flex-end;
   gap: var(--space-2);
   padding: var(--space-0-5) 0 var(--space-1-5);
-  border-bottom: 1px solid var(--foreground-10);
+  border-bottom: var(--border-width-hairline) solid var(--foreground-10);
 }
 
 .maka-daily-review-model-select {
@@ -87,7 +87,7 @@
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) 0 var(--space-2-5);
-    border-bottom: 1px solid var(--foreground-10);
+    border-bottom: var(--border-width-hairline) solid var(--foreground-10);
   }
 
 .maka-daily-review-archives-header {
@@ -130,7 +130,7 @@
 
 .maka-daily-review-archive-row {
   appearance: none;
-  border: 1px solid transparent;
+  border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
   color: inherit;
@@ -178,7 +178,7 @@
     gap: var(--space-2);
     min-width: 0;
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid var(--card-border-color);
+    border: var(--border-width-hairline) solid var(--card-border-color);
     border-radius: var(--radius-surface);
     background: oklch(from var(--foreground) l c h / 0.025);
     box-shadow: var(--card-highlight);
@@ -216,7 +216,7 @@
 
 .maka-daily-review-archive-status {
     flex: none;
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-pill);
     color: var(--muted-foreground);
     font-size: var(--font-size-caption);
@@ -259,7 +259,7 @@
   }
 
 .maka-daily-review-archive-section + .maka-daily-review-archive-section {
-    border-top: 1px solid var(--foreground-10);
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
     padding-top: var(--space-3);
   }
 
@@ -343,7 +343,7 @@
     justify-content: space-between;
     gap: var(--space-2);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px solid oklch(from var(--warning, var(--info)) l c h / 0.3);
+    border: var(--border-width-hairline) solid oklch(from var(--warning, var(--info)) l c h / 0.3);
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning, var(--info)) l c h / 0.08);
     color: var(--warning-text, var(--foreground));
@@ -407,7 +407,7 @@
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3) 0 0;
-    border-top: 1px solid oklch(from var(--foreground) l c h / 0.07);
+    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
   }
 .maka-daily-review-section:first-of-type {
     border-top: 0;

--- a/apps/desktop/src/renderer/styles/health-center.css
+++ b/apps/desktop/src/renderer/styles/health-center.css
@@ -19,7 +19,7 @@
     align-items: flex-start;
     gap: var(--space-5);
     padding: var(--space-4);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -59,7 +59,7 @@
    variant="secondary"` and must outrank the Tailwind utility classes baked
    into the primitive. */
 .settingsHealthRefresh {
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   background: var(--background);
   border-radius: var(--radius-control);
   padding: var(--space-1) var(--space-2-5);
@@ -82,7 +82,7 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-4);
-    border: 1px solid oklch(from var(--destructive) l c h / 0.30);
+    border: var(--border-width-hairline) solid oklch(from var(--destructive) l c h / 0.30);
     background: oklch(from var(--destructive) l c h / 0.08);
     border-radius: var(--radius-surface);
     color: var(--destructive-text);
@@ -120,7 +120,7 @@
     align-items: flex-start;
     gap: var(--space-1);
     padding: var(--space-3) var(--space-3);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
   }
@@ -216,7 +216,7 @@
     flex-direction: column;
     gap: var(--space-1-5);
     padding: var(--space-3) var(--space-3);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
     transition: border-color var(--duration-base) var(--ease-out-strong);
@@ -292,7 +292,7 @@
     font-size: var(--font-size-caption);
     padding: 1px var(--space-2);
     border-radius: var(--radius-pill);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
   }
 
 .settingsHealthSignalBlocker[data-tone="destructive"] {
@@ -310,7 +310,7 @@
 .settingsHealthFootnote {
     margin: 0;
     padding: var(--space-3) var(--space-3);
-    border: 1px dashed var(--border);
+    border: var(--border-width-hairline) dashed var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     color: var(--foreground-secondary);

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -20,7 +20,7 @@
   width: 100%;
   min-width: 120px;
   max-width: min(320px, 28vw);
-  height: 22px;
+  height: var(--h-control-sm);
   display: inline-flex;
   align-items: center;
   justify-content: space-between;

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -26,7 +26,7 @@
   justify-content: space-between;
   gap: var(--space-1-5);
   padding: 1px var(--space-1-5) 1px var(--space-2);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--foreground-5);
   color: var(--foreground);

--- a/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
+++ b/apps/desktop/src/renderer/styles/module-pages/capability-audit.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   border-radius: var(--radius-control);
   background:
     linear-gradient(90deg, oklch(from var(--focus-ring) l c h / 0.06), transparent 42%),
@@ -51,7 +51,7 @@
   display: grid;
   gap: var(--space-0-5);
   min-width: 0;
-  border-left: 1px solid var(--foreground-8);
+  border-left: var(--border-width-hairline) solid var(--foreground-8);
   padding-left: var(--space-2-5);
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -30,7 +30,7 @@
   gap: var(--space-2);
   padding: var(--space-4) var(--space-5) var(--space-5);
   background: var(--card-bg);
-  border: 1px solid var(--card-border-color);
+  border: var(--border-width-hairline) solid var(--card-border-color);
   border-radius: var(--radius-surface);
   box-shadow:
     var(--card-shadow),
@@ -165,7 +165,7 @@
   grid-template-rows: auto minmax(0, 1fr) auto;
   align-items: start;
   gap: var(--space-3);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   box-shadow: none;
@@ -283,7 +283,7 @@
   align-self: start;
   align-items: center;
   gap: var(--space-1);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--foreground-2);
   color: var(--muted-foreground);
@@ -299,7 +299,7 @@
   width: 100%;
   margin-top: auto;
   border: 0;
-  border-top: 1px dashed var(--border);
+  border-top: var(--border-width-hairline) dashed var(--border);
   border-radius: 0;
   background: transparent;
   color: var(--foreground-secondary);
@@ -371,7 +371,7 @@
   align-items: center;
   height: 20px;
   padding: 0 var(--space-2);
-  border: 1px solid oklch(0.56 0.08 245 / 0.4);
+  border: var(--border-width-hairline) solid oklch(0.56 0.08 245 / 0.4);
   border-radius: var(--radius-pill);
   background: oklch(0.56 0.08 245 / 0.10);
   font-weight: var(--font-weight-semibold);
@@ -457,7 +457,7 @@
 .maka-plan-run-row {
   display: grid;
   gap: var(--space-2-5);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   padding: var(--space-4);
@@ -472,7 +472,7 @@
   flex-direction: column;
   gap: var(--space-2-5);
   position: relative;
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   border-radius: var(--radius-surface);
   background: var(--background);
   padding: var(--space-3) var(--space-4) var(--space-3);
@@ -598,7 +598,7 @@
 .maka-plan-field input,
 .maka-plan-field textarea {
   width: 100%;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground);
@@ -637,7 +637,7 @@
 
 .maka-plan-validation {
   margin: 0;
-  border: 1px solid oklch(from var(--warning) l c h / 0.34);
+  border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.34);
   border-radius: var(--radius-control);
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground-secondary);
@@ -702,7 +702,7 @@
 
 .maka-plan-search input {
   width: 100%;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground);
@@ -771,7 +771,7 @@
   order: 3;
   margin-top: auto;
   padding-top: var(--space-3);
-  border-top: 1px dashed var(--border);
+  border-top: var(--border-width-hairline) dashed var(--border);
   justify-content: flex-start;
   flex-wrap: nowrap;
   gap: var(--space-1);

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -102,7 +102,7 @@
   background: oklch(0.18 0 0);
   box-shadow:
     inset 0 1px 0 oklch(1 0 0 / 0.15),
-    0 1px 2px oklch(0 0 0 / 0.10);
+    0 1px 2px oklch(from var(--foreground) l c h / 0.10);
   color: oklch(1 0 0);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
@@ -120,7 +120,7 @@
   transform: translateY(-0.5px);
   box-shadow:
     inset 0 1px 0 oklch(1 0 0 / 0.20),
-    0 4px 14px -8px oklch(0 0 0 / 0.32);
+    0 4px 14px -8px oklch(from var(--foreground) l c h / 0.32);
 }
 
 .maka-plan-new-task-button:active:not(:disabled) {

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -4,7 +4,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1-5);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--muted-foreground);
@@ -64,7 +64,7 @@
   gap: var(--space-2);
   padding: var(--space-4) var(--space-5) var(--space-5);
   background: var(--card-bg);
-  border: 1px solid var(--card-border-color);
+  border: var(--border-width-hairline) solid var(--card-border-color);
   border-radius: var(--radius-surface);
   box-shadow:
     var(--card-shadow),
@@ -83,7 +83,7 @@
   justify-content: space-between;
   gap: var(--space-6);
   overflow: hidden;
-  border: 1px solid oklch(88% 0.035 224 / 0.72);
+  border: var(--border-width-hairline) solid oklch(88% 0.035 224 / 0.72);
   border-radius: var(--radius-surface);
   background:
     radial-gradient(circle at 80% 50%, oklch(100% 0 0 / 0.44) 0 24%, transparent 25%),
@@ -139,7 +139,7 @@
   /* Fixed inks: these floating cards stay white in both themes (they
      sit on the theme-independent banner), so their border/copy must
      not follow --foreground or they wash out in dark mode. */
-  border: 1px solid oklch(0.2 0.01 224 / 0.09);
+  border: var(--border-width-hairline) solid oklch(0.2 0.01 224 / 0.09);
   border-radius: var(--radius-control);
   background: linear-gradient(180deg, oklch(100% 0 0), oklch(98.2% 0.006 96));
   color: oklch(0.44 0.015 220);
@@ -198,7 +198,7 @@ color: oklch(0.55 0.015 220);
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
 .maka-skill-tabs {
@@ -249,7 +249,7 @@ color: oklch(0.55 0.015 220);
   display: inline-flex;
   align-items: center;
   height: 28px;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground-secondary);
@@ -290,7 +290,7 @@ color: oklch(0.55 0.015 220);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   border-radius: var(--radius-control);
   background: var(--background);
   padding: var(--space-4);
@@ -347,7 +347,7 @@ color: oklch(0.55 0.015 220);
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground-secondary);
@@ -368,7 +368,7 @@ color: oklch(0.55 0.015 220);
   display: inline-flex;
   align-items: center;
   height: 22px;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--foreground-2);
   color: var(--muted-foreground);
@@ -474,7 +474,7 @@ color: oklch(0.55 0.015 220);
   display: grid;
   align-content: start;
   gap: 0;
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   border-radius: var(--radius-control);
   background: var(--background);
 }
@@ -484,7 +484,7 @@ color: oklch(0.55 0.015 220);
 }
 
 .maka-skill-library-item + .maka-skill-library-item {
-  border-top: 1px solid var(--foreground-8);
+  border-top: var(--border-width-hairline) solid var(--foreground-8);
 }
 
 /* Justified: this row is a shared `UiButton variant="ghost"` but the surface
@@ -537,7 +537,7 @@ color: oklch(0.55 0.015 220);
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-surface);
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   background: var(--background);
   box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.05);
   color: var(--muted-foreground);
@@ -613,7 +613,7 @@ color: oklch(0.55 0.015 220);
   justify-self: end;
   min-width: 40px;
   padding: var(--space-0-5) var(--space-2);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--muted-foreground);

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -150,7 +150,7 @@
   border-radius: var(--radius-pill);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  border: 1.5px solid var(--border-strong);
+  border: var(--border-width-hairline) solid var(--border-strong);
   color: var(--muted-foreground);
 }
 
@@ -212,7 +212,7 @@
 
 /* --- provider list panel (scrolls vertically as the list grows) --- */
 .maka-firstrun-list {
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   overflow: hidden;
   background: var(--background-elevated);
@@ -228,7 +228,7 @@
   overflow-y: auto;
 }
 .maka-firstrun-list li + li {
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
 }
 
 /* --- "常用" tag inside a provider row title --- */
@@ -437,7 +437,7 @@
   margin-inline: auto;
   position: relative;
   border-radius: var(--radius-modal);
-  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.08);
   background: var(--background-elevated, var(--background));
   box-shadow:
     0 18px 42px oklch(from var(--foreground) l c h / 0.07),
@@ -502,7 +502,7 @@
   width: fit-content;
   max-width: calc(100% - 190px);
   margin: calc(var(--space-2-5) * -1) clamp(var(--space-6), 12vw, 150px) var(--space-4) var(--space-6);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-pill);
   padding: var(--space-1) var(--space-2);
   color: var(--nav-active);
@@ -593,7 +593,7 @@
   justify-content: center;
   width: auto;
   flex: 0 0 auto;
-  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.08);
   border-radius: var(--radius-pill);
   background: oklch(from var(--background-elevated, var(--background)) l c h / 0.78);
   color: var(--foreground-secondary);
@@ -632,7 +632,7 @@
   min-height: 132px;
   margin: auto;
   overflow: hidden;
-  border: 1px solid var(--border-strong);
+  border: var(--border-width-hairline) solid var(--border-strong);
   border-radius: var(--radius-modal);
   background: var(--foreground-5);
   box-shadow:

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -1,6 +1,6 @@
 /* Onboarding hero — first-run, no real connection configured. */
 .maka-onboarding {
-  width: min(680px, 100%);
+  width: min(var(--maka-chat-measure), 100%);
   margin: auto;
   padding: var(--space-3) var(--space-4) var(--space-4);
   display: grid;

--- a/apps/desktop/src/renderer/styles/permission-center.css
+++ b/apps/desktop/src/renderer/styles/permission-center.css
@@ -18,7 +18,7 @@
     align-items: flex-start;
     gap: var(--space-5);
     padding: var(--space-4);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -54,7 +54,7 @@
    variant="secondary"` and must outrank the Tailwind utility classes baked
    into the primitive. */
 .settingsPermissionRefresh {
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   background: var(--background);
   border-radius: var(--radius-control);
   padding: var(--space-1) var(--space-2-5);
@@ -77,7 +77,7 @@
     flex-direction: column;
     gap: var(--space-2);
     padding: var(--space-4);
-    border: 1px solid oklch(from var(--destructive) l c h / 0.30);
+    border: var(--border-width-hairline) solid oklch(from var(--destructive) l c h / 0.30);
     background: oklch(from var(--destructive) l c h / 0.08);
     border-radius: var(--radius-surface);
     color: var(--destructive-text);
@@ -123,7 +123,7 @@
   }
 
 .settingsCapabilityRow {
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
     padding: var(--space-3) var(--space-4);
@@ -256,7 +256,7 @@
     align-items: center;
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-2) var(--space-0-5) var(--space-2-5);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-pill);
     font-size: var(--font-size-caption);
     background: var(--background);
@@ -296,7 +296,7 @@
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     background: var(--foreground-3);
   }
 
@@ -325,7 +325,7 @@
     max-width: 100%;
     overflow: auto;
     padding: var(--space-1-5) var(--space-2);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--background);
     color: var(--foreground-secondary);
@@ -351,7 +351,7 @@
   }
 
 .settingsCapabilityAuditSlot {
-    border-top: 1px dashed var(--border);
+    border-top: var(--border-width-hairline) dashed var(--border);
     padding-top: var(--space-2);
   }
 
@@ -384,7 +384,7 @@
     margin: 0;
     display: flex;
     flex-direction: column;
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--background);
     overflow: hidden;
@@ -394,7 +394,7 @@
      border closes cleanly. */
 
 .settingsOsPermissionRow + .settingsOsPermissionRow {
-    border-top: 1px solid oklch(from var(--foreground) l c h / 0.06);
+    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   }
 
 /* PR-PERMISSION-PAGE-REDESIGN: icon + body + actions row layout.
@@ -556,7 +556,7 @@
     flex-direction: column;
     gap: var(--space-0-5);
     padding: var(--space-3) var(--space-3);
-    border: 1px solid var(--card-border-color, var(--border));
+    border: var(--border-width-hairline) solid var(--card-border-color, var(--border));
     border-radius: var(--radius-surface);
     background: var(--card-bg, var(--background));
     box-shadow:
@@ -610,7 +610,7 @@
 .settingsPermissionFootnote {
     margin: 0;
     padding: var(--space-3) var(--space-3);
-    border: 1px dashed var(--border);
+    border: var(--border-width-hairline) dashed var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     color: var(--foreground-secondary);

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -10,7 +10,7 @@
   ============================================================================= */
 .maka-reasoning-panel {
     margin: var(--space-1) 0 var(--space-2);
-    border: 1px solid oklch(from var(--info) l c h / 0.22);
+    border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.22);
     border-radius: var(--radius-surface);
     background: oklch(from var(--info) l c h / 0.04);
     overflow: hidden;
@@ -81,7 +81,7 @@
 .maka-reasoning-panel-truncated[data-truncated="true"] {
     font-size: var(--font-size-caption);
     color: var(--warning-text, var(--info-text));
-    border: 1px solid oklch(from var(--warning) l c h / 0.24);
+    border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.24);
     background: oklch(from var(--warning) l c h / 0.05);
     border-radius: var(--radius-control);
     padding: 0 var(--space-1);
@@ -103,7 +103,7 @@
 .maka-reasoning-panel-body {
     margin: 0;
     padding: var(--space-1-5) var(--space-2-5) var(--space-2);
-    border-top: 1px solid oklch(from var(--info) l c h / 0.14);
+    border-top: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.14);
     background: transparent;
     color: var(--foreground-secondary);
     font-family: var(--font-mono);

--- a/apps/desktop/src/renderer/styles/settings-select.css
+++ b/apps/desktop/src/renderer/styles/settings-select.css
@@ -7,7 +7,7 @@
    `.settingsSelect*` rules pin the unified chrome. */
 .settingsSelectTrigger {
   min-width: 0;
-  height: 34px;
+  height: var(--h-control-lg);
   justify-content: space-between;
   border-radius: var(--radius-control);
   font-size: var(--font-size-ui);
@@ -66,7 +66,7 @@
 }
 
 .settingsSelectMenuPopup [role="option"] {
-  min-height: 32px;
+  min-height: var(--h-control-lg);
   align-items: center;
   border-radius: var(--radius-surface);
   padding: var(--space-1-5) var(--space-3);

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -2,7 +2,7 @@
   display: grid;
   align-content: start;
   gap: var(--space-1-5);
-  border-right: 1px solid var(--border);
+  border-right: var(--border-width-hairline) solid var(--border);
   padding-right: var(--space-4);
 }
 
@@ -59,7 +59,7 @@
   opacity: 1;
 }
 .settingsBotList button[data-support="planned"] em {
-  border: 1px solid var(--foreground-10);
+  border: var(--border-width-hairline) solid var(--foreground-10);
   border-radius: var(--radius-pill);
   padding: 0 var(--space-1-5);
   color: var(--muted-foreground);
@@ -139,7 +139,7 @@
     gap: var(--space-3);
     border-radius: var(--radius-surface);
     background: color-mix(in srgb, var(--bot-brand-color, var(--bot-brand-default)) 7%, var(--background));
-    border: 1px solid color-mix(in srgb, var(--bot-brand-color, var(--bot-brand-default)) 14%, transparent);
+    border: var(--border-width-hairline) solid color-mix(in srgb, var(--bot-brand-color, var(--bot-brand-default)) 14%, transparent);
     padding: var(--space-4) var(--space-4);
   }
 .settingsBotHero[data-support="planned"] {
@@ -222,7 +222,7 @@
   }
 .settingsBotStatusGrid div {
     min-height: 52px;
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     padding: var(--space-2-5) var(--space-3);
@@ -244,7 +244,7 @@
     word-break: break-word;
   }
 .settingsBotReason {
-    border-left: 2px solid var(--focus-ring);
+    border-left: var(--border-width-thick) solid var(--focus-ring);
     color: var(--foreground-secondary);
     font-size: var(--font-size-ui);
     line-height: var(--leading-normal);
@@ -378,7 +378,7 @@
   width: 100%;
   border-collapse: collapse;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   font-size: var(--font-size-caption);
 }
@@ -386,7 +386,7 @@
 .settingsStatsTable th,
 .settingsStatsTable td {
   font-variant-numeric: tabular-nums;
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
   color: var(--foreground-secondary);
   padding: var(--space-1) var(--space-2);
   text-align: left;
@@ -426,7 +426,7 @@
   gap: var(--space-4);
   padding: var(--space-4) var(--space-5);
   border: 0;
-  border-bottom: 1px solid oklch(from var(--foreground) l c h / 0.06);
+  border-bottom: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   border-radius: 0;
   background: transparent;
   transition: background var(--duration-base) var(--ease-out-strong);
@@ -449,7 +449,7 @@
 .settingsRows {
   display: grid;
   gap: 0;
-  border: 1px solid oklch(from var(--foreground) l c h / 0.08);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.08);
   border-radius: var(--radius-surface);
   overflow: hidden;
 }

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -344,7 +344,7 @@
 .settingsSegmented button[data-pressed] {
   background: var(--background);
   color: var(--foreground);
-  box-shadow: 0 1px 2px oklch(0 0 0 / 0.08);
+  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.08);
 }
 
 .settingsUsageSummary {

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -4,7 +4,7 @@
     gap: var(--space-1-5);
     padding: var(--space-3) var(--space-3);
     border-radius: var(--radius-surface);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     background: var(--foreground-2);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
   }
@@ -72,7 +72,7 @@
     width: 100%;
     padding: var(--space-2);
     border-radius: var(--radius-control);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     background: var(--background);
     color: var(--foreground);
     font-family: var(--font-mono);
@@ -169,7 +169,7 @@
     justify-content: space-between;
     gap: var(--space-3);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px solid var(--border);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
@@ -261,7 +261,7 @@
     color: var(--foreground-secondary);
   }
 .settingsAuthActionPill[data-kind="preview"] {
-    border: 1px dashed oklch(from var(--info) l c h / 0.30);
+    border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.30);
   }
 /* PR-SETTINGS-GROUPED-CARD-0: rows flush inside outer card, hairline
      divider, last-child no border. Matches the reference grouped-list
@@ -304,7 +304,7 @@
        as orphaned fragments. A hairline + breathing room marks it as
        the editor's status footnote (divider over a nested card). */
     padding: var(--space-1-5) var(--space-0-5) 0;
-    border-top: 1px solid var(--foreground-10);
+    border-top: var(--border-width-hairline) solid var(--foreground-10);
   }
 .settingsMemoryPath {
     /* The component already shortens the path for display

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -6,7 +6,7 @@
     border-radius: var(--radius-surface);
     border: var(--border-width-hairline) solid var(--border);
     background: var(--foreground-2);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+    box-shadow: 0 1px 3px oklch(from var(--foreground) l c h / 0.03);
   }
 .settingsConnectionRow[data-status="verified"] {
     border-color: oklch(from var(--success) l c h / 0.24);
@@ -172,7 +172,7 @@
     border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+    box-shadow: 0 1px 3px oklch(from var(--foreground) l c h / 0.03);
   }
 .settingsAuthContractText {
     display: grid;

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -144,7 +144,7 @@
   box-shadow:
     var(--card-shadow),
     var(--card-highlight),
-    0 28px 64px oklch(0 0 0 / 0.10);
+    0 28px 64px oklch(from var(--foreground) l c h / 0.10);
   opacity: 1;
 }
 

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -7,7 +7,7 @@
   line-height: var(--leading-snug);
   color: var(--warning-text);
   background: oklch(from var(--warning) l c h / 0.10);
-  border: 1px solid oklch(from var(--warning) l c h / 0.20);
+  border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.20);
 }
 
 .maka-permission-stale-note[data-status="expired"] {
@@ -49,7 +49,7 @@
 }
 
 .maka-permission-raw {
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--foreground-2);
 }
@@ -86,7 +86,7 @@
 }
 
 .maka-permission-raw[open] > summary {
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
 .maka-permission-raw .maka-code {
@@ -138,7 +138,7 @@
   min-width: min(760px, calc(100vw - 64px));
   min-height: 520px;
   overflow: hidden;
-  border: 1px solid var(--card-border-color);
+  border: var(--border-width-hairline) solid var(--card-border-color);
   border-radius: var(--radius-modal);
   background: var(--card-bg);
   box-shadow:

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -11,7 +11,7 @@
 }
 
 .enabledProvider + .enabledProvider {
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.06);
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
 }
 
 .enabledProviderHead { margin: 0; }
@@ -95,7 +95,7 @@
 
 .enabledProviderPanel {
   background: oklch(from var(--foreground) l c h / 0.02);
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.07);
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
 }
 
 .enabledProviderPanel ul {
@@ -105,7 +105,7 @@
 }
 
 .enabledProviderPanel li + li .enabledConnRow {
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.07);
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
 }
 
 .enabledConnRow[data-default="true"] {
@@ -158,7 +158,7 @@
 
 .providerMarketGrid .providerCatalogRow + .providerCatalogRow,
 .providerOAuthGrid .providerCatalogRow + .providerCatalogRow {
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.06);
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
 }
 
 /* Logo plates match the enabled list (compact 32px) so the page reads as
@@ -231,14 +231,14 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
   padding-top: var(--space-3);
 }
 
 .customProviderEntry button {
   flex: 0 0 auto;
   min-height: 36px;
-  border: 1px dashed oklch(from var(--link) l c h / 0.34);
+  border: var(--border-width-hairline) dashed oklch(from var(--link) l c h / 0.34);
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--link);
@@ -263,7 +263,7 @@
   width: min(430px, 100%);
   min-height: 100%;
   overflow: auto;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-modal);
   background: var(--background);
   box-shadow: 0 18px 46px oklch(0 0 0 / 0.14);
@@ -315,7 +315,7 @@
   width: 520px;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid var(--border);
+  border-left: var(--border-width-hairline) solid var(--border);
   background: var(--background);
   overflow: hidden;
   min-width: 0;
@@ -327,7 +327,7 @@
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-1-5) var(--space-2);
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
 .maka-browser-navbtn {
@@ -337,7 +337,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid transparent;
+  border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground);
@@ -359,7 +359,7 @@
   min-width: 0;
   height: 26px;
   padding: 0 var(--space-2-5);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--surface, var(--background));
   color: var(--foreground);
@@ -391,7 +391,7 @@
      40% of its own rows (#443). minmax(auto,40%) is wrong too: the
      maximize-tracks step inflates it to the full 40% even for one row. */
   grid-template-rows: auto fit-content(40%) minmax(0, 1fr) auto;
-  border-left: 1px solid var(--border);
+  border-left: var(--border-width-hairline) solid var(--border);
   background: var(--background);
   overflow: hidden;
 }
@@ -406,7 +406,7 @@
   align-items: center;
   gap: var(--space-1-5);
   padding: var(--space-1) var(--space-2);
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
   min-height: 28px;
 }
 
@@ -465,7 +465,7 @@
   align-items: start;
   margin: var(--space-2);
   padding: var(--space-2);
-  border: 1px solid oklch(from var(--warning) l c h / 0.28);
+  border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.28);
   border-radius: var(--radius-surface);
   background: oklch(from var(--warning) l c h / 0.08);
   color: var(--foreground);
@@ -495,7 +495,7 @@
   gap: var(--space-1);
   min-height: 26px;
   padding: 0 var(--space-2);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground);
@@ -530,7 +530,7 @@
   margin: 0;
   padding: var(--space-1) var(--space-1) 0;
   overflow-y: auto;
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
   /* No max-height here: a percentage on the item resolves against the
      auto grid track's own content height (Chromium), which crushed the
      list to 40% of ITSELF — a single-file list showed only ~12px of
@@ -550,7 +550,7 @@
   gap: var(--space-1-5);
   padding: var(--space-1) var(--space-1-5);
   margin: 0;
-  border: 1px solid transparent;
+  border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground);
@@ -661,7 +661,7 @@
 .maka-artifact-preview-html-iframe {
   width: 100%;
   height: 100%;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: white;
   /* iframe sandbox attribute on the JSX side carries the real boundary;
@@ -674,7 +674,7 @@
   border-radius: var(--radius-control);
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
-  border: 1px solid oklch(from var(--info) l c h / 0.20);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.20);
 }
 
 .maka-artifact-preview-image {
@@ -694,7 +694,7 @@
   max-height: 100%;
   object-fit: contain;
   border-radius: var(--radius-control);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   background: var(--foreground-3);
 }
 
@@ -708,7 +708,7 @@
   gap: var(--space-3);
   padding: var(--space-4) var(--space-4);
   border-radius: var(--radius-surface);
-  border: 1px dashed oklch(from var(--info) l c h / 0.32);
+  border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.32);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-secondary);
 }
@@ -759,7 +759,7 @@
 }
 
 .maka-artifact-preview-pdf embed {
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: white;
   min-height: 240px;
@@ -791,7 +791,7 @@
   gap: var(--space-1-5);
   padding: var(--space-2-5) var(--space-3);
   border-radius: var(--radius-surface);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   font-size: var(--font-size-ui);
 }
 
@@ -824,7 +824,7 @@
   gap: var(--space-1-5);
   padding: var(--space-2) var(--space-2-5);
   border: 0;
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
   border-radius: 0;
   background: var(--background);
   box-shadow: none;
@@ -859,7 +859,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   background: var(--background);
   color: var(--foreground);
   border-radius: var(--radius-control);
@@ -926,7 +926,7 @@
     max-height: min(42dvh, 360px);
     grid-template-rows: auto minmax(82px, 0.8fr) minmax(0, 1fr) auto;
     border-left: 0;
-    border-top: 1px solid var(--border);
+    border-top: var(--border-width-hairline) solid var(--border);
     box-shadow: 0 -8px 24px oklch(0 0 0 / 0.08);
   }
 
@@ -987,7 +987,7 @@
   padding: var(--space-0-5) var(--space-2);
   margin: var(--space-1-5) var(--space-3) var(--space-1);
   border-radius: var(--radius-pill);
-  border: 1px solid oklch(from var(--info) l c h / 0.20);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.20);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--info-text);
   font-size: var(--font-size-caption);

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -266,7 +266,7 @@
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-modal);
   background: var(--background);
-  box-shadow: 0 18px 46px oklch(0 0 0 / 0.14);
+  box-shadow: 0 18px 46px oklch(from var(--foreground) l c h / 0.14);
   padding: var(--space-4);
 }
 
@@ -927,7 +927,7 @@
     grid-template-rows: auto minmax(82px, 0.8fr) minmax(0, 1fr) auto;
     border-left: 0;
     border-top: var(--border-width-hairline) solid var(--border);
-    box-shadow: 0 -8px 24px oklch(0 0 0 / 0.08);
+    box-shadow: 0 -8px 24px oklch(from var(--foreground) l c h / 0.08);
   }
 
   .maka-artifact-pane[data-collapsed="true"] {

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -257,7 +257,7 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  border: 1px dashed oklch(from var(--info) l c h / 0.32);
+  border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.32);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-secondary);
@@ -285,7 +285,7 @@
   align-items: start;
   gap: var(--space-2-5);
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--foreground-3);
 }
@@ -599,7 +599,7 @@
   gap: var(--space-5);
   padding: var(--space-5) var(--space-6);
   border: 0;
-  border-bottom: 1px solid oklch(from var(--foreground) l c h / 0.06);
+  border-bottom: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   border-radius: 0;
   background: transparent;
   transition: background var(--duration-base) var(--ease-out-strong);
@@ -762,7 +762,7 @@
   row-gap: var(--space-0-5);
   align-items: center;
   padding: var(--space-3) 0;
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 .settingsField[data-orient="horizontal"] > span {
   grid-area: label;

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -31,8 +31,8 @@
      rhythm. Match `.settingsNavItem` exactly so the row reads as part
      of the same vertical list. */
   width: calc(100% - 8px);
-  height: 38px;
-  min-height: 38px;
+  height: var(--h-control-xl);
+  min-height: var(--h-control-xl);
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -126,8 +126,8 @@
      ran 12px short. Switched to flex — glyph is fixed-width, label
      fills, badge sits right-aligned naturally. No phantom gap. */
   width: calc(100% - 8px);
-  height: 38px;
-  min-height: 38px;
+  height: var(--h-control-xl);
+  min-height: var(--h-control-xl);
   display: flex;
   align-items: center;
   gap: var(--space-3);

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -229,7 +229,7 @@
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--foreground-2);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+  box-shadow: 0 1px 3px oklch(from var(--foreground) l c h / 0.03);
 }
 
 .modelTableHeader {

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -22,7 +22,7 @@
   min-height: 38px;
   display: grid;
   gap: var(--space-0-5);
-  border: 1px solid transparent;
+  border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-surface);
   background: var(--foreground-3);
   color: var(--foreground);
@@ -111,7 +111,7 @@
 .providerUnavailableNotice {
   display: grid;
   gap: var(--space-1);
-  border: 1px solid oklch(from var(--info) l c h / 0.22);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.22);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.10);
   color: var(--info-text);
@@ -151,7 +151,7 @@
 .providerEditor select {
   min-width: 0;
   min-height: 36px;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   /* PR-UI-LAYOUT-22: provider editor inputs (used in the
    * ConfigureProvider sheet) brought up to the LAYOUT-11/21 focus
    * ring family. Was: radius 6 + border-only focus.
@@ -226,7 +226,7 @@
   grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2);
   padding: var(--space-3);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--foreground-2);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
@@ -273,7 +273,7 @@
 .modelTableSearch {
   width: 100%;
   padding: var(--space-1-5) var(--space-3);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--foreground);
@@ -307,7 +307,7 @@
   text-align: left;
   padding: var(--space-1-5) var(--space-3);
   border-radius: var(--radius-surface);
-  border: 1px solid oklch(from var(--focus-ring) l c h / 0.22);
+  border: var(--border-width-hairline) solid oklch(from var(--focus-ring) l c h / 0.22);
   background: oklch(from var(--focus-ring) l c h / 0.06);
   color: var(--foreground);
   font-size: var(--font-size-caption);
@@ -343,7 +343,7 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-2-5);
-  border: 1px solid transparent;
+  border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-surface);
   background: transparent;
   color: var(--foreground);
@@ -381,7 +381,7 @@
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  border: 1.5px solid var(--muted-foreground);
+  border: var(--border-width-hairline) solid var(--muted-foreground);
   background: transparent;
   position: relative;
 }
@@ -544,7 +544,7 @@
   padding-right: var(--space-1);
 }
 .providerOAuthError {
-  border: 1px solid color-mix(in srgb, var(--warning) 32%, transparent);
+  border: var(--border-width-hairline) solid color-mix(in srgb, var(--warning) 32%, transparent);
   border-radius: var(--radius-surface);
   background: color-mix(in srgb, var(--warning) 10%, var(--background));
   color: var(--warning-text);
@@ -614,7 +614,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--space-1-5);
-  border: 1px solid var(--border-subtle);
+  border: var(--border-width-hairline) solid var(--border-subtle);
   border-radius: var(--radius-control);
   background: var(--background-elevated);
   color: var(--foreground);

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -584,8 +584,8 @@
   border-radius: var(--radius-modal);
   background: var(--background);
   box-shadow:
-    0 24px 58px oklch(0 0 0 / 0.18),
-    0 8px 18px oklch(0 0 0 / 0.10);
+    0 24px 58px oklch(from var(--foreground) l c h / 0.18),
+    0 8px 18px oklch(from var(--foreground) l c h / 0.10);
   padding: var(--space-4);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -11,7 +11,7 @@
 .settingsUsageFilters select {
   min-width: 0;
   min-height: 34px;
-  border: 1px solid oklch(from var(--foreground) l c h / 0.12);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.12);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground);
@@ -140,7 +140,7 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-4);
-  border: 1px solid oklch(from var(--success) l c h / 0.24);
+  border: var(--border-width-hairline) solid oklch(from var(--success) l c h / 0.24);
   border-radius: var(--radius-surface);
   background: oklch(from var(--success) l c h / 0.04);
 }
@@ -183,7 +183,7 @@
   height: auto;
   min-height: 48px;
   justify-content: stretch;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background-elevated);
   color: var(--foreground);
@@ -210,13 +210,13 @@
   aspect-ratio: 16 / 8;
   border-radius: var(--radius-surface);
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   display: flex;
   background: var(--foreground-5);
 }
 
 .settingsThemePreviewSplit > .settingsThemePreviewPane:first-child {
-  border-right: 1px solid var(--border);
+  border-right: var(--border-width-hairline) solid var(--border);
 }
 
 .settingsThemePreviewPane {
@@ -244,12 +244,12 @@
 
 .settingsThemePreviewPane[data-mode="light"] .settingsThemePreviewSidebar {
   background: oklch(0.955 0 0);
-  border-right: 1px solid oklch(0.88 0 0);
+  border-right: var(--border-width-hairline) solid oklch(0.88 0 0);
 }
 
 .settingsThemePreviewPane[data-mode="dark"] .settingsThemePreviewSidebar {
   background: oklch(0.13 0 0);
-  border-right: 1px solid oklch(0.26 0 0);
+  border-right: var(--border-width-hairline) solid oklch(0.26 0 0);
 }
 
 .settingsThemePreviewChat {
@@ -315,7 +315,7 @@
   width: 34px;
   height: 34px;
   border-radius: 50%;
-  border: 2px solid var(--border);
+  border: var(--border-width-thick) solid var(--border);
   box-shadow: inset 0 0 0 2px oklch(1 0 0 / 0.25);
   /* Fallback in case a swatch name has no per-palette rule below
      (e.g. a new palette landed in `THEME_PALETTES` but its swatch
@@ -420,7 +420,7 @@
   min-width: 110px;
   min-height: 36px;
   padding: 0 var(--space-6);
-  border: 1px solid oklch(from var(--accent) l c h / 0.45);
+  border: var(--border-width-hairline) solid oklch(from var(--accent) l c h / 0.45);
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--accent);
@@ -459,7 +459,7 @@
   padding: var(--space-2-5) var(--space-3);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.10);
-  border: 1px solid oklch(from var(--info) l c h / 0.18);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.18);
   color: var(--info-text);
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
@@ -475,7 +475,7 @@
    compact dialog centered above the backdrop with the QR + status. */
 .settingsBotScanLoginModal {
   background: var(--background);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-modal);
   padding: var(--space-3) var(--space-4);
   width: min(320px, 92vw);
@@ -507,7 +507,7 @@
   border-radius: var(--radius-surface);
   background: white;
   padding: var(--space-2);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   object-fit: contain;
 }
 .settingsBotScanLoginQrPlaceholder {
@@ -517,7 +517,7 @@
   place-items: center;
   border-radius: var(--radius-surface);
   background: var(--foreground-5);
-  border: 1px dashed var(--border);
+  border: var(--border-width-hairline) dashed var(--border);
   color: var(--muted-foreground);
   font-size: 1.6em;
 }
@@ -562,7 +562,7 @@
   flex-direction: column;
   gap: var(--space-3);
   padding-left: var(--space-3);
-  border-left: 2px solid var(--border);
+  border-left: var(--border-width-thick) solid var(--border);
 }
 
 .settingsWechatQrBackdrop {
@@ -580,7 +580,7 @@
   width: min(360px, calc(100vw - 40px));
   display: grid;
   gap: var(--space-4);
-  border: 1px solid color-mix(in srgb, #07C160 18%, var(--border));
+  border: var(--border-width-hairline) solid color-mix(in srgb, #07C160 18%, var(--border));
   border-radius: var(--radius-modal);
   background: var(--background);
   box-shadow:
@@ -643,7 +643,7 @@
   height: 224px;
   display: grid;
   place-items: center;
-  border: 1px solid color-mix(in srgb, #07C160 20%, var(--border));
+  border: var(--border-width-hairline) solid color-mix(in srgb, #07C160 20%, var(--border));
   border-radius: var(--radius-surface);
   background: white;
   padding: var(--space-3);
@@ -663,7 +663,7 @@
   place-items: center;
   align-content: center;
   gap: var(--space-2-5);
-  border: 1px dashed var(--border);
+  border: var(--border-width-hairline) dashed var(--border);
   border-radius: var(--radius-surface);
   background: var(--foreground-3);
   color: var(--foreground-secondary);
@@ -697,7 +697,7 @@
 
 .settingsWechatQrSecondary {
   min-height: 30px;
-  border: 1px solid oklch(from var(--accent) l c h / 0.34);
+  border: var(--border-width-hairline) solid oklch(from var(--accent) l c h / 0.34);
   border-radius: var(--radius-surface);
   background: var(--background);
   color: var(--accent);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -196,8 +196,6 @@
 }
 
 .mainColumn {
-  /* local: chat content max measure */
-  --maka-chat-measure: 680px;
   min-width: 0;
   min-height: 0;
   height: 100%;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -321,8 +321,8 @@
   color: var(--foreground);
 }
 .maka-search-modal-close {
-  width: 22px;
-  height: 22px;
+  width: var(--h-control-sm);
+  height: var(--h-control-sm);
   border: 0;
   background: transparent;
   color: var(--foreground-secondary);
@@ -370,8 +370,8 @@
   display: none;
 }
 .maka-search-modal-clear {
-  width: 22px;
-  height: 22px;
+  width: var(--h-control-sm);
+  height: var(--h-control-sm);
   border-radius: var(--radius-control);
   color: var(--muted-foreground);
 }
@@ -724,7 +724,7 @@
 .maka-list-row {
   position: relative;
   width: 100%;
-  min-height: 30px;
+  min-height: var(--h-control-lg);
   display: flex;
   align-items: stretch;
   border: 0;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -312,7 +312,7 @@
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   padding: var(--space-2) var(--space-3) var(--space-1-5);
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 .maka-search-modal-title {
   margin: 0;
@@ -386,7 +386,7 @@
 
 .maka-search-modal-body {
   display: block;
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
   padding: var(--space-2-5) var(--space-2-5) var(--space-3);
   min-height: 180px;
   max-height: calc(70vh - 110px);
@@ -685,7 +685,7 @@
 .maka-list-group + .maka-list-group {
   margin-top: var(--space-2-5);
   padding-top: var(--space-2);
-  border-top: 1px solid oklch(from var(--foreground) l c h / 0.05);
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.05);
 }
 
 /* Group label — section header for session groups. Weight-based
@@ -861,7 +861,7 @@
   font-weight: var(--font-weight-semibold);
   outline: 0;
   padding: 1px 0;
-  border-bottom: 1px solid oklch(from var(--focus-ring) l c h / 0.4);
+  border-bottom: var(--border-width-hairline) solid oklch(from var(--focus-ring) l c h / 0.4);
 }
 
 .maka-list-row-rename-input:focus {
@@ -910,7 +910,7 @@
    * less card-like. Border drops to hairline `--border`,
    * background to transparent (inherits warm panel bg); hover uses
    * neutral `--state-hover-bg` + `--border-strong` (no brand tint). */
-  border: 1px solid var(--foreground-8);
+  border: var(--border-width-hairline) solid var(--foreground-8);
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground);
@@ -958,7 +958,7 @@
 
 .maka-deep-research-workflow li {
   min-width: 0;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: oklch(from var(--focus-ring) l c h / 0.035);
   padding: var(--space-2-5);
@@ -986,7 +986,7 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-3) 0 0;
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width-hairline) solid var(--border);
 }
 
 .maka-deep-research-report h2,

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -138,7 +138,7 @@ html[data-os="darwin"] .maka-session-panel-footer {
        `5d3b10e5`). The 50% glass base on the panel already provides
        material depth; the footer only needs a hairline border-top
        to separate it from the scroll area. No gradient. No seam. */
-    border-top: 1px solid oklch(from var(--foreground) l c h / 0.05);
+    border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.05);
     background: oklch(from var(--surface-canvas) l c h / 0.15);
   }
 

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -76,8 +76,8 @@
 
 .composer .maka-composer-inner {
   position: relative;
-  width: min(var(--maka-chat-measure, 680px), 100%);
-  max-width: var(--maka-chat-measure, 680px);
+  width: min(var(--maka-chat-measure), 100%);
+  max-width: var(--maka-chat-measure);
   margin-inline: auto;
   box-sizing: border-box;
   /* Composer outer chrome uses the universal page-card recipe (atlas §4

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -84,7 +84,7 @@
      + maka-tokens.css --card-*) at the 12px workspace-plate ceiling.
      The composer reads as a hero card, but radius must still stay within
      the shared chrome vocabulary locked by radius-converge-contract. */
-  border: 1px solid var(--card-border-color);
+  border: var(--border-width-hairline) solid var(--card-border-color);
   border-radius: var(--radius-modal);
   padding: var(--space-2-5) var(--space-3) var(--space-2);
   background: var(--card-bg);
@@ -144,7 +144,7 @@
   font-size: var(--font-size-caption);
   padding: 1px var(--space-1);
   background: var(--foreground-3);
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
 }
 
 .composerActions {
@@ -194,7 +194,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  border: 1px solid var(--color-border-tertiary);
+  border: var(--border-width-hairline) solid var(--color-border-tertiary);
   border-radius: var(--radius-pill);
   padding: 0 var(--space-2);
   background: oklch(from var(--background) l c h / 0.82);
@@ -352,7 +352,7 @@
 .maka-composer-context-plus {
   width: 26px;
   height: 26px;
-  border: 1px solid color-mix(in oklch, var(--foreground) 20%, var(--background));
+  border: var(--border-width-hairline) solid color-mix(in oklch, var(--foreground) 20%, var(--background));
   border-radius: var(--radius-pill);
   background: transparent;
 }

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -60,7 +60,7 @@
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -127,7 +127,7 @@
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -151,7 +151,7 @@
     display: grid;
     gap: var(--space-2);
     padding: var(--space-3);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -196,7 +196,7 @@
     margin: 0;
     padding: var(--space-2-5);
     overflow: auto;
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-control);
     background: var(--background);
     color: var(--foreground-secondary);
@@ -216,7 +216,7 @@
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid oklch(from var(--warning) l c h / 0.34);
+    border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.34);
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning) l c h / 0.08);
   }
@@ -233,7 +233,7 @@
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px solid oklch(from var(--success) l c h / 0.28);
+    border: var(--border-width-hairline) solid oklch(from var(--success) l c h / 0.28);
     border-radius: var(--radius-surface);
     background: oklch(from var(--success) l c h / 0.08);
   }
@@ -259,7 +259,7 @@
     display: grid;
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -294,7 +294,7 @@
     align-items: center;
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-1-5);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-pill);
     background: var(--background);
     color: var(--foreground-secondary);
@@ -333,7 +333,7 @@
 .settingsMemoryEntryDraftNotice {
     margin: 0;
     padding: var(--space-1-5) var(--space-2);
-    border: 1px solid oklch(from var(--warning) l c h / 0.30);
+    border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.30);
     border-radius: var(--radius-surface);
     background: oklch(from var(--warning) l c h / 0.08);
     color: var(--foreground-secondary);
@@ -351,7 +351,7 @@
     padding: 0;
     display: grid;
     gap: 0;
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     overflow: hidden;
     background: var(--foreground-2);
@@ -366,7 +366,7 @@
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-3);
-    border-bottom: 1px solid var(--foreground-8);
+    border-bottom: var(--border-width-hairline) solid var(--foreground-8);
   }
 
 /* PR-MEMORY-ENTRY-DIVIDER-FIX-0 (WAWQAQ msg `610c0e5a`): after
@@ -404,7 +404,7 @@
     width: max-content;
     max-width: 100%;
     padding: var(--space-0-5) var(--space-1-5);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-control);
     background: var(--foreground-5);
     color: var(--foreground-secondary);
@@ -447,7 +447,7 @@
 
 .settingsMemoryFilter input {
   width: 100%;
-  border: 1px solid var(--foreground-10);
+  border: var(--border-width-hairline) solid var(--foreground-10);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground);
@@ -472,7 +472,7 @@
     display: grid;
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
-    border: 1px solid var(--foreground-10);
+    border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
     background: var(--foreground-3);
   }
@@ -494,7 +494,7 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid var(--foreground-10);
+  border: var(--border-width-hairline) solid var(--foreground-10);
   border-radius: var(--radius-surface);
   background: var(--foreground-2);
 }
@@ -522,7 +522,7 @@
 .settingsMemoryManualAddGrid input,
 .settingsMemoryManualAddGrid textarea {
   width: 100%;
-  border: 1px solid var(--foreground-10);
+  border: var(--border-width-hairline) solid var(--foreground-10);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--foreground);
@@ -546,7 +546,7 @@
   display: grid;
   gap: var(--space-1);
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid oklch(from var(--warning) l c h / 0.38);
+  border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.38);
   border-radius: var(--radius-surface);
   background: oklch(from var(--warning) l c h / 0.09);
 }
@@ -577,7 +577,7 @@
   width: 100%;
   min-height: 220px;
   resize: vertical;
-  border: 1px solid var(--border);
+  border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   padding: var(--space-4);
   background: var(--background-elevated, var(--background));
@@ -625,7 +625,7 @@
   }
 .maka-first-run-checklist {
     width: min(760px, 100%);
-    border: 1px solid oklch(from var(--foreground) l c h / 0.07);
+    border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
     border-radius: var(--radius-surface);
     padding: var(--space-3);
     background: oklch(from var(--background-elevated, var(--background)) l c h / 0.58);
@@ -657,7 +657,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-2);
-  border: 1px solid oklch(from var(--warning, var(--info)) l c h / 0.28);
+  border: var(--border-width-hairline) solid oklch(from var(--warning, var(--info)) l c h / 0.28);
   border-radius: var(--radius-surface);
   background: oklch(from var(--warning, var(--info)) l c h / 0.08);
   color: var(--warning-text, var(--info-text));
@@ -674,7 +674,7 @@
   height: auto;
   min-height: var(--h-control-sm);
   padding: 0 var(--space-2);
-  border: 1px solid oklch(from var(--warning, var(--info)) l c h / 0.28);
+  border: var(--border-width-hairline) solid oklch(from var(--warning, var(--info)) l c h / 0.28);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--warning-text, var(--info-text));
@@ -708,7 +708,7 @@
   height: auto;
   min-height: var(--h-control-xl);
   background: var(--background);
-  border: 1px solid oklch(from var(--foreground) l c h / 0.07);
+  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
   border-radius: var(--radius-control);
   padding: var(--space-1-5) var(--space-2-5) var(--space-1-5) var(--space-2);
   display: inline-grid;

--- a/apps/desktop/src/renderer/styles/tool-stream.css
+++ b/apps/desktop/src/renderer/styles/tool-stream.css
@@ -672,7 +672,7 @@
   flex: 0 0 auto;
   gap: var(--space-1);
   height: auto;
-  min-height: 24px;
+  min-height: var(--h-control-sm);
   padding: 0 var(--space-2);
   border: 1px solid oklch(from var(--warning, var(--info)) l c h / 0.28);
   border-radius: var(--radius-control);
@@ -706,7 +706,7 @@
 
 .maka-first-run-checklist-row > button {
   height: auto;
-  min-height: 38px;
+  min-height: var(--h-control-xl);
   background: var(--background);
   border: 1px solid oklch(from var(--foreground) l c h / 0.07);
   border-radius: var(--radius-control);

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -473,7 +473,7 @@ export const Composer = forwardRef<
           ref={textareaRef}
           unstyled
           name="text"
-          className="maka-composer-textarea min-h-[44px] resize-none"
+          className="maka-composer-textarea min-h-11 resize-none"
           placeholder={copy.placeholder}
           aria-label={copy.textareaAriaLabel}
           disabled={props.disabled}

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -309,7 +309,7 @@ const streamVariants = cva("", {
       // `word-break:break-word` stays an arbitrary literal (Tailwind's
       // `break-words` is `overflow-wrap`, a different property).
       body:
-        "m-0 max-h-[220px] overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-[0.78rem] leading-[1.5] bg-[var(--background)] text-[color:var(--foreground-secondary)] [scroll-behavior:auto]",
+        "m-0 max-h-55 overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-[0.78rem] leading-[1.5] bg-[var(--background)] text-[color:var(--foreground-secondary)] [scroll-behavior:auto]",
       // `.maka-tool-output-stream-chunk` (`display:contents`; recolors stderr,
       // dims redacted). The call site keeps `data-stream` / `data-redacted`.
       chunk:
@@ -540,7 +540,7 @@ const previewVariants = cva("", {
         "mt-1 mx-0 mb-0 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-[10px] [white-space:pre-wrap] [word-break:break-word]",
       // `.maka-overlay-close` — the dismiss action (layered over `.maka-button`).
       close:
-        "justify-self-end inline-flex items-center gap-1 min-h-[22px] px-1.5",
+        "justify-self-end inline-flex items-center gap-1 min-h-6 px-1.5",
 
       // ── file diff (shared with apps/desktop artifact-preview) ─────────────
       // `.maka-tool-diff` — the card shell. `[white-space:normal]` overrides the
@@ -553,7 +553,7 @@ const previewVariants = cva("", {
         + " [&_code]:text-[color:var(--foreground-secondary)] [&_code]:bg-transparent",
       // `.maka-tool-diff-body` — the scrolling mono `<pre>`.
       "diff-body":
-        "m-0 px-0 py-1 max-h-[320px] overflow-auto [font-family:var(--font-mono)] text-[11.5px] leading-[1.45] [white-space:pre] [word-break:normal]",
+        "m-0 px-0 py-1 max-h-80 overflow-auto [font-family:var(--font-mono)] text-[11.5px] leading-[1.45] [white-space:pre] [word-break:normal]",
       // `.maka-tool-diff-line` (+ the `[data-line]` add/del/hunk/meta/ctx tints).
       "diff-line":
         "block px-2 py-0 [white-space:pre]"
@@ -616,7 +616,7 @@ const previewVariants = cva("", {
         "m-0 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-[12px] italic",
       // `.maka-office-document-stream` (+ the `[data-stream=stderr]` tone).
       "office-stream":
-        "m-0 px-2.5 py-2 max-h-[200px] overflow-auto [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-control)] bg-[var(--background)] [font-family:var(--font-mono)] text-[12.5px] [white-space:pre-wrap] [word-break:break-word]"
+        "m-0 px-2.5 py-2 max-h-50 overflow-auto [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-control)] bg-[var(--background)] [font-family:var(--font-mono)] text-[12.5px] [white-space:pre-wrap] [word-break:break-word]"
         + " data-[stream=stderr]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)] data-[stream=stderr]:text-[color:var(--destructive)]",
 
       // ── explore agent / subagent (shared shell) ───────────────────────────
@@ -666,7 +666,7 @@ const previewVariants = cva("", {
         "flex items-center justify-between gap-2 min-w-0 [&>strong]:min-w-0 [&>strong]:text-[12px] [&>strong]:text-[color:var(--foreground)]",
       // `.maka-explore-agent-copy` (UiButton) + the copied / shared copy-state tints.
       "agent-copy":
-        "[flex:0_0_auto] gap-1 min-h-[24px] px-2 py-0.5 text-[11px]"
+        "[flex:0_0_auto] gap-1 min-h-6 px-2 py-0.5 text-[11px]"
         + " data-[copied=true]:text-[color:var(--link)] data-[copied=true]:[border-color:oklch(from_var(--link)_l_c_h_/_0.35)]"
         + " data-[pending=true]:cursor-progress"
         + " data-[copy-error=true]:text-[color:var(--destructive)] data-[copy-error=true]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.35)]",

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -24,7 +24,7 @@ import { cva } from 'class-variance-authority';
 
 const rowActionVariants = cva(
   [
-    'grid h-[26px] w-[26px] place-items-center rounded-sm border-0 bg-transparent',
+    'grid h-7 w-7 place-items-center rounded-sm border-0 bg-transparent',
     'text-[var(--foreground-secondary)]',
     'transition-[background-color,color,box-shadow] duration-[var(--duration-quick)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/5 hover:text-foreground',

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -6,7 +6,7 @@ import { cva } from 'class-variance-authority';
 
 const navRowVariants = cva(
   [
-    'min-h-[30px] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
+    'min-h-8 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
     'text-left text-sm leading-[1.43] text-[var(--foreground-secondary)]',
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/6 hover:text-foreground',


### PR DESCRIPTION
## Summary

PR4 of #520 — converges the layout-surface & sizing dimensions onto tokens + contracts, using the same converge-contract pattern as PR1 (#526) and PR3 (#527). Five items, one commit each (each independently revertible), plus one commit fixing two pre-existing test regressions from PR3, and five follow-up commits addressing review feedback (reference-chain DFS, mapped-prop completeness, triangle-caret selector allowlist, contract/comment consistency).

The user's "碍眼" — sidebar / 会话 / 设置 control-height inconsistency — is item 15 (control heights), done first.

## New tokens (`maka-tokens.css`)

| Token | Value | Item |
|-------|-------|------|
| `--h-control-xs/sm/md/lg/xl/2xl` | xs/sm/lg/2xl = `var(--space-5/6/8/10)`, md/xl = `calc(var(--spacing) * 7/9)` (7 and 9 aren't in maka's discrete spacing scale) = 20/24/28/32/36/40px | 15 — control-height scale (on the 4px spacing ruler, shared with Tailwind `h-N`) |
| `--border-width-hairline/thick/accent` | `1px / 2px / 3px` | 14 — border stroke weight |
| `--maka-chat-measure` | `680px` (promoted to `:root` from a local `.mainColumn` token) | 16 — chat content measure |

No `@theme inline` bridge this PR: control height is numeric Tailwind (`h-N`), border-width is static (`border` = 1px), and breakpoints can't use `var()` in `@media` (parse-time evaluation) — see item 16.

## Convergence

- **item 15 — control heights**: 14 CSS control selectors (sidebar nav row, session row, settings nav/back/select, model switcher, composer send, jump-bottom FAB, palette input, first-run checklist rows) snap off-ruler 22/26/30/34/38px onto `--h-control-*`; TSX arbitrary `h-[Npx]`/`min-h-[Npx]`/`max-h-[Npx]` convert to the Tailwind ruler scale (`min-h-8`, `min-h-11`, `max-h-55`, …). The #332 chat-marker/preview contracts deliberately pin `min-h-[28px]` / `max-h-[180px]` as arbitrary literals (a "literalize vehicle" immune to scale re-tuning) — those stay arbitrary and are whitelisted here.
- **item 14 — border width**: 221 `border:` / `border-{side}:` shorthand widths across 25 CSS files → `var(--border-width-*)` (perl with `(?<![-\w])` lookbehind so the token definitions aren't self-referenced). Border-style (`solid`/`dashed`) stays a literal keyword — a named value, not a magic number. CSS-triangle carets (`border-width: 4px 0 4px 5px`) are multi-value geometry, not strokes, so the contract allows them only on allowlisted caret selectors (`TRIANGLE_CARET_SELECTORS`) and flags any bare px — single OR multi-value — elsewhere.
- **item 13 — box-shadow color (P-SHADOW)**: 13 bare pure-black box-shadow usages (`rgba(0,0,0,A)` / `oklch(0 0 0 / A)`) → `oklch(from var(--foreground) l c h / A)`, geometry preserved (only the color warms). The dark-mode recipe overrides in maka-tokens.css intentionally keep pure-black (dark canvas) — those are token defs, not `box-shadow:` usages, so out of scope.
- **item 16 — responsive**: `--maka-chat-measure` promoted to `:root`, 6 redundant `, 680px` fallbacks dropped, onboarding hero adopts the token. `@media` breakpoints can't use `var()`, so a contract whitelists the 8 values in use (620/720/760/820/900/980/990/1100) and bans ad-hoc `Npx`.
- **item 12 — radius nesting**: documents the concentric-radius rule (inner = outer − padding) on the radius tokens; pins the two `calc(var(--radius-modal) - 8px)` nesting sites so they don't regress to a hardcoded tier. Audit confirms settings inner cards + sub-modals already comply via the radius-converge SELECTOR_TIER.

## New contracts

| Contract | Bans | Pins |
|----------|------|------|
| `control-height-converge-contract.test.ts` | bare px height/min-height on 14 curated control selectors (each mapped prop must appear); arbitrary `h-[Npx]`/`min-h-[Npx]`/`max-h-[Npx]` in TSX (whitelist: dots, count badge, 110px scroll cap, two #332 literals) | `--h-control-*` exactly-once → xs/sm/lg/2xl `var(--space-N)`, md/xl `calc(var(--spacing) * N)`; recursive reference-chain closed (undefined ref / cycle throws) |
| `border-width-converge-contract.test.ts` | bare px width in `border:`/`border-{side}:` shorthand; any bare px in `border-width:` longhand (single OR multi-value) unless allowlisted caret selector; non-keyword `border-style:`; arbitrary `border-[Npx]` in TSX | `--border-width-hairline/thick/accent` exactly-once |
| `box-shadow-converge-contract.test.ts` | pure-black color (`oklch(0 0 0/A)`, `rgba(0,0,0,A)`, `#000`, `black`) in `box-shadow:` (multi-line values; token defs not scanned) | `--shadow-*` / `--card-shadow` / `--card-highlight` exist |
| `responsive-breakpoint-contract.test.ts` | `@media (max/min-width: Npx)` outside the 8-value whitelist; bare `680px` in width/max-width/min-width (height caps spared); local `--maka-chat-measure` re-declaration | `--maka-chat-measure: 680px` exactly-once |
| `radius-nesting-contract.test.ts` | radius calc addition (breaks concentricity) | the two `calc(var(--radius-modal) - 8px)` nesting sites |

## Commits

1. `test(desktop): relax exact className match for PR3 min-width additions` — fixes two pre-existing test regressions on `main` (PR3 added `min-w-[Nrem]` to copy/append/save buttons but didn't update the exact-`className="X"` regexes). Unblocks a green baseline for PR4 verification.
2. `refactor(ui): converge control heights onto --h-control-* scale (#520 PR4 item 15)`
3. `refactor(ui): converge border-width onto --border-width-* tokens (#520 PR4 item 14)`
4. `refactor(ui): systematize concentric radius nesting rule (#520 PR4 item 12)`
5. `refactor(ui): converge responsive breakpoints + chat content measure (#520 PR4 item 16)`
6. `refactor(ui): converge box-shadow color onto foreground-derived (P-SHADOW) (#520 PR4 item 13)`

### Review-fix commits

7. `fix(ui): close --h-control-* reference chain + tighten mapped-selector tier check` — P1: `--h-control-md/xl` referenced undefined `--space-7/9`; use `calc(var(--spacing) * 7/9)`. Adds `assertCustomPropRefsDefined` helper. P3: mapped selectors must use exactly their `--h-control-*` tier (no `var(--space-N)` / chrome-token bypass).
8. `fix(ui): ban multi-value bare-px border-width, allowlist triangle carets by selector` — P2: `border-width:` longhand now flags any bare px (single OR multi-value) unless the selector is an allowlisted caret.
9. `fix(test): require every mapped control-height prop to appear, not any one` — P3: `checkSelectorTier` uses `seenProps: Set` so a multi-prop selector missing width / height / min-height is flagged.
10. `docs(test): fix stale SINGLE-only border-width comment to match selector-allowlist impl`.
11. `fix(test): make assertCustomPropRefsDefined a recursive DFS with cycle detection` — P3: the helper now recurses through the whole var() chain (catches undefined 2+ hops down) and detects cycles, not just the first hop.

## Existing test expectations updated

PR3 min-width + this PR's token replacements broke exact-match assertions in 7 existing contracts (renderer-error-boundary, daily-review-copy-feedback, command-palette-a11y-copy, artifact-pane-layout, permissions-unified-card, startup-loading-shell, project-context-badge, settings-form-a11y). Each update preserves the test's intent (semantic class present / geometry / alpha) and only shifts the expected literal to the new token form.

## Verification

- **Tests**: `npm run -w @maka/desktop test` — 1968/1968 pass (was 1935 on `main` + 2 pre-existing failures; this PR fixes the 2 + adds 33 new contract assertions across 5 files, including the recursive reference-chain DFS guard).
- **Typecheck**: `npm run typecheck` — every workspace clean.
- **Screenshots** vs `main` (turn-narrative, settings-appearance, first-run × light/dark, `compare -metric AE -fuzz 2%`):
  - first-run: 0% on items 15/16, +0.00009% on item 14 (onboarding 1.5→1px hairline) — item 13 adds 0.
  - turn-narrative: 0.55–0.62% (the 2px control-height snaps in sidebar/会话/composer).
  - settings-appearance: 1.36% (settings nav rows 38→36, multiple rows; was ~1.6% before the P1 reference-chain fix restored the explicit 36px height on `--h-control-xl`).
  - All diffs are the deliberate 2px control-height snap or the 1.5→1px hairline; no layout-collapse-scale regression. Item 13 (P-SHADOW color) is within the 2% fuzz on light theme (near-black ≈ pure-black at low alpha) — the fix matters on warm/dark shells where pure-black reads as a smudge.

## Deferred / out of scope

- **Full box-shadow recipe-converge**: mapping the ~20 already-foreground-derived elevation shadows onto `var(--shadow-*)` recipes would add the design-system 1px border ring + standardize the blur on each — a visual-weight change to compliant surfaces that needs design review, separate from the P-SHADOW color fix in item 13.
- **`index.html` splash box-shadows**: two pure-black `rgba(0,0,0,…)` shadows live in the pre-render HTML splash (no access to `--foreground`); left for a separate splash pass.
- **scroll-area**: explicitly out of scope per #520 (`overlay-scrollbars-contract.test.ts` locks OverlayScrollbars).

