### PR TITLE
fix(headless): refresh AHE session environment source ref

### DIFF
--- a/packages/headless/src/ahe-target-protocol.ts
+++ b/packages/headless/src/ahe-target-protocol.ts
@@ -214,7 +214,7 @@ export const MAKA_AHE_CURRENT_COMPONENTS: readonly MakaAheTargetComponent[] = [
     editable: true,
     sourceRefs: [
       { path: 'apps/desktop/src/main/system-prompt-main.ts' },
-      { path: 'apps/desktop/src/main/session-environment-prompt.ts' },
+      { path: 'packages/runtime/src/system-prompt/session-environment-prompt.ts' },
       { path: 'apps/desktop/src/main/workspace-instructions.ts' },
     ],
   },


### PR DESCRIPTION
## Summary

- Update the Maka system-prompt AHE component source refs to point at the current runtime session-environment prompt source.
- Fix `maka-headless ahe export` validation during the CLI projection test.

## Why

Refs: N/A

`apps/desktop/src/main/session-environment-prompt.ts` no longer exists; the implementation now lives in `packages/runtime/src/system-prompt/session-environment-prompt.ts`. The stale source ref made AHE target snapshot validation fail and broke the headless CLI test that exercises AHE export.

## Scope

Changed:

- `packages/headless/src/ahe-target-protocol.ts` source ref for the Maka system-prompt component.

Not included:

- No AHE schema changes.
- No prompt behavior changes.
- No changes to editable component boundaries beyond replacing the stale path with the current source file.

## Verification

- RED: `node --test packages/headless/dist/__tests__/cli.test.js` failed on `source ref "apps/desktop/src/main/session-environment-prompt.ts" does not exist under repo root`.
- `npm --workspace @maka/headless run build`
- `node --test packages/headless/dist/__tests__/cli.test.js`
- `node --test packages/headless/dist/__tests__/ahe-target-protocol.test.js`
- `git diff --check`

## User-facing impact

None. This only repairs headless AHE metadata validation. No `CHANGELOG.md`, docs, breaking changes, or migrations.

## Reviewer notes

Review focus: confirm the replacement path is the current source of `buildSessionEnvironmentPromptFragment` and remains part of the Maka system-prompt editing surface.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable