### PR TITLE
feat(headless): add experimental todo task-tool baseline

### DIFF
--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -7,6 +7,7 @@ import {
   buildAiSdkCellBackendRegistration,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellContinuationPolicy,
+  harborCellMaxStepsFromEnv,
   normalizeHarborCellContextEnv,
   runHarborCell,
 } from '#harbor-cell';
@@ -33,6 +34,7 @@ export async function main(options = {}) {
   const contextBudgetPolicy = buildHarborCellContextBudgetPolicySnapshot(contextEnv);
   const continuationPolicy = buildHarborCellContinuationPolicy(env);
   const economyTaskMode = economyTaskModeFromEnv(env.MAKA_ECONOMY_TASK_MODE);
+  const maxSteps = harborCellMaxStepsFromEnv(env);
   const now = Date.now;
   const newId = randomId;
 
@@ -57,6 +59,7 @@ export async function main(options = {}) {
       env: await backendEnv({ ...env, MAKA_OUTPUT_DIR: outputDir, MAKA_STORAGE_ROOT: storageRoot }, provider),
       now,
       newId,
+      ...(maxSteps !== undefined ? { maxSteps } : {}),
     }),
     realBackendIsolation: {
       kind: 'external',

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -7,6 +7,7 @@ import {
   buildAiSdkCellBackendRegistration,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellContinuationPolicy,
+  buildHarborCellTaskLedgerExperimentPolicy,
   harborCellMaxStepsFromEnv,
   normalizeHarborCellContextEnv,
   runHarborCell,
@@ -34,6 +35,7 @@ export async function main(options = {}) {
   const contextBudgetPolicy = buildHarborCellContextBudgetPolicySnapshot(contextEnv);
   const continuationPolicy = buildHarborCellContinuationPolicy(env);
   const economyTaskMode = economyTaskModeFromEnv(env.MAKA_ECONOMY_TASK_MODE);
+  const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(env);
   const maxSteps = harborCellMaxStepsFromEnv(env);
   const now = Date.now;
   const newId = randomId;
@@ -53,6 +55,7 @@ export async function main(options = {}) {
     storageRoot,
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(continuationPolicy ? { continuationPolicy } : {}),
+    ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
     registerBackends: options.registerBackends ?? buildAiSdkCellBackendRegistration({
       provider,
       model,

--- a/packages/headless/src/__tests__/ab-render.test.ts
+++ b/packages/headless/src/__tests__/ab-render.test.ts
@@ -202,26 +202,20 @@ describe('renderAbComparisonMarkdown', () => {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
             actualTaskToolCalls: 5,
-            createCalls: 1,
-            updateCalls: 2,
-            listCalls: 1,
-            getCalls: 1,
-            repeatedUpdateCalls: 1,
+            todoWriteCalls: 5,
           }),
         },
         {
           ...completed('t2', true),
           taskToolSummary: taskToolSummary({
             actualTaskToolCalls: 3,
-            createCalls: 1,
-            updateCalls: 1,
-            listCalls: 1,
+            todoWriteCalls: 3,
           }),
         },
       ]],
     });
 
-    assert.match(renderAbComparisonMarkdown(result), /Task tools: A activated=0\/0 calls=0 create=0 update=0 list=0 get=0 todo_write=0 repeated_updates=0, B activated=2\/2 calls=8 create=2 update=3 list=2 get=1 todo_write=0 repeated_updates=1/);
+    assert.match(renderAbComparisonMarkdown(result), /Task tools: A activated=0\/0 calls=0 todo_write=0, B activated=2\/2 calls=8 todo_write=8/);
   });
 
   test('renders investigation refs', () => {

--- a/packages/headless/src/__tests__/ab-render.test.ts
+++ b/packages/headless/src/__tests__/ab-render.test.ts
@@ -7,6 +7,7 @@ import {
   completed,
   contextBudgetSummary,
   continuationSummary,
+  taskToolSummary,
   withTrace,
   withUsage,
 } from './helpers/ab-summary-fixtures.js';
@@ -186,6 +187,41 @@ describe('renderAbComparisonMarkdown', () => {
     });
 
     assert.match(renderAbComparisonMarkdown(result), /Continuation: A enabled=2\/2 wall_timeout=600000ms turns=5 continued=3 step_cap_hits=4 per_turn_step_cap_hits=\[true,false,true,true,true\] cap_exhausted=1 runtime_steps=102 max_turns=3 max_total_steps=150, B enabled=2\/2 wall_timeout=600000ms turns=3 continued=1 step_cap_hits=1 per_turn_step_cap_hits=\[false,true,false\] cap_exhausted=0 runtime_steps=64 max_turns=3 max_total_steps=150/);
+  });
+
+  test('renders task experiment tool diagnostics', () => {
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'task-tools-off',
+      candidateArmId: 'task-tools-on',
+      evaluationTaskIds: ['t1', 't2'],
+      baselineRuns: [[completed('t1', true), completed('t2', true)]],
+      candidateRuns: [[
+        {
+          ...completed('t1', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 5,
+            createCalls: 1,
+            updateCalls: 2,
+            listCalls: 1,
+            getCalls: 1,
+            repeatedUpdateCalls: 1,
+          }),
+        },
+        {
+          ...completed('t2', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 3,
+            createCalls: 1,
+            updateCalls: 1,
+            listCalls: 1,
+          }),
+        },
+      ]],
+    });
+
+    assert.match(renderAbComparisonMarkdown(result), /Task tools: A activated=0\/0 calls=0 create=0 update=0 list=0 get=0 todo_write=0 repeated_updates=0, B activated=2\/2 calls=8 create=2 update=3 list=2 get=1 todo_write=0 repeated_updates=1/);
   });
 
   test('renders investigation refs', () => {

--- a/packages/headless/src/__tests__/ab-render.test.ts
+++ b/packages/headless/src/__tests__/ab-render.test.ts
@@ -201,21 +201,21 @@ describe('renderAbComparisonMarkdown', () => {
         {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 5,
             todoWriteCalls: 5,
           }),
         },
         {
           ...completed('t2', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 3,
             todoWriteCalls: 3,
           }),
         },
       ]],
     });
 
-    assert.match(renderAbComparisonMarkdown(result), /Task tools: A activated=0\/0 calls=0 todo_write=0, B activated=2\/2 calls=8 todo_write=8/);
+    const markdown = renderAbComparisonMarkdown(result);
+    assert.match(markdown, /Task tools: A activated=0\/0 todo_write=0, B activated=2\/2 todo_write=8/);
+    assert.doesNotMatch(markdown, /\bcalls=/);
   });
 
   test('renders investigation refs', () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -6,6 +6,7 @@ import {
   completed,
   contextBudgetSummary,
   continuationSummary,
+  taskToolSummary,
   withTrace,
   withUsage,
 } from './helpers/ab-summary-fixtures.js';
@@ -362,6 +363,155 @@ describe('summarizeAbComparison', () => {
       maxTotalRuntimeSteps: 150,
     });
 
+  });
+
+  test('summarizes task experiment tool usage for A/B baseline review', () => {
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'task-tools-off',
+      candidateArmId: 'task-tools-on',
+      evaluationTaskIds: ['t1', 't2'],
+      baselineRuns: [[completed('t1', true), completed('t2', true)]],
+      candidateRuns: [[
+        {
+          ...completed('t1', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 5,
+            createCalls: 1,
+            updateCalls: 2,
+            listCalls: 1,
+            getCalls: 1,
+            repeatedUpdateCalls: 1,
+          }),
+        },
+        {
+          ...completed('t2', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 3,
+            createCalls: 1,
+            updateCalls: 1,
+            listCalls: 1,
+          }),
+        },
+      ]],
+    });
+
+    assert.equal(result.baseline.taskTools, undefined);
+    assert.deepEqual(result.candidate.taskTools, {
+      attempts: 2,
+      activatedAttempts: 2,
+      activatedAttemptIds: ['event-t1-pass', 'event-t2-pass'],
+      actualTaskToolCalls: 8,
+      createCalls: 2,
+      updateCalls: 3,
+      listCalls: 2,
+      getCalls: 1,
+      todoWriteCalls: 0,
+      repeatedUpdateCalls: 1,
+    });
+  });
+
+  test('uses observed cell attempts as the task tool activation denominator', () => {
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'task-tools-off',
+      candidateArmId: 'task-tools-on',
+      evaluationTaskIds: ['t1', 't2'],
+      baselineRuns: [[completed('t1', true), completed('t2', true)]],
+      candidateRuns: [[
+        {
+          ...completed('t1', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 1,
+            todoWriteCalls: 1,
+          }),
+        },
+        completed('t2', true),
+      ]],
+    });
+
+    assert.deepEqual(result.candidate.taskTools, {
+      attempts: 2,
+      activatedAttempts: 1,
+      activatedAttemptIds: ['event-t1-pass'],
+      actualTaskToolCalls: 1,
+      createCalls: 0,
+      updateCalls: 0,
+      listCalls: 0,
+      getCalls: 0,
+      todoWriteCalls: 1,
+      repeatedUpdateCalls: 0,
+    });
+  });
+
+  test('counts budget-exhausted attempts in the task tool activation denominator', () => {
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'task-tools-off',
+      candidateArmId: 'task-tools-on',
+      evaluationTaskIds: ['t1', 't2'],
+      baselineRuns: [[completed('t1', true), completed('t2', true)]],
+      candidateRuns: [[
+        {
+          ...completed('t1', true),
+          taskToolSummary: taskToolSummary({
+            actualTaskToolCalls: 1,
+            todoWriteCalls: 1,
+          }),
+        },
+        budgetExhausted('t2'),
+      ]],
+    });
+
+    assert.deepEqual(result.candidate.taskTools, {
+      attempts: 2,
+      activatedAttempts: 1,
+      activatedAttemptIds: ['event-t1-pass'],
+      actualTaskToolCalls: 1,
+      createCalls: 0,
+      updateCalls: 0,
+      listCalls: 0,
+      getCalls: 0,
+      todoWriteCalls: 1,
+      repeatedUpdateCalls: 0,
+    });
+  });
+
+  test('summarizes enabled task tools with zero activation', () => {
+    const result = summarizeAbComparison({
+      runId: 'ab-run',
+      roundId: 'ab-summary',
+      baselineArmId: 'task-tools-off',
+      candidateArmId: 'task-tools-on',
+      evaluationTaskIds: ['t1', 't2'],
+      baselineRuns: [[completed('t1', true), completed('t2', true)]],
+      candidateRuns: [[
+        {
+          ...completed('t1', true),
+          taskToolSummary: taskToolSummary({ activated: false }),
+        },
+        {
+          ...completed('t2', true),
+          taskToolSummary: taskToolSummary({ activated: false }),
+        },
+      ]],
+    });
+
+    assert.deepEqual(result.candidate.taskTools, {
+      attempts: 2,
+      activatedAttempts: 0,
+      activatedAttemptIds: [],
+      actualTaskToolCalls: 0,
+      createCalls: 0,
+      updateCalls: 0,
+      listCalls: 0,
+      getCalls: 0,
+      todoWriteCalls: 0,
+      repeatedUpdateCalls: 0,
+    });
   });
 
   test('records activated attempts and investigation refs for follow-up', () => {

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -378,20 +378,14 @@ describe('summarizeAbComparison', () => {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
             actualTaskToolCalls: 5,
-            createCalls: 1,
-            updateCalls: 2,
-            listCalls: 1,
-            getCalls: 1,
-            repeatedUpdateCalls: 1,
+            todoWriteCalls: 5,
           }),
         },
         {
           ...completed('t2', true),
           taskToolSummary: taskToolSummary({
             actualTaskToolCalls: 3,
-            createCalls: 1,
-            updateCalls: 1,
-            listCalls: 1,
+            todoWriteCalls: 3,
           }),
         },
       ]],
@@ -403,12 +397,7 @@ describe('summarizeAbComparison', () => {
       activatedAttempts: 2,
       activatedAttemptIds: ['event-t1-pass', 'event-t2-pass'],
       actualTaskToolCalls: 8,
-      createCalls: 2,
-      updateCalls: 3,
-      listCalls: 2,
-      getCalls: 1,
-      todoWriteCalls: 0,
-      repeatedUpdateCalls: 1,
+      todoWriteCalls: 8,
     });
   });
 
@@ -437,12 +426,7 @@ describe('summarizeAbComparison', () => {
       activatedAttempts: 1,
       activatedAttemptIds: ['event-t1-pass'],
       actualTaskToolCalls: 1,
-      createCalls: 0,
-      updateCalls: 0,
-      listCalls: 0,
-      getCalls: 0,
       todoWriteCalls: 1,
-      repeatedUpdateCalls: 0,
     });
   });
 
@@ -471,12 +455,7 @@ describe('summarizeAbComparison', () => {
       activatedAttempts: 1,
       activatedAttemptIds: ['event-t1-pass'],
       actualTaskToolCalls: 1,
-      createCalls: 0,
-      updateCalls: 0,
-      listCalls: 0,
-      getCalls: 0,
       todoWriteCalls: 1,
-      repeatedUpdateCalls: 0,
     });
   });
 
@@ -505,12 +484,7 @@ describe('summarizeAbComparison', () => {
       activatedAttempts: 0,
       activatedAttemptIds: [],
       actualTaskToolCalls: 0,
-      createCalls: 0,
-      updateCalls: 0,
-      listCalls: 0,
-      getCalls: 0,
       todoWriteCalls: 0,
-      repeatedUpdateCalls: 0,
     });
   });
 

--- a/packages/headless/src/__tests__/ab-summary.test.ts
+++ b/packages/headless/src/__tests__/ab-summary.test.ts
@@ -377,14 +377,12 @@ describe('summarizeAbComparison', () => {
         {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 5,
             todoWriteCalls: 5,
           }),
         },
         {
           ...completed('t2', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 3,
             todoWriteCalls: 3,
           }),
         },
@@ -396,7 +394,6 @@ describe('summarizeAbComparison', () => {
       attempts: 2,
       activatedAttempts: 2,
       activatedAttemptIds: ['event-t1-pass', 'event-t2-pass'],
-      actualTaskToolCalls: 8,
       todoWriteCalls: 8,
     });
   });
@@ -413,7 +410,6 @@ describe('summarizeAbComparison', () => {
         {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 1,
             todoWriteCalls: 1,
           }),
         },
@@ -425,7 +421,6 @@ describe('summarizeAbComparison', () => {
       attempts: 2,
       activatedAttempts: 1,
       activatedAttemptIds: ['event-t1-pass'],
-      actualTaskToolCalls: 1,
       todoWriteCalls: 1,
     });
   });
@@ -442,7 +437,6 @@ describe('summarizeAbComparison', () => {
         {
           ...completed('t1', true),
           taskToolSummary: taskToolSummary({
-            actualTaskToolCalls: 1,
             todoWriteCalls: 1,
           }),
         },
@@ -454,7 +448,6 @@ describe('summarizeAbComparison', () => {
       attempts: 2,
       activatedAttempts: 1,
       activatedAttemptIds: ['event-t1-pass'],
-      actualTaskToolCalls: 1,
       todoWriteCalls: 1,
     });
   });
@@ -470,11 +463,11 @@ describe('summarizeAbComparison', () => {
       candidateRuns: [[
         {
           ...completed('t1', true),
-          taskToolSummary: taskToolSummary({ activated: false }),
+          taskToolSummary: taskToolSummary({ todoWriteCalls: 0 }),
         },
         {
           ...completed('t2', true),
-          taskToolSummary: taskToolSummary({ activated: false }),
+          taskToolSummary: taskToolSummary({ todoWriteCalls: 0 }),
         },
       ]],
     });
