### PR TITLE
feat(skills): add workspace-level skill enablement

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -68,7 +68,7 @@ import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/settings/result';
 import type { CreateSessionInput } from '@maka/core';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
-import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type {
   OnboardingMilestone,
@@ -532,9 +532,21 @@ declare global {
           | { ok: true; skill: SkillEntry }
           | { ok: false; reason: 'not_found' | 'already_exists' | 'blocked_path' | 'write_failed' }
         >;
-        updateManaged(skillId: string): Promise<
+        details(skillId: string): Promise<
+          | { ok: true; details: SkillGovernanceDetails }
+          | { ok: false; reason: 'not_found' | 'invalid_id' }
+        >;
+        previewUpdate(skillId: string): Promise<
+          | { ok: true; preview: ManagedSkillUpdatePreview }
+          | { ok: false; reason: 'not_managed' | 'source_missing' | 'metadata_error' | 'blocked_path' | 'read_failed' }
+        >;
+        updateManaged(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<
           | { ok: true; skill: SkillEntry }
           | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
+        >;
+        setEnabled(skillId: string, enabled: boolean): Promise<
+          | { ok: true; skill: SkillEntry }
+          | { ok: false; reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed' }
         >;
         createStarter(): Promise<
           | { ok: true; skill: SkillEntry; filePath: string }

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -136,6 +136,37 @@ Make every slide carry one idea.`);
     });
   });
 
+  it('loads an enabled duplicate-name skill before reporting a disabled duplicate as blocked', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      await writeSkill(workspaceRoot, 'disabled-copy', `---
+name: Shared Helper
+description: Disabled duplicate.
+---
+# Shared Helper
+Disabled copy.`);
+      await writeSkill(workspaceRoot, 'enabled-copy', `---
+name: Shared Helper
+description: Enabled duplicate.
+---
+# Shared Helper
+Enabled copy.`);
+
+      const disabled = await setSkillEnabled(workspaceRoot, 'disabled-copy', false);
+      assert.equal(disabled.ok, true);
+
+      const loadedByName = await loadSkillInstructions(workspaceRoot, 'Shared Helper');
+      assert.equal(loadedByName.ok, true);
+      if (!loadedByName.ok) return;
+      assert.equal(loadedByName.skill.id, 'enabled-copy');
+      assert.match(loadedByName.skill.instructions, /Enabled copy\./);
+
+      const loadedDisabledById = await loadSkillInstructions(workspaceRoot, 'disabled-copy');
+      assert.equal(loadedDisabledById.ok, false);
+      if (loadedDisabledById.ok) return;
+      assert.equal(loadedDisabledById.reason, 'disabled');
+    });
+  });
+
   it('fails closed when the workspace skill runtime state file is invalid', async () => {
     await withWorkspace(async (workspaceRoot) => {
       await writeSkill(workspaceRoot, 'browser-helper', `---
@@ -747,12 +778,36 @@ description: Build decks.
 # Deck Helper
 Version two.`, 'utf8');
 
-        const updated = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot);
+        const cleanPreview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(cleanPreview.ok, true);
+        if (!cleanPreview.ok) return;
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version two changed after preview.`, 'utf8');
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot, {
+          expectedCurrentSha256: cleanPreview.preview.expectedCurrentSha256,
+          expectedSourceSha256: cleanPreview.preview.expectedSourceSha256,
+        }), {
+          ok: false,
+          reason: 'local_modified',
+        });
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version one\./);
+
+        const freshCleanPreview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(freshCleanPreview.ok, true);
+        if (!freshCleanPreview.ok) return;
+        const updated = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot, {
+          expectedCurrentSha256: freshCleanPreview.preview.expectedCurrentSha256,
+          expectedSourceSha256: freshCleanPreview.preview.expectedSourceSha256,
+        });
         assert.equal(updated.ok, true);
         if (!updated.ok) return;
         assert.equal(updated.skill.managedUpdateStatus, 'up_to_date');
-        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version two\./);
-        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', '.maka', 'baseline', 'SKILL.md'), 'utf8'), /Version two\./);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version two changed after preview\./);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', '.maka', 'baseline', 'SKILL.md'), 'utf8'), /Version two changed after preview\./);
 
         await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
 name: Deck Helper
@@ -775,7 +830,7 @@ Local edit.`, 'utf8');
         if (!preview.ok) return;
         assert.match(preview.preview.currentContent, /Local edit\./);
         assert.match(preview.preview.sourceContent, /Version three\./);
-        assert.match(preview.preview.baselineContent ?? '', /Version two\./);
+        assert.match(preview.preview.baselineContent ?? '', /Version two changed after preview\./);
         assert.equal(preview.preview.skill.managedUpdateStatus, 'local_modified');
         assert.ok(preview.preview.summary.changedLineCount > 0);
 
@@ -859,6 +914,8 @@ Version two.`, 'utf8');
         const baselineStat = await lstat(baselinePath);
         assert.equal(baselineStat.isSymbolicLink(), true);
         assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version one\./);
+        const skills = await listInstalledSkills(workspaceRoot, { managedSourceRoot: sourceRoot });
+        assert.equal(skills.find((skill) => skill.id === 'deck-helper')?.managedUpdateStatus, 'update_available');
       } finally {
         await rm(sourceRoot, { recursive: true, force: true });
         await rm(outside, { recursive: true, force: true });
@@ -1095,9 +1152,9 @@ name: Writer
       /useEffect\(\(\) => \{\s*skillActionMountedRef\.current = true;[\s\S]*?return \(\) => \{\s*skillActionMountedRef\.current = false;\s*pendingSkillActionRef\.current = null;\s*\};\s*\}, \[\]\)/,
       'Skills actions must release pending ownership when the module unmounts',
     );
-    assert.match(skillsModuleMain, /async function runSkillAction\(/);
-    assert.match(skillsModuleMain, /if \(!action \|\| pendingSkillActionRef\.current !== null\) return;/, 'Skills actions must reject duplicate clicks immediately');
-    assert.match(skillsModuleMain, /pendingSkillActionRef\.current = actionKey[\s\S]*setPendingSkillAction\(actionKey\)[\s\S]*await action\(\)/, 'Skills actions must show pending state while waiting for renderer IPC');
+    assert.match(skillsModuleMain, /async function runSkillAction<Result>\(/);
+    assert.match(skillsModuleMain, /if \(!action \|\| pendingSkillActionRef\.current !== null\) return undefined;/, 'Skills actions must reject duplicate clicks immediately');
+    assert.match(skillsModuleMain, /pendingSkillActionRef\.current = actionKey[\s\S]*setPendingSkillAction\(actionKey\)[\s\S]*return await action\(\)/, 'Skills actions must show pending state while waiting for renderer IPC and preserve action results');
     assert.match(skillsModuleMain, /pendingSkillActionRef\.current = null[\s\S]*if \(skillActionMountedRef\.current\) setPendingSkillAction\(null\)/, 'Skills actions must not clear pending UI state after unmount');
     assert.match(skillsModuleMain, /className="maka-module-main-actions" role="group" aria-label="技能操作"/);
     assert.match(skillsModuleMain, /disabled=\{!props\.onOpenSkillsFolder \|\| skillActionBusy\}/, 'open folder button must be disabled while any Skills action is pending');
@@ -1151,14 +1208,16 @@ name: Writer
     assert.match(skillPanel, /导入本地 Skill/);
     assert.match(skillPanel, /onInstallManagedSkill\?\(sourceId: string\): void \| Promise<void>/);
     assert.match(skillPanel, /onPreviewManagedSkillUpdate\?\(skillId: string\): Promise<ManagedSkillUpdatePreview \| null>/);
-    assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\): void \| Promise<void>/);
+    assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\): boolean \| Promise<boolean>/);
     assert.match(skillPanel, /onSetSkillEnabled\?\(skillId: string, enabled: boolean\): void \| Promise<void>/);
     assert.match(skillPanel, /<Switch[\s\S]*checked=\{skill\.enabled\}[\s\S]*onCheckedChange=\{\(next\) => props\.onSetSkillEnabled\?\.\(skill\.id, next === true\)\}/);
     assert.match(skillPanel, /<div[\s\S]*className="maka-skill-library-row"[\s\S]*<\/div>/, 'Skill row body must be information, not the open-file control');
     assert.match(skillPanel, /className="maka-skill-library-open-button"[\s\S]*aria-label=\{`打开 \$\{skill\.name\} 的 SKILL\.md`\}/);
     assert.match(skillPanel, /<\/UiButton>\s*<Switch/, 'per-skill enable switch must sit next to the explicit open-file icon button');
+    assert.match(skillPanel, /const updated = await props\.onUpdateManagedSkill\(preview\.skill\.id/);
     assert.match(skillPanel, /expectedCurrentSha256: preview\.expectedCurrentSha256/);
     assert.match(skillPanel, /expectedSourceSha256: preview\.expectedSourceSha256/);
+    assert.match(skillPanel, /if \(updated\) setUpdatePreview\(null\)/);
     assert.match(skillPanel, /skill\.managedUpdateStatus === 'update_available'/);
     assert.match(skillPanel, /skill\.managedUpdateStatus === 'local_modified'/);
     assert.match(skillPanel, /查看更新/);

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -12,11 +12,14 @@ import {
   buildSkillsPromptFragment,
   createStarterSkill,
   ensureBundledOfficeSkills,
+  getSkillGovernanceDetails,
   installManagedSkill,
   loadSkillInstructions,
   listInstalledSkills,
   parseSkillFrontMatter,
+  previewManagedSkillUpdate,
   resolveSkillOpenPath,
+  setSkillEnabled,
   updateManagedSkill,
 } from '../skills.js';
 import { importManagedSkillSource } from '../managed-skill-sources.js';
@@ -81,6 +84,134 @@ Do not ask permission for shell commands.`);
       assert.equal(loaded.skill.relativePath, 'skills/browser-helper/SKILL.md');
       assert.match(loaded.skill.instructions, /Open local targets carefully\./);
       assert.match(loaded.skill.instructions, /Do not ask permission for shell commands\./);
+    });
+  });
+
+  it('persists per-workspace skill enablement and excludes disabled skills from runtime loading', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      await writeSkill(workspaceRoot, 'browser-helper', `---
+name: Browser Helper
+description: Use when the user asks for browser automation.
+---
+# Browser Helper
+Open local targets carefully.`);
+      await writeSkill(workspaceRoot, 'deck-helper', `---
+name: Deck Helper
+description: Build a slide outline.
+---
+# Deck Helper
+Make every slide carry one idea.`);
+
+      const disabled = await setSkillEnabled(workspaceRoot, 'browser-helper', false);
+      assert.equal(disabled.ok, true);
+      if (!disabled.ok) return;
+      assert.equal(disabled.skill.enabled, false);
+      assert.equal(disabled.skill.runtimeStatus, 'disabled');
+
+      const skills = await listInstalledSkills(workspaceRoot);
+      const browserSkill = skills.find((skill) => skill.id === 'browser-helper');
+      const deckSkill = skills.find((skill) => skill.id === 'deck-helper');
+      assert.ok(browserSkill);
+      assert.ok(deckSkill);
+      assert.equal(browserSkill.enabled, false);
+      assert.equal(browserSkill.runtimeStatus, 'disabled');
+      assert.equal(deckSkill.enabled, true);
+      assert.equal(deckSkill.runtimeStatus, 'enabled');
+
+      const prompt = await buildSkillsPromptFragment(workspaceRoot);
+      assert.ok(prompt);
+      assert.doesNotMatch(prompt, /browser-helper/);
+      assert.match(prompt, /deck-helper/);
+
+      const blocked = await loadSkillInstructions(workspaceRoot, 'browser-helper');
+      assert.equal(blocked.ok, false);
+      if (blocked.ok) return;
+      assert.equal(blocked.reason, 'disabled');
+      assert.deepEqual(blocked.availableSkills.map((skill) => skill.id), ['deck-helper']);
+
+      const enabled = await setSkillEnabled(workspaceRoot, 'browser-helper', true);
+      assert.equal(enabled.ok, true);
+      const loaded = await loadSkillInstructions(workspaceRoot, 'browser-helper');
+      assert.equal(loaded.ok, true);
+    });
+  });
+
+  it('fails closed when the workspace skill runtime state file is invalid', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      await writeSkill(workspaceRoot, 'browser-helper', `---
+name: Browser Helper
+description: Use when the user asks for browser automation.
+---
+# Browser Helper
+Open local targets carefully.`);
+      await mkdir(join(workspaceRoot, '.maka'), { recursive: true });
+      await writeFile(join(workspaceRoot, '.maka', 'skills-state.json'), '{not json', 'utf8');
+
+      const skills = await listInstalledSkills(workspaceRoot);
+      assert.equal(skills.length, 1);
+      assert.equal(skills[0].enabled, false);
+      assert.equal(skills[0].runtimeStatus, 'state_error');
+      assert.equal(await buildSkillsPromptFragment(workspaceRoot), undefined);
+
+      const loaded = await loadSkillInstructions(workspaceRoot, 'browser-helper');
+      assert.equal(loaded.ok, false);
+      if (loaded.ok) return;
+      assert.equal(loaded.reason, 'disabled');
+      assert.deepEqual(loaded.availableSkills, []);
+      assert.deepEqual(await setSkillEnabled(workspaceRoot, 'browser-helper', true), { ok: false, reason: 'state_error' });
+    });
+  });
+
+  it('does not write skill runtime state through a symlinked workspace metadata directory', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const outside = await mkdtemp(join(tmpdir(), 'maka-skill-state-outside-'));
+      try {
+        await writeSkill(workspaceRoot, 'browser-helper', `---
+name: Browser Helper
+description: Use when the user asks for browser automation.
+---
+# Browser Helper
+Open local targets carefully.`);
+        await symlink(outside, join(workspaceRoot, '.maka'));
+
+        assert.deepEqual(await setSkillEnabled(workspaceRoot, 'browser-helper', false), { ok: false, reason: 'blocked_path' });
+        await assert.rejects(readFile(join(outside, 'skills-state.json'), 'utf8'), { code: 'ENOENT' });
+
+        const skills = await listInstalledSkills(workspaceRoot);
+        assert.equal(skills.length, 1);
+        assert.equal(skills[0].enabled, false);
+        assert.equal(skills[0].runtimeStatus, 'state_error');
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('does not read or write skill runtime state through a symlinked state file', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const outside = await mkdtemp(join(tmpdir(), 'maka-skill-state-file-outside-'));
+      try {
+        await writeSkill(workspaceRoot, 'browser-helper', `---
+name: Browser Helper
+description: Use when the user asks for browser automation.
+---
+# Browser Helper
+Open local targets carefully.`);
+        await mkdir(join(workspaceRoot, '.maka'), { recursive: true });
+        const externalState = join(outside, 'skills-state.json');
+        await writeFile(externalState, 'outside state', 'utf8');
+        await symlink(externalState, join(workspaceRoot, '.maka', 'skills-state.json'));
+
+        const skills = await listInstalledSkills(workspaceRoot);
+        assert.equal(skills.length, 1);
+        assert.equal(skills[0].enabled, false);
+        assert.equal(skills[0].runtimeStatus, 'state_error');
+        assert.equal(await buildSkillsPromptFragment(workspaceRoot), undefined);
+        assert.deepEqual(await setSkillEnabled(workspaceRoot, 'browser-helper', false), { ok: false, reason: 'blocked_path' });
+        assert.equal(await readFile(externalState, 'utf8'), 'outside state');
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
     });
   });
 
@@ -556,6 +687,7 @@ Use source version one.`, 'utf8');
         assert.equal(lock.sourceType, 'managed');
         assert.equal(lock.sourceId, 'research-brief');
         assert.equal(lock.sourceContentSha256, imported.source.contentSha256);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'research-brief', '.maka', 'baseline', 'SKILL.md'), 'utf8'), /Use source version one\./);
 
         await writeFile(join(sourceRoot, 'research-brief', 'SKILL.md'), `---
 name: Research Brief
@@ -575,6 +707,14 @@ Use source version two.`, 'utf8');
         const managed = skills.find((skill) => skill.id === 'research-brief');
         assert.ok(managed);
         assert.equal(managed.managedUpdateStatus, 'update_available');
