### PR TITLE
feat(ui): shared searchable ModelPicker for composer and Settings

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -52,31 +52,30 @@ describe('home composer new-chat model picker', () => {
 
     const picker = ui.match(/function NewChatModelPicker\(props: \{[\s\S]*?\}\) \{[\s\S]*?\n\}/)?.[0] ?? '';
     assert.notEqual(picker, '', 'NewChatModelPicker component must exist');
-    // Interactive: built on SelectRoot, fires the pick on value change.
-    assert.match(picker, /<SelectRoot<string>/, 'NewChatModelPicker must be a real SelectRoot dropdown');
+    // Interactive: built on the shared ModelPicker combobox, fires the pick
+    // on value change.
+    assert.match(picker, /<ModelPicker/, 'NewChatModelPicker must be a real ModelPicker dropdown');
     assert.match(picker, /props\.onPick\(next\)/, 'NewChatModelPicker must call onPick with the chosen model');
-    // No hand-added chevron — SelectTrigger renders its own BaseSelect.Icon.
+    // No hand-added chevron — ModelPicker's ComboboxTrigger renders its own icon.
     assert.doesNotMatch(
       picker,
       /<ChevronDown/,
-      'NewChatModelPicker must not hand-add a chevron (SelectTrigger already renders one) — guards the double-chevron regression',
+      'NewChatModelPicker must not hand-add a chevron (ModelPicker\'s trigger already renders one) — guards the double-chevron regression',
     );
   });
 
