### PR TITLE
[codex] Improve project-grouped sidebar

### DIFF
--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -44,6 +44,40 @@ describe('sidebar project view mode', () => {
     assert.match(fallbackMarkup, /待发送/);
   });
 
+  it('renders the status/project view mode controls as pressed buttons', () => {
+    const statusMarkup = renderSessionListPanel({ viewMode: 'status' });
+    assert.match(statusMarkup, /<button[^>]*type="button"[^>]*aria-pressed="true"[^>]*>[\s\S]*?<span>按状态/);
+    assert.match(statusMarkup, /<button[^>]*type="button"[^>]*aria-pressed="false"[^>]*>[\s\S]*?<span>按项目/);
+
+    const projectMarkup = renderSessionListPanel({ viewMode: 'project' });
+    assert.match(projectMarkup, /<button[^>]*type="button"[^>]*aria-pressed="false"[^>]*>[\s\S]*?<span>按状态/);
+    assert.match(projectMarkup, /<button[^>]*type="button"[^>]*aria-pressed="true"[^>]*>[\s\S]*?<span>按项目/);
+  });
+
+  it('renders project groups as folder headers with an initial four-session preview', () => {
+    const sessions = Array.from({ length: 5 }, (_, index) => makeSessionSummary({
+      id: `project-session-${index + 1}`,
+      name: `Project chat ${index + 1}`,
+      cwd: 'D:\\work\\testzcode',
+      lastMessageAt: 10 - index,
+    }));
+
+    const markup = renderSessionListPanel({
+      sessions,
+      statusGroups: deriveProjectGroups(sessions),
+      viewMode: 'project',
+    });
+
+    assert.match(markup, /class="[^"]*maka-list-project-heading[^"]*"/);
+    assert.match(markup, /<button[^>]*class="[^"]*maka-list-project-heading[^"]*"[^>]*aria-expanded="true"[^>]*aria-controls="maka-list-group-body-project:[^"]+"/);
+    assert.match(markup, /lucide-folder-open/);
+    assert.match(markup, />testzcode</);
+    assert.match(markup, /Project chat 1/);
+    assert.match(markup, /Project chat 4/);
+    assert.doesNotMatch(markup, /Project chat 5/);
+    assert.match(markup, /显示更多/);
+  });
+
   it('AppShell derives status and project groups from the same visible session set', async () => {
     const appShell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
     const panel = await readRepo('packages/ui/src/session-list-panel.tsx');

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -44,14 +44,16 @@ describe('sidebar project view mode', () => {
     assert.match(fallbackMarkup, /待发送/);
   });
 
-  it('renders the status/project view mode controls as pressed buttons', () => {
+  it('renders the status/project view mode controls as a pressed segmented control', () => {
+    // #571 routes the toggle through the shared SettingsSegmented primitive,
+    // whose <button> carries aria-pressed and puts the label inline (no <span>).
     const statusMarkup = renderSessionListPanel({ viewMode: 'status' });
-    assert.match(statusMarkup, /<button[^>]*type="button"[^>]*aria-pressed="true"[^>]*>[\s\S]*?<span>按状态/);
-    assert.match(statusMarkup, /<button[^>]*type="button"[^>]*aria-pressed="false"[^>]*>[\s\S]*?<span>按项目/);
+    assert.match(statusMarkup, /<button[^>]*aria-pressed="true"[^>]*>按状态/);
+    assert.match(statusMarkup, /<button[^>]*aria-pressed="false"[^>]*>按项目/);
 
     const projectMarkup = renderSessionListPanel({ viewMode: 'project' });
-    assert.match(projectMarkup, /<button[^>]*type="button"[^>]*aria-pressed="false"[^>]*>[\s\S]*?<span>按状态/);
-    assert.match(projectMarkup, /<button[^>]*type="button"[^>]*aria-pressed="true"[^>]*>[\s\S]*?<span>按项目/);
+    assert.match(projectMarkup, /<button[^>]*aria-pressed="false"[^>]*>按状态/);
+    assert.match(projectMarkup, /<button[^>]*aria-pressed="true"[^>]*>按项目/);
   });
 
   it('renders project groups as folder headers with an initial four-session preview', () => {

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -68,8 +68,13 @@ describe('sidebar project view mode', () => {
       viewMode: 'project',
     });
 
-    assert.match(markup, /class="[^"]*maka-list-project-heading[^"]*"/);
-    assert.match(markup, /<button[^>]*class="[^"]*maka-list-project-heading[^"]*"[^>]*aria-expanded="true"[^>]*aria-controls="maka-list-group-body-project:[^"]+"/);
+    // The heading is a UiButton (Base UI <button>); BaseButton reorders props
+    // so class is not guaranteed to precede aria-*. Assert the disclosure
+    // contract on the matched opening tag without assuming attribute order.
+    const headingTag = markup.match(/<button[^>]*maka-list-project-heading[^>]*>/)?.[0];
+    assert.ok(headingTag, 'project heading button must render');
+    assert.match(headingTag, /aria-expanded="true"/);
+    assert.match(headingTag, /aria-controls="maka-list-group-body-project:[^"]+"/);
     assert.match(markup, /lucide-folder-open/);
     assert.match(markup, />testzcode</);
     assert.match(markup, /Project chat 1/);

--- a/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
@@ -104,6 +104,17 @@ describe('sidebar session list CSS scroll contract (PR-SIDEBAR-IA-0 Phase 1)', (
     );
   });
 
+  it('.maka-session-panel reserves explicit rows for header, nav, view toggle, list, and footer', async () => {
+    const css = await readRendererContractCss();
+    const ruleBody = extractRuleBody(css, '.maka-session-panel');
+    assert.ok(ruleBody, '.maka-session-panel rule must exist');
+    assert.match(
+      ruleBody,
+      /grid-template-rows:\s*auto\s+auto\s+auto\s+minmax\(\s*0\s*,\s*1fr\s*\)\s+auto/,
+      'sidebar panel must keep the view-mode toggle in its own row above the constrained session list',
+    );
+  });
+
   it('keeps the sidebar shell flat without a shadow-like gray resize gutter', async () => {
     const css = await readRendererContractCss();
     const listPanel = extractRuleBody(css, '.maka-panel-list.maka-floating-panel');

--- a/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
@@ -115,6 +115,21 @@ describe('sidebar session list CSS scroll contract (PR-SIDEBAR-IA-0 Phase 1)', (
     );
   });
 
+  it('.maka-session-panel[data-collapsed="true"] uses a 4-row grid because the view toggle is hidden', async () => {
+    // Collapsed rail sets the view-mode toggle to display:none. A display:none
+    // item does NOT participate in grid layout, so the collapsed panel must not
+    // keep a 5th row reserved for the toggle — otherwise the footer drops into
+    // the minmax(0, 1fr) track and the settings button floats mid-panel.
+    const css = await readRendererContractCss();
+    const ruleBody = extractRuleBody(css, '.maka-session-panel[data-collapsed="true"]');
+    assert.ok(ruleBody, 'collapsed panel rule must exist');
+    assert.match(
+      ruleBody,
+      /grid-template-rows:\s*auto\s+auto\s+minmax\(\s*0\s*,\s*1fr\s*\)\s+auto/,
+      'collapsed panel must use a 4-row grid: the hidden view toggle must not reserve a 5th track',
+    );
+  });
+
   it('keeps the sidebar shell flat without a shadow-like gray resize gutter', async () => {
     const css = await readRendererContractCss();
     const listPanel = extractRuleBody(css, '.maka-panel-list.maka-floating-panel');

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -657,6 +657,10 @@
   display: none;
 }
 
+.maka-session-panel[data-collapsed="true"] .maka-view-mode-toggle {
+  display: none;
+}
+
 .maka-list-stack {
   min-height: 0;
   overflow: hidden;
@@ -688,6 +692,12 @@
   border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.05);
 }
 
+.maka-list-group[data-variant="project"] + .maka-list-group[data-variant="project"] {
+  margin-top: var(--space-3);
+  padding-top: 0;
+  border-top: 0;
+}
+
 /* Group label — section header for session groups. Weight-based
    hierarchy (not uppercase/letter-spacing) so Chinese labels read
    cleanly without artificial tracking. */
@@ -700,6 +710,65 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   font-variant-numeric: tabular-nums;
+}
+
+.maka-list-project-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  width: 100%;
+  min-height: var(--h-control-lg);
+  padding: 0 var(--space-1-5);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
+  text-align: left;
+}
+
+.maka-list-project-heading:hover {
+  background: var(--state-hover-bg);
+  color: var(--foreground);
+}
+
+.maka-list-project-heading:focus-visible {
+  outline: var(--focus-ring-width) solid var(--ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-list-project-heading svg {
+  width: var(--icon-size);
+  height: var(--icon-size);
+  color: var(--muted-foreground);
+  flex: 0 0 auto;
+}
+
+.maka-list-group[data-variant="project"] .maka-list-row-main {
+  padding-left: var(--space-8);
+}
+
+.maka-list-project-more {
+  min-height: var(--h-control-lg);
+  display: inline-flex;
+  align-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-ui);
+  padding: 0 var(--space-1-5) 0 var(--space-8);
+  text-align: left;
+}
+
+.maka-list-project-more:hover {
+  color: var(--foreground-secondary);
+}
+
+.maka-list-project-more:focus-visible {
+  outline: var(--focus-ring-width) solid var(--ring);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: var(--radius-control);
 }
 
 /* PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ msgs `14ed98b5`, `761141c5` —

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -289,7 +289,12 @@
 }
 
 .maka-session-panel[data-collapsed="true"] {
-  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  /* Collapsed rail hides the view-mode toggle (display: none above). A
+     display:none item does NOT participate in grid layout, so reserving a
+     5th row for it drops the footer into the minmax(0, 1fr) track. Keep the
+     4-row layout matching the four participating children
+     (header / nav / list / footer). */
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
 }
 
 /* Search modal: input + local thread-search results, backed by
@@ -715,6 +720,7 @@
 .maka-list-project-heading {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: var(--space-1-5);
   width: 100%;
   min-height: var(--h-control-lg);
@@ -728,19 +734,11 @@
   text-align: left;
 }
 
-.maka-list-project-heading:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
-.maka-list-project-heading:focus-visible {
-  outline: var(--focus-ring-width) solid var(--ring);
-  outline-offset: var(--focus-ring-offset);
-}
-
+/* Hover / focus-visible / svg sizing are contributed by UiButton
+   (variant="quiet" size="nav"), matching the status-group header — no
+   bespoke :hover/:focus-visible here. Only the folder-glyph tint +
+   flex-shrink guard remain heading-specific. */
 .maka-list-project-heading svg {
-  width: var(--icon-size);
-  height: var(--icon-size);
   color: var(--muted-foreground);
   flex: 0 0 auto;
 }
@@ -753,6 +751,7 @@
   min-height: var(--h-control-lg);
   display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
   border: 0;
   background: transparent;
   color: var(--muted-foreground);
@@ -761,15 +760,6 @@
   text-align: left;
 }
 
-.maka-list-project-more:hover {
-  color: var(--foreground-secondary);
-}
-
-.maka-list-project-more:focus-visible {
-  outline: var(--focus-ring-width) solid var(--ring);
-  outline-offset: var(--focus-ring-offset);
-  border-radius: var(--radius-control);
-}
 
 /* PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ msgs `14ed98b5`, `761141c5` —
  * "list 很丑、很肥很臃肿"; xuan `6b28984e` sign-off + "32-40px 薄行";

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -743,9 +743,6 @@
   flex: 0 0 auto;
 }
 
-.maka-list-group[data-variant="project"] .maka-list-row-main {
-  padding-left: var(--space-8);
-}
 
 .maka-list-project-more {
   min-height: var(--h-control-lg);

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   CircleCheckBig,
   Eye,
+  FolderOpen,
   Hourglass,
   Loader2,
   MessageSquare,
@@ -51,6 +52,8 @@ const rowActionVariants = cva(
 );
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
+type SessionHistoryGroupVariant = 'status' | 'project';
+const PROJECT_GROUP_PREVIEW_LIMIT = 4;
 
 export interface SessionRowActions {
   /** Flag (pin) state toggle. */
@@ -100,6 +103,7 @@ export function SessionHistoryList(props: {
    * doesn't have to know about Archived being closed by default.
    */
   statusGroups?: ReadonlyArray<SessionHistoryStatusGroup>;
+  groupVariant?: SessionHistoryGroupVariant;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
 }) {
@@ -206,6 +210,7 @@ export function SessionHistoryList(props: {
                     defaultExpanded: true,
                   }))
             }
+            groupVariant={props.groupVariant ?? 'status'}
             activeId={props.activeId}
             streamingSessionIds={props.streamingSessionIds}
             staleSessionIds={props.staleSessionIds}
@@ -237,6 +242,7 @@ function SessionListGroups(props: {
     collapsible: boolean;
     defaultExpanded: boolean;
   }>;
+  groupVariant: SessionHistoryGroupVariant;
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
@@ -269,8 +275,23 @@ function SessionListGroups(props: {
         const expanded = expandedByKey[group.key] ?? group.defaultExpanded;
         const toggle = () =>
           setExpandedByKey((current) => ({ ...current, [group.key]: !expanded }));
+        if (props.groupVariant === 'project') {
+          return (
+            <ProjectSessionGroup
+              key={group.key}
+              groupKey={group.key}
+              label={group.label}
+              sessions={group.sessions}
+              activeId={props.activeId}
+              streamingSessionIds={props.streamingSessionIds}
+              staleSessionIds={props.staleSessionIds}
+              onSelectSession={props.onSelectSession}
+              rowActions={props.rowActions}
+            />
+          );
+        }
         return (
-          <div key={group.key} className="maka-list-group" data-collapsible={group.collapsible || undefined}>
+          <div key={group.key} className="maka-list-group" data-variant="status" data-collapsible={group.collapsible || undefined}>
             {group.collapsible ? (
               /* PR-LIST-GROUP-TOGGLE-PRIMITIVE-0 (round 10/30):
                  disclosure-pattern toggle (aria-expanded +
@@ -326,6 +347,70 @@ function SessionListGroups(props: {
         );
       })}
     </>
+  );
+}
+
+function ProjectSessionGroup(props: {
+  groupKey: string;
+  label: string;
+  sessions: SessionSummary[];
+  activeId?: string;
+  streamingSessionIds?: Set<string>;
+  staleSessionIds?: Set<string>;
+  onSelectSession(sessionId: string): void;
+  rowActions?: SessionRowActions;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const [expanded, setExpanded] = useState(true);
+  const activeIsHidden = props.activeId
+    ? props.sessions.findIndex((session) => session.id === props.activeId) >= PROJECT_GROUP_PREVIEW_LIMIT
+    : false;
+  const showAll = revealed || activeIsHidden;
+  const visibleSessions = showAll
+    ? props.sessions
+    : props.sessions.slice(0, PROJECT_GROUP_PREVIEW_LIMIT);
+  const hiddenCount = props.sessions.length - visibleSessions.length;
+
+  return (
+    <div className="maka-list-group" data-variant="project">
+      <button
+        type="button"
+        className="maka-list-project-heading"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+        aria-controls={`maka-list-group-body-${props.groupKey}`}
+      >
+        <FolderOpen size={14} strokeWidth={1.75} aria-hidden="true" />
+        <span>{props.label}</span>
+      </button>
+      {expanded && (
+        <>
+          <div id={`maka-list-group-body-${props.groupKey}`}>
+            {visibleSessions.map((session) => (
+              <SessionRow
+                key={session.id}
+                session={session}
+                active={session.id === props.activeId}
+                streaming={props.streamingSessionIds?.has(session.id) ?? false}
+                stale={props.staleSessionIds?.has(session.id) ?? false}
+                onSelect={props.onSelectSession}
+                actions={props.rowActions}
+              />
+            ))}
+          </div>
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              className="maka-list-project-more"
+              onClick={() => setRevealed(true)}
+              aria-label={`显示 ${hiddenCount} 条更多对话`}
+            >
+              显示更多
+            </button>
+          )}
+        </>
+      )}
+    </div>
   );
 }
 

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -373,8 +373,10 @@ function ProjectSessionGroup(props: {
 
   return (
     <div className="maka-list-group" data-variant="project">
-      <button
+      <UiButton
         type="button"
+        variant="quiet"
+        size="nav"
         className="maka-list-project-heading"
         onClick={() => setExpanded((current) => !current)}
         aria-expanded={expanded}
@@ -382,7 +384,7 @@ function ProjectSessionGroup(props: {
       >
         <FolderOpen size={14} strokeWidth={1.75} aria-hidden="true" />
         <span>{props.label}</span>
-      </button>
+      </UiButton>
       {expanded && (
         <>
           <div id={`maka-list-group-body-${props.groupKey}`}>
@@ -399,14 +401,16 @@ function ProjectSessionGroup(props: {
             ))}
           </div>
           {hiddenCount > 0 && (
-            <button
+            <UiButton
               type="button"
+              variant="quiet"
+              size="nav"
               className="maka-list-project-more"
               onClick={() => setRevealed(true)}
               aria-label={`显示 ${hiddenCount} 条更多对话`}
             >
               显示更多
-            </button>
+            </UiButton>
           )}
         </>
       )}

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -64,6 +64,7 @@ export function SessionListPanel(props: {
         activeId={props.activeId}
         streamingSessionIds={props.streamingSessionIds}
         staleSessionIds={props.staleSessionIds}
+        groupVariant={viewMode === 'project' ? 'project' : 'status'}
         statusGroups={statusGroups}
         onSelectSession={props.onSelectSession}
         rowActions={props.rowActions}


### PR DESCRIPTION
## Summary
- Add a clickable status/project grouping toggle with pressed-button semantics.
- Render project-grouped sessions as folder sections with an initial four-session preview and a Show more control.
- Let each project folder header expand or collapse only its own conversations.

## Why
The project grouping view previously did not match the requested folder-style design, and project headers were not interactive. This makes the sidebar behave like a project tree while preserving the compact session rows.

## Validation
- npm --workspace @maka/ui run build
- npm --workspace @maka/desktop run build:main
- node --test dist\\main\\__tests__\\session-project-view-contract.test.js
- node --test dist\\main\\__tests__\\sidebar-scroll-contract.test.js
- npm --workspace @maka/desktop run build:renderer

@Astro-Han please take a look.