### PR TITLE
fix(ui-css): drop unlayered form font reset so font utilities reach form controls

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-form-font-reset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-form-font-reset-contract.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/**
+ * Regression guard for #546 (form-control font reset).
+ *
+ * Tailwind preflight already ships `button, input, select, optgroup,
+ * textarea { font: inherit }` inside `@layer base`. base.css used to carry an
+ * UNLAYERED duplicate of that reset; because unlayered author CSS outranks
+ * every `@layer` rule, the duplicate silently killed all font utilities
+ * (text-*, font-*, leading-*, tracking-*) on every form control in the app —
+ * e.g. the Button cva's `text-sm font-medium` never rendered anywhere.
+ *
+ * Invariant: renderer CSS must not declare font properties on bare
+ * form-element type selectors outside a `@layer`. Font inheritance for form
+ * controls is preflight's job; per-surface font styling belongs on classes.
+ */
+
+const FORM_TYPES = new Set(['button', 'input', 'textarea', 'select', 'optgroup']);
+const FONT_PROP_RE = /(?:^|[;{\s])(font|font-size|font-weight|font-family|line-height|letter-spacing)\s*:/;
+
+interface Violation {
+  selector: string;
+  declaration: string;
+}
+
+/**
+ * Scans expanded renderer CSS for style rules whose selector list consists
+ * solely of bare form-element type selectors (`button, textarea, input,
+ * select`), outside any `@layer` block, that declare font properties.
+ */
+function findUnlayeredFormFontDeclarations(css: string): Violation[] {
+  const violations: Violation[] = [];
+  let i = 0;
+  let ruleStart = 0;
+  // Stack of open blocks; each entry records whether it is an @layer block.
+  const blockStack: { isLayer: boolean }[] = [];
+
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === '{') {
+      const prelude = css.slice(ruleStart, i).trim();
+      if (prelude.startsWith('@')) {
+        blockStack.push({ isLayer: /^@layer\b/.test(prelude) });
+        ruleStart = i + 1;
+        i += 1;
+        continue;
+      }
+      // Style rule: capture its body up to the matching close brace.
+      let depth = 1;
+      let j = i + 1;
+      while (j < css.length && depth > 0) {
+        if (css[j] === '{') depth += 1;
+        else if (css[j] === '}') depth -= 1;
+        j += 1;
+      }
+      const body = css.slice(i + 1, j - 1);
+      const inLayer = blockStack.some((b) => b.isLayer);
+      const parts = prelude.split(',').map((p) => p.trim().toLowerCase());
+      const isBareFormSelector = parts.length > 0 && parts.every((p) => FORM_TYPES.has(p));
+      if (!inLayer && isBareFormSelector) {
+        const match = body.match(FONT_PROP_RE);
+        if (match) {
+          violations.push({
+            selector: prelude.replace(/\s+/g, ' '),
+            declaration: match[1],
+          });
+        }
+      }
+      ruleStart = j;
+      i = j;
+      continue;
+    }
+    if (ch === '}') {
+      blockStack.pop();
+      ruleStart = i + 1;
+    } else if (ch === ';' && blockStack.length === 0) {
+      // Top-level at-statement (e.g. @import) terminator.
+      ruleStart = i + 1;
+    }
+    i += 1;
+  }
+  return violations;
+}
+
+describe('renderer form font reset contract', () => {
+  it('declares no font properties on bare form-element type selectors outside @layer', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const violations = findUnlayeredFormFontDeclarations(css);
+    assert.deepEqual(
+      violations,
+      [],
+      'Unlayered font declarations on bare button/input/textarea/select type selectors ' +
+        'outrank Tailwind layers and disable every font utility on form controls. ' +
+        'Preflight (@layer base) already provides `font: inherit`; style form-control ' +
+        'fonts via classes instead. See #546.',
+    );
+  });
+
+  it('self-check: detector catches the historical unlayered reset', () => {
+    const historical = `button,\n  textarea,\n  input,\n  select {\n    font: inherit;\n  }`;
+    const layered = `@layer base {\n${historical}\n}`;
+    assert.equal(findUnlayeredFormFontDeclarations(historical).length, 1);
+    assert.equal(findUnlayeredFormFontDeclarations(layered).length, 0);
+  });
+});

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -73,6 +73,16 @@
   --text-sm: var(--font-size-ui);
   --text-base: var(--font-size-base);
 
