### PR TITLE
docs: add codex-style sandbox roadmap

### DIFF
--- a/docs/agent-runtime-codex-sandbox-alignment.md
+++ b/docs/agent-runtime-codex-sandbox-alignment.md
@@ -1,0 +1,1033 @@
+# Agent Runtime Codex-Style Permission and Sandbox Alignment Draft
+
+这份文档用于整理 Maka 从旧的 worktree/write-back sandbox 方案，切换到
+Codex-style 权限管理和平台 sandbox 权限兜底方案时，需要理解的核心概念、
+模块对应关系和后续工作。
+
+当前文档是讨论草案，不是最终 implementation plan。
+
+## 当前方向
+
+当前不实现 worktree sandbox，也不做 diff/write-back。
+
+新的目标是：
+
+```text
+在 Maka runtime 内建立 Codex-style 权限语义模型，
+并在工具执行时用平台 sandbox 做底层权限拦截。
+```
+
+核心边界变成：
+
+```text
+PermissionProfile
+  描述 agent 允许访问什么
+
+PermissionEngine / ToolOrchestrator
+  决定是否允许、提示、阻止，或要求更高权限
+
+SandboxManager
+  把权限语义转换成具体平台 sandbox 执行请求
+
+Platform Sandbox Backend
+  macOS Seatbelt / Linux bubblewrap + seccomp
+  真正拦截文件系统、网络和部分进程能力
+```
+
+平台顺序：
+
+```text
+v1: macOS Seatbelt
+v2: Linux bubblewrap + seccomp
+out of scope: Windows
+```
+
+## workspace-write 的含义
+
+`workspace-write` 不是 worktree。
+
+这里的 `workspace` 指 agent 被授权访问的一组真实目录。在 Maka 第一版中，
+可以先把它理解成当前 session 的 `cwd`，未来再扩展成多个
+`workspace_roots`。
+
+`workspace-write` 的含义是：
+
+- agent 可以读 workspace 内文件。
+- agent 可以写 workspace 内普通文件。
+- agent 不应该写 workspace 外路径。
+- agent 不应该默认写 protected metadata，例如 `.git`、`.agents`、`.codex`。
+- 网络默认受限，由 network policy 决定是否允许。
+- 写入会直接作用于真实 workspace，不经过 worktree 副本。
+
+例如 session cwd 是：
+
+```text
+/Users/me/projects/maka-agent
+```
+
+那么 `workspace-write` 允许：
+
+```text
+/Users/me/projects/maka-agent/src/foo.ts
+```
+
+但不允许：
+
+```text
+/Users/me/.ssh/config
+/etc/hosts
+/Users/me/projects/other-repo/file.ts
+```
+
+默认也应保护：
+
+```text
+/Users/me/projects/maka-agent/.git/*
+/Users/me/projects/maka-agent/.agents/*
+/Users/me/projects/maka-agent/.codex/*
+```
+
+所以当前安全目标不是“所有真实文件修改都必须经 diff review”，而是：
+
+```text
+workspace-write 允许 agent 在真实 workspace 内直接修改文件；
+sandbox 的职责是阻止越权访问 workspace 外部、限制网络、保护敏感 metadata。
+```
+
+## Codex 的 unsandboxed retry 是什么
+
+Codex 有一类执行流程：
+
+```text
+先用 sandbox 跑命令
+  -> 如果命令失败，并且看起来是 sandbox 权限拒绝
+  -> 根据 approval policy 判断是否可以升级
+  -> 可能提示用户：是否允许不用 sandbox 或用更宽权限重试
+  -> 用户同意后，再跑一次更宽权限的命令
+```
+
+例如：
+
+```bash
+npm install
+```
+
+第一次在 sandbox 中运行时，可能因为网络被禁、cache 不可写或某个目录没有权限而失败。
+Codex 可能判断这是 sandbox denial，然后询问用户是否允许提升权限重试。
+
+这就是 unsandboxed retry：
+
+```text
+sandboxed attempt failed
+-> retry with sandbox disabled or relaxed
+```
+
+它的价值是可用性，风险是如果边界处理不好，就会出现“看起来有 sandbox，
+实际最后无 sandbox 执行”的绕过感。
+
+Maka 第一版不做 unsandboxed retry：
+
+```text
+sandbox deny -> 直接失败并解释原因
+```
+
+后续更成熟后，再考虑 additional permissions 或 explicit escalation prompt。
+
+## 旧方案和当前方案的区别
+
+旧方案重点是隔离修改结果：
+
+```text
+agent 写 sandbox workspace
+  -> 用户 review diff
+  -> write-back 到真实 workspace
+```
+
+新方案重点是限制进程能力：
+
+```text
+agent 在真实 workspace 运行
+  -> sandbox 限制它能读写哪里、能不能联网
+```
+
+| 维度 | 旧方案 | 当前方案 |
+| --- | --- | --- |
+| 目标 | sandbox workspace + diff/write-back | permission profile + 平台 sandbox enforcement |
+| 第一安全边界 | worktree 隔离真实文件修改 | 系统级 sandbox 权限拦截 |
+| 主要抽象 | `WorkspaceExecutor` / `WorkspaceExecutorFacts` | `PermissionProfile` / `SandboxManager` |
+| Bash 执行 | 在 sandbox cwd 里跑 | 在真实 cwd 语义下跑，但被 sandbox 限权 |
+| 文件写入 | 先写 sandbox，再人工写回 | 受 profile 控制，可写范围内直接执行 |
+| 网络控制 | 旧方案未完整覆盖 | `NetworkSandboxPolicy`，后续接 managed proxy |
+| 复杂度 | 很早引入 cwd 映射、diff、apply patch、UI | 先建立权限模型和平台拦截，产品交互后置 |
+| Codex 对齐度 | 部分相似，但不是核心设计 | 与 Codex 主线一致 |
+
+旧 issue 中的 worktree 和 write-back 已移出当前规划，不再作为这条 sandbox
+路线的后续目标。
+
+## Maka 当前权限管理现状
+
+Maka 当前已经有权限管理，但它主要是 runtime / 业务层权限，不是 OS sandbox。
+
+当前中心是：
+
+```text
+PermissionMode + ToolCategory + PermissionEngine
+```
+
+### PermissionMode
+
+`PermissionMode` 是会话级自动化模式，目前有四档：
+
+```text
+explore
+ask
+execute
+bypass
+```
+
+它表达的是“这个会话整体应该多保守”。
+
+当前大致语义：
+
+- `explore`：只读探索。允许 read / shell_safe，阻止写入和危险 shell。
+- `ask`：写入和危险操作需要询问用户。
+- `execute`：允许更多自动化，包括 file_write 和 shell_unsafe，但 destructive / privileged 仍提示。
+- `bypass`：全部允许。
+
+对应代码主要在：
+
+```text
+packages/core/src/permission.ts
+packages/core/src/session.ts
+packages/core/src/settings.ts
+```
+
+### ToolCategory
+
+`ToolCategory` 是工具风险分类。
+
+当前类别包括：
+
+```text
+read
+web_read
+file_write
+fs_destructive
+shell_safe
+shell_unsafe
+git_destructive
+network_send
+privileged
+browser
+custom_tool
+subagent
+```
+
+Bash 默认是 `shell_unsafe`，然后通过 `categorizeBash(command)` 用 allowlist、
+prefix 和 regex 重新分类。
+
+例如：
+
+```text
+git status        -> shell_safe
+rm file           -> fs_destructive
+git reset --hard  -> git_destructive
+sudo ...          -> privileged
+未知命令          -> shell_unsafe
+```
+
+这套分类可以继续保留，但新方案中它只应作为审批和风险提示的输入，不能作为完整安全边界。
+
+### PermissionEngine
+
+`PermissionEngine` 是 Maka 当前的审批器。
+
+当前流程：
+
+```text
+ToolRuntime
+  -> PermissionEngine.evaluate()
+      -> preToolUse()
+      -> allow / prompt / block
+  -> allowed 后执行 tool.impl()
+```
+
+如果结果是 `prompt`，runtime 会生成 permission request event，等待用户响应。
+用户允许后，tool 才继续执行。用户也可以选择 remember for turn，同一 turn 内相同
+scope 不再重复提示。
+
+对应代码主要在：
+
+```text
+packages/runtime/src/tool-runtime.ts
+packages/runtime/src/permission-engine.ts
+packages/core/src/permission.ts
+```
+
+### 当前 policy matrix
+
+当前核心策略是：
+
+```text
+permissionMode x tool category -> allow / prompt / block
+```
+
+关键点：
+
+```text
+explore:
+  read / shell_safe allow
+  file_write / shell_unsafe / destructive block
+
+ask:
+  read / shell_safe allow
+  write / shell_unsafe / destructive prompt
+
+execute:
+  read / file_write / shell_unsafe allow
+  fs_destructive / git_destructive / privileged prompt
+
+bypass:
+  all allow
+```
+
+当前最大的安全缺口是：
+
+```text
+execute.shell_unsafe = allow
+```
+
+如果某个会修改本地状态的 Bash 命令没有被 regex 分类成 destructive，它就可能以
+`shell_unsafe` 身份自动执行。
+
+### 当前已有的工具级保护
+
+Maka 当前不只有 prompt，也已经有一些工具级保护。
+
+Bash 侧：
+
+- timeout。
+- abort signal。
+- bounded tail output。
+- stdout / stderr streaming。
+- 进程树终止。
+
+文件工具侧：
+
+- `Read` / `Write` / `Edit` 要求路径在 session cwd 内。
+- 使用 realpath 做 symlink escape 防护。
+- `Write` / `Edit` 有同文件串行锁。
+- `Edit` 有精确匹配和受控 fuzzy matching。
+- `Glob` / `Grep` 限制搜索根不能逃出 cwd。
+
+这些能力应该保留并复用。
+
+### 当前没有的内容
+
+当前 Maka 没有这些能力：
+
+- 没有 canonical `PermissionProfile`。
+- 没有 `FileSystemSandboxPolicy` / `NetworkSandboxPolicy`。
+- 没有 `SandboxManager`。
+- 没有 macOS Seatbelt / Linux sandbox backend。
+- Bash 被允许后直接在 host shell 中运行。
+- Node 主进程内的 Read / Write / Edit 没有统一 profile enforcement。
+- 没有 OS 层文件系统 / 网络权限拦截。
+
+所以当前权限管理主要是：
+
+```text
+业务层 allow / prompt / block
++ 工具实现里的局部路径和稳定性保护
+```
+
+而不是：
+
+```text
+PermissionProfile
++ platform sandbox enforcement
+```
+
+## 当前可利用的基础
+
+新方案不需要从零开始。当前 Maka 已有这些可复用基础：
+
+### 可以直接保留
+
+- `PermissionMode`：继续作为用户可理解的高层模式。
+- `ToolCategory`：继续作为风险分类和审批文案输入。
+- `PermissionEngine` 的 parked prompt / remember-for-turn 机制。
+- `ToolRuntime` 的 tool_call / tool_result / permission_request 事件流程。
+- Bash 的 streaming、timeout、abort、bounded output。
+- 文件工具的 path containment、symlink 防护、write lock、Edit matcher。
+- `WorkspaceExecutor` / `LocalWorkspaceExecutor` 作为工具副作用适配层。
+
+### 需要升级
+
+- `permissionMode` 需要编译成默认 `PermissionProfile`。
+- `PermissionEngine` 需要从纯 category matrix 升级为 profile-aware / sandbox-aware。
+- `ToolRuntime` 需要引入 `ToolOrchestrator` 或等价编排层。
+- `shell-exec` 需要支持 argv-based runner，以便执行 sandbox-wrapped command。
+- 文件工具需要基于 active profile 做 read / write / deny 检查。
+
+### 需要新增
+
+- `PermissionProfile`。
+- `FileSystemSandboxPolicy`。
+- `NetworkSandboxPolicy`。
+- protected metadata 规则。
+- `SandboxManager`。
+- macOS Seatbelt policy generator。
+- Linux sandbox backend。
+- sandbox 状态进入 runtime/model context 的展示。
+
+## 当前已完成内容如何处理
+
+### 保留，但重新定位
+
+`WorkspaceExecutor` / `LocalWorkspaceExecutor` 保留。
+
+它们已经把 Bash / Read / Write / Edit / Glob / Grep 的副作用抽成了一层，
+这仍然有价值。但它不再是 sandbox 主模型，而是工具执行适配层。
+
+```text
+旧定位：
+  WorkspaceExecutor 是 sandbox 抽象中心
+
+新定位：
+  WorkspaceExecutor 是工具副作用执行接口
+  PermissionProfile + SandboxManager 才是 sandbox 权限中心
+```
+
+`buildBuiltinTools({ executor })` 也保留。后续可以让 Bash executor 内部走
+sandbox-wrapped spawn，或者让 tool impl 通过 `ToolOrchestrator` 决定执行方式。
+
+### 保留的行为契约
+
+这些已有能力不能回退：
+
+- Bash streaming stdout/stderr。
+- Bash timeout。
+- abort signal。
+- bounded tail output。
+- 进程树终止。
+- Read/Write/Edit 的 path containment。
+- symlink escape 防护。
+- Edit 的精确 / 模糊匹配语义。
+- Write/Edit 同文件串行锁。
+
+### 需要修改的内容
+
+`WorkspaceExecutorFacts` 需要降级。
+
+当前它表达：
+
+```ts
+isolation
+writesAffectHost
+writeBack
+network
+secrets
+```
+
+这些信息仍然有用，但不适合作为主要权限决策依据。新方案中主要决策输入应改成：
+
+```text
+active PermissionProfile
++ sandbox backend availability
++ approval policy
++ tool risk category
+```
+
+`executionFacts` 可以先保留，用于 telemetry、debug、兼容测试，但不作为长期权限模型中心。
+
+`PermissionEngine` 需要升级。
+
+现在它主要是：
+
+```text
+permissionMode x tool category -> allow / prompt / block
+```
+
+后续应变成：
+
+```text
+permissionMode / approval policy
++ PermissionProfile
++ sandbox enforcement availability
++ tool category
+-> allow / prompt / block
+```
+
+尤其要修正：
+
+```text
+execute.shell_unsafe = allow
+```
+
+这个策略只有在 sandbox 可 enforce 时才合理。没有 sandbox 时，`shell_unsafe`
+应该 prompt 或 block。
+
+### 非目标或废弃
+
+以下内容不做：
+
+- WorktreeExecutor。
+- diff/write-back。
+- sandbox cwd 映射。
+- workspace copy lifecycle。
+- apply patch UI。
+
+这些概念都来自旧的 worktree/write-back 方案。Maka 当前没有实现它们；只有继续旧
+worktree 方案时才会需要：
+
+- sandbox cwd 映射：真实 cwd 和 sandbox 副本 cwd 之间的路径映射。例如用户看到
+  `/Users/me/repo`，实际命令跑在 `/tmp/maka-worktree-123/repo`，runtime 需要在
+  prompt、event、artifact、diff 之间转换路径。
+- workspace copy lifecycle：创建、同步、维护、清理 workspace 副本或 worktree 的生命周期。
+- apply patch UI：展示 sandbox 副本相对真实 workspace 的 diff，并让用户选择
+  apply 或 discard 的界面。
+
+当前方案直接在真实 workspace 上运行受 sandbox 限权的进程，因此不需要这些模块。
+
+废弃旧文档中的核心假设：
+
+```text
+sandbox = worktree workspace + write-back
+```
+
+应改成：
+
+```text
+sandbox = PermissionProfile 约束下的平台权限拦截
+```
+
+`docs/agent-runtime-sandbox-executor.md` 后续可以重写为“历史方案与路线切换说明”，
+或者新建一篇正式设计文档取代它。
+
+### headless 相关处理
+
+`packages/headless` 里的 `IsolatedToolExecutor` 暂时不作为 desktop 主线依赖。
+
+它未来可以映射到：
+
+```text
+PermissionProfile.External
+```
+
+也就是：
+
+```text
+文件系统隔离由外部 executor/container 负责；
+Maka runtime 只知道这是 external sandbox，并继续处理 approval/network policy。
+```
+
+但这不是第一阶段内容。
+
+## Codex 与 Maka 的模块对应关系
+
+可以把 Codex 权限和 sandbox 系统拆成 9 个层次：
+
+```text
+1. User configuration entrypoints（用户配置入口）
+   用户或产品入口选择 sandbox / approval / permission profile 的地方。
+2. Canonical PermissionProfile（规范权限模型）
+   用平台无关的数据结构描述文件系统和网络权限。
+3. Profile compilation and materialization（权限编译与运行时展开）
+   把配置、workspace roots 和运行时上下文编译成最终 effective profile。
+4. Tool approval / orchestrator（工具审批与执行编排）
+   统一决定审批、sandbox attempt、失败处理和权限升级策略。
+5. SandboxManager（sandbox 选择与命令转换器）
+   根据 profile 和平台能力选择 sandbox backend，并生成执行请求。
+6. Platform sandbox backend（平台 sandbox 后端）
+   macOS / Linux / Windows 等平台的真实权限拦截机制。
+7. Exec/spawn layer（进程执行层）
+   负责真正 spawn 子进程、处理 cwd/env/timeout/output/abort。
+8. File tool enforcement（文件工具权限检查）
+   对 Read / Write / Edit / Glob / Grep 这类非 Bash 文件操作做同源权限检查。
+9. Observability and context display（可观测性与上下文展示）
+   向用户、模型和诊断工具展示当前生效的权限和 sandbox 状态。
+```
+
+Maka 现在已经有其中一部分，但中心不一样。
+
+Maka 当前的中心是：
+
+```text
+PermissionMode + ToolCategory + PermissionEngine
+```
+
+Codex 的中心是：
+
+```text
+PermissionProfile + SandboxManager + ToolOrchestrator
+```
+
+所以 Maka 要做的不是“加一个 sandbox 函数”，而是把权限中心从 category matrix
+升级成 profile-based runtime policy。
+
+### 1. User configuration entrypoints（用户配置入口）
+
+这一层负责接收用户或产品入口选择的权限模式。它回答：
+
+```text
+用户这次希望 agent 在什么权限边界内运行？
+```
+
+Codex 中对应：
+
+```text
+CLI --sandbox
+config.toml
+SDK sandboxMode
+app-server permissionProfile
+```
+
+Maka 当前对应：
+
+```text
+SessionHeader.permissionMode
+Settings 默认权限模式
+Desktop Settings 权限相关 UI
+```
+
+相关 Maka 代码：
+
+```text
+packages/core/src/permission.ts
+packages/core/src/session.ts
+packages/core/src/settings.ts
+apps/desktop/src/main/permission-mode-default.ts
+```
+
+Maka 要做：
+
+```text
+把现有 permissionMode 映射到默认 PermissionProfile。
+```
+
+例如：
+
+```text
+explore -> read-only
+ask     -> workspace-write + mutating prompt
+execute -> workspace-write + sandboxed execution allow
+bypass  -> danger-full-access
+```
+
+第一版可以只在 runtime 内部编译，不一定马上做 UI。
+
+### 2. Canonical PermissionProfile（规范权限模型）
+
+这一层是权限系统的规范语言。它回答：
+
+```text
+agent 最终被允许读哪里、写哪里、是否可以联网？
+```
+
+Codex 中对应：
+
+```text
+PermissionProfile
+FileSystemSandboxPolicy
+NetworkSandboxPolicy
+FileSystemSandboxEntry
+FileSystemAccessMode
+```
+
+Maka 当前没有等价物。
+
+当前 `packages/core/src/permission.ts` 只有：
+
+```text
+PermissionMode
+ToolCategory
+PERMISSION_POLICY
+categorizeBash()
+ToolExecutionFacts
+```
+
+Maka 要新增：
+
+```text
+packages/core/src/permission-profile.ts
+```
+
+内容包括：
+
+```text
+PermissionProfile
+FileSystemSandboxPolicy
+NetworkSandboxPolicy
+protected metadata
+workspace roots
+special paths
+```
+
+这是最核心的一步。没有这个，后面的 sandbox 只能是零散逻辑。
+
+### 3. Profile compilation and materialization（权限编译与运行时展开）
+
+这一层负责把用户配置和运行时上下文变成最终生效的 profile。它回答：
+
+```text
+当前 session.cwd / workspace roots 下，最终 effective PermissionProfile 是什么？
+```
+
+Codex 做的是：
+
+```text
+用户配置 + workspace roots + requirements
+-> effective PermissionProfile
+```
+
+Maka 目前没有这个阶段。现在工具只拿到：
+
+```text
+header.cwd
+header.permissionMode
+```
+
+Maka 要做：
+
+```text
+packages/core/src/permission-profile-compiler.ts
+或 packages/runtime/src/permission-context.ts
+```
+
+输入：
+
+```text
+session cwd
+permissionMode
+platform capability
+future settings
+```
+
+输出：
+
+```text
+active PermissionProfile
+```
+
+第一版可以非常简单：
+
+```text
+workspaceRoots = [session.cwd]
+profile = compilePermissionMode(permissionMode, workspaceRoots)
+```
+
+### 4. Tool approval / orchestrator（工具审批与执行编排）
+
+这一层负责编排一次工具调用。它回答：
+
+```text
+这个 tool call 是否需要提示用户？
+应该先用 sandbox 跑吗？
+sandbox 失败后怎么处理？
+```
+
+Codex 中对应：
+
+```text
+ToolOrchestrator
+default_exec_approval_requirement()
+sandboxed first attempt
+sandbox denial handling
+optional escalation
+```
+
+Maka 当前对应：
+
+```text
+packages/runtime/src/tool-runtime.ts
+packages/runtime/src/permission-engine.ts
+packages/core/src/permission.ts
+```
+
+现在 Maka 的流程是：
+
+```text
+ToolRuntime
+  -> PermissionEngine.evaluate()
+  -> allow/prompt/block
+  -> tool.impl()
+```
+
+要改成更接近：
+
+```text
+ToolRuntime
+  -> ToolOrchestrator
+      -> PermissionEngine / approval decision
+      -> resolve active PermissionProfile
+      -> decide sandbox attempt
+      -> execute tool under sandbox/profile
+```
+
+第一版不一定要完全新建大 orchestrator，也可以先抽一个小模块：
+
+```text
+packages/runtime/src/tool-orchestrator.ts
+```
+
+先只管 Bash，后续再覆盖文件工具。
+
+### 5. SandboxManager（sandbox 选择与命令转换器）
+
+这一层负责把抽象权限转换成具体执行请求。它回答：
+
+```text
+当前 profile 和平台能力下，应该用哪种 sandbox？
+原始命令要被转换成什么 argv？
+```
+
+Codex 中对应：
+
+```text
+SandboxManager::should_sandbox()
+SandboxManager::select_initial()
+SandboxManager::transform()
+```
+
+Maka 当前没有等价物。`WorkspaceExecutor` 不是这个东西。
+
+Maka 要新增：
+
+```text
+packages/runtime/src/sandbox/sandbox-manager.ts
+```
+
+职责：
+
+```text
+输入:
+  SandboxCommand
+  PermissionProfile
+  cwd
+  platform capability
+
+输出:
+  SandboxExecRequest
+```
+
+例如 macOS 上：
+
+```text
+输入:
+  program: /bin/sh
+  args: ['-lc', command]
+  cwd: /Users/.../repo
+  profile: workspace-write
+
+输出:
+  command:
+    /usr/bin/sandbox-exec -p <sbpl> -- /bin/sh -lc <command>
+```
+
+它只做“转换”，不负责权限业务判断，也不负责 UI。
+
+### 6. Platform sandbox backend（平台 sandbox 后端）
+
+这一层是真正的底层权限拦截机制。它回答：
+
+```text
+怎么把 PermissionProfile 翻译成 macOS / Linux 的系统级 sandbox 规则？
+```
+
+Codex 中对应：
+
+```text
+macOS Seatbelt
+Linux bubblewrap + seccomp
+Windows restricted token
+```
+
+Maka 当前没有等价物。
+
+Maka 这轮只做：
+
+```text
+v1 macOS Seatbelt
+v2 Linux bubblewrap + seccomp
+Windows 不做
+```
+
+建议文件：
+
+```text
+packages/runtime/src/sandbox/macos-seatbelt.ts
+packages/runtime/src/sandbox/linux-sandbox.ts
+```
+
+macOS 第一版职责：
+
+```text
+PermissionProfile -> SBPL policy string
+```
+
+不是直接 spawn。spawn 仍交给 shell runner。
+
+### 7. Exec/spawn layer（进程执行层）
+
+这一层负责真正启动子进程和收集结果。它回答：
+
+```text
+最终 argv 如何 spawn？
+stdout / stderr / timeout / abort / process tree kill 怎么处理？
+```
+
+Codex 中对应：
+
+```text
+ExecRequest
+spawn_child_async
+sandbox wrapper argv
+```
+
+Maka 当前对应：
+
+```text
+packages/runtime/src/shell-exec.ts
+packages/runtime/src/workspace-executor.ts
+```
+
+现在 Maka 的 shell runner 是：
+
+```ts
+spawn(command, { shell: true, cwd })
+```
+
+sandbox 后最好拆出一个 argv runner：
+
+```text
+runProcessWithBoundedTail({
+  command: string[]
+  cwd
+  env
+  timeoutMs
+  abortSignal
+  emitOutput
+})
+```
+
+然后 Bash 可以走：
+
+```text
+SandboxManager.transform()
+  -> argv
+  -> runProcessWithBoundedTail(argv)
+```
+
+这样不要再把 sandbox wrapper 拼成一个大 shell 字符串，避免 quoting 问题。
+
+### 8. File tool enforcement（文件工具权限检查）
+
+这一层负责 Bash 之外的文件工具权限一致性。它回答：
+
+```text
+Node 主进程直接执行 Read / Write / Edit 时，如何遵守同一份 PermissionProfile？
+```
+
+Codex 对文件 API 也会通过 sandbox context / fs-helper。
+
+Maka 第一版可以不做 fs-helper，但必须做 profile check。因为 Read / Write / Edit
+是 Node 主进程直接 fs 操作，不会自动被 `sandbox-exec` 限制。
+
+Maka 当前文件工具在：
+
+```text
+packages/runtime/src/builtin-tools.ts
+packages/runtime/src/workspace-executor.ts
+```
+
+要补：
+
+```text
+Read / Glob / Grep:
+  check readable roots / deny-read
+
+Write / Edit:
+  check writable roots
+  block protected metadata
+```
+
+这一步不是平台 sandbox，但很重要。
+
+### 9. Network policy and proxy（网络策略与代理）
+
+这一层负责网络能力控制。它回答：
+
+```text
+命令能不能联网？
+如果能联网，是否必须经过受管代理和域名/方法审批？
+```
+
+Codex 的网络很完整：
+
+```text
+NetworkSandboxPolicy
+managed network proxy
+HTTP/SOCKS proxy
+domain/method approval
+MITM / credential broker
+```
+
+Maka 第一版不要直接复刻完整网络代理。先做：
+
+```text
+NetworkSandboxPolicy = restricted | enabled
+
+macOS Seatbelt:
+  restricted -> deny network*
+  enabled -> allow network*
+```
+
+后续再做 managed proxy。
+
+## Maka 需要做的内容清单
+
+最小主线：
+
+```text
+1. 新增 PermissionProfile 类型
+2. 新增 permissionMode -> PermissionProfile compiler
+3. 新增 protected metadata policy
+4. 新增 SandboxManager
+5. 新增 macOS Seatbelt policy generator
+6. 给 shell-exec 增加 argv runner
+7. Bash 通过 SandboxManager 执行
+8. 文件工具接入 profile read/write check
+9. PermissionEngine 改成 sandbox-aware
+10. runtime/model context 展示当前 sandbox 状态
+```
+
+## 一张对应表
+
+| Codex 部分 | Maka 当前对应 | Maka 需要新增/修改 |
+| --- | --- | --- |
+| `PermissionProfile` | 没有 | `packages/core/src/permission-profile.ts` |
+| FS / Network policy | `ToolExecutionFacts` 很弱 | 新 FS / Network policy 类型 |
+| config compile | `permissionMode` | `permissionMode -> profile` compiler |
+| TurnContext permissions | `SessionHeader.cwd` / `permissionMode` | runtime active permission context |
+| ToolOrchestrator | `ToolRuntime + PermissionEngine` | 抽 `ToolOrchestrator` 或先 Bash 专用 orchestrator |
+| SandboxManager | 没有 | `packages/runtime/src/sandbox/sandbox-manager.ts` |
+| macOS Seatbelt | 没有 | `macos-seatbelt.ts` |
+| Linux sandbox | 没有 | 第二阶段实现 |
+| Windows sandbox | 没有 | 暂不支持 |
+| exec / spawn | `shell-exec.ts` | 增加 argv runner + sandbox wrapped exec |
+| fs-helper | 没有 | 第一版不做，文件工具先做 profile check |
+| managed network | Tavily / web-search 是另一条线 | 第一版只做 network restricted / enabled |
+| protected metadata | 没有系统规则 | `.git` / `.agents` / `.codex` deny-write |
+
+## 核心理解
+
+可以用三句话理解新方案：
+
+```text
+PermissionProfile 是“允许什么”的规范语言。
+SandboxManager 是“怎么把允许什么变成平台执行限制”的翻译器。
+ToolOrchestrator 是“什么时候允许、什么时候提示、什么时候用 sandbox 跑”的编排器。
+```
+
+Maka 当前缺的正是这三块。

