### PR TITLE
feat(cli): redesign tool-result and thinking rendering (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -395,6 +395,27 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(bodyIndex < expanded.findIndex((line) => line.includes('the answer')));
   });
 
+  test('replaces the streamed thinking entry when thinking_complete arrives after the reply', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'partial thought',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-1', text: 'the reply',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_complete', messageId: 'message-1', text: 'the complete thought',
+    }));
+
+    // No duplicate thinking entry; the streamed one is replaced in place.
+    assert.deepEqual(state.entries.map((entry) => entry.kind), ['thinking', 'assistant']);
+    assert.equal(
+      state.entries[0]?.kind === 'thinking' ? state.entries[0].text : '',
+      'the complete thought',
+    );
+  });
+
   test('keeps tool cards compact until the latest tool is expanded', () => {
     const state = createMakaPiTranscriptState();
     // `head-line` is first; the compact one-line summary shows only the last
@@ -568,6 +589,59 @@ describe('Maka Pi TUI transcript', () => {
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(expanded, /match-0/);
     assert.match(expanded, /match-11/);
+  });
+
+  test('summarizes Glob results as a file count and shows the list expanded', () => {
+    const state = createMakaPiTranscriptState();
+    const files = ['src/a.ts', 'src/b.ts', 'src/c.ts'];
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'glob-1',
+      toolName: 'Glob',
+      args: { pattern: '**/*.ts', cwd: 'packages' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'glob-1',
+      isError: false,
+      content: { kind: 'json', value: { files } },
+    }));
+
+    const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(compactLines.length, 3);
+    const compact = compactLines.join('\n');
+    assert.match(compact, /Tool Glob \*\*\/\*\.ts in packages done/);
+    assert.match(compact, /3 files \(Ctrl\+O\)/);
+    assert.doesNotMatch(compact, /src\/a\.ts/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /src\/a\.ts/);
+    assert.match(expanded, /src\/c\.ts/);
+  });
+
+  test('keeps generic JSON input and result summaries on a single line', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Frobnicate',
+      args: { alpha: 1, beta: 'two' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'json', value: { gamma: 3, delta: 'four' } },
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 200).map(stripAnsi);
+    // Never more than two card lines: multi-line JSON must not split the header.
+    assert.equal(lines.length, 3);
+    assert.match(lines[1] ?? '', /Tool Frobnicate input: \{"alpha":1,"beta":"two"\} done/);
+    assert.match(lines[2] ?? '', /\{"gamma":3,"delta":"four"\}/);
   });
 
   test('summarizes file_diff compactly and colors the expanded diff', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -11,6 +11,7 @@ import {
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
+  toggleLatestThinkingExpansion,
   toggleLatestToolExpansion,
 } from '../pi-transcript.js';
 
@@ -188,6 +189,7 @@ describe('Maka Pi TUI transcript', () => {
         turnId: 'turn-1',
         ts: 2,
         text: 'We decided to keep the TUI small.',
+        thinking: { text: 'recall the decision' },
         modelId: 'deepseek-v4-flash',
       },
       {
@@ -209,13 +211,15 @@ describe('Maka Pi TUI transcript', () => {
       },
     ] satisfies StoredMessage[]);
 
-    assert.deepEqual(state.entries.map((entry) => entry.kind), ['user', 'assistant', 'tool']);
+    // Stored thinking happened before the reply text, so it resumes above it.
+    assert.deepEqual(state.entries.map((entry) => entry.kind), ['user', 'thinking', 'assistant', 'tool']);
     assert.equal(state.entries[0]?.kind === 'user' ? state.entries[0].text : '', 'What did we decide?');
+    assert.equal(state.entries[1]?.kind === 'thinking' ? state.entries[1].text : '', 'recall the decision');
     assert.equal(
-      state.entries[1]?.kind === 'assistant' ? state.entries[1].text : '',
+      state.entries[2]?.kind === 'assistant' ? state.entries[2].text : '',
       'We decided to keep the TUI small.',
     );
-    assert.equal(state.entries[2]?.kind === 'tool' ? state.entries[2].output : '', 'README contents');
+    assert.equal(state.entries[3]?.kind === 'tool' ? state.entries[3].output : '', 'README contents');
   });
 
   test('renders every transcript line within the terminal width', () => {
@@ -350,6 +354,45 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(visibleLines.some((line) => line.includes('npm test')));
     assert.ok(visibleLines.some((line) => line.includes('y/Enter allow')));
     assert.ok(visibleLines.some((line) => line.includes('n/Esc deny')));
+  });
+
+  test('orders thinking entries by arrival, before text and around tools', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'plan ',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'first',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-1', toolName: 'Read', args: { path: 'a.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'tool-1', isError: false, content: { kind: 'text', text: 'ok' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-1', text: 'the answer',
+    }));
+
+    // Entries mirror event order: thinking, then the tool, then the reply.
+    assert.deepEqual(state.entries.map((entry) => entry.kind), ['thinking', 'tool', 'assistant']);
+    assert.equal(state.entries[0]?.kind === 'thinking' ? state.entries[0].text : '', 'plan first');
+
+    const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    const markerIndex = collapsed.findIndex((line) => line.includes('思考（Ctrl+T 展开）'));
+    const toolIndex = collapsed.findIndex((line) => line.includes('Tool Read'));
+    const answerIndex = collapsed.findIndex((line) => line.includes('the answer'));
+    assert.ok(markerIndex >= 0);
+    assert.ok(markerIndex < toolIndex);
+    assert.ok(toolIndex < answerIndex);
+    assert.equal(collapsed.some((line) => line.includes('plan first')), false);
+
+    assert.equal(toggleLatestThinkingExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    const bodyIndex = expanded.findIndex((line) => line.includes('plan first'));
+    assert.ok(bodyIndex >= 0);
+    assert.ok(bodyIndex < expanded.findIndex((line) => line.includes('the answer')));
   });
 
   test('keeps tool cards compact until the latest tool is expanded', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -621,6 +621,57 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /src\/c\.ts/);
   });
 
+  test('does not fabricate a Grep match count from an error-shaped result', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'grep-1', toolName: 'Grep', args: { pattern: 'TODO' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'grep-1',
+      isError: false,
+      content: { kind: 'json', value: { error: 'boom\nsecond line\nthird' } },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    // A 3-line error object must not be reported as "3 matches"; fall back to
+    // the generic first-line summary instead.
+    assert.doesNotMatch(compact, /\d+ matches/);
+    assert.match(compact, /"error":"boom/);
+  });
+
+  test('does not fabricate a Grep match count when matches is not an array', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'grep-1', toolName: 'Grep', args: { pattern: 'TODO' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'grep-1',
+      isError: false,
+      content: { kind: 'json', value: { matches: 'not-an-array' } },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.doesNotMatch(compact, /\d+ matches/);
+  });
+
+  test('does not fabricate a Glob file count when files is null', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'glob-1', toolName: 'Glob', args: { pattern: '**/*.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'glob-1',
+      isError: false,
+      content: { kind: 'json', value: { files: null } },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
+    assert.doesNotMatch(compact, /\d+ files/);
+  });
+
   test('keeps generic JSON input and result summaries on a single line', () => {
     const state = createMakaPiTranscriptState();
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -354,8 +354,8 @@ describe('Maka Pi TUI transcript', () => {
 
   test('keeps tool cards compact until the latest tool is expanded', () => {
     const state = createMakaPiTranscriptState();
-    // `head-line` is first; the compact tail (last ~5 lines) hides it while the
-    // trailing rows stay visible, and expanding reveals the full stdout.
+    // `head-line` is first; the compact one-line summary shows only the last
+    // non-empty line, and expanding reveals the full stdout.
     const stdout = `head-line\n${Array.from({ length: 30 }, (_, i) => `row-${i}`).join('\n')}`;
 
     applyMakaSessionEventToTranscript(state, event({
@@ -378,30 +378,94 @@ describe('Maka Pi TUI transcript', () => {
       },
     }));
 
-    const compact = renderMakaPiTranscript(state, {
-      title: 'Maka',
-      cwd: '/tmp/project',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-    }, 100).map(stripAnsi).join('\n');
+    const compactLines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
+    const compact = compactLines.join('\n');
 
-    assert.match(compact, /Tool Bash done/);
-    assert.match(compact, /\$ npm test/);
-    assert.match(compact, /row-29/);
-    assert.match(compact, /Ctrl\+O expand/);
+    // Compact cards are at most two lines (plus the leading blank separator).
+    assert.equal(compactLines.length, 3);
+    assert.match(compact, /Tool Bash \$ npm test done/);
+    assert.match(compact, /\(31 lines\) row-29 \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /head-line/);
 
     assert.equal(toggleLatestToolExpansion(state), true);
-    const expanded = renderMakaPiTranscript(state, {
-      title: 'Maka',
-      cwd: '/tmp/project',
-      model: 'deepseek-v4-flash',
-      connectionSlug: 'deepseek',
-      permissionMode: 'ask',
-    }, 100).map(stripAnsi).join('\n');
+    const expanded = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
 
     assert.match(expanded, /head-line/);
+    assert.match(expanded, /row-29/);
+  });
+
+  test('summarizes a failing Bash tool with exit code and last stderr line', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'npm test' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      isError: true,
+      content: {
+        kind: 'terminal',
+        cwd: '/repo',
+        cmd: 'npm test',
+        exitCode: 1,
+        stdout: 'some earlier output',
+        stderr: 'first error\nfinal error line\n',
+      },
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 120);
+    assert.equal(lines.length, 3);
+    const compact = lines.map(stripAnsi).join('\n');
+    assert.match(compact, /exit 1 final error line \(Ctrl\+O\)/);
+    // The exit code is red.
+    assert.match(lines.join('\n'), /\x1b\[31mexit 1\x1b\[39m/);
+  });
+
+  test('summarizes a silent successful command as (no output)', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'true' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'terminal', cwd: '/repo', cmd: 'true', exitCode: 0, stdout: '', stderr: '' },
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
+    assert.equal(lines.length, 3);
+    assert.match(lines.join('\n'), /\(no output\)/);
+    assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
+  });
+
+  test('shows the latest live output line while a tool is running', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      args: { command: 'npm run build' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'tool-1', seq: 1, stream: 'stdout', chunk: 'step one\n', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'tool-1', seq: 2, stream: 'stdout', chunk: 'step two\n', redacted: false,
+    }));
+
+    const lines = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi);
+    assert.equal(lines.length, 3);
+    const compact = lines.join('\n');
+    assert.match(compact, /Tool Bash \$ npm run build running/);
+    assert.match(compact, /step two \(Ctrl\+O\)/);
+    assert.doesNotMatch(compact, /step one/);
   });
 
   test('summarizes Read results as a line/byte count when compact and shows text expanded', () => {
@@ -421,9 +485,11 @@ describe('Maka Pi TUI transcript', () => {
       content: { kind: 'json', value: { content: fileText } },
     }));
 
-    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(compactLines.length, 3);
+    const compact = compactLines.join('\n');
     assert.match(compact, /src\/app\.ts offset 10 limit 20/);
-    assert.match(compact, /4 lines,/);
+    assert.match(compact, /4 lines, 59 bytes \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /content-line-0/);
 
     assert.equal(toggleLatestToolExpansion(state), true);
@@ -431,7 +497,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /content-line-0/);
   });
 