+  /* fix(#546): pin the text-* paired line-heights to the 4-tier leading
+     scale. Without these, bare `text-xs`/`text-sm` utilities carry
+     Tailwind's stock ratios (1.333/1.4286) — off-tier values that PR1
+     (#526) removed everywhere else. 11/13px UI text is the snug zone;
+     15px body stays normal (same value as Tailwind's default, pinned so
+     the trio reads as one decision). */
+  --text-xs--line-height: var(--leading-snug);
+  --text-sm--line-height: var(--leading-snug);
+  --text-base--line-height: var(--leading-normal);
+
   /* PR-LEADING-CONVERGE-0 (#520 PR1): bridge --leading-* to Tailwind
      leading-* utilities so `var(--leading-*)` in CSS and `leading-*`
      in TSX share one source — same inline-bridge pattern as --text-*. */

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -67,12 +67,11 @@
     outline: none;
     box-shadow: none;
   }
-button,
-  textarea,
-  input,
-  select {
-    font: inherit;
-  }
+/* Form-control font inheritance is Tailwind preflight's job (`@layer base`:
+   button/input/select/textarea { font: inherit }). Do NOT re-declare it here:
+   an unlayered duplicate outranks every layered rule, which silently kills
+   all font utilities (text-*, font-*, leading-*) on form controls app-wide.
+   Locked by renderer-form-font-reset-contract.test.ts. */
 .maka-visually-hidden {
     position: absolute !important;
     width: 1px !important;

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -7,7 +7,7 @@ import { cva } from 'class-variance-authority';
 const navRowVariants = cva(
   [
     'min-h-8 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
-    'text-left text-sm leading-[1.43] text-[var(--foreground-secondary)]',
+    'text-left text-sm text-[var(--foreground-secondary)]',
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
     'hover:bg-foreground/6 hover:text-foreground',
     'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',


### PR DESCRIPTION
## Summary

Delete the unlayered `button, textarea, input, select { font: inherit }` from `base.css`. It duplicated Tailwind preflight's identical rule (which lives in `@layer base`), and because unlayered author CSS outranks every `@layer` rule, the duplicate silently disabled all font utilities (`text-*`, `font-*`, `leading-*`) on form controls app-wide — e.g. the Button cva's `text-sm font-medium` never actually rendered anywhere.

Companion changes: pin `--text-xs/sm/base--line-height` to the 4-tier leading scale so revived utilities carry tier line-heights instead of Tailwind stock ratios (1.333/1.4286), and drop the now-redundant bare `leading-[1.43]` from `navRowVariants`.

## Why

Refs #546 (problems 1 and 3 — line-height/typography foundation). Found while auditing sidebar typography: nav rows rendered 15px/400 while declaring `text-sm` (13px). Runtime audit across six stories: 73 of 103 sampled form elements were rendering off their declared values; every diff moves rendering back toward declared intent.

## Scope

Changed: `base.css` (reset deletion + comment), `styles.css` (`@theme` line-height bridge), `session-sidebar-nav.tsx` (bare leading removal), new contract test `renderer-form-font-reset-contract.test.ts`.

Not included: sidebar group-label vs `theme-glass` macOS override conflict, remaining #546 polish passes (markdown, tool-call, settings).

## Verification

- `npm run -w @maka/desktop test` — 2112 pass (incl. new contract test); `npm run -w @maka/ui test` — 45 pass; desktop typecheck (main/renderer/storybook) clean.
- CDP computed-style check on Storybook: nav rows now 13px / weight 500 / line-height 17.875px (snug tier); no unlayered form font reset remains in the CSSOM.
- Before/after composite screenshots of six surfaces (sidebar, settings/models, chat, permission dialog, button size matrix, markdown as no-change control group) attached in the PR conversation.

## User-facing impact

Form-control text app-wide returns to declared sizes/weights: most buttons 15px→13px (11px for `text-xs`), weight 400→500. Visual change is intentional and matches the design system; no layout shifts (control heights are fixed).

<img width="1836" height="560" alt="image" src="https://github.com/user-attachments/assets/03bc43df-f91c-4bab-8b4a-fd4c06c9a7c8" />
<img width="2336" height="910" alt="image" src="https://github.com/user-attachments/assets/13491b25-db51-480c-8895-64ef7f39accc" />
<img width="2036" height="960" alt="image" src="https://github.com/user-attachments/assets/0d25f70f-6741-438e-940e-6dd04ed27e39" />
<img width="1836" height="760" alt="image" src="https://github.com/user-attachments/assets/f959f123-e6d0-49c0-8c5f-0cd5b9ef26d7" />
<img width="2336" height="1060" alt="image" src="https://github.com/user-attachments/assets/7ab879b9-965b-49f4-bf1c-f61ac812f25f" />
<img width="876" height="1310" alt="image" src="https://github.com/user-attachments/assets/e0153069-f346-4986-a18b-4f785c902ce3" />

## Reviewer notes

The existing cascade contract (unlayered feature CSS beats utilities) is untouched — this deletes a rule, it does not layer feature files. `.maka-nav-row`'s grid layout still wins over cva's `inline-flex`.
