### PR TITLE
fix(chat-message): prose rendering bug pass at the 13px base (#546 Phase B)

### DIFF
--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -201,17 +201,26 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
     );
   });
 
-  it('prose tables use border-collapse: separate so radius + outer border render', async () => {
+  it('prose tables are frameless with a reinforced header rule', async () => {
     const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
     const blocks = cssBlocks(css);
     const table = blocks.find(({ selectors }) => /^\.maka-prose\s+table$/.test(selectors));
     assert.ok(table, 'expected a .maka-prose table rule');
-    assert.match(
-      table!.decls,
-      /border-collapse:\s*separate/,
-      'collapsed borders void border-radius and swallow the outer hairline — the table edge disappears',
+    // Style picked from a four-way comparison (#546 Phase B): no outer
+    // frame, no radius, no header fill — the header/body split is carried
+    // by semibold + a rule stronger than the hairline row separators.
+    assert.ok(
+      !/(^|;)\s*border\s*:/.test(table!.decls) && !/border-radius/.test(table!.decls),
+      'prose tables are frameless — no outer border/radius on .maka-prose table',
     );
-    assert.match(table!.decls, /border-spacing:\s*0/, 'separate borders need border-spacing: 0 to keep the row grid seamless');
+    assert.match(table!.decls, /border-spacing:\s*0/, 'zero border-spacing keeps the row separators seamless single hairlines');
+    const th = blocks.find(({ selectors }) => /^\.maka-prose\s+th$/.test(selectors));
+    assert.ok(th, 'expected a .maka-prose th rule');
+    assert.ok(
+      !/background/.test(th!.decls)
+      && /border-bottom:\s*var\(--border-width-hairline\)\s+solid\s+oklch\(from var\(--foreground\)/.test(th!.decls),
+      'th carries no fill and a foreground-alpha rule stronger than --border for the header split',
+    );
   });
 
   it('blockquote inner block margins are neutralized at both ends', async () => {

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -188,6 +188,14 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
       /\.maka-bubble-streaming\s*>\s*p:last-child\s*\{[^}]*display:\s*inline/,
       'the caret-inline rule must be scoped to .maka-bubble-streaming so committed messages and .maka-prose reusers (tool results, #546 PR6) keep block paragraphs',
     );
+    // Negative side of the same contract: an unscoped variant on the
+    // committed-message classes would inline the final paragraph of every
+    // settled message — the exact regression this pass removed.
+    assert.ok(
+      !/\.maka-prose\s*>\s*p:last-child/.test(css)
+      && !/\.maka-bubble-assistant\s*>\s*p:last-child/.test(css),
+      'no p:last-child inlining on .maka-prose / .maka-bubble-assistant — committed messages must keep block paragraphs',
+    );
   });
 
   it('the code-block pre code reset clears the inline-code border', async () => {
@@ -245,6 +253,12 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
     assert.ok(
       last,
       'blockquote > :last-child must zero margin-bottom — a trailing p margin stacks on the quote padding (8px top vs 20px bottom) and tilts the quote',
+    );
+    const first = blocks.find(({ selectors, decls }) =>
+      /\.maka-prose\s+blockquote\s*>\s*:first-child/.test(selectors) && /margin-top:\s*0/.test(decls));
+    assert.ok(
+      first,
+      'blockquote > :first-child must zero margin-top — the other end of the same stacking asymmetry',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -221,6 +221,20 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
       && /border-bottom:\s*var\(--border-width-hairline\)\s+solid\s+oklch\(from var\(--foreground\)/.test(th!.decls),
       'th carries no fill and a foreground-alpha rule stronger than --border for the header split',
     );
+    // Cascade guard: the last-row border reset must be tbody-scoped. The
+    // GFM thead row is its parent's :last-child too, and an unscoped
+    // `.maka-prose tr:last-child th` (0,2,2) out-specifies `.maka-prose th`
+    // (0,1,1) — it silently erases the reinforced header rule asserted
+    // above while this declaration-level scan keeps passing.
+    assert.ok(
+      !/\.maka-prose\s+tr:last-child/.test(css),
+      'the last-row border reset must not use an unscoped `.maka-prose tr:last-child` — it matches the thead row and kills the header rule; scope it to tbody',
+    );
+    assert.match(
+      css,
+      /\.maka-prose\s+tbody\s+tr:last-child\s+th,\s*\.maka-prose\s+tbody\s+tr:last-child\s+td\s*\{[^}]*border-bottom:\s*0/,
+      'frameless tables must still drop the stray rule under the final body row',
+    );
   });
 
   it('blockquote inner block margins are neutralized at both ends', async () => {

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -197,7 +197,7 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
       /\.maka-code-block\s+pre\s+code\b/.test(selectors) && /border:\s*0/.test(decls));
     assert.ok(
       reset,
-      '`.maka-prose .maka-code-block pre code` must reset `border: 0` — the inline-code pill border on an inline <code> paints a rounded outline around every wrapped line box inside the pre',
+      '`.maka-prose .maka-code-block pre code` must reset `border: 0` — the inline-code pill dropped its border in this pass, but if one ever returns it paints a rounded outline around every wrapped line box inside the pre (inline elements paint per line box)',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -221,6 +221,11 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
       !/(^|;)\s*border\s*:/.test(table!.decls) && !/border-radius/.test(table!.decls),
       'prose tables are frameless — no outer border/radius on .maka-prose table',
     );
+    // `border-collapse` is the declaration that actually reaches the
+    // anonymous inner table box (inherited); `border-spacing: 0` is intent
+    // documentation — the property is not inherited and its initial value
+    // is already 0.
+    assert.match(table!.decls, /border-collapse:\s*separate/, 'separate border model — collapse would void radius/outer borders if chrome ever returns');
     assert.match(table!.decls, /border-spacing:\s*0/, 'zero border-spacing keeps the row separators seamless single hairlines');
     const th = blocks.find(({ selectors }) => /^\.maka-prose\s+th$/.test(selectors));
     assert.ok(th, 'expected a .maka-prose th rule');

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -88,8 +88,8 @@ describe('MARKDOWN-PROSE-CONVERGE-0 contract (#546 PR4)', () => {
     for (const el of PROSE_ELEMENTS) {
       // `.maka-bubble-assistant <el>` as a descendant — the old prose form.
       // The shell's own `.maka-bubble-assistant {…}` and its generic
-      // `> :first-child` / `> :last-child` / `> :nth-last-child(2)` resets
-      // are element-agnostic, so they don't trip this (no bare element type).
+      // `> :first-child` / `> :last-child` resets are element-agnostic, so
+      // they don't trip this (no bare element type).
       const re = new RegExp(`\\.maka-bubble-assistant\\s+${el}\\b`);
       if (re.test(stripCssComments(css))) lingering.push(el);
     }
@@ -161,6 +161,67 @@ describe('CODE-BLOCK-PRE-FONT-TIER-0 contract (#546 PR5)', () => {
       css,
       /\[data-slot="message"\]\s+pre\s*\{[^}]*font:\s*inherit/,
       'the [data-slot="message"] pre { font: inherit } reset must remain so non-code-block raw <pre> (user / system) inherits the message font instead of UA monospace',
+    );
+  });
+});
+
+describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
+  // Four rendering defects fixed in the 13px prose-polish pass. Each is the
+  // kind of regression that survives visual review (subtle in light theme,
+  // state-dependent, or masked by fixture structure), so the shape of the
+  // fix is pinned here.
+
+  it('no structural :nth-last-child hacks on prose containers (PR #212 timestamp leftovers)', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    // The bubble stopped ending with an inline timestamp child long ago;
+    // these selectors instead zeroed/inlined the second-to-last *markdown*
+    // block (paragraph glued to a heading/table/code block above it).
+    assert.ok(
+      !/\.maka-bubble-assistant\s*>\s*:nth-last-child/.test(css)
+      && !/\.maka-prose\s*>\s*p:nth-last-child/.test(css),
+      'structural :nth-last-child prose hacks must not return — they assume a trailing non-markdown child that no longer exists',
+    );
+    // The streaming caret still needs the trailing paragraph inlined, but
+    // scoped to the streaming bubble only.
+    assert.match(
+      css,
+      /\.maka-bubble-streaming\s*>\s*p:last-child\s*\{[^}]*display:\s*inline/,
+      'the caret-inline rule must be scoped to .maka-bubble-streaming so committed messages and .maka-prose reusers (tool results, #546 PR6) keep block paragraphs',
+    );
+  });
+
+  it('the code-block pre code reset clears the inline-code border', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const reset = blocks.find(({ selectors, decls }) =>
+      /\.maka-code-block\s+pre\s+code\b/.test(selectors) && /border:\s*0/.test(decls));
+    assert.ok(
+      reset,
+      '`.maka-prose .maka-code-block pre code` must reset `border: 0` — the inline-code pill border on an inline <code> paints a rounded outline around every wrapped line box inside the pre',
+    );
+  });
+
+  it('prose tables use border-collapse: separate so radius + outer border render', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const table = blocks.find(({ selectors }) => /^\.maka-prose\s+table$/.test(selectors));
+    assert.ok(table, 'expected a .maka-prose table rule');
+    assert.match(
+      table!.decls,
+      /border-collapse:\s*separate/,
+      'collapsed borders void border-radius and swallow the outer hairline — the table edge disappears',
+    );
+    assert.match(table!.decls, /border-spacing:\s*0/, 'separate borders need border-spacing: 0 to keep the row grid seamless');
+  });
+
+  it('blockquote inner block margins are neutralized at both ends', async () => {
+    const css = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const last = blocks.find(({ selectors, decls }) =>
+      /\.maka-prose\s+blockquote\s*>\s*:last-child/.test(selectors) && /margin-bottom:\s*0/.test(decls));
+    assert.ok(
+      last,
+      'blockquote > :last-child must zero margin-bottom — a trailing p margin stacks on the quote padding (8px top vs 20px bottom) and tilts the quote',
     );
   });
 });

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -529,13 +529,12 @@
   vertical-align: -2px;
 }
 @keyframes maka-cursor { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
-/* The truncation badge (`role="status"`, chat-view.tsx) means rendered
-   output stopped growing — a caret blinking under it promises text that
-   will never come. It also breaks the `> p:last-child` inlining above, so
-   the caret would sit alone on its own line. Drop it. */
-.maka-bubble-streaming:has(> [role="status"])::after {
-  content: none;
-}
+/* When the truncation badge (`role="status"`, chat-view.tsx) is the last
+   child, the caret sits after the badge instead of the text. Accepted: the
+   badge does NOT mean the stream froze — `applyAssistantDelta` also sets
+   `truncated` for a single over-large delta (per-delta cap) while later
+   deltas keep appending, so hiding the caret there would kill a live
+   indicator. CSS can't tell the two truncation kinds apart. */
 @media (prefers-reduced-motion: reduce) {
   .maka-bubble-streaming::after { animation: none; opacity: 1; }
 }

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -401,9 +401,12 @@
   border-bottom: var(--border-width-hairline) solid var(--border);
   text-align: left;
 }