-  test('summarizes Grep results with a match-count truncation notice', () => {
+  test('summarizes Grep results as a match count and shows matches expanded', () => {
     const state = createMakaPiTranscriptState();
     const matches = Array.from({ length: 12 }, (_, i) => `match-${i}`);
 
@@ -448,15 +514,20 @@ describe('Maka Pi TUI transcript', () => {
       content: { kind: 'json', value: { matches } },
     }));
 
-    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    const compactLines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(compactLines.length, 3);
+    const compact = compactLines.join('\n');
     assert.match(compact, /TODO in packages glob \*\.ts/);
-    assert.match(compact, /match-0/);
-    assert.match(compact, /match-4/);
-    assert.doesNotMatch(compact, /match-5/);
-    assert.match(compact, /… \+7 more matches/);
+    assert.match(compact, /12 matches \(Ctrl\+O\)/);
+    assert.doesNotMatch(compact, /match-0/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /match-0/);
+    assert.match(expanded, /match-11/);
   });
 
-  test('colors file_diff results with add/del ANSI', () => {
+  test('summarizes file_diff compactly and colors the expanded diff', () => {
     const state = createMakaPiTranscriptState();
     const diff = ['--- a/file.ts', '+++ b/file.ts', '@@ -1 +1 @@', '-removed line', '+added line'].join('\n');
 
@@ -473,6 +544,16 @@ describe('Maka Pi TUI transcript', () => {
       content: { kind: 'file_diff', paths: ['file.ts'], diff },
     }));
 
+    const compactLines = renderMakaPiTranscript(state, meta(), 100);
+    assert.equal(compactLines.length, 3);
+    const compactRaw = compactLines.join('\n');
+    // Compact: `+1 -1 file.ts` with green add count and red delete count.
+    assert.match(compactLines.map(stripAnsi).join('\n'), /\+1 -1 file\.ts \(Ctrl\+O\)/);
+    assert.match(compactRaw, /\x1b\[32m\+1\x1b\[39m/);
+    assert.match(compactRaw, /\x1b\[31m-1\x1b\[39m/);
+    assert.doesNotMatch(compactLines.map(stripAnsi).join('\n'), /added line/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
     const raw = renderMakaPiTranscript(state, meta(), 100).join('\n');
     // Green (32) around the added line, red (31) around the removed line.
     assert.match(raw, /\x1b\[32m\+added line\x1b\[39m/);
@@ -494,8 +575,10 @@ describe('Maka Pi TUI transcript', () => {
       content: { kind: 'file_write', path: 'out.txt', bytes: 42 },
     }));
 
-    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /Wrote 42 bytes to out\.txt/);
+    const lines = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(lines.length, 3);
+    assert.match(lines.join('\n'), /wrote 42 bytes out\.txt/);
+    assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
 
   test('keeps earlier tools expanded when a later tool starts and finishes', () => {
@@ -553,6 +636,12 @@ describe('Maka Pi TUI transcript', () => {
       type: 'tool_output_delta', toolUseId: 'bash-1', seq: 3, stream: 'stderr', chunk: 'secret', redacted: true,
     }));
 
+    // Compact: the latest live line is the redaction marker, never the secret.
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /\[redacted\]/);
+    assert.doesNotMatch(compact, /secret/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.ok(rendered.indexOf('FIRST') < rendered.indexOf('SECOND'));
     assert.doesNotMatch(rendered, /DUPLICATE/);

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -354,7 +354,9 @@ describe('Maka Pi TUI transcript', () => {
 
   test('keeps tool cards compact until the latest tool is expanded', () => {
     const state = createMakaPiTranscriptState();
-    const longStdout = `${'x'.repeat(900)}\nexpanded-tail`;
+    // `head-line` is first; the compact tail (last ~5 lines) hides it while the
+    // trailing rows stay visible, and expanding reveals the full stdout.
+    const stdout = `head-line\n${Array.from({ length: 30 }, (_, i) => `row-${i}`).join('\n')}`;
 
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start',
@@ -371,7 +373,7 @@ describe('Maka Pi TUI transcript', () => {
         cwd: '/repo',
         cmd: 'npm test',
         exitCode: 0,
-        stdout: longStdout,
+        stdout,
         stderr: '',
       },
     }));
@@ -385,9 +387,10 @@ describe('Maka Pi TUI transcript', () => {
     }, 100).map(stripAnsi).join('\n');
 
     assert.match(compact, /Tool Bash done/);
-    assert.match(compact, /command: npm test/);
+    assert.match(compact, /\$ npm test/);
+    assert.match(compact, /row-29/);
     assert.match(compact, /Ctrl\+O expand/);
-    assert.doesNotMatch(compact, /expanded-tail/);
+    assert.doesNotMatch(compact, /head-line/);
 
     assert.equal(toggleLatestToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, {
@@ -398,9 +401,176 @@ describe('Maka Pi TUI transcript', () => {
       permissionMode: 'ask',
     }, 100).map(stripAnsi).join('\n');
 
-    assert.match(expanded, /expanded-tail/);
+    assert.match(expanded, /head-line/);
+  });
+
+  test('summarizes Read results as a line/byte count when compact and shows text expanded', () => {
+    const state = createMakaPiTranscriptState();
+    const fileText = Array.from({ length: 4 }, (_, i) => `content-line-${i}`).join('\n');
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'read-1',
+      toolName: 'Read',
+      args: { path: 'src/app.ts', offset: 10, limit: 20 },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'read-1',
+      isError: false,
+      content: { kind: 'json', value: { content: fileText } },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /src\/app\.ts offset 10 limit 20/);
+    assert.match(compact, /4 lines,/);
+    assert.doesNotMatch(compact, /content-line-0/);
+
+    assert.equal(toggleLatestToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /content-line-0/);
+  });
+
+  test('summarizes Grep results with a match-count truncation notice', () => {
+    const state = createMakaPiTranscriptState();
+    const matches = Array.from({ length: 12 }, (_, i) => `match-${i}`);
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'grep-1',
+      toolName: 'Grep',
+      args: { pattern: 'TODO', path: 'packages', glob: '*.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'grep-1',
+      isError: false,
+      content: { kind: 'json', value: { matches } },
+    }));
+
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /TODO in packages glob \*\.ts/);
+    assert.match(compact, /match-0/);
+    assert.match(compact, /match-4/);
+    assert.doesNotMatch(compact, /match-5/);
+    assert.match(compact, /… \+7 more matches/);
+  });
+
+  test('colors file_diff results with add/del ANSI', () => {
+    const state = createMakaPiTranscriptState();
+    const diff = ['--- a/file.ts', '+++ b/file.ts', '@@ -1 +1 @@', '-removed line', '+added line'].join('\n');
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'edit-1',
+      toolName: 'Edit',
+      args: { path: 'file.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'edit-1',
+      isError: false,
+      content: { kind: 'file_diff', paths: ['file.ts'], diff },
+    }));
+
+    const raw = renderMakaPiTranscript(state, meta(), 100).join('\n');
+    // Green (32) around the added line, red (31) around the removed line.
+    assert.match(raw, /\x1b\[32m\+added line\x1b\[39m/);
+    assert.match(raw, /\x1b\[31m-removed line\x1b\[39m/);
+  });
+
+  test('renders file_write results as a byte summary', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'write-1',
+      toolName: 'Write',
+      args: { path: 'out.txt' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'write-1',
+      isError: false,
+      content: { kind: 'file_write', path: 'out.txt', bytes: 42 },
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Wrote 42 bytes to out\.txt/);
+  });
+
+  test('keeps earlier tools expanded when a later tool starts and finishes', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-a', toolName: 'Read', args: { path: 'a.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-a',
+      isError: false,
+      content: { kind: 'json', value: { content: 'alpha-body-line' } },
+    }));
+
+    // Expand tool A (the latest tool).
+    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.ok(state.expandedToolUseIds.has('tool-a'));
+
+    // A later tool starts and finishes in a subsequent turn.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'tool-b', toolName: 'Read', args: { path: 'b.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-b',
+      isError: false,
+      content: { kind: 'json', value: { content: 'beta-body-line' } },
+    }));
+
+    // Tool A stays expanded; tool B is still compact.
+    assert.ok(state.expandedToolUseIds.has('tool-a'));
+    assert.equal(state.expandedToolUseIds.has('tool-b'), false);
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /alpha-body-line/);
+    assert.doesNotMatch(rendered, /beta-body-line/);
+  });
+
+  test('orders and de-dupes tool_output_delta by seq and marks redacted chunks', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-1', toolName: 'Bash', args: { command: 'run' },
+    }));
+    // Out-of-order + duplicate seq + a redacted chunk.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'bash-1', seq: 2, stream: 'stdout', chunk: 'SECOND', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'bash-1', seq: 1, stream: 'stdout', chunk: 'FIRST', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'bash-1', seq: 1, stream: 'stdout', chunk: 'DUPLICATE', redacted: false,
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_output_delta', toolUseId: 'bash-1', seq: 3, stream: 'stderr', chunk: 'secret', redacted: true,
+    }));
+
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.ok(rendered.indexOf('FIRST') < rendered.indexOf('SECOND'));
+    assert.doesNotMatch(rendered, /DUPLICATE/);
+    assert.doesNotMatch(rendered, /secret/);
+    assert.match(rendered, /\[redacted\]/);
+    assert.match(rendered, /\[stderr\]/);
   });
 });
