### PR TITLE
fix(ui): drop focus prop from capability-audit-strip stories

### DIFF
--- a/packages/ui/stories/capability-audit-strip.stories.tsx
+++ b/packages/ui/stories/capability-audit-strip.stories.tsx
@@ -62,7 +62,6 @@ export const SkillsFocusHealthy: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="skills"
         report={report({
           sourceCount: 3,
           readySourceCount: 3,
@@ -80,7 +79,6 @@ export const AutomationsFocusHealthy: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="automations"
         report={report({
           sourceCount: 2,
           readySourceCount: 2,
@@ -97,7 +95,6 @@ export const WithRisks: Story = {
   render: () => (
     <StripFrame>
       <CapabilityAuditStrip
-        focus="skills"
         report={report({
           sourceCount: 4,
           readySourceCount: 2,
@@ -121,7 +118,7 @@ export const WithRisks: Story = {
 export const Empty: Story = {
   render: () => (
     <StripFrame>
-      <CapabilityAuditStrip focus="skills" report={report({})} />
+      <CapabilityAuditStrip report={report({})} />
     </StripFrame>
   ),
 };


### PR DESCRIPTION
## Summary

The `CapabilityAuditStrip` component was simplified (designer-audit round 4) and no longer accepts a `focus` prop, but the Storybook stories were not updated. This caused `tsconfig.storybook.json` to fail typecheck with `TS2322` on all four story exports.

## Changes

- `packages/ui/stories/capability-audit-strip.stories.tsx`: remove `focus="skills" | "automations"` from all 4 `CapabilityAuditStrip` usages

## Verification

- `tsc -p tsconfig.storybook.json --noEmit` now passes
- No other files touched
- This fix is a prerequisite for the typecheck job in CI to go green for any PR that touches the storybook typecheck graph