### PR TITLE
fix(desktop): reveal main window only after first React commit

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -407,6 +407,9 @@ declare global {
         // PR-WINDOW-TITLEBAR-0: re-sync the native Windows titleBarOverlay
         // color/symbolColor to the current app theme. No-op on non-Windows.
         setTitleBarOverlayTheme(isDark: boolean): Promise<void>;
+        // PR-SHOW-AFTER-FIRST-COMMIT: signal main after the first React commit
+        // so the hidden window is revealed (see main-window.ts).
+        notifyRendererReady(): Promise<void>;
       };
       config: {
         export(input: { categories: ConfigCategory[] }): Promise<

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -55,12 +55,14 @@ function makeFakeWindow(): RevealableWindow & { showCount: number; destroy(): vo
 function makeFakeFocusableWindow(): FocusableRevealableWindow & {
   showCount: number;
   focusCount: number;
+  maximizeCount: number;
   destroy(): void;
 } {
   let visible = false;
   let destroyed = false;
   let showCount = 0;
   let focusCount = 0;
+  let maximizeCount = 0;
   return {
     isVisible: () => visible,
     isDestroyed: () => destroyed,
@@ -73,6 +75,12 @@ function makeFakeFocusableWindow(): FocusableRevealableWindow & {
     focus() {
       focusCount += 1;
     },
+    maximize() {
+      // Mirror the real Electron behavior this gate exists to contain:
+      // maximize() on a hidden window reveals it (verified on macOS).
+      maximizeCount += 1;
+      visible = true;
+    },
     destroy() {
       destroyed = true;
     },
@@ -81,6 +89,9 @@ function makeFakeFocusableWindow(): FocusableRevealableWindow & {
     },
     get focusCount() {
       return focusCount;
+    },
+    get maximizeCount() {
+      return maximizeCount;
     },
   };
 }
@@ -121,19 +132,57 @@ describe('window reveal gate defers early focus (ChatGPT Pro review P2)', () => 
     assert.equal(win.focusCount, 0);
   });
 
+  // ChatGPT Pro review P2 (round 2): Electron's maximize() reveals a hidden
+  // window, so restoring a saved maximized state in createWindow() bypassed
+  // the gate — a user who closed the app maximized saw the skeleton again on
+  // every launch. The gate must defer the maximize alongside focus.
+  it('saved-maximized restore before renderer-ready stays hidden; markReady applies it', () => {
+    const gate = createWindowRevealGate(false);
+    const win = makeFakeFocusableWindow();
+    // createWindow() restores the persisted maximized state on a hidden window.
+    gate.requestMaximize(win);
+    assert.equal(win.maximizeCount, 0, 'pre-ready maximize must not reveal the skeleton');
+    assert.equal(win.isVisible(), false);
+    // First commit: maximize lands first, so the first visible frame is
+    // already maximized and the reveal itself becomes a no-op.
+    gate.markReady(win);
+    assert.equal(win.maximizeCount, 1);
+    assert.equal(win.isVisible(), true);
+    assert.equal(win.showCount, 0, 'maximize() already revealed; show() must not fire again');
+  });
+
+  it('maximize after renderer-ready applies immediately; keepHidden never maximizes', () => {
+    const readyGate = createWindowRevealGate(false);
+    const readyWin = makeFakeFocusableWindow();
+    readyGate.markReady(readyWin);
+    readyGate.requestMaximize(readyWin);
+    assert.equal(readyWin.maximizeCount, 1);
+
+    const smokeGate = createWindowRevealGate(true);
+    const smokeWin = makeFakeFocusableWindow();
+    smokeGate.requestMaximize(smokeWin);
+    smokeGate.markReady(smokeWin);
+    smokeGate.requestMaximize(smokeWin);
+    assert.equal(smokeWin.maximizeCount, 0);
+    assert.equal(smokeWin.isVisible(), false);
+  });
+
   it('reset() re-arms the gate for a recreated window (macOS close-all)', () => {
     const gate = createWindowRevealGate(false);
     const first = makeFakeFocusableWindow();
     gate.markReady(first);
     gate.reset();
     const second = makeFakeFocusableWindow();
-    // Stale readiness from the first window must not leak: a focus request on
-    // the fresh hidden window defers again until its own first commit.
+    // Stale readiness from the first window must not leak: focus and maximize
+    // requests on the fresh hidden window defer again until its own first commit.
     gate.requestFocus(second);
+    gate.requestMaximize(second);
     assert.equal(second.showCount, 0);
+    assert.equal(second.maximizeCount, 0);
     gate.markReady(second);
     assert.equal(second.isVisible(), true);
     assert.equal(second.focusCount, 1);
+    assert.equal(second.maximizeCount, 1);
   });
 });
 