+
+function meta() {
+  return {
+    title: 'Maka',
+    cwd: '/tmp/project',
+    model: 'deepseek-v4-flash',
+    connectionSlug: 'deepseek',
+    permissionMode: 'ask',
+  } as const;
+}
 
 class RecordingDriver {
   readonly prompts: string[] = [];

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -11,8 +11,8 @@ import {
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
-  toggleLatestThinkingExpansion,
-  toggleLatestToolExpansion,
+  toggleAllThinkingExpansion,
+  toggleAllToolExpansion,
 } from '../pi-transcript.js';
 
 describe('Maka Pi TUI transcript', () => {
@@ -388,7 +388,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(toolIndex < answerIndex);
     assert.equal(collapsed.some((line) => line.includes('plan first')), false);
 
-    assert.equal(toggleLatestThinkingExpansion(state), true);
+    assert.equal(toggleAllThinkingExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
     const bodyIndex = expanded.findIndex((line) => line.includes('plan first'));
     assert.ok(bodyIndex >= 0);
@@ -451,7 +451,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /\(31 lines\) row-29 \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /head-line/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 120).map(stripAnsi).join('\n');
 
     assert.match(expanded, /head-line/);
@@ -556,7 +556,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /4 lines, 59 bytes \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /content-line-0/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(expanded, /content-line-0/);
   });
@@ -585,7 +585,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /12 matches \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /match-0/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(expanded, /match-0/);
     assert.match(expanded, /match-11/);
@@ -615,7 +615,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /3 files \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /src\/a\.ts/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.match(expanded, /src\/a\.ts/);
     assert.match(expanded, /src\/c\.ts/);
@@ -670,7 +670,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compactRaw, /\x1b\[31m-1\x1b\[39m/);
     assert.doesNotMatch(compactLines.map(stripAnsi).join('\n'), /added line/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const raw = renderMakaPiTranscript(state, meta(), 100).join('\n');
     // Green (32) around the added line, red (31) around the removed line.
     assert.match(raw, /\x1b\[32m\+added line\x1b\[39m/);
@@ -698,7 +698,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(lines.join('\n'), /\(Ctrl\+O\)/);
   });
 
-  test('keeps earlier tools expanded when a later tool starts and finishes', () => {
+  test('expands and collapses every tool card with one global toggle', () => {
     const state = createMakaPiTranscriptState();
 
     applyMakaSessionEventToTranscript(state, event({
@@ -710,12 +710,6 @@ describe('Maka Pi TUI transcript', () => {
       isError: false,
       content: { kind: 'json', value: { content: 'alpha-body-line' } },
     }));
-
-    // Expand tool A (the latest tool).
-    assert.equal(toggleLatestToolExpansion(state), true);
-    assert.ok(state.expandedToolUseIds.has('tool-a'));
-
-    // A later tool starts and finishes in a subsequent turn.
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'tool-b', toolName: 'Read', args: { path: 'b.ts' },
     }));
@@ -726,12 +720,63 @@ describe('Maka Pi TUI transcript', () => {
       content: { kind: 'json', value: { content: 'beta-body-line' } },
     }));
 
-    // Tool A stays expanded; tool B is still compact.
-    assert.ok(state.expandedToolUseIds.has('tool-a'));
-    assert.equal(state.expandedToolUseIds.has('tool-b'), false);
-    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(rendered, /alpha-body-line/);
-    assert.doesNotMatch(rendered, /beta-body-line/);
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(compact, /alpha-body-line/);
+    assert.doesNotMatch(compact, /beta-body-line/);
+
+    // One press expands every tool card.
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /alpha-body-line/);
+    assert.match(expanded, /beta-body-line/);
+
+    // A second press collapses every tool card again.
+    assert.equal(toggleAllToolExpansion(state), true);
+    const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.doesNotMatch(collapsed, /alpha-body-line/);
+    assert.doesNotMatch(collapsed, /beta-body-line/);
+  });
+
+  test('expands and collapses every thinking entry with one global toggle', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'first thought body',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-1', text: 'first reply',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-2', text: 'second thought body',
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta', messageId: 'message-2', text: 'second reply',
+    }));
+
+    const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(collapsed.filter((line) => line.includes('思考（Ctrl+T 展开）')).length, 2);
+    assert.equal(collapsed.some((line) => line.includes('thought body')), false);
+
+    // One press expands every thinking entry.
+    assert.equal(toggleAllThinkingExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /first thought body/);
+    assert.match(expanded, /second thought body/);
+
+    // A second press collapses every thinking entry again.
+    assert.equal(toggleAllThinkingExpansion(state), true);
+    const recollapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi);
+    assert.equal(recollapsed.filter((line) => line.includes('思考（Ctrl+T 展开）')).length, 2);
+    assert.equal(recollapsed.some((line) => line.includes('thought body')), false);
+  });
+
+  test('global toggles report false when the transcript has no matching entries', () => {
+    const state = createMakaPiTranscriptState();
+    appendUserPrompt(state, 'hello');
+    assert.equal(toggleAllToolExpansion(state), false);
+    assert.equal(toggleAllThinkingExpansion(state), false);
+    assert.equal(state.expandAllTools, false);
+    assert.equal(state.expandAllThinking, false);
   });
 
   test('orders and de-dupes tool_output_delta by seq and marks redacted chunks', () => {
@@ -758,7 +803,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /\[redacted\]/);
     assert.doesNotMatch(compact, /secret/);
 
-    assert.equal(toggleLatestToolExpansion(state), true);
+    assert.equal(toggleAllToolExpansion(state), true);
     const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
     assert.ok(rendered.indexOf('FIRST') < rendered.indexOf('SECOND'));
     assert.doesNotMatch(rendered, /DUPLICATE/);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -151,6 +151,82 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ToolOutputDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('(Ctrl+O)'));
