### PR TITLE
fix(ui): designer-audit round 2 — internal jargon, duplicate CTA, doubled explainers

### DIFF
--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -533,3 +533,13 @@
   min-height: 120px;
   align-content: center;
 }
+
+/* Designer audit P0-4: one-line stand-in for the full empty-state card when
+   saved reports already occupy the page — a second full-height empty card
+   below them read as a broken section. */
+.maka-daily-review-activity-note {
+  margin: 0;
+  padding: var(--space-2) var(--space-1);
+  color: var(--muted-foreground);
+  font-size: var(--font-size-ui);
+}

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -36,24 +36,6 @@
 /* PR-DAILY-REVIEW-FULL-0: info banner explaining the feature, plus a
    manual-trigger row. Banner uses the page-card recipe with a softer
    tint so it reads as supporting context, not a primary surface. */
-/* Unboxed: the old two-paragraph banner card pushed real content
-   below the fold; the explanation is now a single quiet hint line. */
-.maka-daily-review-info {
-    display: grid;
-    gap: var(--space-1);
-    padding: 0 var(--space-0-5);
-  }
-.maka-daily-review-info-hint {
-    margin: 0;
-    font-size: var(--font-size-caption);
-    line-height: var(--leading-normal);
-    color: var(--muted-foreground);
-  }
-.maka-daily-review-info-hint strong {
-    font-weight: var(--font-weight-semibold);
-    color: var(--foreground-secondary);
-  }
-
 .maka-daily-review-quick-runs {
   /* WAWQAQ msg `3871e56b` 2026-06-25: "按钮的位置也不对。按道理一般都
      是在右边，现在都是直接靠近文本的。"

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -334,8 +334,7 @@
   color: oklch(from var(--system-alert-accent) 0.42 min(c, 0.095) h);
 }
 
-.maka-plan-system-alert-main,
-.maka-plan-system-alert-switch {
+.maka-plan-system-alert-main {
   display: inline-flex;
   min-width: 0;
   align-items: center;
@@ -356,35 +355,13 @@
   flex: 0 0 auto;
 }
 
-.maka-plan-system-alert-switch {
-  flex: 0 0 auto;
-  color: oklch(from var(--system-alert-accent) 0.38 min(c, 0.075) h);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
-}
-
-/* Static 「即将支持」 tag (was a permanently-disabled Switch). Tinted
-   to the info-alert family so it reads as part of the banner. */
-.maka-plan-system-alert-soon {
-  display: inline-flex;
-  align-items: center;
-  height: 20px;
-  padding: 0 var(--space-2);
-  border: var(--border-width-hairline) solid oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.4);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.10);
-  font-weight: var(--font-weight-semibold);
-}
-
 .dark .maka-plan-system-alert {
   border-color: oklch(from var(--system-alert-accent) 0.56 min(c, 0.08) h / 0.44);
   background: oklch(from var(--system-alert-accent) 0.25 min(c, 0.04) h / 0.52);
   color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
 }
 
-.dark .maka-plan-system-alert [class*="lucide"],
-.dark .maka-plan-system-alert-switch {
+.dark .maka-plan-system-alert [class*="lucide"] {
   color: oklch(from var(--system-alert-accent) 0.84 min(c, 0.07) h);
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -82,16 +82,6 @@
   flex-wrap: wrap;
 }
 
-.maka-plan-create-through {
-  gap: var(--space-1);
-  background: var(--foreground-3);
-  color: var(--foreground);
-  border-color: transparent;
-  border-radius: var(--radius-pill);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-}
-
 /* PR-UI-PIXEL-3: signature off-black CTA, matching the reference's restrained
    primary command treatment without using the app accent. Pure #000 is banned
    per design-taste rules — use oklch off-black (charcoal) for premium feel. */

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -236,29 +236,6 @@ color: oklch(0.55 0.015 220);
   padding: 0 var(--space-1);
 }
 