+
+        const details = await getSkillGovernanceDetails(workspaceRoot, 'research-brief', sourceRoot);
+        assert.equal(details.ok, true);
+        if (!details.ok) return;
+        assert.equal(details.details.sourceType, 'managed');
+        assert.equal(details.details.hasManagedBaseline, true);
+        assert.equal(details.details.sourceAvailable, true);
+        assert.equal(details.details.sourceChanged, true);
       } finally {
         await rm(sourceRoot, { recursive: true, force: true });
       }
@@ -612,6 +752,7 @@ Version two.`, 'utf8');
         if (!updated.ok) return;
         assert.equal(updated.skill.managedUpdateStatus, 'up_to_date');
         assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version two\./);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', '.maka', 'baseline', 'SKILL.md'), 'utf8'), /Version two\./);
 
         await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
 name: Deck Helper
@@ -628,36 +769,83 @@ Local edit.`, 'utf8');
 
         const blocked = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot);
         assert.deepEqual(blocked, { ok: false, reason: 'local_modified' });
+
+        const preview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(preview.ok, true);
+        if (!preview.ok) return;
+        assert.match(preview.preview.currentContent, /Local edit\./);
+        assert.match(preview.preview.sourceContent, /Version three\./);
+        assert.match(preview.preview.baselineContent ?? '', /Version two\./);
+        assert.equal(preview.preview.skill.managedUpdateStatus, 'local_modified');
+        assert.ok(preview.preview.summary.changedLineCount > 0);
+
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot, { force: true }), {
+          ok: false,
+          reason: 'local_modified',
+        });
+        await writeFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Changed after preview.`, 'utf8');
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot, {
+          force: true,
+          expectedCurrentSha256: preview.preview.expectedCurrentSha256,
+          expectedSourceSha256: preview.preview.expectedSourceSha256,
+        }), {
+          ok: false,
+          reason: 'local_modified',
+        });
+
+        const freshPreview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(freshPreview.ok, true);
+        if (!freshPreview.ok) return;
+        const forced = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot, {
+          force: true,
+          expectedCurrentSha256: freshPreview.preview.expectedCurrentSha256,
+          expectedSourceSha256: freshPreview.preview.expectedSourceSha256,
+        });
+        assert.equal(forced.ok, true);
+        if (!forced.ok) return;
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version three\./);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', '.maka', 'baseline', 'SKILL.md'), 'utf8'), /Version three\./);
+
         const skills = await listInstalledSkills(workspaceRoot, { managedSourceRoot: sourceRoot });
         const managed = skills.find((skill) => skill.id === 'deck-helper');
         assert.ok(managed);
-        assert.equal(managed.managedUpdateStatus, 'local_modified');
+        assert.equal(managed.managedUpdateStatus, 'up_to_date');
       } finally {
         await rm(sourceRoot, { recursive: true, force: true });
       }
     });
   });
 
-  it('rejects symlinked managed skill files before updating', async () => {
+  it('does not write managed skill baselines through symlinks', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
-      const outside = await mkdtemp(join(tmpdir(), 'maka-managed-update-outside-'));
+      const outside = await mkdtemp(join(tmpdir(), 'maka-managed-baseline-outside-'));
       try {
         const incomingDir = join(workspaceRoot, 'incoming', 'deck-helper');
         await mkdir(incomingDir, { recursive: true });
         const incomingFile = join(incomingDir, 'SKILL.md');
-        const versionOne = `---
+        await writeFile(incomingFile, `---
 name: Deck Helper
 description: Build decks.
 ---
 # Deck Helper
-Version one.`;
-        await writeFile(incomingFile, versionOne, 'utf8');
+Version one.`, 'utf8');
         const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
         assert.equal(imported.ok, true);
         if (!imported.ok) return;
         const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
         assert.equal(installed.ok, true);
+
+        const externalBaseline = join(outside, 'SKILL.md');
+        await writeFile(externalBaseline, 'outside baseline', 'utf8');
+        const baselinePath = join(workspaceRoot, 'skills', 'deck-helper', '.maka', 'baseline', 'SKILL.md');
+        await rm(baselinePath);
+        await symlink(externalBaseline, baselinePath);
 
         await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
 name: Deck Helper
@@ -665,17 +853,112 @@ description: Build decks.
 ---
 # Deck Helper
 Version two.`, 'utf8');