+
+    // Kitty keyboard protocol terminals (Ghostty/Kitty) send one event for the
+    // key press and another for the release. The release must not undo the
+    // toggle, or expansion only lasts while the key is physically held.
+    terminal.input('\x1b[111;5u');
+    terminal.input('\x1b[111;5:3u');
+
+    // The compact-only (Ctrl+O) hint leaving the screen proves the card is
+    // still expanded after the release event.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('(Ctrl+O)'));
+    await delay(20);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('(Ctrl+O)'), false);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('does not treat a kitty Escape press+release as a double Escape', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new InterruptibleTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    // One physical Esc keypress arrives as a press + release pair under the
+    // kitty protocol; it must count as a single Escape, not an interrupt.
+    terminal.input('\x1b[27u');
+    terminal.input('\x1b[27;1:3u');
+    await delay(20);
+    assert.equal(driver.stopCalls, 0);
+
+    // A real second press still interrupts the running turn.
+    terminal.input('\x1b[27u');
+    await waitFor(() => driver.stopCalls === 1);
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('toggles thinking visibility with Ctrl-T', async () => {
     const terminal = new FakeTerminal();
     const driver = new ThinkingOutputDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -136,7 +136,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('n');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Ctrl+O expand'));
+    await waitFor(() => terminal.output().includes('(Ctrl+O)'));
     assert.equal(terminal.output().includes('expanded-tail'), false);
 
     terminal.input('\x0f');

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -118,7 +118,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('toggles the latest tool detail with Ctrl-O', async () => {
+  test('toggles tool detail globally with Ctrl-O', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
     const run = runMakaPiTui({

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1752,7 +1752,9 @@ class ToolOutputDriver implements MakaSessionDriver {
         cwd: '/repo',
         cmd: 'npm test',
         exitCode: 0,
-        stdout: `${'x'.repeat(900)}\nexpanded-tail`,
+        // `expanded-tail` is the FIRST line, so the compact tail (last ~5 lines)
+        // hides it; expanding reveals the full output including this head line.
+        stdout: `expanded-tail\n${Array.from({ length: 30 }, (_, i) => `row-${i}`).join('\n')}`,
         stderr: '',
       },
     };

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -711,16 +711,20 @@ function compactDiffSummary(
   };
 }
 
-/** Row count for list-shaped json results (Grep `matches`, Glob `files`). */
+/**
+ * Row count for list-shaped json results (Grep `matches`, Glob `files`).
+ * Returns a count only when the keyed field is genuinely an array; an
+ * error-shaped result (e.g. `{ error: "..." }`) returns undefined so the
+ * caller falls back to a generic first-line summary rather than reporting a
+ * fabricated "N matches" / "N files" from an unrelated line count.
+ */
 function jsonArrayCount(entry: MakaPiToolEntry, key: string): number | undefined {
   const result = entry.result;
   if (result?.kind === 'json' && result.value !== null && typeof result.value === 'object') {
     const rows = (result.value as Record<string, unknown>)[key];
     if (Array.isArray(rows)) return rows.length;
   }
-  const text = plainResultText(entry);
-  if (!text) return undefined;
-  return text.split('\n').filter((line) => line.trim()).length;
+  return undefined;
 }
 
 /** Latest non-empty output line from live deltas (redaction-aware), else progress. */

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -24,12 +24,13 @@ export interface MakaPiTranscriptState {
   sawTextDeltaMessageIds: Set<string>;
   pendingPermission?: PermissionRequestEvent;
   /**
-   * Per-tool expansion state, keyed by toolUseId. Ctrl+O toggles the latest
-   * tool, but earlier tools stay expanded across later turns within a session.
-   * In-memory only; never persisted to storage. Resume starts empty.
+   * Global expansion toggles: one Ctrl+O press expands every tool card in the
+   * transcript, one Ctrl+T press expands every thinking entry; pressing again
+   * collapses all. In-memory only; never persisted to storage. Resume resets
+   * both to collapsed.
    */
-  expandedToolUseIds: Set<string>;
-  expandedThinkingMessageId?: string;
+  expandAllTools: boolean;
+  expandAllThinking: boolean;
 }
 
 /** A single live output chunk from a `tool_output_delta` event. */
@@ -77,7 +78,8 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
   return {
     entries: [],
     sawTextDeltaMessageIds: new Set(),
-    expandedToolUseIds: new Set(),
+    expandAllTools: false,
+    expandAllThinking: false,
   };
 }
 
@@ -97,34 +99,25 @@ export function replaceTranscriptWithStoredMessages(
       .map((entry) => entry.messageId),
   );
   state.pendingPermission = undefined;
-  state.expandedToolUseIds = new Set();
-  state.expandedThinkingMessageId = undefined;
+  state.expandAllTools = false;
+  state.expandAllThinking = false;
 }
 
-export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean {
-  const latestTool = [...state.entries]
-    .reverse()
-    .find((entry): entry is MakaPiToolEntry => entry.kind === 'tool');
-  if (!latestTool) return false;
-  if (state.expandedToolUseIds.has(latestTool.toolUseId)) {
-    state.expandedToolUseIds.delete(latestTool.toolUseId);
-  } else {
-    state.expandedToolUseIds.add(latestTool.toolUseId);
-  }
+/** Toggle expansion of every tool card at once; false when there is none. */
+export function toggleAllToolExpansion(state: MakaPiTranscriptState): boolean {
+  const hasTool = state.entries.some((entry) => entry.kind === 'tool');
+  if (!hasTool) return false;
+  state.expandAllTools = !state.expandAllTools;
   return true;
 }
 
-export function toggleLatestThinkingExpansion(state: MakaPiTranscriptState): boolean {
-  const latestThinking = [...state.entries]
-    .reverse()
-    .find(
-      (entry): entry is MakaPiThinkingEntry =>
-        entry.kind === 'thinking' && Boolean(entry.text.trim()),
-    );
-  if (!latestThinking) return false;
-  state.expandedThinkingMessageId = state.expandedThinkingMessageId === latestThinking.messageId
-    ? undefined
-    : latestThinking.messageId;
+/** Toggle expansion of every thinking entry at once; false when there is none. */
+export function toggleAllThinkingExpansion(state: MakaPiTranscriptState): boolean {
+  const hasThinking = state.entries.some(
+    (entry) => entry.kind === 'thinking' && Boolean(entry.text.trim()),
+  );
+  if (!hasThinking) return false;
+  state.expandAllThinking = !state.expandAllThinking;
   return true;
 }
 
@@ -475,10 +468,10 @@ export function renderMakaPiTranscript(
         lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.accent }));
         break;
       case 'thinking':
-        lines.push(...renderThinkingBlock(entry, safeWidth, state.expandedThinkingMessageId === entry.messageId));
+        lines.push(...renderThinkingBlock(entry, safeWidth, state.expandAllThinking));
         break;
       case 'tool':
-        lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseIds.has(entry.toolUseId)));
+        lines.push(...renderToolBlock(entry, safeWidth, state.expandAllTools));
         break;
       case 'notice':
         lines.push(...renderNotice(entry, safeWidth));
@@ -535,7 +528,7 @@ function setThinking(state: MakaPiTranscriptState, messageId: string, text: stri
 }
 
 // Thinking stays collapsed to a one-line marker by default so reasoning
-// never floods the scrollback; Ctrl+T expands the latest block on demand.
+// never floods the scrollback; Ctrl+T expands every thinking entry on demand.
 function renderThinkingBlock(entry: MakaPiThinkingEntry, width: number, expanded: boolean): string[] {
   if (!entry.text.trim()) return [];
   if (!expanded) return [fitLine(ansi.dim('思考（Ctrl+T 展开）'), width)];

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -17,7 +17,7 @@ import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
 import { ansi } from './tui-ansi.js';
-import { colorDiff } from './tui-diff.js';
+import { colorDiff, diffLineKind } from './tui-diff.js';
 
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
@@ -565,55 +565,172 @@ function renderTextBlock(
   return lines;
 }
 
-interface RenderedToolPart {
-  lines: string[];
-  /** True when compact rendering hides detail that expanding would reveal. */
-  truncated: boolean;
+function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded: boolean): string[] {
+  return expanded ? renderExpandedToolBlock(entry, width) : renderCompactToolBlock(entry, width);
 }
 
-function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded: boolean): string[] {
+function toolStatusText(entry: MakaPiToolEntry): string {
   const status = entry.status === 'running'
     ? ansi.yellow('running')
     : entry.status === 'error'
       ? ansi.red('error')
       : ansi.green('done');
   const duration = entry.durationMs === undefined ? '' : ansi.dim(` ${entry.durationMs}ms`);
-  const lines = [
-    fitLine(`${ansi.yellow('Tool')} ${entry.title ?? entry.toolName} ${status}${duration}`, width),
-  ];
-  let truncated = false;
+  return `${status}${duration}`;
+}
 
+/**
+ * Compact tool card: at most two lines. Line 1 carries the tool name, an
+ * inline dim input summary, and status; line 2 is a one-line result summary
+ * with a dim `(Ctrl+O)` hint when expanding would reveal more.
+ */
+function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[] {
+  const inputSummary = toolInputSummary(entry);
+  const header = `${ansi.yellow('Tool')} ${entry.title ?? entry.toolName}`
+    + `${inputSummary ? ` ${ansi.dim(inputSummary)}` : ''} ${toolStatusText(entry)}`;
+  const lines = [fitLine(header, width)];
+  const summary = compactToolSummary(entry, width);
+  if (summary) {
+    const hint = summary.expandable ? ansi.dim(' (Ctrl+O)') : '';
+    lines.push(fitLine(`  ${summary.text}${hint}`, width));
+  }
+  return lines;
+}
+
+function renderExpandedToolBlock(entry: MakaPiToolEntry, width: number): string[] {
+  const lines = [
+    fitLine(`${ansi.yellow('Tool')} ${entry.title ?? entry.toolName} ${toolStatusText(entry)}`, width),
+  ];
   const inputSummary = toolInputSummary(entry);
   if (inputSummary) lines.push(...renderIndented(inputSummary, width, 2).map(ansi.dim));
-
   if (entry.progress.length > 0) {
-    const progress = renderToolText(entry.progress.join(''), width, expanded);
-    lines.push(...progress.lines.map(ansi.dim));
-    truncated = truncated || progress.truncated;
+    lines.push(...renderToolText(entry.progress.join(''), width).map(ansi.dim));
   }
-
-  const streams = renderToolStreams(entry.outputDeltas, width, expanded);
-  lines.push(...streams.lines);
-  truncated = truncated || streams.truncated;
-
+  lines.push(...renderToolStreams(entry.outputDeltas, width));
   if (entry.result || entry.output) {
-    const result = renderToolResult(entry, width, expanded);
-    lines.push(...result.lines);
-    truncated = truncated || result.truncated;
-  }
-
-  if (!expanded && truncated) {
-    lines.push(fitLine(ansi.dim('Ctrl+O expand'), width));
+    lines.push(...renderToolResult(entry, width));
   }
   return lines.map((line) => fitLine(line, width));
 }
 
-function renderToolText(text: string, width: number, expanded: boolean): RenderedToolPart {
-  const limit = expanded ? 12_000 : 600;
+interface CompactToolSummary {
+  text: string;
+  /** True when expanding would reveal more than this one-line summary. */
+  expandable: boolean;
+}
+
+function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolSummary | undefined {
+  const hasLiveOutput = entry.outputDeltas.length > 0 || entry.progress.length > 0;
+  if (entry.status === 'running' && hasLiveOutput) {
+    const live = latestLiveOutputLine(entry);
+    if (live) return { text: live, expandable: true };
+  }
+
+  const result = entry.result;
+  if (result?.kind === 'terminal') return compactTerminalSummary(result, hasLiveOutput);
+  if (result?.kind === 'file_diff') return compactDiffSummary(result);
+  if (result?.kind === 'file_write') {
+    return { text: `wrote ${result.bytes} bytes ${result.path}`, expandable: hasLiveOutput };
+  }
+
+  if (entry.toolName === 'Grep') {
+    const count = grepMatchCount(entry);
+    if (count !== undefined) {
+      return {
+        text: `${count} match${count === 1 ? '' : 'es'}`,
+        expandable: count > 0 || hasLiveOutput,
+      };
+    }
+  }
+
+  const text = plainResultText(entry);
+  if (!text) return undefined;
+  if (entry.toolName === 'Read') {
+    const lineCount = text.split('\n').length;
+    return {
+      text: `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`,
+      expandable: true,
+    };
+  }
+  const firstLine = text.split('\n', 1)[0] ?? '';
   return {
-    lines: renderIndented(limitText(text, limit), width, 2),
-    truncated: !expanded && text.length > limit,
+    text: firstLine,
+    expandable: text.includes('\n') || hasLiveOutput || firstLine.length + 2 > width,
   };
+}
+
+function compactTerminalSummary(
+  content: Extract<ToolResultContent, { kind: 'terminal' }>,
+  hasLiveOutput: boolean,
+): CompactToolSummary {
+  const hasOutput = Boolean(content.stdout || content.stderr);
+  if (content.exitCode !== 0) {
+    const stderrLine = lastNonEmptyLine(content.stderr);
+    const exit = ansi.red(`exit ${content.exitCode}`);
+    return {
+      text: stderrLine ? `${exit} ${stderrLine}` : exit,
+      expandable: hasOutput || hasLiveOutput,
+    };
+  }
+  const combined = [content.stdout, content.stderr].filter(Boolean).join('\n').replace(/\n+$/, '');
+  if (!combined) return { text: ansi.dim('(no output)'), expandable: hasLiveOutput };
+  const totalLines = combined.split('\n').length;
+  const prefix = totalLines > 1 ? ansi.dim(`(${totalLines} lines) `) : '';
+  return {
+    text: `${prefix}${lastNonEmptyLine(combined)}`,
+    expandable: totalLines > 1 || hasLiveOutput,
+  };
+}
+
+function compactDiffSummary(
+  content: Extract<ToolResultContent, { kind: 'file_diff' }>,
+): CompactToolSummary {
+  let adds = 0;
+  let dels = 0;
+  for (const line of content.diff.split('\n')) {
+    const kind = diffLineKind(line);
+    if (kind === 'add') adds += 1;
+    else if (kind === 'del') dels += 1;
+  }
+  const path = content.paths[0];
+  return {
+    text: `${ansi.green(`+${adds}`)} ${ansi.red(`-${dels}`)}${path ? ` ${path}` : ''}`,
+    expandable: true,
+  };
+}
+
+function grepMatchCount(entry: MakaPiToolEntry): number | undefined {
+  const result = entry.result;
+  if (result?.kind === 'json' && result.value !== null && typeof result.value === 'object') {
+    const matches = (result.value as { matches?: unknown }).matches;
+    if (Array.isArray(matches)) return matches.length;
+  }
+  const text = plainResultText(entry);
+  if (!text) return undefined;
+  return text.split('\n').filter((line) => line.trim()).length;
+}
+
+/** Latest non-empty output line from live deltas (redaction-aware), else progress. */
+function latestLiveOutputLine(entry: MakaPiToolEntry): string {
+  const groups = groupOutputDeltas(entry.outputDeltas);
+  if (groups.length > 0) {
+    const fromDeltas = lastNonEmptyLine(groups.map((group) => group.text).join('\n'));
+    if (fromDeltas) return fromDeltas;
+  }
+  return lastNonEmptyLine(entry.progress.join(''));
+}
+
+function lastNonEmptyLine(text: string): string {
+  const lines = text.split('\n');
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (line && line.trim()) return line;
+  }
+  return '';
+}
+
+function renderToolText(text: string, width: number): string[] {
+  return renderIndented(limitText(text, 12_000), width, 2);
 }
 
 /**
@@ -622,22 +739,13 @@ function renderToolText(text: string, width: number, expanded: boolean): Rendere
  * same-stream chunks are grouped under a single dim `[stream]` label, and any
  * redacted chunk shows a `[redacted]` marker instead of its raw content.
  */
-function renderToolStreams(
-  deltas: readonly MakaPiToolOutputDelta[],
-  width: number,
-  expanded: boolean,
-): RenderedToolPart {
-  const groups = groupOutputDeltas(deltas);
-  if (groups.length === 0) return { lines: [], truncated: false };
+function renderToolStreams(deltas: readonly MakaPiToolOutputDelta[], width: number): string[] {
   const lines: string[] = [];
-  let truncated = false;
-  for (const group of groups) {
+  for (const group of groupOutputDeltas(deltas)) {
     lines.push(fitLine(ansi.dim(`[${group.stream}]`), width));
-    const body = renderToolText(group.text, width, expanded);
-    lines.push(...body.lines.map(ansi.dim));
-    truncated = truncated || body.truncated;
+    lines.push(...renderToolText(group.text, width).map(ansi.dim));
   }
-  return { lines, truncated };
+  return lines;
 }
 
 function groupOutputDeltas(
@@ -661,18 +769,14 @@ function groupOutputDeltas(
   return groups;
 }
 
-function renderToolResult(entry: MakaPiToolEntry, width: number, expanded: boolean): RenderedToolPart {
+function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
   const result = entry.result;
-  if (result?.kind === 'terminal') return renderTerminalResult(result, width, expanded);
-  if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width, expanded);
+  if (result?.kind === 'terminal') return renderTerminalResult(result, width);
+  if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width);
   if (result?.kind === 'file_write') {
-    return { lines: renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2), truncated: false };
+    return renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2);
   }
-
-  const text = plainResultText(entry);
-  if (entry.toolName === 'Read') return renderReadResult(text, width, expanded);
-  if (entry.toolName === 'Grep') return renderGrepResult(text, width, expanded);
-  return renderToolText(text, width, expanded);
+  return renderToolText(plainResultText(entry), width);
 }
 
 /** Best-effort extraction of the human-readable body from a tool result. */
@@ -695,78 +799,23 @@ function plainResultText(entry: MakaPiToolEntry): string {
 function renderTerminalResult(
   content: Extract<ToolResultContent, { kind: 'terminal' }>,
   width: number,
-  expanded: boolean,
-): RenderedToolPart {
+): string[] {
   const lines: string[] = [];
-  let truncated = false;
   if (content.exitCode !== 0) {
     lines.push(...renderIndented(ansi.red(`exit ${content.exitCode}`), width, 2));
   }
-
-  if (expanded) {
-    if (content.stdout) {
-      const body = renderToolText(content.stdout, width, true);
-      lines.push(...body.lines);
-    }
-    if (content.stderr) {
-      lines.push(...renderIndented(ansi.dim('[stderr]'), width, 2));
-      const body = renderToolText(content.stderr, width, true);
-      lines.push(...body.lines.map(ansi.dim));
-    }
-    return { lines, truncated: false };
+  if (content.stdout) {
+    lines.push(...renderToolText(content.stdout, width));
   }
-
-  // Compact: the tail of combined output is where results and errors land.
-  const combined = [content.stdout, content.stderr].filter(Boolean).join('\n');
-  const tail = tailLines(combined, 5);
-  if (tail.text) lines.push(...renderIndented(tail.text, width, 2));
-  truncated = truncated || tail.hidden > 0;
-  return { lines, truncated };
+  if (content.stderr) {
+    lines.push(...renderIndented(ansi.dim('[stderr]'), width, 2));
+    lines.push(...renderToolText(content.stderr, width).map(ansi.dim));
+  }
+  return lines;
 }
 
-function renderReadResult(text: string, width: number, expanded: boolean): RenderedToolPart {
-  if (expanded) {
-    return { lines: renderIndented(limitText(text, 12_000), width, 2), truncated: false };
-  }
-  if (!text) return { lines: [], truncated: false };
-  const lineCount = text.split('\n').length;
-  const summary = `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
-  return { lines: renderIndented(summary, width, 2).map(ansi.dim), truncated: true };
-}
-
-function renderGrepResult(text: string, width: number, expanded: boolean): RenderedToolPart {
-  if (expanded) {
-    return { lines: renderIndented(limitText(text, 12_000), width, 2), truncated: false };
-  }
-  const allLines = text ? text.split('\n') : [];
-  const head = allLines.slice(0, 5);
-  const hidden = allLines.length - head.length;
-  const lines = head.length > 0 ? renderIndented(head.join('\n'), width, 2) : [];
-  if (hidden > 0) {
-    lines.push(...renderIndented(ansi.dim(`… +${hidden} more matches`), width, 2));
-  }
-  return { lines, truncated: hidden > 0 };
-}
-
-function renderDiffResult(diff: string, width: number, expanded: boolean): RenderedToolPart {
-  const capped = expanded ? limitText(diff, 12_000) : diff;
-  const allLines = capped.split('\n');
-  const maxLines = expanded ? allLines.length : 8;
-  const shown = allLines.slice(0, maxLines);
-  const hidden = allLines.length - shown.length;
-  const lines = renderIndented(colorDiff(shown.join('\n')), width, 2);
-  if (!expanded && hidden > 0) {
-    lines.push(...renderIndented(ansi.dim(`… +${hidden} more lines`), width, 2));
-  }
-  return { lines, truncated: !expanded && hidden > 0 };
-}
-
-/** Return the last `count` lines of `text` plus how many earlier lines were dropped. */
-function tailLines(text: string, count: number): { text: string; hidden: number } {
-  if (!text) return { text: '', hidden: 0 };
-  const allLines = text.split('\n');
-  if (allLines.length <= count) return { text, hidden: 0 };
-  return { text: allLines.slice(-count).join('\n'), hidden: allLines.length - count };
+function renderDiffResult(diff: string, width: number): string[] {
+  return renderIndented(colorDiff(limitText(diff, 12_000)), width, 2);
 }
 
 function byteLength(text: string): number {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -42,7 +42,8 @@ export interface MakaPiToolOutputDelta {
 
 export type MakaPiTranscriptEntry =
   | { kind: 'user'; text: string }
-  | { kind: 'assistant'; messageId: string; text: string; thinking?: string }
+  | { kind: 'assistant'; messageId: string; text: string }
+  | { kind: 'thinking'; messageId: string; text: string }
   | {
       kind: 'tool';
       toolUseId: string;
@@ -89,9 +90,7 @@ export function replaceTranscriptWithStoredMessages(
   messages: readonly StoredMessage[],
 ): void {
   const view = materializeSession(messages);
-  state.entries = view.items
-    .map(chatItemToTranscriptEntry)
-    .filter((entry): entry is MakaPiTranscriptEntry => entry !== undefined);
+  state.entries = view.items.flatMap(chatItemToTranscriptEntries);
   state.sawTextDeltaMessageIds = new Set(
     state.entries
       .filter((entry): entry is Extract<MakaPiTranscriptEntry, { kind: 'assistant' }> => entry.kind === 'assistant')
@@ -119,8 +118,8 @@ export function toggleLatestThinkingExpansion(state: MakaPiTranscriptState): boo
   const latestThinking = [...state.entries]
     .reverse()
     .find(
-      (entry): entry is MakaPiAssistantEntry =>
-        entry.kind === 'assistant' && Boolean(entry.thinking?.trim()),
+      (entry): entry is MakaPiThinkingEntry =>
+        entry.kind === 'thinking' && Boolean(entry.text.trim()),
     );
   if (!latestThinking) return false;
   state.expandedThinkingMessageId = state.expandedThinkingMessageId === latestThinking.messageId
@@ -202,11 +201,11 @@ export function applyMakaSessionEventToTranscript(
       break;
 
     case 'thinking_delta':
-      appendAssistantThinking(state, event.messageId, event.text);
+      appendThinking(state, event.messageId, event.text);
       break;
 
     case 'thinking_complete':
-      if (event.text) setAssistantThinking(state, event.messageId, event.text);
+      if (event.text) setThinking(state, event.messageId, event.text);
       break;
 
     case 'tool_start':
@@ -335,21 +334,26 @@ export function applyMakaSessionEventToTranscript(
   }
 }
 
-function chatItemToTranscriptEntry(item: ChatItem): MakaPiTranscriptEntry | undefined {
+function chatItemToTranscriptEntries(item: ChatItem): MakaPiTranscriptEntry[] {
   switch (item.kind) {
     case 'user':
-      return { kind: 'user', text: item.message.text };
-    case 'assistant':
-      return {
-        kind: 'assistant',
-        messageId: item.message.id,
-        text: item.message.text,
-        ...(item.message.thinking?.text ? { thinking: item.message.thinking.text } : {}),
-      };
+      return [{ kind: 'user', text: item.message.text }];
+    case 'assistant': {
+      const entries: MakaPiTranscriptEntry[] = [];
+      // Stored thinking happened before the reply text, so it resumes above it.
+      const thinking = item.message.thinking?.text;
+      if (thinking?.trim()) {
+        entries.push({ kind: 'thinking', messageId: item.message.id, text: thinking });
+      }
+      entries.push({ kind: 'assistant', messageId: item.message.id, text: item.message.text });
+      return entries;
+    }
     case 'tool':
-      return toolActivityToTranscriptEntry(item.item);
-    case 'system_note':
-      return systemNoteToTranscriptEntry(item.message);
+      return [toolActivityToTranscriptEntry(item.item)];
+    case 'system_note': {
+      const entry = systemNoteToTranscriptEntry(item.message);
+      return entry ? [entry] : [];
+    }
   }
 }
 
@@ -468,7 +472,10 @@ export function renderMakaPiTranscript(
         lines.push(...renderTextBlock('User', entry.text, safeWidth, { markdown: false, heading: ansi.accent }));
         break;
       case 'assistant':
-        lines.push(...renderAssistantBlock(entry, safeWidth, state.expandedThinkingMessageId === entry.messageId));
+        lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.accent }));
+        break;
+      case 'thinking':
+        lines.push(...renderThinkingBlock(entry, safeWidth, state.expandedThinkingMessageId === entry.messageId));
         break;
       case 'tool':
         lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseIds.has(entry.toolUseId)));
@@ -505,40 +512,36 @@ function appendAssistantText(state: MakaPiTranscriptState, messageId: string, te
   state.entries.push({ kind: 'assistant', messageId, text });
 }
 
-function appendAssistantThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
+function appendThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
   const last = state.entries[state.entries.length - 1];
-  if (last?.kind === 'assistant' && last.messageId === messageId) {
-    last.thinking = (last.thinking ?? '') + text;
+  if (last?.kind === 'thinking' && last.messageId === messageId) {
+    last.text += text;
     return;
   }
-  state.entries.push({ kind: 'assistant', messageId, text: '', thinking: text });
+  state.entries.push({ kind: 'thinking', messageId, text });
 }
 
-function setAssistantThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
+function setThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
   const last = state.entries[state.entries.length - 1];
-  if (last?.kind === 'assistant' && last.messageId === messageId) {
-    last.thinking = text;
+  if (last?.kind === 'thinking' && last.messageId === messageId) {
+    last.text = text;
     return;
   }
-  state.entries.push({ kind: 'assistant', messageId, text: '', thinking: text });
+  state.entries.push({ kind: 'thinking', messageId, text });
 }
 
-function renderAssistantBlock(entry: MakaPiAssistantEntry, width: number, thinkingExpanded: boolean): string[] {
-  const lines = renderTextBlock('maka', entry.text, width, { markdown: true, heading: ansi.accent });
-  // Thinking stays collapsed to a one-line marker by default so reasoning
-  // never floods the scrollback; Ctrl+T expands the latest block on demand.
-  if (entry.thinking && entry.thinking.trim()) {
-    if (thinkingExpanded) {
-      lines.push(fitLine(ansi.dim('思考'), width));
-      lines.push(...renderIndented(entry.thinking, width, 2).map((line) => fitLine(ansi.dim(line), width)));
-    } else {
-      lines.push(ansi.dim('思考（Ctrl+T 展开）'));
-    }
-  }
+// Thinking stays collapsed to a one-line marker by default so reasoning
+// never floods the scrollback; Ctrl+T expands the latest block on demand.
+function renderThinkingBlock(entry: MakaPiThinkingEntry, width: number, expanded: boolean): string[] {
+  if (!entry.text.trim()) return [];
+  if (!expanded) return [fitLine(ansi.dim('思考（Ctrl+T 展开）'), width)];
+  const lines = [fitLine(ansi.dim('思考'), width)];
+  lines.push(...renderIndented(entry.text, width, 2).map((line) => fitLine(ansi.dim(line), width)));
   return lines;
 }
 
 type MakaPiAssistantEntry = Extract<MakaPiTranscriptEntry, { kind: 'assistant' }>;
+type MakaPiThinkingEntry = Extract<MakaPiTranscriptEntry, { kind: 'thinking' }>;
 
 type MakaPiToolEntry = Extract<MakaPiTranscriptEntry, { kind: 'tool' }>;
 type MakaPiNoticeEntry = Extract<MakaPiTranscriptEntry, { kind: 'notice' }>;

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -522,10 +522,14 @@ function appendThinking(state: MakaPiTranscriptState, messageId: string, text: s
 }
 
 function setThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {
-  const last = state.entries[state.entries.length - 1];
-  if (last?.kind === 'thinking' && last.messageId === messageId) {
-    last.text = text;
-    return;
+  // thinking_complete can arrive after the reply text or tool events; replace
+  // the streamed entry wherever it sits instead of appending a duplicate.
+  for (let index = state.entries.length - 1; index >= 0; index -= 1) {
+    const entry = state.entries[index];
+    if (entry?.kind === 'thinking' && entry.messageId === messageId) {
+      entry.text = text;
+      return;
+    }
   }
   state.entries.push({ kind: 'thinking', messageId, text });
 }
@@ -588,14 +592,16 @@ function toolStatusText(entry: MakaPiToolEntry): string {
  * with a dim `(Ctrl+O)` hint when expanding would reveal more.
  */
 function renderCompactToolBlock(entry: MakaPiToolEntry, width: number): string[] {
-  const inputSummary = toolInputSummary(entry);
+  // collapseToSingleLine guards both slots: fitLine truncates width, not \n,
+  // so any multi-line summary text would silently break the two-line card.
+  const inputSummary = collapseToSingleLine(toolInputSummary(entry));
   const header = `${ansi.yellow('Tool')} ${entry.title ?? entry.toolName}`
     + `${inputSummary ? ` ${ansi.dim(inputSummary)}` : ''} ${toolStatusText(entry)}`;
   const lines = [fitLine(header, width)];
   const summary = compactToolSummary(entry, width);
   if (summary) {
     const hint = summary.expandable ? ansi.dim(' (Ctrl+O)') : '';
-    lines.push(fitLine(`  ${summary.text}${hint}`, width));
+    lines.push(fitLine(`  ${collapseToSingleLine(summary.text)}${hint}`, width));
   }
   return lines;
 }
@@ -637,10 +643,20 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
   }
 
   if (entry.toolName === 'Grep') {
-    const count = grepMatchCount(entry);
+    const count = jsonArrayCount(entry, 'matches');
     if (count !== undefined) {
       return {
         text: `${count} match${count === 1 ? '' : 'es'}`,
+        expandable: count > 0 || hasLiveOutput,
+      };
+    }
+  }
+
+  if (entry.toolName === 'Glob') {
+    const count = jsonArrayCount(entry, 'files');
+    if (count !== undefined) {
+      return {
+        text: `${count} file${count === 1 ? '' : 's'}`,
         expandable: count > 0 || hasLiveOutput,
       };
     }
@@ -702,11 +718,12 @@ function compactDiffSummary(
   };
 }
 
-function grepMatchCount(entry: MakaPiToolEntry): number | undefined {
+/** Row count for list-shaped json results (Grep `matches`, Glob `files`). */
+function jsonArrayCount(entry: MakaPiToolEntry, key: string): number | undefined {
   const result = entry.result;
   if (result?.kind === 'json' && result.value !== null && typeof result.value === 'object') {
-    const matches = (result.value as { matches?: unknown }).matches;
-    if (Array.isArray(matches)) return matches.length;
+    const rows = (result.value as Record<string, unknown>)[key];
+    if (Array.isArray(rows)) return rows.length;
   }
   const text = plainResultText(entry);
   if (!text) return undefined;
@@ -791,10 +808,13 @@ function plainResultText(entry: MakaPiToolEntry): string {
     if (value !== null && typeof value === 'object') {
       const content = (value as { content?: unknown }).content;
       if (typeof content === 'string') return content;
-      const matches = (value as { matches?: unknown }).matches;
-      if (Array.isArray(matches)) return matches.map((row) => String(row)).join('\n');
+      const record = value as { matches?: unknown; files?: unknown };
+      const rows = record.matches ?? record.files;
+      if (Array.isArray(rows)) return rows.map((row) => String(row)).join('\n');
     }
-    return formatUnknown(value);
+    // Single line: this text can land on the compact summary line, and a
+    // pretty-printed JSON body would break the two-line card contract.
+    return formatUnknownInline(value);
   }
   return entry.output ?? '';
 }
@@ -862,9 +882,19 @@ function toolInputSummary(entry: MakaPiToolEntry): string {
       }
       break;
     }
+    case 'Glob': {
+      const pattern = obj?.pattern;
+      if (typeof pattern === 'string' && pattern.trim()) {
+        const cwd = obj?.cwd;
+        return typeof cwd === 'string' && cwd.trim() ? `${pattern} in ${cwd}` : pattern;
+      }
+      break;
+    }
   }
   if (input === undefined) return '';
-  return `input: ${limitText(formatUnknown(input), 600)}`;
+  // Single line: this summary is inlined into the compact header, and a
+  // pretty-printed JSON body would break the two-line card contract.
+  return `input: ${limitText(formatUnknownInline(input), 600)}`;
 }
 
 function renderNotice(entry: MakaPiNoticeEntry, width: number): string[] {
@@ -962,6 +992,20 @@ function formatUnknown(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function formatUnknownInline(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Fold line breaks into spaces so a summary can never split a one-line slot. */
+function collapseToSingleLine(text: string): string {
+  return text.replace(/\s*\n\s*/g, ' ');
 }
 
 function limitText(text: string, maxChars: number): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -5,20 +5,39 @@ import {
   wrapTextWithAnsi,
   type MarkdownTheme,
 } from '@earendil-works/pi-tui';
-import type { PermissionRequestEvent, SessionEvent, ToolResultContent } from '@maka/core/events';
+import type {
+  PermissionRequestEvent,
+  SessionEvent,
+  ToolOutputStream,
+  ToolResultContent,
+} from '@maka/core/events';
 import type { StoredMessage, SystemNoteMessage } from '@maka/core/session';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
 import type { MakaSessionDriver } from './session-driver.js';
 import { ansi } from './tui-ansi.js';
+import { colorDiff } from './tui-diff.js';
 
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
   sawTextDeltaMessageIds: Set<string>;
   pendingPermission?: PermissionRequestEvent;
-  expandedToolUseId?: string;
+  /**
+   * Per-tool expansion state, keyed by toolUseId. Ctrl+O toggles the latest
+   * tool, but earlier tools stay expanded across later turns within a session.
+   * In-memory only; never persisted to storage. Resume starts empty.
+   */
+  expandedToolUseIds: Set<string>;
   expandedThinkingMessageId?: string;
+}
+
+/** A single live output chunk from a `tool_output_delta` event. */
+export interface MakaPiToolOutputDelta {
+  seq: number;
+  stream: ToolOutputStream;
+  chunk: string;
+  redacted: boolean;
 }
 
 export type MakaPiTranscriptEntry =
@@ -30,8 +49,12 @@ export type MakaPiTranscriptEntry =
       toolName: string;
       title?: string;
       input: unknown;
+      /** Structured result; preferred over `output` when present. */
+      result?: ToolResultContent;
+      /** Flattened result text, kept as a fallback for text/json/unknown kinds. */
       output?: string;
       progress: string[];
+      outputDeltas: MakaPiToolOutputDelta[];
       durationMs?: number;
       status: 'running' | 'done' | 'error';
     }
@@ -53,6 +76,7 @@ export function createMakaPiTranscriptState(): MakaPiTranscriptState {
   return {
     entries: [],
     sawTextDeltaMessageIds: new Set(),
+    expandedToolUseIds: new Set(),
   };
 }
 
@@ -74,7 +98,7 @@ export function replaceTranscriptWithStoredMessages(
       .map((entry) => entry.messageId),
   );
   state.pendingPermission = undefined;
-  state.expandedToolUseId = undefined;
+  state.expandedToolUseIds = new Set();
   state.expandedThinkingMessageId = undefined;
 }
 
@@ -83,9 +107,11 @@ export function toggleLatestToolExpansion(state: MakaPiTranscriptState): boolean
     .reverse()
     .find((entry): entry is MakaPiToolEntry => entry.kind === 'tool');
   if (!latestTool) return false;
-  state.expandedToolUseId = state.expandedToolUseId === latestTool.toolUseId
-    ? undefined
-    : latestTool.toolUseId;
+  if (state.expandedToolUseIds.has(latestTool.toolUseId)) {
+    state.expandedToolUseIds.delete(latestTool.toolUseId);
+  } else {
+    state.expandedToolUseIds.add(latestTool.toolUseId);
+  }
   return true;
 }
 
@@ -191,6 +217,7 @@ export function applyMakaSessionEventToTranscript(
         ...(event.displayName ? { title: event.displayName } : {}),
         input: event.args,
         progress: [],
+        outputDeltas: [],
         status: 'running',
       });
       break;
@@ -199,6 +226,7 @@ export function applyMakaSessionEventToTranscript(
       const tool = findToolEntry(state, event.toolUseId);
       if (tool) {
         tool.status = event.isError ? 'error' : 'done';
+        tool.result = event.content;
         tool.output = formatToolResultContent(event.content);
         tool.durationMs = event.durationMs;
       } else {
@@ -208,6 +236,8 @@ export function applyMakaSessionEventToTranscript(
           toolName: event.toolUseId,
           input: undefined,
           progress: [],
+          outputDeltas: [],
+          result: event.content,
           output: formatToolResultContent(event.content),
           durationMs: event.durationMs,
           status: event.isError ? 'error' : 'done',
@@ -227,7 +257,12 @@ export function applyMakaSessionEventToTranscript(
     case 'tool_output_delta': {
       const tool = findToolEntry(state, event.toolUseId);
       if (tool) {
-        tool.progress.push(`[${event.stream}] ${event.chunk}`);
+        tool.outputDeltas.push({
+          seq: event.seq,
+          stream: event.stream,
+          chunk: event.chunk,
+          redacted: event.redacted,
+        });
       }
       break;
     }
@@ -331,6 +366,8 @@ function toolActivityToTranscriptEntry(item: ToolActivityItem): MakaPiTranscript
     ...(item.displayName ? { title: item.displayName } : {}),
     input: item.args,
     progress: [],
+    outputDeltas: [],
+    ...(item.result ? { result: item.result } : {}),
     ...(output ? { output } : {}),
     ...(item.durationMs !== undefined ? { durationMs: item.durationMs } : {}),
     status: transcriptToolStatus(item.status),
@@ -434,7 +471,7 @@ export function renderMakaPiTranscript(
         lines.push(...renderAssistantBlock(entry, safeWidth, state.expandedThinkingMessageId === entry.messageId));
         break;
       case 'tool':
-        lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseId === entry.toolUseId));
+        lines.push(...renderToolBlock(entry, safeWidth, state.expandedToolUseIds.has(entry.toolUseId)));
         break;
       case 'notice':
         lines.push(...renderNotice(entry, safeWidth));
@@ -528,6 +565,12 @@ function renderTextBlock(
   return lines;
 }
 
+interface RenderedToolPart {
+  lines: string[];
+  /** True when compact rendering hides detail that expanding would reveal. */
+  truncated: boolean;
+}
+
 function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded: boolean): string[] {
   const status = entry.status === 'running'
     ? ansi.yellow('running')
@@ -538,38 +581,235 @@ function renderToolBlock(entry: MakaPiToolEntry, width: number, expanded: boolea
   const lines = [
     fitLine(`${ansi.yellow('Tool')} ${entry.title ?? entry.toolName} ${status}${duration}`, width),
   ];
+  let truncated = false;
+
   const inputSummary = toolInputSummary(entry);
   if (inputSummary) lines.push(...renderIndented(inputSummary, width, 2).map(ansi.dim));
+
   if (entry.progress.length > 0) {
-    lines.push(...renderToolText(entry.progress.join(''), width, expanded).map(ansi.dim));
+    const progress = renderToolText(entry.progress.join(''), width, expanded);
+    lines.push(...progress.lines.map(ansi.dim));
+    truncated = truncated || progress.truncated;
   }
-  if (entry.output) {
-    lines.push(...renderToolText(entry.output, width, expanded));
+
+  const streams = renderToolStreams(entry.outputDeltas, width, expanded);
+  lines.push(...streams.lines);
+  truncated = truncated || streams.truncated;
+
+  if (entry.result || entry.output) {
+    const result = renderToolResult(entry, width, expanded);
+    lines.push(...result.lines);
+    truncated = truncated || result.truncated;
   }
-  if (!expanded && toolHasHiddenDetail(entry)) {
+
+  if (!expanded && truncated) {
     lines.push(fitLine(ansi.dim('Ctrl+O expand'), width));
   }
   return lines.map((line) => fitLine(line, width));
 }
 
-function renderToolText(text: string, width: number, expanded: boolean): string[] {
+function renderToolText(text: string, width: number, expanded: boolean): RenderedToolPart {
   const limit = expanded ? 12_000 : 600;
-  return renderIndented(limitText(text, limit), width, 2);
+  return {
+    lines: renderIndented(limitText(text, limit), width, 2),
+    truncated: !expanded && text.length > limit,
+  };
 }
 
-function toolHasHiddenDetail(entry: MakaPiToolEntry): boolean {
-  return entry.progress.join('').length > 600 || (entry.output?.length ?? 0) > 600;
+/**
+ * Render live `tool_output_delta` chunks. Chunks are de-duped and ordered by
+ * `seq` (so a late or repeated seq cannot corrupt the display), consecutive
+ * same-stream chunks are grouped under a single dim `[stream]` label, and any
+ * redacted chunk shows a `[redacted]` marker instead of its raw content.
+ */
+function renderToolStreams(
+  deltas: readonly MakaPiToolOutputDelta[],
+  width: number,
+  expanded: boolean,
+): RenderedToolPart {
+  const groups = groupOutputDeltas(deltas);
+  if (groups.length === 0) return { lines: [], truncated: false };
+  const lines: string[] = [];
+  let truncated = false;
+  for (const group of groups) {
+    lines.push(fitLine(ansi.dim(`[${group.stream}]`), width));
+    const body = renderToolText(group.text, width, expanded);
+    lines.push(...body.lines.map(ansi.dim));
+    truncated = truncated || body.truncated;
+  }
+  return { lines, truncated };
+}
+
+function groupOutputDeltas(
+  deltas: readonly MakaPiToolOutputDelta[],
+): Array<{ stream: ToolOutputStream; text: string }> {
+  const bySeq = new Map<number, MakaPiToolOutputDelta>();
+  for (const delta of deltas) {
+    if (!bySeq.has(delta.seq)) bySeq.set(delta.seq, delta);
+  }
+  const ordered = [...bySeq.values()].sort((a, b) => a.seq - b.seq);
+  const groups: Array<{ stream: ToolOutputStream; text: string }> = [];
+  for (const delta of ordered) {
+    const chunk = delta.redacted ? '[redacted]' : delta.chunk;
+    const last = groups[groups.length - 1];
+    if (last && last.stream === delta.stream) {
+      last.text += chunk;
+    } else {
+      groups.push({ stream: delta.stream, text: chunk });
+    }
+  }
+  return groups;
+}
+
+function renderToolResult(entry: MakaPiToolEntry, width: number, expanded: boolean): RenderedToolPart {
+  const result = entry.result;
+  if (result?.kind === 'terminal') return renderTerminalResult(result, width, expanded);
+  if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width, expanded);
+  if (result?.kind === 'file_write') {
+    return { lines: renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2), truncated: false };
+  }
+
+  const text = plainResultText(entry);
+  if (entry.toolName === 'Read') return renderReadResult(text, width, expanded);
+  if (entry.toolName === 'Grep') return renderGrepResult(text, width, expanded);
+  return renderToolText(text, width, expanded);
+}
+
+/** Best-effort extraction of the human-readable body from a tool result. */
+function plainResultText(entry: MakaPiToolEntry): string {
+  const result = entry.result;
+  if (result?.kind === 'text') return result.text;
+  if (result?.kind === 'json') {
+    const value = result.value;
+    if (value !== null && typeof value === 'object') {
+      const content = (value as { content?: unknown }).content;
+      if (typeof content === 'string') return content;
+      const matches = (value as { matches?: unknown }).matches;
+      if (Array.isArray(matches)) return matches.map((row) => String(row)).join('\n');
+    }
+    return formatUnknown(value);
+  }
+  return entry.output ?? '';
+}
+
+function renderTerminalResult(
+  content: Extract<ToolResultContent, { kind: 'terminal' }>,
+  width: number,
+  expanded: boolean,
+): RenderedToolPart {
+  const lines: string[] = [];
+  let truncated = false;
+  if (content.exitCode !== 0) {
+    lines.push(...renderIndented(ansi.red(`exit ${content.exitCode}`), width, 2));
+  }
+
+  if (expanded) {
+    if (content.stdout) {
+      const body = renderToolText(content.stdout, width, true);
+      lines.push(...body.lines);
+    }
+    if (content.stderr) {
+      lines.push(...renderIndented(ansi.dim('[stderr]'), width, 2));
+      const body = renderToolText(content.stderr, width, true);
+      lines.push(...body.lines.map(ansi.dim));
+    }
+    return { lines, truncated: false };
+  }
+
+  // Compact: the tail of combined output is where results and errors land.
+  const combined = [content.stdout, content.stderr].filter(Boolean).join('\n');
+  const tail = tailLines(combined, 5);
+  if (tail.text) lines.push(...renderIndented(tail.text, width, 2));
+  truncated = truncated || tail.hidden > 0;
+  return { lines, truncated };
+}
+
+function renderReadResult(text: string, width: number, expanded: boolean): RenderedToolPart {
+  if (expanded) {
+    return { lines: renderIndented(limitText(text, 12_000), width, 2), truncated: false };
+  }
+  if (!text) return { lines: [], truncated: false };
+  const lineCount = text.split('\n').length;
+  const summary = `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
+  return { lines: renderIndented(summary, width, 2).map(ansi.dim), truncated: true };
+}
+
+function renderGrepResult(text: string, width: number, expanded: boolean): RenderedToolPart {
+  if (expanded) {
+    return { lines: renderIndented(limitText(text, 12_000), width, 2), truncated: false };
+  }
+  const allLines = text ? text.split('\n') : [];
+  const head = allLines.slice(0, 5);
+  const hidden = allLines.length - head.length;
+  const lines = head.length > 0 ? renderIndented(head.join('\n'), width, 2) : [];
+  if (hidden > 0) {
+    lines.push(...renderIndented(ansi.dim(`… +${hidden} more matches`), width, 2));
+  }
+  return { lines, truncated: hidden > 0 };
+}
+
+function renderDiffResult(diff: string, width: number, expanded: boolean): RenderedToolPart {
+  const capped = expanded ? limitText(diff, 12_000) : diff;
+  const allLines = capped.split('\n');
+  const maxLines = expanded ? allLines.length : 8;
+  const shown = allLines.slice(0, maxLines);
+  const hidden = allLines.length - shown.length;
+  const lines = renderIndented(colorDiff(shown.join('\n')), width, 2);
+  if (!expanded && hidden > 0) {
+    lines.push(...renderIndented(ansi.dim(`… +${hidden} more lines`), width, 2));
+  }
+  return { lines, truncated: !expanded && hidden > 0 };
+}
+
+/** Return the last `count` lines of `text` plus how many earlier lines were dropped. */
+function tailLines(text: string, count: number): { text: string; hidden: number } {
+  if (!text) return { text: '', hidden: 0 };
+  const allLines = text.split('\n');
+  if (allLines.length <= count) return { text, hidden: 0 };
+  return { text: allLines.slice(-count).join('\n'), hidden: allLines.length - count };
+}
+
+function byteLength(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
 }
 
 function toolInputSummary(entry: MakaPiToolEntry): string {
   const input = entry.input;
-  if (entry.toolName === 'Bash' && input !== null && typeof input === 'object') {
-    const command = (input as { command?: unknown }).command;
-    if (typeof command === 'string' && command.trim()) return `command: ${command}`;
-  }
-  if ((entry.toolName === 'Write' || entry.toolName === 'Edit') && input !== null && typeof input === 'object') {
-    const path = (input as { path?: unknown }).path;
-    if (typeof path === 'string' && path.trim()) return `path: ${path}`;
+  const obj = input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : undefined;
+  switch (entry.toolName) {
+    case 'Bash': {
+      const command = obj?.command;
+      if (typeof command === 'string' && command.trim()) {
+        return `$ ${command.split('\n')[0]}`;
+      }
+      break;
+    }
+    case 'Read': {
+      const path = obj?.path;
+      if (typeof path === 'string' && path.trim()) {
+        const parts = [path];
+        if (typeof obj?.offset === 'number') parts.push(`offset ${obj.offset}`);
+        if (typeof obj?.limit === 'number') parts.push(`limit ${obj.limit}`);
+        return parts.join(' ');
+      }
+      break;
+    }
+    case 'Write':
+    case 'Edit': {
+      const path = obj?.path;
+      if (typeof path === 'string' && path.trim()) return path;
+      break;
+    }
+    case 'Grep': {
+      const pattern = obj?.pattern;
+      if (typeof pattern === 'string' && pattern.trim()) {
+        const parts = [pattern];
+        if (typeof obj?.path === 'string' && obj.path.trim()) parts.push(`in ${obj.path}`);
+        if (typeof obj?.glob === 'string' && obj.glob.trim()) parts.push(`glob ${obj.glob}`);
+        return parts.join(' ');
+      }
+      break;
+    }
   }
   if (input === undefined) return '';
   return `input: ${limitText(formatUnknown(input), 600)}`;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -6,6 +6,8 @@ import {
   ProcessTerminal,
   SelectList,
   TUI,
+  isKeyRelease,
+  isKeyRepeat,
   matchesKey,
   truncateToWidth,
   visibleWidth,
@@ -556,14 +558,21 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // live listener while close() awaits the runtime stop; letting Escape or any
     // other key through here would mutate state or fire a second stop.
     if (closed) return { consume: true };
+    // Kitty keyboard protocol terminals (Ghostty/Kitty) emit separate press and
+    // release events. pi-tui only filters releases on the focused-component
+    // path, but this raw listener runs before that, so a release would
+    // immediately undo a Ctrl+O/Ctrl+T toggle and a single Escape's
+    // press+release pair could count as a double Escape. We never act on
+    // releases here; returning undefined lets the TUI apply its own filtering.
+    if (isKeyRelease(data)) return undefined;
     if (tui.hasOverlay()) return undefined;
-    if (matchesKey(data, Key.ctrl('o'))) {
+    if (matchesKey(data, Key.ctrl('o')) && !isKeyRepeat(data)) {
       if (toggleLatestToolExpansion(state)) {
         requestRender();
         return { consume: true };
       }
     }
-    if (matchesKey(data, Key.ctrl('t'))) {
+    if (matchesKey(data, Key.ctrl('t')) && !isKeyRepeat(data)) {
       if (toggleLatestThinkingExpansion(state)) {
         requestRender();
         return { consume: true };

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -30,8 +30,8 @@ import {
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
-  toggleLatestThinkingExpansion,
-  toggleLatestToolExpansion,
+  toggleAllThinkingExpansion,
+  toggleAllToolExpansion,
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
 } from './pi-transcript.js';
@@ -567,13 +567,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (isKeyRelease(data)) return undefined;
     if (tui.hasOverlay()) return undefined;
     if (matchesKey(data, Key.ctrl('o')) && !isKeyRepeat(data)) {
-      if (toggleLatestToolExpansion(state)) {
+      if (toggleAllToolExpansion(state)) {
         requestRender();
         return { consume: true };
       }
     }
     if (matchesKey(data, Key.ctrl('t')) && !isKeyRepeat(data)) {
-      if (toggleLatestThinkingExpansion(state)) {
+      if (toggleAllThinkingExpansion(state)) {
         requestRender();
         return { consume: true };
       }

--- a/packages/cli/src/tui-diff.ts
+++ b/packages/cli/src/tui-diff.ts
@@ -1,0 +1,38 @@
+import { ansi } from './tui-ansi.js';
+
+export type DiffLineKind = 'add' | 'del' | 'hunk' | 'meta' | 'ctx';
+
+/**
+ * Classify a single unified-diff line. Copied from the renderer-side
+ * `diffLineKind` in `@maka/ui` (tool-result-preview.tsx) so the CLI stays
+ * free of React/DOM imports. `+++`/`---` file headers count as metadata,
+ * `@@` hunk headers get their own kind, and bare `+`/`-` are add/del.
+ */
+export function diffLineKind(line: string): DiffLineKind {
+  if (line.startsWith('+++') || line.startsWith('---')) return 'meta';
+  if (line.startsWith('@@')) return 'hunk';
+  if (line.startsWith('+')) return 'add';
+  if (line.startsWith('-')) return 'del';
+  return 'ctx';
+}
+
+/** Tint a diff line by kind: add→green, del→red, hunk→accent, meta→dim, ctx→plain. */
+export function colorDiffLine(line: string): string {
+  switch (diffLineKind(line)) {
+    case 'add':
+      return ansi.green(line);
+    case 'del':
+      return ansi.red(line);
+    case 'hunk':
+      return ansi.accent(line);
+    case 'meta':
+      return ansi.dim(line);
+    case 'ctx':
+      return line;
+  }
+}
+
+/** Color a whole diff body, preserving line breaks. */
+export function colorDiff(diff: string): string {
+  return diff.split('\n').map(colorDiffLine).join('\n');
+}


### PR DESCRIPTION
## Summary

Redesigns TUI transcript rendering in `packages/cli`: tool cards collapse to a two-line compact summary with per-kind result lines, thinking renders as an ordered transcript entry at its actual position in the turn, and `Ctrl+O`/`Ctrl+T` are global toggles — one press expands (or collapses) every tool card / every thinking entry at once. The raw input listener ignores kitty-protocol key-release/repeat events so the toggles behave as true press-once toggles.

## Why

Refs #549 (T1 "Tool-result redesign"). Tool output flooded scrollback with no structure. On kitty-protocol terminals (Ghostty/Kitty), each key press+release fired two listener events, so expansion toggles behaved as hold-to-show and a single Escape press+release could be miscounted as a double-Escape interrupt. Thinking was pinned below the reply text regardless of when it actually happened.

## Scope

Changed:

- `pi-transcript.ts` — structured `ToolResultContent` retained on entries; compact cards capped at two lines: a header with an inline dim input summary (`$ cmd`, `path`, `pattern in cwd`, single-line JSON fallback) plus a one-line per-kind result summary (terminal last output line or red `exit N` + stderr tail; `+A -D path` diff counts; `wrote N bytes`; Read `N lines, N bytes`; Grep `N matches`; Glob `N files`) with a dim `(Ctrl+O)` hint. Grep/Glob counts are only shown when the keyed field (`matches`/`files`) is genuinely an array, so an error-shaped result never renders a fabricated count. Expanded view keeps full detail (grouped seq-ordered/redaction-aware output streams, colored diff, 12k caps). Thinking is a separate entry kind pushed in arrival order; `thinking_complete` replaces the streamed entry in place even when it arrives late. Expansion is two global booleans (`expandAllTools`/`expandAllThinking`), in-memory only, reset to collapsed on resume. Both compact slots fold newlines into spaces as a layout guard (`fitLine` clamps width, not `\n`).
- `tui-diff.ts` (new) — diff line classification + ANSI coloring, re-implemented from `@maka/ui` tool-result-preview to keep the CLI free of React deps.
- `pi-tui-runner.ts` — the input listener drops kitty key-release events at entry and skips key repeats for the two toggles.

Not included: statusline redesign (moved to T2 in #549), rewind/undo, attention/terminal-title work, and the runtime-side fix for thinking never being persisted (separate PR #592).

## Verification

`npm run -w maka-agent test` — 116 pass, 0 fail. Tests cover per-kind compact summaries (with raw-ANSI color assertions and exact line counts), Grep/Glob count only from real arrays (error/non-array/null shapes never fabricate a count), thinking arrival-order and late `thinking_complete` idempotence, global Ctrl+O/Ctrl+T expanding and collapsing every tool card / every thinking entry with one press, kitty Ctrl+O press+release keeping expansion, a single Escape press+release not triggering the double-Escape interrupt, and seq dedupe/out-of-order/redacted output deltas. Repo-root `npm run typecheck` clean. The kitty release guard was verified red-green by stripping it from dist.

## User-facing impact

CLI only. Compact tool cards drop from unbounded output to two lines; detail moves behind `Ctrl+O` as a global toggle that expands or collapses every card at once, and `Ctrl+T` does the same for every thinking entry. Thinking markers appear where thinking actually happened. No storage or runtime changes.

## Reviewer notes

- Read/Grep/Glob summaries dispatch by tool name because the runtime delivers them as generic `json` results; can tighten if dedicated kinds land later.
- Resumed sessions currently show no thinking at all — that is a runtime persistence gap, fixed separately in PR #592.
- Known follow-ups deferred to #549 (not this PR): live `tool_progress`/`tool_output_delta` buffering is unbounded (pre-existing on `main`; belongs with the memory-budget slice, not this rendering change).