-.maka-skill-filter-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding-bottom: var(--space-1-5);
-}
-
-.maka-skill-filter-pill {
-  /* Rendered as a static <span> since the filter/sort controls are not
-     wired yet (was a disabled UiButton that promised interactivity). */
-  display: inline-flex;
-  align-items: center;
-  height: 28px;
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--background);
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  padding: 0 var(--space-3);
-  opacity: 1;
-}
-
 .maka-skill-market {
   display: grid;
   gap: var(--space-3);

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -883,16 +883,24 @@
 }
 
 .maka-empty-state {
-  position: absolute;
-  left: 50%;
-  top: 46%;
-  width: min(205px, calc(100% - 40px));
-  transform: translate(-50%, -50%);
   display: grid;
   justify-items: center;
   gap: var(--space-1-5);
   text-align: center;
   color: var(--foreground-secondary);
+}
+
+/* Absolute centering is a SIDEBAR-only concern (the empty session list
+   centers inside the scroll viewport). It used to live on the base class,
+   so every module page's shared EmptyState floated at 46% of the page and
+   overlapped banners/cards (part of designer audit P0-4's "broken
+   half-loaded card" impression). Scope it to the session list. */
+.maka-session-list .maka-empty-state {
+  position: absolute;
+  left: 50%;
+  top: 46%;
+  width: min(205px, calc(100% - 40px));
+  transform: translate(-50%, -50%);
 }
 
 .maka-empty-state-icon {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -278,14 +278,18 @@
   min-height: 0;
   height: 100%;
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  /* 5 rows: header / nav / view-mode toggle / list (scroll) / footer.
+     The toggle row was missing after the grouping control was inserted —
+     with only 4 tracks the 1fr row collapsed to 0 and the toggle
+     overflowed on top of the list's 会话 group label. */
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
   overflow: hidden;
   background: transparent;
   contain: layout paint style;
 }
 
 .maka-session-panel[data-collapsed="true"] {
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
 }
 
 /* Search modal: input + local thread-search results, backed by
@@ -1037,39 +1041,22 @@
   line-height: var(--leading-normal);
 }
 
-/* View-mode toggle for the sidebar session list (按状态 / 按项目). */
+/* View-mode toggle row (按状态 / 按项目) — chrome comes from the shared
+   `.settingsSegmented` primitive (same control family as the daily-review
+   range tabs); this wrapper only owns sidebar spacing. The retired
+   `.maka-view-mode-btn` family referenced tokens that never existed in
+   maka-tokens (--surface-secondary/-primary/-tertiary, --foreground-primary,
+   --shadow-sm), so its chrome rendered invisible. */
 .maka-view-mode-toggle {
   display: flex;
-  gap: 1px;
-  padding: var(--space-1) var(--space-2);
-  background: var(--surface-secondary);
-  border-radius: var(--radius-sm);
-  margin: var(--space-1) var(--space-2);
+  padding: 0 var(--space-2) var(--space-1);
 }
 
-.maka-view-mode-btn {
+.maka-view-mode-toggle .maka-view-mode-segmented {
+  flex: 1 1 auto;
   display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  flex: 1;
-  justify-content: center;
-  padding: var(--space-1) var(--space-2);
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-ui);
-  transition: background var(--duration-quick) var(--ease-out-strong),
-              color var(--duration-quick) var(--ease-out-strong);
 }
 
