### PR TITLE
ci(test): run suites against pre-built dist to skip repeated rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: npm ci
       - run: npm run build
-      - run: npm run test
+      # test:dist runs the suites against the dist just built above. The
+      # workspace `test` scripts each do `clean && build` first, which would
+      # throw away this dist and rebuild every package a second time.
+      - run: npm run test:dist
 
   e2e:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "npm run test:scripts && npm --workspace @maka/core test && npm --workspace @maka/storage test && npm --workspace @maka/runtime test && npm --workspace @maka/headless test && npm --workspace maka-agent test && npm --workspace @maka/ui test && npm --workspace @maka/desktop test",
+    "test:dist": "npm run test:scripts && npm exec -w @maka/core -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/storage -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/runtime -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/headless -- node ../../scripts/run-headless-tests.mjs && npm exec -w maka-agent -- node --test \"dist/**/*.test.js\" && npm exec -w @maka/ui -- node --test \"dist/**/*.test.js\" && npm --workspace @maka/desktop run test",
     "test:scripts": "node --test scripts/run-headless-tests.test.mjs",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
     "dev:full": "npm run build && npm --workspace @maka/desktop run start",


### PR DESCRIPTION
## Summary

CI `test` job ran `npm run build` and then `npm run test`. The root `test` script delegates to each workspace's own `test`, which all do `clean && build` first, so the dist just built got thrown away and every package was rebuilt a second time. Build effectively ran twice in the job.

Adds a `test:dist` script that assumes `npm run build` already ran and runs the suites directly against dist, and switches the CI `test` job to it.

## Why

The `test` job was the CI bottleneck (~185s wall, vs ~91s for typecheck/e2e), and most of its `test` step (~111s) was rebuild, not testing. The repeated build is pure waste.

Measured on the last green run:

| step | before |
|---|---|
| `npm run build` | 44s |
| `npm run test` (incl. per-workspace clean+build+test) | 111s |

## Scope

Changed:
- `package.json`: new `test:dist` script.
- `.github/workflows/ci.yml`: `test` job runs `build` then `test:dist` instead of `test`.

Not included:
- `typecheck` and `e2e` jobs untouched.
- The original `test` script is kept as-is so local `npm test` / `npm --workspace X test` stays self-contained (still clean+build+test per workspace).

## How test:dist is built

- The six node packages run `node --test "dist/**/*.test.js"` in their own workspace cwd (same glob and cwd as their `test` script), so no rebuild and behavior is identical.
- headless reuses `scripts/run-headless-tests.mjs` (git-config isolation).
- desktop keeps its own `test` script (`clean:main && build:main && node --test dist/main`). Its main tests import renderer modules that `tsc` emits under `dist/renderer` during `build:main`, which the subsequent `build:renderer` (vite) clears. So desktop must re-run `build:main` before testing — this is inherent to how the package is wired, not something to fold into the skip.

## Verification

In a clean worktree (branch off `main`):

- `npm run build` then `npm run test:dist` → 4863 tests, 0 fail, exit 0, ~25s.
- Per-package test counts match running each workspace's own `test` (same globs/scripts).
- The earlier root-relative-glob variant failed one storage test and all desktop main tests because `process.cwd()` differed; the `-w` form restores each workspace's cwd and they pass.

Expected CI effect: `test` job step `test:dist` ≈ 25–35s instead of 111s; job wall roughly halved.

## User-facing impact

None. CI/dev scripts only; no shipped behavior change.

## Reviewer notes

- The one non-obvious bit is why desktop is special (see above). It is not skipped out of laziness; its main tests structurally depend on `tsc` side-effects that vite wipes.
- `test:dist` requires a prior `npm run build`; the CI job keeps the `build` step right before it, and a comment notes this.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact: none
- [x] Risk/review focus: desktop's retained rebuild is called out
- [x] UI changes: n/a
