### PR TITLE
fix(ui): designer-audit round 5 — defuse the destructive permission confirm

### DIFF
--- a/packages/ui/src/permission-dialog.tsx
+++ b/packages/ui/src/permission-dialog.tsx
@@ -169,10 +169,28 @@ export function PermissionDialog(props: {
           )}
         </div>
         <div className="maka-modal-footer permissionActions">
-          <UiButton className="maka-button" variant="ghost" type="button" disabled={responsePending} onClick={() => submit('deny')}>拒绝</UiButton>
+          {/* Designer audit P2-16: for destructive requests the confirm used
+              to be the dialog's ONLY solid colored button — muscle memory
+              clicks the brightest control, which is exactly wrong for an
+              irreversible action. Danger side drops to a red OUTLINE (still
+              unmistakably destructive, no longer the visual magnet) and the
+              safe side (拒绝) rises from ghost to secondary so both options
+              read as equally pressable. Non-destructive requests keep the
+              plain primary confirm. */}
           <UiButton
             className="maka-button"
-            variant={isDestructive ? 'destructive' : 'default'}
+            variant={isDestructive ? 'secondary' : 'ghost'}
+            type="button"
+            disabled={responsePending}
+            onClick={() => submit('deny')}
+          >
+            拒绝
+          </UiButton>
+          <UiButton
+            className={isDestructive
+              ? 'maka-button border border-[oklch(from_var(--destructive)_l_c_h_/_0.55)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.08)] text-[color:var(--destructive)] hover:bg-[oklch(from_var(--destructive)_l_c_h_/_0.14)] active:bg-[oklch(from_var(--destructive)_l_c_h_/_0.18)]'
+              : 'maka-button'}
+            variant={isDestructive ? 'outline' : 'default'}
             type="button"
             disabled={responsePending}
             onClick={() => submit('allow')}


### PR DESCRIPTION
P2-16：破坏性请求的确认按钮曾是弹窗里唯一的彩色实心控件——肌肉记忆会点最亮的按钮，对不可逆操作正好是反的。现在危险侧变红描边（危险性依然明确，不再是视觉磁铁），「拒绝」从 ghost 升为 secondary（安全出口同等可点）。非破坏性请求保持原主按钮。截图验证；2143/2143。