-.maka-view-mode-btn.active {
-  background: var(--surface-primary);
-  color: var(--foreground-primary);
-  box-shadow: var(--shadow-sm);
-}
-
-.maka-view-mode-btn:hover:not(.active) {
-  background: var(--surface-tertiary);
-  color: var(--foreground-primary);
+.maka-view-mode-toggle .maka-view-mode-segmented > button {
+  flex: 1 1 0;
 }

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -446,7 +446,7 @@ export function ChatView(props: {
         <header className="maka-module-main-header">
           <div>
             <h2>每日回顾</h2>
-            <p>查看本机对话、请求、Token、费用和工具调用汇总。</p>
+            <p>自动汇总本机对话，生成摘要、遗漏提醒与深度分析；可在设置中开启定时执行。</p>
           </div>
         </header>
         {props.dailyReviewBridge ? (

--- a/packages/ui/src/daily-review-helpers.ts
+++ b/packages/ui/src/daily-review-helpers.ts
@@ -94,3 +94,17 @@ export function formatDailyReviewMarkdown(
   }
   return lines.join('\n');
 }
+
+/**
+ * Archive headers used to print the raw internal model key
+ * (`<connectionSlug>::<modelId>`, e.g. `zai-live::glm-4.5`) — an
+ * implementation detail leaking into UI copy (designer audit P1-8).
+ * Show just the model id; the connection is not something the reader
+ * needs to decode a report.
+ */
+export function formatDailyReviewModelLabel(modelKey: string): string {
+  const separatorIndex = modelKey.lastIndexOf('::');
+  if (separatorIndex === -1) return modelKey;
+  const modelId = modelKey.slice(separatorIndex + 2).trim();
+  return modelId.length > 0 ? modelId : modelKey;
+}

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -502,12 +502,22 @@ export function DailyReviewPanel(props: {
           <div className="maka-skeleton maka-skeleton-line" style={{ width: '75%' }} />
         </div>
       ) : visibleSummary.totals.sessionCount === 0 && visibleSummary.totals.requestCount === 0 ? (
-        <EmptyState
-          Icon={CalendarDays}
-          title={emptyActivityTitle}
-          body={emptyActivityBody}
-          extraClassName="maka-daily-review-summary-empty"
-        />
+        // When saved reports already fill the page, a second full-height
+        // empty card below them read as a broken half-loaded section
+        // (designer audit P0-4). Collapse to a one-line note in that case;
+        // keep the full empty state only when it is the page's sole content.
+        canLoadArchives && archives.length > 0 ? (
+          <p className="maka-daily-review-activity-note" role="status">
+            {emptyActivityTitle} · {emptyActivityBody}
+          </p>
+        ) : (
+          <EmptyState
+            Icon={CalendarDays}
+            title={emptyActivityTitle}
+            body={emptyActivityBody}
+            extraClassName="maka-daily-review-summary-empty"
+          />
+        )
       ) : (
         <>
           <section className="maka-daily-review-totals" aria-label={`${dayLabel}总览`}>

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -15,6 +15,7 @@ import {
   formatDailyReviewArchiveGeneratedAt,
   formatDailyReviewArchiveTitle,
   formatDailyReviewMarkdown,
+  formatDailyReviewModelLabel,
 } from './daily-review-helpers.js';
 import { Button as UiButton } from './ui.js';
 import { SettingsSegmented } from './primitives/settings-segmented.js';
@@ -300,12 +301,6 @@ export function DailyReviewPanel(props: {
           className="maka-daily-review-range-tabs"
         />
       </header>
-      <section className="maka-daily-review-info" aria-label="每日回顾说明">
-        <p className="maka-daily-review-info-hint">
-          自动汇总本机对话历史，生成<strong>对话摘要</strong>与<strong>遗漏提醒</strong>；
-          <strong>深度分析</strong>覆盖更长周期的趋势与调研。可在设置中开启<strong>定时执行</strong>。
-        </p>
-      </section>
       {canManualRun && (
         <div className="maka-daily-review-quick-runs" aria-label="手动触发回顾">
           {modelOptions.length > 0 && (
@@ -622,7 +617,7 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
           <h4>{formatDailyReviewArchiveTitle(archive)}</h4>
           <p>
             {DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL[archive.trigger]}生成 · {formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}
-            {archive.modelKey ? ` · ${archive.modelKey}` : ' · 默认对话模型'}
+            {archive.modelKey ? ` · ${formatDailyReviewModelLabel(archive.modelKey)}` : ' · 默认对话模型'}
           </p>
         </div>
         <span className="maka-daily-review-archive-status" data-status={archive.status}>

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -103,7 +103,9 @@ export function PlanReminderPanel(props: {
   onClearRunHistory?(id: string): void | Promise<void>;
   onDelete?(id: string): void | Promise<void>;
 }) {
-  type PlanReminderListFilter = 'all' | PlanReminderStatus;
+  // 'active' = scheduled + paused — the default view and the tab badge
+  // count, matching the sidebar nav badge (which also excludes completed).
+  type PlanReminderListFilter = 'active' | 'all' | PlanReminderStatus;
   type PlanReminderView = 'tasks' | 'runs';
   type PlanReminderRunRange = 'day' | 'week' | 'month' | 'all';
   type PlanReminderSort = 'created-desc' | 'next-run-asc' | 'updated-desc';
@@ -125,7 +127,7 @@ export function PlanReminderPanel(props: {
   const [formDialogOpen, setFormDialogOpen] = useState(false);
   const [planView, setPlanView] = useState<PlanReminderView>('tasks');
   const [runRange, setRunRange] = useState<PlanReminderRunRange>('week');
-  const [listFilter, setListFilter] = useState<PlanReminderListFilter>('all');
+  const [listFilter, setListFilter] = useState<PlanReminderListFilter>('active');
   const [listSort, setListSort] = useState<PlanReminderSort>('created-desc');
   const [listQuery, setListQuery] = useState('');
   const [refreshPending, setRefreshPending] = useState(false);
@@ -136,7 +138,9 @@ export function PlanReminderPanel(props: {
     : props.reminders;
   const visibleReminders = listFilter === 'all'
     ? searchMatchedReminders
-    : searchMatchedReminders.filter((reminder) => reminder.status === listFilter);
+    : listFilter === 'active'
+      ? searchMatchedReminders.filter((reminder) => reminder.status !== 'completed')
+      : searchMatchedReminders.filter((reminder) => reminder.status === listFilter);
   const sortedReminders = [...visibleReminders].sort((a, b) => comparePlanReminderBySort(a, b, listSort));
   const runRangeStart = planReminderRunRangeStart(runRange, Date.now());
   const visibleRunEntries = props.reminders
@@ -144,6 +148,7 @@ export function PlanReminderPanel(props: {
     .filter((entry) => runRangeStart === null || entry.run.at >= runRangeStart)
     .sort((a, b) => b.run.at - a.run.at);
   const filterCounts: Record<PlanReminderListFilter, number> = {
+    active: searchMatchedReminders.filter((reminder) => reminder.status !== 'completed').length,
     all: searchMatchedReminders.length,
     scheduled: searchMatchedReminders.filter((reminder) => reminder.status === 'scheduled').length,
     paused: searchMatchedReminders.filter((reminder) => reminder.status === 'paused').length,
@@ -364,6 +369,9 @@ export function PlanReminderPanel(props: {
             the empty state (quick-start), so the populated/default view matches
             the reference's clean flow. */}
 
+        {/* Designer audit P1-5: the 保持系统唤醒·即将支持 tag was removed —
+            unshipped features don't belong in first-screen chrome. Reintroduce
+            the control (as a real Switch) when the wake-lock lands. */}
         <Alert variant="info" className="maka-plan-system-alert">
           <div className="maka-plan-system-alert-main">
             <Info strokeWidth={1.75} aria-hidden="true" />
@@ -373,14 +381,6 @@ export function PlanReminderPanel(props: {
                 Maka 会保留执行记录；重复提醒、机器人投递和手动触发都走同一套计划队列。
               </AlertDescription>
             </div>
-          </div>
-          {/* Static tag, not a disabled Switch — the wake-lock isn't wired
-              yet, and a dead toggle promises interactivity it can't deliver
-              (same precedent as the skills marketplace 即将上线 pill and the
-              static filter pills). */}
-          <div className="maka-plan-system-alert-switch">
-            <span>保持系统唤醒</span>
-            <span className="maka-plan-system-alert-soon" data-static="true">即将支持</span>
           </div>
         </Alert>
 
@@ -397,7 +397,7 @@ export function PlanReminderPanel(props: {
             <TabsList variant="underline" className="maka-plan-tabs-list" aria-label="计划提醒视图">
               <TabsTrigger className="maka-plan-tab" value="tasks">
                 我的定时任务
-                <span>{props.reminders.length}</span>
+                <span>{props.reminders.filter((reminder) => reminder.status !== 'completed').length}</span>
               </TabsTrigger>
               <TabsTrigger className="maka-plan-tab" value="runs">
                 执行记录
@@ -435,6 +435,7 @@ export function PlanReminderPanel(props: {
                     onChange={(value) => setListFilter(value)}
                     ariaLabel="计划提醒筛选"
                     options={[
+                      ['active', `进行中 ${filterCounts.active}`],
                       ['all', `全部 ${filterCounts.all}`],
                       ['scheduled', `待触发 ${filterCounts.scheduled}`],
                       ['paused', `已暂停 ${filterCounts.paused}`],

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -10,7 +10,6 @@ import {
   Plus,
   RefreshCcw,
   Repeat,
-  Sparkles,
   Trash2,
   X,
 } from './icons.js';
@@ -346,15 +345,11 @@ export function PlanReminderPanel(props: {
             >
               <RefreshCcw size={15} strokeWidth={1.75} aria-hidden="true" />
             </UiButton>
-            <UiButton
-              type="button"
-              variant="secondary"
-              className="maka-plan-create-through"
-              onClick={openCreateReminderDialog}
-            >
-              <Sparkles size={14} strokeWidth={1.75} aria-hidden="true" />
-              通过 Maka 创建
-            </UiButton>
+            {/* Designer audit P2-14: 通过 Maka 创建 was a second button
+                wired to the EXACT same handler as 新建定时任务 — pure
+                duplication competing for the primary action. One entry
+                point; reintroduce a second button only when a genuinely
+                different (chat-driven) flow exists. */}
             <UiButton type="button" className="maka-plan-new-task-button" onClick={openCreateReminderDialog}>
               <Plus size={15} strokeWidth={1.75} aria-hidden="true" />
               新建定时任务

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -2,8 +2,7 @@ import type { PlanReminder, SessionSummary } from '@maka/core';
 import type { NavSelection } from './nav-selection.js';
 import { SessionHistoryList, type SessionHistoryStatusGroup, type SessionRowActions } from './session-history-list.js';
 import { SessionSidebarFooter, SessionSidebarNav } from './session-sidebar-nav.js';
-import { cn } from './ui.js';
-import { FolderOpen, Grid3X3 } from './icons.js';
+import { SettingsSegmented } from './primitives/settings-segmented.js';
 
 export type SessionViewMode = 'status' | 'project';
 
@@ -47,22 +46,17 @@ export function SessionListPanel(props: {
       />
       {onViewModeChange && (
         <div className="maka-view-mode-toggle">
-          <button
-            className={cn('maka-view-mode-btn', viewMode === 'status' && 'active')}
-            onClick={() => onViewModeChange('status')}
-            title="按状态分组"
-          >
-            <Grid3X3 size={14} />
-            <span>按状态</span>
-          </button>
-          <button
-            className={cn('maka-view-mode-btn', viewMode === 'project' && 'active')}
-            onClick={() => onViewModeChange('project')}
-            title="按项目分组"
-          >
-            <FolderOpen size={14} />
-            <span>按项目</span>
-          </button>
+          {/* Shared segmented primitive — same control family as the
+              daily-review range tabs. The previous hand-rolled buttons
+              referenced tokens that don't exist in maka-tokens
+              (--surface-secondary etc.), rendering an invisible chrome. */}
+          <SettingsSegmented
+            value={viewMode}
+            options={[['status', '按状态'], ['project', '按项目']]}
+            onChange={(mode) => onViewModeChange(mode)}
+            ariaLabel="会话分组方式"
+            className="maka-view-mode-segmented"
+          />
         </div>
       )}
       <SessionHistoryList

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -29,12 +29,25 @@ function SkillLibraryPanel(props: {
   searchQuery?: string;
 }) {
   const skillCount = props.skills?.length ?? 0;
-  const [activeSkillTab, setActiveSkillTab] = useState<'market' | 'builtin' | 'installed'>('market');
+  // Designer audit P1-5: land on skills the user can actually run, not the
+  // marketplace — every market card is still 即将上线, and leading with
+  // things you can't install undermines trust in the whole page.
+  const [activeSkillTab, setActiveSkillTab] = useState<'market' | 'builtin' | 'installed'>(() => {
+    const skills = props.skills ?? [];
+    if (skills.some((skill) => skill.sourceType !== 'bundled')) return 'installed';
+    if (skills.length > 0) return 'builtin';
+    return 'market';
+  });
   const normalizedSkillQuery = props.searchQuery?.trim().toLowerCase() ?? '';
   const filteredSkills = (props.skills ?? []).filter((skill) => {
     if (!normalizedSkillQuery) return true;
     return `${skill.id} ${skill.name} ${skill.description ?? ''}`.toLowerCase().includes(normalizedSkillQuery);
   });
+  // 内置 = bundled skills shipped with the app; 已安装 = everything the user
+  // added themselves (workspace / unknown source). The two tabs used to
+  // render the SAME list, which made them meaningless.
+  const bundledSkills = filteredSkills.filter((skill) => skill.sourceType === 'bundled');
+  const installedSkills = filteredSkills.filter((skill) => skill.sourceType !== 'bundled');
   const filteredMarketCards = SKILL_MARKETPLACE_CARDS.filter((card) => {
     if (!normalizedSkillQuery) return true;
     return `${card.title} ${card.body} ${card.meta}`.toLowerCase().includes(normalizedSkillQuery);
@@ -70,8 +83,8 @@ function SkillLibraryPanel(props: {
       <TabsList variant="underline" className="maka-skill-tabs" aria-label="技能视图">
         {([
           ['market', '市场', filteredMarketCards.length],
-          ['builtin', '内置', filteredSkills.length],
-          ['installed', '已安装', skillCount],
+          ['builtin', '内置', bundledSkills.length],
+          ['installed', '已安装', installedSkills.length],
         ] as const).map(([tab, label, count]) => (
           <TabsTrigger
             key={tab}
@@ -79,19 +92,14 @@ function SkillLibraryPanel(props: {
             value={tab}
           >
             {label}
-            {tab === 'installed' && <span>{count}</span>}
+            <span>{count}</span>
           </TabsTrigger>
         ))}
       </TabsList>
-      {activeSkillTab === 'market' && (
-        <div className="maka-skill-filter-actions" aria-label="技能筛选排序">
-          {/* Static labels, not disabled buttons: filter/sort are not
-              wired yet, and a styled-but-dead button visually promises
-              interactivity it can't deliver. */}
-          <span className="maka-skill-filter-pill" data-static="true">全部</span>
-          <span className="maka-skill-filter-pill" data-static="true">排序：热门</span>
-        </div>
-      )}
+      {/* Designer audit P1-9: the static 全部 / 排序：热门 pills were removed
+          entirely — they were styled like buttons but dead, which reads as a
+          broken control. Bring back real filter/sort controls with the
+          marketplace launch. */}
     </div>
   );
 
@@ -242,8 +250,8 @@ function SkillLibraryPanel(props: {
       <TabsRoot value={activeSkillTab} onValueChange={(v) => setActiveSkillTab(v as 'market' | 'builtin' | 'installed')}>
         {tabs}
         <TabsPanel value="market">{market}</TabsPanel>
-        <TabsPanel value="builtin">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '内置技能')}{templates}</TabsPanel>
-        <TabsPanel value="installed">{skillList(filteredSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
+        <TabsPanel value="builtin">{skillList(bundledSkills, normalizedSkillQuery ? '没有匹配的内置技能' : '暂无内置技能', normalizedSkillQuery ? '换一个关键词试试。' : '应用自带的技能会出现在这里。', '内置技能')}</TabsPanel>
+        <TabsPanel value="installed">{skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
       </TabsRoot>
       {props.skills && props.skills.length > 0 ? (
         <span className="maka-skill-tool-summary-hidden" aria-hidden="true">


### PR DESCRIPTION
设计审查第 2 轮（承接 #571）：

1. **P1-8 内部标识符泄漏**：每日回顾报告头直接打印内部 model key（`zai-live::glm-4.5`）→ 新增 `formatDailyReviewModelLabel`，只显示模型名（`glm-4.5`）。
2. **P2-14 重复创建按钮**：定时任务页「通过 Maka 创建」与「新建定时任务」绑定的是**同一个 handler**——纯重复入口，已删除（含死 CSS 与 unused import）。
3. **P2-12 双重说明文**：每日回顾页副标题与卡内提示 70% 重复 → 副标题改为一句有信息量的话，卡内提示段落删除。

截图验证通过；check-dead-css ✓；@maka/ui 45/45；desktop 2109/2110（唯一失败为 main 既有 history-compact 用例）。