### PR TITLE
refactor(ui): re-tier font scale — heading 15 / body 13 / caption 11

### DIFF
--- a/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/typography-converge-contract.test.ts
@@ -6,13 +6,14 @@
  * Three invariants:
  *
  * 1. CSS `font-size` must reference a whitelisted `--font-size-*` token,
- *    use `em` (relative scaling off the 15px root), or be a literal
+ *    use `em` (relative scaling off the 13px root), or be a literal
  *    (`inherit` / `initial` / `0`). Bare `Npx` and `Nrem` drift visually
- *    and bypass the three-tier scale.
+ *    and bypass the tier scale.
  *
- * 2. `--font-size-{base,ui,caption}` tokens are defined in `maka-tokens.css`
- *    with pinned values (15 / 13 / 11). A rename or value change gets
- *    flagged at the test layer before any styles site drifts.
+ * 2. `--font-size-{heading,base,ui,caption}` tokens are defined in
+ *    `maka-tokens.css` with pinned values (#546 re-tier: heading 15 /
+ *    body 13 / caption 11; ui aliases base). A rename or value change
+ *    gets flagged at the test layer before any styles site drifts.
  *
  * 3. Tailwind `--text-{xs,sm,base}` aliases in `styles.css` `@theme inline`
  *    map to the token scale so TSX `text-*` utilities stay single-sourced
