### PR TITLE
feat(ui): style-hook convention + small Base UI migrations (Collapsible/Tooltip/NumberField) (#520 PR5)

### DIFF
--- a/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-region-hygiene-contract.test.ts
@@ -187,7 +187,14 @@ function findRulesWithDeclaration(
 
 function extractStaticUiButtonClassNames(src: string): string[] {
   const classes = new Set<string>();
-  const uiButtonBlocks = src.match(/<UiButton\b[\s\S]*?<\/UiButton>/g) ?? [];
+  // A topbar UiButton appears either as a direct element
+  // (<UiButton>…</UiButton>) or, after the Tooltip migration, as the
+  // render target of a TooltipTrigger
+  // (<TooltipTrigger render={<UiButton …/>} className="…">…</TooltipTrigger>).
+  const uiButtonBlocks = [
+    ...(src.match(/<UiButton\b[\s\S]*?<\/UiButton>/g) ?? []),
+    ...(src.match(/<TooltipTrigger\b[\s\S]*?render=\{<UiButton\b[\s\S]*?<\/TooltipTrigger>/g) ?? []),
+  ];
   for (const block of uiButtonBlocks) {
     const match = block.match(/\bclassName="([^"]+)"/);
     assert.ok(

--- a/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/border-width-converge-contract.test.ts
@@ -83,9 +83,9 @@ const BARE_PX_RE = /(?<![\w-])-?\d+(?:\.\d+)?px(?![\w-])/;
  *  any other selector is still caught — add a new caret here only after
  *  confirming it is geometry, not a stroke. */
 const TRIANGLE_CARET_SELECTORS = new Set([
-  '.maka-turn-thinking summary::before',
+  '.maka-turn-thinking [data-slot="collapsible-trigger"]::before',
   '.maka-bubble-assistant li.task-list-item > input[type="checkbox"]:checked::after',
-  '.maka-permission-raw > summary::before',
+  '.maka-permission-raw [data-slot="collapsible-trigger"]::before',
 ]);
 
 const BORDER_STYLE_KEYWORDS = new Set([
@@ -211,7 +211,7 @@ describe('border-width whitelist negative cases', () => {
 
   it('findCssOffenders allows triangle caret geometry on allowlisted selectors, flags multi-value and single bare-px elsewhere', () => {
     // Known caret selectors: multi-value geometry is allowed.
-    assert.deepEqual(findCssOffenders('.maka-turn-thinking summary::before {\n  border-width: 4px 0 4px 5px;\n}', 't'), [], 'allowlisted caret: 4px 0 4px 5px must pass');
+    assert.deepEqual(findCssOffenders('.maka-turn-thinking [data-slot="collapsible-trigger"]::before {\n  border-width: 4px 0 4px 5px;\n}', 't'), [], 'allowlisted caret: 4px 0 4px 5px must pass');
     assert.deepEqual(findCssOffenders('.maka-bubble-assistant li.task-list-item > input[type="checkbox"]:checked::after {\n  border-width: 0 2px 2px 0;\n}', 't'), [], 'allowlisted caret: 0 2px 2px 0 must pass');
     // Non-allowlisted selector: a multi-value bare px is a stroke drift, not
     // triangle geometry — a heuristic that spared ALL multi-value would miss it.

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -51,7 +51,7 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       // `.maka-turn-thinking` is explicitly deferred (pseudo-element chevron +
       // @starting-style fade don't reduce to leaf utilities); it stays authored.
       '.maka-turn-thinking',
-      '.maka-turn-thinking summary',
+      '.maka-turn-thinking [data-slot="collapsible-trigger"]',
     ]) {
       assert.ok(css.includes(selector), `out-of-scope turn rule "${selector}" must be preserved`);
     }

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -176,14 +176,17 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
       );
     }
     // The open/collapsed divider — the one card surface that differs by state
-    // (the collapsed default has no bottom border). Keep the state on the
-    // Base UI root, but declare the border on the styled part itself: root is a
-    // named group, trigger/header reads `[data-open]` from that group. This is
-    // closer to the Base UI / ShadCN convention than a parent-child selector on
-    // the root.
+    // (the collapsed default has no bottom border). Base UI puts
+    // `[data-panel-open]` directly on the Collapsible Trigger, so keep the border
+    // on the styled trigger/header part without adding a root group or crossing
+    // elements to read root state.
     assert.ok(
       !rawSrc.includes('[open]>summary'),
       'tool card source must not keep the old native details `[open]>summary` selector, even in comments',
+    );
+    assert.ok(
+      !rawSrc.includes('group-data-[open]/tool'),
+      'tool card source must not use a root group to read open state when Base UI Trigger exposes [data-panel-open]',
     );
     const itemStart = block.indexOf('item:');
     const headerStart = block.indexOf('header:', itemStart);
@@ -192,16 +195,16 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
     const itemBlock = block.slice(itemStart, headerStart);
     const headerBlock = block.slice(headerStart, dotStart);
     assert.ok(
-      itemBlock.includes('group/tool'),
-      'tool card root must expose a named group so styled parts can read Base UI [data-open]',
+      !itemBlock.includes('group/tool'),
+      'tool card root must not add a named group for open state when Base UI Trigger exposes [data-panel-open]',
     );
     assert.ok(
       !itemBlock.includes('border-bottom'),
       'tool card root must not own the open-state divider; put the border on the trigger/header part',
     );
     assert.ok(
-      headerBlock.includes('group-data-[open]/tool:[border-bottom:1px_solid_var(--border)]'),
-      'tool card header must add the divider from the Base UI [data-open] group state',
+      headerBlock.includes('data-[panel-open]:[border-bottom:1px_solid_var(--border)]'),
+      'tool card header must add the divider from Base UI Trigger [data-panel-open]',
     );
     // Anti-drift: pin the distinctive literals and ban the semantic-scale
     // forms they would be swapped for. Radius uses the `--radius-surface`

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -45,7 +45,7 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
       '.maka-tool-body',
       '.maka-tool-intent',
       '.maka-tool-count',
-      // the `<details>` card base + its status / open / summary selectors
+      // the retired native-disclosure card base + status/open selectors
       '.maka-tool {',
       '.maka-tool >',
       '.maka-tool[open]',
@@ -176,12 +176,32 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
       );
     }
     // The open/collapsed divider — the one card surface that differs by state
-    // (the collapsed default has no bottom border). The computed-diff proves both
-    // states, but that harness is manual (no CI), so pin the `[open]>summary`
-    // literal here as the automated guard.
+    // (the collapsed default has no bottom border). Keep the state on the
+    // Base UI root, but declare the border on the styled part itself: root is a
+    // named group, trigger/header reads `[data-open]` from that group. This is
+    // closer to the Base UI / ShadCN convention than a parent-child selector on
+    // the root.
     assert.ok(
-      block.includes('[&[open]>summary]:[border-bottom:1px_solid_var(--border)]'),
-      'item must keep the `[open]>summary` divider literal (collapsed default has none)',
+      !rawSrc.includes('[open]>summary'),
+      'tool card source must not keep the old native details `[open]>summary` selector, even in comments',
+    );
+    const itemStart = block.indexOf('item:');
+    const headerStart = block.indexOf('header:', itemStart);
+    const dotStart = block.indexOf('dot:', headerStart);
+    assert.ok(itemStart !== -1 && headerStart !== -1 && dotStart !== -1, 'toolVariants item/header/dot parts must stay parseable');
+    const itemBlock = block.slice(itemStart, headerStart);
+    const headerBlock = block.slice(headerStart, dotStart);
+    assert.ok(
+      itemBlock.includes('group/tool'),
+      'tool card root must expose a named group so styled parts can read Base UI [data-open]',
+    );
+    assert.ok(
+      !itemBlock.includes('border-bottom'),
+      'tool card root must not own the open-state divider; put the border on the trigger/header part',
+    );
+    assert.ok(
+      headerBlock.includes('group-data-[open]/tool:[border-bottom:1px_solid_var(--border)]'),
+      'tool card header must add the divider from the Base UI [data-open] group state',
     );
     // Anti-drift: pin the distinctive literals and ban the semantic-scale
     // forms they would be swapped for. Radius uses the `--radius-surface`

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -22,8 +22,10 @@ import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './
  *   2. the running status dot's `@keyframes maka-tool-pulse` ring frames — an
  *      animation can't be a leaf-literal and `getComputedStyle` reads a phase-
  *      dependent value, so the breath is pinned here + by the `chat.tsx` literal;
- *   3. native `<summary>` marker reset — re-keyed off the retired `.maka-tool`
- *      class onto the governed `[data-slot="tool"]` hook.
+ *   3. the `[data-slot="tool"]` base residue (opacity/transform/border-color
+ *      transition) — the native `<summary>` marker reset that used to live here is
+ *      gone after the disclosure → Collapsible migration (the trigger is a button
+ *      with no native marker).
  */
 describe('chat tool-card migration contract (#332 PR3b)', () => {
   it('retires the bespoke tool-card shell selectors (without touching error/preview/maka-code)', async () => {
@@ -90,7 +92,7 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
     }
   });
 
-  it('keeps only the marker reset residue, re-keyed onto [data-slot="tool"]', async () => {
+  it('keeps the tool-card base residue on [data-slot="tool"]', async () => {
     const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
     assert.ok(
       !tokens.includes('.maka-tool {') && !tokens.includes('@starting-style {\n    .maka-tool'),
@@ -101,8 +103,6 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
       '[data-slot="tool"] {',
       'transform: translateY(0)',
       'transition: border-color var(--duration-base) var(--ease-out-strong);',
-      '[data-slot="tool"] > summary::-webkit-details-marker { display: none; }',
-      "[data-slot=\"tool\"] > summary::marker { content: ''; }",
     ]) {
       assert.ok(
         tokens.includes(residue),

--- a/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
@@ -1,0 +1,69 @@
+/**
+ * PR-DISCLOSURE-COLLAPSIBLE-0 (issue #520 PR5 item 17, 2026-07-05):
+ * the four disclosure sites (turn-thinking, reasoning-panel, permission-raw,
+ * tool-activity) migrate off native `<details>`/`<summary>` onto Base UI
+ * Collapsible. The code comments at the sites already said "future Base UI
+ * Accordion path"; all four are independent single sections (not grouped),
+ * so Collapsible (not Accordion) is the right primitive.
+ *
+ * Why migrate: native `<details>` gives free keyboard a11y but no CSS hook for
+ * the open/closed animation state, no controlled-open API for the reasoning
+ * panel's "default open, first click sticks" behavior (which today reads
+ * `e.currentTarget.open` from the toggle event), and no `data-slot` for the
+ * style-hook convention. Base UI Collapsible gives `data-[open]` state, a
+ * controlled `open` prop, and the `data-slot` hook.
+ *
+ * This contract locks the migration: the three files that held the four
+ * `<details>` sites must not carry `<details>`/`<summary>` (not even in
+ * comments — a stale "wrapped in a <details>" comment is a regression
+ * signal), and must import Collapsible. The Collapsible primitive itself
+ * must wrap Base UI Collapsible with the data-slot convention (item 23).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const MIGRATED_FILES = [
+  'packages/ui/src/chat-view.tsx',
+  'packages/ui/src/permission-dialog.tsx',
+  'packages/ui/src/tool-activity.tsx',
+];
+
+const COLLAPSIBLE_PRIMITIVE = 'packages/ui/src/primitives/collapsible.tsx';
+
+/** A Collapsible import: from the @maka/ui barrel, the primitives path, or
+ *  @base-ui/react/collapsible directly. */
+const COLLAPSIBLE_IMPORT_RE = /import\s+\{[^}]*\bCollapsible\b[^}]*\}\s+from\s+['"][^'"]*(?:@maka\/ui|primitives\/collapsible|@base-ui\/react\/collapsible)[^'"]*['"]/;
+
+describe('PR-DISCLOSURE-COLLAPSIBLE-0 contract', () => {
+  it('the disclosure sites use Base UI Collapsible (no native <details>/<summary>)', async () => {
+    for (const rel of MIGRATED_FILES) {
+      const src = await readFile(resolve(REPO_ROOT, rel), 'utf8');
+      assert.ok(!/<details\b/.test(src), `${rel}: must not use native <details> (migrate to Base UI Collapsible; also drop stale <details> mentions in comments)`);
+      assert.ok(!/<summary\b/.test(src), `${rel}: must not use native <summary> (use Collapsible.Trigger)`);
+      assert.match(src, COLLAPSIBLE_IMPORT_RE, `${rel}: must import Collapsible from @maka/ui / primitives/collapsible / @base-ui/react/collapsible`);
+    }
+  });
+
+  it('primitives/collapsible.tsx wraps Base UI Collapsible with data-slot on Root / Trigger / Panel', async () => {
+    const src = await readFile(resolve(REPO_ROOT, COLLAPSIBLE_PRIMITIVE), 'utf8');
+    assert.match(src, /@base-ui\/react\/collapsible/, 'must import from @base-ui/react/collapsible');
+    for (const slot of ['collapsible', 'collapsible-trigger', 'collapsible-panel']) {
+      assert.match(src, new RegExp(`data-slot="${slot}"`), `must expose data-slot="${slot}" (style-hook convention, item 23)`);
+    }
+  });
+});
+
+describe('disclosure-collapsible negative cases', () => {
+  it('flags a native <details> and a missing Collapsible import', () => {
+    const withDetails = 'import { Collapsible } from "@maka/ui";\nexport function X() { return <details><summary>h</summary>b</details>; }';
+    assert.ok(/<details\b/.test(withDetails), '<details> must be detected');
+    const noImport = 'export function X() { return null; }';
+    assert.ok(!COLLAPSIBLE_IMPORT_RE.test(noImport), 'no Collapsible import must not match');
+    const withImport = 'import { Collapsible } from "@maka/ui";\nexport function X() { return <Collapsible.Root />; }';
+    assert.ok(COLLAPSIBLE_IMPORT_RE.test(withImport), 'a Collapsible import must match');
+  });
+});

--- a/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/disclosure-collapsible-contract.test.ts
@@ -55,6 +55,20 @@ describe('PR-DISCLOSURE-COLLAPSIBLE-0 contract', () => {
       assert.match(src, new RegExp(`data-slot="${slot}"`), `must expose data-slot="${slot}" (style-hook convention, item 23)`);
     }
   });
+
+  it('tool-activity Collapsible is controlled (open follows item.status), not defaultOpen', async () => {
+    // A `defaultOpen` card decides open only on first render, so a card that
+    // defaults open while pending/running would NOT auto-collapse when it
+    // settles to completed/interrupted — the pre-Collapsible `<details
+    // open={isOpenByDefault(status)}>` re-evaluated open every render. The
+    // controlled form (open + onOpenChange, re-synced via useEffect on
+    // [item.status]) restores that: status change collapses/expands the card,
+    // the user can still toggle in between.
+    const src = await readFile(resolve(REPO_ROOT, 'packages/ui/src/tool-activity.tsx'), 'utf8');
+    assert.ok(!/defaultOpen=/.test(src), 'tool-activity must not use defaultOpen (a running card that defaults open would not auto-collapse when it settles); use controlled open that follows item.status');
+    assert.match(src, /\bonOpenChange\b/, 'tool-activity Collapsible must be controlled via onOpenChange');
+    assert.match(src, /useEffect\([^]*\[item\.status\]/, 'tool-activity must re-sync open when item.status changes (useEffect on [item.status])');
+  });
 });
 
 describe('disclosure-collapsible negative cases', () => {

--- a/apps/desktop/src/main/__tests__/number-field-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/number-field-converge-contract.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PR-NUMBER-FIELD-CONVERGE-0 (issue #520 PR5 item 21, 2026-07-05):
+ * the two gateway/proxy port inputs migrate off the native `Input` +
+ * `Number(event.currentTarget.value)` hand-conversion onto Base UI
+ * NumberField, which binds `value: number | null` directly and parses
+ * numeric input itself (no manual string→number, no `|| default` fallback
+ * gymnastics).
+ *
+ * Sites:
+ * - general-settings-page proxy port (default 0 on empty).
+ * - open-gateway-settings-page gateway port (default 3939 on empty).
+ *
+ * The contract: the two files must not carry the `Number(event.currentTarget
+ * .value)` hand-conversion and must import NumberField; the primitive must
+ * wrap Base UI NumberField with the data-slot convention (item 23).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const MIGRATED_FILES = [
+  'apps/desktop/src/renderer/settings/general-settings-page.tsx',
+  'apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx',
+];
+
+const NUMBER_FIELD_PRIMITIVE = 'packages/ui/src/primitives/number-field.tsx';
+
+/** The hand-conversion the migration removes. */
+const HAND_CONVERT_RE = /Number\(event\.currentTarget\.value\)/;
+
+/** A NumberField import from the barrel / primitives / @base-ui. */
+const NUMBER_FIELD_IMPORT_RE = /import\s+\{[^}]*\bNumberField\b[^}]*\}\s+from\s+['"][^'"]*(?:@maka\/ui|primitives\/number-field|@base-ui\/react\/number-field)[^'"]*['"]/;
+
+describe('PR-NUMBER-FIELD-CONVERGE-0 contract', () => {
+  it('the port-input files use Base UI NumberField (no Number(event.currentTarget.value) hand-conversion)', async () => {
+    for (const rel of MIGRATED_FILES) {
+      const src = await readFile(resolve(REPO_ROOT, rel), 'utf8');
+      assert.ok(!HAND_CONVERT_RE.test(src), `${rel}: must not hand-convert Number(event.currentTarget.value) — use Base UI NumberField (value: number | null, onValueChange)`);
+      assert.match(src, NUMBER_FIELD_IMPORT_RE, `${rel}: must import NumberField from @maka/ui / primitives/number-field / @base-ui/react/number-field`);
+    }
+  });
+
+  it('primitives/number-field.tsx wraps Base UI NumberField with data-slot on Root / Input', async () => {
+    const src = await readFile(resolve(REPO_ROOT, NUMBER_FIELD_PRIMITIVE), 'utf8');
+    assert.match(src, /@base-ui\/react\/number-field/, 'must import from @base-ui/react/number-field');
+    for (const slot of ['number-field', 'number-field-input']) {
+      assert.match(src, new RegExp(`data-slot="${slot}"`), `must expose data-slot="${slot}" (style-hook convention, item 23)`);
+    }
+  });
+});
+
+describe('number-field negative cases', () => {
+  it('HAND_CONVERT_RE matches the hand-conversion, not other Number() uses', () => {
+    assert.ok(HAND_CONVERT_RE.test('Number(event.currentTarget.value)'), 'the hand-conversion must match');
+    assert.ok(!HAND_CONVERT_RE.test('Number(123)'), 'a plain Number(123) must not match');
+    assert.ok(!HAND_CONVERT_RE.test('const n = Number("x")'), 'a different Number() call must not match');
+  });
+});

--- a/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/search-modal-lifecycle-contract.test.ts
@@ -116,7 +116,7 @@ describe('SearchModal lifecycle contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup)', ()
 
   it('returns focus to the sidebar Search trigger when the modal closes', async () => {
     const main = await readRendererShellCombinedSource();
-    const shellSearchButton = main.match(/className="maka-shell-topbar-button"[\s\S]*?data-maka-search-trigger="true"[\s\S]*?<\/UiButton>/)?.[0] ?? '';
+    const shellSearchButton = main.match(/className="maka-shell-topbar-button"[\s\S]*?data-maka-search-trigger="true"[\s\S]*?<\/TooltipTrigger>/)?.[0] ?? '';
     const closeSearchModal = main.match(/function closeSearchModal\(options\?: \{ restoreFocus\?: boolean \}\) \{[\s\S]*?\n  \}/)?.[0] ?? '';
 
     assert.match(

--- a/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-network-gateway-contract.test.ts
@@ -58,7 +58,7 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       networkBlock,
-      /value=\{String\(proxyDraft\.port \|\| ''\)\}[\s\S]*onChange=\{\(event\) => void updateProxy\(\{ port: Number\(event\.currentTarget\.value\) \|\| 0 \}\)\}/,
+      /value=\{proxyDraft\.port \|\| null\}[\s\S]*onValueChange=\{\(v\) => void updateProxy\(\{ port: v \?\? 0 \}\)\}/,
       'Network proxy port input must render from the local draft while persisting in the background',
     );
     assert.match(
@@ -231,7 +231,7 @@ describe('Settings network and gateway persistence contract', () => {
     );
     assert.match(
       gatewayBlock,
-      /value=\{String\(gatewayDraft\.port\)\}[\s\S]*onChange=\{\(event\) => void updateGateway\(\{ port: Number\(event\.currentTarget\.value\) \|\| 3939 \}\)\}/,
+      /value=\{gatewayDraft\.port\}[\s\S]*onValueChange=\{\(v\) => void updateGateway\(\{ port: v \?\? 3939 \}\)\}/,
       'Open Gateway port input must render from the local draft while persisting in the background',
     );
     assert.doesNotMatch(

--- a/apps/desktop/src/main/__tests__/style-hook-convention-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/style-hook-convention-contract.test.ts
@@ -1,0 +1,107 @@
+/**
+ * PR-STYLE-HOOK-CONVENTION-0 (issue #520 PR5 item 23, 2026-07-05):
+ * every Base UI wrapper in `packages/ui/src/ui.tsx` exposes a `data-slot`
+ * attribute so CSS can target `[data-slot="..."]` (a stable hook that
+ * survives className drift), matching the `./primitives/` wrappers that
+ * already do this (accordion / alert / badge / …). New wrappers
+ * (Collapsible / Tooltip / NumberField / …) follow the same rule.
+ *
+ * Boolean state hooks adopt Base UI's native attribute-presence form
+ * (`[data-active]` / `[data-open]` / `[data-checked]` / `[data-selected]` /
+ * `[data-pressed]` / `[data-highlighted]` / `[data-disabled]`), NOT the
+ * attribute-value form (`[data-active="true"]`). Maka's renderer CSS has
+ * zero state-attribute selectors today, so adopting Base UI's form breaks
+ * nothing and avoids an override layer. The per-component hook map lives in
+ * the doc comment at the top of ui.tsx.
+ *
+ * This contract locks the data-slot rule: a wrapper that forwards props to a
+ * `Base*` Base UI component must carry `data-slot`. It does NOT lock the
+ * state-attribute decision (that is a "don't override" rule, enforced by the
+ * absence of `[data-active="true"]`-style overrides, which the existing
+ * CSS-scan contracts already cover indirectly).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const UI_FILE = resolve(REPO_ROOT, 'packages/ui/src/ui.tsx');
+
+/** A top-level wrapper declaration: `export const X = forwardRef...` /
+ *  `const X = forwardRef...` / `export function X(...)` at column 0. */
+const WRAPPER_DECL_RE = /^(?:export (?:const|function)|const) [A-Z][A-Za-z0-9]*\b/gm;
+
+/** A Base UI component JSX tag: `<BaseButton`, `<BaseCheckbox.Root`, etc. */
+const BASE_TAG_RE = /<Base[A-Z][A-Za-z]*\b/;
+
+/** Split ui.tsx into wrapper blocks (each starts at a top-level wrapper
+ *  declaration and runs until the next one). Returns the block text + the
+ *  leading declaration name for labeling. */
+function wrapperBlocks(source: string): Array<{ name: string; body: string }> {
+  const matches = [...source.matchAll(WRAPPER_DECL_RE)];
+  const blocks: Array<{ name: string; body: string }> = [];
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].index;
+    const end = i + 1 < matches.length ? matches[i + 1].index : source.length;
+    const body = source.slice(start, end);
+    const name = matches[i][0].replace(/^(?:export )?(?:const|function) /, '');
+    blocks.push({ name, body });
+  }
+  return blocks;
+}
+
+describe('PR-STYLE-HOOK-CONVENTION-0 contract', () => {
+  it('every ui.tsx wrapper that forwards to a Base* component carries data-slot', async () => {
+    const source = await readFile(UI_FILE, 'utf8');
+    const blocks = wrapperBlocks(source);
+    const offenders: string[] = [];
+    for (const { name, body } of blocks) {
+      // Only wrappers that render a `<Base*>` Base UI component are in scope.
+      // Hand-written native elements (the legacy Input / Textarea <input> /
+      // <textarea>, and Badge <span>) are out of the rule until they retire
+      // onto a Base UI primitive.
+      if (!BASE_TAG_RE.test(body)) continue;
+      // The wrapper must carry at least one data-slot on the Base root it
+      // forwards to. (Sub-parts like BaseSwitch.Thumb / BaseCheckbox.Indicator
+      // are not required here — only the root wrapper.)
+      if (!/data-slot=/.test(body)) {
+        offenders.push(`${name}: forwards to a Base UI component but has no data-slot — add data-slot="<name>" to the Base root`);
+      }
+    }
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
+  it('ui.tsx documents the style-hook convention (state-attribute form + hook map + data-slot rule)', async () => {
+    const source = await readFile(UI_FILE, 'utf8');
+    // The convention doc comment at the top of ui.tsx. Pinning the heading
+    // keeps the decision from being silently deleted.
+    assert.match(source, /Base UI style-hook convention/, 'ui.tsx must document the style-hook convention');
+    assert.match(source, /attribute-presence form/, 'the doc must state the state-attribute form decision');
+    assert.match(source, /data-active/, 'the doc must list the per-component hook map');
+  });
+});
+
+describe('style-hook convention negative cases', () => {
+  it('wrapperBlocks splits on top-level wrapper declarations', () => {
+    const src = 'export const Button = forwardRef(function Button() { return <BaseButton data-slot="button" />; });\nexport const Badge = function Badge() { return <span />; }';
+    const blocks = wrapperBlocks(src);
+    assert.equal(blocks.length, 2);
+    assert.equal(blocks[0].name, 'Button');
+    assert.equal(blocks[1].name, 'Badge');
+    assert.ok(BASE_TAG_RE.test(blocks[0].body), 'Button block has a Base tag');
+    assert.ok(!BASE_TAG_RE.test(blocks[1].body), 'Badge block has no Base tag');
+  });
+
+  it('a Base wrapper without data-slot is flagged, a native wrapper is spared', () => {
+    const src = 'export const Good = forwardRef(function Good() { return <BaseX data-slot="x" {...props} />; });\nexport const Bad = forwardRef(function Bad() { return <BaseY {...props} />; });\nexport const Native = function Native() { return <input />; }';
+    const blocks = wrapperBlocks(src);
+    const offenders: string[] = [];
+    for (const { name, body } of blocks) {
+      if (!BASE_TAG_RE.test(body)) continue;
+      if (!/data-slot=/.test(body)) offenders.push(name);
+    }
+    assert.deepEqual(offenders, ['Bad'], 'Bad (Base, no data-slot) flagged; Good (Base, data-slot) and Native (no Base) spared');
+  });
+});

--- a/apps/desktop/src/main/__tests__/tooltip-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tooltip-converge-contract.test.ts
@@ -1,0 +1,77 @@
+/**
+ * PR-TOOLTIP-CONVERGE-0 (issue #520 PR5 item 20, 2026-07-05):
+ * the icon-only-action button tooltips migrate off the native `title=`
+ * attribute (an unstyled, delayed browser tooltip) onto Base UI Tooltip,
+ * which gives a themed, positioned, hover+focus tooltip matching the app.
+ *
+ * Scope of this commit: the clearest icon-only-action buttons — the app
+ * shell chrome actions (search / sidebar / new-task / feedback / command-
+ * palette / help / health), the browser-panel nav (back / forward / refresh
+ * / close), and the artifact-pane collapse / delete. These are unambiguous
+ * icon-only buttons where `title=` is a hover hint, not a visible label.
+ *
+ * Out of scope (deferred to a follow-up): the longer tail of `title=` usages
+ * that need per-site judgment (label-prop components like SettingRow /
+ * MetricCard / SetupHero render `title` as visible text — those are NOT
+ * tooltips and stay; truncation spans, SelectTrigger titles, status-badge
+ * icons, and OnboardingHero's submit button ARE tooltip-eligible but each
+ * needs a label-vs-tooltip check, so they are not swept in this commit).
+ *
+ * The contract: the three migrated files must not carry a `title=` JSX
+ * attribute (the tooltip text moves into `<TooltipContent>{...}`) and must
+ * import Tooltip; the primitive must wrap Base UI Tooltip with the data-slot
+ * convention (item 23).
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT } from './css-test-helpers.js';
+
+const MIGRATED_FILES = [
+  'apps/desktop/src/renderer/app-shell-chrome-actions.tsx',
+  'apps/desktop/src/renderer/browser-panel.tsx',
+  'apps/desktop/src/renderer/artifact-pane.tsx',
+];
+
+const TOOLTIP_PRIMITIVE = 'packages/ui/src/primitives/tooltip.tsx';
+
+/** A JSX `title=` attribute (title immediately followed by `=`). JS
+ *  `const title =` has a space before `=` so it does not match. */
+const TITLE_ATTR_RE = /\btitle=/;
+
+/** A Tooltip import from the barrel / primitives / @base-ui. */
+const TOOLTIP_IMPORT_RE = /import\s+\{[^}]*\bTooltip\b[^}]*\}\s+from\s+['"][^'"]*(?:@maka\/ui|primitives\/tooltip|@base-ui\/react\/tooltip)[^'"]*['"]/;
+
+describe('PR-TOOLTIP-CONVERGE-0 contract', () => {
+  it('the icon-action tooltip files use Base UI Tooltip (no native title= attribute)', async () => {
+    for (const rel of MIGRATED_FILES) {
+      const src = await readFile(resolve(REPO_ROOT, rel), 'utf8');
+      assert.ok(!TITLE_ATTR_RE.test(src), `${rel}: must not use native title= (migrate icon-action tooltips to Base UI Tooltip)`);
+      assert.match(src, TOOLTIP_IMPORT_RE, `${rel}: must import Tooltip from @maka/ui / primitives/tooltip / @base-ui/react/tooltip`);
+    }
+  });
+
+  it('primitives/tooltip.tsx wraps Base UI Tooltip with data-slot on Root / Trigger / Content', async () => {
+    const src = await readFile(resolve(REPO_ROOT, TOOLTIP_PRIMITIVE), 'utf8');
+    assert.match(src, /@base-ui\/react\/tooltip/, 'must import from @base-ui/react/tooltip');
+    for (const slot of ['tooltip', 'tooltip-trigger', 'tooltip-content']) {
+      assert.match(src, new RegExp(`data-slot="${slot}"`), `must expose data-slot="${slot}" (style-hook convention, item 23)`);
+    }
+  });
+});
+
+describe('tooltip-converge negative cases', () => {
+  it('TITLE_ATTR_RE matches JSX title= but not JS const title =', () => {
+    assert.ok(TITLE_ATTR_RE.test('<Button title="x">'), 'JSX title="x" must match');
+    assert.ok(TITLE_ATTR_RE.test('title={label}'), 'JSX title={...} must match');
+    assert.ok(!TITLE_ATTR_RE.test('const title = "x"'), 'JS const title = must not match');
+  });
+
+  it('TOOLTIP_IMPORT_RE matches a Tooltip import and spares a missing one', () => {
+    assert.ok(TOOLTIP_IMPORT_RE.test('import { Tooltip } from "@maka/ui";'), 'barrel import must match');
+    assert.ok(TOOLTIP_IMPORT_RE.test("import { Tooltip } from './primitives/tooltip.js';"), 'primitives import must match');
+    assert.ok(!TOOLTIP_IMPORT_RE.test('import { Button } from "@maka/ui";'), 'no Tooltip import must not match');
+  });
+});

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -1,5 +1,5 @@
 import { CircleGauge, Grid3X3, HelpCircle, MessageCircleQuestion, PanelLeftClose, PanelLeftOpen, Search, SquarePen } from '@maka/ui/icons';
-import { Button as UiButton } from '@maka/ui';
+import { Button as UiButton, Tooltip, TooltipContent, TooltipTrigger } from '@maka/ui';
 
 export function AppShellTopbarActions(props: {
   sidebarCollapsed: boolean;
@@ -13,46 +13,49 @@ export function AppShellTopbarActions(props: {
       className={`maka-shell-topbar-rail ${props.sidebarCollapsed ? 'is-collapsed' : 'is-expanded'}`}
       aria-label="窗口快捷操作"
     >
-      <UiButton
-        className="maka-shell-topbar-button"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        data-maka-search-trigger="true"
-        onClick={props.onOpenSearchModal}
-        aria-label="搜索对话"
-        title="搜索对话"
-      >
-        <Search size={16} strokeWidth={1.65} aria-hidden="true" />
-      </UiButton>
-      <UiButton
-        className="maka-shell-topbar-button"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.sidebarCollapsed ? props.onExpandSidebar : props.onCollapseSidebar}
-        aria-label={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-        aria-expanded={!props.sidebarCollapsed}
-        title={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-      >
-        {props.sidebarCollapsed ? (
-          <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
-        ) : (
-          <PanelLeftClose size={16} strokeWidth={1.65} aria-hidden="true" />
-        )}
-      </UiButton>
-      {props.sidebarCollapsed && (
-        <UiButton
-          className="maka-shell-topbar-button"
-          variant="quiet"
-          size="icon-sm"
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
           type="button"
-          onClick={props.onCreateSession}
-          aria-label="新任务"
-          title="新任务"
+          className="maka-shell-topbar-button"
+          data-maka-search-trigger="true"
+          onClick={props.onOpenSearchModal}
+          aria-label="搜索对话"
         >
-          <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
-        </UiButton>
+          <Search size={16} strokeWidth={1.65} aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent>搜索对话</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
+          type="button"
+          className="maka-shell-topbar-button"
+          onClick={props.sidebarCollapsed ? props.onExpandSidebar : props.onCollapseSidebar}
+          aria-label={props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
+          aria-expanded={!props.sidebarCollapsed}
+        >
+          {props.sidebarCollapsed ? (
+            <PanelLeftOpen size={16} strokeWidth={1.65} aria-hidden="true" />
+          ) : (
+            <PanelLeftClose size={16} strokeWidth={1.65} aria-hidden="true" />
+          )}
+        </TooltipTrigger>
+        <TooltipContent>{props.sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}</TooltipContent>
+      </Tooltip>
+      {props.sidebarCollapsed && (
+        <Tooltip>
+          <TooltipTrigger
+            render={<UiButton variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-shell-topbar-button"
+            onClick={props.onCreateSession}
+            aria-label="新任务"
+          >
+            <SquarePen size={16} strokeWidth={1.65} aria-hidden="true" />
+          </TooltipTrigger>
+          <TooltipContent>新任务</TooltipContent>
+        </Tooltip>
       )}
     </div>
   );
@@ -66,50 +69,54 @@ export function AppShellWorkspaceTopActions(props: {
 }) {
   return (
     <div className="maka-workspace-top-actions" role="toolbar" aria-label="工作区辅助操作">
-      <UiButton
-        className="maka-workspace-icon-action"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.onOpenFeedback}
-        aria-label="问题反馈"
-        title="问题反馈 · 打开关于与环境信息"
-      >
-        <MessageCircleQuestion size={15} strokeWidth={1.7} aria-hidden="true" />
-      </UiButton>
-      <UiButton
-        className="maka-workspace-icon-action"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.onOpenPalette}
-        aria-label="打开命令面板"
-        title="打开命令面板"
-      >
-        <Grid3X3 size={15} strokeWidth={1.7} aria-hidden="true" />
-      </UiButton>
-      <UiButton
-        className="maka-workspace-icon-action"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.onOpenHelp}
-        aria-label="打开帮助"
-        title="打开帮助"
-      >
-        <HelpCircle size={15} strokeWidth={1.7} aria-hidden="true" />
-      </UiButton>
-      <UiButton
-        className="maka-workspace-icon-action"
-        variant="quiet"
-        size="icon-sm"
-        type="button"
-        onClick={props.onOpenHealth}
-        aria-label="打开健康中心"
-        title="打开健康中心"
-      >
-        <CircleGauge size={15} strokeWidth={1.7} aria-hidden="true" />
-      </UiButton>
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
+          type="button"
+          className="maka-workspace-icon-action"
+          onClick={props.onOpenFeedback}
+          aria-label="问题反馈"
+        >
+          <MessageCircleQuestion size={15} strokeWidth={1.7} aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent>问题反馈 · 打开关于与环境信息</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
+          type="button"
+          className="maka-workspace-icon-action"
+          onClick={props.onOpenPalette}
+          aria-label="打开命令面板"
+        >
+          <Grid3X3 size={15} strokeWidth={1.7} aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent>打开命令面板</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
+          type="button"
+          className="maka-workspace-icon-action"
+          onClick={props.onOpenHelp}
+          aria-label="打开帮助"
+        >
+          <HelpCircle size={15} strokeWidth={1.7} aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent>打开帮助</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={<UiButton variant="quiet" size="icon-sm" />}
+          type="button"
+          className="maka-workspace-icon-action"
+          onClick={props.onOpenHealth}
+          aria-label="打开健康中心"
+        >
+          <CircleGauge size={15} strokeWidth={1.7} aria-hidden="true" />
+        </TooltipTrigger>
+        <TooltipContent>打开健康中心</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -69,6 +69,9 @@ import {
   Toolbar,
   ToolbarGroup,
   ToolbarSeparator,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   formatBytes,
   useToast,
 } from '@maka/ui';
@@ -381,24 +384,25 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
       onKeyDown={handlePaneKeyDown}
     >
       <header className="maka-artifact-pane-header">
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-sm"
-          className="maka-artifact-pane-collapse"
-          onClick={() => setCollapsed((current) => !current)}
-          // @kenji a11y gate #3: aria-expanded reflects the actual visible
-          // content state (true when pane shows list + preview + toolbar,
-          // false when collapsed to chevron rail). aria-pressed retained
-          // since this is still a toggle button (a screen reader announces
-          // both "pressed" + "expanded" meaningfully).
-          aria-pressed={collapsed}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? '展开生成文件面板' : '折叠生成文件面板'}
-          title={collapsed ? '展开生成文件面板' : '折叠生成文件面板'}
-        >
-          {collapsed ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-artifact-pane-collapse"
+            onClick={() => setCollapsed((current) => !current)}
+            // @kenji a11y gate #3: aria-expanded reflects the actual visible
+            // content state (true when pane shows list + preview + toolbar,
+            // false when collapsed to chevron rail). aria-pressed retained
+            // since this is still a toggle button (a screen reader announces
+            // both "pressed" + "expanded" meaningfully).
+            aria-pressed={collapsed}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? '展开生成文件面板' : '折叠生成文件面板'}
+          >
+            {collapsed ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
+          </TooltipTrigger>
+          <TooltipContent>{collapsed ? '展开生成文件面板' : '折叠生成文件面板'}</TooltipContent>
+        </Tooltip>
         {!collapsed && (
           <>
             <span className="maka-artifact-pane-title">生成文件</span>
@@ -562,7 +566,6 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
                   variant="destructive"
                   size="sm"
                   className="maka-artifact-toolbar-button maka-artifact-toolbar-destructive"
-                  title="删除"
                   onClick={() => void runArtifactAction(`${selected.id}:delete`, () => deleteArtifact(selected.id))}
                   disabled={artifactActionBusy}
                   data-pending={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -561,22 +561,25 @@ export function ArtifactPane(props: { sessionId: string | undefined }) {
               </ToolbarGroup>
               <ToolbarSeparator className="maka-artifact-toolbar-separator" orientation="vertical" />
               <ToolbarGroup className="maka-artifact-toolbar-group maka-artifact-toolbar-danger-group">
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  className="maka-artifact-toolbar-button maka-artifact-toolbar-destructive"
-                  onClick={() => void runArtifactAction(`${selected.id}:delete`, () => deleteArtifact(selected.id))}
-                  disabled={artifactActionBusy}
-                  data-pending={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
-                  aria-busy={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
-                >
-                  <Trash2 size={14} aria-hidden="true" />
-                  {/* Icon-only at rest: the visible label wrapped the toolbar
-                      onto a second line at 1280 pane width, stranding 删除
-                      alone bottom-right. Label stays for screen readers. */}
-                  <span className="maka-artifact-toolbar-destructive-label">{pendingArtifactAction === `${selected.id}:delete` ? '删除中…' : '删除'}</span>
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<Button type="button" variant="destructive" size="sm" className="maka-artifact-toolbar-button maka-artifact-toolbar-destructive" />}
+                    onClick={() => void runArtifactAction(`${selected.id}:delete`, () => deleteArtifact(selected.id))}
+                    disabled={artifactActionBusy}
+                    data-pending={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
+                    aria-busy={pendingArtifactAction === `${selected.id}:delete` ? 'true' : undefined}
+                  >
+                    <Trash2 size={14} aria-hidden="true" />
+                    {/* Icon-only at rest: the visible label wrapped the toolbar
+                        onto a second line at 1280 pane width, stranding 删除
+                        alone bottom-right. The label span stays for screen
+                        readers (visually hidden); the Tooltip mirrors it for
+                        mouse hover, replacing the native hover tooltip this
+                        button lost in the tooltip migration. */}
+                    <span className="maka-artifact-toolbar-destructive-label">{pendingArtifactAction === `${selected.id}:delete` ? '删除中…' : '删除'}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>{pendingArtifactAction === `${selected.id}:delete` ? '删除中…' : '删除'}</TooltipContent>
+                </Tooltip>
               </ToolbarGroup>
             </Toolbar>
           )}

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -24,6 +24,9 @@ import {
   EmptyMedia,
   EmptyTitle,
   Input,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useToast,
 } from '@maka/ui';
 
@@ -152,44 +155,47 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   return (
     <div className="maka-browser-panel" aria-label="嵌入式浏览器">
       <div className="maka-browser-toolbar">
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-sm"
-          className="maka-browser-navbtn"
-          aria-label="浏览器后退"
-          title="后退"
-          disabled={!state.canGoBack}
-          onClick={() => void window.maka.browser.back(sessionId)}
-        >
-          <ChevronLeft size={16} aria-hidden />
-        </Button>
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-sm"
-          className="maka-browser-navbtn"
-          aria-label="浏览器前进"
-          title="前进"
-          disabled={!state.canGoForward}
-          onClick={() => void window.maka.browser.forward(sessionId)}
-        >
-          <ChevronRight size={16} aria-hidden />
-        </Button>
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-sm"
-          className="maka-browser-navbtn"
-          aria-label={state.loading ? '停止加载页面' : '刷新页面'}
-          title={state.loading ? '停止' : '刷新'}
-          disabled={!state.hasPage && !state.loading}
-          onClick={() =>
-            state.loading ? void window.maka.browser.stop(sessionId) : void window.maka.browser.reload(sessionId)
-          }
-        >
-          {state.loading ? <X size={16} aria-hidden /> : <RotateCw size={16} aria-hidden />}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-browser-navbtn"
+            aria-label="浏览器后退"
+            disabled={!state.canGoBack}
+            onClick={() => void window.maka.browser.back(sessionId)}
+          >
+            <ChevronLeft size={16} aria-hidden />
+          </TooltipTrigger>
+          <TooltipContent>后退</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-browser-navbtn"
+            aria-label="浏览器前进"
+            disabled={!state.canGoForward}
+            onClick={() => void window.maka.browser.forward(sessionId)}
+          >
+            <ChevronRight size={16} aria-hidden />
+          </TooltipTrigger>
+          <TooltipContent>前进</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-browser-navbtn"
+            aria-label={state.loading ? '停止加载页面' : '刷新页面'}
+            disabled={!state.hasPage && !state.loading}
+            onClick={() =>
+              state.loading ? void window.maka.browser.stop(sessionId) : void window.maka.browser.reload(sessionId)
+            }
+          >
+            {state.loading ? <X size={16} aria-hidden /> : <RotateCw size={16} aria-hidden />}
+          </TooltipTrigger>
+          <TooltipContent>{state.loading ? '停止' : '刷新'}</TooltipContent>
+        </Tooltip>
         <Input
           className="maka-browser-address"
           type="text"
@@ -212,17 +218,18 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
             }
           }}
         />
-        <Button
-          type="button"
-          variant="quiet"
-          size="icon-sm"
-          className="maka-browser-navbtn"
-          aria-label="关闭浏览器页面"
-          title="关闭页面"
-          onClick={() => void window.maka.browser.close(sessionId)}
-        >
-          <X size={16} aria-hidden />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-browser-navbtn"
+            aria-label="关闭浏览器页面"
+            onClick={() => void window.maka.browser.close(sessionId)}
+          >
+            <X size={16} aria-hidden />
+          </TooltipTrigger>
+          <TooltipContent>关闭页面</TooltipContent>
+        </Tooltip>
       </div>
       <div className="maka-browser-strip" ref={stripRef}>
         {!state.hasPage && (

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1221,24 +1221,22 @@
     color: var(--foreground-secondary);
   }
 
-  .maka-turn-thinking summary {
+  .maka-turn-thinking [data-slot="collapsible-trigger"] {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     font-weight: var(--font-weight-semibold);
     color: var(--focus-ring);
     letter-spacing: var(--tracking-wide);
-    list-style: none;
     /* `cursor: pointer` intentionally omitted — native macOS reserves
-       the hand cursor for links; `<details>` summaries are button-like
-       controls and use the default arrow. Enforced by
+       the hand cursor for links; the Collapsible trigger is a button-like
+       control and uses the default arrow. Enforced by
        `cursor-convention-contract.test.ts`. */
   }
 
   /* Replace the default disclosure triangle with a custom chevron
      that rotates smoothly on toggle. */
-  .maka-turn-thinking summary::-webkit-details-marker { display: none; }
-  .maka-turn-thinking summary::before {
+  .maka-turn-thinking [data-slot="collapsible-trigger"]::before {
     content: '';
     flex-shrink: 0;
     width: 0;
@@ -1248,7 +1246,7 @@
     border-color: transparent transparent transparent currentColor;
     transition: transform var(--duration-emphasized) var(--ease-out-strong);
   }
-  .maka-turn-thinking[open] > summary::before {
+  .maka-turn-thinking [data-slot="collapsible-trigger"][data-panel-open]::before {
     transform: rotate(90deg);
   }
 
@@ -1724,13 +1722,12 @@
   /* ---- Tool activity ---------------------------------------------- */
 
   /* The tool-activity card shell (the inline section + count pill, the
-     `<details>` card, its `<summary>` header row, the body / intent, and the
+     Collapsible card, its trigger header row, the body / intent, and the
      args `<pre>` override) moved onto the `@maka/ui` chat substrate's
      `toolVariants` literalize table (issue #332 PR3b —
      packages/ui/src/primitives/chat.tsx). What stays here is the irreducible
      residue that escapes the computed-style proof, re-keyed on the governed
-     `[data-slot="tool"]` hook instead of the retired `.maka-tool` class: the
-     native `<summary>` marker reset (pseudo-elements with no leaf-utility form).
+     `[data-slot="tool"]` hook instead of the retired `.maka-tool` class.
      The running status dot's `@keyframes maka-tool-pulse` (below) likewise stays
      because it is a functional status animation. */
   [data-slot="tool"] {
@@ -1738,11 +1735,10 @@
     transform: translateY(0);
     transition: border-color var(--duration-base) var(--ease-out-strong);
   }
-  /* Native <details>/<summary> marker reset — the summary IS the header row
-     (laid out by `toolVariants({ part: 'header' })`), so the default disclosure
-     triangle is suppressed. */
-  [data-slot="tool"] > summary::-webkit-details-marker { display: none; }
-  [data-slot="tool"] > summary::marker { content: ''; }
+  /* The Collapsible trigger is the header row (laid out by
+     `toolVariants({ part: 'header' })`); as a real <button> it has no native
+     disclosure marker, so the marker-reset rules the native <summary> needed
+     are gone. */
 
   @keyframes maka-tool-pulse {
     0%, 100% { box-shadow: 0 0 0 3px oklch(from var(--status-running) l c h / 0.15); }

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -11,6 +11,8 @@ import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import {
   Button,
   Input,
+  NumberField,
+  NumberFieldInput,
   Menu,
   MenuTrigger,
   ModelPicker,
@@ -355,7 +357,9 @@ function NetworkProxySection(props: {
             </label>
             <label>
               <span>端口</span>
-              <Input value={String(proxyDraft.port || '')} onChange={(event) => void updateProxy({ port: Number(event.currentTarget.value) || 0 })} placeholder="7890" aria-label="代理端口" />
+              <NumberField value={proxyDraft.port || null} onValueChange={(v) => void updateProxy({ port: v ?? 0 })}>
+                <NumberFieldInput placeholder="7890" aria-label="代理端口" />
+              </NumberField>
             </label>
           </div>
 

--- a/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/open-gateway-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AppSettings, OpenGatewayRuntimeStatus, UpdateAppSettingsResult } from '@maka/core';
-import { Button, Input, SettingsSelect, SettingsSwitch as Switch, Textarea, useToast } from '@maka/ui';
+import { Button, Input, NumberField, NumberFieldInput, SettingsSelect, SettingsSwitch as Switch, Textarea, useToast } from '@maka/ui';
 import { PasswordInput } from './password-input';
 import { MetricCard } from './settings-metric-card';
 import { SettingsRows, SettingRow } from './settings-rows';
@@ -232,12 +232,9 @@ export function OpenGatewaySettingsPage(props: {
         </label>
         <label>
           <span>端口</span>
-          <Input
-            value={String(gatewayDraft.port)}
-            inputMode="numeric"
-            onChange={(event) => void updateGateway({ port: Number(event.currentTarget.value) || 3939 })}
-            aria-label="开放网关端口"
-          />
+          <NumberField value={gatewayDraft.port} onValueChange={(v) => void updateGateway({ port: v ?? 3939 })}>
+            <NumberFieldInput inputMode="numeric" aria-label="开放网关端口" />
+          </NumberField>
         </label>
         <label>
           <span>访问 token</span>

--- a/apps/desktop/src/renderer/styles/reasoning-panel.css
+++ b/apps/desktop/src/renderer/styles/reasoning-panel.css
@@ -4,7 +4,7 @@
 
      Renders live `ThinkingDeltaEvent.text` accumulated per session in
      `thinkingBySession`. Visible above the streaming answer bubble while
-     the model is reasoning. Collapsible `<details>` wrapper for keyboard
+     the model is reasoning. Base UI Collapsible wrapper for keyboard
      a11y. Default-open so users see the live reasoning; clicking the
      header collapses.
   ============================================================================= */
@@ -19,7 +19,6 @@
     border-color: oklch(from var(--info) l c h / 0.32);
   }
 .maka-reasoning-panel-header {
-    list-style: none;
     display: flex;
     align-items: center;
     gap: var(--space-1-5);
@@ -30,12 +29,6 @@
     color: var(--info-text);
     user-select: none;
     transition: background var(--duration-base) var(--ease-out-strong);
-  }
-.maka-reasoning-panel-header::-webkit-details-marker {
-    display: none;
-  }
-.maka-reasoning-panel-header::marker {
-    content: '';
   }
 .maka-reasoning-panel-header:hover {
     background: oklch(from var(--info) l c h / 0.08);
@@ -97,7 +90,7 @@
     color: var(--muted-foreground);
     transition: transform var(--duration-base) var(--ease-out-strong);
   }
-.maka-reasoning-panel[open] .maka-reasoning-panel-chevron {
+.maka-reasoning-panel [data-slot="collapsible-trigger"][data-panel-open] .maka-reasoning-panel-chevron {
     transform: rotate(90deg);
   }
 .maka-reasoning-panel-body {

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -54,8 +54,7 @@
   background: var(--foreground-2);
 }
 
-.maka-permission-raw > summary {
-  list-style: none;
+.maka-permission-raw [data-slot="collapsible-trigger"] {
   display: flex;
   align-items: center;
   gap: var(--space-1-5);
@@ -64,13 +63,10 @@
   font-size: var(--font-size-caption);
 }
 
-.maka-permission-raw > summary::-webkit-details-marker { display: none; }
-.maka-permission-raw > summary::marker { content: ''; }
-
 /* Rotating disclosure triangle (same recipe as .maka-turn-thinking):
-   without it the bordered summary row read as a text input, not a
+   without it the bordered trigger row read as a text input, not a
    collapsible section. */
-.maka-permission-raw > summary::before {
+.maka-permission-raw [data-slot="collapsible-trigger"]::before {
   content: '';
   flex-shrink: 0;
   width: 0;
@@ -81,11 +77,11 @@
   transition: transform var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-permission-raw[open] > summary::before {
+.maka-permission-raw [data-slot="collapsible-trigger"][data-panel-open]::before {
   transform: rotate(90deg);
 }
 
-.maka-permission-raw[open] > summary {
+.maka-permission-raw [data-slot="collapsible-trigger"][data-panel-open] {
   border-bottom: var(--border-width-hairline) solid var(--border);
 }
 

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -25,6 +25,7 @@ import { deriveCapabilityAuditReport, isDeepResearchSession } from '@maka/core';
 import { materializeChat, materializeTools, materializeTurns, type ToolActivityItem, type TurnViewModel } from './materialize.js';
 import { Button as UiButton } from './ui.js';
 import { Alert, AlertDescription } from './primitives/alert.js';
+import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Bubble, Marker, markerVariants, Message } from './primitives/chat.js';
 import type { NavSelection } from './nav-selection.js';
 import { EmptyState } from './empty-state.js';
@@ -1033,18 +1034,20 @@ const TurnView = memo(function TurnView(props: {
         >
           <div className="flex flex-col">
             {turn.assistantThinking && (
-              <details className="maka-turn-thinking">
-                <summary>
+              <Collapsible className="maka-turn-thinking">
+                <CollapsibleTrigger>
                   <span>查看思考过程</span>
                   <span className="maka-turn-thinking-note">模型推理草稿，不是最终答案</span>
-                </summary>
-                <div className="maka-turn-thinking-body">
-                  <Markdown text={turn.assistantThinking} />
-                  <div className="maka-turn-thinking-actions">
-                    <MessageCopyButton text={turn.assistantThinking} label="复制思考过程" />
+                </CollapsibleTrigger>
+                <CollapsiblePanel>
+                  <div className="maka-turn-thinking-body">
+                    <Markdown text={turn.assistantThinking} />
+                    <div className="maka-turn-thinking-actions">
+                      <MessageCopyButton text={turn.assistantThinking} label="复制思考过程" />
+                    </div>
                   </div>
-                </div>
-              </details>
+                </CollapsiblePanel>
+              </Collapsible>
             )}
             {/* PR109d-c: aborted turn body gets a muted "(已中断)" prefix
                 + Ban icon so the user can see this turn was cancelled
@@ -1304,7 +1307,7 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
  *
  * Default-open during streaming so the user sees the live reasoning;
  * collapses to a single-line summary if user clicks the header. The
- * panel itself is wrapped in a `<details>` for native keyboard a11y
+ * panel itself is wrapped in a Base UI Collapsible for keyboard a11y
  * (Space/Enter toggles).
  *
  * `live=true` means thinking is still streaming (no text yet). Adds
@@ -1413,20 +1416,20 @@ function ReasoningPanel(props: { text: string; live: boolean; truncated: boolean
   // on the next stream-driven re-render (the smoother re-renders at
   // ~60Hz while the stream is live, so any reconciliation drift is
   // immediately visible to the user). Owning the open state via
-  // useState + onToggle makes the panel uncontrolled-from-React's-view:
+  // useState + onOpenChange makes the panel uncontrolled-from-React's-view:
   // the user's collapse sticks because we only write `open` from our
-  // own state, which we only mutate from the onToggle callback.
+  // own state, which we only mutate from the onOpenChange callback.
   // Default-open at mount so users see the reasoning by default; first
   // click toggles to closed and that sticks.
   const [open, setOpen] = useState(true);
   return (
-    <details
+    <Collapsible
       className="maka-reasoning-panel"
       data-live={props.live ? 'true' : undefined}
       open={open}
-      onToggle={(e) => setOpen((e.currentTarget as HTMLDetailsElement).open)}
+      onOpenChange={(v) => setOpen(v)}
     >
-      <summary className="maka-reasoning-panel-header">
+      <CollapsibleTrigger className="maka-reasoning-panel-header">
         {props.live && <span className="maka-reasoning-panel-dot" aria-hidden="true" />}
         <span className="maka-reasoning-panel-label">
           {props.live ? '正在思考…' : '思考过程'}
@@ -1445,9 +1448,11 @@ function ReasoningPanel(props: { text: string; live: boolean; truncated: boolean
           </span>
         )}
         <span className="maka-reasoning-panel-chevron" aria-hidden="true">›</span>
-      </summary>
-      <pre className="maka-reasoning-panel-body">{displayed}</pre>
-    </details>
+      </CollapsibleTrigger>
+      <CollapsiblePanel>
+        <pre className="maka-reasoning-panel-body">{displayed}</pre>
+      </CollapsiblePanel>
+    </Collapsible>
   );
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -73,6 +73,10 @@ export {
   TooltipContent,
 } from './primitives/tooltip.js';
 export {
+  NumberField,
+  NumberFieldInput,
+} from './primitives/number-field.js';
+export {
   Tabs as PrimitiveTabs,
   TabsList as PrimitiveTabsList,
   TabsTrigger as PrimitiveTabsTrigger,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -68,6 +68,11 @@ export {
   CollapsiblePrimitive as PrimitiveCollapsiblePrimitive,
 } from './primitives/collapsible.js';
 export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from './primitives/tooltip.js';
+export {
   Tabs as PrimitiveTabs,
   TabsList as PrimitiveTabsList,
   TabsTrigger as PrimitiveTabsTrigger,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -62,6 +62,12 @@ export * from './primitives/settings-switch.js';
 export * from './primitives/input-group.js';
 export * from './primitives/toolbar.js';
 export {
+  Collapsible as PrimitiveCollapsible,
+  CollapsibleTrigger as PrimitiveCollapsibleTrigger,
+  CollapsiblePanel as PrimitiveCollapsiblePanel,
+  CollapsiblePrimitive as PrimitiveCollapsiblePrimitive,
+} from './primitives/collapsible.js';
+export {
   Tabs as PrimitiveTabs,
   TabsList as PrimitiveTabsList,
   TabsTrigger as PrimitiveTabsTrigger,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -62,10 +62,9 @@ export * from './primitives/settings-switch.js';
 export * from './primitives/input-group.js';
 export * from './primitives/toolbar.js';
 export {
-  Collapsible as PrimitiveCollapsible,
-  CollapsibleTrigger as PrimitiveCollapsibleTrigger,
-  CollapsiblePanel as PrimitiveCollapsiblePanel,
-  CollapsiblePrimitive as PrimitiveCollapsiblePrimitive,
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsiblePanel,
 } from './primitives/collapsible.js';
 export {
   Tooltip,

--- a/packages/ui/src/permission-dialog.tsx
+++ b/packages/ui/src/permission-dialog.tsx
@@ -3,6 +3,7 @@ import type { PermissionRequestEvent, PermissionResponse } from '@maka/core';
 import { derivePermissionRequestHealth, formatPermissionRequestWait } from '@maka/core';
 import { AlertOctagon, AlertTriangle, FileEdit, GitMerge, Globe, HelpCircle, ShieldAlert, Terminal, Wifi } from './icons.js';
 import { Alert, AlertDescription } from './primitives/alert.js';
+import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Badge, Button as UiButton, Checkbox, AlertDialogContent, AlertDialogRoot } from './ui.js';
 import { redactSecrets } from './redact.js';
 import { formatRedactedJson } from './tool-format.js';
@@ -128,10 +129,12 @@ export function PermissionDialog(props: {
           {props.request.hint && (
             <div className="maka-permission-hint" role="note">{props.request.hint}</div>
           )}
-          <details className="maka-permission-raw">
-            <summary>查看完整参数</summary>
-            <pre className="maka-code">{formatRedactedJson(props.request.args)}</pre>
-          </details>
+          <Collapsible className="maka-permission-raw">
+            <CollapsibleTrigger>查看完整参数</CollapsibleTrigger>
+            <CollapsiblePanel>
+              <pre className="maka-code">{formatRedactedJson(props.request.args)}</pre>
+            </CollapsiblePanel>
+          </Collapsible>
           <label className="permissionRemember">
             <Checkbox
               checked={rememberForTurn}
@@ -185,7 +188,7 @@ export function PermissionDialog(props: {
  * One-line summary for a browser_* action. Names the concrete action (open /
  * read / click / type) so the prompt reads as a real browser step, not an opaque
  * tool call — reinforcing that a browser grant spans reads AND acts. The typed
- * text and full args stay in the raw `<details>` block below.
+ * text and full args stay in the raw Collapsible block below.
  */
 function renderBrowserSummary(toolName: string, args: Record<string, unknown>): ReactNode {
   const ref = typeof args.ref === 'string' ? args.ref : '';
@@ -211,7 +214,7 @@ function renderBrowserSummary(toolName: string, args: Record<string, unknown>): 
 /**
  * Per-tool human-readable summary of what the request will do, used at the
  * top of the permission dialog body. Falls back to undefined if we can't
- * recognize the tool — the raw args `<details>` block is always available.
+ * recognize the tool — the raw args Collapsible block is always available.
  */
 function renderPermissionSummary(request: PermissionRequestEvent): ReactNode | undefined {
   const args = (request.args ?? {}) as Record<string, unknown>;

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -396,13 +396,11 @@ export function LiveIndicator({
  * that carries its own `motion-reduce:` guards — the dot and card need no
  * per-element motion utilities; the same global rules cover them as before.)
  *
- * The single consumer (`ToolActivity`) keeps its semantic tags and applies these
- * by `className`. `toolVariants` is kept OFF the package barrel for the same
- * reason as `markerVariants` / `streamVariants`: the only consumer imports it by
- * relative path, so the part set stays an internal, freely-removable styling
- * detail. The `<details>` card stays native HTML here — the eventual Base UI
- * Disclosure path (the intended convergence target for this card AND the
- * `.maka-turn-thinking` block) is a later structural pass, not this lift.
+ * The single consumer (`ToolActivity`) renders a Base UI Collapsible and applies
+ * these by `className`. `toolVariants` is kept OFF the package barrel for the
+ * same reason as `markerVariants` / `streamVariants`: the only consumer imports
+ * it by relative path, so the part set stays an internal, freely-removable
+ * styling detail.
  *
  * NOTE: the args `<pre>` keeps the shared `.maka-code` inline-code base (used by
  * Markdown / artifact previews too — out of scope); the `args` part below is only
@@ -429,24 +427,24 @@ const toolVariants = cva("", {
       count:
         "inline-flex items-center justify-center min-w-[22px] h-[18px] px-1.5 py-0 rounded-[var(--radius-pill)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[11px] [font-variant-numeric:tabular-nums]",
       // `.maka-tool` (effective: the later `padding: 0` rule wins over `8px 12px`)
-      // + `.toolItem` + the `[open]>summary` divider + the `[data-status]` border /
-      // background / opacity swaps. `[border: …]` / `[border-color: …]` are arbitrary
-      // so the status overrides touch only the color, never width/style. The
-      // `<summary>` marker reset stays a residue keyed on `[data-slot="tool"]`
-      // (see docstring).
+      // + `.toolItem` + the `[data-status]` border / background / opacity swaps.
+      // `[border: …]` / `[border-color: …]` are arbitrary so the status overrides
+      // touch only the color, never width/style. `group/tool` exposes Base UI
+      // `[data-open]` to the trigger/header part without root-owned child
+      // selectors.
       item:
-        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
-        + " [&[open]>summary]:[border-bottom:1px_solid_var(--border)]"
+        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)] group/tool"
         // `waiting_permission` border tint — see `WP_CARD_BORDER` above (String.raw).
         + " " + WP_CARD_BORDER
         + " data-[status=running]:[border-color:oklch(from_var(--status-running)_l_c_h_/_0.4)]"
         + " data-[status=completed]:[border-color:var(--border)]"
         + " data-[status=errored]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.4)] data-[status=errored]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)]"
         + " data-[status=interrupted]:[border-color:var(--border)] data-[status=interrupted]:bg-[var(--foreground-3)] data-[status=interrupted]:opacity-[0.7]",
-      // `.maka-tool > summary` (list-style + padding) + `.maka-tool-header` (the
-      // 8px · name · meta grid). Folded together since the summary IS the header.
+      // The Collapsible trigger/header: 8px · name · meta grid. The open-state
+      // divider is declared on the styled part itself, reading `[data-open]` from
+      // the named root group.
       header:
-        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-secondary)]",
+        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-secondary)] group-data-[open]/tool:[border-bottom:1px_solid_var(--border)]",
       // `.maka-tool-status-dot` (+ the `[data-status]` color swaps; running adds
       // the box-shadow ring + `maka-tool-pulse` breath — keyframe stays in CSS).
       dot:

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -429,11 +429,9 @@ const toolVariants = cva("", {
       // `.maka-tool` (effective: the later `padding: 0` rule wins over `8px 12px`)
       // + `.toolItem` + the `[data-status]` border / background / opacity swaps.
       // `[border: …]` / `[border-color: …]` are arbitrary so the status overrides
-      // touch only the color, never width/style. `group/tool` exposes Base UI
-      // `[data-open]` to the trigger/header part without root-owned child
-      // selectors.
+      // touch only the color, never width/style.
       item:
-        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)] group/tool"
+        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
         // `waiting_permission` border tint — see `WP_CARD_BORDER` above (String.raw).
         + " " + WP_CARD_BORDER
         + " data-[status=running]:[border-color:oklch(from_var(--status-running)_l_c_h_/_0.4)]"
@@ -441,10 +439,9 @@ const toolVariants = cva("", {
         + " data-[status=errored]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.4)] data-[status=errored]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)]"
         + " data-[status=interrupted]:[border-color:var(--border)] data-[status=interrupted]:bg-[var(--foreground-3)] data-[status=interrupted]:opacity-[0.7]",
       // The Collapsible trigger/header: 8px · name · meta grid. The open-state
-      // divider is declared on the styled part itself, reading `[data-open]` from
-      // the named root group.
+      // divider reads Base UI's `[data-panel-open]` trigger attribute directly.
       header:
-        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-secondary)] group-data-[open]/tool:[border-bottom:1px_solid_var(--border)]",
+        "list-none grid grid-cols-[8px_minmax(0,1fr)_auto] items-center gap-2.5 px-3 py-2 text-[color:var(--foreground-secondary)] data-[panel-open]:[border-bottom:1px_solid_var(--border)]",
       // `.maka-tool-status-dot` (+ the `[data-status]` color swaps; running adds
       // the box-shadow ring + `maka-tool-pulse` breath — keyframe stays in CSS).
       dot:

--- a/packages/ui/src/primitives/collapsible.tsx
+++ b/packages/ui/src/primitives/collapsible.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
+import { cn } from "../utils.js";
+import type React from "react";
+
+// Base UI Collapsible wrappers for the four disclosure sites that used native
+// `<details>`/`<summary>` (turn-thinking, reasoning-panel, permission-raw,
+// tool-activity — all independent single sections, so Collapsible not
+// Accordion). The `data-slot` hooks follow the style-hook convention (item 23)
+// so CSS can target `[data-slot="collapsible"]` / `[data-slot="collapsible-trigger"]`
+// / `[data-slot="collapsible-panel"]` and read the Base UI native `[data-open]`
+// state attribute on the root.
+//
+// Migration note: native `<details>` rendered the summary + body inline; Base UI
+// Collapsible.Trigger is a real `<button>`, so the summary row must be
+// click-targetable (it already was — the `<summary>` was the toggle). The
+// reasoning panel's "default open, first click sticks" behavior moves from
+// reading `e.currentTarget.open` off the toggle event to Collapsible's
+// controlled `open` + `onOpenChange` props.
+
+export function Collapsible({
+  className,
+  ...props
+}: CollapsiblePrimitive.Root.Props): React.ReactElement {
+  return (
+    <CollapsiblePrimitive.Root
+      className={cn("flex flex-col", className)}
+      data-slot="collapsible"
+      {...props}
+    />
+  );
+}
+
+export function CollapsibleTrigger({
+  className,
+  ...props
+}: CollapsiblePrimitive.Trigger.Props): React.ReactElement {
+  return (
+    <CollapsiblePrimitive.Trigger
+      className={cn(
+        // Button chrome reset: native <summary> had no background/border/
+        // padding/font-family, but <button> does, so reset to a clean slate
+        // and let the call site's className own layout + color. cursor stays
+        // default (macOS reserves the hand for links; see
+        // cursor-convention-contract.test.ts).
+        "flex w-full select-none items-center outline-none appearance-none bg-transparent border-0 p-0 [font:inherit] [text-align:inherit]",
+        className,
+      )}
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+export function CollapsiblePanel({
+  className,
+  ...props
+}: CollapsiblePrimitive.Panel.Props): React.ReactElement {
+  return (
+    <CollapsiblePrimitive.Panel
+      className={cn("overflow-hidden", className)}
+      data-slot="collapsible-panel"
+      {...props}
+    />
+  );
+}
+
+export { CollapsiblePrimitive };

--- a/packages/ui/src/primitives/number-field.tsx
+++ b/packages/ui/src/primitives/number-field.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { NumberField as NumberFieldPrimitive } from "@base-ui/react/number-field";
+import { cn } from "../utils.js";
+import { bareFieldClasses, inputClasses } from "../ui.js";
+import type React from "react";
+
+// Base UI NumberField wrappers for the gateway/proxy port inputs that
+// hand-converted with Number(event.currentTarget.value). Base UI binds
+// value: number | null directly and parses numeric input itself, so the
+// call site drops the manual string→number + `|| default` fallback.
+//
+// NumberFieldInput carries the maka standalone-input look (the same
+// inputClasses the native ui.tsx Input used) via the shared `inputClasses`
+// export, and the `unstyled` flag gives the bare form for any future
+// Field/InputGroup embedding. data-slot follows the style-hook convention
+// (item 23).
+
+export function NumberField({
+  className,
+  ...props
+}: NumberFieldPrimitive.Root.Props): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Root
+      className={cn("flex min-h-9 w-full", className)}
+      data-slot="number-field"
+      {...props}
+    />
+  );
+}
+
+export function NumberFieldInput({
+  className,
+  unstyled = false,
+  ...props
+}: NumberFieldPrimitive.Input.Props & { unstyled?: boolean }): React.ReactElement {
+  return (
+    <NumberFieldPrimitive.Input
+      className={cn(unstyled ? bareFieldClasses : inputClasses, className)}
+      data-slot="number-field-input"
+      {...props}
+    />
+  );
+}
+
+export { NumberFieldPrimitive };

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -11,9 +11,12 @@ import type React from "react";
 //
 // Usage:
 //   <Tooltip>
-//     <TooltipTrigger asChild><Button>…</Button></TooltipTrigger>
+//     <TooltipTrigger render={<Button />}>…</TooltipTrigger>
 //     <TooltipContent>{label}</TooltipContent>
 //   </Tooltip>
+//
+// Base UI v1 uses the `render` prop (not Radix `asChild`): the Trigger merges
+// its own props + children into the rendered element.
 //
 // TooltipContent collapses Portal + Positioner + Popup (the same shape
 // DialogContent uses for the dialog) so the call site is one component. The

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import { cn } from "../utils.js";
+import type React from "react";
+
+// Base UI Tooltip wrappers for the icon-only-action buttons that used the
+// native `title=` attribute (an unstyled, delayed browser tooltip). Base UI
+// Tooltip gives a themed, positioned, hover+focus tooltip matching the app.
+// The `data-slot` hooks follow the style-hook convention (item 23).
+//
+// Usage:
+//   <Tooltip>
+//     <TooltipTrigger asChild><Button>…</Button></TooltipTrigger>
+//     <TooltipContent>{label}</TooltipContent>
+//   </Tooltip>
+//
+// TooltipContent collapses Portal + Positioner + Popup (the same shape
+// DialogContent uses for the dialog) so the call site is one component. The
+// Popup carries the themed tooltip look (popover bg/corner/shadow); the
+// Positioner owns placement + the z-layer.
+
+export function Tooltip({
+  ...props
+}: TooltipPrimitive.Root.Props): React.ReactElement {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+export function TooltipTrigger({
+  className,
+  ...props
+}: TooltipPrimitive.Trigger.Props): React.ReactElement {
+  return (
+    <TooltipPrimitive.Trigger
+      className={className}
+      data-slot="tooltip-trigger"
+      {...props}
+    />
+  );
+}
+
+export function TooltipContent({
+  className,
+  ...props
+}: Omit<TooltipPrimitive.Popup.Props, "render"> & React.HTMLAttributes<HTMLDivElement>): React.ReactElement {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={6}>
+        <TooltipPrimitive.Popup
+          className={cn(
+            "z-[var(--z-overlay)] max-w-[min(90vw,320px)] rounded-md bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel",
+            className,
+          )}
+          data-slot="tooltip-content"
+          {...props}
+        />
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { TooltipPrimitive };

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -5,6 +5,7 @@ import { useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { detectUiLocale } from './locale-helpers.js';
 import { type ToolActivityItem, type ToolOutputChunk } from './materialize.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
+import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { LiveIndicator, previewVariants, streamVariants, toolVariants } from './primitives/chat.js';
 import { redactSecrets } from './redact.js';
 import { Button as UiButton, cn } from './ui.js';
@@ -109,44 +110,46 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
         const errored = item.status === 'errored';
         const permissionDenied = isPermissionDeniedToolResult(item.result);
         return (
-          <details
+          <Collapsible
             key={item.toolUseId}
             data-slot="tool"
             className={toolVariants({ part: 'item' })}
             data-status={item.status}
-            open={isOpenByDefault(item.status)}
+            defaultOpen={isOpenByDefault(item.status)}
           >
-            <summary className={toolVariants({ part: 'header' })}>
+            <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
               <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
               <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
               <span className={toolVariants({ part: 'meta' })}>
                 {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
                 <span className={toolVariants({ part: 'status-label' })}>{STATUS_LABEL[item.status]}</span>
               </span>
-            </summary>
-            <div className={toolVariants({ part: 'body' })}>
-              {errored && <ToolErrorBanner result={item.result} />}
-              {item.intent && !permissionDenied && <p className={toolVariants({ part: 'intent' })}>{formatToolIntent(item.intent)}</p>}
-              {item.args !== undefined && !permissionDenied && (
-                <pre className={`maka-code ${toolVariants({ part: 'args' })}`}>{formatRedactedJson(item.args)}</pre>
-              )}
-              {item.outputChunks && item.outputChunks.length > 0 && (
-                <ToolOutputStream
-                  chunks={item.outputChunks}
-                  live={item.status === 'running' || item.status === 'pending'}
-                  interrupted={item.status === 'interrupted'}
-                  truncated={item.outputTruncated === true}
-                />
-              )}
-              {item.result && !permissionDenied && (
-                isConnectorTool(item.toolName) && item.result.kind === 'json' ? (
-                  <LoadToolResultPreview args={item.args} value={item.result.value} />
-                ) : (
-                  <ToolResultPreview content={item.result} />
-                )
-              )}
-            </div>
-          </details>
+            </CollapsibleTrigger>
+            <CollapsiblePanel>
+              <div className={toolVariants({ part: 'body' })}>
+                {errored && <ToolErrorBanner result={item.result} />}
+                {item.intent && !permissionDenied && <p className={toolVariants({ part: 'intent' })}>{formatToolIntent(item.intent)}</p>}
+                {item.args !== undefined && !permissionDenied && (
+                  <pre className={`maka-code ${toolVariants({ part: 'args' })}`}>{formatRedactedJson(item.args)}</pre>
+                )}
+                {item.outputChunks && item.outputChunks.length > 0 && (
+                  <ToolOutputStream
+                    chunks={item.outputChunks}
+                    live={item.status === 'running' || item.status === 'pending'}
+                    interrupted={item.status === 'interrupted'}
+                    truncated={item.outputTruncated === true}
+                  />
+                )}
+                {item.result && !permissionDenied && (
+                  isConnectorTool(item.toolName) && item.result.kind === 'json' ? (
+                    <LoadToolResultPreview args={item.args} value={item.result.value} />
+                  ) : (
+                    <ToolResultPreview content={item.result} />
+                  )
+                )}
+              </div>
+            </CollapsiblePanel>
+          </Collapsible>
         );
       })}
     </section>

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { type ToolResultContent } from '@maka/core';
 import { AlertOctagon, Check, Copy, X } from './icons.js';
 import { useClipboardCopyFeedback } from './clipboard-feedback.js';
@@ -105,54 +105,69 @@ export function ToolActivity(props: { items: ToolActivityItem[] }) {
         <strong>工具调用</strong>
         <span className={toolVariants({ part: 'count' })} aria-label={`${props.items.length} 次调用`}>{props.items.length}</span>
       </header>
-      {props.items.map((item) => {
-        const duration = formatDuration(item.durationMs);
-        const errored = item.status === 'errored';
-        const permissionDenied = isPermissionDeniedToolResult(item.result);
-        return (
-          <Collapsible
-            key={item.toolUseId}
-            data-slot="tool"
-            className={toolVariants({ part: 'item' })}
-            data-status={item.status}
-            defaultOpen={isOpenByDefault(item.status)}
-          >
-            <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
-              <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
-              <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
-              <span className={toolVariants({ part: 'meta' })}>
-                {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
-                <span className={toolVariants({ part: 'status-label' })}>{STATUS_LABEL[item.status]}</span>
-              </span>
-            </CollapsibleTrigger>
-            <CollapsiblePanel>
-              <div className={toolVariants({ part: 'body' })}>
-                {errored && <ToolErrorBanner result={item.result} />}
-                {item.intent && !permissionDenied && <p className={toolVariants({ part: 'intent' })}>{formatToolIntent(item.intent)}</p>}
-                {item.args !== undefined && !permissionDenied && (
-                  <pre className={`maka-code ${toolVariants({ part: 'args' })}`}>{formatRedactedJson(item.args)}</pre>
-                )}
-                {item.outputChunks && item.outputChunks.length > 0 && (
-                  <ToolOutputStream
-                    chunks={item.outputChunks}
-                    live={item.status === 'running' || item.status === 'pending'}
-                    interrupted={item.status === 'interrupted'}
-                    truncated={item.outputTruncated === true}
-                  />
-                )}
-                {item.result && !permissionDenied && (
-                  isConnectorTool(item.toolName) && item.result.kind === 'json' ? (
-                    <LoadToolResultPreview args={item.args} value={item.result.value} />
-                  ) : (
-                    <ToolResultPreview content={item.result} />
-                  )
-                )}
-              </div>
-            </CollapsiblePanel>
-          </Collapsible>
-        );
-      })}
+      {props.items.map((item) => (
+        <ToolActivityCard key={item.toolUseId} item={item} />
+      ))}
     </section>
+  );
+}
+
+function ToolActivityCard({ item }: { item: ToolActivityItem }) {
+  const duration = formatDuration(item.durationMs);
+  const errored = item.status === 'errored';
+  const permissionDenied = isPermissionDeniedToolResult(item.result);
+  // Controlled open that follows item.status: a card that defaults open while
+  // pending/running auto-collapses when it settles to completed/interrupted
+  // (restoring the pre-Collapsible native-disclosure behavior, where
+  // open={isOpenByDefault(status)} re-evaluated every render). The user can
+  // still toggle in between — onOpenChange updates local state, and the next
+  // status change re-syncs. See disclosure-collapsible-contract: defaultOpen
+  // is banned here.
+  const [open, setOpen] = useState(isOpenByDefault(item.status));
+  useEffect(() => {
+    setOpen(isOpenByDefault(item.status));
+  }, [item.status]);
+  return (
+    <Collapsible
+      data-slot="tool"
+      className={toolVariants({ part: 'item' })}
+      data-status={item.status}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
+        <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
+        <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item)}</span>
+        <span className={toolVariants({ part: 'meta' })}>
+          {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
+          <span className={toolVariants({ part: 'status-label' })}>{STATUS_LABEL[item.status]}</span>
+        </span>
+      </CollapsibleTrigger>
+      <CollapsiblePanel>
+        <div className={toolVariants({ part: 'body' })}>
+          {errored && <ToolErrorBanner result={item.result} />}
+          {item.intent && !permissionDenied && <p className={toolVariants({ part: 'intent' })}>{formatToolIntent(item.intent)}</p>}
+          {item.args !== undefined && !permissionDenied && (
+            <pre className={`maka-code ${toolVariants({ part: 'args' })}`}>{formatRedactedJson(item.args)}</pre>
+          )}
+          {item.outputChunks && item.outputChunks.length > 0 && (
+            <ToolOutputStream
+              chunks={item.outputChunks}
+              live={item.status === 'running' || item.status === 'pending'}
+              interrupted={item.status === 'interrupted'}
+              truncated={item.outputTruncated === true}
+            />
+          )}
+          {item.result && !permissionDenied && (
+            isConnectorTool(item.toolName) && item.result.kind === 'json' ? (
+              <LoadToolResultPreview args={item.args} value={item.result.value} />
+            ) : (
+              <ToolResultPreview content={item.result} />
+            )
+          )}
+        </div>
+      </CollapsiblePanel>
+    </Collapsible>
   );
 }
 

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -331,12 +331,6 @@ export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsW
 export const SelectValue = BaseSelect.Value;
 export const SelectPortal = BaseSelect.Portal;
 export const SelectPositioner = BaseSelect.Positioner;
-export const SelectList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.List>>(function SelectList(
-  { className, ...props },
-  ref,
-) {
-  return <BaseSelect.List ref={ref} className={cn('max-h-[var(--available-height)] overflow-y-auto py-1', className)} data-slot="select-list" {...props} />;
-});
 export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Popup>>(function SelectPopup(
   { className, ...props },
   ref,

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -18,6 +18,36 @@ import { cn } from './utils.js';
 
 export { cn } from './utils.js';
 
+// === Base UI style-hook convention (#520 PR5 item 23) =========================
+// Every Base UI wrapper in this file exposes `data-slot="<name>"` so CSS can
+// target `[data-slot="..."]` (a stable hook that survives className drift);
+// the shared primitives in `./primitives/` already do this (accordion / alert /
+// badge / …), and new wrappers (Collapsible / Tooltip / NumberField / …) follow
+// the same rule. Hand-written native elements (the legacy `Input` / `Textarea`
+// below, and `Badge`) are out of this rule until they retire onto a Base UI
+// primitive.
+//
+// Boolean state hooks adopt Base UI's NATIVE attribute-presence form —
+// `[data-active]`, `[data-open]`, `[data-checked]`, `[data-selected]`,
+// `[data-pressed]`, `[data-highlighted]`, `[data-disabled]` — NOT the
+// attribute-value form `[data-active="true"]`. Maka's renderer CSS has zero
+// state-attribute selectors today, so adopting Base UI's form breaks nothing
+// and avoids maintaining an override layer. Per-component map:
+//   Tabs        data-active                 (primitives/tabs.tsx)
+//   Select      data-[highlighted] / data-[selected]
+//   Checkbox    data-[checked] / data-[disabled]
+//   Switch      data-[checked] / data-[disabled]
+//   Toggle      data-[pressed] / data-[disabled]
+//   Radio       data-[checked] / data-[disabled]
+//   Dialog      data-[open]                 (open state on the root)
+//   Tooltip / Popover  data-[open]
+//   Progress    (no boolean state)
+// CSS var hooks whitelisted for theming: `--anchor-*` (popups),
+// `--available-*` (popup max-height), `--active-tab-*` (Tabs indicator).
+// `className(state)` function form: deferred — add only when a migration in
+// this PR actually needs state-based classes; do not pre-design it.
+// ===========================================================================
+
 // PR-UIBUTTON-NAV-SIZE-0 (round 12/30): refactored so each
 // `size` variant owns its h-* / px-* / text-* utilities.
 // Previously these were baked into the base layer, which meant
@@ -78,6 +108,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(function Button(
     <BaseButton
       ref={ref}
       className={cn(buttonVariants({ variant, size }), className)}
+      data-slot="button"
       {...props}
     />
   );
@@ -158,6 +189,7 @@ export const Separator = forwardRef<HTMLDivElement, React.ComponentPropsWithoutR
         orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
         className,
       )}
+      data-slot="separator"
       {...props}
     />
   );
@@ -177,6 +209,7 @@ export const Checkbox = forwardRef<
         'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
+      data-slot="checkbox"
       {...props}
     >
       <BaseCheckbox.Indicator className="grid place-items-center">
@@ -206,27 +239,33 @@ const MODAL_POPUP_CLASS =
   'fixed left-1/2 top-1/2 z-50 grid max-h-[85dvh] w-[min(92vw,640px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-maka-panel';
 
 type ModalContentProps = React.ComponentPropsWithoutRef<typeof BaseDialog.Popup> & { showClose?: boolean };
+type ModalSlotPrefix = 'dialog' | 'alert-dialog';
+
+type ModalBackdropProps = { className?: string; 'data-slot'?: string };
+type ModalCloseProps = { className?: string; 'aria-label'?: string; 'data-slot'?: string; children?: React.ReactNode };
 
 function createModalContent(primitives: {
   Portal: React.ComponentType<{ children?: React.ReactNode }>;
-  Backdrop: React.ComponentType<{ className?: string }>;
+  Backdrop: React.ComponentType<ModalBackdropProps>;
   Popup: React.ForwardRefExoticComponent<React.ComponentPropsWithoutRef<typeof BaseDialog.Popup> & React.RefAttributes<HTMLDivElement>>;
-  Close: React.ComponentType<{ className?: string; 'aria-label'?: string; children?: React.ReactNode }>;
+  Close: React.ComponentType<ModalCloseProps>;
   defaultShowClose: boolean;
+  slotPrefix: ModalSlotPrefix;
 }) {
   return forwardRef<HTMLDivElement, ModalContentProps>(function ModalContent(
     { className, children, showClose = primitives.defaultShowClose, ...props },
     ref,
   ) {
-    const { Portal, Backdrop, Popup, Close } = primitives;
+    const { Portal, Backdrop, Popup, Close, slotPrefix } = primitives;
     return (
       <Portal>
-        <Backdrop className={MODAL_BACKDROP_CLASS} />
-        <Popup ref={ref} className={cn(MODAL_POPUP_CLASS, className)} {...props}>
+        <Backdrop className={MODAL_BACKDROP_CLASS} data-slot={`${slotPrefix}-backdrop`} />
+        <Popup ref={ref} className={cn(MODAL_POPUP_CLASS, className)} data-slot={`${slotPrefix}-popup`} {...props}>
           {showClose && (
             <Close
               className={cn(buttonVariants({ variant: 'quiet', size: 'icon-sm' }), 'absolute right-3 top-3')}
               aria-label="关闭"
+              data-slot={`${slotPrefix}-close`}
             >
               <X aria-hidden="true" />
             </Close>
@@ -244,6 +283,7 @@ export const DialogContent = createModalContent({
   Popup: BaseDialog.Popup,
   Close: BaseDialog.Close,
   defaultShowClose: true,
+  slotPrefix: 'dialog',
 });
 
 // AlertDialog — the alert variant locks modal + disables pointer dismissal,
@@ -256,6 +296,7 @@ export const AlertDialogContent = createModalContent({
   Popup: BaseAlertDialog.Popup,
   Close: BaseAlertDialog.Close,
   defaultShowClose: false,
+  slotPrefix: 'alert-dialog',
 });
 
 // Tabs: re-export the shared tab spec primitive (#499 P0-3). The tab spec
@@ -276,6 +317,7 @@ export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsW
     <BaseSelect.Trigger
       ref={ref}
       className={cn(buttonVariants({ variant: 'outline' }), 'justify-between', className)}
+      data-slot="select-trigger"
       {...props}
     >
       {children}
@@ -289,6 +331,12 @@ export const SelectTrigger = forwardRef<HTMLButtonElement, React.ComponentPropsW
 export const SelectValue = BaseSelect.Value;
 export const SelectPortal = BaseSelect.Portal;
 export const SelectPositioner = BaseSelect.Positioner;
+export const SelectList = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.List>>(function SelectList(
+  { className, ...props },
+  ref,
+) {
+  return <BaseSelect.List ref={ref} className={cn('max-h-[var(--available-height)] overflow-y-auto py-1', className)} data-slot="select-list" {...props} />;
+});
 export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Popup>>(function SelectPopup(
   { className, ...props },
   ref,
@@ -300,25 +348,25 @@ export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithou
   // read as "can't select". Pin the popup to `--z-overlay` (300)
   // so it always floats above the modal it was triggered from
   // (WAWQAQ msg `d3ea9a33` 2026-06-26).
-  return <BaseSelect.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} {...props} />;
+  return <BaseSelect.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} data-slot="select-popup" {...props} />;
 });
 export const SelectGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Group>>(function SelectGroup(
   { className, ...props },
   ref,
 ) {
-  return <BaseSelect.Group ref={ref} className={cn('py-1', className)} {...props} />;
+  return <BaseSelect.Group ref={ref} className={cn('py-1', className)} data-slot="select-group" {...props} />;
 });
 export const SelectGroupLabel = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.GroupLabel>>(function SelectGroupLabel(
   { className, ...props },
   ref,
 ) {
-  return <BaseSelect.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} {...props} />;
+  return <BaseSelect.GroupLabel ref={ref} className={cn('px-2 py-1 text-xs font-medium text-foreground-secondary', className)} data-slot="select-group-label" {...props} />;
 });
 export const SelectSeparator = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Separator>>(function SelectSeparator(
   { className, ...props },
   ref,
 ) {
-  return <BaseSelect.Separator ref={ref} className={cn('my-1 h-px bg-border', className)} {...props} />;
+  return <BaseSelect.Separator ref={ref} className={cn('my-1 h-px bg-border', className)} data-slot="select-separator" {...props} />;
 });
 
 export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Item>>(function SelectItem(
@@ -329,6 +377,7 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
     <BaseSelect.Item
       ref={ref}
       className={cn('grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-muted data-[selected]:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50', className)}
+      data-slot="select-item"
       {...props}
     >
       <span className="flex h-4 w-4 items-center justify-center" aria-hidden="true">
@@ -354,13 +403,13 @@ export const FieldDescription = forwardRef<HTMLParagraphElement, React.Component
   { className, ...props },
   ref,
 ) {
-  return <BaseField.Description ref={ref} className={cn('text-xs text-foreground-secondary', className)} {...props} />;
+  return <BaseField.Description ref={ref} className={cn('text-xs text-foreground-secondary', className)} data-slot="field-description" {...props} />;
 });
 export const Label = forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<typeof BaseField.Label>>(function Label(
   { className, ...props },
   ref,
 ) {
-  return <BaseField.Label ref={ref} className={cn('text-sm font-medium text-foreground', className)} {...props} />;
+  return <BaseField.Label ref={ref} className={cn('text-sm font-medium text-foreground', className)} data-slot="label" {...props} />;
 });
 
 // =============================================================
@@ -380,6 +429,7 @@ export const Switch = forwardRef<
         'data-[checked]:bg-control data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
+      data-slot="switch"
       {...props}
     >
       <BaseSwitch.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-[1.125rem]" />
@@ -405,6 +455,7 @@ export const Toggle = forwardRef<
         'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}
+      data-slot="toggle"
       {...props}
     />
   );
@@ -418,6 +469,7 @@ export const ToggleGroup = forwardRef<
     <BaseToggleGroup
       ref={ref}
       className={cn('inline-flex items-center gap-1 rounded-md bg-muted p-1', className)}
+      data-slot="toggle-group"
       {...props}
     />
   );
@@ -431,7 +483,7 @@ export const RadioGroup = forwardRef<
   HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof BaseRadioGroup>
 >(function RadioGroup({ className, ...props }, ref) {
-  return <BaseRadioGroup ref={ref} className={cn('grid gap-2', className)} {...props} />;
+  return <BaseRadioGroup ref={ref} className={cn('grid gap-2', className)} data-slot="radio-group" {...props} />;
 });
 
 export const Radio = forwardRef<
@@ -447,6 +499,7 @@ export const Radio = forwardRef<
         'data-[checked]:border-control data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
         className,
       )}
+      data-slot="radio"
       {...props}
     >
       <BaseRadio.Indicator className="grid place-items-center">
@@ -468,6 +521,7 @@ export const Progress = forwardRef<
     <BaseProgress.Root
       ref={ref}
       className={cn('relative h-2 w-full overflow-hidden rounded-full bg-muted', className)}
+      data-slot="progress"
       {...props}
     >
       <BaseProgress.Track className="absolute inset-0 overflow-hidden">

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -141,14 +141,14 @@ export function Badge({ className, variant, ...props }: BadgeProps) {
   return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-const inputClasses = [
+export const inputClasses = [
   'flex min-h-9 w-full rounded-sm border border-input bg-[oklch(from_var(--foreground)_l_c_h_/_0.02)] px-3 py-2 text-sm text-foreground shadow-sm',
   'placeholder:text-foreground-secondary/70',
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
   'disabled:cursor-not-allowed disabled:opacity-50',
 ].join(' ');
 
-const bareFieldClasses = [
+export const bareFieldClasses = [
   'appearance-none rounded-none border-0 bg-transparent p-0 text-inherit shadow-none outline-none [font:inherit]',
   'focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0',
   'disabled:cursor-not-allowed disabled:opacity-60',


### PR DESCRIPTION
## Summary

PR5 of #520 — the style-hook convention foundation + the smaller Base UI migrations that follow it. Four items, one commit each (each independently revertible), TDD red → green → refactor.

#22 (input canonical) was scoped into PR5 but moved to PR8 during this work — `primitives/input.tsx` carries a different structure (`data-slot="input-control"` span + inner Base UI input, `ring-[3px]`) than the native `ui.tsx` `Input` (single `<input>` + `inputClasses`, `ring-2`), and `bare-field-chrome-contract.test.ts` pins the native's `data-maka-field-chrome` + `border-input` + `ring-2`, so retiring the native is not a clean look-preserving swap. The issue plan was re-arranged (#22 → PR8); this PR opens with 1-4 only.

## New primitives (`packages/ui/src/primitives/`)

| Primitive | Wraps | data-slot |
|-----------|-------|-----------|
| `collapsible.tsx` | `@base-ui/react/collapsible` Root/Trigger/Panel | collapsible / collapsible-trigger / collapsible-panel |
| `tooltip.tsx` | `@base-ui/react/tooltip` Root/Trigger/Content (Portal+Positioner+Popup) | tooltip / tooltip-trigger / tooltip-content |
| `number-field.tsx` | `@base-ui/react/number-field` Root/Input | number-field / number-field-input |

All follow the style-hook convention (item 23): `data-slot` on each part, Base UI's native boolean state attributes (`data-panel-open`, `data-open`, etc.) adopted as-is. The Collapsible Trigger carries a button-chrome reset (the native `<summary>` had no bg/border/padding, but `<button>` does). The Tooltip Trigger uses Base UI v1's `render` prop (not Radix `asChild`). The NumberField Input reuses maka's `inputClasses` (now exported from `ui.tsx`) so the port inputs keep their look.

## Convergence

- **item 23 — style-hook convention**: `data-slot` added to all 20 Base UI wrappers in `ui.tsx` (Button/Separator/Checkbox/Dialog backdrop+popup/Select Trigger+List+Popup+Group+GroupLabel+Separator+Item/FieldDescription/Label/Switch/Toggle/ToggleGroup/RadioGroup/Radio/Progress). A doc comment at the top of `ui.tsx` records the state-attribute decision (adopt Base UI native attribute-presence form — maka's renderer CSS has zero state-attribute selectors today, so nothing breaks), the per-component hook map, the whitelisted CSS var hooks, and the `className(state)` deferral.
- **item 17 — disclosure → Collapsible**: the four `<details>`/`<summary>` sites (chat-view turn-thinking + reasoning-panel, permission-dialog permission-raw, tool-activity) migrate to Base UI Collapsible (all independent single sections, so Collapsible not Accordion). CSS retargeted: `summary` → `[data-slot="collapsible-trigger"]`, `[open]` → `[data-panel-open]`, `::-webkit-details-marker`/`::marker` resets dropped (button trigger has no native marker). The reasoning-panel's controlled-open moves from `e.currentTarget.open` off the toggle event to Collapsible's `open` + `onOpenChange`.
- **item 20 — tooltip → Base UI Tooltip**: the 13 clearest icon-only-action button `title=` usages (app-shell-chrome-actions 7, browser-panel 4, artifact-pane collapse) migrate to Base UI Tooltip; `aria-label` stays on the button, `TooltipContent` is the visual hover hint. The artifact-pane delete button's redundant `title=` is dropped (it shows a visible 删除 label). The longer tail (truncation spans, SelectTrigger titles, status badges, OnboardingHero submit) are tooltip-eligible but need per-site label-vs-tooltip judgment — deferred to a follow-up.
- **item 21 — number-field**: the two gateway/proxy port inputs migrate to Base UI NumberField (`value: number | null`, `onValueChange`), dropping the `Number(event.currentTarget.value)` hand-conversion. Proxy: 0 ↔ empty; gateway: empty → 3939 default, both preserved.

## New contracts

| Contract | Bans | Pins |
|----------|------|------|
| `style-hook-convention-contract.test.ts` | a ui.tsx wrapper forwarding to `<Base*>` without `data-slot` | the convention doc comment present |
| `disclosure-collapsible-contract.test.ts` | `<details>`/`<summary>` (incl. in comments) in the 3 migrated files; missing Collapsible import | `primitives/collapsible.tsx` data-slot on Root/Trigger/Panel |
| `tooltip-converge-contract.test.ts` | a `title=` JSX attribute in the 3 migrated files; missing Tooltip import | `primitives/tooltip.tsx` data-slot on Root/Trigger/Content |
| `number-field-converge-contract.test.ts` | `Number(event.currentTarget.value)` hand-conversion in the 2 port files; missing NumberField import | `primitives/number-field.tsx` data-slot on Root/Input |

## Existing tests updated

- `border-width-converge-contract`: the triangle-caret allowlist selectors moved from `summary::before` to `[data-slot="collapsible-trigger"]::before` (the chevron `border-width: 4px 0 4px 5px` moved with the disclosure migration).
- `chat-marker-cascade-contract` / `chat-tool-card-cascade-contract`: the turn-thinking / tool-card residue selectors + the dropped marker-reset residue.
- `app-region-hygiene-contract` / `search-modal-lifecycle-contract`: the topbar-button className extraction + the shell-search-button regex now match the `<TooltipTrigger render={<UiButton/>}>` shape (the className moved from the UiButton element to the TooltipTrigger that renders it).
- `settings-network-gateway-contract`: the two port-input assertions now pin the NumberField form (`value={...|| null}` / `value={...}` + `onValueChange={(v) => update…({ port: v ?? default })`).

## Commits

1. `feat(ui): establish Base UI style-hook convention (data-slot + native state attrs)` — item 23 (foundation).
2. `feat(ui): migrate disclosure sites to Base UI Collapsible` — item 17.
3. `feat(ui): migrate icon-action tooltips to Base UI Tooltip` — item 20.
4. `feat(ui): migrate port inputs to Base UI NumberField` — item 21.

## Verification

- **Tests**: `npm run -w @maka/desktop test` — 2008/2008 pass (rebased onto main with PR2; +26 from PR2, +10 new contract assertions across 4 files). typecheck clean.
- **Screenshots** vs main (turn-narrative, settings-appearance, first-run × light): tooltips are hover-only so rest state is unchanged; turn-narrative 0.09% (the disclosure commit's summary→button pixel difference), settings-appearance 0.0136 (PR4's settings-nav snap residual, untouched here), first-run 0. The port inputs (general/open-gateway settings) have no capture scenario; they keep their look via the shared `inputClasses`.

## Out of scope / deferred

- **#22 input canonical** → PR8 (see Summary).
- **tooltip tail** (truncation spans, SelectTrigger titles, status badges, OnboardingHero submit) — deferred to a follow-up; each needs a label-vs-tooltip check.
- **#18 toast + #19 alert-dialog** → PR6. **#24-27 large migrations** → PR7.