--- a/docs/agent-runtime-codex-sandbox-todo.md
+++ b/docs/agent-runtime-codex-sandbox-todo.md
@@ -1,0 +1,548 @@
+# Agent Runtime Codex-Style Sandbox Todo
+
+这份文档是 Maka 参考 Codex 实现权限管理和 sandbox 权限兜底的分阶段工程任务清单。
+
+关联背景文档：
+
+- `docs/agent-runtime-codex-sandbox-alignment.md`
+- `docs/agent-runtime-sandbox-executor.md`
+
+当前路线已经明确：
+
+```text
+主线：PermissionProfile + SandboxManager + 平台 sandbox enforcement
+第一平台：macOS Seatbelt
+第二平台：Linux bubblewrap + seccomp
+不做：Windows
+不做：worktree / diff / write-back / apply patch UI
+```
+
+## 目标
+
+在 Maka runtime 中建立 Codex-style 权限管理系统：
+
+- 用 `PermissionProfile` 描述 agent 能读哪里、写哪里、是否能联网。
+- 用 `SandboxManager` 把权限语义转换成平台 sandbox 执行请求。
+- 用平台 sandbox backend 做底层权限拦截。
+- 让 Bash 和文件工具都遵守同一份 active permission profile。
+- 让 `execute` 模式不再依赖 Bash regex 分类作为安全边界。
+
+## 非目标
+
+本轮不做：
+
+- WorktreeExecutor。
+- workspace 副本。
+- diff/write-back。
+- apply patch UI。
+- sandbox cwd 映射。
+- Windows sandbox。
+- Docker / remote executor。
+- Codex-style unsandboxed retry。
+- 完整 managed network proxy。
+
+## 阶段总览
+
+```text
+Phase 0: 清理旧方案假设
+Phase 1: PermissionProfile 数据模型
+Phase 2: permissionMode -> PermissionProfile compiler
+Phase 3: SandboxManager 骨架
+Phase 4: macOS Seatbelt policy generator
+Phase 5: argv-based shell runner
+Phase 6: Bash 接入 sandboxed execution
+Phase 7: 文件工具接入 profile enforcement
+Phase 8: sandbox-aware PermissionEngine / policy
+Phase 9: runtime/model context 与 diagnostics
+Phase 10: Linux sandbox backend
+```
+
+## Phase 0: 清理旧方案假设
+
+目标：让文档和 issue 语义不再把 worktree/write-back 当成当前实现方向。
+
+范围：
+
+- `docs/agent-runtime-sandbox-executor.md`
+- `docs/agent-runtime-codex-sandbox-alignment.md`
+- GitHub issue 后续评论
+
+任务：
+
+- [ ] 在旧方案文档顶部标注：这是历史方案，当前路线已切换到 Codex-style permission profile + platform sandbox enforcement。
+- [ ] 明确写出当前不做 WorktreeExecutor。
+- [ ] 明确写出当前不做 diff/write-back。
+- [ ] 明确写出当前不做 apply patch UI。
+- [ ] 明确写出当前 `workspace-write` 是直接写真实 workspace，并依赖 sandbox 限制越权访问。
+- [ ] 在 GitHub issue 下追加评论，说明实现方向已经从 worktree/write-back 调整为 permission profile + platform sandbox。
+
+验收标准：
+
+- 新旧文档读起来不会让人误以为 Maka 已经实现或将要实现 worktree sandbox。
+- `workspace-write` 的定义清楚：真实 workspace 直接写入，sandbox 限制访问边界。
+
+测试建议：
+
+- 文档检查即可。
+- 搜索 `worktree`、`write-back`、`apply patch`，确认这些词只出现在历史方案或明确非目标上下文中。
+
+## Phase 1: PermissionProfile 数据模型
+
+目标：在 core 层建立平台无关的规范权限模型。
+
+建议文件：
+
+- 新增：`packages/core/src/permission-profile.ts`
+- 修改：`packages/core/src/index.ts`
+- 测试：`packages/core/src/__tests__/permission-profile.test.ts`
+
+核心类型：
+
+```text
+PermissionProfile
+FileSystemSandboxPolicy
+FileSystemSandboxEntry
+FileSystemAccessMode
+FileSystemSandboxKind
+FileSystemSpecialPath
+NetworkSandboxPolicy
+```
+
+任务：
+
+- [ ] 定义 `PermissionProfile.Managed`，包含 file system policy 和 network policy。
+- [ ] 定义 `PermissionProfile.Disabled`，表示不启用 Maka-managed sandbox。
+- [ ] 定义 `PermissionProfile.External`，表示文件系统隔离由外部环境负责，Maka 仍可表达 network policy。
+- [ ] 定义 `FileSystemSandboxKind`：`restricted`、`unrestricted`、`external_sandbox`。
+- [ ] 定义 `FileSystemAccessMode`：`read`、`write`、`deny`。
+- [ ] 定义 `FileSystemSandboxEntry`：path + access。
+- [ ] 定义 `NetworkSandboxPolicy`：`restricted`、`enabled`。
+- [ ] 定义 special paths：`:root`、`:workspace_roots`、`:tmpdir`、`:slash_tmp`、`:minimal`。
+- [ ] 定义 protected metadata 名称：`.git`、`.agents`、`.codex`。
+- [ ] 实现基础 matcher：判断某个 path 是否可读、可写、被 deny。
+- [ ] 实现 protected metadata 判断：workspace-write 下默认 deny-write。
+- [ ] 从 `@maka/core` 导出这些类型和 helper。
+
+验收标准：
+
+- core 层可以单独表达 read-only、workspace-write、danger-full-access。
+- protected metadata 规则不依赖 runtime 或 desktop。
+- 不引入 Node-only runtime 依赖到 core 的纯类型逻辑中，除非现有 core 已接受相同依赖模式。
+
+测试建议：
+
+- `read-only`：workspace 内可读不可写。
+- `workspace-write`：workspace 内普通文件可写。
+- `workspace-write`：workspace 外不可写。
+- `workspace-write`：`.git` / `.agents` / `.codex` 默认不可写。
+- `danger-full-access`：文件系统 unrestricted。
+
+## Phase 2: permissionMode -> PermissionProfile compiler
+
+目标：把 Maka 现有四档 permission mode 编译成默认 active permission profile。
+
+建议文件：
+
+- 新增：`packages/core/src/permission-profile-compiler.ts`
+- 修改：`packages/core/src/index.ts`
+- 测试：`packages/core/src/__tests__/permission-profile-compiler.test.ts`
+
+输入：
+
+```text
+permissionMode
+session cwd
+workspace roots
+platform capability
+future settings
+```
+
+第一版输入可以简化成：
+
+```text
+permissionMode
+cwd
+```
+
+任务：
+
+- [ ] 定义 compiler 输入类型，例如 `CompilePermissionProfileInput`。
+- [ ] 第一版将 `workspaceRoots` 默认设为 `[session.cwd]`。
+- [ ] 实现 `explore -> read-only`。
+- [ ] 实现 `ask -> workspace-write`。
+- [ ] 实现 `execute -> workspace-write`。
+- [ ] 实现 `bypass -> danger-full-access`。
+- [ ] 为 `ask` / `execute` 保留 approval policy 差异，不把所有语义塞进 profile。
+- [ ] 输出包含 profile、workspace roots、network policy、用于 diagnostics 的 profile name。
+
+验收标准：
+
+- 现有 `PermissionMode` 仍是用户可理解的入口。
+- core 可以从 session cwd 生成 active profile。
+- `ask` 和 `execute` 可以使用同一 workspace-write profile，但保留不同 approval 行为。
+
+测试建议：
+
+- 每个 permission mode 都有固定 profile 输出。
+- `explore` 生成 restricted/read-only。
+- `ask` 和 `execute` 生成 workspace-write，但不要丢失 mode 信息。
+- `bypass` 生成 disabled 或 unrestricted profile，具体命名在实现中保持一致。
+
+## Phase 3: SandboxManager 骨架
+
+目标：在 runtime 层建立 sandbox 选择和命令转换边界。
+
+建议文件：
+
+- 新增目录：`packages/runtime/src/sandbox/`
+- 新增：`packages/runtime/src/sandbox/sandbox-manager.ts`
+- 新增：`packages/runtime/src/sandbox/types.ts`
+- 修改：`packages/runtime/src/index.ts`
+- 测试：`packages/runtime/src/__tests__/sandbox-manager.test.ts`
+
+核心类型：
+
+```text
+SandboxType
+SandboxCommand
+SandboxExecRequest
+SandboxablePreference
+SandboxTransformRequest
+SandboxTransformResult
+```
+
+任务：
+
+- [ ] 定义 `SandboxType`：`none`、`macos-seatbelt`、`linux`。
+- [ ] 明确 Windows unsupported。
+- [ ] 定义 `SandboxCommand`：program、args、cwd、env、profile。
+- [ ] 定义 `SandboxExecRequest`：argv、cwd、env、sandbox type、effective profile。
+- [ ] 实现 `shouldSandbox(profile, preference, platform)`。
+- [ ] 实现 `selectInitial(profile, platform)`。
+- [ ] 实现 `transform()` 骨架。
+- [ ] 当 profile 是 `disabled` 或 unrestricted 时允许 `none`。
+- [ ] 当 profile 需要 sandbox 但平台不支持时 fail closed。
+- [ ] macOS 平台先路由到 macOS Seatbelt backend。
+- [ ] Linux 平台先返回 unsupported 或 feature-gated stub，等 Phase 10 实现。
+
+验收标准：
+
+- 上层不直接知道 `sandbox-exec` 细节。
+- `SandboxManager` 只负责选择和转换，不负责 UI，不负责审批。
+- sandbox 不可用时不会静默降级到 host shell。
+
+测试建议：
+
+- macOS + workspace-write -> `macos-seatbelt`。
+- Linux + workspace-write -> `linux` 或明确 unsupported stub。
+- unsupported platform + workspace-write -> fail closed。
+- danger-full-access -> `none`。
+
+## Phase 4: macOS Seatbelt policy generator
+
+目标：实现 `PermissionProfile -> SBPL` 的 macOS 后端。
+
+建议文件：
+
+- 新增：`packages/runtime/src/sandbox/macos-seatbelt.ts`
+- 测试：`packages/runtime/src/__tests__/macos-seatbelt.test.ts`
+- 可选 smoke：`packages/runtime/src/__tests__/macos-seatbelt-smoke.test.ts`
+
+任务：
+
+- [ ] 生成基础 SBPL policy。
+- [ ] 支持 workspace readable roots。
+- [ ] 支持 workspace writable roots。
+- [ ] 支持 tmpdir / slash_tmp write。
+- [ ] 支持 protected metadata deny-write。
+- [ ] 支持 network restricted。
+- [ ] 支持 network enabled。
+- [ ] 固定使用 `/usr/bin/sandbox-exec`，不要从 PATH 查找。
+- [ ] 确认 policy string 不把未转义路径直接拼进危险位置。
+- [ ] 提供 `createSeatbeltExecArgs()`，输出 `['-p', policy, '--', ...innerArgv]` 或完整 wrapper argv。
+
+验收标准：
+
+- macOS backend 可以独立从 profile 生成 sandbox wrapper argv。
+- workspace-write 允许写 workspace 普通文件。
+- workspace-write 默认阻止写 `.git` / `.agents` / `.codex`。
+- network restricted 下普通网络访问被拒绝。
+
+测试建议：
+
+- policy string contract test。
+- path escaping test。
+- macOS-only smoke：
+  - workspace 内写文件成功。
+  - workspace 外写文件失败。
+  - protected metadata 写入失败。
+  - network restricted 下 `curl` 或 Node socket 失败。
+- 非 macOS 环境自动 skip smoke。
+
+## Phase 5: argv-based shell runner
+
+目标：让 Maka 能执行 sandbox wrapper argv，而不是把 wrapper 拼成 shell 字符串。
+
+建议文件：
+
+- 修改：`packages/runtime/src/shell-exec.ts`
+- 测试：`packages/runtime/src/__tests__/workspace-executor.test.ts`
+- 测试：`packages/runtime/src/__tests__/shell-exec.test.ts`，如果需要新增
+
+任务：
+
+- [ ] 新增 `runProcessWithBoundedTail()` 或等价函数。
+- [ ] 输入 argv：`command: string[]` 或 `program + args`。
+- [ ] 保留 cwd。
+- [ ] 保留 env。
+- [ ] 保留 timeout。
+- [ ] 保留 abort signal。
+- [ ] 保留 stdout/stderr streaming。
+- [ ] 保留 bounded tail output。
+- [ ] 保留 POSIX process group termination。
+- [ ] 保留 Windows taskkill 逻辑，但 Windows sandbox 本轮不实现。
+- [ ] 保留现有 `runShellWithBoundedTail()`，作为 shell-string compatibility path。
+
+验收标准：
+
+- 现有 Bash 行为不回退。
+- 新 argv runner 可以执行普通命令。
+- 新 argv runner 可以执行 wrapper command，例如 `/usr/bin/env ...`。
+- timeout / abort / output caps 与旧 runner 行为一致。
+
+测试建议：
+
+- argv runner stdout/stderr。
+- non-zero exit code。
+- timeout。
+- abort。
+- large output tail retention。
+- process tree kill 行为沿用现有测试。
+
+## Phase 6: Bash 接入 sandboxed execution
+
+目标：让 Bash tool 在 active profile 需要 sandbox 时，通过 `SandboxManager` 执行。
+
+建议文件：
+
+- 修改：`packages/runtime/src/builtin-tools.ts`
+- 修改：`packages/runtime/src/workspace-executor.ts`
+- 新增或修改：`packages/runtime/src/tool-orchestrator.ts`
+- 测试：`packages/runtime/src/__tests__/builtin-tools.test.ts`
+- 测试：`packages/runtime/src/__tests__/tool-runtime.test.ts`，如已有相关覆盖则扩展
+
+任务：
+
+- [ ] 定义 Bash 执行所需的 permission context 输入。
+- [ ] 让 Bash impl 能拿到 active `PermissionProfile`。
+- [ ] Bash command 转换成 `/bin/sh -lc <command>` 内层 argv。
+- [ ] 调用 `SandboxManager.transform()` 得到最终 argv。
+- [ ] 使用 argv runner 执行。
+- [ ] 保留 terminal result shape：cwd、cmd、exitCode、stdout、stderr。
+- [ ] sandbox denial 返回清晰错误。
+- [ ] 不做 unsandboxed retry。
+- [ ] sandbox 必需但不可用时 fail closed 或明确 prompt/block。
+
+验收标准：
+
+- Bash 在 macOS workspace-write 下默认经过 `sandbox-exec`。
+- Bash 不再只依赖 `categorizeBash()` 作为安全边界。
+- streaming、timeout、abort 仍可用。
+
+测试建议：
+
+- fake SandboxManager 注入，确认 Bash 调用 transform。
+- fake runner 注入，确认最终 argv 被执行。
+- macOS smoke：workspace 内写入成功，workspace 外写入失败。
+- denied case 产生 recoverable tool error。
+
+## Phase 7: 文件工具接入 profile enforcement
+
+目标：让 Read / Write / Edit / Glob / Grep 遵守同一份 active profile。
+
+建议文件：
+
+- 修改：`packages/runtime/src/builtin-tools.ts`
+- 修改：`packages/runtime/src/workspace-executor.ts`
+- 新增：`packages/runtime/src/permission-profile-enforcement.ts`，或放在 sandbox/permission-context 相关模块
+- 测试：`packages/runtime/src/__tests__/builtin-tools.test.ts`
+- 测试：`packages/runtime/src/__tests__/workspace-executor.test.ts`
+
+任务：
+
+- [ ] 为 file tools 注入 active profile。
+- [ ] `Read` 检查 readable roots。
+- [ ] `Read` 检查 deny-read。
+- [ ] `Glob` / `Grep` 检查搜索根可读。
+- [ ] `Write` 检查 writable roots。
+- [ ] `Write` 阻止 protected metadata。
+- [ ] `Edit` 检查 writable roots。
+- [ ] `Edit` 阻止 protected metadata。
+- [ ] 保留 realpath containment。
+- [ ] 保留 symlink escape 防护。
+- [ ] 保留 file write lock。
+- [ ] 保留 Edit matcher 行为。
+
+验收标准：
+
+- Node 主进程内的文件工具不会绕过 PermissionProfile。
+- 文件工具和 Bash 对 workspace-write 的理解一致。
+- protected metadata 在 Bash sandbox 和文件工具 enforcement 中都被保护。
+
+测试建议：
+
+- read-only 下 Write/Edit 失败。
+- workspace-write 下普通 Write/Edit 成功。
+- workspace-write 下写 `.git/config` 失败。
+- workspace 外 Read/Write 失败。
+- symlink escape 仍失败。
+
+## Phase 8: sandbox-aware PermissionEngine / policy
+
+目标：让权限决策理解 active profile 和 sandbox availability，而不是只看 mode x category。
+
+建议文件：
+
+- 修改：`packages/core/src/permission.ts`
+- 修改：`packages/runtime/src/permission-engine.ts`
+- 测试：`packages/core/src/__tests__/permission.test.ts`
+- 测试：`packages/runtime/src/__tests__/permission-engine.test.ts`
+
+任务：
+
+- [ ] 扩展 `PreToolUseInput`，加入 active profile summary 或 sandbox availability。
+- [ ] 保留现有 `PermissionMode` 输入。
+- [ ] 保留 `ToolCategory` 分类。
+- [ ] 调整 `execute.shell_unsafe`：不再无条件 allow。
+- [ ] sandbox 可 enforce 时，允许普通 workspace mutating shell 自动执行。
+- [ ] sandbox 不可 enforce 时，`shell_unsafe` prompt 或 block。
+- [ ] `fs_destructive` 继续 prompt 或更保守。
+- [ ] `git_destructive` 继续 prompt 或更保守。
+- [ ] `privileged` 继续 prompt 或更保守。
+- [ ] `bypass` 仍保留危险全权限语义。
+
+验收标准：
+
+- `execute` 模式不再把 regex 漏判作为唯一安全边界。
+- 没有 sandbox enforcement 时，unknown/mutating shell 更保守。
+- 现有 ask/explore/bypass 的基本用户语义不被破坏。
+
+测试建议：
+
+- `execute + shell_unsafe + sandbox available -> allow`。
+- `execute + shell_unsafe + sandbox unavailable -> prompt/block`。
+- `execute + rm -> prompt`。
+- `explore + shell_unsafe -> block`。
+- `ask + shell_unsafe -> prompt`。
+- `bypass + shell_unsafe -> allow`。
+
+## Phase 9: runtime/model context 与 diagnostics
+
+目标：让用户、模型和诊断工具知道当前实际权限和 sandbox 状态。
+
+建议文件：
+
+- 修改：`packages/runtime/src/ai-sdk-backend.ts`
+- 修改：`packages/runtime/src/system-prompt` 相关模块，如实际存在
+- 修改：`apps/desktop/src/main/system-prompt-main.ts`
+- 可选：`apps/desktop/src/main/capability-snapshot.ts`
+- 测试：对应 runtime / desktop contract tests
+
+任务：
+
+- [ ] 在 model context 中展示 active profile 名称。
+- [ ] 展示 workspace roots。
+- [ ] 展示 filesystem policy：read-only / workspace-write / danger-full-access。
+- [ ] 展示 protected metadata。
+- [ ] 展示 network policy。
+- [ ] 展示 sandbox backend：`macos-seatbelt` / `linux` / `none` / `unsupported`。
+- [ ] 在 diagnostics 或 capability snapshot 中暴露 sandbox availability。
+- [ ] 确保 context 不泄露敏感路径以外的凭据或 env。
+
+验收标准：
+
+- 模型知道自己是否处在 read-only / workspace-write / danger-full-access。
+- 用户能诊断某条命令为什么被 sandbox 拒绝。
+- 支持平台和不支持平台的状态都能清楚展示。
+
+测试建议：
+
+- system prompt/context snapshot contract test。
+- capability snapshot test。
+- sandbox unavailable 状态展示测试。
+
+## Phase 10: Linux sandbox backend
+
+目标：在 macOS 主线稳定后，接入 Linux 权限兜底。
+
+建议文件：
+
+- 新增：`packages/runtime/src/sandbox/linux-sandbox.ts`
+- 可能新增 helper package 或 bundled helper，取决于实现语言和发布策略
+- 测试：`packages/runtime/src/__tests__/linux-sandbox.test.ts`
+- Linux-only smoke tests
+
+任务：
+
+- [ ] 确认 Linux backend 技术方案：bubblewrap + seccomp。
+- [ ] 确认 helper 分发方式。
+- [ ] 实现 filesystem view：workspace read/write，workspace 外限制。
+- [ ] 实现 protected metadata deny-write。
+- [ ] 实现 tmp write。
+- [ ] 实现 network restricted。
+- [ ] 实现 network enabled。
+- [ ] 接入 `SandboxManager.selectInitial()`。
+- [ ] 接入 `SandboxManager.transform()`。
+- [ ] Linux 不可用时 fail closed。
+
+验收标准：
+
+- Linux 下 workspace-write 可以写 workspace 普通文件。
+- Linux 下 workspace-write 不能写 workspace 外文件。
+- Linux 下 protected metadata 默认不可写。
+- Linux 下 network restricted 可阻止直接联网。
+
+测试建议：
+
+- Linux-only smoke。
+- bubblewrap 不可用时错误清晰。
+- seccomp/network 限制 smoke。
+- 非 Linux 环境自动 skip。
+
+## 里程碑
+
+```text
+M1: PermissionProfile 模型存在，但 runtime 行为不变。
+M2: permissionMode 可以编译成 active PermissionProfile。
+M3: SandboxManager 可以选择和转换 sandbox request。
+M4: macOS Seatbelt 可以独立生成并验证策略。
+M5: Bash 在 macOS 下默认经过 sandbox。
+M6: 文件工具遵守同一 PermissionProfile。
+M7: execute 模式不再依赖 shell_unsafe regex 作为安全边界。
+M8: runtime/model context 可以展示当前 sandbox 状态。
+M9: Linux backend 接入。
+```
+
+## 建议实施顺序
+
+优先保持每个阶段可测试、可回滚：
+
+```text
+1. 先加模型，不改行为。
+2. 再加 compiler，不改行为。
+3. 再加 SandboxManager，不执行真实 sandbox。
+4. 再加 macOS Seatbelt policy generator，并用 smoke 验证。
+5. 再改 shell runner，保持旧 Bash 行为不回退。
+6. 再让 Bash 走 sandbox。
+7. 再让文件工具遵守同一 profile。
+8. 最后收紧 PermissionEngine 的 execute 策略。
+```
+
+关键原则：
+
+- 不把 Bash regex 当安全边界。
+- 不静默从 sandbox 降级到 host shell。
+- 不在第一版做 unsandboxed retry。
+- 不引入 worktree/write-back 相关实现。
+- 每个阶段都必须有 focused tests。
+


