### PR TITLE
feat(ui): prompt anchor rail — jump between prompts in a conversation

### DIFF
--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -30,6 +30,7 @@
 @import "./styles/tool-stream.css";
 @import "./styles/daily-review.css";
 @import "./styles/theme-glass.css";
+@import "./styles/prompt-rail.css";
 
 @theme inline {
   --font-sans: "Geist Variable", "Geist", ui-sans-serif, system-ui, sans-serif;

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -1,0 +1,105 @@
+/* Codex-style prompt navigation rail: one tick per user prompt, pinned to the
+   right edge of the chat scroll shell. Low-key by default, brightens on hover;
+   each tick jumps to that prompt and the active turn's tick stays highlighted.
+   The tick bar draws in `currentColor` so active/hover just shift the neutral
+   text color (muted -> primary) — no brand rail, no hover-surface background. */
+.maka-prompt-rail {
+  position: absolute;
+  top: var(--space-8);
+  bottom: var(--space-8);
+  right: var(--space-1);
+  z-index: var(--z-panel-action);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  opacity: var(--opacity-muted);
+  transition: opacity var(--duration-base) var(--ease-out-strong);
+  -webkit-app-region: no-drag;
+}
+
+.maka-prompt-rail:hover {
+  opacity: 1;
+}
+
+.maka-prompt-rail-tick {
+  appearance: none;
+  border: 0;
+  margin: 0;
+  padding: var(--space-0-5) 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  position: relative;
+  transition: color var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-prompt-rail-tick:hover,
+.maka-prompt-rail-tick[data-active="true"] {
+  color: var(--foreground);
+}
+
+.maka-prompt-rail-tick::after {
+  content: "";
+  width: 14px;
+  height: 3px;
+  border-radius: var(--radius-pill);
+  background: currentColor;
+  transition: width var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-prompt-rail-tick:hover::after {
+  width: 20px;
+}
+
+.maka-prompt-rail-tick[data-active="true"]::after {
+  width: 22px;
+}
+
+.maka-prompt-rail-preview {
+  position: absolute;
+  right: calc(100% + var(--space-2));
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+  width: max-content;
+  max-width: 280px;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-control);
+  border: var(--border-width-hairline) solid var(--border);
+  background: var(--card-bg);
+  box-shadow: var(--card-shadow);
+  font-size: var(--font-size-caption);
+  text-align: left;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-prompt-rail-preview-prompt {
+  min-width: 0;
+  color: var(--foreground);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.maka-prompt-rail-preview-reply {
+  color: var(--muted-foreground);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.maka-prompt-rail-tick:hover .maka-prompt-rail-preview,
+.maka-prompt-rail-tick:focus-visible .maka-prompt-rail-preview {
+  opacity: 1;
+}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -20,6 +20,7 @@ import { formatAbsoluteTimestamp, formatTurnDuration, turnAbortMarkerLabel } fro
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
+import { PromptAnchorRail } from './prompt-anchor-rail.js';
 import type { PlanReminder, ProviderType, SessionSummary, StoredMessage } from '@maka/core';
 import { deriveCapabilityAuditReport, isDeepResearchSession } from '@maka/core';
 import { materializeChat, materializeTools, materializeTurns, type ToolActivityItem, type TurnViewModel } from './materialize.js';
@@ -297,6 +298,20 @@ export function ChatView(props: {
   const storedTools = useMemo(() => materializeTools(visibleMessages), [visibleMessages]);
   const tools = useMemo(() => mergeTools(storedTools, props.tools), [storedTools, props.tools]);
   const turns = useMemo(() => materializeTurns(visibleMessages, props.tools), [visibleMessages, props.tools]);
+  // One rail tick per turn that carries a user prompt (Codex-style prompt
+  // navigation). Memoized so the rail's IntersectionObserver isn't rebuilt
+  // on every render.
+  const promptRailTurns = useMemo(
+    () =>
+      turns
+        .filter((turn) => (turn.user?.text ?? '').trim().length > 0)
+        .map((turn) => ({
+          turnId: turn.turnId,
+          label: turn.user?.text ?? '',
+          reply: turn.assistant?.text ?? '',
+        })),
+    [turns],
+  );
   // Stable event wrappers (advanced-use-latest): parent handlers are
   // recreated per render upstream; routing through refs keeps the
   // memoized TurnView's function props identity-stable without
@@ -661,6 +676,7 @@ export function ChatView(props: {
               folds these into the `__loose` turn, so this is normally a
               no-op. */}
         </OverlayScrollArea>
+        <PromptAnchorRail turns={promptRailTurns} scrollRef={scrollRef} />
         {!pinnedToBottom && (
           <UiButton
             type="button"

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState, type RefObject } from 'react';
+
+export interface PromptAnchorRailTurn {
+  turnId: string;
+  /** The user prompt text for this turn; used as the hover preview + a11y label. */
+  label: string;
+  /** The start of the assistant reply, shown under the prompt in the preview. */
+  reply?: string;
+}
+
+export interface PromptAnchorRailProps {
+  turns: PromptAnchorRailTurn[];
+  /** The scroll container that holds the `[data-turn-id]` turn sections. */
+  scrollRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * A slim right-edge rail with one tick per user prompt — jump between your
+ * questions in a long conversation (Codex / ChatGPT style). Reuses the
+ * `[data-turn-id]` anchors the chat view already renders, so a click just
+ * scrolls the target turn into view; an IntersectionObserver highlights the
+ * tick whose turn is currently at the top of the viewport.
+ */
+export function PromptAnchorRail({ turns, scrollRef }: PromptAnchorRailProps): React.ReactElement | null {
+  const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const root = scrollRef.current;
+    if (!root || turns.length === 0) return;
+
+    const idByElement = new Map<Element, string>();
+    for (const turn of turns) {
+      const el = root.querySelector(`[data-turn-id="${CSS.escape(turn.turnId)}"]`);
+      if (el) idByElement.set(el, turn.turnId);
+    }
+    if (idByElement.size === 0) return;
+
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = idByElement.get(entry.target);
+          if (!id) continue;
+          if (entry.isIntersecting) visible.add(id);
+          else visible.delete(id);
+        }
+        // The topmost prompt still in view is the "current" one.
+        const firstVisible = turns.find((turn) => visible.has(turn.turnId));
+        if (firstVisible) setActiveTurnId(firstVisible.turnId);
+      },
+      // Only count a turn as active once it reaches the top third of the
+      // viewport, so the highlight tracks reading position, not mere presence.
+      { root, rootMargin: '0px 0px -66% 0px', threshold: 0 },
+    );
+    for (const el of idByElement.keys()) observer.observe(el);
+    return () => observer.disconnect();
+  }, [scrollRef, turns]);
+
+  function jumpTo(turnId: string): void {
+    const el = scrollRef.current?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    if (el && 'scrollIntoView' in el) {
+      (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    setActiveTurnId(turnId);
+  }
+
+  // A rail is only useful once there are a few prompts to jump between.
+  if (turns.length < 3) return null;
+
+  return (
+    <nav className="maka-prompt-rail" aria-label="按提问跳转">
+      {turns.map((turn) => {
+        const isActive = turn.turnId === activeTurnId;
+        const preview = turn.label.trim() || '（空提问）';
+        const replyPreview = (turn.reply ?? '').replace(/\s+/g, ' ').trim().slice(0, 140);
+        return (
+          <button
+            key={turn.turnId}
+            type="button"
+            className="maka-prompt-rail-tick"
+            data-active={isActive ? 'true' : undefined}
+            aria-current={isActive ? 'true' : undefined}
+            aria-label={`跳到提问：${preview}`}
+            onClick={() => jumpTo(turn.turnId)}
+          >
+            <span className="maka-prompt-rail-preview" aria-hidden="true">
+              <span className="maka-prompt-rail-preview-prompt">{preview}</span>
+              {replyPreview ? (
+                <span className="maka-prompt-rail-preview-reply">{replyPreview}</span>
+              ) : null}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## What

A slim **prompt navigation rail** on the right edge of the chat view — one tick per user prompt, so you can jump between your questions in a long conversation (Codex / ChatGPT style).

- Click a tick → scrolls that prompt into view.
- The tick for the turn currently at the top of the viewport stays highlighted (via `IntersectionObserver`).
- Hovering a tick previews the **prompt** plus the **start of its reply**.
- Low-key by default (dim), brightens on hover. Hidden until there are 3+ prompts.

## How

Reuses infrastructure the chat view already has, so the surface area is small:

- Turns already render with `[data-turn-id]`, and there's already a scroll-into-view path — a tick click just calls `scrollIntoView` on the anchor.
- New `PromptAnchorRail` (`packages/ui/src/prompt-anchor-rail.tsx`) owns the ticks + an `IntersectionObserver` for the active turn.
- `chat-view.tsx` renders it inside `.maka-chat-shell` with a memoized `{turnId, label, reply}` list derived from the existing `turns`.

## Design / governance notes

- The tick bar draws in `currentColor`; active/hover only shift the **neutral** text color (`--muted-foreground` → `--foreground`) — no brand rail, no hover-surface background (keeps it within the `#499` state-token + `#406` accent-ban governance).
- CSS is on the `--space-*` / `--opacity-*` / `--z-*` / semantic-color tokens per the spacing / foreground-tier / opacity / z-index / focus-ring / cursor contracts.
- Ticks are keyboard-focusable `<button>`s with `aria-label` (jump to prompt: …) and `aria-current` on the active one.

## Testing

`npm run build`, desktop `typecheck`, the full desktop test suite (incl. the CSS-governance + a11y contracts above), and `check-dead-css` all pass. Verified live in the running app: rail renders one tick per prompt, active tracking follows scroll, click jumps, and the hover preview shows prompt + reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
