### PR TITLE
fix(ui): detail-audit round 2 — bordered actions, aligned switches, de-greened emphasis cards

### DIFF
--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -404,11 +404,11 @@ function WeChatScanLoginModal(props: {
         </div>
         <div className="settingsBotScanLoginActions" role="group" aria-label="微信扫码登录操作">
           {(status === 'expired' || status === 'error') && (
-            <Button className="settingsBotAction" type="button" variant="secondary" onClick={() => void fetchQr()}>
+            <Button type="button" variant="secondary" onClick={() => void fetchQr()}>
               刷新二维码
             </Button>
           )}
-          <Button className="settingsBotAction" type="button" variant="secondary" onClick={props.onClose}>
+          <Button type="button" variant="secondary" onClick={props.onClose}>
             {status === 'confirmed' ? '关闭' : '取消'}
           </Button>
         </div>
@@ -1128,7 +1128,7 @@ export function BotChatSettingsPage(props: {
           {selected === 'wechat' ? (
             <>
               <Button
-                className="settingsBotAction"
+               
                 type="button"
                 variant="secondary"
                 disabled={botActionBusy}
@@ -1138,7 +1138,7 @@ export function BotChatSettingsPage(props: {
               </Button>
               {(channel.token || selectedStatus?.identity) && (
                 <Button
-                  className="settingsBotAction"
+                 
                   type="button"
                   variant="secondary"
                   disabled={botActionBusy}
@@ -1148,7 +1148,7 @@ export function BotChatSettingsPage(props: {
                 </Button>
               )}
               <Button
-                className="settingsBotAction"
+               
                 type="button"
                 variant="secondary"
                 disabled={botActionBusy}
@@ -1157,7 +1157,7 @@ export function BotChatSettingsPage(props: {
                 本机桥接二维码
               </Button>
               <Button
-                className="settingsBotAction"
+               
                 type="button"
                 variant="secondary"
                 disabled={botActionBusy}
@@ -1168,7 +1168,6 @@ export function BotChatSettingsPage(props: {
             </>
           ) : support === 'runtime' && !selectedStatus?.running ? (
             <Button
-              className="settingsBotAction"
               type="button"
               variant="secondary"
               disabled={botActionBusy}
@@ -1178,7 +1177,6 @@ export function BotChatSettingsPage(props: {
             </Button>
           ) : (
             <Button
-              className="settingsBotAction"
               type="button"
               variant="secondary"
               disabled={botActionBusy || support === 'planned'}
@@ -1196,7 +1194,6 @@ export function BotChatSettingsPage(props: {
               resolution feedback. */}
           {support === 'runtime' && (selectedStatus?.running || restarting) && selected !== 'wechat' && (
             <Button
-              className="settingsBotAction"
               type="button"
               variant="secondary"
               disabled={botActionBusy}

--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -142,15 +142,15 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
 
   return (
     <section className="settingsFeatureStatusPage" aria-label="每日回顾">
-      <header className="settingsFeatureStatusBanner" role="status">
-        <span className="settingsFeatureStatusBannerDot" aria-hidden="true" />
-        <strong>每日回顾</strong>
-        <span>
-          {hasConfigIpc
-            ? '每天自动分析本机对话，生成摘要、遗漏提醒和建议。模型按需消耗。'
-            : '当前版本仅本地数字聚合，定时生成 / LLM 摘要尚未连接到后端。'}
-        </span>
-      </header>
+      {/* Detail audit: the always-on feature banner repeated the page
+          subtitle — report by exception instead: only the not-wired
+          fallback state warrants a banner. */}
+      {!hasConfigIpc && (
+        <header className="settingsFeatureStatusBanner" role="status">
+          <span className="settingsFeatureStatusBannerDot" aria-hidden="true" />
+          <span>当前版本仅本地数字聚合，定时生成 / LLM 摘要尚未连接到后端。</span>
+        </header>
+      )}
 
       {loadError ? (
         <Alert variant="error" className="settingsSurfaceAlert">

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -202,9 +202,15 @@ export function DataSettingsPage() {
           value="本机 localStorage"
         />
       </SettingsRows>
+      {/* Detail audit: was two wrapped rows with 打开文件夹 wearing primary
+          (a utility action) and destructive 清空输入历史 dressed neutral.
+          One row; utilities are secondary; the destructive action reads
+          destructive (red outline family, same recipe as the permission
+          dialog confirm). */}
       <div className="settingsActionRow" role="group" aria-label="工作区数据操作">
         <Button
           type="button"
+          variant="secondary"
           onClick={() => void openWorkspace()}
           disabled={!info || dataActionDisabled}
         >
@@ -218,11 +224,10 @@ export function DataSettingsPage() {
         >
           {isDataActionPending('workspace:path:copy') ? '复制中…' : '复制路径'}
         </Button>
-      </div>
-      <div className="settingsActionRow" role="group" aria-label="输入历史操作">
         <Button
           type="button"
-          variant="secondary"
+          variant="outline"
+          className="border-[oklch(from_var(--destructive)_l_c_h_/_0.45)] text-[color:var(--destructive)] hover:bg-[oklch(from_var(--destructive)_l_c_h_/_0.08)]"
           onClick={() => void clearInputHistory()}
           disabled={dataActionDisabled}
         >

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -646,9 +646,9 @@ export function MemorySettingsPage(props: {
                 {(file.status === 'available' || file.status === 'empty') && (
                   <Button
                     type="button"
-                    variant="quiet"
+                    variant="outline"
                     size="sm"
-                    className="settingsInlineTextButton min-w-[4rem]"
+                    className="min-w-[4rem]"
                     aria-label={`打开项目指令文件 ${file.file}`}
                     disabled={memoryControlsDisabled || isMemoryActionPending(`instruction:${file.file}:open`)}
                     onClick={() => void openWorkspaceInstructionFile(file.file)}
@@ -659,9 +659,9 @@ export function MemorySettingsPage(props: {
                 {file.status === 'missing' && (
                   <Button
                     type="button"
-                    variant="quiet"
+                    variant="outline"
                     size="sm"
-                    className="settingsInlineTextButton min-w-[4rem]"
+                    className="min-w-[4rem]"
                     aria-label={`创建项目指令文件 ${file.file}`}
                     disabled={memoryControlsDisabled || isMemoryActionPending(`instruction:${file.file}:create`)}
                     onClick={() => void createWorkspaceInstructionFile(file.file)}
@@ -720,9 +720,9 @@ export function MemorySettingsPage(props: {
                   <span>{backupCandidateLabel} · <RelativeTime ts={backup.updatedAt} /></span>
                   <Button
                     type="button"
-                    variant="quiet"
+                    variant="outline"
                     size="sm"
-                    className="settingsInlineTextButton min-w-[4rem]"
+                    className="min-w-[4rem]"
                     aria-label={`打开备份候选 ${backupCandidateLabel}`}
                     disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending(`backup:${backup.kind}:open`)}
                     onClick={() => void openBackupCandidate(backup)}
@@ -731,9 +731,9 @@ export function MemorySettingsPage(props: {
                   </Button>
                   <Button
                     type="button"
-                    variant="quiet"
+                    variant="outline"
                     size="sm"
-                    className="settingsInlineTextButton min-w-[4rem]"
+                    className="min-w-[4rem]"
                     aria-label={`恢复备份候选 ${backupCandidateLabel}`}
                     disabled={memoryControlsDisabled || !effective.enabled || isMemoryActionPending(`backup:${backup.kind}:restore`)}
                     onClick={() => void restoreBackupCandidate(backup)}
@@ -742,9 +742,9 @@ export function MemorySettingsPage(props: {
                   </Button>
                   <Button
                     type="button"
-                    variant="quiet"
+                    variant="outline"
                     size="sm"
-                    className="settingsInlineTextButton min-w-[4rem]"
+                    className="min-w-[4rem]"
                     aria-label={`复制备份候选引用 ${backupCandidateLabel}`}
                     disabled={isMemoryActionPending(`backup:${backup.kind}:copy`)}
                     onClick={() => void copyBackupReference(backup)}
@@ -783,9 +783,9 @@ export function MemorySettingsPage(props: {
             <span>{promptPreviewWillInject ? '发送时会注入' : '当前不会注入'}</span>
             <Button
               type="button"
-              variant="quiet"
+              variant="outline"
               size="sm"
-              className="settingsInlineTextButton min-w-[5rem]"
+              className="min-w-[5rem]"
               disabled={!localMemoryPromptPreview || isMemoryActionPending('memory:prompt-preview:copy')}
               onClick={() => void copyLocalMemoryPromptPreview()}
             >
@@ -818,9 +818,8 @@ export function MemorySettingsPage(props: {
             {normalizedMemoryEntryQuery ? (
               <Button
                 type="button"
-                variant="quiet"
+                variant="outline"
                 size="sm"
-                className="settingsInlineTextButton"
                 onClick={() => setMemoryEntryQuery('')}
               >
                 清除
@@ -909,7 +908,7 @@ export function MemorySettingsPage(props: {
         </div>
         <Button
           type="button"
-          variant="ghost"
+          variant="secondary"
           disabled={memoryControlsDisabled || effective.status === 'incognito_blocked' || !effective.enabled}
           onClick={addManualMemoryDraftEntry}
         >
@@ -1052,9 +1051,9 @@ function MemoryEntryList(props: {
                     {props.onCopyReference && (
                       <Button
                         type="button"
-                        variant="quiet"
+                        variant="outline"
                         size="sm"
-                        className="settingsInlineTextButton min-w-[4rem]"
+                        className="min-w-[4rem]"
                         disabled={copyPending}
                         onClick={() => void props.onCopyReference?.(entry)}
                       >
@@ -1064,9 +1063,8 @@ function MemoryEntryList(props: {
                     {props.onFocusDraft && (
                       <Button
                         type="button"
-                        variant="quiet"
+                        variant="outline"
                         size="sm"
-                        className="settingsInlineTextButton"
                         onClick={() => void props.onFocusDraft?.(entry)}
                       >
                         定位草稿
@@ -1075,9 +1073,9 @@ function MemoryEntryList(props: {
                     {props.onStatusChange && (
                       <Button
                         type="button"
-                        variant="quiet"
+                        variant="outline"
                         size="sm"
-                        className="settingsInlineTextButton min-w-[5rem]"
+                        className="min-w-[5rem]"
                         aria-label={statusActionAriaLabel}
                         disabled={props.busy}
                         onClick={() => void props.onStatusChange?.(entry, props.archived ? 'active' : 'archived')}

--- a/apps/desktop/src/renderer/settings/settings-nav.ts
+++ b/apps/desktop/src/renderer/settings/settings-nav.ts
@@ -93,7 +93,7 @@ export const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'memory', label: '记忆', Icon: Brain, enabled: true, group: 'AI 与集成',
     description: '本地 MEMORY.md、项目指令文件与上下文注入开关。' },
   { id: 'daily-review', label: '每日回顾', Icon: CalendarDays, enabled: true, group: 'AI 与集成',
-    description: '当天对话、模型与工具用量汇总。' },
+    description: '每天自动分析本机对话，生成摘要、遗漏提醒和建议。模型按需消耗。' },
   { id: 'voice', label: '语音', Icon: Mic, enabled: true, group: 'AI 与集成',
     description: '语音转写、麦克风权限与本地音频管线设置。' },
   { id: 'open-gateway', label: '开放网关', Icon: Network, enabled: true, group: 'AI 与集成',

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -216,7 +216,9 @@
   }
 .settingsBotStatusGrid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    /* Detail audit: fixed 4 columns orphaned the 5th status card onto its
+       own row. Auto-fit keeps one balanced row and degrades gracefully. */
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: var(--space-2);
     margin: 0;
   }
@@ -410,6 +412,13 @@
   border-radius: 0;
   background: transparent;
   transition: background var(--duration-base) var(--ease-out-strong);
+}
+
+/* Detail audit: bare Switch controls sat at the value column's START
+   (x≈mid-page) while inputs/selects hug the right rail — two alignments
+   in one list. Controls end-align like every other row control. */
+.settingsRow > button[role="switch"] {
+  justify-self: end;
 }
 
 /* #520 PR9: .settingsBadge retired onto the Chip primitive variant="neutral"

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -210,16 +210,6 @@
     align-items: center;
     gap: var(--space-1-5);
   }
-.settingsInlineTextButton {
-    border: 0;
-    padding: 0;
-    background: transparent;
-    color: var(--link);
-    font: inherit;
-  }
-.settingsInlineTextButton:hover {
-    text-decoration: underline;
-  }
 .settingsConnectionActions {
     display: flex;
     flex-wrap: wrap;

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -492,11 +492,12 @@
 .settingsMemoryMeta {
     flex-wrap: wrap;
     row-gap: var(--space-1);
-    /* Anchor the strip: it floated unboxed between two cards and read
-       as orphaned fragments. A hairline + breathing room marks it as
-       the editor's status footnote (divider over a nested card). */
-    padding: var(--space-1-5) var(--space-0-5) 0;
-    border-top: var(--border-width-hairline) solid var(--foreground-10);
+    /* Detail audit round 2: the hairline alone still read as orphaned
+       fragments floating between two cards (user screenshot). A quiet
+       filled strip gives the path + status words a real container. */
+    padding: var(--space-1-5) var(--space-2-5);
+    border-radius: var(--radius-control);
+    background: var(--foreground-3);
   }
 .settingsMemoryPath {
     /* The component already shortens the path for display

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -257,7 +257,7 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
-  border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.32);
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.32);
   border-radius: var(--radius-surface);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-secondary);

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -140,14 +140,17 @@
   display: grid;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-4);
-  border: var(--border-width-hairline) solid oklch(from var(--success) l c h / 0.24);
+  /* Detail audit: this card family (关于 privacy card + 数据 import/export)
+     wore --success green as SECTION EMPHASIS — a non-status use that read
+     as residual brand-green after the blue rebrand. Brand family instead. */
+  border: var(--border-width-hairline) solid oklch(from var(--brand-deep) l c h / 0.22);
   border-radius: var(--radius-surface);
-  background: oklch(from var(--success) l c h / 0.04);
+  background: oklch(from var(--brand-deep) l c h / 0.04);
 }
 
 .settingsAboutPrivacy h3 {
   margin: 0;
-  color: var(--success);
+  color: oklch(from var(--brand-deep) calc(l - 0.12) c h);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-bold);
   letter-spacing: var(--tracking-wider);
@@ -448,31 +451,10 @@
   gap: var(--space-3);
   margin-top: var(--space-2);
 }
-.settingsBotAction {
-  appearance: none;
-  min-width: 110px;
-  min-height: 36px;
-  padding: 0 var(--space-6);
-  border: var(--border-width-hairline) solid oklch(from var(--accent) l c h / 0.45);
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--accent);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
-  transition: background var(--duration-quick) var(--ease-out-strong), border-color var(--duration-quick) var(--ease-out-strong), color var(--duration-quick) var(--ease-out-strong);
-}
-.settingsBotAction:hover {
-  background: oklch(from var(--accent) l c h / 0.08);
-}
-.settingsBotAction:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.22);
-}
-.settingsBotAction[disabled] {
-  opacity: var(--opacity-disabled);
-  cursor: not-allowed;
-}
-
+/* Detail audit: the .settingsBotAction pill re-skin (radius-pill + raw
+   accent chrome smuggled through this file's governance allowlist) was
+   removed — the buttons render as standard UiButton secondary chips like
+   every other settings action. */
 /* Inline hint after a field label — mirrors "(国内网络必填)" /
    "(仅用于 Bot 鉴权)" in the reference. */
 .settingsFieldHint {


### PR DESCRIPTION
细节审查第 2 轮（7 个 settings 页逐帧过完；响应用户「很多按钮没有边缘、像没组件」的截图反馈）：

| 页面 | 修复 |
|---|---|
| 记忆 | 铲除 `.settingsInlineTextButton` 反模式（border:0+padding:0 把组件按钮打回裸蓝字）——10 处升级为 outline 按钮；「添加到草稿」ghost→secondary；MEMORY.md 路径/状态条从裸浮改为带底色容器 |
| 关于+数据 | 「绿色强调卡」家族（隐私卡/配置导入导出——非状态语义用 success 绿）→ 品牌色系 |
| 数据 | 按钮组并回一行；「打开文件夹」主色降级 secondary；「清空输入历史」获得破坏性红描边语义 |
| 每日回顾设置 | 开关右缘对齐（原先悬在值列起点）；常驻虚线横幅删除（信息句升级为页副标题，仅未接通 fallback 态保留横幅并改实线） |
| 机器人对话 | 状态卡 auto-fit（消灭 4+1 孤儿行）；`.settingsBotAction` 胶囊重皮肤删除（借豁免文件夹带裸 accent），按钮回归标准 secondary chip |

每页截图验证；2149/2149；typecheck 0。