### PR TITLE
fix(ui): designer-audit round 6 — one time-control cluster, deduped archive rows, single first-run CTA

### DIFF
--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -315,13 +315,11 @@ function NeedsConnectionHero(props: {
         </ul>
       </div>
 
+      {/* Designer audit P2-15: the footer's primary 打开设置·模型 button
+          duplicated what clicking any provider row above already does (the
+          list header even says 点一个进入设置). One affordance per action —
+          the footer keeps only the two genuinely distinct paths. */}
       <footer className="maka-onboarding-footer">
-        <Button
-          type="button"
-          onClick={() => props.onOpenSettings('models')}
-        >
-          打开设置 · 模型
-        </Button>
         {props.onRefreshConnections && (
           <Button
             type="button"

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -19,9 +19,11 @@
 .maka-daily-review-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    /* P2-10: range picker + stepper are one time-control cluster on the
+       left (was space-between, which split them to opposite corners). */
+    justify-content: flex-start;
     flex-wrap: wrap;
-    gap: var(--space-2);
+    gap: var(--space-3);
     padding: var(--space-0-5) var(--space-0-5) var(--space-1-5);
     border-bottom: var(--border-width-hairline) solid var(--foreground-10);
   }

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -267,7 +267,21 @@ export function DailyReviewPanel(props: {
           day/week/month tabs and the date stepper — now lives in ONE
           header bar instead of the tabs floating mid-page above the
           stats they control. */}
+      {/* Designer audit P2-10: the range tabs sat at the far right while
+          the stepper sat at the far left — two time controls that read as
+          unrelated widgets. They now form ONE cluster: pick the range,
+          then step through it; the stepper steps by the selected span. */}
       <header className="maka-daily-review-header">
+        <SettingsSegmented
+          value={String(range)}
+          options={[['1', '今日'], ['7', '本周'], ['30', '本月']]}
+          onChange={(v) => {
+            setRange(Number(v) as DailyReviewRange);
+            setOffsetDays(0);
+          }}
+          ariaLabel="时间范围切换"
+          className="maka-daily-review-range-tabs"
+        />
         <div className="maka-daily-review-header-time">
           <UiButton
             type="button"
@@ -292,16 +306,6 @@ export function DailyReviewPanel(props: {
             ›
           </UiButton>
         </div>
-        <SettingsSegmented
-          value={String(range)}
-          options={[['1', '今日'], ['7', '本周'], ['30', '本月']]}
-          onChange={(v) => {
-            setRange(Number(v) as DailyReviewRange);
-            setOffsetDays(0);
-          }}
-          ariaLabel="时间范围切换"
-          className="maka-daily-review-range-tabs"
-        />
       </header>
       {canManualRun && (
         <div className="maka-daily-review-quick-runs" aria-label="手动触发回顾">
@@ -393,8 +397,13 @@ export function DailyReviewPanel(props: {
                       <span className="maka-daily-review-archive-row-title">
                         {formatDailyReviewArchiveTitle(archive)}
                       </span>
+                      {/* Designer audit P2-11: the row used to repeat the
+                          detail card's entire header (status + timestamp).
+                          The list only needs to identify the report; status
+                          and generation time live in the detail. */}
                       <span className="maka-daily-review-archive-row-meta">
-                        {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]} · {archive.totals.sessionCount} 对话 · {formatDailyReviewArchiveGeneratedAt(archive.generatedAt)}
+                        {archive.totals.sessionCount} 对话
+                        {archive.status !== 'ok' ? ` · ${DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}` : ''}
                       </span>
                     </UiButton>
                   </li>

--- a/packages/ui/stories/capability-audit-strip.stories.tsx
+++ b/packages/ui/stories/capability-audit-strip.stories.tsx
@@ -62,7 +62,6 @@ export const SkillsFocusHealthy: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="skills"
         report={report({
           sourceCount: 3,
           readySourceCount: 3,
@@ -80,7 +79,6 @@ export const AutomationsFocusHealthy: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="automations"
         report={report({
           sourceCount: 2,
           readySourceCount: 2,
@@ -97,7 +95,6 @@ export const WithRisks: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="skills"
         report={report({
           sourceCount: 4,
           readySourceCount: 2,
@@ -121,7 +118,7 @@ export const WithRisks: Story = {
 export const Empty: Story = {
   render: () => (
     <StripFrame>
-      <CapabilityAuditStrip focus="skills" report={report({})} />
+      <CapabilityAuditStrip report={report({})} />
     </StripFrame>
   ),
 };


### PR DESCRIPTION
设计审查第 6 轮：

1. **P2-10** 每日回顾头部两套时间控件分居两角（步进器最左、范围 tab 最右）读作互不相关 → 合为左侧一簇：先选范围（今日/本周/本月）再步进，步进按所选跨度走。
2. **P2-11** 报告列表行重复详情卡的整个头部（状态+生成时间）→ 列表行只负责识别（标题 + N 对话，仅异常时附状态），其余归详情卡。
3. **P2-15 残余** 首启页底部主按钮「打开设置·模型」与点击任意 provider 行的行为重复（列表头就写着「点一个进入设置」）→ 删除,保留两条真正不同的路径。
4. Round-4 补漏：stories 里残留的 focus prop 导致 storybook 工程 typecheck 红 → 清理。

截图验证；typecheck 0；2143/2143。