### PR TITLE
fix(desktop): 修复模型配置侧栏定位

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -288,7 +288,15 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(overlay, /className="providerConfigSheetClose"/);
     assert.match(overlay, /aria-label="关闭模型配置"/);
     assert.match(overlay, /<X strokeWidth=\{1\.75\} aria-hidden="true" \/>/);
-    assert.match(styles, /\.providerConfigSheet\s*\{[\s\S]*position:\s*relative;/);
+    assert.match(styles, /\.providerConfigOverlay\s*\{[^}]*position:\s*absolute;[^}]*inset:\s*0;/);
+    assert.doesNotMatch(
+      styles,
+      /\.providerConfigOverlay\s*\{[^}]*justify-content:\s*flex-end;/,
+      'Base UI renders Backdrop and Popup as siblings; overlay flex must not be treated as sheet layout',
+    );
+    assert.match(styles, /\.providerConfigSheet\s*\{[^}]*position:\s*absolute;/);
+    assert.match(styles, /\.providerConfigSheet\s*\{[^}]*inset:\s*var\(--space-3\)\s+var\(--space-3\)\s+var\(--space-3\)\s+auto;/);
+    assert.match(styles, /\.providerConfigSheet\s*\{[^}]*width:\s*min\(430px,\s*calc\(100%\s*-\s*\(var\(--space-3\)\s*\*\s*2\)\)\);/);
     assert.match(styles, /\.providerConfigSheetClose\s*\{[\s\S]*position:\s*absolute;[\s\S]*right:\s*14px;/);
     // The close button reuses the governed quiet icon Button, so its rest /
     // hover / focus states come from the component, not hand-written CSS. The

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -250,18 +250,16 @@
 .providerConfigOverlay {
   position: absolute;
   inset: 0;
-  display: flex;
-  justify-content: flex-end;
   background: oklch(from var(--background) calc(l - 0.05) c h / 0.64);
   backdrop-filter: blur(2px);
   border-radius: var(--radius-modal);
-  padding: var(--space-3);
 }
 
 .providerConfigSheet {
-  position: relative;
-  width: min(430px, 100%);
-  min-height: 100%;
+  position: absolute;
+  inset: var(--space-3) var(--space-3) var(--space-3) auto;
+  width: min(430px, calc(100% - (var(--space-3) * 2)));
+  min-height: 0;
   overflow: auto;
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-modal);
@@ -1016,4 +1014,3 @@
   border-color: oklch(from var(--warning) l c h / 0.42);
   color: var(--warning-text, var(--info-text));
 }
-

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -239,6 +239,10 @@
   gap: var(--space-3);
 }
 
+.modelTableHeader > button {
+  flex: 0 0 auto;
+}
+
 .modelTableHeaderText {
   display: grid;
   gap: var(--space-0-5);
@@ -256,6 +260,7 @@
   font-size: var(--font-size-caption);
   line-height: var(--leading-normal);
   color: var(--foreground-secondary);
+  overflow-wrap: anywhere;
 }
 
 .modelTable[data-source="fetched"] .modelTableHeaderText small {
@@ -339,7 +344,7 @@
 .modelTableRow {
   width: 100%;
   display: grid;
-  grid-template-columns: 16px minmax(0, 1fr) auto auto;
+  grid-template-columns: 16px minmax(0, 1fr) minmax(0, auto) auto;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-2-5);
@@ -437,6 +442,7 @@
   flex-wrap: wrap;
   gap: var(--space-1);
   justify-self: end;
+  min-width: 0;
 }
 
 .modelTableChip {


### PR DESCRIPTION
 ## Summary

  - Fix provider config sheet positioning after the Base UI Dialog migration.
  - Remove stale overlay flex layout that no longer controls the sheet because Backdrop and Popup are siblings.
  - Keep the model table layout from being squeezed by adding bounded shrink/wrap rules.
  - Update the provider sheet contract test to lock the new absolute-positioned sheet behavior.

  ## Test Plan

  - `npm --workspace @maka/core run build`
  - `npm --workspace @maka/runtime run build`
  - `npm --workspace @maka/ui run build`
  - `npm --workspace @maka/desktop run build:main`
  - `git diff --check`
  - Targeted desktop contract tests for provider sheet/CSS behavior