### PR TITLE
feat(desktop): task ledger panel — snapshot pull, honest cancel, race-hardened refresh (#15 P0-task UI)

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -356,7 +356,7 @@ declare global {
       };
       tasks: {
         list(sessionId: string): Promise<Task[]>;
-        cancel(sessionId: string, taskId: string): Promise<{ updated: Task; all: Task[] }>;
+        cancel(sessionId: string, taskId: string): Promise<{ outcome: 'cancelled' | 'already_terminal'; tasks: Task[] }>;
       };
       usage: {
         summary(query: UsageQuery): Promise<Result<UsageSummaryV2>>;

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,7 @@ import type {
   PlanReminder,
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
+  Task,
   DailyReviewArchive,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
@@ -352,6 +353,10 @@ declare global {
           handler: (event: { type: 'plans_changed'; reason: string; reminderId?: string; ts: number }) => void,
         ): () => void;
         subscribeDue(handler: (reminder: PlanReminder) => void): () => void;
+      };
+      tasks: {
+        list(sessionId: string): Promise<Task[]>;
+        cancel(sessionId: string, taskId: string): Promise<{ updated: Task; all: Task[] }>;
       };
       usage: {
         summary(query: UsageQuery): Promise<Result<UsageSummaryV2>>;

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -199,6 +199,7 @@ function BootstrapSubscriptionProbe(props: {
     refreshMemoryActive: async () => {},
     refreshMessages: async () => true,
     refreshPlanReminders: async () => {},
+    refreshSessionTasks: async () => {},
     refreshShellSettings: async () => {},
     refreshSkills: async () => {},
     refreshSessions: async () => [],

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -25,6 +25,7 @@ type CapturedSubscriptions = {
   connectionSubscribeCount: number;
   planDue?: (reminder: PlanReminder) => void;
   planDueSubscribeCount: number;
+  sessionsChanged?: (event: { reason: string; sessionId?: string; ts: number }) => void;
 };
 type RendererMakaStub = {
   appWindow: {
@@ -165,6 +166,58 @@ describe('AppShell effect stability contract', () => {
     assert.deepEqual(navSections, ['automations']);
   });
 
+  it('routes task-updated to the ledger refresh only: no session-list re-pull, no health reset', async () => {
+    const effects = await importAppShellEffects();
+    const refs = createBootstrapRefs();
+    const captured: CapturedSubscriptions = {
+      activeSessionSubscribeCount: 0,
+      connectionSubscribeCount: 0,
+      planDueSubscribeCount: 0,
+    };
+    const root = installReactRenderer(captured);
+    const sessionListRefreshes: number[] = [];
+    const ledgerRefreshes: Array<string | undefined> = [];
+    const healthUpdates: number[] = [];
+
+    await render(root, createElement(BootstrapSubscriptionProbe, {
+      effects,
+      onConnectionEvent: () => {},
+      onRefreshSessions: () => sessionListRefreshes.push(1),
+      onRefreshSessionTasks: (sessionId) => ledgerRefreshes.push(sessionId),
+      onSessionEventHealthUpdate: () => healthUpdates.push(1),
+      refs,
+    }));
+    assert.ok(captured.sessionsChanged, 'the probe must capture the sessions:changed subscription');
+    const baselineSessionRefreshes = sessionListRefreshes.length;
+
+    // task-updated for the active session: ledger refresh only.
+    await act(async () => {
+      captured.sessionsChanged?.({ reason: 'task-updated', sessionId: 'session-1', ts: 1 });
+    });
+    assert.deepEqual(ledgerRefreshes, ['session-1'], 'task-updated must re-pull the active session ledger');
+    assert.equal(
+      sessionListRefreshes.length,
+      baselineSessionRefreshes,
+      'task-updated must not re-pull the session list',
+    );
+    assert.equal(healthUpdates.length, 0, 'task-updated must not touch the event-stream health map');
+
+    // task-updated for a background session: no ledger refresh either.
+    await act(async () => {
+      captured.sessionsChanged?.({ reason: 'task-updated', sessionId: 'session-2', ts: 2 });
+    });
+    assert.deepEqual(ledgerRefreshes, ['session-1'], 'a background session ledger change must not refresh the panel');
+
+    // Control: an ordinary reason still re-pulls the session list and updates
+    // health, proving the captured callback actually drives the handler.
+    await act(async () => {
+      captured.sessionsChanged?.({ reason: 'updated', sessionId: 'session-1', ts: 3 });
+    });
+    assert.equal(sessionListRefreshes.length, baselineSessionRefreshes + 1, 'ordinary reasons must keep refreshing the list');
+    assert.equal(healthUpdates.length, 1, 'ordinary reasons must keep recording event-stream health');
+    assert.deepEqual(ledgerRefreshes, ['session-1'], 'ordinary reasons must not re-pull the ledger');
+  });
+
   it('uses React effect events instead of a local latest-ref helper', async () => {
     const src = await readRendererShellSource('app-shell-effects.ts');
 
@@ -178,6 +231,9 @@ function BootstrapSubscriptionProbe(props: {
   onConnectionEvent(event: ConnectionEvent): void;
   onNavSelection?(selection: { section: string }): void;
   onToastAction?(onClick: (() => void) | undefined): void;
+  onRefreshSessions?(): void;
+  onRefreshSessionTasks?(sessionId: string | undefined): void;
+  onSessionEventHealthUpdate?(): void;
   refs: ReturnType<typeof createBootstrapRefs>;
 }) {
   props.effects.useAppShellBootstrapSubscriptions({
@@ -199,17 +255,24 @@ function BootstrapSubscriptionProbe(props: {
     refreshMemoryActive: async () => {},
     refreshMessages: async () => true,
     refreshPlanReminders: async () => {},
-    refreshSessionTasks: async () => {},
+    refreshSessionTasks: async (sessionId) => {
+      props.onRefreshSessionTasks?.(sessionId);
+    },
     refreshShellSettings: async () => {},
     refreshSkills: async () => {},
-    refreshSessions: async () => [],
+    refreshSessions: async () => {
+      props.onRefreshSessions?.();
+      return [];
+    },
     rendererMountedRef: props.refs.rendererMountedRef,
     setActiveId: () => {},
     setMessages: () => {},
     setNavSelection: (selection) => {
       props.onNavSelection?.(selection);
     },
-    setSessionEventHealthBySession: () => {},
+    setSessionEventHealthBySession: () => {
+      props.onSessionEventHealthUpdate?.();
+    },
     toastApi: {
       error: () => {},
       info: () => {},
@@ -329,7 +392,10 @@ function installFakeMaka(captured: CapturedSubscriptions): void {
     },
     sessions: {
       readMessages: async () => [],
-      subscribeChanges: () => noop,
+      subscribeChanges(callback: (event: { reason: string; sessionId?: string; ts: number }) => void) {
+        captured.sessionsChanged = callback;
+        return noop;
+      },
       subscribeEvents(_sessionId: string, callback: (event: SessionEvent) => void) {
         captured.activeSessionSubscribeCount += 1;
         captured.activeSessionEvent = callback;

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -21,6 +21,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/subscription-model-fetch.ts',
   'apps/desktop/src/main/subscription-ipc-main.ts',
   'apps/desktop/src/main/system-prompt-main.ts',
+  'apps/desktop/src/main/task-ledger-ipc-main.ts',
   'apps/desktop/src/main/usage-ipc-main.ts',
   'apps/desktop/src/main/web-search-ipc-main.ts',
   'apps/desktop/src/main/workspace-resources-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Contract for the task-ledger desktop UI slice (PR2, issue #15).
+ *
+ * Locks the seams between the model-owned ledger and the renderer panel:
+ *   (a) the tasks IPC surface is registered, and the cancel handler pins the
+ *       status literal to 'cancelled' — the renderer may never pass an
+ *       arbitrary status through to the store.
+ *   (b) the preload bridge exposes the tasks namespace (list/cancel).
+ *   (c) SessionChangedReason includes 'task-updated' — the panel's only
+ *       realtime refresh signal.
+ *   (d) main.ts wraps the store in the notification decorator so every
+ *       mutation (model tools and the cancel IPC alike) broadcasts a
+ *       sessions:changed event, and the renderer effect consumes it.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+import { resolve } from 'node:path';
+import { readMainTsSource } from './main-process-contract-source-helpers.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+function repoFile(path: string): Promise<string> {
+  return readFile(resolve(REPO_ROOT, path), 'utf8');
+}
+
+describe('task ledger UI contract', () => {
+  it('registers the tasks IPC surface and pins cancel to the cancelled status', async () => {
+    const src = await repoFile('apps/desktop/src/main/task-ledger-ipc-main.ts');
+
+    assert.match(src, /ipcMain\.handle\('tasks:list'/, 'tasks:list handler must be registered');
+    assert.match(src, /ipcMain\.handle\('tasks:cancel'/, 'tasks:cancel handler must be registered');
+    assert.match(
+      src,
+      /update\(sessionId,\s*taskId,\s*\{ status: 'cancelled' \}\)/,
+      'cancel must pass the pinned status literal to the store',
+    );
+    // No renderer-supplied status/subject may flow into the cancel patch:
+    // the handler signature accepts only (sessionId, taskId).
+    assert.doesNotMatch(
+      src,
+      /ipcMain\.handle\('tasks:cancel',[^)]*(?:status|patch|subject)\s*[:,)]/,
+      'tasks:cancel must not accept a status/subject argument from the renderer',
+    );
+
+    const mainSrc = await readMainTsSource();
+    assert.match(
+      mainSrc,
+      /registerTaskLedgerIpc\(\{ taskLedger: taskLedgerStore \}\)/,
+      'main.ts must register the tasks IPC with the (decorated) task ledger store',
+    );
+  });
+
+  it('exposes the tasks namespace on the preload bridge', async () => {
+    const src = await repoFile('apps/desktop/src/preload/preload.ts');
+
+    assert.match(src, /tasks:\s*\{/, 'preload must expose a tasks namespace');
+    assert.match(src, /ipcRenderer\.invoke\('tasks:list', sessionId\)/, 'tasks.list must invoke tasks:list');
+    assert.match(
+      src,
+      /ipcRenderer\.invoke\('tasks:cancel', sessionId, taskId\)/,
+      'tasks.cancel must invoke tasks:cancel with sessionId and taskId only',
+    );
+  });
+
+  it('declares task-updated as a SessionChangedReason', async () => {
+    const src = await repoFile('packages/core/src/session.ts');
+    const reasonUnion = src.slice(src.indexOf('export type SessionChangedReason'), src.indexOf('export interface SessionChangedEvent'));
+    assert.match(reasonUnion, /'task-updated'/, "SessionChangedReason must include 'task-updated'");
+  });
+
+  it('notifies onMutation for every committed wired-store mutation, and observer failures stay contained', async () => {
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { createMainTaskLedgerWiring } = await import('../task-ledger-wiring.js');
+
+    const events: string[] = [];
+    const wiring = createMainTaskLedgerWiring(await mkdtemp(join(tmpdir(), 'maka-ledger-ui-')), {
+      onMutation: (sessionId) => {
+        events.push(sessionId);
+        throw new Error('renderer window gone');
+      },
+    });
+    const { created: [task] } = await wiring.store.create('sess-ui', [{ subject: '面板联动' }]);
+    assert.ok(task, 'a throwing observer must not fail the mutation');
+    await wiring.store.update('sess-ui', task.id, { status: 'in_progress' });
+    assert.deepEqual(events, ['sess-ui', 'sess-ui'], 'create and update must both notify');
+
+    const mainSrc = await readMainTsSource();
+    assert.match(
+      mainSrc,
+      /onMutation: \(sessionId\) => emitSessionsChanged\('task-updated', sessionId\)/,
+      'main.ts must bridge wiring mutations to sessions:changed(task-updated)',
+    );
+
+    const effectsSrc = await repoFile('apps/desktop/src/renderer/app-shell-effects.ts');
+    assert.match(
+      effectsSrc,
+      /event\.reason === 'task-updated'/,
+      'the renderer session-change handler must refresh on task-updated',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
@@ -101,5 +101,29 @@ describe('task ledger UI contract', () => {
       /event\.reason === 'task-updated'/,
       'the renderer session-change handler must refresh on task-updated',
     );
+    // task-updated is ledger-only: it must not re-pull the session list and
+    // must not reset the per-session event-stream health (it is not paired
+    // with a transcript re-pull, so it would mask a dead event stream).
+    assert.match(
+      effectsSrc,
+      /if \(event\.reason !== 'task-updated'\) void options\.refreshSessions\(\);/,
+      'task-updated must skip the full session-list refresh',
+    );
+    assert.match(
+      effectsSrc,
+      /event\.sessionId && event\.reason !== 'task-updated'/,
+      'task-updated must not reset session event-stream health',
+    );
+  });
+
+  it('clears the panel instead of showing a stale ledger when a refresh fails', async () => {
+    const actionsSrc = await repoFile('apps/desktop/src/renderer/app-shell-task-actions.ts');
+    // Fail to empty, guarded by the active-session check so a slow rejection
+    // for an abandoned session cannot clobber the current one.
+    assert.match(
+      actionsSrc,
+      /catch[\s\S]*?if \(getActiveSessionId\(\) === sessionId\) setSessionTasks\(\[\]\);/,
+      'a failed tasks:list must clear the panel for the still-active session',
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
@@ -43,6 +43,17 @@ describe('task ledger UI contract', () => {
       /ipcMain\.handle\('tasks:cancel',[^)]*(?:status|patch|subject)\s*[:,)]/,
       'tasks:cancel must not accept a status/subject argument from the renderer',
     );
+    // Terminal-race contract: a user click racing the model's own terminal
+    // transition reports the truth (already_terminal + fresh snapshot) rather
+    // than a misleading store error — on the pre-check and inside the
+    // pre-check/update race window alike; anything else rethrows.
+    assert.match(src, /outcome: 'already_terminal'/, 'cancel must report already_terminal instead of erroring');
+    assert.match(src, /outcome: 'cancelled'/, 'a performed cancel must report the cancelled outcome');
+    assert.match(
+      src,
+      /catch \(error\)[\s\S]*?already_terminal[\s\S]*?throw error/,
+      'the pre-check/update race window must re-read and only rethrow real errors',
+    );
 
     const mainSrc = await readMainTsSource();
     assert.match(
@@ -95,35 +106,49 @@ describe('task ledger UI contract', () => {
       'main.ts must bridge wiring mutations to sessions:changed(task-updated)',
     );
 
-    const effectsSrc = await repoFile('apps/desktop/src/renderer/app-shell-effects.ts');
-    assert.match(
-      effectsSrc,
-      /event\.reason === 'task-updated'/,
-      'the renderer session-change handler must refresh on task-updated',
-    );
-    // task-updated is ledger-only: it must not re-pull the session list and
-    // must not reset the per-session event-stream health (it is not paired
-    // with a transcript re-pull, so it would mask a dead event stream).
-    assert.match(
-      effectsSrc,
-      /if \(event\.reason !== 'task-updated'\) void options\.refreshSessions\(\);/,
-      'task-updated must skip the full session-list refresh',
-    );
-    assert.match(
-      effectsSrc,
-      /event\.sessionId && event\.reason !== 'task-updated'/,
-      'task-updated must not reset session event-stream health',
-    );
+    // The renderer-side routing of task-updated (refresh the active session's
+    // ledger only; skip the session-list re-pull; leave event-stream health
+    // untouched) is asserted at behavior level by the BootstrapSubscriptionProbe
+    // harness in app-shell-effect-stability-contract.test.ts, not by source
+    // regexes here.
   });
 
-  it('clears the panel instead of showing a stale ledger when a refresh fails', async () => {
+  it('clears the panel on session switch and keeps the last snapshot on refresh failure', async () => {
+    // R2: the switch effect clears synchronously — within the IPC round-trip a
+    // stale panel would offer cancel buttons wired to the previous session's
+    // task ids.
+    const appShellSrc = await repoFile('apps/desktop/src/renderer/app-shell.tsx');
+    assert.match(
+      appShellSrc,
+      /useEffect\(\(\) => \{\s*setSessionTasks\(\[\]\);\s*void refreshSessionTasksRef\.current\(activeId\);\s*\}, \[activeId\]\);/,
+      'switching sessions must synchronously clear the ledger before pulling the new one',
+    );
+
+    // R1: with the switch path clearing synchronously, whatever is rendered is
+    // this session's own ledger — a transient list failure keeps the last
+    // known snapshot instead of blanking the panel.
     const actionsSrc = await repoFile('apps/desktop/src/renderer/app-shell-task-actions.ts');
-    // Fail to empty, guarded by the active-session check so a slow rejection
-    // for an abandoned session cannot clobber the current one.
+    assert.doesNotMatch(
+      actionsSrc,
+      /catch[\s\S]*?setSessionTasks\(\[\]\)/,
+      'a failed refresh must not clear the panel (the switch path already prevents cross-session staleness)',
+    );
+
+    // R4: responses are ordered by a monotonic sequence so an older snapshot
+    // (e.g. a slow list racing a cancel result) can never overwrite a newer one.
+    assert.match(actionsSrc, /snapshotSeq/, 'snapshot application must be sequence-ordered');
     assert.match(
       actionsSrc,
-      /catch[\s\S]*?if \(getActiveSessionId\(\) === sessionId\) setSessionTasks\(\[\]\);/,
-      'a failed tasks:list must clear the panel for the still-active session',
+      /if \(seq !== snapshotSeq\) return;/,
+      'only the newest in-flight snapshot may land',
+    );
+
+    // R3 renderer side: the cancel result snapshot is applied directly (no
+    // follow-up list), and already_terminal is not surfaced as an error.
+    assert.match(
+      actionsSrc,
+      /const result = await window\.maka\.tasks\.cancel\(sessionId, taskId\);[\s\S]*?applySnapshot\(sessionId, seq, result\.tasks\);/,
+      'cancel must render the snapshot the IPC returned instead of re-pulling',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/task-ledger-ui-contract.test.ts
@@ -151,4 +151,54 @@ describe('task ledger UI contract', () => {
       'cancel must render the snapshot the IPC returned instead of re-pulling',
     );
   });
+
+  it('hosts the panel in the right-side collapsible task rail, not the chat column', async () => {
+    const railSrc = await repoFile('apps/desktop/src/renderer/task-rail.tsx');
+
+    // (a) collapse state persists under a stable key, defaulting to expanded
+    // on a fresh profile (absent key must not read as collapsed).
+    assert.match(railSrc, /'maka-task-rail-collapsed-v1'/, 'the rail must persist its collapse state');
+    assert.match(
+      railSrc,
+      /safeLocalStorageGet\(COLLAPSE_KEY\) === '1'/,
+      'only an explicit stored flag may collapse the rail — absent key means expanded',
+    );
+    assert.match(railSrc, /safeLocalStorageSet\(COLLAPSE_KEY, collapsed \? '1' : '0'\)/);
+
+    // (b) an empty ledger takes no space.
+    assert.match(
+      railSrc,
+      /if \(props\.tasks\.length === 0\) return null;/,
+      'the rail must return null for an empty ledger',
+    );
+
+    // (c) the collapsed strip still communicates the task count, and an
+    // in-progress dot only when something is actually running.
+    assert.match(railSrc, /maka-task-rail-strip-count/, 'the collapsed strip must show the task count');
+    assert.match(
+      railSrc,
+      /hasInProgress && <span className="maka-task-rail-strip-dot" \/>/,
+      'the in-progress dot must be conditional',
+    );
+
+    // Mounted in the app shell, as a sibling before ArtifactPane in the same
+    // right-side stack — and gone from the chat column entirely.
+    const appShellSrc = await repoFile('apps/desktop/src/renderer/app-shell.tsx');
+    assert.match(
+      appShellSrc,
+      /<TaskRail[\s\S]{0,300}<ArtifactPane sessionId=\{activeId\} \/>/,
+      'the task rail must sit before ArtifactPane in the right-side stack',
+    );
+    assert.match(
+      appShellSrc,
+      /activeId && sessionTasks\.length > 0 &&/,
+      'the rail mount must be gated on a known non-empty ledger (lazy-fallback contract)',
+    );
+    const chatViewSrc = await repoFile('packages/ui/src/chat-view.tsx');
+    assert.doesNotMatch(
+      chatViewSrc,
+      /TaskLedgerPanel/,
+      'the chat column must no longer render the task panel',
+    );
+  });
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -181,6 +181,7 @@ import { registerSubscriptionIpc } from './subscription-ipc-main.js';
 import { registerBrowserIpc } from './browser-ipc-main.js';
 import { registerConnectionsIpc } from './connections-ipc-main.js';
 import { registerPlanReminderIpc } from './plan-reminders-ipc-main.js';
+import { registerTaskLedgerIpc } from './task-ledger-ipc-main.js';
 import { registerWorkspaceResourcesIpc } from './workspace-resources-ipc-main.js';
 import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
@@ -303,7 +304,11 @@ const antigravitySubscription = new AntigravitySubscriptionService({
 });
 
 const planReminderStore = createPlanReminderStore(workspaceRoot);
-const taskLedgerWiring = createMainTaskLedgerWiring(workspaceRoot);
+const taskLedgerWiring = createMainTaskLedgerWiring(workspaceRoot, {
+  // Model tools and the renderer cancel IPC share the wired store, so every
+  // ledger mutation refreshes the task panel via sessions:changed.
+  onMutation: (sessionId) => emitSessionsChanged('task-updated', sessionId),
+});
 const taskLedgerStore = taskLedgerWiring.store;
 
 async function getWorkspacePrivacyContext(): Promise<WorkspacePrivacyContext> {
@@ -1024,6 +1029,7 @@ function registerIpc(): void {
     },
   );
   registerPlanReminderIpc({ planReminders, getWorkspacePrivacyContext });
+  registerTaskLedgerIpc({ taskLedger: taskLedgerStore });
   ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => runtime.listSessions(filter));
   ipcMain.handle('sessions:create', async (_event, input?: Partial<CreateSessionInput>) => {
     const cwd = input?.cwd ?? process.cwd();

--- a/apps/desktop/src/main/task-ledger-ipc-main.ts
+++ b/apps/desktop/src/main/task-ledger-ipc-main.ts
@@ -1,8 +1,24 @@
 import { ipcMain } from 'electron';
-import type { TaskLedgerStore } from '@maka/core';
+import type { Task, TaskLedgerStore, TaskStatus } from '@maka/core';
 
 interface TaskLedgerIpcDeps {
   taskLedger: TaskLedgerStore;
+}
+
+export interface TaskCancelResult {
+  /**
+   * 'cancelled' — this call performed the cancel. 'already_terminal' — the
+   * task had already reached completed/cancelled (typically the model racing
+   * the user's click); the returned snapshot is the truth and the renderer
+   * must not surface an error for it.
+   */
+  outcome: 'cancelled' | 'already_terminal';
+  /** Post-operation ledger snapshot, so the renderer needs no follow-up list. */
+  tasks: Task[];
+}
+
+function isTerminalStatus(status: TaskStatus): boolean {
+  return status === 'completed' || status === 'cancelled';
 }
 
 /**
@@ -15,7 +31,28 @@ export function registerTaskLedgerIpc(deps: TaskLedgerIpcDeps): void {
   ipcMain.handle('tasks:list', (_event, sessionId: string) => deps.taskLedger.list(sessionId));
   // The status literal is pinned here, not taken from renderer args: the
   // renderer may only cancel, never flip subjects or other statuses.
-  ipcMain.handle('tasks:cancel', (_event, sessionId: string, taskId: string) =>
-    deps.taskLedger.update(sessionId, taskId, { status: 'cancelled' }),
-  );
+  ipcMain.handle('tasks:cancel', async (_event, sessionId: string, taskId: string): Promise<TaskCancelResult> => {
+    const current = await deps.taskLedger.list(sessionId);
+    const target = current.find((task) => task.id === taskId);
+    if (!target) throw new Error(`No such task: ${taskId}`);
+    // A user click racing the model's own terminal transition is not an
+    // error: report the truth so the renderer just shows the fresh snapshot.
+    if (isTerminalStatus(target.status)) {
+      return { outcome: 'already_terminal', tasks: current };
+    }
+    try {
+      await deps.taskLedger.update(sessionId, taskId, { status: 'cancelled' });
+    } catch (error) {
+      // The pre-check and the update are not atomic: if the task reached a
+      // terminal status inside that window, re-read and report the truth
+      // instead of a misleading failure. Anything else is a real error.
+      const after = await deps.taskLedger.list(sessionId);
+      const now = after.find((task) => task.id === taskId);
+      if (now && isTerminalStatus(now.status)) {
+        return { outcome: 'already_terminal', tasks: after };
+      }
+      throw error;
+    }
+    return { outcome: 'cancelled', tasks: await deps.taskLedger.list(sessionId) };
+  });
 }

--- a/apps/desktop/src/main/task-ledger-ipc-main.ts
+++ b/apps/desktop/src/main/task-ledger-ipc-main.ts
@@ -1,0 +1,21 @@
+import { ipcMain } from 'electron';
+import type { TaskLedgerStore } from '@maka/core';
+
+interface TaskLedgerIpcDeps {
+  taskLedger: TaskLedgerStore;
+}
+
+/**
+ * Renderer surface for the session task ledger. Read-mostly by design: the
+ * ledger belongs to the model (TaskCreate/TaskUpdate tools); the only user
+ * action is cancelling a task. Session-id validation lives in the store
+ * (assertSafeSessionId), so both handlers pass ids straight through.
+ */
+export function registerTaskLedgerIpc(deps: TaskLedgerIpcDeps): void {
+  ipcMain.handle('tasks:list', (_event, sessionId: string) => deps.taskLedger.list(sessionId));
+  // The status literal is pinned here, not taken from renderer args: the
+  // renderer may only cancel, never flip subjects or other statuses.
+  ipcMain.handle('tasks:cancel', (_event, sessionId: string, taskId: string) =>
+    deps.taskLedger.update(sessionId, taskId, { status: 'cancelled' }),
+  );
+}

--- a/apps/desktop/src/main/task-ledger-wiring.ts
+++ b/apps/desktop/src/main/task-ledger-wiring.ts
@@ -17,10 +17,50 @@ export interface MainTaskLedgerWiring {
   tools: MakaTool[];
 }
 
-export function createMainTaskLedgerWiring(workspaceRoot: string): MainTaskLedgerWiring {
-  const store = createTaskLedgerStore(workspaceRoot);
+export interface MainTaskLedgerWiringOptions {
+  /**
+   * Fired after every committed ledger mutation — model tools and any host
+   * surface (e.g. the renderer cancel IPC) share the wired store, so they all
+   * notify. Best-effort: a throwing observer must never fail the mutation
+   * that already committed.
+   */
+  onMutation?: (sessionId: string) => void;
+}
+
+export function createMainTaskLedgerWiring(
+  workspaceRoot: string,
+  options: MainTaskLedgerWiringOptions = {},
+): MainTaskLedgerWiring {
+  const store = withMutationNotifications(createTaskLedgerStore(workspaceRoot), options.onMutation);
   return {
     store,
     tools: buildTaskLedgerTools({ store }),
+  };
+}
+
+function withMutationNotifications(
+  store: TaskLedgerStore,
+  onMutation: ((sessionId: string) => void) | undefined,
+): TaskLedgerStore {
+  if (!onMutation) return store;
+  const notify = (sessionId: string): void => {
+    try {
+      onMutation(sessionId);
+    } catch {
+      // Observer failure (renderer window gone, …) must not surface here.
+    }
+  };
+  return {
+    list: (sessionId) => store.list(sessionId),
+    create: async (sessionId, drafts) => {
+      const result = await store.create(sessionId, drafts);
+      notify(sessionId);
+      return result;
+    },
+    update: async (sessionId, id, patch) => {
+      const result = await store.update(sessionId, id, patch);
+      notify(sessionId);
+      return result;
+    },
   };
 }

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -8,6 +8,7 @@ import type {
   PlanReminder,
   SessionHeader,
   StoredMessage,
+  Task,
   VisualSmokeScenario,
   VisualSmokeState,
 } from '@maka/core';
@@ -104,6 +105,10 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   // Captures the actions-revealed state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',
+  // PR-task-ledger-ui (#15 P0-task): seeds the turn session with a
+  // tasks.json covering all four statuses so the baseline captures the
+  // session task panel above the chat.
+  'task-ledger',
 ]);
 
 // Fixed clock for screenshot fixtures. All seeded timestamps and
@@ -306,6 +311,12 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
     case 'artifact-preview-oversize':
       return { ...state, activeSessionId: ARTIFACT_SESSION_ID };
     case 'turn-narrative':
+      return { ...state, activeSessionId: TURN_SESSION_ID };
+    case 'task-ledger':
+      // Active = the turn session (seeded with a tasks.json below), so the
+      // task panel renders above the familiar chat narrative. The renderer's
+      // active-session effect pulls tasks:list on mount, populating the panel
+      // before auto-capture settles.
       return { ...state, activeSessionId: TURN_SESSION_ID };
     case 'streaming-sidebar':
       return {
@@ -522,6 +533,9 @@ export async function seedVisualSmokeFixture(input: {
   if (input.fixture.scenario === 'plan-reminders') {
     await writePlanReminders(input.workspaceRoot, now);
   }
+  if (input.fixture.scenario === 'task-ledger') {
+    await writeTaskLedger(input.workspaceRoot, TURN_SESSION_ID, now);
+  }
   if (input.fixture.scenario === 'module-daily-review' || input.fixture.scenario === 'settings-daily-review') {
     await writeDailyReviewArchives(input.workspaceRoot, now);
   }
@@ -681,6 +695,50 @@ async function writePlanReminders(workspaceRoot: string, now: number): Promise<v
     },
   ];
   await writeJson(join(workspaceRoot, 'plan-reminders.json'), reminders);
+}
+
+// PR-task-ledger-ui (#15 P0-task): seed a session ledger covering all four
+// statuses so the panel screenshot shows the badge palette, the relative-time
+// column, and the cancel affordance (rendered only on the non-terminal rows).
+async function writeTaskLedger(workspaceRoot: string, sessionId: string, now: number): Promise<void> {
+  const tasks: Task[] = [
+    {
+      id: 'visual-task-in-progress',
+      subject: '接入任务台账面板与聊天视图',
+      status: 'in_progress',
+      createdAt: now - 40 * 60_000,
+      updatedAt: now - 5 * 60_000,
+    },
+    {
+      id: 'visual-task-pending-schema',
+      subject: '补齐 TaskCreate/TaskUpdate 的 schema 约束',
+      status: 'pending',
+      createdAt: now - 38 * 60_000,
+      updatedAt: now - 38 * 60_000,
+    },
+    {
+      id: 'visual-task-pending-a11y',
+      subject: '取消按钮的键盘焦点与读屏播报',
+      status: 'pending',
+      createdAt: now - 36 * 60_000,
+      updatedAt: now - 36 * 60_000,
+    },
+    {
+      id: 'visual-task-completed',
+      subject: '会话级持久化与重启恢复',
+      status: 'completed',
+      createdAt: now - 90 * 60_000,
+      updatedAt: now - 20 * 60_000,
+    },
+    {
+      id: 'visual-task-cancelled',
+      subject: '实时事件推流方案（改为快照拉取）',
+      status: 'cancelled',
+      createdAt: now - 85 * 60_000,
+      updatedAt: now - 25 * 60_000,
+    },
+  ];
+  await writeJson(join(workspaceRoot, 'sessions', sessionId, 'tasks.json'), tasks);
 }
 
 async function writeDailyReviewArchives(workspaceRoot: string, now: number): Promise<void> {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -713,7 +713,7 @@ contextBridge.exposeInMainWorld('maka', {
     list(sessionId: string): Promise<Task[]> {
       return ipcRenderer.invoke('tasks:list', sessionId);
     },
-    cancel(sessionId: string, taskId: string): Promise<{ updated: Task; all: Task[] }> {
+    cancel(sessionId: string, taskId: string): Promise<{ outcome: 'cancelled' | 'already_terminal'; tasks: Task[] }> {
       return ipcRenderer.invoke('tasks:cancel', sessionId, taskId);
     },
   },

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -48,6 +48,7 @@ import type {
   PlanReminder,
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
+  Task,
   DailyReviewArchive,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
@@ -704,6 +705,16 @@ contextBridge.exposeInMainWorld('maka', {
       { ok: true; path: string } | { ok: false; reason: 'canceled' | 'write_failed' | 'invalid_input' }
     > {
       return ipcRenderer.invoke('daily-review:saveMarkdownToFile', input);
+    },
+  },
+  // Session task ledger (model-owned; renderer is read-mostly). Updates
+  // arrive as sessions:changed events with reason 'task-updated'.
+  tasks: {
+    list(sessionId: string): Promise<Task[]> {
+      return ipcRenderer.invoke('tasks:list', sessionId);
+    },
+    cancel(sessionId: string, taskId: string): Promise<{ updated: Task; all: Task[] }> {
+      return ipcRenderer.invoke('tasks:cancel', sessionId, taskId);
     },
   },
   webSearch: {

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -195,8 +195,13 @@ export function useAppShellBootstrapSubscriptions(options: {
     options.handleConnectionEvent(event);
   });
   const handleSessionChange = useEffectEvent((event: { reason: string; sessionId?: string; ts: number; modelId?: string }) => {
-    void options.refreshSessions();
-    if (event.sessionId) {
+    // task-updated is a ledger-only signal: it never changes session-list
+    // metadata (skip the full list re-pull), and it repairs only the task
+    // panel — unlike message-appended it is not accompanied by a transcript
+    // re-pull, so letting it reset staleSince would mask a dead per-session
+    // event stream while the model keeps updating tasks.
+    if (event.reason !== 'task-updated') void options.refreshSessions();
+    if (event.sessionId && event.reason !== 'task-updated') {
       options.setSessionEventHealthBySession((current) => {
         const previous = current[event.sessionId!];
         if (!previous) return current;

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -173,6 +173,7 @@ export function useAppShellBootstrapSubscriptions(options: {
   refreshMemoryActive: (failureTitle?: string) => Promise<void>;
   refreshMessages: (sessionId: string) => Promise<boolean>;
   refreshPlanReminders: (options?: { shouldShowError?: () => boolean }) => Promise<void>;
+  refreshSessionTasks: (sessionId: string | undefined) => Promise<void>;
   refreshShellSettings: () => Promise<void>;
   refreshSkills: (options?: { shouldShowError?: () => boolean }) => Promise<void>;
   refreshSessions: () => Promise<SessionSummary[]>;
@@ -214,6 +215,11 @@ export function useAppShellBootstrapSubscriptions(options: {
     const changedSessionId = event.sessionId;
     if (event.reason === 'message-appended' && changedSessionId && changedSessionId === options.activeIdRef.current) {
       void options.refreshMessages(changedSessionId);
+    }
+    // Model mutated the session task ledger (TaskCreate/TaskUpdate tools or
+    // the renderer cancel IPC): re-pull the visible session's snapshot.
+    if (event.reason === 'task-updated' && changedSessionId && changedSessionId === options.activeIdRef.current) {
+      void options.refreshSessionTasks(changedSessionId);
     }
     if (event.reason === 'rebound') {
       const modelSuffix = event.modelId ? ` · ${event.modelId}` : '';

--- a/apps/desktop/src/renderer/app-shell-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-task-actions.ts
@@ -1,0 +1,59 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { Task } from '@maka/core';
+import { generalizedErrorMessageChinese } from '@maka/core';
+
+type ToastApi = {
+  error(title: string, description?: string): void;
+};
+
+export interface AppShellTaskActions {
+  refreshSessionTasks(sessionId: string | undefined, options?: { shouldShowError?: () => boolean }): Promise<void>;
+  cancelSessionTask(sessionId: string, taskId: string): Promise<void>;
+}
+
+/**
+ * Session task ledger actions (plan-actions paradigm). The ledger is the
+ * model's; the renderer only pulls snapshots and cancels tasks. Refreshes are
+ * triggered by the mount, by session switches, and by sessions:changed events
+ * with reason 'task-updated'.
+ */
+export function createAppShellTaskActions(deps: {
+  getActiveSessionId: () => string | undefined;
+  setSessionTasks: Dispatch<SetStateAction<Task[]>>;
+  toastApi: ToastApi;
+}): AppShellTaskActions {
+  const { getActiveSessionId, setSessionTasks, toastApi } = deps;
+
+  async function refreshSessionTasks(
+    sessionId: string | undefined,
+    options: { shouldShowError?: () => boolean } = {},
+  ): Promise<void> {
+    if (!sessionId) {
+      setSessionTasks([]);
+      return;
+    }
+    try {
+      const tasks = await window.maka.tasks.list(sessionId);
+      // A slow response for a session the user already left must not
+      // clobber the newer session's list.
+      if (getActiveSessionId() === sessionId) setSessionTasks(tasks);
+    } catch (error) {
+      if (options.shouldShowError?.() ?? false) {
+        toastApi.error('刷新任务清单失败', generalizedErrorMessageChinese(error, '读取会话任务失败，请稍后重试。'));
+      }
+    }
+  }
+
+  async function cancelSessionTask(sessionId: string, taskId: string): Promise<void> {
+    try {
+      await window.maka.tasks.cancel(sessionId, taskId);
+      // The cancel IPC also emits a task-updated event, but refresh directly
+      // so the row flips without depending on the broadcast round-trip.
+      await refreshSessionTasks(sessionId);
+    } catch (error) {
+      toastApi.error('取消任务失败', generalizedErrorMessageChinese(error, '取消任务失败，请稍后重试。'));
+    }
+  }
+
+  return { refreshSessionTasks, cancelSessionTask };
+}

--- a/apps/desktop/src/renderer/app-shell-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-task-actions.ts
@@ -23,25 +23,39 @@ export function createAppShellTaskActions(deps: {
   toastApi: ToastApi;
 }): AppShellTaskActions {
   const { getActiveSessionId, setSessionTasks, toastApi } = deps;
+  // Monotonic snapshot sequence: every operation that will produce a ledger
+  // snapshot takes a number up front, and only the newest number may land.
+  // This orders concurrent responses (cancel result vs broadcast-triggered
+  // refresh) so an older snapshot can never overwrite a newer one.
+  let snapshotSeq = 0;
+
+  function applySnapshot(sessionId: string, seq: number, tasks: Task[]): void {
+    // Both guards are required: seq orders same-session responses; the
+    // active-session check drops responses for a session the user already left
+    // (the switch path cleared the panel synchronously).
+    if (seq !== snapshotSeq) return;
+    if (getActiveSessionId() !== sessionId) return;
+    setSessionTasks(tasks);
+  }
 
   async function refreshSessionTasks(
     sessionId: string | undefined,
     options: { shouldShowError?: () => boolean } = {},
   ): Promise<void> {
     if (!sessionId) {
+      snapshotSeq += 1;
       setSessionTasks([]);
       return;
     }
+    const seq = ++snapshotSeq;
     try {
       const tasks = await window.maka.tasks.list(sessionId);
-      // A slow response for a session the user already left must not
-      // clobber the newer session's list.
-      if (getActiveSessionId() === sessionId) setSessionTasks(tasks);
+      applySnapshot(sessionId, seq, tasks);
     } catch (error) {
-      // Fail to empty rather than stale: after a session switch a rejected
-      // fetch must not leave the previous session's tasks rendered under the
-      // new session. The next task-updated event re-pulls the real list.
-      if (getActiveSessionId() === sessionId) setSessionTasks([]);
+      // Keep the last known snapshot: the session-switch path clears the
+      // panel synchronously, so whatever is rendered is this session's own
+      // ledger — a transient list failure must not blank the panel (the next
+      // task-updated event re-pulls the real list).
       if (options.shouldShowError?.() ?? false) {
         toastApi.error('刷新任务清单失败', generalizedErrorMessageChinese(error, '读取会话任务失败，请稍后重试。'));
       }
@@ -49,11 +63,13 @@ export function createAppShellTaskActions(deps: {
   }
 
   async function cancelSessionTask(sessionId: string, taskId: string): Promise<void> {
+    const seq = ++snapshotSeq;
     try {
-      await window.maka.tasks.cancel(sessionId, taskId);
-      // The cancel IPC also emits a task-updated event, but refresh directly
-      // so the row flips without depending on the broadcast round-trip.
-      await refreshSessionTasks(sessionId);
+      const result = await window.maka.tasks.cancel(sessionId, taskId);
+      // The IPC returns the post-operation snapshot, so no follow-up list is
+      // needed. 'already_terminal' (the model finished or cancelled the task
+      // first) is not an error: the snapshot already shows the truth.
+      applySnapshot(sessionId, seq, result.tasks);
     } catch (error) {
       toastApi.error('取消任务失败', generalizedErrorMessageChinese(error, '取消任务失败，请稍后重试。'));
     }

--- a/apps/desktop/src/renderer/app-shell-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-task-actions.ts
@@ -38,6 +38,10 @@ export function createAppShellTaskActions(deps: {
       // clobber the newer session's list.
       if (getActiveSessionId() === sessionId) setSessionTasks(tasks);
     } catch (error) {
+      // Fail to empty rather than stale: after a session switch a rejected
+      // fetch must not leave the previous session's tasks rendered under the
+      // new session. The next task-updated event re-pulls the real list.
+      if (getActiveSessionId() === sessionId) setSessionTasks([]);
       if (options.shouldShowError?.() ?? false) {
         toastApi.error('刷新任务清单失败', generalizedErrorMessageChinese(error, '读取会话任务失败，请稍后重试。'));
       }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -51,6 +51,15 @@ function BrowserPanelFallback() {
     </div>
   );
 }
+const TaskRail = lazy(() => import('./task-rail').then((m) => ({ default: m.TaskRail })));
+
+function TaskRailFallback() {
+  return (
+    <div className="maka-task-rail" role="status" aria-busy="true" aria-label="正在加载任务栏">
+      <div className="maka-lazy-fallback" data-surface="panel">正在加载任务栏…</div>
+    </div>
+  );
+}
 import { deriveChatHeaderAlert } from './chat-header-alert';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveSessionStatusGroups } from './session-status-grouping';
@@ -1386,8 +1395,6 @@ export function AppShell({
                 onSnoozePlanReminder={(id) => snoozePlanReminder(id)}
                 onClearPlanReminderRunHistory={(id) => clearPlanReminderRunHistory(id)}
                 onDeletePlanReminder={(id) => deletePlanReminder(id)}
-                tasks={sessionTasks}
-                onCancelTask={activeId ? (taskId) => cancelSessionTask(activeId, taskId) : undefined}
                 dailyReviewBridge={dailyReviewBridge}
                 onSelectSession={openSessionInChat}
                 onCopyDailyReviewMarkdown={(input) => copyDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}
@@ -1511,6 +1518,17 @@ export function AppShell({
             {activeId && liveBrowserSessionIds.includes(activeId) && (
               <Suspense fallback={<BrowserPanelFallback />}>
                 <BrowserPanel sessionId={activeId} hidden={hasModalOpen} />
+              </Suspense>
+            )}
+            {/* Task rail mounts only when AppShell already holds a non-empty
+                ledger snapshot, so a space-reserving fallback is safe (cf. the
+                lazy-fallback contract: explicit visibility gate required). */}
+            {activeId && sessionTasks.length > 0 && (
+              <Suspense fallback={<TaskRailFallback />}>
+                <TaskRail
+                  tasks={sessionTasks}
+                  onCancel={(taskId) => cancelSessionTask(activeId, taskId)}
+                />
               </Suspense>
             )}
             <Suspense fallback={null}>

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -792,9 +792,11 @@ export function AppShell({
   });
   const refreshSessionTasksRef = useRef(refreshSessionTasks);
   refreshSessionTasksRef.current = refreshSessionTasks;
-  // Pull the ledger snapshot whenever the visible session changes. No
-  // sessionId (or no tasks) resolves to an empty list, which hides the panel.
+  // Pull the ledger snapshot whenever the visible session changes. Clear
+  // synchronously first: within the IPC round-trip a stale panel would keep
+  // offering cancel buttons wired to the previous session's task ids.
   useEffect(() => {
+    setSessionTasks([]);
     void refreshSessionTasksRef.current(activeId);
   }, [activeId]);
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -8,6 +8,7 @@ import type {
   SessionSummary,
   SettingsSection,
   StoredMessage,
+  Task,
   ThemePalette,
   ThemePreference,
   ThinkingLevel,
@@ -84,6 +85,7 @@ import { AppShellTopbarActions, AppShellWorkspaceTopActions } from './app-shell-
 import { AppShellOverlays } from './app-shell-overlays';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
 import { createAppShellPlanActions } from './app-shell-plan-actions';
+import { createAppShellTaskActions } from './app-shell-task-actions';
 import { createAppShellProjectActions, type RendererAppInfo } from './app-shell-project-actions';
 import { createAppShellSkillActions } from './app-shell-skill-actions';
 import { createAppShellSessionEventHandlers } from './app-shell-session-events';
@@ -204,6 +206,8 @@ export function AppShell({
   const [defaultPermissionMode, setDefaultPermissionMode] = useState<ChatDefaultPermissionMode>('ask');
   const [skills, setSkills] = useState<SkillEntry[]>([]);
   const [planReminders, setPlanReminders] = useState<PlanReminder[]>([]);
+  // Active session's task ledger snapshot (model-owned; renderer read-mostly).
+  const [sessionTasks, setSessionTasks] = useState<Task[]>([]);
   const [appInfo, setAppInfo] = useState<RendererAppInfo | null>(null);
   const [projectPickerPending, setProjectPickerPending] = useState(false);
   const [helpOpen, closeHelp, openHelp] = useKeyboardHelp();
@@ -781,6 +785,19 @@ export function AppShell({
     toastApi,
   });
 
+  const { refreshSessionTasks, cancelSessionTask } = createAppShellTaskActions({
+    getActiveSessionId: () => activeIdRef.current,
+    setSessionTasks,
+    toastApi,
+  });
+  const refreshSessionTasksRef = useRef(refreshSessionTasks);
+  refreshSessionTasksRef.current = refreshSessionTasks;
+  // Pull the ledger snapshot whenever the visible session changes. No
+  // sessionId (or no tasks) resolves to an empty list, which hides the panel.
+  useEffect(() => {
+    void refreshSessionTasksRef.current(activeId);
+  }, [activeId]);
+
   const {
     refreshAppInfo,
     selectProjectDirectory,
@@ -938,6 +955,7 @@ export function AppShell({
     refreshMemoryActive,
     refreshMessages,
     refreshPlanReminders,
+    refreshSessionTasks,
     refreshShellSettings,
     refreshSkills,
     refreshSessions,
@@ -1366,6 +1384,8 @@ export function AppShell({
                 onSnoozePlanReminder={(id) => snoozePlanReminder(id)}
                 onClearPlanReminderRunHistory={(id) => clearPlanReminderRunHistory(id)}
                 onDeletePlanReminder={(id) => deletePlanReminder(id)}
+                tasks={sessionTasks}
+                onCancelTask={activeId ? (taskId) => cancelSessionTask(activeId, taskId) : undefined}
                 dailyReviewBridge={dailyReviewBridge}
                 onSelectSession={openSessionInChat}
                 onCopyDailyReviewMarkdown={(input) => copyDailyReviewMarkdown(input, { shouldShowFeedback: isDailyReviewSurfaceActive })}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -28,6 +28,7 @@
 @import "./styles/permission-center.css";
 @import "./styles/health-center.css";
 @import "./styles/tool-stream.css";
+@import "./styles/task-ledger.css";
 @import "./styles/daily-review.css";
 @import "./styles/theme-glass.css";
 

--- a/apps/desktop/src/renderer/styles/task-ledger.css
+++ b/apps/desktop/src/renderer/styles/task-ledger.css
@@ -1,9 +1,10 @@
-/* Session task ledger strip (PR2, issue #15). Sits above the chat shell with
-   the other status surfaces; class family `.maka-task-*` lives outside
-   module-pages/ because this is a per-session chat surface, not a nav module
-   page (module-pages selectors are prefix-locked to maka-plan/skill/module/
-   capability). Card recipe follows the atlas hairline pattern used by
-   plan-reminders. */
+/* Session task ledger (PR2, issue #15). The `.maka-task-panel` family is the
+   controlled list (packages/ui TaskLedgerPanel); `.maka-task-rail` is the
+   desktop collapsible right-side shell hosting it (ArtifactPane precedent:
+   fixed expanded width / thin collapsed strip / null when empty). Class
+   family lives outside module-pages/ because this is a per-session chat
+   surface, not a nav module page (module-pages selectors are prefix-locked
+   to maka-plan/skill/module/capability). */
 
 .maka-task-panel {
   margin: var(--space-1) var(--space-4) 0;
@@ -81,4 +82,126 @@
 
 .maka-task-cancel {
   flex: none;
+}
+
+/* ── Right-side rail shell ─────────────────────────────────────────────── */
+
+.maka-task-rail {
+  flex: 0 0 auto;
+  width: 300px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border-left: var(--border-width-hairline) solid var(--border);
+  background: var(--background);
+  overflow: hidden;
+}
+
+.maka-task-rail[data-collapsed='true'] {
+  width: 32px;
+}
+
+.maka-task-rail-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: var(--space-1) var(--space-2);
+  min-height: 28px;
+}
+
+.maka-task-rail[data-collapsed='true'] .maka-task-rail-header {
+  padding: var(--space-1) 0;
+  justify-content: center;
+}
+
+.maka-task-rail-body {
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: var(--space-2);
+}
+
+/* Inside the rail the panel is the rail's content, not a floating card:
+   drop the card chrome and let the rail borders/background own the frame.
+   The internal list cap also goes away — the rail body is the scroller. */
+.maka-task-rail .maka-task-panel {
+  margin: 0;
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.maka-task-rail .maka-task-list {
+  max-height: none;
+  overflow-y: visible;
+}
+
+/* Collapsed strip: vertical 「任务」 label + count + in-progress dot. All
+   informational content is mirrored into the toggle's aria-label; the strip
+   is aria-hidden. */
+.maka-task-rail-strip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: var(--space-2) 0;
+}
+
+.maka-task-rail-strip-label {
+  writing-mode: vertical-rl;
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+.maka-task-rail-strip-count {
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-tight);
+}
+
+.maka-task-rail-strip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--success);
+}
+
+/* Narrow window: like ArtifactPane, the rail becomes a bottom sheet instead
+   of squeezing the chat column (same 990px boundary; the parent
+   .maka-detail-with-artifacts grid auto-places extra children into implicit
+   rows). */
+@media (max-width: 990px) {
+  .maka-task-rail {
+    width: 100%;
+    max-height: min(32dvh, 280px);
+    border-left: 0;
+    border-top: var(--border-width-hairline) solid var(--border);
+  }
+
+  /* Collapsed bottom-sheet form: one 34px horizontal bar carrying the
+     toggle followed by the inline strip (label + count + dot). */
+  .maka-task-rail[data-collapsed='true'] {
+    width: 100%;
+    min-height: 34px;
+    max-height: 34px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .maka-task-rail[data-collapsed='true'] .maka-task-rail-header {
+    padding: 0 var(--space-1);
+  }
+
+  .maka-task-rail[data-collapsed='true'] .maka-task-rail-strip {
+    flex-direction: row;
+    align-items: center;
+    padding: 0 var(--space-2);
+  }
+
+  .maka-task-rail[data-collapsed='true'] .maka-task-rail-strip-label {
+    writing-mode: horizontal-tb;
+  }
 }

--- a/apps/desktop/src/renderer/styles/task-ledger.css
+++ b/apps/desktop/src/renderer/styles/task-ledger.css
@@ -1,0 +1,91 @@
+/* Session task ledger strip (PR2, issue #15). Sits above the chat shell with
+   the other status surfaces; class family `.maka-task-*` lives outside
+   module-pages/ because this is a per-session chat surface, not a nav module
+   page (module-pages selectors are prefix-locked to maka-plan/skill/module/
+   capability). Card recipe follows the atlas hairline pattern used by
+   plan-reminders. */
+
+.maka-task-panel {
+  margin: var(--space-1) var(--space-4) 0;
+  padding: var(--space-2) var(--space-3);
+  display: grid;
+  gap: var(--space-1-5);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border-color);
+  border-radius: var(--radius-surface);
+}
+
+.maka-task-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1-5);
+}
+
+.maka-task-title {
+  color: var(--foreground);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--leading-tight);
+}
+
+.maka-task-count {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-tight);
+}
+
+.maka-task-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-1);
+  max-height: 176px;
+  overflow-y: auto;
+}
+
+.maka-task-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.maka-task-status {
+  flex: none;
+}
+
+.maka-task-subject {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--foreground);
+  font-size: var(--font-size-ui);
+  line-height: var(--leading-snug);
+}
+
+.maka-task-row[data-status='completed'] .maka-task-subject,
+.maka-task-row[data-status='cancelled'] .maka-task-subject {
+  color: var(--muted-foreground);
+  text-decoration: line-through;
+}
+
+.maka-task-time {
+  flex: none;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-tight);
+}
+
+.maka-task-cancel {
+  flex: none;
+}
+
+.maka-task-empty {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-snug);
+}

--- a/apps/desktop/src/renderer/styles/task-ledger.css
+++ b/apps/desktop/src/renderer/styles/task-ledger.css
@@ -11,7 +11,7 @@
   display: grid;
   gap: var(--space-1-5);
   background: var(--card-bg);
-  border: 1px solid var(--card-border-color);
+  border: var(--border-width-hairline) solid var(--card-border-color);
   border-radius: var(--radius-surface);
 }
 
@@ -81,11 +81,4 @@
 
 .maka-task-cancel {
   flex: none;
-}
-
-.maka-task-empty {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  line-height: var(--leading-snug);
 }

--- a/apps/desktop/src/renderer/task-rail.tsx
+++ b/apps/desktop/src/renderer/task-rail.tsx
@@ -1,0 +1,85 @@
+/**
+ * Right-side collapsible task rail for the chat shell.
+ *
+ * The session task ledger is persistent state (unlike the transient tool /
+ * reasoning / streaming surfaces in the main column), so it lives in its own
+ * rail instead of competing for main-column vertical space. Layout follows
+ * the ArtifactPane collapsible-aside precedent: fixed expanded width,
+ * thin collapsed strip, localStorage-remembered collapse state, and
+ * `return null` when there is nothing to show (the rail never reserves
+ * space for an empty ledger).
+ *
+ * The rail is only the collapse shell — list rendering, cancel affordance,
+ * focus recovery, and the aria-live announcement all stay in the controlled
+ * `TaskLedgerPanel` (@maka/ui).
+ */
+import { useEffect, useState } from 'react';
+import type { Task } from '@maka/core';
+import { ChevronLeft, ChevronRight } from '@maka/ui/icons';
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@maka/ui';
+import { TaskLedgerPanel } from '@maka/ui/task-ledger-panel';
+import { safeLocalStorageGet, safeLocalStorageSet } from './browser-storage';
+
+const COLLAPSE_KEY = 'maka-task-rail-collapsed-v1';
+
+export function TaskRail(props: {
+  tasks: Task[];
+  onCancel?: (taskId: string) => void | Promise<void>;
+}) {
+  const [collapsed, setCollapsed] = useState<boolean>(() => readCollapsed());
+
+  useEffect(() => {
+    safeLocalStorageSet(COLLAPSE_KEY, collapsed ? '1' : '0');
+  }, [collapsed]);
+
+  // No tasks → no rail. The host also gates the mount, but the guard keeps
+  // the "never reserve space for an empty ledger" contract local.
+  if (props.tasks.length === 0) return null;
+
+  const total = props.tasks.length;
+  const hasInProgress = props.tasks.some((task) => task.status === 'in_progress');
+
+  return (
+    <aside
+      className="maka-task-rail"
+      data-collapsed={collapsed ? 'true' : 'false'}
+      aria-label="会话任务栏"
+    >
+      <header className="maka-task-rail-header">
+        <Tooltip>
+          <TooltipTrigger
+            render={<Button variant="quiet" size="icon-sm" />}
+            type="button"
+            className="maka-task-rail-collapse"
+            onClick={() => setCollapsed((current) => !current)}
+            aria-pressed={collapsed}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? `展开任务栏（共 ${total} 项任务）` : '折叠任务栏'}
+          >
+            {collapsed ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
+          </TooltipTrigger>
+          <TooltipContent>{collapsed ? '展开任务栏' : '折叠任务栏'}</TooltipContent>
+        </Tooltip>
+      </header>
+      {collapsed ? (
+        // Screen readers get the count via the toggle's aria-label; the strip
+        // itself is a purely visual affordance.
+        <div className="maka-task-rail-strip" aria-hidden="true">
+          <span className="maka-task-rail-strip-label">任务</span>
+          <span className="maka-task-rail-strip-count tabular-nums">{total}</span>
+          {hasInProgress && <span className="maka-task-rail-strip-dot" />}
+        </div>
+      ) : (
+        <div className="maka-task-rail-body">
+          <TaskLedgerPanel tasks={props.tasks} onCancel={props.onCancel} />
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function readCollapsed(): boolean {
+  // Absent key → expanded: a fresh profile (and the visual-smoke fixture's
+  // isolated userDataDir) shows the rail open by default.
+  return safeLocalStorageGet(COLLAPSE_KEY) === '1';
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -455,6 +455,7 @@ export {
   TASK_LEDGER_MAX_TASKS,
   TASK_STATUSES,
   TASK_SUBJECT_MAX_CHARS,
+  explainTaskUpdateRejection,
   isSafeTaskId,
   isTaskStatus,
   normalizeCreateTaskInput,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -146,7 +146,8 @@ export type SessionChangedReason =
   | 'mode-change'
   | 'status-change'
   | 'turn-status-change'
-  | 'rebound';
+  | 'rebound'
+  | 'task-updated';
 
 export interface SessionChangedEvent {
   type: 'sessions_changed';

--- a/packages/core/src/task-ledger.ts
+++ b/packages/core/src/task-ledger.ts
@@ -148,6 +148,24 @@ export function normalizeUpdateTaskInput(
 }
 
 /**
+ * Transition rule for TaskUpdate (model tool and renderer cancel IPC alike).
+ * `cancelled` records a user veto, so a cancelled task is frozen — no status
+ * or subject change may resurrect it (the model starts a new task instead).
+ * Cancelling `completed` work is rejected as meaningless: it would destroy the
+ * completion record if the user's stale snapshot races the model's finish.
+ * Reopening completed work (completed → pending/in_progress) stays legal.
+ */
+export function explainTaskUpdateRejection(from: TaskStatus, to?: TaskStatus): string | undefined {
+  if (from === 'cancelled') {
+    return 'This task was cancelled (user veto) and is frozen; create a new task instead of modifying it';
+  }
+  if (from === 'completed' && to === 'cancelled') {
+    return 'A completed task cannot be cancelled; the work is already done';
+  }
+  return undefined;
+}
+
+/**
  * Safe-render the task ledger for any face that persists into history or is
  * re-injected into a prompt (tool results, turn-tail fragment). Two invariants:
  *   - the canonical id is rendered verbatim, and the subject is a safe

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -98,7 +98,15 @@ export type VisualSmokeScenario =
   // becomes visible (via `:focus-within`). Verifies that the
   // time meta + unread dot do NOT leak through the action icons
   // — the bug WAWQAQ flagged.
-  | 'sidebar-row-actions-visible';
+  | 'sidebar-row-actions-visible'
+  // PR-task-ledger-ui (#15 P0-task): seed the turn-narrative session
+  // with a tasks.json covering all four statuses (in_progress / pending
+  // / completed / cancelled) so the screenshot pipeline baselines the
+  // session task panel above the chat — status badges, relative time,
+  // and the cancel affordance on non-terminal rows. Reuses the standard
+  // turn session so the chat surface behind the panel is the familiar
+  // narrative baseline.
+  | 'task-ledger';
 
 export interface VisualSmokeLiveTool {
   toolUseId: string;

--- a/packages/runtime/src/task-ledger-tools.ts
+++ b/packages/runtime/src/task-ledger-tools.ts
@@ -56,7 +56,9 @@ function buildTaskUpdateTool(
     displayName: 'Task Update',
     description:
       'Update a task in the session task ledger by id. Provide status and/or a revised subject. '
-      + 'Mark tasks in_progress when you start them and completed (or cancelled) when done.',
+      + 'Mark tasks in_progress when you start them and completed (or cancelled) when done. '
+      + 'Cancelled tasks are frozen (they record a user veto) — create a new task instead of editing one; '
+      + 'completed tasks cannot be cancelled but may be reopened.',
     parameters: z.object({
       id: z.string().min(1).max(TASK_ID_MAX_CHARS).refine(isSafeTaskId, 'Task id must be a stable token (alphanumeric plus . _ : -, max 64 chars) from the current ledger.').describe('Task id from the current ledger.'),
       status: z.enum(TASK_STATUSES).optional().describe('New task status.'),

--- a/packages/storage/src/__tests__/task-ledger-store.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-store.test.ts
@@ -77,6 +77,23 @@ describe('TaskLedgerStore', () => {
     await assert.rejects(() => store.create(SESSION_ID, [{ subject: '   ' }]), /empty/);
   });
 
+  it('freezes cancelled tasks and refuses to cancel completed work', async () => {
+    const root = await tempRoot();
+    const store = createTaskLedgerStore(root);
+    const { created: [cancelled, completed] } = await store.create(SESSION_ID, [{ subject: 'a' }, { subject: 'b' }]);
+    assert.ok(cancelled && completed);
+    await store.update(SESSION_ID, cancelled.id, { status: 'cancelled' });
+    await store.update(SESSION_ID, completed.id, { status: 'completed' });
+
+    // A user veto is final: no status flip, no subject edit.
+    await assert.rejects(() => store.update(SESSION_ID, cancelled.id, { status: 'in_progress' }), /frozen/);
+    await assert.rejects(() => store.update(SESSION_ID, cancelled.id, { subject: '改名' }), /frozen/);
+    // Completed work cannot be vetoed after the fact, but may be reopened.
+    await assert.rejects(() => store.update(SESSION_ID, completed.id, { status: 'cancelled' }), /already done/);
+    const { updated } = await store.update(SESSION_ID, completed.id, { status: 'in_progress' });
+    assert.equal(updated.status, 'in_progress');
+  });
+
   it('does not rewrite the file when the update target does not exist', async () => {
     const root = await tempRoot();
     const store = createTaskLedgerStore(root);

--- a/packages/storage/src/__tests__/task-ledger-store.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-store.test.ts
@@ -94,6 +94,25 @@ describe('TaskLedgerStore', () => {
     assert.equal(updated.status, 'in_progress');
   });
 
+  it('treats cancelled -> cancelled (status-only) as an idempotent no-op without writing the file', async () => {
+    const root = await tempRoot();
+    const store = createTaskLedgerStore(root);
+    const { created: [task] } = await store.create(SESSION_ID, [{ subject: 'a' }]);
+    assert.ok(task);
+    const { updated: cancelled } = await store.update(SESSION_ID, task.id, { status: 'cancelled' });
+    const before = await readFile(tasksFilePath(root), 'utf8');
+
+    // Re-cancelling converges: same record back (updatedAt untouched), no error.
+    const { updated: again, total } = await store.update(SESSION_ID, task.id, { status: 'cancelled' });
+    assert.deepEqual(again, cancelled);
+    assert.equal(total, 1);
+    assert.equal(await readFile(tasksFilePath(root), 'utf8'), before, 'idempotent cancel must not rewrite the file');
+
+    // The frozen guard still applies to anything beyond the pure re-cancel.
+    await assert.rejects(() => store.update(SESSION_ID, task.id, { status: 'cancelled', subject: '改名' }), /frozen/);
+    await assert.rejects(() => store.update(SESSION_ID, task.id, { subject: '改名' }), /frozen/);
+  });
+
   it('does not rewrite the file when the update target does not exist', async () => {
     const root = await tempRoot();
     const store = createTaskLedgerStore(root);

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
   TASK_LEDGER_MAX_TASKS,
+  explainTaskUpdateRejection,
   isSafeTaskId,
   isTaskStatus,
   normalizeCreateTaskInput,
@@ -89,6 +90,8 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       const index = tasks.findIndex((task) => task.id === id);
       const current = index === -1 ? undefined : tasks[index];
       if (!current) throw new Error(`No such task: ${id}`);
+      const rejection = explainTaskUpdateRejection(current.status, normalized.value.status);
+      if (rejection) throw new Error(rejection);
       updated = {
         ...current,
         ...(normalized.value.subject !== undefined ? { subject: normalized.value.subject } : {}),

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -90,6 +90,18 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       const index = tasks.findIndex((task) => task.id === id);
       const current = index === -1 ? undefined : tasks[index];
       if (!current) throw new Error(`No such task: ${id}`);
+      // Idempotent cancel: cancelled -> cancelled with a status-only patch is
+      // a no-op success (no write, no error) so a user cancel racing another
+      // cancel converges instead of tripping the frozen guard. A subject
+      // change still falls through to the frozen rejection below.
+      if (
+        current.status === 'cancelled' &&
+        normalized.value.status === 'cancelled' &&
+        normalized.value.subject === undefined
+      ) {
+        updated = current;
+        return null;
+      }
       const rejection = explainTaskUpdateRejection(current.status, normalized.value.status);
       if (rejection) throw new Error(rejection);
       updated = {
@@ -146,11 +158,21 @@ class FileTaskLedgerStore implements TaskLedgerStore {
     }
   }
 
-  private async mutate(sessionId: string, fn: (tasks: Task[]) => Task[]): Promise<Task[]> {
+  /**
+   * Serialized read-modify-write. A callback may return `null` to declare the
+   * mutation an idempotent no-op: the current list is kept and nothing is
+   * written (so no-op updates neither bump mtime nor risk a rewrite).
+   */
+  private async mutate(sessionId: string, fn: (tasks: Task[]) => Task[] | null): Promise<Task[]> {
     let next: Task[] = [];
     await chainWrite(this.writeQueues, sessionId, async () => {
       const current = await this.readForMutate(sessionId);
-      next = fn(current);
+      const result = fn(current);
+      if (result === null) {
+        next = current;
+        return;
+      }
+      next = result;
       await this.write(sessionId, next);
     });
     return next;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,8 @@
     "./assistant-stream": "./dist/assistant-stream.js",
     "./icons": "./dist/icons.js",
     "./maka-uri": "./dist/maka-uri.js",
-    "./smooth-stream": "./dist/smooth-stream.js"
+    "./smooth-stream": "./dist/smooth-stream.js",
+    "./task-ledger-panel": "./dist/task-ledger-panel.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -20,7 +20,7 @@ import { formatAbsoluteTimestamp, formatTurnDuration, turnAbortMarkerLabel } fro
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
-import type { PlanReminder, ProviderType, SessionSummary, StoredMessage } from '@maka/core';
+import type { PlanReminder, ProviderType, SessionSummary, StoredMessage, Task } from '@maka/core';
 import { deriveCapabilityAuditReport, isDeepResearchSession } from '@maka/core';
 import { materializeChat, materializeTools, materializeTurns, type ToolActivityItem, type TurnViewModel } from './materialize.js';
 import { Button as UiButton } from './ui.js';
@@ -44,6 +44,9 @@ import type {
 const SkillsModuleMain = lazy(() => import('./skills-panel.js').then((m) => ({ default: m.SkillsModuleMain })));
 const DailyReviewPanel = lazy(() => import('./daily-review-panel.js').then((m) => ({ default: m.DailyReviewPanel })));
 const PlanReminderPanel = lazy(() => import('./plan-reminder-panel.js').then((m) => ({ default: m.PlanReminderPanel })));
+// Per-session task ledger strip. Lazy for the same reason as the module
+// panels: sessions without tasks (the common case) never pay for its code.
+const TaskLedgerPanel = lazy(() => import('./task-ledger-panel.js').then((m) => ({ default: m.TaskLedgerPanel })));
 
 function ModulePageFallback(props: { label: string; message: string }) {
   return (
@@ -243,6 +246,9 @@ export function ChatView(props: {
   onSnoozePlanReminder?: (id: string) => void | Promise<void>;
   onClearPlanReminderRunHistory?: (id: string) => void | Promise<void>;
   onDeletePlanReminder?: (id: string) => void | Promise<void>;
+  /** Active session's task ledger snapshot (model-owned; shell pulls it). */
+  tasks?: Task[];
+  onCancelTask?: (taskId: string) => void | Promise<void>;
   dailyReviewBridge?: DailyReviewBridge;
   onCopyDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
   onAppendDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
@@ -545,6 +551,14 @@ export function ChatView(props: {
             当前会话来自旧的本地模拟连接。要拿到真实 LLM 回复，请到 <strong>设置 · 模型</strong> 添加 Anthropic / OpenAI / GLM 等 API key。
           </AlertDescription>
         </Alert>
+      )}
+      {/* Per-session task ledger: mounts only once the model has created
+          tasks, so ordinary chats keep a clean chrome strip. Sits with the
+          other above-shell status surfaces (status cluster / banners). */}
+      {(props.tasks?.length ?? 0) > 0 && (
+        <Suspense fallback={<ModulePanelFallback message="正在加载任务清单…" />}>
+          <TaskLedgerPanel tasks={props.tasks ?? []} onCancel={props.onCancelTask} />
+        </Suspense>
       )}
       <div className="maka-chat-shell">
         {props.branchBanner && (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -20,7 +20,7 @@ import { formatAbsoluteTimestamp, formatTurnDuration, turnAbortMarkerLabel } fro
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
-import type { PlanReminder, ProviderType, SessionSummary, StoredMessage, Task } from '@maka/core';
+import type { PlanReminder, ProviderType, SessionSummary, StoredMessage } from '@maka/core';
 import { deriveCapabilityAuditReport, isDeepResearchSession } from '@maka/core';
 import { materializeChat, materializeTools, materializeTurns, type ToolActivityItem, type TurnViewModel } from './materialize.js';
 import { Button as UiButton } from './ui.js';
@@ -44,9 +44,6 @@ import type {
 const SkillsModuleMain = lazy(() => import('./skills-panel.js').then((m) => ({ default: m.SkillsModuleMain })));
 const DailyReviewPanel = lazy(() => import('./daily-review-panel.js').then((m) => ({ default: m.DailyReviewPanel })));
 const PlanReminderPanel = lazy(() => import('./plan-reminder-panel.js').then((m) => ({ default: m.PlanReminderPanel })));
-// Per-session task ledger strip. Lazy for the same reason as the module
-// panels: sessions without tasks (the common case) never pay for its code.
-const TaskLedgerPanel = lazy(() => import('./task-ledger-panel.js').then((m) => ({ default: m.TaskLedgerPanel })));
 
 function ModulePageFallback(props: { label: string; message: string }) {
   return (
@@ -246,9 +243,6 @@ export function ChatView(props: {
   onSnoozePlanReminder?: (id: string) => void | Promise<void>;
   onClearPlanReminderRunHistory?: (id: string) => void | Promise<void>;
   onDeletePlanReminder?: (id: string) => void | Promise<void>;
-  /** Active session's task ledger snapshot (model-owned; shell pulls it). */
-  tasks?: Task[];
-  onCancelTask?: (taskId: string) => void | Promise<void>;
   dailyReviewBridge?: DailyReviewBridge;
   onCopyDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
   onAppendDailyReviewMarkdown?: (input: DailyReviewMarkdownActionInput) => Promise<void> | void;
@@ -551,14 +545,6 @@ export function ChatView(props: {
             当前会话来自旧的本地模拟连接。要拿到真实 LLM 回复，请到 <strong>设置 · 模型</strong> 添加 Anthropic / OpenAI / GLM 等 API key。
           </AlertDescription>
         </Alert>
-      )}
-      {/* Per-session task ledger: mounts only once the model has created
-          tasks, so ordinary chats keep a clean chrome strip. Sits with the
-          other above-shell status surfaces (status cluster / banners). */}
-      {(props.tasks?.length ?? 0) > 0 && (
-        <Suspense fallback={<ModulePanelFallback message="正在加载任务清单…" />}>
-          <TaskLedgerPanel tasks={props.tasks ?? []} onCancel={props.onCancelTask} />
-        </Suspense>
       )}
       <div className="maka-chat-shell">
         {props.branchBanner && (

--- a/packages/ui/src/task-ledger-panel.tsx
+++ b/packages/ui/src/task-ledger-panel.tsx
@@ -6,7 +6,9 @@ import { RelativeTime } from './relative-time.js';
 // Controlled panel (plan-reminder-panel paradigm): the session task ledger is
 // owned by the model's TaskCreate/TaskUpdate tools, so this surface is
 // read-mostly — the only user action is cancelling a task. Data arrives via
-// props; the mount owns fetching and refresh.
+// props; the mount owns fetching and refresh, and the host is responsible for
+// not mounting the panel at all when the ledger is empty (there is no
+// empty-state branch here).
 export interface TaskLedgerPanelProps {
   tasks: Task[];
   onCancel?(taskId: string): void | Promise<void>;
@@ -32,8 +34,10 @@ function isTerminalTaskStatus(status: TaskStatus): boolean {
 
 export function TaskLedgerPanel(props: TaskLedgerPanelProps) {
   const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [announcement, setAnnouncement] = useState('');
   const mountedRef = useRef(true);
   const pendingIdsRef = useRef<Set<string>>(new Set());
+  const rootRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -43,7 +47,7 @@ export function TaskLedgerPanel(props: TaskLedgerPanelProps) {
     };
   }, []);
 
-  async function cancelTask(taskId: string) {
+  async function cancelTask(taskId: string, subject: string) {
     if (!props.onCancel || pendingIdsRef.current.has(taskId)) return;
     const withTask = new Set(pendingIdsRef.current);
     withTask.add(taskId);
@@ -51,56 +55,63 @@ export function TaskLedgerPanel(props: TaskLedgerPanelProps) {
     setPendingIds(withTask);
     try {
       await props.onCancel(taskId);
+      if (mountedRef.current) setAnnouncement(`任务清单已更新：${subject}`);
     } finally {
       const withoutTask = new Set(pendingIdsRef.current);
       withoutTask.delete(taskId);
       pendingIdsRef.current = withoutTask;
       if (mountedRef.current) setPendingIds(withoutTask);
+      // When the row goes terminal its cancel button unmounts and keyboard
+      // focus silently drops to <body>; catch that after React commits the
+      // snapshot and park focus on the panel root instead.
+      window.requestAnimationFrame(() => {
+        if (!mountedRef.current) return;
+        if (document.activeElement === document.body) rootRef.current?.focus();
+      });
     }
   }
 
   const doneCount = props.tasks.filter((task) => task.status === 'completed').length;
 
   return (
-    <section className="maka-task-panel" aria-label="会话任务清单">
+    <section className="maka-task-panel" aria-label="会话任务清单" tabIndex={-1} ref={rootRef}>
       <header className="maka-task-header">
         <span className="maka-task-title">任务</span>
         <span className="maka-task-count tabular-nums" aria-label={`已完成 ${doneCount} 项，共 ${props.tasks.length} 项`}>
           {doneCount}/{props.tasks.length}
         </span>
       </header>
-      {props.tasks.length === 0 ? (
-        <p className="maka-task-empty">当前会话还没有任务；模型规划工作时会在这里记录进展。</p>
-      ) : (
-        <ul className="maka-task-list">
-          {props.tasks.map((task) => {
-            const cancelPending = pendingIds.has(task.id);
-            return (
-              <li key={task.id} className="maka-task-row" data-status={task.status}>
-                <Badge variant={TASK_STATUS_BADGE_VARIANTS[task.status]} className="maka-task-status">
-                  {TASK_STATUS_LABELS[task.status]}
-                </Badge>
-                <span className="maka-task-subject" title={task.subject}>{task.subject}</span>
-                <RelativeTime ts={task.updatedAt} className="maka-task-time" />
-                {!isTerminalTaskStatus(task.status) && props.onCancel ? (
-                  <UiButton
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="maka-task-cancel"
-                    onClick={() => void cancelTask(task.id)}
-                    disabled={cancelPending}
-                    aria-busy={cancelPending ? 'true' : undefined}
-                    aria-label={`取消任务：${task.subject}`}
-                  >
-                    取消
-                  </UiButton>
-                ) : null}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      <span className="maka-visually-hidden" role="status" aria-live="polite">
+        {announcement}
+      </span>
+      <ul className="maka-task-list">
+        {props.tasks.map((task) => {
+          const cancelPending = pendingIds.has(task.id);
+          return (
+            <li key={task.id} className="maka-task-row" data-status={task.status}>
+              <Badge variant={TASK_STATUS_BADGE_VARIANTS[task.status]} className="maka-task-status">
+                {TASK_STATUS_LABELS[task.status]}
+              </Badge>
+              <span className="maka-task-subject" title={task.subject}>{task.subject}</span>
+              <RelativeTime ts={task.updatedAt} className="maka-task-time" />
+              {!isTerminalTaskStatus(task.status) && props.onCancel ? (
+                <UiButton
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="maka-task-cancel"
+                  onClick={() => void cancelTask(task.id, task.subject)}
+                  disabled={cancelPending}
+                  aria-busy={cancelPending ? 'true' : undefined}
+                  aria-label={`取消任务：${task.subject}`}
+                >
+                  取消
+                </UiButton>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
     </section>
   );
 }

--- a/packages/ui/src/task-ledger-panel.tsx
+++ b/packages/ui/src/task-ledger-panel.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Task, TaskStatus } from '@maka/core';
+import { Badge, Button as UiButton } from './ui.js';
+import { RelativeTime } from './relative-time.js';
+
+// Controlled panel (plan-reminder-panel paradigm): the session task ledger is
+// owned by the model's TaskCreate/TaskUpdate tools, so this surface is
+// read-mostly — the only user action is cancelling a task. Data arrives via
+// props; the mount owns fetching and refresh.
+export interface TaskLedgerPanelProps {
+  tasks: Task[];
+  onCancel?(taskId: string): void | Promise<void>;
+}
+
+const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  pending: '待处理',
+  in_progress: '进行中',
+  completed: '已完成',
+  cancelled: '已取消',
+};
+
+const TASK_STATUS_BADGE_VARIANTS: Record<TaskStatus, 'muted' | 'success' | 'secondary' | 'warning'> = {
+  pending: 'muted',
+  in_progress: 'success',
+  completed: 'secondary',
+  cancelled: 'warning',
+};
+
+function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return status === 'completed' || status === 'cancelled';
+}
+
+export function TaskLedgerPanel(props: TaskLedgerPanelProps) {
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(() => new Set());
+  const mountedRef = useRef(true);
+  const pendingIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      pendingIdsRef.current = new Set();
+    };
+  }, []);
+
+  async function cancelTask(taskId: string) {
+    if (!props.onCancel || pendingIdsRef.current.has(taskId)) return;
+    const withTask = new Set(pendingIdsRef.current);
+    withTask.add(taskId);
+    pendingIdsRef.current = withTask;
+    setPendingIds(withTask);
+    try {
+      await props.onCancel(taskId);
+    } finally {
+      const withoutTask = new Set(pendingIdsRef.current);
+      withoutTask.delete(taskId);
+      pendingIdsRef.current = withoutTask;
+      if (mountedRef.current) setPendingIds(withoutTask);
+    }
+  }
+
+  const doneCount = props.tasks.filter((task) => task.status === 'completed').length;
+
+  return (
+    <section className="maka-task-panel" aria-label="会话任务清单">
+      <header className="maka-task-header">
+        <span className="maka-task-title">任务</span>
+        <span className="maka-task-count tabular-nums" aria-label={`已完成 ${doneCount} 项，共 ${props.tasks.length} 项`}>
+          {doneCount}/{props.tasks.length}
+        </span>
+      </header>
+      {props.tasks.length === 0 ? (
+        <p className="maka-task-empty">当前会话还没有任务；模型规划工作时会在这里记录进展。</p>
+      ) : (
+        <ul className="maka-task-list">
+          {props.tasks.map((task) => {
+            const cancelPending = pendingIds.has(task.id);
+            return (
+              <li key={task.id} className="maka-task-row" data-status={task.status}>
+                <Badge variant={TASK_STATUS_BADGE_VARIANTS[task.status]} className="maka-task-status">
+                  {TASK_STATUS_LABELS[task.status]}
+                </Badge>
+                <span className="maka-task-subject" title={task.subject}>{task.subject}</span>
+                <RelativeTime ts={task.updatedAt} className="maka-task-time" />
+                {!isTerminalTaskStatus(task.status) && props.onCancel ? (
+                  <UiButton
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="maka-task-cancel"
+                    onClick={() => void cancelTask(task.id)}
+                    disabled={cancelPending}
+                    aria-busy={cancelPending ? 'true' : undefined}
+                    aria-label={`取消任务：${task.subject}`}
+                  >
+                    取消
+                  </UiButton>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -128,6 +128,11 @@ const ALL_SCENARIOS = [
   // Reviewers should see the 4 action icons cleanly painted with
   // NO `Nm ago` peeking through and NO unread dot stacked behind.
   'sidebar-row-actions-visible',
+  // PR-task-ledger-ui (#15 P0-task): seeds the turn session with a
+  // tasks.json covering all four statuses so the baseline shows the
+  // session task panel above the chat — status badges, relative time,
+  // and the cancel affordance on non-terminal rows.
+  'task-ledger',
 ];
 
 const VARIANTS = [


### PR DESCRIPTION
#15 task-tracking 的 UI 切片,接 #537(model-facing 原语,已合并)。

## 做了什么

聊天界面上方新增会话任务面板:实时展示模型台账(状态徽标 + 标题 + 相对时间),用户唯一操作是**取消任务**(叫停某项工作)。台账归模型所有,面板刻意只读为主——#15 原文:「not a UI-only checklist」。

### 架构(全部锚在现有先例)

| 层 | 实现 | 先例 |
|---|---|---|
| 信号 | `SessionChangedReason` + `'task-updated'`;wiring 的 `onMutation` 观察者把每次台账变更(模型工具与取消 IPC 共享同一 wired store)桥到 `sessions:changed` | 现有 sessions:changed 通道 |
| IPC | `tasks:list` / `tasks:cancel`(invoke);cancel 的 status 字面量钉死在 main 进程 handler,渲染层只传 id | plan-reminders-ipc |
| 数据流 | invoke 拉快照 + task-updated 触发刷新,不进逐 token 事件流 | plan-reminder-panel |
| 面板 | `packages/ui/src/task-ledger-panel.tsx` 受控组件;空清单不挂载,零视觉负担 | plan-reminder-panel 受控范式 |
| 样式 | 全 design token,过 #430/#448/#499/#527 全部 converge 契约 | plan-reminders.css |

### 关键语义(三轮对抗审查驱动,共修复 9 项确认发现)

**取消是不可逆的用户否决**:`cancelled` 在 store 层冻结(模型不能翻回、不能改标题;想继续只能建新任务);`completed` 不可被取消(用户的陈旧快照与模型完成竞态时,不能摧毁完成记录);重开 completed 合法;cancelled→cancelled 幂等(无写、无错)。

**取消对竞态诚实**:`tasks:cancel` 返回 `{ outcome: 'cancelled' | 'already_terminal', tasks }`——用户点取消恰逢模型改终态时,渲染层静默收敛到真实状态,不弹「请稍后重试」这种永远重试不通的误导 toast。

**刷新无竞态**:会话切换同步清空(旧会话任务不会在新会话下渲染、stale 取消按钮不会错配 id);同会话请求单调 seq 排序(旧响应不覆盖新快照);瞬时失败保留最后已知快照(不再静默清空面板)。

**信号最小化**:task-updated 不触发全量会话列表刷新(台账不改列表元数据),不重置会话事件流健康(它不伴随 transcript 重拉,重置会掩盖死掉的事件流)。

**a11y**:取消按钮 unmount 后焦点回收到面板根;aria-live 播报结果;过 check-a11y。

## 验证

- `@maka/core` / `@maka/storage` / `@maka/runtime` / `@maka/ui` / `@maka/desktop` 五套件(数字见 PR 评论区补充)
- 新契约测试:IPC 面(cancel 钉死 status、outcome 契约)、preload 命名空间、task-updated reason、wiring onMutation 行为级用例(观察者抛错不影响已提交变更)、幂等取消不写盘、失败保留快照
- check-console / check-a11y / check-copy 门禁全过;`npm run typecheck` / `git diff --check` 干净
