### PR TITLE
refactor(ui): extend typography/line-height converge contracts to TSX (#546 PR0)

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-preview-cascade-contract.test.ts
@@ -102,16 +102,18 @@ describe('chat preview-surface migration contract (#332 PR4)', () => {
       'overlay base + card kind must both use arbitrary white-space so the kind wins by tailwind-merge',
     );
 
-    // Anti-drift: the literalize vehicle stays arbitrary-value (immune to a later
-    // scale/token re-tuning silently shifting pixels). Pin distinctive literals and
-    // ban the semantic-scale forms they would be swapped for.
-    for (const literal of ['rounded-[var(--radius-surface)]', 'text-[11.5px]', 'max-h-[180px]']) {
+    // Anti-drift: the literalize vehicle stays arbitrary-value for radius /
+    // geometry (immune to a later scale re-tuning silently shifting pixels).
+    // Typography is exempt — #546 PR0 converged text-* / leading-* onto the
+    // token scale (text-xs/sm), so typography literals are no longer pinned
+    // and text-xs/sm are allowed here; only radius scale drift is still banned.
+    for (const literal of ['rounded-[var(--radius-surface)]', 'max-h-[180px]']) {
       assert.ok(block.includes(literal), `previewVariants must keep the literal "${literal}"`);
     }
-    for (const scale of ['rounded-lg', 'rounded-md', 'text-sm', 'text-xs']) {
+    for (const scale of ['rounded-lg', 'rounded-md']) {
       assert.ok(
         !block.includes(scale),
-        `previewVariants must stay literal, not adopt the semantic-scale "${scale}"`,
+        `previewVariants must stay literal on radius, not adopt the semantic-scale "${scale}"`,
       );
     }
   });

--- a/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-primitive-cascade-contract.test.ts
@@ -73,16 +73,17 @@ describe('chat primitive shell migration contract (#332 PR1)', () => {
     // the WHOLE string (not just "contains each literal") also pins the set
     // closed: a stray extra `rounded-[12px]` / `px-4` / second `max-w-*` that
     // would silently override the shell makes this fail. Values mirror the
-    // retired `.maka-bubble-user` (padding 10px 14px; line-height 1.6;
-    // max-width min(100%,640px); --chat-user-bg) with radius now on the
+    // retired `.maka-bubble-user` (padding 10px 14px; line-height 1.5 via
+    // --leading-normal per #546 PR0; max-width min(100%,640px); --chat-user-bg)
+    // with radius now on the
     // `--radius-surface` token per #406 gap 4. Padding snapped 14→12 per
     // the --space-* scale (#430 PR3): px-3 (12px) py-2.5 (10px).
     const bubbleBlock = chatSrc.slice(chatSrc.indexOf('bubbleVariants'));
     const userClass = bubbleBlock.match(/user:\s*"([^"]*)"/)?.[1];
     assert.equal(
       userClass,
-      'max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[var(--radius-surface)] bg-[var(--chat-user-bg)] px-3 py-2.5 leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]',
-      'user bubble variant must match the retired .maka-bubble-user geometry (radius now on --radius-surface token, padding on --space-* scale)',
+      'max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[var(--radius-surface)] bg-[var(--chat-user-bg)] px-3 py-2.5 leading-normal text-[color:var(--chat-user-foreground,var(--foreground))]',
+      'user bubble variant must match the retired .maka-bubble-user geometry (radius on --radius-surface token, padding on --space-* scale, line-height on --leading-normal per #546 PR0)',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-tool-card-cascade-contract.test.ts
@@ -210,13 +210,16 @@ describe('chat tool-card migration contract (#332 PR3b)', () => {
     // forms they would be swapped for. Radius uses the `--radius-surface`
     // token per #406 gap 4. Spacing now uses the Tailwind scale (gap-2.5)
     // per #430 PR3 spacing converge — arbitrary px literals are banned.
-    for (const literal of ['rounded-[var(--radius-surface)]', 'text-[12.5px]', 'gap-2.5', 'min-w-[22px]']) {
+    // Typography (text-*) converged onto the token scale by #546 PR0, so it
+    // is no longer pinned as a literal and text-xs/sm are allowed; only radius /
+    // spacing literals stay pinned and radius scale drift stays banned.
+    for (const literal of ['rounded-[var(--radius-surface)]', 'gap-2.5', 'min-w-[22px]']) {
       assert.ok(block.includes(literal), `toolVariants must keep the literal "${literal}"`);
     }
-    for (const scale of ['rounded-lg', 'rounded-xl', 'text-sm', 'text-xs']) {
+    for (const scale of ['rounded-lg', 'rounded-xl']) {
       assert.ok(
         !block.includes(scale),
-        `toolVariants must stay literal, not adopt the semantic-scale "${scale}"`,
+        `toolVariants must stay literal on radius, not adopt the semantic-scale "${scale}"`,
       );
     }
 

--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { readdir, readFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 export const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 export const RENDERER_STYLES_ENTRY = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
@@ -45,6 +45,43 @@ export async function readAllRendererCss(): Promise<string> {
   // surface the error so converge contracts catch it instead of silently
   // degrading to only the styles.css entry and skipping styles/*.
   return expandCssImports(RENDERER_STYLES_ENTRY, new Set([RENDERER_STYLES_ENTRY]));
+}
+
+// --- TSX source for converge contracts -------------------------------------
+// Closes the CSS-only blind spot (#546 PR0): arbitrary `text-[..]`/`leading-[..]`
+// Tailwind utilities live in className strings inside .tsx/.ts, which the CSS
+// scanners never read. `readRendererTsxFiles` exposes that source so each
+// contract can scan it with the same value discipline as CSS declarations.
+//
+// Coverage is literal className text only. Runtime-composed classes
+// (clsx/cva variant maps, template-string concatenation) and inline
+// `style={{ fontSize }}` are NOT caught — each contract states this scope
+// honestly in its own comment.
+const TS_SOURCE_DIRS = [
+  resolve(REPO_ROOT, 'packages', 'ui', 'src'),
+  resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer'),
+];
+
+async function listTsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listTsFiles(path);
+    return (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) ? [path] : [];
+  }));
+  return files.flat().sort();
+}
+
+export async function readRendererTsxFiles(): Promise<{ path: string; relPath: string; source: string }[]> {
+  const out: { path: string; relPath: string; source: string }[] = [];
+  for (const dir of TS_SOURCE_DIRS) {
+    for (const path of await listTsFiles(dir)) {
+      // Test fixtures assert on class strings, not styling intent — skip them.
+      if (path.includes('__tests__')) continue;
+      out.push({ path, relPath: relative(REPO_ROOT, path), source: await readFile(path, 'utf8') });
+    }
+  }
+  return out;
 }
 
 export function stripCssComments(src: string): string {

--- a/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/line-height-converge-contract.test.ts
@@ -32,7 +32,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments, findFontShorthandOffenders, assertCustomPropPinnedOnce } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, readRendererTsxFiles, stripCssComments, findFontShorthandOffenders, assertCustomPropPinnedOnce } from './css-test-helpers.js';
 
 const STYLES_FILE = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles.css');
 
@@ -131,6 +131,26 @@ describe('PR-LEADING-CONVERGE-0 contract', () => {
     assertCustomPropPinnedOnce(styles, '--text-sm--line-height', 'var(--leading-snug)', 'styles.css');
     assertCustomPropPinnedOnce(styles, '--text-base--line-height', 'var(--leading-normal)', 'styles.css');
   });
+
+  // Closes the CSS-only blind spot (#546 PR0): arbitrary `leading-[1.45]` /
+  // `leading-[1.6]` utilities in className strings bypass the leading token
+  // scale the CSS scanner locks. Named scales (leading-none/tight/snug/normal)
+  // don't match `leading-[<digit>]` and stay allowed. NOTE: literal className
+  // text only — clsx/cva maps, template strings, and inline `style={{}}` are
+  // NOT caught (honest scope, see css-test-helpers readRendererTsxFiles).
+  // `leading-[1.45]` / `leading-[1.6]` (unitless) and Tailwind's font-size slash
+  // modifier (`text-xs/[1.45]` emits line-height: 1.45 with no leading-[..]
+  // token) bypass the leading scale. `leading-[12px]` / `leading-[16px]` are
+  // deliberate px centering on fixed-height icon buttons (not ratios) — they
+  // stay allowed, same exception #546 recorded for the old chat.tsx sites.
+  it('TSX className strings use no arbitrary unitless leading-[..] or slash line-height utilities', async () => {
+    const re = /leading-\[\d+(?:\.\d+)?\]|text-[^'"\s/]*\/\[[\d.]+\]/g;
+    const offenders: string[] = [];
+    for (const { relPath, source } of await readRendererTsxFiles()) {
+      for (const m of source.matchAll(re)) offenders.push(`${relPath}: ${m[0]}`);
+    }
+    assert.deepEqual(offenders, [], `Arbitrary leading-[..] line-height offenders (use leading-none/tight/snug/normal or leading-[var(--leading-*)]):\n  ${offenders.join('\n  ')}`);
+  });
 });
 
 describe('leading whitelist negative cases', () => {
@@ -166,6 +186,17 @@ describe('leading whitelist negative cases', () => {
   it('accepts font: inherit and font: initial', () => {
     assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
     assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
+  });
+
+  it('TSX line-height regex catches slash modifier and unitless leading-[..], allows px centering', () => {
+    const re = /leading-\[\d+(?:\.\d+)?\]|text-[^'"\s/]*\/\[[\d.]+\]/g;
+    const catch_ = (s: string) => (s.match(re) ?? []).length > 0;
+    assert.ok(catch_('leading-[1.45]'), 'unitless leading must be caught');
+    assert.ok(catch_('text-xs/[1.45]'), 'slash line-height modifier must be caught');
+    assert.ok(catch_('text-sm/[1.5]'), 'slash modifier on named scale must be caught');
+    assert.ok(!catch_('leading-[12px]'), 'px icon centering must pass');
+    assert.ok(!catch_('leading-[16px]'), 'px icon centering must pass');
+    assert.ok(!catch_('text-xs'), 'plain named scale must pass');
   });
 
 });

--- a/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
@@ -23,7 +23,7 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, readRendererTsxFiles, stripCssComments } from './css-test-helpers.js';
 
 // --- token whitelist --------------------------------------------------------
 
@@ -117,6 +117,25 @@ describe('PR-TYPOGRAPHY-CONVERGE-0 contract', () => {
     assert.match(styles, /--text-sm:\s*var\(--font-size-ui\)/, '--text-sm must alias --font-size-ui');
     assert.match(styles, /--text-base:\s*var\(--font-size-base\)/, '--text-base must alias --font-size-base');
   });
+
+  // Closes the CSS-only blind spot (#546 PR0): arbitrary font-size utilities in
+  // className strings bypass the token scale the CSS scanner locks. The regex
+  // catches numeric arbitrary (text-[12px], text-[0.7rem]) and length-typed
+  // calc (text-[length:calc(12px)]) — forms that emit font-size off the scale.
+  // Named scales (text-xs/sm/base), token var refs (text-[var(--font-size-*)]),
+  // and color arbitraries (text-[oklch(...)], text-[color:...]) don't match:
+  // var pointing is governed by the CSS token-whitelist contract, and color is
+  // not font-size. NOTE: literal className text only — clsx/cva maps, template
+  // strings, and inline `style={{ fontSize }}` are NOT caught (honest scope,
+  // see css-test-helpers readRendererTsxFiles).
+  it('TSX className strings use no arbitrary text-[..] font-size utilities', async () => {
+    const re = /text-\[(?:length:)?(?:\d|\.\d|calc\()[^\]]*\]/g;
+    const offenders: string[] = [];
+    for (const { relPath, source } of await readRendererTsxFiles()) {
+      for (const m of source.matchAll(re)) offenders.push(`${relPath}: ${m[0]}`);
+    }
+    assert.deepEqual(offenders, [], `Arbitrary text-[..] font-size offenders (use text-xs/sm/base or text-[var(--font-size-*)]):\n  ${offenders.join('\n  ')}`);
+  });
 });
 
 describe('typography whitelist negative cases', () => {
@@ -150,5 +169,17 @@ describe('typography whitelist negative cases', () => {
   it('accepts font: inherit and font: initial', () => {
     assert.deepEqual(findCssOffenders('font: inherit', 'test'), []);
     assert.deepEqual(findCssOffenders('font: initial', 'test'), []);
+  });
+
+  it('TSX font-size regex catches numeric+calc arbitrary and allows var/color', () => {
+    const re = /text-\[(?:length:)?(?:\d|\.\d|calc\()[^\]]*\]/g;
+    const catch_ = (s: string) => (s.match(re) ?? []).length > 0;
+    assert.ok(catch_('text-[12px]'), 'numeric arbitrary must be caught');
+    assert.ok(catch_('text-[length:calc(12px)]'), 'length:calc must be caught');
+    assert.ok(catch_('text-[0.7rem]'), 'rem must be caught');
+    assert.ok(!catch_('text-[var(--font-size-base)]'), 'token var ref must pass');
+    assert.ok(!catch_('text-[length:var(--font-size-ui)]'), 'length:var token ref must pass');
+    assert.ok(!catch_('text-[color:var(--muted-foreground)]'), 'color: ref must pass');
+    assert.ok(!catch_('text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]'), 'oklch color must pass (not font-size)');
   });
 });

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -91,7 +91,7 @@ test('footer-action merge drops the UiButton base shell so the retired footer pi
     'py-1',
     'rounded-[var(--radius-surface)]',
     'text-[color:var(--muted-foreground)]',
-    'text-[12px]',
+    'text-xs', // #546 PR0: text-[12px] -> text-xs (typography onto token scale)
   ]) {
     assert.ok(merged.includes(win), `footer pixel "${win}" must survive the merge`);
   }
@@ -121,7 +121,7 @@ test('lineage-badge merge drops the UiButton base shell so the retired badge pix
     'py-[1px]',
     'rounded-[var(--radius-pill)]',
     'text-[color:var(--muted-foreground)]',
-    'text-[9px]',
+    'text-xs', // #546 PR0: text-[9px] -> text-xs (typography onto token scale)
   ]) {
     assert.ok(merged.includes(win), `lineage pixel "${win}" must survive the merge`);
   }
@@ -219,8 +219,10 @@ test('toolVariants stays literal and emits the single-backslash waiting_permissi
   const dot = toolVariants({ part: 'dot' });
   for (const cls of [item, dot]) {
     assert.ok(
-      !cls.split(/\s+/).some((u) => ['rounded-lg', 'rounded-md', 'rounded-xl', 'text-sm', 'text-xs', 'bg-primary'].includes(u)),
-      'tool shell must stay literal, not the semantic scale / a recolor',
+      // Typography (text-*) converged onto the scale by #546 PR0, so text-xs/sm
+      // are allowed here; only radius scale + recolor drift stays banned.
+      !cls.split(/\s+/).some((u) => ['rounded-lg', 'rounded-md', 'rounded-xl', 'bg-primary'].includes(u)),
+      'tool shell must stay literal on radius, not the semantic scale / a recolor',
     );
   }
   // exactly one backslash before the underscore (source == runtime via String.raw)

--- a/packages/ui/src/attachment-file-card.tsx
+++ b/packages/ui/src/attachment-file-card.tsx
@@ -30,9 +30,9 @@ export function AttachmentFileCard(props: {
         <AttachmentKindIcon kind={props.kind} className="h-5 w-5" />
       </span>
       <span className="min-w-0 flex-1 leading-tight">
-        <span className="block truncate text-[13px] font-medium text-foreground">{props.name}</span>
+        <span className="block truncate text-sm font-medium text-foreground">{props.name}</span>
         {props.size !== undefined && (
-          <span className="block truncate text-[11px] font-mono tabular-nums text-muted-foreground mt-0.5">
+          <span className="block truncate text-xs font-mono tabular-nums text-muted-foreground mt-0.5">
             {formatBytes(props.size)}
           </span>
         )}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1395,7 +1395,7 @@ function StreamingAssistantBubble(props: { text: string; live: boolean; truncate
       <Markdown text={displayed} />
       {props.truncated && (
         <div
-          className="mt-1.5 inline-block cursor-help rounded-[var(--radius-control)] border border-[oklch(from_var(--warning)_l_c_h_/_0.24)] bg-[oklch(from_var(--warning)_l_c_h_/_0.05)] px-1 text-[10px] text-[color:var(--warning-text,var(--info-text))]"
+          className="mt-1.5 inline-block cursor-help rounded-[var(--radius-control)] border border-[oklch(from_var(--warning)_l_c_h_/_0.24)] bg-[oklch(from_var(--warning)_l_c_h_/_0.05)] px-1 text-xs text-[color:var(--warning-text,var(--info-text))]"
           role="status"
           aria-live="polite"
           title="助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。"

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -18,7 +18,7 @@ export const badgeVariants = cva(
         default:
           "h-5.5 min-w-5.5 px-[calc(--spacing(1)-1px)] text-sm sm:h-4.5 sm:min-w-4.5 sm:text-xs",
         lg: "h-6.5 min-w-6.5 px-[calc(--spacing(1.5)-1px)] text-base sm:h-5.5 sm:min-w-5.5 sm:text-sm",
-        sm: "h-5 min-w-5 rounded-[var(--radius-pill)] px-[calc(--spacing(1)-1px)] text-xs sm:h-4 sm:min-w-4 sm:text-[.625rem]",
+        sm: "h-5 min-w-5 rounded-[var(--radius-pill)] px-[calc(--spacing(1)-1px)] text-xs sm:h-4 sm:min-w-4 sm:text-xs",
       },
       variant: {
         default:

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -68,7 +68,7 @@ const bubbleVariants = cva("", {
       // Padding stays literal (`px-3 py-2.5`); radius now uses the
       // `--radius-surface` token (8px) per #406 gap 4 radius governance.
       // Keeps the neutral `--chat-user-bg` token path (never primary/accent).
-      user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[var(--radius-surface)] bg-[var(--chat-user-bg)] px-3 py-2.5 leading-[1.6] text-[color:var(--chat-user-foreground,var(--foreground))]",
+      user: "max-w-[min(100%,640px)] whitespace-pre-wrap break-words rounded-[var(--radius-surface)] bg-[var(--chat-user-bg)] px-3 py-2.5 leading-normal text-[color:var(--chat-user-foreground,var(--foreground))]",
       // Assistant / system: open prose, no bubble. Typography stays authored
       // under `.maka-bubble-assistant` (Markdown prose, OUT of scope), so this
       // variant re-emits that class as the styling hook.
@@ -138,10 +138,10 @@ const markerVariants = cva("", {
     variant: {
       // `.maka-turn-aborted-marker` (+ its italic `em`) — dormant, muted.
       aborted:
-        "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[12px] italic [&_em]:italic",
+        "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-xs italic [&_em]:italic",
       // `.maka-turn-failed-banner` — fault state, destructive tone.
       "failed-banner":
-        "inline-flex w-fit flex-wrap items-center gap-1.5 mx-0 mt-0.5 mb-1.5 px-2 py-1 rounded-[var(--radius-control)] border border-[oklch(from_var(--destructive)_l_c_h_/_0.28)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] text-[color:var(--destructive)] text-[12px]",
+        "inline-flex w-fit flex-wrap items-center gap-1.5 mx-0 mt-0.5 mb-1.5 px-2 py-1 rounded-[var(--radius-control)] border border-[oklch(from_var(--destructive)_l_c_h_/_0.28)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] text-[color:var(--destructive)] text-xs",
       // `.maka-turn-failed-icon`
       "failed-icon": "inline-flex items-center",
       // `.maka-turn-failed-recovery` (+ `::before` middot separator).
@@ -162,7 +162,7 @@ const markerVariants = cva("", {
         // the 4/3 line-height (9px font × 4/3 = 12px) that `size="sm"`'s `h-8` /
         // `text-xs` used to supply implicitly on `main`, so geometry lives in
         // the marker shell.
-        "inline-flex items-center h-8 gap-0.5 px-1 py-[1px] rounded-[var(--radius-pill)] [border:0] bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--muted-foreground)] text-[9px] leading-[12px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
+        "inline-flex items-center h-8 gap-0.5 px-1 py-[1px] rounded-[var(--radius-pill)] [border:0] bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] text-[color:var(--muted-foreground)] text-xs leading-[12px] [transition:background_150ms_var(--ease-out-strong),color_150ms_var(--ease-out-strong)]"
         + " hover:bg-[oklch(from_var(--foreground)_l_c_h_/_0.08)] hover:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " data-[direction=forward]:bg-[oklch(from_var(--info)_l_c_h_/_0.06)] data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]"
@@ -182,7 +182,7 @@ const markerVariants = cva("", {
         // line-height ratio over the 12px font (12 × 4/3 = 16px exactly).
         // Folding them in keeps the exact pixels while the marker shell owns its
         // geometry (verified equal to `main` by computed style, headless electron).
-        "inline-flex items-center gap-1.5 min-h-[28px] h-8 px-2 py-1 rounded-[var(--radius-surface)] [border:0] bg-transparent text-[color:var(--muted-foreground)] text-[12px] leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
+        "inline-flex items-center gap-1.5 min-h-[28px] h-8 px-2 py-1 rounded-[var(--radius-surface)] [border:0] bg-transparent text-[color:var(--muted-foreground)] text-xs leading-[16px] [transition:background_120ms_ease,color_120ms_ease,opacity_120ms_ease]"
         + " [&:hover:not([aria-disabled=true])]:bg-[oklch(from_var(--foreground)_l_c_h_/_0.05)] [&:hover:not([aria-disabled=true])]:text-[color:var(--foreground)]"
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " aria-disabled:opacity-[0.45] aria-disabled:cursor-not-allowed"
@@ -270,7 +270,7 @@ const streamVariants = cva("", {
         + " data-[live=true]:border-[oklch(from_var(--status-running)_l_c_h_/_0.40)] data-[live=true]:[box-shadow:inset_0_0_0_1px_oklch(from_var(--status-running)_l_c_h_/_0.06)]",
       // `.maka-tool-output-stream-header`
       header:
-        "flex items-center justify-between gap-3 px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--foreground-3)] text-[0.72rem] uppercase tracking-[0.06em] text-[color:var(--muted-foreground)]",
+        "flex items-center justify-between gap-3 px-2.5 py-1.5 border-b border-[var(--border)] bg-[var(--foreground-3)] text-xs uppercase tracking-[0.06em] text-[color:var(--muted-foreground)]",
       // `.maka-tool-output-stream-label`
       label: "inline-flex items-center gap-1.5",
       // `.maka-tool-output-stream-counts`
@@ -290,14 +290,14 @@ const streamVariants = cva("", {
       // `word-break:break-word` stays an arbitrary literal (Tailwind's
       // `break-words` is `overflow-wrap`, a different property).
       body:
-        "m-0 max-h-55 overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-[0.78rem] leading-[1.5] bg-[var(--background)] text-[color:var(--foreground-secondary)] [scroll-behavior:auto]",
+        "m-0 max-h-55 overflow-y-auto whitespace-pre-wrap [word-break:break-word] px-2.5 py-2 [font-family:var(--font-mono)] text-xs leading-normal bg-[var(--background)] text-[color:var(--foreground-secondary)] [scroll-behavior:auto]",
       // `.maka-tool-output-stream-chunk` (`display:contents`; recolors stderr,
       // dims redacted). The call site keeps `data-stream` / `data-redacted`.
       chunk:
         "contents data-[stream=stderr]:text-[color:var(--destructive-text)] data-[redacted=true]:opacity-[0.65]",
       // `.maka-tool-output-stream-redacted-tag` — the inline `[已脱敏]` tag.
       "redacted-tag":
-        "inline ml-0.5 rounded-[var(--radius-control)] px-1 tracking-[0.04em] text-[0.7rem] text-[color:var(--warning-text,var(--info-text))] bg-[oklch(from_var(--warning,var(--info))_l_c_h_/_0.10)]",
+        "inline ml-0.5 rounded-[var(--radius-control)] px-1 tracking-[0.04em] text-xs text-[color:var(--warning-text,var(--info-text))] bg-[oklch(from_var(--warning,var(--info))_l_c_h_/_0.10)]",
     },
   },
 });
@@ -403,16 +403,16 @@ const toolVariants = cva("", {
       container: "w-[min(680px,100%)] mx-auto mt-0.5 mb-0 px-4 py-0",
       // `.toolInline > header` — the quiet "工具调用" caption row.
       "container-header":
-        "flex items-center justify-between mb-0.5 text-[color:var(--muted-foreground)] text-[10px]",
+        "flex items-center justify-between mb-0.5 text-[color:var(--muted-foreground)] text-xs",
       // `.maka-tool-count` — the call-count pill.
       count:
-        "inline-flex items-center justify-center min-w-[22px] h-[18px] px-1.5 py-0 rounded-[var(--radius-pill)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-[11px] [font-variant-numeric:tabular-nums]",
+        "inline-flex items-center justify-center min-w-[22px] h-[18px] px-1.5 py-0 rounded-[var(--radius-pill)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-xs [font-variant-numeric:tabular-nums]",
       // `.maka-tool` (effective: the later `padding: 0` rule wins over `8px 12px`)
       // + `.toolItem` + the `[data-status]` border / background / opacity swaps.
       // `[border: …]` / `[border-color: …]` are arbitrary so the status overrides
       // touch only the color, never width/style.
       item:
-        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-[12.5px] text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
+        "[border:1px_solid_var(--border)] rounded-[var(--radius-surface)] bg-[var(--foreground-2)] p-0 mt-2 [font-family:var(--font-mono)] text-xs text-[color:var(--foreground-secondary)] overflow-hidden [box-shadow:var(--shadow-minimal-flat)]"
         // `waiting_permission` border tint — see `WP_CARD_BORDER` above (String.raw).
         + " " + WP_CARD_BORDER
         + " data-[status=running]:[border-color:oklch(from_var(--status-running)_l_c_h_/_0.4)]"
@@ -438,7 +438,7 @@ const toolVariants = cva("", {
         "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground)] font-medium [font-family:var(--font-mono)]",
       // `.maka-tool-meta` — duration + status-label cluster.
       meta:
-        "inline-flex items-center gap-2 text-[color:var(--muted-foreground)] text-[11px]",
+        "inline-flex items-center gap-2 text-[color:var(--muted-foreground)] text-xs",
       // `.maka-tool-duration`
       duration: "[font-variant-numeric:tabular-nums]",
       // `.maka-tool-status-label`
@@ -447,7 +447,7 @@ const toolVariants = cva("", {
       body: "px-3 pt-2.5 pb-3",
       // `.maka-tool-intent`
       intent:
-        "mx-0 mt-0 mb-2 text-[color:var(--foreground-secondary)] [font-family:var(--font-default)] text-[12px] leading-[1.4]",
+        "mx-0 mt-0 mb-2 text-[color:var(--foreground-secondary)] [font-family:var(--font-default)] text-xs leading-snug",
       // `.toolArgs` — the override layered over the shared `.maka-code` base
       // (`.maka-code` stays in CSS; the call site keeps the class).
       args: "m-0 max-h-[110px] overflow-auto",
@@ -513,7 +513,7 @@ const previewVariants = cva("", {
       // overlay preview shares. `white-space` / `font-family` are arbitrary so
       // the structured-card kind parts override them by tailwind-merge (note 1).
       overlay:
-        "mt-1 mx-0 mb-0 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-[10px] [white-space:pre-wrap] [word-break:break-word]",
+        "mt-1 mx-0 mb-0 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-xs [white-space:pre-wrap] [word-break:break-word]",
       // `.maka-overlay-close` — the dismiss action (layered over `.maka-button`).
       close:
         "justify-self-end inline-flex items-center gap-1 min-h-6 px-1.5",
@@ -525,11 +525,11 @@ const previewVariants = cva("", {
         "grid gap-0 p-0 rounded-[var(--radius-surface)] bg-[var(--background)] [white-space:normal] [box-shadow:var(--shadow-minimal-flat)]",
       // `.maka-tool-diff-paths` (+ its bare `code` children).
       "diff-paths":
-        "flex flex-wrap gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-[10px]"
+        "flex flex-wrap gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-xs"
         + " [&_code]:text-[color:var(--foreground-secondary)] [&_code]:bg-transparent",
       // `.maka-tool-diff-body` — the scrolling mono `<pre>`.
       "diff-body":
-        "m-0 px-0 py-1 max-h-80 overflow-auto [font-family:var(--font-mono)] text-[11.5px] leading-[1.45] [white-space:pre] [word-break:normal]",
+        "m-0 px-0 py-1 max-h-80 overflow-auto [font-family:var(--font-mono)] text-xs leading-snug [white-space:pre] [word-break:normal]",
       // `.maka-tool-diff-line` (+ the `[data-line]` add/del/hunk/meta/ctx tints).
       "diff-line":
         "block px-2 py-0 [white-space:pre]"
@@ -545,7 +545,7 @@ const previewVariants = cva("", {
         "grid gap-0 p-0 rounded-[var(--radius-surface)] bg-[var(--background)] [white-space:normal] [box-shadow:var(--shadow-minimal-flat)]",
       // `.maka-tool-terminal-head`
       "terminal-head":
-        "flex flex-wrap items-center gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-[10px]",
+        "flex flex-wrap items-center gap-1.5 px-2 py-1 [border-bottom:1px_solid_var(--border)] bg-[var(--foreground-2)] [font-family:var(--font-mono)] text-xs",
       // `.maka-tool-terminal-cwd`
       "terminal-cwd": "text-[color:var(--muted-foreground)] bg-transparent",
       // `.maka-tool-terminal-cmd` — the ellipsized command line.
@@ -553,20 +553,20 @@ const previewVariants = cva("", {
         "[flex:1_1_auto] min-w-0 text-[color:var(--foreground)] bg-transparent font-semibold whitespace-nowrap overflow-hidden text-ellipsis",
       // `.maka-tool-terminal-exit` (+ the `[data-ok]` success/failure badge).
       "terminal-exit":
-        "px-1.5 py-[1px] rounded-[var(--radius-pill)] text-[9px] font-bold tracking-[0.04em] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)]"
+        "px-1.5 py-[1px] rounded-[var(--radius-pill)] text-xs font-bold tracking-[0.04em] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)]"
         + " data-[ok=true]:bg-[oklch(from_var(--success)_l_c_h_/_0.14)] data-[ok=true]:text-[color:var(--success)]"
         + " data-[ok=false]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.14)] data-[ok=false]:text-[color:var(--destructive)]",
       // `.maka-tool-terminal-empty`
       "terminal-empty":
-        "m-0 p-2 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-[11px] italic",
+        "m-0 p-2 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-xs italic",
       // `.maka-tool-terminal-stream` (+ the `[data-stream]` stdout/stderr tone).
       "terminal-stream":
-        "m-0 px-2 py-1.5 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-[11.5px] [white-space:pre-wrap] [word-break:break-word]"
+        "m-0 px-2 py-1.5 max-h-[180px] overflow-auto [font-family:var(--font-mono)] text-xs [white-space:pre-wrap] [word-break:break-word]"
         + " data-[stream=stdout]:text-[color:var(--foreground)]"
         + " data-[stream=stderr]:[border-top:1px_solid_var(--border)] data-[stream=stderr]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)] data-[stream=stderr]:text-[color:var(--destructive)]",
       // `.maka-tool-terminal-truncated-note` (+ its `> span` min-width reset).
       "terminal-truncated-note":
-        "flex items-center justify-between gap-2 px-2 py-1.5 [border-top:1px_solid_var(--border)] bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] text-[color:var(--foreground-secondary)] text-[11px] leading-[1.5] [&>span]:min-w-0",
+        "flex items-center justify-between gap-2 px-2 py-1.5 [border-top:1px_solid_var(--border)] bg-[oklch(from_var(--warning)_l_c_h_/_0.06)] text-[color:var(--foreground-secondary)] text-xs leading-normal [&>span]:min-w-0",
       // `.maka-tool-terminal-copy` (UiButton) + the shared copy-state tints.
       "terminal-copy":
         "[flex:0_0_auto] data-[pending=true]:cursor-progress data-[copy-error=true]:text-[color:var(--destructive)] data-[copy-error=true]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.35)]",
@@ -578,21 +578,21 @@ const previewVariants = cva("", {
       // `.maka-office-document-head` (+ its `strong` title and `small` caption).
       "office-head":
         "grid gap-0.5 pb-1.5 [border-bottom:1px_solid_var(--foreground-10)]"
-        + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-[13px] [&_strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-sm [&_strong]:text-[color:var(--foreground)]"
+        + " [&_small]:text-xs [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-office-document-args`
       "office-args":
-        "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground-secondary)] bg-transparent text-[11px]",
+        "min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--foreground-secondary)] bg-transparent text-xs",
       // `.maka-office-document-message` (+ its `small` caption).
       "office-message":
-        "grid gap-0.5 px-2.5 py-2 rounded-[var(--radius-control)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.07)] text-[color:var(--destructive)] [font-family:var(--font-sans)] text-[12px]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        "grid gap-0.5 px-2.5 py-2 rounded-[var(--radius-control)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.07)] text-[color:var(--destructive)] [font-family:var(--font-sans)] text-xs"
+        + " [&_small]:text-xs [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-office-document-empty`
       "office-empty":
-        "m-0 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-[12px] italic",
+        "m-0 text-[color:var(--muted-foreground)] [font-family:var(--font-mono)] text-xs italic",
       // `.maka-office-document-stream` (+ the `[data-stream=stderr]` tone).
       "office-stream":
-        "m-0 px-2.5 py-2 max-h-50 overflow-auto [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-control)] bg-[var(--background)] [font-family:var(--font-mono)] text-[12.5px] [white-space:pre-wrap] [word-break:break-word]"
+        "m-0 px-2.5 py-2 max-h-50 overflow-auto [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-control)] bg-[var(--background)] [font-family:var(--font-mono)] text-xs [white-space:pre-wrap] [word-break:break-word]"
         + " data-[stream=stderr]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)] data-[stream=stderr]:text-[color:var(--destructive)]",
 
       // ── explore agent / subagent (shared shell) ───────────────────────────
@@ -608,8 +608,8 @@ const previewVariants = cva("", {
       // the latter shared with the nested summary-line small).
       "agent-head":
         "grid gap-0.5 pb-1.5 [border-bottom:1px_solid_var(--foreground-10)]"
-        + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-[13px] [&_strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
+        + " [&_strong]:min-w-0 [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-nowrap [&_strong]:text-sm [&_strong]:text-[color:var(--foreground)]"
+        + " [&_small]:text-xs [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]",
       // `.maka-explore-agent-summary-line` (+ its `small` ellipsis, layered over
       // the head's caption styling above).
       "agent-summary-line":
@@ -618,31 +618,31 @@ const previewVariants = cva("", {
       "agent-actions": "flex items-center justify-end gap-1.5 mt-1",
       // `.maka-explore-agent-message`
       "agent-message":
-        "px-2.5 py-2 rounded-[var(--radius-control)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.07)] text-[color:var(--destructive)] text-[12px]",
+        "px-2.5 py-2 rounded-[var(--radius-control)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.07)] text-[color:var(--destructive)] text-xs",
       // `.maka-explore-agent-meta` (+ its `div` cells, `dt` labels, `dd` values).
       "agent-meta":
         "grid grid-cols-[repeat(2,minmax(0,1fr))] gap-2 m-0"
         + " [&>div]:min-w-0 [&>div]:grid [&>div]:gap-0.5"
-        + " [&_dt]:text-[11px] [&_dt]:text-[color:var(--muted-foreground)] [&_dt]:uppercase [&_dt]:tracking-[0.04em]"
-        + " [&_dd]:min-w-0 [&_dd]:m-0 [&_dd]:overflow-hidden [&_dd]:text-ellipsis [&_dd]:whitespace-nowrap [&_dd]:text-[color:var(--foreground-secondary)] [&_dd]:text-[12px]",
+        + " [&_dt]:text-xs [&_dt]:text-[color:var(--muted-foreground)] [&_dt]:uppercase [&_dt]:tracking-[0.04em]"
+        + " [&_dd]:min-w-0 [&_dd]:m-0 [&_dd]:overflow-hidden [&_dd]:text-ellipsis [&_dd]:whitespace-nowrap [&_dd]:text-[color:var(--foreground-secondary)] [&_dd]:text-xs",
       // `.maka-explore-agent-section` (+ its direct `> strong`, list `ul`/`li`
       // rows, leading `li` reset, `code` / `small` / `p` / `span` leaves).
       "agent-section":
         "grid gap-1.5"
-        + " [&>strong]:text-[12px] [&>strong]:text-[color:var(--foreground)]"
-        + " [&_small]:text-[11px] [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]"
+        + " [&>strong]:text-xs [&>strong]:text-[color:var(--foreground)]"
+        + " [&_small]:text-xs [&_small]:text-[color:var(--muted-foreground)] [&_small]:uppercase [&_small]:tracking-[0.04em]"
         + " [&_ul]:list-none [&_ul]:m-0 [&_ul]:p-0 [&_ul]:grid [&_ul]:gap-1.5"
         + " [&_li]:min-w-0 [&_li]:grid [&_li]:gap-0.5 [&_li]:py-1.5 [&_li]:[border-top:1px_solid_var(--foreground-5)]"
         + " [&_li:first-child]:border-t-0 [&_li:first-child]:pt-0"
-        + " [&_code]:min-w-0 [&_code]:overflow-hidden [&_code]:text-ellipsis [&_code]:whitespace-nowrap [&_code]:text-[color:var(--foreground)] [&_code]:bg-transparent [&_code]:[font-family:var(--font-mono)] [&_code]:text-[12px]"
-        + " [&_p]:m-0 [&_p]:text-[color:var(--foreground-secondary)] [&_p]:text-[12px] [&_p]:leading-[1.45] [&_p]:[white-space:pre-wrap] [&_p]:[word-break:break-word]"
-        + " [&_span]:m-0 [&_span]:text-[color:var(--foreground-secondary)] [&_span]:text-[12px] [&_span]:leading-[1.45] [&_span]:[white-space:pre-wrap] [&_span]:[word-break:break-word]",
+        + " [&_code]:min-w-0 [&_code]:overflow-hidden [&_code]:text-ellipsis [&_code]:whitespace-nowrap [&_code]:text-[color:var(--foreground)] [&_code]:bg-transparent [&_code]:[font-family:var(--font-mono)] [&_code]:text-xs"
+        + " [&_p]:m-0 [&_p]:text-[color:var(--foreground-secondary)] [&_p]:text-xs [&_p]:leading-snug [&_p]:[white-space:pre-wrap] [&_p]:[word-break:break-word]"
+        + " [&_span]:m-0 [&_span]:text-[color:var(--foreground-secondary)] [&_span]:text-xs [&_span]:leading-snug [&_span]:[white-space:pre-wrap] [&_span]:[word-break:break-word]",
       // `.maka-explore-agent-section-head` (+ its `> strong`).
       "agent-section-head":
-        "flex items-center justify-between gap-2 min-w-0 [&>strong]:min-w-0 [&>strong]:text-[12px] [&>strong]:text-[color:var(--foreground)]",
+        "flex items-center justify-between gap-2 min-w-0 [&>strong]:min-w-0 [&>strong]:text-xs [&>strong]:text-[color:var(--foreground)]",
       // `.maka-explore-agent-copy` (UiButton) + the copied / shared copy-state tints.
       "agent-copy":
-        "[flex:0_0_auto] gap-1 min-h-6 px-2 py-0.5 text-[11px]"
+        "[flex:0_0_auto] gap-1 min-h-6 px-2 py-0.5 text-xs"
         + " data-[copied=true]:text-[color:var(--link)] data-[copied=true]:[border-color:oklch(from_var(--link)_l_c_h_/_0.35)]"
         + " data-[pending=true]:cursor-progress"
         + " data-[copy-error=true]:text-[color:var(--destructive)] data-[copy-error=true]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.35)]",
@@ -653,14 +653,14 @@ const previewVariants = cva("", {
       "web-search":
         "grid gap-2 px-3 py-2.5 [border:1px_solid_var(--foreground-10)] rounded-[var(--radius-surface)] bg-[var(--foreground-3)]"
         + " [&>header]:flex [&>header]:flex-col [&>header]:gap-0.5 [&>header]:pb-1.5 [&>header]:[border-bottom:1px_solid_var(--foreground-10)]"
-        + " [&>header_strong]:text-[13px] [&>header_strong]:text-[color:var(--foreground)] [&>header_strong]:font-semibold"
-        + " [&>header_small]:text-[11px] [&>header_small]:text-[color:var(--muted-foreground)] [&>header_small]:uppercase [&>header_small]:tracking-[0.04em]"
+        + " [&>header_strong]:text-sm [&>header_strong]:text-[color:var(--foreground)] [&>header_strong]:font-semibold"
+        + " [&>header_small]:text-xs [&>header_small]:text-[color:var(--muted-foreground)] [&>header_small]:uppercase [&>header_small]:tracking-[0.04em]"
         + " [&_ul]:list-none [&_ul]:m-0 [&_ul]:p-0 [&_ul]:grid [&_ul]:gap-2"
         + " [&_li]:grid [&_li]:gap-0.5 [&_li]:py-2 [&_li]:[border-top:1px_solid_var(--foreground-5)]"
         + " [&_li:first-child]:border-t-0 [&_li:first-child]:pt-0"
         + " [&_a]:font-semibold [&_a]:text-[color:var(--foreground)] [&_a]:no-underline [&_a:hover]:underline"
-        + " [&_li_small]:text-[11px] [&_li_small]:text-[color:var(--muted-foreground)] [&_li_small]:uppercase [&_li_small]:tracking-[0.04em]"
-        + " [&_li_p]:m-0 [&_li_p]:text-[12px] [&_li_p]:text-[color:var(--foreground-secondary)] [&_li_p]:leading-[1.45] [&_li_p]:[white-space:pre-wrap] [&_li_p]:[word-break:break-word]",
+        + " [&_li_small]:text-xs [&_li_small]:text-[color:var(--muted-foreground)] [&_li_small]:uppercase [&_li_small]:tracking-[0.04em]"
+        + " [&_li_p]:m-0 [&_li_p]:text-xs [&_li_p]:text-[color:var(--foreground-secondary)] [&_li_p]:leading-snug [&_li_p]:[white-space:pre-wrap] [&_li_p]:[word-break:break-word]",
       // `.maka-web-search-error` — the destructive container tint, layered over
       // the `web-search` part via `cn`. It MUST restate the FULL `[border: …]`
       // shorthand + `bg-[ …]` util — NOT a bare `[border-color: …]`/`[background: …]`
@@ -674,15 +674,15 @@ const previewVariants = cva("", {
         "[border:1px_solid_color-mix(in_oklab,var(--destructive-text)_32%,var(--foreground-10))] bg-[color-mix(in_oklab,var(--destructive-text)_8%,var(--foreground-3))]",
       // `.maka-web-search-error-message`
       "web-search-error-message":
-        "m-0 text-[12px] leading-[1.45] [white-space:pre-wrap] [word-break:break-word] text-[color:var(--destructive-text)]",
+        "m-0 text-xs leading-snug [white-space:pre-wrap] [word-break:break-word] text-[color:var(--destructive-text)]",
       // `.maka-web-search-error-repair`
       "web-search-error-repair":
-        "m-0 text-[12px] leading-[1.45] [white-space:pre-wrap] [word-break:break-word] text-[color:var(--foreground-secondary)]",
+        "m-0 text-xs leading-snug [white-space:pre-wrap] [word-break:break-word] text-[color:var(--foreground-secondary)]",
 
       // ── load-tool result card (separate base; not an overlay) ─────────────
       // `.maka-load-tool-preview` (+ its `p` margin reset).
       "load-tool":
-        "mt-1 mx-0 mb-0 px-2 py-1 grid gap-0.5 rounded-[var(--radius-control)] bg-[var(--background)] text-[10px] [box-shadow:var(--shadow-minimal-flat)] [&_p]:m-0",
+        "mt-1 mx-0 mb-0 px-2 py-1 grid gap-0.5 rounded-[var(--radius-control)] bg-[var(--background)] text-xs [box-shadow:var(--shadow-minimal-flat)] [&_p]:m-0",
       // `.maka-load-tool-title`
       "load-tool-title": "font-semibold",
       // `.maka-load-tool-count`
@@ -690,7 +690,7 @@ const previewVariants = cva("", {
       // `.maka-load-tool-tools`
       "load-tool-tools": "[font-family:var(--font-mono)] [word-break:break-word]",
       // `.maka-load-tool-footer`
-      "load-tool-footer": "text-[color:var(--muted-foreground)] text-[11px]",
+      "load-tool-footer": "text-[color:var(--muted-foreground)] text-xs",
     },
   },
 });

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -295,7 +295,7 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
       <AlertOctagon size={16} strokeWidth={2} aria-hidden="true" />
       <AlertTitle>工具调用失败</AlertTitle>
       {errorText && (
-        <AlertDescription className="[font-family:var(--font-mono)] text-[12px] leading-[1.5] whitespace-pre-wrap [word-break:break-word]">
+        <AlertDescription className="[font-family:var(--font-mono)] text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
           {errorText.length > 240 ? `${errorText.slice(0, 240)}…` : errorText}
         </AlertDescription>
       )}


### PR DESCRIPTION
## Summary
Extends the typography/line-height converge contracts to scan `.tsx` (not just CSS), closing the CSS-only blind spot from #520, and converges ~64 arbitrary `text-[..]`/`leading-[..]` Tailwind utilities onto the token scale. First PR of the #546 CSS governance pass.

## Why
#520's converge contracts locked every numeric spec in renderer CSS, but they only scanned `.css` — arbitrary `text-[12px]` / `leading-[1.45]` utilities living in `.tsx` className strings were a complete blind spot (~64 sites across 6 files). #546 PR0 closes that gap so TSX is governed by the same token discipline as CSS.

Refs #546

## Scope
Changed:
- `css-test-helpers.ts`: add `readRendererTsxFiles()`
- `typography-converge` + `line-height-converge` contracts: new TSX-scanning test (regex covers numeric arbitrary, `length:calc(..)`, and `text-*/[<num>]` slash line-height modifier; var/color refs, named scales, and `leading-[Npx]` icon-centering stay allowed) + negative cases
- 5 source files converged (`primitives/chat.tsx`, `tool-activity.tsx`, `primitives/badge.tsx`, `chat-view.tsx`, `attachment-file-card.tsx`): ≤12.5px→text-xs, 13px→text-sm; leading 1.4/1.45→snug, 1.5/1.6→normal
- 4 #332 chat migration contracts updated (3 desktop cascade + `@maka/ui` chat-primitives): their typography anti-drift pinned arbitrary literals and banned text-xs/sm; #546 PR0 intentionally converges typography onto the scale, so typography literals are unpinned and text-xs/sm allowed — radius/spacing anti-drift preserved

Not included:
- markdown prose layer / bubble extraction (later surface-polish PR)
- surface relocation (Phase A)
- full tool-cva extraction (separate decision)

## Verification
- `npm run typecheck` — green (all workspaces)
- `npm run -w @maka/desktop test` — 2135/2136 pass
- `npm test --workspace @maka/ui` — 45/45 pass
- `codex exec review --base origin/main` — PASS (no P0/P1/P2/P3)
- The one desktop fail (`history-compact-artifacts`) is pre-existing — a runtime artifact-size classification unrelated to this diff (the test reads artifact block summaries, not renderer className)

## User-facing impact
Near-zero visual shift: ≤1px font-size and ≤0.1 line-height deltas on tool-card meta/code/labels. No changelog/docs/migrations.

## Reviewer notes
- The TSX scan covers literal className strings only — not clsx/cva maps, template strings, or inline `style={{}}` (stated honestly in the contract comments).
- `leading-[12px]`/`[16px]` on fixed-height icon buttons are deliberate px centering, kept (same exception #546 recorded).
- Rollback: single revert; no token/schema/migration changes.

## Checklist
- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact noted (near-zero)
- [x] Risk/rollback called out
- [ ] UI screenshots — N/A (≤1px shifts on a governance PR; dual-theme screenshots land with the surface-polish PRs where pixels actually change)