@@ -226,6 +275,19 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
       src,
       /revealGate\.reset\(\);\s*mainWindow = new BrowserWindow\(/,
       'createWindow must reset the reveal gate for each window lifecycle',
+    );
+    // ChatGPT Pro review P2 (round 2): the saved-maximized restore must defer
+    // through the gate — a direct mainWindow.maximize() reveals the hidden
+    // window before the renderer's first commit.
+    assert.match(
+      src,
+      /if \(bounds\.isMaximized\) \{\s*revealGate\.requestMaximize\(mainWindow\);/,
+      'saved-maximized restore must route through revealGate.requestMaximize',
+    );
+    assert.doesNotMatch(
+      src,
+      /mainWindow\.maximize\(\)/,
+      'createWindow must never call mainWindow.maximize() directly',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -18,7 +18,12 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { showWindowOnceReady, type RevealableWindow } from '../window-reveal.js';
+import {
+  createWindowRevealGate,
+  showWindowOnceReady,
+  type FocusableRevealableWindow,
+  type RevealableWindow,
+} from '../window-reveal.js';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
@@ -45,6 +50,92 @@ function makeFakeWindow(): RevealableWindow & { showCount: number; destroy(): vo
     },
   };
 }
+
+/** Fake window with the focus surface the reveal gate's deferred focus touches. */
+function makeFakeFocusableWindow(): FocusableRevealableWindow & {
+  showCount: number;
+  focusCount: number;
+  destroy(): void;
+} {
+  let visible = false;
+  let destroyed = false;
+  let showCount = 0;
+  let focusCount = 0;
+  return {
+    isVisible: () => visible,
+    isDestroyed: () => destroyed,
+    isMinimized: () => false,
+    restore() {},
+    show() {
+      showCount += 1;
+      visible = true;
+    },
+    focus() {
+      focusCount += 1;
+    },
+    destroy() {
+      destroyed = true;
+    },
+    get showCount() {
+      return showCount;
+    },
+    get focusCount() {
+      return focusCount;
+    },
+  };
+}
+
+// ChatGPT Pro review P2: second-instance / 'activate' land in controller
+// focus() while the window may still be pre-first-commit. The gate must defer
+// (not show) those requests, then flush them when the renderer signals ready.
+describe('window reveal gate defers early focus (ChatGPT Pro review P2)', () => {
+  it('focus before renderer-ready does not show; markReady flushes show+focus', () => {
+    const gate = createWindowRevealGate(false);
+    const win = makeFakeFocusableWindow();
+    // User re-launches / clicks the dock icon while the window is hidden.
+    gate.requestFocus(win);
+    assert.equal(win.showCount, 0, 'pre-ready focus must not reveal the skeleton');
+    assert.equal(win.isVisible(), false);
+    // First commit arrives: reveal once and honor the deferred foreground intent.
+    gate.markReady(win);
+    assert.equal(win.isVisible(), true);
+    assert.equal(win.focusCount, 1);
+  });
+
+  it('focus after renderer-ready shows and focuses immediately (old behavior)', () => {
+    const gate = createWindowRevealGate(false);
+    const win = makeFakeFocusableWindow();
+    gate.markReady(win);
+    gate.requestFocus(win);
+    assert.equal(win.isVisible(), true);
+    assert.equal(win.focusCount, 1);
+  });
+
+  it('keepHidden (visual-smoke / E2E) never shows or focuses from any path', () => {
+    const gate = createWindowRevealGate(true);
+    const win = makeFakeFocusableWindow();
+    gate.requestFocus(win);
+    gate.markReady(win);
+    gate.requestFocus(win);
+    assert.equal(win.showCount, 0);
+    assert.equal(win.focusCount, 0);
+  });
+
+  it('reset() re-arms the gate for a recreated window (macOS close-all)', () => {
+    const gate = createWindowRevealGate(false);
+    const first = makeFakeFocusableWindow();
+    gate.markReady(first);
+    gate.reset();
+    const second = makeFakeFocusableWindow();
+    // Stale readiness from the first window must not leak: a focus request on
+    // the fresh hidden window defers again until its own first commit.
+    gate.requestFocus(second);
+    assert.equal(second.showCount, 0);
+    gate.markReady(second);
+    assert.equal(second.isVisible(), true);
+    assert.equal(second.focusCount, 1);
+  });
+});
 
 describe('window reveal gate (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
   it('renderer-ready reveals the hidden window exactly once (idempotent)', () => {
@@ -106,8 +197,8 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     assert.match(src, /SHOW_FALLBACK_TIMEOUT_MS\s*=\s*4000/);
     assert.match(
       src,
-      /setTimeout\([\s\S]*?showWindowOnceReady\(mainWindow, keepHiddenForVisualSmoke\)[\s\S]*?SHOW_FALLBACK_TIMEOUT_MS\)/,
-      'the fallback timer must reveal through showWindowOnceReady',
+      /setTimeout\([\s\S]*?revealGate\.markReady\(mainWindow\)[\s\S]*?SHOW_FALLBACK_TIMEOUT_MS\)/,
+      'the fallback timer must reveal through the reveal gate',
     );
     // Timer must not run for visual-smoke windows, and must clear on close.
     assert.match(src, /if \(!keepHiddenForVisualSmoke\) \{\s*showFallbackTimer = setTimeout/);
@@ -119,8 +210,22 @@ describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
     // Renderer-ready controller method cancels the timer then reveals.
     assert.match(
       src,
-      /notifyRendererReady\(\) \{[\s\S]*?clearShowFallbackTimer\(\);[\s\S]*?showWindowOnceReady\(mainWindow, keepHiddenForVisualSmoke\);/,
+      /notifyRendererReady\(\) \{[\s\S]*?clearShowFallbackTimer\(\);[\s\S]*?revealGate\.markReady\(mainWindow\);/,
       'notifyRendererReady must clear the timer and reveal through the gate',
+    );
+    // ChatGPT Pro review P2: focus() (second-instance / activate) must route
+    // through the gate instead of calling mainWindow.show() directly, so a
+    // pre-first-commit focus request can never flash the skeleton.
+    assert.match(
+      src,
+      /focus\(\) \{[\s\S]*?revealGate\.requestFocus\(mainWindow\);\s*\},/,
+      'controller focus() must defer through revealGate.requestFocus',
+    );
+    // A fresh window re-arms the gate before creation.
+    assert.match(
+      src,
+      /revealGate\.reset\(\);\s*mainWindow = new BrowserWindow\(/,
+      'createWindow must reset the reveal gate for each window lifecycle',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/window-reveal-after-first-commit-contract.test.ts
@@ -1,0 +1,153 @@
+/**
+ * PR-SHOW-AFTER-FIRST-COMMIT contract.
+ *
+ * The BrowserWindow is now created `show: false` on every run so the OS never
+ * flashes the index.html `.maka-preload` skeleton before React paints. The
+ * renderer signals `window:notifyRendererReady` after its first React commit,
+ * and a fallback timer reveals the window if that signal never arrives. Under
+ * visual-smoke capture the window must stay hidden for its whole life.
+ *
+ * The reveal decision lives in showWindowOnceReady (window-reveal.ts) precisely
+ * so it can be exercised behaviorally here — main-window.ts can't be imported
+ * under plain `node --test` because it pulls in `electron`, whose API is only
+ * present inside the Electron binary. The timer / IPC / creation wiring around
+ * the gate is pinned with source-contract assertions below.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { showWindowOnceReady, type RevealableWindow } from '../window-reveal.js';
+import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const readRepoFile = (repoPath: string): Promise<string> =>
+  readFile(resolve(REPO_ROOT, repoPath), 'utf8');
+
+/** Fake window that flips visible on show() and records every show() call. */
+function makeFakeWindow(): RevealableWindow & { showCount: number; destroy(): void } {
+  let visible = false;
+  let destroyed = false;
+  let showCount = 0;
+  return {
+    isVisible: () => visible,
+    isDestroyed: () => destroyed,
+    show() {
+      showCount += 1;
+      visible = true;
+    },
+    destroy() {
+      destroyed = true;
+    },
+    get showCount() {
+      return showCount;
+    },
+  };
+}
+
+describe('window reveal gate (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
+  it('renderer-ready reveals the hidden window exactly once (idempotent)', () => {
+    const win = makeFakeWindow();
+    // First commit signal reveals the hidden window.
+    showWindowOnceReady(win, false);
+    assert.equal(win.showCount, 1);
+    assert.equal(win.isVisible(), true);
+    // HMR reload re-fires the signal, and the fallback timer may race it — the
+    // isVisible() guard makes every later call a no-op so focus is never stolen.
+    showWindowOnceReady(win, false);
+    showWindowOnceReady(win, false);
+    assert.equal(win.showCount, 1);
+  });
+
+  it('fallback timer path reveals a window that never signaled', () => {
+    // The timer routes through the same gate with keepHidden=false: a wedged
+    // renderer still gets a visible window.
+    const win = makeFakeWindow();
+    showWindowOnceReady(win, false);
+    assert.equal(win.showCount, 1);
+    assert.equal(win.isVisible(), true);
+  });
+
+  it('visual-smoke (keepHidden) never reveals, from either the signal or the timer', () => {
+    const win = makeFakeWindow();
+    // Renderer-ready path.
+    showWindowOnceReady(win, true);
+    // Fallback-timer path.
+    showWindowOnceReady(win, true);
+    assert.equal(win.showCount, 0);
+    assert.equal(win.isVisible(), false);
+  });
+
+  it('never reveals a null or destroyed window (teardown raced the timer/IPC)', () => {
+    assert.doesNotThrow(() => showWindowOnceReady(null, false));
+    const win = makeFakeWindow();
+    win.destroy();
+    showWindowOnceReady(win, false);
+    assert.equal(win.showCount, 0);
+  });
+});
+
+describe('window reveal wiring (PR-SHOW-AFTER-FIRST-COMMIT)', () => {
+  it('main-window creates the window hidden and wires the reveal fallback timer', async () => {
+    const src = await readRepoFile('apps/desktop/src/main/main-window.ts');
+    // Every run now creates hidden — no `!app.isPackaged && startHidden` gate.
+    assert.match(
+      src,
+      /new BrowserWindow\(\{[\s\S]*?\n\s*show: false,/,
+      'BrowserWindow must be created with show: false unconditionally',
+    );
+    assert.doesNotMatch(
+      src,
+      /\?\?\?|!app\.isPackaged && startHidden \? \{ show: false \} : \{\}/,
+      'the old conditional show: false creation gate must be gone',
+    );
+    // Fallback timer with the documented 4s budget, routed through the gate.
+    assert.match(src, /SHOW_FALLBACK_TIMEOUT_MS\s*=\s*4000/);
+    assert.match(
+      src,
+      /setTimeout\([\s\S]*?showWindowOnceReady\(mainWindow, keepHiddenForVisualSmoke\)[\s\S]*?SHOW_FALLBACK_TIMEOUT_MS\)/,
+      'the fallback timer must reveal through showWindowOnceReady',
+    );
+    // Timer must not run for visual-smoke windows, and must clear on close.
+    assert.match(src, /if \(!keepHiddenForVisualSmoke\) \{\s*showFallbackTimer = setTimeout/);
+    assert.match(
+      src,
+      /mainWindow\.on\('close', \(\) => \{\s*clearShowFallbackTimer\(\);/,
+      'the fallback timer must be cleared when the window closes',
+    );
+    // Renderer-ready controller method cancels the timer then reveals.
+    assert.match(
+      src,
+      /notifyRendererReady\(\) \{[\s\S]*?clearShowFallbackTimer\(\);[\s\S]*?showWindowOnceReady\(mainWindow, keepHiddenForVisualSmoke\);/,
+      'notifyRendererReady must clear the timer and reveal through the gate',
+    );
+  });
+
+  it('main registers the window:notifyRendererReady IPC handler', async () => {
+    const src = await readMainProcessCombinedSource();
+    assert.match(
+      src,
+      /ipcMain\.handle\('window:notifyRendererReady',[\s\S]*?mainWindowController\.notifyRendererReady\(\)/,
+      'main must forward window:notifyRendererReady to the controller',
+    );
+  });
+
+  it('preload exposes appWindow.notifyRendererReady over the same channel', async () => {
+    const src = await readRepoFile('apps/desktop/src/preload/preload.ts');
+    assert.match(
+      src,
+      /notifyRendererReady\(\): Promise<void> \{\s*return ipcRenderer\.invoke\('window:notifyRendererReady'\);/,
+    );
+  });
+
+  it('the renderer signals ready after the first commit, unconditionally', async () => {
+    const src = await readRepoFile('apps/desktop/src/renderer/app.tsx');
+    // useLayoutEffect fires post-commit; the empty dep array makes it fire once.
+    // The guarded chain must not depend on the onboarding snapshot value.
+    assert.match(
+      src,
+      /useLayoutEffect\(\(\) => \{\s*void window\.maka\?\.appWindow\?\.notifyRendererReady\?\.\(\);\s*\}, \[\]\)/,
+    );
+  });
+});

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -9,6 +9,7 @@ import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { VisualSmokeFixture } from './visual-smoke-fixture.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
+import { showWindowOnceReady } from './window-reveal.js';
 
 type SettingsReader = {
   get(): Promise<AppSettings>;
@@ -17,6 +18,9 @@ type SettingsReader = {
 export interface MainWindowController {
   createWindow(): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
+  // PR-SHOW-AFTER-FIRST-COMMIT: reveal the hidden window after the renderer's
+  // first React commit. Idempotent + visual-smoke-safe (see notifyRendererReady).
+  notifyRendererReady(): void;
   setTitlebarControlsVisible(sender: Electron.WebContents, visible: unknown): void;
   setThemeSource(sender: Electron.WebContents, themePref: unknown): void;
   setTitleBarOverlayTheme(sender: Electron.WebContents, isDark: unknown): void;
@@ -63,6 +67,12 @@ export function safeSendToRenderer(channel: string, ...args: unknown[]): void {
 const MAIN_WINDOW_TRAFFIC_LIGHT_POSITION = { x: 14, y: 14 } as const;
 const HIDDEN_TRAFFIC_LIGHT_POSITION = { x: -100, y: -100 } as const;
 
+// PR-SHOW-AFTER-FIRST-COMMIT: fallback reveal delay for a renderer that never
+// signals its first commit (window:notifyRendererReady). main.tsx's onboarding
+// prefetch bails at 2500ms; the remainder is headroom for load + first paint,
+// so a wedged renderer can never leave the window invisible forever.
+const SHOW_FALLBACK_TIMEOUT_MS = 4000;
+
 // PR-WINDOW-TITLEBAR-0: the Windows titleBarOverlay height matches the
 // renderer `--h-titlebar: 36px` token so the native control strip and the
 // in-app top chrome share a baseline. The overlay color/symbolColor are
@@ -78,6 +88,22 @@ const titleBarOverlayOptions = (isDark: boolean): { color: string; symbolColor: 
 
 export function createMainWindowController(deps: MainWindowControllerDeps): MainWindowController {
   const { workspaceRoot, visualSmokeFixture, settingsStore, startHidden } = deps;
+
+  // PR-SHOW-AFTER-FIRST-COMMIT: windows launched hidden (startHidden covers
+  // visual-smoke capture and E2E — see main.ts) must never be revealed;
+  // visual-smoke captures run on the hidden window and E2E drives it headless.
+  // `!app.isPackaged` mirrors the original creation-time gate so a packaged
+  // build ignores a stray startHidden flag. Both the fallback timer and the
+  // renderer-ready IPC route their show() through this predicate via
+  // showWindowOnceReady.
+  const keepHiddenForVisualSmoke = !app.isPackaged && startHidden;
+  let showFallbackTimer: NodeJS.Timeout | undefined;
+  const clearShowFallbackTimer = (): void => {
+    if (showFallbackTimer) {
+      clearTimeout(showFallbackTimer);
+      showFallbackTimer = undefined;
+    }
+  };
 
   function getBrowserViews(): BrowserViewManager<BrowserViewController> {
     if (!browserViews) {
@@ -175,13 +201,16 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // renderer side of the same gate.
       resizable: true,
       backgroundColor: initialBg,
-      // PR-VISUAL-SMOKE-HEADLESS: under visual-smoke capture, never show the
-      // window or let the app take foreground — captures run while the
-      // developer keeps working in another app. `webContents.capturePage()`
-      // still returns a painted frame on a hidden window because
-      // `paintWhenInitiallyHidden` defaults to true. Real runs keep the
-      // default `show: true`.
-      ...(!app.isPackaged && startHidden ? { show: false } : {}),
+      // PR-SHOW-AFTER-FIRST-COMMIT: create hidden on every run so the OS never
+      // flashes the index.html `.maka-preload` skeleton before React paints.
+      // The renderer signals `window:notifyRendererReady` after its first
+      // commit (app.tsx) and a fallback timer below reveals the window if that
+      // signal never arrives; the reveal gate (showWindowOnceReady) keeps the
+      // window hidden for its whole life under visual-smoke capture, where
+      // `webContents.capturePage()` still returns a painted frame because
+      // `paintWhenInitiallyHidden` defaults to true and the app must never take
+      // foreground while the developer keeps working in another app.
+      show: false,
       // Glass material — reference-atlas §1 + §12.1 documents the upstream
       // reference layout's `light-glass` / `dark-glass` themes that paint
       // the sidebar against native macOS vibrancy material. Enabling
@@ -289,6 +318,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     mainWindow.on('maximize', scheduleSave);
     mainWindow.on('unmaximize', scheduleSave);
     mainWindow.on('close', () => {
+      clearShowFallbackTimer();
       if (saveTimer) clearTimeout(saveTimer);
       // The window owns the embedded-browser views (children of its contentView);
       // tear them down so their WebContents close with it instead of leaking.
@@ -299,6 +329,18 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         : { ...mainWindow.getBounds(), isMaximized: false };
       void writeSavedBounds(workspaceRoot, final);
     });
+
+    // PR-SHOW-AFTER-FIRST-COMMIT: reveal fallback. The window stays hidden
+    // until the renderer signals its first commit; if the renderer wedges and
+    // never signals, reveal it anyway after SHOW_FALLBACK_TIMEOUT_MS. Skipped
+    // for visual-smoke windows, which must stay hidden; cleared on
+    // renderer-ready (notifyRendererReady) and on close.
+    if (!keepHiddenForVisualSmoke) {
+      showFallbackTimer = setTimeout(() => {
+        showFallbackTimer = undefined;
+        showWindowOnceReady(mainWindow, keepHiddenForVisualSmoke);
+      }, SHOW_FALLBACK_TIMEOUT_MS);
+    }
 
     if (process.env.VITE_DEV_SERVER_URL) {
       await mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
@@ -314,6 +356,15 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
   return {
     createWindow,
     send: safeSendToRenderer,
+    notifyRendererReady() {
+      // PR-SHOW-AFTER-FIRST-COMMIT: the renderer finished its first React
+      // commit. Cancel the fallback timer and reveal the window through the
+      // shared gate — idempotent, so an HMR reload re-firing this signal (or a
+      // timer racing it) never re-shows or steals focus, and suppressed for
+      // visual-smoke windows.
+      clearShowFallbackTimer();
+      showWindowOnceReady(mainWindow, keepHiddenForVisualSmoke);
+    },
     setTitlebarControlsVisible(sender, visible) {
       const target = BrowserWindow.fromWebContents(sender);
       if (!target || target !== mainWindow || process.platform !== 'darwin') return;

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -9,7 +9,7 @@ import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { VisualSmokeFixture } from './visual-smoke-fixture.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
-import { showWindowOnceReady } from './window-reveal.js';
+import { createWindowRevealGate } from './window-reveal.js';
 
 type SettingsReader = {
   get(): Promise<AppSettings>;
@@ -93,10 +93,15 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
   // visual-smoke capture and E2E — see main.ts) must never be revealed;
   // visual-smoke captures run on the hidden window and E2E drives it headless.
   // `!app.isPackaged` mirrors the original creation-time gate so a packaged
-  // build ignores a stray startHidden flag. Both the fallback timer and the
-  // renderer-ready IPC route their show() through this predicate via
-  // showWindowOnceReady.
+  // build ignores a stray startHidden flag. The fallback timer, the
+  // renderer-ready IPC, and focus() all route their show() through this
+  // predicate via the reveal gate below.
   const keepHiddenForVisualSmoke = !app.isPackaged && startHidden;
+  // ChatGPT Pro review P2: focus() (second-instance / activate) used to call
+  // mainWindow.show() directly, bypassing the reveal gate — re-launching or
+  // clicking the dock icon during the pre-commit window would flash the
+  // skeleton anyway. The gate defers those focus requests until markReady.
+  const revealGate = createWindowRevealGate(keepHiddenForVisualSmoke);
   let showFallbackTimer: NodeJS.Timeout | undefined;
   const clearShowFallbackTimer = (): void => {
     if (showFallbackTimer) {
@@ -160,6 +165,10 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // disagrees with the persisted in-app preference.
     nativeTheme.themeSource = toNativeThemeSource(themePref);
 
+    // Re-arm the reveal gate for this window's lifecycle (macOS keeps the app
+    // alive after close-all; the next createWindow starts hidden again and a
+    // stale ready/pending-focus state must not reveal it early).
+    revealGate.reset();
     mainWindow = new BrowserWindow({
       width: bounds.width,
       height: bounds.height,
@@ -338,7 +347,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     if (!keepHiddenForVisualSmoke) {
       showFallbackTimer = setTimeout(() => {
         showFallbackTimer = undefined;
-        showWindowOnceReady(mainWindow, keepHiddenForVisualSmoke);
+        revealGate.markReady(mainWindow);
       }, SHOW_FALLBACK_TIMEOUT_MS);
     }
 
@@ -361,9 +370,10 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // commit. Cancel the fallback timer and reveal the window through the
       // shared gate — idempotent, so an HMR reload re-firing this signal (or a
       // timer racing it) never re-shows or steals focus, and suppressed for
-      // visual-smoke windows.
+      // visual-smoke windows. markReady also flushes a focus request that
+      // arrived while the window was still hidden (second-instance/activate).
       clearShowFallbackTimer();
-      showWindowOnceReady(mainWindow, keepHiddenForVisualSmoke);
+      revealGate.markReady(mainWindow);
     },
     setTitlebarControlsVisible(sender, visible) {
       const target = BrowserWindow.fromWebContents(sender);
@@ -406,10 +416,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       return BrowserWindow.getAllWindows().length > 0;
     },
     focus() {
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.show();
-      mainWindow.focus();
+      // ChatGPT Pro review P2: second-instance / activate must not show() the
+      // still-hidden window ahead of the renderer's first commit — that would
+      // flash the `.maka-preload` skeleton past the reveal gate. The gate
+      // defers the request and flushes it (restore+show+focus) on markReady;
+      // after that, focus behaves exactly as before.
+      revealGate.requestFocus(mainWindow);
     },
   };
 }

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -302,10 +302,12 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     });
 
     // Restore maximized state after construction (BrowserWindow constructor
-    // doesn't accept it directly; calling here keeps the unmaximized bounds
-    // accurate for the next save).
+    // doesn't accept it directly). ChatGPT Pro review P2 (round 2): a direct
+    // maximize() here reveals the still-hidden window (verified on macOS),
+    // bypassing the reveal gate — defer it so markReady applies it right
+    // before the reveal and the first visible frame is already maximized.
     if (bounds.isMaximized) {
-      mainWindow.maximize();
+      revealGate.requestMaximize(mainWindow);
     }
 
     // Persist bounds across launches. Debounce so a continuous resize drag

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -888,6 +888,12 @@ function registerIpc(): void {
   ipcMain.handle('window:setTitlebarControlsVisible', (event, visible: unknown): void => {
     mainWindowController.setTitlebarControlsVisible(event.sender, visible);
   });
+  // PR-SHOW-AFTER-FIRST-COMMIT: the renderer signals its first React commit so
+  // the hidden window (main-window.ts show: false) is revealed only once real
+  // content can paint. Idempotent + visual-smoke-safe inside the controller.
+  ipcMain.handle('window:notifyRendererReady', (): void => {
+    mainWindowController.notifyRendererReady();
+  });
   ipcMain.handle('window:setThemeSource', (event, themePref: unknown): void => {
     mainWindowController.setThemeSource(event.sender, themePref);
   });

--- a/apps/desktop/src/main/window-reveal.ts
+++ b/apps/desktop/src/main/window-reveal.ts
@@ -32,3 +32,65 @@ export function showWindowOnceReady(win: RevealableWindow | null, keepHidden: bo
   if (win.isVisible()) return;
   win.show();
 }
+
+/** Focus surface for deferred focus requests (see createWindowRevealGate). */
+export interface FocusableRevealableWindow extends RevealableWindow {
+  isMinimized(): boolean;
+  restore(): void;
+  focus(): void;
+}
+
+export interface WindowRevealGate {
+  /** Re-arm for a freshly created window (macOS recreate after close-all). */
+  reset(): void;
+  /** Renderer first commit or fallback timeout: reveal + flush deferred focus. */
+  markReady(win: FocusableRevealableWindow | null): void;
+  /** Focus request (second-instance / activate): deferred until markReady. */
+  requestFocus(win: FocusableRevealableWindow | null): void;
+}
+
+/**
+ * Readiness-aware wrapper around showWindowOnceReady. Focus requests that
+ * arrive before the renderer's first commit (user re-launches or clicks the
+ * dock icon while the window is still hidden) must NOT show() the window —
+ * that would flash the `.maka-preload` skeleton the hidden creation exists to
+ * suppress. They are remembered and flushed as show()+focus() when markReady
+ * fires, so the user's foreground intent is honored, just not early.
+ *
+ * `keepHidden` windows (visual-smoke capture / E2E) never show or take
+ * focus from any path — captures run while the developer works elsewhere.
+ */
+export function createWindowRevealGate(keepHidden: boolean): WindowRevealGate {
+  let ready = false;
+  let pendingFocus = false;
+
+  const focusNow = (win: FocusableRevealableWindow | null): void => {
+    if (keepHidden) return;
+    if (!win || win.isDestroyed()) return;
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+  };
+
+  return {
+    reset() {
+      ready = false;
+      pendingFocus = false;
+    },
+    markReady(win) {
+      ready = true;
+      showWindowOnceReady(win, keepHidden);
+      if (pendingFocus) {
+        pendingFocus = false;
+        focusNow(win);
+      }
+    },
+    requestFocus(win) {
+      if (!ready) {
+        pendingFocus = true;
+        return;
+      }
+      focusNow(win);
+    },
+  };
+}

--- a/apps/desktop/src/main/window-reveal.ts
+++ b/apps/desktop/src/main/window-reveal.ts
@@ -38,15 +38,19 @@ export interface FocusableRevealableWindow extends RevealableWindow {
   isMinimized(): boolean;
   restore(): void;
   focus(): void;
+  maximize(): void;
 }
 
 export interface WindowRevealGate {
   /** Re-arm for a freshly created window (macOS recreate after close-all). */
   reset(): void;
-  /** Renderer first commit or fallback timeout: reveal + flush deferred focus. */
+  /** Renderer first commit or fallback timeout: reveal + flush deferred work. */
   markReady(win: FocusableRevealableWindow | null): void;
   /** Focus request (second-instance / activate): deferred until markReady. */
   requestFocus(win: FocusableRevealableWindow | null): void;
+  /** Saved-bounds maximize restore: deferred until markReady — Electron's
+   * maximize() shows a hidden window, which would bypass the gate. */
+  requestMaximize(win: FocusableRevealableWindow | null): void;
 }
 
 /**
@@ -57,12 +61,19 @@ export interface WindowRevealGate {
  * suppress. They are remembered and flushed as show()+focus() when markReady
  * fires, so the user's foreground intent is honored, just not early.
  *
- * `keepHidden` windows (visual-smoke capture / E2E) never show or take
- * focus from any path — captures run while the developer works elsewhere.
+ * The same deferral applies to restoring a saved maximized state: Electron's
+ * BrowserWindow.maximize() reveals a still-hidden window (verified on macOS),
+ * so createWindow must not call it directly — requestMaximize holds the
+ * intent and markReady applies it right before the reveal, so the window's
+ * first on-screen frame is already maximized.
+ *
+ * `keepHidden` windows (visual-smoke capture / E2E) never show, maximize, or
+ * take focus from any path — captures run while the developer works elsewhere.
  */
 export function createWindowRevealGate(keepHidden: boolean): WindowRevealGate {
   let ready = false;
   let pendingFocus = false;
+  let pendingMaximize = false;
 
   const focusNow = (win: FocusableRevealableWindow | null): void => {
     if (keepHidden) return;
@@ -72,13 +83,26 @@ export function createWindowRevealGate(keepHidden: boolean): WindowRevealGate {
     win.focus();
   };
 
+  const maximizeNow = (win: FocusableRevealableWindow | null): void => {
+    if (keepHidden) return;
+    if (!win || win.isDestroyed()) return;
+    win.maximize();
+  };
+
   return {
     reset() {
       ready = false;
       pendingFocus = false;
+      pendingMaximize = false;
     },
     markReady(win) {
       ready = true;
+      // Maximize first: it implicitly shows the window, so the reveal below
+      // becomes a no-op and the first visible frame is already maximized.
+      if (pendingMaximize) {
+        pendingMaximize = false;
+        maximizeNow(win);
+      }
       showWindowOnceReady(win, keepHidden);
       if (pendingFocus) {
         pendingFocus = false;
@@ -91,6 +115,13 @@ export function createWindowRevealGate(keepHidden: boolean): WindowRevealGate {
         return;
       }
       focusNow(win);
+    },
+    requestMaximize(win) {
+      if (!ready) {
+        pendingMaximize = true;
+        return;
+      }
+      maximizeNow(win);
     },
   };
 }

--- a/apps/desktop/src/main/window-reveal.ts
+++ b/apps/desktop/src/main/window-reveal.ts
@@ -1,0 +1,34 @@
+/**
+ * PR-SHOW-AFTER-FIRST-COMMIT: shared reveal gate for the hidden main window.
+ *
+ * The BrowserWindow is created with `show: false` (main-window.ts) so the OS
+ * never flashes the index.html `.maka-preload` skeleton before React paints.
+ * Two callers reveal it: the `window:notifyRendererReady` IPC (fired from the
+ * renderer's first React commit) and a fallback timer for a wedged renderer.
+ * Both route through here so the show() decision lives in one place — and so
+ * it stays unit-testable without an Electron runtime (main-window.ts itself
+ * can't be imported under plain `node --test` because it pulls in `electron`).
+ */
+
+/** Minimal structural view of the BrowserWindow surface the gate touches. */
+export interface RevealableWindow {
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  show(): void;
+}
+
+/**
+ * Reveal `win` unless it must stay hidden. Idempotent and focus-safe:
+ * - `keepHidden` true (visual-smoke capture): never reveal — capture runs on
+ *   the hidden window via `paintWhenInitiallyHidden`.
+ * - null / destroyed window: no-op (teardown raced the timer or the IPC).
+ * - already visible: no-op, so a second signal (HMR reload re-fires
+ *   notifyRendererReady, or the timer races the signal) never re-shows and
+ *   never steals foreground focus.
+ */
+export function showWindowOnceReady(win: RevealableWindow | null, keepHidden: boolean): void {
+  if (keepHidden) return;
+  if (!win || win.isDestroyed()) return;
+  if (win.isVisible()) return;
+  win.show();
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -746,6 +746,11 @@ contextBridge.exposeInMainWorld('maka', {
     setTitleBarOverlayTheme(isDark: boolean): Promise<void> {
       return ipcRenderer.invoke('window:setTitleBarOverlayTheme', isDark);
     },
+    // PR-SHOW-AFTER-FIRST-COMMIT: tell main the renderer finished its first
+    // React commit so the hidden window can be revealed. Fire-and-forget.
+    notifyRendererReady(): Promise<void> {
+      return ipcRenderer.invoke('window:notifyRendererReady');
+    },
   },
   config: {
     export(input: { categories: ConfigCategory[] }): Promise<

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import { StrictMode, useLayoutEffect } from 'react';
 import { ToastProvider } from '@maka/ui';
 import { AppShell } from './app-shell';
 import { ErrorBoundary } from './error-boundary';
@@ -10,6 +10,18 @@ export function App({
   /** Pre-mount snapshot prefetched by main.tsx — see prefetchOnboardingSnapshot. */
   initialOnboardingSnapshot?: OnboardingSnapshot | null;
 }) {
+  // PR-SHOW-AFTER-FIRST-COMMIT: the BrowserWindow is created hidden
+  // (main-window.ts show: false) so the OS never flashes the index.html
+  // `.maka-preload` skeleton before React paints. Signal main after the first
+  // real commit — useLayoutEffect fires post-commit — unconditionally: even
+  // when the onboarding snapshot is null and AppShell mounts its fail-soft
+  // loading state, the window should still appear. A fallback timer in main
+  // reveals it if this signal never arrives. `window.maka` is undefined
+  // outside the Electron renderer (storybook), so guard the chain like
+  // theme.ts.
+  useLayoutEffect(() => {
+    void window.maka?.appWindow?.notifyRendererReady?.();
+  }, []);
   return (
     <StrictMode>
       <ErrorBoundary>


### PR DESCRIPTION
## Summary

Create the main BrowserWindow hidden and reveal it only after the renderer's first React commit (via a new `window:notifyRendererReady` IPC), with a 4s fallback timer. Users no longer see the `.maka-preload` startup skeleton card on every launch.

## Why

User report: "every time I open the app there's a placeholder box — feels like a bug." The window showed immediately (`show: true`) while React mount waits on the onboarding snapshot prefetch (#525, up to 2.5s fallback), so every launch exposed the index.html skeleton — worst case for 2.5s on slow machines. This flips the causality: the window waits for content instead of content decorating a premature window, removing the whole class of startup-flash issues (#429, #493, #525 patched individual layers of it).

## Scope

Changed:
- `main-window.ts`: `show: false` always; reveal via shared gate on renderer-ready signal or 4s fallback; timer cleared on close.
- `window-reveal.ts` (new): pure reveal gate — idempotent (`isVisible()` guard, no focus stealing on HMR re-signal), never reveals `startHidden` (visual-smoke/E2E) windows, testable without Electron.
- `main.ts` / `preload.ts` / `global.d.ts`: `window:notifyRendererReady` handler + `appWindow.notifyRendererReady()`.
- `app.tsx`: one-shot `useLayoutEffect` signaling after first commit, unconditional (fires even on the fail-soft null-snapshot path).
- New contract test locking: hidden creation, reveal-once idempotency, fallback reveal, startHidden never reveals.

Not included: removing the `.maka-preload` skeleton (kept as reload-time anti-flash layer); `paintWhenInitiallyHidden` untouched (visual-smoke capture depends on it).

## Verification

- `npm run typecheck`, `npm run -w @maka/desktop test` (2151 pass / 0 fail, +8 new), `npm run build` — all green.
- Runtime check via main-process inspector: cold start reveals at ~680ms with `isVisible()` flipping only after the skeleton is gone and the real app frame is mounted; reveal is ~140ms later than the old show-immediately behavior.

## User-facing impact

Launch no longer flashes a skeleton card; the window appears already rendered. No changelog entry needed (unreleased).

## Reviewer notes

`document.visibilityState` is misleading for verifying this: `paintWhenInitiallyHidden` makes hidden windows paint, so it flips before the window is actually on screen — hence the main-process `isVisible()` verification. Review focus: the `keepHiddenForVisualSmoke` predicate must exactly mirror the old creation-time `!app.isPackaged && startHidden` gate.
