### PR TITLE
fix(ui): green code strings + stale purple copy under the blue brand

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -162,7 +162,9 @@ describe('Settings theme page contract', () => {
     ].join('\n');
 
     assert.match(themeCopy, /匹配 macOS 当前浅色或深色偏好。/);
-    assert.match(themeCopy, /Maka 原本的紫色强调色/);
+    // Brand accent is logo blue now (owner decision 2026-07-03); the old
+    // pinned copy still claimed a purple accent.
+    assert.match(themeCopy, /Maka 品牌蓝强调色/);
     assert.match(themeCopy, /湖蓝强调色，干净冷静/);
     assert.match(themeCopy, /保存在本地外观设置里下次启动延续/);
     assert.doesNotMatch(

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -280,7 +280,7 @@ const PALETTE_LABEL: Record<ThemePalette, string> = {
 };
 
 const PALETTE_HELP: Record<ThemePalette, string> = {
-  'default': 'Maka 原本的紫色强调色',
+  'default': 'Maka 品牌蓝强调色',
   'onedark': '编辑器经典深色',
   'catppuccin-mocha': '紫调柔和深色',
   'tokyo-night': '深蓝主题',

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -281,9 +281,14 @@
 .hljs-selector-tag,
 .hljs-literal,
 .hljs-tag        { color: oklch(from var(--link) calc(l - 0.05) calc(c + 0.04) h); }
+/* Strings are the largest ink mass in highlighted code; keying them to the
+   semantic --success green made whole answers read as leftover brand-green
+   under the blue theme (user report 2026-07-07). Deep navy from the --link
+   family instead — distinct from keywords (brighter blue) and built-ins
+   (violet-shifted); green stays reserved for hljs-addition (real diffs). */
 .hljs-string,
 .hljs-doctag,
-.hljs-regexp     { color: oklch(from var(--success) calc(l + 0.02) c h); }
+.hljs-regexp     { color: oklch(from var(--link) calc(l - 0.15) c calc(h + 15)); }
 .hljs-number,
 .hljs-symbol,
 .hljs-bullet,


### PR DESCRIPTION
用户反馈：蓝色主题下很多**文字**仍是绿色；设置里默认主题的文案写着紫色。

1. **绿色文字主源**：代码高亮的字符串色绑定在语义 `--success` 绿上（`.hljs-string` 等）。字符串是代码块里最大的墨水面积，AI 回答里代码占比又高 → 整段回答读作品牌绿残留。改为 `--link` 家族派生的深藏蓝（与关键字亮蓝、内建紫调可区分），语义绿只保留给 `hljs-addition`（真实 diff）。跟随 palette。
2. **紫色文案**：默认色板描述「Maka 原本的紫色强调色」是两轮换色前的老文案（色板本身已是 logo 蓝）→「Maka 品牌蓝强调色」。契约测试同步更新。

其余 `--success` 绿色文字均为合法状态语义（复制成功、已生成、diff 新增、连接正常），已逐一核对保留。2149/2149；typecheck 0。