### PR TITLE
fix(scripts): allowlist runtime hljs/GFM classes in check-dead-css

### DIFF
--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -66,6 +66,44 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'settingsPaletteSwatch-dusk',
   'settingsPaletteSwatch-sand',
   'settingsPaletteSwatch-mono',
+  // highlight.js token classes — emitted at runtime by rehype-highlight
+  // (highlight.js v11 via lowlight) inside markdown code blocks, styled in
+  // chat-message.css (#546 PR4). Verified emitted by the installed
+  // highlight.js 11.11.1 against the lowlight `common` grammar set.
+  // `class_` / `function_` are the v11 sub-scope classes of `hljs-title`
+  // (rendered as class="hljs-title class_"); `hljs-class` is the v10-era
+  // scope still emitted by php/perl/c grammars in the common set.
+  'hljs-addition',
+  'hljs-attr',
+  'hljs-attribute',
+  'hljs-built_in',
+  'hljs-bullet',
+  'hljs-class',
+  'hljs-comment',
+  'hljs-deletion',
+  'hljs-doctag',
+  'hljs-emphasis',
+  'hljs-keyword',
+  'hljs-literal',
+  'hljs-meta',
+  'hljs-name',
+  'hljs-number',
+  'hljs-quote',
+  'hljs-regexp',
+  'hljs-selector-tag',
+  'hljs-string',
+  'hljs-strong',
+  'hljs-symbol',
+  'hljs-tag',
+  'hljs-title',
+  'hljs-type',
+  'hljs-variable',
+  'class_',
+  'function_',
+  // GFM task-list classes — emitted at runtime by remark-gfm + remark-rehype
+  // on `- [ ]` / `- [x]` list items, styled in chat-message.css (#546 PR4).
+  'contains-task-list',
+  'task-list-item',
 ]);
 
 async function readCssFiles(dir) {


### PR DESCRIPTION
## Summary

`node scripts/check-dead-css.mjs` reported 29 dead classes on main after the #546 PR4 chat-message.css/.maka-prose refactor. All 29 are **false positives** — runtime-generated classes that never appear as string literals in source — so this PR adds them to `DYNAMIC_STYLE_HOOKS` rather than deleting any CSS. The script now returns clean on main.

## Verification

Each class was verified as actually emitted at runtime using the exact packages installed in the repo (no CSS was deleted because none turned out to be dead):

- **27 highlight.js classes** (`hljs-*`, `class_`, `function_`): emitted by `rehype-highlight` → lowlight 3.3.0 → highlight.js 11.11.1 inside markdown code blocks ([markdown-body.tsx](https://github.com/maka-agent/maka-agent/blob/main/packages/ui/src/markdown-body.tsx)). Verified by running lowlight from `node_modules` against sample code in ~20 `common`-set languages and collecting every emitted class:
  - `class_` / `function_` are highlight.js v11 sub-scope classes of `hljs-title` (rendered as `class="hljs-title class_"`).
  - `hljs-class` is the v10-era scope — still emitted by the php, perl, and c grammars in the `common` set (confirmed by direct highlight runs).
- **2 GFM task-list classes** (`contains-task-list`, `task-list-item`): emitted by `remark-gfm` + `remark-rehype` on `- [ ]` / `- [x]` list items. Verified by running the unified pipeline and walking the resulting hast tree.

## Result

```
$ node scripts/check-dead-css.mjs
check-dead-css: no dead classes found ✓
```