### PR TITLE
feat(skills): add managed source workflow

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -68,7 +68,7 @@ import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/settings/result';
 import type { CreateSessionInput } from '@maka/core';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
-import type { SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type {
   OnboardingMilestone,
@@ -521,6 +521,21 @@ declare global {
       };
       skills: {
         list(): Promise<SkillEntry[]>;
+        sources: {
+          list(): Promise<ManagedSkillSourceEntry[]>;
+          importLocalFile(): Promise<
+            | { ok: true; source: ManagedSkillSourceEntry }
+            | { ok: false; reason: 'cancelled' | 'invalid_skill' | 'already_exists' | 'blocked_path' | 'write_failed' }
+          >;
+        };
+        installManaged(sourceId: string): Promise<
+          | { ok: true; skill: SkillEntry }
+          | { ok: false; reason: 'not_found' | 'already_exists' | 'blocked_path' | 'write_failed' }
+        >;
+        updateManaged(skillId: string): Promise<
+          | { ok: true; skill: SkillEntry }
+          | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
+        >;
         createStarter(): Promise<
           | { ok: true; skill: SkillEntry; filePath: string }
           | { ok: false; reason: 'blocked_path' | 'already_exists' | 'write_failed' }

--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -201,6 +201,7 @@ function BootstrapSubscriptionProbe(props: {
     refreshPlanReminders: async () => {},
     refreshShellSettings: async () => {},
     refreshSkills: async () => {},
+    refreshManagedSkillSources: async () => {},
     refreshSessions: async () => [],
     rendererMountedRef: props.refs.rendererMountedRef,
     setActiveId: () => {},

--- a/apps/desktop/src/main/__tests__/managed-skill-sources.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-skill-sources.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  importManagedSkillSource,
+  listManagedSkillSources,
+  readManagedSkillSource,
+  resolveManagedSkillSourcesRoot,
+} from '../managed-skill-sources.js';
+
+describe('managed skill sources', () => {
+  it('resolves the global source cache under .maka without making it a runtime path', () => {
+    assert.equal(resolveManagedSkillSourcesRoot('C:\\Users\\Ada'), join('C:\\Users\\Ada', '.maka', 'skill-sources'));
+  });
+
+  it('imports a local SKILL.md into a managed source cache', async () => {
+    await withTempRoot(async (root) => {
+      const sourceDir = join(root, 'incoming', 'research-brief');
+      await mkdir(sourceDir, { recursive: true });
+      const sourceFile = join(sourceDir, 'SKILL.md');
+      const sourceText = `---
+name: Research Brief
+description: Summarize research notes.
+allowed-tools: [Read]
+---
+# Research Brief
+Use concise bullets.`;
+      await writeFile(sourceFile, sourceText, 'utf8');
+
+      const cacheRoot = join(root, 'cache');
+      const result = await importManagedSkillSource({ root: cacheRoot, sourceFile });
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.source.id, 'research-brief');
+      assert.equal(result.source.name, 'Research Brief');
+      assert.equal(result.source.description, 'Summarize research notes.');
+      assert.equal(result.source.sourceType, 'local');
+      assert.match(result.source.contentSha256, /^sha256:[a-f0-9]{64}$/);
+      assert.equal(result.source.sourcePath, join(cacheRoot, 'research-brief', 'SKILL.md'));
+
+      assert.equal(await readFile(join(cacheRoot, 'research-brief', 'SKILL.md'), 'utf8'), sourceText);
+
+      const listed = await listManagedSkillSources(cacheRoot);
+      assert.deepEqual(listed.map((source) => source.id), ['research-brief']);
+      assert.equal(listed[0].contentSha256, result.source.contentSha256);
+
+      const read = await readManagedSkillSource(cacheRoot, 'research-brief');
+      assert.equal(read.ok, true);
+      if (!read.ok) return;
+      assert.equal(read.source.id, 'research-brief');
+      assert.equal(read.content, sourceText);
+    });
+  });
+
+  it('rejects invalid or duplicate managed sources', async () => {
+    await withTempRoot(async (root) => {
+      const cacheRoot = join(root, 'cache');
+      const invalid = join(root, 'not-a-skill.md');
+      await writeFile(invalid, '# Missing front matter name', 'utf8');
+
+      assert.deepEqual(await importManagedSkillSource({ root: cacheRoot, sourceFile: invalid }), {
+        ok: false,
+        reason: 'invalid_skill',
+      });
+
+      const sourceDir = join(root, 'incoming', 'deck-helper');
+      await mkdir(sourceDir, { recursive: true });
+      const sourceFile = join(sourceDir, 'SKILL.md');
+      await writeFile(sourceFile, `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper`, 'utf8');
+
+      const first = await importManagedSkillSource({ root: cacheRoot, sourceFile });
+      assert.equal(first.ok, true);
+      assert.deepEqual(await importManagedSkillSource({ root: cacheRoot, sourceFile }), {
+        ok: false,
+        reason: 'already_exists',
+      });
+    });
+  });
+});
+
+async function withTempRoot(fn: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-managed-sources-'));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/apps/desktop/src/main/__tests__/managed-skill-sources.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-skill-sources.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -51,6 +51,80 @@ Use concise bullets.`;
       if (!read.ok) return;
       assert.equal(read.source.id, 'research-brief');
       assert.equal(read.content, sourceText);
+    });
+  });
+
+  it('lists managed sources from the real SKILL.md instead of stale registry metadata', async () => {
+    await withTempRoot(async (root) => {
+      const sourceDir = join(root, 'incoming', 'research-brief');
+      await mkdir(sourceDir, { recursive: true });
+      const sourceFile = join(sourceDir, 'SKILL.md');
+      await writeFile(sourceFile, `---
+name: Research Brief
+description: Summarize research notes.
+---
+# Research Brief`, 'utf8');
+
+      const cacheRoot = join(root, 'cache');
+      const imported = await importManagedSkillSource({ root: cacheRoot, sourceFile });
+      assert.equal(imported.ok, true);
+
+      await writeFile(join(cacheRoot, 'registry.json'), JSON.stringify({
+        schemaVersion: 1,
+        sources: [{
+          id: 'research-brief',
+          name: 'Stale Registry Name',
+          description: 'Stale registry description.',
+          sourceType: 'local',
+          sourcePath: join(cacheRoot, 'research-brief', 'SKILL.md'),
+          contentSha256: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+        }],
+      }), 'utf8');
+      await writeFile(join(cacheRoot, 'research-brief', 'source.json'), JSON.stringify({
+        id: 'research-brief',
+        name: 'Stale Source Json Name',
+      }), 'utf8');
+      await writeFile(join(cacheRoot, 'research-brief', 'SKILL.md'), `---
+name: Updated Source Name
+description: Updated source description.
+---
+# Updated Source`, 'utf8');
+
+      const listed = await listManagedSkillSources(cacheRoot);
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0].name, 'Updated Source Name');
+      assert.equal(listed[0].description, 'Updated source description.');
+
+      await rm(join(cacheRoot, 'registry.json'), { force: true });
+      const listedWithoutRegistry = await listManagedSkillSources(cacheRoot);
+      assert.deepEqual(listedWithoutRegistry.map((source) => source.id), ['research-brief']);
+    });
+  });
+
+  it('rejects symlinked managed source cache roots before writing', async () => {
+    await withTempRoot(async (root) => {
+      const sourceDir = join(root, 'incoming', 'deck-helper');
+      await mkdir(sourceDir, { recursive: true });
+      const sourceFile = join(sourceDir, 'SKILL.md');
+      await writeFile(sourceFile, `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper`, 'utf8');
+
+      const outside = join(root, 'outside-cache-target');
+      const cacheRoot = join(root, 'cache-link');
+      await mkdir(outside);
+      await symlink(outside, cacheRoot);
+
+      assert.deepEqual(await importManagedSkillSource({ root: cacheRoot, sourceFile }), {
+        ok: false,
+        reason: 'blocked_path',
+      });
+      assert.deepEqual(await listManagedSkillSources(cacheRoot), []);
+      await assert.rejects(readFile(join(outside, 'deck-helper', 'SKILL.md'), 'utf8'));
     });
   });
 

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -638,6 +638,51 @@ Local edit.`, 'utf8');
     });
   });
 
+  it('rejects symlinked managed skill files before updating', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      const outside = await mkdtemp(join(tmpdir(), 'maka-managed-update-outside-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'deck-helper');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        const versionOne = `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version one.`;
+        await writeFile(incomingFile, versionOne, 'utf8');
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+        const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
+        assert.equal(installed.ok, true);
+
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version two.`, 'utf8');
+
+        const outsideTarget = join(outside, 'target.md');
+        await writeFile(outsideTarget, versionOne, 'utf8');
+        await rm(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'));
+        await symlink(outsideTarget, join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'));
+
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot), {
+          ok: false,
+          reason: 'blocked_path',
+        });
+        assert.equal(await readFile(outsideTarget, 'utf8'), versionOne);
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('rejects a symlinked skills directory instead of writing through it', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const outside = await mkdtemp(join(tmpdir(), 'maka-skills-outside-'));

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -12,11 +12,14 @@ import {
   buildSkillsPromptFragment,
   createStarterSkill,
   ensureBundledOfficeSkills,
+  installManagedSkill,
   loadSkillInstructions,
   listInstalledSkills,
   parseSkillFrontMatter,
   resolveSkillOpenPath,
+  updateManagedSkill,
 } from '../skills.js';
+import { importManagedSkillSource } from '../managed-skill-sources.js';
 import { readRendererShellCombinedSource } from './renderer-shell-source-helpers.js';
 import { extractFunctionBlock } from './function-block-helpers.js';
 
@@ -466,10 +469,184 @@ name: Managed Forgery
     });
   });
 
