### PR TITLE
test(headless): retrieval arm activation contract + prune A/B smoke profiles

### DIFF
--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1232,6 +1232,51 @@ describe('runHarborCell', () => {
     });
   });
 
+  // Eager retrieval only hydrates stale-kind placeholders, so a retrieval arm
+  // is structurally inert unless a placeholder producer (stale prune) and the
+  // archive reader are wired alongside it. The #340-era arms enabled retrieval
+  // without stale prune and it never fired; this contract pins the live shape.
+  test('Harbor eager archive-retrieval arm gets a placeholder producer and archive reader by default', async () => {
+    await withDirs(async ({ workspaceDir, outputDir }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_CONTEXT_ARCHIVE_RETRIEVAL: 'on',
+        },
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-4o-mini',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        workspaceDir,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (backend as unknown as {
+        input: ReturnType<typeof buildHarborCellContextBudgetBackendOptions>;
+      }).input;
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.enabled, true);
+      assert.equal(backendInput.contextBudget?.staleToolResultPrune?.minRecentTurnsFull, 2);
+      assert.equal(backendInput.contextBudget?.archiveRetrieval?.enabled, true);
+      assert.equal(backendInput.contextBudget?.archiveRetrieval?.mode, undefined);
+      assert.ok(backendInput.archiveToolResult, 'expected archive writer for the placeholder producer');
+      assert.ok(backendInput.readToolResultArchive, 'expected archive reader for eager hydration');
+    });
+  });
+
   test('Harbor ai-sdk backend leaves context budget policy off when explicitly disabled', async () => {
     await withDirs(async ({ workspaceDir }) => {
       const registry = new BackendRegistry();

--- a/terminal-bench-smoke/run-terminal-bench-sample.sh
+++ b/terminal-bench-smoke/run-terminal-bench-sample.sh
@@ -32,11 +32,18 @@ Profiles:
   maka-heavy-prune
                Maka heavy-task bridge with autonomous prior-attempt runtime replay
                and stale tool-result archive pruning enabled
+  maka-prune-default
+               Post-#621 default prune pipeline with continuation (stale A/B B arm,
+               retrieval A/B A arm)
+  maka-stale-off
+               maka-prune-default with stale prune explicitly off (stale A/B A arm)
+  maka-retrieval-on
+               maka-prune-default plus eager archive retrieval (retrieval A/B B arm)
   opencode     OpenCode Harbor wrapper
   oracle       Harbor oracle agent for cheap wrapper/dataset smoke tests
 
 Options:
-  --profile NAME              Run profile: maka-basic, maka-heavy, maka-heavy-prune, opencode, oracle
+  --profile NAME              Run profile: maka-basic, maka-heavy, maka-heavy-prune, maka-prune-default, maka-stale-off, maka-retrieval-on, opencode, oracle
   --compare                   Run comparison profiles sequentially (default: maka-basic,opencode)
   --compare-profiles LIST     Comma-separated profiles for --compare
   --task PATTERN              Harbor task pattern (default: *sqlite-with-gcov)

--- a/terminal-bench-smoke/terminal-bench-sample-runs.json
+++ b/terminal-bench-smoke/terminal-bench-sample-runs.json
@@ -74,6 +74,59 @@
         }
       }
     },
+    "maka-prune-default": {
+      "description": "Post-#621 default prune pipeline (active + stale on) with continuation enabled. Per-turn step cap deliberately low so tasks cross turn boundaries and stale prune fires. B arm for the stale-prune A/B; A arm for the retrieval A/B.",
+      "agentTimeoutMultiplier": 4.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "0",
+          "MAKA_HARBOR_AUTONOMOUS": "0",
+          "MAKA_HARBOR_CONTINUATION": "on",
+          "MAKA_HARBOR_CONTINUATION_MAX_TURNS": "3",
+          "MAKA_HARBOR_CONTINUATION_MAX_TOTAL_RUNTIME_STEPS": "150",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "50",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+        }
+      }
+    },
+    "maka-stale-off": {
+      "description": "Same as maka-prune-default but stale tool-result prune explicitly off. A arm for the stale-prune A/B.",
+      "agentTimeoutMultiplier": 4.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "0",
+          "MAKA_HARBOR_AUTONOMOUS": "0",
+          "MAKA_HARBOR_CONTINUATION": "on",
+          "MAKA_HARBOR_CONTINUATION_MAX_TURNS": "3",
+          "MAKA_HARBOR_CONTINUATION_MAX_TOTAL_RUNTIME_STEPS": "150",
+          "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE": "off",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "50",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+        }
+      }
+    },
+    "maka-retrieval-on": {
+      "description": "Same as maka-prune-default plus eager archive retrieval, so stale-pruned placeholders hydrate back (newest first, bounded). B arm for the retrieval A/B.",
+      "agentTimeoutMultiplier": 4.0,
+      "agent": {
+        "importPath": "maka_harbor_agent:MakaHarborAgent",
+        "env": {
+          "MAKA_HARBOR_USE_TASK_RUN": "0",
+          "MAKA_HARBOR_AUTONOMOUS": "0",
+          "MAKA_HARBOR_CONTINUATION": "on",
+          "MAKA_HARBOR_CONTINUATION_MAX_TURNS": "3",
+          "MAKA_HARBOR_CONTINUATION_MAX_TOTAL_RUNTIME_STEPS": "150",
+          "MAKA_CONTEXT_ARCHIVE_RETRIEVAL": "on",
+          "MAKA_MODEL": "deepseek-v4-pro",
+          "MAKA_MAX_STEPS": "50",
+          "MAKA_HARBOR_AGENT_TIMEOUT_SEC": "3600"
+        }
+      }
+    },
     "opencode": {
       "description": "OpenCode Harbor wrapper against terminal-bench-sample for Maka/OpenCode comparison.",
       "agentTimeoutMultiplier": 4.0,


### PR DESCRIPTION
## Summary

Two pieces preparing the next #481 measurement slices (stale-prune multi-turn A/B, then eager-retrieval A/B):

1. A harbor-cell contract test pinning the live shape of an eager archive-retrieval arm: with post-#621 defaults plus `MAKA_CONTEXT_ARCHIVE_RETRIEVAL=on`, the built backend options must carry the placeholder producer (`staleToolResultPrune.enabled`), the eager retrieval policy, and both archive writer/reader callbacks.
2. Three Terminal-Bench smoke profiles encoding the exact A/B arm shapes: `maka-prune-default` (defaults + continuation, low per-turn step cap so turns actually roll over), `maka-stale-off` (A arm for the stale A/B), `maka-retrieval-on` (B arm for the retrieval A/B).

## Why

Refs #481 (see the status-update comment). The #340-era arms enabled `MAKA_CONTEXT_ARCHIVE_RETRIEVAL` without stale prune; eager retrieval only hydrates stale-kind placeholders, so the flag was structurally inert and nobody noticed. The contract test makes that failure mode impossible to reintroduce silently, and the committed profiles make tomorrow's runs reproducible instead of living in local runner configs.

## Verification

- `npm run -w @maka/headless test`: 737 pass / 0 fail / 1 skipped (new contract test included)
- `terminal-bench-sample-runs.json` parses (`python3 json.load`); the smoke script resolves profiles dynamically from the manifest, usage text updated

## Reviewer notes

- Two commits: the contract test and the benchmark profiles are independent rollback units.
- The profiles deliberately set `MAKA_MAX_STEPS=50` with continuation max 3 turns / 150 total steps so tasks cross turn boundaries — stale prune and retrieval only act cross-turn, and a single-turn run measures nothing (the #340 lesson).