-/* Without a frame the table must not end on a stray rule. */
-.maka-prose tr:last-child th,
-.maka-prose tr:last-child td {
+/* Without a frame the table must not end on a stray rule. Scoped to
+   tbody: the thead row is its parent's :last-child too, and an unscoped
+   `tr:last-child th` (0,2,2) out-specifies `.maka-prose th` (0,1,1) —
+   it would erase the reinforced header rule below. */
+.maka-prose tbody tr:last-child th,
+.maka-prose tbody tr:last-child td {
   border-bottom: 0;
 }
 .maka-prose th {

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -147,10 +147,16 @@
 .maka-prose code {
   font-variant-numeric: tabular-nums;
 }
-.maka-prose h1 { font-size: 1.4667em; }
-.maka-prose h2 { font-size: 1.2667em; }
-.maka-prose h3 { font-size: 1.0667em; }
-.maka-prose h4 { font-size: 0.9333em; color: var(--foreground-secondary); }
+/* Heading ladder re-pinned for the 13px body base (#546 Phase B): the old
+   em values were derived for 15px (22/19/16/14) and landed on fractional
+   pixels at 13 (19.07/16.47/13.87/12.13), with h3 only 0.87px above body
+   and h4 *below* body. Integer targets now: 19 / 16 / 14 / 13. h4 sits at
+   1em and reads as a heading via weight + secondary color (same convention
+   as GitHub's 1em h4). */
+.maka-prose h1 { font-size: 1.4615em; }
+.maka-prose h2 { font-size: 1.2308em; }
+.maka-prose h3 { font-size: 1.0769em; }
+.maka-prose h4 { font-size: 1em; color: var(--foreground-secondary); }
 .maka-prose ul,
 .maka-prose ol {
   margin: 0 0 var(--space-3);

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -527,6 +527,13 @@
   vertical-align: -2px;
 }
 @keyframes maka-cursor { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+/* The truncation badge (`role="status"`, chat-view.tsx) means rendered
+   output stopped growing — a caret blinking under it promises text that
+   will never come. It also breaks the `> p:last-child` inlining above, so
+   the caret would sit alone on its own line. Drop it. */
+.maka-bubble-streaming:has(> [role="status"])::after {
+  content: none;
+}
 @media (prefers-reduced-motion: reduce) {
   .maka-bubble-streaming::after { animation: none; opacity: 1; }
 }

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -118,8 +118,15 @@
 }
 .maka-bubble-assistant > :first-child { margin-top: 0; }
 .maka-bubble-assistant > :last-child { margin-bottom: 0; }
-.maka-bubble-assistant > :nth-last-child(2) { margin-bottom: 0; }
-.maka-prose > p:nth-last-child(2) { display: inline; }
+/* Streaming caret rides the last text line: the caret is
+   `.maka-bubble-streaming::after`, and after a block-level trailing <p> it
+   would wrap onto its own anonymous line. Inline the trailing paragraph
+   only while streaming. (PR #212 used `:nth-last-child(2)` variants of
+   this + the margin reset above because the bubble then ended with an
+   inline timestamp child; the timestamp moved to the turn footer and the
+   stale hacks instead zeroed/inlined the second-to-last *markdown* block —
+   issue #546 Phase B.) */
+.maka-bubble-streaming > p:last-child { display: inline; }
 .maka-prose p {
   margin: 0 0 var(--space-3);
   text-wrap: pretty;
@@ -278,6 +285,10 @@
   padding: 0;
   background: transparent;
   font-size: inherit;
+  /* The inline-code pill border must not leak in here: <code> is an inline
+     box, so a leftover border paints a rounded outline around every wrapped
+     line box inside the pre (clearly visible in dark). */
+  border: 0;
 }
 
 /* Syntax highlight palette for highlight.js / lowlight class names.
@@ -336,10 +347,19 @@
   border-radius: 0 var(--radius-surface) var(--radius-surface) 0;
   color: var(--foreground-secondary);
 }
+/* Inner block margins would stack on the quote's own padding (8px top vs
+   8px + trailing p margin = 20px bottom) and tilt the quote visually. */
+.maka-prose blockquote > :first-child { margin-top: 0; }
+.maka-prose blockquote > :last-child { margin-bottom: 0; }
 .maka-prose table {
   width: 100%;
   margin: 0 0 var(--space-3);
-  border-collapse: collapse;
+  /* `separate` (not `collapse`): collapsed borders void border-radius and
+     swallow the outer hairline, leaving the table with no visible edge.
+     Cells only paint bottom borders, so zero spacing keeps the grid
+     seamless while the outer border + rounded corners actually render. */
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: var(--font-size-ui);
   overflow: hidden;
   /* PR-UI-LAYOUT-28: table radius 8 → 10 joins the card family,

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -358,7 +358,17 @@
 .maka-prose blockquote > :first-child { margin-top: 0; }
 .maka-prose blockquote > :last-child { margin-bottom: 0; }
 .maka-prose table {
-  width: 100%;
+  /* Shrink-wrap to content (GitHub's markdown-table shape): a short
+     three-column table stretched to the full measure reads as voids
+     between columns. `display: block` makes the element a scroll
+     container, `max-content` lets narrow tables hug their cells, and the
+     100% cap + overflow-x turns over-wide tables into a horizontal
+     scroller inside the prose measure. border-collapse/spacing are
+     inherited properties, so the anonymous inner table keeps them. */
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
   margin: 0 0 var(--space-3);
   /* `separate` (not `collapse`): collapsed borders void border-radius and
      swallow the outer hairline, leaving the table with no visible edge.
@@ -367,7 +377,6 @@
   border-collapse: separate;
   border-spacing: 0;
   font-size: var(--font-size-ui);
-  overflow: hidden;
   /* PR-UI-LAYOUT-28: table radius 8 → 10 joins the card family,
    * and a hairline outer border gives the table chrome a clean
    * edge against the warm panel. Without the border the rounded
@@ -391,6 +400,11 @@
   color: var(--foreground-secondary);
   font-weight: var(--font-weight-semibold);
   background: var(--foreground-3);
+  /* Headers are short labels; letting them wrap means a column-squeezed
+     table pulverizes 2-char CJK headers into vertical stacks. Locking
+     them to one line raises the table's min-content width so degenerate
+     tables hit the overflow-x scroller instead. Body cells still wrap. */
+  white-space: nowrap;
   /* PR-UI-LAYOUT-28: header tone slightly darker than body cell
    * to make the header row read at first glance — was the same
    * `--foreground-3` as nothing else, now sits between cell and

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -357,6 +357,12 @@
    8px + trailing p margin = 20px bottom) and tilt the quote visually. */
 .maka-prose blockquote > :first-child { margin-top: 0; }
 .maka-prose blockquote > :last-child { margin-bottom: 0; }
+/* Borderless minimal table (#546 Phase B, picked from a four-way style
+   comparison): no outer frame or header fill — the header reads via
+   semibold + a reinforced rule, rows via hairline separators. Replaces
+   the PR-UI-LAYOUT-28 card chrome (radius + outer hairline + th tint):
+   the 3% th tint was invisible in practice and the frame boxed the
+   table in for no informational gain. */
 .maka-prose table {
   /* Shrink-wrap to content (GitHub's markdown-table shape): a short
      three-column table stretched to the full measure reads as voids
@@ -370,19 +376,11 @@
   max-width: 100%;
   overflow-x: auto;
   margin: 0 0 var(--space-3);
-  /* `separate` (not `collapse`): collapsed borders void border-radius and
-     swallow the outer hairline, leaving the table with no visible edge.
-     Cells only paint bottom borders, so zero spacing keeps the grid
-     seamless while the outer border + rounded corners actually render. */
+  /* `separate` + zero spacing: cells only paint bottom borders, so the
+     row separators stay seamless single hairlines. */
   border-collapse: separate;
   border-spacing: 0;
   font-size: var(--font-size-ui);
-  /* PR-UI-LAYOUT-28: table radius 8 → 10 joins the card family,
-   * and a hairline outer border gives the table chrome a clean
-   * edge against the warm panel. Without the border the rounded
-   * corners would clip nothing visible. */
-  border-radius: var(--radius-surface);
-  border: var(--border-width-hairline) solid var(--border);
 }
 .maka-prose th,
 .maka-prose td {
@@ -390,8 +388,7 @@
   border-bottom: var(--border-width-hairline) solid var(--border);
   text-align: left;
 }
-/* PR-UI-LAYOUT-28: drop the trailing border on the last row so the
- * rounded corner reads cleanly. */
+/* Without a frame the table must not end on a stray rule. */
 .maka-prose tr:last-child th,
 .maka-prose tr:last-child td {
   border-bottom: 0;
@@ -399,16 +396,14 @@
 .maka-prose th {
   color: var(--foreground-secondary);
   font-weight: var(--font-weight-semibold);
-  background: var(--foreground-3);
+  /* Frameless header: no fill — semibold plus a rule visibly stronger
+     than the hairline row separators carries the header/body split. */
+  border-bottom: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.25);
   /* Headers are short labels; letting them wrap means a column-squeezed
      table pulverizes 2-char CJK headers into vertical stacks. Locking
      them to one line raises the table's min-content width so degenerate
      tables hit the overflow-x scroller instead. Body cells still wrap. */
   white-space: nowrap;
-  /* PR-UI-LAYOUT-28: header tone slightly darker than body cell
-   * to make the header row read at first glance — was the same
-   * `--foreground-3` as nothing else, now sits between cell and
-   * code-block tints. */
   letter-spacing: var(--tracking-normal);
 }
 .maka-prose hr {

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -203,13 +203,18 @@
   /* 0.92em of the 13px body ≈ 12px; at 0.86em it would fall to caption
      size (11.2px) and stop reading as body-level code. */
   font-size: 0.92em;
-  padding: 1px var(--space-1-5);
+  /* No vertical padding and no border: the Geist Mono font box is already
+     15.5px at this size, and with 1px padding + 1px border the pill's ink
+     box hit 19.5px — the full line box — so hard-break lines carrying
+     pills touched (measured 1.5px to the next line's glyphs, 0 between
+     two pills). Bg-only pills leave ~5.5px of inter-line air, matching
+     plain text; the dropped border was 3% alpha and read as invisible. */
+  padding: 0 var(--space-1-5);
   /* PR-UI-LAYOUT-28: inline code radius 4 → 5. Tiny bump but
    * pulls it slightly out of the "tight tag" feel into a calmer
    * pill rhythm that matches the rest of the warm-canvas chrome. */
   border-radius: var(--radius-control);
   background: var(--foreground-5);
-  border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.03);
 }
 /* Block code goes inside a maka-code-block wrapper that adds a language
    pill + copy button on top of the pre. Pre keeps its monospace styling

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -135,7 +135,12 @@
 .maka-prose h2,
 .maka-prose h3,
 .maka-prose h4 {
-  margin: var(--space-4) 0 var(--space-2);
+  /* Section rhythm keyed to the 12px paragraph gap: 20px above (clearly
+     more than a paragraph break, so sections separate) and 12px below
+     (exactly the paragraph rhythm, so the heading holds its section).
+     The old 16/8 sat too close to the paragraph gap on both sides —
+     headings neither separated sections nor matched the body rhythm. */
+  margin: var(--space-5) 0 var(--space-3);
   line-height: var(--leading-tight);
   font-weight: var(--font-weight-semibold);
   text-wrap: balance;
@@ -384,7 +389,10 @@
 }
 .maka-prose th,
 .maka-prose td {
-  padding: var(--space-2) var(--space-3);
+  /* Frameless tables read denser: 8px vertical padding made rows 36.5px —
+     the inter-row whitespace was 2.5× the paragraph line gap and rows
+     floated apart. 6px lands rows at ~32px. */
+  padding: var(--space-1-5) var(--space-3);
   border-bottom: var(--border-width-hairline) solid var(--border);
   text-align: left;
 }

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -379,8 +379,10 @@
      between columns. `display: block` makes the element a scroll
      container, `max-content` lets narrow tables hug their cells, and the
      100% cap + overflow-x turns over-wide tables into a horizontal
-     scroller inside the prose measure. border-collapse/spacing are
-     inherited properties, so the anonymous inner table keeps them. */
+     scroller inside the prose measure. The rows re-wrap in an anonymous
+     inner table box: `border-collapse` is inherited so `separate`
+     reaches it; `border-spacing` is NOT inherited — its initial value
+     is already 0, the declaration below just documents the intent. */
   display: block;
   width: max-content;
   max-width: 100%;

--- a/packages/ui/stories/markdown.stories.tsx
+++ b/packages/ui/stories/markdown.stories.tsx
@@ -210,6 +210,20 @@ export const LongFormArticle: Story = {
             '## 验证',
             '',
             '写完后跑一次 `npm run build-storybook`，确认所有 story 编译通过；再视情况补回归截图。',
+            '',
+            '### 截图基线怎么补',
+            '',
+            '新 story 落地后跑一遍采集脚本，把首轮产物当作基线入库。',
+            '',
+            '#### 已知噪声',
+            '',
+            '字体渲染在不同 GPU 下有亚像素差异，比对时用容差阈值。',
+            '',
+            // hr; `***` instead of triple-dash so the storybook-baseline token
+            // scan doesn't read the quoted literal as a custom-property token.
+            '***',
+            '',
+            '以上是全部范围；有疑问先在 issue 里讨论再动手。',
           ].join('\n')}
         />
       </Bubble>