+  it('does not trust forged managed locks that do not match the source snapshot', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'research-brief');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        await writeFile(incomingFile, `---
+name: Research Brief
+description: Summarize research.
+---
+# Research Brief
+Source snapshot.`, 'utf8');
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+
+        await writeSkill(workspaceRoot, 'research-brief', `---
+name: Research Brief
+description: Forged workspace copy.
+---
+# Research Brief
+Forged workspace content.`);
+        const forgedContent = await readFile(join(workspaceRoot, 'skills', 'research-brief', 'SKILL.md'), 'utf8');
+        const forgedContentSha256 = `sha256:${sha256Hex(forgedContent)}`;
+        assert.notEqual(forgedContentSha256, imported.source.contentSha256);
+        await writeFile(join(workspaceRoot, 'skills', 'research-brief', 'skill.lock.json'), JSON.stringify({
+          schemaVersion: 1,
+          id: 'research-brief',
+          sourceType: 'managed',
+          sourceName: 'local-library',
+          sourceVersion: '1',
+          contentSha256: forgedContentSha256,
+          installedAt: new Date(0).toISOString(),
+          sourceId: 'research-brief',
+          sourceContentSha256: imported.source.contentSha256,
+        }), 'utf8');
+
+        const skills = await listInstalledSkills(workspaceRoot, { managedSourceRoot: sourceRoot });
+        const forged = skills.find((skill) => skill.id === 'research-brief');
+        assert.ok(forged);
+        assert.equal(forged.sourceType, 'unknown');
+        assert.equal(forged.validationStatus, 'metadata_error');
+        assert.deepEqual(forged.validationCodes, ['unsupported_schema']);
+        assert.equal(forged.managedUpdateStatus, 'metadata_error');
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'research-brief', sourceRoot), {
+          ok: false,
+          reason: 'metadata_error',
+        });
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('installs managed sources into the workspace without using the source cache at runtime', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'research-brief');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        await writeFile(incomingFile, `---
+name: Research Brief
+description: Summarize research.
+allowed-tools: [Read]
+---
+# Research Brief
+Use source version one.`, 'utf8');
+
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+
+        const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
+        assert.equal(installed.ok, true);
+        if (!installed.ok) return;
+        assert.equal(installed.skill.id, 'research-brief');
+        assert.equal(installed.skill.sourceType, 'managed');
+        assert.equal(installed.skill.sourceName, 'local-library');
+        assert.equal(installed.skill.managedSourceId, 'research-brief');
+        assert.equal(installed.skill.managedUpdateStatus, 'up_to_date');
+
+        const lock = JSON.parse(await readFile(join(workspaceRoot, 'skills', 'research-brief', 'skill.lock.json'), 'utf8')) as Record<string, unknown>;
+        assert.equal(lock.sourceType, 'managed');
+        assert.equal(lock.sourceId, 'research-brief');
+        assert.equal(lock.sourceContentSha256, imported.source.contentSha256);
+
+        await writeFile(join(sourceRoot, 'research-brief', 'SKILL.md'), `---
+name: Research Brief
+description: Summarize research.
+allowed-tools: [Read]
+---
+# Research Brief
+Use source version two.`, 'utf8');
+
+        const loaded = await loadSkillInstructions(workspaceRoot, 'research-brief');
+        assert.equal(loaded.ok, true);
+        if (!loaded.ok) return;
+        assert.match(loaded.skill.instructions, /Use source version one\./);
+        assert.doesNotMatch(loaded.skill.instructions, /Use source version two\./);
+
+        const skills = await listInstalledSkills(workspaceRoot, { managedSourceRoot: sourceRoot });
+        const managed = skills.find((skill) => skill.id === 'research-brief');
+        assert.ok(managed);
+        assert.equal(managed.managedUpdateStatus, 'update_available');
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('updates managed skills only when the workspace copy is clean', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'deck-helper');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        await writeFile(incomingFile, `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version one.`, 'utf8');
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+        const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
+        assert.equal(installed.ok, true);
+
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version two.`, 'utf8');
+
+        const updated = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(updated.ok, true);
+        if (!updated.ok) return;
+        assert.equal(updated.skill.managedUpdateStatus, 'up_to_date');
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version two\./);
+
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version three.`, 'utf8');
+        await writeFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Local edit.`, 'utf8');
+
+        const blocked = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.deepEqual(blocked, { ok: false, reason: 'local_modified' });
+        const skills = await listInstalledSkills(workspaceRoot, { managedSourceRoot: sourceRoot });
+        const managed = skills.find((skill) => skill.id === 'deck-helper');
+        assert.ok(managed);
+        assert.equal(managed.managedUpdateStatus, 'local_modified');
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('rejects a symlinked skills directory instead of writing through it', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const outside = await mkdtemp(join(tmpdir(), 'maka-skills-outside-'));
       try {
+        await mkdir(join(outside, 'external'), { recursive: true });
+        await writeFile(join(outside, 'external', 'SKILL.md'), `---
+name: External
+---
+# External`, 'utf8');
         await symlink(outside, join(workspaceRoot, 'skills'));
         assert.deepEqual(await createStarterSkill(workspaceRoot), { ok: false, reason: 'blocked_path' });
         assert.deepEqual(await ensureBundledOfficeSkills(workspaceRoot), {
@@ -597,6 +774,9 @@ name: Writer
     assert.match(skillPanel, /actionBusy\?: boolean/);
     assert.match(skillPanel, /createPending\?: boolean/);
     assert.match(skillPanel, /openingSkillId\?: string \| null/);
+    assert.match(skillPanel, /managedSkillSources\?: ManagedSkillSourceEntry\[]/);
+    assert.match(skillPanel, /installingSourceId\?: string \| null/);
+    assert.match(skillPanel, /updatingSkillId\?: string \| null/);
     assert.match(skillPanel, /const templates = \(/);
     assert.doesNotMatch(skillPanel, /maka-skill-workbench-rail/);
     assert.doesNotMatch(skillPanel, /maka-skill-workbench-summary/);
@@ -614,20 +794,29 @@ name: Writer
     assert.match(ui, /metadata_error[\s\S]*元数据异常/);
     assert.match(ui, /userModified[\s\S]*已修改/);
     assert.match(ui, /sourceType === 'bundled'[\s\S]*内置/);
-    assert.doesNotMatch(ui, /sourceType === 'managed'[\s\S]*受管理/, 'Phase 1 must not present forged managed locks as trusted');
+    assert.match(ui, /sourceType === 'managed'[\s\S]*managedUpdateStatus[\s\S]*受管理/, 'Phase 2 can present verified managed state derived by main');
     assert.match(ui, /return '本地'/);
-    assert.match(skillEntryContract, /sourceType\?: 'workspace' \| 'bundled' \| 'unknown'/);
-    assert.doesNotMatch(skillEntryContract, /managed|sourceName|sourceVersion|contentSha256|installedAt|validationCodes|validationMessages|write_failed/, 'renderer SkillEntry must not expose Phase 1 lock internals');
+    assert.match(skillEntryContract, /sourceType\?: 'workspace' \| 'bundled' \| 'managed' \| 'unknown'/);
+    assert.match(skillEntryContract, /managedUpdateStatus\?:/);
+    assert.doesNotMatch(skillEntryContract, /sourceName|sourceVersion|contentSha256|installedAt|validationCodes|validationMessages|write_failed/, 'renderer SkillEntry must not expose lock internals');
     assert.match(workspaceResourcesIpc, /toSkillEntry/, 'Skills IPC must scrub main-internal lock fields before crossing to renderer');
     assert.doesNotMatch(workspaceResourcesIpc, /ipcMain\.handle\('skills:list'[\s\S]*listInstalledSkills\(deps\.workspaceRoot\)/, 'Skills list IPC must not return InstalledSkill objects directly');
-    assert.doesNotMatch(skillPanel, /更新|恢复|修复|合并/, 'Phase 1 Skills status UI must stay informational only');
-    assert.match(skillPanel, /<span className="maka-skill-library-action" aria-hidden="true">[\s\S]*打开[\s\S]*<\/span>/);
+    assert.match(skillPanel, /const managedSources = \(/, 'Phase 2 must surface the managed source cache without making it runtime');
+    assert.match(skillPanel, /<section className="maka-skill-installed" aria-label="来源库">/);
+    assert.match(skillPanel, /导入本地 Skill/);
+    assert.match(skillPanel, /onInstallManagedSkill\?\(sourceId: string\): void \| Promise<void>/);
+    assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string\): void \| Promise<void>/);
+    assert.match(skillPanel, /skill\.managedUpdateStatus === 'update_available'/);
+    assert.match(skillPanel, /updating \? '更新中…' : '更新'/);
+    assert.doesNotMatch(skillPanel, /恢复|修复|合并/, 'Phase 2 must not imply automatic merge or repair flows');
+    assert.match(skillPanel, /<span className="maka-skill-library-action" aria-hidden="true">[\s\S]*可更新[\s\S]*打开[\s\S]*<\/span>/);
     assert.match(skillPanel, /label: props\.createPending \? '创建中…' : '创建示例技能'/);
     assert.match(skillPanel, /label: props\.refreshPending \? '刷新中…' : '刷新技能'/);
     assert.match(skillPanel, /disabled: props\.actionBusy/);
     assert.match(skillPanel, /aria-busy=\{props\.actionBusy \? 'true' : undefined\}/);
     assert.match(skillPanel, /disabled=\{props\.actionBusy\}/, 'Skill row open buttons must be disabled while a Skills action is pending');
     assert.match(skillPanel, /opening && <span>打开中…<\/span>/);
+    assert.match(skillPanel, /updating && <span>更新中…<\/span>/);
     assert.match(emptyState, /disabled\?: boolean/);
     assert.match(emptyState, /disabled=\{props\.cta\.disabled\}/);
     assert.match(emptyState, /disabled=\{props\.secondaryCta\.disabled\}/);

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { basename, dirname, extname, isAbsolute, join, relative } from 'node:path';
+import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
+
+export interface ManagedSkillSourceRegistry {
+  schemaVersion: 1;
+  sources: ManagedSkillSourceRecord[];
+}
+
+export interface ManagedSkillSourceRecord {
+  id: string;
+  name: string;
+  description: string;
+  sourceType: 'local';
+  sourcePath: string;
+  contentSha256: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type ImportManagedSkillSourceResult =
+  | { ok: true; source: ManagedSkillSourceRecord }
+  | { ok: false; reason: 'cancelled' | 'invalid_skill' | 'already_exists' | 'blocked_path' | 'write_failed' };
+
+export type ReadManagedSkillSourceResult =
+  | { ok: true; source: ManagedSkillSourceRecord; content: string; contentSha256: string }
+  | { ok: false; reason: 'not_found' | 'blocked_path' | 'read_failed' };
+
+export function resolveManagedSkillSourcesRoot(homeDir = homedir()): string {
+  return join(homeDir, '.maka', 'skill-sources');
+}
+
+export async function listManagedSkillSources(root = resolveManagedSkillSourcesRoot()): Promise<ManagedSkillSourceRecord[]> {
+  const registry = await readRegistry(root);
+  return registry.sources.slice().sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function importManagedSkillSource(input: {
+  root?: string;
+  sourceFile: string;
+}): Promise<ImportManagedSkillSourceResult> {
+  const root = input.root ?? resolveManagedSkillSourcesRoot();
+  let sourceStat: Awaited<ReturnType<typeof lstat>>;
+  try {
+    sourceStat = await lstat(input.sourceFile);
+  } catch {
+    return { ok: false, reason: 'invalid_skill' };
+  }
+  if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(input.sourceFile);
+  } catch {
+    return { ok: false, reason: 'invalid_skill' };
+  }
+
+  const content = bytes.toString('utf8');
+  const parsed = parseSkillFrontMatterForSource(content);
+  if (!parsed.name) return { ok: false, reason: 'invalid_skill' };
+
+  const id = sourceIdFromPath(input.sourceFile);
+  if (!id) return { ok: false, reason: 'invalid_skill' };
+
+  const sourceDir = join(root, id);
+  const managedSkillPath = join(sourceDir, 'SKILL.md');
+  const now = new Date().toISOString();
+  const contentSha256 = `sha256:${sha256(bytes)}`;
+
+  try {
+    await mkdir(root, { recursive: true, mode: 0o700 });
+    const registry = await readRegistry(root);
+    if (registry.sources.some((source) => source.id === id)) return { ok: false, reason: 'already_exists' };
+
+    await mkdir(sourceDir, { mode: 0o700 });
+    await writeFile(managedSkillPath, bytes, { flag: 'wx', mode: 0o600 });
+
+    const source: ManagedSkillSourceRecord = {
+      id,
+      name: parsed.name,
+      description: parsed.description ?? '',
+      sourceType: 'local',
+      sourcePath: managedSkillPath,
+      contentSha256,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await writeFile(join(sourceDir, 'source.json'), `${JSON.stringify(source, null, 2)}\n`, { mode: 0o600 });
+    await writeRegistry(root, {
+      schemaVersion: 1,
+      sources: [...registry.sources, source],
+    });
+    return { ok: true, source };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return { ok: false, reason: 'already_exists' };
+    return { ok: false, reason: 'write_failed' };
+  }
+}
+
+export async function readManagedSkillSource(
+  root: string,
+  sourceId: string,
+): Promise<ReadManagedSkillSourceResult> {
+  if (!isSafeSkillId(sourceId)) return { ok: false, reason: 'not_found' };
+
+  const sourcePath = join(root, sourceId, 'SKILL.md');
+  try {
+    const [rootReal, sourceReal] = await Promise.all([realpath(root), realpath(sourcePath)]);
+    if (!isContainedPath(rootReal, sourceReal)) return { ok: false, reason: 'blocked_path' };
+  } catch {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  try {
+    const sourceStat = await lstat(sourcePath);
+    if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const bytes = await readFile(sourcePath);
+    const registry = await readRegistry(root);
+    const registryRecord = registry.sources.find((source) => source.id === sourceId);
+    const contentSha256 = `sha256:${sha256(bytes)}`;
+    const content = bytes.toString('utf8');
+    const parsed = parseSkillFrontMatterForSource(content);
+    const source: ManagedSkillSourceRecord = registryRecord ?? {
+      id: sourceId,
+      name: parsed.name ?? sourceId,
+      description: parsed.description ?? '',
+      sourceType: 'local',
+      sourcePath,
+      contentSha256,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    return { ok: true, source: { ...source, contentSha256, sourcePath }, content, contentSha256 };
+  } catch {
+    return { ok: false, reason: 'read_failed' };
+  }
+}
+
+async function readRegistry(root: string): Promise<ManagedSkillSourceRegistry> {
+  try {
+    const parsed = JSON.parse(await readFile(join(root, 'registry.json'), 'utf8')) as Partial<ManagedSkillSourceRegistry>;
+    if (parsed.schemaVersion !== 1 || !Array.isArray(parsed.sources)) return { schemaVersion: 1, sources: [] };
+    return {
+      schemaVersion: 1,
+      sources: parsed.sources.filter(isManagedSkillSourceRecord),
+    };
+  } catch {
+    return { schemaVersion: 1, sources: [] };
+  }
+}
+
+async function writeRegistry(root: string, registry: ManagedSkillSourceRegistry): Promise<void> {
+  await writeFile(join(root, 'registry.json'), `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
+}
+
+function sourceIdFromPath(filePath: string): string | undefined {
+  const fileName = basename(filePath).toLowerCase() === 'skill.md'
+    ? basename(dirname(filePath))
+    : basename(filePath, extname(filePath));
+  const normalized = fileName
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return isSafeSkillId(normalized) ? normalized : undefined;
+}
+
+function parseSkillFrontMatterForSource(text: string): { name?: string; description?: string } {
+  if (!text.startsWith('---')) return {};
+  const close = text.indexOf('\n---', 3);
+  if (close < 0) return {};
+  const block = text.slice(3, close);
+  const result: { name?: string; description?: string } = {};
+  for (const raw of block.split(/\r?\n/)) {
+    const match = raw.match(/^(name|description):\s*(.*)$/);
+    if (!match) continue;
+    const value = match[2].trim().replace(/^['"]|['"]$/g, '');
+    if (value) result[match[1] as 'name' | 'description'] = value;
+  }
+  return result;
+}
+
+function isManagedSkillSourceRecord(value: unknown): value is ManagedSkillSourceRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const record = value as Partial<ManagedSkillSourceRecord>;
+  return typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.description === 'string' &&
+    record.sourceType === 'local' &&
+    typeof record.sourcePath === 'string' &&
+    typeof record.contentSha256 === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string';
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function isSafeSkillId(value: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(value);
+}
+
+function isContainedPath(root: string, child: string): boolean {
+  const rel = relative(root, child);
+  return rel === '' || (!!rel && !rel.startsWith('..') && !isAbsolute(rel));
+}

--- a/apps/desktop/src/main/managed-skill-sources.ts
+++ b/apps/desktop/src/main/managed-skill-sources.ts
@@ -1,12 +1,7 @@
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { basename, dirname, extname, isAbsolute, join, relative } from 'node:path';
-import { lstat, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
-
-export interface ManagedSkillSourceRegistry {
-  schemaVersion: 1;
-  sources: ManagedSkillSourceRecord[];
-}
+import { lstat, mkdir, readdir, readFile, realpath, rename, unlink, writeFile } from 'node:fs/promises';
 
 export interface ManagedSkillSourceRecord {
   id: string;
@@ -17,6 +12,13 @@ export interface ManagedSkillSourceRecord {
   contentSha256: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ManagedSkillSourceEntry {
+  id: string;
+  name: string;
+  description: string;
+  sourceType: 'local';
 }
 
 export type ImportManagedSkillSourceResult =
@@ -32,8 +34,17 @@ export function resolveManagedSkillSourcesRoot(homeDir = homedir()): string {
 }
 
 export async function listManagedSkillSources(root = resolveManagedSkillSourcesRoot()): Promise<ManagedSkillSourceRecord[]> {
-  const registry = await readRegistry(root);
-  return registry.sources.slice().sort((a, b) => a.name.localeCompare(b.name));
+  const sourceRoot = await resolveExistingSourceRoot(root);
+  if (!sourceRoot.ok) return [];
+
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const sources: ManagedSkillSourceRecord[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink() || !isSafeSkillId(entry.name)) continue;
+    const source = await readManagedSkillSource(root, entry.name);
+    if (source.ok) sources.push(source.source);
+  }
+  return sources.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function importManagedSkillSource(input: {
@@ -70,11 +81,15 @@ export async function importManagedSkillSource(input: {
 
   try {
     await mkdir(root, { recursive: true, mode: 0o700 });
-    const registry = await readRegistry(root);
-    if (registry.sources.some((source) => source.id === id)) return { ok: false, reason: 'already_exists' };
+    const sourceRoot = await resolveExistingSourceRoot(root);
+    if (!sourceRoot.ok) return { ok: false, reason: 'blocked_path' };
 
     await mkdir(sourceDir, { mode: 0o700 });
-    await writeFile(managedSkillPath, bytes, { flag: 'wx', mode: 0o600 });
+    const sourceDirReal = await resolveContainedDirectory(sourceRoot.rootReal, sourceDir);
+    if (!sourceDirReal.ok) return { ok: false, reason: 'blocked_path' };
+    if (!await writeContainedBufferFile(sourceDirReal.path, managedSkillPath, bytes, { failIfExists: true })) {
+      return { ok: false, reason: 'write_failed' };
+    }
 
     const source: ManagedSkillSourceRecord = {
       id,
@@ -86,11 +101,6 @@ export async function importManagedSkillSource(input: {
       createdAt: now,
       updatedAt: now,
     };
-    await writeFile(join(sourceDir, 'source.json'), `${JSON.stringify(source, null, 2)}\n`, { mode: 0o600 });
-    await writeRegistry(root, {
-      schemaVersion: 1,
-      sources: [...registry.sources, source],
-    });
     return { ok: true, source };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') return { ok: false, reason: 'already_exists' };
@@ -104,54 +114,112 @@ export async function readManagedSkillSource(
 ): Promise<ReadManagedSkillSourceResult> {
   if (!isSafeSkillId(sourceId)) return { ok: false, reason: 'not_found' };
 
+  const sourceRoot = await resolveExistingSourceRoot(root);
+  if (!sourceRoot.ok) return { ok: false, reason: sourceRoot.reason };
+
+  const sourceDir = join(root, sourceId);
   const sourcePath = join(root, sourceId, 'SKILL.md');
-  try {
-    const [rootReal, sourceReal] = await Promise.all([realpath(root), realpath(sourcePath)]);
-    if (!isContainedPath(rootReal, sourceReal)) return { ok: false, reason: 'blocked_path' };
-  } catch {
-    return { ok: false, reason: 'not_found' };
-  }
+  const sourceDirReal = await resolveContainedDirectory(sourceRoot.rootReal, sourceDir);
+  if (!sourceDirReal.ok) return { ok: false, reason: sourceDirReal.reason };
 
   try {
     const sourceStat = await lstat(sourcePath);
     if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const sourceReal = await realpath(sourcePath);
+    if (!isContainedPath(sourceDirReal.path, sourceReal)) return { ok: false, reason: 'blocked_path' };
     const bytes = await readFile(sourcePath);
-    const registry = await readRegistry(root);
-    const registryRecord = registry.sources.find((source) => source.id === sourceId);
     const contentSha256 = `sha256:${sha256(bytes)}`;
     const content = bytes.toString('utf8');
     const parsed = parseSkillFrontMatterForSource(content);
-    const source: ManagedSkillSourceRecord = registryRecord ?? {
+    const source: ManagedSkillSourceRecord = {
       id: sourceId,
       name: parsed.name ?? sourceId,
       description: parsed.description ?? '',
       sourceType: 'local',
       sourcePath,
       contentSha256,
-      createdAt: new Date(0).toISOString(),
-      updatedAt: new Date(0).toISOString(),
+      createdAt: sourceStat.birthtime.toISOString(),
+      updatedAt: sourceStat.mtime.toISOString(),
     };
-    return { ok: true, source: { ...source, contentSha256, sourcePath }, content, contentSha256 };
+    return { ok: true, source, content, contentSha256 };
   } catch {
     return { ok: false, reason: 'read_failed' };
   }
 }
 
-async function readRegistry(root: string): Promise<ManagedSkillSourceRegistry> {
+export function toManagedSkillSourceEntry(source: ManagedSkillSourceRecord): ManagedSkillSourceEntry {
+  return {
+    id: source.id,
+    name: source.name,
+    description: source.description,
+    sourceType: source.sourceType,
+  };
+}
+
+async function resolveExistingSourceRoot(root: string): Promise<
+  | { ok: true; rootReal: string }
+  | { ok: false; reason: 'not_found' | 'blocked_path' }
+> {
   try {
-    const parsed = JSON.parse(await readFile(join(root, 'registry.json'), 'utf8')) as Partial<ManagedSkillSourceRegistry>;
-    if (parsed.schemaVersion !== 1 || !Array.isArray(parsed.sources)) return { schemaVersion: 1, sources: [] };
-    return {
-      schemaVersion: 1,
-      sources: parsed.sources.filter(isManagedSkillSourceRecord),
-    };
+    const rootStat = await lstat(root);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    return { ok: true, rootReal: await realpath(root) };
   } catch {
-    return { schemaVersion: 1, sources: [] };
+    return { ok: false, reason: 'not_found' };
   }
 }
 
-async function writeRegistry(root: string, registry: ManagedSkillSourceRegistry): Promise<void> {
-  await writeFile(join(root, 'registry.json'), `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
+async function resolveContainedDirectory(rootReal: string, directory: string): Promise<
+  | { ok: true; path: string }
+  | { ok: false; reason: 'not_found' | 'blocked_path' }
+> {
+  try {
+    const directoryStat = await lstat(directory);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const directoryReal = await realpath(directory);
+    if (!isContainedPath(rootReal, directoryReal)) return { ok: false, reason: 'blocked_path' };
+    return { ok: true, path: directoryReal };
+  } catch {
+    return { ok: false, reason: 'not_found' };
+  }
+}
+
+async function writeContainedBufferFile(
+  rootDir: string,
+  filePath: string,
+  bytes: Buffer,
+  options: { failIfExists?: boolean } = {},
+): Promise<boolean> {
+  const tempPath = join(rootDir, `.maka-source-write.${process.pid}.${Date.now()}.tmp`);
+  try {
+    const rootReal = await realpath(rootDir);
+    const existing = await lstat(filePath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (existing !== null) {
+      if (options.failIfExists) return false;
+      if (!existing.isFile() || existing.isSymbolicLink()) return false;
+      const fileReal = await realpath(filePath);
+      if (!isContainedPath(rootReal, fileReal)) return false;
+    }
+    await writeFile(tempPath, bytes, { flag: 'wx', mode: 0o600 });
+    const tempStat = await lstat(tempPath);
+    if (!tempStat.isFile() || tempStat.isSymbolicLink()) {
+      await unlink(tempPath).catch(() => {});
+      return false;
+    }
+    const tempReal = await realpath(tempPath);
+    if (!isContainedPath(rootReal, tempReal)) {
+      await unlink(tempPath).catch(() => {});
+      return false;
+    }
+    await rename(tempPath, filePath);
+    return true;
+  } catch {
+    await unlink(tempPath).catch(() => {});
+    return false;
+  }
 }
 
 function sourceIdFromPath(filePath: string): string | undefined {
@@ -180,19 +248,6 @@ function parseSkillFrontMatterForSource(text: string): { name?: string; descript
     if (value) result[match[1] as 'name' | 'description'] = value;
   }
   return result;
-}
-
-function isManagedSkillSourceRecord(value: unknown): value is ManagedSkillSourceRecord {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-  const record = value as Partial<ManagedSkillSourceRecord>;
-  return typeof record.id === 'string' &&
-    typeof record.name === 'string' &&
-    typeof record.description === 'string' &&
-    record.sourceType === 'local' &&
-    typeof record.sourcePath === 'string' &&
-    typeof record.contentSha256 === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string';
 }
 
 function sha256(bytes: Buffer): string {

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -3,9 +3,20 @@ import { lstat, mkdir, readdir, readFile, realpath, rename, stat, unlink, writeF
 import { dirname, isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
 import type { MakaTool } from '@maka/runtime';
+import {
+  readManagedSkillSource,
+  resolveManagedSkillSourcesRoot,
+} from './managed-skill-sources.js';
 
 export type SkillSourceType = 'workspace' | 'bundled' | 'managed' | 'unknown';
 export type SkillValidationStatus = 'ok' | 'missing_lock' | 'modified' | 'metadata_error';
+export type ManagedSkillUpdateStatus =
+  | 'not_managed'
+  | 'source_missing'
+  | 'up_to_date'
+  | 'update_available'
+  | 'local_modified'
+  | 'metadata_error';
 export type SkillValidationCode =
   | 'missing_lock'
   | 'modified'
@@ -31,6 +42,9 @@ export interface InstalledSkill {
   validationStatus: SkillValidationStatus;
   validationCodes: SkillValidationCode[];
   validationMessages?: string[];
+  managedSourceId?: string;
+  managedUpdateStatus?: ManagedSkillUpdateStatus;
+  sourceContentSha256?: string;
 }
 
 export interface SkillEntry {
@@ -39,9 +53,10 @@ export interface SkillEntry {
   description: string;
   path: string;
   declaredTools: string[];
-  sourceType: 'workspace' | 'bundled' | 'unknown';
+  sourceType: 'workspace' | 'bundled' | 'managed' | 'unknown';
   userModified: boolean;
   validationStatus: SkillValidationStatus;
+  managedUpdateStatus?: ManagedSkillUpdateStatus;
 }
 
 export type CreateStarterSkillResult =
@@ -69,6 +84,22 @@ export type LoadSkillInstructionsResult =
 
 interface SkillDefinition extends InstalledSkill {
   content: string;
+}
+
+interface SkillLockFile {
+  schemaVersion: 1;
+  id: string;
+  sourceType: 'bundled' | 'managed';
+  sourceName?: string;
+  sourceVersion?: string;
+  contentSha256: string;
+  installedAt: string;
+  sourceId?: string;
+  sourceContentSha256?: string;
+}
+
+interface SkillReadOptions {
+  managedSourceRoot?: string;
 }
 
 export const MAX_SKILLS_IN_PROMPT = 12;
@@ -104,8 +135,8 @@ const LEGACY_BUNDLED_OFFICE_SKILL_SHA256: Record<string, string> = {
  * `allowed-tools` is intentionally surfaced as "declared/requested" - never
  * granted. PermissionEngine remains the only authority over tool calls.
  */
-export async function listInstalledSkills(root: string): Promise<InstalledSkill[]> {
-  const definitions = await readInstalledSkillDefinitions(root);
+export async function listInstalledSkills(root: string, options: SkillReadOptions = {}): Promise<InstalledSkill[]> {
+  const definitions = await readInstalledSkillDefinitions(root, options);
   return definitions.map(({ content: _content, ...skill }) => skill);
 }
 
@@ -120,9 +151,12 @@ export function toSkillEntry(skill: InstalledSkill): SkillEntry {
     description: skill.description,
     path: skill.path,
     declaredTools: skill.declaredTools,
-    sourceType: skill.sourceType === 'bundled' || skill.sourceType === 'unknown' ? skill.sourceType : 'workspace',
+    sourceType: skill.sourceType === 'bundled' || skill.sourceType === 'managed' || skill.sourceType === 'unknown'
+      ? skill.sourceType
+      : 'workspace',
     userModified: skill.userModified,
     validationStatus: skill.validationStatus,
+    ...(skill.sourceType === 'managed' && skill.managedUpdateStatus ? { managedUpdateStatus: skill.managedUpdateStatus } : {}),
   };
 }
 
@@ -230,7 +264,7 @@ async function writeBundledSkillLock(skillDir: string, id: string, body: string)
     }
   }
 
-  const lock = {
+  return writeSkillLock(skillDir, {
     schemaVersion: 1,
     id,
     sourceType: 'bundled',
@@ -238,7 +272,11 @@ async function writeBundledSkillLock(skillDir: string, id: string, body: string)
     sourceVersion: BUNDLED_OFFICE_SKILL_SOURCE_VERSION,
     contentSha256,
     installedAt: new Date().toISOString(),
-  };
+  });
+}
+
+async function writeSkillLock(skillDir: string, lock: SkillLockFile): Promise<boolean> {
+  const lockPath = join(skillDir, 'skill.lock.json');
   const tempPath = join(skillDir, `.skill.lock.json.${process.pid}.${Date.now()}.tmp`);
   try {
     await writeFile(tempPath, `${JSON.stringify(lock, null, 2)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
@@ -338,6 +376,119 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
   }
 
   return { ok: false, reason: 'already_exists' };
+}
+
+export async function installManagedSkill(
+  root: string,
+  sourceId: string,
+  sourceRoot = resolveManagedSkillSourcesRoot(),
+): Promise<
+  | { ok: true; skill: InstalledSkill }
+  | { ok: false; reason: 'not_found' | 'already_exists' | 'blocked_path' | 'write_failed' }
+> {
+  if (!isSafeSkillId(sourceId)) return { ok: false, reason: 'not_found' };
+  const source = await readManagedSkillSource(sourceRoot, sourceId);
+  if (!source.ok) {
+    if (source.reason === 'blocked_path') return { ok: false, reason: 'blocked_path' };
+    return { ok: false, reason: 'not_found' };
+  }
+
+  const skillsDir = join(root, 'skills');
+  let skillsReal: string;
+  try {
+    await mkdir(skillsDir, { recursive: true, mode: 0o700 });
+    const skillsStat = await lstat(skillsDir);
+    if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const rootReal = await realpath(root);
+    skillsReal = await realpath(skillsDir);
+    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+  } catch {
+    return { ok: false, reason: 'write_failed' };
+  }
+
+  const skillDir = join(skillsDir, sourceId);
+  const skillFile = join(skillDir, 'SKILL.md');
+  try {
+    await mkdir(skillDir, { mode: 0o700 });
+    const skillReal = await realpath(skillDir);
+    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    await writeFile(skillFile, source.content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    if (!await writeSkillLock(skillDir, managedSkillLock(sourceId, source.contentSha256, source.contentSha256))) {
+      return { ok: false, reason: 'write_failed' };
+    }
+    const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
+    const skill = installed.find((candidate) => candidate.id === sourceId);
+    if (!skill) return { ok: false, reason: 'write_failed' };
+    return { ok: true, skill };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return { ok: false, reason: 'already_exists' };
+    return { ok: false, reason: 'write_failed' };
+  }
+}
+
+export async function updateManagedSkill(
+  root: string,
+  skillId: string,
+  sourceRoot = resolveManagedSkillSourcesRoot(),
+): Promise<
+  | { ok: true; skill: InstalledSkill }
+  | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
+> {
+  if (!isSafeSkillId(skillId)) return { ok: false, reason: 'not_managed' };
+  const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
+  const skill = installed.find((candidate) => candidate.id === skillId);
+  if (!skill) return { ok: false, reason: 'not_managed' };
+  if (skill.validationStatus === 'metadata_error' || skill.managedUpdateStatus === 'metadata_error') {
+    return { ok: false, reason: 'metadata_error' };
+  }
+  if (skill.sourceType !== 'managed' || !skill.managedSourceId) return { ok: false, reason: 'not_managed' };
+  if (skill.managedUpdateStatus === 'local_modified') return { ok: false, reason: 'local_modified' };
+  if (skill.managedUpdateStatus === 'source_missing') return { ok: false, reason: 'source_missing' };
+
+  const source = await readManagedSkillSource(sourceRoot, skill.managedSourceId);
+  if (!source.ok) {
+    if (source.reason === 'blocked_path') return { ok: false, reason: 'blocked_path' };
+    return { ok: false, reason: 'source_missing' };
+  }
+
+  const skillDir = join(root, 'skills', skillId);
+  const skillFile = join(skillDir, 'SKILL.md');
+  try {
+    const [skillsReal, skillReal] = await Promise.all([
+      realpath(join(root, 'skills')),
+      realpath(skillDir),
+    ]);
+    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    await writeFile(skillFile, source.content, { encoding: 'utf8', mode: 0o600 });
+    if (!await writeSkillLock(skillDir, managedSkillLock(skillId, source.contentSha256, source.contentSha256, skill.managedSourceId))) {
+      return { ok: false, reason: 'write_failed' };
+    }
+    const refreshed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
+    const updated = refreshed.find((candidate) => candidate.id === skillId);
+    if (!updated) return { ok: false, reason: 'write_failed' };
+    return { ok: true, skill: updated };
+  } catch {
+    return { ok: false, reason: 'write_failed' };
+  }
+}
+
+function managedSkillLock(
+  id: string,
+  contentSha256: string,
+  sourceContentSha256: string,
+  sourceId = id,
+): SkillLockFile {
+  return {
+    schemaVersion: 1,
+    id,
+    sourceType: 'managed',
+    sourceName: 'local-library',
+    sourceVersion: '1',
+    contentSha256,
+    installedAt: new Date().toISOString(),
+    sourceId,
+    sourceContentSha256,
+  };
 }
 
 export async function resolveSkillOpenPath(
@@ -462,10 +613,14 @@ export function buildSkillAgentTool(root: string): MakaTool<{ name: string }, Lo
   };
 }
 
-async function readInstalledSkillDefinitions(root: string): Promise<SkillDefinition[]> {
+async function readInstalledSkillDefinitions(root: string, options: SkillReadOptions = {}): Promise<SkillDefinition[]> {
   const dir = join(root, 'skills');
   let entries: import('node:fs').Dirent[];
   try {
+    const [rootReal, dirStat] = await Promise.all([realpath(root), lstat(dir)]);
+    if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return [];
+    const dirReal = await realpath(dir);
+    if (!isContainedPath(rootReal, dirReal)) return [];
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return [];
@@ -480,7 +635,7 @@ async function readInstalledSkillDefinitions(root: string): Promise<SkillDefinit
       const bytes = await readFile(skillFile);
       const text = bytes.toString('utf8');
       const { name, description, allowedTools } = parseSkillFrontMatter(text);
-      const status = await readSkillLockStatus(skillPath, entry.name, `sha256:${sha256Buffer(bytes)}`);
+      const status = await readSkillLockStatus(skillPath, entry.name, `sha256:${sha256Buffer(bytes)}`, options);
       out.push({
         id: entry.name,
         name: name ?? entry.name,
@@ -498,7 +653,7 @@ async function readInstalledSkillDefinitions(root: string): Promise<SkillDefinit
   return out;
 }
 
-async function readSkillLockStatus(skillPath: string, id: string, currentHash: string): Promise<Pick<
+async function readSkillLockStatus(skillPath: string, id: string, currentHash: string, options: SkillReadOptions = {}): Promise<Pick<
   InstalledSkill,
   | 'sourceType'
   | 'sourceName'
@@ -509,6 +664,9 @@ async function readSkillLockStatus(skillPath: string, id: string, currentHash: s
   | 'validationStatus'
   | 'validationCodes'
   | 'validationMessages'
+  | 'managedSourceId'
+  | 'managedUpdateStatus'
+  | 'sourceContentSha256'
 >> {
   const lockPath = join(skillPath, 'skill.lock.json');
   let lockStat: Awaited<ReturnType<typeof lstat>>;
@@ -520,6 +678,7 @@ async function readSkillLockStatus(skillPath: string, id: string, currentHash: s
       userModified: false,
       validationStatus: 'missing_lock',
       validationCodes: ['missing_lock'],
+      managedUpdateStatus: 'not_managed',
     };
   }
 
@@ -543,11 +702,17 @@ async function readSkillLockStatus(skillPath: string, id: string, currentHash: s
   if (typeof parsed.contentSha256 !== 'string' || !/^sha256:[a-f0-9]{64}$/i.test(parsed.contentSha256)) {
     return metadataError(['invalid_hash'], 'Skill lock hash is invalid.');
   }
-  if (!isTrustedSkillLockSource(parsed, id)) {
+  if (parsed.sourceType === 'bundled' && !isTrustedBundledSkillLockSource(parsed, id)) {
     return metadataError(['unsupported_schema'], 'Skill lock source is not trusted in this Maka version.');
   }
 
   const userModified = parsed.contentSha256.toLowerCase() !== currentHash.toLowerCase();
+  const managed = parsed.sourceType === 'managed'
+    ? await managedStatusForLock(parsed, userModified, options.managedSourceRoot)
+    : { managedUpdateStatus: 'not_managed' as const };
+  if (managed.managedUpdateStatus === 'metadata_error') {
+    return metadataError(['unsupported_schema'], 'Managed skill lock source metadata is invalid.');
+  }
   return {
     sourceType: parsed.sourceType,
     ...(typeof parsed.sourceName === 'string' && parsed.sourceName ? { sourceName: parsed.sourceName } : {}),
@@ -557,10 +722,50 @@ async function readSkillLockStatus(skillPath: string, id: string, currentHash: s
     userModified,
     validationStatus: userModified ? 'modified' : 'ok',
     validationCodes: userModified ? ['modified'] : [],
+    ...managed,
   };
 }
 
-function isTrustedSkillLockSource(lock: Record<string, unknown>, id: string): boolean {
+async function managedStatusForLock(
+  lock: Record<string, unknown>,
+  userModified: boolean,
+  managedSourceRoot = resolveManagedSkillSourcesRoot(),
+): Promise<Pick<InstalledSkill, 'managedSourceId' | 'managedUpdateStatus' | 'sourceContentSha256'>> {
+  if (lock.sourceName !== 'local-library' || lock.sourceVersion !== '1') {
+    return { managedUpdateStatus: 'metadata_error' };
+  }
+  const sourceId = typeof lock.sourceId === 'string' && isSafeSkillId(lock.sourceId) ? lock.sourceId : undefined;
+  const sourceContentSha256 = typeof lock.sourceContentSha256 === 'string' && /^sha256:[a-f0-9]{64}$/i.test(lock.sourceContentSha256)
+    ? lock.sourceContentSha256
+    : undefined;
+  if (!sourceId || !sourceContentSha256) {
+    return {
+      ...(sourceId ? { managedSourceId: sourceId } : {}),
+      managedUpdateStatus: 'metadata_error',
+      ...(sourceContentSha256 ? { sourceContentSha256 } : {}),
+    };
+  }
+  if (
+    typeof lock.contentSha256 !== 'string' ||
+    lock.contentSha256.toLowerCase() !== sourceContentSha256.toLowerCase()
+  ) {
+    return { managedSourceId: sourceId, managedUpdateStatus: 'metadata_error', sourceContentSha256 };
+  }
+  if (userModified) {
+    return { managedSourceId: sourceId, managedUpdateStatus: 'local_modified', sourceContentSha256 };
+  }
+  const source = await readManagedSkillSource(managedSourceRoot, sourceId);
+  if (!source.ok) {
+    return { managedSourceId: sourceId, managedUpdateStatus: 'source_missing', sourceContentSha256 };
+  }
+  return {
+    managedSourceId: sourceId,
+    managedUpdateStatus: source.contentSha256 === sourceContentSha256 ? 'up_to_date' : 'update_available',
+    sourceContentSha256,
+  };
+}
+
+function isTrustedBundledSkillLockSource(lock: Record<string, unknown>, id: string): boolean {
   const expectedHash = BUNDLED_OFFICE_SKILL_HASH_BY_ID.get(id);
   return lock.sourceType === 'bundled' &&
     BUNDLED_OFFICE_SKILL_IDS.has(id) &&
@@ -573,7 +778,7 @@ function isTrustedSkillLockSource(lock: Record<string, unknown>, id: string): bo
 
 function metadataError(validationCodes: SkillValidationCode[], message: string): Pick<
   InstalledSkill,
-  'sourceType' | 'userModified' | 'validationStatus' | 'validationCodes' | 'validationMessages'
+  'sourceType' | 'userModified' | 'validationStatus' | 'validationCodes' | 'validationMessages' | 'managedUpdateStatus'
 > {
   return {
     sourceType: 'unknown',
@@ -581,6 +786,7 @@ function metadataError(validationCodes: SkillValidationCode[], message: string):
     validationStatus: 'metadata_error',
     validationCodes,
     validationMessages: [message],
+    managedUpdateStatus: 'metadata_error',
   };
 }
 

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -304,6 +304,50 @@ async function readExistingRegularFile(path: string): Promise<{ kind: 'missing' 
   }
 }
 
+async function readContainedRegularFile(rootDir: string, filePath: string): Promise<{ ok: true; bytes: Buffer } | { ok: false }> {
+  try {
+    const [rootReal, fileStat] = await Promise.all([realpath(rootDir), lstat(filePath)]);
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false };
+    const fileReal = await realpath(filePath);
+    if (!isContainedPath(rootReal, fileReal)) return { ok: false };
+    return { ok: true, bytes: await readFile(filePath) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function writeContainedRegularTextFile(rootDir: string, filePath: string, content: string): Promise<boolean> {
+  const tempPath = join(rootDir, `.maka-write.${process.pid}.${Date.now()}.tmp`);
+  try {
+    const rootReal = await realpath(rootDir);
+    const existing = await lstat(filePath).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (existing !== null && (!existing.isFile() || existing.isSymbolicLink())) return false;
+    if (existing !== null) {
+      const fileReal = await realpath(filePath);
+      if (!isContainedPath(rootReal, fileReal)) return false;
+    }
+    await writeFile(tempPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    const tempStat = await lstat(tempPath);
+    if (!tempStat.isFile() || tempStat.isSymbolicLink()) {
+      await unlink(tempPath).catch(() => {});
+      return false;
+    }
+    const tempReal = await realpath(tempPath);
+    if (!isContainedPath(rootReal, tempReal)) {
+      await unlink(tempPath).catch(() => {});
+      return false;
+    }
+    await rename(tempPath, filePath);
+    return true;
+  } catch {
+    await unlink(tempPath).catch(() => {});
+    return false;
+  }
+}
+
 function isMatchingBundledSkillLock(value: unknown, id: string, contentSha256: string): boolean {
   if (!isRecord(value)) return false;
   return value.schemaVersion === 1 &&
@@ -435,6 +479,8 @@ export async function updateManagedSkill(
   | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
 > {
   if (!isSafeSkillId(skillId)) return { ok: false, reason: 'not_managed' };
+  const updateTarget = await resolveSkillFileUpdateTarget(root, skillId);
+  if (!updateTarget.ok && updateTarget.reason === 'blocked_path') return { ok: false, reason: 'blocked_path' };
   const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
   const skill = installed.find((candidate) => candidate.id === skillId);
   if (!skill) return { ok: false, reason: 'not_managed' };
@@ -459,7 +505,9 @@ export async function updateManagedSkill(
       realpath(skillDir),
     ]);
     if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
-    await writeFile(skillFile, source.content, { encoding: 'utf8', mode: 0o600 });
+    if (!await writeContainedRegularTextFile(skillDir, skillFile, source.content)) {
+      return { ok: false, reason: 'write_failed' };
+    }
     if (!await writeSkillLock(skillDir, managedSkillLock(skillId, source.contentSha256, source.contentSha256, skill.managedSourceId))) {
       return { ok: false, reason: 'write_failed' };
     }
@@ -469,6 +517,34 @@ export async function updateManagedSkill(
     return { ok: true, skill: updated };
   } catch {
     return { ok: false, reason: 'write_failed' };
+  }
+}
+
+async function resolveSkillFileUpdateTarget(root: string, skillId: string): Promise<
+  | { ok: true }
+  | { ok: false; reason: 'missing' | 'blocked_path' }
+> {
+  const skillsDir = join(root, 'skills');
+  const skillDir = join(skillsDir, skillId);
+  const skillFile = join(skillDir, 'SKILL.md');
+  try {
+    const [rootReal, skillsStat] = await Promise.all([realpath(root), lstat(skillsDir)]);
+    if (!skillsStat.isDirectory() || skillsStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const skillsReal = await realpath(skillsDir);
+    if (!isContainedPath(rootReal, skillsReal)) return { ok: false, reason: 'blocked_path' };
+
+    const skillStat = await lstat(skillDir);
+    if (!skillStat.isDirectory() || skillStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const skillReal = await realpath(skillDir);
+    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+
+    const fileStat = await lstat(skillFile);
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const fileReal = await realpath(skillFile);
+    if (!isContainedPath(skillReal, fileReal)) return { ok: false, reason: 'blocked_path' };
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'missing' };
   }
 }
 
@@ -632,7 +708,9 @@ async function readInstalledSkillDefinitions(root: string, options: SkillReadOpt
     const skillPath = join(dir, entry.name);
     const skillFile = join(skillPath, 'SKILL.md');
     try {
-      const bytes = await readFile(skillFile);
+      const read = await readContainedRegularFile(skillPath, skillFile);
+      if (!read.ok) continue;
+      const bytes = read.bytes;
       const text = bytes.toString('utf8');
       const { name, description, allowedTools } = parseSkillFrontMatter(text);
       const status = await readSkillLockStatus(skillPath, entry.name, `sha256:${sha256Buffer(bytes)}`, options);

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -6,10 +6,16 @@ import { createArtifactStore, resolveArtifactPath } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 import {
   createStarterSkill,
+  installManagedSkill,
   listSkillEntries,
   resolveSkillOpenPath,
   toSkillEntry,
+  updateManagedSkill,
 } from './skills.js';
+import {
+  importManagedSkillSource,
+  listManagedSkillSources,
+} from './managed-skill-sources.js';
 
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
@@ -106,6 +112,29 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
   ipcMain.handle('skills:list', async () => {
     await deps.bundledSkillsReady?.catch(() => {});
     return listSkillEntries(deps.workspaceRoot);
+  });
+  ipcMain.handle('skills:sources:list', async () => listManagedSkillSources());
+  ipcMain.handle('skills:sources:importLocalFile', async () => {
+    const result = await deps.mainWindowController.showOpenDialog({
+      title: '导入 Skill 来源',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Skill Markdown', extensions: ['md'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    });
+    if (result.canceled || result.filePaths.length === 0) return { ok: false as const, reason: 'cancelled' as const };
+    return importManagedSkillSource({ sourceFile: result.filePaths[0] });
+  });
+  ipcMain.handle('skills:installManaged', async (_event, sourceId: string) => {
+    const result = await installManagedSkill(deps.workspaceRoot, sourceId);
+    if (!result.ok) return result;
+    return { ok: true as const, skill: toSkillEntry(result.skill) };
+  });
+  ipcMain.handle('skills:updateManaged', async (_event, skillId: string) => {
+    const result = await updateManagedSkill(deps.workspaceRoot, skillId);
+    if (!result.ok) return result;
+    return { ok: true as const, skill: toSkillEntry(result.skill) };
   });
   ipcMain.handle('skills:createStarter', async () => {
     const result = await createStarterSkill(deps.workspaceRoot);

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -15,6 +15,7 @@ import {
 import {
   importManagedSkillSource,
   listManagedSkillSources,
+  toManagedSkillSourceEntry,
 } from './managed-skill-sources.js';
 
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
@@ -113,7 +114,10 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
     await deps.bundledSkillsReady?.catch(() => {});
     return listSkillEntries(deps.workspaceRoot);
   });
-  ipcMain.handle('skills:sources:list', async () => listManagedSkillSources());
+  ipcMain.handle('skills:sources:list', async () => {
+    const sources = await listManagedSkillSources();
+    return sources.map(toManagedSkillSourceEntry);
+  });
   ipcMain.handle('skills:sources:importLocalFile', async () => {
     const result = await deps.mainWindowController.showOpenDialog({
       title: '导入 Skill 来源',
@@ -124,7 +128,9 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
       ],
     });
     if (result.canceled || result.filePaths.length === 0) return { ok: false as const, reason: 'cancelled' as const };
-    return importManagedSkillSource({ sourceFile: result.filePaths[0] });
+    const imported = await importManagedSkillSource({ sourceFile: result.filePaths[0] });
+    if (!imported.ok) return imported;
+    return { ok: true as const, source: toManagedSkillSourceEntry(imported.source) };
   });
   ipcMain.handle('skills:installManaged', async (_event, sourceId: string) => {
     const result = await installManagedSkill(deps.workspaceRoot, sourceId);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -68,7 +68,7 @@ import type {
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
-import type { SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/settings/result';
@@ -890,6 +890,29 @@ contextBridge.exposeInMainWorld('maka', {
   skills: {
     list(): Promise<SkillEntry[]> {
       return ipcRenderer.invoke('skills:list');
+    },
+    sources: {
+      list(): Promise<ManagedSkillSourceEntry[]> {
+        return ipcRenderer.invoke('skills:sources:list');
+      },
+      importLocalFile(): Promise<
+        | { ok: true; source: ManagedSkillSourceEntry }
+        | { ok: false; reason: 'cancelled' | 'invalid_skill' | 'already_exists' | 'blocked_path' | 'write_failed' }
+      > {
+        return ipcRenderer.invoke('skills:sources:importLocalFile');
+      },
+    },
+    installManaged(sourceId: string): Promise<
+      | { ok: true; skill: SkillEntry }
+      | { ok: false; reason: 'not_found' | 'already_exists' | 'blocked_path' | 'write_failed' }
+    > {
+      return ipcRenderer.invoke('skills:installManaged', sourceId);
+    },
+    updateManaged(skillId: string): Promise<
+      | { ok: true; skill: SkillEntry }
+      | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
+    > {
+      return ipcRenderer.invoke('skills:updateManaged', skillId);
     },
     createStarter(): Promise<
       | { ok: true; skill: SkillEntry; filePath: string }

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -175,6 +175,7 @@ export function useAppShellBootstrapSubscriptions(options: {
   refreshPlanReminders: (options?: { shouldShowError?: () => boolean }) => Promise<void>;
   refreshShellSettings: () => Promise<void>;
   refreshSkills: (options?: { shouldShowError?: () => boolean }) => Promise<void>;
+  refreshManagedSkillSources: (options?: { shouldShowError?: () => boolean }) => Promise<void>;
   refreshSessions: () => Promise<SessionSummary[]>;
   rendererMountedRef: RefBox<boolean>;
   setActiveId: (sessionId: string | undefined) => void;
@@ -187,6 +188,7 @@ export function useAppShellBootstrapSubscriptions(options: {
     void options.refreshAppInfo();
     void options.refreshMemoryActive('载入本地记忆状态失败');
     void options.refreshSkills();
+    void options.refreshManagedSkillSources();
     void options.refreshPlanReminders();
     void options.applyVisualSmokeFixture();
   });

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -151,7 +151,7 @@ function managedInstallFailureCopy(reason: 'not_found' | 'already_exists' | 'blo
 function managedUpdateFailureCopy(reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed'): string {
   if (reason === 'not_managed') return '这个 Skill 不是受管理来源。';
   if (reason === 'source_missing') return '来源库中找不到对应来源。';
-  if (reason === 'local_modified') return '工作区副本已经被修改，需要先进入人工合并流程。';
+  if (reason === 'local_modified') return '工作区副本已经被修改。请打开本地文件和来源文件手动比较后再更新。';
   if (reason === 'metadata_error') return 'Skill 元数据异常，不能安全更新。';
   if (reason === 'blocked_path') return '目标路径不允许写入。';
   return '写入工作区失败，请检查文件权限。';

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { generalizedErrorMessageChinese } from '@maka/core';
-import type { SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
 import { createSkillFailureCopy, openSkillFailureCopy } from './app-shell-copy';
 import { createOpenSkillAction } from './app-shell-open-skill-action';
 
@@ -11,16 +11,21 @@ type ToastApi = {
 
 export interface AppShellSkillActions {
   refreshSkills(options?: { shouldShowError?: () => boolean }): Promise<void>;
+  refreshManagedSkillSources(options?: { shouldShowError?: () => boolean }): Promise<void>;
   createSkillTemplate(): Promise<void>;
+  importManagedSkillSource(): Promise<void>;
+  installManagedSkill(sourceId: string): Promise<void>;
+  updateManagedSkill(skillId: string): Promise<void>;
   openSkill(skillId: string): Promise<void>;
 }
 
 export function createAppShellSkillActions(deps: {
   isSkillsSurfaceActive: () => boolean;
   setSkills: Dispatch<SetStateAction<SkillEntry[]>>;
+  setManagedSkillSources: Dispatch<SetStateAction<ManagedSkillSourceEntry[]>>;
   toastApi: ToastApi;
 }): AppShellSkillActions {
-  const { isSkillsSurfaceActive, setSkills, toastApi } = deps;
+  const { isSkillsSurfaceActive, setManagedSkillSources, setSkills, toastApi } = deps;
   const openSkill = createOpenSkillAction({ isSkillsSurfaceActive, toastApi });
 
   async function refreshSkills(options: { shouldShowError?: () => boolean } = {}) {
@@ -30,6 +35,17 @@ export function createAppShellSkillActions(deps: {
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         toastApi.error('刷新技能失败', generalizedErrorMessageChinese(error, '刷新技能失败，请稍后重试。'));
+      }
+    }
+  }
+
+  async function refreshManagedSkillSources(options: { shouldShowError?: () => boolean } = {}) {
+    try {
+      const next = await window.maka.skills.sources.list();
+      setManagedSkillSources(next);
+    } catch (error) {
+      if (options.shouldShowError?.() ?? true) {
+        toastApi.error('刷新来源库失败', generalizedErrorMessageChinese(error, '刷新来源库失败，请稍后重试。'));
       }
     }
   }
@@ -55,9 +71,88 @@ export function createAppShellSkillActions(deps: {
     }
   }
 
+  async function importManagedSkillSource() {
+    try {
+      const result = await window.maka.skills.sources.importLocalFile();
+      if (!result.ok) {
+        if (result.reason !== 'cancelled' && isSkillsSurfaceActive()) {
+          toastApi.error('无法导入 Skill 来源', managedSourceFailureCopy(result.reason));
+        }
+        return;
+      }
+      await refreshManagedSkillSources({ shouldShowError: isSkillsSurfaceActive });
+      if (isSkillsSurfaceActive()) toastApi.success('已导入 Skill 来源', result.source.name);
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法导入 Skill 来源', generalizedErrorMessageChinese(error, '无法导入 Skill 来源，请稍后重试。'));
+      }
+    }
+  }
+
+  async function installManagedSkill(sourceId: string) {
+    try {
+      const result = await window.maka.skills.installManaged(sourceId);
+      if (!result.ok) {
+        if (isSkillsSurfaceActive()) toastApi.error('无法安装 Skill', managedInstallFailureCopy(result.reason));
+        return;
+      }
+      await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
+      await refreshManagedSkillSources({ shouldShowError: isSkillsSurfaceActive });
+      if (isSkillsSurfaceActive()) toastApi.success('已安装 Skill', `${result.skill.id}/SKILL.md 已放到当前工作区。`);
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法安装 Skill', generalizedErrorMessageChinese(error, '无法安装 Skill，请稍后重试。'));
+      }
+    }
+  }
+
+  async function updateManagedSkill(skillId: string) {
+    try {
+      const result = await window.maka.skills.updateManaged(skillId);
+      if (!result.ok) {
+        if (isSkillsSurfaceActive()) toastApi.error('无法更新 Skill', managedUpdateFailureCopy(result.reason));
+        return;
+      }
+      await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
+      if (isSkillsSurfaceActive()) toastApi.success('已更新 Skill', `${result.skill.id}/SKILL.md 已更新到来源库版本。`);
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法更新 Skill', generalizedErrorMessageChinese(error, '无法更新 Skill，请稍后重试。'));
+      }
+    }
+  }
+
   return {
     refreshSkills,
+    refreshManagedSkillSources,
     createSkillTemplate,
+    importManagedSkillSource,
+    installManagedSkill,
+    updateManagedSkill,
     openSkill,
   };
+}
+
+function managedSourceFailureCopy(reason: 'invalid_skill' | 'already_exists' | 'blocked_path' | 'write_failed' | 'cancelled'): string {
+  if (reason === 'invalid_skill') return '请选择有效的 SKILL.md 文件。';
+  if (reason === 'already_exists') return '来源库里已经有同名 Skill。';
+  if (reason === 'blocked_path') return '该文件路径不允许导入。';
+  if (reason === 'write_failed') return '写入来源库失败，请检查文件权限。';
+  return '已取消。';
+}
+
+function managedInstallFailureCopy(reason: 'not_found' | 'already_exists' | 'blocked_path' | 'write_failed'): string {
+  if (reason === 'not_found') return '没有找到这个 Skill 来源。';
+  if (reason === 'already_exists') return '当前工作区已经有同名 Skill。';
+  if (reason === 'blocked_path') return '目标路径不允许写入。';
+  return '写入工作区失败，请检查文件权限。';
+}
+
+function managedUpdateFailureCopy(reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed'): string {
+  if (reason === 'not_managed') return '这个 Skill 不是受管理来源。';
+  if (reason === 'source_missing') return '来源库中找不到对应来源。';
+  if (reason === 'local_modified') return '工作区副本已经被修改，需要先进入人工合并流程。';
+  if (reason === 'metadata_error') return 'Skill 元数据异常，不能安全更新。';
+  if (reason === 'blocked_path') return '目标路径不允许写入。';
+  return '写入工作区失败，请检查文件权限。';
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -22,9 +22,10 @@ import {
   type MakaUriDest,
   MakaUriContext,
   type NavSelection,
-	  SessionListPanel,
-	  type SessionViewMode,
-	  type SkillEntry,
+  SessionListPanel,
+  type ManagedSkillSourceEntry,
+  type SessionViewMode,
+  type SkillEntry,
   type TurnFooterActionMeta,
   useToast,
   activePermissionFor,
@@ -239,6 +240,7 @@ export function AppShell({
   // which mode a session is created with.
   const [defaultPermissionMode, setDefaultPermissionMode] = useState<ChatDefaultPermissionMode>('ask');
   const [skills, setSkills] = useState<SkillEntry[]>([]);
+  const [managedSkillSources, setManagedSkillSources] = useState<ManagedSkillSourceEntry[]>([]);
   const [planReminders, setPlanReminders] = useState<PlanReminder[]>([]);
   // Persisted composer defaults seed the empty-state model, project path, and
   // recent workspace history so the home view is populated before the async
@@ -857,11 +859,16 @@ export function AppShell({
 
   const {
     refreshSkills,
+    refreshManagedSkillSources,
     createSkillTemplate,
+    importManagedSkillSource,
+    installManagedSkill,
+    updateManagedSkill,
     openSkill,
   } = createAppShellSkillActions({
     isSkillsSurfaceActive,
     setSkills,
+    setManagedSkillSources,
     toastApi,
   });
 
@@ -1015,6 +1022,7 @@ export function AppShell({
     refreshPlanReminders,
     refreshShellSettings,
     refreshSkills,
+    refreshManagedSkillSources,
     refreshSessions,
     rendererMountedRef,
     setActiveId,
@@ -1433,10 +1441,15 @@ export function AppShell({
                 turnLineageBadgesByTurn={turnLineageBadgesByTurn}
                 onLineageBadgeClick={handleLineageBadgeClick}
                 skills={skills}
+                managedSkillSources={managedSkillSources}
                 onRefreshSkills={() => refreshSkills()}
+                onRefreshManagedSkillSources={() => refreshManagedSkillSources()}
                 onCreateSkillTemplate={() => createSkillTemplate()}
                 onOpenSkill={(skillId) => openSkill(skillId)}
                 onOpenSkillsFolder={() => openSkillsFolder()}
+                onImportManagedSkillSource={() => importManagedSkillSource()}
+                onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}
+                onUpdateManagedSkill={(skillId) => updateManagedSkill(skillId)}
                 planReminders={planReminders}
                 onRefreshPlanReminders={() => refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive })}
                 onCreatePlanReminder={(input) => createPlanReminder(input)}

--- a/packages/ui/src/capability-audit-strip.tsx
+++ b/packages/ui/src/capability-audit-strip.tsx
@@ -10,7 +10,7 @@ import { Alert, AlertDescription } from './primitives/alert.js';
  * waiting for auth / erroring, automations that failed or were skipped
  * last run), and render nothing at all when everything is fine.
  */
-export function CapabilityAuditStrip(props: { report: CapabilityAuditReport }) {
+export function CapabilityAuditStrip(props: { report: CapabilityAuditReport; focus?: 'skills' | 'automations' }) {
   const issues = capabilityAuditIssues(props.report);
   if (issues.length === 0) return null;
   return (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -37,6 +37,7 @@ import { EmptyState } from './empty-state.js';
 import type {
   DailyReviewBridge,
   DailyReviewMarkdownActionInput,
+  ManagedSkillSourceEntry,
   PlanReminderDraftInput,
   PlanReminderUpdatePatch,
   SkillEntry,
@@ -239,6 +240,11 @@ export function ChatView(props: {
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
   onOpenSkillsFolder?(): void | Promise<void>;
+  managedSkillSources?: ManagedSkillSourceEntry[];
+  onRefreshManagedSkillSources?(): void | Promise<void>;
+  onImportManagedSkillSource?(): void | Promise<void>;
+  onInstallManagedSkill?(sourceId: string): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
   planReminders?: PlanReminder[];
   onRefreshPlanReminders?: () => void | Promise<void>;
   onCreatePlanReminder?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
@@ -411,6 +417,11 @@ export function ChatView(props: {
           onCreateSkillTemplate={props.onCreateSkillTemplate}
           onOpenSkill={props.onOpenSkill}
           onOpenSkillsFolder={props.onOpenSkillsFolder}
+          managedSkillSources={props.managedSkillSources}
+          onRefreshManagedSkillSources={props.onRefreshManagedSkillSources}
+          onImportManagedSkillSource={props.onImportManagedSkillSource}
+          onInstallManagedSkill={props.onInstallManagedSkill}
+          onUpdateManagedSkill={props.onUpdateManagedSkill}
         />
       </Suspense>
     );

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -3,7 +3,7 @@ export { CapabilityAuditStrip } from './capability-audit-strip.js';
 export { SearchModal } from './search-modal.js';
 export { SessionListPanel } from './session-list-panel.js';
 export type { SessionViewMode } from './session-list-panel.js';
-export type { SkillEntry } from './module-panel-types.js';
+export type { ManagedSkillSourceEntry, SkillEntry } from './module-panel-types.js';
 export { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
 export { formatBytes, OverlayHost, ToolActivity } from './tool-activity.js';
 export { PermissionDialog } from './permission-dialog.js';

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -32,10 +32,6 @@ export interface ManagedSkillSourceEntry {
   name: string;
   description: string;
   sourceType: 'local';
-  sourcePath: string;
-  contentSha256: string;
-  createdAt: string;
-  updatedAt: string;
 }
 
 export type PlanReminderDraftInput = {

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -21,9 +21,21 @@ export interface SkillEntry {
    * can see what a skill is asking for before they install / enable it.
    */
   declaredTools?: string[];
-  sourceType?: 'workspace' | 'bundled' | 'unknown';
+  sourceType?: 'workspace' | 'bundled' | 'managed' | 'unknown';
   userModified?: boolean;
   validationStatus?: 'ok' | 'missing_lock' | 'modified' | 'metadata_error';
+  managedUpdateStatus?: 'not_managed' | 'source_missing' | 'up_to_date' | 'update_available' | 'local_modified' | 'metadata_error';
+}
+
+export interface ManagedSkillSourceEntry {
+  id: string;
+  name: string;
+  description: string;
+  sourceType: 'local';
+  sourcePath: string;
+  contentSha256: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export type PlanReminderDraftInput = {

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -15,18 +15,24 @@ import { Button as UiButton, TabsRoot, TabsList, TabsTrigger, TabsPanel } from '
 import { Input } from './primitives/input.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
-import type { SkillEntry } from './module-panel-types.js';
+import type { ManagedSkillSourceEntry, SkillEntry } from './module-panel-types.js';
 
 function SkillLibraryPanel(props: {
   skills?: SkillEntry[];
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
+  onImportManagedSkillSource?(): void | Promise<void>;
+  onInstallManagedSkill?(sourceId: string): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
   actionBusy?: boolean;
   refreshPending?: boolean;
   createPending?: boolean;
   openingSkillId?: string | null;
+  installingSourceId?: string | null;
+  updatingSkillId?: string | null;
   searchQuery?: string;
+  managedSkillSources?: ManagedSkillSourceEntry[];
 }) {
   const skillCount = props.skills?.length ?? 0;
   // Designer audit P1-5: land on skills the user can actually run, not the
@@ -59,6 +65,10 @@ function SkillLibraryPanel(props: {
       {' '}<code className="maka-empty-state-code">skills/</code> 目录下，刷新后会出现在这里。
     </>
   );
+  const filteredManagedSources = (props.managedSkillSources ?? []).filter((source) => {
+    if (!normalizedSkillQuery) return true;
+    return `${source.id} ${source.name} ${source.description}`.toLowerCase().includes(normalizedSkillQuery);
+  });
   const templates = (
     <section className="maka-skill-examples" aria-label="技能示例">
       <ul className="maka-skill-example-grid" aria-label="技能模板示例">
@@ -203,6 +213,7 @@ function SkillLibraryPanel(props: {
               const description = formatSkillLibraryDescription(skill);
               const statusLabel = formatSkillStatusLabel(skill);
               const opening = props.openingSkillId === skill.id;
+              const updating = props.updatingSkillId === skill.id;
               const hoverText = tools.length > 0
                 ? `打开技能文件：${skill.id}\n\n来源状态：${statusLabel}\n声明工具：${toolsLabel}\n权限仍按当前会话策略判断；这里不是授权。`
                 : `打开技能文件：${skill.id}\n\n来源状态：${statusLabel}`;
@@ -229,17 +240,92 @@ function SkillLibraryPanel(props: {
                       <span>{skill.id}</span>
                       <span>{statusLabel}</span>
                       {opening && <span>打开中…</span>}
+                      {updating && <span>更新中…</span>}
                     </span>
                     <span className="maka-skill-library-action" aria-hidden="true">
-                      打开
+                      {skill.managedUpdateStatus === 'update_available' ? '可更新' : '打开'}
                     </span>
                     <span className="maka-skill-library-switch" aria-hidden="true" data-state="on" />
                   </UiButton>
+                  {skill.managedUpdateStatus === 'update_available' && props.onUpdateManagedSkill && (
+                    <UiButton
+                      type="button"
+                      variant="ghost"
+                      className="maka-skill-market-install"
+                      onClick={() => props.onUpdateManagedSkill?.(skill.id)}
+                      disabled={props.actionBusy}
+                    >
+                      {updating ? '更新中…' : '更新'}
+                    </UiButton>
+                  )}
                 </li>
               );
             })}
           </ul>
         </>
+      )}
+    </section>
+  );
+
+  const managedSources = (
+    <section className="maka-skill-installed" aria-label="来源库">
+      <div className="maka-skill-section-row">
+        <span className="maka-skill-section-label">来源库</span>
+        <small>{filteredManagedSources.length} 个</small>
+      </div>
+      <div className="maka-skill-filter-actions" aria-label="来源库操作">
+        <UiButton
+          type="button"
+          variant="secondary"
+          className="maka-skill-filter-pill"
+          onClick={props.onImportManagedSkillSource}
+          disabled={!props.onImportManagedSkillSource || props.actionBusy}
+        >
+          导入本地 Skill
+        </UiButton>
+      </div>
+      {filteredManagedSources.length === 0 ? (
+        normalizedSkillQuery ? (
+          <EmptyState
+            Icon={BookOpen}
+            title="没有匹配的来源"
+            body="换一个关键词，或清空搜索查看全部来源。"
+            extraClassName="maka-skill-installed-empty"
+          />
+        ) : null
+      ) : (
+        <ul className="maka-skill-library-list" aria-label="来源列表">
+          {filteredManagedSources.map((source) => {
+            const installed = (props.skills ?? []).some((skill) => skill.id === source.id);
+            const installing = props.installingSourceId === source.id;
+            return (
+              <li key={source.id} className="maka-skill-library-item">
+                <div className="maka-skill-library-row" title={`来源：${source.id}`}>
+                  <span className="maka-skill-library-status" aria-hidden="true">
+                    <BookOpen size={16} strokeWidth={1.8} />
+                  </span>
+                  <span className="maka-skill-library-copy">
+                    <span className="maka-skill-library-name">{source.name}</span>
+                    <span className="maka-skill-library-description">{source.description || '本地来源库 Skill。'}</span>
+                  </span>
+                  <span className="maka-skill-library-meta">
+                    <span>{source.id}</span>
+                    <span>{installed ? '已安装' : '未安装'}</span>
+                  </span>
+                  <UiButton
+                    type="button"
+                    variant="ghost"
+                    className="maka-skill-market-install"
+                    onClick={() => props.onInstallManagedSkill?.(source.id)}
+                    disabled={installed || props.actionBusy || !props.onInstallManagedSkill}
+                  >
+                    {installing ? '安装中…' : installed ? '已安装' : '安装'}
+                  </UiButton>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
       )}
     </section>
   );
@@ -251,7 +337,11 @@ function SkillLibraryPanel(props: {
         {tabs}
         <TabsPanel value="market">{market}</TabsPanel>
         <TabsPanel value="builtin">{skillList(bundledSkills, normalizedSkillQuery ? '没有匹配的内置技能' : '暂无内置技能', normalizedSkillQuery ? '换一个关键词试试。' : '应用自带的技能会出现在这里。', '内置技能')}</TabsPanel>
-        <TabsPanel value="installed">{skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}{templates}</TabsPanel>
+        <TabsPanel value="installed">
+          {skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}
+          {managedSources}
+          {templates}
+        </TabsPanel>
       </TabsRoot>
       {props.skills && props.skills.length > 0 ? (
         <span className="maka-skill-tool-summary-hidden" aria-hidden="true">
@@ -348,6 +438,13 @@ function formatSkillLibraryDescription(skill: SkillEntry): string | undefined {
 
 function formatSkillStatusLabel(skill: SkillEntry): string {
   if (skill.validationStatus === 'metadata_error') return '元数据异常';
+  if (skill.sourceType === 'managed') {
+    if (skill.managedUpdateStatus === 'source_missing') return '来源缺失';
+    if (skill.managedUpdateStatus === 'update_available') return '可更新';
+    if (skill.managedUpdateStatus === 'local_modified') return '本地已修改';
+    if (skill.managedUpdateStatus === 'metadata_error') return '元数据异常';
+    return '受管理';
+  }
   if (skill.userModified) return '已修改';
   if (skill.sourceType === 'bundled') return '内置';
   return '本地';
@@ -357,11 +454,16 @@ function formatSkillStatusLabel(skill: SkillEntry): string {
 
 export function SkillsModuleMain(props: {
   skills?: SkillEntry[];
+  managedSkillSources?: ManagedSkillSourceEntry[];
   auditReport?: CapabilityAuditReport;
   onRefreshSkills?(): void | Promise<void>;
   onCreateSkillTemplate?(): void | Promise<void>;
   onOpenSkill?(skillId: string): void | Promise<void>;
   onOpenSkillsFolder?(): void | Promise<void>;
+  onRefreshManagedSkillSources?(): void | Promise<void>;
+  onImportManagedSkillSource?(): void | Promise<void>;
+  onInstallManagedSkill?(sourceId: string): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
 }) {
   const [pendingSkillAction, setPendingSkillAction] = useState<string | null>(null);
   const [skillSearchQuery, setSkillSearchQuery] = useState('');
@@ -448,13 +550,19 @@ export function SkillsModuleMain(props: {
       <CapabilityAuditStrip report={auditReport} />
       <SkillLibraryPanel
         skills={props.skills}
+        managedSkillSources={props.managedSkillSources}
         onRefreshSkills={props.onRefreshSkills ? () => runSkillAction('refresh', props.onRefreshSkills) : undefined}
         onCreateSkillTemplate={props.onCreateSkillTemplate ? () => runSkillAction('create', props.onCreateSkillTemplate) : undefined}
         onOpenSkill={props.onOpenSkill ? (skillId) => runSkillAction(`open:${skillId}`, () => props.onOpenSkill?.(skillId)) : undefined}
+        onImportManagedSkillSource={props.onImportManagedSkillSource ? () => runSkillAction('source:import', props.onImportManagedSkillSource) : undefined}
+        onInstallManagedSkill={props.onInstallManagedSkill ? (sourceId) => runSkillAction(`source:install:${sourceId}`, () => props.onInstallManagedSkill?.(sourceId)) : undefined}
+        onUpdateManagedSkill={props.onUpdateManagedSkill ? (skillId) => runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId)) : undefined}
         actionBusy={skillActionBusy}
         refreshPending={pendingSkillAction === 'refresh'}
         createPending={pendingSkillAction === 'create'}
         openingSkillId={pendingSkillAction?.startsWith('open:') ? pendingSkillAction.slice('open:'.length) : null}
+        installingSourceId={pendingSkillAction?.startsWith('source:install:') ? pendingSkillAction.slice('source:install:'.length) : null}
+        updatingSkillId={pendingSkillAction?.startsWith('managed:update:') ? pendingSkillAction.slice('managed:update:'.length) : null}
         searchQuery={skillSearchQuery}
       />
     </main>


### PR DESCRIPTION
## Summary
- Add a global managed skill source cache under `~/.maka/skill-sources`.
- Add local `SKILL.md` source import, workspace installation, and explicit managed update flows.
- Extend skill provenance with managed update states: up to date, update available, local modified, source missing, and metadata error.
- Keep runtime skill loading anchored to `<workspace>/skills/<id>/SKILL.md`; the source cache is never used as a runtime path.
- Harden managed lock validation so forged managed baselines are rejected.

## Validation
- `npm --workspace @maka/desktop test`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/ui test`