### PR TITLE
fix(ui): usage page refresh — quiet icon form, same as every other refresh

### DIFF
--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { AppSettings, UpdateAppSettingsResult, UsageRange, UsageStats } from '@maka/core';
 import { Button, Input, SettingsSegmented as Segmented, SettingsSelect, SettingsSwitch as Switch, useToast } from '@maka/ui';
+import { RefreshCcw } from '@maka/ui/icons';
 import { MetricCard } from './settings-metric-card';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
@@ -119,14 +120,22 @@ export function UsageSettingsPage(props: {
           ]}
           onChange={(value) => void setRange(value as UsageRange)}
         />
+        {/* Detail audit: 刷新 was a primary --action chip glued to the
+            segmented — two control styles fighting in one row for a
+            low-frequency utility. Same quiet icon form as the automations
+            page refresh (one action, one shape everywhere). */}
         <Button
           type="button"
+          variant="quiet"
+          size="icon-sm"
           disabled={refreshing}
           aria-busy={refreshing}
           data-pending={refreshing ? 'true' : undefined}
+          aria-label={refreshing ? '正在刷新使用统计' : '刷新使用统计'}
+          title={refreshing ? '正在刷新使用统计' : '刷新使用统计'}
           onClick={() => void refresh()}
         >
-          {refreshing ? '刷新中…' : '刷新'}
+          <RefreshCcw size={15} strokeWidth={1.75} aria-hidden="true" />
         </Button>
       </div>
 


### PR DESCRIPTION
细节审查（用户截图指出）：使用统计页的「刷新」是主色 chip 且与时间范围 segmented 贴成一排——低频辅助动作用主色、两种控件形态打架，而定时任务页的刷新早已是 quiet 图标形态。统一为同一形态（RefreshCcw quiet icon）。保留契约要求的 ref 门闩 / aria-busy / data-pending。2149/2149。