### PR TITLE
test(desktop): align permission default contracts

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-startup-fail-soft-contract.test.ts
@@ -53,7 +53,7 @@ describe('renderer startup fail-soft contract', () => {
     );
     assert.match(
       refreshConnections,
-      /try \{[\s\S]*window\.maka\.connections\.list\(\)[\s\S]*window\.maka\.connections\.getDefault\(\)[\s\S]*setConnections\(next\)[\s\S]*setDefaultConnection\(nextDefault\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新模型连接失败', generalizedErrorMessageChinese\(error, '模型连接暂时无法刷新，请稍后重试。'\)\)/,
+      /try \{[\s\S]*window\.maka\.connections\.list\(\)[\s\S]*window\.maka\.connections\.getDefault\(\)[\s\S]*setConnections\((?:next|\(prev\) => connectionsEqual\(prev, next\) \? prev : next)\)[\s\S]*setDefaultConnection\(nextDefault\)[\s\S]*\} catch \(error\) \{[\s\S]*toastApi\.error\('刷新模型连接失败', generalizedErrorMessageChinese\(error, '模型连接暂时无法刷新，请稍后重试。'\)\)/,
       'startup / connections:event refreshConnections is fire-and-forget and must catch IPC failures without exposing raw provider/storage details',
     );
     assert.doesNotMatch(refreshConnections, /toastApi\.error\('刷新模型连接失败', cleanErrorMessage\(error\)\)/);

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -204,7 +204,7 @@ describe('permission mode transition guard copy', () => {
     assert.match(menuModule, /PERMISSION_MODE_ORDER\.map\(\(mode\) =>/);
   });
 
-  it('scrubs thrown permission-mode IPC failures before toast', async () => {
+  it('persists permission-mode picks as the global default and scrubs failures before toast', async () => {
     const renderer = await readRendererShellCombinedSource();
     const setPermissionModeBlock = renderer.match(/async function setPermissionMode[\s\S]*?async function setSessionModel/)?.[0] ?? '';
 
@@ -213,26 +213,27 @@ describe('permission mode transition guard copy', () => {
     assert.match(renderer, /const \{[\s\S]*pendingPermissionModeBySession,[\s\S]*\} = sessionUiState;/);
     assert.match(
       setPermissionModeBlock,
-      /const sessionId = activeIdRef\.current;[\s\S]*if \(!sessionId\) \{[\s\S]*setPendingNewChatPermissionMode\(mode\);[\s\S]*return;[\s\S]*\}[\s\S]*pendingPermissionModeChangesRef\.current\.has\(sessionId\)/,
-      'Permission mode changes must capture the active session id, store no-session picks for the next chat, and gate duplicate changes for active sessions',
+      /if \(mode === 'explore'\) return;[\s\S]*const sessionId = activeIdRef\.current;[\s\S]*const pendingKey = sessionId \?\? '__global_permission_mode__';[\s\S]*pendingPermissionModeChangesRef\.current\.has\(pendingKey\)/,
+      'Permission mode changes must reject explore, capture the active session id, and gate duplicate active/global saves',
     );
-    assert.match(setPermissionModeBlock, /pendingPermissionModeChangesRef\.current\.add\(sessionId\);[\s\S]*setPendingPermissionModeBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: true \}\)\);/);
-    assert.match(setPermissionModeBlock, /sessionsRef\.current\.find\(\(session\) => session\.id === sessionId\)/);
-    assert.match(setPermissionModeBlock, /window\.maka\.sessions\.setPermissionMode\(sessionId, mode\)/);
+    assert.match(setPermissionModeBlock, /pendingPermissionModeChangesRef\.current\.add\(pendingKey\);[\s\S]*if \(sessionId\) setPendingPermissionModeBySession\(\(current\) => \(\{ \.\.\.current, \[sessionId\]: true \}\)\);/);
     assert.match(
       setPermissionModeBlock,
-      /if \(activeIdRef\.current === sessionId\) \{[\s\S]*setSessions\(\(prev\) => prev\.map\(\(session\) => \(session\.id === next\.id \? next : session\)\)\);[\s\S]*\}/,
-      'Permission mode success must not patch the visible chat header after the user switches sessions',
+      /window\.maka\.settings\.update\(\{ chatDefaults: \{ permissionMode: mode \} \}\)/,
+      'Permission mode changes must persist the Settings -> General chat default instead of mutating one session',
     );
-    assert.match(setPermissionModeBlock, /if \(activeIdRef\.current === sessionId\) toastApi\.success\(`已切到 \$\{labels\[mode\]\}`/);
+    assert.match(setPermissionModeBlock, /const nextMode = result\.settings\.chatDefaults\.permissionMode;/);
+    assert.match(setPermissionModeBlock, /setDefaultPermissionMode\(nextMode\);/);
+    assert.match(setPermissionModeBlock, /setSessions\(\(prev\) => prev\.map\(\(session\) => \(\{ \.\.\.session, permissionMode: nextMode \}\)\)\);/);
+    assert.match(setPermissionModeBlock, /toastApi\.success\(`已切到 \$\{permissionModeLabels\[nextMode\]\}`, permissionModeDescriptions\[nextMode\]\);/);
     assert.match(setPermissionModeBlock, /await refreshSessions\(\)/, 'Permission mode changes must still refresh the sidebar/session list');
     assert.match(
       setPermissionModeBlock,
-      /if \(activeIdRef\.current === sessionId\) \{[\s\S]*toastApi\.error\(\s*'切换权限模式失败',\s*generalizedErrorMessageChinese\(error, '权限模式暂时无法切换，请稍后重试。'\)/,
+      /catch \(error\) \{[\s\S]*toastApi\.error\(\s*'切换权限模式失败',\s*generalizedErrorMessageChinese\(error, '权限模式暂时无法切换，请稍后重试。'\)/,
       'Permission mode failures must use shared Chinese error classification/redaction before reaching toast',
     );
-    assert.match(setPermissionModeBlock, /finally \{[\s\S]*pendingPermissionModeChangesRef\.current\.delete\(sessionId\);[\s\S]*\}/);
-    assert.match(setPermissionModeBlock, /delete next\[sessionId\];/);
+    assert.match(setPermissionModeBlock, /finally \{[\s\S]*pendingPermissionModeChangesRef\.current\.delete\(pendingKey\);[\s\S]*\}/);
+    assert.match(setPermissionModeBlock, /if \(sessionId\) setPendingPermissionModeBySession\(\(current\) => omitSessionKey\(current, sessionId\)\);/);
     assert.match(renderer, /permissionModePending=\{activeId \? pendingPermissionModeBySession\[activeId\] === true : false\}/);
     assert.match(renderer, /onPermissionModeChange=\{\(mode\) => setPermissionMode\(mode\)\}/);
     assert.doesNotMatch(renderer, /onPermissionModeChange=\{\(mode\) => void setPermissionMode\(mode\)\}/);
@@ -241,36 +242,40 @@ describe('permission mode transition guard copy', () => {
       /error instanceof Error \? error\.message : String\(error\)/,
       'Permission mode failures must not render raw thrown Error.message',
     );
+    assert.doesNotMatch(setPermissionModeBlock, /setPendingNewChatPermissionMode\(mode\)/);
+    assert.doesNotMatch(setPermissionModeBlock, /window\.maka\.sessions\.setPermissionMode\(sessionId, mode\)/);
     assert.doesNotMatch(setPermissionModeBlock, /window\.maka\.sessions\.setPermissionMode\(activeId, mode\)/);
   });
 
-  it('uses pending new-chat permission mode for the first new session', async () => {
+  it('uses the configured default permission mode without one-shot new-chat state', async () => {
     const renderer = await readRendererShellCombinedSource();
+    const sendBlock = renderer.match(/async function send\(text: string[\s\S]*?\n  async function respondToPermission/)?.[0] ?? '';
 
-    assert.match(
+    assert.doesNotMatch(
       renderer,
       /const \[pendingNewChatPermissionMode, setPendingNewChatPermissionMode\] = useState<PermissionMode \| null>\(null\)/,
-      'The shell must keep a renderer-only permission mode pick while no session is active',
+      'The shell must not keep renderer-only permission mode state while no session is active',
     );
-    assert.match(
-      renderer,
+    assert.doesNotMatch(
+      sendBlock,
       /\.\.\.\(pendingNewChatPermissionMode \? \{ permissionMode: pendingNewChatPermissionMode \} : \{\}\)/,
-      'New session creation must send the no-session pick when made, and OMIT permissionMode otherwise so main.ts resolves the configured Settings → 通用 default as the single authority',
+      'New session creation must omit permissionMode so main.ts resolves the configured Settings -> General default as the single authority',
     );
-    assert.match(
-      renderer,
+    assert.doesNotMatch(
+      sendBlock,
       /setPendingNewChatPermissionMode\(null\)/,
-      'Successful first send must clear the pending no-session permission mode pick',
+      'Successful first send must not clear a removed renderer-only permission mode pick',
     );
     assert.match(
       renderer,
-      /permissionMode=\{activeSessionForView\?\.permissionMode \?\? pendingNewChatPermissionMode \?\? defaultPermissionMode\}/,
-      'The Composer mode chip must show the pending no-session pick (or the configured default) before the first message creates a session',
+      /permissionMode=\{defaultPermissionMode\}/,
+      'The Composer mode chip must show the configured global default',
     );
+    assert.match(renderer, /setDefaultPermissionMode\(next\.chatDefaults\?\.permissionMode \?\? 'ask'\)/);
     assert.match(
       renderer,
       /permissionModeDisabledReason=\{[\s\S]*activeId && activeSessionForView\?\.status === 'running'/,
-      'No-session permission mode picks must stay enabled while running/waiting guards apply only to existing sessions',
+      'No-session default permission changes must stay enabled while running/waiting guards apply only to existing sessions',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -102,7 +102,7 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     );
     assert.match(
       renderer,
-      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) toastApi\.error\('切换模型失败', generalizedErrorMessageChinese\(error, '模型暂时无法切换，请稍后重试。'\)\);[\s\S]*\} finally/,
+      /catch \(error\) \{[\s\S]*if \(activeIdRef\.current === sessionId\) \{[\s\S]*toastApi\.error\('切换模型失败', generalizedErrorMessageChinese\(error, '模型暂时无法切换，请稍后重试。'\)\);[\s\S]*\}[\s\S]*\} finally/,
       'model switch failure toast must not surface stale failures after the user switches sessions',
     );
     assert.doesNotMatch(

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -194,12 +194,8 @@ export function createAppShellChatActions(deps: {
       if (!initialSessionId) {
         if (pending && pending.length > 0) preflightAttachmentItems(pending);
         const session = await window.maka.sessions.create({
-          // Only send permissionMode when the user explicitly picked one in
-          // the composer. Omitting it lets main.ts's sessions:create resolve
-          // the configured chatDefaults.permissionMode as the single
-	          // authority — a renderer-side copy of the default can be stale
-          // (e.g. before the mount-time settings load resolves on a cold
-          // start), which would silently override the configured setting.
+          // Omit permissionMode so main.ts's sessions:create resolves the
+          // configured chatDefaults.permissionMode as the single authority.
           name: text.slice(0, 42) || '新建对话',
           ...(validPendingNewChatModel
             ? { llmConnectionSlug: validPendingNewChatModel.llmConnectionSlug, model: validPendingNewChatModel.model }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -247,12 +247,6 @@ export function AppShell({
   const [pendingNewChatModel, setPendingNewChatModel] = useState<{ llmConnectionSlug: string; model: string } | null>(
     persistedComposerDefaults?.model ?? null,
   );
-  // Permission mode is renderer-only, scoped to one new-chat decision.
-  // It must NOT persist across reloads — persisted permission would
-  // silently inherit a previous session's mode (e.g. auto-edit) after
-  // restart with no visible signal, which is a safety regression.
-  // The single authority is main.ts's Settings → 通用 default. See
-  // session-status-presentation.test.ts for the contract.
   const [appInfo, setAppInfo] = useState<RendererAppInfo | null>(
     persistedComposerDefaults?.projectPath
       ? { projectPath: persistedComposerDefaults.projectPath, projectGit: { isGitRepo: false } }
@@ -713,8 +707,7 @@ export function AppShell({
     model: 'fake-model',
     // Transient placeholder while the real SessionSummary loads --
     // matches the configured default so the composer doesn't flash a
-    // hardcoded value before the real session data (or its own
-    // pendingNewChatPermissionMode fallback) supersedes it.
+    // hardcoded value before the real session data settles.
     permissionMode: defaultPermissionMode,
   } : undefined);
   const activeMessageLoading = Boolean(activeId && messageLoadPending);


### PR DESCRIPTION
## Summary

Align desktop source-grep contracts with the permission-mode behavior merged in #573.

## Why

Refs #573

#573 moved composer permission-mode picks from one-shot renderer state to the persisted global `chatDefaults.permissionMode`, but two older desktop contracts still required `pendingNewChatPermissionMode`. Main CI also still had one over-specific `refreshConnections` assertion that rejected the current deduping updater shape.

## Scope

Changed:

- Updated the permission-mode transition contract to require `settings.update({ chatDefaults: { permissionMode } })`, global/default pending guards, and omission of `permissionMode` from new session creation.
- Relaxed source-grep contracts that were binding to formatting or implementation shape rather than behavior.
- Removed stale renderer comments that still described one-shot permission mode behavior.

Not included:

- No runtime behavior changes.
- No dependency, migration, docs, or changelog changes.

## Verification

- `npm run build:test` passed
- `npm run test:dist` passed

## User-facing impact

None. Test/contract alignment only.

## Reviewer notes

This fixes the post-#573 CI failure on `npm run test:dist`; the failing desktop contracts now match the new global default permission-mode design.

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results, or explains why they were not run
- [x] User-facing impact, docs, changelog, migrations, and breaking changes are noted, or marked none
- [x] Risk, rollback, or review focus is called out for non-trivial changes
- [x] UI changes include screenshots/video, or explain why not applicable