@@ -28,6 +29,7 @@ import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, readRendererTsxFiles, strip
 // --- token whitelist --------------------------------------------------------
 
 const FONT_SIZE_TOKEN_WHITELIST = new Set([
+  '--font-size-heading',
   '--font-size-base',
   '--font-size-ui',
   '--font-size-caption',
@@ -97,17 +99,23 @@ describe('PR-TYPOGRAPHY-CONVERGE-0 contract', () => {
     const tokens = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
     // Strip the token declaration lines themselves (they legitimately spell px)
     const stripped = tokens
-      .replace(/^\s*--font-size-base:\s*15px\s*;?\s*$/gm, '')
-      .replace(/^\s*--font-size-ui:\s*13px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-heading:\s*15px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-base:\s*13px\s*;?\s*$/gm, '')
+      .replace(/^\s*--font-size-ui:\s*var\(--font-size-base\)\s*;?\s*$/gm, '')
       .replace(/^\s*--font-size-caption:\s*11px\s*;?\s*$/gm, '');
     const offenders = findCssOffenders(stripped, 'maka-tokens.css');
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
-  it('--font-size-{base,ui,caption} tokens are defined with pinned values', async () => {
+  it('--font-size-{heading,base,ui,caption} tokens are defined with pinned values', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
-    assert.match(tokens, /--font-size-base:\s*15px/, '--font-size-base must be 15px');
-    assert.match(tokens, /--font-size-ui:\s*13px/, '--font-size-ui must be 13px');
+    assert.match(tokens, /--font-size-heading:\s*15px/, '--font-size-heading must be 15px');
+    assert.match(tokens, /--font-size-base:\s*13px/, '--font-size-base must be 13px (#546 re-tier)');
+    assert.match(
+      tokens,
+      /--font-size-ui:\s*var\(--font-size-base\)/,
+      '--font-size-ui must alias --font-size-base (#546 re-tier: body == chrome)'
+    );
     assert.match(tokens, /--font-size-caption:\s*11px/, '--font-size-caption must be 11px');
   });
 

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -288,15 +288,17 @@
   --font-default: var(--font-sans);
 
   /* === typography ===
-     PR-TYPOGRAPHY-CONVERGE-0 (issue #430 PR2, 2026-07-03):
-     three-tier scale. Body 15 is the root (html font-size); UI 13 is the
-     chrome/control tier (sidebar rows, labels, buttons, form fields);
-     caption 11 is dense meta (timestamps, badges, kbd, overlines).
-     9/10/10.5/11/11.5px and sub-0.8rem collapse to caption;
-     12/12.5/13/13.5/14px and 0.8-0.95rem collapse to ui.
-     Bubble h1-h4 scale in em off body 15 so they track the root automatically. */
-  --font-size-base: 15px;
-  --font-size-ui: 13px;
+     PR-TYPOGRAPHY-CONVERGE-0 (issue #430 PR2, 2026-07-03), re-tiered for
+     #546 density: heading 15 / body 13 / caption 11. Body 13 is the root
+     (html font-size) and also the chrome/control tier — ui aliases base
+     (macOS/VS Code shape: body == chrome == 13, hierarchy by weight/color).
+     Heading 15 is the old body value, demoted to section/card/modal
+     titles only — those sites keep their exact pixels, renamed honestly.
+     Caption 11 is dense meta (timestamps, badges, kbd, overlines).
+     Bubble h1-h4 scale in em off body 13 so they track the root automatically. */
+  --font-size-heading: 15px;
+  --font-size-base: 13px;
+  --font-size-ui: var(--font-size-base);
   --font-size-caption: 11px;
 
   /* === line-height ===
@@ -1462,7 +1464,7 @@
     border-bottom: var(--border-width-hairline) solid var(--border);
   }
   .maka-modal-title {
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-heading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
     letter-spacing: var(--tracking-normal);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -84,9 +84,9 @@
   /* fix(#546): pin the text-* paired line-heights to the 4-tier leading
      scale. Without these, bare `text-xs`/`text-sm` utilities carry
      Tailwind's stock ratios (1.333/1.4286) — off-tier values that PR1
-     (#526) removed everywhere else. 11/13px UI text is the snug zone;
-     15px body stays normal (same value as Tailwind's default, pinned so
-     the trio reads as one decision). */
+     (#526) removed everywhere else. 11px caption is the snug zone;
+     13px body (base == ui after the #546 re-tier) stays normal so prose
+     keeps a ≥1.5 ratio (WCAG 1.4.12 headroom at the denser body size). */
   --text-xs--line-height: var(--leading-snug);
   --text-sm--line-height: var(--leading-snug);
   --text-base--line-height: var(--leading-normal);

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -58,7 +58,8 @@
   border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground);
-  font-size: var(--font-size-base);
+  /* Glyph size for the 26px nav button, not body text — stays 15. */
+  font-size: var(--font-size-heading);
   line-height: var(--leading-none);
 }
 

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -182,7 +182,9 @@
 }
 .maka-prose code {
   font-family: var(--font-mono);
-  font-size: 0.86em;
+  /* 0.92em of the 13px body ≈ 12px; at 0.86em it would fall to caption
+     size (11.2px) and stop reading as body-level code. */
+  font-size: 0.92em;
   padding: 1px var(--space-1-5);
   /* PR-UI-LAYOUT-28: inline code radius 4 → 5. Tiny bump but
    * pulls it slightly out of the "tight tag" feel into a calmer

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -243,7 +243,7 @@
 }
 
 .maka-plan-template-strip[data-layout="cards"] .maka-plan-template-title {
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-heading);
   line-height: var(--leading-snug);
 }
 
@@ -716,7 +716,7 @@
   margin: 0;
   min-width: 0;
   color: var(--foreground);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -293,7 +293,7 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
 .maka-skill-market-card h3 {
   margin: 0;
   color: var(--foreground);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-heading);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-tight);
 }

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -687,7 +687,7 @@
 .settingsFormGrid label span {
   display: block;
   color: var(--foreground);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-heading);
   font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
 }
@@ -697,8 +697,7 @@
   display: block;
   margin-top: var(--space-1-5);
   color: var(--muted-foreground);
-  /* Hint is the most-read body text on the page; use the base scale so
-     it clears the 14px legibility floor. */
+  /* Hint is the most-read body text on the page; body tier (13). */
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
 }

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -451,7 +451,7 @@
   }
 
 .settingsOsPermissionHeading strong {
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-heading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
   }


### PR DESCRIPTION
## Summary

Re-tier the font-size tokens: body drops 15 → 13 and becomes both the root (`html`) and the chrome tier (`--font-size-ui` now aliases `--font-size-base`); the old 15px is demoted to a new `--font-size-heading` tier consumed only by title-class sites, which keep their exact pixels. Caption stays 11. Inline code compensates 0.86em → 0.92em so it stays above caption size at the denser body.

## Why

15px chat body reads oversized for a coding-agent working surface. Peer measurement puts editor-embedded agent chat at 12–13px (VS Code `chat.fontSize` default 13, source-verified; Zed user messages 12), and the resulting shape — body == chrome == 13, hierarchy carried by weight/color — is exactly the VS Code (workbench 13 == chat 13) and macOS (13pt body == 13pt controls) precedent. A chat-scoped override was considered and rejected: it would create a second parallel scale, the dual-scale maintenance risk design systems warn about. Full analysis in the #546 thread.

Refs #546

## Scope

Changed: `maka-tokens.css` (token block re-pin + modal title → heading), `styles.css` (text-* line-height comment), `chat-message.css` (inline-code 0.92em), 6 title-class sites re-pointed to `--font-size-heading` (settings field labels, settings hint comment, OS-permission heading, skill card h3, plan titles ×2, browser nav-button glyph), `typography-converge-contract.test.ts` re-pinned to the four-token vocabulary.

Not included: markdown body redesign (next PR per the re-ordered #546 plan), tool rendering, any spacing/layout changes, user-facing font-size setting.

## Verification

- `npm run -w @maka/desktop test` — 2178 pass, 0 fail (contract re-pinned: heading 15 / base 13 / ui aliases base / caption 11).
- Dual-theme screenshots: `turn-narrative` scenario captured light + dark at 1280 and visually reviewed — chat body/tool rows/composer coherent at 13px, no layout breakage. Full-suite capture intentionally skipped in favor of the core chat scenario.
- Storybook side-by-side (6006 baseline vs 6008 worktree): chat prose, markdown, settings pages — title-class sites pixel-identical, body text 15→13.
- Line height ≥1.5 at 13px body (`--leading-normal: 1.5` → 19.5px, WCAG 1.4.12 headroom).

## User-facing impact

Chat prose, composer input, onboarding textarea, and settings hint text render at 13px (previously 15px). All title-tier text, chrome, and captions are pixel-unchanged.

## Reviewer notes

The blast radius is deliberately four body-text populations; every other `--font-size-base` consumer was audited and either re-pointed to `heading` (7 title sites, zero visual change) or confirmed as body. `text-sm` and `text-base` now resolve to the same 13px — acceptable by design (body == chrome), flagged here so it doesn't read as an accident.
