### PR TITLE
feat(cli): double-Escape interrupt, /rename, and Ctrl+T thinking toggle

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1316,6 +1316,44 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(driver.stopCalls, 1);
   });
 
+  test('does not stop again when Esc arrives after Ctrl-C started closing', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new HangingStopDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    // Quit first: close() flips `closed`, then parks awaiting a slow runtime stop.
+    terminal.input('\x03');
+    await waitFor(() => driver.stopCalls === 1);
+
+    // The TUI is half-closed but its input listener is still live. A double
+    // Escape in this window must not slip a second stopSession past close().
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await delay(30);
+    assert.equal(driver.stopCalls, 1);
+
+    // Releasing the parked stop lets close() finish shutting the TUI down.
+    driver.releaseStop();
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps Escape as permission deny while a permission prompt is pending', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();
@@ -1558,6 +1596,64 @@ class SlowStopDriver implements MakaSessionDriver {
   // stopSession that has not finished aborting yet.
   async stop(): Promise<void> {
     this.stopCalls += 1;
+  }
+
+  endTurn(): void {
+    this.releaseTurn?.();
+    this.releaseTurn = null;
+  }
+
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class HangingStopDriver implements MakaSessionDriver {
+  stopCalls = 0;
+  private releaseTurn: (() => void) | null = null;
+  private releaseStopFns: Array<() => void> = [];
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    await new Promise<void>((resolve) => {
+      this.releaseTurn = resolve;
+    });
+    yield {
+      type: 'abort',
+      id: 'event-abort',
+      turnId: 'turn-1',
+      ts: 1,
+      reason: 'user_stop',
+    };
+  }
+
+  // stop() parks until releaseStop(), mimicking a runtime whose stopSession has
+  // not finished aborting. close() awaits this while the input listener is still
+  // live, which is the window the Ctrl-C-then-Escape regression exercises.
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    await new Promise<void>((resolve) => {
+      this.releaseStopFns.push(resolve);
+    });
+  }
+
+  releaseStop(): void {
+    for (const resolve of this.releaseStopFns) resolve();
+    this.releaseStopFns = [];
   }
 
   endTurn(): void {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1281,6 +1281,41 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('does not stop again when Ctrl-C exits mid-interrupt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlowStopDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await waitFor(() => driver.stopCalls === 1);
+
+    // The interrupt is issued but the runtime stop has not settled and the turn
+    // is still parked. Quitting with Ctrl-C must reuse that in-flight stop, not
+    // fire a second stopSession through close() that appends a duplicate abort.
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+
+    assert.equal(driver.stopCalls, 1);
+  });
+
   test('keeps Escape as permission deny while a permission prompt is pending', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -151,6 +151,40 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('toggles thinking visibility with Ctrl-T', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ThinkingOutputDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('思考（Ctrl+T 展开）'));
+    assert.equal(plainTerminalOutput(terminal.output()).includes('secret reasoning tail'), false);
+
+    terminal.input('\x14');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('secret reasoning tail'));
+
+    terminal.input('\x14');
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('secret reasoning tail'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('renders the statusline below the input editor', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -1407,6 +1441,54 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
     this.releaseTurn = null;
   }
 
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class ThinkingOutputDriver implements MakaSessionDriver {
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'thinking_delta',
+      id: 'event-thinking',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: 'secret reasoning tail',
+    };
+    yield {
+      type: 'text_complete',
+      id: 'event-text',
+      turnId: 'turn-1',
+      ts: 2,
+      messageId: 'message-1',
+      text: 'visible answer',
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 3,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -850,6 +850,66 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('handles /rename without sending a prompt', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rename PR 946 修复');
+    terminal.input('\r');
+
+    await waitFor(() => driver.renames.length === 1);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Session renamed to "PR 946 修复"'));
+
+    assert.deepEqual(driver.renames, ['PR 946 修复']);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('rejects /rename without a new name', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rename');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Usage: /rename <new name>'));
+    assert.deepEqual(driver.renames, []);
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /session without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([fakeSessionSummary('session-2', '/repo')]);
@@ -1235,6 +1295,7 @@ class RejectingStopDriver implements MakaSessionDriver {
   }
 
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
@@ -1303,6 +1364,7 @@ class PermissionPromptDriver implements MakaSessionDriver {
     this.permissionResponses.push(response);
     this.continueAfterPermission?.();
   }
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
@@ -1346,6 +1408,7 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
   }
 
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
@@ -1402,6 +1465,7 @@ class ToolOutputDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
@@ -1419,6 +1483,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly permissionModes: PermissionMode[] = [];
   readonly thinkingLevelUpdates: Array<ThinkingLevel | undefined> = [];
   readonly sessionIds: string[] = [];
+  readonly renames: string[] = [];
   private sessionId = 'session-1';
 
   constructor(
@@ -1455,6 +1520,9 @@ class SlashCommandDriver implements MakaSessionDriver {
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(model: string): Promise<void> {
     this.models.push(model);
+  }
+  async renameSession(name: string): Promise<void> {
+    this.renames.push(name);
   }
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
@@ -1581,6 +1649,7 @@ class DeferredControlDriver implements MakaSessionDriver {
     this.resolveSetModel = null;
   }
 
+  async renameSession(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
@@ -1625,6 +1694,7 @@ class RejectingPermissionDriver implements MakaSessionDriver {
     throw new Error('permission response rejected');
   }
 
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}
@@ -1702,6 +1772,7 @@ class PermissionThenErrorDriver implements MakaSessionDriver {
     this.respondCalls += 1;
   }
 
+  async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1240,6 +1240,47 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('interrupts at most once while the stop is still settling', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlowStopDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await waitFor(() => driver.stopCalls === 1);
+
+    // The turn has not ended yet (runtime stop is still settling). Further
+    // double-Escapes must be swallowed, not fire a second stopSession that
+    // would append a duplicate abort note to the session log.
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await delay(30);
+    assert.equal(driver.stopCalls, 1);
+
+    driver.endTurn();
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps Escape as permission deny while a permission prompt is pending', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionPromptDriver();
@@ -1437,6 +1478,54 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {
     this.stopCalls += 1;
+    this.releaseTurn?.();
+    this.releaseTurn = null;
+  }
+
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class SlowStopDriver implements MakaSessionDriver {
+  stopCalls = 0;
+  private releaseTurn: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    await new Promise<void>((resolve) => {
+      this.releaseTurn = resolve;
+    });
+    yield {
+      type: 'abort',
+      id: 'event-abort',
+      turnId: 'turn-1',
+      ts: 1,
+      reason: 'user_stop',
+    };
+  }
+
+  // stop() records the request but leaves the turn parked, mimicking a runtime
+  // stopSession that has not finished aborting yet.
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
+
+  endTurn(): void {
     this.releaseTurn?.();
     this.releaseTurn = null;
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1105,6 +1105,82 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('interrupts the running turn on double Escape', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new InterruptibleTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    terminal.input('\x1b');
+    await delay(20);
+    assert.equal(driver.stopCalls, 0);
+
+    terminal.input('\x1b');
+    await waitFor(() => driver.stopCalls === 1);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Stopped: user_stop'));
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    // Idle double Escape must not stop anything: the session is between turns.
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await delay(20);
+    assert.equal(driver.stopCalls, 1);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('keeps Escape as permission deny while a permission prompt is pending', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => driver.permissionRequests === 1);
+    await delay(20);
+
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await waitFor(() => driver.permissionResponses.length >= 1);
+
+    // Both Escapes route to the permission prompt, never to turn interruption.
+    assert.equal(driver.permissionResponses[0]?.decision, 'deny');
+    assert.equal(driver.stopCalls, 0);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('clears the permission prompt when the turn errors', async () => {
     const terminal = new FakeTerminal();
     const driver = new PermissionThenErrorDriver();
@@ -1174,6 +1250,7 @@ class RejectingStopDriver implements MakaSessionDriver {
 class PermissionPromptDriver implements MakaSessionDriver {
   readonly permissionResponses: PermissionResponse[] = [];
   permissionRequests = 0;
+  stopCalls = 0;
   private continueAfterPermission: (() => void) | null = null;
 
   async listSessions(): Promise<SessionSummary[]> {
@@ -1218,12 +1295,57 @@ class PermissionPromptDriver implements MakaSessionDriver {
     };
   }
 
-  async stop(): Promise<void> {}
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+  }
 
   async respondToPermission(response: PermissionResponse): Promise<void> {
     this.permissionResponses.push(response);
     this.continueAfterPermission?.();
   }
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class InterruptibleTurnDriver implements MakaSessionDriver {
+  stopCalls = 0;
+  private releaseTurn: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // The turn parks like a real long-running provider call until stop() aborts it.
+    await new Promise<void>((resolve) => {
+      this.releaseTurn = resolve;
+    });
+    yield {
+      type: 'abort',
+      id: 'event-abort',
+      turnId: 'turn-1',
+      ts: 1,
+      reason: 'user_stop',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    this.releaseTurn?.();
+    this.releaseTurn = null;
+  }
+
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}
   async setThinkingLevel(): Promise<void> {}

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -125,6 +125,37 @@ describe('Maka session driver', () => {
     }]);
   });
 
+  test('renames the active session through runtime updateSession', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.renameSession('watcher 根目录事件风暴修复');
+
+    assert.deepEqual(runtime.sessionUpdates, [{
+      sessionId: 'session-1',
+      patch: { name: 'watcher 根目录事件风暴修复' },
+    }]);
+  });
+
+  test('rejects rename before a session starts', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await assert.rejects(driver.renameSession('too early'), /before a session starts/);
+    assert.deepEqual(runtime.sessionUpdates, []);
+  });
+
   test('switches to an existing session for the next prompt', async () => {
     const repo = await mkdtemp(join(tmpdir(), 'maka-switch-cwd-'));
     try {
@@ -360,7 +391,7 @@ class RecordingRuntime {
   readonly compacted: Array<{ sessionId: string; input: { turnId?: string } }> = [];
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
-  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined } }> = [];
+  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
   sessionSummaries: SessionSummary[] = [];
 
@@ -434,7 +465,7 @@ class RecordingRuntime {
     };
   }
 
-  async updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined }): Promise<SessionSummary> {
+  async updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
     this.sessionUpdates.push({ sessionId, patch });
     return {
       id: sessionId,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -18,6 +18,7 @@ export interface MakaPiTranscriptState {
   sawTextDeltaMessageIds: Set<string>;
   pendingPermission?: PermissionRequestEvent;
   expandedToolUseId?: string;
+  expandedThinkingMessageId?: string;
 }
 
 export type MakaPiTranscriptEntry =
@@ -74,6 +75,7 @@ export function replaceTranscriptWithStoredMessages(
   );
   state.pendingPermission = undefined;
   state.expandedToolUseId = undefined;
+  state.expandedThinkingMessageId = undefined;
 }
 
 export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean {
@@ -84,6 +86,20 @@ export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean
   state.expandedToolUseId = state.expandedToolUseId === latestTool.toolUseId
     ? undefined
     : latestTool.toolUseId;
+  return true;
+}
+
+export function toggleLatestThinkingExpansion(state: MakaPiTranscriptState): boolean {
+  const latestThinking = [...state.entries]
+    .reverse()
+    .find(
+      (entry): entry is MakaPiAssistantEntry =>
+        entry.kind === 'assistant' && Boolean(entry.thinking?.trim()),
+    );
+  if (!latestThinking) return false;
+  state.expandedThinkingMessageId = state.expandedThinkingMessageId === latestThinking.messageId
+    ? undefined
+    : latestThinking.messageId;
   return true;
 }
 
@@ -415,7 +431,7 @@ export function renderMakaPiTranscript(
         lines.push(...renderTextBlock('User', entry.text, safeWidth, { markdown: false, heading: ansi.accent }));
         break;
       case 'assistant':
-        lines.push(...renderAssistantBlock(entry, safeWidth));
+        lines.push(...renderAssistantBlock(entry, safeWidth, state.expandedThinkingMessageId === entry.messageId));
         break;
       case 'tool':
         lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseId === entry.toolUseId));
@@ -470,16 +486,17 @@ function setAssistantThinking(state: MakaPiTranscriptState, messageId: string, t
   state.entries.push({ kind: 'assistant', messageId, text: '', thinking: text });
 }
 
-function renderAssistantBlock(entry: MakaPiAssistantEntry, width: number): string[] {
+function renderAssistantBlock(entry: MakaPiAssistantEntry, width: number, thinkingExpanded: boolean): string[] {
   const lines = renderTextBlock('maka', entry.text, width, { markdown: true, heading: ansi.accent });
-  // Thinking blocks are collapsed in the transcript: a terminal transcript is
-  // static (no interactive toggle), so we render a one-line marker instead of
-  // the full body, which would flood the scrollback. The text stays on the
-  // entry in case a future viewer wants to surface it; this satisfies the
-  // "can be collapsed/hidden" acceptance without dumping reasoning into the
-  // terminal.
+  // Thinking stays collapsed to a one-line marker by default so reasoning
+  // never floods the scrollback; Ctrl+T expands the latest block on demand.
   if (entry.thinking && entry.thinking.trim()) {
-    lines.push(ansi.dim('思考（已隐藏）'));
+    if (thinkingExpanded) {
+      lines.push(fitLine(ansi.dim('思考'), width));
+      lines.push(...renderIndented(entry.thinking, width, 2).map((line) => fitLine(ansi.dim(line), width)));
+    } else {
+      lines.push(ansi.dim('思考（Ctrl+T 展开）'));
+    }
   }
   return lines;
 }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -130,7 +130,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (closed) return;
     closed = true;
     try {
-      await input.driver.stop();
+      // A double-Escape interrupt may already have a stop in flight for this
+      // turn; reuse it instead of firing a second stopSession that would append
+      // a duplicate abort note. Otherwise stop the runtime as part of closing.
+      if (!interruptRequested) {
+        await input.driver.stop();
+      }
     } catch {
       // Closing the terminal must win even if the runtime stop path
       // has already failed or the session never fully started.

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -552,6 +552,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   editor.setAutocompleteProvider(new MakaAutocompleteProvider(input.cwd, slashCommands));
 
   tui.addInputListener((data) => {
+    // Once closing has begun, swallow every key. A half-closed TUI still has a
+    // live listener while close() awaits the runtime stop; letting Escape or any
+    // other key through here would mutate state or fire a second stop.
+    if (closed) return { consume: true };
     if (tui.hasOverlay()) return undefined;
     if (matchesKey(data, Key.ctrl('o'))) {
       if (toggleLatestToolExpansion(state)) {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -64,6 +64,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let closed = false;
   let permissionInFlight = false;
   let turnRunning = false;
+  let interruptRequested = false;
   let lastTurnEscapeAt = 0;
   let resolveClosed: () => void;
   const closedPromise = new Promise<void>((resolve) => {
@@ -180,6 +181,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
     busy = true;
     turnRunning = true;
+    interruptRequested = false;
     lastTurnEscapeAt = 0;
     editor.disableSubmit = true;
     terminal.setProgress(true);
@@ -193,6 +195,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     }).finally(() => {
       busy = false;
       turnRunning = false;
+      interruptRequested = false;
       editor.disableSubmit = false;
       terminal.setProgress(false);
       requestRender();
@@ -571,10 +574,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // permission branch so Escape keeps meaning "deny" while a prompt is
     // pending, and it only arms while a prompt turn is actually running.
     if (turnRunning && matchesKey(data, Key.escape)) {
+      // Once an interrupt is issued, swallow further Escapes until the turn
+      // ends so a still-settling stop is not requested twice. A rejected stop
+      // re-arms interruption so the user can retry within the same turn.
+      if (interruptRequested) return { consume: true };
       const now = Date.now();
       if (now - lastTurnEscapeAt <= DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS) {
         lastTurnEscapeAt = 0;
-        void input.driver.stop().catch(reportError);
+        interruptRequested = true;
+        void input.driver.stop().catch((error) => {
+          interruptRequested = false;
+          reportError(error);
+        });
       } else {
         lastTurnEscapeAt = now;
       }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -28,6 +28,7 @@ import {
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
+  toggleLatestThinkingExpansion,
   toggleLatestToolExpansion,
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
@@ -546,6 +547,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (tui.hasOverlay()) return undefined;
     if (matchesKey(data, Key.ctrl('o'))) {
       if (toggleLatestToolExpansion(state)) {
+        requestRender();
+        return { consume: true };
+      }
+    }
+    if (matchesKey(data, Key.ctrl('t'))) {
+      if (toggleLatestThinkingExpansion(state)) {
         requestRender();
         return { consume: true };
       }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -62,6 +62,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let busy = false;
   let closed = false;
   let permissionInFlight = false;
+  let turnRunning = false;
+  let lastTurnEscapeAt = 0;
   let resolveClosed: () => void;
   const closedPromise = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -176,6 +178,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (handleSlashCommand(prompt)) return;
 
     busy = true;
+    turnRunning = true;
+    lastTurnEscapeAt = 0;
     editor.disableSubmit = true;
     terminal.setProgress(true);
     requestRender();
@@ -187,6 +191,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       onChange: requestRender,
     }).finally(() => {
       busy = false;
+      turnRunning = false;
       editor.disableSubmit = false;
       terminal.setProgress(false);
       requestRender();
@@ -530,6 +535,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return { consume: true };
       }
     }
+    // Double Escape interrupts the running turn. This must sit below the
+    // permission branch so Escape keeps meaning "deny" while a prompt is
+    // pending, and it only arms while a prompt turn is actually running.
+    if (turnRunning && matchesKey(data, Key.escape)) {
+      const now = Date.now();
+      if (now - lastTurnEscapeAt <= DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS) {
+        lastTurnEscapeAt = 0;
+        void input.driver.stop().catch(reportError);
+      } else {
+        lastTurnEscapeAt = now;
+      }
+      return { consume: true };
+    }
     if (matchesKey(data, Key.ctrl('c')) || matchesKey(data, Key.ctrl('d'))) {
       void close();
       return { consume: true };
@@ -753,3 +771,6 @@ function padLine(text: string, width: number): string {
 }
 
 const BOTTOM_PICKER_MARGIN_ROWS = 4;
+
+// Two Escapes this close together read as one deliberate "stop the turn".
+const DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS = 600;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -485,6 +485,31 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     {
+      name: 'rename',
+      description: 'Rename current session',
+      run: (parts: string[]) => {
+        const name = parts.slice(1).join(' ').trim();
+        if (!name) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Usage: /rename <new name>',
+          });
+          requestRender();
+          return;
+        }
+        void runControl(async () => {
+          await input.driver.renameSession(name);
+          state.entries.push({
+            kind: 'notice',
+            level: 'info',
+            text: `Session renamed to "${name}"`,
+          });
+          requestRender();
+        });
+      },
+    },
+    {
       name: 'session',
       description: 'Resume session',
       run: (parts: string[]) => {

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -15,7 +15,7 @@ export interface MakaSessionRuntime {
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: ThinkingLevel | undefined }): Promise<SessionSummary>;
+  updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
 }
 
 export interface MakaSessionDriverInput {
@@ -40,6 +40,7 @@ export interface MakaSessionDriver {
   setModel(model: string): Promise<void>;
   setThinkingLevel(level: ThinkingLevel | undefined): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
+  renameSession(name: string): Promise<void>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
   stop(): Promise<void>;
   getSessionId(): string | null;
@@ -123,6 +124,11 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       return;
     }
     this.permissionMode = mode;
+  }
+
+  async renameSession(name: string): Promise<void> {
+    if (!this.sessionId) throw new Error('Cannot rename before a session starts.');
+    await this.input.runtime.updateSession(this.sessionId, { name });
   }
 
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {


### PR DESCRIPTION
## Summary

Three thin TUI control features from the #549 T1 list, kept as one PR of low-risk wiring with three atomic commits:

- **Double-Escape interrupt** — while a prompt turn is running, pressing `Esc` twice within 600ms calls `driver.stop()` (runtime `stopSession`), aborting the active turn. `Esc` still means "deny" while a permission prompt is pending; idle presses stay inert.
- **`/rename`** — renames the current session via a `name` patch through runtime `updateSession`, with usage error and transcript feedback; rejects before a session exists.
- **`Ctrl+T` thinking toggle** — the collapsed thinking marker now advertises the toggle (`思考（Ctrl+T 展开）`), and `Ctrl+T` expands/collapses the newest thinking block in place. Default output stays quiet; session switches reset expansion state.

## Why

CLI usability tracking issue #549 (T1): users need a way to stop a bad turn without killing the whole session, rename sessions without the desktop app, and inspect hidden reasoning.

Refs #549

## Scope

Changed: `packages/cli` only — `pi-tui-runner.ts`, `pi-transcript.ts`, `session-driver.ts`, plus tests.

Not included: statusline redesign, attention/terminal title, tool-result redesign, rewind (tracked separately in #549). Note: this PR intentionally bundles three T1 checkboxes; they are all thin TUI wiring sharing one review lens.

## Verification

- TDD throughout: each feature landed as failing test → minimal implementation (`node:test` with `FakeTerminal`, real key-byte input through the real runner).
- `npm run -w maka-agent test` — 93 pass, 0 fail.
- `npm run typecheck` — all workspaces clean.
- Not exercised against a live provider session (interrupt path reuses the same `stopSession` the desktop stop button already drives).

## User-facing impact

New CLI keybindings (`Esc Esc`, `Ctrl+T`) and `/rename` command; collapsed-thinking marker copy changed. No breaking changes, no migrations.

## Reviewer notes

Interrupt precedence lives in the input listener ordering: permission-deny branch first, then turn interrupt, then Ctrl+C/D close. The 600ms window is a constant (`DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS`).
