### PR TITLE
fix(vite): dedupe react/react-dom to prevent dual-instance white screen

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
+    dedupe: ['react', 'react-dom'],
     alias: [
       { find: '@maka/ui/icons', replacement: resolve(UI_SRC, 'icons.tsx') },
       { find: '@maka/ui/artifact-preview-registry', replacement: resolve(UI_SRC, 'artifact-preview-registry.ts') },


### PR DESCRIPTION
## Add resolve.dedupe for React in Vite config

### Problem

A fresh npm install (new worktree, new machine, lock-file change) can cause a white screen in dev mode:

`Uncaught TypeError: Cannot read properties of null (reading 'useLayoutEffect')`

This is the classic dual React instance bug. 

The Vite config aliases `@maka/ui `to its source (packages/ui/src), so Vite resolves `import 'react' `from different file locations — and without dedupe, it may load two separate React modules.
 
Hooks read from one instance's internals while the reconciler uses the other's, which is null.

### Fix

`resolve.dedupe` is the Vite-recommended approach (https://vitejs.dev/config/shared-options.html#resolve-dedupe) for monorepo React setups. 

It guarantees a single module instance regardless of where the import originates.

### Scope

One line, one file. 

No runtime behavior change in production builds — only affects dev-server module resolution.