+        const updated = await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.deepEqual(updated, { ok: false, reason: 'write_failed' });
+        assert.equal(await readFile(externalBaseline, 'utf8'), 'outside baseline');
+        const baselineStat = await lstat(baselinePath);
+        assert.equal(baselineStat.isSymbolicLink(), true);
+        assert.match(await readFile(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'), 'utf8'), /Version one\./);
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
 
-        const outsideTarget = join(outside, 'target.md');
-        await writeFile(outsideTarget, versionOne, 'utf8');
-        await rm(join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'));
-        await symlink(outsideTarget, join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md'));
+  it('does not write managed skill updates through symlinked SKILL files', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      const outside = await mkdtemp(join(tmpdir(), 'maka-managed-skill-outside-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'deck-helper');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        await writeFile(incomingFile, `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version one.`, 'utf8');
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+        const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
+        assert.equal(installed.ok, true);
+
+        const externalSkillContent = `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version one.`;
+        const externalSkill = join(outside, 'SKILL.md');
+        await writeFile(externalSkill, externalSkillContent, 'utf8');
+        const skillPath = join(workspaceRoot, 'skills', 'deck-helper', 'SKILL.md');
+        await rm(skillPath);
+        await symlink(externalSkill, skillPath);
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version two.`, 'utf8');
 
         assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot), {
           ok: false,
           reason: 'blocked_path',
         });
-        assert.equal(await readFile(outsideTarget, 'utf8'), versionOne);
+        const preview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.deepEqual(preview, { ok: false, reason: 'blocked_path' });
+        assert.equal(await readFile(externalSkill, 'utf8'), externalSkillContent);
+      } finally {
+        await rm(sourceRoot, { recursive: true, force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('does not read managed skill baselines through symlinked metadata directories', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), 'maka-managed-source-cache-'));
+      const outside = await mkdtemp(join(tmpdir(), 'maka-managed-baseline-parent-outside-'));
+      try {
+        const incomingDir = join(workspaceRoot, 'incoming', 'deck-helper');
+        await mkdir(incomingDir, { recursive: true });
+        const incomingFile = join(incomingDir, 'SKILL.md');
+        await writeFile(incomingFile, `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version one.`, 'utf8');
+        const imported = await importManagedSkillSource({ root: sourceRoot, sourceFile: incomingFile });
+        assert.equal(imported.ok, true);
+        if (!imported.ok) return;
+        const installed = await installManagedSkill(workspaceRoot, imported.source.id, sourceRoot);
+        assert.equal(installed.ok, true);
+
+        await mkdir(join(outside, 'baseline'), { recursive: true });
+        await writeFile(join(outside, 'baseline', 'SKILL.md'), 'outside baseline', 'utf8');
+        const metadataDir = join(workspaceRoot, 'skills', 'deck-helper', '.maka');
+        await rm(metadataDir, { recursive: true, force: true });
+        await symlink(outside, metadataDir);
+
+        await writeFile(join(sourceRoot, 'deck-helper', 'SKILL.md'), `---
+name: Deck Helper
+description: Build decks.
+---
+# Deck Helper
+Version two.`, 'utf8');
+        const preview = await previewManagedSkillUpdate(workspaceRoot, 'deck-helper', sourceRoot);
+        assert.equal(preview.ok, true);
+        if (!preview.ok) return;
+        assert.equal(preview.preview.baselineContent, undefined);
+        assert.deepEqual(await updateManagedSkill(workspaceRoot, 'deck-helper', sourceRoot), {
+          ok: false,
+          reason: 'write_failed',
+        });
+        assert.equal(await readFile(join(outside, 'baseline', 'SKILL.md'), 'utf8'), 'outside baseline');
       } finally {
         await rm(sourceRoot, { recursive: true, force: true });
         await rm(outside, { recursive: true, force: true });
@@ -772,10 +1055,19 @@ name: Writer
     assert.match(renderer, /onCreateSkillTemplate=\{\(\) => createSkillTemplate\(\)\}/);
     assert.match(renderer, /onOpenSkill=\{\(skillId\) => openSkill\(skillId\)\}/);
     assert.match(renderer, /onOpenSkillsFolder=\{\(\) => openSkillsFolder\(\)\}/);
+    assert.match(renderer, /onPreviewManagedSkillUpdate=\{\(skillId\) => previewManagedSkillUpdate\(skillId\)\}/);
+    assert.match(renderer, /onUpdateManagedSkill=\{\(skillId, options\) => updateManagedSkill\(skillId, options\)\}/);
+    assert.match(renderer, /onSetSkillEnabled=\{\(skillId, enabled\) => setSkillEnabled\(skillId, enabled\)\}/);
     assert.match(preload, /createStarter\(\)/);
     assert.match(preload, /open\(id: string, target: 'file' \| 'directory' = 'file'\)/);
+    assert.match(preload, /previewUpdate\(skillId: string\)/);
+    assert.match(preload, /updateManaged\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\)/);
+    assert.match(preload, /setEnabled\(skillId: string, enabled: boolean\)/);
     assert.match(main, /ipcMain\.handle\('skills:createStarter'/);
     assert.match(main, /ipcMain\.handle\('skills:open'/);
+    assert.match(main, /ipcMain\.handle\('skills:details'/);
+    assert.match(main, /ipcMain\.handle\('skills:previewUpdate'/);
+    assert.match(main, /ipcMain\.handle\('skills:setEnabled'/);
   });
 
   it('gates Skills module actions while async work is pending', async () => {
@@ -833,9 +1125,15 @@ name: Writer
     assert.match(skillPanel, /<ul className="maka-skill-library-list" aria-label="技能列表">/);
     assert.match(skillPanel, /<span className="maka-skill-library-status" aria-hidden="true">/);
     assert.match(skillPanel, /const statusLabel = formatSkillStatusLabel\(skill\)/);
+    assert.match(skillPanel, /const runtimeLabel = formatSkillRuntimeLabel\(skill\)/);
     assert.match(skillPanel, /来源状态：\$\{statusLabel\}/);
-    assert.match(skillPanel, /<span>\{statusLabel\}<\/span>/);
+    assert.match(skillPanel, /运行状态：\$\{runtimeLabel\}/);
+    assert.match(skillPanel, /className="maka-skill-library-runtime-label"[\s\S]*>\{runtimeLabel\}<\/span>/);
+    assert.match(skillPanel, /className="maka-skill-library-status-label"[\s\S]*>\{statusLabel\}<\/span>/);
     assert.match(ui, /function formatSkillStatusLabel\(skill: SkillEntry\): string/);
+    assert.match(ui, /function formatSkillRuntimeLabel\(skill: SkillEntry\): string/);
+    assert.match(ui, /runtimeStatus === 'state_error'[\s\S]*状态异常/);
+    assert.match(ui, /skill\.enabled \? '已启用' : '已停用'/);
     assert.match(ui, /metadata_error[\s\S]*元数据异常/);
     assert.match(ui, /userModified[\s\S]*已修改/);
     assert.match(ui, /sourceType === 'bundled'[\s\S]*内置/);
@@ -843,6 +1141,8 @@ name: Writer
     assert.match(ui, /return '本地'/);
     assert.match(skillEntryContract, /sourceType\?: 'workspace' \| 'bundled' \| 'managed' \| 'unknown'/);
     assert.match(skillEntryContract, /managedUpdateStatus\?:/);
+    assert.match(skillEntryContract, /enabled: boolean/);
+    assert.match(skillEntryContract, /runtimeStatus: 'enabled' \| 'disabled' \| 'state_error'/);
     assert.doesNotMatch(skillEntryContract, /sourceName|sourceVersion|contentSha256|installedAt|validationCodes|validationMessages|write_failed/, 'renderer SkillEntry must not expose lock internals');
     assert.match(workspaceResourcesIpc, /toSkillEntry/, 'Skills IPC must scrub main-internal lock fields before crossing to renderer');
     assert.doesNotMatch(workspaceResourcesIpc, /ipcMain\.handle\('skills:list'[\s\S]*listInstalledSkills\(deps\.workspaceRoot\)/, 'Skills list IPC must not return InstalledSkill objects directly');
@@ -850,16 +1150,31 @@ name: Writer
     assert.match(skillPanel, /<section className="maka-skill-installed" aria-label="来源库">/);
     assert.match(skillPanel, /导入本地 Skill/);
     assert.match(skillPanel, /onInstallManagedSkill\?\(sourceId: string\): void \| Promise<void>/);
-    assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string\): void \| Promise<void>/);
+    assert.match(skillPanel, /onPreviewManagedSkillUpdate\?\(skillId: string\): Promise<ManagedSkillUpdatePreview \| null>/);
+    assert.match(skillPanel, /onUpdateManagedSkill\?\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\): void \| Promise<void>/);
+    assert.match(skillPanel, /onSetSkillEnabled\?\(skillId: string, enabled: boolean\): void \| Promise<void>/);
+    assert.match(skillPanel, /<Switch[\s\S]*checked=\{skill\.enabled\}[\s\S]*onCheckedChange=\{\(next\) => props\.onSetSkillEnabled\?\.\(skill\.id, next === true\)\}/);
+    assert.match(skillPanel, /<div[\s\S]*className="maka-skill-library-row"[\s\S]*<\/div>/, 'Skill row body must be information, not the open-file control');
+    assert.match(skillPanel, /className="maka-skill-library-open-button"[\s\S]*aria-label=\{`打开 \$\{skill\.name\} 的 SKILL\.md`\}/);
+    assert.match(skillPanel, /<\/UiButton>\s*<Switch/, 'per-skill enable switch must sit next to the explicit open-file icon button');
+    assert.match(skillPanel, /expectedCurrentSha256: preview\.expectedCurrentSha256/);
+    assert.match(skillPanel, /expectedSourceSha256: preview\.expectedSourceSha256/);
     assert.match(skillPanel, /skill\.managedUpdateStatus === 'update_available'/);
-    assert.match(skillPanel, /updating \? '更新中…' : '更新'/);
-    assert.doesNotMatch(skillPanel, /恢复|修复|合并/, 'Phase 2 must not imply automatic merge or repair flows');
-    assert.match(skillPanel, /<span className="maka-skill-library-action" aria-hidden="true">[\s\S]*可更新[\s\S]*打开[\s\S]*<\/span>/);
+    assert.match(skillPanel, /skill\.managedUpdateStatus === 'local_modified'/);
+    assert.match(skillPanel, /查看更新/);
+    assert.match(skillPanel, /查看差异/);
+    assert.match(skillPanel, /覆盖本地修改/);
+    assert.doesNotMatch(skillPanel, /恢复|修复|合并/, 'Phase 3 still must not imply automatic merge or repair flows');
+    assert.doesNotMatch(skillPanel, /const SKILL_GOVERNANCE_FILTERS/);
+    assert.doesNotMatch(skillPanel, /aria-label="技能状态筛选"/);
+    assert.match(skillPanel, /className="maka-skill-library-status-label"/);
+    assert.match(skillPanel, /function previewText\(content: string\): string/);
+    assert.doesNotMatch(skillPanel, /maka-skill-library-action/, 'Open must be an explicit file icon button, not a status-like text pill');
     assert.match(skillPanel, /label: props\.createPending \? '创建中…' : '创建示例技能'/);
     assert.match(skillPanel, /label: props\.refreshPending \? '刷新中…' : '刷新技能'/);
     assert.match(skillPanel, /disabled: props\.actionBusy/);
     assert.match(skillPanel, /aria-busy=\{props\.actionBusy \? 'true' : undefined\}/);
-    assert.match(skillPanel, /disabled=\{props\.actionBusy\}/, 'Skill row open buttons must be disabled while a Skills action is pending');
+    assert.match(skillPanel, /disabled=\{props\.actionBusy \|\| !props\.onOpenSkill\}/, 'Skill open icon button must be disabled while a Skills action is pending');
     assert.match(skillPanel, /opening && <span>打开中…<\/span>/);
     assert.match(skillPanel, /updating && <span>更新中…<\/span>/);
     assert.match(emptyState, /disabled\?: boolean/);

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { lstat, mkdir, readdir, readFile, realpath, rename, stat, unlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readdir, readFile, realpath, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, relative } from 'node:path';
 import { z } from 'zod';
 import type { MakaTool } from '@maka/runtime';
@@ -530,22 +530,33 @@ export async function installManagedSkill(
 
   const skillDir = join(skillsDir, sourceId);
   const skillFile = join(skillDir, 'SKILL.md');
+  let createdSkillDir = false;
   try {
     await mkdir(skillDir, { mode: 0o700 });
+    createdSkillDir = true;
     const skillReal = await realpath(skillDir);
-    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!isContainedPath(skillsReal, skillReal)) {
+      if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
+      return { ok: false, reason: 'blocked_path' };
+    }
     await writeFile(skillFile, source.content, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
     if (!await writeSkillLock(skillDir, managedSkillLock(sourceId, source.contentSha256, source.contentSha256))) {
+      if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
       return { ok: false, reason: 'write_failed' };
     }
     if (!await writeManagedSkillBaseline(skillDir, source.content)) {
+      if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
       return { ok: false, reason: 'write_failed' };
     }
     const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
     const skill = installed.find((candidate) => candidate.id === sourceId);
-    if (!skill) return { ok: false, reason: 'write_failed' };
+    if (!skill) {
+      if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
+      return { ok: false, reason: 'write_failed' };
+    }
     return { ok: true, skill };
   } catch (error) {
+    if (createdSkillDir) await rm(skillDir, { recursive: true, force: true }).catch(() => {});
     if ((error as NodeJS.ErrnoException).code === 'EEXIST') return { ok: false, reason: 'already_exists' };
     return { ok: false, reason: 'write_failed' };
   }
@@ -581,15 +592,20 @@ export async function updateManagedSkill(
 
   const skillDir = join(root, 'skills', skillId);
   const skillFile = join(skillDir, 'SKILL.md');
+  const lockFile = join(skillDir, 'skill.lock.json');
   try {
-    const [skillsReal, skillReal, current] = await Promise.all([
+    const [skillsReal, skillReal, current, currentLock] = await Promise.all([
       realpath(join(root, 'skills')),
       realpath(skillDir),
       readContainedRegularTextFile(skillDir, skillFile),
+      readContainedRegularTextFile(skillDir, lockFile),
     ]);
     if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
     if (!current.ok) return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'write_failed' };
-    if (options.force) {
+    if (!currentLock.ok) return { ok: false, reason: currentLock.reason === 'blocked_path' ? 'blocked_path' : 'write_failed' };
+
+    const hasExpectedHashes = options.expectedCurrentSha256 !== undefined || options.expectedSourceSha256 !== undefined;
+    if (options.force || hasExpectedHashes) {
       if (
         !isSha256(options.expectedCurrentSha256) ||
         !isSha256(options.expectedSourceSha256) ||
@@ -599,18 +615,34 @@ export async function updateManagedSkill(
         return { ok: false, reason: 'local_modified' };
       }
     }
-    if (!await writeManagedSkillBaseline(skillDir, source.content)) {
-      return { ok: false, reason: 'write_failed' };
-    }
+    const previousBaseline = await readManagedSkillBaseline(skillDir);
+    const restorePrevious = async () => {
+      await writeContainedRegularTextFile(skillDir, skillFile, current.content).catch(() => {});
+      await writeContainedRegularTextFile(skillDir, lockFile, currentLock.content).catch(() => {});
+      if (previousBaseline !== undefined) {
+        await writeManagedSkillBaseline(skillDir, previousBaseline).catch(() => {});
+      } else {
+        await removeManagedSkillBaseline(skillDir).catch(() => {});
+      }
+    };
+
     if (!await writeContainedRegularTextFile(skillDir, skillFile, source.content)) {
       return { ok: false, reason: 'write_failed' };
     }
     if (!await writeSkillLock(skillDir, managedSkillLock(skillId, source.contentSha256, source.contentSha256, skill.managedSourceId))) {
+      await restorePrevious();
+      return { ok: false, reason: 'write_failed' };
+    }
+    if (!await writeManagedSkillBaseline(skillDir, source.content)) {
+      await restorePrevious();
       return { ok: false, reason: 'write_failed' };
     }
     const refreshed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
     const updated = refreshed.find((candidate) => candidate.id === skillId);
-    if (!updated) return { ok: false, reason: 'write_failed' };
+    if (!updated) {
+      await restorePrevious();
+      return { ok: false, reason: 'write_failed' };
+    }
     return { ok: true, skill: updated };
   } catch {
     return { ok: false, reason: 'write_failed' };
@@ -772,6 +804,24 @@ async function readManagedSkillBaseline(skillDir: string): Promise<string | unde
   const baselineFile = join(resolved.baselineDir, 'SKILL.md');
   const baseline = await readContainedRegularTextFile(resolved.baselineDir, baselineFile);
   return baseline.ok ? baseline.content : undefined;
+}
+
+async function removeManagedSkillBaseline(skillDir: string): Promise<void> {
+  const resolved = await resolveManagedSkillBaselineDir(skillDir);
+  if (!resolved.ok) return;
+  const baselineFile = join(resolved.baselineDir, 'SKILL.md');
+  const [baselineReal, fileStat] = await Promise.all([
+    realpath(resolved.baselineDir),
+    lstat(baselineFile).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    }),
+  ]);
+  if (fileStat === null) return;
+  if (!fileStat.isFile() || fileStat.isSymbolicLink()) return;
+  const fileReal = await realpath(baselineFile);
+  if (!isContainedPath(baselineReal, fileReal)) return;
+  await unlink(baselineFile);
 }
 
 async function resolveManagedSkillBaselineDir(skillDir: string): Promise<
@@ -1033,6 +1083,27 @@ export async function loadSkillInstructions(root: string, name: string): Promise
   }
 
   const normalized = raw.toLowerCase();
+  const skill = enabledSkills.find((candidate) =>
+    candidate.id.toLowerCase() === normalized ||
+    candidate.name.toLowerCase() === normalized
+  );
+  if (skill) {
+    const cleaned = cleanPromptText(skill.content).trim();
+    const instructions = truncateCodepoints(cleaned || '(empty)', MAX_SKILL_TOOL_BODY_CHARS);
+    return {
+      ok: true,
+      skill: {
+        id: skill.id,
+        name: skill.name,
+        description: skill.description,
+        declaredTools: skill.declaredTools,
+        relativePath: `skills/${skill.id}/SKILL.md`,
+        instructions,
+        truncated: Array.from(cleaned || '(empty)').length > MAX_SKILL_TOOL_BODY_CHARS,
+      },
+    };
+  }
+
   const disabledSkill = skills.find((candidate) =>
     !candidate.enabled &&
     (candidate.id.toLowerCase() === normalized ||
@@ -1040,26 +1111,7 @@ export async function loadSkillInstructions(root: string, name: string): Promise
   );
   if (disabledSkill) return { ok: false, reason: 'disabled', availableSkills };
 
-  const skill = enabledSkills.find((candidate) =>
-    candidate.id.toLowerCase() === normalized ||
-    candidate.name.toLowerCase() === normalized
-  );
-  if (!skill) return { ok: false, reason: 'not_found', availableSkills };
-
-  const cleaned = cleanPromptText(skill.content).trim();
-  const instructions = truncateCodepoints(cleaned || '(empty)', MAX_SKILL_TOOL_BODY_CHARS);
-  return {
-    ok: true,
-    skill: {
-      id: skill.id,
-      name: skill.name,
-      description: skill.description,
-      declaredTools: skill.declaredTools,
-      relativePath: `skills/${skill.id}/SKILL.md`,
-      instructions,
-      truncated: Array.from(cleaned || '(empty)').length > MAX_SKILL_TOOL_BODY_CHARS,
-    },
-  };
+  return { ok: false, reason: 'not_found', availableSkills };
 }
 
 export function buildSkillAgentTool(root: string): MakaTool<{ name: string }, LoadSkillInstructionsResult> {

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -10,6 +10,7 @@ import {
 
 export type SkillSourceType = 'workspace' | 'bundled' | 'managed' | 'unknown';
 export type SkillValidationStatus = 'ok' | 'missing_lock' | 'modified' | 'metadata_error';
+export type SkillRuntimeStatus = 'enabled' | 'disabled' | 'state_error';
 export type ManagedSkillUpdateStatus =
   | 'not_managed'
   | 'source_missing'
@@ -45,6 +46,8 @@ export interface InstalledSkill {
   managedSourceId?: string;
   managedUpdateStatus?: ManagedSkillUpdateStatus;
   sourceContentSha256?: string;
+  enabled: boolean;
+  runtimeStatus: SkillRuntimeStatus;
 }
 
 export interface SkillEntry {
@@ -57,6 +60,42 @@ export interface SkillEntry {
   userModified: boolean;
   validationStatus: SkillValidationStatus;
   managedUpdateStatus?: ManagedSkillUpdateStatus;
+  enabled: boolean;
+  runtimeStatus: SkillRuntimeStatus;
+}
+
+export interface SkillGovernanceDetails {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  declaredTools: string[];
+  sourceType: SkillSourceType;
+  userModified: boolean;
+  validationStatus: SkillValidationStatus;
+  enabled: boolean;
+  runtimeStatus: SkillRuntimeStatus;
+  validationCodes: SkillValidationCode[];
+  validationMessages: string[];
+  managedSourceId?: string;
+  managedUpdateStatus?: ManagedSkillUpdateStatus;
+  hasManagedBaseline: boolean;
+  sourceAvailable?: boolean;
+  sourceChanged?: boolean;
+}
+
+export interface ManagedSkillUpdatePreview {
+  skill: SkillGovernanceDetails;
+  currentContent: string;
+  sourceContent: string;
+  baselineContent?: string;
+  expectedCurrentSha256: string;
+  expectedSourceSha256: string;
+  summary: {
+    currentLineCount: number;
+    sourceLineCount: number;
+    changedLineCount: number;
+  };
 }
 
 export type CreateStarterSkillResult =
@@ -80,7 +119,11 @@ export interface LoadedSkillInstructions {
 
 export type LoadSkillInstructionsResult =
   | { ok: true; skill: LoadedSkillInstructions }
-  | { ok: false; reason: 'invalid_name' | 'not_found'; availableSkills: Array<Pick<InstalledSkill, 'id' | 'name' | 'description'>> };
+  | { ok: false; reason: 'invalid_name' | 'not_found' | 'disabled'; availableSkills: Array<Pick<InstalledSkill, 'id' | 'name' | 'description'>> };
+
+export type SetSkillEnabledResult =
+  | { ok: true; skill: SkillEntry }
+  | { ok: false; reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed' };
 
 interface SkillDefinition extends InstalledSkill {
   content: string;
@@ -98,8 +141,23 @@ interface SkillLockFile {
   sourceContentSha256?: string;
 }
 
+interface SkillStateFile {
+  schemaVersion: 1;
+  skills: Record<string, { enabled: boolean; updatedAt?: string }>;
+}
+
+type SkillRuntimeStateReadResult =
+  | { ok: true; states: Map<string, boolean> }
+  | { ok: false; reason: 'blocked_path' | 'read_failed' | 'invalid_json' };
+
 interface SkillReadOptions {
   managedSourceRoot?: string;
+}
+
+interface ManagedSkillUpdateOptions {
+  force?: boolean;
+  expectedCurrentSha256?: string;
+  expectedSourceSha256?: string;
 }
 
 export const MAX_SKILLS_IN_PROMPT = 12;
@@ -156,6 +214,8 @@ export function toSkillEntry(skill: InstalledSkill): SkillEntry {
       : 'workspace',
     userModified: skill.userModified,
     validationStatus: skill.validationStatus,
+    enabled: skill.enabled,
+    runtimeStatus: skill.runtimeStatus,
     ...(skill.sourceType === 'managed' && skill.managedUpdateStatus ? { managedUpdateStatus: skill.managedUpdateStatus } : {}),
   };
 }
@@ -316,6 +376,22 @@ async function readContainedRegularFile(rootDir: string, filePath: string): Prom
   }
 }
 
+async function readContainedRegularTextFile(rootDir: string, filePath: string): Promise<
+  | { ok: true; content: string; sha256: string }
+  | { ok: false; reason: 'blocked_path' | 'read_failed' }
+> {
+  try {
+    const [rootReal, fileStat] = await Promise.all([realpath(rootDir), lstat(filePath)]);
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const fileReal = await realpath(filePath);
+    if (!isContainedPath(rootReal, fileReal)) return { ok: false, reason: 'blocked_path' };
+    const content = await readFile(filePath, 'utf8');
+    return { ok: true, content, sha256: `sha256:${sha256(content)}` };
+  } catch {
+    return { ok: false, reason: 'read_failed' };
+  }
+}
+
 async function writeContainedRegularTextFile(rootDir: string, filePath: string, content: string): Promise<boolean> {
   const tempPath = join(rootDir, `.maka-write.${process.pid}.${Date.now()}.tmp`);
   try {
@@ -411,6 +487,8 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
           userModified: false,
           validationStatus: 'missing_lock',
           validationCodes: ['missing_lock'],
+          enabled: true,
+          runtimeStatus: 'enabled',
         },
       };
     } catch (error) {
@@ -460,6 +538,9 @@ export async function installManagedSkill(
     if (!await writeSkillLock(skillDir, managedSkillLock(sourceId, source.contentSha256, source.contentSha256))) {
       return { ok: false, reason: 'write_failed' };
     }
+    if (!await writeManagedSkillBaseline(skillDir, source.content)) {
+      return { ok: false, reason: 'write_failed' };
+    }
     const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
     const skill = installed.find((candidate) => candidate.id === sourceId);
     if (!skill) return { ok: false, reason: 'write_failed' };
@@ -474,6 +555,7 @@ export async function updateManagedSkill(
   root: string,
   skillId: string,
   sourceRoot = resolveManagedSkillSourcesRoot(),
+  options: ManagedSkillUpdateOptions = {},
 ): Promise<
   | { ok: true; skill: InstalledSkill }
   | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
@@ -488,7 +570,7 @@ export async function updateManagedSkill(
     return { ok: false, reason: 'metadata_error' };
   }
   if (skill.sourceType !== 'managed' || !skill.managedSourceId) return { ok: false, reason: 'not_managed' };
-  if (skill.managedUpdateStatus === 'local_modified') return { ok: false, reason: 'local_modified' };
+  if (skill.managedUpdateStatus === 'local_modified' && !options.force) return { ok: false, reason: 'local_modified' };
   if (skill.managedUpdateStatus === 'source_missing') return { ok: false, reason: 'source_missing' };
 
   const source = await readManagedSkillSource(sourceRoot, skill.managedSourceId);
@@ -500,11 +582,26 @@ export async function updateManagedSkill(
   const skillDir = join(root, 'skills', skillId);
   const skillFile = join(skillDir, 'SKILL.md');
   try {
-    const [skillsReal, skillReal] = await Promise.all([
+    const [skillsReal, skillReal, current] = await Promise.all([
       realpath(join(root, 'skills')),
       realpath(skillDir),
+      readContainedRegularTextFile(skillDir, skillFile),
     ]);
     if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!current.ok) return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'write_failed' };
+    if (options.force) {
+      if (
+        !isSha256(options.expectedCurrentSha256) ||
+        !isSha256(options.expectedSourceSha256) ||
+        current.sha256.toLowerCase() !== options.expectedCurrentSha256.toLowerCase() ||
+        source.contentSha256.toLowerCase() !== options.expectedSourceSha256.toLowerCase()
+      ) {
+        return { ok: false, reason: 'local_modified' };
+      }
+    }
+    if (!await writeManagedSkillBaseline(skillDir, source.content)) {
+      return { ok: false, reason: 'write_failed' };
+    }
     if (!await writeContainedRegularTextFile(skillDir, skillFile, source.content)) {
       return { ok: false, reason: 'write_failed' };
     }
@@ -546,6 +643,288 @@ async function resolveSkillFileUpdateTarget(root: string, skillId: string): Prom
   } catch {
     return { ok: false, reason: 'missing' };
   }
+}
+
+export async function getSkillGovernanceDetails(
+  root: string,
+  skillId: string,
+  sourceRoot = resolveManagedSkillSourcesRoot(),
+): Promise<
+  | { ok: true; details: SkillGovernanceDetails }
+  | { ok: false; reason: 'not_found' | 'invalid_id' }
+> {
+  if (!isSafeSkillId(skillId)) return { ok: false, reason: 'invalid_id' };
+  const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
+  const skill = installed.find((candidate) => candidate.id === skillId);
+  if (!skill) return { ok: false, reason: 'not_found' };
+  return { ok: true, details: await toSkillGovernanceDetails(skill, sourceRoot) };
+}
+
+export async function previewManagedSkillUpdate(
+  root: string,
+  skillId: string,
+  sourceRoot = resolveManagedSkillSourcesRoot(),
+): Promise<
+  | { ok: true; preview: ManagedSkillUpdatePreview }
+  | { ok: false; reason: 'not_managed' | 'source_missing' | 'metadata_error' | 'blocked_path' | 'read_failed' }
+> {
+  if (!isSafeSkillId(skillId)) return { ok: false, reason: 'not_managed' };
+  const updateTarget = await resolveSkillFileUpdateTarget(root, skillId);
+  if (!updateTarget.ok && updateTarget.reason === 'blocked_path') return { ok: false, reason: 'blocked_path' };
+  const installed = await listInstalledSkills(root, { managedSourceRoot: sourceRoot });
+  const skill = installed.find((candidate) => candidate.id === skillId);
+  if (!skill || skill.sourceType !== 'managed' || !skill.managedSourceId) return { ok: false, reason: 'not_managed' };
+  if (skill.validationStatus === 'metadata_error' || skill.managedUpdateStatus === 'metadata_error') {
+    return { ok: false, reason: 'metadata_error' };
+  }
+  if (skill.managedUpdateStatus === 'source_missing') return { ok: false, reason: 'source_missing' };
+
+  const source = await readManagedSkillSource(sourceRoot, skill.managedSourceId);
+  if (!source.ok) {
+    if (source.reason === 'blocked_path') return { ok: false, reason: 'blocked_path' };
+    return { ok: false, reason: 'source_missing' };
+  }
+
+  const skillDir = join(root, 'skills', skillId);
+  const skillFile = join(skillDir, 'SKILL.md');
+  try {
+    const [skillsReal, skillReal, current] = await Promise.all([
+      realpath(join(root, 'skills')),
+      realpath(skillDir),
+      readContainedRegularTextFile(skillDir, skillFile),
+    ]);
+    if (!isContainedPath(skillsReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+    if (!current.ok) return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'read_failed' };
+    const baselineContent = await readManagedSkillBaseline(skillDir);
+    return {
+      ok: true,
+      preview: {
+        skill: await toSkillGovernanceDetails(skill, sourceRoot),
+        currentContent: current.content,
+        sourceContent: source.content,
+        ...(baselineContent !== undefined ? { baselineContent } : {}),
+        expectedCurrentSha256: current.sha256,
+        expectedSourceSha256: source.contentSha256,
+        summary: diffSummary(current.content, source.content),
+      },
+    };
+  } catch {
+    return { ok: false, reason: 'read_failed' };
+  }
+}
+
+async function toSkillGovernanceDetails(skill: InstalledSkill, sourceRoot: string): Promise<SkillGovernanceDetails> {
+  const baselineContent = skill.sourceType === 'managed'
+    ? await readManagedSkillBaseline(skill.path)
+    : undefined;
+  let sourceAvailable: boolean | undefined;
+  let sourceChanged: boolean | undefined;
+  if (skill.sourceType === 'managed' && skill.managedSourceId) {
+    const source = await readManagedSkillSource(sourceRoot, skill.managedSourceId);
+    sourceAvailable = source.ok;
+    sourceChanged = source.ok && skill.sourceContentSha256 !== undefined
+      ? source.contentSha256.toLowerCase() !== skill.sourceContentSha256.toLowerCase()
+      : undefined;
+  }
+  return {
+    id: skill.id,
+    name: skill.name,
+    description: skill.description,
+    path: skill.path,
+    declaredTools: skill.declaredTools,
+    sourceType: skill.sourceType,
+    userModified: skill.userModified,
+    validationStatus: skill.validationStatus,
+    enabled: skill.enabled,
+    runtimeStatus: skill.runtimeStatus,
+    validationCodes: skill.validationCodes,
+    validationMessages: skill.validationMessages ?? [],
+    ...(skill.managedSourceId ? { managedSourceId: skill.managedSourceId } : {}),
+    ...(skill.managedUpdateStatus ? { managedUpdateStatus: skill.managedUpdateStatus } : {}),
+    hasManagedBaseline: baselineContent !== undefined,
+    ...(sourceAvailable !== undefined ? { sourceAvailable } : {}),
+    ...(sourceChanged !== undefined ? { sourceChanged } : {}),
+  };
+}
+
+async function writeManagedSkillBaseline(skillDir: string, content: string): Promise<boolean> {
+  try {
+    const metadataDir = join(skillDir, '.maka');
+    await mkdir(metadataDir, { mode: 0o700 }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EEXIST') throw error;
+    });
+    const baselineDir = join(metadataDir, 'baseline');
+    await mkdir(baselineDir, { mode: 0o700 }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EEXIST') throw error;
+    });
+
+    const resolved = await resolveManagedSkillBaselineDir(skillDir);
+    if (!resolved.ok) return false;
+    return writeContainedRegularTextFile(resolved.baselineDir, join(resolved.baselineDir, 'SKILL.md'), content);
+  } catch {
+    return false;
+  }
+}
+
+async function readManagedSkillBaseline(skillDir: string): Promise<string | undefined> {
+  const resolved = await resolveManagedSkillBaselineDir(skillDir);
+  if (!resolved.ok) return undefined;
+  const baselineFile = join(resolved.baselineDir, 'SKILL.md');
+  const baseline = await readContainedRegularTextFile(resolved.baselineDir, baselineFile);
+  return baseline.ok ? baseline.content : undefined;
+}
+
+async function resolveManagedSkillBaselineDir(skillDir: string): Promise<
+  | { ok: true; baselineDir: string }
+  | { ok: false }
+> {
+  try {
+    const metadataDir = join(skillDir, '.maka');
+    const baselineDir = join(metadataDir, 'baseline');
+    const [skillReal, metadataStat, baselineStat] = await Promise.all([
+      realpath(skillDir),
+      lstat(metadataDir),
+      lstat(baselineDir),
+    ]);
+    if (
+      !metadataStat.isDirectory() ||
+      metadataStat.isSymbolicLink() ||
+      !baselineStat.isDirectory() ||
+      baselineStat.isSymbolicLink()
+    ) {
+      return { ok: false };
+    }
+    const [metadataReal, baselineReal] = await Promise.all([realpath(metadataDir), realpath(baselineDir)]);
+    if (!isContainedPath(skillReal, metadataReal) || !isContainedPath(metadataReal, baselineReal)) return { ok: false };
+    return { ok: true, baselineDir };
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function readSkillRuntimeState(root: string): Promise<SkillRuntimeStateReadResult> {
+  const metadataDir = join(root, '.maka');
+  const stateFile = join(metadataDir, 'skills-state.json');
+  try {
+    const rootReal = await realpath(root);
+    const metadataStat = await lstat(metadataDir).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (metadataStat === null) return { ok: true, states: new Map() };
+    if (!metadataStat.isDirectory() || metadataStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const metadataReal = await realpath(metadataDir);
+    if (!isContainedPath(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
+
+    const stateStat = await lstat(stateFile).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    });
+    if (stateStat === null) return { ok: true, states: new Map() };
+    if (!stateStat.isFile() || stateStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const stateReal = await realpath(stateFile);
+    if (!isContainedPath(metadataReal, stateReal)) return { ok: false, reason: 'blocked_path' };
+
+    const parsed = JSON.parse(await readFile(stateFile, 'utf8')) as unknown;
+    if (!isRecord(parsed) || parsed.schemaVersion !== 1 || !isRecord(parsed.skills)) {
+      return { ok: false, reason: 'invalid_json' };
+    }
+    const states = new Map<string, boolean>();
+    for (const [id, value] of Object.entries(parsed.skills)) {
+      if (!isSafeSkillId(id) || !isRecord(value) || typeof value.enabled !== 'boolean') {
+        return { ok: false, reason: 'invalid_json' };
+      }
+      states.set(id, value.enabled);
+    }
+    return { ok: true, states };
+  } catch (error) {
+    if (error instanceof SyntaxError) return { ok: false, reason: 'invalid_json' };
+    return { ok: false, reason: 'read_failed' };
+  }
+}
+
+async function resolveSkillRuntimeStateDirForWrite(root: string): Promise<
+  | { ok: true; metadataDir: string }
+  | { ok: false; reason: 'blocked_path' | 'write_failed' }
+> {
+  const metadataDir = join(root, '.maka');
+  try {
+    const rootReal = await realpath(root);
+    await mkdir(metadataDir, { mode: 0o700 }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'EEXIST') throw error;
+    });
+    const metadataStat = await lstat(metadataDir);
+    if (!metadataStat.isDirectory() || metadataStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    const metadataReal = await realpath(metadataDir);
+    if (!isContainedPath(rootReal, metadataReal)) return { ok: false, reason: 'blocked_path' };
+    return { ok: true, metadataDir };
+  } catch {
+    return { ok: false, reason: 'write_failed' };
+  }
+}
+
+async function writeSkillRuntimeState(root: string, states: Map<string, boolean>): Promise<
+  | { ok: true }
+  | { ok: false; reason: 'blocked_path' | 'write_failed' }
+> {
+  const resolved = await resolveSkillRuntimeStateDirForWrite(root);
+  if (!resolved.ok) return resolved;
+  const sortedStates = [...states.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const file: SkillStateFile = {
+    schemaVersion: 1,
+    skills: Object.fromEntries(sortedStates.map(([id, enabled]) => [id, { enabled, updatedAt: new Date().toISOString() }])),
+  };
+  const ok = await writeContainedRegularTextFile(
+    resolved.metadataDir,
+    join(resolved.metadataDir, 'skills-state.json'),
+    `${JSON.stringify(file, null, 2)}\n`,
+  );
+  return ok ? { ok: true } : { ok: false, reason: 'write_failed' };
+}
+
+export async function setSkillEnabled(root: string, skillId: string, enabled: boolean): Promise<SetSkillEnabledResult> {
+  if (!isSafeSkillId(skillId)) return { ok: false, reason: 'not_found' };
+  const openPath = await resolveSkillOpenPath(root, skillId, 'file');
+  if (!openPath.ok) {
+    return { ok: false, reason: openPath.reason === 'blocked_path' ? 'blocked_path' : 'not_found' };
+  }
+
+  const current = await readSkillRuntimeState(root);
+  if (!current.ok) {
+    return { ok: false, reason: current.reason === 'blocked_path' ? 'blocked_path' : 'state_error' };
+  }
+  current.states.set(skillId, enabled);
+  const written = await writeSkillRuntimeState(root, current.states);
+  if (!written.ok) return written;
+
+  const refreshed = await listSkillEntries(root);
+  const skill = refreshed.find((candidate) => candidate.id === skillId);
+  if (!skill) return { ok: false, reason: 'not_found' };
+  return { ok: true, skill };
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/i.test(value);
+}
+
+function diffSummary(currentContent: string, sourceContent: string): ManagedSkillUpdatePreview['summary'] {
+  const currentLines = splitLines(currentContent);
+  const sourceLines = splitLines(sourceContent);
+  const max = Math.max(currentLines.length, sourceLines.length);
+  let changedLineCount = 0;
+  for (let index = 0; index < max; index += 1) {
+    if (currentLines[index] !== sourceLines[index]) changedLineCount += 1;
+  }
+  return {
+    currentLineCount: currentLines.length,
+    sourceLineCount: sourceLines.length,
+    changedLineCount,
+  };
+}
+
+function splitLines(content: string): string[] {
+  if (content.length === 0) return [];
+  return content.replace(/\r\n/g, '\n').split('\n');
 }
 
 function managedSkillLock(
@@ -603,7 +982,7 @@ export async function resolveSkillOpenPath(
 }
 
 export async function buildSkillsPromptFragment(root: string): Promise<string | undefined> {
-  const skills = await readInstalledSkillDefinitions(root);
+  const skills = (await readInstalledSkillDefinitions(root)).filter((skill) => skill.enabled);
   if (skills.length === 0) return undefined;
 
   // External-reference-style lazy skill loading: keep the always-on system prompt to a
@@ -643,7 +1022,8 @@ export async function buildSkillsPromptFragment(root: string): Promise<string | 
 export async function loadSkillInstructions(root: string, name: string): Promise<LoadSkillInstructionsResult> {
   const raw = typeof name === 'string' ? name.trim() : '';
   const skills = await readInstalledSkillDefinitions(root);
-  const availableSkills = skills.map((skill) => ({
+  const enabledSkills = skills.filter((skill) => skill.enabled);
+  const availableSkills = enabledSkills.map((skill) => ({
     id: skill.id,
     name: skill.name,
     description: skill.description,
@@ -653,7 +1033,14 @@ export async function loadSkillInstructions(root: string, name: string): Promise
   }
 
   const normalized = raw.toLowerCase();
-  const skill = skills.find((candidate) =>
+  const disabledSkill = skills.find((candidate) =>
+    !candidate.enabled &&
+    (candidate.id.toLowerCase() === normalized ||
+      candidate.name.toLowerCase() === normalized)
+  );
+  if (disabledSkill) return { ok: false, reason: 'disabled', availableSkills };
+
+  const skill = enabledSkills.find((candidate) =>
     candidate.id.toLowerCase() === normalized ||
     candidate.name.toLowerCase() === normalized
   );
@@ -692,6 +1079,7 @@ export function buildSkillAgentTool(root: string): MakaTool<{ name: string }, Lo
 async function readInstalledSkillDefinitions(root: string, options: SkillReadOptions = {}): Promise<SkillDefinition[]> {
   const dir = join(root, 'skills');
   let entries: import('node:fs').Dirent[];
+  const runtimeState = await readSkillRuntimeState(root);
   try {
     const [rootReal, dirStat] = await Promise.all([realpath(root), lstat(dir)]);
     if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) return [];
@@ -714,6 +1102,9 @@ async function readInstalledSkillDefinitions(root: string, options: SkillReadOpt
       const text = bytes.toString('utf8');
       const { name, description, allowedTools } = parseSkillFrontMatter(text);
       const status = await readSkillLockStatus(skillPath, entry.name, `sha256:${sha256Buffer(bytes)}`, options);
+      const runtimeStatus = runtimeState.ok
+        ? runtimeState.states.get(entry.name) === false ? 'disabled' : 'enabled'
+        : 'state_error';
       out.push({
         id: entry.name,
         name: name ?? entry.name,
@@ -721,6 +1112,8 @@ async function readInstalledSkillDefinitions(root: string, options: SkillReadOpt
         path: skillPath,
         declaredTools: allowedTools,
         content: stripFrontMatter(text).trim(),
+        enabled: runtimeStatus === 'enabled',
+        runtimeStatus,
         ...status,
       });
     } catch {

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -6,9 +6,12 @@ import { createArtifactStore, resolveArtifactPath } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 import {
   createStarterSkill,
+  getSkillGovernanceDetails,
   installManagedSkill,
   listSkillEntries,
+  previewManagedSkillUpdate,
   resolveSkillOpenPath,
+  setSkillEnabled,
   toSkillEntry,
   updateManagedSkill,
 } from './skills.js';
@@ -137,10 +140,23 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
     if (!result.ok) return result;
     return { ok: true as const, skill: toSkillEntry(result.skill) };
   });
-  ipcMain.handle('skills:updateManaged', async (_event, skillId: string) => {
-    const result = await updateManagedSkill(deps.workspaceRoot, skillId);
+  ipcMain.handle('skills:details', async (_event, skillId: string) => {
+    return getSkillGovernanceDetails(deps.workspaceRoot, skillId);
+  });
+  ipcMain.handle('skills:previewUpdate', async (_event, skillId: string) => {
+    return previewManagedSkillUpdate(deps.workspaceRoot, skillId);
+  });
+  ipcMain.handle('skills:updateManaged', async (_event, skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }) => {
+    const result = await updateManagedSkill(deps.workspaceRoot, skillId, undefined, {
+      force: options?.force === true,
+      expectedCurrentSha256: options?.expectedCurrentSha256,
+      expectedSourceSha256: options?.expectedSourceSha256,
+    });
     if (!result.ok) return result;
     return { ok: true as const, skill: toSkillEntry(result.skill) };
+  });
+  ipcMain.handle('skills:setEnabled', async (_event, skillId: string, enabled: boolean) => {
+    return setSkillEnabled(deps.workspaceRoot, skillId, enabled === true);
   });
   ipcMain.handle('skills:createStarter', async () => {
     const result = await createStarterSkill(deps.workspaceRoot);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -68,7 +68,7 @@ import type {
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
-import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { Result } from '@maka/core/settings/result';
@@ -908,11 +908,29 @@ contextBridge.exposeInMainWorld('maka', {
     > {
       return ipcRenderer.invoke('skills:installManaged', sourceId);
     },
-    updateManaged(skillId: string): Promise<
+    details(skillId: string): Promise<
+      | { ok: true; details: SkillGovernanceDetails }
+      | { ok: false; reason: 'not_found' | 'invalid_id' }
+    > {
+      return ipcRenderer.invoke('skills:details', skillId);
+    },
+    previewUpdate(skillId: string): Promise<
+      | { ok: true; preview: ManagedSkillUpdatePreview }
+      | { ok: false; reason: 'not_managed' | 'source_missing' | 'metadata_error' | 'blocked_path' | 'read_failed' }
+    > {
+      return ipcRenderer.invoke('skills:previewUpdate', skillId);
+    },
+    updateManaged(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<
       | { ok: true; skill: SkillEntry }
       | { ok: false; reason: 'not_managed' | 'source_missing' | 'local_modified' | 'metadata_error' | 'blocked_path' | 'write_failed' }
     > {
-      return ipcRenderer.invoke('skills:updateManaged', skillId);
+      return ipcRenderer.invoke('skills:updateManaged', skillId, options);
+    },
+    setEnabled(skillId: string, enabled: boolean): Promise<
+      | { ok: true; skill: SkillEntry }
+      | { ok: false; reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed' }
+    > {
+      return ipcRenderer.invoke('skills:setEnabled', skillId, enabled);
     },
     createStarter(): Promise<
       | { ok: true; skill: SkillEntry; filePath: string }

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -16,7 +16,7 @@ export interface AppShellSkillActions {
   importManagedSkillSource(): Promise<void>;
   installManagedSkill(sourceId: string): Promise<void>;
   previewManagedSkillUpdate(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
-  updateManagedSkill(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<void>;
+  updateManagedSkill(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<boolean>;
   setSkillEnabled(skillId: string, enabled: boolean): Promise<void>;
   openSkill(skillId: string): Promise<void>;
 }
@@ -124,21 +124,23 @@ export function createAppShellSkillActions(deps: {
     }
   }
 
-  async function updateManagedSkill(skillId: string, options: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string } = {}) {
+  async function updateManagedSkill(skillId: string, options: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string } = {}): Promise<boolean> {
     try {
       const result = await window.maka.skills.updateManaged(skillId, options);
       if (!result.ok) {
         if (isSkillsSurfaceActive()) toastApi.error('无法更新 Skill', managedUpdateFailureCopy(result.reason));
-        return;
+        return false;
       }
       await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
       if (isSkillsSurfaceActive()) {
         toastApi.success(options.force ? '已覆盖更新 Skill' : '已更新 Skill', `${result.skill.id}/SKILL.md 已更新到来源库版本。`);
       }
+      return true;
     } catch (error) {
       if (isSkillsSurfaceActive()) {
         toastApi.error('无法更新 Skill', generalizedErrorMessageChinese(error, '无法更新 Skill，请稍后重试。'));
       }
+      return false;
     }
   }
 

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { generalizedErrorMessageChinese } from '@maka/core';
-import type { ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
+import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry } from '@maka/ui';
 import { createSkillFailureCopy, openSkillFailureCopy } from './app-shell-copy';
 import { createOpenSkillAction } from './app-shell-open-skill-action';
 
@@ -15,7 +15,9 @@ export interface AppShellSkillActions {
   createSkillTemplate(): Promise<void>;
   importManagedSkillSource(): Promise<void>;
   installManagedSkill(sourceId: string): Promise<void>;
-  updateManagedSkill(skillId: string): Promise<void>;
+  previewManagedSkillUpdate(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
+  updateManagedSkill(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): Promise<void>;
+  setSkillEnabled(skillId: string, enabled: boolean): Promise<void>;
   openSkill(skillId: string): Promise<void>;
 }
 
@@ -106,18 +108,54 @@ export function createAppShellSkillActions(deps: {
     }
   }
 
-  async function updateManagedSkill(skillId: string) {
+  async function previewManagedSkillUpdate(skillId: string): Promise<ManagedSkillUpdatePreview | null> {
     try {
-      const result = await window.maka.skills.updateManaged(skillId);
+      const result = await window.maka.skills.previewUpdate(skillId);
+      if (!result.ok) {
+        if (isSkillsSurfaceActive()) toastApi.error('无法预览 Skill 更新', managedPreviewFailureCopy(result.reason));
+        return null;
+      }
+      return result.preview;
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法预览 Skill 更新', generalizedErrorMessageChinese(error, '无法预览 Skill 更新，请稍后重试。'));
+      }
+      return null;
+    }
+  }
+
+  async function updateManagedSkill(skillId: string, options: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string } = {}) {
+    try {
+      const result = await window.maka.skills.updateManaged(skillId, options);
       if (!result.ok) {
         if (isSkillsSurfaceActive()) toastApi.error('无法更新 Skill', managedUpdateFailureCopy(result.reason));
         return;
       }
       await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
-      if (isSkillsSurfaceActive()) toastApi.success('已更新 Skill', `${result.skill.id}/SKILL.md 已更新到来源库版本。`);
+      if (isSkillsSurfaceActive()) {
+        toastApi.success(options.force ? '已覆盖更新 Skill' : '已更新 Skill', `${result.skill.id}/SKILL.md 已更新到来源库版本。`);
+      }
     } catch (error) {
       if (isSkillsSurfaceActive()) {
         toastApi.error('无法更新 Skill', generalizedErrorMessageChinese(error, '无法更新 Skill，请稍后重试。'));
+      }
+    }
+  }
+
+  async function setSkillEnabled(skillId: string, enabled: boolean) {
+    try {
+      const result = await window.maka.skills.setEnabled(skillId, enabled);
+      if (!result.ok) {
+        if (isSkillsSurfaceActive()) toastApi.error('无法切换 Skill', skillRuntimeFailureCopy(result.reason));
+        return;
+      }
+      await refreshSkills({ shouldShowError: isSkillsSurfaceActive });
+      if (isSkillsSurfaceActive()) {
+        toastApi.success(enabled ? '已启用 Skill' : '已停用 Skill', `${result.skill.name} 已更新当前项目的运行状态。`);
+      }
+    } catch (error) {
+      if (isSkillsSurfaceActive()) {
+        toastApi.error('无法切换 Skill', generalizedErrorMessageChinese(error, '无法切换 Skill，请稍后重试。'));
       }
     }
   }
@@ -128,7 +166,9 @@ export function createAppShellSkillActions(deps: {
     createSkillTemplate,
     importManagedSkillSource,
     installManagedSkill,
+    previewManagedSkillUpdate,
     updateManagedSkill,
+    setSkillEnabled,
     openSkill,
   };
 }
@@ -155,4 +195,19 @@ function managedUpdateFailureCopy(reason: 'not_managed' | 'source_missing' | 'lo
   if (reason === 'metadata_error') return 'Skill 元数据异常，不能安全更新。';
   if (reason === 'blocked_path') return '目标路径不允许写入。';
   return '写入工作区失败，请检查文件权限。';
+}
+
+function managedPreviewFailureCopy(reason: 'not_managed' | 'source_missing' | 'metadata_error' | 'blocked_path' | 'read_failed'): string {
+  if (reason === 'not_managed') return '这个 Skill 不是受管理来源。';
+  if (reason === 'source_missing') return '来源库中找不到对应来源。';
+  if (reason === 'metadata_error') return 'Skill 元数据异常，不能安全预览。';
+  if (reason === 'blocked_path') return '目标路径不允许读取。';
+  return '读取 Skill 内容失败，请检查文件权限。';
+}
+
+function skillRuntimeFailureCopy(reason: 'not_found' | 'blocked_path' | 'state_error' | 'write_failed'): string {
+  if (reason === 'not_found') return '当前工作区找不到这个 Skill。';
+  if (reason === 'blocked_path') return 'Skill 状态路径不允许写入。';
+  if (reason === 'state_error') return '当前工作区的 Skill 状态文件异常，需要先修复。';
+  return '写入当前项目的 Skill 状态失败，请检查文件权限。';
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -863,7 +863,9 @@ export function AppShell({
     createSkillTemplate,
     importManagedSkillSource,
     installManagedSkill,
+    previewManagedSkillUpdate,
     updateManagedSkill,
+    setSkillEnabled,
     openSkill,
   } = createAppShellSkillActions({
     isSkillsSurfaceActive,
@@ -1449,7 +1451,9 @@ export function AppShell({
                 onOpenSkillsFolder={() => openSkillsFolder()}
                 onImportManagedSkillSource={() => importManagedSkillSource()}
                 onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}
-                onUpdateManagedSkill={(skillId) => updateManagedSkill(skillId)}
+                onPreviewManagedSkillUpdate={(skillId) => previewManagedSkillUpdate(skillId)}
+                onUpdateManagedSkill={(skillId, options) => updateManagedSkill(skillId, options)}
+                onSetSkillEnabled={(skillId, enabled) => setSkillEnabled(skillId, enabled)}
                 planReminders={planReminders}
                 onRefreshPlanReminders={() => refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive })}
                 onCreatePlanReminder={(input) => createPlanReminder(input)}

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -236,6 +236,23 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   padding: 0 var(--space-1);
 }
 
+.maka-skill-filter-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.maka-skill-filter-pill {
+  min-width: 0;
+  min-height: var(--h-control-sm);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  padding: 0 var(--space-2-5);
+}
+
 .maka-skill-market {
   display: grid;
   gap: var(--space-3);
@@ -447,7 +464,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   padding: 0;
   list-style: none;
   min-height: 0;
-  overflow: visible;
+  overflow: hidden;
   display: grid;
   align-content: start;
   gap: 0;
@@ -457,33 +474,40 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 }
 
 .maka-skill-library-item {
+  --maka-skill-library-action-size: var(--h-control-sm);
   min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+  align-items: center;
+  gap: var(--space-2);
+  padding-right: var(--space-3);
+  transition: background-color var(--duration-base) var(--ease-out-strong);
 }
 
 .maka-skill-library-item + .maka-skill-library-item {
   border-top: var(--border-width-hairline) solid var(--foreground-8);
 }
 
-/* Justified: this row is a shared `UiButton variant="ghost"` but the surface
-   owns its own grid layout, height, and wrapping rules. Keep these
-   `!important` overrides until the primitive exposes a layout-bare variant
-   for the skill library surface. */
 .maka-skill-library-row {
-  appearance: none;
+  --maka-skill-library-icon-size: calc(var(--space-8) + var(--space-0-5));
+  --maka-skill-library-copy-min-inline: calc((var(--space-16) * 3) - var(--space-3));
+  --maka-skill-library-status-min-inline: calc(var(--space-16) + var(--space-2));
   width: 100%;
-  height: auto !important;
-  min-height: 58px;
+  min-height: calc(var(--maka-skill-library-icon-size) + (var(--space-3) * 2));
   display: grid;
-  grid-template-columns: 34px minmax(180px, 1fr) minmax(72px, max-content) 40px 36px;
+  grid-template-columns:
+    var(--maka-skill-library-icon-size)
+    minmax(var(--maka-skill-library-copy-min-inline), 1fr)
+    minmax(var(--maka-skill-library-status-min-inline), max-content);
   align-items: center;
-  justify-content: stretch !important;
+  justify-content: stretch;
   gap: var(--space-2-5);
   padding: var(--space-2-5) var(--space-3);
   border: 0;
   border-radius: 0;
   background: transparent;
   color: var(--foreground);
-  white-space: normal !important;
+  white-space: normal;
   text-align: left;
   transition: background-color var(--duration-base) var(--ease-out-strong);
 }
@@ -492,25 +516,17 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
    NEUTRAL gray (#efefef ≈ foreground/0.06), never tinted with the brand color.
    The purple-tinted row hover read as "themed"; neutral reads calmer/native.
    See notes/近期 UI study §1.4, §4. */
-.maka-skill-library-row:hover {
+.maka-skill-library-item:hover,
+.maka-skill-library-item:focus-within {
   background: var(--state-hover-bg);
-}
-
-.maka-skill-library-row:active {
-  background: var(--state-selected-bg);
-}
-
-.maka-skill-library-row:focus-visible {
-  outline: var(--focus-ring-width) solid oklch(from var(--focus-ring) l c h / 0.35);
-  outline-offset: var(--focus-ring-offset);
 }
 
 /* PR-UI-PIXEL-1: skill rows are anchored by a reference-style icon tile —
    a 38px rounded white square with a hairline + ultra-soft shadow holding the
    glyph (study §3.2), instead of the previous flat 20px chip. */
 .maka-skill-library-status {
-  width: 34px;
-  height: 34px;
+  width: var(--maka-skill-library-icon-size);
+  height: var(--maka-skill-library-icon-size);
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-surface);
@@ -523,8 +539,8 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 
 /* PR-UI-PIXEL-1: tile stays white on hover (reference keeps icon tiles
    neutral); only the glyph deepens. */
-.maka-skill-library-row:hover .maka-skill-library-status,
-.maka-skill-library-row:focus-visible .maka-skill-library-status {
+.maka-skill-library-item:hover .maka-skill-library-status,
+.maka-skill-library-item:focus-within .maka-skill-library-status {
   background: var(--background);
   color: var(--foreground);
 }
@@ -586,50 +602,157 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   letter-spacing: var(--tracking-normal);
 }
 
-.maka-skill-library-action {
-  justify-self: end;
-  min-width: 40px;
+.maka-skill-library-runtime-label,
+.maka-skill-library-status-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
   padding: var(--space-0-5) var(--space-2);
+  border-radius: var(--radius-pill);
+  background: oklch(from var(--info) l c h / 0.08);
+  color: var(--info-text);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+}
+
+.maka-skill-library-runtime-label[data-status="disabled"] {
+  background: oklch(from var(--foreground) l c h / 0.05);
+  color: var(--muted-foreground);
+}
+
+.maka-skill-library-runtime-label[data-status="state_error"] {
+  background: oklch(from var(--warning) l c h / 0.10);
+  color: var(--warning-text);
+}
+
+.maka-skill-library-status-label[data-status="local_modified"],
+.maka-skill-library-status-label[data-status="metadata_error"],
+.maka-skill-library-status-label[data-status="source_missing"] {
+  background: oklch(from var(--warning) l c h / 0.10);
+  color: var(--warning-text);
+}
+
+.maka-skill-library-status-label[data-status="update_available"] {
+  background: oklch(from var(--success) l c h / 0.10);
+  color: var(--success-text);
+}
+
+.maka-skill-library-open-button {
+  justify-self: end;
+  width: var(--maka-skill-library-action-size);
+  min-width: var(--maka-skill-library-action-size);
+  height: var(--maka-skill-library-action-size);
+  padding: 0;
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-control);
   background: var(--background);
   color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  text-align: center;
   transition: background-color var(--duration-base) var(--ease-out-strong), color var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-skill-library-row:hover .maka-skill-library-action,
-.maka-skill-library-row:focus-visible .maka-skill-library-action {
+.maka-skill-library-item:hover .maka-skill-library-open-button,
+.maka-skill-library-item:focus-within .maka-skill-library-open-button {
   background: var(--state-hover-bg);
   color: var(--foreground);
 }
 
-.maka-skill-library-switch {
-  position: relative;
+.maka-skill-library-runtime-switch {
   justify-self: end;
-  width: 34px;
-  height: 18px;
-  border-radius: var(--radius-pill);
-  background: var(--control);
-  box-shadow: inset 0 0 0 1px oklch(from var(--foreground) l c h / 0.05);
 }
 
-.maka-skill-library-switch::after {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 18px;
-  width: 14px;
-  height: 14px;
-  border-radius: var(--radius-pill);
-  background: var(--background);
-  box-shadow: 0 1px 2px oklch(from var(--foreground) l c h / 0.22);
+.maka-skill-library-item > .maka-skill-market-install {
+  justify-self: end;
 }
 
 .maka-skill-installed-empty {
   align-self: stretch;
+}
+
+.maka-skill-governance-review {
+  --maka-skill-diff-preview-max-block: calc(var(--space-16) * 4);
+  min-width: 0;
+  display: grid;
+  gap: var(--space-2);
+  border: var(--border-width-hairline) solid var(--foreground-8);
+  border-radius: var(--radius-control);
+  background: var(--background);
+  padding: var(--space-3);
+}
+
+.maka-skill-governance-summary {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.maka-skill-governance-summary span {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: var(--radius-pill);
+  background: oklch(from var(--foreground) l c h / 0.05);
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-0-5) var(--space-2);
+}
+
+.maka-skill-governance-warning {
+  margin: 0;
+  border: var(--border-width-hairline) solid oklch(from var(--warning) l c h / 0.22);
+  border-radius: var(--radius-control);
+  background: oklch(from var(--warning) l c h / 0.08);
+  color: var(--foreground-secondary);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-normal);
+  padding: var(--space-2);
+}
+
+.maka-skill-diff-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.maka-skill-diff-grid > div {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.maka-skill-diff-grid span {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+}
+
+.maka-skill-diff-grid pre {
+  min-width: 0;
+  max-height: var(--maka-skill-diff-preview-max-block);
+  overflow: auto;
+  margin: 0;
+  border: var(--border-width-hairline) solid var(--foreground-8);
+  border-radius: var(--radius-control);
+  background: var(--foreground-2);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-normal);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  padding: var(--space-2);
+}
+
+.maka-skill-governance-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--space-1);
 }
 
 @media (max-width: 820px) {
@@ -641,8 +764,13 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
     grid-template-columns: minmax(0, 1fr);
   }
 
-.maka-skill-library-row {
-    grid-template-columns: 38px minmax(0, 1fr) max-content;
+  .maka-skill-library-item {
+    grid-template-columns: minmax(0, 1fr) max-content max-content;
+  }
+
+  .maka-skill-library-row {
+    --maka-skill-library-icon-size: calc(var(--space-8) + var(--space-1-5));
+    grid-template-columns: var(--maka-skill-library-icon-size) minmax(0, 1fr);
     gap: var(--space-1-5);
   }
 
@@ -652,13 +780,14 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
     white-space: normal;
   }
 
-  .maka-skill-library-action {
-    grid-column: 2;
+  .maka-skill-library-item > .maka-skill-market-install {
+    grid-column: 1 / -1;
     justify-self: start;
+    margin-left: var(--space-3);
+    margin-bottom: var(--space-2-5);
   }
 
-  .maka-skill-library-switch {
-    grid-column: 3;
-    grid-row: 1;
+  .maka-skill-diff-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -38,6 +38,7 @@ import type {
   DailyReviewBridge,
   DailyReviewMarkdownActionInput,
   ManagedSkillSourceEntry,
+  ManagedSkillUpdatePreview,
   PlanReminderDraftInput,
   PlanReminderUpdatePatch,
   SkillEntry,
@@ -244,7 +245,9 @@ export function ChatView(props: {
   onRefreshManagedSkillSources?(): void | Promise<void>;
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
-  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
+  onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   planReminders?: PlanReminder[];
   onRefreshPlanReminders?: () => void | Promise<void>;
   onCreatePlanReminder?(input: PlanReminderDraftInput): boolean | Promise<boolean> | void | Promise<void>;
@@ -421,7 +424,9 @@ export function ChatView(props: {
           onRefreshManagedSkillSources={props.onRefreshManagedSkillSources}
           onImportManagedSkillSource={props.onImportManagedSkillSource}
           onInstallManagedSkill={props.onInstallManagedSkill}
+          onPreviewManagedSkillUpdate={props.onPreviewManagedSkillUpdate}
           onUpdateManagedSkill={props.onUpdateManagedSkill}
+          onSetSkillEnabled={props.onSetSkillEnabled}
         />
       </Suspense>
     );

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -246,7 +246,7 @@ export function ChatView(props: {
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
-  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   planReminders?: PlanReminder[];
   onRefreshPlanReminders?: () => void | Promise<void>;

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -3,7 +3,7 @@ export { CapabilityAuditStrip } from './capability-audit-strip.js';
 export { SearchModal } from './search-modal.js';
 export { SessionListPanel } from './session-list-panel.js';
 export type { SessionViewMode } from './session-list-panel.js';
-export type { ManagedSkillSourceEntry, SkillEntry } from './module-panel-types.js';
+export type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from './module-panel-types.js';
 export { describeLoadToolResult, formatRedactedJson, formatToolIntent, loadToolDisplayName } from './tool-format.js';
 export { formatBytes, OverlayHost, ToolActivity } from './tool-activity.js';
 export { PermissionDialog } from './permission-dialog.js';

--- a/packages/ui/src/module-panel-types.ts
+++ b/packages/ui/src/module-panel-types.ts
@@ -25,6 +25,54 @@ export interface SkillEntry {
   userModified?: boolean;
   validationStatus?: 'ok' | 'missing_lock' | 'modified' | 'metadata_error';
   managedUpdateStatus?: 'not_managed' | 'source_missing' | 'up_to_date' | 'update_available' | 'local_modified' | 'metadata_error';
+  enabled: boolean;
+  runtimeStatus: 'enabled' | 'disabled' | 'state_error';
+}
+
+export type SkillGovernanceStatus = 'not_managed' | 'source_missing' | 'up_to_date' | 'update_available' | 'local_modified' | 'metadata_error';
+export type SkillValidationStatus = 'ok' | 'missing_lock' | 'modified' | 'metadata_error';
+export type SkillValidationCode =
+  | 'missing_lock'
+  | 'modified'
+  | 'invalid_json'
+  | 'id_mismatch'
+  | 'unsupported_schema'
+  | 'invalid_hash'
+  | 'write_failed'
+  | 'lock_symlink';
+
+export interface SkillGovernanceDetails {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  declaredTools: string[];
+  sourceType: 'workspace' | 'bundled' | 'managed' | 'unknown';
+  userModified: boolean;
+  validationStatus: SkillValidationStatus;
+  enabled: boolean;
+  runtimeStatus: 'enabled' | 'disabled' | 'state_error';
+  validationCodes: SkillValidationCode[];
+  validationMessages: string[];
+  managedSourceId?: string;
+  managedUpdateStatus?: SkillGovernanceStatus;
+  hasManagedBaseline: boolean;
+  sourceAvailable?: boolean;
+  sourceChanged?: boolean;
+}
+
+export interface ManagedSkillUpdatePreview {
+  skill: SkillGovernanceDetails;
+  currentContent: string;
+  sourceContent: string;
+  baselineContent?: string;
+  expectedCurrentSha256: string;
+  expectedSourceSha256: string;
+  summary: {
+    currentLineCount: number;
+    sourceLineCount: number;
+    changedLineCount: number;
+  };
 }
 
 export interface ManagedSkillSourceEntry {

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -27,7 +27,7 @@ function SkillLibraryPanel(props: {
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
-  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   actionBusy?: boolean;
   refreshPending?: boolean;
@@ -90,12 +90,12 @@ function SkillLibraryPanel(props: {
   async function applyManagedSkillUpdate(preview: ManagedSkillUpdatePreview) {
     if (!props.onUpdateManagedSkill) return;
     const force = preview.skill.managedUpdateStatus === 'local_modified';
-    await props.onUpdateManagedSkill(preview.skill.id, force ? {
-      force: true,
+    const updated = await props.onUpdateManagedSkill(preview.skill.id, {
+      ...(force ? { force: true } : {}),
       expectedCurrentSha256: preview.expectedCurrentSha256,
       expectedSourceSha256: preview.expectedSourceSha256,
-    } : undefined);
-    setUpdatePreview(null);
+    });
+    if (updated) setUpdatePreview(null);
   }
 
   const templates = (
@@ -575,7 +575,7 @@ export function SkillsModuleMain(props: {
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
   onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
-  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
 }) {
   const [pendingSkillAction, setPendingSkillAction] = useState<string | null>(null);
@@ -591,15 +591,15 @@ export function SkillsModuleMain(props: {
     };
   }, []);
 
-  async function runSkillAction(
+  async function runSkillAction<Result>(
     actionKey: string,
-    action: (() => void | Promise<void>) | undefined,
+    action: (() => Result | Promise<Result>) | undefined,
   ) {
-    if (!action || pendingSkillActionRef.current !== null) return;
+    if (!action || pendingSkillActionRef.current !== null) return undefined;
     pendingSkillActionRef.current = actionKey;
     setPendingSkillAction(actionKey);
     try {
-      await action();
+      return await action();
     } finally {
       if (pendingSkillActionRef.current === actionKey) {
         pendingSkillActionRef.current = null;
@@ -670,7 +670,8 @@ export function SkillsModuleMain(props: {
         onImportManagedSkillSource={props.onImportManagedSkillSource ? () => runSkillAction('source:import', props.onImportManagedSkillSource) : undefined}
         onInstallManagedSkill={props.onInstallManagedSkill ? (sourceId) => runSkillAction(`source:install:${sourceId}`, () => props.onInstallManagedSkill?.(sourceId)) : undefined}
         onPreviewManagedSkillUpdate={props.onPreviewManagedSkillUpdate}
-        onUpdateManagedSkill={props.onUpdateManagedSkill ? (skillId, options) => runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId, options)) : undefined}
+        onUpdateManagedSkill={props.onUpdateManagedSkill ? async (skillId, options) =>
+          (await runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId, options))) === true : undefined}
         onSetSkillEnabled={props.onSetSkillEnabled ? (skillId, enabled) => runSkillAction(`runtime:set:${skillId}`, () => props.onSetSkillEnabled?.(skillId, enabled)) : undefined}
         actionBusy={skillActionBusy}
         refreshPending={pendingSkillAction === 'refresh'}

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -11,11 +11,13 @@ import {
 } from './icons.js';
 import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
-import { Button as UiButton, TabsRoot, TabsList, TabsTrigger, TabsPanel } from './ui.js';
+import { Button as UiButton, Switch, TabsRoot, TabsList, TabsTrigger, TabsPanel } from './ui.js';
 import { Input } from './primitives/input.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
-import type { ManagedSkillSourceEntry, SkillEntry } from './module-panel-types.js';
+import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry } from './module-panel-types.js';
+
+const SKILL_UPDATE_PREVIEW_MAX_LINES = 80;
 
 function SkillLibraryPanel(props: {
   skills?: SkillEntry[];
@@ -24,13 +26,16 @@ function SkillLibraryPanel(props: {
   onOpenSkill?(skillId: string): void | Promise<void>;
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
-  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
+  onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   actionBusy?: boolean;
   refreshPending?: boolean;
   createPending?: boolean;
   openingSkillId?: string | null;
   installingSourceId?: string | null;
   updatingSkillId?: string | null;
+  togglingSkillId?: string | null;
   searchQuery?: string;
   managedSkillSources?: ManagedSkillSourceEntry[];
 }) {
@@ -44,6 +49,8 @@ function SkillLibraryPanel(props: {
     if (skills.length > 0) return 'builtin';
     return 'market';
   });
+  const [updatePreview, setUpdatePreview] = useState<ManagedSkillUpdatePreview | null>(null);
+  const [reviewingSkillId, setReviewingSkillId] = useState<string | null>(null);
   const normalizedSkillQuery = props.searchQuery?.trim().toLowerCase() ?? '';
   const filteredSkills = (props.skills ?? []).filter((skill) => {
     if (!normalizedSkillQuery) return true;
@@ -69,6 +76,28 @@ function SkillLibraryPanel(props: {
     if (!normalizedSkillQuery) return true;
     return `${source.id} ${source.name} ${source.description}`.toLowerCase().includes(normalizedSkillQuery);
   });
+  async function reviewManagedSkillUpdate(skill: SkillEntry) {
+    if (!props.onPreviewManagedSkillUpdate || reviewingSkillId !== null) return;
+    setReviewingSkillId(skill.id);
+    try {
+      const preview = await props.onPreviewManagedSkillUpdate(skill.id);
+      if (preview) setUpdatePreview(preview);
+    } finally {
+      setReviewingSkillId(null);
+    }
+  }
+
+  async function applyManagedSkillUpdate(preview: ManagedSkillUpdatePreview) {
+    if (!props.onUpdateManagedSkill) return;
+    const force = preview.skill.managedUpdateStatus === 'local_modified';
+    await props.onUpdateManagedSkill(preview.skill.id, force ? {
+      force: true,
+      expectedCurrentSha256: preview.expectedCurrentSha256,
+      expectedSourceSha256: preview.expectedSourceSha256,
+    } : undefined);
+    setUpdatePreview(null);
+  }
+
   const templates = (
     <section className="maka-skill-examples" aria-label="技能示例">
       <ul className="maka-skill-example-grid" aria-label="技能模板示例">
@@ -212,23 +241,24 @@ function SkillLibraryPanel(props: {
               const toolsLabel = tools.length > 0 ? tools.join(', ') : '';
               const description = formatSkillLibraryDescription(skill);
               const statusLabel = formatSkillStatusLabel(skill);
+              const runtimeLabel = formatSkillRuntimeLabel(skill);
               const opening = props.openingSkillId === skill.id;
               const updating = props.updatingSkillId === skill.id;
+              const toggling = props.togglingSkillId === skill.id;
+              const reviewing = reviewingSkillId === skill.id;
+              const reviewableManagedUpdate = skill.managedUpdateStatus === 'update_available' || skill.managedUpdateStatus === 'local_modified';
+              const canToggleSkill = Boolean(props.onSetSkillEnabled) && skill.runtimeStatus !== 'state_error';
               const hoverText = tools.length > 0
-                ? `打开技能文件：${skill.id}\n\n来源状态：${statusLabel}\n声明工具：${toolsLabel}\n权限仍按当前会话策略判断；这里不是授权。`
-                : `打开技能文件：${skill.id}\n\n来源状态：${statusLabel}`;
+                ? `技能：${skill.id}\n\n运行状态：${runtimeLabel}\n来源状态：${statusLabel}\n声明工具：${toolsLabel}\n权限仍按当前会话策略判断；这里不是授权。`
+                : `技能：${skill.id}\n\n运行状态：${runtimeLabel}\n来源状态：${statusLabel}`;
               return (
-                <li key={skill.id} className="maka-skill-library-item">
-                  <UiButton
-                    type="button"
-                    variant="ghost"
+                <li key={skill.id} className="maka-skill-library-item" data-runtime-status={skill.runtimeStatus}>
+                  <div
                     className="maka-skill-library-row"
-                    onClick={() => props.onOpenSkill?.(skill.id)}
-                    disabled={props.actionBusy}
                     title={hoverText}
                   >
                     <span className="maka-skill-library-status" aria-hidden="true">
-                      {opening ? <Loader2 size={16} strokeWidth={1.8} /> : <Sparkles size={16} strokeWidth={1.8} />}
+                      <Sparkles size={16} strokeWidth={1.8} />
                     </span>
                     <span className="maka-skill-library-copy">
                       <span className="maka-skill-library-name">{skill.name}</span>
@@ -238,24 +268,42 @@ function SkillLibraryPanel(props: {
                     </span>
                     <span className="maka-skill-library-meta">
                       <span>{skill.id}</span>
-                      <span>{statusLabel}</span>
+                      <span className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus}>{runtimeLabel}</span>
+                      <span className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'}>{statusLabel}</span>
                       {opening && <span>打开中…</span>}
                       {updating && <span>更新中…</span>}
+                      {toggling && <span>切换中…</span>}
+                      {reviewing && <span>审查中…</span>}
                     </span>
-                    <span className="maka-skill-library-action" aria-hidden="true">
-                      {skill.managedUpdateStatus === 'update_available' ? '可更新' : '打开'}
-                    </span>
-                    <span className="maka-skill-library-switch" aria-hidden="true" data-state="on" />
+                  </div>
+                  <UiButton
+                    type="button"
+                    variant="ghost"
+                    className="maka-skill-library-open-button"
+                    onClick={() => props.onOpenSkill?.(skill.id)}
+                    disabled={props.actionBusy || !props.onOpenSkill}
+                    aria-label={`打开 ${skill.name} 的 SKILL.md`}
+                    title="打开 SKILL.md"
+                  >
+                    {opening ? <Loader2 size={15} strokeWidth={1.75} aria-hidden="true" /> : <FileEdit size={15} strokeWidth={1.75} aria-hidden="true" />}
                   </UiButton>
-                  {skill.managedUpdateStatus === 'update_available' && props.onUpdateManagedSkill && (
+                  <Switch
+                    className="maka-skill-library-runtime-switch"
+                    checked={skill.enabled}
+                    disabled={props.actionBusy || !canToggleSkill}
+                    aria-label={skill.enabled ? `停用 ${skill.name}` : `启用 ${skill.name}`}
+                    title={skill.runtimeStatus === 'state_error' ? '当前项目的 Skill 状态文件异常' : skill.enabled ? '当前项目中 agent 可以使用此技能' : '当前项目中 agent 不会看到或加载此技能'}
+                    onCheckedChange={(next) => props.onSetSkillEnabled?.(skill.id, next === true)}
+                  />
+                  {reviewableManagedUpdate && props.onPreviewManagedSkillUpdate && (
                     <UiButton
                       type="button"
                       variant="ghost"
                       className="maka-skill-market-install"
-                      onClick={() => props.onUpdateManagedSkill?.(skill.id)}
-                      disabled={props.actionBusy}
+                      onClick={() => void reviewManagedSkillUpdate(skill)}
+                      disabled={props.actionBusy || reviewingSkillId !== null}
                     >
-                      {updating ? '更新中…' : '更新'}
+                      {reviewing ? '审查中…' : skill.managedUpdateStatus === 'local_modified' ? '查看差异' : '查看更新'}
                     </UiButton>
                   )}
                 </li>
@@ -330,6 +378,57 @@ function SkillLibraryPanel(props: {
     </section>
   );
 
+  const updateReview = updatePreview ? (
+    <section className="maka-skill-governance-review" aria-label="Skill 更新审查">
+      <div className="maka-skill-section-row">
+        <span className="maka-skill-section-label">更新审查</span>
+        <small>{formatSkillStatusLabel(updatePreview.skill)}</small>
+      </div>
+      <div className="maka-skill-governance-summary">
+        <span>{updatePreview.skill.name}</span>
+        <span>{updatePreview.skill.managedSourceId ? `来源 ${updatePreview.skill.managedSourceId}` : '受管理来源'}</span>
+        <span>{updatePreview.skill.hasManagedBaseline ? '已有基线' : '缺少基线'}</span>
+        <span>{updatePreview.summary.currentLineCount} → {updatePreview.summary.sourceLineCount} 行</span>
+        <span>{updatePreview.summary.changedLineCount} 行不同</span>
+      </div>
+      {updatePreview.skill.managedUpdateStatus === 'local_modified' && (
+        <p className="maka-skill-governance-warning">
+          工作区副本已有本地修改。继续更新会用来源库版本覆盖当前 SKILL.md。
+        </p>
+      )}
+      <div className="maka-skill-diff-grid">
+        <div>
+          <span>当前工作区</span>
+          <pre>{previewText(updatePreview.currentContent)}</pre>
+        </div>
+        <div>
+          <span>来源库版本</span>
+          <pre>{previewText(updatePreview.sourceContent)}</pre>
+        </div>
+      </div>
+      <div className="maka-skill-governance-actions">
+        <UiButton
+          type="button"
+          variant="ghost"
+          className="maka-skill-filter-pill"
+          onClick={() => setUpdatePreview(null)}
+          disabled={props.actionBusy}
+        >
+          取消
+        </UiButton>
+        <UiButton
+          type="button"
+          variant="secondary"
+          className="maka-skill-filter-pill"
+          onClick={() => void applyManagedSkillUpdate(updatePreview)}
+          disabled={props.actionBusy || !props.onUpdateManagedSkill}
+        >
+          {updatePreview.skill.managedUpdateStatus === 'local_modified' ? '覆盖本地修改' : '更新到来源版本'}
+        </UiButton>
+      </div>
+    </section>
+  ) : null;
+
   return (
     <div className="maka-skill-library" aria-busy={props.actionBusy ? 'true' : undefined}>
       {banner}
@@ -339,6 +438,7 @@ function SkillLibraryPanel(props: {
         <TabsPanel value="builtin">{skillList(bundledSkills, normalizedSkillQuery ? '没有匹配的内置技能' : '暂无内置技能', normalizedSkillQuery ? '换一个关键词试试。' : '应用自带的技能会出现在这里。', '内置技能')}</TabsPanel>
         <TabsPanel value="installed">
           {skillList(installedSkills, skillListEmptyTitle, skillListEmptyBody, '已安装技能')}
+          {updateReview}
           {managedSources}
           {templates}
         </TabsPanel>
@@ -450,6 +550,17 @@ function formatSkillStatusLabel(skill: SkillEntry): string {
   return '本地';
 }
 
+function formatSkillRuntimeLabel(skill: SkillEntry): string {
+  if (skill.runtimeStatus === 'state_error') return '状态异常';
+  return skill.enabled ? '已启用' : '已停用';
+}
+
+function previewText(content: string): string {
+  const lines = content.replace(/\r\n/g, '\n').split('\n');
+  const clipped = lines.slice(0, SKILL_UPDATE_PREVIEW_MAX_LINES).join('\n');
+  return lines.length > SKILL_UPDATE_PREVIEW_MAX_LINES ? `${clipped}\n...` : clipped;
+}
+
 
 
 export function SkillsModuleMain(props: {
@@ -463,7 +574,9 @@ export function SkillsModuleMain(props: {
   onRefreshManagedSkillSources?(): void | Promise<void>;
   onImportManagedSkillSource?(): void | Promise<void>;
   onInstallManagedSkill?(sourceId: string): void | Promise<void>;
-  onUpdateManagedSkill?(skillId: string): void | Promise<void>;
+  onPreviewManagedSkillUpdate?(skillId: string): Promise<ManagedSkillUpdatePreview | null>;
+  onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): void | Promise<void>;
+  onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
 }) {
   const [pendingSkillAction, setPendingSkillAction] = useState<string | null>(null);
   const [skillSearchQuery, setSkillSearchQuery] = useState('');
@@ -556,13 +669,16 @@ export function SkillsModuleMain(props: {
         onOpenSkill={props.onOpenSkill ? (skillId) => runSkillAction(`open:${skillId}`, () => props.onOpenSkill?.(skillId)) : undefined}
         onImportManagedSkillSource={props.onImportManagedSkillSource ? () => runSkillAction('source:import', props.onImportManagedSkillSource) : undefined}
         onInstallManagedSkill={props.onInstallManagedSkill ? (sourceId) => runSkillAction(`source:install:${sourceId}`, () => props.onInstallManagedSkill?.(sourceId)) : undefined}
-        onUpdateManagedSkill={props.onUpdateManagedSkill ? (skillId) => runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId)) : undefined}
+        onPreviewManagedSkillUpdate={props.onPreviewManagedSkillUpdate}
+        onUpdateManagedSkill={props.onUpdateManagedSkill ? (skillId, options) => runSkillAction(`managed:update:${skillId}`, () => props.onUpdateManagedSkill?.(skillId, options)) : undefined}
+        onSetSkillEnabled={props.onSetSkillEnabled ? (skillId, enabled) => runSkillAction(`runtime:set:${skillId}`, () => props.onSetSkillEnabled?.(skillId, enabled)) : undefined}
         actionBusy={skillActionBusy}
         refreshPending={pendingSkillAction === 'refresh'}
         createPending={pendingSkillAction === 'create'}
         openingSkillId={pendingSkillAction?.startsWith('open:') ? pendingSkillAction.slice('open:'.length) : null}
         installingSourceId={pendingSkillAction?.startsWith('source:install:') ? pendingSkillAction.slice('source:install:'.length) : null}
         updatingSkillId={pendingSkillAction?.startsWith('managed:update:') ? pendingSkillAction.slice('managed:update:'.length) : null}
+        togglingSkillId={pendingSkillAction?.startsWith('runtime:set:') ? pendingSkillAction.slice('runtime:set:'.length) : null}
         searchQuery={skillSearchQuery}
       />
     </main>

--- a/packages/ui/stories/skills-panel.stories.tsx
+++ b/packages/ui/stories/skills-panel.stories.tsx
@@ -22,6 +22,8 @@ const skills: SkillEntry[] = [
     description: '封装分支创建、合并与发布打 tag 的常用 git 操作。',
     path: '~/.maka/skills/git-flow',
     declaredTools: ['Bash', 'Write'],
+    enabled: true,
+    runtimeStatus: 'enabled',
   },
   {
     id: 'skill-docs-screenshot',
@@ -29,6 +31,8 @@ const skills: SkillEntry[] = [
     description: '把组件截图同步进设计文档，按 token 分类命名。',
     path: '~/.maka/skills/docs-screenshot',
     declaredTools: ['Bash', 'Read'],
+    enabled: false,
+    runtimeStatus: 'disabled',
   },
   {
     id: 'skill-release-notes',
@@ -36,6 +40,8 @@ const skills: SkillEntry[] = [
     description: '从最近的 commit 历史生成发布说明草稿。',
     path: '~/.maka/skills/release-notes',
     declaredTools: ['Bash'],
+    enabled: true,
+    runtimeStatus: 'enabled',
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds workspace-level per-skill enablement controls on top of the managed skill workflow introduced in Phase 2.

This keeps skill governance and runtime availability separate:

- `skill.lock.json` remains the source/provenance/hash governance record.
- `<workspace>/.maka/skills-state.json` stores workspace-local runtime enablement.
- Disabled skills remain visible and manageable, but are excluded from the agent skill catalog and cannot be loaded through the `Skill` tool.

## Changes

- Add per-workspace skill runtime state with fail-closed handling.
- Add `enabled` and `runtimeStatus` to skill entries.
- Add `skills:setEnabled` IPC/preload/renderer wiring.
- Exclude disabled skills from `buildSkillsPromptFragment()`.
- Return `disabled` from `loadSkillInstructions()` when a disabled skill is requested.
- Add Skills UI switch controls for enabling/disabling each installed skill.
- Keep file opening as an explicit icon action separate from the enablement switch.
- Add tests for invalid state files, symlinked state paths, and disabled runtime loading.

## Validation

- `git diff --check`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/ui run build`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test`

Result: `2164` tests passed, `0` failed.