### PR TITLE
feat(ui): icon-only turn footer with meta tooltip; merge retry into regenerate (#546)

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -35,7 +35,6 @@ import type {
   BranchFromTurnInput,
   CapabilitySnapshotCollection,
   RegenerateTurnInput,
-  RetryTurnInput,
   TurnRecord,
   PermissionSnapshot,
   OpenGatewayRuntimeStatus,
@@ -136,7 +135,6 @@ declare global {
         stop(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
         readMessages(sessionId: string): Promise<StoredMessage[]>;
         listTurns(sessionId: string): Promise<TurnRecord[]>;
-        retryTurn(sessionId: string, input: RetryTurnInput): Promise<void>;
         regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void>;
         branchFromTurn(sessionId: string, input: BranchFromTurnInput): Promise<SessionSummary>;
         respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -90,7 +90,7 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       // now that the call sites use `UiButton size="nav"` (bare); it used to
       // come implicitly from `size="sm"`.
       'h-8',
-      '[&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)]',
+      '[&:hover:not([aria-disabled=true])]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)]',
       // focus-visible is a non-leaf conflict (the footer action's outline vs
       // UiButton's box-shadow ring), so the rendered-style script can't force
       // it reliably; this exact literalization of the retired
@@ -98,11 +98,10 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       'focus-visible:[outline:2px_solid_var(--focus-ring)]',
       'focus-visible:[outline-offset:2px]',
       'data-[pending=true]:opacity-[0.78]',
-      // the combined disabled+pending guards: a copy button can be both
-      // `disabled` and `data-pending` (transient copy click), and the retired
-      // CSS kept the 0.78 pending dim winning over the 0.45 disabled dim — these
-      // raise the specificity so emit order can't flip it.
-      'disabled:data-[pending=true]:opacity-[0.78]',
+      // the combined aria-disabled+pending guard: a copy button can be both
+      // `aria-disabled` and `data-pending` (transient copy click), and the
+      // retired CSS kept the 0.78 pending dim winning over the 0.45 disabled
+      // dim — this raises the specificity so emit order can't flip it.
       'aria-disabled:data-[pending=true]:opacity-[0.78]',
       'data-[copy-feedback=copied]:text-[color:var(--link)]',
     ]) {

--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -71,20 +71,8 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
     // retired `.maka-turn-*` rules exactly (pixels, oklch relative-color tints,
     // var() tokens) and never the semantic scale.
     for (const literal of [
-      // summary strip + chip + switched pill (maka-tokens.css)
+      // footer / lineage-row measure column (maka-tokens.css)
       'max-w-[var(--maka-chat-measure,680px)]',
-      "[&:not(:first-child)]:before:content-['·']",
-      '[&_code]:[font-family:var(--font-mono)]',
-      'data-[kind=model]:[&_code]:text-[color:var(--foreground-secondary)]',
-      // every chip `data-[kind]` conditional is pinned, not just `model`, so
-      // dropping the tools tint / duration+tokens tabular-nums / tokens mono
-      // fails the contract.
-      'data-[kind=tools]:text-[color:var(--muted-foreground)]',
-      'data-[kind=duration]:[font-variant-numeric:tabular-nums]',
-      'data-[kind=tokens]:[font-family:var(--font-mono)]',
-      'data-[state=in-progress]:text-[color:var(--status-running)]',
-      'data-[state=in-progress]:font-semibold',
-      'bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)]',
       // aborted marker (models.css)
       'bg-[var(--foreground-5)]',
       '[&_em]:italic',

--- a/apps/desktop/src/main/__tests__/derive-turn-lineage-badges.test.ts
+++ b/apps/desktop/src/main/__tests__/derive-turn-lineage-badges.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the turn lineage badge derivation (#546).
+ *
+ * retry was merged into regenerate, so the badge vocabulary is uniform:
+ * "重新生成自" (forward) and "已重新生成" (reverse), regardless of which
+ * path wrote the lineage. Legacy retried* fields from old sessions are
+ * read back as regenerate lineages.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { deriveTurnLineageBadges } from '../../renderer/derive-turn-lineage-badges.js';
+
+describe('deriveTurnLineageBadges (#546 retry→regenerate merge)', () => {
+  it('legacy retriedFromTurnId shows a forward "重新生成自" badge, never "重试自"', () => {
+    const badges = deriveTurnLineageBadges({
+      turnId: 'turn-retry-new',
+      retriedFromTurnId: 'turn-retry-origin',
+      existsTurn: () => true,
+    });
+    const forward = badges.find((b) => b.direction === 'forward');
+    assert.match(forward?.label ?? '', /重新生成自/);
+    assert.doesNotMatch(forward?.label ?? '', /重试自/);
+  });
+
+  it('legacy retriedToTurnId shows a reverse "已重新生成" badge, never "已重试"', () => {
+    const badges = deriveTurnLineageBadges({
+      turnId: 'turn-retry-origin',
+      retriedToTurnId: 'turn-retry-new',
+      existsTurn: () => true,
+    });
+    const reverse = badges.find((b) => b.direction === 'reverse');
+    assert.match(reverse?.label ?? '', /已重新生成/);
+    assert.doesNotMatch(reverse?.label ?? '', /已重试/);
+  });
+
+  it('regeneratedFromTurnId shows "重新生成自" (unchanged path)', () => {
+    const badges = deriveTurnLineageBadges({
+      turnId: 'turn-regen-new',
+      regeneratedFromTurnId: 'turn-regen-origin',
+      existsTurn: () => true,
+    });
+    const forward = badges.find((b) => b.direction === 'forward');
+    assert.match(forward?.label ?? '', /重新生成自/);
+  });
+
+  it('prefers regenerated over legacy retried when both are present', () => {
+    const badges = deriveTurnLineageBadges({
+      turnId: 't',
+      retriedFromTurnId: 'origin-a',
+      regeneratedFromTurnId: 'origin-b',
+      existsTurn: () => true,
+    });
+    const forward = badges.find((b) => b.direction === 'forward');
+    assert.equal(forward?.targetTurnId, 'origin-b');
+  });
+
+  it('omits a badge when the target turn does not exist', () => {
+    const badges = deriveTurnLineageBadges({
+      turnId: 't',
+      regeneratedFromTurnId: 'gone',
+      existsTurn: () => false,
+    });
+    assert.equal(badges.length, 0);
+  });
+
+  it('emits no badges for a turn with no lineage', () => {
+    const badges = deriveTurnLineageBadges({ turnId: 'solo', existsTurn: () => true });
+    assert.equal(badges.length, 0);
+  });
+});

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -354,7 +354,7 @@ describe('deriveTurnLineageMap', () => {
 
   it('multi-retry uses last-wins semantics (most recent retry surfaced)', () => {
     // Two retries off the same origin: the most recent one in the
-    // input array wins. UI consumers can show "已重试 → turn ${id}"
+    // input array wins. UI consumers can show "已重新生成 → turn ${id}"
     // pointing at the latest attempt; older retries are still findable
     // by scanning the turn list for `retriedFromTurnId === origin`.
     const map = deriveTurnLineageMap([

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -12,7 +12,6 @@ import {
   normalizeBranchFromTurnInput,
   normalizePermissionResponse,
   normalizeRegenerateTurnInput,
-  normalizeRetryTurnInput,
   normalizeSessionSendCommand,
   normalizeStopSessionInput,
 } from '../permission-response-guard.js';
@@ -60,11 +59,7 @@ describe('permission response IPC boundary', () => {
     assert.doesNotMatch(handler, /runtime\.respondToPermission\(sessionId,\s*response\)/);
   });
 
-  it('normalizes turn action inputs before retry / regenerate / branch runtime calls', () => {
-    assert.deepEqual(
-      normalizeRetryTurnInput({ sourceTurnId: 'turn-1', turnId: 'retry-1', extra: true }),
-      { sourceTurnId: 'turn-1', turnId: 'retry-1' },
-    );
+  it('normalizes turn action inputs before regenerate / branch runtime calls', () => {
     assert.deepEqual(
       normalizeRegenerateTurnInput({ sourceTurnId: 'turn-2' }),
       { sourceTurnId: 'turn-2' },
@@ -76,8 +71,6 @@ describe('permission response IPC boundary', () => {
   });
 
   it('rejects malformed turn action inputs at the IPC boundary', () => {
-    assert.throws(() => normalizeRetryTurnInput(null), /retry turn input/);
-    assert.throws(() => normalizeRetryTurnInput({ sourceTurnId: '' }), /sourceTurnId/);
     assert.throws(() => normalizeRegenerateTurnInput({ sourceTurnId: 'turn-1', turnId: 1 }), /turnId/);
     assert.throws(() => normalizeBranchFromTurnInput({ sourceTurnId: 'turn-1', name: 1 }), /branch name/);
   });
@@ -85,12 +78,9 @@ describe('permission response IPC boundary', () => {
   it('routes turn actions through main-process normalizers', async () => {
     const mainPath = fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url));
     const main = await readFile(mainPath, 'utf8');
-    const retryHandler = main.match(/ipcMain\.handle\('sessions:retryTurn'[\s\S]*?\n  \);/)?.[0] ?? '';
     const regenerateHandler = main.match(/ipcMain\.handle\('sessions:regenerateTurn'[\s\S]*?\n  \);/)?.[0] ?? '';
     const branchHandler = main.match(/ipcMain\.handle\('sessions:branchFromTurn'[\s\S]*?\n  \);/)?.[0] ?? '';
 
-    assert.match(retryHandler, /normalizeRetryTurnInput\(input\)/);
-    assert.doesNotMatch(retryHandler, /runtime\.retryTurn\(sessionId,\s*\{\s*\.\.\.input/);
     assert.match(regenerateHandler, /normalizeRegenerateTurnInput\(input\)/);
     assert.doesNotMatch(regenerateHandler, /runtime\.regenerateTurn\(sessionId,\s*\{\s*\.\.\.input/);
     assert.match(branchHandler, /normalizeBranchFromTurnInput\(input\)/);

--- a/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-open-routing-contract.test.ts
@@ -40,11 +40,6 @@ describe('session open routing contract', () => {
     assert.match(handlerBlock, /const sessionId = activeIdRef\.current;/);
     assert.match(
       handlerBlock,
-      /await window\.maka\.sessions\.retryTurn\(sessionId, \{ sourceTurnId: turnId \}\);[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.info\('已发起重试'/,
-      'retry feedback must stay owned by the source session',
-    );
-    assert.match(
-      handlerBlock,
       /await window\.maka\.sessions\.regenerateTurn\(sessionId, \{ sourceTurnId: turnId \}\);[\s\S]*?if \(activeIdRef\.current === sessionId\) toastApi\.info\('已发起重新生成'/,
       'regenerate feedback must stay owned by the source session',
     );

--- a/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
@@ -44,10 +44,4 @@ describe('session startup recovery contract', () => {
       'recovery must skip sessions with live runs — this guard is what makes background recovery safe',
     );
   });
-
-  it('turn summary only shows in-progress for genuinely running turns', async () => {
-    const src = await readFile(join(REPO_ROOT, 'packages/ui/src/chat-view.tsx'), 'utf8');
-
-    assert.match(src, /const inProgress = turn\.status === 'running' && turn\.user !== undefined && turn\.assistant === undefined;/);
-  });
 });

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -187,13 +187,4 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     assert.match(styles, /\.maka-thinking-section\s*\{[\s\S]*flex:\s*0 0 auto;[\s\S]*\}/);
     assert.match(styles, /\.settingsSelectMenuPopup \[role="option"\]\s*\{[\s\S]*min-height: 32px;[\s\S]*\}/);
   });
-
-  it('flags per-turn model departures against the session sticky model', async () => {
-    const ui = await readModelSwitcherUiSource();
-
-    assert.match(ui, /props\.activeSession\?\.model && props\.activeSession\.model\.length > 0/);
-    assert.match(ui, /previousModelId=\{expectedModelId\}/);
-    assert.match(ui, /本轮使用 \$\{turn\.modelId\}，session 期望 \$\{props\.previousModelId\}/);
-    assert.match(ui, /本轮切换了模型/);
-  });
 });

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -41,7 +41,7 @@
  *    its onClick handler. The scan also requires every discovered button to
  *    be value-pinned here (or in EXCEPTIONS) so a too-small `min-w-[1rem]`
  *    can't bypass the value lock; the whitelist pins the exact value so a
- *    refactor can't shrink a real lock to the wrong value. Chat summary-chip / stream-count variant locks live in
+ *    refactor can't shrink a real lock to the wrong value. Chat stream-count variant locks live in
  *    the variant definition, so they're pinned by their literal declaration
  *    substrings.
  */
@@ -173,7 +173,7 @@ describe('PR-ANTI-LAYOUT-SHIFT-TEXT-SWAP-0 contract', () => {
     }
   });
 
-  it('chat summary-chip / stream-count variants keep their min-w declarations', async () => {
+  it('chat stream-count variants keep their min-w declarations', async () => {
     const byFile = new Map<string, typeof CHAT_VARIANT_LOCKS>();
     for (const l of CHAT_VARIANT_LOCKS) {
       const arr = byFile.get(l.file) ?? [];

--- a/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/text-swap-min-width-contract.test.ts
@@ -108,12 +108,10 @@ const TEXT_SWAP_BUTTONS: Array<{ file: string; onClick: string; minW: string; no
   { file: 'apps/desktop/src/renderer/error-boundary.tsx', onClick: 'onClick={this.handleCopyReport}', minW: '5.5rem', note: '复制诊断信息 ↔ 复制中… ↔ 已复制 ↔ 复制失败' },
 ];
 
-// Chat summary-chip / stream-count variant locks: the min-w-[Nrem]
+// Chat stream-count variant lock: the min-w-[Nrem]
 // declaration lives in the variant definition (chat.tsx), not at the call
 // site, so we pin the literal declaration substrings.
 const CHAT_VARIANT_LOCKS: Array<{ file: string; substr: string; note: string }> = [
-  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'data-[kind=tools]:min-w-[5rem]', note: 'summary-chip tools count (N 个工具)' },
-  { file: 'packages/ui/src/primitives/chat.tsx', substr: 'data-[kind=duration]:min-w-[4rem]', note: 'summary-chip duration (进行中 ↔ 时长)' },
   { file: 'packages/ui/src/primitives/chat.tsx', substr: 'min-w-[5rem] [font-variant-numeric:tabular-nums]', note: 'streamVariants count (stdout/stderr/已脱敏 N)' },
 ];
 

--- a/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
@@ -194,11 +194,11 @@ describe('deriveTurnFooterActions', () => {
   describe('info action carries the meta summary (#546)', () => {
     it('appends an info action whose tooltip is the meta summary, when provided', () => {
       const actions = deriveTurnFooterActions(
-        ctx({ status: 'completed', metaSummary: 'gpt-5.5 · 4.9s · 1,417 → 19 tok' }),
+        ctx({ status: 'completed', metaSummary: 'gpt-5.5 · 4.9s · $0.0123' }),
       );
       const info = actions.find((a) => a.id === 'info');
       assert.ok(info, 'info action should be present when metaSummary is set');
-      assert.equal(info?.tooltip, 'gpt-5.5 · 4.9s · 1,417 → 19 tok');
+      assert.equal(info?.tooltip, 'gpt-5.5 · 4.9s · $0.0123');
     });
 
     it('omits the info action when no meta summary is provided', () => {
@@ -212,6 +212,24 @@ describe('deriveTurnFooterActions', () => {
       );
       const info = actions.find((a) => a.id === 'info');
       assert.equal(info?.enabled, true);
+    });
+  });
+
+  describe('copy action tooltip reflects enabled state (#546)', () => {
+    it('shows the copy affordance when there is content', () => {
+      const copy = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: true })).find(
+        (a) => a.id === 'copy',
+      );
+      assert.equal(copy?.enabled, true);
+      assert.equal(copy?.tooltip, '复制回答到剪贴板');
+    });
+
+    it('shows the disabled reason when there is no content', () => {
+      const copy = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: false })).find(
+        (a) => a.id === 'copy',
+      );
+      assert.equal(copy?.enabled, false);
+      assert.equal(copy?.tooltip, '此回答尚无可复制的内容');
     });
   });
 

--- a/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
@@ -1,9 +1,13 @@
 /**
- * Tests for the Turn footer action helper (PR109d-b).
+ * Tests for the Turn footer action helper.
  *
- * @kenji PR109d review gate #1: footer action enabled set must come
+ * @kenji review gate #1: footer action enabled set must come
  * exclusively from `TurnStatus` + lineage map — never from the turn's
  * text content or optimistic UI guesses. This matrix locks that down.
+ *
+ * #546: retry was merged into regenerate. The footer now has one
+ * "重新生成" action that re-runs the turn regardless of how the
+ * previous attempt ended (failed / aborted / completed).
  */
 
 import { strict as assert } from 'node:assert';
@@ -29,9 +33,9 @@ function enabledIds(input: TurnFooterContext): TurnFooterActionId[] {
 }
 
 describe('deriveTurnFooterActions', () => {
-  it('always returns the same 4 actions in fixed order', () => {
+  it('always returns the same 3 actions in fixed order', () => {
     const ids = deriveTurnFooterActions(ctx({})).map((a) => a.id);
-    assert.deepEqual(ids, ['retry', 'regenerate', 'branch', 'copy']);
+    assert.deepEqual(ids, ['regenerate', 'branch', 'copy']);
   });
 
   it('labels are Chinese', () => {
@@ -46,16 +50,16 @@ describe('deriveTurnFooterActions', () => {
       assert.deepEqual(enabledIds(ctx({ status: 'running' })), ['copy']);
     });
 
-    it('completed: regenerate + branch + copy enabled (retry disabled)', () => {
+    it('completed: regenerate + branch + copy enabled', () => {
       assert.deepEqual(enabledIds(ctx({ status: 'completed' })), ['regenerate', 'branch', 'copy']);
     });
 
-    it('failed: retry + branch + copy enabled (regenerate disabled)', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'failed' })), ['retry', 'branch', 'copy']);
+    it('failed: regenerate + branch + copy enabled (retry merged into regenerate)', () => {
+      assert.deepEqual(enabledIds(ctx({ status: 'failed' })), ['regenerate', 'branch', 'copy']);
     });
 
-    it('aborted: retry + branch + copy enabled (regenerate disabled)', () => {
-      assert.deepEqual(enabledIds(ctx({ status: 'aborted' })), ['retry', 'branch', 'copy']);
+    it('aborted: regenerate + branch + copy enabled (retry merged into regenerate)', () => {
+      assert.deepEqual(enabledIds(ctx({ status: 'aborted' })), ['regenerate', 'branch', 'copy']);
     });
   });
 
@@ -72,7 +76,6 @@ describe('deriveTurnFooterActions', () => {
     it('tooltips are Chinese only', () => {
       for (const action of deriveTurnFooterActions(ctx({}))) {
         assert.match(action.tooltip ?? '', /[一-鿿]/, `${action.id} tooltip should be Chinese`);
-        // Tooltips may reference 「分支」or other Chinese terms but no enum identifiers
         const TURN_STATUSES = new Set(['running', 'completed', 'aborted', 'failed']);
         for (const status of TURN_STATUSES) {
           assert.doesNotMatch(
@@ -89,22 +92,20 @@ describe('deriveTurnFooterActions', () => {
       assert.match(abortedBranch?.tooltip ?? '', /中断/);
     });
 
-    it('alreadyRetried changes the retry tooltip hint without disabling the button', () => {
-      const first = deriveTurnFooterActions(ctx({ status: 'failed' })).find((a) => a.id === 'retry');
-      const second = deriveTurnFooterActions(ctx({ status: 'failed', alreadyRetried: true })).find(
-        (a) => a.id === 'retry',
+    it('alreadyRegenerated changes the regenerate tooltip hint without disabling the button', () => {
+      const first = deriveTurnFooterActions(ctx({ status: 'completed' })).find((a) => a.id === 'regenerate');
+      const second = deriveTurnFooterActions(ctx({ status: 'completed', alreadyRegenerated: true })).find(
+        (a) => a.id === 'regenerate',
       );
       assert.equal(first?.enabled, true);
       assert.equal(second?.enabled, true);
       assert.notEqual(first?.tooltip, second?.tooltip);
-      assert.match(second?.tooltip ?? '', /已重试/);
+      assert.match(second?.tooltip ?? '', /已重新生成/);
     });
   });
 
   describe('matrix invariants (regression-proof)', () => {
     it('action enabled-state does NOT depend on hasContent (except for copy)', () => {
-      // hasContent is decoupled from status-based enablement. Changing
-      // it should only flip the `copy` slot.
       const withContent = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: true }));
       const noContent = deriveTurnFooterActions(ctx({ status: 'completed', hasContent: false }));
       for (const action of withContent) {
@@ -126,16 +127,7 @@ describe('deriveTurnFooterActions', () => {
   });
 
   describe('pending mask (@kenji review: double-click guard)', () => {
-    it('pending retry returns enabled=false + "正在处理…" tooltip', () => {
-      const actions = deriveTurnFooterActions(
-        ctx({ status: 'failed', pendingActions: new Set(['retry']) }),
-      );
-      const retry = actions.find((a) => a.id === 'retry');
-      assert.equal(retry?.enabled, false);
-      assert.equal(retry?.tooltip, '正在处理…');
-    });
-
-    it('pending regenerate returns enabled=false + busy tooltip', () => {
+    it('pending regenerate returns enabled=false + "正在处理…" tooltip', () => {
       const actions = deriveTurnFooterActions(
         ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
       );
@@ -155,7 +147,7 @@ describe('deriveTurnFooterActions', () => {
 
     it('pending on one action does NOT disable other actions', () => {
       const actions = deriveTurnFooterActions(
-        ctx({ status: 'failed', pendingActions: new Set(['retry']) }),
+        ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
       );
       const branch = actions.find((a) => a.id === 'branch');
       assert.equal(branch?.enabled, true);
@@ -163,39 +155,34 @@ describe('deriveTurnFooterActions', () => {
     });
 
     it('pending labels preserved (screen readers still hear which action)', () => {
-      // @kenji: don't replace label with spinner-only — screen reader
-      // needs to know which action is processing.
       const actions = deriveTurnFooterActions(
-        ctx({ status: 'failed', pendingActions: new Set(['retry']) }),
+        ctx({ status: 'completed', pendingActions: new Set(['regenerate']) }),
       );
-      const retry = actions.find((a) => a.id === 'retry');
-      assert.equal(retry?.label, '重试'); // label stays
+      const regen = actions.find((a) => a.id === 'regenerate');
+      assert.equal(regen?.label, '重新生成');
     });
 
     it('empty pending set behaves identically to undefined', () => {
-      const baseline = deriveTurnFooterActions(ctx({ status: 'failed' }));
+      const baseline = deriveTurnFooterActions(ctx({ status: 'completed' }));
       const withEmpty = deriveTurnFooterActions(
-        ctx({ status: 'failed', pendingActions: new Set() }),
+        ctx({ status: 'completed', pendingActions: new Set() }),
       );
       assert.deepEqual(baseline, withEmpty);
     });
 
-    it('pending mask overrides the "alreadyRetried" hint (busy tooltip wins)', () => {
+    it('pending mask overrides the "alreadyRegenerated" hint (busy tooltip wins)', () => {
       const actions = deriveTurnFooterActions(
         ctx({
-          status: 'failed',
-          alreadyRetried: true,
-          pendingActions: new Set(['retry']),
+          status: 'completed',
+          alreadyRegenerated: true,
+          pendingActions: new Set(['regenerate']),
         }),
       );
-      const retry = actions.find((a) => a.id === 'retry');
-      assert.equal(retry?.tooltip, '正在处理…');
+      const regen = actions.find((a) => a.id === 'regenerate');
+      assert.equal(regen?.tooltip, '正在处理…');
     });
 
     it('copy is NOT affected by pending mask (it is in-component clipboard)', () => {
-      // The pending mask currently doesn't disable copy — clipboard
-      // writes are fast + idempotent. If we ever add a clipboard IPC
-      // that's slow, revisit.
       const actions = deriveTurnFooterActions(
         ctx({ status: 'completed', pendingActions: new Set(['copy']) }),
       );
@@ -204,14 +191,7 @@ describe('deriveTurnFooterActions', () => {
     });
   });
 
-  // Sanity: SessionStatus and TurnStatus are different enums; this
-  // test makes sure the file references the right one. Tied to the
-  // import path; if the helper accidentally imported SessionStatus
-  // instead, the import fails the test build.
   it('SessionStatus and TurnStatus are kept distinct', () => {
-    // SessionStatus includes `active` / `running` / `blocked` etc.; the
-    // footer helper accepts TurnStatus which does NOT include those.
-    // No direct assertion here — type guard handled at compile time.
     assert.ok(SESSION_STATUSES.includes('active'));
     assert.ok(SESSION_STATUSES.includes('blocked'));
   });

--- a/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/turn-footer-actions.test.ts
@@ -191,6 +191,30 @@ describe('deriveTurnFooterActions', () => {
     });
   });
 
+  describe('info action carries the meta summary (#546)', () => {
+    it('appends an info action whose tooltip is the meta summary, when provided', () => {
+      const actions = deriveTurnFooterActions(
+        ctx({ status: 'completed', metaSummary: 'gpt-5.5 · 4.9s · 1,417 → 19 tok' }),
+      );
+      const info = actions.find((a) => a.id === 'info');
+      assert.ok(info, 'info action should be present when metaSummary is set');
+      assert.equal(info?.tooltip, 'gpt-5.5 · 4.9s · 1,417 → 19 tok');
+    });
+
+    it('omits the info action when no meta summary is provided', () => {
+      const actions = deriveTurnFooterActions(ctx({ status: 'completed' }));
+      assert.equal(actions.find((a) => a.id === 'info'), undefined);
+    });
+
+    it('info action is always enabled (it is informational, not an operation)', () => {
+      const actions = deriveTurnFooterActions(
+        ctx({ status: 'running', metaSummary: 'gpt-5.5 · 进行中' }),
+      );
+      const info = actions.find((a) => a.id === 'info');
+      assert.equal(info?.enabled, true);
+    });
+  });
+
   it('SessionStatus and TurnStatus are kept distinct', () => {
     assert.ok(SESSION_STATUSES.includes('active'));
     assert.ok(SESSION_STATUSES.includes('blocked'));

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -525,13 +525,13 @@ describe('turn footer copy feedback contract', () => {
       /data-\[copy-feedback=failed\]:text-\[color:var\(--destructive\)\]/,
       'Turn footer failed copy state should have a stable styling hook.',
     );
-    // Copy-in-progress is disabled AND pending at once; the pending 0.78 dim
-    // must beat the disabled 0.45 dim by specificity (combined-modifier guard),
-    // not by Tailwind emit order — so it stays stable across rebuilds.
+    // Copy-in-progress is aria-disabled AND pending at once; the pending 0.78
+    // dim must beat the aria-disabled 0.45 dim by specificity (combined-modifier
+    // guard), not by Tailwind emit order — so it stays stable across rebuilds.
     assert.match(
       src,
-      /disabled:data-\[pending=true\]:opacity-\[0\.78\]/,
-      'Pending copy opacity must outrank the disabled dim by specificity, not source order.',
+      /aria-disabled:data-\[pending=true\]:opacity-\[0\.78\]/,
+      'Pending copy opacity must outrank the aria-disabled dim by specificity, not source order.',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -491,7 +491,8 @@ describe('turn footer copy feedback contract', () => {
     assert.match(footerBlock, /复制失败/, 'Turn footer copy should show failure feedback.');
     assert.match(footerBlock, /data-copy-feedback/, 'Turn footer copy should expose stable state data for CSS and review.');
     assert.match(footerBlock, /aria-busy=\{isActionPending/, 'Turn footer copy should expose busy state to assistive tech.');
-    assert.match(footerBlock, /disabled=\{!action\.enabled \|\| copyIsPending\}/, 'Turn footer copy should disable while pending.');
+    assert.match(footerBlock, /aria-disabled=\{!action\.enabled \|\| copyIsPending\}/, 'Turn footer copy should set aria-disabled while pending.');
+    assert.doesNotMatch(footerBlock, /[^-]disabled=\{/, 'Turn footer copy must not set a real disabled prop — it brings pointer-events-none and hides the tooltip.');
     assert.doesNotMatch(
       footerBlock,
       /silent — clipboard may be unavailable/,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -49,7 +49,6 @@ import {
   normalizeBranchFromTurnInput,
   normalizePermissionResponse,
   normalizeRegenerateTurnInput,
-  normalizeRetryTurnInput,
   normalizeSessionSendCommand,
   normalizeStopSessionInput,
 } from './permission-response-guard.js';
@@ -1187,12 +1186,6 @@ function registerIpc(): void {
       return { ok: true, base64: result.base64, mimeType: result.mimeType };
     },
   );
-  ipcMain.handle('sessions:retryTurn', async (_event, sessionId: string, input: unknown) => {
-    await ensureSessionCanSend(sessionId);
-    const normalized = normalizeRetryTurnInput(input);
-    const turnId = normalized.turnId ?? randomUUID();
-    void streamEvents(sessionId, runtime.retryTurn(sessionId, { ...normalized, turnId }), turnId);
-  });
   ipcMain.handle('sessions:regenerateTurn', async (_event, sessionId: string, input: unknown) => {
     await ensureSessionCanSend(sessionId);
     const normalized = normalizeRegenerateTurnInput(input);

--- a/apps/desktop/src/main/permission-response-guard.ts
+++ b/apps/desktop/src/main/permission-response-guard.ts
@@ -2,7 +2,6 @@ import type {
   BranchFromTurnInput,
   PermissionResponse,
   RegenerateTurnInput,
-  RetryTurnInput,
 } from '@maka/core';
 
 const MAX_PERMISSION_REQUEST_ID_LENGTH = 128;
@@ -40,14 +39,6 @@ export function normalizePermissionResponse(input: unknown): PermissionResponse 
     requestId: value.requestId,
     decision: value.decision,
     ...(value.rememberForTurn !== undefined ? { rememberForTurn: value.rememberForTurn } : {}),
-  };
-}
-
-export function normalizeRetryTurnInput(input: unknown): RetryTurnInput {
-  const value = requireObject(input, 'Invalid retry turn input');
-  return {
-    sourceTurnId: normalizeRequiredString(value.sourceTurnId, 'Invalid retry turn sourceTurnId', MAX_TURN_ID_LENGTH),
-    ...normalizeOptionalTurnId(value.turnId),
   };
 }
 

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -1262,7 +1262,7 @@ function turnControlSessions(now: number): Array<{ header: SessionHeader; messag
 /**
  * Primary-session message log covering every turn-control surface in
  * one fixture. The turn IDs are short, human-readable strings so the
- * lineage-badge copy (e.g. "重试自 turn turn-ret") stays stable across
+ * lineage-badge copy (e.g. "重新生成自 turn turn-ret") stays stable across
  * regenerations.
  *
  * Turns:
@@ -1370,7 +1370,7 @@ function turnControlPrimaryMessages(now: number): StoredMessage[] {
     partialOutputRetained: true,
   });
 
-  // 4. retry new (forward "重试自 turn-retry-origin" + reverse "已重试 → turn-retry-new")
+  // 4. retry new (forward "重新生成自 turn-retry-origin" + reverse "已重新生成 → turn-retry-new")
   cursor += tickUser;
   messages.push({
     type: 'user',

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -37,7 +37,6 @@ import type {
   BranchFromTurnInput,
   CapabilitySnapshotCollection,
   RegenerateTurnInput,
-  RetryTurnInput,
   TurnRecord,
   PermissionSnapshot,
   OpenGatewayRuntimeStatus,
@@ -160,9 +159,6 @@ contextBridge.exposeInMainWorld('maka', {
     },
     listTurns(sessionId: string): Promise<TurnRecord[]> {
       return ipcRenderer.invoke('sessions:listTurns', sessionId);
-    },
-    retryTurn(sessionId: string, input: RetryTurnInput): Promise<void> {
-      return ipcRenderer.invoke('sessions:retryTurn', sessionId, input);
     },
     regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void> {
       return ipcRenderer.invoke('sessions:regenerateTurn', sessionId, input);

--- a/apps/desktop/src/renderer/app-shell-turn-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-actions.ts
@@ -53,12 +53,9 @@ export function createAppShellTurnActions(deps: {
     // retry/regenerate IPC returns after starting the stream asynchronously.
     if (!addPendingTurnAction(key)) return;
     try {
-      if (actionId === 'retry') {
-        await window.maka.sessions.retryTurn(sessionId, { sourceTurnId: turnId });
-        if (activeIdRef.current === sessionId) toastApi.info('已发起重试', '正在生成新的一轮回答');
-      } else if (actionId === 'regenerate') {
+      if (actionId === 'regenerate') {
         await window.maka.sessions.regenerateTurn(sessionId, { sourceTurnId: turnId });
-        if (activeIdRef.current === sessionId) toastApi.info('已发起重新生成', '保留旧回答，生成新的并行回答');
+        if (activeIdRef.current === sessionId) toastApi.info('已发起重新生成', '正在生成新的一轮回答');
       } else if (actionId === 'branch') {
         const newSession = await window.maka.sessions.branchFromTurn(sessionId, { sourceTurnId: turnId });
         upsertSessionSummary(newSession);

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -38,7 +38,7 @@ export function deriveAppShellTurnViewModel(input: {
   for (const turn of turnsForLineage) {
     const lineageEntry = lineage.get(turn.turnId);
     const pendingForTurn = new Set<TurnFooterActionMeta['id']>();
-    for (const id of ['retry', 'regenerate', 'branch', 'copy'] as const) {
+    for (const id of ['regenerate', 'branch', 'copy'] as const) {
       if (input.activeId && input.pendingTurnActions.has(input.pendingKeyOf(input.activeId, turn.turnId, id))) {
         pendingForTurn.add(id);
       }
@@ -46,7 +46,6 @@ export function deriveAppShellTurnViewModel(input: {
     footer[turn.turnId] = deriveTurnFooterActions({
       status: turn.status,
       hasContent: Boolean(turn.assistant?.text && turn.assistant.text.trim().length > 0),
-      ...(lineageEntry?.retriedToTurnId ? { alreadyRetried: true } : {}),
       ...(lineageEntry?.regeneratedToTurnId ? { alreadyRegenerated: true } : {}),
       ...(pendingForTurn.size > 0 ? { pendingActions: pendingForTurn } : {}),
     });

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -49,7 +49,11 @@ export function deriveAppShellTurnViewModel(input: {
     footer[turn.turnId] = deriveTurnFooterActions({
       status: turn.status,
       hasContent: Boolean(turn.assistant?.text && turn.assistant.text.trim().length > 0),
-      ...(lineageEntry?.regeneratedToTurnId ? { alreadyRegenerated: true } : {}),
+      // Match the badge lineage rule (regenerate ?? legacy retry) so a turn
+      // that already has a parallel answer hints at it in the tooltip too.
+      ...((lineageEntry?.regeneratedToTurnId ?? lineageEntry?.retriedToTurnId)
+        ? { alreadyRegenerated: true }
+        : {}),
       ...(pendingForTurn.size > 0 ? { pendingActions: pendingForTurn } : {}),
       ...(metaSummary ? { metaSummary } : {}),
     });

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -8,6 +8,7 @@ import {
 } from '@maka/ui';
 import { deriveFailedTurnRecovery, describeTurnErrorClass } from './session-status-presentation';
 import { deriveTurnFooterActions } from './turn-footer-actions';
+import { deriveTurnLineageBadges } from './derive-turn-lineage-badges';
 
 export interface AppShellTurnViewModel {
   turnFooterActionsByTurn: Record<string, ReadonlyArray<TurnFooterActionMeta>>;
@@ -26,10 +27,6 @@ export function deriveAppShellTurnViewModel(input: {
   const turnsForLineage = materializeTurns(input.messages, input.liveTools);
   const lineage = deriveTurnLineageMap(turnsForLineage);
   const turnsById = new Map(turnsForLineage.map((turn) => [turn.turnId, turn]));
-  // Strip the `turn-` id prefix before truncating — labels interpolate as
-  // `turn ${shortId(...)}`, so a raw slice rendered「已重新生成 → turn
-  // turn-r」: doubled word, one useful character of id left.
-  const shortId = (turnId: string) => turnId.replace(/^turn-/, '').slice(0, 6);
   const footer: Record<string, ReadonlyArray<TurnFooterActionMeta>> = {};
   const failedLabels: Record<string, string> = {};
   const failedRecoveryLabels: Record<string, string> = {};
@@ -60,43 +57,14 @@ export function deriveAppShellTurnViewModel(input: {
       }).label;
     }
 
-    const turnBadges: TurnLineageBadge[] = [];
-    if (turn.retriedFromTurnId && turnsById.has(turn.retriedFromTurnId)) {
-      turnBadges.push({
-        id: `forward-retry-${turn.turnId}`,
-        label: `重试自 turn ${shortId(turn.retriedFromTurnId)}`,
-        tooltip: `这是对上一轮回答的重试`,
-        targetTurnId: turn.retriedFromTurnId,
-        direction: 'forward',
-      });
-    }
-    if (turn.regeneratedFromTurnId && turnsById.has(turn.regeneratedFromTurnId)) {
-      turnBadges.push({
-        id: `forward-regen-${turn.turnId}`,
-        label: `重新生成自 turn ${shortId(turn.regeneratedFromTurnId)}`,
-        tooltip: `保留旧回答，重新生成的并行回答`,
-        targetTurnId: turn.regeneratedFromTurnId,
-        direction: 'forward',
-      });
-    }
-    if (lineageEntry?.retriedToTurnId && turnsById.has(lineageEntry.retriedToTurnId)) {
-      turnBadges.push({
-        id: `reverse-retry-${turn.turnId}`,
-        label: `已重试 → turn ${shortId(lineageEntry.retriedToTurnId)}`,
-        tooltip: `跳转到对此回答的重试`,
-        targetTurnId: lineageEntry.retriedToTurnId,
-        direction: 'reverse',
-      });
-    }
-    if (lineageEntry?.regeneratedToTurnId && turnsById.has(lineageEntry.regeneratedToTurnId)) {
-      turnBadges.push({
-        id: `reverse-regen-${turn.turnId}`,
-        label: `已重新生成 → turn ${shortId(lineageEntry.regeneratedToTurnId)}`,
-        tooltip: `跳转到对此回答的重新生成`,
-        targetTurnId: lineageEntry.regeneratedToTurnId,
-        direction: 'reverse',
-      });
-    }
+    const turnBadges = deriveTurnLineageBadges({
+      turnId: turn.turnId,
+      retriedFromTurnId: turn.retriedFromTurnId,
+      regeneratedFromTurnId: turn.regeneratedFromTurnId,
+      retriedToTurnId: lineageEntry?.retriedToTurnId,
+      regeneratedToTurnId: lineageEntry?.regeneratedToTurnId,
+      existsTurn: (id) => turnsById.has(id),
+    });
     if (turnBadges.length > 0) badges[turn.turnId] = turnBadges;
   }
 

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -1,6 +1,7 @@
 import type { StoredMessage } from '@maka/core';
 import {
   deriveTurnLineageMap,
+  formatTurnDuration,
   materializeTurns,
   type ToolActivityItem,
   type TurnFooterActionMeta,
@@ -40,11 +41,20 @@ export function deriveAppShellTurnViewModel(input: {
         pendingForTurn.add(id);
       }
     }
+    const metaParts: string[] = [];
+    if (turn.modelId) metaParts.push(turn.modelId);
+    if (turn.durationMs && turn.durationMs > 0) metaParts.push(formatTurnDuration(turn.durationMs));
+    if (turn.tokens && (turn.tokens.input > 0 || turn.tokens.output > 0)) {
+      metaParts.push(`${turn.tokens.input.toLocaleString()} → ${turn.tokens.output.toLocaleString()} tok`);
+    }
+    if (turn.tokens?.costUsd && turn.tokens.costUsd > 0) metaParts.push(`$${turn.tokens.costUsd.toFixed(4)}`);
+    const metaSummary = metaParts.length > 0 ? metaParts.join(' · ') : undefined;
     footer[turn.turnId] = deriveTurnFooterActions({
       status: turn.status,
       hasContent: Boolean(turn.assistant?.text && turn.assistant.text.trim().length > 0),
       ...(lineageEntry?.regeneratedToTurnId ? { alreadyRegenerated: true } : {}),
       ...(pendingForTurn.size > 0 ? { pendingActions: pendingForTurn } : {}),
+      ...(metaSummary ? { metaSummary } : {}),
     });
 
     if (turn.status === 'failed') {

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -44,9 +44,6 @@ export function deriveAppShellTurnViewModel(input: {
     const metaParts: string[] = [];
     if (turn.modelId) metaParts.push(turn.modelId);
     if (turn.durationMs && turn.durationMs > 0) metaParts.push(formatTurnDuration(turn.durationMs));
-    if (turn.tokens && (turn.tokens.input > 0 || turn.tokens.output > 0)) {
-      metaParts.push(`${turn.tokens.input.toLocaleString()} → ${turn.tokens.output.toLocaleString()} tok`);
-    }
     if (turn.tokens?.costUsd && turn.tokens.costUsd > 0) metaParts.push(`$${turn.tokens.costUsd.toFixed(4)}`);
     const metaSummary = metaParts.length > 0 ? metaParts.join(' · ') : undefined;
     footer[turn.turnId] = deriveTurnFooterActions({

--- a/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
+++ b/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure derivation of a turn's lineage badges.
+ *
+ * Extracted from `app-shell-turn-view-model` so the badge matrix is
+ * unit-testable without dragging in the renderer's relative-import
+ * graph (which node ESM can't resolve extension-less).
+ *
+ * #546: retry was merged into regenerate. The badge vocabulary is now
+ * uniform — "重新生成自" (forward) and "已重新生成" (reverse) — regardless
+ * of which path wrote the lineage. Old sessions may still carry
+ * `retriedFromTurnId` / `retriedToTurnId` (written by the since-removed
+ * retryTurn path); those are read back as regenerate lineages via the
+ * `?? ` fallback, never shown as the legacy "重试自" / "已重试".
+ */
+
+import type { TurnLineageBadge } from '@maka/ui';
+
+/** Strip the `turn-` id prefix before truncating, matching the view-model. */
+function shortId(turnId: string): string {
+  return turnId.replace(/^turn-/, '').slice(0, 6);
+}
+
+export interface TurnLineageBadgeInput {
+  turnId: string;
+  /** Legacy retry lineage (old data). Falls back behind regenerated. */
+  retriedFromTurnId?: string;
+  regeneratedFromTurnId?: string;
+  /** Legacy reverse retry target (old data). Falls back behind regenerated. */
+  retriedToTurnId?: string;
+  regeneratedToTurnId?: string;
+  /** True when the target turn id still exists in the materialized view. */
+  existsTurn(turnId: string): boolean;
+}
+
+export function deriveTurnLineageBadges(input: TurnLineageBadgeInput): TurnLineageBadge[] {
+  const badges: TurnLineageBadge[] = [];
+
+  const forwardFrom = input.regeneratedFromTurnId ?? input.retriedFromTurnId;
+  if (forwardFrom && input.existsTurn(forwardFrom)) {
+    badges.push({
+      id: `forward-regen-${input.turnId}`,
+      label: `重新生成自 turn ${shortId(forwardFrom)}`,
+      tooltip: `保留旧回答，重新生成的并行回答`,
+      targetTurnId: forwardFrom,
+      direction: 'forward',
+    });
+  }
+
+  const reverseTo = input.regeneratedToTurnId ?? input.retriedToTurnId;
+  if (reverseTo && input.existsTurn(reverseTo)) {
+    badges.push({
+      id: `reverse-regen-${input.turnId}`,
+      label: `已重新生成 → turn ${shortId(reverseTo)}`,
+      tooltip: `跳转到对此回答的重新生成`,
+      targetTurnId: reverseTo,
+      direction: 'reverse',
+    });
+  }
+
+  return badges;
+}

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1214,11 +1214,6 @@
     padding: 0 var(--space-2) 0 0;
   }
 
-  /* Turn summary strip + chips (model · tools · duration · tokens) and the
-   * "切换" pill retired to the `@maka/ui` Marker chat primitive
-   * (`summary` / `summary-chip` / `summary-switched`), issue #332 PR2 —
-   * packages/ui/src/primitives/chat.tsx. */
-
   /* Optional reasoning block — collapsed by default, expandable to inspect
    * the model's chain of thought without cluttering the answer.
    *

--- a/apps/desktop/src/renderer/turn-footer-actions.ts
+++ b/apps/desktop/src/renderer/turn-footer-actions.ts
@@ -1,23 +1,25 @@
 /**
- * Pure derivation of turn footer action enabled-set (PR109d-b,
- * design-system §9.8 / §9.9).
+ * Pure derivation of turn footer action enabled-set.
  *
  * Lives outside the React component layer so the action × TurnStatus
  * × lineage matrix can be unit-tested with node:test. Mirrors the
  * `session-status-grouping.ts` + `chat-header-alert.ts` pattern.
  *
- * Footer actions (icon + Chinese text — see PR109d-b component for the
- * actual buttons):
+ * Footer actions (icon + Chinese text — see the TurnFooterActions
+ * component for the actual buttons):
  *
- *   - retry          ↻ 重试       → for failed / aborted turns
- *   - regenerate     🔁 重新生成   → for completed turns
- *   - branch         🌿 分支       → for any non-running turn (incl. aborted)
- *   - copy           📋 复制       → always available when there's content
+ *   - regenerate     🔁 重新生成 → for any non-running turn (failed / aborted / completed)
+ *   - branch         🌿 分支     → for any non-running turn (incl. aborted)
+ *   - copy           📋 复制     → always available when there's content
  *
  * Running turns get only `copy` (the long-running operation finishes
  * naturally; cancel lives in the Composer Stop button, not the footer).
  *
- * @kenji PR109d review gate #1: footer enabled set is computed
+ * #546: retry was merged into regenerate. One "重新生成" action re-runs
+ * the turn regardless of how the previous attempt ended. The separate
+ * retry action / lineage field is gone.
+ *
+ * @kenji review gate #1: footer enabled set is computed
  * **exclusively** from `TurnStatus` + lineage map, NOT from text
  * content or any optimistic UI state. This file is the canonical
  * source of that decision.
@@ -25,7 +27,7 @@
 
 import type { TurnStatus } from '@maka/core';
 
-export type TurnFooterActionId = 'retry' | 'regenerate' | 'branch' | 'copy';
+export type TurnFooterActionId = 'regenerate' | 'branch' | 'copy';
 
 export interface TurnFooterAction {
   id: TurnFooterActionId;
@@ -54,25 +56,22 @@ export interface TurnFooterContext {
    */
   hasContent: boolean;
   /**
-   * True when there's already a retry / regenerate sibling for this
-   * turn. Used to hint at "已重试" in the disabled-action tooltip so
-   * the user understands why the button is greyed out — they already
-   * retried.
+   * True when there's already a regenerate sibling for this turn.
+   * Used to hint at "已重新生成" in the tooltip so the user
+   * understands a parallel answer already exists.
    */
-  alreadyRetried?: boolean;
   alreadyRegenerated?: boolean;
   /**
-   * Per @kenji PR109d review: prevent double-click duplicate sibling
-   * turns. The renderer marks an action `pending` from click time
-   * until `sessions:changed` (or timeout) clears it; the footer
-   * renders that action as disabled + busy with a "正在处理…"
-   * tooltip. Other turns / other action types stay clickable.
+   * Per @kenji review: prevent double-click duplicate sibling turns.
+   * The renderer marks an action `pending` from click time until
+   * `sessions:changed` (or timeout) clears it; the footer renders that
+   * action as disabled + busy with a "正在处理…" tooltip. Other turns
+   * / other action types stay clickable.
    */
   pendingActions?: ReadonlySet<TurnFooterActionId>;
 }
 
 const ACTION_LABEL: Record<TurnFooterActionId, string> = {
-  retry: '重试',
   regenerate: '重新生成',
   branch: '分支',
   copy: '复制',
@@ -80,45 +79,30 @@ const ACTION_LABEL: Record<TurnFooterActionId, string> = {
 
 /**
  * Derive the ordered list of footer actions to render for a turn.
- * The order is fixed at the matrix level (retry → regenerate → branch
- * → copy) so adjacent buttons line up across rows even when some are
- * disabled.
+ * The order is fixed at the matrix level (regenerate → branch → copy)
+ * so adjacent buttons line up across rows even when some are disabled.
  *
- * @kenji PR109d gate: returned `enabled` flags depend only on
- * `TurnStatus` and lineage state; we never sniff the turn text or
- * fall back to optimistic guesses.
+ * @kenji gate: returned `enabled` flags depend only on `TurnStatus`
+ * and lineage state; we never sniff the turn text or fall back to
+ * optimistic guesses.
  */
 export function deriveTurnFooterActions(input: TurnFooterContext): TurnFooterAction[] {
-  const { status, hasContent, alreadyRetried, alreadyRegenerated, pendingActions } = input;
+  const { status, hasContent, alreadyRegenerated, pendingActions } = input;
   const isPending = (id: TurnFooterActionId) => pendingActions?.has(id) ?? false;
   const PENDING_TOOLTIP = '正在处理…';
 
-  // Build entries in fixed order; later filtering / disabling per matrix.
-  const retry: TurnFooterAction = isPending('retry')
-    ? { id: 'retry', label: ACTION_LABEL.retry, enabled: false, tooltip: PENDING_TOOLTIP }
-    : {
-        id: 'retry',
-        label: ACTION_LABEL.retry,
-        enabled: status === 'failed' || status === 'aborted',
-        tooltip:
-          status === 'failed' || status === 'aborted'
-            ? alreadyRetried
-              ? '已重试过，再次重试将创建新一轮回答'
-              : '使用相同问题重新尝试'
-            : '只有失败或被取消的回答可以重试',
-      };
   const regenerate: TurnFooterAction = isPending('regenerate')
     ? { id: 'regenerate', label: ACTION_LABEL.regenerate, enabled: false, tooltip: PENDING_TOOLTIP }
     : {
         id: 'regenerate',
         label: ACTION_LABEL.regenerate,
-        enabled: status === 'completed',
+        enabled: status !== 'running',
         tooltip:
-          status === 'completed'
-            ? alreadyRegenerated
-              ? '已重新生成过，再次点击将创建新的并行回答'
-              : '保留当前回答，让模型再回答一次'
-            : '只有已完成的回答可以重新生成',
+          status === 'running'
+            ? '当前回答仍在进行中，结束后再重新生成'
+            : alreadyRegenerated
+            ? '已重新生成过，再次点击将创建新的并行回答'
+            : '让模型重新生成本轮回答',
       };
   const branch: TurnFooterAction = isPending('branch')
     ? { id: 'branch', label: ACTION_LABEL.branch, enabled: false, tooltip: PENDING_TOOLTIP }
@@ -140,7 +124,7 @@ export function deriveTurnFooterActions(input: TurnFooterContext): TurnFooterAct
     tooltip: hasContent ? '复制回答到剪贴板' : '此回答尚无可复制的内容',
   };
 
-  return [retry, regenerate, branch, copy];
+  return [regenerate, branch, copy];
 }
 
 /**

--- a/apps/desktop/src/renderer/turn-footer-actions.ts
+++ b/apps/desktop/src/renderer/turn-footer-actions.ts
@@ -27,7 +27,7 @@
 
 import type { TurnStatus } from '@maka/core';
 
-export type TurnFooterActionId = 'regenerate' | 'branch' | 'copy';
+export type TurnFooterActionId = 'regenerate' | 'branch' | 'copy' | 'info';
 
 export interface TurnFooterAction {
   id: TurnFooterActionId;
@@ -62,6 +62,14 @@ export interface TurnFooterContext {
    */
   alreadyRegenerated?: boolean;
   /**
+   * Optional one-line summary of the turn's meta (model · duration ·
+   * tokens · cost). When present, the footer renders an `info` action
+   * whose tooltip carries this text — the single home for turn meta
+   * now that the top summary row is gone (#546). Absent on turns with
+   * no meta (fake backend, not-yet-streamed).
+   */
+  metaSummary?: string;
+  /**
    * Per @kenji review: prevent double-click duplicate sibling turns.
    * The renderer marks an action `pending` from click time until
    * `sessions:changed` (or timeout) clears it; the footer renders that
@@ -75,6 +83,7 @@ const ACTION_LABEL: Record<TurnFooterActionId, string> = {
   regenerate: '重新生成',
   branch: '分支',
   copy: '复制',
+  info: '详情',
 };
 
 /**
@@ -87,7 +96,7 @@ const ACTION_LABEL: Record<TurnFooterActionId, string> = {
  * optimistic guesses.
  */
 export function deriveTurnFooterActions(input: TurnFooterContext): TurnFooterAction[] {
-  const { status, hasContent, alreadyRegenerated, pendingActions } = input;
+  const { status, hasContent, alreadyRegenerated, pendingActions, metaSummary } = input;
   const isPending = (id: TurnFooterActionId) => pendingActions?.has(id) ?? false;
   const PENDING_TOOLTIP = '正在处理…';
 
@@ -124,7 +133,14 @@ export function deriveTurnFooterActions(input: TurnFooterContext): TurnFooterAct
     tooltip: hasContent ? '复制回答到剪贴板' : '此回答尚无可复制的内容',
   };
 
-  return [regenerate, branch, copy];
+  // info is informational, not an operation: no pending state, always
+  // enabled, and its tooltip carries the turn meta summary. Rendered
+  // only when there is meta to show (#546).
+  const info: TurnFooterAction | undefined = metaSummary
+    ? { id: 'info', label: ACTION_LABEL.info, enabled: true, tooltip: metaSummary }
+    : undefined;
+
+  return [regenerate, branch, copy, ...(info ? [info] : [])];
 }
 
 /**

--- a/apps/desktop/src/renderer/turn-footer-actions.ts
+++ b/apps/desktop/src/renderer/turn-footer-actions.ts
@@ -63,7 +63,7 @@ export interface TurnFooterContext {
   alreadyRegenerated?: boolean;
   /**
    * Optional one-line summary of the turn's meta (model · duration ·
-   * tokens · cost). When present, the footer renders an `info` action
+   * cost). When present, the footer renders an `info` action
    * whose tooltip carries this text — the single home for turn meta
    * now that the top summary row is gone (#546). Absent on turns with
    * no meta (fake backend, not-yet-streamed).

--- a/apps/desktop/tests/smoke.md
+++ b/apps/desktop/tests/smoke.md
@@ -405,8 +405,9 @@ Fixture scenario: `turn-narrative`.
   *"查看思考过程 — 模型推理草稿，不是最终答案"* appears above the
   assistant answer; expanding it shows the reasoning with its own
   "复制思考过程" button.
-- For an in-progress turn (user sent, assistant hasn't landed),
-  the duration chip reads *"进行中"*, not a ticking ms count.
+- For an in-progress turn (user sent, assistant hasn't landed), no
+  duration is shown — the footer info tooltip omits the duration line
+  until the assistant turn lands.
 
 **Fail signals.**
 - Tool activity at the very bottom of the chat instead of inside its

--- a/apps/desktop/tests/smoke.md
+++ b/apps/desktop/tests/smoke.md
@@ -398,9 +398,9 @@ Fixture scenario: `turn-narrative`.
 - The user message, the tool activity panel, and the assistant
   answer are visually grouped as **one turn block** (`<section
   class="maka-turn">`), not three free-floating items.
-- Below the user message, a summary chip strip shows the model id
-  (e.g. `claude-sonnet-4-5`), tool count (`1 个工具`), duration
-  (`X.X s`), and tokens (`N → N tok`).
+- Turn meta (model id e.g. `claude-sonnet-4-5`, duration `X.X s`, cost
+  `$X.XXXX`) lives in the footer's info-action tooltip, shown on hover
+  (#546 removed the top summary chip strip).
 - If the model supplied thinking, a collapsed `<details>` block
   *"查看思考过程 — 模型推理草稿，不是最终答案"* appears above the
   assistant answer; expanding it shows the reasoning with its own

--- a/apps/desktop/tests/smoke.md
+++ b/apps/desktop/tests/smoke.md
@@ -797,14 +797,12 @@ Repeat with `turn-control-branch-visible` and `turn-control-branch-orphan`.
   inline marker "(已中断)" beside the assistant text; partial output is
   preserved (the user can still read what was generated before abort).
 - **S3 — lineage badges scroll.**
-  - *Forward (descendant top):* on `turn-retry-new` the badge reads
-    "重试自 turn turn-ret" and clicking it scrolls `turn-retry-origin`
+  - *Forward (descendant top):* on `turn-regen-new` the badge reads
+    "重新生成自 turn turn-regen" and clicking it scrolls `turn-regen-origin`
     into the center of the viewport.
-  - *Reverse (origin footer):* on `turn-retry-origin` the badge reads
-    "已重试 → turn turn-ret" and clicking it scrolls `turn-retry-new`
+  - *Reverse (origin footer):* on `turn-regen-origin` the badge reads
+    "已重新生成 → turn turn-regen" and clicking it scrolls `turn-regen-new`
     into the center of the viewport.
-  - The same pair exists for regenerate (`turn-regen-origin` ↔
-    `turn-regen-new`) with "重新生成自" / "已重新生成 →".
 - **S4 — branch banner positive vs negative.**
   - In `turn-control-branch-visible`, the chat header shows
     `分自 ${primary.name}`. The banner is a clickable button that

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -441,26 +441,16 @@ spinner、status pulse、streaming caret、shimmer，以及必要的 hover/press
   - 5 态：default / hover (button) / focus / active — 同 Button；
     disabled / loading / error 不适用
 
-### 3.8 TurnView + TurnSummary（`components.tsx:1237` + `:1174`）
+### 3.8 TurnView + footer info tooltip（`chat-view.tsx`）
 
 - **职责**：把"user → tools → assistant"渲染为一个 visual unit (`<section
-  class="maka-turn">`)。TurnSummary 是 chip strip：model · tools · duration ·
-  tokens。
-- **token**：chip 走 `.maka-turn-summary-chip` recipe；`data-kind="tools"`
-  着色为 accent；`data-state="in-progress"` 用 in-progress accent fill。
-- **ARIA**：summary chip 是普通 span；不打 button role（不可交互）；duration
-  chip 用 `font-variant-numeric: tabular-nums`。
-- **关键不变量**（`materialize.ts:158-160`）：
-  - `durationMs` 仅在 assistant message 落地后赋值，否则保持 undefined → UI
-    渲染 **"进行中"** 字符串（不要把 Date.now() - startedAt 显式 tick）。
-  - `tokens.costUsd` 仅当 > 0 时显示 tooltip；从不渲染 `$0.0000`。
-- **5 态**：
-  - default：完成态，chip 灰底
-  - hover：chip 不响应 hover；title 提供 tooltip（model id 用 mono）
-  - focus：N/A（不可交互）
-  - active：N/A
-  - in-progress：duration chip swap 为 "进行中"，accent fill；不显示
-    duration 数字
+  class="maka-turn">`)。turn 的 meta（model · duration · cost）落在 footer
+  的 info action tooltip——#546 删除了顶部 TurnSummary chip strip，meta 收进
+  tooltip，tooltip 只在 hover 时出现。
+- **关键不变量**（`materialize.ts`）：
+  - `durationMs` 仅在 assistant message 落地后赋值，否则保持 undefined →
+    info tooltip 不含 duration 项。
+  - `tokens.costUsd` 仅当 > 0 时进 tooltip；从不渲染 `$0.0000`。
 
 ### 3.9 ToolActivity（`components.tsx:1524`）
 
@@ -1334,15 +1324,14 @@ interface TurnRecord {
 
 Lineage 只写正向字段。旧 turn immutable：除自身 `running →
 completed/aborted/failed` 的状态变化外，未来 sibling 出现不会回写旧 turn。
-UI 需要 "已重试 →" / "已重新生成 →" 时，从当前 turn list derive 反向 map
+UI 需要 "已重新生成 →" 时，从当前 turn list derive 反向 map
 via `deriveTurnLineageMap()`（PR109d）。
 
 **操作清单**（UI 触发 → core/runtime 处理）：
 
 | 操作 | UI 文案 | 触发位置 | 适用 turn.status | 行为 | 旧 turn 处理 |
 |---|---|---|---|---|---|
-| `retry` | 「重试」 | turn footer hover | `failed` / `aborted` | sibling turn 复用同 user message + 写 `retriedFromTurnId` | immutable，自身 status 不变 |
-| `regenerate` | 「重新生成」 | assistant message footer hover | `completed` | sibling turn 复用同 user message + 写 `regeneratedFromTurnId` | immutable |
+| `regenerate` | 「重新生成」 | assistant message footer | `failed` / `aborted` / `completed` | sibling turn 复用同 user message + 写 `regeneratedFromTurnId`（legacy retry 的 `retriedFromTurnId` 在 badge 层 fallback 读） | immutable |
 | `branch-from-turn` | 「分支」 | turn header context menu | 任意（含 `aborted`） | 新 session via `sessions:branchFromTurn` + `branchOfTurnId` + `parentSessionId` + 复制至该 turn boundary（aborted 起点复制到中断前最后可用 boundary） | 原 session 不变；artifacts v1 只复制引用，不复制 bytes |
 | `cancel` | 「取消」 | streaming 中的 Composer Stop / Esc | `running` | turn → `aborted`；session → `aborted`；partial output 保留 | n/a — turn 自身 status 转 |
 | `checkpoint-before-tools` | n/a (自动) | 自动（destructive tool 前） | n/a | snapshot workspace；失败阻止 tool | n/a |

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1346,22 +1346,22 @@ via `deriveTurnLineageMap()`（PR109d）。
   `deriveTurnLineageMap(turns)` 在 PR109d 加入 `materialize-turns.ts`，
   只 derive 反向 UI 链接，不持久化反向字段
 
-**UI 表现** (PR109d 接口约定):
+**UI 表现**（#546 接口约定）:
 
-- **Turn footer hover actions** (`↻ 重试 / 🌿 分支 / 📋 复制`)：根据 turn.status
-  动态决定 enabled set
-  - `running`：仅显示 `📋 复制`（其他 action 长任务结束后再露）
-  - `completed`：`🔁 重新生成 / 🌿 分支 / 📋 复制`
-  - `failed` / `aborted`：`↻ 重试 / 🌿 分支 / 📋 复制`
+- **Turn footer actions**（icon-only：`🔁 重新生成 / 🌿 分支 / 📋 复制 / ℹ 详情`）：
+  根据 turn.status 动态决定 enabled set
+  - `running`：仅 `📋 复制`（其他 action 长任务结束后再露）
+  - `completed` / `failed` / `aborted`：`🔁 重新生成 / 🌿 分支 / 📋 复制`，
+    外加 `ℹ 详情`（hover tooltip：model · duration · cost）
 - **Aborted turn 视觉**：assistant message body 前缀灰色斜体 "(已中断)"；
   turn header 显示 muted `Ban` icon
 - **Failed turn 视觉**：使用 PR58 的 AlertOctagon 红色 banner + copy-error
   按钮，文案走 generalizedErrorMessage
 - **Lineage badges**：
-  - 新 turn 顶部 small badge「重试自 turn ${shortId}」/「重新生成自
-    turn ${shortId}」点击 scroll 到原 turn
-  - 旧 turn footer 通过 UI-side derive 显示「已重试 → turn ${shortId}」/
-    「已重新生成 → turn ${shortId}」点击 scroll 到新 turn
+  - 新 turn 顶部 small badge「重新生成自 turn ${shortId}」点击 scroll 到原 turn
+  - 旧 turn footer 通过 UI-side derive 显示「已重新生成 → turn ${shortId}」
+    点击 scroll 到新 turn（legacy retry 的 retriedFromTurnId 在 badge 层
+    fallback 读，统一显示为「重新生成」语义）
   - branched session sidebar 顶部 banner「分自 ${parentSessionName}」+
     点击跳回 parent
 - **Branch 复制语义**：aborted 起点的 branch 文案明示「从中断前分支」
@@ -1382,7 +1382,7 @@ via `deriveTurnLineageMap()`（PR109d）。
   failed × 1）+ 1 retry sibling + 1 regenerate sibling，让截图覆盖所有
   footer 状态
 - smoke Path 15（PR109d）：从 active session cancel → 验 aborted 出现 +
-  「(已中断)」prefix + retry button 可用；点 retry → 新 turn 出现 +
+  「(已中断)」prefix + regenerate button 可用；点 regenerate → 新 turn 出现 +
   badge 链接；点 regenerate completed → sibling 出现，原 assistant
   仍可见
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1371,15 +1371,15 @@ via `deriveTurnLineageMap()`（PR109d）。
 
 **Gate**：
 - core/storage/runtime tests (PR109c) 锁 turn 状态机：cancel 写 aborted
-  且 partial 保留；retry/regenerate 创建新 sibling 不覆盖旧 turn；
+  且 partial 保留；regenerate 创建新 sibling 不覆盖旧 turn；
   branch 复制至 turn boundary + aborted 起点 fallback 到中断前 boundary
 - node:test 锁 UI lineage derive helper：`deriveTurnLineageMap(turns)`
-  返回正确的 `retriedTo` / `regeneratedTo` 反向映射；旧 turn 无
-  retried-to 时不影响
+  返回正确的 `regeneratedTo` 反向映射（含 legacy `retriedTo` fallback）；
+  旧 turn 无 regenerated-to 时不影响
 - node:test 锁 footer action × turn.status enabled matrix
 - fixture scenario `turn-control-history`（PR109d）：seed 一个含 5 turn
   的 session 覆盖每个状态（running × 1, completed × 2, aborted × 1,
-  failed × 1）+ 1 retry sibling + 1 regenerate sibling，让截图覆盖所有
+  failed × 1）+ 1 regenerate sibling（含 1 legacy retried sibling 测 fallback），让截图覆盖所有
   footer 状态
 - smoke Path 15（PR109d）：从 active session cancel → 验 aborted 出现 +
   「(已中断)」prefix + regenerate button 可用；点 regenerate → 新 turn 出现 +

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1349,7 +1349,6 @@ via `deriveTurnLineageMap()`（PR109d）。
 
 **IPC / projection（PR109c locked）**：
 - `sessions:listTurns(sessionId) -> TurnRecord[]`
-- `sessions:retryTurn(sessionId, { sourceTurnId, turnId? })`
 - `sessions:regenerateTurn(sessionId, { sourceTurnId, turnId? })`
 - `sessions:branchFromTurn(sessionId, { sourceTurnId, name? }) -> SessionSummary`
 - `SessionChangedReason` 新增 `turn-status-change`（独立于 session-level

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -233,7 +233,6 @@ export type {
   ChildAgentTurnInput,
   CreateSessionInput,
   RegenerateTurnInput,
-  RetryTurnInput,
   UserMessageInput,
   SessionListFilter,
 } from './runtime-inputs.js';

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -57,11 +57,6 @@ export interface ChildAgentTurnInput {
   prompt: string;
 }
 
-export interface RetryTurnInput {
-  sourceTurnId: string;
-  turnId?: string;
-}
-
 export interface RegenerateTurnInput {
   sourceTurnId: string;
   turnId?: string;

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -2263,6 +2263,36 @@ describe('SessionManager permission mode updates', () => {
     expect(regenState?.regeneratedFromTurnId).toBe('source');
   });
 
+  test('regenerate accepts an aborted source turn (retry semantics merged into regenerate)', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new EventBackend(ctx, [
+      { type: 'complete', stopReason: 'end_turn' },
+    ]));
+    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(6_780) });
+    const session = await manager.createSession(makeInput());
+    await seedRuntimeRun(runStore, makeRunHeader({
+      sessionId: session.id,
+      runId: 'source-run',
+      turnId: 'source',
+      status: 'cancelled',
+      createdAt: 100,
+      updatedAt: 102,
+      completedAt: 102,
+    }), [
+      runtimeEvent({ id: 'source-user', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 101, role: 'user', author: 'user', content: { kind: 'text', text: 'aborted turn text' } }),
+      runtimeEvent({ id: 'source-abort', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 102, role: 'system', author: 'system', status: 'aborted', actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } } }),
+    ]);
+    store.failNextReadMessagesFor.set(session.id, 1);
+
+    await drain(manager.regenerateTurn(session.id, { sourceTurnId: 'source', turnId: 'regen-aborted' }));
+
+    const regenUser = (await store.readMessages(session.id))
+      .find((message) => message.type === 'user' && message.turnId === 'regen-aborted');
+    expect(regenUser?.type === 'user' ? regenUser.text : undefined).toBe('aborted turn text');
+  });
+
   test('branchFromTurn copies through the RuntimeEvent-primary message boundary', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -2203,36 +2203,6 @@ describe('SessionManager permission mode updates', () => {
     ]);
   });
 
-  test('retry finds aborted source turns and user messages through the RuntimeEvent-primary view', async () => {
-    const store = new MemorySessionStore();
-    const runStore = new MemoryAgentRunStore();
-    const backends = new BackendRegistry();
-    backends.register('fake', (ctx) => new EventBackend(ctx, [
-      { type: 'complete', stopReason: 'end_turn' },
-    ]));
-    const manager = new SessionManager({ store, runStore, runtimeEventStore: runStore, backends, newId: nextId(), now: nextNow(6_760) });
-    const session = await manager.createSession(makeInput());
-    await seedRuntimeRun(runStore, makeRunHeader({
-      sessionId: session.id,
-      runId: 'source-run',
-      turnId: 'source',
-      status: 'cancelled',
-      createdAt: 100,
-      updatedAt: 102,
-      completedAt: 102,
-    }), [
-      runtimeEvent({ id: 'source-user', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 101, role: 'user', author: 'user', content: { kind: 'text', text: 'runtime retry text' } }),
-      runtimeEvent({ id: 'source-abort', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 102, role: 'system', author: 'system', status: 'aborted', actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } } }),
-    ]);
-    store.failNextReadMessagesFor.set(session.id, 1);
-
-    await drain(manager.retryTurn(session.id, { sourceTurnId: 'source', turnId: 'retry-1' }));
-
-    const retryUser = (await store.readMessages(session.id))
-      .find((message) => message.type === 'user' && message.turnId === 'retry-1');
-    expect(retryUser?.type === 'user' ? retryUser.text : undefined).toBe('runtime retry text');
-  });
-
   test('regenerate finds completed source turns through the RuntimeEvent-primary view', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -4486,7 +4456,7 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(active.id)).status).toBe('active');
   });
 
-  test('retry creates a new sibling turn and does not rewrite the aborted source turn', async () => {
+  test('regenerate creates a new sibling turn from an aborted source turn (retry merged)', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -4507,16 +4477,16 @@ describe('SessionManager permission mode updates', () => {
       runtimeEvent({ id: 'source-abort', sessionId: session.id, runId: 'source-run', turnId: 'source', ts: 102, role: 'system', author: 'system', status: 'aborted', actions: { endInvocation: true, stateDelta: { abortSource: 'renderer.stop_button' } } }),
     ]);
 
-    await drain(manager.retryTurn(session.id, { sourceTurnId: 'source', turnId: 'retry-1' }));
+    await drain(manager.regenerateTurn(session.id, { sourceTurnId: 'source', turnId: 'regen-1' }));
 
     const turns = await manager.listTurns(session.id);
     expect(turns.find((turn) => turn.turnId === 'source')?.status).toBe('aborted');
-    const retry = turns.find((turn) => turn.turnId === 'retry-1');
-    expect(retry?.status).toBe('completed');
-    expect(retry?.retriedFromTurnId).toBe('source');
-    const retryUser = (await store.readMessages(session.id))
-      .find((message) => message.type === 'user' && message.turnId === 'retry-1');
-    expect(retryUser?.type === 'user' ? retryUser.text : undefined).toBe('try this');
+    const regen = turns.find((turn) => turn.turnId === 'regen-1');
+    expect(regen?.status).toBe('completed');
+    expect(regen?.regeneratedFromTurnId).toBe('source');
+    const regenUser = (await store.readMessages(session.id))
+      .find((message) => message.type === 'user' && message.turnId === 'regen-1');
+    expect(regenUser?.type === 'user' ? regenUser.text : undefined).toBe('try this');
   });
 
   test('regenerate creates a new sibling turn from a completed source turn', async () => {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -629,7 +629,10 @@ export class SessionManager {
     sessionId: string,
     input: RegenerateTurnInput,
   ): AsyncIterable<SessionEvent> {
-    const source = await this.requireTurnForAction(sessionId, input.sourceTurnId, ['completed'], 'regenerate');
+    // retry semantics merged into regenerate (#546): regenerate now accepts
+    // failed/aborted turns too, not just completed — one action re-runs the
+    // turn regardless of how the previous attempt ended.
+    const source = await this.requireTurnForAction(sessionId, input.sourceTurnId, ['failed', 'aborted', 'completed'], 'regenerate');
     const user = await this.requireUserMessageForTurn(sessionId, source.turnId);
     yield* this.sendMessage(sessionId, {
       turnId: input.turnId ?? this.deps.newId(),

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -41,7 +41,6 @@ import type {
   CreateSessionInput,
   BranchFromTurnInput,
   RegenerateTurnInput,
-  RetryTurnInput,
   UserMessageInput,
   SessionListFilter,
 } from '@maka/core/runtime-inputs';
@@ -608,21 +607,6 @@ export class SessionManager {
 
   async stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
     await this.runtimeKernel.stopSession(sessionId, input);
-  }
-
-  async *retryTurn(
-    sessionId: string,
-    input: RetryTurnInput,
-  ): AsyncIterable<SessionEvent> {
-    const source = await this.requireTurnForAction(sessionId, input.sourceTurnId, ['failed', 'aborted'], 'retry');
-    const user = await this.requireUserMessageForTurn(sessionId, source.turnId);
-    yield* this.sendMessage(sessionId, {
-      turnId: input.turnId ?? this.deps.newId(),
-      text: user.text,
-      ...(user.attachments ? { attachments: user.attachments } : {}),
-      parentTurnId: source.turnId,
-      retriedFromTurnId: source.turnId,
-    });
   }
 
   async *regenerateTurn(

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -32,7 +32,7 @@ test('Bubble keeps its own data-slot/data-variant over conflicting props', () =>
 
 test('Marker keeps its own data-slot/data-variant but forwards the styling data-* hooks', () => {
   const el = Marker({
-    variant: 'summary-chip',
+    variant: 'footer-action',
     as: 'span',
     'data-slot': 'spoofed',
     'data-variant': 'aborted',
@@ -43,7 +43,7 @@ test('Marker keeps its own data-slot/data-variant but forwards the styling data-
   const props = el.props as Record<string, unknown>;
   assert.equal(el.type, 'span');
   assert.equal(props['data-slot'], 'marker');
-  assert.equal(props['data-variant'], 'summary-chip');
+  assert.equal(props['data-variant'], 'footer-action');
   assert.equal(props['data-kind'], 'model');
 });
 

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -11,7 +11,6 @@ import {
   GitBranch,
   Loader2,
   RefreshCcw,
-  Repeat,
   Sparkles,
 } from './icons.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
@@ -1208,10 +1207,10 @@ const TurnView = memo(function TurnView(props: {
  *
  * Copy action is handled locally (write to clipboard) so the
  * consumer doesn't need a clipboard IPC for it. Other actions
- * (retry / regenerate / branch) bubble up via `onAction`.
+ * (regenerate / branch) bubble up via `onAction`.
  */
 export interface TurnFooterActionMeta {
-  id: 'retry' | 'regenerate' | 'branch' | 'copy';
+  id: 'regenerate' | 'branch' | 'copy';
   label: string;
   enabled: boolean;
   tooltip?: string;
@@ -1381,7 +1380,6 @@ function TurnFooterActions(props: {
 }
 
 const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
-  retry: <Repeat size={12} strokeWidth={2} aria-hidden="true" />,
   regenerate: <RefreshCcw size={12} strokeWidth={2} aria-hidden="true" />,
   branch: <GitBranch size={12} strokeWidth={2} aria-hidden="true" />,
   copy: <Copy size={12} strokeWidth={2} aria-hidden="true" />,

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1297,7 +1297,6 @@ function TurnFooterActions(props: {
                   data-action={action.id}
                   data-pending={isActionPending || undefined}
                   data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
-                  disabled={!action.enabled || copyIsPending}
                   aria-disabled={!action.enabled || copyIsPending}
                   aria-busy={isActionPending || undefined}
                   onClick={() => void handleClick(action)}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -785,8 +785,9 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
       </>
     );
   }
-  // Assistant / system body: open prose, no bubble. Per-turn timing lives in
-  // the turn summary; copy + the other actions live in the turn footer.
+  // Assistant / system body: open prose, no bubble. Per-turn meta (model ·
+  // duration · cost) lives in the footer's info tooltip; copy + the other
+  // actions live in the turn footer.
   return (
     <Bubble variant="assistant" className="maka-bubble-with-actions">
       <Markdown text={props.text} />
@@ -1120,10 +1121,12 @@ const TurnView = memo(function TurnView(props: {
 });
 
 /**
- * Turn footer actions row (PR109d-b). Renders icon+text buttons for
- * `重试 / 重新生成 / 分支 / 复制` driven by the pure helper's enabled
- * matrix. Disabled buttons stay rendered so the user can see what
- * actions exist on the turn; click handlers no-op when disabled.
+ * Turn footer actions row. Renders icon-only buttons (regenerate /
+ * branch / copy, plus an optional info action whose tooltip carries
+ * the turn meta) driven by the pure helper's enabled matrix. Disabled
+ * buttons stay rendered so the user can see what actions exist on the
+ * turn; click handlers no-op when disabled (#546: retry merged into
+ * regenerate).
  *
  * Copy action is handled locally (write to clipboard) so the
  * consumer doesn't need a clipboard IPC for it. Other actions

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1045,7 +1045,6 @@ const TurnView = memo(function TurnView(props: {
           variant="assistant"
           data-turn-status={turn.status}
           aria-label="Maka 的回答"
-          title={turn.assistant.ts ? formatAbsoluteTimestamp(turn.assistant.ts) : undefined}
         >
           <div className="flex flex-col">
             {turn.assistantThinking && (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1275,7 +1275,12 @@ function TurnFooterActions(props: {
               ? '复制失败'
               : action.label;
         const isActionPending = isPending || copyIsPending;
-        const tooltipText = isCopyAction ? copyFeedbackLabel : (action.tooltip ?? action.label);
+        // Copy's tooltip comes from the helper (enabled affordance vs disabled
+        // reason). Only while clipboard feedback is active do we surface that
+        // transient state; otherwise the helper's tooltip wins.
+        const tooltipText = isCopyAction
+          ? (copyPhase ? copyFeedbackLabel : (action.tooltip ?? action.label))
+          : (action.tooltip ?? action.label);
         const icon = isCopyAction && copyPhase === 'copied'
           ? <Check size={12} strokeWidth={2} aria-hidden="true" />
           : STATUS_FOOTER_ICON[action.id];

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -17,7 +17,7 @@ import {
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
-import { formatAbsoluteTimestamp, formatTurnDuration, turnAbortMarkerLabel } from './chat-display-helpers.js';
+import { formatAbsoluteTimestamp, turnAbortMarkerLabel } from './chat-display-helpers.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
@@ -602,24 +602,6 @@ export function ChatView(props: {
             )
           )}
           {turns.map((turn, idx) => {
-            // PR-CHAT-NON-DEFAULT-MODEL-CHIP-0 (kenji `af77f61`
-            // session-sticky merge): prefer comparing against the
-            // session's sticky model when available, falling back
-            // to the previous turn's modelId for older sessions
-            // that pre-date the sticky-model field. Either way,
-            // TurnSummary flags the chip when this turn departs
-            // from the expected baseline.
-            const expectedModelId =
-              (props.activeSession?.model && props.activeSession.model.length > 0
-                ? props.activeSession.model
-                : undefined)
-              ?? (() => {
-                for (let i = idx - 1; i >= 0; i--) {
-                  const earlier = turns[i];
-                  if (earlier && earlier.modelId) return earlier.modelId;
-                }
-                return undefined;
-              })();
             return (
               <TurnView
                 key={turn.turnId}
@@ -631,7 +613,6 @@ export function ChatView(props: {
                 failedRecoveryLabel={props.turnFailedRecoveryLabels?.[turn.turnId]}
                 lineageBadges={props.turnLineageBadgesByTurn?.[turn.turnId]}
                 onLineageBadgeClick={stableLineageBadgeClick}
-                previousModelId={expectedModelId}
                 searchHighlighted={highlightedTurnId === turn.turnId}
               />
             );
@@ -934,81 +915,6 @@ function ChatHeaderAlertBadge(props: { alert: ChatHeaderAlert }) {
  * least one signal is present so an in-flight first-render doesn't show
  * an empty chip strip.
  */
-function TurnSummary(props: { turn: TurnViewModel; previousModelId?: string }) {
-  const { turn } = props;
-  const hasModel = Boolean(turn.modelId);
-  // PR-CHAT-NON-DEFAULT-MODEL-CHIP-0: per-turn override is allowed
-  // but must be visible (kenji 3-way decision lock 7749c411).
-  // When the prior turn used a different model, mark this turn's
-  // model chip with a "切换" pill so the user notices.
-  const modelSwitched =
-    hasModel
-    && typeof props.previousModelId === 'string'
-    && props.previousModelId.length > 0
-    && props.previousModelId !== turn.modelId;
-  const hasTools = turn.tools.length > 0;
-  // Show duration only when the assistant has actually landed (durationMs
-  // is computed from assistant.ts). For in-progress turns we render an
-  // "进行中" pill instead of a number that would tick up forever — per
-  // @kenji's PR82 review.
-  const hasDuration = turn.durationMs !== undefined && turn.durationMs > 0;
-  const inProgress = turn.status === 'running' && turn.user !== undefined && turn.assistant === undefined;
-  const hasTokens = Boolean(turn.tokens && (turn.tokens.input > 0 || turn.tokens.output > 0));
-  // costUsd is only meaningful when present AND > 0 — never fabricate a
-  // "$0.00" hover, that reads as false precision (also @kenji PR82 review).
-  const hasCost = turn.tokens?.costUsd !== undefined && turn.tokens.costUsd > 0;
-  if (!hasModel && !hasTools && !hasDuration && !hasTokens && !inProgress) return null;
-  return (
-    <Marker variant="summary" aria-label="本轮对话摘要">
-      {hasModel && (
-        <Marker
-          as="span"
-          variant="summary-chip"
-          data-kind="model"
-          data-switched={modelSwitched ? 'true' : undefined}
-          title={
-            modelSwitched
-              ? `本轮使用 ${turn.modelId}，session 期望 ${props.previousModelId}`
-              : turn.modelId
-          }
-        >
-          <code>{turn.modelId}</code>
-          {modelSwitched && (
-            <Marker as="span" variant="summary-switched" aria-label="本轮切换了模型">
-              切换
-            </Marker>
-          )}
-        </Marker>
-      )}
-      {hasTools && (
-        <Marker as="span" variant="summary-chip" data-kind="tools">
-          {turn.tools.length} 个工具
-        </Marker>
-      )}
-      {hasDuration ? (
-        <Marker as="span" variant="summary-chip" data-kind="duration">
-          {formatTurnDuration(turn.durationMs!)}
-        </Marker>
-      ) : inProgress ? (
-        <Marker as="span" variant="summary-chip" data-kind="duration" data-state="in-progress">
-          进行中
-        </Marker>
-      ) : null}
-      {hasTokens && (
-        <Marker
-          as="span"
-          variant="summary-chip"
-          data-kind="tokens"
-          title={hasCost ? `$${turn.tokens!.costUsd!.toFixed(4)}` : undefined}
-        >
-          {turn.tokens!.input.toLocaleString()} → {turn.tokens!.output.toLocaleString()} tok
-        </Marker>
-      )}
-    </Marker>
-  );
-}
-
-
 /**
  * Renders one conversational turn: user message → tools used → assistant
  * answer, in that order, as a single visual unit. Replaces the previous
@@ -1050,13 +956,6 @@ const TurnView = memo(function TurnView(props: {
   /** PR109e-e: invoked when the user clicks a lineage badge. The
    *  renderer scrolls the target turn into view. */
   onLineageBadgeClick?: (targetTurnId: string) => void;
-  /**
-   * PR-CHAT-NON-DEFAULT-MODEL-CHIP-0: the most-recent prior turn's
-   * assistant modelId, used by TurnSummary to flag a per-turn
-   * model switch (kenji `7749c411` lock decision: per-turn override
-   * is allowed but MUST be visible).
-   */
-  previousModelId?: string;
   /** True when a search result just navigated to this turn. */
   searchHighlighted?: boolean;
 }) {
@@ -1098,8 +997,6 @@ const TurnView = memo(function TurnView(props: {
           <MessageBody role="user" text={turn.user.text} ts={turn.user.ts} attachments={turn.user.attachments} />
         </Message>
       )}
-      <TurnSummary turn={turn} previousModelId={props.previousModelId} />
-
       {turn.notes.map((note) => (
         <Message
           key={note.id}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -811,7 +811,6 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
   // construction — same primitive, same class, same icon metrics — instead
   // of a look-alike bespoke treatment.
   const footer = props.footerStyle === true;
-  const visibleLabel = footer ? (props.label ?? '复制') : props.label;
   const iconSize = footer ? 12 : 14;
 
   const baseLabel = props.label ?? (footer ? '复制' : '复制消息');
@@ -822,15 +821,45 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
       : copyPhase === 'failed'
         ? '复制失败'
         : baseLabel;
+  const icon = copied
+    ? <Check size={iconSize} strokeWidth={2} aria-hidden="true" />
+    : <Copy size={iconSize} strokeWidth={footer ? 2 : 1.75} aria-hidden="true" />;
+
+  if (footer) {
+    // icon-only + tooltip, matching the assistant footer copy action (#546)
+    // so the user-message copy and the assistant copy read as one button.
+    return (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <UiButton
+              type="button"
+              className={markerVariants({ variant: 'footer-action' })}
+              variant="quiet"
+              size="nav"
+              aria-label={baseLabel}
+              aria-busy={copyPending ? 'true' : undefined}
+              disabled={copyPending}
+              data-copied={copied}
+              data-copy-feedback={copyPhase ?? undefined}
+              data-pending={copyPending ? 'true' : undefined}
+              onClick={() => void copy()}
+            />
+          }
+        >
+          {icon}
+        </TooltipTrigger>
+        <TooltipContent>{actionLabel}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
   return (
     <UiButton
       type="button"
-      className={footer ? markerVariants({ variant: 'footer-action' }) : 'maka-message-copy'}
+      className="maka-message-copy"
       variant="quiet"
-      // `nav` is the bare size: the footer-action marker shell owns its own
-      // height/padding/font (see `markerVariants`), so it doesn't inherit —
-      // and then have to merge out — `sm`'s `h-8`/`px-2.5`/`text-xs`.
-      size={footer ? 'nav' : 'icon-sm'}
+      size="icon-sm"
       onClick={() => void copy()}
       aria-label={copyPhase ? `${actionLabel} · ${baseLabel}` : baseLabel}
       aria-busy={copyPending ? 'true' : undefined}
@@ -838,10 +867,10 @@ function MessageCopyButton(props: { text: string; label?: string; footerStyle?: 
       data-copied={copied}
       data-copy-feedback={copyPhase ?? undefined}
       data-pending={copyPending ? 'true' : undefined}
-      data-labelled={(!footer && props.label) ? 'true' : undefined}
+      data-labelled={props.label ? 'true' : undefined}
     >
-      {copied ? <Check size={iconSize} strokeWidth={2} aria-hidden="true" /> : <Copy size={iconSize} strokeWidth={footer ? 2 : 1.75} aria-hidden="true" />}
-      {visibleLabel && <span>{copyPhase === 'pending' ? '复制中…' : copyPhase === 'failed' ? '复制失败' : copied ? '已复制' : visibleLabel}</span>}
+      {icon}
+      {props.label && <span>{copyPhase === 'pending' ? '复制中…' : copyPhase === 'failed' ? '复制失败' : copied ? '已复制' : props.label}</span>}
     </UiButton>
   );
 }

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1254,7 +1254,7 @@ function SessionBranchBanner(props: {
 
 /**
  * Lineage badge rendered on a turn, either pointing to its origin
- * ("重试自 turn ${id}") or to a descendant ("已重试 → turn ${id}").
+ * ("重新生成自 turn ${id}") or to a descendant ("已重新生成 → turn ${id}").
  * Renderer (main.tsx) computes the labels and targets from the lineage
  * map; @maka/ui renders the badge UI. PR109e-e.
  */

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1304,11 +1304,11 @@ function TurnFooterActions(props: {
                   aria-disabled={!action.enabled || copyIsPending}
                   aria-busy={isActionPending || undefined}
                   onClick={() => void handleClick(action)}
-                >
-                  {icon}
-                </UiButton>
+                />
               }
-            />
+            >
+              {icon}
+            </TooltipTrigger>
             <TooltipContent>{tooltipText}</TooltipContent>
           </Tooltip>
         );

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -938,13 +938,6 @@ function ChatHeaderAlertBadge(props: { alert: ChatHeaderAlert }) {
 // base-ui Menu's built-in arrow/Home/End handling.
 
 /**
- * Compact summary strip rendered between the user message and the tools/
- * answer for the current turn. Surfaces the @kenji UI-04 follow-up
- * questions: which model, how many tools, how long. Only renders when at
- * least one signal is present so an in-flight first-render doesn't show
- * an empty chip strip.
- */
-/**
  * Renders one conversational turn: user message → tools used → assistant
  * answer, in that order, as a single visual unit. Replaces the previous
  * "message stack + tools panel at end" layout so the user sees the

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -31,6 +31,7 @@ import { AttachmentFileCard } from './attachment-file-card.js';
 import { Alert, AlertDescription } from './primitives/alert.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Bubble, Marker, markerVariants, Message } from './primitives/chat.js';
+import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js';
 import type { NavSelection } from './nav-selection.js';
 import { EmptyState } from './empty-state.js';
 import type {
@@ -1356,25 +1357,34 @@ function TurnFooterActions(props: {
               ? '复制失败'
               : action.label;
         const isActionPending = isPending || copyIsPending;
+        const tooltipText = isCopyAction ? copyFeedbackLabel : (action.tooltip ?? action.label);
+        const icon = isCopyAction && copyPhase === 'copied'
+          ? <Check size={12} strokeWidth={2} aria-hidden="true" />
+          : STATUS_FOOTER_ICON[action.id];
         return (
-          <UiButton
-            key={action.id}
-            type="button"
-            className={markerVariants({ variant: 'footer-action' })}
-            variant="quiet"
-            size="nav"
-            data-action={action.id}
-            data-pending={isActionPending || undefined}
-            data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
-            disabled={!action.enabled || copyIsPending}
-            aria-disabled={!action.enabled || copyIsPending}
-            aria-busy={isActionPending || undefined}
-            title={action.tooltip ?? action.label}
-            onClick={() => void handleClick(action)}
-          >
-            {isCopyAction && copyPhase === 'copied' ? <Check size={12} strokeWidth={2} aria-hidden="true" /> : STATUS_FOOTER_ICON[action.id]}
-            <span>{isCopyAction ? copyFeedbackLabel : action.label}</span>
-          </UiButton>
+          <Tooltip key={action.id}>
+            <TooltipTrigger
+              render={
+                <UiButton
+                  type="button"
+                  className={markerVariants({ variant: 'footer-action' })}
+                  variant="quiet"
+                  size="nav"
+                  aria-label={action.label}
+                  data-action={action.id}
+                  data-pending={isActionPending || undefined}
+                  data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
+                  disabled={!action.enabled || copyIsPending}
+                  aria-disabled={!action.enabled || copyIsPending}
+                  aria-busy={isActionPending || undefined}
+                  onClick={() => void handleClick(action)}
+                >
+                  {icon}
+                </UiButton>
+              }
+            />
+            <TooltipContent>{tooltipText}</TooltipContent>
+          </Tooltip>
         );
       })}
     </Marker>

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -9,6 +9,7 @@ import {
   Check,
   Copy,
   GitBranch,
+  Info,
   Loader2,
   RefreshCcw,
   Sparkles,
@@ -1210,7 +1211,7 @@ const TurnView = memo(function TurnView(props: {
  * (regenerate / branch) bubble up via `onAction`.
  */
 export interface TurnFooterActionMeta {
-  id: 'regenerate' | 'branch' | 'copy';
+  id: 'regenerate' | 'branch' | 'copy' | 'info';
   label: string;
   enabled: boolean;
   tooltip?: string;
@@ -1332,6 +1333,7 @@ function TurnFooterActions(props: {
       await copyAssistantText();
       return;
     }
+    if (action.id === 'info') return; // tooltip-only meta display, no action
     props.onAction?.(action.id);
   }
   return (
@@ -1383,6 +1385,7 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
   regenerate: <RefreshCcw size={12} strokeWidth={2} aria-hidden="true" />,
   branch: <GitBranch size={12} strokeWidth={2} aria-hidden="true" />,
   copy: <Copy size={12} strokeWidth={2} aria-hidden="true" />,
+  info: <Info size={12} strokeWidth={2} aria-hidden="true" />,
 };
 
 /**

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -46,6 +46,7 @@ export * from './primitives/card.js';
 // cross-package consumer — `apps/desktop`'s `artifact-preview.tsx` — which is the
 // promotion condition the off-barrel convention named, so the export is the rule.
 export { Bubble, Marker, Message, previewVariants } from './primitives/chat.js';
+export { formatTurnDuration } from './chat-display-helpers.js';
 export type {
   BubbleProps,
   MarkerProps,

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -186,6 +186,10 @@ const markerVariants = cva("", {
         + " [&:hover:not([aria-disabled=true])]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not([aria-disabled=true])]:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
+        // footer actions drop the real `disabled` attr so tooltips can show
+        // on disabled actions; neutralize the UiButton `quiet` variant's base
+        // hover/active so an aria-disabled action does not look clickable.
+        + " [&[aria-disabled=true]]:hover:bg-transparent [&[aria-disabled=true]]:hover:text-[color:var(--muted-foreground)] [&[aria-disabled=true]]:active:bg-transparent"
         + " data-[pending=true]:opacity-[0.78] data-[pending=true]:cursor-progress"
         // Copy-in-progress sets `aria-disabled` and `data-pending` together.
         // `aria-disabled:opacity-[0.45]` and `data-[pending=true]:opacity-[0.78]`

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -183,18 +183,17 @@ const markerVariants = cva("", {
         // Folding them in keeps the exact pixels while the marker shell owns its
         // geometry (verified equal to `main` by computed style, headless electron).
         "inline-flex items-center gap-1.5 min-h-[28px] h-8 px-2 py-1 rounded-[var(--radius-surface)] [border:0] bg-transparent text-[color:var(--muted-foreground)] text-[12px] leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
-        + " [&:hover:not(:disabled)]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not(:disabled)]:text-[color:var(--foreground)]"
+        + " [&:hover:not([aria-disabled=true])]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not([aria-disabled=true])]:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
-        + " disabled:opacity-[0.45] disabled:cursor-not-allowed aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
+        + " aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
         + " data-[pending=true]:opacity-[0.78] data-[pending=true]:cursor-progress"
-        // Copy-in-progress sets BOTH `disabled` and `data-pending`. The plain
-        // `data-[pending=true]:opacity-[0.78]` and `disabled:opacity-[0.45]`
-        // utilities have equal specificity (0,2,0), so the pending value would
-        // only win on Tailwind's source order. These combined-modifier guards
-        // raise pending to (0,3,0) so it beats the disabled dim by specificity,
-        // not order — keeping the in-progress 0.78 stable regardless of emit
-        // sequence. (Both `disabled`/`aria-disabled` are always set together.)
-        + " disabled:data-[pending=true]:opacity-[0.78] aria-disabled:data-[pending=true]:opacity-[0.78]"
+        // Copy-in-progress sets `aria-disabled` and `data-pending` together.
+        // `aria-disabled:opacity-[0.45]` and `data-[pending=true]:opacity-[0.78]`
+        // have equal specificity (0,2,0), so pending would only win on source
+        // order. This combined modifier raises pending to (0,3,0) so it beats
+        // the disabled dim by specificity, not order — keeping the in-progress
+        // 0.78 stable regardless of emit sequence.
+        + " aria-disabled:data-[pending=true]:opacity-[0.78]"
         + " data-[copy-feedback=copied]:text-[color:var(--link)] data-[copy-feedback=failed]:text-[color:var(--destructive)]",
     },
   },

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -136,28 +136,6 @@ export function Bubble({
 const markerVariants = cva("", {
   variants: {
     variant: {
-      // `.maka-turn-summary` + the `tool-output.css` measure-column re-anchor:
-      // one quiet caption line (model · tools · duration · tokens).
-      summary:
-        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-1.5 mb-0.5 ml-0 mr-auto text-[color:var(--muted-foreground)] [font-variant-numeric:tabular-nums]",
-      // `.maka-turn-summary-chip` (+ `::before` middot, nested `code`, and the
-      // `[data-kind]` / `[data-state]` / `[data-switched]` conditionals). The
-      // call site keeps passing `data-kind` / `data-state` / `data-switched`,
-      // which the literalized `data-[…]:` variants read.
-      "summary-chip":
-        "inline-flex items-center gap-1 text-[color:var(--muted-foreground)] text-[12px] font-medium leading-[1.4]"
-        + " [&:not(:first-child)]:before:content-['·'] [&:not(:first-child)]:before:mr-1 [&:not(:first-child)]:before:text-[color:var(--muted-foreground)] [&:not(:first-child)]:before:font-normal"
-        + " [&_code]:bg-transparent [&_code]:text-[color:inherit] [&_code]:[font-family:var(--font-mono)] [&_code]:text-[12px]"
-        + " data-[kind=model]:[&_code]:text-[color:var(--foreground-secondary)] data-[kind=model]:[&_code]:font-semibold"
-        + " data-[kind=tools]:text-[color:var(--muted-foreground)]"
-        + " data-[kind=duration]:[font-variant-numeric:tabular-nums]"
-        + " data-[kind=tools]:min-w-[5rem] data-[kind=duration]:min-w-[4rem]"
-        + " data-[kind=tokens]:[font-variant-numeric:tabular-nums] data-[kind=tokens]:[font-family:var(--font-mono)] data-[kind=tokens]:text-[12px]"
-        + " data-[state=in-progress]:text-[color:var(--status-running)] data-[state=in-progress]:font-semibold"
-        + " data-[kind=model]:data-[switched=true]:[&_code]:text-[color:var(--foreground-secondary)]",
-      // `.maka-turn-summary-chip-switched` — the muted "切换" pill.
-      "summary-switched":
-        "ml-1 px-1.5 py-[1px] rounded-[var(--radius-pill)] bg-[oklch(from_var(--foreground)_l_c_h_/_0.06)] text-[color:var(--foreground-secondary)] text-[11px] font-semibold",
       // `.maka-turn-aborted-marker` (+ its italic `em`) — dormant, muted.
       aborted:
         "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[12px] italic [&_em]:italic",

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -51,7 +51,7 @@ export function TooltipContent({
       <TooltipPrimitive.Positioner sideOffset={6}>
         <TooltipPrimitive.Popup
           className={cn(
-            "z-[var(--z-overlay)] max-w-[min(90vw,320px)] rounded-md bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel",
+            "z-[var(--z-overlay)] max-w-[min(90vw,460px)] rounded-md bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel",
             className,
           )}
           data-slot="tooltip-content"

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps, ReactNode } from 'react';
 import type { SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView, Composer } from '../src/components.js';
+import type { TurnFooterActionMeta } from '../src/chat-view.js';
 import type { ChatModelChoice } from '../src/chat-model-helpers.js';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
@@ -104,6 +105,16 @@ const baseChatProps: ChatViewProps = {
   onPromptSuggestion: noop,
 };
 
+// #546: default footer actions shown on every turn in the story so the
+// redesigned icon-only footer (regenerate / branch / copy / info) is
+// visible without each story wiring it up by hand.
+const DEFAULT_FOOTER_ACTIONS: ReadonlyArray<TurnFooterActionMeta> = [
+  { id: 'regenerate', label: '重新生成', enabled: true, tooltip: '让模型重新生成本轮回答' },
+  { id: 'branch', label: '分支', enabled: true, tooltip: '基于此回答的上下文分支出新对话' },
+  { id: 'copy', label: '复制', enabled: true, tooltip: '复制回答到剪贴板' },
+  { id: 'info', label: '详情', enabled: true, tooltip: 'claude-sonnet-4-5 · 4.9s · 1,417 → 19 tok · $0.0123' },
+];
+
 const baseComposerProps: ComposerProps = {
   draftKey: 'storybook-chat-surface',
   onSend: noop,
@@ -150,6 +161,10 @@ function ChatSurface(props: {
   composer?: Partial<ComposerProps>;
   narrow?: boolean;
 }) {
+  const messages = props.chat?.messages ?? baseChatProps.messages;
+  const turnFooterActionsByTurn = Object.fromEntries(
+    [...new Set(messages.map((m) => m.turnId))].map((id) => [id, DEFAULT_FOOTER_ACTIONS]),
+  );
   return (
     <SurfaceFrame narrow={props.narrow}>
       <div
@@ -161,7 +176,7 @@ function ChatSurface(props: {
           background: 'var(--background)',
         }}
       >
-        <ChatView {...baseChatProps} {...props.chat} />
+        <ChatView {...baseChatProps} turnFooterActionsByTurn={turnFooterActionsByTurn} {...props.chat} />
         <div style={{ padding: '0 24px 24px' }}>
           <Composer {...baseComposerProps} {...props.composer} />
         </div>

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -112,7 +112,7 @@ const DEFAULT_FOOTER_ACTIONS: ReadonlyArray<TurnFooterActionMeta> = [
   { id: 'regenerate', label: '重新生成', enabled: true, tooltip: '让模型重新生成本轮回答' },
   { id: 'branch', label: '分支', enabled: true, tooltip: '基于此回答的上下文分支出新对话' },
   { id: 'copy', label: '复制', enabled: true, tooltip: '复制回答到剪贴板' },
-  { id: 'info', label: '详情', enabled: true, tooltip: 'claude-sonnet-4-5 · 4.9s · 1,417 → 19 tok · $0.0123' },
+  { id: 'info', label: '详情', enabled: true, tooltip: 'claude-sonnet-4-5 · 4.9s · $0.0123' },
 ];
 
 const baseComposerProps: ComposerProps = {

--- a/scripts/check-chat-marker-computed-style.mjs
+++ b/scripts/check-chat-marker-computed-style.mjs
@@ -35,13 +35,11 @@
  * action across resting / pending / copy-pending / copied / failed —
  * including `main`'s old pending `secondary` variant vs the new always-
  * `quiet` shell, which proves that variant switch was visually inert (the
- * reason this PR drops it). The DOM mirrors `TurnView` nesting (chips in a
- * summary, actions in a footer, badges in a lineage row) so positional
- * pseudo-classes and inheritance resolve as in production — including the
- * `summary-switched` "切换" pill nested in a `data-switched` model chip, the
- * `lineage-row-reverse` container, and the `::before` middot separators on
- * summary chips / failed-recovery (all migrated variants, all real once the
- * CSS is inlined).
+ * reason this PR drops it). The DOM mirrors `TurnView` nesting (actions in a
+ * footer, badges in a lineage row) so positional pseudo-classes and
+ * inheritance resolve as in production — including the `lineage-row-reverse`
+ * container and the `::before` middot separator on failed-recovery (all
+ * migrated variants, all real once the CSS is inlined).
  *
  * What is STILL not observable here, and why — locked by the cascade
  * contract's exact source-string literals instead (each a LEAF
@@ -52,11 +50,11 @@
  *     Chromium behavior — the force drives the inspector, not in-page
  *     computed style; verified resting == forced-"hover" even with the CSS
  *     applied). The rules themselves DO compile into the bundle (greppable:
- *     `…:hover:not(:disabled){background-color:oklch(…/ .05)}`). Their
- *     NON-leaf merge winner is a deterministic specificity fact: the marker's
- *     `[&:hover:not(:disabled)]` (0,3,0) outranks UiButton quiet's
- *     `hover:bg-muted` (0,2,0), exactly as the retired
- *     `.maka-turn-footer-action:hover:not(:disabled)` did on main.
+ *     `…:hover:not([aria-disabled=true]){background-color:oklch(…/ .05)}`).
+ *     Their NON-leaf merge winner is a deterministic specificity fact: the
+ *     marker's `[&:hover:not([aria-disabled=true])]` (0,3,0) outranks UiButton
+ *     quiet's `hover:bg-muted` (0,2,0). Footer actions use `aria-disabled`
+ *     (not a real `disabled` attr) so tooltips can show on disabled actions.
  * So this is a rendered proof of the RESTING surface plus the `::before`
  * middots, with only the interactive pseudo-states pinned by source string.
  *
@@ -242,29 +240,11 @@ const TREE = (side) => {
   const C = (p) => p[side];
   const el = (tag, id, p, attrs, kids = '') => `<${tag} id="${id}" class="${C(p)}" ${attrs}>${kids}</${tag}>`;
   const action = (id, p, attrs) => el('button', id, p, `${attrs} type="button"`, '<svg width="11" height="11"></svg><span>复制中…</span>');
-  const chip = (id) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model"', '<span>x</span>');
-  // Every other chip `data-[kind]` (and the in-progress `data-[state]`) gets a
-  // row too, so the tools tint / duration+tokens tabular-nums / in-progress
-  // accent+semibold are diffed for real, not only pinned as source strings.
-  const kindChip = (id, attrs) => el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), attrs, '<span>x</span>');
-  // The "切换" pill nests inside a model chip carrying `data-switched=true`,
-  // exactly as TurnSummary renders it — both the switched-model chip path and
-  // the pill itself are migrated variants, so each is measured as its own row.
-  const switchedChip = (id, pillId) =>
-    el('span', id, pair('maka-turn-summary-chip', mv('summary-chip')), 'data-kind="model" data-switched="true"',
-      '<code>m</code>' + el('span', pillId, pair('maka-turn-summary-chip-switched', mv('summary-switched')), '', '切换'));
   return [
-    el('div', 'summary', pair('maka-turn-summary', mv('summary')), '',
-      chip('summary-chip-1') + chip('summary-chip-2')
-      + kindChip('summary-chip-tools', 'data-kind="tools"')
-      + kindChip('summary-chip-duration', 'data-kind="duration"')
-      + kindChip('summary-chip-tokens', 'data-kind="tokens"')
-      + kindChip('summary-chip-inprogress', 'data-kind="duration" data-state="in-progress"')
-      + switchedChip('summary-chip-switched', 'summary-switched')),
     el('div', 'footer', pair('maka-turn-footer', mv('footer')), 'role="toolbar"',
       action('footer-rest', fa('quiet'), '') +
       action('footer-pending', fa('secondary'), 'data-pending="true" aria-busy="true"') +
-      action('footer-copy-pending', fa('secondary'), 'data-pending="true" data-copy-feedback="pending" aria-busy="true" disabled aria-disabled="true"') +
+      action('footer-copy-pending', fa('secondary'), 'data-pending="true" data-copy-feedback="pending" aria-busy="true" aria-disabled="true"') +
       action('footer-copied', fa('quiet'), 'data-copy-feedback="copied"') +
       action('footer-failed', fa('quiet'), 'data-copy-feedback="failed"')),
     el('div', 'lineage-row', pair('maka-turn-lineage-row', mv('lineage-row')), '',
@@ -288,7 +268,7 @@ const TREE = (side) => {
 };
 
 const PROPS = ['display', 'height', 'minHeight', 'width', 'maxWidth', 'maxHeight', 'minWidth', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth', 'borderTopColor', 'borderBottomColor', 'borderTopStyle', 'borderTopLeftRadius', 'boxShadow', 'overflowX', 'overflowY', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'letterSpacing', 'lineHeight', 'textTransform', 'gridTemplateColumns', 'columnGap', 'color', 'backgroundColor', 'opacity', 'transition', 'justifyContent', 'alignItems', 'flexWrap', 'flexDirection', 'fontVariantNumeric', 'whiteSpace', 'wordBreak', 'textOverflow', 'textAlign', 'cursor'];
-const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools', 'summary-chip-duration', 'summary-chip-tokens', 'summary-chip-inprogress', 'summary-chip-switched', 'summary-switched', 'footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery',
+const IDS = ['footer', 'footer-rest', 'footer-pending', 'footer-copy-pending', 'footer-copied', 'footer-failed', 'lineage-row', 'lineage-fwd', 'lineage-row-reverse', 'lineage-rev', 'aborted', 'failed-banner', 'failed-recovery',
   // PR3 stream shell (resting + live border ring). The pulse dot is excluded
   // (animated → phase-dependent computed style).
   'stream', 'stream-header', 'stream-label', 'stream-counts', 'stream-count', 'stream-count-stderr', 'stream-count-redacted', 'stream-count-truncated', 'stream-body', 'stream-chunk', 'stream-chunk-stderr', 'stream-chunk-redacted', 'stream-redacted-tag', 'stream-live',
@@ -313,9 +293,8 @@ const IDS = ['summary', 'summary-chip-1', 'summary-chip-2', 'summary-chip-tools'
   'err-banner'];
 // `::before` middot separators are now diffed for real (they render once the
 // CSS is inlined — the old `<link>` build couldn't apply them, masking this).
-// summary-chip-2 is a non-first chip (`[&:not(:first-child)]:before:…`);
 // failed-recovery carries the always-on `before:content-['·']`.
-const PSEUDO_IDS = ['summary-chip-2', 'failed-recovery'];
+const PSEUDO_IDS = ['failed-recovery'];
 const PSEUDO_PROPS = ['content', 'marginRight', 'color', 'fontWeight'];
 
 function pageHtml(cssText, side) {


### PR DESCRIPTION
## Summary
Redesign the assistant turn chrome: remove the top TurnSummary meta row, merge retry into regenerate end-to-end, and make the footer icon-only (regenerate / branch / copy / info) with turn meta in the info tooltip.

## Why
The old chrome carried a top meta row (model · tools · duration · tokens) plus an icon+text footer with mutually-exclusive retry/regenerate buttons — redundant surface and two parallel "re-run" concepts. Simplify to one icon-only footer whose meta lives behind a single info tooltip, and one regenerate action that works regardless of how the previous attempt ended.

Refs #546

## Scope
Changed:
- **runtime/core**: `regenerateTurn` accepts failed/aborted/completed source turns (was completed-only); retry removed from runtime, IPC, preload, core types.
- **ui**: `TurnSummary` row + markerVariants summary shells removed; footer actions icon-only with Base UI Tooltip; new `info` action carries meta (model · duration · cost); tooltip widened so long meta doesn't truncate; user-message copy icon-only; assistant hover time dropped (redundant with the user message's relative time).
- **renderer**: `deriveTurnFooterActions` pure helper (node:test-able); lineage badges unified to "重新生成自" with legacy `retriedFromTurnId` read-fallback; `alreadyRegenerated` honors the same `?? retriedToTurnId` fallback.
- **footer a11y**: footer actions use `aria-disabled` (not real `disabled`) so the disabled-reason tooltip can still trigger; marker shell gates hover/active on aria-disabled.
- docs/smoke + design-system updated to the post-redesign model; `check:chat-visual` fixture dropped the removed summary chrome.

Not included: the per-turn model-switch ("切换") pill — dropped (flagged in the issue); token counts in the info tooltip — dropped as unreadable, cost already summarizes them.

## Verification
- `npm run build` + `npm run typecheck` — clean.
- `npm run -w @maka/runtime test` — 916 pass / 0 fail.
- `npm run -w @maka/ui test` — 45 pass.
- desktop main contracts (turn-footer-actions, derive-turn-lineage-badges, chat-marker-cascade, visible-copy-hygiene, text-swap-min-width, chat-tool-card-cascade) — pass.
- 7 rounds of codex review (xhigh) — final round PASS, no P0/P1/P2.

## User-facing impact
- Footer is now icon-only; turn meta (model · duration · cost) shows in the info-action tooltip on hover.
- "重试" is gone — one "重新生成" works for failed / aborted / completed turns.
- Lineage badges unified to "重新生成自" (legacy retry sessions render as regenerate).
- No top meta row; assistant hover timestamp removed (the user message already shows relative time).

Screenshot: _(paste compare-footer.png — before/after footer)_

## Reviewer notes
- The `aria-disabled` (not `disabled`) switch on footer actions is intentional: a real `disabled` attr brings `pointer-events-none`, which hid the disabled-reason tooltip. Clicks stay guarded by `handleClick`'s `!action.enabled` check + `copyAssistantText`'s `copyPendingRef`.
- Legacy `retriedFromTurnId` / `retriedToTurnId` storage fields are intentionally kept (read-compat for old sessions) — badges + `alreadyRegenerated` both fall back via `??`, so old retry lineage renders as "重新生成".