--- a/packages/ui/stories/markdown.stories.tsx
+++ b/packages/ui/stories/markdown.stories.tsx
@@ -179,6 +179,30 @@ export const LinkRouting: Story = {
   ),
 };
 
+// Tables shrink-wrap to content and only scroll when wider than the prose
+// measure — this story pins the over-wide branch (horizontal scroller
+// inside the rounded border) next to the narrow tables in the stories above.
+export const WideTable: Story = {
+  render: () => (
+    <ProseFrame>
+      <Bubble variant="assistant" className="maka-bubble-with-actions">
+        <Markdown
+          text={[
+            '列多且内容长的表格会在正文宽度内横向滚动：',
+            '',
+            '| 会话 ID | 连接 | 模型 | 状态 | 最近一条消息时间 | 输入 tokens | 输出 tokens | 费用（USD） |',
+            '| --- | --- | --- | --- | --- | --- | --- | --- |',
+            '| visual-smoke-turn-control-primary | zai-live | glm-5.1 | waiting_for_user | 2026-07-07 18:42:11 | 125,032 | 32,480 | 0.4210 |',
+            '| visual-smoke-turn-control-branch-visible | zai-live | glm-5 | running | 2026-07-07 18:40:02 | 98,771 | 21,006 | 0.2988 |',
+            '',
+            '表格后的正文保持正常段落间距。',
+          ].join('\n')}
+        />
+      </Bubble>
+    </ProseFrame>
+  ),
+};
+
 export const LongFormArticle: Story = {
   render: () => (
     <ProseFrame width={680}>

--- a/packages/ui/stories/markdown.stories.tsx
+++ b/packages/ui/stories/markdown.stories.tsx
@@ -180,8 +180,8 @@ export const LinkRouting: Story = {
 };
 
 // Tables shrink-wrap to content and only scroll when wider than the prose
-// measure — this story pins the over-wide branch (horizontal scroller
-// inside the rounded border) next to the narrow tables in the stories above.
+// measure — this story pins the over-wide branch (frameless horizontal
+// scroller) next to the narrow tables in the stories above.
 export const WideTable: Story = {
   render: () => (
     <ProseFrame>


### PR DESCRIPTION
## Summary

Bug pass over the chat Markdown body (`.maka-prose`) at the new 13px base: remove the stale PR #212 structural hacks that glued the second-to-last block to its neighbor, re-pin the heading ladder to integer pixels, restyle tables to the frameless GitHub shape (shrink-wrap + horizontal scroll + reinforced header rule), square blockquote/inline-code metrics, and key heading/table-row rhythm to the 12px paragraph gap. Every fix is probe-verified and contract-locked; the branch then passed a two-round external review gate (details below).

## Why

Four user-reported rendering bugs at 13px, all reproduced and measured:

- **Paragraphs glued to the block above** (code block / heading / table): PR #212's `:nth-last-child(2)` hacks assumed a trailing inline timestamp child; the timestamp moved to the turn footer long ago, so the hacks zeroed/inlined the second-to-last *markdown* block instead. Removed; the streaming caret now rides `.maka-bubble-streaming > p:last-child` only.
- **Invisible table chrome**: `border-collapse: collapse` voided the radius and outer hairline, and the 3% header tint never read. Replaced (via a four-way style comparison) with frameless tables: hairline row separators + a 25% foreground header rule.
- **Per-line outline inside code blocks**: the inline-code pill border painted around every wrapped line box of the inline `<code>` inside `pre`. Reset, and the pill itself slimmed (no vertical padding/border) so hard-break lines breathe.
- **Lopsided blockquotes**: trailing paragraph margin stacked on the quote padding (8px top vs 20px bottom). First/last child margins neutralized.

Plus rhythm: the heading em ladder was derived for 15px and landed on fractional pixels at 13 (h4 *below* body); re-pinned to 19/16/14/13 with 20px-above / 12px-below section spacing keyed to the paragraph gap.

Refs #546 (Phase B). Verified-but-out-of-scope findings tracked in #618.

## Scope

Changed: `chat-message.css` (prose layer only), `markdown-prose-contract.test.ts` (new `PROSE-POLISH-13PX-0` contract, 4 tests), `markdown.stories.tsx` (h3/h4/hr samples + `WideTable` story pinning the horizontal-scroll branch).

Not included (tracked in #618): `markdown-link.css` layering (pre-existing double underline on external links), re-homing load-bearing typography onto `.maka-prose` before PR6 reuse, prose file split, table a11y wrapper.

## Review gate

Two rounds of independent review, findings verified against source before accepting:

- **Round 1** (Fable subagent + codex `xhigh` + pi glm-5.2 `xhigh`): shared P1 — the unscoped `tr:last-child` reset out-specified `.maka-prose th` and erased the reinforced header rule on every GFM table (thead's row is always its `:last-child`). Fixed by tbody-scoping; the contract now bans the unscoped form (it had passed on a declaration-level scan while the rendered style was dead).
- **Round 2** (codex native review + pi, full PR diff): no P0/P1. codex caught that my round-1 caret suppression under the truncation badge was wrong — `applyAssistantDelta` sets `truncated` for the per-delta cap too, so the badge can show while output still grows; suppression reverted, caret-after-badge documented as accepted. pi's P2 (GitHub-shape `display: block` tables strip ARIA table semantics) accepted as the same trade-off GitHub ships, tracked in #618 with the wrapper-div fix shape.

## Verification

- `npm run -w @maka/desktop test` — 2182 pass, 0 fail (worktree suite).
- Offscreen-Electron computed-style/geometry probes for each fix: th `border-bottom` 0 → 1px @25% alpha; pill ink box 19.5 → 15.5px (inter-line ink gap 1.5 → 3.5px); heading gaps 20/12; table rows ~32px; caret `▎` present in normal streaming.
- Storybook light + dark recaptured each round (`product-markdown` stories incl. `WideTable`); dev Electron app run twice for visual sign-off on real chat content.

## User-facing impact

Assistant Markdown only: paragraphs no longer glue to the preceding block; tables shrink-wrap, scroll horizontally when wide, and show a visible header rule with no outer frame; code blocks lose the phantom per-line outline; blockquotes sit level; headings separate their sections (20px above / 12px below); inline-code pills are slimmer so wrapped lines keep their line gap.

## Reviewer notes

The new contract tests guard **cascades**, not just declarations: unscoped `.maka-prose tr:last-child` and any `p:last-child` inlining on committed-message classes are banned outright — both are regressions that survive declaration-level scans. `border-spacing: 0` on the block-display table is intent documentation (the property isn't inherited; the anonymous inner table's initial value is already 0) — `border-collapse: separate` is the load-bearing declaration and is pinned.
