### PR TITLE
refactor(chat-message): polish code-block tier, alpha tokens, uniform turn gap, timestamp

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
@@ -1,0 +1,41 @@
+/**
+ * CHAT-TURN-SPACING-0 (issue #546 PR5): the chat surface uses one uniform
+ * turn gap — `.maka-chat` (between turns) and `.maka-turn` (within a turn)
+ * both at `--space-3` (12px) — instead of the earlier loose-between /
+ * tight-within split (24px / 8px). Uniform density reads as a continuous
+ * coding-agent stream rather than stacked Q+A blocks; the single token
+ * keeps both on the spacing scale so neither drifts to a magic number.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, TOKENS_FILE, stripCssComments } from './css-test-helpers.js';
+
+/** Extract the declaration body of a top-level `selector { … }` rule (no
+ *  nested blocks — .maka-chat / .maka-turn are flat declaration lists). */
+function ruleBody(css: string, selector: string): string | null {
+  const pattern = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{([^}]*)\\}';
+  return css.match(new RegExp(pattern, 'm'))?.[1] ?? null;
+}
+
+describe('CHAT-TURN-SPACING-0 contract (#546 PR5)', () => {
+  it('.maka-chat and .maka-turn both use gap: var(--space-3) (uniform 12/12)', async () => {
+    const css = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const chat = ruleBody(css, '.maka-chat');
+    const turn = ruleBody(css, '.maka-turn');
+    assert.ok(chat, '.maka-chat rule must exist in maka-tokens.css');
+    assert.ok(turn, '.maka-turn rule must exist in maka-tokens.css');
+    assert.match(
+      chat,
+      /gap:\s*var\(--space-3\)/,
+      '.maka-chat gap must be var(--space-3) (12px), uniform with .maka-turn — the between-turn gap',
+    );
+    assert.match(
+      turn,
+      /gap:\s*var\(--space-3\)/,
+      '.maka-turn gap must be var(--space-3) (12px), uniform with .maka-chat — the within-turn gap',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
@@ -5,6 +5,14 @@
  * tight-within split (24px / 8px). Uniform density reads as a continuous
  * coding-agent stream rather than stacked Q+A blocks; the single token
  * keeps both on the spacing scale so neither drifts to a magic number.
+ *
+ * CHAT-MESSAGE-TIME-0 (issue #546 PR5): the inline message timestamp
+ * (`.maka-message-time-inline`) aligns to the caption tier
+ * (`--font-size-caption`, 11px) at normal weight (`--font-weight-normal`,
+ * 400) in muted color, so it reads as quiet meta — the same tier the
+ * footer-action cva already uses via `text-xs` (the caption alias). It
+ * was previously the UI tier (13px / medium 500), one step louder than
+ * the surrounding chrome.
  */
 
 import { strict as assert } from 'node:assert';
@@ -13,8 +21,10 @@ import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT, TOKENS_FILE, stripCssComments } from './css-test-helpers.js';
 
+const CHAT_MESSAGE_CSS = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles', 'chat-message.css');
+
 /** Extract the declaration body of a top-level `selector { … }` rule (no
- *  nested blocks — .maka-chat / .maka-turn are flat declaration lists). */
+ *  nested blocks — the rules asserted here are flat declaration lists). */
 function ruleBody(css: string, selector: string): string | null {
   const pattern = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{([^}]*)\\}';
   return css.match(new RegExp(pattern, 'm'))?.[1] ?? null;
@@ -36,6 +46,29 @@ describe('CHAT-TURN-SPACING-0 contract (#546 PR5)', () => {
       turn,
       /gap:\s*var\(--space-3\)/,
       '.maka-turn gap must be var(--space-3) (12px), uniform with .maka-chat — the within-turn gap',
+    );
+  });
+});
+
+describe('CHAT-MESSAGE-TIME-0 contract (#546 PR5)', () => {
+  it('.maka-message-time-inline uses the caption tier at normal weight in muted color', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    const block = ruleBody(css, '.maka-message-time-inline');
+    assert.ok(block, '.maka-message-time-inline rule must exist in chat-message.css');
+    assert.match(
+      block,
+      /font-size:\s*var\(--font-size-caption\)/,
+      '.maka-message-time-inline font-size must be var(--font-size-caption) (11px caption tier), not --font-size-ui (13px)',
+    );
+    assert.match(
+      block,
+      /font-weight:\s*var\(--font-weight-normal\)/,
+      '.maka-message-time-inline font-weight must be var(--font-weight-normal) (400), not --font-weight-medium (500) — quiet meta',
+    );
+    assert.match(
+      block,
+      /color:\s*var\(--muted-foreground\)/,
+      '.maka-message-time-inline color must stay var(--muted-foreground) (muted)',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/foreground-alpha-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/foreground-alpha-contract.test.ts
@@ -1,0 +1,89 @@
+/**
+ * FOREGROUND-ALPHA-TOKEN-0 (issue #546 PR5): the file-attachment card's
+ * semi-transparent foreground washes (card bg, icon-tile bg, inset ring, and
+ * the remove-button hover) are governed by named alpha-tint tokens, not
+ * scattered arbitrary Tailwind alpha utilities.
+ *
+ * Two invariants:
+ *
+ * 1. `--foreground-alpha-{6,10,12}` are declared in `maka-tokens.css` as
+ *    color-mix alpha of `--foreground` over `transparent` (NOT the solid
+ *    `--foreground-N` tints, which mix with `--background` and would change
+ *    rendering — the ring would thicken, the wash would stop tracking the
+ *    backdrop). The alpha form preserves the existing semi-transparent
+ *    look exactly while naming the three values the card uses (0.06 / 0.10 /
+ *    0.12).
+ *
+ * 2. `attachment-file-card.tsx` references these tokens (via
+ *    `bg-[var(--foreground-alpha-N)]` / `ring-[var(--foreground-alpha-N)]`)
+ *    and contains no bare `foreground/[0.0X]` / `foreground/NN` arbitrary
+ *    alpha utility. Scanning the literal className text (the
+ *    `readRendererTsxFiles` seam) is enough here because the card's classes
+ *    are all literal strings, not runtime-composed.
+ *
+ * Scope note: this contract governs the attachment card's alphas only. The
+ * existing `opacity-converge-contract` governs the `opacity:` property (and
+ * explicitly excludes TSX Tailwind utilities), so the alpha *color* washes
+ * were a blind spot — this contract fills it for the one component that
+ * carried arbitrary foreground alphas.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  REPO_ROOT,
+  TOKENS_FILE,
+  parseCssCustomProps,
+  readRendererTsxFiles,
+  stripCssComments,
+} from './css-test-helpers.js';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const CARD_FILE = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'attachment-file-card.tsx');
+
+const ALPHA_TOKENS = [
+  { name: '--foreground-alpha-6', alpha: '0.06' },
+  { name: '--foreground-alpha-10', alpha: '0.10' },
+  { name: '--foreground-alpha-12', alpha: '0.12' },
+] as const;
+
+describe('FOREGROUND-ALPHA-TOKEN-0 contract (#546 PR5)', () => {
+  it('maka-tokens.css declares each --foreground-alpha-N once, as oklch alpha of --foreground (NOT the solid --foreground-N tint)', async () => {
+    const css = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
+    const props = parseCssCustomProps(css);
+    for (const { name, alpha } of ALPHA_TOKENS) {
+      const values = props.get(name) ?? [];
+      assert.equal(
+        values.length,
+        1,
+        `maka-tokens.css: ${name} must be declared exactly once; got ${values.length}: ${JSON.stringify(values)}`,
+      );
+      assert.match(
+        values[0],
+        new RegExp(`^oklch\\(from var\\(--foreground\\) l c h / ${alpha.replace('.', '\\.')}\\)$`),
+        `maka-tokens.css: ${name} must be oklch(from var(--foreground) l c h / ${alpha}) (alpha over the backdrop, NOT the solid --foreground-N tint that mixes with --background); got ${values[0]}`,
+      );
+    }
+  });
+
+  it('attachment-file-card.tsx uses the alpha tokens and has no bare foreground/ alpha utility', async () => {
+    const src = await readFile(CARD_FILE, 'utf8');
+    // 1) references all three tokens
+    for (const { name } of ALPHA_TOKENS) {
+      assert.match(
+        src,
+        new RegExp(`var\\(${name.replace(/[()]/g, '\\$&')}\\)`),
+        `attachment-file-card.tsx must reference ${name} (bg-/ring-[${name}])`,
+      );
+    }
+    // 2) no bare foreground alpha — any `foreground/` (slash opacity modifier)
+    //    is an ungoverned arbitrary alpha; after convergence none remain.
+    const offenders = [...src.matchAll(/foreground\/\S+/g)].map((m) => m[0]);
+    assert.deepEqual(
+      offenders,
+      [],
+      `attachment-file-card.tsx must use --foreground-alpha-* tokens, not bare foreground/ alphas: ${offenders.join(', ')}`,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -118,3 +118,49 @@ describe('MARKDOWN-PROSE-CONVERGE-0 contract (#546 PR4)', () => {
     );
   });
 });
+
+/**
+ * Split a comment-stripped CSS string into [selectorList, decls] block pairs.
+ * Flat parser (chat-message.css has no nesting beyond @media/@keyframes, whose
+ * inner rules still split cleanly).
+ */
+function cssBlocks(css: string): Array<{ selectors: string; decls: string }> {
+  return css
+    .split('}')
+    .map((chunk) => chunk.split('{'))
+    .filter((parts) => parts.length === 2)
+    .map(([selectors, decls]) => ({ selectors: selectors.trim(), decls: (decls ?? '').trim() }));
+}
+
+describe('CODE-BLOCK-PRE-FONT-TIER-0 contract (#546 PR5)', () => {
+  // The assistant code block <pre> must render at the UI/chrome tier
+  // (--font-size-ui), NOT inherit the prose body size. A pre-existing reset
+  //   [data-slot="message"] pre { margin: 0; font: inherit }   (specificity 0,1,1)
+  // authored LATER in chat-message.css clobbers a bare `.maka-prose pre` rule
+  // (same specificity 0,1,1, earlier source → loses). The code-block pre rule
+  // must therefore carry an extra class — `.maka-prose .maka-code-block pre`
+  // (specificity 0,2,1) — so it outweighs the reset and the token tier holds.
+  // The reset itself stays, so non-code-block raw <pre> (user / system) still
+  // inherits the message font instead of falling back to the UA monospace.
+
+  it('the code-block pre is scoped to outweigh the [data-slot=message] reset and uses --font-size-ui', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const cb = blocks.find(({ selectors, decls }) =>
+      /\.maka-code-block\s+pre\b/.test(selectors)
+      && /font-size:\s*var\(--font-size-ui\)/.test(decls));
+    assert.ok(
+      cb,
+      'expected a rule scoped `.maka-prose .maka-code-block pre { font-size: var(--font-size-ui) }` (specificity 0,2,1) to outweigh the `[data-slot="message"] pre { font: inherit }` reset (0,1,1); a bare `.maka-prose pre` is clobbered by the later reset',
+    );
+  });
+
+  it('the [data-slot=message] pre reset still exists for non-code-block raw pre', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    assert.match(
+      css,
+      /\[data-slot="message"\]\s+pre\s*\{[^}]*font:\s*inherit/,
+      'the [data-slot="message"] pre { font: inherit } reset must remain so non-code-block raw <pre> (user / system) inherits the message font instead of UA monospace',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1179,23 +1179,22 @@
     padding: var(--space-6) 0 var(--space-4) 0;
     display: flex;
     flex-direction: column;
-    /* PR-CHAT-CHROME-FOLLOWUP-0: looser separation BETWEEN turns so each
-       Q+A unit reads as its own block (the within-turn gap stays tight). */
-    gap: var(--space-6);
+    /* PR5 CHAT-TURN-SPACING-0: uniform 12px turn gap (between turns =
+       within turn) — the chat reads as a continuous coding-agent stream
+       instead of stacked Q+A blocks. */
+    gap: var(--space-3);
   }
 
   /* Turn grouping (per kenji UI-04): user msg + tools + assistant answer
-   * cluster into one visual unit. The section is just a flex container —
-   * the spacing between turns is established by the outer chat gap; spacing
-   * inside a turn is tighter so the unit reads as one work block. */
+   * cluster into one visual unit. The section is a flex container; both the
+   * between-turn and within-turn gaps are uniform (CHAT-TURN-SPACING-0), so
+   * a turn reads as one unit by grouping, not by tighter internal spacing. */
   .maka-turn {
     display: flex;
     flex-direction: column;
-    /* PR-CHAT-CHROME-FOLLOWUP-0: 4px → 8px. The parts of one turn (user
-       block, summary, tools, answer) were cramped; 8px gives a calmer
-       internal rhythm while still reading as one unit against the 24px
-       between-turn gap. */
-    gap: var(--space-2);
+    /* PR5 CHAT-TURN-SPACING-0: uniform 12px within-turn gap, matching the
+       between-turn gap (.maka-chat) — one density, no between/within split. */
+    gap: var(--space-3);
     max-width: var(--maka-chat-measure);
     margin: 0 auto;
     width: 100%;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -188,6 +188,16 @@
   --ring:          oklch(from var(--foreground) l c h / 0.25);
   --state-hover-bg:    oklch(from var(--foreground) l c h / 0.04);
   --state-selected-bg: oklch(from var(--foreground) l c h / 0.065);
+  /* PR5 FOREGROUND-ALPHA-TOKEN-0: raw foreground-alpha tiers for component
+     washes that need a semi-transparent foreground over their backdrop
+     (NOT the solid --foreground-N tints, which mix with --background and
+     would change rendering — the ring would thicken, the wash would stop
+     tracking the backdrop). The file-attachment card uses these for its bg
+     (0.06), icon-tile (0.10), and inset ring (0.12); other components at
+     the same density can reuse the tier instead of a fresh alpha. */
+  --foreground-alpha-6:  oklch(from var(--foreground) l c h / 0.06);
+  --foreground-alpha-10: oklch(from var(--foreground) l c h / 0.10);
+  --foreground-alpha-12: oklch(from var(--foreground) l c h / 0.12);
   /* User bubble color is intentionally distinct from `--accent` so users can
      re-tint the accent without ruining chat legibility.
      PR-GRAY-CARD-LIFT-0: bubble shifts to neutral gray (hue 0)

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -479,15 +479,16 @@
 }
 
 /* --- User-turn meta row (relocated from tool-output.css) ----------------- */
-/* PR-CHAT-CHROME-FOLLOWUP-0: the relative time is always visible now
-   (it was `opacity: 0` until hover, which hid it on touch + from
-   assistive tech). It stays quiet — 12px at the shared chrome size,
-   muted — and rides in the user turn's meta row beneath the block. */
+/* PR-CHAT-CHROME-FOLLOWUP-0 / PR5 CHAT-MESSAGE-TIME-0: the relative time is
+   always visible now (it was `opacity: 0` until hover, which hid it on
+   touch + from assistive tech). It stays quiet — caption tier (11px) at
+   normal weight, muted — and rides in the user turn's meta row beneath
+   the block. Aligned to the same tier the footer-action cva uses (text-xs). */
 .maka-message-time-inline {
   display: inline-block;
   color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-normal);
   line-height: var(--leading-none);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -253,7 +253,14 @@
 .maka-code-block-copy[data-copy-feedback="failed"] {
   color: var(--destructive);
 }
-.maka-prose pre {
+/* Scoped to `.maka-prose .maka-code-block pre` (specificity 0,2,1), NOT a bare
+   `.maka-prose pre` (0,1,1): the `[data-slot="message"] pre { font: inherit }`
+   reset later in this file is also 0,1,1 and would clobber a bare
+   `.maka-prose pre` by source order, re-inheriting the prose body size +
+   family and killing the --font-size-ui tier. The extra `.maka-code-block`
+   class outweighs the reset so the token tier holds.
+   CODE-BLOCK-PRE-FONT-TIER-0 contract locks this. */
+.maka-prose .maka-code-block pre {
   margin: 0;
   padding: var(--space-3) var(--space-3);
   border: 0;
@@ -265,7 +272,7 @@
   line-height: var(--leading-normal);
   white-space: pre;
 }
-.maka-prose pre code {
+.maka-prose .maka-code-block pre code {
   padding: 0;
   background: transparent;
   font-size: inherit;

--- a/packages/ui/src/__tests__/chat-primitives.test.ts
+++ b/packages/ui/src/__tests__/chat-primitives.test.ts
@@ -53,6 +53,10 @@ test('markerVariants resolves a leaf shell string the UiButton call sites can ap
   const footerAction = markerVariants({ variant: 'footer-action' });
   assert.match(footerAction, /min-h-\[28px\]/);
   assert.match(footerAction, /data-\[copy-feedback=copied\]:text-\[color:var\(--link\)\]/);
+  // PR5 CHAT-MESSAGE-TIME-0: footer-action stays at the caption tier
+  // (text-xs aliases --font-size-caption, 11px), aligned with the inline
+  // message timestamp — both read as quiet meta, one step below the UI tier.
+  assert.match(footerAction, /text-xs/);
   const lineageBadge = markerVariants({ variant: 'lineage-badge' });
   assert.match(lineageBadge, /rounded-\[var\(--radius-pill\)\]/);
   assert.match(lineageBadge, /data-\[direction=forward\]:/);

--- a/packages/ui/src/attachment-file-card.tsx
+++ b/packages/ui/src/attachment-file-card.tsx
@@ -22,11 +22,11 @@ export function AttachmentFileCard(props: {
   return (
     <div
       className={cn(
-        'flex items-center gap-2.5 rounded-lg bg-foreground/[0.06] ring-1 ring-inset ring-foreground/[0.12] p-2 w-[200px] max-w-full',
+        'flex items-center gap-2.5 rounded-lg bg-[var(--foreground-alpha-6)] ring-1 ring-inset ring-[color:var(--foreground-alpha-12)] p-2 w-[200px] max-w-full',
         props.className,
       )}
     >
-      <span className="h-9 w-9 shrink-0 rounded-md bg-foreground/[0.10] grid place-items-center text-foreground-secondary">
+      <span className="h-9 w-9 shrink-0 rounded-md bg-[var(--foreground-alpha-10)] grid place-items-center text-foreground-secondary">
         <AttachmentKindIcon kind={props.kind} className="h-5 w-5" />
       </span>
       <span className="min-w-0 flex-1 leading-tight">
@@ -41,7 +41,7 @@ export function AttachmentFileCard(props: {
         <button
           type="button"
           onClick={props.onRemove}
-          className="ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-foreground/10 hover:text-foreground transition"
+          className="ml-1 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-[var(--foreground-alpha-10)] hover:text-foreground transition"
           aria-label={`移除 ${props.name}`}
         >
           <X className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- Fix the assistant code-block `<pre>` so it renders at the UI tier (`--font-size-ui`, 13px) — a pre-existing reset was clobbering it to the prose body size.
- Govern the file-attachment card's foreground alphas via three named `--foreground-alpha-*` tokens (replaces scattered `bg-foreground/[0.06]` etc.).
- Uniform 12px turn gap (`.maka-chat` between = `.maka-turn` within), replacing the 24/8 loose-between/tight-within split.
- Align the inline message timestamp to the caption tier (11px / normal weight / muted).

## Why
Refs #546. The chat message surface had a latent code-block font bug, scattered arbitrary alphas, a turn-spacing split that read as stacked Q+A blocks instead of a coding-agent stream, and a timestamp one tier louder than the surrounding chrome.

## Scope
**Changed**
- `chat-message.css`: scope `.maka-prose pre` → `.maka-prose .maka-code-block pre` (specificity 0,2,1) to outweigh the `[data-slot="message"] pre { font: inherit }` reset; drop `.maka-message-time-inline` to caption/normal.
- `maka-tokens.css`: add `--foreground-alpha-6/-10/-12`; uniform `.maka-chat` + `.maka-turn` gap to `--space-3`.
- `attachment-file-card.tsx`: converge 4 bare foreground alphas to the tokens.
- Contracts: `CODE-BLOCK-PRE-FONT-TIER-0`, `FOREGROUND-ALPHA-TOKEN-0`, `CHAT-TURN-SPACING-0`, `CHAT-MESSAGE-TIME-0`, + footer-action `text-xs` lock in `chat-primitives`.

**Not included (deferred)**
- 13/12 font-scale governance (chat body 15→13). Shape analysis done; deferred to a separate PR (recommended chat-surface-scoped 13/12/11 via a `data-density` hook; verified `--spacing:4px` makes Tailwind spacing px, so no layout ripple).
- 640/128/200px width literals — kept.

## Verification
- `npm run typecheck` — all workspaces pass.
- `npm run build` — all workspaces build.
- `node --test "dist/main/**/*.test.js"` — 2164 pass, 0 fail.
- CDP (headless Chrome): code-block `<pre>` computed font-size = `--font-size-ui` (13px), not prose body size.
- Renderer CSS bundle: timestamp emits `var(--font-size-caption)` + `var(--font-weight-normal)`; `.maka-chat`/`.maka-turn` emit `gap: var(--space-3)`; `bg-[var(--foreground-alpha-N)]` / `ring-[color:var(--foreground-alpha-N)]` utilities generate.
- Screenshots: the repo pipeline is a dimensions-only sanity gate (no pixel baseline for turn-narrative); changes don't alter capture dimensions, so no baseline update needed.

## User-facing impact
- Turns cluster tighter (uniform 12px gap vs 24/8).
- Timestamps smaller (11px) + lighter (normal weight).
- Assistant code blocks 13px (UI tier) instead of 15px (prose body) — the intended behavior the token comment always described.
- Attachment card look unchanged (alphas tokenized, same values).

<img width="5120" height="1674" alt="image" src="https://github.com/user-attachments/assets/d9198bbd-0796-4297-89a4-2d0d77577f30" />


## Reviewer notes
- Code-block fix is a pre-existing bug (`[data-slot="message"] pre { font: inherit }` from #332 PR2 clobbered `.maka-prose pre`); fixed by scoping, not by removing the reset (reset stays for non-code-block raw `<pre>`).
- Alpha tokens are `oklch(from var(--foreground) l c h / N)` (alpha over backdrop), NOT the solid `--foreground-N` tints (which mix with `--background` and would change rendering).
- Rebased onto latest `main`; each commit independently revertable.

## Checklist
- [x] Scope matches title; excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact noted
- [x] Risk/rollback called out
- [x] UI changes: no pixel screenshot (pipeline is dimensions-only); verified via CDP + CSS bundle + contracts
