### PR TITLE
feat: enable staleToolResultPrune by default on headless, desktop, and CLI

### DIFF
--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -191,6 +191,20 @@ describe('desktop staleToolResultPrune policy', () => {
     assert.equal(policy?.staleToolResultPrune, undefined);
   });
 
+  test('accepts standard truthy values as enabled', () => {
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE = 'true';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.staleToolResultPrune?.enabled, true);
+  });
+
+  test('rejects malformed boolean values instead of silently disabling', () => {
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE = 'maybe';
+    assert.throws(
+      () => buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' }),
+      /MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE must be a boolean/,
+    );
+  });
+
   test('respects max result estimated tokens env', () => {
     process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS = '4096';
     const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });

--- a/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/context-budget-policy.test.ts
@@ -146,3 +146,70 @@ describe('desktop activeToolResultPrune policy', () => {
     assert.equal(policy?.maxHistoryEstimatedTokens, 128_000 - 4096);
   });
 });
+
+const STALE_PRUNE_ENV_KEYS = [
+  'MAKA_CONTEXT_BUDGET',
+  'MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE',
+  'MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS',
+  'MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS',
+  'MAKA_CONTEXT_MIN_RECENT_TURNS',
+] as const;
+
+describe('desktop staleToolResultPrune policy', () => {
+  const savedStaleEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of STALE_PRUNE_ENV_KEYS) {
+      savedStaleEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of STALE_PRUNE_ENV_KEYS) {
+      if (savedStaleEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedStaleEnv[key];
+    }
+  });
+
+  test('is enabled by default with the measured 2048-token threshold', () => {
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.staleToolResultPrune?.enabled, true);
+    assert.equal(policy?.staleToolResultPrune?.maxResultEstimatedTokens, 2048);
+    assert.equal(policy?.staleToolResultPrune?.minRecentTurnsFull, 2);
+  });
+
+  test('can be disabled with explicit false', () => {
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE = 'false';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.staleToolResultPrune, undefined);
+  });
+
+  test('can be disabled with explicit off', () => {
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE = 'off';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.staleToolResultPrune, undefined);
+  });
+
+  test('respects max result estimated tokens env', () => {
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_TOKENS = '4096';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy?.staleToolResultPrune?.maxResultEstimatedTokens, 4096);
+  });
+
+  test('respects min recent turns full env with MAKA_CONTEXT_MIN_RECENT_TURNS fallback', () => {
+    process.env.MAKA_CONTEXT_MIN_RECENT_TURNS = '3';
+    const fallbackPolicy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(fallbackPolicy?.staleToolResultPrune?.minRecentTurnsFull, 3);
+
+    process.env.MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS = '5';
+    const explicitPolicy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(explicitPolicy?.staleToolResultPrune?.minRecentTurnsFull, 5);
+  });
+
+  test('MAKA_CONTEXT_BUDGET=off disables the whole policy including staleToolResultPrune', () => {
+    process.env.MAKA_CONTEXT_BUDGET = 'off';
+    const policy = buildDefaultContextBudgetPolicy(openaiConnection(), { name: 'desktop-default-history-budget' });
+    assert.equal(policy, undefined);
+  });
+});

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1473,12 +1473,15 @@ describe('runHarborCell', () => {
   test('Harbor active tool result prune can be disabled with explicit off', () => {
     const options = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' });
     assert.equal(options.contextBudget?.activeToolResultPrune, undefined);
-    assert.deepEqual(options.contextBudget?.staleToolResultPrune, { enabled: true });
+    assert.deepEqual(options.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 2 });
   });
 
   test('Harbor stale tool result prune is enabled by default without any env', () => {
     const backend = buildHarborCellContextBudgetBackendOptions({});
-    assert.deepEqual(backend.contextBudget?.staleToolResultPrune, { enabled: true });
+    // minRecentTurnsFull is set explicitly so the runtime protection window
+    // matches the policy snapshot and desktop default instead of the runtime's
+    // internal ?? 1 fallback.
+    assert.deepEqual(backend.contextBudget?.staleToolResultPrune, { enabled: true, minRecentTurnsFull: 2 });
 
     const snapshot = buildHarborCellContextBudgetPolicySnapshot({});
     assert.equal(snapshot?.enabled, true);
@@ -1491,6 +1494,17 @@ describe('runHarborCell', () => {
     const options = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'off' });
     assert.equal(options.contextBudget?.staleToolResultPrune, undefined);
     assert.deepEqual(options.contextBudget?.activeToolResultPrune, { enabled: true });
+  });
+
+  test('Harbor stale tool result prune min recent turns falls back to MAKA_CONTEXT_MIN_RECENT_TURNS', () => {
+    const fallback = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_MIN_RECENT_TURNS: '3' });
+    assert.equal(fallback.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 3);
+
+    const explicit = buildHarborCellContextBudgetBackendOptions({
+      MAKA_CONTEXT_MIN_RECENT_TURNS: '3',
+      MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS: '5',
+    });
+    assert.equal(explicit.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 5);
   });
 
   test('Harbor context budget is empty when both default-on prunes are explicitly off', () => {

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1430,7 +1430,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor context budget env treats explicit false-like booleans as disabled', () => {
-    // stale and archive default off; activeToolResultPrune defaults on, so disabling
+    // archive retrieval defaults off; stale and active prune default on, so disabling
     // stale/archive alone still leaves an enabled activeToolResultPrune policy.
     assert.deepEqual(
       buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'false' }).contextBudget?.activeToolResultPrune,
@@ -1471,14 +1471,35 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor active tool result prune can be disabled with explicit off', () => {
-    assert.equal(
-      buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' }).contextBudget,
-      undefined,
-    );
-    assert.equal(
-      buildHarborCellContextBudgetPolicySnapshot({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' }),
-      undefined,
-    );
+    const options = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off' });
+    assert.equal(options.contextBudget?.activeToolResultPrune, undefined);
+    assert.deepEqual(options.contextBudget?.staleToolResultPrune, { enabled: true });
+  });
+
+  test('Harbor stale tool result prune is enabled by default without any env', () => {
+    const backend = buildHarborCellContextBudgetBackendOptions({});
+    assert.deepEqual(backend.contextBudget?.staleToolResultPrune, { enabled: true });
+
+    const snapshot = buildHarborCellContextBudgetPolicySnapshot({});
+    assert.equal(snapshot?.enabled, true);
+    assert.equal(snapshot?.staleToolResultPrune?.enabled, true);
+    assert.equal(snapshot?.staleToolResultPrune?.maxResultEstimatedTokens, 2048);
+    assert.equal(snapshot?.staleToolResultPrune?.minRecentTurnsFull, 2);
+  });
+
+  test('Harbor stale tool result prune can be disabled with explicit off', () => {
+    const options = buildHarborCellContextBudgetBackendOptions({ MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'off' });
+    assert.equal(options.contextBudget?.staleToolResultPrune, undefined);
+    assert.deepEqual(options.contextBudget?.activeToolResultPrune, { enabled: true });
+  });
+
+  test('Harbor context budget is empty when both default-on prunes are explicitly off', () => {
+    const env = {
+      MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'off',
+      MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'off',
+    };
+    assert.equal(buildHarborCellContextBudgetBackendOptions({ ...env }).contextBudget, undefined);
+    assert.equal(buildHarborCellContextBudgetPolicySnapshot({ ...env }), undefined);
   });
 
   test('Harbor parses semantic compact policy for headless runs', () => {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -704,7 +704,7 @@ export function buildHarborCellContextBudgetBackendOptions(
     env.MAKA_HARBOR_CONTEXT_STALE_TOOL_RESULT_PRUNE ??
     env.MAKA_TOOL_RESULT_PRUNE,
     'MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE',
-  ) ?? false;
+  ) ?? true;
   const activePruneEnabled = booleanEnv(
     env.MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE ??
     env.MAKA_HARBOR_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE ??

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -760,7 +760,9 @@ export function buildHarborCellContextBudgetBackendOptions(
     contextBudget.staleToolResultPrune = {
       enabled: true,
       ...(maxResultEstimatedTokens !== undefined ? { maxResultEstimatedTokens } : {}),
-      ...(minRecentTurnsFull !== undefined ? { minRecentTurnsFull } : {}),
+      // Explicit so the runtime protection window matches the policy snapshot
+      // and desktop default (2) instead of the runtime's internal ?? 1 fallback.
+      minRecentTurnsFull: minRecentTurnsFull ?? minRecentTurns ?? 2,
     };
   }
 

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -95,7 +95,11 @@ export function buildManualCompactLookupPolicy(
 function buildStaleToolResultPrunePolicy(
   env: Record<string, string | undefined>,
 ): NonNullable<ContextBudgetPolicy['staleToolResultPrune']> | undefined {
-  if (env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE !== 'on') return undefined;
+  const enabled = parseOptionalBoolean(
+    env.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE,
+    'MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE',
+  );
+  if (enabled === false) return undefined;
   return {
     enabled: true,
     maxResultEstimatedTokens: parsePositiveInt(


### PR DESCRIPTION
## Summary

Enable `staleToolResultPrune` (prior-turn oversized tool-result pruning) by default on headless Harbor cells and in the shared `buildDefaultContextBudgetPolicy` used by desktop and the CLI. This completes the tool-result prune pipeline that #498 started: `activeToolResultPrune` already trims oversized results within the current turn, but without stale prune the full results re-enter the request on every subsequent turn when history is rebuilt from runtime events, re-spending the tokens active prune saved.

## Why

Active and stale prune are the same invariant applied at two sites — oversized tool results (default 2048 estimated tokens) never re-enter model computation in full; they are archived and replaced with placeholders. #498 enabled the within-turn half by default; this PR enables the cross-turn half so the invariant holds across multi-turn sessions (desktop conversations, continuation-enabled benchmark runs).

Both sites share the same archive wiring and the stale prune degrades safely: it only prunes results that archived successfully with a matching hash, and keeps originals (counting `archiveWriteFailures`) otherwise. The most recent `minRecentTurnsFull` turns (default 2) always keep full results.

Refs #481

## Scope

Changed:

- headless `harbor-cell.ts`: `pruneEnabled` default `?? false` → `?? true`; `staleToolResultPrune.minRecentTurnsFull` now set explicitly (stale env → `MAKA_CONTEXT_MIN_RECENT_TURNS` → 2) so the runtime protection window matches the policy snapshot and desktop default instead of the runtime's internal `?? 1` fallback (review finding)
- headless `harbor-cell.test.ts`: default-on/explicit-off coverage for stale prune, `minRecentTurnsFull` fallback/override coverage, adjusted active-prune explicit-off expectations, both-off empty case
- runtime `context-budget-policy.ts`: `buildStaleToolResultPrunePolicy` from "explicit `on` required" to default-on with explicit `off`/`false` opt-out, mirroring `buildActiveToolResultPrunePolicy`
- desktop `__tests__/context-budget-policy.test.ts`: new `staleToolResultPrune` suite (default-on, opt-out ×2, truthy values, malformed-value rejection, threshold env, min-recent-turns fallback/override, `MAKA_CONTEXT_BUDGET=off`)

Not included:

- No pruning mechanism change; thresholds and protection-window semantics untouched (env *parsing* semantics do change, see Reviewer notes)
- No archive retrieval default change (stays off; its isolated A/B is the next #481 slice)
- No A/B benchmark data for stale prune yet — this flip is motivated by mechanism coherence with #498; multi-turn benchmark validation can land in `docs/economic-mechanisms-benchmark.md` as follow-up

## Verification

- `npm run -w @maka/headless test`: 736 pass / 0 fail / 1 skipped
- `npm run -w @maka/desktop test`: 2190 pass / 0 fail
- `npm run -w @maka/runtime test`: 951 pass / 0 fail
- `npm run typecheck`: clean
- TDD: new default-on tests observed red before the flips, green after
- External review: codex (xhigh) round 1 found the `minRecentTurnsFull` mismatch (fixed in `399e239b`), round 2 clean; GLM-5.2 (xhigh) P3-only, both addressed (contract tests + disclosure below)

## User-facing impact

- Desktop/CLI: prior-turn tool results over 2048 estimated tokens are replaced with archive placeholders when rebuilding history; the 2 most recent turns keep full results. Opt out with `MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE=off`.
- Headless: Harbor runs that didn't set `MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE` see a behavior change; existing A/B profiles that toggle it explicitly are unaffected.

## Reviewer notes

- Four commits, one per rollback dimension: headless flip, runtime flip (desktop/CLI share the builder), the protection-window fix, and the env-contract tests.
- Env parsing semantics change on the runtime builder: previously only the literal `on` enabled stale prune and any other value silently disabled; now standard truthy booleans (`true`/`1`/`yes`/`enabled`) also enable, and malformed values throw at policy-build time instead of silently disabling. This aligns with `activeToolResultPrune` and the other `parseOptionalBoolean` knobs; the throw is fail-loud at backend construction (no catch in desktop `main.ts`), same as the existing knobs — no new risk category.
- Headless previously had a latent mismatch even with explicit `MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE=on`: the policy snapshot reported `minRecentTurnsFull: 2` while the runtime protected only 1 turn. The explicit default fixes both the default-on path and that pre-existing divergence (slightly less aggressive pruning than before).