### PR TITLE
feat(runtime): introduce workspace executor

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,6 +11,7 @@
     "./permission-engine": "./dist/permission-engine.js",
     "./ai-sdk-backend": "./dist/ai-sdk-backend.js",
     "./builtin-tools": "./dist/builtin-tools.js",
+    "./workspace-executor": "./dist/workspace-executor.js",
     "./tool-artifacts": "./dist/tool-artifacts.js",
     "./tool-output-delta": "./dist/tool-output-delta.js",
     "./stream-watchdog": "./dist/stream-watchdog.js",

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -1,9 +1,10 @@
 import { describe, test } from 'node:test';
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect } from '../test-helpers.js';
 import { buildBuiltinTools } from '../builtin-tools.js';
+import type { WorkspaceExecutor } from '../workspace-executor.js';
 
 describe('builtin Bash streaming output', () => {
   test('emits stdout/stderr chunks before returning terminal result', async () => {
@@ -14,7 +15,7 @@ describe('builtin Bash streaming output', () => {
 
     const result = await bash.impl(
       {
-        command: 'printf "out"; printf "err" >&2',
+        command: 'node -e "process.stdout.write(\'out\'); process.stderr.write(\'err\')"',
         timeout_ms: 5_000,
       },
       {
@@ -32,7 +33,7 @@ describe('builtin Bash streaming output', () => {
     expect(result).toMatchObject({
       kind: 'terminal',
       cwd,
-      cmd: 'printf "out"; printf "err" >&2',
+      cmd: 'node -e "process.stdout.write(\'out\'); process.stderr.write(\'err\')"',
       exitCode: 0,
       stdout: 'out',
       stderr: 'err',
@@ -48,7 +49,7 @@ describe('builtin Bash streaming output', () => {
 
     const run = bash.impl(
       {
-        command: 'printf "started"; sleep 5',
+        command: 'node -e "process.stdout.write(\'started\'); setTimeout(() => {}, 5000)"',
         timeout_ms: 10_000,
       },
       {
@@ -73,7 +74,7 @@ describe('builtin Bash streaming output', () => {
     if (!bash) throw new Error('Bash tool missing');
 
     const result = await bash.impl(
-      { command: "awk 'BEGIN{for(i=1;i<=5000;i++)print \"line\"i}'", timeout_ms: 10_000 },
+      { command: 'node -e "for (let i = 1; i <= 5000; i++) console.log(\'line\' + i)"', timeout_ms: 10_000 },
       {
         sessionId: 'session-1',
         turnId: 'turn-1',
@@ -98,7 +99,10 @@ describe('builtin Bash streaming output', () => {
     let err: { code?: number; stdout?: string; stderr?: string } | null = null;
     try {
       await bash.impl(
-        { command: 'printf "out-data"; printf "err-data" >&2; exit 3', timeout_ms: 5_000 },
+        {
+          command: 'node -e "process.stdout.write(\'out-data\'); process.stderr.write(\'err-data\'); process.exit(3)"',
+          timeout_ms: 5_000,
+        },
         {
           sessionId: 'session-1',
           turnId: 'turn-1',
@@ -125,7 +129,10 @@ describe('builtin Bash streaming output', () => {
     let err: { code?: number; stdout?: string; stderr?: string } | null = null;
     try {
       await bash.impl(
-        { command: 'printf "out-before"; printf "err-before" >&2; sleep 5', timeout_ms: 200 },
+        {
+          command: 'node -e "process.stdout.write(\'out-before\'); process.stderr.write(\'err-before\'); setTimeout(() => {}, 5000)"',
+          timeout_ms: 200,
+        },
         {
           sessionId: 'session-1',
           turnId: 'turn-1',
@@ -147,18 +154,71 @@ describe('builtin Bash streaming output', () => {
   });
 });
 
+describe('builtin tools workspace executor routing', () => {
+  test('Bash and file tools can be redirected to a sandbox cwd without mutating the real cwd', async () => {
+    const realCwd = await mkdtemp(join(tmpdir(), 'maka-real-workspace-'));
+    const sandboxCwd = await mkdtemp(join(tmpdir(), 'maka-sandbox-workspace-'));
+    await mkdir(join(realCwd, 'src'), { recursive: true });
+    await mkdir(join(sandboxCwd, 'src'), { recursive: true });
+    await writeFile(join(realCwd, 'src', 'data.txt'), 'real token\n', 'utf8');
+    await writeFile(join(sandboxCwd, 'src', 'data.txt'), 'sandbox token\n', 'utf8');
+
+    const executor = makeSandboxExecutor(realCwd, sandboxCwd);
+    const tools = buildBuiltinTools({ executor });
+    const bash = requireTool(tools, 'Bash');
+    const read = requireTool(tools, 'Read');
+    const write = requireTool(tools, 'Write');
+    const edit = requireTool(tools, 'Edit');
+    const glob = requireTool(tools, 'Glob');
+    const grep = requireTool(tools, 'Grep');
+
+    const events: Array<{ stream: 'stdout' | 'stderr'; chunk: string }> = [];
+    const bashResult = await runTool(bash, { command: 'touch generated-by-bash.txt', timeout_ms: 5_000 }, realCwd, {
+      emitOutput: (stream, chunk) => events.push({ stream, chunk }),
+    });
+    await runTool(write, { path: 'src/new.txt', content: 'created in sandbox\n' }, realCwd);
+    await runTool(edit, {
+      path: 'src/data.txt',
+      old_string: 'sandbox token',
+      new_string: 'edited sandbox token',
+    }, realCwd);
+
+    const readResult = await runTool(read, { path: 'src/data.txt' }, realCwd);
+    const globResult = await runTool(glob, { pattern: '*.txt', cwd: 'src' }, realCwd);
+    const grepResult = await runTool(grep, { pattern: 'edited sandbox token', path: 'src' }, realCwd);
+
+    expect(bashResult).toMatchObject({
+      kind: 'terminal',
+      cwd: realCwd,
+      cmd: 'touch generated-by-bash.txt',
+      exitCode: 0,
+      stdout: 'sandbox stdout',
+    });
+    expect(events.some((event) => event.stream === 'stdout' && event.chunk.includes('sandbox stdout'))).toBe(true);
+    expect(readResult).toMatchObject({ content: 'edited sandbox token\n' });
+    expect(globResult).toMatchObject({ files: ['data.txt', 'new.txt'] });
+    expect(grepResult).toMatchObject({ matches: ['src/data.txt:1:edited sandbox token'] });
+    expect(await readOptional(join(realCwd, 'src', 'data.txt'))).toBe('real token\n');
+    expect(await readOptional(join(realCwd, 'src', 'new.txt'))).toBeNull();
+    expect(await readOptional(join(realCwd, 'generated-by-bash.txt'))).toBeNull();
+    expect(await readFile(join(sandboxCwd, 'src', 'data.txt'), 'utf8')).toBe('edited sandbox token\n');
+    expect(await readFile(join(sandboxCwd, 'src', 'new.txt'), 'utf8')).toBe('created in sandbox\n');
+    expect(await readFile(join(sandboxCwd, 'generated-by-bash.txt'), 'utf8')).toBe('touch generated-by-bash.txt\n');
+  });
+});
+
 describe('builtin read tools path containment', () => {
   test('Read rejects absolute, parent traversal, and symlink escape paths', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-read-root-'));
     const outside = await mkdtemp(join(tmpdir(), 'maka-read-outside-'));
     await writeFile(join(root, 'inside.txt'), 'inside', 'utf8');
     await writeFile(join(outside, 'secret.txt'), 'secret', 'utf8');
-    await symlink(join(outside, 'secret.txt'), join(root, 'secret-link.txt'));
+    await linkDirectory(outside, join(root, 'outside-link'));
     const read = tool('Read');
 
     await expectRejects(runTool(read, { path: '/etc/hosts' }, root), /Read path must be relative/);
     await expectRejects(runTool(read, { path: '../outside.txt' }, root), /Read path must stay inside/);
-    await expectRejects(runTool(read, { path: 'secret-link.txt' }, root), /Read path must stay inside/);
+    await expectRejects(runTool(read, { path: 'outside-link/secret.txt' }, root), /Read path must stay inside/);
 
     const result = await runTool(read, { path: 'inside.txt' }, root);
     expect(result).toMatchObject({ content: 'inside' });
@@ -169,7 +229,7 @@ describe('builtin read tools path containment', () => {
     const outside = await mkdtemp(join(tmpdir(), 'maka-read-outside-'));
     await mkdir(join(root, 'src'), { recursive: true });
     await writeFile(join(root, 'src', 'main.ts'), 'export const token = 1;\n', 'utf8');
-    await symlink(outside, join(root, 'outside-link'));
+    await linkDirectory(outside, join(root, 'outside-link'));
     const glob = tool('Glob');
     const grep = tool('Grep');
 
@@ -189,7 +249,7 @@ describe('builtin write tools path containment', () => {
   test('Write rejects absolute, parent traversal, and symlink-parent escape paths', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-write-root-'));
     const outside = await mkdtemp(join(tmpdir(), 'maka-write-outside-'));
-    await symlink(outside, join(root, 'outside-link'));
+    await linkDirectory(outside, join(root, 'outside-link'));
     const write = tool('Write');
 
     await expectRejects(runTool(write, { path: '/tmp/outside.txt', content: 'x' }, root), /Write path must be relative/);
@@ -206,12 +266,12 @@ describe('builtin write tools path containment', () => {
     const outside = await mkdtemp(join(tmpdir(), 'maka-edit-outside-'));
     await writeFile(join(root, 'inside.txt'), 'hello world', 'utf8');
     await writeFile(join(outside, 'secret.txt'), 'secret', 'utf8');
-    await symlink(join(outside, 'secret.txt'), join(root, 'secret-link.txt'));
+    await linkDirectory(outside, join(root, 'outside-link'));
     const edit = tool('Edit');
 
     await expectRejects(runTool(edit, { path: '/tmp/outside.txt', old_string: 'x', new_string: 'y' }, root), /Edit path must be relative/);
     await expectRejects(runTool(edit, { path: '../outside.txt', old_string: 'x', new_string: 'y' }, root), /Edit path must stay inside/);
-    await expectRejects(runTool(edit, { path: 'secret-link.txt', old_string: 'secret', new_string: 'edited' }, root), /Edit path must stay inside/);
+    await expectRejects(runTool(edit, { path: 'outside-link/secret.txt', old_string: 'secret', new_string: 'edited' }, root), /Edit path must stay inside/);
 
     await runTool(edit, { path: 'inside.txt', old_string: 'world', new_string: 'Maka' }, root);
     expect(await readFile(join(root, 'inside.txt'), 'utf8')).toBe('hello Maka');
@@ -301,13 +361,107 @@ function tool(name: string) {
   return found;
 }
 
-function runTool(tool: ReturnType<typeof buildBuiltinTools>[number], args: unknown, cwd: string): Promise<unknown> {
+function requireTool(tools: ReturnType<typeof buildBuiltinTools>, name: string) {
+  const found = tools.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`${name} tool missing`);
+  return found;
+}
+
+function runTool(
+  tool: ReturnType<typeof buildBuiltinTools>[number],
+  args: unknown,
+  cwd: string,
+  options: { emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void } = {},
+): Promise<unknown> {
   return Promise.resolve(tool.impl(args as never, {
     sessionId: 'session-1',
     turnId: 'turn-1',
     cwd,
     toolCallId: 'tool-1',
     abortSignal: new AbortController().signal,
-    emitOutput: () => {},
+    emitOutput: options.emitOutput ?? (() => {}),
   }));
+}
+
+function makeSandboxExecutor(realCwd: string, sandboxCwd: string): WorkspaceExecutor {
+  const mapCwd = (cwd: string) => {
+    expect(cwd).toBe(realCwd);
+    return sandboxCwd;
+  };
+  return {
+    facts: {
+      isolation: 'worktree',
+      writesAffectHost: false,
+      writeBack: 'diff_review',
+      network: 'host',
+      secrets: 'host_env',
+      gitMetadata: 'host_shared',
+    },
+    exec: async ({ command, cwd, emitOutput }: {
+      command: string;
+      cwd: string;
+      emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
+    }) => {
+      const sandbox = mapCwd(cwd);
+      await writeFile(join(sandbox, 'generated-by-bash.txt'), `${command}\n`, 'utf8');
+      emitOutput?.('stdout', 'sandbox stdout');
+      return { exitCode: 0, stdout: 'sandbox stdout', stderr: '', timedOut: false, aborted: false };
+    },
+    readFile: async ({ cwd, path, offset, limit }: {
+      cwd: string;
+      path: string;
+      offset?: number;
+      limit?: number;
+    }) => {
+      const content = await readFile(join(mapCwd(cwd), path), 'utf8');
+      if (offset === undefined && limit === undefined) return { content };
+      const lines = content.split('\n');
+      const start = offset ?? 0;
+      const end = limit ? start + limit : lines.length;
+      return { content: lines.slice(start, end).join('\n') };
+    },
+    writeFile: async ({ cwd, path, content }: { cwd: string; path: string; content: string }) => {
+      const abs = join(mapCwd(cwd), path);
+      await mkdir(join(abs, '..'), { recursive: true });
+      await writeFile(abs, content, 'utf8');
+      return { ok: true, path: abs, bytes: Buffer.byteLength(content, 'utf8') };
+    },
+    globFiles: async ({ cwd, searchCwd }: { cwd: string; pattern: string; searchCwd?: string }) => {
+      const base = searchCwd ? join(mapCwd(cwd), searchCwd) : mapCwd(cwd);
+      const files = (await readdir(base)).filter((name) => name.endsWith('.txt')).sort();
+      return { files };
+    },
+    grepFiles: async ({ cwd, pattern, path }: { cwd: string; pattern: string; path?: string }) => {
+      const base = path ? join(mapCwd(cwd), path) : mapCwd(cwd);
+      const matches: string[] = [];
+      await collectTextMatches(base, path ?? '', pattern, matches);
+      return { matches };
+    },
+  };
+}
+
+async function collectTextMatches(abs: string, rel: string, pattern: string, matches: string[]): Promise<void> {
+  const current = await stat(abs);
+  if (current.isDirectory()) {
+    for (const name of await readdir(abs)) {
+      await collectTextMatches(join(abs, name), rel ? `${rel}/${name}` : name, pattern, matches);
+    }
+    return;
+  }
+  const lines = (await readFile(abs, 'utf8')).split('\n');
+  lines.forEach((line, index) => {
+    if (line.includes(pattern)) matches.push(`${rel}:${index + 1}:${line}`);
+  });
+}
+
+async function readOptional(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function linkDirectory(target: string, path: string): Promise<void> {
+  await symlink(target, path, process.platform === 'win32' ? 'junction' : 'dir');
 }

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -10,7 +10,7 @@ const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('runShellWithBoundedTail', () => {
   test('returns full small output and exit 0 without throwing', async () => {
-    const r = await runShellWithBoundedTail("printf 'hello\\nworld\\n'", base());
+    const r = await runShellWithBoundedTail("node -e \"process.stdout.write('hello\\nworld\\n')\"", base());
     assert.deepEqual(
       { exitCode: r.exitCode, stdout: r.stdout, stderr: r.stderr, timedOut: r.timedOut, aborted: r.aborted },
       { exitCode: 0, stdout: 'hello\nworld\n', stderr: '', timedOut: false, aborted: false },
@@ -19,7 +19,7 @@ describe('runShellWithBoundedTail', () => {
 
   test('keeps only the bounded, line-aligned TAIL of large output (never killed by size)', async () => {
     const r = await runShellWithBoundedTail(
-      "printf 'HEADMARK\\n'; seq 1 50; printf 'TAILMARK\\n'",
+      "node -e \"console.log('HEADMARK'); for (let i = 1; i <= 50; i++) console.log(i); console.log('TAILMARK')\"",
       base({ maxRetainedChars: 12 }),
     );
     assert.equal(r.exitCode, 0);
@@ -29,19 +29,19 @@ describe('runShellWithBoundedTail', () => {
   });
 
   test('captures stderr and a non-zero exit code as data (does not reject)', async () => {
-    const r = await runShellWithBoundedTail("printf 'oops\\n' >&2; exit 3", base());
+    const r = await runShellWithBoundedTail("node -e \"process.stderr.write('oops\\n'); process.exit(3)\"", base());
     assert.equal(r.exitCode, 3);
     assert.equal(r.stderr, 'oops\n');
     assert.equal(r.stdout, '');
   });
 
   test('times out a slow command, kills it, and reports timedOut', async () => {
-    const r = await runShellWithBoundedTail('sleep 5', base({ timeoutMs: 150 }));
+    const r = await runShellWithBoundedTail('node -e "setTimeout(() => {}, 5000)"', base({ timeoutMs: 150 }));
     assert.equal(r.timedOut, true);
     assert.equal(r.exitCode, 124);
   });
 
-  test('on timeout, escalates SIGTERM->SIGKILL and resolves only after the child is actually dead', async () => {
+  test('on timeout, escalates SIGTERM->SIGKILL and resolves only after the child is actually dead', { skip: process.platform === 'win32' }, async () => {
     // A child that traps/ignores SIGTERM would, under the old "kill then resolve
     // immediately" path, keep running (and emitting) after we told the caller
     // "timed out". Now we wait for the child to actually exit (SIGKILL after the
@@ -71,7 +71,7 @@ describe('runShellWithBoundedTail', () => {
     }
   });
 
-  test('on timeout, kills the whole process tree so a child holding the pipe cannot hang the runner', async () => {
+  test('on timeout, kills the whole process tree so a child holding the pipe cannot hang the runner', { skip: process.platform === 'win32' }, async () => {
     // The shell spawns a grandchild (node) that inherits stdout and never exits.
     // Killing only the shell PID would leave it holding the pipe, so 'close'
     // would never fire and this test would HANG. Killing the process group lets
@@ -97,7 +97,7 @@ describe('runShellWithBoundedTail', () => {
     // One 500-char line with no newline, cap 50: BashTailBuffer drops it whole
     // (no safe truncation boundary), so without a marker the result would look
     // like the command produced nothing.
-    const r = await runShellWithBoundedTail("head -c 500 /dev/zero | tr '\\0' x", base({ maxRetainedChars: 50 }));
+    const r = await runShellWithBoundedTail("node -e \"process.stdout.write('x'.repeat(500))\"", base({ maxRetainedChars: 50 }));
     assert.equal(r.exitCode, 0);
     assert.ok(!r.stdout.includes('xxxx'), 'dropped content is not leaked');
     assert.ok(r.stdout.includes('omitted for safety'), 'a recoverable safety marker is present');
@@ -109,7 +109,7 @@ describe('runShellWithBoundedTail', () => {
   test('emits every chunk live via emitOutput', async () => {
     const seen: Array<[string, string]> = [];
     await runShellWithBoundedTail(
-      "printf 'aaa'; printf 'bbb' >&2",
+      "node -e \"process.stdout.write('aaa'); process.stderr.write('bbb')\"",
       base({ emitOutput: (s: 'stdout' | 'stderr', c: string) => seen.push([s, c]) }),
     );
     assert.ok(seen.some(([s, c]) => s === 'stdout' && c.includes('aaa')));
@@ -119,7 +119,7 @@ describe('runShellWithBoundedTail', () => {
   test('caps live emitOutput per stream with a single suppressed marker (result keeps full tail)', async () => {
     const seen: Array<[string, string]> = [];
     const r = await runShellWithBoundedTail(
-      "printf 'HEAD\\n'; seq 1 2000; printf 'TAIL\\n'",
+      "node -e \"console.log('HEAD'); for (let i = 1; i <= 2000; i++) console.log(i); console.log('TAIL')\"",
       base({
         maxLiveEmitChars: 20, // tiny cap so the stream trips it almost immediately
         emitOutput: (s: 'stdout' | 'stderr', c: string) => seen.push([s, c]),

--- a/packages/runtime/src/__tests__/tool-artifacts.test.ts
+++ b/packages/runtime/src/__tests__/tool-artifacts.test.ts
@@ -52,7 +52,7 @@ describe('deriveToolArtifactCandidates', () => {
       result: { stdout: 'wrote /tmp/guessed.html', stderr: 'see report.pdf' },
     });
 
-    expect(candidate?.sourcePath).toBe('/workspace/maka/reports/build.log');
+    expect(portablePath(candidate?.sourcePath)).toBe('/workspace/maka/reports/build.log');
     expect(candidate?.kind).toBe('file');
 
     expect(deriveToolArtifactCandidates({
@@ -200,4 +200,8 @@ function nextId(): () => string {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function portablePath(path: string | undefined): string | undefined {
+  return path?.replace(/^[A-Z]:/i, '').replaceAll('\\', '/');
 }

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -130,7 +130,7 @@ describe('RunTrace extraction contract', () => {
     assert.match(backend, /trace\.turnStarted\(\)/);
     assert.match(backend, /trace\.modelResolved\(\)/);
     assert.match(backend, /trace\.modelStreamStarted\(activeTools, \{/);
-    assert.match(backend, /trace\.usageRecorded\(\{\n\s+\.\.\.tokenUsage,/);
+    assert.match(backend, /trace\.usageRecorded\(\{\r?\n\s+\.\.\.tokenUsage,/);
     assert.match(backend, /this\.currentRunTrace\?\.abortRequested\(_reason\)/);
     assert.match(barrel, /RunTraceEvent/);
     assert.match(barrel, /RunTraceRecorder/);

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -1,44 +1,29 @@
 // packages/runtime/src/builtin-tools.ts
-// Phase 1 baseline tool set. Each tool returned as MakaTool[] so
-// wrapToolExecute can decorate with permission round-trip + tool_call/tool_result write.
-//
-// Read / Glob / Grep auto-approve.
-// Bash / Write / Edit go through PermissionEngine.
+// Built-in tool set. Each tool is returned as MakaTool[] so wrapToolExecute can
+// decorate with permission round-trip + tool_call/tool_result write.
 
 import { z } from 'zod';
-import { promises as fs } from 'node:fs';
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
-import { glob as nodeGlob } from 'node:fs/promises'; // Node 22+ stable glob
-import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { computeEditedSource } from './edit-replace.js';
+import { withFileWriteLock } from './file-write-lock.js';
 import { truncateToolOutput } from './tool-output.js';
-import { runShellWithBoundedTail } from './shell-exec.js';
+import {
+  LocalWorkspaceExecutor,
+  defaultWorkspaceFileLockKey,
+  type WorkspaceExecutor,
+} from './workspace-executor.js';
 
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
 // builtin-tools directly.
 import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
 export type { MakaTool, MakaToolContext };
-import { withFileWriteLock } from './file-write-lock.js';
 
-const execAsync = promisify(exec);
-// Generous wall-clock cap for the ripgrep-backed Grep tool. A search should be
-// near-instant; this only bounds a pathological hang now that the stream
-// watchdog is paused during tool execution.
-const GREP_TIMEOUT_MS = 120_000;
-
-// Key Write and Edit on the lexically resolved absolute path so both lock the
-// same file and spellings ("a", "./a", "d//a") collapse onto one key. realpath
-// canonicalizes only the cwd (which always exists); the path itself stays lexical,
-// so the key is stable across the file's creation and never splits it mid-flight.
-// (withFileWriteLock documents why concurrent writes are serialized and which
-// aliases a lexical key does not merge.)
-async function fileWriteLockKey(cwd: string, inputPath: string): Promise<string> {
-  return resolve(await fs.realpath(cwd), inputPath);
+export interface BuildBuiltinToolsOptions {
+  executor?: WorkspaceExecutor;
 }
 
-export function buildBuiltinTools(): MakaTool[] {
+export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaTool[] {
+  const executor = options.executor ?? new LocalWorkspaceExecutor();
   return [
     {
       name: 'Bash',
@@ -49,7 +34,7 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: true,
       impl: async ({ command, timeout_ms }, { cwd, abortSignal, emitOutput }) => {
-        const result = await runStreamingShell(command, {
+        const result = await runExecutorShell(executor, command, {
           cwd,
           timeout: timeout_ms ?? 120_000,
           abortSignal,
@@ -75,13 +60,7 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: false,
       impl: async ({ path, offset, limit }, { cwd }) => {
-        const abs = await resolveExistingInsideCwd(cwd, path, 'Read');
-        const content = await fs.readFile(abs, 'utf8');
-        if (offset === undefined && limit === undefined) return { content };
-        const lines = content.split('\n');
-        const start = offset ?? 0;
-        const end = limit ? start + limit : lines.length;
-        return { content: lines.slice(start, end).join('\n') };
+        return await executor.readFile({ cwd, path, offset, limit });
       },
     },
     {
@@ -90,15 +69,10 @@ export function buildBuiltinTools(): MakaTool[] {
       parameters: z.object({ path: z.string(), content: z.string() }),
       permissionRequired: true,
       impl: async ({ path, content }, { cwd }) => {
-        // Resolve inside the lock so the containment check and the write are one
-        // atomic critical section per file (no concurrent op can alter the target
-        // between them). The key is lexical, so it is stable whether or not the
-        // file exists yet.
-        return await withFileWriteLock(await fileWriteLockKey(cwd, path), async () => {
-          const abs = await resolveWritableInsideCwd(cwd, path, 'Write');
-          await fs.writeFile(abs, content, 'utf8');
-          return { ok: true, path: abs, bytes: Buffer.byteLength(content, 'utf8') };
-        });
+        return await withFileWriteLock(
+          await defaultWorkspaceFileLockKey(executor, { cwd, path }),
+          async () => await executor.writeFile({ cwd, path, content }),
+        );
       },
     },
     {
@@ -106,7 +80,7 @@ export function buildBuiltinTools(): MakaTool[] {
       description:
         'Replace old_string with new_string in a file. Prefers an exact, unique match; '
         + 'if exact fails it tolerates limited whitespace/indentation/escape drift in old_string, '
-        + 'but only when the match is unambiguous (otherwise it errors — re-read and retry with exact text). '
+        + 'but only when the match is unambiguous (otherwise it errors - re-read and retry with exact text). '
         + 'new_string is written verbatim, so provide the exact final text/indentation you want. '
         + 'Errors if old_string is not found or not unique.',
       parameters: z.object({
@@ -116,18 +90,13 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: true,
       impl: async ({ path, old_string, new_string }, { cwd }) => {
-        // Resolve + read + write all inside the lock so the read-modify-write is
-        // one atomic critical section per file. The key is lexical (stable across
-        // creation), so a Write that creates this file and a following Edit share
-        // the lock rather than racing.
-        return await withFileWriteLock(await fileWriteLockKey(cwd, path), async () => {
-          const abs = await resolveExistingInsideCwd(cwd, path, 'Edit');
-          const current = await fs.readFile(abs, 'utf8');
+        return await withFileWriteLock(await defaultWorkspaceFileLockKey(executor, { cwd, path }), async () => {
+          const { content: current } = await executor.readFile({ cwd, path, label: 'Edit' });
           const result = computeEditedSource(current, old_string, new_string, path);
-          await fs.writeFile(abs, result.content, 'utf8');
+          const write = await executor.writeFile({ cwd, path, label: 'Edit', content: result.content });
           return {
             ok: true,
-            path: abs,
+            path: write.path,
             replacements: 1,
             matchedVia: result.matchedVia,
             startLine: result.startLine,
@@ -146,14 +115,7 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: false,
       impl: async ({ pattern, cwd: relCwd }, { cwd }) => {
-        assertRelativeGlobPattern(pattern);
-        const base = relCwd ? await resolveExistingInsideCwd(cwd, relCwd, 'Glob cwd') : await fs.realpath(cwd);
-        const files: string[] = [];
-        for await (const f of nodeGlob(pattern, { cwd: base })) {
-          files.push(typeof f === 'string' ? f : (f as any).name);
-          if (files.length >= 200) break;
-        }
-        return { files };
+        return await executor.globFiles({ cwd, pattern, searchCwd: relCwd });
       },
     },
     {
@@ -166,38 +128,17 @@ export function buildBuiltinTools(): MakaTool[] {
       }),
       permissionRequired: false,
       impl: async ({ pattern, path, glob }, { cwd, abortSignal }) => {
-        const args = ['-n', '--no-heading', '--max-count=50'];
-        if (glob) args.push('--glob', glob);
-        args.push(pattern);
-        const searchPath = path ? await resolveExistingInsideCwd(cwd, path, 'Grep') : await fs.realpath(cwd);
-        args.push(searchPath);
-        const cmd = `rg ${args.map(shellEscape).join(' ')}`;
-        try {
-          // Self-bound: ripgrep finishes in well under a second normally, but a
-          // pathological tree (network mount, /proc, a FIFO) could hang it. The
-          // stream watchdog no longer caps tool execution, so each spawning tool
-          // must carry its own wall-clock timeout and honour the turn's abort.
-          const { stdout } = await execAsync(cmd, {
-            cwd,
-            maxBuffer: 5 * 1024 * 1024,
-            timeout: GREP_TIMEOUT_MS,
-            ...(abortSignal ? { signal: abortSignal } : {}),
-          });
-          return { matches: stdout.split('\n').filter(Boolean).slice(0, 200) };
-        } catch (e: any) {
-          if (e?.code === 1) return { matches: [] }; // ripgrep "no match"
-          throw e;
-        }
+        return await executor.grepFiles({ cwd, pattern, path, glob, abortSignal });
       },
     },
   ];
 }
 
-// Thin wrapper over the shared runShellWithBoundedTail (the one place a shell
-// command actually runs — see shell-exec.ts). Keeps the builtin's contract:
-// throw on timeout / abort / non-zero exit (with stdout+stderr+code attached),
-// stream live via emitOutput, and return the bounded tail on success.
-async function runStreamingShell(
+// Keeps the builtin Bash contract: throw on timeout / abort / non-zero exit
+// with stdout+stderr+code attached, stream live via emitOutput, and return the
+// bounded tail on success.
+async function runExecutorShell(
+  executor: WorkspaceExecutor,
   command: string,
   options: {
     cwd: string;
@@ -206,17 +147,13 @@ async function runStreamingShell(
     emitOutput: (stream: 'stdout' | 'stderr', chunk: string) => void;
   },
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const result = await runShellWithBoundedTail(command, {
+  const result = await executor.exec({
+    command,
     cwd: options.cwd,
     timeoutMs: options.timeout,
     abortSignal: options.abortSignal,
     emitOutput: options.emitOutput,
   });
-  // Attach the captured (bounded) stdout/stderr + an exit code to EVERY failure,
-  // not just non-zero exit. coerceTerminalFailure only folds the tail into the
-  // model-facing result when error.code is a number, so without a code on
-  // timeout/abort the model would be blind to the logs leading up to the failure
-  // (124 = timeout, 130 = aborted, both conventional).
   if (result.timedOut) throw terminalError(`Command timed out after ${options.timeout}ms`, result, 124);
   if (result.aborted) throw terminalError('Command aborted', result, 130);
   if (result.exitCode !== 0) throw terminalError(`Command failed with exit code ${result.exitCode}`, result, result.exitCode);
@@ -231,51 +168,4 @@ function terminalError(
   const error = new Error(message);
   Object.assign(error, { stdout: result.stdout, stderr: result.stderr, code });
   return error;
-}
-
-function shellEscape(arg: string): string {
-  return `'${arg.replaceAll("'", "'\\''")}'`;
-}
-
-async function resolveWritableInsideCwd(cwd: string, inputPath: string, label: string): Promise<string> {
-  if (isAbsolute(inputPath)) {
-    throw new Error(`${label} path must be relative to session cwd`);
-  }
-  const root = await fs.realpath(cwd);
-  const candidate = resolve(root, inputPath);
-  if (!isInside(root, candidate)) {
-    throw new Error(`${label} path must stay inside session cwd`);
-  }
-  const parent = await fs.realpath(dirname(candidate));
-  if (!isInside(root, parent)) {
-    throw new Error(`${label} path must stay inside session cwd`);
-  }
-  return candidate;
-}
-
-async function resolveExistingInsideCwd(cwd: string, inputPath: string, label: string): Promise<string> {
-  if (isAbsolute(inputPath)) {
-    throw new Error(`${label} path must be relative to session cwd`);
-  }
-  const root = await fs.realpath(cwd);
-  const candidate = resolve(root, inputPath);
-  if (!isInside(root, candidate)) {
-    throw new Error(`${label} path must stay inside session cwd`);
-  }
-  const target = await fs.realpath(candidate);
-  if (!isInside(root, target)) {
-    throw new Error(`${label} path must stay inside session cwd`);
-  }
-  return target;
-}
-
-function isInside(root: string, target: string): boolean {
-  const rel = relative(root, target);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-}
-
-function assertRelativeGlobPattern(pattern: string): void {
-  if (isAbsolute(pattern) || pattern.split(/[\\/]+/).includes('..')) {
-    throw new Error('Glob pattern must stay inside session cwd');
-  }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,7 +66,30 @@ export type {
 } from './pi-agent-backend.js';
 
 export { buildBuiltinTools } from './builtin-tools.js';
-export type { MakaTool as BuiltinMakaTool, MakaToolContext as BuiltinMakaToolContext } from './builtin-tools.js';
+export type {
+  BuildBuiltinToolsOptions,
+  MakaTool as BuiltinMakaTool,
+  MakaToolContext as BuiltinMakaToolContext,
+} from './builtin-tools.js';
+export {
+  LocalWorkspaceExecutor,
+  defaultWorkspaceFileLockKey,
+} from './workspace-executor.js';
+export type {
+  WorkspaceExecutor,
+  WorkspaceExecutorFacts,
+  WorkspaceExecInput,
+  WorkspaceExecResult,
+  WorkspaceFileLockKeyInput,
+  WorkspaceGlobInput,
+  WorkspaceGlobResult,
+  WorkspaceGrepInput,
+  WorkspaceGrepResult,
+  WorkspaceReadFileInput,
+  WorkspaceReadFileResult,
+  WorkspaceWriteFileInput,
+  WorkspaceWriteFileResult,
+} from './workspace-executor.js';
 export { computeEditedSource, COMPUTE_EDITED_SOURCE_FN_SOURCE } from './edit-replace.js';
 export type { EditMatch, EditMatchStrategy } from './edit-replace.js';
 export { truncateToolOutput } from './tool-output.js';

--- a/packages/runtime/src/workspace-executor.ts
+++ b/packages/runtime/src/workspace-executor.ts
@@ -1,0 +1,225 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { glob as nodeGlob } from 'node:fs/promises';
+import { dirname, isAbsolute, relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { runShellWithBoundedTail } from './shell-exec.js';
+
+const execFileAsync = promisify(execFile);
+const GREP_TIMEOUT_MS = 120_000;
+
+export interface WorkspaceExecutorFacts {
+  isolation: 'none' | 'worktree' | 'container' | 'remote';
+  writesAffectHost: boolean;
+  writeBack: 'direct' | 'diff_review';
+  network: 'host' | 'sandbox' | 'disabled';
+  secrets: 'host_env' | 'brokered' | 'none';
+  gitMetadata: 'host_shared' | 'sandbox_local' | 'none';
+}
+
+export interface WorkspaceExecInput {
+  command: string;
+  cwd: string;
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+  emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
+}
+
+export interface WorkspaceExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut?: boolean;
+  aborted?: boolean;
+}
+
+export interface WorkspaceReadFileInput {
+  cwd: string;
+  path: string;
+  label?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export interface WorkspaceReadFileResult {
+  content: string;
+}
+
+export interface WorkspaceWriteFileInput {
+  cwd: string;
+  path: string;
+  label?: string;
+  content: string;
+}
+
+export interface WorkspaceWriteFileResult {
+  ok: boolean;
+  path: string;
+  bytes: number;
+}
+
+export interface WorkspaceGlobInput {
+  cwd: string;
+  pattern: string;
+  searchCwd?: string;
+}
+
+export interface WorkspaceGlobResult {
+  files: string[];
+}
+
+export interface WorkspaceGrepInput {
+  cwd: string;
+  pattern: string;
+  path?: string;
+  glob?: string;
+  abortSignal?: AbortSignal;
+}
+
+export interface WorkspaceGrepResult {
+  matches: string[];
+}
+
+export interface WorkspaceFileLockKeyInput {
+  cwd: string;
+  path: string;
+}
+
+export interface WorkspaceExecutor {
+  facts: WorkspaceExecutorFacts;
+  exec(input: WorkspaceExecInput): Promise<WorkspaceExecResult>;
+  readFile(input: WorkspaceReadFileInput): Promise<WorkspaceReadFileResult>;
+  writeFile(input: WorkspaceWriteFileInput): Promise<WorkspaceWriteFileResult>;
+  globFiles(input: WorkspaceGlobInput): Promise<WorkspaceGlobResult>;
+  grepFiles(input: WorkspaceGrepInput): Promise<WorkspaceGrepResult>;
+  fileLockKey?(input: WorkspaceFileLockKeyInput): Promise<string>;
+  diff?(): Promise<string>;
+}
+
+export class LocalWorkspaceExecutor implements WorkspaceExecutor {
+  readonly facts: WorkspaceExecutorFacts = {
+    isolation: 'none',
+    writesAffectHost: true,
+    writeBack: 'direct',
+    network: 'host',
+    secrets: 'host_env',
+    gitMetadata: 'host_shared',
+  };
+
+  async exec(input: WorkspaceExecInput): Promise<WorkspaceExecResult> {
+    return await runShellWithBoundedTail(input.command, {
+      cwd: input.cwd,
+      timeoutMs: input.timeoutMs ?? 120_000,
+      abortSignal: input.abortSignal,
+      emitOutput: input.emitOutput,
+    });
+  }
+
+  async readFile(input: WorkspaceReadFileInput): Promise<WorkspaceReadFileResult> {
+    const abs = await resolveExistingInsideCwd(input.cwd, input.path, input.label ?? 'Read');
+    const content = await fs.readFile(abs, 'utf8');
+    if (input.offset === undefined && input.limit === undefined) return { content };
+    const lines = content.split('\n');
+    const start = input.offset ?? 0;
+    const end = input.limit ? start + input.limit : lines.length;
+    return { content: lines.slice(start, end).join('\n') };
+  }
+
+  async writeFile(input: WorkspaceWriteFileInput): Promise<WorkspaceWriteFileResult> {
+    const abs = await resolveWritableInsideCwd(input.cwd, input.path, input.label ?? 'Write');
+    await fs.writeFile(abs, input.content, 'utf8');
+    return { ok: true, path: abs, bytes: Buffer.byteLength(input.content, 'utf8') };
+  }
+
+  async globFiles(input: WorkspaceGlobInput): Promise<WorkspaceGlobResult> {
+    assertRelativeGlobPattern(input.pattern);
+    const base = input.searchCwd
+      ? await resolveExistingInsideCwd(input.cwd, input.searchCwd, 'Glob cwd')
+      : await fs.realpath(input.cwd);
+    const files: string[] = [];
+    for await (const f of nodeGlob(input.pattern, { cwd: base })) {
+      const name = typeof f === 'string' ? f : (f as any).name;
+      files.push(name.replaceAll('\\', '/'));
+      if (files.length >= 200) break;
+    }
+    return { files };
+  }
+
+  async grepFiles(input: WorkspaceGrepInput): Promise<WorkspaceGrepResult> {
+    const args = ['-n', '--no-heading', '--max-count=50'];
+    if (input.glob) args.push('--glob', input.glob);
+    args.push(input.pattern);
+    const searchPath = input.path
+      ? await resolveExistingInsideCwd(input.cwd, input.path, 'Grep')
+      : await fs.realpath(input.cwd);
+    args.push(searchPath);
+    try {
+      const { stdout } = await execFileAsync('rg', args, {
+        cwd: input.cwd,
+        maxBuffer: 5 * 1024 * 1024,
+        timeout: GREP_TIMEOUT_MS,
+        ...(input.abortSignal ? { signal: input.abortSignal } : {}),
+      });
+      return { matches: stdout.split('\n').filter(Boolean).slice(0, 200) };
+    } catch (e: any) {
+      if (e?.code === 1) return { matches: [] };
+      throw e;
+    }
+  }
+
+  async fileLockKey(input: WorkspaceFileLockKeyInput): Promise<string> {
+    return resolve(await fs.realpath(input.cwd), input.path);
+  }
+}
+
+export async function defaultWorkspaceFileLockKey(
+  executor: WorkspaceExecutor,
+  input: WorkspaceFileLockKeyInput,
+): Promise<string> {
+  return executor.fileLockKey
+    ? await executor.fileLockKey(input)
+    : JSON.stringify([executor.facts.isolation, input.cwd, input.path]);
+}
+
+async function resolveWritableInsideCwd(cwd: string, inputPath: string, label: string): Promise<string> {
+  if (isAbsolute(inputPath)) {
+    throw new Error(`${label} path must be relative to session cwd`);
+  }
+  const root = await fs.realpath(cwd);
+  const candidate = resolve(root, inputPath);
+  if (!isInside(root, candidate)) {
+    throw new Error(`${label} path must stay inside session cwd`);
+  }
+  const parent = await fs.realpath(dirname(candidate));
+  if (!isInside(root, parent)) {
+    throw new Error(`${label} path must stay inside session cwd`);
+  }
+  return candidate;
+}
+
+async function resolveExistingInsideCwd(cwd: string, inputPath: string, label: string): Promise<string> {
+  if (isAbsolute(inputPath)) {
+    throw new Error(`${label} path must be relative to session cwd`);
+  }
+  const root = await fs.realpath(cwd);
+  const candidate = resolve(root, inputPath);
+  if (!isInside(root, candidate)) {
+    throw new Error(`${label} path must stay inside session cwd`);
+  }
+  const target = await fs.realpath(candidate);
+  if (!isInside(root, target)) {
+    throw new Error(`${label} path must stay inside session cwd`);
+  }
+  return target;
+}
+
+function isInside(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function assertRelativeGlobPattern(pattern: string): void {
+  if (isAbsolute(pattern) || pattern.split(/[\\/]+/).includes('..')) {
+    throw new Error('Glob pattern must stay inside session cwd');
+  }
+}


### PR DESCRIPTION
## Summary

Part of #509.

This PR introduces the first runtime-side foundation for sandboxed workspace execution. It does not implement the full desktop worktree sandbox or diff/write-back flow yet; instead, it makes built-in tools routable through a common executor abstraction while preserving the current local behavior by default.

Changes:
- Add a `WorkspaceExecutor` interface and `LocalWorkspaceExecutor` compatibility implementation.
- Allow `buildBuiltinTools({ executor })` so Bash, Read, Write, Edit, Glob, and Grep can be redirected through an executor.
- Preserve existing Bash behavior for streaming output, timeout, abort, cwd, and output caps.
- Preserve file path containment, symlink escape protection, Edit semantics, and file-write serialization.
- Add tests proving built-in tools can operate against a sandbox cwd without mutating the real cwd.

## Why

Issue #509 needs a real workspace execution boundary instead of relying only on Bash risk classification. This PR creates the runtime seam needed for later worktree/container/remote sandbox executors, while keeping the first change small and behavior-compatible.

## Test Plan

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime test`