### PR TITLE
refactor(ui): composer toolbar redesign — Select pickers, unified triggers, consolidated CSS

### DIFF
--- a/apps/desktop/src/main/__tests__/composer-container-single-source-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-container-single-source-contract.test.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/**
+ * Composer container single-source contract.
+ *
+ * The composer card (`.maka-composer-inner`) + its textarea + placeholder
+ * were triplicated across maka-tokens.css (@layer components),
+ * styles/tool-output.css, and reference-shell.css — three definitions of the
+ * same selector fighting by specificity/layer, plus dead `::before/::after`
+ * and a duplicated textarea font. They are consolidated into
+ * styles/composer.css as one definition per selector. This contract pins
+ * that single source so the scattered duplicates cannot silently come back,
+ * and that the placeholder font is declared explicitly (not left to the
+ * fragile `[font: inherit]` chain from the bare-field reset).
+ */
+
+/** All style rules in `css` as [prelude, body] pairs, comments stripped,
+ *  at-rule preludes skipped, and any text left of a `;` (prior statements)
+ *  discarded — same shape the form-font-reset contract uses. */
+function styleRules(css: string): Array<[string, string]> {
+  const stripped = stripCssComments(css);
+  return [...stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((m) => {
+    const prelude = m[1].replace(/^[\s\S]*;/, '').trim();
+    return [prelude, m[2]] as [string, string];
+  });
+}
+
+/** Count rest-state rules whose subject is `subjectClass` (optionally with a
+ *  trailing `.class` qualifier), excluding any selector that carries a state
+ *  pseudo (`:focus-within`) or attribute (`[data-drag-active]`). The
+ *  drag-active rule `.maka-composer[data-drag-active="true"]
+ *  .maka-composer-inner` is an ancestor-scoped state rule, not a rest
+ *  definition, so it is correctly excluded by the `[` guard. */
+function restRulesFor(css: string, subjectClass: string): string[] {
+  const re = new RegExp(
+    String.raw`\.${subjectClass}(?:\.[\w-]+)?\s*$`,
+  );
+  return styleRules(css)
+    .filter(([prelude]) => prelude && !prelude.startsWith('@'))
+    .filter(([prelude]) => re.test(prelude))
+    .filter(([prelude]) => !/[:[]/.test(prelude))
+    .map(([prelude]) => prelude.replace(/\s+/g, ' '));
+}
+
+describe('composer container single-source contract', () => {
+  it('`.maka-composer-inner` rest state is defined exactly once (in composer.css)', async () => {
+    const css = await readAllRendererCss();
+    const rest = restRulesFor(css, 'maka-composer-inner');
+    assert.equal(
+      rest.length,
+      1,
+      `composer card rest state must have one definition (styles/composer.css); got ${rest.length}: ${JSON.stringify(rest)}`,
+    );
+  });
+
+  it('`.maka-composer-textarea` rest state is defined exactly once (in composer.css)', async () => {
+    const css = await readAllRendererCss();
+    // Count rest rules whose subject is the composer textarea across BOTH
+    // selector forms — the class `.maka-composer-textarea` and the scoped
+    // type `.composer textarea` / `.maka-composer textarea`. The old
+    // duplicate used the type form, so counting only the class form would
+    // miss a re-added type-form duplicate (same gap the placeholder test
+    // closes for `::placeholder`).
+    const rest = styleRules(css)
+      .filter(([prelude]) => prelude && !prelude.startsWith('@'))
+      .filter(([prelude]) => !/[:[]/.test(prelude))
+      .filter(
+        ([prelude]) =>
+          /\.maka-composer-textarea\s*$/.test(prelude) ||
+          /(?:\.composer|\.maka-composer)\s+textarea\s*$/.test(prelude),
+      )
+      .map(([prelude]) => prelude.replace(/\s+/g, ' '));
+    assert.equal(
+      rest.length,
+      1,
+      `composer textarea rest state must have one definition (styles/composer.css); got ${rest.length}: ${JSON.stringify(rest)}`,
+    );
+  });
+
+  it('the composer placeholder has one rest definition and declares its font explicitly', async () => {
+    const css = await readAllRendererCss();
+    // A rest `::placeholder` rule (not the :focus variant) whose subject is
+    // the composer textarea. Covers BOTH selector forms — the class
+    // `.maka-composer-textarea::placeholder` and the scoped type
+    // `.composer textarea::placeholder` — so the old triplicate duplicate
+    // cannot sneak back in either form.
+    const restPlaceholders = styleRules(css)
+      .filter(([prelude]) => prelude && !prelude.startsWith('@'))
+      .filter(([prelude]) => /::placeholder/.test(prelude) && !/:focus/.test(prelude))
+      .filter(([prelude]) =>
+        /maka-composer-textarea|\.composer\s+textarea|\.maka-composer\s+textarea/.test(
+          prelude,
+        ),
+      )
+      .map(([prelude, body]) => [prelude.replace(/\s+/g, ' '), body] as [string, string]);
+    assert.equal(
+      restPlaceholders.length,
+      1,
+      `composer placeholder rest state must have one definition; got ${restPlaceholders.length}: ${JSON.stringify(restPlaceholders.map(([p]) => p))}`,
+    );
+    const [, body] = restPlaceholders[0];
+    assert.match(
+      body,
+      /font-family\s*:/,
+      'composer placeholder must declare font-family explicitly (no inheritance reliance)',
+    );
+    assert.match(body, /font-size\s*:/, 'composer placeholder must declare font-size explicitly');
+  });
+});

--- a/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/default-permission-mode-contract.test.ts
@@ -139,11 +139,11 @@ describe('General settings page 默认权限模式 picker', () => {
     );
   });
 
-  it('renders the shared PermissionModeMenuPopup so options and hints cannot drift from the composer picker', async () => {
+  it('renders the shared PermissionModeSelect so options and hints cannot drift from the composer picker', async () => {
     const src = await readSettingsCombinedSource();
     assert.match(
       src,
-      /<PermissionModeMenuPopup\s+activeMode=\{props\.permissionMode\}/,
+      /<PermissionModeSelect\s+activeMode=\{props\.permissionMode\}/,
       '默认权限模式 must render the shared popup from @maka/ui (label + hint per option, same markup as the composer picker), not a bespoke copy',
     );
   });

--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -259,11 +259,6 @@ describe('issue #406 design-system governance contract', () => {
       assert.ok(contrastRatio(destrText, bg) >= 4.5, `${selector} --destructive-text contrast < 4.5:1`);
       assert.ok(contrastRatio(accentText, bg) >= 4.5, `${selector} accent chip (foreground-secondary) contrast < 4.5:1`);
     }
-    // Structural: chip text color must be the readable variant, not the raw tone.
-    const chipCss = stripCssComments(await readFile(resolve(RENDERER_STYLES_DIR, 'tool-output.css'), 'utf8'));
-    assert.match(chipCss, /\.maka-composer-mode-chip\[data-tone="info"\]\s*\{[^}]*color:\s*var\(--info-text\)/);
-    assert.match(chipCss, /\.maka-composer-mode-chip\[data-tone="destructive"\]\s*\{[^}]*color:\s*var\(--destructive-text\)/);
-    assert.match(chipCss, /\.maka-composer-mode-chip\[data-tone="accent"\]\s*\{[^}]*color:\s*var\(--foreground-secondary\)/);
   });
 
   it('uses radius tokens for preview card surfaces', async () => {

--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -370,7 +370,7 @@ describe('radius token governance (#406 gap 4)', () => {
     const SELECTOR_TIER: Record<string, string> = {
       '.maka-code': '--radius-surface',
       '.maka-skeleton-card': '--radius-surface',
-      '.maka-composer-inner': '--radius-modal',
+      '.composer .maka-composer-inner': '--radius-modal',
       '.settingsPermissionRefresh': '--radius-control',
       '.settingsCapabilityGuidanceActions code': '--radius-surface',
       '.settingsModal': '--radius-modal',

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -88,7 +88,7 @@ const RETIRED_RING_RESET_BLOCKS = [
     anchor: '.maka-onboarding-quickchat .maka-onboarding-quickchat-input',
   },
   {
-    fileSuffix: 'apps/desktop/src/renderer/styles/tool-output.css',
+    fileSuffix: 'apps/desktop/src/renderer/styles/composer.css',
     anchor: '.composer .maka-composer-textarea',
   },
 ];

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -166,19 +166,17 @@ describe('permission mode transition guard copy', () => {
     assert.match(composerReasonBlock, /当前有工具调用正在等待确认，处理后再切换权限模式。/);
   });
 
-  it('composer mode chip disables itself when pending or disabledReason is present', async () => {
+  it('composer permission picker disables itself when pending or disabledReason is present', async () => {
     const ui = await readFile(join(REPO_ROOT, 'packages/ui/src/composer.tsx'), 'utf8');
-    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \(\(\) => \{[\s\S]*?<\/Menu>/)?.[0] ?? '';
+    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \([\s\S]*?\) : null/)?.[0] ?? '';
 
-    assert.ok(dropdownBlock, 'composer.tsx must render a composer permission-mode Menu dropdown');
-    assert.match(dropdownBlock, /const triggerDisabled = props\.permissionModePending === true \|\| Boolean\(props\.permissionModeDisabledReason\);/);
-    assert.match(dropdownBlock, /disabled=\{triggerDisabled\}/);
-    assert.match(dropdownBlock, /title=\{props\.permissionModeDisabledReason \?\? meta\.hint\}/);
-    assert.match(dropdownBlock, /data-pending=\{props\.permissionModePending \? 'true' : undefined\}/);
-    assert.match(dropdownBlock, /aria-label=\{`权限模式：\$\{meta\.label\}`\}/);
+    assert.ok(dropdownBlock, 'composer.tsx must render a PermissionModeSelect picker');
+    assert.match(dropdownBlock, /<PermissionModeSelect/);
+    assert.match(dropdownBlock, /disabled=\{props\.permissionModePending === true \|\| Boolean\(props\.permissionModeDisabledReason\)\}/);
+    assert.match(dropdownBlock, /disabledReason=\{props\.permissionModeDisabledReason\}/);
   });
 
-  it('composer mode menu offers the user-facing permission modes via base-ui Menu', async () => {
+  it('composer permission picker uses the shared Base UI Select', async () => {
     const ui = await readFile(join(REPO_ROOT, 'packages/ui/src/composer.tsx'), 'utf8');
     const menuModule = await readFile(join(REPO_ROOT, 'packages/ui/src/permission-mode-menu.tsx'), 'utf8');
 
@@ -193,16 +191,16 @@ describe('permission mode transition guard copy', () => {
       /export const PERMISSION_MODE_ORDER: readonly ChatDefaultPermissionMode\[\] = CHAT_DEFAULT_PERMISSION_MODES;/,
     );
 
-    // Mode chip uses base-ui Menu (not a custom radiogroup) — keyboard
-    // arrow / Home / End navigation is delegated to the primitive. The
-    // popup body is the shared PermissionModeMenuPopup so the composer and
-    // Settings pickers render identical option markup.
-    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \(\(\) => \{[\s\S]*?<\/Menu>/)?.[0] ?? '';
-    assert.match(dropdownBlock, /<Menu>/);
-    assert.match(dropdownBlock, /<MenuTrigger/);
-    assert.match(dropdownBlock, /<PermissionModeMenuPopup/);
+    // Permission picker is Base UI Select (the correct primitive for a
+    // single-value choice), not a hand-styled Menu + chip. The composer
+    // renders the shared PermissionModeSelect so option markup can't drift
+    // from the Settings picker; keyboard arrow/Home/End is delegated to
+    // the Select primitive.
+    const dropdownBlock = ui.match(/props\.onPermissionModeChange \? \([\s\S]*?\) : null/)?.[0] ?? '';
+    assert.match(dropdownBlock, /<PermissionModeSelect/);
+    assert.match(dropdownBlock, /activeMode=\{props\.permissionMode/);
     assert.match(dropdownBlock, /void props\.onPermissionModeChange\?\.\(mode\);/);
-    assert.match(menuModule, /<MenuPopup className="maka-composer-mode-menu"/);
+    assert.match(menuModule, /export function PermissionModeSelect/);
     assert.match(menuModule, /PERMISSION_MODE_ORDER\.map\(\(mode\) =>/);
   });
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1789,43 +1789,6 @@
     padding: var(--space-4) var(--space-6);
     background: var(--background);
   }
-  .maka-composer-inner {
-    max-width: 760px;
-    margin: 0 auto;
-    /* PR-UI-LAYOUT-8: composer chrome refresh.
-     * - Radius 14 → 16 (matches the new floating panel feel without
-     *   feeling like a pillow).
-     * - Background: var(--background-elevated) instead of plain
-     *   `--background` so the composer reads as "the thing you
-     *   type into" with a slight lift from the panel surface.
-     * - Padding 12/14 → 14/16 for more typing room.
-     * - Box shadow drops 3-layer `--shadow-minimal` for a single
-     *   1px ring + 4px soft glow that's calm at rest. */
-    box-shadow:
-      0 0 0 1px oklch(from var(--foreground) l c h / 0.04),
-      0 1px 3px oklch(from var(--foreground) l c h / 0.04);
-    border-radius: var(--radius-modal);
-    background: var(--background-elevated);
-    padding: var(--space-3) var(--space-4);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2-5);
-    border: var(--border-width-hairline) solid var(--border);
-    transition: border-color var(--duration-base) var(--ease-out-strong), box-shadow var(--duration-base) var(--ease-out-strong), background var(--duration-base) var(--ease-out-strong);
-  }
-
-  /* Composer focus ring — `:focus-within` lets the wrapping shell glow
-     when the textarea or any toolbar button is focused, instead of the
-     ugly textarea native outline. PR-UI-LAYOUT-8: ring opacity dropped
-     slightly so the focus state feels alert without being aggressive. */
-  .maka-composer-inner:focus-within {
-    border-color: oklch(from var(--focus-ring) l c h / 0.40);
-    background: var(--background);
-    box-shadow:
-      0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.20),
-      0 0 0 var(--focus-glow-width) oklch(from var(--focus-ring) l c h / 0.08),
-      0 1px 3px oklch(from var(--foreground) l c h / 0.04);
-  }
   .maka-composer[data-drag-active="true"] .maka-composer-inner {
     border-color: oklch(from var(--focus-ring) l c h / 0.46);
     background: oklch(from var(--focus-ring) 0.98 calc(c * 0.20) h / 0.35);
@@ -1833,33 +1796,6 @@
       0 0 0 1px oklch(from var(--focus-ring) l c h / 0.22),
       0 0 0 4px oklch(from var(--focus-ring) l c h / 0.08),
       0 1px 3px oklch(from var(--foreground) l c h / 0.04);
-  }
-  .maka-composer textarea {
-    appearance: none;
-    border: none;
-    outline: none;
-    width: 100%;
-    resize: none;
-    background: transparent;
-    color: var(--foreground);
-    font-family: var(--font-default);
-    font-size: var(--font-size-base);
-    line-height: var(--leading-normal);
-    min-height: var(--h-composer-min);
-    max-height: 240px;
-  }
-  .maka-composer textarea::placeholder {
-    color: var(--muted-foreground);
-    /* PR-CHAT-COMPOSER-PLACEHOLDER-0 (WAWQAQ 10min loop):
-       fade the placeholder slightly when the textarea is focused
-       and not yet typed in, so the focus state reads as "we're
-       listening" instead of "the placeholder is just sitting
-       there." The fade is small (1 → 0.55) — enough to register,
-       small enough not to feel like a glitch. */
-    transition: opacity var(--duration-emphasized) var(--ease-out-strong);
-  }
-  .maka-composer textarea:focus::placeholder {
-    opacity: var(--opacity-disabled);
   }
   .maka-composer-toolbar {
     display: flex;

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -108,29 +108,14 @@
   box-shadow: none;
 }
 
-/* `.agents-parchment-paper-surface` is reused by the composer body —
-   composer keeps its border (overridden below). The bare class on the
-   content area drops its border so we don't double up with the
-   floating-panel rule above. */
+/* `.agents-parchment-paper-surface` is reused by the composer body. The bare
+   class drops its border so the content area doesn't double up with the
+   floating-panel rule above; the composer re-establishes its own card chrome
+   on top (see `.composer .maka-composer-inner` in styles/composer.css). */
 .agents-parchment-paper-surface {
   border: 0;
   background-color: var(--agents-content-area-bg);
   box-shadow: none;
-}
-
-.composer .maka-composer-inner.agents-parchment-paper-surface {
-  border: var(--border-width-hairline) solid var(--color-border-tertiary);
-  background-color: var(--agents-content-area-bg);
-  /* #546: single hairline ring at rest — dropped the 1px/3px drop shadow so the
-     calm parchment card doesn't carry a heavy lift. */
-  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.035);
-}
-
-.composer .maka-composer-inner.agents-parchment-paper-surface:focus-within {
-  /* #546: focus reads as a single accent ring (focus-ring recipe) instead of
-     a neutral ring + drop shadow, so the typing state is alert without a lift. */
-  border-color: oklch(from var(--focus-ring) l c h / 0.45);
-  box-shadow: 0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.30);
 }
 
 .agents-chat-panel {

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -121,16 +121,16 @@
 .composer .maka-composer-inner.agents-parchment-paper-surface {
   border: var(--border-width-hairline) solid var(--color-border-tertiary);
   background-color: var(--agents-content-area-bg);
-  box-shadow:
-    0 0 0 1px oklch(from var(--foreground) l c h / 0.035),
-    0 1px 3px oklch(from var(--foreground) l c h / 0.025);
+  /* #546: single hairline ring at rest — dropped the 1px/3px drop shadow so the
+     calm parchment card doesn't carry a heavy lift. */
+  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.035);
 }
 
 .composer .maka-composer-inner.agents-parchment-paper-surface:focus-within {
-  border-color: var(--color-border-tertiary);
-  box-shadow:
-    0 0 0 1px oklch(from var(--foreground) l c h / 0.07),
-    0 2px 8px -6px oklch(from var(--foreground) l c h / 0.16);
+  /* #546: focus reads as a single accent ring (focus-ring recipe) instead of
+     a neutral ring + drop shadow, so the typing state is alert without a lift. */
+  border-color: oklch(from var(--focus-ring) l c h / 0.45);
+  box-shadow: 0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.30);
 }
 
 .agents-chat-panel {

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -13,11 +13,8 @@ import {
   Input,
   NumberField,
   NumberFieldInput,
-  Menu,
-  MenuTrigger,
   ModelPicker,
-  PERMISSION_MODE_META,
-  PermissionModeMenuPopup,
+  PermissionModeSelect,
   SettingsSelect,
   SettingsSwitch as Switch,
   modelChoiceValue,
@@ -25,7 +22,6 @@ import {
   parseModelChoiceValue,
   useToast,
 } from '@maka/ui';
-import { ChevronDown } from '@maka/ui/icons';
 import { ProviderLogo } from './ProvidersPanel';
 import { buildCatalogChatModelChoices } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
@@ -89,10 +85,9 @@ export function GeneralSettingsPage(props: {
  * a second picker right below 默认模型, backed by
  * `settings.chatDefaults.permissionMode` (persisted via the generic
  * `settings.update` patch, unlike the model picker's dedicated
- * `connections.setDefaultModel` IPC). Reuses `PERMISSION_MODE_META` from
- * `@maka/ui` so the labels/hints can never drift from the composer picker
- * (see PR-DEFAULT-PERMISSION-MODE-1 below for why it's a `<Menu>`, not a
- * `<SettingsSelect>`).
+ * `connections.setDefaultModel` IPC). Renders the shared
+ * `PermissionModeSelect` (Base UI Select) so labels, hints, and markup
+ * can't drift from the composer picker.
  */
 function GeneralDefaultsCard(props: {
   connections: readonly LlmConnection[];
@@ -207,34 +202,19 @@ function GeneralDefaultsCard(props: {
               hint — the shared popup already shows every option's hint). */}
           <small>新对话默认使用的权限模式；可在对话内随时切换，仅影响新建对话的初始值。</small>
         </div>
-        {/* Shared popup with the composer's picker (PermissionModeMenuPopup)
-            so every option shows its label + hint before picking, and the
-            two surfaces can't drift. Only the trigger differs: a
-            select-style outline button here vs. the composer's tinted chip. */}
-        <Menu>
-          <MenuTrigger
-            render={(triggerProps) => (
-              <Button
-                {...triggerProps}
-                type="button"
-                variant="outline"
-                className="settingsSelectTrigger max-w-[320px] w-full justify-between"
-                disabled={savingPermissionMode}
-                aria-label="默认权限模式"
-              >
-                <span>{PERMISSION_MODE_META[props.permissionMode].label}</span>
-                <ChevronDown size={14} strokeWidth={1.75} aria-hidden="true" />
-              </Button>
-            )}
-          />
-          <PermissionModeMenuPopup
-            activeMode={props.permissionMode}
-            onSelect={(mode) => {
-              void persistPermissionMode(mode);
-            }}
-            align="end"
-          />
-        </Menu>
+        {/* Shared Base UI Select picker with the composer (PermissionModeSelect)
+            — same component, so option markup can't drift between the two
+            surfaces. Every option shows its label + hint before picking. */}
+        <PermissionModeSelect
+          activeMode={props.permissionMode}
+          onSelect={(mode) => {
+            void persistPermissionMode(mode);
+          }}
+          align="end"
+          disabled={savingPermissionMode}
+          ariaLabel="默认权限模式"
+          className="settingsSelectTrigger max-w-[320px] w-full justify-between"
+        />
       </div>
     </SettingsRows>
   );

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -1,42 +1,23 @@
-/* Reference's round send button is an off-black pill gradient with a 1px
-   inner top highlight — a tiny physical sheen, not flat pure #000 (banned
-   per design-taste rules). Uses oklch off-black (charcoal) so the button
-   reads as premium machined hardware. */
+/* Composer send button — flat solid action fill. #546: dropped the gradient
+   + inner sheen + drop shadow (the "machined hardware" look read heavy next
+   to the calm parchment container). Flat --action with darken on hover/press
+   keeps it the clear primary CTA without the weight. */
 .maka-composer-send-button {
   width: var(--h-control-lg);
   height: var(--h-control-lg);
   border-radius: var(--radius-pill);
-  background: linear-gradient(
-    oklch(from var(--action) calc(l - 0.10) c h),
-    oklch(from var(--action) calc(l - 0.20) c h)
-  );
+  background: var(--action);
   color: var(--action-foreground);
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.18),
-    0 8px 18px -14px oklch(from var(--action) l c h / 0.5);
-  transition:
-    background var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-emphasized) var(--ease-out-strong),
-    box-shadow var(--duration-emphasized) var(--ease-out-strong);
+  transition: background var(--duration-base) var(--ease-out-strong);
 }
 
-/* PR-FE-BUG-HUNT-7: send button is a primary CTA so it gets a hair
-   more travel than the tool buttons, but still inside the global
-   tactile press range. 1.06→1.03 hover. */
 .maka-composer-send-button:hover:not(:disabled) {
-  background: linear-gradient(
-    oklch(from var(--action) calc(l - 0.05) c h),
-    oklch(from var(--action) calc(l - 0.15) c h)
-  );
+  background: oklch(from var(--action) calc(l - 0.08) c h);
   color: var(--action-foreground);
-  transform: scale(var(--scale-hover));
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.18),
-    0 10px 22px -14px oklch(from var(--action) l c h / 0.55);
 }
 
 .maka-composer-send-button:active:not(:disabled) {
-  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.10);
+  background: oklch(from var(--action) calc(l - 0.14) c h);
 }
 
 .maka-composer-send-button:disabled {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -1,3 +1,84 @@
+/* ============================================================================
+   Composer container + input field — single source
+   ----------------------------------------------------------------------------
+   The composer card (`.maka-composer-inner`) + its textarea + placeholder
+   used to be triplicated across maka-tokens.css (@layer components),
+   styles/tool-output.css, and reference-shell.css — three definitions of the
+   same selector fighting by specificity/layer, plus a duplicated textarea
+   font. Consolidated here as one definition per selector (pinned by
+   composer-container-single-source-contract).
+
+   Rest / textarea / placeholder values are the exact computed winners — no
+   visual change for those. One deliberate change: tool-output's
+   `.composer .maka-composer-inner::before { content: none }` shared specificity
+   (0,2,1) with — and was imported after — the streaming top-sweep in
+   chat-header.css (`.maka-composer-inner[data-streaming="true"]::before`), so
+   it was silently suppressing that deliberate streaming indicator. Removing
+   the reset restores the sweep; the matching `::after` reset had no competing
+   rule and was genuinely dead. */
+
+/* The composer card — a calm parchment surface: hairline border + 1px ring
+   at rest, single accent ring on focus. The shared `.agents-parchment-paper-
+   surface` base (reference-shell.css) resets border/bg/box-shadow; this rule
+   re-establishes the composer's own chrome on top of it. */
+.composer .maka-composer-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-5);
+  width: min(var(--maka-chat-measure), 100%);
+  max-width: var(--maka-chat-measure);
+  margin: 0 auto;
+  margin-inline: auto;
+  box-sizing: border-box;
+  border: var(--border-width-hairline) solid var(--color-border-tertiary);
+  border-radius: var(--radius-modal);
+  padding: var(--space-2-5) var(--space-3) var(--space-2);
+  background-color: var(--agents-content-area-bg);
+  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.035);
+  transition:
+    border-color var(--duration-emphasized) var(--ease-out-strong),
+    box-shadow var(--duration-emphasized) var(--ease-out-strong);
+}
+
+.composer .maka-composer-inner:focus-within {
+  border-color: oklch(from var(--focus-ring) l c h / 0.45);
+  box-shadow: 0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.30);
+}
+
+/* The textarea owns no chrome (the card does). It auto-resizes from
+   --h-composer-min up to 240px (capped in @maka/ui), then scrolls. Font is
+   set explicitly on the element AND its placeholder so neither relies on the
+   fragile `[font: inherit]` chain from the bare-field reset. */
+.composer .maka-composer-textarea {
+  display: block;
+  width: 100%;
+  appearance: none;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow-y: auto;
+  background: transparent;
+  color: var(--foreground);
+  font-family: var(--font-default);
+  font-size: var(--font-size-base);
+  line-height: var(--leading-normal);
+  min-height: var(--h-composer-min);
+  max-height: 240px;
+}
+
+.composer .maka-composer-textarea::placeholder {
+  color: var(--muted-foreground);
+  font-family: var(--font-default);
+  font-size: var(--font-size-base);
+  line-height: var(--leading-normal);
+  transition: opacity var(--duration-emphasized) var(--ease-out-strong);
+}
+
+.composer .maka-composer-textarea:focus::placeholder {
+  opacity: var(--opacity-disabled);
+}
+
 /* Composer send button — flat solid action fill. #546: dropped the gradient
    + inner sheen + drop shadow (the "machined hardware" look read heavy next
    to the calm parchment container). Flat --action with darken on hover/press
@@ -53,7 +134,7 @@
   background: transparent;
   color: var(--muted-foreground);
   font: inherit;
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   line-height: var(--leading-tight);
   text-align: left;
   transition: color var(--duration-quick) var(--ease-out-strong);
@@ -97,7 +178,7 @@
   background: transparent;
   color: var(--muted-foreground);
   font: inherit;
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   line-height: var(--leading-tight);
   text-align: left;
   transition: color var(--duration-quick) var(--ease-out-strong);

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -74,72 +74,6 @@
   background: transparent;
 }
 
-.composer .maka-composer-inner {
-  position: relative;
-  width: min(var(--maka-chat-measure), 100%);
-  max-width: var(--maka-chat-measure);
-  margin-inline: auto;
-  box-sizing: border-box;
-  /* Composer outer chrome uses the universal page-card recipe (atlas §4
-     + maka-tokens.css --card-*) at the 12px workspace-plate ceiling.
-     The composer reads as a hero card, but radius must still stay within
-     the shared chrome vocabulary locked by radius-converge-contract. */
-  border: var(--border-width-hairline) solid var(--card-border-color);
-  border-radius: var(--radius-modal);
-  padding: var(--space-2-5) var(--space-3) var(--space-2);
-  background: var(--card-bg);
-  box-shadow:
-    0 10px 30px -24px oklch(from var(--foreground) l c h / 0.25),
-    0 1px 0 oklch(1 0 0 / 0.76);
-  transition:
-    border-color var(--duration-emphasized) var(--ease-out-strong),
-    box-shadow var(--duration-emphasized) var(--ease-out-strong);
-}
-
-.composer .maka-composer-inner::before,
-.composer .maka-composer-inner::after {
-  content: none;
-}
-
-.composer .maka-composer-inner::before {
-  box-shadow: none;
-}
-
-.composer .maka-composer-inner::after {
-  box-shadow: none;
-}
-
-/* PR-UI-PIXEL-3: on focus the composer gains a soft lift (ring + faint
-   drop glow), so the input feels alive — the reference's composer breathes
-   rather than sitting flat (study §8.1, §8.4). */
-.composer .maka-composer-inner:focus-within {
-  box-shadow:
-    0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.24),
-    0 14px 34px -28px oklch(from var(--foreground) l c h / 0.24);
-}
-
-.composer textarea {
-  /* Auto-resizing textarea: starts at min-height for a single line, grows up
-     to max-height as the user adds lines, then scrolls internally. The JS
-     side caps at 240px (see `COMPOSER_MAX_HEIGHT` in @maka/ui). */
-  min-height: var(--h-composer-min, 84px);
-  max-height: 240px;
-  resize: none;
-  overflow-y: auto;
-}
-
-/* The composer wrapper owns the visible field chrome. The textarea uses
-   bare field reset from the shared UI component. */
-.composer .maka-composer-textarea {
-  display: block;
-  width: 100%;
-  min-height: var(--h-composer-min, 56px);
-  color: var(--foreground);
-  font-family: var(--font-default);
-  font-size: var(--font-size-base);
-  line-height: var(--leading-normal);
-}
-
 .maka-composer-streaming-hint .maka-shortcut-kbd {
   font-size: var(--font-size-caption);
   padding: 1px var(--space-1);
@@ -188,67 +122,56 @@
   text-align: center;
 }
 
+/* Unified composer picker trigger — permission Select ([data-slot="select-trigger"])
+   + both model pickers (active .maka-model-switcher-trigger, empty-state
+   .maka-composer-model-chip) share ONE quiet-chip geometry so the two
+   controls read identical at rest and on hover. */
+.maka-composer-left-controls [data-slot="select-trigger"],
+.maka-composer-right-controls .maka-model-switcher-trigger,
 .maka-composer-model-chip {
   height: 26px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-1);
-  border: var(--border-width-hairline) solid var(--color-border-tertiary);
-  border-radius: var(--radius-pill);
   padding: 0 var(--space-2);
-  background: oklch(from var(--background) l c h / 0.82);
+  border: var(--border-width-hairline) solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
   color: var(--foreground-secondary);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
   transition:
     background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong),
-    border-color var(--duration-base) var(--ease-out-strong);
+    color var(--duration-base) var(--ease-out-strong);
 }
-
+.maka-composer-left-controls [data-slot="select-trigger"]:hover,
+.maka-composer-right-controls .maka-model-switcher-trigger:hover:not(:disabled):not([data-disabled]),
 .maka-composer-model-chip:hover {
   background: var(--state-hover-bg);
   color: var(--foreground);
-  border-color: oklch(from var(--foreground) l c h / 0.16);
+  border-color: transparent;
 }
 
 .maka-composer-model-chip {
   max-width: min(180px, 28vw);
 }
-
-
 .maka-composer-right-controls .maka-model-switcher {
   margin: 0;
   max-width: min(180px, 28vw);
-  font-size: var(--font-size-caption);
 }
-
 .maka-composer-right-controls .maka-model-switcher-trigger {
   min-width: 100px;
   max-width: min(180px, 28vw);
-  height: 26px;
-  gap: var(--space-1);
-  padding: 0 var(--space-2);
-  border-color: var(--color-border-tertiary);
-  background: var(--background);
-  color: var(--foreground-secondary);
 }
-
-.maka-composer-right-controls .maka-model-switcher-trigger:hover:not(:disabled):not([data-disabled]) {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-  border-color: oklch(from var(--foreground) l c h / 0.16);
-}
-
 .maka-composer-right-controls .maka-model-switcher-label {
   display: none;
 }
-
 .maka-composer-right-controls .maka-model-switcher-value {
   max-width: 128px;
   color: inherit;
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
 }
 
@@ -286,7 +209,6 @@
 .maka-composer-context-plus {
   width: 26px;
   height: 26px;
-  border: var(--border-width-hairline) solid color-mix(in oklch, var(--foreground) 20%, var(--background));
   border-radius: var(--radius-pill);
   background: transparent;
 }

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -188,7 +188,6 @@
   text-align: center;
 }
 
-.maka-composer-mode-chip,
 .maka-composer-model-chip {
   height: 26px;
   display: inline-flex;
@@ -208,7 +207,6 @@
     border-color var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-composer-mode-chip:hover,
 .maka-composer-model-chip:hover {
   background: var(--state-hover-bg);
   color: var(--foreground);
@@ -219,70 +217,6 @@
   max-width: min(180px, 28vw);
 }
 
-/* PR-MOVE-PERMISSION-MODE (WAWQAQ 2026-06-23): permission-mode chip
-   in the composer left-controls + its dropdown menu. The chip reuses
-   the shared `.maka-composer-role-chip` / `.maka-composer-mode-chip`
-   geometry (h-24 pill, foreground-65 ink); only the menu styling
-   below is new. */
-.maka-composer-mode-chip {
-  font-variant-numeric: tabular-nums;
-}
-.maka-composer-mode-chip[data-tone="accent"] {
-  border-color: oklch(from var(--nav-active) l c h / 0.32);
-  color: var(--foreground-secondary);
-}
-.maka-composer-mode-chip[data-tone="destructive"] {
-  border-color: oklch(from var(--destructive) l c h / 0.32);
-  color: var(--destructive-text);
-}
-.maka-composer-mode-chip[data-tone="info"] {
-  border-color: oklch(from var(--info) l c h / 0.32);
-  color: var(--info-text);
-}
-.maka-composer-mode-chip[data-pending="true"] {
-  opacity: var(--opacity-muted);
-}
-.maka-composer-mode-chip:disabled {
-  cursor: not-allowed;
-  opacity: var(--opacity-disabled);
-}
-
-.maka-composer-mode-menu {
-  min-width: 280px;
-  padding: var(--space-1);
-  border-radius: var(--radius-surface);
-}
-.maka-composer-mode-menu [role="menuitem"] {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-2-5);
-  border-radius: var(--radius-control);
-}
-.maka-composer-mode-menu-item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-0-5);
-  min-width: 0;
-}
-.maka-composer-mode-menu-label {
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  color: var(--foreground);
-}
-.maka-composer-mode-menu-hint {
-  font-size: var(--font-size-caption);
-  color: var(--muted-foreground);
-  line-height: var(--leading-snug);
-  white-space: normal;
-}
-.maka-composer-mode-menu [data-active="true"] {
-  background: var(--state-selected-bg);
-}
-.maka-composer-mode-menu [data-active="true"] .maka-composer-mode-menu-label {
-  color: var(--foreground);
-}
 
 .maka-composer-right-controls .maka-model-switcher {
   margin: 0;

--- a/apps/desktop/src/renderer/styles/tool-output.css
+++ b/apps/desktop/src/renderer/styles/tool-output.css
@@ -357,13 +357,6 @@
   background: transparent;
 }
 
-.maka-composer-tool-button.maka-composer-mic-button {
-  width: 26px;
-  height: 26px;
-  border: 0;
-  background: transparent;
-}
-
 .maka-composer-tool-button:hover:not(:disabled) {
   color: var(--foreground);
   background: var(--state-hover-bg);
@@ -379,9 +372,3 @@
   cursor: not-allowed;
 }
 
-.maka-composer-tool-button.maka-composer-mic-button:disabled {
-  border: 0;
-  background: transparent;
-  color: var(--muted-foreground);
-  opacity: 1;
-}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -933,10 +933,9 @@ function ChatHeaderAlertBadge(props: { alert: ChatHeaderAlert }) {
 
 // PR-MOVE-PERMISSION-MODE: the chat-header `PermissionModeSwitcher`
 // radiogroup was deleted. Mode picking now lives inside the composer's
-// left-controls dropdown (see Composer + maka-composer-mode-chip / -menu)
-// so the picker sits where you actually start typing, matching the
-// reference product. The `radiogroup` keyboard contract was traded for
-// base-ui Menu's built-in arrow/Home/End handling.
+// left-controls as a Base UI Select (PermissionModeSelect), so the picker
+// sits where you actually start typing, matching the reference product.
+// Keyboard arrow/Home/End handling is delegated to the Select primitive.
 
 /**
  * Renders one conversational turn: user message → tools used → assistant

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -14,7 +14,7 @@ export type { ComposerHandle } from './composer.js';
 export {
   PERMISSION_MODE_META,
   PERMISSION_MODE_ORDER,
-  PermissionModeMenuPopup,
+  PermissionModeSelect,
 } from './permission-mode-menu.js';
 export type { PermissionModeMeta } from './permission-mode-menu.js';
 export { RelativeTime } from './relative-time.js';

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -29,7 +29,7 @@ import { Button as UiButton } from './ui.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { AttachmentFileCard } from './attachment-file-card.js';
 import { Kbd } from './primitives/kbd.js';
-import { PERMISSION_MODE_META, PermissionModeMenuPopup } from './permission-mode-menu.js';
+import { PermissionModeSelect } from './permission-mode-menu.js';
 import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from './primitives/menu.js';
 
 const COMPOSER_MAX_HEIGHT = 240;
@@ -590,54 +590,17 @@ export const Composer = forwardRef<
                 display because Deep Research sessions use it
                 internally but it's not a useful runtime toggle for
                 normal chat. */}
-            {props.onPermissionModeChange ? (() => {
-              const rawMode = props.permissionMode ?? 'ask';
-              const displayMode: PermissionMode = rawMode === 'explore' ? 'ask' : rawMode;
-              const meta = PERMISSION_MODE_META[displayMode];
-              const triggerDisabled = props.permissionModePending === true || Boolean(props.permissionModeDisabledReason);
-              return (
-                <Menu>
-                  {/* PR-COMPOSER-MODE-CHIP-PRIMITIVE-0 (round 15/30):
-                      LAST raw <button> in `components.tsx`. The
-                      permission mode chip (自动执行 ▾) is wrapped in
-                      a MenuTrigger render-prop. Kept the callback
-                      form (the menu library wants explicit
-                      triggerProps spread) but the button now flows
-                      through UiButton variant="quiet" size="nav" —
-                      the bespoke `.maka-composer-mode-chip` class
-                      still owns the chip's accent-tinted background,
-                      data-mode + data-tone state visuals, and tight
-                      composer-chrome density. */}
-                  <MenuTrigger
-                    render={(triggerProps) => (
-                      <UiButton
-                        {...triggerProps}
-                        variant="quiet"
-                        size="nav"
-                        type="button"
-                        className="maka-composer-mode-chip"
-                        data-mode={displayMode}
-                        data-tone={meta.tone}
-                        data-pending={props.permissionModePending ? 'true' : undefined}
-                        disabled={triggerDisabled}
-                        aria-label={`权限模式：${meta.label}`}
-                        title={props.permissionModeDisabledReason ?? meta.hint}
-                      >
-                        <span className="maka-composer-mode-chip-label">{meta.label}</span>
-                        <ChevronDown size={12} strokeWidth={1.8} aria-hidden="true" />
-                      </UiButton>
-                    )}
-                  />
-                  <PermissionModeMenuPopup
-                    activeMode={displayMode}
-                    onSelect={(mode) => {
-                      void props.onPermissionModeChange?.(mode);
-                    }}
-                    align="start"
-                  />
-                </Menu>
-              );
-            })() : null}
+            {props.onPermissionModeChange ? (
+              <PermissionModeSelect
+                activeMode={props.permissionMode ?? 'ask'}
+                onSelect={(mode) => {
+                  void props.onPermissionModeChange?.(mode);
+                }}
+                align="start"
+                disabled={props.permissionModePending === true || Boolean(props.permissionModeDisabledReason)}
+                disabledReason={props.permissionModeDisabledReason}
+              />
+            ) : null}
           </div>
           <span className="maka-composer-status-slot">
             {props.disabled ? (

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from 'react';
-import { ArrowUp, Check, ChevronDown, FileEdit, FolderOpen, GitBranch, History, Mic, Plus } from './icons.js';
+import { ArrowUp, Check, ChevronDown, FileEdit, FolderOpen, GitBranch, History, Plus } from './icons.js';
 import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-model-switcher.js';
 import { type UiLocale, detectUiLocale } from './locale-helpers.js';
 import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js';
@@ -701,17 +701,6 @@ export const Composer = forwardRef<
                 ) : (
                   <ModelChipStatic label={modelChipLabel} onOpenSettings={props.onOpenModelSettings} />
                 )}
-                <UiButton
-                  variant="quiet"
-                  size="icon-sm"
-                  className="maka-composer-tool-button maka-composer-mic-button"
-                  type="button"
-                  disabled
-                  aria-label="语音输入暂未启用"
-                  title="语音输入暂未启用"
-                >
-                  <Mic size={14} strokeWidth={1.75} aria-hidden="true" />
-                </UiButton>
               </>
             )}
             {props.streaming ? (

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -1,7 +1,14 @@
-import { Check } from './icons.js';
 import type { ChatDefaultPermissionMode, PermissionMode } from '@maka/core';
 import { CHAT_DEFAULT_PERMISSION_MODES } from '@maka/core';
-import { MenuItem, MenuPopup } from './primitives/menu.js';
+import {
+  SelectItem,
+  SelectPopup,
+  SelectPortal,
+  SelectPositioner,
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+} from './ui.js';
 
 export interface PermissionModeMeta {
   label: string;
@@ -20,9 +27,9 @@ export interface PermissionModeMeta {
  * Labels follow WAWQAQ's a667cf6c renaming — direct, action-led copy
  * instead of engineering shorthand.
  *
- * This module is the ONE home for the mode table and the shared popup —
- * both the composer picker and Settings → 通用 → 默认权限模式 render
- * from it, so labels/hints/markup can't drift between the two surfaces.
+ * This module is the ONE home for the mode table and the shared picker —
+ * both the composer and Settings → 通用 → 默认权限模式 render from it, so
+ * labels/hints/markup can't drift between the two surfaces.
  */
 export const PERMISSION_MODE_META: Record<PermissionMode, PermissionModeMeta> = {
   explore: {
@@ -53,39 +60,64 @@ export const PERMISSION_MODE_META: Record<PermissionMode, PermissionModeMeta> = 
 export const PERMISSION_MODE_ORDER: readonly ChatDefaultPermissionMode[] = CHAT_DEFAULT_PERMISSION_MODES;
 
 /**
- * The shared popup body: every option renders its label AND full hint up
- * front, so the user never has to select a mode to learn what it does.
- * Callers own the trigger (composer: tinted chip; Settings: outline
- * select-style button) and pass their active mode + select handler.
+ * The shared permission-mode picker, built on Base UI Select — the
+ * semantically correct primitive for a single-value choice (the earlier
+ * Menu + hand-styled "chip" trigger was a category error: Menu is for
+ * actions, and the bespoke chip CSS existed to compensate). Both the
+ * composer and Settings → 通用 → 默认权限模式 render this, so labels,
+ * hints, and markup can't drift. Every option shows its label AND full
+ * hint in the popup so the user never has to select a mode to learn what
+ * it does; the selected option carries the standard Select check indicator.
+ *
+ * `explore` collapses to `ask` for display (Deep Research uses it
+ * internally; it's not a useful user toggle).
  */
-export function PermissionModeMenuPopup(props: {
+export function PermissionModeSelect(props: {
   activeMode: PermissionMode;
   onSelect(mode: ChatDefaultPermissionMode): void | Promise<void>;
   align?: 'start' | 'end';
+  disabled?: boolean;
+  disabledReason?: string;
+  ariaLabel?: string;
+  className?: string;
 }) {
+  const displayMode: PermissionMode = props.activeMode === 'explore' ? 'ask' : props.activeMode;
+  const meta = PERMISSION_MODE_META[displayMode];
   return (
-    <MenuPopup className="maka-composer-mode-menu" align={props.align ?? 'start'}>
-      {PERMISSION_MODE_ORDER.map((mode) => {
-        const optionMeta = PERMISSION_MODE_META[mode];
-        const active = mode === props.activeMode;
-        return (
-          <MenuItem
-            key={mode}
-            onClick={() => {
-              if (active) return;
-              void props.onSelect(mode);
-            }}
-            data-active={active}
-            data-tone={optionMeta.tone}
-          >
-            <div className="maka-composer-mode-menu-item">
-              <span className="maka-composer-mode-menu-label">{optionMeta.label}</span>
-              <span className="maka-composer-mode-menu-hint">{optionMeta.hint}</span>
-            </div>
-            {active ? <Check size={12} strokeWidth={2} aria-hidden="true" /> : null}
-          </MenuItem>
-        );
-      })}
-    </MenuPopup>
+    <SelectRoot
+      value={displayMode}
+      items={PERMISSION_MODE_ORDER.map((mode) => ({ value: mode, label: PERMISSION_MODE_META[mode].label }))}
+      disabled={props.disabled}
+      onValueChange={(value) => {
+        if (value !== null) void props.onSelect(value as ChatDefaultPermissionMode);
+      }}
+    >
+      <SelectTrigger
+        aria-label={props.ariaLabel ?? `权限模式：${meta.label}`}
+        title={props.disabledReason ?? meta.hint}
+        className={props.className}
+      >
+        <SelectValue>
+          {(value: string) => PERMISSION_MODE_META[value as PermissionMode]?.label ?? meta.label}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectPortal>
+        <SelectPositioner alignItemWithTrigger={false} align={props.align ?? 'start'} sideOffset={6}>
+          <SelectPopup className="min-w-[280px] max-w-[320px]">
+            {PERMISSION_MODE_ORDER.map((mode) => {
+              const optionMeta = PERMISSION_MODE_META[mode];
+              return (
+                <SelectItem key={mode} value={mode}>
+                  <span className="flex flex-col gap-0.5">
+                    <span className="text-sm font-medium text-foreground">{optionMeta.label}</span>
+                    <span className="text-xs leading-snug text-muted-foreground">{optionMeta.hint}</span>
+                  </span>
+                </SelectItem>
+              );
+            })}
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectPortal>
+    </SelectRoot>
   );
 }

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -119,6 +119,8 @@ const baseComposerProps: ComposerProps = {
   draftKey: 'storybook-chat-surface',
   onSend: noop,
   onStop: noop,
+  onPickAttachments: noop,
+  onAttachFilePaths: noop,
   modelLabel: 'Claude Sonnet 4.5',
   activeSession: session(),
   activeConnectionLabel: 'Anthropic',


### PR DESCRIPTION
## What
Composer toolbar follow-up to #546 (turn-chrome-redesign). Three commits:

- **Simpler toolbar chrome** — drop the dead mic button, flatten the send button (no gradient/sheen), and calm the container focus ring (parchment focus → accent recipe ring).
- **Permission picker → Base UI Select** — replace the Menu-based `PermissionModeMenuPopup` with a `PermissionModeSelect` (Select primitive). A single-value picker reads correctly as a Select, not a Menu.
- **Consolidated CSS + unified triggers + type scale** — move the triplicated `.maka-composer-inner` / textarea / placeholder CSS (maka-tokens `@layer components` / tool-output / reference-shell) into one source in `styles/composer.css` (exact computed cascade preserved; pinned by a new `composer-container-single-source-contract`). Unify the three picker triggers on one quiet-chip geometry. Correct the trigger type scale: caption (11px) is reserved for annotations, so picker triggers move to **ui (13px)** to match their dropdown items.

## Notes
- Removing tool-output's `::before { content: none }` reset (collateral from an old card recipe) restores the deliberate streaming top-sweep indicator in `chat-header.css` that it was silently overriding on specificity + import order.
- Type-scale fix covers: permission/model triggers, `.maka-model-switcher-value`, workspace + branch pickers. Annotation text (streaming/permission hints, dialog copy) stays at caption.
- Verified: 39 CSS contracts green (incl. the new one); Codex review PASS over 3 rounds (model-trigger child font, placeholder/textarea single-source contract coverage, stale story removed).

## Out of scope
- `.maka-composer[data-drag-active] .maka-composer-inner` is latent-dead (layered, beaten by the unlayered rest rule) — pre-existing, untouched.
