### PR TITLE
chore(headless): default Harbor runs to Terminal-Bench 2.1

### DIFF
--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -213,6 +213,7 @@ describe('maka-headless CLI', () => {
       assert.equal(taskRunJson.policy.economyTask.triggerSource, 'config');
       assert.equal(taskRunJson.verifier.kind, 'terminal_bench');
       assert.equal(taskRunJson.verifier.benchmark.instanceId, 'tb-real-backend');
+      assert.equal(taskRunJson.verifier.benchmark.dataset, 'terminal-bench/terminal-bench-2-1');
       assert.equal(taskRunJson.verifier.benchmark.pendingExternalHarborVerifier, true);
       assert.equal(taskRunJson.verifier.authority.authoritative, false);
       assert.equal(taskRunJson.verifier.authority.label, 'external Harbor verifier pending');
@@ -224,6 +225,40 @@ describe('maka-headless CLI', () => {
       const resultJson = await readFile(join(outDir, 'exports', 'harbor-run-1', 'result.json'), 'utf8');
       assert.doesNotMatch(resultJson, /verificationPlaceholder/);
       assert.doesNotMatch(resultJson, /unsupported local benchmark placeholder/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('harbor run task-run honors an explicit benchmark dataset override', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      const fixture = join(dir, 'fixture');
+      const outDir = join(dir, 'out');
+      await mkdir(fixture, { recursive: true });
+
+      const result = await runCli([
+        'harbor',
+        'run',
+        '--backend',
+        'fake',
+        '--isolation',
+        'none',
+        '--instruction',
+        'solve it',
+        '--workdir',
+        fixture,
+        '--task-id',
+        'tb-custom-dataset',
+        '--task-run-id',
+        'harbor-run-custom-dataset',
+        '--out',
+        outDir,
+      ], { env: { MAKA_BENCHMARK_DATASET: 'terminal-bench/custom' } });
+      assert.equal(result.code, 0, result.stderr);
+
+      const taskRunJson = JSON.parse(await readFile(join(outDir, 'exports', 'harbor-run-custom-dataset', 'task-run.json'), 'utf8'));
+      assert.equal(taskRunJson.verifier.benchmark.dataset, 'terminal-bench/custom');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -153,6 +153,44 @@ describe('Harbor adapter contract', () => {
     }
   });
 
+  test('Terminal-Bench sample task-run configs tag Maka metadata with the selected dataset', async (t: TestContext) => {
+    const jobName = `maka-sample-dataset-contract-${Date.now()}`;
+    const scriptPath = resolve(repoRoot, 'terminal-bench-smoke/run-terminal-bench-sample.sh');
+    const result = spawnSync('bash', [
+      scriptPath,
+      '--profile',
+      'maka-heavy',
+      '--job-name',
+      jobName,
+      '--dry-run',
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HARBOR_BIN: process.execPath,
+      },
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('bash is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
+
+    const configPath = result.stdout.match(/Generated Harbor config: (.+)/)?.[1]?.trim();
+    assert.ok(configPath, result.stdout);
+    try {
+      const config = JSON.parse(await readFile(configPath, 'utf8'));
+      const dataset = config.datasets[0];
+      const agentEnv = config.agents[0].env;
+      assert.equal(dataset.name, 'terminal-bench-sample');
+      assert.equal(dataset.version, '2.0');
+      assert.equal(agentEnv.MAKA_BENCHMARK_DATASET, dataset.name);
+    } finally {
+      rmSync(configPath, { force: true });
+    }
+  });
+
   test('run-prompt-optimization.mjs wires the headless run API with a key file, not a raw key', async () => {
     const source = await readRepoFile('packages/headless/harbor/run-prompt-optimization.mjs');
     assert.match(source, /runPromptOptimizationRun/);

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -320,7 +320,7 @@ function buildHarborTask(options: HarborRunOptions): Task {
       kind: 'terminal_bench',
       adapter: 'terminal-bench',
       instanceId: options.env.MAKA_INSTANCE_ID ?? options.taskId,
-      dataset: options.env.MAKA_BENCHMARK_DATASET ?? 'terminal-bench/terminal-bench-2',
+      dataset: options.env.MAKA_BENCHMARK_DATASET ?? 'terminal-bench/terminal-bench-2-1',
       protectedPaths: [],
       adapterOptions: {
         officialVerifier: options.officialVerifier,

--- a/terminal-bench-smoke/maka_harbor_runner.mjs
+++ b/terminal-bench-smoke/maka_harbor_runner.mjs
@@ -80,6 +80,7 @@ const autonomousMaxWallTimeMs = process.env.MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC
   ? Number(process.env.MAKA_AUTONOMOUS_MAX_WALL_TIME_SEC) * 1000
   : undefined;
 const taskRunOutDir = process.env.MAKA_TASK_RUN_OUT_DIR;
+const benchmarkDataset = process.env.MAKA_BENCHMARK_DATASET ?? 'terminal-bench/terminal-bench-2-1';
 const now = Date.now;
 const useMakeMipsAutonomousSelfCheck = makeMipsSmokeHint || controlledMakeMipsSmoke;
 
@@ -524,7 +525,7 @@ try {
             kind: 'terminal_bench',
             adapter: 'terminal-bench',
             instanceId: taskId,
-            dataset: 'terminal-bench/terminal-bench-2',
+            dataset: benchmarkDataset,
             testCommand: 'false',
             protectedPaths: [],
             adapterOptions: {

--- a/terminal-bench-smoke/run-terminal-bench-sample.sh
+++ b/terminal-bench-smoke/run-terminal-bench-sample.sh
@@ -187,6 +187,8 @@ function retryConfig() {
 }
 
 const taskPattern = env('TASK_PATTERN') || defaults.taskPattern || '*sqlite-with-gcov';
+const datasetName = env('DATASET_NAME') || (defaults.dataset && defaults.dataset.name) || 'terminal-bench-sample';
+const datasetVersion = env('DATASET_VERSION') || (defaults.dataset && defaults.dataset.version) || '2.0';
 const nTasksRaw = env('N_TASKS');
 const nTasks = nTasksRaw ? Number(nTasksRaw) : null;
 if (nTasksRaw && (!Number.isInteger(nTasks) || nTasks <= 0)) {
@@ -217,6 +219,9 @@ const maxSteps = env('MAX_STEPS');
 if (maxSteps) agentEnv.MAKA_MAX_STEPS = maxSteps;
 const agentTimeoutSec = env('AGENT_TIMEOUT_SEC');
 if (agentTimeoutSec) agentEnv.MAKA_HARBOR_AGENT_TIMEOUT_SEC = agentTimeoutSec;
+if (profileName.startsWith('maka-') && !agentEnv.MAKA_BENCHMARK_DATASET) {
+  agentEnv.MAKA_BENCHMARK_DATASET = env('MAKA_BENCHMARK_DATASET') || datasetName;
+}
 
 const extraInstructionPaths = Object.prototype.hasOwnProperty.call(profile, 'extraInstructionPaths')
   ? profile.extraInstructionPaths
@@ -278,8 +283,8 @@ const config = {
   datasets: [
     {
       path: null,
-      name: env('DATASET_NAME') || (defaults.dataset && defaults.dataset.name) || 'terminal-bench-sample',
-      version: env('DATASET_VERSION') || (defaults.dataset && defaults.dataset.version) || '2.0',
+      name: datasetName,
+      version: datasetVersion,
       ref: null,
       registry_url: null,
       registry_path: null,


### PR DESCRIPTION
## Summary

- Default `maka-headless harbor run` Terminal-Bench metadata to `terminal-bench/terminal-bench-2-1`.
- Default the legacy Terminal-Bench smoke task-run metadata to 2.1 while preserving `MAKA_BENCHMARK_DATASET` override support.
- Make the sample config generator inject `MAKA_BENCHMARK_DATASET` from the selected outer dataset for Maka profiles, so `terminal-bench-sample@2.0` smoke runs do not get exported as Terminal-Bench 2.1 metadata.
- Add CLI/sample coverage for the 2.1 default, explicit dataset overrides, and sample dataset metadata alignment.

## Why

Refs: N/A

Future Maka leaderboard runs should target Terminal-Bench 2.1 instead of carrying forward the historical Terminal-Bench 2.0 default. Keeping the env override preserves one-off dataset experiments without making the normal path depend on operators remembering to set it.

The local sample harness still defaults to `terminal-bench-sample@2.0`, so its generated Maka task-run metadata must follow the selected sample dataset instead of inheriting the mainline 2.1 fallback.

## Scope

Changed:

- `packages/headless/src/harbor-cli.ts` default Terminal-Bench dataset for Harbor task-run metadata.
- `terminal-bench-smoke/maka_harbor_runner.mjs` default Terminal-Bench dataset metadata and override handling.
- `terminal-bench-smoke/run-terminal-bench-sample.sh` sample config generation so Maka profiles receive `MAKA_BENCHMARK_DATASET` derived from the selected Harbor dataset name unless explicitly set.
- `packages/headless/src/__tests__/cli.test.ts` coverage for default and override behavior.
- `packages/headless/src/__tests__/harbor-adapter.test.ts` coverage for sample config metadata alignment.

Not included:

- No official Terminal-Bench run is started or submitted.
- No benchmark result artifacts are committed.
- No change to `terminal-bench-sample@2.0` sample dataset docs.
- No fix for the unrelated AHE source-ref failure; that is split into #552.

## Verification

- RED: targeted Harbor CLI test first failed with actual `terminal-bench/terminal-bench-2` vs expected `terminal-bench/terminal-bench-2-1`.
- RED: sample config contract test first failed because `agentEnv.MAKA_BENCHMARK_DATASET` was `undefined` for `maka-heavy` while the outer dataset was `terminal-bench-sample@2.0`.
- `npm --workspace @maka/headless run build`
- `node --test --test-name-pattern "harbor run task-run" packages/headless/dist/__tests__/cli.test.js`
- `node --test --test-name-pattern "Terminal-Bench sample task-run configs tag Maka metadata" packages/headless/dist/__tests__/harbor-adapter.test.js`
- `node --test packages/headless/dist/__tests__/harbor-adapter.test.js`
- `python3 -m py_compile terminal-bench-smoke/maka_harbor_agent.py terminal-bench-smoke/opencode_title_harbor_agent.py`
- `node --check terminal-bench-smoke/maka_harbor_runner.mjs`
- `bash -n terminal-bench-smoke/run-terminal-bench-sample.sh`
- `git diff --check`

`node --test packages/headless/dist/__tests__/cli.test.js` still had an unrelated pre-existing AHE source-ref failure for `apps/desktop/src/main/session-environment-prompt.ts`; that fix is split into #552.

## User-facing impact

No desktop UI impact. Headless/Harbor benchmark metadata now defaults to Terminal-Bench 2.1. Terminal-Bench 2.0 comparison runs remain available by selecting the 2.0 dataset in the outer Harbor config and setting `MAKA_BENCHMARK_DATASET=terminal-bench/terminal-bench-2` so Maka exports carry the matching dataset metadata. Sample harness runs keep their metadata aligned with the selected sample dataset. No `CHANGELOG.md`, docs, breaking changes, or migrations.

## Reviewer notes

Review focus: confirm the mainline Harbor default changes only the normal Terminal-Bench dataset metadata; `MAKA_BENCHMARK_DATASET` remains available for explicit overrides, including historical Terminal-Bench 2.0 comparison runs; and the sample harness now derives Maka metadata from the selected sample dataset rather than the mainline 2.1 fallback.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable