### PR TITLE
fix(ui): designer-audit round 3 — dark surface hierarchy, humanized copy, scroll affordance

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -558,6 +558,8 @@
 ============================================================================= */
 
 .dark {
+  /* Designer audit P1-6: composer edge ring — see styles/composer.css. */
+  --composer-ring-alpha: 0.12;
   /* PR-GRAY-CARD-LIFT-0: dark mode follows the same neutral gray
    * (hue 0, no chroma) hierarchy. Lightness anchors keep existing
    * contrast tuning. */

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -108,6 +108,16 @@
   box-shadow: none;
 }
 
+/* Designer audit P1-6: in dark mode the canvas (l≈0.14) and the content
+   card (l≈0.24) sit close enough that the floating-card edge disappears —
+   the light theme's whole surface hierarchy collapsed to one murk. A 1px
+   inner top-light hairline gives the eye a physical edge without pushing
+   the canvas darker. Light mode keeps box-shadow: none (the lightness gap
+   already reads there). */
+.dark .maka-panel-detail.maka-floating-panel.agents-content-area {
+  box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.07);
+}
+
 /* `.agents-parchment-paper-surface` is reused by the composer body. The bare
    class drops its border so the content area doesn't double up with the
    floating-panel rule above; the composer re-establishes its own card chrome

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -180,9 +180,12 @@ function PersonalizationSettingsPage(props: {
           aria-label="助手语气偏好"
           className="min-h-21"
         />
+        {/* Designer audit P1-8: was engineering-speak ("以低优先级拼到
+            system prompt"、"Runtime 独立判定") — user copy shouldn't require
+            understanding the implementation. */}
         <small>
-          以低优先级用户偏好拼到 system prompt，500 字符内。Runtime 仍按权限策略和工具规则
-          独立判定 —— 此处不能写成"忽略前面规则"或"不要再询问"这种指令，会被忽略。
+          最多 500 字，只影响回答的语气和风格。权限确认与安全规则不受它影响——
+          写"跳过确认"这类指令不会生效。
         </small>
       </label>
 

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -212,7 +212,11 @@
   border-radius: var(--radius-modal);
   padding: var(--space-2-5) var(--space-3) var(--space-2);
   background-color: var(--agents-content-area-bg);
-  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / 0.035);
+  /* Ring alpha is a token so dark mode can strengthen the edge without a
+     second rest rule (composer-container-single-source-contract). In dark
+     the composer and pane share the same bg, and 3.5% of the near-white
+     foreground vanished — the card lost its outline (designer audit P1-6). */
+  box-shadow: 0 0 0 1px oklch(from var(--foreground) l c h / var(--composer-ring-alpha, 0.035));
   transition:
     border-color var(--duration-emphasized) var(--ease-out-strong),
     box-shadow var(--duration-emphasized) var(--ease-out-strong);

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -212,10 +212,27 @@
 
 /* --- provider list panel (scrolls vertically as the list grows) --- */
 .maka-firstrun-list {
+  position: relative;
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   overflow: hidden;
   background: var(--background-elevated);
+}
+
+/* Designer audit P2-15: the height clamp cut the last visible provider row
+   in half with no cue that the list scrolls — it read as broken clipping.
+   A bottom fade signals "more below" (the provider count always exceeds the
+   clamp, so the cue never lies); pointer-events none keeps rows clickable. */
+.maka-firstrun-list::after {
+  content: "";
+  position: absolute;
+  left: var(--border-width-hairline);
+  right: var(--border-width-hairline);
+  bottom: var(--border-width-hairline);
+  height: 28px;
+  border-radius: 0 0 var(--radius-surface) var(--radius-surface);
+  background: linear-gradient(to bottom, oklch(from var(--background-elevated) l c h / 0), var(--background-elevated));
+  pointer-events: none;
 }
 .maka-firstrun-list ul {
   margin: 0;


### PR DESCRIPTION
设计审查第 3 轮（承接 #571/#572，依赖的 #534 已合并）：

1. **P1-6 dark 模式层级坍塌**：暗端 canvas/内容卡/composer 挤在一个窄亮度带里，浮卡边缘消失。内容卡加 dark 专属 1px 内侧高光；composer 描边 alpha 提为 token（light 0.035 / dark 0.12），同一条 rest 规则内完成——**不违反 composer 单源契约**。
2. **P1-8 残余**：外观页语气偏好说明从工程话术（system prompt / Runtime 判定）改为用户视角（字数上限、影响范围、什么写了也没用）。
3. **P2-15 首启列表腰斩**：高度 clamp 把最后一行切半且无滚动暗示 → 底部渐隐提示（provider 数恒超 clamp，提示永不撒谎）。

dark 截图验证边缘可读；2143/2143 全绿；check-dead-css 增量干净（29 个 hljs 类是 #546 合并带来的 main 存量,另行处理）。