-  it('shares one ModelChoiceOptions list between both model pickers', async () => {
-    // The pickers live in `chat-model-switcher.tsx`; the composer renders
-    // them from `composer.tsx`. Search the union so the contract holds across
-    // the seam.
-    const ui =
-      (await readRepo('packages/ui/src/composer.tsx')) +
-      '\n' +
-      (await readRepo('packages/ui/src/chat-model-switcher.tsx'));
-    assert.match(ui, /function ModelChoiceOptions\(\{\s*groups,/, 'shared ModelChoiceOptions list component must exist');
-    const usages = ui.match(/<ModelChoiceOptions groups=\{grouped\} renderProviderMark=\{props\.renderProviderMark\} \/>/g) ?? [];
+  it('shares one ModelPicker popup between both model pickers', async () => {
+    // The pickers live in `chat-model-switcher.tsx`; the shared searchable
+    // popup lives in `model-picker.tsx`. Both ChatModelSwitcher and
+    // NewChatModelPicker must render it (no duplicated grouped-list JSX).
+    const ui = await readRepo('packages/ui/src/chat-model-switcher.tsx');
+    const picker = await readRepo('packages/ui/src/model-picker.tsx');
+    assert.match(picker, /export function ModelPicker\(/, 'shared ModelPicker component must exist');
+    const usages = ui.match(/<ModelPicker/g) ?? [];
     assert.equal(
       usages.length,
       2,
-      'both ChatModelSwitcher and NewChatModelPicker must render the shared <ModelChoiceOptions> (no duplicated grouped list)',
+      'both ChatModelSwitcher and NewChatModelPicker must render the shared <ModelPicker> (no duplicated grouped list)',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/general-settings-configurable-contract.test.ts
@@ -35,12 +35,12 @@ describe('General settings configurable contract', () => {
       'General page must not re-introduce the read-only 新对话模式 row — permission mode is per-session in the composer.',
     );
     // The 默认模型 row was: `<SettingRow ... value={props.defaultSlug ?? '未设置'} />`.
-    // Block the SettingRow shape specifically; the new real control is a
-    // `<SettingsSelect>` inside `<GeneralDefaultsCard>`.
+    // Block the SettingRow shape specifically; the new real control is the
+    // shared searchable `<ModelPicker>` inside `<GeneralDefaultsCard>`.
     assert.doesNotMatch(
       src,
       /<SettingRow\s+title="默认模型"[\s\S]*?value=\{props\.defaultSlug/,
-      'General page 默认模型 row must use the real <SettingsSelect> inside <GeneralDefaultsCard>, not a read-only <SettingRow>.',
+      'General page 默认模型 row must use the real <ModelPicker> inside <GeneralDefaultsCard>, not a read-only <SettingRow>.',
     );
   });
 
@@ -57,19 +57,21 @@ describe('General settings configurable contract', () => {
       /<GeneralDefaultsCard\s+connections=\{props\.connections\}\s+defaultSlug=\{props\.defaultSlug\}\s+onRefresh=\{props\.onRefreshConnections\}/,
       '<GeneralDefaultsCard> must be mounted by the General-page render branch with connections / defaultSlug / onRefresh wired through',
     );
-    // The actual select + persistence must use the shared SettingsSelect
-    // and the model-level default IPC. The old connection-only selector used
-    // `connection.name`, which can embed OAuth account email; default-model
-    // choices are now grouped from safe model catalog choices.
+    // The actual picker + persistence must use the shared searchable
+    // ModelPicker (also behind the composer's model switcher, so the two
+    // surfaces can't drift) and the model-level default IPC. The old
+    // connection-only selector used `connection.name`, which can embed OAuth
+    // account email; default-model choices are grouped from safe model
+    // catalog choices, with '未设置' as the pinned empty row.
     assert.match(
       src,
-      /<SettingsSelect[\s\S]*ariaLabel="默认模型"[\s\S]*optionGroups=\{optionGroups\}[\s\S]*onChange=/,
-      'GeneralDefaultsCard must use the shared <SettingsSelect> primitive (not a custom dropdown) so the popup layering, keyboard nav, and chrome match the rest of Settings',
+      /<ModelPicker[\s\S]*pinnedItem=\{\{ value: '', label: '未设置' \}\}[\s\S]*ariaLabel="默认模型"[\s\S]*onValueChange=/,
+      'GeneralDefaultsCard must use the shared <ModelPicker> (same popup as the composer model switcher) so the two surfaces cannot drift',
     );
     assert.match(
       src,
       /buildCatalogChatModelChoices\(props\.connections\)[\s\S]*modelMenuGroups\(modelChoices\)[\s\S]*modelChoiceValue\(choice\.connectionSlug, choice\.model\)/,
-      'GeneralDefaultsCard must flatten safe model catalog choices into grouped connection/model options',
+      'GeneralDefaultsCard must derive grouped connection/model choices from the safe model catalog',
     );
     assert.doesNotMatch(
       src,

--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -16,6 +16,7 @@ type ModelCatalogChoicesModule = {
     providerType: string;
     model: string;
     label: string;
+    connectionName?: string;
   }>;
   pickCatalogDefaultChatModel(connection: LlmConnection): {
     llmConnectionSlug: string;
@@ -88,6 +89,44 @@ describe('model catalog picker helpers', () => {
       choices.map((choice) => `${choice.connectionSlug}:${choice.model}:${choice.label}`),
       ['codex-account:gpt-5.5:GPT-5.5'],
     );
+  });
+
+  it('surfaces connectionName for api-key connections but never for OAuth ones', async () => {
+    const { buildCatalogChatModelChoices } = await importModelCatalogChoices();
+
+    const choices = buildCatalogChatModelChoices([
+      connection({
+        slug: 'openrouter',
+        name: 'Openrouter',
+        providerType: 'openai-compatible',
+        models: [{ id: 'anthropic/claude-sonnet-5' }],
+        modelSource: 'fetched',
+      }),
+      connection({
+        slug: 'claude-sub',
+        name: 'person@example.com',
+        providerType: 'claude-subscription',
+        models: [{ id: 'claude-sonnet-4-5-20250929' }],
+        modelSource: 'fetched',
+      }),
+      connection({
+        slug: 'codex-account',
+        name: 'person@example.com',
+        providerType: 'codex-subscription',
+        models: [{ id: 'gpt-5.5' }],
+        modelSource: 'fetched',
+      }),
+    ]);
+
+    const bySlug = new Map(choices.map((choice) => [choice.connectionSlug, choice]));
+    assert.equal(bySlug.get('openrouter')?.connectionName, 'Openrouter');
+    // OAuth connection.name embeds the account email — it must never reach
+    // the picker's ChatModelChoice (PR-CHAT-CHROME-FIX-0).
+    assert.equal(bySlug.get('claude-sub')?.connectionName, undefined);
+    assert.equal(bySlug.get('codex-account')?.connectionName, undefined);
+    for (const choice of choices) {
+      assert.ok(!(choice.connectionName ?? '').includes('@example.com'));
+    }
   });
 
   it('keeps Daily Review runtime-wired model choices while using leak-safe duplicate labels', async () => {

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -8,17 +8,18 @@ import { readRendererShellCombinedSource } from './renderer-shell-source-helpers
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
-// The model switcher / picker JSX lives in `chat-model-switcher.tsx`, the
-// composer renders it from `composer.tsx`, and turn chips render in
-// `chat-view.tsx`. These source-grep contracts assert behavior that spans the
-// seam, so search their union.
+// The model switcher / picker JSX lives in `chat-model-switcher.tsx`, its
+// shared searchable popup in `model-picker.tsx`, the composer renders it from
+// `composer.tsx`, and turn chips render in `chat-view.tsx`. These source-grep
+// contracts assert behavior that spans the seam, so search their union.
 async function readModelSwitcherUiSource(): Promise<string> {
-  const [composer, chatView, switcher] = await Promise.all([
+  const [composer, chatView, switcher, picker] = await Promise.all([
     readFile(resolve(REPO_ROOT, 'packages/ui/src/composer.tsx'), 'utf8'),
     readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8'),
     readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-model-switcher.tsx'), 'utf8'),
+    readFile(resolve(REPO_ROOT, 'packages/ui/src/model-picker.tsx'), 'utf8'),
   ]);
-  return `${composer}\n${chatView}\n${switcher}`;
+  return `${composer}\n${chatView}\n${switcher}\n${picker}`;
 }
 
 describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
@@ -126,7 +127,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(ui, /pending=\{props\.modelChangePending\}/);
     assert.match(ui, /activeModel\?: string/);
     assert.match(ui, /const currentModel = props\.activeModel \?\? props\.activeSession\.model/);
-    assert.match(ui, /aria-label="切换当前会话模型"/);
+    assert.match(ui, /ariaLabel="切换当前会话模型"/);
     assert.match(ui, /pending\?: boolean/);
     assert.match(ui, /const \[localPending,\s*setLocalPending\] = useState\(false\);/);
     assert.match(ui, /const pendingRef = useRef\(false\);/);
@@ -153,17 +154,17 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     );
     assert.match(ui, /aria-busy=\{pending \? 'true' : undefined\}/);
     assert.match(ui, /data-pending=\{pending \? 'true' : undefined\}/);
-    assert.match(ui, /<SelectRoot<string>[\s\S]*items=\{modelSelectItems\}[\s\S]*value=\{currentValue\}[\s\S]*onValueChange=\{\(value\) => \{/);
-    assert.match(ui, /<SelectPositioner alignItemWithTrigger=\{false\} sideOffset=\{8\}/);
-    assert.match(ui, /<SelectList>/);
+    assert.match(ui, /<ModelPicker[\s\S]*groups=\{grouped\}[\s\S]*value=\{currentValue\}[\s\S]*onValueChange=\{\(value\) => \{/);
+    assert.match(ui, /<ComboboxPositioner sideOffset=\{8\}/);
+    assert.match(ui, /<ComboboxList>/);
     // The grouped menu renders provider groups keyed by connection, each heading
     // carrying the injected brand mark (kept out of @maka/ui via renderProviderMark),
     // on the shared `.settingsSelectMenu*` recipe.
-    assert.match(ui, /<SelectGroup key=\{group\.connectionSlug\}/);
+    assert.match(ui, /<ComboboxGroup key=\{group\.connectionSlug\}/);
     assert.match(ui, /renderProviderMark\?\.\(group\.providerType\)/);
     assert.match(ui, /className="settingsSelectMenuGroupLogo"/);
-    assert.match(uiPrimitives, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseSelect\.ItemIndicator>/);
-    assert.match(uiPrimitives, /<span className="min-w-0">[\s\S]*<BaseSelect\.ItemText>\{children\}<\/BaseSelect\.ItemText>/);
+    assert.match(uiPrimitives, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseCombobox\.ItemIndicator>/);
+    assert.match(uiPrimitives, /<BaseCombobox\.Item[\s\S]*<span className="min-w-0">\{children\}<\/span>/);
     assert.doesNotMatch(ui, /<select\b[\s\S]*aria-label="切换当前会话模型"/);
     assert.match(ui, /<span className="maka-model-switcher-label">\{pending \? '切换中' : '模型'\}<\/span>/);
     assert.match(styles, /\.maka-model-switcher\s*\{/);

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -155,16 +155,21 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(ui, /aria-busy=\{pending \? 'true' : undefined\}/);
     assert.match(ui, /data-pending=\{pending \? 'true' : undefined\}/);
     assert.match(ui, /<ModelPicker[\s\S]*groups=\{grouped\}[\s\S]*value=\{currentValue\}[\s\S]*onValueChange=\{\(value\) => \{/);
-    assert.match(ui, /<ComboboxPositioner sideOffset=\{8\}/);
-    assert.match(ui, /<ComboboxList>/);
-    // The grouped menu renders provider groups keyed by connection, each heading
-    // carrying the injected brand mark (kept out of @maka/ui via renderProviderMark),
-    // on the shared `.settingsSelectMenu*` recipe.
-    assert.match(ui, /<ComboboxGroup key=\{group\.connectionSlug\}/);
+    assert.match(ui, /<BaseCombobox\.Positioner sideOffset=\{8\}/);
+    assert.match(ui, /<BaseCombobox\.List className="modelPickerList">/);
+    assert.match(ui, /inputValue=\{query\}/);
+    assert.match(ui, /filter=\{filterModelPickerOption\}/);
+    assert.match(ui, /BaseCombobox\.useFilteredItems<ModelPickerOptionGroup>\(\)/);
+    // The grouped menu renders provider groups from Base UI's filtered item
+    // source, each heading carrying the injected brand mark (kept out of
+    // @maka/ui via renderProviderMark), on the shared `.settingsSelectMenu*`
+    // recipe.
+    assert.match(ui, /<ModelPickerGroup key=\{group\.key\} items=\{group\.items\}>/);
     assert.match(ui, /renderProviderMark\?\.\(group\.providerType\)/);
     assert.match(ui, /className="settingsSelectMenuGroupLogo"/);
-    assert.match(uiPrimitives, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseCombobox\.ItemIndicator>/);
-    assert.match(uiPrimitives, /<BaseCombobox\.Item[\s\S]*<span className="min-w-0">\{children\}<\/span>/);
+    assert.match(ui, /<span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">[\s\S]*<BaseCombobox\.ItemIndicator>/);
+    assert.match(ui, /<BaseCombobox\.Item[\s\S]*<span className="min-w-0">\{children\}<\/span>/);
+    assert.doesNotMatch(uiPrimitives, /BaseCombobox/, 'Combobox stays private to ModelPicker until a second real consumer appears');
     assert.doesNotMatch(ui, /<select\b[\s\S]*aria-label="切换当前会话模型"/);
     assert.match(ui, /<span className="maka-model-switcher-label">\{pending \? '切换中' : '模型'\}<\/span>/);
     assert.match(styles, /\.maka-model-switcher\s*\{/);

--- a/apps/desktop/src/main/__tests__/z-index-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/z-index-contract.test.ts
@@ -28,6 +28,11 @@ const BARE_ALLOWLIST: ReadonlyArray<{ selector: string; value: number; reason: s
     value: 2,
     reason: 'decorative sticker stack — 3 spans inside a fixed container, no escape',
   },
+  {
+    selector: '.modelPickerSearchInput',
+    value: 1,
+    reason: 'sticky search input inside the model-picker popup — must paint above the option rows scrolling beneath it, local stacking only',
+  },
 ];
 
 describe('PR-FE-BUG-HUNT-9 z-index contract', () => {

--- a/apps/desktop/src/main/__tests__/z-index-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/z-index-contract.test.ts
@@ -28,11 +28,6 @@ const BARE_ALLOWLIST: ReadonlyArray<{ selector: string; value: number; reason: s
     value: 2,
     reason: 'decorative sticker stack — 3 spans inside a fixed container, no escape',
   },
-  {
-    selector: '.modelPickerSearchInput',
-    value: 1,
-    reason: 'sticky search input inside the model-picker popup — must paint above the option rows scrolling beneath it, local stacking only',
-  },
 ];
 
 describe('PR-FE-BUG-HUNT-9 z-index contract', () => {

--- a/apps/desktop/src/renderer/model-catalog-choices.ts
+++ b/apps/desktop/src/renderer/model-catalog-choices.ts
@@ -32,12 +32,20 @@ export function buildCatalogChatModelChoices(connections: readonly LlmConnection
   const choices: ChatModelChoice[] = [];
   for (const connection of connections) {
     if (!isModelConsumerConnection(connection)) continue;
+    // Only non-OAuth connections get their user-chosen name surfaced in the
+    // menu heading — see `ChatModelChoice.connectionName`. OAuth providers'
+    // `connection.name` embeds the account email, so this stays undefined
+    // for them and the menu falls back to the provider label.
+    const connectionName = PROVIDER_DEFAULTS[connection.providerType].authKind === 'oauth_token'
+      ? undefined
+      : connection.name;
     for (const entry of selectableCatalogEntries(connection)) {
       choices.push({
         connectionSlug: connection.slug,
         providerType: connection.providerType,
         model: entry.id,
         label: modelDisplayLabel(entry),
+        connectionName,
       });
     }
   }

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -13,6 +13,7 @@ import {
   Input,
   Menu,
   MenuTrigger,
+  ModelPicker,
   PERMISSION_MODE_META,
   PermissionModeMenuPopup,
   SettingsSelect,
@@ -115,29 +116,18 @@ function GeneralDefaultsCard(props: {
   }, []);
 
   const modelChoices = useMemo(() => buildCatalogChatModelChoices(props.connections), [props.connections]);
-  const optionGroups = useMemo(() => {
-    return modelMenuGroups(modelChoices).map((group) => ({
-      label: group.heading,
-      icon: <ProviderLogo type={group.providerType} compact />,
-      options: group.choices.map((choice) => [
-        modelChoiceValue(choice.connectionSlug, choice.model),
-        choice.label,
-      ] as const),
-    }));
-  }, [modelChoices]);
-  const options = useMemo<ReadonlyArray<readonly [string, string]>>(() => {
-    return [
-      ['', '未设置'],
-      ...optionGroups.flatMap((group) => group.options),
-    ];
-  }, [optionGroups]);
+  const modelGroups = useMemo(() => modelMenuGroups(modelChoices), [modelChoices]);
   const selectedValue = useMemo(() => {
     if (!props.defaultSlug) return '';
     const connection = props.connections.find((candidate) => candidate.slug === props.defaultSlug);
     if (!connection?.defaultModel) return '';
     const value = modelChoiceValue(connection.slug, connection.defaultModel);
-    return options.some(([candidate]) => candidate === value) ? value : '';
-  }, [options, props.connections, props.defaultSlug]);
+    return modelChoices.some((choice) => modelChoiceValue(choice.connectionSlug, choice.model) === value) ? value : '';
+  }, [modelChoices, props.connections, props.defaultSlug]);
+  const selectedLabel = useMemo(() => {
+    if (!selectedValue) return '未设置';
+    return modelChoices.find((choice) => modelChoiceValue(choice.connectionSlug, choice.model) === selectedValue)?.label ?? '未设置';
+  }, [modelChoices, selectedValue]);
 
   async function persistDefault(nextValue: string) {
     if (savingRef.current) return;
@@ -190,16 +180,23 @@ function GeneralDefaultsCard(props: {
           <strong>默认模型</strong>
           <small>新对话默认使用的具体模型；按连接分组，不显示 OAuth 账号邮箱。</small>
         </div>
-        <SettingsSelect
+        {/* Shared searchable picker with the composer's model switcher
+            (ModelPicker in @maka/ui) so the grouped list, provider marks,
+            and search behavior can't drift between the two surfaces. */}
+        <ModelPicker
+          groups={modelGroups}
           value={selectedValue}
+          pinnedItem={{ value: '', label: '未设置' }}
+          renderProviderMark={(type) => <ProviderLogo type={type} compact />}
           ariaLabel="默认模型"
-          options={options}
-          optionGroups={optionGroups}
           disabled={saving}
-          onChange={(value) => {
+          triggerClassName="settingsSelectTrigger max-w-[320px] w-full"
+          onValueChange={(value) => {
             void persistDefault(value);
           }}
-        />
+        >
+          <span className="settingsSelectMenuOption">{selectedLabel}</span>
+        </ModelPicker>
       </div>
       <div className="settingsRow" data-control-width="select">
         <div>

--- a/apps/desktop/src/renderer/styles/settings-select.css
+++ b/apps/desktop/src/renderer/styles/settings-select.css
@@ -119,19 +119,25 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  overflow: hidden;
 }
 
 .modelPickerSearchInput {
-  position: sticky;
-  top: 0;
-  z-index: 1;
   flex: 0 0 auto;
-  height: 30px;
+  height: var(--h-control-md);
   padding: 0 var(--space-3);
   margin-bottom: var(--space-1);
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   background: var(--background);
+}
+
+.modelPickerList {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--space-1) 0;
 }
 
 .modelPickerSearchInput:focus-visible {

--- a/apps/desktop/src/renderer/styles/settings-select.css
+++ b/apps/desktop/src/renderer/styles/settings-select.css
@@ -109,3 +109,39 @@
   width: 100%;
   height: 100%;
 }
+
+/* Model picker (`ModelPicker` in `@maka/ui`): a Combobox-backed variant of
+   the grouped select above, with a search `<input>` pinned above the list so
+   long catalogs (dozens of models across many connections) stay findable.
+   Reuses every `.settingsSelectMenu*` row/heading/logo rule as-is — only the
+   search bar and empty state are new. */
+.modelPickerPopup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.modelPickerSearchInput {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 var(--space-3);
+  margin-bottom: var(--space-1);
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-surface);
+  background: var(--background);
+}
+
+.modelPickerSearchInput:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.modelPickerEmpty {
+  padding: var(--space-4) var(--space-3);
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-ui);
+}

--- a/packages/ui/src/__tests__/chat-model-helpers.test.ts
+++ b/packages/ui/src/__tests__/chat-model-helpers.test.ts
@@ -59,12 +59,71 @@ test('each group carries its providerType so the menu can pick the right brand m
 });
 
 test('headings never leak an account email (no @), even with slug disambiguation', () => {
-  // modelMenuGroups never receives connection.name, so a leak is impossible by
-  // construction; this guards against a future regression that reintroduces it.
+  // Callers only populate connectionName for non-OAuth providers, so OAuth
+  // groups can never carry the account email; this guards against a future
+  // regression that passes connection.name through unguarded.
   const groups = modelMenuGroups([
     choice('openai-a', 'openai', 'gpt-5.5'),
     choice('openai-b', 'openai', 'gpt-5.5'),
     choice('claude-sub', 'claude-subscription', 'claude-opus-4-8'),
   ]);
   for (const g of groups) assert.ok(!g.heading.includes('@'), `heading "${g.heading}" looks like it leaks an email`);
+});
+
+test('connectionName wins over the provider label when supplied', () => {
+  // A user-named openai-compatible gateway must read as its own name
+  // ("Openrouter"), not the generic "自定义" fallback.
+  const groups = modelMenuGroups([
+    { ...choice('openrouter', 'openai-compatible', 'anthropic/claude-sonnet-5'), connectionName: 'Openrouter' },
+    choice('deepseek', 'deepseek', 'deepseek-v4-flash'),
+  ]);
+  const bySlug = new Map(groups.map((g) => [g.connectionSlug, g]));
+  assert.equal(bySlug.get('openrouter')?.heading, 'Openrouter');
+  assert.equal(bySlug.get('deepseek')?.heading, 'DeepSeek');
+});
+
+test('blank connectionName falls back to the provider label', () => {
+  const groups = modelMenuGroups([
+    { ...choice('gateway', 'openai-compatible', 'some/model'), connectionName: '   ' },
+  ]);
+  assert.equal(groups[0]?.heading, '自定义');
+});
+
+test('unnamed connection keeps slug disambiguation even when a sibling is named', () => {
+  // Two openai-compatible connections, only one named: the named one uses its
+  // name, the unnamed one still needs the slug suffix to stay distinguishable.
+  const groups = modelMenuGroups([
+    { ...choice('openrouter', 'openai-compatible', 'a/m1'), connectionName: 'Openrouter' },
+    choice('other-gateway', 'openai-compatible', 'b/m2'),
+  ]);
+  const bySlug = new Map(groups.map((g) => [g.connectionSlug, g]));
+  assert.equal(bySlug.get('openrouter')?.heading, 'Openrouter');
+  assert.equal(bySlug.get('other-gateway')?.heading, '自定义 · other-gateway');
+});
+
+test('connectionName is read from the first choice of each connection', () => {
+  // All choices of one connection carry the same connectionName (they come
+  // from one LlmConnection); grouping keys off the first and must keep every
+  // model row in that single named group.
+  const groups = modelMenuGroups([
+    { ...choice('openrouter', 'openai-compatible', 'a/m1'), connectionName: 'Openrouter' },
+    { ...choice('openrouter', 'openai-compatible', 'b/m2'), connectionName: 'Openrouter' },
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0]?.heading, 'Openrouter');
+  assert.equal(groups[0]?.choices.length, 2);
+});
+
+test('two connections sharing the same connectionName are disambiguated by slug', () => {
+  // The add form defaults the name to the provider's display label, so two
+  // quickly-added keys can easily share a name — they must not collapse into
+  // identical headings.
+  const groups = modelMenuGroups([
+    { ...choice('openrouter-a', 'openai-compatible', 'a/m1'), connectionName: 'OpenRouter' },
+    { ...choice('openrouter-b', 'openai-compatible', 'b/m2'), connectionName: 'OpenRouter' },
+  ]);
+  assert.deepEqual(
+    groups.map((g) => g.heading).sort(),
+    ['OpenRouter · openrouter-a', 'OpenRouter · openrouter-b'],
+  );
 });

--- a/packages/ui/src/__tests__/model-picker.test.ts
+++ b/packages/ui/src/__tests__/model-picker.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildModelPickerGroups,
+  filterModelPickerOption,
+  modelPickerHasCatalogMatches,
+  type ModelPickerOption,
+} from '../model-picker-internals.js';
+import type { ModelMenuGroup } from '../chat-model-helpers.js';
+
+const groups: ModelMenuGroup[] = [
+  {
+    connectionSlug: 'openai-main',
+    providerType: 'openai',
+    heading: 'OpenAI main',
+    choices: [
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'gpt-5', label: 'GPT-5' },
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'o3-mini', label: 'o3 mini' },
+    ],
+  },
+  {
+    connectionSlug: 'anthropic-team',
+    providerType: 'anthropic',
+    heading: 'Claude Team',
+    choices: [
+      { connectionSlug: 'anthropic-team', providerType: 'anthropic', model: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+    ],
+  },
+];
+
+describe('ModelPicker filtering', () => {
+  it('matches model labels and group headings with the same Base UI item data', () => {
+    const pickerGroups = buildModelPickerGroups(groups);
+    const options = pickerGroups.flatMap((group) => group.items);
+
+    assert.deepEqual(
+      options.filter((option) => filterModelPickerOption(option, 'sonnet')).map((option) => option.value),
+      ['anthropic-team:claude-sonnet-4'],
+    );
+    assert.deepEqual(
+      options.filter((option) => filterModelPickerOption(option, 'openai')).map((option) => option.value),
+      ['openai-main:gpt-5', 'openai-main:o3-mini'],
+    );
+  });
+
+  it('keeps a pinned item visible without counting it as a catalog match', () => {
+    const pickerGroups = buildModelPickerGroups(groups, { value: '', label: '未设置' });
+    const pinned = pickerGroups.flatMap((group) => group.items).find((option) => option.pinned) as ModelPickerOption;
+
+    assert.equal(filterModelPickerOption(pinned, 'no-such-model'), true);
+    assert.equal(modelPickerHasCatalogMatches([pinned]), false);
+  });
+
+  it('reports an empty state when no option matches', () => {
+    const options = buildModelPickerGroups(groups).flatMap((group) => group.items);
+    const visible = options.filter((option) => filterModelPickerOption(option, 'no-such-model'));
+
+    assert.equal(modelPickerHasCatalogMatches(visible), false);
+  });
+});

--- a/packages/ui/src/chat-model-helpers.ts
+++ b/packages/ui/src/chat-model-helpers.ts
@@ -27,10 +27,18 @@ export interface ChatModelChoice {
   providerType: ProviderType;
   model: string;
   label: string;
-  /* Intentionally NO connection-name / account label field. `connection.name`
-     embeds the OAuth account email (PR-CHAT-CHROME-FIX-0); the menu heading
-     is derived from `providerType` (+ slug on collision) in `modelMenuGroups`,
-     never from the name. `label` is only the safe model display name. */
+  /**
+   * User-chosen connection label — ONLY for non-OAuth providers (`api_key` /
+   * `none` auth), where `connection.name` is a plain label the user typed in
+   * Settings when adding the connection (e.g. "OpenRouter", "My Together AI
+   * key"). Must stay `undefined` for `claude-subscription` /
+   * `codex-subscription` / `gemini-cli`, whose `connection.name` embeds the
+   * OAuth account email (PR-CHAT-CHROME-FIX-0) — those three keep falling
+   * back to the leak-safe provider label in `modelMenuGroups`. Callers
+   * populate this field; `@maka/ui` doesn't know about `LlmConnection` and
+   * can't enforce the guard itself.
+   */
+  connectionName?: string;
 }
 
 /**
@@ -61,24 +69,28 @@ export interface ModelMenuGroup {
   /** Provider of this group, so the menu can render its brand mark on the heading. */
   providerType: ProviderType;
   /**
-   * Leak-safe, de-duplicated heading. Derived from `providerType` (plus the
-   * slug when the same provider has multiple connections); never from
-   * `connection.name`.
+   * De-duplicated heading. The user's own connection name when one was
+   * safely supplied (see `ChatModelChoice.connectionName`); otherwise the
+   * short provider label, plus the slug when the same provider has multiple
+   * connections. Never derived from an OAuth connection's `connection.name`.
    */
   heading: string;
   choices: ChatModelChoice[];
 }
 
 /**
- * Group choices by connection and give each group a leak-safe, distinguishable
- * heading. The heading is the short provider label; when two or more
- * connections of the SAME provider are present (e.g. two OpenAI keys), the
- * connection slug is appended so the user can tell them apart. The slug is a
- * safe `[a-z0-9-]` identifier and never carries the account email that
- * `connection.name` does, so the heading is leak-safe by construction.
+ * Group choices by connection and give each group a distinguishable heading.
+ * Prefers the user's own connection name (`ChatModelChoice.connectionName`)
+ * when the caller supplied one — safe by construction, since callers only
+ * populate it for non-OAuth providers. Falls back to the short provider
+ * label, with the connection slug appended when two or more connections of
+ * the SAME provider are present and neither supplied a name (e.g. two OpenAI
+ * keys) — the slug is a safe `[a-z0-9-]` identifier, never the OAuth
+ * account email `connection.name` carries for `claude-subscription` /
+ * `codex-subscription` / `gemini-cli`.
  */
 export function modelMenuGroups(choices: ChatModelChoice[]): ModelMenuGroup[] {
-  const bySlug = new Map<string, { connectionSlug: string; providerType: ProviderType; choices: ChatModelChoice[] }>();
+  const bySlug = new Map<string, { connectionSlug: string; providerType: ProviderType; connectionName?: string; choices: ChatModelChoice[] }>();
   for (const choice of choices) {
     const group = bySlug.get(choice.connectionSlug);
     if (group) {
@@ -87,16 +99,33 @@ export function modelMenuGroups(choices: ChatModelChoice[]): ModelMenuGroup[] {
       bySlug.set(choice.connectionSlug, {
         connectionSlug: choice.connectionSlug,
         providerType: choice.providerType,
+        connectionName: choice.connectionName,
         choices: [choice],
       });
     }
   }
   const groups = [...bySlug.values()];
   const connectionsPerType = new Map<ProviderType, number>();
+  const connectionsPerName = new Map<string, number>();
   for (const group of groups) {
     connectionsPerType.set(group.providerType, (connectionsPerType.get(group.providerType) ?? 0) + 1);
+    const ownName = group.connectionName?.trim();
+    if (ownName) connectionsPerName.set(ownName, (connectionsPerName.get(ownName) ?? 0) + 1);
   }
   return groups.map((group) => {
+    const ownName = group.connectionName?.trim();
+    if (ownName) {
+      // Two connections can carry the same user-chosen name (the add form
+      // defaults it to the provider's display label) — keep them
+      // distinguishable with the same slug suffix the label path uses.
+      const nameAmbiguous = (connectionsPerName.get(ownName) ?? 0) > 1;
+      return {
+        connectionSlug: group.connectionSlug,
+        providerType: group.providerType,
+        heading: nameAmbiguous ? `${ownName} · ${group.connectionSlug}` : ownName,
+        choices: group.choices,
+      };
+    }
     const label = PROVIDER_SHORT_LABEL[group.providerType];
     const ambiguous = (connectionsPerType.get(group.providerType) ?? 0) > 1;
     return {

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -11,76 +11,16 @@
  */
 
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Button as UiButton,
-  SelectGroup,
-  SelectGroupLabel,
-  SelectItem,
-  SelectList,
-  SelectPopup,
-  SelectPortal,
-  SelectPositioner,
-  SelectRoot,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from './ui.js';
+import { Button as UiButton } from './ui.js';
+import { ModelPicker } from './model-picker.js';
 import { Settings } from './icons.js';
 import {
   type ChatModelChoice,
-  type ModelMenuGroup,
   modelMenuGroups,
   modelChoiceValue,
   parseModelChoiceValue,
 } from './chat-model-helpers.js';
 import { type ProviderType, type SessionSummary } from '@maka/core';
-
-/**
- * Shared grouped option rows for both model pickers: one `<SelectItem>` per
- * model, grouped under a leak-safe heading from `modelMenuGroups` — the short
- * provider label, disambiguated by connection slug when the same provider has
- * multiple connections. The heading never derives from the connection name
- * (which embeds the OAuth account email). Its brand mark is injected by the
- * desktop app via `renderProviderMark` so `@maka/ui` stays free of the provider
- * SVG library. Headings + rows wear the shared `.settingsSelectMenu*` recipe so
- * the menu reads as the governed grouped form; the selected-row check is the
- * `SelectItem` primitive's built-in `ItemIndicator`.
- */
-function ModelChoiceOptions({
-  groups,
-  renderProviderMark,
-}: {
-  groups: ModelMenuGroup[];
-  renderProviderMark?: (type: ProviderType) => ReactNode;
-}) {
-  return (
-    <>
-      {groups.map((group) => {
-        const logo = renderProviderMark?.(group.providerType);
-        return (
-          <SelectGroup key={group.connectionSlug}>
-            <SelectGroupLabel className="settingsSelectMenuGroupLabel">
-              {logo ? (
-                <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{logo}</span>
-              ) : (
-                <span aria-hidden="true" />
-              )}
-              <span>{group.heading}</span>
-            </SelectGroupLabel>
-            {group.choices.map((choice) => {
-              const value = modelChoiceValue(choice.connectionSlug, choice.model);
-              return (
-                <SelectItem key={value} value={value}>
-                  <span className="settingsSelectMenuOption">{choice.label}</span>
-                </SelectItem>
-              );
-            })}
-          </SelectGroup>
-        );
-      })}
-    </>
-  );
-}
 
 export function ChatModelSwitcher(props: {
   activeSession: SessionSummary;
@@ -104,18 +44,12 @@ export function ChatModelSwitcher(props: {
   const disabled = pending || Boolean(props.disabledReason) || !props.onChange || props.choices.length === 0;
   const grouped = modelMenuGroups(props.choices);
   const currentKnownChoice = props.choices.some((choice) => modelChoiceValue(choice.connectionSlug, choice.model) === currentValue);
-  const modelSelectItems = useMemo(
-    () => [
-      // Keep the Select value as the stable model id, but render the
-      // catalog display label when present. Account / connection names
-      // still stay out of the option row to avoid OAuth email leaks.
-      ...(!currentKnownChoice ? [{ value: currentValue, label: currentModel }] : []),
-      ...props.choices.map((choice) => ({
-        value: modelChoiceValue(choice.connectionSlug, choice.model),
-        label: choice.label,
-      })),
-    ],
-    [currentKnownChoice, currentModel, currentValue, props.choices],
+  // Render the catalog display label when the current model is a known
+  // choice; account / connection names still stay out of the trigger to
+  // avoid OAuth email leaks.
+  const currentLabel = useMemo(
+    () => props.choices.find((choice) => modelChoiceValue(choice.connectionSlug, choice.model) === currentValue)?.label ?? currentModel,
+    [currentModel, currentValue, props.choices],
   );
   const currentSessionModelTitle = props.activeConnectionLabel && props.activeModelLabel
     ? `本会话固定模型：${props.activeConnectionLabel} · ${props.activeModelLabel}`
@@ -150,13 +84,21 @@ export function ChatModelSwitcher(props: {
       data-pending={pending ? 'true' : undefined}
       aria-busy={pending ? 'true' : undefined}
     >
-      <SelectRoot<string>
-        items={modelSelectItems}
+      <ModelPicker
+        groups={grouped}
         value={currentValue}
         disabled={disabled}
+        renderProviderMark={props.renderProviderMark}
+        ariaLabel="切换当前会话模型"
+        title={title}
+        triggerClassName="maka-model-switcher-trigger"
+        // PR-CHAT-CHROME-FIX-0 (WAWQAQ msg `ccce4a31`): menu rows show only
+        // the raw model name, never the connection/account name (which
+        // embeds the OAuth email).
+        pinnedItem={!currentKnownChoice ? { value: currentValue, label: currentModel } : undefined}
         onValueChange={(value) => {
           if (pendingRef.current || props.pending) return;
-          const next = typeof value === 'string' ? parseModelChoiceValue(value) : undefined;
+          const next = parseModelChoiceValue(value);
           if (!next) return;
           if (
             next.llmConnectionSlug === props.activeSession.llmConnectionSlug &&
@@ -186,41 +128,9 @@ export function ChatModelSwitcher(props: {
           })();
         }}
       >
-        <SelectTrigger
-          className="maka-model-switcher-trigger"
-          aria-label="切换当前会话模型"
-          title={title}
-        >
-          <span className="maka-model-switcher-label">{pending ? '切换中' : '模型'}</span>
-          <SelectValue className="maka-model-switcher-value" />
-        </SelectTrigger>
-        <SelectPortal>
-          <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="settingsSelectPositioner">
-            <SelectPopup className="settingsSelectMenuPopup">
-              {/* PR-CHAT-CHROME-FIX-0 (WAWQAQ msg `ccce4a31`):
-                   menu rows show only the raw model name. The
-                   group label (connection + email) and the meta
-                   line (duplicate model id) used to render below
-                   each row but produced "Codex OAuth ·
-                   kabikabigoog@gmail.com / gpt-5.5 / gpt-5.5" —
-                   user wanted just "gpt-5.5". Groups still
-                   separate connections visually via
-                   `<SelectSeparator>` between them. */}
-              <SelectList>
-                {!currentKnownChoice && (
-                  <>
-                    <SelectItem value={currentValue}>
-                      <span className="settingsSelectMenuOption">{currentModel}</span>
-                    </SelectItem>
-                    {grouped.length > 0 && <SelectSeparator />}
-                  </>
-                )}
-                <ModelChoiceOptions groups={grouped} renderProviderMark={props.renderProviderMark} />
-              </SelectList>
-            </SelectPopup>
-          </SelectPositioner>
-        </SelectPortal>
-      </SelectRoot>
+        <span className="maka-model-switcher-label">{pending ? '切换中' : '模型'}</span>
+        <span className="maka-model-switcher-value">{currentLabel}</span>
+      </ModelPicker>
     </div>
   );
 }
@@ -241,37 +151,22 @@ export function NewChatModelPicker(props: {
 }) {
   const grouped = modelMenuGroups(props.choices);
   return (
-    <SelectRoot<string>
-      items={props.choices.map((choice) => ({
-        value: modelChoiceValue(choice.connectionSlug, choice.model),
-        label: choice.label,
-      }))}
-      value={props.currentValue}
+    <ModelPicker
+      groups={grouped}
+      value={props.currentValue ?? ''}
+      renderProviderMark={props.renderProviderMark}
+      ariaLabel={`选择新对话模型，当前 ${props.label}`}
+      title={`新对话使用的模型：${props.label}`}
+      triggerClassName="maka-composer-model-chip"
       onValueChange={(value) => {
-        if (typeof value !== 'string') return;
         const next = parseModelChoiceValue(value);
         if (next) void props.onPick(next);
       }}
     >
-      <SelectTrigger
-        className="maka-composer-model-chip"
-        aria-label={`选择新对话模型，当前 ${props.label}`}
-        title={`新对话使用的模型：${props.label}`}
-      >
-        <span className="maka-composer-model-chip-text">{props.label}</span>
-        <span className="maka-composer-model-status" aria-hidden="true" />
-        {/* SelectTrigger already renders a BaseSelect.Icon chevron — no manual one. */}
-      </SelectTrigger>
-      <SelectPortal>
-        <SelectPositioner alignItemWithTrigger={false} sideOffset={8} className="settingsSelectPositioner">
-          <SelectPopup className="settingsSelectMenuPopup">
-            <SelectList>
-              <ModelChoiceOptions groups={grouped} renderProviderMark={props.renderProviderMark} />
-            </SelectList>
-          </SelectPopup>
-        </SelectPositioner>
-      </SelectPortal>
-    </SelectRoot>
+      <span className="maka-composer-model-chip-text">{props.label}</span>
+      <span className="maka-composer-model-status" aria-hidden="true" />
+      {/* ModelPicker's trigger already renders a chevron — no manual one. */}
+    </ModelPicker>
   );
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './locale-helpers.js';
 export * from './markdown.js';
 export * from './maka-uri.js';
 export * from './materialize.js';
+export * from './model-picker.js';
 export * from './permission-queue.js';
 export * from './redact.js';
 export * from './overlay-scroll-area.js';

--- a/packages/ui/src/model-picker-internals.ts
+++ b/packages/ui/src/model-picker-internals.ts
@@ -1,0 +1,72 @@
+import { type ModelMenuGroup, modelChoiceValue } from './chat-model-helpers.js';
+import type { ProviderType } from '@maka/core';
+
+export interface ModelPickerOption {
+  /** Encoded `<connectionSlug>:<model>` pair, or a pinned item's raw value. */
+  value: string;
+  label: string;
+  groupHeading?: string;
+  providerType?: ProviderType;
+  pinned?: boolean;
+}
+
+export interface ModelPickerOptionGroup {
+  key: string;
+  connectionSlug?: string;
+  providerType?: ProviderType;
+  heading?: string;
+  items: ModelPickerOption[];
+}
+
+export interface ModelPickerPinnedItem {
+  value: string;
+  label: string;
+}
+
+function normalizeSearch(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
+export function buildModelPickerGroups(
+  groups: readonly ModelMenuGroup[],
+  pinnedItem?: ModelPickerPinnedItem,
+): ModelPickerOptionGroup[] {
+  const pickerGroups: ModelPickerOptionGroup[] = [];
+
+  if (pinnedItem) {
+    pickerGroups.push({
+      key: '__pinned',
+      items: [{ ...pinnedItem, pinned: true }],
+    });
+  }
+
+  for (const group of groups) {
+    pickerGroups.push({
+      key: group.connectionSlug,
+      connectionSlug: group.connectionSlug,
+      providerType: group.providerType,
+      heading: group.heading,
+      items: group.choices.map((choice) => ({
+        value: modelChoiceValue(choice.connectionSlug, choice.model),
+        label: choice.label,
+        groupHeading: group.heading,
+        providerType: group.providerType,
+      })),
+    });
+  }
+
+  return pickerGroups;
+}
+
+export function filterModelPickerOption(option: ModelPickerOption, query: string): boolean {
+  if (option.pinned) return true;
+
+  const q = normalizeSearch(query);
+  if (!q) return true;
+
+  return normalizeSearch(option.label).includes(q) || normalizeSearch(option.groupHeading ?? '').includes(q);
+}
+
+export function modelPickerHasCatalogMatches(options: readonly ModelPickerOption[]): boolean {
+  return options.some((option) => !option.pinned);
+}

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -5,8 +5,8 @@
  * between the two surfaces (same governance goal as `PermissionModeMenuPopup`
  * in `permission-mode-menu.tsx`).
  *
- * Built on Base UI's `Combobox` (button trigger + popup-internal search
- * `<input>`) rather than `Select`, because `Select`'s built-in typeahead
+ * Built on Base UI's `Combobox` (button trigger + popup-internal search input)
+ * rather than `Select`, because `Select`'s built-in typeahead
  * isn't enough once a connection has dozens of catalog models.
  * `@maka/ui` stays icon-agnostic: `renderProviderMark` is supplied by the
  * desktop app, same convention as `ChatModelSwitcher`/`NewChatModelPicker`.

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -1,47 +1,24 @@
 /**
- * Shared, searchable model picker popup — one component behind both the
- * chat composer's model switcher and the Settings → 通用 → 默认模型 select,
- * so the grouped list, provider marks, and search behavior can't drift
- * between the two surfaces (same governance goal as `PermissionModeMenuPopup`
- * in `permission-mode-menu.tsx`).
- *
- * Built on Base UI's `Combobox` (button trigger + popup-internal search input)
- * rather than `Select`, because `Select`'s built-in typeahead
- * isn't enough once a connection has dozens of catalog models.
- * `@maka/ui` stays icon-agnostic: `renderProviderMark` is supplied by the
- * desktop app, same convention as `ChatModelSwitcher`/`NewChatModelPicker`.
- *
- * Filtering is done by hand (`visibleGroups` below) rather than via
- * Combobox's built-in `filter` prop: a `<Combobox.Group items={...}>`
- * renders exactly the array it's given — it does not re-slice that array
- * against the live query itself. The built-in `filter` only affects the
- * root's own bookkeeping (e.g. `Combobox.Empty`'s empty check), not what a
- * manually-declared group renders, so grouped + filterable has to compute
- * its own per-group subsets from the query and hand those to each group.
+ * Shared, searchable model picker popup: one component behind both the chat
+ * composer's model switcher and Settings → 通用 → 默认模型, so grouping,
+ * provider marks, and search behavior cannot drift between the two surfaces.
  */
 
-import { type ReactNode, useMemo, useState } from 'react';
-import {
-  ComboboxRoot,
-  ComboboxTrigger,
-  ComboboxPortal,
-  ComboboxPositioner,
-  ComboboxPopup,
-  ComboboxInput,
-  ComboboxList,
-  ComboboxGroup,
-  ComboboxGroupLabel,
-  ComboboxCollection,
-  ComboboxItem,
-} from './ui.js';
-import { type ModelMenuGroup, modelChoiceValue } from './chat-model-helpers.js';
+import { type ReactNode, forwardRef, useMemo, useState } from 'react';
+import { Combobox as BaseCombobox } from '@base-ui/react/combobox';
 import type { ProviderType } from '@maka/core';
-
-interface ModelPickerItem {
-  /** Encoded `<connectionSlug>:<model>` pair, or the pinned item's raw value (e.g. `''` for 未设置). */
-  value: string;
-  label: string;
-}
+import { type ModelMenuGroup } from './chat-model-helpers.js';
+import { Check, ChevronDown } from './icons.js';
+import {
+  buildModelPickerGroups,
+  filterModelPickerOption,
+  modelPickerHasCatalogMatches,
+  type ModelPickerOption,
+  type ModelPickerOptionGroup,
+  type ModelPickerPinnedItem,
+} from './model-picker-internals.js';
+import { cn } from './utils.js';
+import { buttonVariants } from './ui.js';
 
 export interface ModelPickerProps {
   groups: ModelMenuGroup[];
@@ -49,120 +26,192 @@ export interface ModelPickerProps {
   onValueChange(value: string): void;
   renderProviderMark?(type: ProviderType): ReactNode;
   disabled?: boolean;
-  /**
-   * Extra row pinned above the groups and exempt from search filtering —
-   * e.g. Settings' "未设置" or the composer's "current model isn't in the
-   * catalog anymore" fallback row.
-   */
-  pinnedItem?: { value: string; label: string };
+  /** Row pinned above catalog groups and exempt from search filtering. */
+  pinnedItem?: ModelPickerPinnedItem;
   searchPlaceholder?: string;
   emptyMessage?: string;
   triggerClassName?: string;
   popupClassName?: string;
   ariaLabel: string;
   title?: string;
-  /** Trigger button inner content (icon + label + whatever chrome the call site wants); the chevron is added automatically. */
+  /** Trigger button inner content; the chevron is added by ModelPicker. */
   children: ReactNode;
 }
 
-function toItem(connectionSlug: string, model: string, label: string): ModelPickerItem {
-  return { value: modelChoiceValue(connectionSlug, model), label };
+const ModelPickerTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger>>(function ModelPickerTrigger(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <BaseCombobox.Trigger
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'outline' }), 'justify-between', className)}
+      {...props}
+    >
+      {children}
+      <BaseCombobox.Icon>
+        <ChevronDown size={14} strokeWidth={1.75} aria-hidden="true" />
+      </BaseCombobox.Icon>
+    </BaseCombobox.Trigger>
+  );
+});
+
+const ModelPickerInput = forwardRef<HTMLInputElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Input>>(function ModelPickerInput(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.Input ref={ref} className={cn('w-full bg-transparent text-sm outline-none placeholder:text-foreground-secondary', className)} {...props} />;
+});
+
+const ModelPickerPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Popup>>(function ModelPickerPopup(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
+});
+
+const ModelPickerGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Group>>(function ModelPickerGroup(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.Group ref={ref} className={cn('py-1', className)} {...props} />;
+});
+
+const ModelPickerGroupLabel = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.GroupLabel>>(function ModelPickerGroupLabel(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} {...props} />;
+});
+
+const ModelPickerItem = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Item>>(function ModelPickerItem(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <BaseCombobox.Item
+      ref={ref}
+      className={cn('grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-muted data-[selected]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50', className)}
+      {...props}
+    >
+      <span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">
+        <BaseCombobox.ItemIndicator>
+          <Check size={13} strokeWidth={2} aria-hidden="true" />
+        </BaseCombobox.ItemIndicator>
+      </span>
+      <span className="min-w-0">{children}</span>
+    </BaseCombobox.Item>
+  );
+});
+
+function ModelPickerOptions(props: {
+  query: string;
+  hasPinnedItem: boolean;
+  emptyMessage?: string;
+  renderProviderMark?(type: ProviderType): ReactNode;
+}) {
+  const filteredGroups = BaseCombobox.useFilteredItems<ModelPickerOptionGroup>();
+  const filteredOptions = filteredGroups.flatMap((group) => group.items);
+  const noMatches = !modelPickerHasCatalogMatches(filteredOptions) && (props.query.trim().length > 0 || !props.hasPinnedItem);
+
+  return (
+    <>
+      {noMatches && (
+        <div className="modelPickerEmpty">{props.emptyMessage ?? '没有匹配的模型'}</div>
+      )}
+      <BaseCombobox.List className="modelPickerList">
+        {filteredGroups.map((group) => {
+          if (!group.heading) {
+            return group.items.map((item) => (
+              <ModelPickerItem key={item.value} value={item}>
+                <span className="settingsSelectMenuOption">{item.label}</span>
+              </ModelPickerItem>
+            ));
+          }
+
+          const logo = group.providerType ? props.renderProviderMark?.(group.providerType) : null;
+          return (
+            <ModelPickerGroup key={group.key} items={group.items}>
+              <ModelPickerGroupLabel className="settingsSelectMenuGroupLabel">
+                {logo ? (
+                  <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{logo}</span>
+                ) : (
+                  <span aria-hidden="true" />
+                )}
+                <span>{group.heading}</span>
+              </ModelPickerGroupLabel>
+              <BaseCombobox.Collection>
+                {(item: ModelPickerOption) => (
+                  <ModelPickerItem key={item.value} value={item}>
+                    <span className="settingsSelectMenuOption">{item.label}</span>
+                  </ModelPickerItem>
+                )}
+              </BaseCombobox.Collection>
+            </ModelPickerGroup>
+          );
+        })}
+      </BaseCombobox.List>
+    </>
+  );
 }
 
 export function ModelPicker(props: ModelPickerProps) {
+  const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-
-  const allItems = useMemo<ModelPickerItem[]>(() => [
-    ...(props.pinnedItem ? [props.pinnedItem] : []),
-    ...props.groups.flatMap((group) => group.choices.map((choice) => toItem(choice.connectionSlug, choice.model, choice.label))),
-  ], [props.groups, props.pinnedItem]);
-
+  const groups = useMemo(() => buildModelPickerGroups(props.groups, props.pinnedItem), [props.groups, props.pinnedItem]);
+  const allOptions = useMemo(() => groups.flatMap((group) => group.items), [groups]);
   const selectedItem = useMemo(
-    () => allItems.find((item) => item.value === props.value) ?? null,
-    [allItems, props.value],
+    () => allOptions.find((item) => item.value === props.value) ?? null,
+    [allOptions, props.value],
   );
 
-  const visibleGroups = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return props.groups;
-    return props.groups
-      .map((group) => ({
-        ...group,
-        choices: group.choices.filter(
-          (choice) => choice.label.toLowerCase().includes(q) || group.heading.toLowerCase().includes(q),
-        ),
-      }))
-      .filter((group) => group.choices.length > 0);
-  }, [props.groups, query]);
-
-  // The pinned row is exempt from filtering, so it alone doesn't count as a
-  // match: an active query with zero real hits still shows the empty message.
-  const noMatches = visibleGroups.length === 0 && (query.trim().length > 0 || !props.pinnedItem);
-
   return (
-    <ComboboxRoot<ModelPickerItem>
-      items={allItems}
+    <BaseCombobox.Root<ModelPickerOption>
+      items={groups}
       value={selectedItem}
-      onValueChange={(item) => {
-        if (item) props.onValueChange(item.value);
+      inputValue={query}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setQuery('');
       }}
-      onInputValueChange={(next) => setQuery(next)}
+      onValueChange={(item) => {
+        if (!item) return;
+        props.onValueChange(item.value);
+        setQuery('');
+        setOpen(false);
+      }}
+      onInputValueChange={(next) => setQuery(String(next))}
+      filter={filterModelPickerOption}
       isItemEqualToValue={(item, value) => item.value === value.value}
       itemToStringLabel={(item) => item.label}
       disabled={props.disabled}
     >
-      <ComboboxTrigger
+      <ModelPickerTrigger
         className={props.triggerClassName}
         aria-label={props.ariaLabel}
         title={props.title}
         disabled={props.disabled}
       >
         {props.children}
-      </ComboboxTrigger>
-      <ComboboxPortal>
-        <ComboboxPositioner sideOffset={8} className="settingsSelectPositioner">
-          <ComboboxPopup className={props.popupClassName ?? 'settingsSelectMenuPopup modelPickerPopup'}>
-            <ComboboxInput
+      </ModelPickerTrigger>
+      <BaseCombobox.Portal>
+        <BaseCombobox.Positioner sideOffset={8} className="settingsSelectPositioner">
+          <ModelPickerPopup className={props.popupClassName ?? 'settingsSelectMenuPopup modelPickerPopup'}>
+            <ModelPickerInput
               className="modelPickerSearchInput"
               placeholder={props.searchPlaceholder ?? '搜索模型…'}
               aria-label={props.searchPlaceholder ?? '搜索模型'}
             />
-            {noMatches && (
-              <div className="modelPickerEmpty">{props.emptyMessage ?? '没有匹配的模型'}</div>
-            )}
-            <ComboboxList>
-              {props.pinnedItem && (
-                <ComboboxItem value={props.pinnedItem}>
-                  <span className="settingsSelectMenuOption">{props.pinnedItem.label}</span>
-                </ComboboxItem>
-              )}
-              {visibleGroups.map((group) => {
-                const logo = props.renderProviderMark?.(group.providerType);
-                const groupItems = group.choices.map((choice) => toItem(choice.connectionSlug, choice.model, choice.label));
-                return (
-                  <ComboboxGroup key={group.connectionSlug} items={groupItems}>
-                    <ComboboxGroupLabel className="settingsSelectMenuGroupLabel">
-                      {logo ? (
-                        <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{logo}</span>
-                      ) : (
-                        <span aria-hidden="true" />
-                      )}
-                      <span>{group.heading}</span>
-                    </ComboboxGroupLabel>
-                    <ComboboxCollection>
-                      {(item: ModelPickerItem) => (
-                        <ComboboxItem key={item.value} value={item}>
-                          <span className="settingsSelectMenuOption">{item.label}</span>
-                        </ComboboxItem>
-                      )}
-                    </ComboboxCollection>
-                  </ComboboxGroup>
-                );
-              })}
-            </ComboboxList>
-          </ComboboxPopup>
-        </ComboboxPositioner>
-      </ComboboxPortal>
-    </ComboboxRoot>
+            <ModelPickerOptions
+              query={query}
+              hasPinnedItem={Boolean(props.pinnedItem)}
+              emptyMessage={props.emptyMessage}
+              renderProviderMark={props.renderProviderMark}
+            />
+          </ModelPickerPopup>
+        </BaseCombobox.Positioner>
+      </BaseCombobox.Portal>
+    </BaseCombobox.Root>
   );
 }

--- a/packages/ui/src/model-picker.tsx
+++ b/packages/ui/src/model-picker.tsx
@@ -1,0 +1,168 @@
+/**
+ * Shared, searchable model picker popup — one component behind both the
+ * chat composer's model switcher and the Settings → 通用 → 默认模型 select,
+ * so the grouped list, provider marks, and search behavior can't drift
+ * between the two surfaces (same governance goal as `PermissionModeMenuPopup`
+ * in `permission-mode-menu.tsx`).
+ *
+ * Built on Base UI's `Combobox` (button trigger + popup-internal search
+ * `<input>`) rather than `Select`, because `Select`'s built-in typeahead
+ * isn't enough once a connection has dozens of catalog models.
+ * `@maka/ui` stays icon-agnostic: `renderProviderMark` is supplied by the
+ * desktop app, same convention as `ChatModelSwitcher`/`NewChatModelPicker`.
+ *
+ * Filtering is done by hand (`visibleGroups` below) rather than via
+ * Combobox's built-in `filter` prop: a `<Combobox.Group items={...}>`
+ * renders exactly the array it's given — it does not re-slice that array
+ * against the live query itself. The built-in `filter` only affects the
+ * root's own bookkeeping (e.g. `Combobox.Empty`'s empty check), not what a
+ * manually-declared group renders, so grouped + filterable has to compute
+ * its own per-group subsets from the query and hand those to each group.
+ */
+
+import { type ReactNode, useMemo, useState } from 'react';
+import {
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxPortal,
+  ComboboxPositioner,
+  ComboboxPopup,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxGroup,
+  ComboboxGroupLabel,
+  ComboboxCollection,
+  ComboboxItem,
+} from './ui.js';
+import { type ModelMenuGroup, modelChoiceValue } from './chat-model-helpers.js';
+import type { ProviderType } from '@maka/core';
+
+interface ModelPickerItem {
+  /** Encoded `<connectionSlug>:<model>` pair, or the pinned item's raw value (e.g. `''` for 未设置). */
+  value: string;
+  label: string;
+}
+
+export interface ModelPickerProps {
+  groups: ModelMenuGroup[];
+  value: string;
+  onValueChange(value: string): void;
+  renderProviderMark?(type: ProviderType): ReactNode;
+  disabled?: boolean;
+  /**
+   * Extra row pinned above the groups and exempt from search filtering —
+   * e.g. Settings' "未设置" or the composer's "current model isn't in the
+   * catalog anymore" fallback row.
+   */
+  pinnedItem?: { value: string; label: string };
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  triggerClassName?: string;
+  popupClassName?: string;
+  ariaLabel: string;
+  title?: string;
+  /** Trigger button inner content (icon + label + whatever chrome the call site wants); the chevron is added automatically. */
+  children: ReactNode;
+}
+
+function toItem(connectionSlug: string, model: string, label: string): ModelPickerItem {
+  return { value: modelChoiceValue(connectionSlug, model), label };
+}
+
+export function ModelPicker(props: ModelPickerProps) {
+  const [query, setQuery] = useState('');
+
+  const allItems = useMemo<ModelPickerItem[]>(() => [
+    ...(props.pinnedItem ? [props.pinnedItem] : []),
+    ...props.groups.flatMap((group) => group.choices.map((choice) => toItem(choice.connectionSlug, choice.model, choice.label))),
+  ], [props.groups, props.pinnedItem]);
+
+  const selectedItem = useMemo(
+    () => allItems.find((item) => item.value === props.value) ?? null,
+    [allItems, props.value],
+  );
+
+  const visibleGroups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return props.groups;
+    return props.groups
+      .map((group) => ({
+        ...group,
+        choices: group.choices.filter(
+          (choice) => choice.label.toLowerCase().includes(q) || group.heading.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((group) => group.choices.length > 0);
+  }, [props.groups, query]);
+
+  // The pinned row is exempt from filtering, so it alone doesn't count as a
+  // match: an active query with zero real hits still shows the empty message.
+  const noMatches = visibleGroups.length === 0 && (query.trim().length > 0 || !props.pinnedItem);
+
+  return (
+    <ComboboxRoot<ModelPickerItem>
+      items={allItems}
+      value={selectedItem}
+      onValueChange={(item) => {
+        if (item) props.onValueChange(item.value);
+      }}
+      onInputValueChange={(next) => setQuery(next)}
+      isItemEqualToValue={(item, value) => item.value === value.value}
+      itemToStringLabel={(item) => item.label}
+      disabled={props.disabled}
+    >
+      <ComboboxTrigger
+        className={props.triggerClassName}
+        aria-label={props.ariaLabel}
+        title={props.title}
+        disabled={props.disabled}
+      >
+        {props.children}
+      </ComboboxTrigger>
+      <ComboboxPortal>
+        <ComboboxPositioner sideOffset={8} className="settingsSelectPositioner">
+          <ComboboxPopup className={props.popupClassName ?? 'settingsSelectMenuPopup modelPickerPopup'}>
+            <ComboboxInput
+              className="modelPickerSearchInput"
+              placeholder={props.searchPlaceholder ?? '搜索模型…'}
+              aria-label={props.searchPlaceholder ?? '搜索模型'}
+            />
+            {noMatches && (
+              <div className="modelPickerEmpty">{props.emptyMessage ?? '没有匹配的模型'}</div>
+            )}
+            <ComboboxList>
+              {props.pinnedItem && (
+                <ComboboxItem value={props.pinnedItem}>
+                  <span className="settingsSelectMenuOption">{props.pinnedItem.label}</span>
+                </ComboboxItem>
+              )}
+              {visibleGroups.map((group) => {
+                const logo = props.renderProviderMark?.(group.providerType);
+                const groupItems = group.choices.map((choice) => toItem(choice.connectionSlug, choice.model, choice.label));
+                return (
+                  <ComboboxGroup key={group.connectionSlug} items={groupItems}>
+                    <ComboboxGroupLabel className="settingsSelectMenuGroupLabel">
+                      {logo ? (
+                        <span className="settingsSelectMenuGroupLogo" aria-hidden="true">{logo}</span>
+                      ) : (
+                        <span aria-hidden="true" />
+                      )}
+                      <span>{group.heading}</span>
+                    </ComboboxGroupLabel>
+                    <ComboboxCollection>
+                      {(item: ModelPickerItem) => (
+                        <ComboboxItem key={item.value} value={item}>
+                          <span className="settingsSelectMenuOption">{item.label}</span>
+                        </ComboboxItem>
+                      )}
+                    </ComboboxCollection>
+                  </ComboboxGroup>
+                );
+              })}
+            </ComboboxList>
+          </ComboboxPopup>
+        </ComboboxPositioner>
+      </ComboboxPortal>
+    </ComboboxRoot>
+  );
+}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -341,7 +341,7 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
 
 // =============================================================
 // Combobox — a Select-shaped trigger button whose popup embeds a
-// search `<input>` above the (optionally grouped) item list. Used
+// search input above the (optionally grouped) item list. Used
 // for pickers with long/filterable option lists (e.g. the model
 // picker) where a plain Select's typeahead isn't enough. Same
 // forwardRef + `cn(...)` wrapping recipe as the Select block above.

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -10,6 +10,7 @@ import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { Toggle as BaseToggle } from '@base-ui/react/toggle';
 import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
 import { Select as BaseSelect } from '@base-ui/react/select';
+import { Combobox as BaseCombobox } from '@base-ui/react/combobox';
 import { Separator as BaseSeparator } from '@base-ui/react/separator';
 import { Check, ChevronDown, X } from './icons.js';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -284,12 +285,6 @@ export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsW
 export const SelectValue = BaseSelect.Value;
 export const SelectPortal = BaseSelect.Portal;
 export const SelectPositioner = BaseSelect.Positioner;
-export const SelectList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.List>>(function SelectList(
-  { className, ...props },
-  ref,
-) {
-  return <BaseSelect.List ref={ref} className={cn('max-h-[var(--available-height)] overflow-y-auto py-1', className)} {...props} />;
-});
 export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Popup>>(function SelectPopup(
   { className, ...props },
   ref,
@@ -341,6 +336,87 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
         <BaseSelect.ItemText>{children}</BaseSelect.ItemText>
       </span>
     </BaseSelect.Item>
+  );
+});
+
+// =============================================================
+// Combobox — a Select-shaped trigger button whose popup embeds a
+// search `<input>` above the (optionally grouped) item list. Used
+// for pickers with long/filterable option lists (e.g. the model
+// picker) where a plain Select's typeahead isn't enough. Same
+// forwardRef + `cn(...)` wrapping recipe as the Select block above.
+// =============================================================
+
+export const ComboboxRoot = BaseCombobox.Root;
+export const ComboboxTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger>>(function ComboboxTrigger(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <BaseCombobox.Trigger
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'outline' }), 'justify-between', className)}
+      {...props}
+    >
+      {children}
+      <BaseCombobox.Icon>
+        <ChevronDown size={14} strokeWidth={1.75} aria-hidden="true" />
+      </BaseCombobox.Icon>
+    </BaseCombobox.Trigger>
+  );
+});
+export const ComboboxPortal = BaseCombobox.Portal;
+export const ComboboxPositioner = BaseCombobox.Positioner;
+export const ComboboxInput = forwardRef<HTMLInputElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Input>>(function ComboboxInput(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.Input ref={ref} className={cn('w-full bg-transparent text-sm outline-none placeholder:text-foreground-secondary', className)} {...props} />;
+});
+export const ComboboxList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.List>>(function ComboboxList(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.List ref={ref} className={cn('max-h-[var(--available-height)] overflow-y-auto py-1', className)} {...props} />;
+});
+export const ComboboxPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Popup>>(function ComboboxPopup(
+  { className, ...props },
+  ref,
+) {
+  // Same z-index reasoning as `SelectPopup` above — must float above a
+  // Settings modal's `--z-modal` layer.
+  return <BaseCombobox.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
+});
+export const ComboboxGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Group>>(function ComboboxGroup(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.Group ref={ref} className={cn('py-1', className)} {...props} />;
+});
+export const ComboboxGroupLabel = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.GroupLabel>>(function ComboboxGroupLabel(
+  { className, ...props },
+  ref,
+) {
+  return <BaseCombobox.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} {...props} />;
+});
+export const ComboboxCollection = BaseCombobox.Collection;
+export const ComboboxItem = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Item>>(function ComboboxItem(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <BaseCombobox.Item
+      ref={ref}
+      className={cn('grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-muted data-[selected]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50', className)}
+      {...props}
+    >
+      <span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">
+        <BaseCombobox.ItemIndicator>
+          <Check size={13} strokeWidth={2} aria-hidden="true" />
+        </BaseCombobox.ItemIndicator>
+      </span>
+      <span className="min-w-0">{children}</span>
+    </BaseCombobox.Item>
   );
 });
 

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -10,7 +10,6 @@ import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { Toggle as BaseToggle } from '@base-ui/react/toggle';
 import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
 import { Select as BaseSelect } from '@base-ui/react/select';
-import { Combobox as BaseCombobox } from '@base-ui/react/combobox';
 import { Separator as BaseSeparator } from '@base-ui/react/separator';
 import { Check, ChevronDown, X } from './icons.js';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -336,87 +335,6 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
         <BaseSelect.ItemText>{children}</BaseSelect.ItemText>
       </span>
     </BaseSelect.Item>
-  );
-});
-
-// =============================================================
-// Combobox — a Select-shaped trigger button whose popup embeds a
-// search input above the (optionally grouped) item list. Used
-// for pickers with long/filterable option lists (e.g. the model
-// picker) where a plain Select's typeahead isn't enough. Same
-// forwardRef + `cn(...)` wrapping recipe as the Select block above.
-// =============================================================
-
-export const ComboboxRoot = BaseCombobox.Root;
-export const ComboboxTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Trigger>>(function ComboboxTrigger(
-  { className, children, ...props },
-  ref,
-) {
-  return (
-    <BaseCombobox.Trigger
-      ref={ref}
-      className={cn(buttonVariants({ variant: 'outline' }), 'justify-between', className)}
-      {...props}
-    >
-      {children}
-      <BaseCombobox.Icon>
-        <ChevronDown size={14} strokeWidth={1.75} aria-hidden="true" />
-      </BaseCombobox.Icon>
-    </BaseCombobox.Trigger>
-  );
-});
-export const ComboboxPortal = BaseCombobox.Portal;
-export const ComboboxPositioner = BaseCombobox.Positioner;
-export const ComboboxInput = forwardRef<HTMLInputElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Input>>(function ComboboxInput(
-  { className, ...props },
-  ref,
-) {
-  return <BaseCombobox.Input ref={ref} className={cn('w-full bg-transparent text-sm outline-none placeholder:text-foreground-secondary', className)} {...props} />;
-});
-export const ComboboxList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.List>>(function ComboboxList(
-  { className, ...props },
-  ref,
-) {
-  return <BaseCombobox.List ref={ref} className={cn('max-h-[var(--available-height)] overflow-y-auto py-1', className)} {...props} />;
-});
-export const ComboboxPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Popup>>(function ComboboxPopup(
-  { className, ...props },
-  ref,
-) {
-  // Same z-index reasoning as `SelectPopup` above — must float above a
-  // Settings modal's `--z-modal` layer.
-  return <BaseCombobox.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
-});
-export const ComboboxGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Group>>(function ComboboxGroup(
-  { className, ...props },
-  ref,
-) {
-  return <BaseCombobox.Group ref={ref} className={cn('py-1', className)} {...props} />;
-});
-export const ComboboxGroupLabel = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.GroupLabel>>(function ComboboxGroupLabel(
-  { className, ...props },
-  ref,
-) {
-  return <BaseCombobox.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} {...props} />;
-});
-export const ComboboxCollection = BaseCombobox.Collection;
-export const ComboboxItem = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseCombobox.Item>>(function ComboboxItem(
-  { className, children, ...props },
-  ref,
-) {
-  return (
-    <BaseCombobox.Item
-      ref={ref}
-      className={cn('grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-muted data-[selected]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50', className)}
-      {...props}
-    >
-      <span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">
-        <BaseCombobox.ItemIndicator>
-          <Check size={13} strokeWidth={2} aria-hidden="true" />
-        </BaseCombobox.ItemIndicator>
-      </span>
-      <span className="min-w-0">{children}</span>
-    </BaseCombobox.Item>
   );
 });
 

--- a/packages/ui/stories/model-picker.stories.tsx
+++ b/packages/ui/stories/model-picker.stories.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ProviderType } from '@maka/core';
+import { ModelPicker } from '../src/model-picker.js';
+import type { ModelMenuGroup } from '../src/chat-model-helpers.js';
+
+const meta = {
+  title: 'Product/Model Picker',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const GROUPS: ModelMenuGroup[] = [
+  {
+    connectionSlug: 'openai-main',
+    providerType: 'openai',
+    heading: 'OpenAI main',
+    choices: [
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'gpt-5', label: 'GPT-5' },
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'gpt-5-mini', label: 'GPT-5 mini' },
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'o3', label: 'o3' },
+      { connectionSlug: 'openai-main', providerType: 'openai', model: 'o3-mini', label: 'o3 mini' },
+    ],
+  },
+  {
+    connectionSlug: 'anthropic-team',
+    providerType: 'anthropic',
+    heading: 'Claude Team',
+    choices: [
+      { connectionSlug: 'anthropic-team', providerType: 'anthropic', model: 'claude-opus-4-1', label: 'Claude Opus 4.1' },
+      { connectionSlug: 'anthropic-team', providerType: 'anthropic', model: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+      { connectionSlug: 'anthropic-team', providerType: 'anthropic', model: 'claude-haiku-3-5', label: 'Claude Haiku 3.5' },
+    ],
+  },
+  {
+    connectionSlug: 'google-lab',
+    providerType: 'google',
+    heading: 'Gemini Lab',
+    choices: [
+      { connectionSlug: 'google-lab', providerType: 'google', model: 'gemini-3-pro', label: 'Gemini 3 Pro' },
+      { connectionSlug: 'google-lab', providerType: 'google', model: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    ],
+  },
+  {
+    connectionSlug: 'openrouter',
+    providerType: 'openai-compatible',
+    heading: 'OpenRouter',
+    choices: Array.from({ length: 14 }, (_, index) => ({
+      connectionSlug: 'openrouter',
+      providerType: 'openai-compatible' as const,
+      model: `catalog-model-${index + 1}`,
+      label: `Catalog model ${index + 1}`,
+    })),
+  },
+];
+
+function providerMark(type: ProviderType) {
+  const labels: Partial<Record<ProviderType, string>> = {
+    openai: 'O',
+    anthropic: 'A',
+    google: 'G',
+    'openai-compatible': 'R',
+  };
+  return <span style={{ fontSize: 11, fontWeight: 700 }}>{labels[type] ?? 'M'}</span>;
+}
+
+function selectedLabel(value: string) {
+  if (!value) return '未设置';
+  return GROUPS.flatMap((group) => group.choices).find((choice) => `${choice.connectionSlug}:${choice.model}` === value)?.label ?? value;
+}
+
+function ModelPickerFrame() {
+  const [value, setValue] = useState('');
+  const label = useMemo(() => selectedLabel(value), [value]);
+
+  return (
+    <div style={{ display: 'grid', gap: 12, width: 280 }}>
+      <ModelPicker
+        groups={GROUPS}
+        value={value}
+        onValueChange={setValue}
+        pinnedItem={{ value: '', label: '未设置' }}
+        renderProviderMark={providerMark}
+        ariaLabel="选择模型"
+        triggerClassName="settingsSelectTrigger"
+        popupClassName="settingsSelectMenuPopup modelPickerPopup"
+      >
+        <span className="settingsSelectMenuOption">{label}</span>
+      </ModelPicker>
+      <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>
+        试试搜索 “sonnet”、“OpenAI” 或一个不存在的词。
+      </span>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ModelPickerFrame />,
+};

--- a/packages/ui/stories/select.stories.tsx
+++ b/packages/ui/stories/select.stories.tsx
@@ -5,7 +5,6 @@ import {
   SelectGroup,
   SelectGroupLabel,
   SelectItem,
-  SelectList,
   SelectPortal,
   SelectPositioner,
   SelectPopup,
@@ -53,7 +52,7 @@ function SelectPopupFrame({ children }: { children: React.ReactNode }) {
     <SelectPortal>
       <SelectPositioner alignItemWithTrigger={false} sideOffset={8}>
         <SelectPopup>
-          <SelectList>{children}</SelectList>
+          {children}
         </SelectPopup>
       </SelectPositioner>
     </SelectPortal>


### PR DESCRIPTION

<img width="343" height="473" alt="image" src="https://github.com/user-attachments/assets/9043c8f0-7c36-4f11-b647-5d0bdeefa96e" />

↓

<img width="323" height="423" alt="image" src="https://github.com/user-attachments/assets/b0ca6fe9-f791-49ad-be50-1461a70c4ce1" />

## Summary

The model dropdown previously shipped as two drifting implementations — the composer's `ChatModelSwitcher`/`NewChatModelPicker` (Select-based) and Settings → 通用 → 默认模型 (`SettingsSelect` assembly) — with no way to search once a connection exposes a large catalog (an OpenRouter connection easily lists 300+ models).

This PR replaces both with one shared, searchable `ModelPicker` in `@maka/ui`:

- **Search**: a filter input pinned above the list (Base UI `Combobox`); typing matches both model labels and group headings, so `deepseek` narrows across connections. Filtering is computed per-group by hand because `Combobox.Group items={...}` renders exactly what it's given — the built-in `filter` prop can't drive manually-declared groups.
- **Provider icons**: group headings keep their brand marks, still injected by the desktop app via `renderProviderMark` so `@maka/ui` stays free of the provider SVG library.
- **Connection names**: non-OAuth connections now show the user's own connection name as the group heading (e.g. "Openrouter" instead of the generic "自定义"). OAuth providers (`claude-subscription` / `codex-subscription` / `gemini-cli`) keep the leak-safe provider label because their `connection.name` embeds the account email (PR-CHAT-CHROME-FIX-0). Same-name and same-provider collisions both disambiguate with the connection slug.
- **One popup, three surfaces**: the composer's in-session switcher, the new-chat picker, and Settings 默认模型 (pinned 未设置 row) all render the same component, so they can't drift.

## Review + fixes folded in

A high-effort review pass on the diff surfaced and this PR fixes:
- same-name connections collapsing into indistinguishable group headings (now slug-suffixed);
- the no-match empty message being suppressed whenever a pinned row exists;
- contract tests pinning the old `SelectRoot`/`ModelChoiceOptions` source structure (updated to the new shape);
- unused `ComboboxValue`/`ComboboxEmpty`/`SelectList` exports (removed — `SelectList`'s last real consumer was the old switcher).

## Tests

- New unit tests for the `connectionName` heading rules (name wins, blank falls back, same-name disambiguation, OAuth email-leak guard in `buildCatalogChatModelChoices`).
- `apps/desktop` suite: 1866/1866 pass. `@maka/ui` suite: the only 2 failures are the pre-existing `chat-primitives` tailwind-merge failures, verified present on a pristine checkout of the branch point.
- Manually verified in the running app (composer picker: 343 items filter correctly; Settings picker: search + pinned 未设置 + grouped headings Claude 订阅 / Openrouter / DeepSeek; no-match query shows the empty message alongside the pinned row).

Co-Authored-By: Claude <noreply@anthropic.com>