### PR TITLE
feat: replace one-shot pending permission mode with global chat default

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -142,45 +142,35 @@ describe('home composer new-chat model picker', () => {
     );
   });
 
-  it('wires the picked new-chat permission mode to one sessions.create call only', async () => {
+  it('wires composer permission mode picks to the global chat default', async () => {
     const renderer = await readRendererShellCombinedSource();
     const setPermissionModeBlock = renderer.match(/async function setPermissionMode[\s\S]*?async function setSessionModel/)?.[0] ?? '';
     const sendBlock = renderer.match(/async function send\(text: string[\s\S]*?\n  async function respondToPermission/)?.[0] ?? '';
 
-    assert.match(
-      renderer,
-      /const \[pendingNewChatPermissionMode, setPendingNewChatPermissionMode\] = useState<PermissionMode \| null>\(null\)/,
-      'AppShell must keep the no-session permission pick renderer-only and start it from null',
-    );
     assert.doesNotMatch(
       renderer,
       /saveComposerDefaults\(\{\s*permissionMode:/,
       'permission mode must not be persisted into composer defaults',
     );
-    assert.match(
+    assert.doesNotMatch(
       renderer,
-      /setPendingNewChatPermissionMode: \(mode: PendingNewChatPermissionMode\) => void;/,
-      'createAppShellChatActions deps must include setPendingNewChatPermissionMode so send() can reset the one-shot pick',
+      /const \[pendingNewChatPermissionMode, setPendingNewChatPermissionMode\] = useState<PermissionMode \| null>\(null\)/,
+      'composer permission picks are no longer one-shot renderer state',
     );
-    assert.match(
-      renderer,
-      /setPendingNewChatPermissionMode,[\s\S]*validPendingNewChatModel,/,
-      'createAppShellChatActions must destructure setPendingNewChatPermissionMode before send() calls it',
+    assert.doesNotMatch(
+      setPermissionModeBlock,
+      /setPendingNewChatPermissionMode\(mode\)/,
+      'composer permission picks must not be stored for only the next new chat',
     );
     assert.match(
       setPermissionModeBlock,
-      /if \(!sessionId\) \{[\s\S]*setPendingNewChatPermissionMode\(mode\);[\s\S]*return;[\s\S]*\}/,
-      'permission-mode picks without an active session must update pendingNewChatPermissionMode instead of calling IPC',
+      /window\.maka\.settings\.update\(\{ chatDefaults: \{ permissionMode: mode \} \}\)/,
+      'every composer permission-mode pick must persist the global chat default',
     );
-    assert.match(
+    assert.doesNotMatch(
       sendBlock,
       /\.\.\.\(pendingNewChatPermissionMode \? \{ permissionMode: pendingNewChatPermissionMode \} : \{\}\)/,
-      'new-chat sessions.create must send the picked pending permission mode when one exists, and omit the field otherwise (main.ts resolves the configured default)',
-    );
-    assert.match(
-      sendBlock,
-      /setPendingNewChatPermissionMode\(null\);/,
-      'pending new-chat permission mode must be one-shot and reset after creating a session',
+      'new-chat sessions.create must never shadow the persisted global default with one-shot renderer state',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -5,15 +5,11 @@
  * Two bug classes this guards:
  *
  * 1. Renderer-side shadow authority. An early draft had the renderer
- *    resolve the default locally and always send an explicit
- *    `permissionMode` to sessions:create -- which made main.ts's
- *    settings-backed fallback unreachable, and silently used a stale
- *    renderer copy of the setting (seeded 'ask', updated only after the
- *    mount-time settings IPC resolved) for e.g. the first send after a
- *    cold start. The contract now is: the renderer sends permissionMode
- *    ONLY when the user explicitly picked one in the composer; otherwise
- *    it omits the field and main.ts resolves the configured default as
- *    the single authority.
+ *    resolve the default locally or store a one-shot composer pick and send
+ *    an explicit `permissionMode` to sessions:create -- which made main.ts's
+ *    settings-backed fallback unreachable. The contract now is: composer
+ *    permission picks update the persisted chat default, and the renderer
+ *    always omits permissionMode when creating a session.
  *
  * 2. Settings-store coupling. The pre-feature fallback was a synchronous
  *    `'ask'` literal that could never fail. Reading the configured
@@ -29,13 +25,13 @@ import { readSettingsCombinedSource } from './settings-contract-source-helpers.j
 import { readMainTsSource } from './main-process-contract-source-helpers.js';
 
 describe('default permission mode contract', () => {
-  it('renderer omits permissionMode unless the user explicitly picked one', async () => {
+  it('renderer always omits permissionMode when creating sessions', async () => {
     const src = await readRendererShellSources(['app-shell-chat-actions.ts']);
 
-    assert.match(
+    assert.doesNotMatch(
       src,
       /\.\.\.\(pendingNewChatPermissionMode \? \{ permissionMode: pendingNewChatPermissionMode \} : \{\}\)/,
-      'send() must spread permissionMode conditionally -- omitting it lets main.ts resolve the configured default as the single authority',
+      'send() must not shadow the persisted global default with renderer-only permission state',
     );
     assert.doesNotMatch(
       src,

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -173,8 +173,6 @@ describe('assistant streaming handoff', () => {
         showModelSetupToast: () => {},
         toastApi: { error: () => {} },
         upsertSessionSummary: () => {},
-        pendingNewChatPermissionMode: null,
-        setPendingNewChatPermissionMode: () => {},
         validPendingNewChatModel: null,
         pendingNewChatThinkingLevel: null,
       });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -13,6 +13,7 @@ import {
   healthSignalFromConnection,
   healthSignalFromConnectionRuntime,
   isPermissionMode,
+  isDeepResearchSession,
   isThinkingLevel,
   thinkingVariantsForModel,
   resolveModelVisionSupport,
@@ -1492,6 +1493,25 @@ async function applySettingsRuntimeEffects(settings: AppSettings, patch: UpdateA
     const status = await openGateway.sync(settings.openGateway);
     safeSendToRenderer('gateway:statusChanged', status);
   }
+  if (patch.chatDefaults?.permissionMode) {
+    await syncDefaultPermissionModeToSessions(settings.chatDefaults.permissionMode);
+  }
+}
+
+async function syncDefaultPermissionModeToSessions(mode: Exclude<PermissionMode, 'explore'>): Promise<void> {
+  const sessions = await runtime.listSessions();
+  await Promise.all(sessions.map(async (session) => {
+    if (session.permissionMode === mode) return;
+    if (isDeepResearchSession(session.labels)) return;
+    if (session.status === 'running' || session.status === 'waiting_for_user') return;
+    try {
+      await runtime.setPermissionMode(session.id, mode);
+      emitSessionsChanged('mode-change', session.id);
+    } catch {
+      // Best effort: the persisted global default is still the authority for
+      // new sessions; busy sessions can be reconciled on a later change.
+    }
+  }));
 }
 
 async function handleExternalSettingsChange(): Promise<void> {

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -1,4 +1,4 @@
-import type { PermissionMode, PermissionResponse, SessionSummary, StoredMessage, ThinkingLevel } from '@maka/core';
+import type { PermissionResponse, SessionSummary, StoredMessage, ThinkingLevel } from '@maka/core';
 import { generalizedErrorMessageChinese } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
 import { messageRefreshErrorMessage } from './app-shell-copy.js';
@@ -35,8 +35,6 @@ type PendingNewChatModel = {
   llmConnectionSlug: string;
   model: string;
 } | null;
-
-type PendingNewChatPermissionMode = PermissionMode | null;
 
 type PendingNewChatThinkingLevel = ThinkingLevel | null;
 
@@ -112,8 +110,6 @@ export function createAppShellChatActions(deps: {
   isNewChatSendSurfaceActive: (owner: ComposerImportOwner) => boolean;
   markSessionReadLocally: (sessionId: string, readMessages: readonly StoredMessage[]) => void;
   messageRetryPendingRef: RefBox<Set<string>>;
-  pendingNewChatPermissionMode: PendingNewChatPermissionMode;
-  setPendingNewChatPermissionMode: (mode: PendingNewChatPermissionMode) => void;
   refreshSessions: () => Promise<SessionSummary[]>;
   setActiveId: (sessionId: string | undefined) => void;
   setMessageLoadErrorBySession: MessageLoadErrorUpdater;
@@ -134,14 +130,12 @@ export function createAppShellChatActions(deps: {
     isNewChatSendSurfaceActive,
     markSessionReadLocally,
     messageRetryPendingRef,
-    pendingNewChatPermissionMode,
     refreshSessions,
     setActiveId,
     setMessageLoadErrorBySession,
     setMessageRetryPendingBySession,
     setMessages,
     setNavSelection,
-    setPendingNewChatPermissionMode,
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
@@ -206,14 +200,12 @@ export function createAppShellChatActions(deps: {
 	          // authority — a renderer-side copy of the default can be stale
           // (e.g. before the mount-time settings load resolves on a cold
           // start), which would silently override the configured setting.
-          ...(pendingNewChatPermissionMode ? { permissionMode: pendingNewChatPermissionMode } : {}),
           name: text.slice(0, 42) || '新建对话',
           ...(validPendingNewChatModel
             ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }
             : {}),
           ...(pendingNewChatThinkingLevel ? { thinkingLevel: pendingNewChatThinkingLevel } : {}),
         });
-        setPendingNewChatPermissionMode(null);
         upsertSessionSummary(session);
         optimisticSessionId = session.id;
         optimisticTurnId = turnId;

--- a/apps/desktop/src/renderer/app-shell-session-settings-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-session-settings-actions.ts
@@ -1,4 +1,4 @@
-import type { LlmConnection, PermissionMode, SessionSummary, ThinkingLevel } from '@maka/core';
+import type { ChatDefaultPermissionMode, LlmConnection, PermissionMode, SessionSummary, ThinkingLevel } from '@maka/core';
 import { generalizedErrorMessageChinese } from '@maka/core';
 import { permissionModeDescriptions } from './app-shell-copy';
 import { saveComposerDefaults } from './composer-defaults';
@@ -24,8 +24,8 @@ export function createAppShellSessionSettingsActions(deps: {
   pendingSessionModelChangesRef: RefBox<Set<string>>;
   refreshSessions: () => Promise<SessionSummary[]>;
   sessionsRef: RefBox<SessionSummary[]>;
+  setDefaultPermissionMode: (mode: ChatDefaultPermissionMode) => void;
   setPendingPermissionModeBySession: BooleanRecordUpdater;
-  setPendingNewChatPermissionMode: (mode: PermissionMode | null) => void;
   setPendingSessionModelBySession: BooleanRecordUpdater;
   setSessions: (updater: (current: SessionSummary[]) => SessionSummary[]) => void;
   toastApi: ToastApi;
@@ -37,8 +37,8 @@ export function createAppShellSessionSettingsActions(deps: {
     pendingSessionModelChangesRef,
     refreshSessions,
     sessionsRef,
+    setDefaultPermissionMode,
     setPendingPermissionModeBySession,
-    setPendingNewChatPermissionMode,
     setPendingSessionModelBySession,
     setSessions,
     toastApi,
@@ -52,46 +52,28 @@ export function createAppShellSessionSettingsActions(deps: {
   }
 
   async function setPermissionMode(mode: PermissionMode) {
+    if (mode === 'explore') return;
     const sessionId = activeIdRef.current;
-    if (!sessionId) {
-      setPendingNewChatPermissionMode(mode);
-      return;
-    }
-    if (pendingPermissionModeChangesRef.current.has(sessionId)) return;
-    const current = sessionsRef.current.find((session) => session.id === sessionId);
-    if (!current || current.permissionMode === mode) return;
-    pendingPermissionModeChangesRef.current.add(sessionId);
-    setPendingPermissionModeBySession((current) => ({ ...current, [sessionId]: true }));
+    const pendingKey = sessionId ?? '__global_permission_mode__';
+    if (pendingPermissionModeChangesRef.current.has(pendingKey)) return;
+
+    pendingPermissionModeChangesRef.current.add(pendingKey);
+    if (sessionId) setPendingPermissionModeBySession((current) => ({ ...current, [sessionId]: true }));
     try {
-      const next = await window.maka.sessions.setPermissionMode(sessionId, mode);
-      // Patch the session in-place so the chat header reflects the new mode
-      // immediately without waiting for a full list refresh.
-      if (activeIdRef.current === sessionId) {
-        setSessions((prev) => prev.map((session) => (session.id === next.id ? next : session)));
-      }
-      const labels: Record<PermissionMode, string> = {
-        explore: '只读模式',
-        ask: '询问权限',
-        execute: '自动执行',
-        bypass: '跳过确认',
-      };
-      if (activeIdRef.current === sessionId) toastApi.success(`已切到 ${labels[mode]}`, permissionModeDescriptions[mode]);
+      const result = await window.maka.settings.update({ chatDefaults: { permissionMode: mode } });
+      const nextMode = result.settings.chatDefaults.permissionMode;
+      setDefaultPermissionMode(nextMode);
+      setSessions((prev) => prev.map((session) => ({ ...session, permissionMode: nextMode })));
+      toastApi.success(`已切到 ${permissionModeLabels[nextMode]}`, permissionModeDescriptions[nextMode]);
       await refreshSessions();
     } catch (error) {
-      if (activeIdRef.current === sessionId) {
-        toastApi.error(
-          '切换权限模式失败',
-          generalizedErrorMessageChinese(error, '权限模式暂时无法切换，请稍后重试。'),
-        );
-      }
+      toastApi.error(
+        '切换权限模式失败',
+        generalizedErrorMessageChinese(error, '权限模式暂时无法切换，请稍后重试。'),
+      );
     } finally {
-      pendingPermissionModeChangesRef.current.delete(sessionId);
-      setPendingPermissionModeBySession((current) => {
-        if (!(sessionId in current)) return current;
-        const next = { ...current };
-        delete next[sessionId];
-        return next;
-      });
+      pendingPermissionModeChangesRef.current.delete(pendingKey);
+      if (sessionId) setPendingPermissionModeBySession((current) => omitSessionKey(current, sessionId));
     }
   }
 
@@ -111,26 +93,17 @@ export function createAppShellSessionSettingsActions(deps: {
           `${connection?.name ?? next.llmConnectionSlug} · ${next.model}`,
         );
       }
-      // Sync the global default so a subsequent "新任务" inherits this pick.
       saveComposerDefaults({ model: input });
       await refreshSessions();
     } catch (error) {
-      if (activeIdRef.current === sessionId) toastApi.error('切换模型失败', generalizedErrorMessageChinese(error, '模型暂时无法切换，请稍后重试。'));
+      if (activeIdRef.current === sessionId) {
+        toastApi.error('切换模型失败', generalizedErrorMessageChinese(error, '模型暂时无法切换，请稍后重试。'));
+      }
     } finally {
       pendingSessionModelChangesRef.current.delete(sessionId);
       setPendingSessionModelBySession((current) => omitSessionKey(current, sessionId));
     }
   }
-
-  const thinkingLevelLabels: Record<ThinkingLevel, string> = {
-    off: '关',
-    minimal: '最小',
-    low: '低',
-    medium: '中',
-    high: '高',
-    xhigh: '超高',
-    max: '最高',
-  };
 
   async function setSessionThinkingLevel(level: ThinkingLevel | undefined) {
     const sessionId = activeIdRef.current;
@@ -157,3 +130,19 @@ export function createAppShellSessionSettingsActions(deps: {
     setSessionThinkingLevel,
   };
 }
+
+const permissionModeLabels: Record<ChatDefaultPermissionMode, string> = {
+  ask: '询问权限',
+  execute: '自动执行',
+  bypass: '跳过确认',
+};
+
+const thinkingLevelLabels: Record<ThinkingLevel, string> = {
+  off: '关',
+  minimal: '最少',
+  low: '低',
+  medium: '中',
+  high: '高',
+  xhigh: '超高',
+  max: '最高',
+};

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -245,7 +245,6 @@ export function AppShell({
   // restart with no visible signal, which is a safety regression.
   // The single authority is main.ts's Settings → 通用 default. See
   // session-status-presentation.test.ts for the contract.
-  const [pendingNewChatPermissionMode, setPendingNewChatPermissionMode] = useState<PermissionMode | null>(null);
   const [appInfo, setAppInfo] = useState<RendererAppInfo | null>(
     persistedComposerDefaults?.projectPath
       ? { projectPath: persistedComposerDefaults.projectPath, projectGit: { isGitRepo: false } }
@@ -566,8 +565,8 @@ export function AppShell({
     pendingSessionModelChangesRef,
     refreshSessions,
     sessionsRef,
+    setDefaultPermissionMode,
     setPendingPermissionModeBySession,
-    setPendingNewChatPermissionMode,
     setPendingSessionModelBySession,
     setSessions,
     toastApi,
@@ -902,8 +901,6 @@ export function AppShell({
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
-    pendingNewChatPermissionMode,
-    setPendingNewChatPermissionMode,
     validPendingNewChatModel,
     pendingNewChatThinkingLevel: newChatThinkingLevel ?? null,
   });
@@ -1570,7 +1567,7 @@ export function AppShell({
                       }
                     : undefined
                 }
-                permissionMode={activeSessionForView?.permissionMode ?? pendingNewChatPermissionMode ?? defaultPermissionMode}
+                permissionMode={defaultPermissionMode}
                 permissionModePending={activeId ? pendingPermissionModeBySession[activeId] === true : false}
                 permissionModeDisabledReason={
                   activeId && pendingPermissionModeBySession[activeId] === true


### PR DESCRIPTION
## Summary

Replace the one-shot **pendingNewChatPermissionMode** mechanism with a global default permission mode stored in user settings.

### Changes

1. **app-shell-session-settings-actions.ts** — \setPermissionMode()\ now directly updates \settings.update({ chatDefaults: { permissionMode } })\ instead of calling \sessions.setPermissionMode()\. Filters out \'explore'\ mode.

2. **app-shell.tsx** — Removed \pendingNewChatPermissionMode\ state. The \permissionMode\ prop is now derived directly from \defaultPermissionMode\. Added \setDefaultPermissionMode\ callback.

3. **app-shell-chat-actions.ts** — Removed \PendingNewChatPermissionMode\ type and its related deps. New sessions no longer receive \permissionMode\ override.

4. **main.ts** — Added \syncDefaultPermissionModeToSessions()\ which, when \chatDefaults.permissionMode\ changes, syncs all non-deep-research and non-running sessions to the new default.

5. **Test files** — Updated contract tests and mocks to reflect the removed \pendingNewChatPermissionMode\ parameter.

### Files changed

\\\
7 files changed, 82 insertions(+), 100 deletions(-)
\\\

Closes the old one-shot permission-mode toggle flow. All sessions now inherit the global default, and changing the default propagates to existing sessions.