@@ -483,7 +476,6 @@ describe('summarizeAbComparison', () => {
       attempts: 2,
       activatedAttempts: 0,
       activatedAttemptIds: [],
-      actualTaskToolCalls: 0,
       todoWriteCalls: 0,
     });
   });

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -299,8 +299,6 @@ describe('Harbor cell output contract', () => {
     });
 
     assert.deepEqual(output.taskToolSummary, {
-      activated: true,
-      actualTaskToolCalls: 1,
       todoWriteCalls: 1,
     });
     assert.deepEqual(validateHarborCellOutput(output), output);
@@ -335,8 +333,6 @@ describe('Harbor cell output contract', () => {
       taskToolSummaryEnabled: true,
     });
     assert.deepEqual(enabled.taskToolSummary, {
-      activated: false,
-      actualTaskToolCalls: 0,
       todoWriteCalls: 0,
     });
     assert.deepEqual(validateHarborCellOutput(enabled), enabled);

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -272,6 +272,105 @@ describe('Harbor cell output contract', () => {
     });
     assert.deepEqual(validateHarborCellOutput(output), output);
   });
+
+  test('summarizes task experiment tool activation and repeated updates', () => {
+    const output = buildHarborCellOutput({
+      invocation: {
+        invocationId: 'inv-1',
+        runId: 'run-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        events: [
+          runtimeEvent({
+            id: 'task-create',
+            content: { kind: 'function_call', id: 'tool-1', name: 'task_create', args: { description: 'Inspect parser' } },
+          }),
+          runtimeEvent({
+            id: 'task-update-1',
+            content: { kind: 'function_call', id: 'tool-2', name: 'task_update', args: { id: 'task-1', status: 'in_progress' } },
+          }),
+          runtimeEvent({
+            id: 'task-update-2',
+            content: { kind: 'function_call', id: 'tool-3', name: 'task_update', args: { id: 'task-1', status: 'in_progress' } },
+          }),
+          runtimeEvent({
+            id: 'task-list',
+            content: { kind: 'function_call', id: 'tool-4', name: 'task_list', args: {} },
+          }),
+          runtimeEvent({
+            id: 'task-get',
+            content: { kind: 'function_call', id: 'tool-5', name: 'task_get', args: { id: 'task-1' } },
+          }),
+          runtimeEvent({
+            id: 'todo-write',
+            content: {
+              kind: 'function_call',
+              id: 'tool-6',
+              name: 'todo_write',
+              args: { todos: [{ content: 'Run focused check', status: 'pending', priority: 'high' }] },
+            },
+          }),
+        ],
+        startedAt: 100,
+        finishedAt: 250,
+      },
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+
+    assert.deepEqual(output.taskToolSummary, {
+      activated: true,
+      actualTaskToolCalls: 6,
+      createCalls: 1,
+      updateCalls: 2,
+      listCalls: 1,
+      getCalls: 1,
+      todoWriteCalls: 1,
+      repeatedUpdateCalls: 1,
+    });
+    assert.deepEqual(validateHarborCellOutput(output), output);
+  });
+
+  test('records zero task tool calls only when the task tool experiment is enabled', () => {
+    const invocation: InvocationResult = {
+      invocationId: 'inv-task-tools-zero',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'completed',
+      events: [
+        runtimeEvent({
+          id: 'regular-tool',
+          content: { kind: 'function_call', id: 'tool-regular', name: 'Read', args: { path: 'README.md' } },
+        }),
+      ],
+      startedAt: 100,
+      finishedAt: 250,
+    };
+
+    const disabled = buildHarborCellOutput({
+      invocation,
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    });
+    assert.equal(disabled.taskToolSummary, undefined);
+
+    const enabled = buildHarborCellOutput({
+      invocation,
+      runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+      taskToolSummaryEnabled: true,
+    });
+    assert.deepEqual(enabled.taskToolSummary, {
+      activated: false,
+      actualTaskToolCalls: 0,
+      createCalls: 0,
+      updateCalls: 0,
+      listCalls: 0,
+      getCalls: 0,
+      todoWriteCalls: 0,
+      repeatedUpdateCalls: 0,
+    });
+    assert.deepEqual(validateHarborCellOutput(enabled), enabled);
+  });
 });
 
 function runtimeEvent(extra: Partial<RuntimeEvent>): RuntimeEvent {

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -273,7 +273,7 @@ describe('Harbor cell output contract', () => {
     assert.deepEqual(validateHarborCellOutput(output), output);
   });
 
-  test('summarizes task experiment tool activation and repeated updates', () => {
+  test('summarizes todo_write task experiment activation', () => {
     const output = buildHarborCellOutput({
       invocation: {
         invocationId: 'inv-1',
@@ -282,26 +282,6 @@ describe('Harbor cell output contract', () => {
         turnId: 'turn-1',
         status: 'completed',
         events: [
-          runtimeEvent({
-            id: 'task-create',
-            content: { kind: 'function_call', id: 'tool-1', name: 'task_create', args: { description: 'Inspect parser' } },
-          }),
-          runtimeEvent({
-            id: 'task-update-1',
-            content: { kind: 'function_call', id: 'tool-2', name: 'task_update', args: { id: 'task-1', status: 'in_progress' } },
-          }),
-          runtimeEvent({
-            id: 'task-update-2',
-            content: { kind: 'function_call', id: 'tool-3', name: 'task_update', args: { id: 'task-1', status: 'in_progress' } },
-          }),
-          runtimeEvent({
-            id: 'task-list',
-            content: { kind: 'function_call', id: 'tool-4', name: 'task_list', args: {} },
-          }),
-          runtimeEvent({
-            id: 'task-get',
-            content: { kind: 'function_call', id: 'tool-5', name: 'task_get', args: { id: 'task-1' } },
-          }),
           runtimeEvent({
             id: 'todo-write',
             content: {
@@ -320,13 +300,8 @@ describe('Harbor cell output contract', () => {
 
     assert.deepEqual(output.taskToolSummary, {
       activated: true,
-      actualTaskToolCalls: 6,
-      createCalls: 1,
-      updateCalls: 2,
-      listCalls: 1,
-      getCalls: 1,
+      actualTaskToolCalls: 1,
       todoWriteCalls: 1,
-      repeatedUpdateCalls: 1,
     });
     assert.deepEqual(validateHarborCellOutput(output), output);
   });
@@ -362,12 +337,7 @@ describe('Harbor cell output contract', () => {
     assert.deepEqual(enabled.taskToolSummary, {
       activated: false,
       actualTaskToolCalls: 0,
-      createCalls: 0,
-      updateCalls: 0,
-      listCalls: 0,
-      getCalls: 0,
       todoWriteCalls: 0,
-      repeatedUpdateCalls: 0,
     });
     assert.deepEqual(validateHarborCellOutput(enabled), enabled);
   });

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1003,6 +1003,44 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('records task tool summary in completed task WAL events', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const taskToolSummary = {
+        activated: true,
+        actualTaskToolCalls: 5,
+        createCalls: 1,
+        updateCalls: 2,
+        listCalls: 1,
+        getCalls: 1,
+        todoWriteCalls: 0,
+        repeatedUpdateCalls: 1,
+      };
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        harborRunner: async () => harborOutput({ taskId: 'task-a', taskToolSummary }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      if (result.events[0]?.type === 'task_completed') {
+        assert.deepEqual(result.events[0].taskToolSummary, taskToolSummary);
+      }
+      const event = JSON.parse((await readFile(resultsJsonlPath, 'utf8')).trimEnd());
+      assert.deepEqual(event.taskToolSummary, taskToolSummary);
+    });
+  });
+
   test('classifies completed Harbor reward failures as benchmark failures', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -1197,6 +1235,7 @@ function harborOutput(input: {
   contextBudgetPolicy?: HarborTaskRunOutput['cell']['contextBudgetPolicy'];
   contextBudgetSummary?: HarborTaskRunOutput['cell']['contextBudgetSummary'];
   continuationSummary?: HarborTaskRunOutput['cell']['continuationSummary'];
+  taskToolSummary?: HarborTaskRunOutput['cell']['taskToolSummary'];
   errorClass?: string;
 }): HarborTaskRunOutput {
   return {
@@ -1212,6 +1251,7 @@ function harborOutput(input: {
       ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
       ...(input.contextBudgetSummary ? { contextBudgetSummary: input.contextBudgetSummary } : {}),
       ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),
+      ...(input.taskToolSummary ? { taskToolSummary: input.taskToolSummary } : {}),
       toolSummary: {
         providerVisibleToolCount: 0,
         actualToolCalls: 0,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1009,8 +1009,6 @@ describe('fixed prompt controller', () => {
       const resultsJsonlPath = join(dir, 'results.jsonl');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
       const taskToolSummary = {
-        activated: true,
-        actualTaskToolCalls: 5,
         todoWriteCalls: 5,
       };
 

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -1011,12 +1011,7 @@ describe('fixed prompt controller', () => {
       const taskToolSummary = {
         activated: true,
         actualTaskToolCalls: 5,
-        createCalls: 1,
-        updateCalls: 2,
-        listCalls: 1,
-        getCalls: 1,
-        todoWriteCalls: 0,
-        repeatedUpdateCalls: 1,
+        todoWriteCalls: 5,
       };
 
       const result = await runFixedPromptController({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -953,16 +953,19 @@ describe('runHarborCell', () => {
 
   test('Harbor task experiment context flag enables task tools and replay only when requested', async () => {
     assert.ok(HARBOR_CELL_CONTEXT_ENV_KEYS.includes('MAKA_CONTEXT_TASK_TOOLS' as never));
-    assert.ok(HARBOR_CELL_CONTEXT_ENV_KEYS.includes('MAKA_CONTEXT_TASK_TOOL_SHAPE' as never));
+    assert.ok(!HARBOR_CELL_CONTEXT_ENV_KEYS.includes('MAKA_CONTEXT_TASK_TOOL_SHAPE' as never));
     assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({ MAKA_CONTEXT_TASK_TOOLS: 'off' }), undefined);
     assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({
       MAKA_CONTEXT_TASK_TOOLS: 'on',
       MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
-    }), { enabled: true, replayMaxChars: 700, shape: 'todo_write' });
-    assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({
-      MAKA_CONTEXT_TASK_TOOLS: 'on',
-      MAKA_CONTEXT_TASK_TOOL_SHAPE: 'todo_write',
-    }), { enabled: true, replayMaxChars: 4_000, shape: 'todo_write' });
+    }), { enabled: true, replayMaxChars: 700 });
+    assert.throws(
+      () => buildHarborCellTaskLedgerExperimentPolicy({
+        MAKA_CONTEXT_TASK_TOOLS: 'on',
+        MAKA_CONTEXT_TASK_TOOL_SHAPE: 'crud',
+      } as never),
+      /unsupported Harbor context env key: MAKA_CONTEXT_TASK_TOOL_SHAPE/,
+    );
 
     await withDirs(async ({ workspaceDir }) => {
       const offRegistry = new BackendRegistry();
@@ -992,59 +995,6 @@ describe('runHarborCell', () => {
       }).input;
       assert.ok(!offInput.tools.some((tool) => tool.name.startsWith('task_')));
       assert.equal(offInput.turnTailPrompt, undefined);
-
-      const crudRegistry = new BackendRegistry();
-      const crudRegister = buildAiSdkCellBackendRegistration({
-        provider: 'openai',
-        model: 'gpt-4o-mini',
-        env: {
-          OPENAI_API_KEY: 'test-key',
-          MAKA_CONTEXT_TASK_TOOLS: 'on',
-          MAKA_CONTEXT_TASK_TOOL_SHAPE: 'crud',
-          MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
-        },
-        now: () => 123,
-        newId: testIdFactory(),
-      });
-      await crudRegister(crudRegistry, {
-        config: {
-          id: 'harbor-ai-sdk',
-          backend: 'ai-sdk',
-          llmConnectionSlug: 'openai',
-          model: 'gpt-4o-mini',
-        },
-        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
-        workspaceDir,
-        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
-        toolExecutor,
-      });
-      const crudBackend = await crudRegistry.build('ai-sdk', backendContext(workspaceDir));
-      const crudInput = (crudBackend as unknown as {
-        input: {
-          tools: Array<{ name: string; impl: Function }>;
-          turnTailPrompt?: (context: { sessionId: string; cwd?: string; workspaceRoot?: string }) => Promise<string | undefined>;
-        };
-      }).input;
-      for (const expected of ['task_create', 'task_update', 'task_list', 'task_get']) {
-        assert.ok(crudInput.tools.some((tool) => tool.name === expected), `expected task tool ${expected}`);
-      }
-
-      const create = crudInput.tools.find((tool) => tool.name === 'task_create');
-      assert.ok(create);
-      await create.impl({ description: 'Inspect parser failure' }, {
-        sessionId: 'session-task',
-        turnId: 'turn-1',
-        cwd: workspaceDir,
-        toolCallId: 'tool-task-create',
-        abortSignal: new AbortController().signal,
-        emitOutput: () => {},
-      });
-
-      assert.ok(crudInput.turnTailPrompt);
-      const replay = await crudInput.turnTailPrompt({ sessionId: 'session-task', cwd: workspaceDir });
-      assert.match(replay ?? '', /Task ledger experiment state/);
-      assert.match(replay ?? '', /Inspect parser failure/);
-      assert.ok((replay ?? '').length <= 700);
 
       const todoRegistry = new BackendRegistry();
       const todoRegister = buildAiSdkCellBackendRegistration({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -25,6 +25,7 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellAiSdkTools,
+  harborCellMaxStepsFromEnv,
   createHarborCellLocalToolExecutor,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
@@ -827,6 +828,13 @@ describe('runHarborCell', () => {
       assert.match(seenPrompts[0] ?? '', /Use the benchmark prompt/);
       assert.doesNotMatch(seenPrompts[0] ?? '', /Economy-task benchmark policy/);
     });
+  });
+
+  test('parses host-side max steps from MAKA_MAX_STEPS', () => {
+    assert.equal(harborCellMaxStepsFromEnv({ MAKA_MAX_STEPS: '200' }), 200);
+    assert.throws(() => harborCellMaxStepsFromEnv({ MAKA_MAX_STEPS: '0' }), /MAKA_MAX_STEPS must be a positive integer/);
+    assert.throws(() => harborCellMaxStepsFromEnv({ MAKA_MAX_STEPS: 'oops' }), /MAKA_MAX_STEPS must be a positive integer/);
+    assert.equal(harborCellMaxStepsFromEnv({}), undefined);
   });
 
   test('host-side Harbor cell config reads MAKA_ECONOMY_TASK_MODE', async () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -25,8 +25,10 @@ import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellAiSdkTools,
+  buildHarborCellTaskLedgerExperimentPolicy,
   harborCellMaxStepsFromEnv,
   createHarborCellLocalToolExecutor,
+  HARBOR_CELL_CONTEXT_ENV_KEYS,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
   resolveHarborCellAiSdkEnv,
@@ -946,6 +948,156 @@ describe('runHarborCell', () => {
       assert.equal(backendInput.tools.find((tool) => tool.name === 'Bash')?.permissionRequired, false);
       assert.equal(backendInput.tools.find((tool) => tool.name === 'Write')?.permissionRequired, false);
       assert.match(backendInput.systemPrompt ?? '', /Prefer Read, Glob, and Grep/);
+    });
+  });
+
+  test('Harbor task experiment context flag enables task tools and replay only when requested', async () => {
+    assert.ok(HARBOR_CELL_CONTEXT_ENV_KEYS.includes('MAKA_CONTEXT_TASK_TOOLS' as never));
+    assert.ok(HARBOR_CELL_CONTEXT_ENV_KEYS.includes('MAKA_CONTEXT_TASK_TOOL_SHAPE' as never));
+    assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({ MAKA_CONTEXT_TASK_TOOLS: 'off' }), undefined);
+    assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({
+      MAKA_CONTEXT_TASK_TOOLS: 'on',
+      MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
+    }), { enabled: true, replayMaxChars: 700, shape: 'todo_write' });
+    assert.deepEqual(buildHarborCellTaskLedgerExperimentPolicy({
+      MAKA_CONTEXT_TASK_TOOLS: 'on',
+      MAKA_CONTEXT_TASK_TOOL_SHAPE: 'todo_write',
+    }), { enabled: true, replayMaxChars: 4_000, shape: 'todo_write' });
+
+    await withDirs(async ({ workspaceDir }) => {
+      const offRegistry = new BackendRegistry();
+      const offRegister = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+      });
+      const toolExecutor = fakeToolExecutor();
+      await offRegister(offRegistry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const offBackend = await offRegistry.build('ai-sdk', backendContext(workspaceDir));
+      const offInput = (offBackend as unknown as {
+        input: { tools: Array<{ name: string }>; turnTailPrompt?: unknown };
+      }).input;
+      assert.ok(!offInput.tools.some((tool) => tool.name.startsWith('task_')));
+      assert.equal(offInput.turnTailPrompt, undefined);
+
+      const crudRegistry = new BackendRegistry();
+      const crudRegister = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_CONTEXT_TASK_TOOLS: 'on',
+          MAKA_CONTEXT_TASK_TOOL_SHAPE: 'crud',
+          MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
+        },
+        now: () => 123,
+        newId: testIdFactory(),
+      });
+      await crudRegister(crudRegistry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const crudBackend = await crudRegistry.build('ai-sdk', backendContext(workspaceDir));
+      const crudInput = (crudBackend as unknown as {
+        input: {
+          tools: Array<{ name: string; impl: Function }>;
+          turnTailPrompt?: (context: { sessionId: string; cwd?: string; workspaceRoot?: string }) => Promise<string | undefined>;
+        };
+      }).input;
+      for (const expected of ['task_create', 'task_update', 'task_list', 'task_get']) {
+        assert.ok(crudInput.tools.some((tool) => tool.name === expected), `expected task tool ${expected}`);
+      }
+
+      const create = crudInput.tools.find((tool) => tool.name === 'task_create');
+      assert.ok(create);
+      await create.impl({ description: 'Inspect parser failure' }, {
+        sessionId: 'session-task',
+        turnId: 'turn-1',
+        cwd: workspaceDir,
+        toolCallId: 'tool-task-create',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      });
+
+      assert.ok(crudInput.turnTailPrompt);
+      const replay = await crudInput.turnTailPrompt({ sessionId: 'session-task', cwd: workspaceDir });
+      assert.match(replay ?? '', /Task ledger experiment state/);
+      assert.match(replay ?? '', /Inspect parser failure/);
+      assert.ok((replay ?? '').length <= 700);
+
+      const todoRegistry = new BackendRegistry();
+      const todoRegister = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_CONTEXT_TASK_TOOLS: 'on',
+        },
+        now: () => 123,
+        newId: testIdFactory(),
+      });
+      await todoRegister(todoRegistry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const todoBackend = await todoRegistry.build('ai-sdk', backendContext(workspaceDir));
+      const todoInput = (todoBackend as unknown as {
+        input: {
+          tools: Array<{ name: string; impl: Function }>;
+          turnTailPrompt?: (context: { sessionId: string; cwd?: string; workspaceRoot?: string }) => Promise<string | undefined>;
+        };
+      }).input;
+      assert.ok(todoInput.tools.some((tool) => tool.name === 'todo_write'));
+      assert.ok(!todoInput.tools.some((tool) => tool.name.startsWith('task_')));
+      assert.ok(todoInput.turnTailPrompt);
+      const emptyTodoReplay = await todoInput.turnTailPrompt({ sessionId: 'session-todo', cwd: workspaceDir });
+      assert.match(emptyTodoReplay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
+
+      const todoWrite = todoInput.tools.find((tool) => tool.name === 'todo_write');
+      assert.ok(todoWrite);
+      await todoWrite.impl({
+        todos: [{ content: 'Run focused benchmark slice', status: 'in_progress' }],
+      }, {
+        sessionId: 'session-todo',
+        turnId: 'turn-1',
+        cwd: workspaceDir,
+        toolCallId: 'tool-todo-write',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      });
+
+      const todoReplay = await todoInput.turnTailPrompt({ sessionId: 'session-todo', cwd: workspaceDir });
+      assert.match(todoReplay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
+      assert.match(todoReplay ?? '', /Run focused benchmark slice/);
     });
   });
 
@@ -1992,6 +2144,11 @@ function fakeToolExecutor(): IsolatedToolExecutor {
       return { exitCode: 0, stdout: '', stderr: '' };
     },
   };
+}
+
+function testIdFactory(): () => string {
+  let i = 0;
+  return () => `id-${++i}`;
 }
 
 function sha256(text: string): string {

--- a/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
+++ b/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
@@ -119,3 +119,19 @@ export function continuationSummary(
     ...input,
   };
 }
+
+export function taskToolSummary(
+  input: Partial<NonNullable<FixedPromptTaskCompletedEvent['taskToolSummary']>>,
+): NonNullable<FixedPromptTaskCompletedEvent['taskToolSummary']> {
+  return {
+    activated: true,
+    actualTaskToolCalls: 0,
+    createCalls: 0,
+    updateCalls: 0,
+    listCalls: 0,
+    getCalls: 0,
+    todoWriteCalls: 0,
+    repeatedUpdateCalls: 0,
+    ...input,
+  };
+}

--- a/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
+++ b/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
@@ -126,12 +126,7 @@ export function taskToolSummary(
   return {
     activated: true,
     actualTaskToolCalls: 0,
-    createCalls: 0,
-    updateCalls: 0,
-    listCalls: 0,
-    getCalls: 0,
     todoWriteCalls: 0,
-    repeatedUpdateCalls: 0,
     ...input,
   };
 }

--- a/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
+++ b/packages/headless/src/__tests__/helpers/ab-summary-fixtures.ts
@@ -124,8 +124,6 @@ export function taskToolSummary(
   input: Partial<NonNullable<FixedPromptTaskCompletedEvent['taskToolSummary']>>,
 ): NonNullable<FixedPromptTaskCompletedEvent['taskToolSummary']> {
   return {
-    activated: true,
-    actualTaskToolCalls: 0,
     todoWriteCalls: 0,
     ...input,
   };

--- a/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
@@ -66,6 +66,66 @@ describe('runRuntimePolicyAbComparison', () => {
     ]);
   });
 
+  test('builds and runs task-tool runtime-policy arms with arm-local context env', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      const resultsJsonlPath = join(dir, 'results.jsonl');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const taskToolsOff = { id: 'task-tools-off', contextEnv: {} } as const;
+      const taskToolsOn = {
+        id: 'task-tools-on',
+        contextEnv: {
+          MAKA_CONTEXT_TASK_TOOLS: 'on',
+          MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
+        },
+      } as const;
+      const manifest = buildRuntimePolicyAbRunManifest({
+        arms: [taskToolsOff, taskToolsOn],
+        promptHash: sha256('p'),
+        provider: 'deepseek',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek/deepseek-v4-flash',
+        taskBudgetSec: 1800,
+        harborTimeoutMs: 2_100_000,
+        subjectFingerprint: sha256('s'),
+        taskSourceFingerprint: sha256('t'),
+        toolchainFingerprint: sha256('c'),
+        evaluationTaskIds: ['t1'],
+        reps: 1,
+        candidateLimit: null,
+        maxConcurrency: 1,
+      });
+      const calls: string[] = [];
+
+      await runRuntimePolicyAbComparison({
+        runId: 'runtime-ab-run',
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        evaluationTasks: [{ id: 't1', path: '/bench/t1' }],
+        reps: 1,
+        arms: [taskToolsOff, taskToolsOn],
+        resumeFingerprint: 'caller-salt',
+        harborRunner: async (input) => {
+          calls.push(`${input.roundId}:${JSON.stringify(input.agentEnv ?? {})}`);
+          return harborOutput(input);
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.notEqual(manifest.arms[0].fingerprint, manifest.arms[1].fingerprint);
+      assert.deepEqual(manifest.arms[1].metadata?.contextEnv, {
+        MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS: '700',
+        MAKA_CONTEXT_TASK_TOOLS: 'on',
+      });
+      assert.deepEqual(calls.sort(), [
+        'ab-task-tools-off-r0-t1:{}',
+        'ab-task-tools-on-r0-t1:{"MAKA_CONTEXT_TASK_TOOLS":"on","MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS":"700"}',
+      ]);
+    });
+  });
+
   test('rejects unsupported context env keys before fingerprinting runtime-policy arms', () => {
     assert.throws(
       () => buildRuntimePolicyAbRunManifest({

--- a/packages/headless/src/__tests__/task-ledger-experiment.test.ts
+++ b/packages/headless/src/__tests__/task-ledger-experiment.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
-  TASK_LEDGER_EXPERIMENT_TOOL_NAMES,
   buildTaskLedgerExperimentTools,
   createInMemoryTaskLedgerExperimentStore,
   renderTaskLedgerExperimentReplay,
@@ -24,42 +23,9 @@ describe('task ledger experiment tools', () => {
     assert.deepEqual(tools.map((tool) => tool.name), ['todo_write']);
   });
 
-  test('builds CRUD-lite task tools that share one session ledger', async () => {
-    const store = createInMemoryTaskLedgerExperimentStore({ now: () => 100, newId: idFactory() });
-    const tools = buildTaskLedgerExperimentTools({ store, shape: 'crud' });
-    assert.deepEqual(tools.map((tool) => tool.name), TASK_LEDGER_EXPERIMENT_TOOL_NAMES);
-
-    const create = tools.find((tool) => tool.name === 'task_create');
-    const update = tools.find((tool) => tool.name === 'task_update');
-    const list = tools.find((tool) => tool.name === 'task_list');
-    const get = tools.find((tool) => tool.name === 'task_get');
-    assert.ok(create);
-    assert.ok(update);
-    assert.ok(list);
-    assert.ok(get);
-
-    const createResult = String(await create.impl({
-      description: 'Inspect failing parser test',
-    }, toolContext));
-    const createdId = createResult.match(/id=([A-Za-z0-9._:-]+)/)?.[1];
-    assert.ok(createdId);
-
-    await update.impl({
-      id: createdId,
-      status: 'in_progress',
-    }, toolContext);
-
-    const listed = String(await list.impl({}, toolContext));
-    assert.match(listed, /Inspect failing parser test/);
-    assert.match(listed, /status=in_progress/);
-
-    const fetched = String(await get.impl({ id: createdId }, toolContext));
-    assert.match(fetched, /Inspect failing parser test/);
-  });
-
   test('builds a todo_write task tool that replaces the session todo list', async () => {
     const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
-    const tools = buildTaskLedgerExperimentTools({ store, shape: 'todo_write' });
+    const tools = buildTaskLedgerExperimentTools({ store });
     assert.deepEqual(tools.map((tool) => tool.name), ['todo_write']);
 
     const todoWrite = tools.find((tool) => tool.name === 'todo_write');
@@ -82,12 +48,11 @@ describe('task ledger experiment tools', () => {
       ],
     }, toolContext);
 
-    const emptyReplay = renderTaskLedgerExperimentReplay([], { maxChars: 600, shape: 'todo_write' });
+    const emptyReplay = renderTaskLedgerExperimentReplay([], { maxChars: 600 });
     assert.match(emptyReplay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
 
     const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), {
       maxChars: 600,
-      shape: 'todo_write',
     });
     assert.match(replay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
     assert.match(replay ?? '', /Run narrow regression test/);
@@ -97,42 +62,30 @@ describe('task ledger experiment tools', () => {
 
   test('renders a capped replay of active pending and recently completed tasks', async () => {
     const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
-    const tools = buildTaskLedgerExperimentTools({ store, shape: 'crud' });
-    const create = tools.find((tool) => tool.name === 'task_create');
-    const update = tools.find((tool) => tool.name === 'task_update');
-    assert.ok(create);
-    assert.ok(update);
-
-    const active = await create.impl({ description: 'Patch implementation' }, toolContext);
-    const pending = await create.impl({ description: 'Run public check' }, toolContext);
-    const done = await create.impl({ description: 'Inspect README' }, toolContext);
-    const cancelled = await create.impl({ description: 'Discard obsolete branch' }, toolContext);
-    const activeId = String(active).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
-    const pendingId = String(pending).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
-    const doneId = String(done).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
-    const cancelledId = String(cancelled).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
-    assert.ok(activeId);
-    assert.ok(pendingId);
-    assert.ok(doneId);
-    assert.ok(cancelledId);
-    await update.impl({ id: activeId, status: 'in_progress' }, toolContext);
-    await update.impl({ id: pendingId, status: 'pending' }, toolContext);
-    await update.impl({ id: doneId, status: 'completed' }, toolContext);
-    await update.impl({ id: cancelledId, status: 'cancelled' }, toolContext);
+    const tools = buildTaskLedgerExperimentTools({ store });
+    const todoWrite = tools.find((tool) => tool.name === 'todo_write');
+    assert.ok(todoWrite);
+    await todoWrite.impl({
+      todos: [
+        { content: 'Patch implementation', status: 'in_progress' },
+        { content: 'Run public check', status: 'pending' },
+        { content: 'Inspect README', status: 'completed' },
+      ],
+    }, toolContext);
 
     const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), { maxChars: 600 });
 
+    assert.match(replay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
     assert.match(replay ?? '', /Task ledger experiment state/);
     assert.match(replay ?? '', /Patch implementation/);
     assert.match(replay ?? '', /Run public check/);
     assert.match(replay ?? '', /Inspect README/);
-    assert.doesNotMatch(replay ?? '', /Discard obsolete branch/);
     assert.ok((replay ?? '').length <= 600);
   });
 
   test('scrubs task text before it persists through tool results or replay', async () => {
     const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
-    const tools = buildTaskLedgerExperimentTools({ store, shape: 'todo_write' });
+    const tools = buildTaskLedgerExperimentTools({ store });
     const todoWrite = tools.find((tool) => tool.name === 'todo_write');
     assert.ok(todoWrite);
 
@@ -147,7 +100,6 @@ describe('task ledger experiment tools', () => {
 
     const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), {
       maxChars: 600,
-      shape: 'todo_write',
     }) ?? '';
     assert.equal(replay.includes('sk-live-secret-token-value'), false);
     assert.match(replay, /\[redacted\]/);

--- a/packages/headless/src/__tests__/task-ledger-experiment.test.ts
+++ b/packages/headless/src/__tests__/task-ledger-experiment.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  TASK_LEDGER_EXPERIMENT_TOOL_NAMES,
+  buildTaskLedgerExperimentTools,
+  createInMemoryTaskLedgerExperimentStore,
+  renderTaskLedgerExperimentReplay,
+} from '../task-ledger-experiment.js';
+
+const toolContext = {
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  cwd: '/workspace',
+  toolCallId: 'tool-1',
+  abortSignal: new AbortController().signal,
+  emitOutput: () => {},
+};
+
+describe('task ledger experiment tools', () => {
+  test('defaults to the todo_write baseline shape', () => {
+    const store = createInMemoryTaskLedgerExperimentStore();
+    const tools = buildTaskLedgerExperimentTools({ store });
+
+    assert.deepEqual(tools.map((tool) => tool.name), ['todo_write']);
+  });
+
+  test('builds CRUD-lite task tools that share one session ledger', async () => {
+    const store = createInMemoryTaskLedgerExperimentStore({ now: () => 100, newId: idFactory() });
+    const tools = buildTaskLedgerExperimentTools({ store, shape: 'crud' });
+    assert.deepEqual(tools.map((tool) => tool.name), TASK_LEDGER_EXPERIMENT_TOOL_NAMES);
+
+    const create = tools.find((tool) => tool.name === 'task_create');
+    const update = tools.find((tool) => tool.name === 'task_update');
+    const list = tools.find((tool) => tool.name === 'task_list');
+    const get = tools.find((tool) => tool.name === 'task_get');
+    assert.ok(create);
+    assert.ok(update);
+    assert.ok(list);
+    assert.ok(get);
+
+    const createResult = String(await create.impl({
+      description: 'Inspect failing parser test',
+    }, toolContext));
+    const createdId = createResult.match(/id=([A-Za-z0-9._:-]+)/)?.[1];
+    assert.ok(createdId);
+
+    await update.impl({
+      id: createdId,
+      status: 'in_progress',
+    }, toolContext);
+
+    const listed = String(await list.impl({}, toolContext));
+    assert.match(listed, /Inspect failing parser test/);
+    assert.match(listed, /status=in_progress/);
+
+    const fetched = String(await get.impl({ id: createdId }, toolContext));
+    assert.match(fetched, /Inspect failing parser test/);
+  });
+
+  test('builds a todo_write task tool that replaces the session todo list', async () => {
+    const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
+    const tools = buildTaskLedgerExperimentTools({ store, shape: 'todo_write' });
+    assert.deepEqual(tools.map((tool) => tool.name), ['todo_write']);
+
+    const todoWrite = tools.find((tool) => tool.name === 'todo_write');
+    assert.ok(todoWrite);
+
+    const result = await todoWrite.impl({
+      todos: [
+        { content: 'Inspect failing parser test', status: 'in_progress' },
+        { content: 'Run narrow regression test', status: 'pending' },
+      ],
+    }, toolContext);
+
+    assert.match(String(result), /Inspect failing parser test/);
+    assert.match(String(result), /Run narrow regression test/);
+    assert.match(String(result), /status=in_progress/);
+
+    await todoWrite.impl({
+      todos: [
+        { content: 'Run narrow regression test', status: 'completed' },
+      ],
+    }, toolContext);
+
+    const emptyReplay = renderTaskLedgerExperimentReplay([], { maxChars: 600, shape: 'todo_write' });
+    assert.match(emptyReplay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
+
+    const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), {
+      maxChars: 600,
+      shape: 'todo_write',
+    });
+    assert.match(replay ?? '', /Use todo_write at the start of long-running, multi-step tasks/);
+    assert.match(replay ?? '', /Run narrow regression test/);
+    assert.match(replay ?? '', /status=completed/);
+    assert.doesNotMatch(replay ?? '', /Inspect failing parser test/);
+  });
+
+  test('renders a capped replay of active pending and recently completed tasks', async () => {
+    const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
+    const tools = buildTaskLedgerExperimentTools({ store, shape: 'crud' });
+    const create = tools.find((tool) => tool.name === 'task_create');
+    const update = tools.find((tool) => tool.name === 'task_update');
+    assert.ok(create);
+    assert.ok(update);
+
+    const active = await create.impl({ description: 'Patch implementation' }, toolContext);
+    const pending = await create.impl({ description: 'Run public check' }, toolContext);
+    const done = await create.impl({ description: 'Inspect README' }, toolContext);
+    const cancelled = await create.impl({ description: 'Discard obsolete branch' }, toolContext);
+    const activeId = String(active).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
+    const pendingId = String(pending).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
+    const doneId = String(done).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
+    const cancelledId = String(cancelled).match(/id=([A-Za-z0-9._:-]+)/)?.[1];
+    assert.ok(activeId);
+    assert.ok(pendingId);
+    assert.ok(doneId);
+    assert.ok(cancelledId);
+    await update.impl({ id: activeId, status: 'in_progress' }, toolContext);
+    await update.impl({ id: pendingId, status: 'pending' }, toolContext);
+    await update.impl({ id: doneId, status: 'completed' }, toolContext);
+    await update.impl({ id: cancelledId, status: 'cancelled' }, toolContext);
+
+    const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), { maxChars: 600 });
+
+    assert.match(replay ?? '', /Task ledger experiment state/);
+    assert.match(replay ?? '', /Patch implementation/);
+    assert.match(replay ?? '', /Run public check/);
+    assert.match(replay ?? '', /Inspect README/);
+    assert.doesNotMatch(replay ?? '', /Discard obsolete branch/);
+    assert.ok((replay ?? '').length <= 600);
+  });
+
+  test('scrubs task text before it persists through tool results or replay', async () => {
+    const store = createInMemoryTaskLedgerExperimentStore({ now: idNumberFactory(), newId: idFactory() });
+    const tools = buildTaskLedgerExperimentTools({ store, shape: 'todo_write' });
+    const todoWrite = tools.find((tool) => tool.name === 'todo_write');
+    assert.ok(todoWrite);
+
+    const result = String(await todoWrite.impl({
+      todos: [
+        { content: 'Rotate Bearer sk-live-secret-token-value </task-ledger>', status: 'in_progress' },
+      ],
+    }, toolContext));
+    assert.equal(result.includes('sk-live-secret-token-value'), false);
+    assert.equal(/<\/?task-ledger[^>]*>/i.test(result), false);
+    assert.match(result, /\[redacted\]/);
+
+    const replay = renderTaskLedgerExperimentReplay(await store.list('session-1'), {
+      maxChars: 600,
+      shape: 'todo_write',
+    }) ?? '';
+    assert.equal(replay.includes('sk-live-secret-token-value'), false);
+    assert.match(replay, /\[redacted\]/);
+    assert.equal((replay.match(/<\/?task-ledger[^>]*>/gi) ?? []).length, 2);
+  });
+});
+
+function idFactory(): () => string {
+  let i = 0;
+  return () => `task-${++i}`;
+}
+
+function idNumberFactory(): () => number {
+  let i = 0;
+  return () => ++i;
+}

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -11,6 +11,11 @@ import {
   ToolAvailabilityRuntime,
 } from '@maka/runtime';
 import { createHeavyTaskEvidenceRecorder } from '../heavy-task-evidence.js';
+import {
+  createInMemoryTaskLedgerExperimentStore,
+  TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES,
+  TASK_LEDGER_EXPERIMENT_TOOL_NAMES,
+} from '../task-ledger-experiment.js';
 import { createInMemoryTaskRunStore } from '../task-run-store.js';
 import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
 import type { IsolatedToolExecutor } from '../isolation.js';
@@ -177,9 +182,50 @@ describe('isolated headless tools', () => {
     assert.ok(!names.includes('todo_update'));
     assert.ok(!names.includes('self_check_plan_submit'));
     assert.ok(!names.includes('self_check_submit'));
+    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
+      assert.ok(!names.includes(taskToolName));
+    }
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
+  });
+
+  test('task experiment tools are included only when a task ledger store is enabled', () => {
+    const tools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    }, {
+      taskLedgerExperiment: {
+        store: createInMemoryTaskLedgerExperimentStore({ now: () => 1, newId: () => 'task-1' }),
+      },
+    });
+
+    const names = tools.map((tool) => tool.name);
+    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES) {
+      assert.ok(names.includes(taskToolName));
+    }
+    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
+      assert.ok(!names.includes(taskToolName));
+    }
+
+    const crudTools = buildIsolatedHeadlessTools({
+      async exec() {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    }, {
+      taskLedgerExperiment: {
+        store: createInMemoryTaskLedgerExperimentStore({ now: () => 1, newId: () => 'task-1' }),
+        shape: 'crud',
+      },
+    });
+    const crudNames = crudTools.map((tool) => tool.name);
+    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
+      assert.ok(crudNames.includes(taskToolName));
+    }
+    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES) {
+      assert.ok(!crudNames.includes(taskToolName));
+    }
   });
 
   test('progress and self-check tools are included only when heavy-task recorders are enabled', () => {

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -14,7 +14,6 @@ import { createHeavyTaskEvidenceRecorder } from '../heavy-task-evidence.js';
 import {
   createInMemoryTaskLedgerExperimentStore,
   TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES,
-  TASK_LEDGER_EXPERIMENT_TOOL_NAMES,
 } from '../task-ledger-experiment.js';
 import { createInMemoryTaskRunStore } from '../task-run-store.js';
 import { buildIsolatedBashTool, buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools } from '../tools.js';
@@ -182,9 +181,7 @@ describe('isolated headless tools', () => {
     assert.ok(!names.includes('todo_update'));
     assert.ok(!names.includes('self_check_plan_submit'));
     assert.ok(!names.includes('self_check_submit'));
-    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
-      assert.ok(!names.includes(taskToolName));
-    }
+    assert.ok(!names.some((name) => name.startsWith('task_')));
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(buildChildAgentTools(tools).map((tool) => tool.name), ['Read', 'Glob', 'Grep']);
     assert.ok(!buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)));
@@ -205,27 +202,7 @@ describe('isolated headless tools', () => {
     for (const taskToolName of TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES) {
       assert.ok(names.includes(taskToolName));
     }
-    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
-      assert.ok(!names.includes(taskToolName));
-    }
-
-    const crudTools = buildIsolatedHeadlessTools({
-      async exec() {
-        return { exitCode: 0, stdout: '', stderr: '' };
-      },
-    }, {
-      taskLedgerExperiment: {
-        store: createInMemoryTaskLedgerExperimentStore({ now: () => 1, newId: () => 'task-1' }),
-        shape: 'crud',
-      },
-    });
-    const crudNames = crudTools.map((tool) => tool.name);
-    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TOOL_NAMES) {
-      assert.ok(crudNames.includes(taskToolName));
-    }
-    for (const taskToolName of TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES) {
-      assert.ok(!crudNames.includes(taskToolName));
-    }
+    assert.ok(!names.some((name) => name.startsWith('task_')));
   });
 
   test('progress and self-check tools are included only when heavy-task recorders are enabled', () => {

--- a/packages/headless/src/ab-render.ts
+++ b/packages/headless/src/ab-render.ts
@@ -123,12 +123,7 @@ function renderTaskToolMetrics(summary: AbTaskToolSummary): string {
   return [
     `activated=${summary.activatedAttempts}/${summary.attempts}`,
     `calls=${summary.actualTaskToolCalls}`,
-    `create=${summary.createCalls}`,
-    `update=${summary.updateCalls}`,
-    `list=${summary.listCalls}`,
-    `get=${summary.getCalls}`,
     `todo_write=${summary.todoWriteCalls}`,
-    `repeated_updates=${summary.repeatedUpdateCalls}`,
   ].join(' ');
 }
 
@@ -138,12 +133,7 @@ function taskToolsOrZero(summary: AbTaskToolSummary | undefined): AbTaskToolSumm
     activatedAttempts: 0,
     activatedAttemptIds: [],
     actualTaskToolCalls: 0,
-    createCalls: 0,
-    updateCalls: 0,
-    listCalls: 0,
-    getCalls: 0,
     todoWriteCalls: 0,
-    repeatedUpdateCalls: 0,
   };
 }
 

--- a/packages/headless/src/ab-render.ts
+++ b/packages/headless/src/ab-render.ts
@@ -5,6 +5,7 @@ import type {
   AbContextBudgetSummary,
   AbDecision,
   AbPairInvestigationRef,
+  AbTaskToolSummary,
   AbTokenCostSummary,
 } from './ab-types.js';
 
@@ -13,6 +14,7 @@ export function renderAbComparisonMarkdown(summary: AbComparisonSummary): string
   const activePruneSubsetLine = renderActivePruneSubsetLine(summary);
   const contextBudgetPolicyLine = renderContextBudgetPolicyLine(summary);
   const continuationLine = renderContinuationLine(summary);
+  const taskToolLine = renderTaskToolLine(summary);
   const investigationRefLines = renderInvestigationRefLines(summary);
   const lines = [
     '# A/B Comparison',
@@ -34,6 +36,7 @@ export function renderAbComparisonMarkdown(summary: AbComparisonSummary): string
     `- Infra outcomes: A infra_failed=${summary.baseline.infraFailed}, B infra_failed=${summary.candidate.infraFailed}; A plumbing_failed=${summary.baseline.plumbingFailed}, B plumbing_failed=${summary.candidate.plumbingFailed}`,
     ...(contextBudgetPolicyLine ? [contextBudgetPolicyLine] : []),
     ...(continuationLine ? [continuationLine] : []),
+    ...(taskToolLine ? [taskToolLine] : []),
     ...(contextBudgetLine ? [contextBudgetLine] : []),
     ...(activePruneSubsetLine ? [activePruneSubsetLine] : []),
     '',
@@ -109,6 +112,39 @@ function renderContinuationMetrics(summary: AbContinuationSummary): string {
     `max_turns=${summary.maxTurns ?? 'null'}`,
     `max_total_steps=${summary.maxTotalRuntimeSteps ?? 'null'}`,
   ].join(' ');
+}
+
+function renderTaskToolLine(summary: AbComparisonSummary): string | undefined {
+  if (!summary.baseline.taskTools && !summary.candidate.taskTools) return undefined;
+  return `- Task tools: A ${renderTaskToolMetrics(taskToolsOrZero(summary.baseline.taskTools))}, B ${renderTaskToolMetrics(taskToolsOrZero(summary.candidate.taskTools))}`;
+}
+
+function renderTaskToolMetrics(summary: AbTaskToolSummary): string {
+  return [
+    `activated=${summary.activatedAttempts}/${summary.attempts}`,
+    `calls=${summary.actualTaskToolCalls}`,
+    `create=${summary.createCalls}`,
+    `update=${summary.updateCalls}`,
+    `list=${summary.listCalls}`,
+    `get=${summary.getCalls}`,
+    `todo_write=${summary.todoWriteCalls}`,
+    `repeated_updates=${summary.repeatedUpdateCalls}`,
+  ].join(' ');
+}
+
+function taskToolsOrZero(summary: AbTaskToolSummary | undefined): AbTaskToolSummary {
+  return summary ?? {
+    attempts: 0,
+    activatedAttempts: 0,
+    activatedAttemptIds: [],
+    actualTaskToolCalls: 0,
+    createCalls: 0,
+    updateCalls: 0,
+    listCalls: 0,
+    getCalls: 0,
+    todoWriteCalls: 0,
+    repeatedUpdateCalls: 0,
+  };
 }
 
 function continuationOrZero(summary: AbContinuationSummary | undefined): AbContinuationSummary {

--- a/packages/headless/src/ab-render.ts
+++ b/packages/headless/src/ab-render.ts
@@ -122,7 +122,6 @@ function renderTaskToolLine(summary: AbComparisonSummary): string | undefined {
 function renderTaskToolMetrics(summary: AbTaskToolSummary): string {
   return [
     `activated=${summary.activatedAttempts}/${summary.attempts}`,
-    `calls=${summary.actualTaskToolCalls}`,
     `todo_write=${summary.todoWriteCalls}`,
   ].join(' ');
 }
@@ -132,7 +131,6 @@ function taskToolsOrZero(summary: AbTaskToolSummary | undefined): AbTaskToolSumm
     attempts: 0,
     activatedAttempts: 0,
     activatedAttemptIds: [],
-    actualTaskToolCalls: 0,
     todoWriteCalls: 0,
   };
 }

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -282,12 +282,7 @@ function summarizeTaskTools(events: readonly FixedPromptTaskWalEvent[]): AbTaskT
       .filter((entry) => entry.summary.activated)
       .map((entry) => entry.event.id),
     actualTaskToolCalls: sum(summaries.map((entry) => entry.summary.actualTaskToolCalls)),
-    createCalls: sum(summaries.map((entry) => entry.summary.createCalls)),
-    updateCalls: sum(summaries.map((entry) => entry.summary.updateCalls)),
-    listCalls: sum(summaries.map((entry) => entry.summary.listCalls)),
-    getCalls: sum(summaries.map((entry) => entry.summary.getCalls)),
     todoWriteCalls: sum(summaries.map((entry) => entry.summary.todoWriteCalls)),
-    repeatedUpdateCalls: sum(summaries.map((entry) => entry.summary.repeatedUpdateCalls)),
   };
 }
 

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -16,10 +16,11 @@ import type {
   AbTaskArmSummary,
   AbTaskComparison,
   AbTaskLevelSummary,
+  AbTaskToolSummary,
   AbTokenCostSummary,
   SummarizeAbComparisonInput,
 } from './ab-types.js';
-import type { HarborCellContextBudgetSummary } from './cell-output.js';
+import type { HarborCellContextBudgetSummary, HarborCellTaskToolSummary } from './cell-output.js';
 
 const DEFAULT_NON_INFERIORITY_MARGIN = 0.10;
 const NON_INFERIORITY_CONFIDENCE_LEVEL = 0.95;
@@ -89,6 +90,7 @@ function summarizeArm(
   const durations = budgetedRuns.map((event) => event.durationMs);
   const contextBudget = summarizeContextBudget(observedAttempts);
   const continuation = summarizeContinuation(observed, wallTimeoutMs);
+  const taskTools = summarizeTaskTools(observed);
   const activePruneSubset = summarizeActivePruneSubset(observedAttempts, activePrunePairIds);
   const contextBudgetPolicy = summarizeContextBudgetPolicy(observed);
   const tokenCostSummary = summarizeTokenCost(budgetedRuns);
@@ -110,6 +112,7 @@ function summarizeArm(
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(contextBudget ? { contextBudget } : {}),
     ...(continuation ? { continuation } : {}),
+    ...(taskTools ? { taskTools } : {}),
     ...(activePruneSubset ? { activePruneSubset } : {}),
   };
 }
@@ -261,6 +264,30 @@ function summarizeContinuation(
     perTurnStepCapHits: summaries.flatMap((summary) => summary.turns.map((turn) => turn.stepCapHit)),
     maxTurns: summaries.length > 0 ? Math.max(...summaries.map((summary) => summary.maxTurns)) : null,
     maxTotalRuntimeSteps: summaries.length > 0 ? Math.max(...summaries.map((summary) => summary.maxTotalRuntimeSteps)) : null,
+  };
+}
+
+function summarizeTaskTools(events: readonly FixedPromptTaskWalEvent[]): AbTaskToolSummary | undefined {
+  const summaries: { event: FixedPromptTaskWalEvent; summary: HarborCellTaskToolSummary }[] = [];
+  for (const event of events) {
+    if ((event.type === 'task_completed' || event.type === 'task_plumbing_failed') && event.taskToolSummary) {
+      summaries.push({ event, summary: event.taskToolSummary });
+    }
+  }
+  if (summaries.length === 0) return undefined;
+  return {
+    attempts: events.length,
+    activatedAttempts: summaries.filter((entry) => entry.summary.activated).length,
+    activatedAttemptIds: summaries
+      .filter((entry) => entry.summary.activated)
+      .map((entry) => entry.event.id),
+    actualTaskToolCalls: sum(summaries.map((entry) => entry.summary.actualTaskToolCalls)),
+    createCalls: sum(summaries.map((entry) => entry.summary.createCalls)),
+    updateCalls: sum(summaries.map((entry) => entry.summary.updateCalls)),
+    listCalls: sum(summaries.map((entry) => entry.summary.listCalls)),
+    getCalls: sum(summaries.map((entry) => entry.summary.getCalls)),
+    todoWriteCalls: sum(summaries.map((entry) => entry.summary.todoWriteCalls)),
+    repeatedUpdateCalls: sum(summaries.map((entry) => entry.summary.repeatedUpdateCalls)),
   };
 }
 

--- a/packages/headless/src/ab-summary.ts
+++ b/packages/headless/src/ab-summary.ts
@@ -275,13 +275,11 @@ function summarizeTaskTools(events: readonly FixedPromptTaskWalEvent[]): AbTaskT
     }
   }
   if (summaries.length === 0) return undefined;
+  const activatedSummaries = summaries.filter((entry) => entry.summary.todoWriteCalls > 0);
   return {
     attempts: events.length,
-    activatedAttempts: summaries.filter((entry) => entry.summary.activated).length,
-    activatedAttemptIds: summaries
-      .filter((entry) => entry.summary.activated)
-      .map((entry) => entry.event.id),
-    actualTaskToolCalls: sum(summaries.map((entry) => entry.summary.actualTaskToolCalls)),
+    activatedAttempts: activatedSummaries.length,
+    activatedAttemptIds: activatedSummaries.map((entry) => entry.event.id),
     todoWriteCalls: sum(summaries.map((entry) => entry.summary.todoWriteCalls)),
   };
 }

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -146,7 +146,6 @@ export interface AbTaskToolSummary {
   attempts: number;
   activatedAttempts: number;
   activatedAttemptIds: string[];
-  actualTaskToolCalls: number;
   todoWriteCalls: number;
 }
 

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -66,6 +66,7 @@ export interface AbArmSummary {
   contextBudgetPolicy?: AbContextBudgetPolicySummary;
   contextBudget?: AbContextBudgetSummary;
   continuation?: AbContinuationSummary;
+  taskTools?: AbTaskToolSummary;
   activePruneSubset?: AbActivePruneSubsetSummary;
 }
 
@@ -139,6 +140,19 @@ export interface AbContinuationSummary {
   perTurnStepCapHits: boolean[];
   maxTurns: number | null;
   maxTotalRuntimeSteps: number | null;
+}
+
+export interface AbTaskToolSummary {
+  attempts: number;
+  activatedAttempts: number;
+  activatedAttemptIds: string[];
+  actualTaskToolCalls: number;
+  createCalls: number;
+  updateCalls: number;
+  listCalls: number;
+  getCalls: number;
+  todoWriteCalls: number;
+  repeatedUpdateCalls: number;
 }
 
 export interface AbTaskArmSummary {

--- a/packages/headless/src/ab-types.ts
+++ b/packages/headless/src/ab-types.ts
@@ -147,12 +147,7 @@ export interface AbTaskToolSummary {
   activatedAttempts: number;
   activatedAttemptIds: string[];
   actualTaskToolCalls: number;
-  createCalls: number;
-  updateCalls: number;
-  listCalls: number;
-  getCalls: number;
   todoWriteCalls: number;
-  repeatedUpdateCalls: number;
 }
 
 export interface AbTaskArmSummary {

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -81,6 +81,17 @@ export interface HarborCellToolSummary {
   actualToolCallCounts: Record<string, number>;
 }
 
+export interface HarborCellTaskToolSummary {
+  activated: boolean;
+  actualTaskToolCalls: number;
+  createCalls: number;
+  updateCalls: number;
+  listCalls: number;
+  getCalls: number;
+  todoWriteCalls: number;
+  repeatedUpdateCalls: number;
+}
+
 export interface HarborCellOutput {
   schemaVersion: typeof HARBOR_CELL_OUTPUT_SCHEMA_VERSION;
   status: InvocationResult['status'];
@@ -92,6 +103,7 @@ export interface HarborCellOutput {
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
   toolSummary: HarborCellToolSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
   steps: number;
   durationMs: number;
   startedAt: number;
@@ -104,6 +116,7 @@ export function buildHarborCellOutput(input: {
   runtimeEventsPath: string;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummaryEnabled?: boolean;
 }): HarborCellOutput {
   const { invocation } = input;
   return {
@@ -117,6 +130,7 @@ export function buildHarborCellOutput(input: {
     ...contextBudgetSummaryField(invocation.events),
     ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),
     toolSummary: summarizeCellTools(invocation.events),
+    ...taskToolSummaryField(invocation.events, input.taskToolSummaryEnabled ?? false),
     steps: invocation.events.length,
     durationMs: invocation.finishedAt - invocation.startedAt,
     startedAt: invocation.startedAt,
@@ -153,6 +167,9 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     ? validateContinuationSummary(value.continuationSummary)
     : undefined;
   const toolSummary = validateToolSummary(value.toolSummary);
+  const taskToolSummary = 'taskToolSummary' in value
+    ? validateTaskToolSummary(value.taskToolSummary)
+    : undefined;
   const steps = requireNumber(value.steps, 'steps');
   const durationMs = requireNumber(value.durationMs, 'durationMs');
   const startedAt = requireNumber(value.startedAt, 'startedAt');
@@ -169,6 +186,7 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     ...(contextBudgetSummary !== undefined ? { contextBudgetSummary } : {}),
     ...(continuationSummary !== undefined ? { continuationSummary } : {}),
     toolSummary,
+    ...(taskToolSummary !== undefined ? { taskToolSummary } : {}),
     steps,
     durationMs,
     startedAt,
@@ -176,6 +194,49 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
     runtimeRefs,
   };
   return output;
+}
+
+export function summarizeCellTaskTools(events: readonly RuntimeEvent[]): HarborCellTaskToolSummary {
+  const summary: HarborCellTaskToolSummary = {
+    activated: false,
+    actualTaskToolCalls: 0,
+    createCalls: 0,
+    updateCalls: 0,
+    listCalls: 0,
+    getCalls: 0,
+    todoWriteCalls: 0,
+    repeatedUpdateCalls: 0,
+  };
+  const seenUpdates = new Set<string>();
+  for (const event of events) {
+    if (event.content?.kind !== 'function_call') continue;
+    const name = event.content.name;
+    if (!['task_create', 'task_update', 'task_list', 'task_get', 'todo_write'].includes(name)) continue;
+    summary.activated = true;
+    summary.actualTaskToolCalls += 1;
+    switch (name) {
+      case 'task_create':
+        summary.createCalls += 1;
+        break;
+      case 'task_update': {
+        summary.updateCalls += 1;
+        const key = canonicalJson(event.content.args);
+        if (seenUpdates.has(key)) summary.repeatedUpdateCalls += 1;
+        seenUpdates.add(key);
+        break;
+      }
+      case 'task_list':
+        summary.listCalls += 1;
+        break;
+      case 'task_get':
+        summary.getCalls += 1;
+        break;
+      case 'todo_write':
+        summary.todoWriteCalls += 1;
+        break;
+    }
+  }
+  return summary;
 }
 
 function validateContinuationSummary(value: unknown): HarborCellContinuationSummary {
@@ -365,6 +426,25 @@ function contextBudgetSummaryField(
   return contextBudgetSummary ? { contextBudgetSummary } : {};
 }
 
+function taskToolSummaryField(
+  events: readonly RuntimeEvent[],
+  enabled: boolean,
+): Pick<HarborCellOutput, 'taskToolSummary'> {
+  const taskToolSummary = summarizeCellTaskTools(events);
+  return enabled || taskToolSummary.activated ? { taskToolSummary } : {};
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalJson(entryValue)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function validateTokenSummary(value: unknown): HarborCellTokenSummary {
   if (!isRecord(value)) throw new Error('tokenSummary must be a JSON object');
   return {
@@ -395,6 +475,20 @@ function validateToolSummary(value: unknown): HarborCellToolSummary {
     actualToolCalls: requireNumber(value.actualToolCalls, 'toolSummary.actualToolCalls'),
     actualToolNames: validateStringArray(value.actualToolNames, 'toolSummary.actualToolNames'),
     actualToolCallCounts,
+  };
+}
+
+function validateTaskToolSummary(value: unknown): HarborCellTaskToolSummary {
+  if (!isRecord(value)) throw new Error('taskToolSummary must be a JSON object');
+  return {
+    activated: requireBoolean(value.activated, 'taskToolSummary.activated'),
+    actualTaskToolCalls: requireNumber(value.actualTaskToolCalls, 'taskToolSummary.actualTaskToolCalls'),
+    createCalls: requireNumber(value.createCalls, 'taskToolSummary.createCalls'),
+    updateCalls: requireNumber(value.updateCalls, 'taskToolSummary.updateCalls'),
+    listCalls: requireNumber(value.listCalls, 'taskToolSummary.listCalls'),
+    getCalls: requireNumber(value.getCalls, 'taskToolSummary.getCalls'),
+    todoWriteCalls: requireNumber(value.todoWriteCalls, 'taskToolSummary.todoWriteCalls'),
+    repeatedUpdateCalls: requireNumber(value.repeatedUpdateCalls, 'taskToolSummary.repeatedUpdateCalls'),
   };
 }
 

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -84,12 +84,7 @@ export interface HarborCellToolSummary {
 export interface HarborCellTaskToolSummary {
   activated: boolean;
   actualTaskToolCalls: number;
-  createCalls: number;
-  updateCalls: number;
-  listCalls: number;
-  getCalls: number;
   todoWriteCalls: number;
-  repeatedUpdateCalls: number;
 }
 
 export interface HarborCellOutput {
@@ -200,41 +195,15 @@ export function summarizeCellTaskTools(events: readonly RuntimeEvent[]): HarborC
   const summary: HarborCellTaskToolSummary = {
     activated: false,
     actualTaskToolCalls: 0,
-    createCalls: 0,
-    updateCalls: 0,
-    listCalls: 0,
-    getCalls: 0,
     todoWriteCalls: 0,
-    repeatedUpdateCalls: 0,
   };
-  const seenUpdates = new Set<string>();
   for (const event of events) {
     if (event.content?.kind !== 'function_call') continue;
     const name = event.content.name;
-    if (!['task_create', 'task_update', 'task_list', 'task_get', 'todo_write'].includes(name)) continue;
+    if (name !== 'todo_write') continue;
     summary.activated = true;
     summary.actualTaskToolCalls += 1;
-    switch (name) {
-      case 'task_create':
-        summary.createCalls += 1;
-        break;
-      case 'task_update': {
-        summary.updateCalls += 1;
-        const key = canonicalJson(event.content.args);
-        if (seenUpdates.has(key)) summary.repeatedUpdateCalls += 1;
-        seenUpdates.add(key);
-        break;
-      }
-      case 'task_list':
-        summary.listCalls += 1;
-        break;
-      case 'task_get':
-        summary.getCalls += 1;
-        break;
-      case 'todo_write':
-        summary.todoWriteCalls += 1;
-        break;
-    }
+    summary.todoWriteCalls += 1;
   }
   return summary;
 }
@@ -434,17 +403,6 @@ function taskToolSummaryField(
   return enabled || taskToolSummary.activated ? { taskToolSummary } : {};
 }
 
-function canonicalJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
-  if (value && typeof value === 'object') {
-    const entries = Object.entries(value)
-      .filter(([, entryValue]) => entryValue !== undefined)
-      .sort(([a], [b]) => a.localeCompare(b));
-    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalJson(entryValue)}`).join(',')}}`;
-  }
-  return JSON.stringify(value);
-}
-
 function validateTokenSummary(value: unknown): HarborCellTokenSummary {
   if (!isRecord(value)) throw new Error('tokenSummary must be a JSON object');
   return {
@@ -483,12 +441,7 @@ function validateTaskToolSummary(value: unknown): HarborCellTaskToolSummary {
   return {
     activated: requireBoolean(value.activated, 'taskToolSummary.activated'),
     actualTaskToolCalls: requireNumber(value.actualTaskToolCalls, 'taskToolSummary.actualTaskToolCalls'),
-    createCalls: requireNumber(value.createCalls, 'taskToolSummary.createCalls'),
-    updateCalls: requireNumber(value.updateCalls, 'taskToolSummary.updateCalls'),
-    listCalls: requireNumber(value.listCalls, 'taskToolSummary.listCalls'),
-    getCalls: requireNumber(value.getCalls, 'taskToolSummary.getCalls'),
     todoWriteCalls: requireNumber(value.todoWriteCalls, 'taskToolSummary.todoWriteCalls'),
-    repeatedUpdateCalls: requireNumber(value.repeatedUpdateCalls, 'taskToolSummary.repeatedUpdateCalls'),
   };
 }
 

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -82,8 +82,6 @@ export interface HarborCellToolSummary {
 }
 
 export interface HarborCellTaskToolSummary {
-  activated: boolean;
-  actualTaskToolCalls: number;
   todoWriteCalls: number;
 }
 
@@ -193,16 +191,12 @@ export function validateHarborCellOutput(value: unknown): HarborCellOutput {
 
 export function summarizeCellTaskTools(events: readonly RuntimeEvent[]): HarborCellTaskToolSummary {
   const summary: HarborCellTaskToolSummary = {
-    activated: false,
-    actualTaskToolCalls: 0,
     todoWriteCalls: 0,
   };
   for (const event of events) {
     if (event.content?.kind !== 'function_call') continue;
     const name = event.content.name;
     if (name !== 'todo_write') continue;
-    summary.activated = true;
-    summary.actualTaskToolCalls += 1;
     summary.todoWriteCalls += 1;
   }
   return summary;
@@ -400,7 +394,7 @@ function taskToolSummaryField(
   enabled: boolean,
 ): Pick<HarborCellOutput, 'taskToolSummary'> {
   const taskToolSummary = summarizeCellTaskTools(events);
-  return enabled || taskToolSummary.activated ? { taskToolSummary } : {};
+  return enabled || taskToolSummary.todoWriteCalls > 0 ? { taskToolSummary } : {};
 }
 
 function validateTokenSummary(value: unknown): HarborCellTokenSummary {
@@ -439,8 +433,6 @@ function validateToolSummary(value: unknown): HarborCellToolSummary {
 function validateTaskToolSummary(value: unknown): HarborCellTaskToolSummary {
   if (!isRecord(value)) throw new Error('taskToolSummary must be a JSON object');
   return {
-    activated: requireBoolean(value.activated, 'taskToolSummary.activated'),
-    actualTaskToolCalls: requireNumber(value.actualTaskToolCalls, 'taskToolSummary.actualTaskToolCalls'),
     todoWriteCalls: requireNumber(value.todoWriteCalls, 'taskToolSummary.todoWriteCalls'),
   };
 }

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -7,6 +7,7 @@ import {
   type HarborCellContextBudgetSummary,
   type HarborCellContinuationSummary,
   type HarborCellOutput,
+  type HarborCellTaskToolSummary,
   type HarborCellTokenSummary,
 } from './cell-output.js';
 import type { Config } from './contracts.js';
@@ -92,6 +93,7 @@ export interface FixedPromptTaskCompletedEvent {
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
   steps: number;
   durationMs: number;
   runtimeEventsPath: string;
@@ -161,6 +163,7 @@ export interface FixedPromptTaskPlumbingFailedEvent {
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   contextBudgetSummary?: HarborCellContextBudgetSummary;
   continuationSummary?: HarborCellContinuationSummary;
+  taskToolSummary?: HarborCellTaskToolSummary;
   steps: number;
   durationMs: number;
   runtimeEventsPath: string;
@@ -619,6 +622,7 @@ function taskCompletedEvent(input: {
     ...(output.cell.contextBudgetPolicy ? { contextBudgetPolicy: output.cell.contextBudgetPolicy } : {}),
     ...(output.cell.contextBudgetSummary ? { contextBudgetSummary: output.cell.contextBudgetSummary } : {}),
     ...(output.cell.continuationSummary ? { continuationSummary: output.cell.continuationSummary } : {}),
+    ...(output.cell.taskToolSummary ? { taskToolSummary: output.cell.taskToolSummary } : {}),
     steps: output.cell.steps,
     durationMs: output.cell.durationMs,
     runtimeEventsPath: output.cell.runtimeEventsPath,
@@ -672,6 +676,9 @@ function taskPlumbingFailedEvent(input: {
       : {}),
     ...(input.output.cell.continuationSummary
       ? { continuationSummary: input.output.cell.continuationSummary }
+      : {}),
+    ...(input.output.cell.taskToolSummary
+      ? { taskToolSummary: input.output.cell.taskToolSummary }
       : {}),
     steps: input.output.cell.steps,
     durationMs: input.output.cell.durationMs,

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -52,7 +52,6 @@ import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools, type
 import {
   createInMemoryTaskLedgerExperimentStore,
   renderTaskLedgerExperimentReplay,
-  type TaskLedgerExperimentShape,
 } from './task-ledger-experiment.js';
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
@@ -136,7 +135,6 @@ export interface HarborCellContextBudgetBackendOptions {
 export interface HarborCellTaskLedgerExperimentPolicy {
   enabled: true;
   replayMaxChars: number;
-  shape: TaskLedgerExperimentShape;
 }
 
 export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
@@ -205,7 +203,6 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES',
   'MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR',
   'MAKA_CONTEXT_TASK_TOOLS',
-  'MAKA_CONTEXT_TASK_TOOL_SHAPE',
   'MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS',
 ] as const;
 
@@ -656,7 +653,7 @@ export function buildAiSdkCellBackendRegistration(input: {
           ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
           ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
           ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
-            ? { taskLedgerExperiment: { store: taskLedgerExperimentStore, shape: taskLedgerExperimentPolicy.shape } }
+            ? { taskLedgerExperiment: { store: taskLedgerExperimentStore } }
             : {}),
         }),
         toolAvailability: buildIsolatedHeadlessToolAvailability(),
@@ -667,7 +664,6 @@ export function buildAiSdkCellBackendRegistration(input: {
               turnTailPrompt: async ({ sessionId }) =>
                 renderTaskLedgerExperimentReplay(await taskLedgerExperimentStore.list(sessionId), {
                   maxChars: taskLedgerExperimentPolicy.replayMaxChars,
-                  shape: taskLedgerExperimentPolicy.shape,
                 }),
             }
           : {}),
@@ -971,11 +967,9 @@ export function buildHarborCellTaskLedgerExperimentPolicy(
   normalizeHarborCellContextEnv(env);
   const enabled = booleanEnv(env.MAKA_CONTEXT_TASK_TOOLS, 'MAKA_CONTEXT_TASK_TOOLS') ?? false;
   if (!enabled) return undefined;
-  const shape = taskLedgerExperimentShapeEnv(env.MAKA_CONTEXT_TASK_TOOL_SHAPE) ?? 'todo_write';
   return {
     enabled: true,
     replayMaxChars: positiveIntEnv(env.MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS, 'MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS') ?? 4_000,
-    shape,
   };
 }
 
@@ -1274,12 +1268,6 @@ function numericEnv(raw: string | undefined): number | undefined {
   if (raw === undefined || raw.trim() === '') return undefined;
   const value = Number(raw);
   return Number.isFinite(value) && value >= 0 ? value : undefined;
-}
-
-function taskLedgerExperimentShapeEnv(raw: string | undefined): TaskLedgerExperimentShape | undefined {
-  if (raw === undefined || raw.trim() === '') return undefined;
-  if (raw === 'crud' || raw === 'todo_write') return raw;
-  throw new Error(`MAKA_CONTEXT_TASK_TOOL_SHAPE must be crud or todo_write, got ${JSON.stringify(raw)}`);
 }
 
 function positiveIntEnv(raw: string | undefined, name: string): number | undefined {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -383,6 +383,7 @@ export async function runHarborCellFromEnv(
   const contextBudgetPolicy = buildHarborCellContextBudgetPolicySnapshot(resolvedEnv);
   const continuationPolicy = buildHarborCellContinuationPolicy(resolvedEnv);
   const economyTaskMode = economyTaskModeFromEnv(resolvedEnv.MAKA_ECONOMY_TASK_MODE);
+  const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const baseConfig = {
     id: resolvedEnv.MAKA_CONFIG_ID ?? 'harbor-cell',
     backend,
@@ -409,6 +410,7 @@ export async function runHarborCellFromEnv(
         env: resolvedEnv,
         now,
         newId,
+        ...(maxSteps !== undefined ? { maxSteps } : {}),
       });
       break;
     }
@@ -495,6 +497,10 @@ export function buildHarborCellContinuationPolicy(
     ) ?? maxTurns * HARBOR_CELL_DEFAULT_MAX_STEPS_PER_TURN,
     prompt: env.MAKA_HARBOR_CONTINUATION_PROMPT ?? HARBOR_CELL_DEFAULT_CONTINUATION_PROMPT,
   };
+}
+
+export function harborCellMaxStepsFromEnv(env: RunHarborCellEnv = process.env): number | undefined {
+  return positiveIntEnv(env.MAKA_MAX_STEPS, 'MAKA_MAX_STEPS');
 }
 
 function isToolCallStepCap(invocation: InvocationResult): boolean {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -49,6 +49,11 @@ import { ISOLATED_HEADLESS_TOOL_NAMES, validateRealBackendIsolation } from './is
 import { PiCliJsonTransport } from './pi-cli-json-transport.js';
 import { backendNeedsIsolation } from './runner.js';
 import { buildIsolatedHeadlessToolAvailability, buildIsolatedHeadlessTools, type BuildIsolatedHeadlessToolsOptions } from './tools.js';
+import {
+  createInMemoryTaskLedgerExperimentStore,
+  renderTaskLedgerExperimentReplay,
+  type TaskLedgerExperimentShape,
+} from './task-ledger-experiment.js';
 
 export const HARBOR_CELL_OUTPUT_FILENAME = 'maka-cell-output.json';
 export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
@@ -68,6 +73,7 @@ export interface RunHarborCellInput {
   realBackendIsolation?: RealBackendIsolation;
   contextBudgetPolicy?: HarborCellContextBudgetPolicySnapshot;
   continuationPolicy?: HarborCellContinuationPolicy;
+  taskToolSummaryEnabled?: boolean;
   now?: () => number;
   newId?: () => string;
 }
@@ -125,6 +131,12 @@ export interface HarborCellContextBudgetBackendOptions {
   contextBudget?: ContextBudgetPolicy;
   archiveToolResult?: ToolResultArchiveRecorder;
   readToolResultArchive?: ToolResultArchiveReader;
+}
+
+export interface HarborCellTaskLedgerExperimentPolicy {
+  enabled: true;
+  replayMaxChars: number;
+  shape: TaskLedgerExperimentShape;
 }
 
 export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
@@ -192,6 +204,9 @@ export const HARBOR_CELL_CONTEXT_ENV_KEYS = [
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_TOKENS',
   'MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MAX_BYTES',
   'MAKA_CONTEXT_TOOL_RESULT_ARCHIVE_DIR',
+  'MAKA_CONTEXT_TASK_TOOLS',
+  'MAKA_CONTEXT_TASK_TOOL_SHAPE',
+  'MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS',
 ] as const;
 
 export type HarborCellContextEnvKey = typeof HARBOR_CELL_CONTEXT_ENV_KEYS[number];
@@ -364,6 +379,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     runtimeEventsPath,
     ...(input.contextBudgetPolicy ? { contextBudgetPolicy: input.contextBudgetPolicy } : {}),
     ...(continuationSummary ? { continuationSummary } : {}),
+    ...(input.taskToolSummaryEnabled !== undefined ? { taskToolSummaryEnabled: input.taskToolSummaryEnabled } : {}),
   }));
   await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
 
@@ -383,6 +399,7 @@ export async function runHarborCellFromEnv(
   const contextBudgetPolicy = buildHarborCellContextBudgetPolicySnapshot(resolvedEnv);
   const continuationPolicy = buildHarborCellContinuationPolicy(resolvedEnv);
   const economyTaskMode = economyTaskModeFromEnv(resolvedEnv.MAKA_ECONOMY_TASK_MODE);
+  const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(resolvedEnv);
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const baseConfig = {
     id: resolvedEnv.MAKA_CONFIG_ID ?? 'harbor-cell',
@@ -461,6 +478,7 @@ export async function runHarborCellFromEnv(
     storageRoot,
     ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
     ...(continuationPolicy ? { continuationPolicy } : {}),
+    ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
     ...(registerBackends ? { registerBackends } : {}),
     ...(backendNeedsIsolation(backend)
       ? {
@@ -615,6 +633,10 @@ export function buildAiSdkCellBackendRegistration(input: {
     : getBuiltinPricing;
   const permissionEngine = new PermissionEngine({ newId: input.newId, now: input.now });
   const contextBudgetBackendOptions = buildHarborCellContextBudgetBackendOptions(input.env);
+  const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(input.env);
+  const taskLedgerExperimentStore = taskLedgerExperimentPolicy
+    ? createInMemoryTaskLedgerExperimentStore({ now: input.now, newId: input.newId })
+    : undefined;
   return (registry, context) => {
     if (!context.toolExecutor) {
       throw new Error('Harbor ai-sdk backend requires an isolated tool executor');
@@ -633,10 +655,22 @@ export function buildAiSdkCellBackendRegistration(input: {
           ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
           ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
           ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),
+          ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
+            ? { taskLedgerExperiment: { store: taskLedgerExperimentStore, shape: taskLedgerExperimentPolicy.shape } }
+            : {}),
         }),
         toolAvailability: buildIsolatedHeadlessToolAvailability(),
         providerOptions: buildProviderOptions(connection, input.model, ctx.header.thinkingLevel),
         systemPrompt: harborCellSystemPrompt(context.config.systemPrompt),
+        ...(taskLedgerExperimentStore && taskLedgerExperimentPolicy
+          ? {
+              turnTailPrompt: async ({ sessionId }) =>
+                renderTaskLedgerExperimentReplay(await taskLedgerExperimentStore.list(sessionId), {
+                  maxChars: taskLedgerExperimentPolicy.replayMaxChars,
+                  shape: taskLedgerExperimentPolicy.shape,
+                }),
+            }
+          : {}),
         lookupPricing,
         ...contextBudgetBackendOptions,
         ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
@@ -928,6 +962,20 @@ export function buildHarborCellContextBudgetBackendOptions(
       }
       return { ok: true, serializedResult: parsed.serializedResult };
     },
+  };
+}
+
+export function buildHarborCellTaskLedgerExperimentPolicy(
+  env: RunHarborCellEnv = process.env,
+): HarborCellTaskLedgerExperimentPolicy | undefined {
+  normalizeHarborCellContextEnv(env);
+  const enabled = booleanEnv(env.MAKA_CONTEXT_TASK_TOOLS, 'MAKA_CONTEXT_TASK_TOOLS') ?? false;
+  if (!enabled) return undefined;
+  const shape = taskLedgerExperimentShapeEnv(env.MAKA_CONTEXT_TASK_TOOL_SHAPE) ?? 'todo_write';
+  return {
+    enabled: true,
+    replayMaxChars: positiveIntEnv(env.MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS, 'MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS') ?? 4_000,
+    shape,
   };
 }
 
@@ -1226,6 +1274,12 @@ function numericEnv(raw: string | undefined): number | undefined {
   if (raw === undefined || raw.trim() === '') return undefined;
   const value = Number(raw);
   return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function taskLedgerExperimentShapeEnv(raw: string | undefined): TaskLedgerExperimentShape | undefined {
+  if (raw === undefined || raw.trim() === '') return undefined;
+  if (raw === 'crud' || raw === 'todo_write') return raw;
+  throw new Error(`MAKA_CONTEXT_TASK_TOOL_SHAPE must be crud or todo_write, got ${JSON.stringify(raw)}`);
 }
 
 function positiveIntEnv(raw: string | undefined, name: string): number | undefined {

--- a/packages/headless/src/task-ledger-experiment.ts
+++ b/packages/headless/src/task-ledger-experiment.ts
@@ -1,0 +1,292 @@
+import { randomUUID } from 'node:crypto';
+import {
+  TASK_ID_MAX_CHARS,
+  TASK_LEDGER_MAX_TASKS,
+  TASK_STATUSES,
+  TASK_SUBJECT_MAX_CHARS,
+  isSafeTaskId,
+  renderSafeTaskLedgerText,
+  type Task,
+  type TaskStatus,
+} from '@maka/core/task-ledger';
+import type { MakaTool } from '@maka/runtime';
+import { z } from 'zod';
+
+export const TASK_LEDGER_EXPERIMENT_TOOL_NAMES = ['task_create', 'task_update', 'task_list', 'task_get'] as const;
+export const TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES = ['todo_write'] as const;
+
+export const TASK_LEDGER_EXPERIMENT_STATUSES = TASK_STATUSES;
+
+export type TaskLedgerExperimentStatus = TaskStatus;
+export type TaskLedgerExperimentShape = 'crud' | 'todo_write';
+export type TaskLedgerExperimentTodoStatus = 'pending' | 'in_progress' | 'completed';
+export type TaskLedgerExperimentTask = Task;
+
+export interface TaskLedgerExperimentStore {
+  create(sessionId: string, input: {
+    description: string;
+  }): Promise<TaskLedgerExperimentTask>;
+  update(sessionId: string, id: string, patch: {
+    description?: string;
+    status?: TaskLedgerExperimentStatus;
+  }): Promise<TaskLedgerExperimentTask>;
+  replace(sessionId: string, todos: Array<{
+    content: string;
+    status: TaskLedgerExperimentTodoStatus;
+  }>): Promise<TaskLedgerExperimentTask[]>;
+  list(sessionId: string): Promise<TaskLedgerExperimentTask[]>;
+  get(sessionId: string, id: string): Promise<TaskLedgerExperimentTask>;
+}
+
+const DEFAULT_REPLAY_MAX_CHARS = 4_000;
+const TODO_WRITE_GUIDANCE_LINES: string[] = [
+  'Todo tool guidance:',
+  '<todo-tool-guidance>',
+  '- Use todo_write at the start of long-running, multi-step tasks with a short outcome-focused plan.',
+  '- Keep exactly one in_progress item while working; mark items completed as soon as they are done.',
+  '- Rewrite the list when the plan changes, keeping items concise.',
+  '</todo-tool-guidance>',
+];
+
+const taskDescriptionSchema = z.string().trim().min(1).max(TASK_SUBJECT_MAX_CHARS);
+const taskIdSchema = z.string().trim().min(1).max(TASK_ID_MAX_CHARS)
+  .refine(isSafeTaskId, 'Task id must be a stable token from task_list or task_create.');
+
+const taskCreateSchema = z.object({
+  description: taskDescriptionSchema.describe('Short description of the task.'),
+}).strict();
+
+const taskUpdateSchema = z.object({
+  id: taskIdSchema.describe('Task id from task_list or the task_create result.'),
+  description: taskDescriptionSchema.optional().describe('Replacement task description.'),
+  status: z.enum(TASK_LEDGER_EXPERIMENT_STATUSES).optional().describe('New task status.'),
+}).strict().superRefine((value, ctx) => {
+  if (
+    value.description === undefined &&
+    value.status === undefined
+  ) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Provide at least one field to update.' });
+  }
+});
+
+const taskGetSchema = z.object({ id: taskIdSchema }).strict();
+const taskListSchema = z.object({}).strict();
+const todoWriteSchema = z.object({
+  todos: z.array(z.object({
+    content: taskDescriptionSchema.describe('Short todo item content.'),
+    status: z.enum(['pending', 'in_progress', 'completed']).describe('Current todo status.'),
+  }).strict()).max(TASK_LEDGER_MAX_TASKS).describe('The complete current todo list, replacing any previous todo list.'),
+}).strict();
+
+export function createInMemoryTaskLedgerExperimentStore(input: {
+  now?: () => number;
+  newId?: () => string;
+} = {}): TaskLedgerExperimentStore {
+  return new InMemoryTaskLedgerExperimentStore(input.now ?? Date.now, input.newId ?? defaultId);
+}
+
+export function buildTaskLedgerExperimentTools(input: {
+  store: TaskLedgerExperimentStore;
+  shape?: TaskLedgerExperimentShape;
+}): MakaTool[] {
+  if ((input.shape ?? 'todo_write') === 'todo_write') {
+    return [{
+      name: 'todo_write',
+      description:
+        'Replace the current todo list for a long-running task. '
+        + 'Use it when planning work, when switching the active item, and when marking work complete.',
+      parameters: todoWriteSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const parsed = todoWriteSchema.parse(args);
+        const todos = await input.store.replace(ctx.sessionId, parsed.todos);
+        return renderMutationResult('Replaced todo list', todos.length, todos);
+      },
+    }];
+  }
+  return [
+    {
+      name: 'task_create',
+      description: 'Create one short task in the experimental session task ledger.',
+      parameters: taskCreateSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const parsed = taskCreateSchema.parse(args);
+        const task = await input.store.create(ctx.sessionId, parsed);
+        const total = (await input.store.list(ctx.sessionId)).length;
+        return renderMutationResult('Created 1 task', total, [task]);
+      },
+    },
+    {
+      name: 'task_update',
+      description: 'Update one task in the experimental session task ledger.',
+      parameters: taskUpdateSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const parsed = taskUpdateSchema.parse(args);
+        const { id, ...patch } = parsed;
+        const task = await input.store.update(ctx.sessionId, id, patch);
+        const total = (await input.store.list(ctx.sessionId)).length;
+        return renderMutationResult('Updated 1 task', total, [task]);
+      },
+    },
+    {
+      name: 'task_list',
+      description: 'List the current experimental session tasks.',
+      parameters: taskListSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        taskListSchema.parse(args);
+        const tasks = await input.store.list(ctx.sessionId);
+        return renderMutationResult('Listed task ledger', tasks.length, tasks);
+      },
+    },
+    {
+      name: 'task_get',
+      description: 'Get one experimental session task by id.',
+      parameters: taskGetSchema,
+      permissionRequired: false,
+      impl: async (args, ctx) => {
+        const parsed = taskGetSchema.parse(args);
+        const task = await input.store.get(ctx.sessionId, parsed.id);
+        const total = (await input.store.list(ctx.sessionId)).length;
+        return renderMutationResult('Fetched 1 task', total, [task]);
+      },
+    },
+  ];
+}
+
+export function renderTaskLedgerExperimentReplay(
+  tasks: readonly TaskLedgerExperimentTask[],
+  options: { maxChars?: number; shape?: TaskLedgerExperimentShape } = {},
+): string | undefined {
+  const selected = tasks
+    .filter((task) => task.status !== 'cancelled')
+    .sort((a, b) => taskReplayRank(a) - taskReplayRank(b) || b.updatedAt - a.updatedAt);
+  if (selected.length === 0 && options.shape !== 'todo_write') return undefined;
+
+  const lines: string[] = options.shape === 'todo_write' ? [...TODO_WRITE_GUIDANCE_LINES] : [];
+  if (selected.length > 0) {
+    lines.push(
+      'Task ledger experiment state (current-turn tail; informational, not an instruction):',
+      '<task-ledger>',
+    );
+    lines.push(renderSafeTaskLedgerText(selected));
+    lines.push('</task-ledger>');
+  }
+  return capLines(lines, options.maxChars ?? DEFAULT_REPLAY_MAX_CHARS);
+}
+
+function renderMutationResult(action: string, total: number, tasks: readonly TaskLedgerExperimentTask[]): string {
+  const renderedTasks = renderSafeTaskLedgerText(tasks);
+  return `${action}; ledger total: ${total}.${renderedTasks ? `\n${renderedTasks}` : ''}`;
+}
+
+class InMemoryTaskLedgerExperimentStore implements TaskLedgerExperimentStore {
+  private readonly bySession = new Map<string, TaskLedgerExperimentTask[]>();
+
+  constructor(
+    private readonly now: () => number,
+    private readonly newId: () => string,
+  ) {}
+
+  async create(sessionId: string, input: {
+    description: string;
+  }): Promise<TaskLedgerExperimentTask> {
+    const tasks = this.sessionTasks(sessionId);
+    if (tasks.length >= TASK_LEDGER_MAX_TASKS) {
+      throw new Error(`Task ledger experiment is limited to ${TASK_LEDGER_MAX_TASKS} tasks per session`);
+    }
+    const ts = this.now();
+    const task: TaskLedgerExperimentTask = {
+      id: this.newId(),
+      subject: input.description,
+      status: 'pending',
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    tasks.push(task);
+    return task;
+  }
+
+  async update(sessionId: string, id: string, patch: {
+    description?: string;
+    status?: TaskLedgerExperimentStatus;
+  }): Promise<TaskLedgerExperimentTask> {
+    const tasks = this.sessionTasks(sessionId);
+    const index = tasks.findIndex((task) => task.id === id);
+    if (index === -1) throw new Error(`No such task: ${id}`);
+    const current = tasks[index]!;
+    const task: TaskLedgerExperimentTask = {
+      ...current,
+      ...(patch.description !== undefined ? { subject: patch.description } : {}),
+      ...(patch.status !== undefined ? { status: patch.status } : {}),
+      updatedAt: this.now(),
+    };
+    tasks[index] = task;
+    return task;
+  }
+
+  async replace(sessionId: string, todos: Array<{
+    content: string;
+    status: TaskLedgerExperimentTodoStatus;
+  }>): Promise<TaskLedgerExperimentTask[]> {
+    if (todos.length > TASK_LEDGER_MAX_TASKS) {
+      throw new Error(`Task ledger experiment is limited to ${TASK_LEDGER_MAX_TASKS} tasks per session`);
+    }
+    const ts = this.now();
+    const tasks = todos.map((todo) => ({
+      id: this.newId(),
+      subject: todo.content,
+      status: todo.status,
+      createdAt: ts,
+      updatedAt: ts,
+    }));
+    this.bySession.set(sessionId, tasks);
+    return tasks.map((task) => ({ ...task }));
+  }
+
+  async list(sessionId: string): Promise<TaskLedgerExperimentTask[]> {
+    return this.sessionTasks(sessionId).map((task) => ({ ...task }));
+  }
+
+  async get(sessionId: string, id: string): Promise<TaskLedgerExperimentTask> {
+    const task = this.sessionTasks(sessionId).find((candidate) => candidate.id === id);
+    if (!task) throw new Error(`No such task: ${id}`);
+    return { ...task };
+  }
+
+  private sessionTasks(sessionId: string): TaskLedgerExperimentTask[] {
+    const existing = this.bySession.get(sessionId);
+    if (existing) return existing;
+    const tasks: TaskLedgerExperimentTask[] = [];
+    this.bySession.set(sessionId, tasks);
+    return tasks;
+  }
+}
+
+function taskReplayRank(task: TaskLedgerExperimentTask): number {
+  if (task.status === 'in_progress') return 0;
+  if (task.status === 'pending') return 1;
+  if (task.status === 'completed') return 2;
+  return 3;
+}
+
+function capLines(lines: string[], maxChars: number): string {
+  const kept: string[] = [];
+  let total = 0;
+  for (const line of lines) {
+    const cost = line.length + (kept.length === 0 ? 0 : 1);
+    if (kept.length > 0 && total + cost > maxChars) {
+      kept.push(`... omitted to stay within ${maxChars} chars`);
+      break;
+    }
+    kept.push(line);
+    total += cost;
+  }
+  return kept.join('\n').slice(0, maxChars);
+}
+
+function defaultId(): string {
+  return randomUUID();
+}

--- a/packages/headless/src/task-ledger-experiment.ts
+++ b/packages/headless/src/task-ledger-experiment.ts
@@ -1,41 +1,24 @@
 import { randomUUID } from 'node:crypto';
 import {
-  TASK_ID_MAX_CHARS,
   TASK_LEDGER_MAX_TASKS,
-  TASK_STATUSES,
   TASK_SUBJECT_MAX_CHARS,
-  isSafeTaskId,
   renderSafeTaskLedgerText,
   type Task,
-  type TaskStatus,
 } from '@maka/core/task-ledger';
 import type { MakaTool } from '@maka/runtime';
 import { z } from 'zod';
 
-export const TASK_LEDGER_EXPERIMENT_TOOL_NAMES = ['task_create', 'task_update', 'task_list', 'task_get'] as const;
 export const TASK_LEDGER_EXPERIMENT_TODO_TOOL_NAMES = ['todo_write'] as const;
 
-export const TASK_LEDGER_EXPERIMENT_STATUSES = TASK_STATUSES;
-
-export type TaskLedgerExperimentStatus = TaskStatus;
-export type TaskLedgerExperimentShape = 'crud' | 'todo_write';
 export type TaskLedgerExperimentTodoStatus = 'pending' | 'in_progress' | 'completed';
 export type TaskLedgerExperimentTask = Task;
 
 export interface TaskLedgerExperimentStore {
-  create(sessionId: string, input: {
-    description: string;
-  }): Promise<TaskLedgerExperimentTask>;
-  update(sessionId: string, id: string, patch: {
-    description?: string;
-    status?: TaskLedgerExperimentStatus;
-  }): Promise<TaskLedgerExperimentTask>;
   replace(sessionId: string, todos: Array<{
     content: string;
     status: TaskLedgerExperimentTodoStatus;
   }>): Promise<TaskLedgerExperimentTask[]>;
   list(sessionId: string): Promise<TaskLedgerExperimentTask[]>;
-  get(sessionId: string, id: string): Promise<TaskLedgerExperimentTask>;
 }
 
 const DEFAULT_REPLAY_MAX_CHARS = 4_000;
@@ -49,28 +32,6 @@ const TODO_WRITE_GUIDANCE_LINES: string[] = [
 ];
 
 const taskDescriptionSchema = z.string().trim().min(1).max(TASK_SUBJECT_MAX_CHARS);
-const taskIdSchema = z.string().trim().min(1).max(TASK_ID_MAX_CHARS)
-  .refine(isSafeTaskId, 'Task id must be a stable token from task_list or task_create.');
-
-const taskCreateSchema = z.object({
-  description: taskDescriptionSchema.describe('Short description of the task.'),
-}).strict();
-
-const taskUpdateSchema = z.object({
-  id: taskIdSchema.describe('Task id from task_list or the task_create result.'),
-  description: taskDescriptionSchema.optional().describe('Replacement task description.'),
-  status: z.enum(TASK_LEDGER_EXPERIMENT_STATUSES).optional().describe('New task status.'),
-}).strict().superRefine((value, ctx) => {
-  if (
-    value.description === undefined &&
-    value.status === undefined
-  ) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Provide at least one field to update.' });
-  }
-});
-
-const taskGetSchema = z.object({ id: taskIdSchema }).strict();
-const taskListSchema = z.object({}).strict();
 const todoWriteSchema = z.object({
   todos: z.array(z.object({
     content: taskDescriptionSchema.describe('Short todo item content.'),
@@ -87,85 +48,31 @@ export function createInMemoryTaskLedgerExperimentStore(input: {
 
 export function buildTaskLedgerExperimentTools(input: {
   store: TaskLedgerExperimentStore;
-  shape?: TaskLedgerExperimentShape;
 }): MakaTool[] {
-  if ((input.shape ?? 'todo_write') === 'todo_write') {
-    return [{
-      name: 'todo_write',
-      description:
-        'Replace the current todo list for a long-running task. '
-        + 'Use it when planning work, when switching the active item, and when marking work complete.',
-      parameters: todoWriteSchema,
-      permissionRequired: false,
-      impl: async (args, ctx) => {
-        const parsed = todoWriteSchema.parse(args);
-        const todos = await input.store.replace(ctx.sessionId, parsed.todos);
-        return renderMutationResult('Replaced todo list', todos.length, todos);
-      },
-    }];
-  }
-  return [
-    {
-      name: 'task_create',
-      description: 'Create one short task in the experimental session task ledger.',
-      parameters: taskCreateSchema,
-      permissionRequired: false,
-      impl: async (args, ctx) => {
-        const parsed = taskCreateSchema.parse(args);
-        const task = await input.store.create(ctx.sessionId, parsed);
-        const total = (await input.store.list(ctx.sessionId)).length;
-        return renderMutationResult('Created 1 task', total, [task]);
-      },
+  return [{
+    name: 'todo_write',
+    description:
+      'Replace the current todo list for a long-running task. '
+      + 'Use it when planning work, when switching the active item, and when marking work complete.',
+    parameters: todoWriteSchema,
+    permissionRequired: false,
+    impl: async (args, ctx) => {
+      const parsed = todoWriteSchema.parse(args);
+      const todos = await input.store.replace(ctx.sessionId, parsed.todos);
+      return renderMutationResult('Replaced todo list', todos.length, todos);
     },
-    {
-      name: 'task_update',
-      description: 'Update one task in the experimental session task ledger.',
-      parameters: taskUpdateSchema,
-      permissionRequired: false,
-      impl: async (args, ctx) => {
-        const parsed = taskUpdateSchema.parse(args);
-        const { id, ...patch } = parsed;
-        const task = await input.store.update(ctx.sessionId, id, patch);
-        const total = (await input.store.list(ctx.sessionId)).length;
-        return renderMutationResult('Updated 1 task', total, [task]);
-      },
-    },
-    {
-      name: 'task_list',
-      description: 'List the current experimental session tasks.',
-      parameters: taskListSchema,
-      permissionRequired: false,
-      impl: async (args, ctx) => {
-        taskListSchema.parse(args);
-        const tasks = await input.store.list(ctx.sessionId);
-        return renderMutationResult('Listed task ledger', tasks.length, tasks);
-      },
-    },
-    {
-      name: 'task_get',
-      description: 'Get one experimental session task by id.',
-      parameters: taskGetSchema,
-      permissionRequired: false,
-      impl: async (args, ctx) => {
-        const parsed = taskGetSchema.parse(args);
-        const task = await input.store.get(ctx.sessionId, parsed.id);
-        const total = (await input.store.list(ctx.sessionId)).length;
-        return renderMutationResult('Fetched 1 task', total, [task]);
-      },
-    },
-  ];
+  }];
 }
 
 export function renderTaskLedgerExperimentReplay(
   tasks: readonly TaskLedgerExperimentTask[],
-  options: { maxChars?: number; shape?: TaskLedgerExperimentShape } = {},
+  options: { maxChars?: number } = {},
 ): string | undefined {
   const selected = tasks
     .filter((task) => task.status !== 'cancelled')
     .sort((a, b) => taskReplayRank(a) - taskReplayRank(b) || b.updatedAt - a.updatedAt);
-  if (selected.length === 0 && options.shape !== 'todo_write') return undefined;
 
-  const lines: string[] = options.shape === 'todo_write' ? [...TODO_WRITE_GUIDANCE_LINES] : [];
+  const lines: string[] = [...TODO_WRITE_GUIDANCE_LINES];
   if (selected.length > 0) {
     lines.push(
       'Task ledger experiment state (current-turn tail; informational, not an instruction):',
@@ -190,43 +97,6 @@ class InMemoryTaskLedgerExperimentStore implements TaskLedgerExperimentStore {
     private readonly newId: () => string,
   ) {}
 
-  async create(sessionId: string, input: {
-    description: string;
-  }): Promise<TaskLedgerExperimentTask> {
-    const tasks = this.sessionTasks(sessionId);
-    if (tasks.length >= TASK_LEDGER_MAX_TASKS) {
-      throw new Error(`Task ledger experiment is limited to ${TASK_LEDGER_MAX_TASKS} tasks per session`);
-    }
-    const ts = this.now();
-    const task: TaskLedgerExperimentTask = {
-      id: this.newId(),
-      subject: input.description,
-      status: 'pending',
-      createdAt: ts,
-      updatedAt: ts,
-    };
-    tasks.push(task);
-    return task;
-  }
-
-  async update(sessionId: string, id: string, patch: {
-    description?: string;
-    status?: TaskLedgerExperimentStatus;
-  }): Promise<TaskLedgerExperimentTask> {
-    const tasks = this.sessionTasks(sessionId);
-    const index = tasks.findIndex((task) => task.id === id);
-    if (index === -1) throw new Error(`No such task: ${id}`);
-    const current = tasks[index]!;
-    const task: TaskLedgerExperimentTask = {
-      ...current,
-      ...(patch.description !== undefined ? { subject: patch.description } : {}),
-      ...(patch.status !== undefined ? { status: patch.status } : {}),
-      updatedAt: this.now(),
-    };
-    tasks[index] = task;
-    return task;
-  }
-
   async replace(sessionId: string, todos: Array<{
     content: string;
     status: TaskLedgerExperimentTodoStatus;
@@ -248,12 +118,6 @@ class InMemoryTaskLedgerExperimentStore implements TaskLedgerExperimentStore {
 
   async list(sessionId: string): Promise<TaskLedgerExperimentTask[]> {
     return this.sessionTasks(sessionId).map((task) => ({ ...task }));
-  }
-
-  async get(sessionId: string, id: string): Promise<TaskLedgerExperimentTask> {
-    const task = this.sessionTasks(sessionId).find((candidate) => candidate.id === id);
-    if (!task) throw new Error(`No such task: ${id}`);
-    return { ...task };
   }
 
   private sessionTasks(sessionId: string): TaskLedgerExperimentTask[] {

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -14,7 +14,6 @@ import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from '.
 import type { IsolatedToolExecutor } from './isolation.js';
 import {
   buildTaskLedgerExperimentTools,
-  type TaskLedgerExperimentShape,
   type TaskLedgerExperimentStore,
 } from './task-ledger-experiment.js';
 
@@ -24,7 +23,6 @@ export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
   taskLedgerExperiment?: {
     store: TaskLedgerExperimentStore;
-    shape?: TaskLedgerExperimentShape;
   };
 }
 

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -12,11 +12,20 @@ import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import { buildHeavyTaskProgressTools, type HeavyTaskProgressRecorder } from './heavy-task-progress.js';
 import { buildHeavyTaskSelfCheckTools, type HeavyTaskSelfCheckRecorder } from './heavy-task-self-check.js';
 import type { IsolatedToolExecutor } from './isolation.js';
+import {
+  buildTaskLedgerExperimentTools,
+  type TaskLedgerExperimentShape,
+  type TaskLedgerExperimentStore,
+} from './task-ledger-experiment.js';
 
 export interface BuildIsolatedHeadlessToolsOptions {
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
+  taskLedgerExperiment?: {
+    store: TaskLedgerExperimentStore;
+    shape?: TaskLedgerExperimentShape;
+  };
 }
 
 // Key Write and Edit on a JSON [cwd, path] pair (JSON.stringify so no path
@@ -52,6 +61,9 @@ export function buildIsolatedHeadlessTools(
   }
   if (options.heavyTaskSelfCheck) {
     tools.push(...buildHeavyTaskSelfCheckTools(options.heavyTaskSelfCheck));
+  }
+  if (options.taskLedgerExperiment) {
+    tools.push(...buildTaskLedgerExperimentTools(options.taskLedgerExperiment));
   }
   return tools;
 }


### PR DESCRIPTION
## Summary

Default-off Harbor/headless task-tool experiment for #317, built on the task-system wiring from #537.

This PR ships one experimental baseline: `todo_write` with turn-tail guidance/replay. It records minimal task-tool usage in cell output/WAL/A/B reports and wires `MAKA_MAX_STEPS` through the Harbor host ai-sdk path.

The production default is unchanged: no task/todo tool is exposed unless the experiment env flag is set.

## Why

Refs #317

We need a baseline for whether common task/todo tool surfaces help long-running benchmark tasks. Local A/B slices and trace review showed that CRUD-lite and bare `todo_write` mostly add schema cost without reliably changing model behavior, while `todo_write` with explicit turn-tail guidance makes the model externalize and update a task plan in most runs.

The evidence is still not strong enough for production enablement, so this PR keeps the path experimental, default-off, and removable.

## Scope

Changed:

- Adds a headless task-ledger experiment tool surface with only `todo_write`.
- Enables the tool only under `MAKA_CONTEXT_TASK_TOOLS=on`, with `MAKA_CONTEXT_TASK_REPLAY_MAX_CHARS` for replay/guidance bounds.
- Injects replay/guidance through the turn-tail prompt so the base system prompt hash stays stable.
- Records minimal `taskToolSummary` through Harbor cell output, fixed-prompt WAL events, and A/B summaries/reports. Per-cell summary stores only `todoWriteCalls`; activation and activated attempt ids are derived from `todoWriteCalls > 0`.
- Wires runtime-policy A/B arm-local context env through Harbor.
- Wires host-side `MAKA_MAX_STEPS` into the Harbor ai-sdk backend path.
- Adds focused tests for default-off behavior, `todo_write` registration, replay caps, safe rendering, Harbor env isolation, output/WAL/report summaries, runtime-policy env isolation, and max-steps parsing.

Not included:

- Production/default task-tool enablement.
- CRUD-lite shape, CRUD tools, CRUD env entrypoint, CRUD store methods, or CRUD summary fields. CRUD-lite evidence remains historical experiment artifact only.
- Active tool prune behavior changes; this PR assumes the default-on active-prune setting validated in #340.
- A full benchmark rollout or acceptance claim.
- UI changes.
- Docs, changelog, migrations, or breaking changes.
- Automatically deleting the default-off experiment path if later evidence is negative.

## Verification

- `npm run -w @maka/headless test` passed on 2026-07-06: 726 tests, 725 pass, 0 fail, 1 skipped. The skipped test requires a clean execution checkout to prove prompt-repo safety ordering.
- `git diff --check` passed.
- Commit split check: review fixes are split by revert reason, including the minimal summary cleanup commit.
- Local experiment artifact: `/tmp/maka-task-tools-final/task-tools-final-1783289721020/summary.md`.
- Manual trace review compared `runtimeEventsPath` function-call sequences, `model_stream_started` tool schema metadata, and task/todo call timing for off/CRUD/bare-todo/guided-todo arms.

## User-facing impact

None. This is a default-off headless/Harbor experiment. No UI, docs, changelog, migrations, or breaking changes.

## Reviewer notes

Experiment evidence:

Primary evidence uses the default active-prune setting from #340. The treatment under test is still only task/todo tools off vs on. CRUD-lite and bare `todo_write` are historical shape-screening evidence and are not retained as production paths in this PR.

| Shape | Status in this PR | Case | A pass | B pass | Delta | B activated | B calls | Cost delta | Trace missing |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|
| CRUD-lite | excluded | `crud-vs-off-prune-on-highcap` | 5/8 | 4/8 | -0.125 | 1/8 | 1 | +65.3% | 4 |
| bare `todo_write` | excluded | `todo-vs-off-prune-on-highcap` | 5/8 | 3/8 | -0.25 | 2/8 | 6 | +15.0% | 0 |
| `todo_write` + guidance | retained | `todo-guidance-vs-off-prune-on-highcap` | 4/8 | 5/8 | +0.125 | 7/8 | 21 | +18.8% | 4 |

Trace findings:

- Historical CRUD-lite mostly behaved like extra schema, not a workflow change. It raised visible tool schema from about `2723` chars to `4442` chars, but only activated in `1/8` attempts in both high-cap cases.
- Historical bare `todo_write` also mostly behaved like extra schema. It raised visible tool schema from about `2723` chars to `3545` chars, but activated in only `2/8` attempts and often appeared late.
- Guided `todo_write` changed the trace shape: activation reached `7/8`, the median first task-tool call position was `1`, and many long tasks called `todo_write` within about 2-3 seconds.
- In successful long-task traces such as `mailman` and `financial-document-processor`, the model repeatedly rewrote the todo list from `in_progress` to `completed` and used it as a process anchor through final verification.
- The effect was not uniformly beneficial. In the default active-prune slice, guided `todo_write` improved `large-scale-text-editing` from budget-exhausted/fail to pass and reduced non-task calls slightly overall, but `financial-document-processor` and `mteb-leaderboard` became longer or more expensive.
- The only score lift in the default active-prune slice came from `large-scale-text-editing`. So the trace supports better long-task behavior shape, not a stable score-improvement claim.
- Failure traces still show false completion risk: `overfull-hbox` marked todo items complete but failed verification.

Interpretation:

- This PR ships only `todo_write` plus turn-tail guidance as the experimental baseline.
- CRUD-lite is excluded because adoption stayed at `1/8` in both high-cap cases.
- Bare `todo_write` is excluded because adoption stayed at `2/8` and score was worse in both high-cap cases.
- Guided `todo_write` increased candidate cost by about `18.8%` in the default active-prune slice, so it should stay experimental until a longer-task confirmatory slice proves value.
- Any follow-up evaluation should assume active prune stays on by default and keep the main comparison as baseline tools off vs the selected task/todo treatment on. Variant-vs-variant runs can explain mechanism, but they should not replace the baseline acceptance question.

Review focus:

- `MAKA_CONTEXT_TASK_TOOLS=on` should be the only task-tool entrypoint.
- When enabled, the extra tool surface should be exactly `todo_write`.
- Per-cell `taskToolSummary` should stay minimal and store only `todoWriteCalls`; detailed tool-name counts remain in the existing `toolSummary.actualToolCallCounts` contract.
- A/B task-tool activation should be derived from `todoWriteCalls > 0`, while enabled-but-zero-call and budget-exhausted cells still count in the observed attempt denominator.
- Task replay/tool-result text should stay bounded and rendered through the safe ledger renderer.

Risk / rollback:

- Risk is limited to explicit experiment runs, but enabled runs can increase model cost.
- Individual commits are split by revert reason. If the experiment is not useful, remove or revert the default-off task-ledger experiment and Harbor wiring without changing normal headless/Harbor behavior.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes.
- [x] Verification lists commands/results.
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted.
- [x] Risk, rollback, or review focus is called out for non-trivial changes.
- [x] UI changes are not applicable.