### PR DESCRIPTION
https://github.com/maka-agent/maka-agent/issues/509

## Summary

This PR adds documentation for the updated runtime sandbox direction.

The previous sandbox executor proposal was centered around `WorktreeExecutor`, workspace copies, diff review, and explicit write-back. After reviewing Codex's sandbox design, the current direction is adjusted to focus on a Codex-style permission model plus platform-level sandbox enforcement.

The new direction is:

- Introduce a canonical `PermissionProfile`.
- Add a runtime `SandboxManager`.
- Use platform sandbox backends as the enforcement layer.
- Start with macOS Seatbelt.
- Add Linux support later.
- Leave Windows out of scope for the first version.
- Do not implement worktree / diff / write-back / apply patch UI in this phase.

## Changes

Added two design documents:

- `docs/agent-runtime-codex-sandbox-alignment.md`
  - Compares the old Maka proposal with the Codex-style approach.
  - Explains Maka's current `PermissionMode`, `ToolCategory`, and `PermissionEngine`.
  - Maps Codex concepts such as `PermissionProfile`, `SandboxManager`, and tool orchestration to Maka's current runtime structure.
  - Clarifies what existing Maka pieces can be reused.

- `docs/agent-runtime-codex-sandbox-todo.md`
  - Provides a phased implementation roadmap.
  - Breaks the work into permission profile modeling, sandbox manager, macOS Seatbelt backend, Bash integration, file tool enforcement, permission engine updates, diagnostics, and later Linux support.

## Notes

This PR is documentation-only. It does not change runtime behavior.

## Testing

Not run. Documentation-only change.