### PR TITLE
fix(renderer): stop daily review page flickering from connection refresh loop

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -110,6 +110,14 @@ import {
 } from './app-shell-effects';
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
 
+function connectionsEqual(a: LlmConnection[], b: LlmConnection[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].slug !== b[i].slug || a[i].updatedAt !== b[i].updatedAt) return false;
+  }
+  return true;
+}
+
 type ComposerImportOwner = {
   sessionId: string | undefined;
   navSection: NavSelection['section'];
@@ -1138,7 +1146,7 @@ export function AppShell({
         window.maka.connections.list(),
         window.maka.connections.getDefault(),
       ]);
-      setConnections(next);
+      setConnections((prev) => connectionsEqual(prev, next) ? prev : next);
       setDefaultConnection(nextDefault);
     } catch (error) {
       toastApi.error('刷新模型连接失败', generalizedErrorMessageChinese(error, '模型连接暂时无法刷新，请稍后重试。'));

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { CalendarDays } from './icons.js';
 import { SettingsSelect } from './primitives/settings-select.js';
 import type {
@@ -47,6 +47,8 @@ const DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL: Record<DailyReviewArchive['trigger'], 
   manual: '手动',
 };
 
+const EMPTY_MODEL_OPTIONS: ReadonlyArray<readonly [string, string]> = [];
+
 export function DailyReviewPanel(props: {
   bridge: DailyReviewBridge;
   onSelectSession?: (sessionId: string) => void;
@@ -71,7 +73,7 @@ export function DailyReviewPanel(props: {
   const [archiveLoading, setArchiveLoading] = useState(false);
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const [archiveReloadToken, setArchiveReloadToken] = useState(0);
-  const modelOptions = props.bridge.modelOptions ?? [];
+  const modelOptions = useMemo(() => props.bridge.modelOptions ?? EMPTY_MODEL_OPTIONS, [props.bridge.modelOptions]);
   const [selectedModelKey, setSelectedModelKey] = useState<string>(modelOptions[0]?.[0] ?? '');
   const dailyReviewMountedRef = useRef(true);
   const summaryScopeKeyRef = useRef<string | null>(null);


### PR DESCRIPTION
## Summary

The Daily Review page (每日回顾) flickered continuously — measured at ~250 DOM mutations every 5 seconds on a page that should be static after initial load.

## Root cause

A cascade of unstable references:

1. **File watcher** (`config-file-watcher.ts`): `fs.watch` on the workspace directory fires on every write to `llm-connections.json` / `credentials.json` / `settings.json`, debounced 300ms — including the app's own writes.
2. **`refreshConnections()`** (`app-shell.tsx`): called `setConnections(next)` unconditionally on every watcher event. Each IPC call returns a fresh array reference even when the connection list is byte-identical.
3. **`dailyReviewBridge`** (`useMemo(() => createAppShellDailyReviewBridge(connections), [connections])`): invalidated on every new `connections` reference.
4. **`DailyReviewPanel`**: all three `useEffect`s depend on `props.bridge`, so a bridge identity change re-triggers `setLoading(true)` → fetch → `setLoading(false)` → next watcher tick → repeat — a ~300ms render loop that never converges.

## Fix

- **Primary**: `setConnections` now uses a functional updater with `connectionsEqual(prev, next)` — compares `slug` + `updatedAt` per entry. If nothing changed, the state reference stays stable and the `dailyReviewBridge` memo holds.
- **Defensive**: wrapped `modelOptions` in `DailyReviewPanel` with `useMemo` to eliminate a latent unstable-array-literal dependency (the `?? []` fallback allocated a new empty array on every render).

## Verification

- Measured via CDP `MutationObserver`: **250+ mutations / 5s → 2 mutations / 5s** on the Daily Review page.
- Visually confirmed: page no longer flickers.

Co-Authored-By: Claude <noreply@anthropic.com>