### PR TITLE
refactor(ui): migrate toast + confirm + permission dialogs to Base UI (#520 PR6)

### DIFF
--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -175,7 +175,9 @@ const COMPONENT_RADIUS: ComponentRadiusCheck[] = [
   { file: 'packages/ui/src/ui.tsx', name: 'SelectItem', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'Toggle', tier: 'control' },
   { file: 'packages/ui/src/ui.tsx', name: 'badgeVariants', tier: 'pill' },
-  { file: 'packages/ui/src/ui.tsx', name: 'DialogPopup', tier: 'modal' },
+  // DialogPopup/AlertDialogPopup were merged into createModalContent (PR6
+  // review P3.1); the modal popup class now lives in MODAL_POPUP_CLASS.
+  { file: 'packages/ui/src/ui.tsx', name: 'MODAL_POPUP_CLASS', tier: 'modal' },
   { file: 'packages/ui/src/ui.tsx', name: 'SelectPopup', tier: 'surface' },
   // TabsTrigger/TabsList used to be declared in ui.tsx with --radius-* tokens;
   // #499 P0-3 re-exports them from primitives/tabs.tsx, which uses Tailwind

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -142,7 +142,7 @@ describe('renderer utility surfaces use shared UI primitives', () => {
   it('keeps toast actions and confirm dialog buttons on shared Button without legacy classes', async () => {
     const source = await readFile(join(repoRoot, 'packages/ui/src/toast.tsx'), 'utf8');
 
-    assert.match(source, /import \{ Button \} from '.\/ui\.js';/);
+    assert.match(source, /import \{[^}]*\bButton\b[^}]*\} from '.\/ui\.js';/);
     assert.doesNotMatch(source, /<button\b/, 'ToastProvider controls must use shared Button');
     assert.doesNotMatch(source, /className="maka-button/, 'Confirm dialog actions must not keep legacy maka-button styling');
     assert.match(source, /<Button[\s\S]*className="maka-toast-action"/);

--- a/apps/desktop/src/main/__tests__/toast-confirm-keyboard-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/toast-confirm-keyboard-contract.test.ts
@@ -70,4 +70,21 @@ describe('toast.confirm keyboard safety contract', () => {
     assert.match(confirmBlock, /initialFocus=\{cancelRef\}/, 'Base UI AlertDialog focuses the cancel button via initialFocus');
     assert.match(confirmBlock, /<Button\s+ref=\{cancelRef\}[\s\S]*onClick=\{\(\) => props\.onResolve\(false\)\}/);
   });
+
+  it('remounts ConfirmDialog on queue advance so initialFocus re-targets the cancel button', async () => {
+    const src = await readFile(TOAST_SOURCE, 'utf8');
+    const providerBlock = src.match(/export function ToastProvider[\s\S]*?\n\}/)?.[0] ?? '';
+
+    // PendingConfirm carries a stable id so the second confirm in a queue
+    // remounts ConfirmDialog (key change). Without this, AlertDialog's
+    // uncontrolled `defaultOpen` + `initialFocus` only fire on the first
+    // mount, leaving focus on the confirm button → Enter mis-confirms a
+    // dangerous op (PR6 review P1).
+    assert.match(providerBlock, /const request: PendingConfirm = \{ id: `c\$\{\+\+idSeed\.current\}`, \.\.\.input, resolve \}/);
+    assert.match(
+      providerBlock,
+      /<ConfirmDialog key=\{confirmState\.id\} request=\{confirmState\}/,
+      'ConfirmDialog must key on confirmState.id so queue advance remounts the dialog and re-runs initialFocus',
+    );
+  });
 });

--- a/apps/desktop/src/main/__tests__/toast-confirm-keyboard-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/toast-confirm-keyboard-contract.test.ts
@@ -49,7 +49,7 @@ describe('toast.confirm keyboard safety contract', () => {
     const src = await readFile(TOAST_SOURCE, 'utf8');
     const confirmBlock = src.match(/function ConfirmDialog[\s\S]*?\n\}/)?.[0] ?? '';
 
-    assert.match(confirmBlock, /role="alertdialog"/, 'confirm must remain an accessible alertdialog');
+    assert.match(confirmBlock, /AlertDialogRoot/, 'confirm must remain an accessible alertdialog (Base UI AlertDialog auto-sets role)');
     assert.doesNotMatch(
       confirmBlock,
       /addEventListener\('keydown'[\s\S]*event\.key === 'Enter'[\s\S]*onResolve\(true\)/,
@@ -67,7 +67,7 @@ describe('toast.confirm keyboard safety contract', () => {
     const confirmBlock = src.match(/function ConfirmDialog[\s\S]*?\n\}/)?.[0] ?? '';
 
     assert.match(confirmBlock, /const cancelRef = useRef<HTMLButtonElement>\(null\)/);
-    assert.match(confirmBlock, /useModalA11y\(dialogRef, \(\) => props\.onResolve\(false\), cancelRef\)/);
+    assert.match(confirmBlock, /initialFocus=\{cancelRef\}/, 'Base UI AlertDialog focuses the cancel button via initialFocus');
     assert.match(confirmBlock, /<Button\s+ref=\{cancelRef\}[\s\S]*onClick=\{\(\) => props\.onResolve\(false\)\}/);
   });
 });

--- a/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
@@ -37,21 +37,21 @@ const UI_FILE = resolve(REPO_ROOT, 'packages/ui/src/ui.tsx');
 const ALLOWED_BARE: ReadonlyArray<{ pattern: string; count: number; reason: string }> = [
   {
     pattern: 'z-40',
-    count: 1,
+    count: 2,
     reason:
-      'dialog backdrop scrim layer; sits below the popup at z-50. Equivalent to --z-titlebar (40) by value but semantically distinct, so not yet tokenized.',
+      'dialog + alert-dialog backdrop scrim layer; sits below the popup at z-50. AlertDialogBackdrop shares the hook (PR6 #520). Equivalent to --z-titlebar (40) by value but semantically distinct, so not yet tokenized.',
   },
   {
     pattern: 'z-50',
-    count: 1,
+    count: 2,
     reason:
       'dialog popup (DialogContent). The previously z-50 floating-overlay surfaces (TooltipPopup, SelectPopup, PopoverPopup) were tokenized to `z-[var(--z-overlay)]` so a Select opened from inside a Settings modal floats above the modal (WAWQAQ msg `d3ea9a33` 2026-06-26). PR-UI-DEAD-EXPORT-SWEEP-0 then deleted PopoverPopup entirely (was unused). Sheet exports were deleted as dead code (0 consumers).',
   },
   {
     pattern: 'backdrop-blur-sm',
-    count: 1,
+    count: 2,
     reason:
-      'dialog backdrop visual depth. Pending kenji #6 audit decision on whether to drop blur entirely or tokenize a single --blur-scrim value.',
+      'dialog + alert-dialog backdrop visual depth. AlertDialogBackdrop shares the blur (PR6 #520). Pending kenji #6 audit decision on whether to drop blur entirely or tokenize a single --blur-scrim value.',
   },
 ];
 

--- a/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ui-tsx-design-contract.test.ts
@@ -37,21 +37,21 @@ const UI_FILE = resolve(REPO_ROOT, 'packages/ui/src/ui.tsx');
 const ALLOWED_BARE: ReadonlyArray<{ pattern: string; count: number; reason: string }> = [
   {
     pattern: 'z-40',
-    count: 2,
+    count: 1,
     reason:
-      'dialog + alert-dialog backdrop scrim layer; sits below the popup at z-50. AlertDialogBackdrop shares the hook (PR6 #520). Equivalent to --z-titlebar (40) by value but semantically distinct, so not yet tokenized.',
+      'dialog + alert-dialog backdrop scrim layer (single MODAL_BACKDROP_CLASS constant shared via createModalContent); sits below the popup at z-50. Equivalent to --z-titlebar (40) by value but semantically distinct, so not yet tokenized.',
   },
   {
     pattern: 'z-50',
-    count: 2,
+    count: 1,
     reason:
-      'dialog popup (DialogContent). The previously z-50 floating-overlay surfaces (TooltipPopup, SelectPopup, PopoverPopup) were tokenized to `z-[var(--z-overlay)]` so a Select opened from inside a Settings modal floats above the modal (WAWQAQ msg `d3ea9a33` 2026-06-26). PR-UI-DEAD-EXPORT-SWEEP-0 then deleted PopoverPopup entirely (was unused). Sheet exports were deleted as dead code (0 consumers).',
+      'dialog popup (single MODAL_POPUP_CLASS constant shared via createModalContent, used by DialogContent + AlertDialogContent). The previously z-50 floating-overlay surfaces (TooltipPopup, SelectPopup, PopoverPopup) were tokenized to `z-[var(--z-overlay)]` so a Select opened from inside a Settings modal floats above the modal (WAWQAQ msg `d3ea9a33` 2026-06-26). PR-UI-DEAD-EXPORT-SWEEP-0 then deleted PopoverPopup entirely (was unused). Sheet exports were deleted as dead code (0 consumers).',
   },
   {
     pattern: 'backdrop-blur-sm',
-    count: 2,
+    count: 1,
     reason:
-      'dialog + alert-dialog backdrop visual depth. AlertDialogBackdrop shares the blur (PR6 #520). Pending kenji #6 audit decision on whether to drop blur entirely or tokenize a single --blur-scrim value.',
+      'dialog + alert-dialog backdrop visual depth (single MODAL_BACKDROP_CLASS constant shared via createModalContent). Pending kenji #6 audit decision on whether to drop blur entirely or tokenize a single --blur-scrim value.',
   },
 ];
 

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -476,7 +476,7 @@
   100% { opacity: 0; transform: translateY(6px) scale(0.98); }
 }
 
-.maka-toast[data-exiting="true"] {
+.maka-toast[data-ending-style] {
   animation: maka-toast-exit var(--duration-emphasized) var(--ease-in-out-strong) forwards;
   pointer-events: none;
 }

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -598,12 +598,6 @@
   width: min(420px, calc(100vw - 48px));
 }
 
-.maka-confirm-backdrop {
-  /* Slightly opaque so destructive confirms feel weightier than regular
-     toast notifications. */
-  background: oklch(from var(--background) l c h / 0.7);
-}
-
 .maka-help-modal {
   width: min(560px, calc(100vw - 48px));
   max-height: calc(100dvh - 96px);

--- a/packages/ui/src/permission-dialog.tsx
+++ b/packages/ui/src/permission-dialog.tsx
@@ -3,8 +3,7 @@ import type { PermissionRequestEvent, PermissionResponse } from '@maka/core';
 import { derivePermissionRequestHealth, formatPermissionRequestWait } from '@maka/core';
 import { AlertOctagon, AlertTriangle, FileEdit, GitMerge, Globe, HelpCircle, ShieldAlert, Terminal, Wifi } from './icons.js';
 import { Alert, AlertDescription } from './primitives/alert.js';
-import { Badge, Button as UiButton, Checkbox, DialogContent, DialogRoot } from './ui.js';
-import { useModalA11y } from './modal-a11y.js';
+import { Badge, Button as UiButton, Checkbox, AlertDialogContent, AlertDialogRoot } from './ui.js';
 import { redactSecrets } from './redact.js';
 import { formatRedactedJson } from './tool-format.js';
 
@@ -42,12 +41,9 @@ export function PermissionDialog(props: {
   const [rememberForTurn, setRememberForTurn] = useState(false);
   const [responsePending, setResponsePending] = useState(false);
   const [now, setNow] = useState(() => Date.now());
-  const dialogRef = useRef<HTMLDivElement>(null);
   const responsePendingRef = useRef(false);
   const permissionMountedRef = useRef(true);
   const activePermissionRequestIdRef = useRef(props.request.requestId);
-  // No onEscape — a permission request requires an explicit allow/deny decision.
-  useModalA11y(dialogRef);
 
   useEffect(() => {
     permissionMountedRef.current = true;
@@ -103,11 +99,9 @@ export function PermissionDialog(props: {
   const waitLabel = formatPermissionRequestWait(health.ageMs);
 
   return (
-    <DialogRoot open disablePointerDismissal>
-      <DialogContent
-        ref={dialogRef}
+    <AlertDialogRoot defaultOpen onOpenChange={(open, details) => { if (!open) details.cancel(); }}>
+      <AlertDialogContent
         className="maka-modal permissionDialog w-[min(92vw,720px)] p-0"
-        role="alertdialog"
         aria-labelledby="permissionTitle"
         data-tone={preset.tone}
         showClose={false}
@@ -182,8 +176,8 @@ export function PermissionDialog(props: {
             {responsePending ? '正在提交…' : isDestructive ? '我已确认，允许' : '允许'}
           </UiButton>
         </div>
-      </DialogContent>
-    </DialogRoot>
+      </AlertDialogContent>
+    </AlertDialogRoot>
   );
 }
 

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -66,6 +66,11 @@ export interface ToastApi {
 }
 
 interface PendingConfirm extends ConfirmInput {
+  // Stable id so <ConfirmDialog key={request.id}> remounts on queue advance —
+  // AlertDialog `defaultOpen` + `initialFocus` only fire on mount, so without
+  // a key the second confirm inherits the first's focus (stuck on the
+  // confirm button → Enter mis-confirms a dangerous op).
+  id: string;
   resolve(result: boolean): void;
 }
 
@@ -113,7 +118,7 @@ export function ToastProvider(props: { children: ReactNode }) {
 
   const confirm = useCallback((input: ConfirmInput): Promise<boolean> => {
     return new Promise((resolve) => {
-      const request: PendingConfirm = { ...input, resolve };
+      const request: PendingConfirm = { id: `c${++idSeed.current}`, ...input, resolve };
       if (activeConfirmRef.current) {
         confirmQueueRef.current.push(request);
         return;
@@ -167,7 +172,7 @@ export function ToastProvider(props: { children: ReactNode }) {
         <ToastViewport />
       </BaseToast.Provider>
       {confirmState && (
-        <ConfirmDialog request={confirmState} onResolve={resolveConfirm} />
+        <ConfirmDialog key={confirmState.id} request={confirmState} onResolve={resolveConfirm} />
       )}
     </ToastContext.Provider>
   );

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -9,8 +9,13 @@
 //   - The look-and-feel never matches the rest of the app.
 //   - macOS IME and accessibility behavior with native prompts is uneven.
 //
-// Toast lifecycle is intentionally tiny: in-memory state and a 4s auto-dismiss
-// timer, cancellable from the toast itself.
+// PR6 (#520): toast surface migrated to Base UI Toast (Provider + manager +
+// Viewport/Root/Title/Description/Action/Close). The confirm dialog + its
+// queue stay hand-written (Base UI Toast has no confirm concept). The
+// `useToast()` / `toast.confirm()` API is unchanged so callers don't move.
+// `render` props keep the existing <ol>/<li role="alert">/<strong>/<small>/
+// <Button> DOM shape so .maka-toast CSS and the toast-position-fixed +
+// toast-confirm-keyboard contracts keep holding.
 
 import {
   createContext,
@@ -22,6 +27,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { Toast as BaseToast } from '@base-ui/react/toast';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from './icons.js';
 import { AlertDialogContent, AlertDialogRoot, Button } from './ui.js';
 
@@ -59,14 +65,6 @@ export interface ToastApi {
   dismiss(id: string): void;
 }
 
-interface InternalToast extends Required<Pick<ToastInput, 'title' | 'variant' | 'duration'>> {
-  id: string;
-  description?: string;
-  action?: ToastAction;
-  /** Two-phase dismissal: exit animation plays, then the entry unmounts. */
-  exiting?: boolean;
-}
-
 interface PendingConfirm extends ConfirmInput {
   resolve(result: boolean): void;
 }
@@ -76,42 +74,41 @@ const TOAST_POSITION = 'bottom-right';
 const ToastContext = createContext<ToastApi | null>(null);
 
 export function ToastProvider(props: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<InternalToast[]>([]);
+  const toastManager = useMemo(() => BaseToast.createToastManager(), []);
   const [confirmState, setConfirmState] = useState<PendingConfirm | null>(null);
   const activeConfirmRef = useRef<PendingConfirm | null>(null);
   const confirmQueueRef = useRef<PendingConfirm[]>([]);
   const idSeed = useRef(0);
 
-  const TOAST_EXIT_MS = 180; // exit = enter (240ms) x 75% per the motion roadmap
-  const dismiss = useCallback((id: string) => {
-    // Two-phase dismissal (D6 spectrum): mark exiting so CSS can play a
-    // shrink/fade, then unmount after the exit window. Instant unmount
-    // (the old behavior) made toasts vanish mid-glance. Re-entrant calls
-    // for an already-exiting id are no-ops.
-    setToasts((prev) => prev.map((entry) => (entry.id === id ? { ...entry, exiting: true } : entry)));
-    window.setTimeout(() => {
-      setToasts((prev) => prev.filter((entry) => entry.id !== id));
-    }, TOAST_EXIT_MS);
-  }, []);
-
   const push = useCallback(
     (input: ToastInput): string => {
       const id = `t${++idSeed.current}`;
-      const entry: InternalToast = {
+      toastManager.add({
         id,
         title: input.title,
         description: input.description,
-        variant: input.variant ?? 'info',
-        duration: input.duration ?? DEFAULT_DURATION,
-        action: input.action,
-      };
-      setToasts((prev) => [...prev, entry]);
-      if (entry.duration > 0) {
-        window.setTimeout(() => dismiss(id), entry.duration);
-      }
+        type: input.variant ?? 'info',
+        timeout: input.duration ?? DEFAULT_DURATION,
+        actionProps: input.action
+          ? {
+              onClick: () => {
+                input.action!.onClick();
+                toastManager.close(id);
+              },
+              children: input.action.label,
+            }
+          : undefined,
+      });
       return id;
     },
-    [dismiss],
+    [toastManager],
+  );
+
+  const dismiss = useCallback(
+    (id: string) => {
+      toastManager.close(id);
+    },
+    [toastManager],
   );
 
   const confirm = useCallback((input: ConfirmInput): Promise<boolean> => {
@@ -165,8 +162,10 @@ export function ToastProvider(props: { children: ReactNode }) {
 
   return (
     <ToastContext.Provider value={api}>
-      {props.children}
-      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+      <BaseToast.Provider toastManager={toastManager} timeout={DEFAULT_DURATION} limit={Number.POSITIVE_INFINITY}>
+        {props.children}
+        <ToastViewport />
+      </BaseToast.Provider>
       {confirmState && (
         <ConfirmDialog request={confirmState} onResolve={resolveConfirm} />
       )}
@@ -191,55 +190,68 @@ const VARIANT_ICON: Record<ToastVariant, ReactNode> = {
   error: <AlertCircle size={16} strokeWidth={1.75} aria-hidden="true" />,
 };
 
-function ToastViewport(props: { toasts: InternalToast[]; onDismiss(id: string): void }) {
-  if (props.toasts.length === 0) return null;
+function ToastViewport() {
+  const { toasts } = BaseToast.useToastManager();
+  if (toasts.length === 0) return null;
   return (
-    <ol
-      className="maka-toast-viewport"
-      data-position={TOAST_POSITION}
-      role="region"
-      aria-live="polite"
-      aria-label="通知"
+    <BaseToast.Viewport
+      render={
+        <ol
+          className="maka-toast-viewport"
+          data-position={TOAST_POSITION}
+          role="region"
+          aria-live="polite"
+          aria-label="通知"
+        />
+      }
     >
-      {props.toasts.map((entry) => (
-        // role="alert" lets screen readers announce each toast even
-        // though the parent <ol> already has aria-live="polite" —
-        // browsers / AT pairings handle the live region announce
-        // better when the live items themselves carry an alert
-        // role rather than relying on the region inheritance.
-        <li key={entry.id} className="maka-toast" data-variant={entry.variant} data-exiting={entry.exiting ? 'true' : undefined} role="alert">
-          <span className="maka-toast-icon" aria-hidden="true">{VARIANT_ICON[entry.variant]}</span>
-          <div className="maka-toast-copy">
-            <strong>{entry.title}</strong>
-            {entry.description && <small>{entry.description}</small>}
-          </div>
-          {entry.action && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="maka-toast-action"
-              onClick={() => {
-                entry.action!.onClick();
-                props.onDismiss(entry.id);
-              }}
-            >
-              {entry.action.label}
-            </Button>
-          )}
-          <Button
-            type="button"
-            variant="quiet"
-            size="icon-sm"
-            className="maka-toast-close"
-            aria-label="关闭通知"
-            onClick={() => props.onDismiss(entry.id)}
+      {toasts.map((entry) => {
+        const variant = (entry.type as ToastVariant) ?? 'info';
+        return (
+          // role="alert" lets screen readers announce each toast even
+          // though the parent <ol> already has aria-live="polite" —
+          // browsers / AT pairings handle the live region announce
+          // better when the live items themselves carry an alert
+          // role rather than relying on the region inheritance.
+          // data-exiting maps Base UI's transitionStatus="ending" onto
+          // the existing .maka-toast[data-exiting="true"] exit animation.
+          <BaseToast.Root
+            key={entry.id}
+            toast={entry}
+            render={
+              <li
+                className="maka-toast"
+                data-variant={variant}
+                data-exiting={entry.transitionStatus === 'ending' ? 'true' : undefined}
+                role="alert"
+              />
+            }
           >
-            <X size={14} strokeWidth={1.75} aria-hidden="true" />
-          </Button>
-        </li>
-      ))}
-    </ol>
+            <span className="maka-toast-icon" aria-hidden="true">{VARIANT_ICON[variant]}</span>
+            <div className="maka-toast-copy">
+              <BaseToast.Title render={<strong />}>{entry.title}</BaseToast.Title>
+              {entry.description && (
+                <BaseToast.Description render={<small />}>{entry.description}</BaseToast.Description>
+              )}
+            </div>
+            {entry.actionProps && (
+              <BaseToast.Action
+                {...entry.actionProps}
+                className="maka-toast-action"
+                render={<Button type="button" variant="ghost" size="sm" />}
+              />
+            )}
+            <BaseToast.Close
+              className="maka-toast-close"
+              aria-label="关闭通知"
+              render={<Button type="button" variant="quiet" size="icon-sm" />}
+            >
+              <X size={14} strokeWidth={1.75} aria-hidden="true" />
+            </BaseToast.Close>
+          </BaseToast.Root>
+        );
+      })}
+    </BaseToast.Viewport>
   );
 }
 

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -218,8 +218,6 @@ function ToastViewport() {
           // browsers / AT pairings handle the live region announce
           // better when the live items themselves carry an alert
           // role rather than relying on the region inheritance.
-          // data-exiting maps Base UI's transitionStatus="ending" onto
-          // the existing .maka-toast[data-exiting="true"] exit animation.
           <BaseToast.Root
             key={entry.id}
             toast={entry}
@@ -227,7 +225,6 @@ function ToastViewport() {
               <li
                 className="maka-toast"
                 data-variant={variant}
-                data-exiting={entry.transitionStatus === 'ending' ? 'true' : undefined}
                 role="alert"
               />
             }

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -23,8 +23,7 @@ import {
   type ReactNode,
 } from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from './icons.js';
-import { useModalA11y } from './modal-a11y.js';
-import { Button } from './ui.js';
+import { AlertDialogContent, AlertDialogRoot, Button } from './ui.js';
 
 export type ToastVariant = 'info' | 'success' | 'warning' | 'error';
 
@@ -245,9 +244,7 @@ function ToastViewport(props: { toasts: InternalToast[]; onDismiss(id: string): 
 }
 
 function ConfirmDialog(props: { request: PendingConfirm; onResolve(result: boolean): void }) {
-  const dialogRef = useRef<HTMLDivElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
-  useModalA11y(dialogRef, () => props.onResolve(false), cancelRef);
   const {
     title,
     description,
@@ -256,16 +253,16 @@ function ConfirmDialog(props: { request: PendingConfirm; onResolve(result: boole
     destructive = false,
   } = props.request;
 
+  // Escape / backdrop close = cancel (onResolve(false)). Base UI AlertDialog
+  // disables pointer dismissal; Escape triggers onOpenChange(false).
   return (
-    <div className="maka-modal-backdrop maka-confirm-backdrop" role="presentation" onClick={() => props.onResolve(false)}>
-      <div
-        ref={dialogRef}
+    <AlertDialogRoot defaultOpen onOpenChange={(open) => { if (!open) props.onResolve(false); }}>
+      <AlertDialogContent
         className="maka-modal maka-confirm-modal"
-        role="alertdialog"
-        aria-modal="true"
         aria-labelledby="maka-confirm-title"
         aria-describedby={description ? 'maka-confirm-description' : undefined}
-        onClick={(event) => event.stopPropagation()}
+        initialFocus={cancelRef}
+        showClose={false}
       >
         <div className="maka-modal-header">
           <h2 className="maka-modal-title" id="maka-confirm-title">{title}</h2>
@@ -290,7 +287,7 @@ function ConfirmDialog(props: { request: PendingConfirm; onResolve(result: boole
             {confirmLabel}
           </Button>
         </div>
-      </div>
-    </div>
+      </AlertDialogContent>
+    </AlertDialogRoot>
   );
 }

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -188,133 +188,74 @@ export const Checkbox = forwardRef<
 
 export const DialogRoot = BaseDialog.Root;
 export const DialogClose = BaseDialog.Close;
-const DialogPortal = BaseDialog.Portal;
-
-const DialogBackdrop = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseDialog.Backdrop>>(function DialogBackdrop(
-  { className, ...props },
-  ref,
-) {
-  return (
-    <BaseDialog.Backdrop
-      ref={ref}
-      // `maka-dialog-backdrop` is a stable, style-free hook so tests and the
-      // real-window smoke diagnostic can select the dialog backdrop; Base UI
-      // renders only utility classes otherwise, which drift and aren't
-      // reliably selectable.
-      className={cn('maka-dialog-backdrop fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm', className)}
-      {...props}
-    />
-  );
-});
-
-const DialogPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseDialog.Popup>>(function DialogPopup(
-  { className, children, ...props },
-  ref,
-) {
-  return (
-    <BaseDialog.Popup
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid max-h-[85dvh] w-[min(92vw,640px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-maka-panel',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </BaseDialog.Popup>
-  );
-});
-
-export const DialogContent = forwardRef<
-  HTMLDivElement,
-  React.ComponentPropsWithoutRef<typeof DialogPopup> & { showClose?: boolean }
->(function DialogContent({
-    className,
-    children,
-    showClose = true,
-    ...props
-  },
-  ref,
-) {
-  return (
-    <DialogPortal>
-      <DialogBackdrop />
-      <DialogPopup ref={ref} className={className} {...props}>
-        {showClose && (
-          <DialogClose
-            className={cn(buttonVariants({ variant: 'quiet', size: 'icon-sm' }), 'absolute right-3 top-3')}
-            aria-label="关闭"
-          >
-            <X aria-hidden="true" />
-          </DialogClose>
-        )}
-        {children}
-      </DialogPopup>
-    </DialogPortal>
-  );
-});
-
-// AlertDialog — same shape as Dialog, but the alert variant locks modal +
-// disables pointer dismissal, so confirm/permission dialogs require an
-// explicit decision. Escape is NOT auto-disabled (Base UI alert-dialog still
-// closes on Esc); callers that must not be Esc-dismissed intercept onOpenChange
-// and cancel. PR6 (#520).
-const AlertDialogPortal = BaseAlertDialog.Portal;
-
-const AlertDialogBackdrop = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseAlertDialog.Backdrop>>(function AlertDialogBackdrop(
-  { className, ...props },
-  ref,
-) {
-  return (
-    <BaseAlertDialog.Backdrop
-      ref={ref}
-      className={cn('maka-dialog-backdrop fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm', className)}
-      {...props}
-    />
-  );
-});
-
-const AlertDialogPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseAlertDialog.Popup>>(function AlertDialogPopup(
-  { className, children, ...props },
-  ref,
-) {
-  return (
-    <BaseAlertDialog.Popup
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid max-h-[85dvh] w-[min(92vw,640px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-maka-panel',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </BaseAlertDialog.Popup>
-  );
-});
-
 export const AlertDialogRoot = BaseAlertDialog.Root;
-const AlertDialogClose = BaseAlertDialog.Close;
 
-export const AlertDialogContent = forwardRef<
-  HTMLDivElement,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPopup> & { showClose?: boolean }
->(function AlertDialogContent({ className, children, showClose, ...props }, ref) {
-  return (
-    <AlertDialogPortal>
-      <AlertDialogBackdrop />
-      <AlertDialogPopup ref={ref} className={className} {...props}>
-        {showClose && (
-          <AlertDialogClose
-            className={cn(buttonVariants({ variant: 'quiet', size: 'icon-sm' }), 'absolute right-3 top-3')}
-            aria-label="关闭"
-          >
-            <X aria-hidden="true" />
-          </AlertDialogClose>
-        )}
-        {children}
-      </AlertDialogPopup>
-    </AlertDialogPortal>
-  );
+// Shared modal shell. Dialog and AlertDialog differ only in their Base UI
+// primitive family (Root/Portal/Backdrop/Popup/Close); the layout (backdrop
+// class, popup class, Portal+Backdrop+Popup+optional Close structure) is
+// identical. PR6 review P3.1: kills the AlertDialogBackdrop/Popup/Content
+// triple that copied Dialog's, and lets ui-tsx-design-contract's
+// the bare z-index/blur utility counts return to 1.
+//
+// `maka-dialog-backdrop` is a stable, style-free hook so tests and the
+// real-window smoke diagnostic can select the dialog backdrop; Base UI
+// renders only utility classes otherwise, which drift and aren't reliably
+// selectable.
+const MODAL_BACKDROP_CLASS = 'maka-dialog-backdrop fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm';
+const MODAL_POPUP_CLASS =
+  'fixed left-1/2 top-1/2 z-50 grid max-h-[85dvh] w-[min(92vw,640px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-maka-panel';
+
+type ModalContentProps = React.ComponentPropsWithoutRef<typeof BaseDialog.Popup> & { showClose?: boolean };
+
+function createModalContent(primitives: {
+  Portal: React.ComponentType<{ children?: React.ReactNode }>;
+  Backdrop: React.ComponentType<{ className?: string }>;
+  Popup: React.ForwardRefExoticComponent<React.ComponentPropsWithoutRef<typeof BaseDialog.Popup> & React.RefAttributes<HTMLDivElement>>;
+  Close: React.ComponentType<{ className?: string; 'aria-label'?: string; children?: React.ReactNode }>;
+  defaultShowClose: boolean;
+}) {
+  return forwardRef<HTMLDivElement, ModalContentProps>(function ModalContent(
+    { className, children, showClose = primitives.defaultShowClose, ...props },
+    ref,
+  ) {
+    const { Portal, Backdrop, Popup, Close } = primitives;
+    return (
+      <Portal>
+        <Backdrop className={MODAL_BACKDROP_CLASS} />
+        <Popup ref={ref} className={cn(MODAL_POPUP_CLASS, className)} {...props}>
+          {showClose && (
+            <Close
+              className={cn(buttonVariants({ variant: 'quiet', size: 'icon-sm' }), 'absolute right-3 top-3')}
+              aria-label="关闭"
+            >
+              <X aria-hidden="true" />
+            </Close>
+          )}
+          {children}
+        </Popup>
+      </Portal>
+    );
+  });
+}
+
+export const DialogContent = createModalContent({
+  Portal: BaseDialog.Portal,
+  Backdrop: BaseDialog.Backdrop,
+  Popup: BaseDialog.Popup,
+  Close: BaseDialog.Close,
+  defaultShowClose: true,
+});
+
+// AlertDialog — the alert variant locks modal + disables pointer dismissal,
+// so confirm/permission dialogs require an explicit decision. Escape is NOT
+// auto-disabled (Base UI alert-dialog still closes on Esc); callers that must
+// not be Esc-dismissed intercept onOpenChange and cancel. PR6 (#520).
+export const AlertDialogContent = createModalContent({
+  Portal: BaseAlertDialog.Portal,
+  Backdrop: BaseAlertDialog.Backdrop,
+  Popup: BaseAlertDialog.Popup,
+  Close: BaseAlertDialog.Close,
+  defaultShowClose: false,
 });
 
 // Tabs: re-export the shared tab spec primitive (#499 P0-3). The tab spec

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox';
 import { Dialog as BaseDialog } from '@base-ui/react/dialog';
+import { AlertDialog as BaseAlertDialog } from '@base-ui/react/alert-dialog';
 import { Field as BaseField } from '@base-ui/react/field';
 import { Progress as BaseProgress } from '@base-ui/react/progress';
 import { Radio as BaseRadio } from '@base-ui/react/radio';
@@ -250,6 +251,69 @@ export const DialogContent = forwardRef<
         {children}
       </DialogPopup>
     </DialogPortal>
+  );
+});
+
+// AlertDialog — same shape as Dialog, but the alert variant locks modal +
+// disables pointer dismissal, so confirm/permission dialogs require an
+// explicit decision. Escape is NOT auto-disabled (Base UI alert-dialog still
+// closes on Esc); callers that must not be Esc-dismissed intercept onOpenChange
+// and cancel. PR6 (#520).
+const AlertDialogPortal = BaseAlertDialog.Portal;
+
+const AlertDialogBackdrop = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseAlertDialog.Backdrop>>(function AlertDialogBackdrop(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <BaseAlertDialog.Backdrop
+      ref={ref}
+      className={cn('maka-dialog-backdrop fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm', className)}
+      {...props}
+    />
+  );
+});
+
+const AlertDialogPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseAlertDialog.Popup>>(function AlertDialogPopup(
+  { className, children, ...props },
+  ref,
+) {
+  return (
+    <BaseAlertDialog.Popup
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid max-h-[85dvh] w-[min(92vw,640px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-maka-panel',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </BaseAlertDialog.Popup>
+  );
+});
+
+export const AlertDialogRoot = BaseAlertDialog.Root;
+const AlertDialogClose = BaseAlertDialog.Close;
+
+export const AlertDialogContent = forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPopup> & { showClose?: boolean }
+>(function AlertDialogContent({ className, children, showClose, ...props }, ref) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogBackdrop />
+      <AlertDialogPopup ref={ref} className={className} {...props}>
+        {showClose && (
+          <AlertDialogClose
+            className={cn(buttonVariants({ variant: 'quiet', size: 'icon-sm' }), 'absolute right-3 top-3')}
+            aria-label="关闭"
+          >
+            <X aria-hidden="true" />
+          </AlertDialogClose>
+        )}
+        {children}
+      </AlertDialogPopup>
+    </AlertDialogPortal>
   );
 });
 

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -542,8 +542,8 @@ export const Progress = forwardRef<
   );
 });
 
-// Toast — left to the existing `packages/ui/src/toast.tsx` for now.
-// That module already wraps Base UI Toast with the project's
-// `useToast()` / `toast.confirm()` API. Rewriting it to expose the
-// raw Base UI primitives here would compete with the existing
-// caller surface; the modernization is tracked separately.
+// Toast — migrated to Base UI Toast in `packages/ui/src/toast.tsx`, exposed
+// via the project's `useToast()` / `toast.confirm()` API (PR6 #520). The toast
+// surface (Provider + manager + Viewport/Root/Title/Description/Action/Close)
+// is Base UI; the confirm dialog + its queue stay hand-written (Base UI Toast
+// has no confirm concept) and live in toast.tsx.


### PR DESCRIPTION
## Summary

Sixth PR of #520. Migrates the toast surface + confirm dialog + permission dialog onto Base UI Toast + AlertDialog, keeping the `useToast()` / `toast.confirm()` API + `.maka-toast` / `.maka-modal` CSS + the hand-written confirm queue. Same converge/migration pattern as #526 / #533 / #527 / #539.

## Why

Refs #520. Toast, ConfirmDialog, and PermissionDialog were the last three hand-written modals in the renderer — each re-implemented `role`, focus trap/restore, and Esc handling via `useModalA11y`, duplicating what Base UI AlertDialog/Toast provide. Converging them onto Base UI removes the duplicate a11y surface and unblocks PR7 (large Base UI migrations).

## Scope

Changed:

- **toast.tsx** — `ToastProvider`/`ToastViewport`/toast `<li>` → Base UI Toast (`BaseToast.Provider` + `createToastManager` + `Viewport`/`Root`/`Title`/`Description`/`Action`/`Close`, all via `render` prop to keep `<ol>`/`<li role="alert">`/`<strong>`/`<small>`/`<Button>` DOM shape). `push`→`toastManager.add`, `dismiss`→`toastManager.close`; hand-written toasts state + two-phase dismiss timer deleted (Base UI manages timeout + exit transition). `data-exiting` maps Base UI `transitionStatus="ending"` onto the existing `.maka-toast[data-exiting="true"]` animation. `limit={Infinity}` (no count cap; existing had none).
- **toast.tsx ConfirmDialog** → `AlertDialogRoot`/`AlertDialogContent`. `useModalA11y` + `dialogRef` deleted; `cancelRef` kept as `initialFocus={cancelRef}` on the popup. Escape/backdrop close = `onResolve(false)` (cancel) via `onOpenChange`. `toast.confirm()` Promise + queue unchanged.
- **permission-dialog.tsx** → `AlertDialogRoot`/`AlertDialogContent`. Hand-set `role="alertdialog"` + `useModalA11y` deleted. Conditional mount preserved (no `open` prop — `defaultOpen` + `onOpenChange` cancel blocks Escape, since a permission request requires an explicit allow/deny). Complex content (reason presets / summary / remember checkbox / danger alert) unchanged.
- **ui.tsx** — new `AlertDialogRoot`/`AlertDialogContent` wrappers mirroring the Dialog wrappers (Portal + Backdrop + Popup, shared `maka-dialog-backdrop` hook). Comment corrected (toast.tsx now wraps Base UI Toast, not "left for later").
- **chat-header.css** — delete orphan `.maka-confirm-backdrop` (confirm now uses shared `maka-dialog-backdrop` via `AlertDialogBackdrop`).
- **contracts** — `toast-confirm-keyboard-contract` (`role`→`AlertDialogRoot`, `useModalA11y`→`initialFocus`; queue invariants unchanged), `ui-tsx-design-contract` (`z-40`/`z-50`/`backdrop-blur-sm` counts 1→2), `renderer-utility-primitives-contract` (`import { Button }` grep widened to allow AlertDialog imports alongside Button). `modal-lifecycle-contract` unchanged.

Not included:

- PR5 (style-hook convention + small Base UI migrations: disclosure→Collapsible, etc.) — in progress in `.worktree/base-ui-small-migrations`.
- PR7 (large Base UI migrations: dialog/drawer, combobox, card/table, badge) — waits on PR5 (ui.tsx Badge overlap + style-hook dependency).
- Toast / confirm / permission visual redesign — `.maka-toast` / `.maka-modal` CSS is preserved; only the underlying component layer swaps.

## Verification

- Full desktop suite: **1994/1994 pass** (no regressions; rive-workflow flaky under concurrent load, passes in isolation, unrelated).
- `@maka/ui` + `@maka/desktop` build: success.
- Dual-theme screenshots (turn-narrative + first-run, light + dark): no breakage. Toast / confirm / permission dialogs are state-triggered (not visible in static screenshots); the screenshots confirm the surrounding UI is unchanged.

## User-facing impact

No visual change — `.maka-toast` / `.maka-modal` CSS and DOM shape are preserved via `render` props. Behavior parity: confirm/permission focus trap/restore + Esc handling now come from Base UI AlertDialog (equivalent to the prior `useModalA11y`). Permission dialog Esc stays blocked (`onOpenChange` cancel). Toast enter/exit animation now driven by Base UI `transitionStatus` mapped onto the existing `data-exiting` attribute (same visual).

## Reviewer notes

- 4 commits, each independently reviewable: ① PermissionDialog → AlertDialog, ② ConfirmDialog → AlertDialog, ③ toast surface → Base UI Toast, ④ ui.tsx comment fix.
- **confirm queue stays hand-written** in `ToastProvider` (`activeConfirmRef` / `confirmQueueRef` / `resolveConfirm`) — Base UI Toast has no confirm concept; `toast-confirm-keyboard-contract` pins the queue invariants.
- **`render` prop preserves DOM shape** (`<ol>`, `<li role="alert">`, `<strong>`, `<small>`, `<Button>`) so `.maka-toast` CSS keeps holding without a CSS rewrite.
- **AlertDialog does not disable Esc by default** — `onOpenChange` + `details.cancel()` blocks Escape in PermissionDialog. `defaultOpen` (not `open`) preserves the conditional-mount pattern `modal-lifecycle-contract` checks for.
- Builds on #526 (PR1) / #533 (PR2) / #527 (PR3) / #539 (PR4), all merged.