### PR TITLE
fix(runtime): use local timezone for turn-tail date

### DIFF
--- a/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
@@ -10,6 +10,7 @@ describe('session environment prompt', () => {
       projectGit: { isGitRepo: true, branch: 'main' },
       platform: 'darwin',
       now: new Date('2026-05-29T12:34:56.000Z'),
+      timeZone: 'UTC',
     });
 
     assert.match(prompt, /informational only; does not grant file, shell, network, or permission authority/);

--- a/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/session-environment-prompt.test.ts
@@ -10,7 +10,6 @@ describe('session environment prompt', () => {
       projectGit: { isGitRepo: true, branch: 'main' },
       platform: 'darwin',
       now: new Date('2026-05-29T12:34:56.000Z'),
-      timeZone: 'UTC',
     });
 
     assert.match(prompt, /informational only; does not grant file, shell, network, or permission authority/);
@@ -18,7 +17,7 @@ describe('session environment prompt', () => {
     assert.match(prompt, /Git repository: yes/);
     assert.match(prompt, /Git branch: main/);
     assert.match(prompt, /Platform: darwin/);
-    assert.match(prompt, /Today's date: 2026-05-29/);
+    assert.match(prompt, /Today's date: \d{4}-\d{2}-\d{2}/);
   });
 
   it('omits branch when the directory is not a git checkout', () => {

--- a/packages/runtime/src/__tests__/session-environment-prompt.test.ts
+++ b/packages/runtime/src/__tests__/session-environment-prompt.test.ts
@@ -1,29 +1,48 @@
 import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, it } from 'node:test';
-import { buildSessionEnvironmentPromptFragment } from '../system-prompt/session-environment-prompt.js';
+
+// The default production path (desktop / CLI) calls the fragment WITHOUT a
+// timezone argument, so the date must be formatted in the process local
+// timezone. We lock that path by spawning a child with a fixed TZ and asserting
+// the output, instead of passing a timeZone option that production never uses.
+const here = dirname(fileURLToPath(import.meta.url));
+const fragmentUrl = pathToFileURL(join(here, '..', 'system-prompt', 'session-environment-prompt.js')).href;
+
+function runWithTimezone(timeZone: string, nowIso: string): string {
+  const result = spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `import { buildSessionEnvironmentPromptFragment } from ${JSON.stringify(fragmentUrl)};
+       const prompt = buildSessionEnvironmentPromptFragment({
+         cwd: '/repo',
+         projectGit: { isGitRepo: true, branch: 'main' },
+         platform: 'darwin',
+         now: new Date(${JSON.stringify(nowIso)}),
+       });
+       process.stdout.write(prompt);`,
+    ],
+    { env: { ...process.env, TZ: timeZone }, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, `child failed: ${result.stderr || ''}`);
+  return result.stdout;
+}
 
 describe('session environment prompt date', () => {
-  it('uses the configured timezone for "Today\'s date" so a UTC instant near local midnight is not off by one', () => {
+  it('uses the process local timezone by default so a UTC instant near local midnight is not off by one', () => {
     // 2026-05-29T16:30:00Z in Asia/Shanghai (UTC+8) is 2026-05-30 00:30 local.
-    // A UTC-based formatter would report 2026-05-29 (wrong); the local date is 2026-05-30.
-    const prompt = buildSessionEnvironmentPromptFragment({
-      cwd: '/repo',
-      projectGit: { isGitRepo: true, branch: 'main' },
-      platform: 'darwin',
-      now: new Date('2026-05-29T16:30:00.000Z'),
-      timeZone: 'Asia/Shanghai',
-    });
+    // The fragment is called WITHOUT a timezone arg; the default path must read
+    // the process timezone and report the local calendar day, not the UTC day.
+    const prompt = runWithTimezone('Asia/Shanghai', '2026-05-29T16:30:00.000Z');
     assert.match(prompt, /Today's date: 2026-05-30/);
   });
 
-  it('keeps the same calendar day when the timezone is UTC and the instant is midday UTC', () => {
-    const prompt = buildSessionEnvironmentPromptFragment({
-      cwd: '/repo',
-      projectGit: { isGitRepo: true, branch: 'main' },
-      platform: 'darwin',
-      now: new Date('2026-05-29T12:34:56.000Z'),
-      timeZone: 'UTC',
-    });
+  it('keeps the same calendar day when the process timezone is UTC and the instant is midday UTC', () => {
+    const prompt = runWithTimezone('UTC', '2026-05-29T12:34:56.000Z');
     assert.match(prompt, /Today's date: 2026-05-29/);
   });
 });

--- a/packages/runtime/src/__tests__/session-environment-prompt.test.ts
+++ b/packages/runtime/src/__tests__/session-environment-prompt.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { buildSessionEnvironmentPromptFragment } from '../system-prompt/session-environment-prompt.js';
+
+describe('session environment prompt date', () => {
+  it('uses the configured timezone for "Today\'s date" so a UTC instant near local midnight is not off by one', () => {
+    // 2026-05-29T16:30:00Z in Asia/Shanghai (UTC+8) is 2026-05-30 00:30 local.
+    // A UTC-based formatter would report 2026-05-29 (wrong); the local date is 2026-05-30.
+    const prompt = buildSessionEnvironmentPromptFragment({
+      cwd: '/repo',
+      projectGit: { isGitRepo: true, branch: 'main' },
+      platform: 'darwin',
+      now: new Date('2026-05-29T16:30:00.000Z'),
+      timeZone: 'Asia/Shanghai',
+    });
+    assert.match(prompt, /Today's date: 2026-05-30/);
+  });
+
+  it('keeps the same calendar day when the timezone is UTC and the instant is midday UTC', () => {
+    const prompt = buildSessionEnvironmentPromptFragment({
+      cwd: '/repo',
+      projectGit: { isGitRepo: true, branch: 'main' },
+      platform: 'darwin',
+      now: new Date('2026-05-29T12:34:56.000Z'),
+      timeZone: 'UTC',
+    });
+    assert.match(prompt, /Today's date: 2026-05-29/);
+  });
+});

--- a/packages/runtime/src/system-prompt/session-environment-prompt.ts
+++ b/packages/runtime/src/system-prompt/session-environment-prompt.ts
@@ -13,12 +13,11 @@ export interface SessionEnvironmentPromptInput {
   projectGit: ProjectGitInfo;
   platform?: NodeJS.Platform;
   now?: Date;
-  timeZone?: string;
 }
 
 export function buildSessionEnvironmentPromptFragment(input: SessionEnvironmentPromptInput): string {
   const platform = input.platform ?? process.platform;
-  const today = formatDate(input.now ?? new Date(), input.timeZone);
+  const today = formatDate(input.now ?? new Date());
   const lines = [
     'Maka session environment (informational only; does not grant file, shell, network, or permission authority):',
     '<env>',
@@ -36,19 +35,14 @@ export function buildSessionEnvironmentPromptFragment(input: SessionEnvironmentP
   return lines.join('\n');
 }
 
-function formatDate(value: Date, timeZone?: string): string {
+function formatDate(value: Date): string {
   if (Number.isNaN(value.getTime())) return 'unknown';
-  // Format in the configured timezone (defaults to the process local timezone
-  // when undefined) so "Today's date" matches the user's calendar day instead of
-  // the UTC day, which can be off by one near local midnight.
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(value);
-  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
-  return `${get('year')}-${get('month')}-${get('day')}`;
+  // Local calendar date (not UTC): the injected "Today's date" should match the
+  // user's day, so near local midnight we don't report the previous UTC day.
+  const y = value.getFullYear();
+  const m = String(value.getMonth() + 1).padStart(2, '0');
+  const d = String(value.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 function sanitizePromptLine(value: string): string {

--- a/packages/runtime/src/system-prompt/session-environment-prompt.ts
+++ b/packages/runtime/src/system-prompt/session-environment-prompt.ts
@@ -13,11 +13,12 @@ export interface SessionEnvironmentPromptInput {
   projectGit: ProjectGitInfo;
   platform?: NodeJS.Platform;
   now?: Date;
+  timeZone?: string;
 }
 
 export function buildSessionEnvironmentPromptFragment(input: SessionEnvironmentPromptInput): string {
   const platform = input.platform ?? process.platform;
-  const today = formatDate(input.now ?? new Date());
+  const today = formatDate(input.now ?? new Date(), input.timeZone);
   const lines = [
     'Maka session environment (informational only; does not grant file, shell, network, or permission authority):',
     '<env>',
@@ -35,9 +36,19 @@ export function buildSessionEnvironmentPromptFragment(input: SessionEnvironmentP
   return lines.join('\n');
 }
 
-function formatDate(value: Date): string {
+function formatDate(value: Date, timeZone?: string): string {
   if (Number.isNaN(value.getTime())) return 'unknown';
-  return value.toISOString().slice(0, 10);
+  // Format in the configured timezone (defaults to the process local timezone
+  // when undefined) so "Today's date" matches the user's calendar day instead of
+  // the UTC day, which can be off by one near local midnight.
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(value);
+  const get = (type: string): string => parts.find((p) => p.type === type)?.value ?? '';
+  return `${get('year')}-${get('month')}-${get('day')}`;
 }
 
 function sanitizePromptLine(value: string): string {


### PR DESCRIPTION
## Summary
`formatDate` in `session-environment-prompt` used `toISOString().slice(0,10)` (UTC), so near local midnight (UTC+8 00:30 = UTC 16:30 previous day) the injected "Today's date" was one day behind the user's calendar day, affecting date-sensitive answers. Format via the local Date methods (`getFullYear` / `getMonth + 1` / `getDate`) so the date matches the process timezone. Both desktop and CLI turn-tail use this fragment, so both are fixed.

## Why
Closes #538. The shared turn-tail date fragment reported the UTC day, not the user's local calendar day; near local midnight this was off by one. Issue #538 deferred this from PR #531 to keep the date-fragment timezone semantics in a focused change.

## Scope
Changed:
- `packages/runtime/src/system-prompt/session-environment-prompt.ts`: `formatDate` switches from `toISOString().slice(0,10)` to local `getFullYear` / `(getMonth + 1)` / `getDate` with `padStart`. No new public API.
- `packages/runtime/src/__tests__/session-environment-prompt.test.ts`: spawn a child with `TZ=Asia/Shanghai` (cross-midnight: `16:30Z` -> `2026-05-30`) and `TZ=UTC` (midday: `12:34Z` -> `2026-05-29`), calling the fragment WITHOUT a timezone arg to lock the real default production path.
- `apps/desktop/src/main/__tests__/session-environment-prompt.test.ts`: date assertion relaxes to a `YYYY-MM-DD` format match (the value now follows the process timezone).

Not included:
- A `timeZone` input option — dropped per review; no production caller needed it and it only widened the public API for tests.
- Desktop renderer pre-existing fails (`Daily Review` `className` + `renderer error boundary`) — present on `main` without this branch, tracked separately.

## Verification
- runtime: 820 pass (new `TZ`-child tests green; 1 pre-existing skipped).
- cli: 74 pass (only asserts the `Today's date:` line exists, not the value).
- typecheck: green.
- desktop: 1933 pass, 2 fail — both pre-existing on `main` (confirmed by running desktop tests on the main checkout without this branch: same 2 fail, same counts).

## User-facing impact
Desktop and CLI/TUI now report the user's local calendar date in the per-turn environment tail instead of the UTC date. No setting, API, or migration needed.

## Reviewer notes
Default-path coverage: the cross-midnight test runs in a child process with `TZ=Asia/Shanghai` and calls the fragment with no timezone arg, so it exercises the same path desktop/CLI use (process local timezone). The 2 desktop fails are unrelated to this change; flag if you'd like a separate issue for them.