### PR TITLE
refactor(settings): move identity fields to 通用 — appearance page is theme-only (P2-13)

### DIFF
--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -26,9 +26,10 @@ export function AppearanceSettingsPage(props: {
 }) {
   return (
     <div className="settingsStructuredPage">
-      <h2 className="settingsSectionHeading">个性化</h2>
-      <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdate} />
-      <h2 className="settingsSectionHeading">主题</h2>
+      {/* Designer audit P2-13: 显示名称/界面语言/语气偏好 are identity, not
+          appearance — PersonalizationSettingsPage now renders on the 通用
+          page. The duplicated 主题 section heading is gone too: the page IS
+          the theme page now. */}
       <ThemeSettingsPage
         themePref={props.themePref}
         themePalette={props.themePalette}
@@ -41,7 +42,7 @@ export function AppearanceSettingsPage(props: {
   );
 }
 
-function PersonalizationSettingsPage(props: {
+export function PersonalizationSettingsPage(props: {
   settings: AppSettings;
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
 }) {

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { PersonalizationSettingsPage } from './appearance-settings-page';
 import type {
   AppSettings,
   ChatDefaultPermissionMode,
@@ -38,6 +39,10 @@ export function GeneralSettingsPage(props: {
   const toast = useToast();
   return (
     <div className="settingsStructuredPage">
+      {/* Designer audit P2-13: identity fields (显示名称/界面语言/语气偏好)
+          moved here from the 外观 page — they configure who you are to the
+          app, not how the app looks. The component keeps its save flow. */}
+      <PersonalizationSettingsPage settings={props.settings} onUpdate={props.onUpdate} />
       <SettingsRows>
         <div className="settingsFormRow">
           <div>

--- a/apps/desktop/src/renderer/settings/settings-nav.ts
+++ b/apps/desktop/src/renderer/settings/settings-nav.ts
@@ -84,7 +84,7 @@ export const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'general', label: '通用', Icon: SettingsIcon, enabled: true, group: '通用',
     description: '隐身、启动、对话默认与网络代理等系统偏好。' },
   { id: 'appearance', label: '外观', Icon: Palette, enabled: true, group: '通用',
-    description: '主题、配色、字体面板与个性化身份。' },
+    description: '主题与配色。' },
   // Group 2: AI 与集成 — models, usage, memory, daily-review, voice+gateway, bots, search
   { id: 'models', label: '模型', Icon: Cpu, enabled: true, group: 'AI 与集成',
     description: '模型连接、API key 与 OAuth 订阅管理。' },

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -565,19 +565,6 @@
    (cards carry their own L padding internally), and bump the heading
    to 12/2px tracking so it reads as a real sub-section break rather
    than a hairline. */
-.settingsSectionHeading {
-  margin: var(--space-6) var(--space-0-5) var(--space-2-5);
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--tracking-widest);
-  text-transform: uppercase;
-}
-.settingsStructuredPage > .settingsSectionHeading:first-child {
-  margin-top: 0;
-}
-
-
 .settingsEmptyState {
   min-height: 240px;
   display: grid;


### PR DESCRIPTION
设计审查最后一个中型项（P2-13 外观页大杂烩）：

- **显示名称 / 界面语言 / 助手语气偏好**是身份配置而非外观——副标题自己都承认（"…与个性化身份"）。`PersonalizationSettingsPage`（自包含组件，含保存流程）整体移到「通用」页顶部。
- 外观页只剩主题面板，删除重复的「主题」区块标题（页面标题已说明），及失去消费者的 `.settingsSectionHeading` CSS。
- 导航描述改为「主题与配色。」。

typecheck 0；2149/2149；check-dead-css 增量干净。