### PR TITLE
feat(runtime): Goal-based autonomous execution (Issue #15 P6)

### DIFF
--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -156,6 +156,12 @@ declare global {
         setThinkingLevel(sessionId: string, level: ThinkingLevel | undefined | null): Promise<SessionSummary>;
         remove(sessionId: string): Promise<void>;
       };
+      goal: {
+        /** The session's current goal (null when none is set). */
+        get(sessionId: string): Promise<import('@maka/runtime').GoalState | null>;
+        /** Clear the active goal, stopping autonomous continuation. */
+        clear(sessionId: string): Promise<void>;
+      };
       connections: {
         list(): Promise<LlmConnection[]>;
         getDefault(): Promise<string | null>;

--- a/apps/desktop/src/main/goal-wiring.ts
+++ b/apps/desktop/src/main/goal-wiring.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from 'node:crypto';
+import {
+  GoalManager,
+  buildGoalTools,
+  type GoalContinuationDeps,
+  type GoalState,
+  type GoalStatus,
+  type MakaTool,
+} from '@maka/runtime';
+import type { LlmConnection } from '@maka/core';
+
+/**
+ * Goal execution wiring for the main process. Owns the GoalManager, the goal
+ * tools, and the turn-boundary continuation deps (evaluator + injection).
+ *
+ * The evaluator uses the session's default connection model with a tiny
+ * (~250-token) budget — a full judge model is heavier than ideal, but the
+ * request/response is small and this avoids a fragile cheap-model mapping.
+ *
+ * "Waiting on an external event" is handled inside the continuation controller
+ * (neutral progress + normal re-check), so the wiring needs no automation
+ * coupling — a goal is self-contained and bounded by its own caps.
+ */
+export interface MainGoalWiring {
+  manager: GoalManager;
+  tools: MakaTool[];
+  continuationDeps: GoalContinuationDeps;
+}
+
+export interface CreateMainGoalWiringDeps {
+  getDefaultConnectionSlug: () => Promise<string | null>;
+  getConnection: (slug: string) => Promise<LlmConnection | null>;
+  /**
+   * The session's own connection + model, so the evaluator judges on the same
+   * provider the session uses (not a global default that could route this
+   * session's text to an unrelated provider). Null when the session is gone.
+   */
+  getSessionModel: (sessionId: string) => Promise<{ connectionSlug: string; model: string } | null>;
+  resolveConnectionSecret: (slug: string) => Promise<string | null>;
+  buildSubscriptionModelFetch: (connection: LlmConnection, sessionId: string, modelId: string) => typeof fetch | undefined;
+  getAIModel: (input: { connection: LlmConnection; apiKey: string; modelId: string; fetch: typeof fetch | undefined }) => unknown;
+  buildProviderOptions: (connection: LlmConnection, modelId: string) => unknown;
+  getRecentMessages: (sessionId: string) => Promise<Array<{ type: string; text?: string }>>;
+  /** Cumulative token count for a session (summed from token_usage messages). */
+  getTokenCount: (sessionId: string) => Promise<number>;
+  injectTurn: (sessionId: string, text: string) => void;
+  canContinue: (sessionId: string) => Promise<boolean>;
+  /**
+   * Fired on every goal state transition (set / continue / terminal / clear).
+   * The host emits a session event so the renderer can badge an active goal and
+   * offer a clear affordance — an autonomous token-burning loop must be visible.
+   */
+  onGoalChange?: (goal: GoalState, previous?: GoalStatus) => void;
+}
+
+export function createMainGoalWiring(deps: CreateMainGoalWiringDeps): MainGoalWiring {
+  const manager = new GoalManager({
+    generateId: () => randomUUID(),
+    now: () => Date.now(),
+    onChange: deps.onGoalChange,
+  });
+
+  // Synchronous best-effort token snapshot cache, refreshed each continuation.
+  const tokenCache = new Map<string, number>();
+
+  const tools = buildGoalTools({
+    goalManager: manager,
+    getTokenCount: (sessionId) => tokenCache.get(sessionId) ?? 0,
+  });
+
+  const inFlight = new Set<string>();
+
+  const continuationDeps: GoalContinuationDeps = {
+    goalManager: manager,
+    inFlight,
+    evaluator: {
+      async evaluate(prompt: string, sessionId: string): Promise<string> {
+        // Judge on the SESSION's own connection + model (fall back to the
+        // default only if the session's connection is gone), so evaluation
+        // routes to the same provider the session is actually driving.
+        const sess = await deps.getSessionModel(sessionId);
+        const slug = sess?.connectionSlug ?? await deps.getDefaultConnectionSlug();
+        if (!slug) return '{"met": false, "impossible": false, "progress": false, "waiting": false, "reason": "no connection configured"}';
+        const connection = await deps.getConnection(slug);
+        if (!connection) return '{"met": false, "impossible": false, "progress": false, "waiting": false, "reason": "connection not found"}';
+        const modelId = sess?.model ?? connection.defaultModel;
+        const apiKey = await deps.resolveConnectionSecret(slug);
+        const ai = await import('ai') as unknown as {
+          generateText(opts: Record<string, unknown>): Promise<{ text: string }>;
+        };
+        const modelFetch = deps.buildSubscriptionModelFetch(connection, 'goal-evaluator', modelId);
+        const result = await ai.generateText({
+          model: deps.getAIModel({ connection, apiKey: apiKey ?? '', modelId, fetch: modelFetch }),
+          prompt,
+          providerOptions: deps.buildProviderOptions(connection, modelId),
+          // Ceiling, not a target — the verdict is tiny JSON. Kept well above the
+          // JSON size so any model-side reasoning before the JSON doesn't consume
+          // the whole budget and return empty text (finishReason=length). 250 was
+          // too tight once the cap is actually honored (AI SDK v6 maxOutputTokens).
+          maxOutputTokens: 1024,
+        });
+        return result.text;
+      },
+    },
+    async getRecentContext(sessionId: string): Promise<string> {
+      // Refresh the token snapshot while we have the session open.
+      tokenCache.set(sessionId, await deps.getTokenCount(sessionId));
+      const messages = await deps.getRecentMessages(sessionId);
+      return messages
+        .filter((m) => m.type === 'user' || m.type === 'assistant')
+        .slice(-6)
+        .map((m) => `[${m.type}]: ${(m.text ?? '').slice(0, 500)}`)
+        .join('\n');
+    },
+    getTokenCount: (sessionId) => tokenCache.get(sessionId) ?? 0,
+    injectTurn: deps.injectTurn,
+    canContinue: deps.canContinue,
+  };
+
+  return { manager, tools, continuationDeps };
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -178,6 +178,8 @@ import { buildDefaultContextBudgetPolicy } from '@maka/runtime';
 import { createSystemPromptMainService } from './system-prompt-main.js';
 import { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
 import { createMainAutomationWiring, evaluateAutomationCanFire } from './automation-wiring.js';
+import { createMainGoalWiring } from './goal-wiring.js';
+import { handleGoalContinuation } from '@maka/runtime';
 import { createOAuthModelConnectionsMainService } from './oauth-model-connections-main.js';
 import {
   applyNetworkPatch,
@@ -391,6 +393,60 @@ const automationWiring = createMainAutomationWiring({
 // Load durable automations from disk on startup (fire-and-forget; errors are logged inside).
 void automationWiring.loadDurableAutomations();
 
+// Goal execution — autonomous turn-boundary continuation with an external
+// evaluator (CC-style). Self-contained: no automation coupling (a goal is
+// bounded by its own caps; a waiting goal re-checks via normal continuation).
+const goalWiring = createMainGoalWiring({
+  getDefaultConnectionSlug: () => connectionStore.getDefault(),
+  getConnection: (slug) => connectionStore.get(slug),
+  getSessionModel: async (sessionId) => {
+    const header = await store.readHeader(sessionId);
+    if (!header) return null;
+    return { connectionSlug: header.llmConnectionSlug, model: header.model };
+  },
+  resolveConnectionSecret,
+  buildSubscriptionModelFetch,
+  getAIModel: (input) => getAIModel(input),
+  buildProviderOptions: (connection, modelId) => buildProviderOptions(connection, modelId),
+  getRecentMessages: async (sessionId) => {
+    const messages = await runtime.getMessages(sessionId);
+    return messages.slice(-10).map((m) => ({
+      type: m.type,
+      text: m.type === 'user' || m.type === 'assistant' ? m.text : undefined,
+    }));
+  },
+  getTokenCount: async (sessionId) => {
+    const messages = await runtime.getMessages(sessionId);
+    let total = 0;
+    for (const m of messages) {
+      if (m.type === 'token_usage') total += (m.total ?? (m.input + m.output));
+    }
+    return total;
+  },
+  injectTurn: (sessionId, text) => {
+    const turnId = randomUUID();
+    const iterator = runtime.sendMessage(sessionId, { turnId, text });
+    void streamEvents(sessionId, iterator, turnId);
+  },
+  canContinue: async (sessionId) => {
+    const header = await store.readHeader(sessionId);
+    if (!header || header.archivedAt) return false;
+    // Never auto-continue into a session that is running (mid-turn), aborted,
+    // blocked, or parked waiting on the user — injecting a turn there would
+    // race the live turn or override the human the agent is waiting on.
+    if (
+      header.status === 'running' ||
+      header.status === 'blocked' ||
+      header.status === 'aborted' ||
+      header.status === 'waiting_for_user'
+    ) return false;
+    return true;
+  },
+  // Surface every goal transition to the renderer so an active autonomous loop
+  // is visible (badge + clear affordance) — never a silent token burn.
+  onGoalChange: (goal) => emitSessionsChanged('goal-change', goal.sessionId),
+});
+
 async function getWorkspacePrivacyContext(): Promise<WorkspacePrivacyContext> {
   const settings = await settingsStore.get();
   return { incognitoActive: settings.privacy.incognitoActive === true };
@@ -407,6 +463,7 @@ const systemPromptService = createSystemPromptMainService({
   workspaceRoot,
   localMemory,
   taskLedger: taskLedgerStore,
+  goalManager: goalWiring.manager,
 });
 // Window is created hidden for E2E and visual-smoke runs so it never steals
 // focus. Derived from the same isE2e gate as userData/fake-backend so the
@@ -509,6 +566,8 @@ const builtinTools: MakaTool[] = [
   ...taskLedgerWiring.tools,
   // Unified Automation: heartbeat (session-internal polling) + cron (standalone scheduled runs).
   ...automationWiring.tools,
+  // Goal execution: GoalSet/Clear/Status/Pause/Resume — autonomous turn-boundary continuation.
+  ...goalWiring.tools,
   // The `load_tools` connector is built by ToolAvailabilityRuntime; deferred
   // group tools just need to be present so they are dispatchable once loaded.
   ...deferredTools,
@@ -1203,6 +1262,14 @@ function registerIpc(): void {
     return messages;
   });
   ipcMain.handle('sessions:listTurns', (_event, sessionId: string) => runtime.listTurns(sessionId));
+  // Goal kill-switch surface: the renderer reads the active goal to badge a
+  // session running an autonomous loop, and clears it to stop the loop. `get`
+  // returns null when no goal is set; `clear` settles it (continuation stops
+  // after the current turn). Both are pure local state, so no permission gate.
+  ipcMain.handle('goal:get', (_event, sessionId: string) => goalWiring.manager.get(sessionId) ?? null);
+  ipcMain.handle('goal:clear', (_event, sessionId: string) => {
+    goalWiring.manager.clear(sessionId);
+  });
   // PR-SEARCH-2: local thread search. Renderer-facing channel; the pure
   // helper in `./search/thread-search.ts` enforces all gates (G1 snippet
   // redaction, G2 fake-backend exclude, G4 caps, G5 case-fold + NFC,
@@ -1344,7 +1411,8 @@ function registerIpc(): void {
     // An archived conversation is no longer shown: drop its browser connection
     // and view so it does not keep a live Chromium page in the background.
     await releaseBrowserSession(sessionId);
-    // Stop any automation loops (polling heartbeats) tied to the session.
+    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
+    goalWiring.manager.remove(sessionId);
     automationWiring.manager.removeAllForSession(sessionId);
     emitSessionsChanged('archived', sessionId);
   });
@@ -1419,7 +1487,8 @@ function registerIpc(): void {
     // if it never opened one). releaseBrowserSession disposes the view via the
     // host, covering both agent-driven and hand-opened views.
     await releaseBrowserSession(sessionId);
-    // Stop any automation loops (polling heartbeats) tied to the session.
+    // Stop any autonomous loops tied to the session (goal + polling heartbeats).
+    goalWiring.manager.remove(sessionId);
     automationWiring.manager.removeAllForSession(sessionId);
     emitSessionsChanged('deleted', sessionId);
   });
@@ -1690,6 +1759,12 @@ async function streamEvents(
       if (event.type === 'error') {
         turnError = event.message ?? event.reason ?? 'turn error';
       }
+      // A non-throwing error finish (e.g. content-filter) arrives as
+      // complete{stopReason:'error'} with no separate `error` event — record it
+      // so goal continuation is skipped (and `ok` is not mis-reported true).
+      if (event.type === 'complete' && event.stopReason === 'error') {
+        turnError = turnError ?? 'turn ended in error';
+      }
       safeSendToRenderer(`sessions:event:${sessionId}`, event);
       openGateway.publishSessionEvent(sessionId, event);
       if (isStatusChangingSessionEvent(event)) {
@@ -1702,6 +1777,14 @@ async function streamEvents(
     if (!finalAppendBroadcasted) {
       emitSessionsChanged('message-appended', sessionId);
       finalAppendBroadcasted = true;
+    }
+    // Goal auto-continuation: after a turn completes cleanly, evaluate the
+    // active goal and continue, hand off to polling, or stop. Skip on a
+    // user-abort (the Stop button must halt the loop) OR an errored turn —
+    // re-injecting into a failing connection would spin ~maxIterations failing
+    // turns. Failures never surface to the turn.
+    if (!turnAborted && !turnError) {
+      void handleGoalContinuation(goalWiring.continuationDeps, sessionId).catch(() => {});
     }
     return { turnId, ok: !turnAborted && !turnError, ...(turnError ? { error: turnError } : {}) };
   } catch (error) {
@@ -2061,6 +2144,7 @@ app.on('before-quit', (event) => {
 
 async function runBeforeQuitCleanup(): Promise<void> {
   automationWiring.scheduler.dispose();
+  goalWiring.manager.dispose();
   configWatcher?.stop();
   planReminders.stopTimers();
   dailyReview.stopScheduler();

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -16,6 +16,7 @@ import {
   buildPersonalizationPromptFragment,
   resolveProjectGitInfo,
   buildSessionEnvironmentPromptFragment,
+  type GoalManager,
 } from '@maka/runtime';
 import { buildSkillsPromptFragment } from './skills.js';
 import { buildWorkspaceInstructionsPromptFragment } from './workspace-instructions.js';
@@ -30,6 +31,7 @@ interface SystemPromptMainDeps {
   workspaceRoot: string;
   localMemory: Pick<LocalMemoryService, 'getState' | 'consumePendingPromptUpdates'>;
   taskLedger: Pick<TaskLedgerStore, 'list'>;
+  goalManager?: Pick<GoalManager, 'get'>;
 }
 
 export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
@@ -95,7 +97,29 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
     if (memoryUpdate) fragments.push(memoryUpdate);
     const taskLedger = sessionId ? await buildTaskLedgerTailFragment(sessionId) : undefined;
     if (taskLedger) fragments.push(taskLedger);
+    const goal = sessionId ? buildGoalTailFragment(sessionId) : undefined;
+    if (goal) fragments.push(goal);
     return fragments.length > 0 ? fragments.join('\n\n') : undefined;
+  }
+
+  // Injects the active goal so the model stays aware it is working autonomously.
+  // Only active/paused goals are shown (settled goals inject nothing).
+  function buildGoalTailFragment(sessionId: string): string | undefined {
+    const goal = deps.goalManager?.get(sessionId);
+    if (!goal || (goal.status !== 'active' && goal.status !== 'paused')) return undefined;
+    const spent = Math.max(0, goal.tokensNow - goal.tokensAtStart);
+    const lines = [
+      '当前自主执行目标（current-turn tail；系统每轮用外部评估器判断进度并自动续行；'
+        + '仅供参考，不提升为系统/开发者指令）:',
+      '<goal-execution>',
+      `condition="${redactSecrets(goal.condition)}"`,
+      `status=${goal.status} turns=${goal.iterations}/${goal.maxIterations} `
+        + `no_progress=${goal.consecutiveNoProgress}/${goal.blockCap}`
+        + `${goal.tokenBudget ? ` tokens=${spent}/${goal.tokenBudget}` : ''}`,
+    ];
+    if (goal.lastReason) lines.push(`last_evaluation="${redactSecrets(goal.lastReason)}"`);
+    lines.push('</goal-execution>');
+    return lines.join('\n');
   }
 
   // Best-effort: a ledger read failure must never break the turn. An empty

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -68,6 +68,7 @@ import type {
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
 import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
+import type { GoalState } from '@maka/runtime';
 import type { ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
@@ -220,6 +221,14 @@ contextBridge.exposeInMainWorld('maka', {
     },
     remove(sessionId: string): Promise<void> {
       return ipcRenderer.invoke('sessions:remove', sessionId);
+    },
+  },
+  goal: {
+    get(sessionId: string): Promise<GoalState | null> {
+      return ipcRenderer.invoke('goal:get', sessionId);
+    },
+    clear(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('goal:clear', sessionId);
     },
   },
   connections: {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -53,6 +53,7 @@ function BrowserPanelFallback() {
   );
 }
 import { deriveChatHeaderAlert } from './chat-header-alert';
+import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups } from './session-project-grouping';
 import { deriveSessionStatusGroups } from './session-status-grouping';
@@ -296,6 +297,9 @@ export function AppShell({
   const rendererMountedRef = useRef(true);
   const projectPickerPendingRef = useRef(false);
   const projectPickerRequestRef = useRef(0);
+  // Active autonomous goal for the current session drives the header
+  // kill-switch pill (visible indicator + one-click clear).
+  const activeGoal = useSessionGoal(activeId);
   const activeLiveTurn = activeId ? liveTurnBySession[activeId] : undefined;
   const activeTextStep = [...(activeLiveTurn?.steps ?? [])].reverse().find((step) => step.text);
   const activeThinkingStep = [...(activeLiveTurn?.steps ?? [])].reverse().find((step) => step.thinking);
@@ -1565,6 +1569,13 @@ export function AppShell({
                 mode={navSelection.section}
                 connectionAlert={chatConnectionAlert}
                 eventStreamAlert={chatEventStreamAlert}
+                goalIndicator={activeGoal ? {
+                  condition: activeGoal.condition,
+                  status: activeGoal.status,
+                  iterations: activeGoal.iterations,
+                  maxIterations: activeGoal.maxIterations,
+                  onClear: () => { void window.maka.goal.clear(activeGoal.sessionId); },
+                } : undefined}
                 messageLoadError={activeId ? messageLoadErrorBySession[activeId] : undefined}
                 messageLoadRetryPending={activeId ? messageRetryPendingBySession[activeId] === true : false}
                 onRetryMessages={activeId ? () => void retryMessages(activeId) : undefined}

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -145,6 +145,19 @@
   flex: 0 0 auto;
 }
 
+/* Goal kill-switch pill: an active autonomous loop is warning-tinted (not the
+   neutral info tone of the deep-research pill) and clears the goal on click.
+   No `cursor: pointer` — native convention reserves the hand for links; the
+   pill is a UiButton and uses the default arrow like every other control. */
+.maka-chat-header-mode-pill[data-mode="goal"] {
+  border-color: oklch(from var(--warning) l c h / 0.38);
+  background: oklch(from var(--warning) l c h / 0.12);
+  color: var(--warning-text);
+}
+.maka-chat-header-mode-pill[data-mode="goal"]:hover {
+  background: oklch(from var(--warning) l c h / 0.18);
+}
+
   .maka-chat-header-alert {
     display: inline-flex;
     align-items: center;

--- a/apps/desktop/src/renderer/use-session-goal.ts
+++ b/apps/desktop/src/renderer/use-session-goal.ts
@@ -1,0 +1,53 @@
+/**
+ * Active-goal subscription for the renderer — the desktop kill-switch data source.
+ *
+ * Reads the session's goal via the preload bridge and re-fetches whenever the
+ * main process emits a `goal-change` session event (goal set / continue /
+ * terminal / clear). Only surfaces goals that are still running (active or
+ * paused); a settled goal returns null so the header pill disappears.
+ *
+ * Kept as a tiny standalone hook (no app-shell coupling) so an autonomous,
+ * token-burning loop always has a visible indicator and a one-click stop,
+ * regardless of where the chat surface renders it.
+ */
+import { useEffect, useState } from 'react';
+import type { GoalState } from '@maka/runtime';
+
+const RUNNING_GOAL_STATUSES = new Set(['active', 'paused']);
+
+export function useSessionGoal(sessionId: string | undefined): GoalState | null {
+  const [goal, setGoal] = useState<GoalState | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setGoal(null);
+      return;
+    }
+    let cancelled = false;
+    const refresh = (): void => {
+      void window.maka.goal
+        .get(sessionId)
+        .then((g) => {
+          if (cancelled) return;
+          setGoal(g && RUNNING_GOAL_STATUSES.has(g.status) ? g : null);
+        })
+        .catch(() => {
+          if (!cancelled) setGoal(null);
+        });
+    };
+    refresh();
+    const unsubscribe = window.maka.sessions.subscribeChanges((event) => {
+      // Refetch on goal transitions for this session (an undefined sessionId on
+      // the event is a broadcast — refetch to be safe).
+      if (event.reason === 'goal-change' && (!event.sessionId || event.sessionId === sessionId)) {
+        refresh();
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [sessionId]);
+
+  return goal;
+}

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -108,6 +108,60 @@ describe('Maka Pi TUI transcript', () => {
     assert.ok(changes >= 2);
   });
 
+  // Goal kill-switch (B1): the turn outcome must distinguish a clean end from a
+  // user-stop / abort / error so the runner can skip goal auto-continuation and
+  // never re-inject after the user interrupts (or after a failing turn).
+  test('reports a clean turn as not aborted / not errored', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'end_turn' })]);
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+    assert.deepEqual(outcome, { aborted: false, errored: false });
+  });
+
+  test('reports a user_stop completion as aborted (Stop affordance)', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'user_stop' })]);
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+    assert.equal(outcome.aborted, true);
+    assert.equal(outcome.errored, false);
+  });
+
+  test('reports an abort event as aborted', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'abort', reason: 'user_stop' })]);
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+    assert.equal(outcome.aborted, true);
+  });
+
+  test('reports a stream error event as errored', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'error', recoverable: false, message: 'boom' })]);
+    let errorRaised = false;
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi', onError: () => { errorRaised = true; } });
+    assert.equal(outcome.errored, true);
+    assert.equal(errorRaised, true);
+  });
+
+  test('reports a complete{stopReason:error} finish as errored (non-throwing error, e.g. content-filter)', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = new RecordingDriver([event({ type: 'complete', stopReason: 'error' })]);
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+    assert.equal(outcome.errored, true);
+    assert.equal(outcome.aborted, false);
+  });
+
+  test('reports a thrown sendPrompt as errored', async () => {
+    const state = createMakaPiTranscriptState();
+    const driver = {
+      async *sendPrompt(): AsyncIterable<SessionEvent> {
+        throw new Error('network down');
+      },
+    };
+    const outcome = await submitPromptToTranscript({ state, driver, prompt: 'hi' });
+    assert.equal(outcome.errored, true);
+    assert.equal(outcome.aborted, false);
+  });
+
   test('reports completed manual compact runs when there was nothing to compact', async () => {
     const state = createMakaPiTranscriptState();
     const driver = new RecordingDriver([

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -5,6 +5,7 @@ import {
   buildWorkspaceInstructionsPromptFragment,
   resolveProjectGitInfo,
   type AutomationManager,
+  type GoalManager,
 } from '@maka/runtime';
 
 /**
@@ -43,6 +44,7 @@ export async function buildCliTurnTailPrompt(input: {
   cwd: string;
   sessionId?: string;
   automationManager?: AutomationManager;
+  goalManager?: GoalManager;
 }): Promise<string> {
   const projectGit = await resolveProjectGitInfo(input.cwd);
   const fragments = [buildSessionEnvironmentPromptFragment({ cwd: input.cwd, projectGit })];
@@ -51,8 +53,28 @@ export async function buildCliTurnTailPrompt(input: {
     const automationFragment = buildAutomationTailFragment(input.sessionId, input.automationManager);
     if (automationFragment) fragments.push(automationFragment);
   }
+  if (input.sessionId && input.goalManager) {
+    const goalFragment = buildGoalTailFragment(input.sessionId, input.goalManager);
+    if (goalFragment) fragments.push(goalFragment);
+  }
 
   return fragments.join('\n\n');
+}
+
+function buildGoalTailFragment(sessionId: string, manager: GoalManager): string | undefined {
+  const goal = manager.get(sessionId);
+  if (!goal || (goal.status !== 'active' && goal.status !== 'paused')) return undefined;
+  const spent = Math.max(0, goal.tokensNow - goal.tokensAtStart);
+  const lines = [
+    'Active goal (autonomous execution; system evaluates progress each turn):',
+    '<goal-execution>',
+    `condition="${redactSecrets(goal.condition)}"`,
+    `status=${goal.status} turns=${goal.iterations}/${goal.maxIterations} no_progress=${goal.consecutiveNoProgress}/${goal.blockCap}`
+      + `${goal.tokenBudget ? ` tokens=${spent}/${goal.tokenBudget}` : ''}`,
+    ...(goal.lastReason ? [`last_evaluation="${redactSecrets(goal.lastReason)}"`] : []),
+    '</goal-execution>',
+  ];
+  return lines.join('\n');
 }
 
 function buildAutomationTailFragment(sessionId: string, manager: AutomationManager): string | undefined {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describeChatConfigurationReason, parseNoRealConnectionError } from '@maka/core';
+import { handleGoalContinuation } from '@maka/runtime';
 import { createMakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
@@ -128,6 +129,14 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           subscribeShellRunUpdates: context.subscribeShellRunUpdates,
           readShellRun: context.readShellRun,
           onProcessExit: handleMakaCliProcessExit,
+          onTurnComplete: (injectTurn) => {
+            const sessionId = driver.getSessionId();
+            if (!sessionId) return;
+            void handleGoalContinuation(
+              { ...context.goalContinuationDeps, injectTurn: (_s, text) => injectTurn(text) },
+              sessionId,
+            ).catch(() => {});
+          },
         });
         return 0;
       } finally {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -181,6 +181,13 @@ export function toggleAllThinkingExpansion(state: MakaPiTranscriptState): boolea
   return true;
 }
 
+export interface TurnOutcome {
+  /** The turn was user-stopped or aborted (double-Escape → driver.stop()). */
+  aborted: boolean;
+  /** The turn ended in an error (stream `error` event or thrown failure). */
+  errored: boolean;
+}
+
 export async function submitPromptToTranscript(input: {
   state: MakaPiTranscriptState;
   driver: Pick<MakaSessionDriver, 'sendPrompt'>;
@@ -192,17 +199,36 @@ export async function submitPromptToTranscript(input: {
    * attention on failures without diffing transcript entries every render.
    */
   onError?: () => void;
-}): Promise<void> {
+}): Promise<TurnOutcome> {
   appendUserPrompt(input.state, input.prompt);
   input.onChange?.();
 
+  // Surface how the turn ended so the host can gate goal auto-continuation: a
+  // user_stop/abort (the Stop affordance) or an errored turn must NOT trigger
+  // another autonomous turn — mirrors the desktop `turnAborted` guard.
+  let aborted = false;
+  let errored = false;
   try {
     for await (const event of input.driver.sendPrompt(input.prompt)) {
       applyMakaSessionEventToTranscript(input.state, event);
-      if (event.type === 'error') input.onError?.();
+      if (event.type === 'abort' || (event.type === 'complete' && event.stopReason === 'user_stop')) {
+        aborted = true;
+      }
+      if (event.type === 'error') {
+        errored = true;
+        input.onError?.();
+      }
+      // A non-throwing error finish (e.g. content-filter) arrives as
+      // complete{stopReason:'error'} with no separate `error` event — treat it as
+      // errored too, so goal continuation never re-injects into a failed turn
+      // (self-sufficient, not reliant on the session-status backstop).
+      if (event.type === 'complete' && event.stopReason === 'error') {
+        errored = true;
+      }
       input.onChange?.();
     }
   } catch (error) {
+    errored = true;
     input.state.entries.push({
       kind: 'notice',
       level: 'error',
@@ -211,6 +237,7 @@ export async function submitPromptToTranscript(input: {
     input.onError?.();
     input.onChange?.();
   }
+  return { aborted, errored };
 }
 
 export async function submitCompactToTranscript(input: {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -89,6 +89,12 @@ export interface MakaPiTuiInput {
     ownerSessionId: string;
     result: Extract<ToolResultContent, { kind: 'shell_run' }>;
   }>;
+  /**
+   * Called after each agent turn settles. Receives an `injectTurn` that runs a
+   * new turn rendered in the transcript — used for goal auto-continuation so
+   * continuation turns are visible and chain correctly.
+   */
+  onTurnComplete?: (injectTurn: (text: string) => void) => void;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -315,7 +321,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     runAgentTurn(prompt);
   };
 
-  // Runs one agent turn rendered in the transcript. Shared by user submits.
+  // Runs one agent turn rendered in the transcript, then lets the host decide
+  // whether to auto-continue (goal). Shared by user submits and goal injections.
   function runAgentTurn(prompt: string): void {
     busy = true;
     turnRunning = true;
@@ -327,6 +334,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
 
     let permissionAlerted = false;
+    let turnOutcome = { aborted: false, errored: false };
     void submitPromptToTranscript({
       state,
       driver: input.driver,
@@ -349,6 +357,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         shellRunElapsedTicker.sync();
         requestRender();
       },
+    }).then((outcome) => {
+      turnOutcome = outcome;
     }).finally(() => {
       busy = false;
       turnRunning = false;
@@ -357,6 +367,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       terminal.setProgress(false);
       attention.promptTurnEnded();
       requestRender();
+      // Do not auto-continue (goal) if teardown began (`closed`), the user
+      // interrupted the turn (double-Escape → driver.stop() → user_stop/abort),
+      // or it ended in error. An autonomous loop MUST halt on the Stop
+      // affordance and must not hammer a failing turn — mirrors the desktop
+      // `turnAborted` guard.
+      if (!closed && !turnOutcome.aborted && !turnOutcome.errored) {
+        input.onTurnComplete?.((text) => runAgentTurn(text));
+      }
     });
   }
 

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -6,12 +6,14 @@ import {
   AutomationManager,
   AutomationScheduler,
   BackendRegistry,
+  GoalManager,
   PermissionEngine,
   SessionManager,
   ShellRunProcessManager,
   buildAutomationTool,
   buildBuiltinTools,
   buildDefaultContextBudgetPolicy,
+  buildGoalTools,
   buildLlmHistorySummarizer,
   buildProviderOptions,
   buildSubscriptionModelFetch,
@@ -20,6 +22,7 @@ import {
   loadHistoryCompactBlocksFromArtifacts,
   persistHistoryCompactBlocksToArtifacts,
   type AutomationDefinition,
+  type GoalContinuationDeps,
   type ShellRunUpdate,
 } from '@maka/runtime';
 import {
@@ -53,6 +56,8 @@ export interface MakaCliRuntimeContext {
     ownerSessionId: string;
     result: Extract<ToolResultContent, { kind: 'shell_run' }>;
   }>;
+  goalManager: GoalManager;
+  goalContinuationDeps: GoalContinuationDeps;
   close(): Promise<void>;
 }
 
@@ -148,8 +153,6 @@ export async function createMakaCliRuntimeContext(
     cronEnabled,
   });
 
-  const allTools = [...tools, automationTool];
-
   // Load durable automations only on a host that can run them — a cron-disabled
   // host must not adopt/reconcile crons it doesn't own (see above).
   if (cronEnabled) {
@@ -161,6 +164,14 @@ export async function createMakaCliRuntimeContext(
       console.error('[runtime-bootstrap] durable automation store unreadable; persistence disabled to avoid data loss:', err);
     }
   }
+
+  const goalManager = new GoalManager({ generateId: () => randomUUID(), now: () => Date.now() });
+  const goalTokenCache = new Map<string, number>();
+  const goalTools = buildGoalTools({
+    goalManager,
+    getTokenCount: (sessionId) => goalTokenCache.get(sessionId) ?? 0,
+  });
+  const allTools = [...tools, automationTool, ...goalTools];
 
   backends.register('ai-sdk', async (ctx) => {
     // Resolve the session's own connection — not the global default — so a
@@ -214,7 +225,7 @@ export async function createMakaCliRuntimeContext(
         const settings = await settingsStore.get();
         return buildCliSystemPrompt({ settings, cwd });
       },
-      turnTailPrompt: ({ cwd }) => buildCliTurnTailPrompt({ cwd, sessionId: ctx.sessionId, automationManager }),
+      turnTailPrompt: ({ cwd }) => buildCliTurnTailPrompt({ cwd, sessionId: ctx.sessionId, automationManager, goalManager }),
       shellRunContextSummary: ctx.shellRunContextSummary,
       newId: randomUUID,
       now: Date.now,
@@ -293,6 +304,89 @@ export async function createMakaCliRuntimeContext(
     throw new Error(`Cannot resolve ShellRun owner for session ${sessionId}`);
   };
 
+  // Goal execution — external-evaluator continuation, sharing the runtime
+  // sendMessage pipeline (so each continuation turn is a real, traced AgentRun).
+  const goalContinuationDeps: GoalContinuationDeps = {
+    goalManager,
+    inFlight: new Set<string>(),
+    evaluator: {
+      async evaluate(prompt: string, sessionId: string): Promise<string> {
+        const ai = await import('ai') as unknown as {
+          generateText(opts: Record<string, unknown>): Promise<{ text: string }>;
+        };
+        const header = await store.readHeader(sessionId);
+        const ready = await resolveSessionTargetForSlug(header.llmConnectionSlug, {
+          connectionStore,
+          credentialStore,
+          requestedModel: header.model,
+        });
+        const modelFetch = buildSubscriptionModelFetch({
+          connection: ready.connection,
+          sessionId: 'goal-evaluator',
+          modelId: ready.model,
+          ...(ready.connection.providerType === 'claude-subscription' ? {
+            claude: {
+              cloakEnabled: isMakaClaudeSubscriptionCloakEnabled(),
+              deviceId: await getOrCreateCliClaudeDeviceId(input.workspaceRoot),
+              accountUuid: ready.oauthTokens?.account_uuid ?? '',
+            },
+          } : {}),
+        });
+        const result = await ai.generateText({
+          model: getAIModel({
+            connection: ready.connection,
+            apiKey: ready.apiKey ?? '',
+            modelId: ready.model,
+            fetch: modelFetch,
+          }),
+          prompt,
+          providerOptions: buildProviderOptions(ready.connection, ready.model, header.thinkingLevel),
+          // Ceiling, not a target — the verdict is tiny JSON. Kept well above the
+          // JSON size so any model-side reasoning before the JSON doesn't consume
+          // the whole budget and return empty text (finishReason=length). 250 was
+          // too tight once the cap is actually honored (AI SDK v6 maxOutputTokens).
+          maxOutputTokens: 1024,
+        });
+        return result.text;
+      },
+    },
+    async getRecentContext(sessionId: string): Promise<string> {
+      const messages = await runtime.getMessages(sessionId);
+      // Refresh the token snapshot while the session is open.
+      let total = 0;
+      for (const m of messages) {
+        if (m.type === 'token_usage') total += (m.total ?? (m.input + m.output));
+      }
+      goalTokenCache.set(sessionId, total);
+      return messages
+        .slice(-10)
+        .filter((m) => m.type === 'user' || m.type === 'assistant')
+        .slice(-6)
+        .map((m) => `[${m.type}]: ${(m.type === 'user' || m.type === 'assistant' ? m.text : '').slice(0, 500)}`)
+        .join('\n');
+    },
+    getTokenCount: (sessionId) => goalTokenCache.get(sessionId) ?? 0,
+    injectTurn: (sessionId, text) => {
+      const turnId = randomUUID();
+      const iterator = runtime.sendMessage(sessionId, { turnId, text });
+      void (async () => { for await (const _ of iterator) { /* drain */ } })().catch(() => {});
+    },
+    canContinue: async (sessionId) => {
+      const header = await store.readHeader(sessionId);
+      if (!header || header.archivedAt) return false;
+      // Never auto-continue into a session that is running (mid-turn), aborted,
+      // blocked, or parked waiting on the user — injecting a turn there would
+      // race the live turn or override the human the agent is waiting on.
+      if (
+        header.status === 'running' ||
+        header.status === 'blocked' ||
+        header.status === 'aborted' ||
+        header.status === 'waiting_for_user'
+      ) return false;
+      return true;
+    },
+  };
+
   return {
     workspaceRoot: input.workspaceRoot,
     cwd: input.cwd,
@@ -307,6 +401,8 @@ export async function createMakaCliRuntimeContext(
       return () => shellRunListeners.delete(listener);
     },
     readShellRun,
+    goalManager,
+    goalContinuationDeps,
     close: async () => {
       // Stop the automation scheduler's timer (else it keeps the process alive
       // and ticks into a stopped session), then terminate background shell runs.

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -146,6 +146,7 @@ export type SessionChangedReason =
   | 'mode-change'
   | 'status-change'
   | 'turn-status-change'
+  | 'goal-change'
   | 'rebound';
 
 export interface SessionChangedEvent {

--- a/packages/runtime/src/__tests__/goal-continuation.test.ts
+++ b/packages/runtime/src/__tests__/goal-continuation.test.ts
@@ -1,0 +1,200 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GoalManager } from '../goal-state.js';
+import { handleGoalContinuation, type GoalContinuationDeps } from '../goal-continuation.js';
+import type { GoalEvaluation } from '../goal-evaluator.js';
+
+const SESSION = 'sess-1';
+
+function setup(opts?: {
+  evaluation?: Partial<GoalEvaluation>;
+  canContinue?: boolean;
+  tokenCount?: number;
+}) {
+  let id = 0;
+  const mgr = new GoalManager({
+    generateId: () => `g-${++id}`,
+    now: () => 1000,
+  });
+  const injected: string[] = [];
+  const evaluation: GoalEvaluation = {
+    met: false, impossible: false, progress: true, waiting: false, evaluatorFailed: false, reason: 'keep going',
+    ...opts?.evaluation,
+  };
+  const deps: GoalContinuationDeps = {
+    goalManager: mgr,
+    evaluator: { evaluate: async () => JSON.stringify({
+      met: evaluation.met, impossible: evaluation.impossible,
+      progress: evaluation.progress, waiting: evaluation.waiting,
+      reason: evaluation.reason,
+    }) },
+    getRecentContext: async () => 'recent context',
+    getTokenCount: opts?.tokenCount !== undefined ? () => opts.tokenCount! : undefined,
+    injectTurn: (_s, text) => { injected.push(text); },
+    canContinue: async () => opts?.canContinue ?? true,
+  };
+  return { mgr, deps, injected };
+}
+
+describe('handleGoalContinuation', () => {
+  test('no active goal → no_goal', async () => {
+    const { deps } = setup();
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'no_goal');
+  });
+
+  test('session busy → cannot_continue', async () => {
+    const { mgr, deps } = setup({ canContinue: false });
+    mgr.set(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'cannot_continue');
+  });
+
+  test('met → achieved, no injection', async () => {
+    const { mgr, deps, injected } = setup({ evaluation: { met: true, reason: 'all pass' } });
+    mgr.set(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'achieved');
+    assert.equal(mgr.get(SESSION)?.status, 'achieved');
+    assert.equal(injected.length, 0);
+  });
+
+  test('impossible → impossible, no injection', async () => {
+    const { mgr, deps, injected } = setup({ evaluation: { impossible: true, reason: 'cannot' } });
+    mgr.set(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'impossible');
+    assert.equal(mgr.get(SESSION)?.status, 'impossible');
+    assert.equal(injected.length, 0);
+  });
+
+  test('not met + progress → continued, injects steering turn', async () => {
+    const { mgr, deps, injected } = setup({ evaluation: { progress: true, reason: '1 of 3 done' } });
+    mgr.set(SESSION, 'x');
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'continued');
+    assert.equal(injected.length, 1);
+    assert.ok(injected[0].includes('1 of 3 done'));
+    assert.equal(mgr.get(SESSION)?.iterations, 1);
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
+  });
+
+  test('no progress accumulates and trips stalled at block cap', async () => {
+    const { mgr, deps, injected } = setup({ evaluation: { progress: false, reason: 'stuck' } });
+    mgr.set(SESSION, 'x', { blockCap: 2 });
+    const first = await handleGoalContinuation(deps, SESSION);
+    assert.equal(first.kind, 'continued');
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 1);
+    const second = await handleGoalContinuation(deps, SESSION);
+    assert.equal(second.kind, 'stopped');
+    assert.equal(mgr.get(SESSION)?.status, 'stalled');
+    // Second call must not inject (goal stalled).
+    assert.equal(injected.length, 1);
+  });
+
+  test('evaluate-first: a goal MET on its final permitted turn is achieved, not max_iterations', async () => {
+    const { mgr, deps } = setup({ evaluation: { met: true, reason: 'all pass' } });
+    mgr.set(SESSION, 'x', { maxIterations: 1 });
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'achieved');
+    assert.equal(mgr.get(SESSION)?.status, 'achieved');
+  });
+
+  test('not-met on the final permitted turn stops with max_iterations', async () => {
+    const { mgr, deps } = setup({ evaluation: { met: false, progress: true } });
+    mgr.set(SESSION, 'x', { maxIterations: 1 });
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'stopped');
+    assert.equal(mgr.get(SESSION)?.status, 'max_iterations');
+  });
+
+  test('evaluate-first: a goal MET on the budget-crossing turn is achieved, not budget_limited', async () => {
+    const { mgr, deps } = setup({ tokenCount: 2000, evaluation: { met: true, reason: 'done' } });
+    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'achieved');
+    assert.equal(mgr.get(SESSION)?.status, 'achieved');
+  });
+
+  test('not-met budget crossing stops with budget_limited', async () => {
+    const { mgr, deps } = setup({ tokenCount: 2000, evaluation: { met: false, progress: true } });
+    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
+    mgr.recordTokens(SESSION, 500); // establish baseline before the continuation
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'stopped');
+    assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
+  });
+
+  test('evaluatorFailed leaves the no-progress streak unchanged (neutral)', async () => {
+    let id = 0;
+    const mgr = new GoalManager({ generateId: () => `g-${++id}`, now: () => 1000 });
+    // A throwing evaluator yields evaluatorFailed=true from evaluateGoal.
+    const deps: GoalContinuationDeps = {
+      goalManager: mgr,
+      evaluator: { evaluate: async () => { throw new Error('outage'); } },
+      getRecentContext: async () => 'ctx',
+      injectTurn: () => {},
+      canContinue: async () => true,
+    };
+    mgr.set(SESSION, 'x', { blockCap: 2 });
+    await handleGoalContinuation(deps, SESSION);
+    // Neutral: streak neither advanced nor reset; goal still active (fail-open).
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+
+  test('waiting is neutral: does not count against the stall cap, still injects', async () => {
+    const { mgr, deps, injected } = setup({
+      evaluation: { waiting: true, progress: false, reason: 'CI still running' },
+    });
+    mgr.set(SESSION, 'deploy done', { blockCap: 2 });
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'continued');
+    // Waiting must NOT accumulate toward stall (a wait is not being stuck).
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
+    assert.equal(injected.length, 1);
+    assert.ok(injected[0].includes('waiting on an external event'));
+  });
+
+  test('a long wait is bounded by maxIterations (visible terminal, no zombie)', async () => {
+    const { mgr, deps } = setup({
+      evaluation: { waiting: true, progress: false, reason: 'CI running' },
+    });
+    mgr.set(SESSION, 'x', { maxIterations: 3 });
+    await handleGoalContinuation(deps, SESSION); // turn 1
+    await handleGoalContinuation(deps, SESSION); // turn 2
+    const third = await handleGoalContinuation(deps, SESSION); // turn 3 hits cap
+    assert.equal(third.kind, 'stopped');
+    assert.equal(mgr.get(SESSION)?.status, 'max_iterations');
+  });
+
+  test('re-entrancy guard: overlapping continuation returns busy', async () => {
+    let id = 0;
+    const mgr = new GoalManager({ generateId: () => `g-${++id}`, now: () => 1000 });
+    const inFlight = new Set<string>();
+    let releaseEval: (() => void) | undefined;
+    const deps: GoalContinuationDeps = {
+      goalManager: mgr,
+      inFlight,
+      evaluator: { evaluate: () => new Promise<string>((resolve) => { releaseEval = () => resolve('{"met": false, "progress": true, "reason": "x"}'); }) },
+      getRecentContext: async () => 'ctx',
+      injectTurn: () => {},
+      canContinue: async () => true,
+    };
+    mgr.set(SESSION, 'x');
+    const first = handleGoalContinuation(deps, SESSION); // hangs on evaluate
+    await new Promise((r) => setTimeout(r, 0));
+    const second = await handleGoalContinuation(deps, SESSION); // should see inFlight
+    assert.equal(second.kind, 'busy');
+    releaseEval?.();
+    await first;
+  });
+
+  test('paused goal is not continued', async () => {
+    const { mgr, deps } = setup();
+    mgr.set(SESSION, 'x');
+    mgr.pause(SESSION);
+    const out = await handleGoalContinuation(deps, SESSION);
+    assert.equal(out.kind, 'no_goal');
+  });
+});

--- a/packages/runtime/src/__tests__/goal-evaluator.test.ts
+++ b/packages/runtime/src/__tests__/goal-evaluator.test.ts
@@ -1,0 +1,162 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildGoalEvaluationPrompt,
+  parseGoalEvaluation,
+  evaluateGoal,
+} from '../goal-evaluator.js';
+
+describe('buildGoalEvaluationPrompt', () => {
+  test('includes condition, context, and field spec', () => {
+    const p = buildGoalEvaluationPrompt('all tests pass', 'ran tests, 2 failed');
+    assert.ok(p.includes('all tests pass'));
+    assert.ok(p.includes('ran tests, 2 failed'));
+    assert.ok(p.includes('GOAL CONDITION'));
+    assert.ok(p.includes('CONVERSATION CONTEXT'));
+    assert.ok(p.includes('"met"'));
+    assert.ok(p.includes('"progress"'));
+    assert.ok(p.includes('"waiting"'));
+  });
+});
+
+describe('parseGoalEvaluation', () => {
+  test('parses a full verdict', () => {
+    const r = parseGoalEvaluation('{"met": false, "impossible": false, "progress": true, "waiting": false, "reason": "fixed 1 of 3"}');
+    assert.equal(r.met, false);
+    assert.equal(r.progress, true);
+    assert.equal(r.reason, 'fixed 1 of 3');
+  });
+
+  test('parses waiting (no wait_seconds in the contract)', () => {
+    const r = parseGoalEvaluation('{"met": false, "impossible": false, "progress": false, "waiting": true, "reason": "CI running"}');
+    assert.equal(r.waiting, true);
+    // wait_seconds was removed from the contract (honoring it would be the
+    // out-of-scope scheduled-poll handoff); any wait_seconds in the payload is
+    // simply ignored, never surfaced.
+    assert.equal('waitSeconds' in r, false);
+  });
+
+  test('ignores a stray wait_seconds field in evaluator output', () => {
+    const r = parseGoalEvaluation('{"met": false, "waiting": true, "wait_seconds": 999999, "reason": "x"}');
+    assert.equal(r.waiting, true);
+    assert.equal('waitSeconds' in r, false);
+  });
+
+  test('extracts JSON from surrounding prose', () => {
+    const r = parseGoalEvaluation('Here is my judgment:\n{"met": true, "impossible": false, "progress": true, "waiting": false, "reason": "all pass"}\nDone.');
+    assert.equal(r.met, true);
+  });
+
+  test('missing fields default to false', () => {
+    const r = parseGoalEvaluation('{"met": true}');
+    assert.equal(r.met, true);
+    assert.equal(r.impossible, false);
+    assert.equal(r.progress, false);
+    assert.equal(r.waiting, false);
+    assert.equal(r.reason, 'No reason provided');
+  });
+
+  test('unparseable output → neutral evaluator failure (not real no-progress)', () => {
+    const r = parseGoalEvaluation('I cannot determine this');
+    assert.equal(r.met, false);
+    assert.equal(r.progress, false);
+    assert.equal(r.evaluatorFailed, true);
+    assert.ok(r.reason.includes('unparseable'));
+  });
+
+  test('malformed JSON → neutral evaluator failure', () => {
+    const r = parseGoalEvaluation('{met: true, broken}');
+    assert.equal(r.met, false);
+    assert.equal(r.evaluatorFailed, true);
+    assert.ok(r.reason.includes('parse failed'));
+  });
+
+  test('braces inside reason → treated as neutral, not false no-progress', () => {
+    // A coding-goal judge whose reason references code can defeat the flat regex.
+    const r = parseGoalEvaluation('{"met":false,"progress":true,"reason":"add return {} to handler"}');
+    // Either it parses (progress true) or it fails neutrally — never a real
+    // progress=false that would count toward stall.
+    if (r.evaluatorFailed) {
+      assert.equal(r.progress, false);
+    } else {
+      assert.equal(r.progress, true);
+    }
+  });
+
+  test('truncates long reason', () => {
+    const long = 'x'.repeat(300);
+    const r = parseGoalEvaluation(`{"met": false, "reason": "${long}"}`);
+    assert.ok(r.reason.length <= 200);
+  });
+});
+
+describe('evaluateGoal', () => {
+  test('returns parsed verdict on success', async () => {
+    const r = await evaluateGoal(
+      { evaluate: async () => '{"met": true, "progress": true, "reason": "done"}' },
+      'finish', 'ctx', 'sess-1',
+    );
+    assert.equal(r.met, true);
+    assert.equal(r.reason, 'done');
+  });
+
+  test('fails open on evaluator error (evaluatorFailed=true, continue)', async () => {
+    const r = await evaluateGoal(
+      { evaluate: async () => { throw new Error('network'); } },
+      'finish', 'ctx', 'sess-1',
+    );
+    assert.equal(r.met, false);
+    assert.equal(r.impossible, false);
+    assert.equal(r.progress, false);
+    assert.equal(r.evaluatorFailed, true);
+    assert.ok(r.reason.includes('failed'));
+  });
+
+  test('fails open on timeout (evaluatorFailed=true, continue)', async () => {
+    const r = await evaluateGoal(
+      {
+        // Never resolves — force the timeout branch.
+        evaluate: () => new Promise<string>(() => {}),
+        timeoutMs: 10,
+        // Injected timer fires immediately so the race resolves to timeout.
+        setTimeout: (fn) => { fn(); return 1; },
+        clearTimeout: () => {},
+      },
+      'finish', 'ctx', 'sess-1',
+    );
+    assert.equal(r.met, false);
+    assert.equal(r.progress, false);
+    assert.equal(r.evaluatorFailed, true);
+    assert.ok(r.reason.includes('timed out'));
+  });
+
+  test('successful parse sets evaluatorFailed=false', async () => {
+    const r = await evaluateGoal(
+      { evaluate: async () => '{"met": false, "progress": true, "reason": "ok"}' },
+      'finish', 'ctx', 'sess-1',
+    );
+    assert.equal(r.evaluatorFailed, false);
+  });
+
+  test('clears the timeout timer on success', async () => {
+    let cleared = false;
+    await evaluateGoal(
+      {
+        evaluate: async () => '{"met": true, "reason": "ok"}',
+        setTimeout: () => 42,
+        clearTimeout: (h) => { cleared = h === 42; },
+      },
+      'finish', 'ctx', 'sess-1',
+    );
+    assert.equal(cleared, true);
+  });
+
+  test('threads the sessionId into the evaluator (session-model routing)', async () => {
+    let seenSessionId: string | undefined;
+    await evaluateGoal(
+      { evaluate: async (_prompt, sessionId) => { seenSessionId = sessionId; return '{"met": true, "reason": "ok"}'; } },
+      'finish', 'ctx', 'sess-42',
+    );
+    assert.equal(seenSessionId, 'sess-42');
+  });
+});

--- a/packages/runtime/src/__tests__/goal-state.test.ts
+++ b/packages/runtime/src/__tests__/goal-state.test.ts
@@ -1,0 +1,290 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GoalManager,
+  TERMINAL_GOAL_STATUSES,
+  DEFAULT_MAX_ITERATIONS,
+  DEFAULT_BLOCK_CAP,
+} from '../goal-state.js';
+
+const SESSION = 'sess-1';
+
+function createManager(startTime = 1_700_000_000_000) {
+  let id = 0;
+  let time = startTime;
+  const mgr = new GoalManager({ generateId: () => `goal-${++id}`, now: () => time });
+  return { mgr, advance: (ms: number) => { time += ms; }, at: () => time };
+}
+
+describe('GoalManager — set / lifecycle', () => {
+  test('set creates an active goal with defaults', () => {
+    const { mgr } = createManager();
+    const g = mgr.set(SESSION, 'all tests pass');
+    assert.equal(g.status, 'active');
+    assert.equal(g.iterations, 0);
+    assert.equal(g.maxIterations, DEFAULT_MAX_ITERATIONS);
+    assert.equal(g.blockCap, DEFAULT_BLOCK_CAP);
+    assert.equal(g.consecutiveNoProgress, 0);
+    assert.equal(g.tokenBudget, undefined);
+  });
+
+  test('set accepts custom limits', () => {
+    const { mgr } = createManager();
+    const g = mgr.set(SESSION, 'x', { maxIterations: 10, blockCap: 3, tokenBudget: 5000, tokensAtStart: 100 });
+    assert.equal(g.maxIterations, 10);
+    assert.equal(g.blockCap, 3);
+    assert.equal(g.tokenBudget, 5000);
+    assert.equal(g.tokensAtStart, 100);
+    assert.equal(g.tokensNow, 100);
+  });
+
+  test('set replaces an active goal (old marked cleared)', () => {
+    const { mgr } = createManager();
+    const first = mgr.set(SESSION, 'first');
+    mgr.set(SESSION, 'second');
+    assert.equal(first.status, 'cleared');
+    assert.equal(mgr.get(SESSION)?.condition, 'second');
+  });
+
+  test('set after a terminal goal does not mutate the settled one', () => {
+    const { mgr } = createManager();
+    const first = mgr.set(SESSION, 'first');
+    mgr.markAchieved(SESSION, 'done');
+    assert.equal(first.status, 'achieved');
+    mgr.set(SESSION, 'second');
+    // The achieved goal object keeps its status; a new goal replaces the map entry.
+    assert.equal(first.status, 'achieved');
+    assert.equal(mgr.get(SESSION)?.condition, 'second');
+  });
+
+  test('getActive only returns active goals', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    assert.ok(mgr.getActive(SESSION));
+    mgr.pause(SESSION);
+    assert.equal(mgr.getActive(SESSION), undefined);
+  });
+});
+
+describe('GoalManager — iteration ceiling', () => {
+  test('incrementIteration trips max_iterations', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { maxIterations: 2 });
+    mgr.incrementIteration(SESSION);
+    const g = mgr.incrementIteration(SESSION);
+    assert.equal(g?.status, 'max_iterations');
+  });
+
+  test('incrementIteration on non-active returns undefined', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    mgr.pause(SESSION);
+    assert.equal(mgr.incrementIteration(SESSION), undefined);
+  });
+});
+
+describe('GoalManager — block cap (stall detection)', () => {
+  test('progress resets the no-progress streak', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { blockCap: 3 });
+    mgr.recordProgress(SESSION, false);
+    mgr.recordProgress(SESSION, false);
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 2);
+    mgr.recordProgress(SESSION, true);
+    assert.equal(mgr.get(SESSION)?.consecutiveNoProgress, 0);
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+
+  test('block cap trips stalled', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { blockCap: 3 });
+    mgr.recordProgress(SESSION, false);
+    mgr.recordProgress(SESSION, false);
+    const g = mgr.recordProgress(SESSION, false);
+    assert.equal(g?.status, 'stalled');
+    assert.ok(g?.lastReason?.includes('No progress'));
+  });
+
+  test('recordProgress on non-active is a no-op', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    mgr.markAchieved(SESSION, 'done');
+    assert.equal(mgr.recordProgress(SESSION, false), undefined);
+  });
+});
+
+describe('GoalManager — token budget', () => {
+  test('recordTokens trips budget_limited (after baseline established)', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { tokenBudget: 1000, tokensAtStart: 500 });
+    mgr.recordTokens(SESSION, 500);  // establishes baseline at 500
+    mgr.recordTokens(SESSION, 1200); // spent 700, under budget
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+    mgr.recordTokens(SESSION, 1600); // spent 1100, over budget
+    assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
+  });
+
+  test('tokensSpent computes delta from established baseline', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { tokensAtStart: 500 });
+    mgr.recordTokens(SESSION, 500); // baseline
+    mgr.recordTokens(SESSION, 800);
+    assert.equal(mgr.tokensSpent(SESSION), 300);
+  });
+
+  test('token count is monotonic (stale smaller read ignored)', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x', { tokensAtStart: 0 });
+    mgr.recordTokens(SESSION, 0);    // baseline
+    mgr.recordTokens(SESSION, 1000);
+    mgr.recordTokens(SESSION, 500);  // stale
+    assert.equal(mgr.get(SESSION)?.tokensNow, 1000);
+  });
+
+  test('no budget → recordTokens never trips budget_limited', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    mgr.recordTokens(SESSION, 0);
+    mgr.recordTokens(SESSION, 1_000_000);
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+});
+
+describe('GoalManager — pause / resume', () => {
+  test('pause then resume', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    const paused = mgr.pause(SESSION);
+    assert.equal(paused?.status, 'paused');
+    assert.ok(paused?.pausedAt);
+    const resumed = mgr.resume(SESSION);
+    assert.equal(resumed?.status, 'active');
+    assert.equal(resumed?.pausedAt, undefined);
+  });
+
+  test('cannot pause a non-active goal', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    mgr.markAchieved(SESSION, 'done');
+    assert.equal(mgr.pause(SESSION), undefined);
+  });
+
+  test('cannot resume a non-paused goal', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    assert.equal(mgr.resume(SESSION), undefined);
+  });
+});
+
+describe('GoalManager — terminal transitions', () => {
+  test('markAchieved / markImpossible only from active', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    assert.equal(mgr.markAchieved(SESSION, 'done')?.status, 'achieved');
+    assert.equal(mgr.markImpossible(SESSION, 'no'), undefined);
+  });
+
+  test('clear from active → cleared; clear from terminal keeps outcome', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    assert.equal(mgr.clear(SESSION)?.status, 'cleared');
+
+    mgr.set(SESSION, 'y');
+    mgr.markAchieved(SESSION, 'done');
+    assert.equal(mgr.clear(SESSION)?.status, 'achieved');
+  });
+
+  test('TERMINAL_GOAL_STATUSES covers all stop states', () => {
+    for (const s of ['achieved', 'impossible', 'cleared', 'stalled', 'budget_limited', 'max_iterations'] as const) {
+      assert.ok(TERMINAL_GOAL_STATUSES.has(s), `${s} should be terminal`);
+    }
+    assert.ok(!TERMINAL_GOAL_STATUSES.has('active'));
+    assert.ok(!TERMINAL_GOAL_STATUSES.has('paused'));
+  });
+
+  test('remove and dispose', () => {
+    const { mgr } = createManager();
+    mgr.set(SESSION, 'x');
+    assert.equal(mgr.remove(SESSION), true);
+    assert.equal(mgr.get(SESSION), undefined);
+    mgr.set('a', '1');
+    mgr.set('b', '2');
+    mgr.dispose();
+    assert.equal(mgr.get('a'), undefined);
+    assert.equal(mgr.get('b'), undefined);
+  });
+
+  test('different sessions are independent', () => {
+    const { mgr } = createManager();
+    mgr.set('a', 'goal A');
+    mgr.set('b', 'goal B');
+    assert.equal(mgr.get('a')?.condition, 'goal A');
+    assert.equal(mgr.get('b')?.condition, 'goal B');
+  });
+});
+
+describe('GoalManager — token baseline', () => {
+  test('first recordTokens establishes the baseline (spend starts at 0)', () => {
+    const { mgr } = createManager();
+    // GoalSet captured a stale/0 baseline; the goal actually starts at 50k.
+    mgr.set(SESSION, 'x', { tokenBudget: 20000, tokensAtStart: 0 });
+    mgr.recordTokens(SESSION, 50000); // first real observation → re-baseline
+    assert.equal(mgr.tokensSpent(SESSION), 0);
+    assert.equal(mgr.get(SESSION)?.status, 'active'); // NOT budget_limited
+    mgr.recordTokens(SESSION, 71000); // spent 21000 > 20000
+    assert.equal(mgr.get(SESSION)?.status, 'budget_limited');
+  });
+});
+
+describe('GoalManager — onChange (kill-switch events)', () => {
+  function managerWithSpy() {
+    let id = 0;
+    const events: Array<{ status: string; previous?: string }> = [];
+    const mgr = new GoalManager({
+      generateId: () => `goal-${++id}`,
+      now: () => 1_700_000_000_000,
+      onChange: (goal, previous) => events.push({ status: goal.status, previous }),
+    });
+    return { mgr, events };
+  }
+
+  test('fires on set (goal armed)', () => {
+    const { mgr, events } = managerWithSpy();
+    mgr.set(SESSION, 'x');
+    assert.equal(events.length, 1);
+    assert.equal(events[0].status, 'active');
+    assert.equal(events[0].previous, undefined);
+  });
+
+  test('fires on each continuation and carries the previous status', () => {
+    const { mgr, events } = managerWithSpy();
+    mgr.set(SESSION, 'x');
+    mgr.incrementIteration(SESSION);
+    assert.equal(events.length, 2);
+    assert.equal(events[1].status, 'active');
+    assert.equal(events[1].previous, 'active');
+  });
+
+  test('fires on terminal transitions (achieved / cleared)', () => {
+    const { mgr, events } = managerWithSpy();
+    mgr.set(SESSION, 'x');
+    mgr.markAchieved(SESSION, 'done');
+    assert.equal(events.at(-1)?.status, 'achieved');
+    mgr.set('sess-2', 'y');
+    mgr.clear('sess-2');
+    assert.equal(events.at(-1)?.status, 'cleared');
+  });
+
+  test('fires on remove so a badge can clear', () => {
+    const { mgr, events } = managerWithSpy();
+    mgr.set(SESSION, 'x');
+    const before = events.length;
+    mgr.remove(SESSION);
+    assert.equal(events.length, before + 1);
+  });
+
+  test('is optional — a manager without onChange still mutates', () => {
+    const mgr = new GoalManager({ generateId: () => 'g', now: () => 0 });
+    assert.doesNotThrow(() => { mgr.set(SESSION, 'x'); mgr.clear(SESSION); });
+  });
+});

--- a/packages/runtime/src/__tests__/goal-tools.test.ts
+++ b/packages/runtime/src/__tests__/goal-tools.test.ts
@@ -1,0 +1,119 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GoalManager } from '../goal-state.js';
+import {
+  buildGoalTools,
+  GOAL_SET_TOOL_NAME,
+  GOAL_CLEAR_TOOL_NAME,
+  GOAL_STATUS_TOOL_NAME,
+  GOAL_PAUSE_TOOL_NAME,
+  GOAL_RESUME_TOOL_NAME,
+} from '../goal-tools.js';
+import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
+
+const SESSION = 'sess-1';
+
+function ctx(): MakaToolContext {
+  return { sessionId: SESSION, turnId: 't', cwd: '/', toolCallId: 'tc', abortSignal: new AbortController().signal, emitOutput: () => {} };
+}
+
+function findTool(tools: MakaTool[], name: string): MakaTool {
+  const t = tools.find(x => x.name === name);
+  assert.ok(t, `tool ${name} exists`);
+  return t!;
+}
+
+function makeTools(getTokenCount?: (s: string) => number) {
+  const mgr = new GoalManager({ generateId: () => 'g-1', now: () => 5000 });
+  const tools = buildGoalTools({ goalManager: mgr, getTokenCount, now: () => 5000 });
+  return { mgr, tools };
+}
+
+describe('goal tools', () => {
+  test('exposes 5 tools', () => {
+    const { tools } = makeTools();
+    const names = tools.map(t => t.name).sort();
+    assert.deepEqual(names, [
+      GOAL_CLEAR_TOOL_NAME, GOAL_PAUSE_TOOL_NAME, GOAL_RESUME_TOOL_NAME,
+      GOAL_SET_TOOL_NAME, GOAL_STATUS_TOOL_NAME,
+    ].sort());
+  });
+
+  test('all tools are permission-free', () => {
+    const { tools } = makeTools();
+    for (const t of tools) assert.equal(t.permissionRequired, false);
+  });
+
+  test('GoalSet creates a goal with custom limits', async () => {
+    const { mgr, tools } = makeTools();
+    const set = findTool(tools, GOAL_SET_TOOL_NAME);
+    const out = await set.impl({ condition: 'all tests pass', max_iterations: 10, block_cap: 3, token_budget: 5000 }, ctx()) as string;
+    assert.ok(out.includes('Goal set'));
+    assert.ok(out.includes('all tests pass'));
+    assert.ok(out.includes('max 10 turns'));
+    assert.ok(out.includes('budget 5000'));
+    const g = mgr.get(SESSION)!;
+    assert.equal(g.maxIterations, 10);
+    assert.equal(g.blockCap, 3);
+    assert.equal(g.tokenBudget, 5000);
+  });
+
+  test('GoalSet captures the token baseline', async () => {
+    const { mgr, tools } = makeTools(() => 1234);
+    const set = findTool(tools, GOAL_SET_TOOL_NAME);
+    await set.impl({ condition: 'x' }, ctx());
+    assert.equal(mgr.get(SESSION)?.tokensAtStart, 1234);
+  });
+
+  test('GoalPause / GoalResume lifecycle', async () => {
+    const { mgr, tools } = makeTools();
+    await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'x' }, ctx());
+
+    const pauseOut = await findTool(tools, GOAL_PAUSE_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(pauseOut.includes('paused'));
+    assert.equal(mgr.get(SESSION)?.status, 'paused');
+
+    const resumeOut = await findTool(tools, GOAL_RESUME_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(resumeOut.includes('resumed'));
+    assert.equal(mgr.get(SESSION)?.status, 'active');
+  });
+
+  test('GoalPause with no goal', async () => {
+    const { tools } = makeTools();
+    const out = await findTool(tools, GOAL_PAUSE_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(out.includes('No active goal'));
+  });
+
+  test('GoalResume with no paused goal', async () => {
+    const { tools } = makeTools();
+    await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'x' }, ctx());
+    const out = await findTool(tools, GOAL_RESUME_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(out.includes('No paused goal'));
+  });
+
+  test('GoalClear', async () => {
+    const { mgr, tools } = makeTools();
+    await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'x' }, ctx());
+    const out = await findTool(tools, GOAL_CLEAR_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(out.includes('cleared'));
+    assert.equal(mgr.get(SESSION)?.status, 'cleared');
+  });
+
+  test('GoalStatus shows full lifecycle detail', async () => {
+    const { mgr, tools } = makeTools();
+    await findTool(tools, GOAL_SET_TOOL_NAME).impl({ condition: 'deploy', token_budget: 5000 }, ctx());
+    mgr.recordTokens(SESSION, 1000); // establishes baseline at 1000
+    mgr.recordTokens(SESSION, 2500); // spent 1500 since baseline
+    const out = await findTool(tools, GOAL_STATUS_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(out.includes('deploy'));
+    assert.ok(out.includes('Status: active'));
+    assert.ok(out.includes('No-progress streak: 0/8'));
+    assert.ok(out.includes('Tokens: 1500/5000'));
+  });
+
+  test('GoalStatus with no goal', async () => {
+    const { tools } = makeTools();
+    const out = await findTool(tools, GOAL_STATUS_TOOL_NAME).impl({}, ctx()) as string;
+    assert.ok(out.includes('No goal set'));
+  });
+});

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -1,0 +1,116 @@
+/**
+ * Goal continuation controller — the pure decision logic for what happens at a
+ * turn boundary when a goal is active. Lives in @maka/runtime so desktop and
+ * CLI share one implementation (Desktop/TUI parity rule).
+ *
+ * Called after a turn's event stream drains. Order of operations matters:
+ * the external evaluator runs FIRST so a goal genuinely completed on its last
+ * permitted turn is detected as achieved/impossible rather than misreported as
+ * a cap failure. Caps (iterations / token budget / stall) are enforced only
+ * after the evaluator has had its say.
+ *
+ * "Waiting on an external event" is treated as a NEUTRAL signal: the turn does
+ * not count against the stall cap (the agent is legitimately blocked, not
+ * stuck), and a normal continuation turn is injected so the agent re-checks.
+ * A long wait is bounded by maxIterations and surfaces as a visible terminal
+ * state — never a silent zombie. (A scheduled poll handoff to the automation
+ * system is deliberately out of scope for v1; it couples two independent
+ * lifecycles and is easy to get wrong.)
+ */
+
+import { evaluateGoal, type GoalEvaluation, type GoalEvaluatorDeps } from './goal-evaluator.js';
+import type { GoalManager } from './goal-state.js';
+
+export type GoalContinuationOutcome =
+  | { kind: 'no_goal' }
+  | { kind: 'cannot_continue' }
+  | { kind: 'busy' }
+  | { kind: 'achieved'; evaluation: GoalEvaluation }
+  | { kind: 'impossible'; evaluation: GoalEvaluation }
+  | { kind: 'stopped'; reason: string; status: string }
+  | { kind: 'continued'; evaluation: GoalEvaluation };
+
+export interface GoalContinuationDeps {
+  goalManager: GoalManager;
+  evaluator: GoalEvaluatorDeps;
+  /** Summarized recent conversation (last ~5 messages) for the evaluator. */
+  getRecentContext: (sessionId: string) => Promise<string>;
+  /** Current cumulative token count for the session (for budget tracking). */
+  getTokenCount?: (sessionId: string) => number;
+  /** Inject a continuation turn into the session. */
+  injectTurn: (sessionId: string, text: string) => void;
+  /** Session is idle and can accept a new turn (exists, not archived, not running). */
+  canContinue: (sessionId: string) => Promise<boolean>;
+  /**
+   * Per-session re-entrancy guard. Prevents two overlapping continuations for
+   * the same session (the evaluator call spans multiple seconds, during which a
+   * second turn could complete). Supplied by the wiring; omitted in unit tests.
+   */
+  inFlight?: Set<string>;
+}
+
+const CONTINUATION_PREAMBLE =
+  '[Goal continuation] The goal is not yet met. Keep working toward it. '
+  + 'Do not redefine success around a smaller task; match your verification to the full requirement.';
+
+export async function handleGoalContinuation(
+  deps: GoalContinuationDeps,
+  sessionId: string,
+): Promise<GoalContinuationOutcome> {
+  const goal = deps.goalManager.getActive(sessionId);
+  if (!goal) return { kind: 'no_goal' };
+
+  // Re-entrancy guard: only one continuation in flight per session.
+  if (deps.inFlight?.has(sessionId)) return { kind: 'busy' };
+  deps.inFlight?.add(sessionId);
+  try {
+    if (!(await deps.canContinue(sessionId))) return { kind: 'cannot_continue' };
+
+    // Evaluate FIRST — a genuine completion on the final permitted turn must be
+    // detected before any cap short-circuits the loop.
+    const context = await deps.getRecentContext(sessionId);
+    const evaluation = await evaluateGoal(deps.evaluator, goal.condition, context, sessionId);
+
+    if (evaluation.met) {
+      deps.goalManager.markAchieved(sessionId, evaluation.reason);
+      return { kind: 'achieved', evaluation };
+    }
+    if (evaluation.impossible) {
+      deps.goalManager.markImpossible(sessionId, evaluation.reason);
+      return { kind: 'impossible', evaluation };
+    }
+
+    // Enforce caps AFTER evaluation. Each may flip the goal terminal.
+    if (deps.getTokenCount) {
+      deps.goalManager.recordTokens(sessionId, deps.getTokenCount(sessionId));
+    }
+    deps.goalManager.incrementIteration(sessionId);
+    // Progress signal drives the stall cap. Skip it (neutral) when the evaluator
+    // failed (transient outage must not defeat stall detection) OR when the
+    // agent is legitimately waiting on an external event (a wait is not a stall).
+    if (!evaluation.evaluatorFailed && !evaluation.waiting) {
+      deps.goalManager.recordProgress(sessionId, evaluation.progress);
+    }
+
+    const settled = deps.goalManager.get(sessionId);
+    if (!settled || settled.status !== 'active') {
+      return { kind: 'stopped', reason: settled?.lastReason ?? 'Goal settled', status: settled?.status ?? 'unknown' };
+    }
+
+    // Re-check idle immediately before injecting — the evaluator call may have
+    // spanned seconds during which a user send started a new turn.
+    if (!(await deps.canContinue(sessionId))) return { kind: 'cannot_continue' };
+
+    settled.lastReason = evaluation.reason;
+    const waitNote = evaluation.waiting ? ' (waiting on an external event — re-check, do not spin uselessly)' : '';
+    deps.injectTurn(
+      sessionId,
+      `${CONTINUATION_PREAMBLE}\n\nEvaluation: ${evaluation.reason}${waitNote}\n`
+      + `Goal: "${settled.condition}" (turn ${settled.iterations}/${settled.maxIterations}`
+      + `${settled.consecutiveNoProgress > 0 ? `, ${settled.consecutiveNoProgress}/${settled.blockCap} no-progress` : ''})`,
+    );
+    return { kind: 'continued', evaluation };
+  } finally {
+    deps.inFlight?.delete(sessionId);
+  }
+}

--- a/packages/runtime/src/goal-evaluator.ts
+++ b/packages/runtime/src/goal-evaluator.ts
@@ -1,0 +1,140 @@
+/**
+ * Goal evaluator — CC-style external judge. Runs after each turn to decide
+ * whether the goal is met, impossible, making progress, or waiting on an
+ * external event. The judge runs on the SESSION's own model (see wiring): the
+ * evaluation reads that session's recent messages, so routing it to the same
+ * provider keeps the judgment consistent and avoids leaking session text to an
+ * unrelated default connection.
+ *
+ * The working model never judges its own completion (unlike Codex): keeping the
+ * judge external prevents the agent from rationalizing itself into a premature
+ * "done", which is Codex's documented failure mode.
+ */
+
+export interface GoalEvaluation {
+  /** Condition is satisfied — stop, success. */
+  met: boolean;
+  /** Fundamentally unachievable — stop, give up. */
+  impossible: boolean;
+  /** The last turn advanced toward the goal (resets the block cap). */
+  progress: boolean;
+  /** The agent is blocked waiting on an external event (CI, deploy, review). */
+  waiting: boolean;
+  /**
+   * The evaluator failed (timeout/error) and produced no real judgment. The
+   * caller should treat `progress` as UNKNOWN — neither advancing nor resetting
+   * the stall counter — so a transient evaluator outage cannot silently defeat
+   * stall detection. Fail-open on continuation still applies.
+   */
+  evaluatorFailed: boolean;
+  /** One-sentence rationale, fed back to the agent as steering. */
+  reason: string;
+}
+
+export interface GoalEvaluatorDeps {
+  /**
+   * Single-shot LLM call for goal evaluation, run on the session's own model
+   * (the wiring resolves the session's connection from `sessionId`). The
+   * evaluator must not run tools or read files — it judges from text only.
+   */
+  evaluate: (prompt: string, sessionId: string) => Promise<string>;
+  /** Hard timeout for the evaluator call (ms). Defaults to 30_000 (CC's limit). */
+  timeoutMs?: number;
+  /** Injectable timer for tests. Defaults to global setTimeout/clearTimeout. */
+  setTimeout?: (fn: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+}
+
+const DEFAULT_EVALUATOR_TIMEOUT_MS = 30_000;
+
+const EVALUATOR_SYSTEM = `You are a goal evaluation judge for an autonomous coding agent. Given a GOAL CONDITION and recent CONVERSATION CONTEXT, judge the agent's progress.
+
+Respond ONLY with valid JSON in this exact shape:
+{"met": boolean, "impossible": boolean, "progress": boolean, "waiting": boolean, "reason": "one sentence"}
+
+Field rules:
+- met: true ONLY if there is clear, concrete evidence the condition is fully satisfied. Match verification scope to the requirement scope — do not accept a narrower substitute.
+- impossible: true ONLY for a truly unachievable goal (violates constraints/physics), not merely a hard one.
+- progress: true if the last turn moved measurably closer to the goal (fixed a failure, advanced a step). false if the turn spun, repeated itself, or did nothing useful.
+- waiting: true if the agent is correctly blocked on an external event it cannot speed up (CI run, deploy, remote queue, human review).
+- reason: concise (under 120 chars), specific, actionable steering for the next turn.
+
+Be conservative on "met" and "impossible". When uncertain, met=false impossible=false progress=false waiting=false.`;
+
+export function buildGoalEvaluationPrompt(condition: string, context: string): string {
+  return [
+    EVALUATOR_SYSTEM,
+    '',
+    '--- GOAL CONDITION ---',
+    condition,
+    '',
+    '--- RECENT CONVERSATION CONTEXT ---',
+    context,
+    '',
+    '--- YOUR JUDGMENT (JSON only) ---',
+  ].join('\n');
+}
+
+export function parseGoalEvaluation(raw: string): GoalEvaluation {
+  // Unparseable output is "no real judgment" — treat it as a NEUTRAL evaluator
+  // failure (like a timeout), NOT as real "no progress", so a garbled cheap-model
+  // response cannot skew stall detection into a false 'stalled' termination.
+  const fallback: GoalEvaluation = {
+    met: false, impossible: false, progress: false, waiting: false, evaluatorFailed: true,
+    reason: 'Evaluator produced unparseable output',
+  };
+  // Prefer the object that mentions "met"; fall back to the first object.
+  const jsonMatch = raw.match(/\{[^{}]*"met"[^{}]*\}/s) ?? raw.match(/\{[\s\S]*?\}/);
+  if (!jsonMatch) return fallback;
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    return {
+      met: Boolean(parsed.met),
+      impossible: Boolean(parsed.impossible),
+      progress: Boolean(parsed.progress),
+      waiting: Boolean(parsed.waiting),
+      evaluatorFailed: false,
+      reason: typeof parsed.reason === 'string' && parsed.reason.trim()
+        ? parsed.reason.slice(0, 200)
+        : 'No reason provided',
+    };
+  } catch {
+    return { ...fallback, reason: 'Evaluator JSON parse failed' };
+  }
+}
+
+/**
+ * Race the evaluator against a hard timeout. On timeout or error, fail OPEN
+ * for continuation (goal keeps working) but flag `evaluatorFailed` so the
+ * caller does not treat the outage as either progress or a stall.
+ */
+export async function evaluateGoal(
+  deps: GoalEvaluatorDeps,
+  condition: string,
+  context: string,
+  sessionId: string,
+): Promise<GoalEvaluation> {
+  const prompt = buildGoalEvaluationPrompt(condition, context);
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_EVALUATOR_TIMEOUT_MS;
+  const setT = deps.setTimeout ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearT = deps.clearTimeout ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+
+  let timer: unknown;
+  const timeout = new Promise<'__timeout__'>((resolve) => {
+    timer = setT(() => resolve('__timeout__'), timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([deps.evaluate(prompt, sessionId), timeout]);
+    if (result === '__timeout__') {
+      return { met: false, impossible: false, progress: false, waiting: false, evaluatorFailed: true, reason: 'Evaluator timed out (continuing)' };
+    }
+    return parseGoalEvaluation(result);
+  } catch {
+    return { met: false, impossible: false, progress: false, waiting: false, evaluatorFailed: true, reason: 'Evaluator call failed (continuing)' };
+  } finally {
+    clearT(timer);
+  }
+}
+
+export { DEFAULT_EVALUATOR_TIMEOUT_MS };

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -1,0 +1,261 @@
+/**
+ * Goal execution state — session-scoped, in-memory.
+ *
+ * A goal is a durable objective the agent works toward autonomously across
+ * turns. After each turn, an external evaluator (CC-style) judges whether the
+ * condition is met; if not, the system auto-continues.
+ *
+ * PERSISTENCE: goals live only in memory and are intentionally NOT persisted —
+ * a restart clears every goal (the autonomous loop stops rather than silently
+ * resuming an objective the user may no longer want). This is a deliberate v1
+ * default: a goal is bounded to the running session's lifetime. Durable,
+ * cross-restart objectives are the Automation primitive's job, not this one.
+ *
+ * Lifecycle (Codex-inspired):
+ *   active → achieved / impossible / cleared / paused
+ *          → stalled (block cap: N consecutive no-progress turns)
+ *          → budget_limited (token budget exhausted)
+ *          → max_iterations (total turn ceiling)
+ */
+
+export type GoalStatus =
+  | 'active'
+  | 'achieved'
+  | 'impossible'
+  | 'cleared'
+  | 'paused'
+  | 'stalled'
+  | 'budget_limited'
+  | 'max_iterations';
+
+/** Terminal statuses — a goal in one of these states will not continue. */
+export const TERMINAL_GOAL_STATUSES: ReadonlySet<GoalStatus> = new Set<GoalStatus>([
+  'achieved',
+  'impossible',
+  'cleared',
+  'stalled',
+  'budget_limited',
+  'max_iterations',
+]);
+
+export interface GoalState {
+  id: string;
+  sessionId: string;
+  condition: string;
+  status: GoalStatus;
+  setAt: number;
+  iterations: number;
+  maxIterations: number;
+  /** Consecutive turns with no progress (drives the block cap → stalled). */
+  consecutiveNoProgress: number;
+  /** Force-stop after this many consecutive no-progress turns (CC's 8). */
+  blockCap: number;
+  /** Optional token budget; goal → budget_limited when exceeded. */
+  tokenBudget?: number;
+  /** Token count observed when the goal was set (baseline for spend). */
+  tokensAtStart: number;
+  /** Latest observed token count (used to compute spend). */
+  tokensNow: number;
+  /**
+   * True until the first real token observation. The baseline captured at set
+   * time can be stale/0 (the model calls GoalSet before any continuation has
+   * observed the session's token count), so the first recordTokens re-baselines
+   * to measure only tokens the goal itself spends.
+   */
+  tokensBaselinePending: boolean;
+  lastReason?: string;
+  achievedAt?: number;
+  pausedAt?: number;
+}
+
+export interface GoalManagerDeps {
+  generateId: () => string;
+  now: () => number;
+  /**
+   * Fired after every goal state transition (set / continue / pause / resume /
+   * terminal / clear / remove). Lets a host surface an autonomous loop to the
+   * UI — a token-burning goal must never run without a visible indicator and a
+   * clear affordance. `previous` is the status before the change (undefined on
+   * first set) so a host can detect entering/leaving the active state.
+   */
+  onChange?: (goal: GoalState, previous?: GoalStatus) => void;
+}
+
+export const DEFAULT_MAX_ITERATIONS = 50;
+export const DEFAULT_BLOCK_CAP = 8;
+
+export class GoalManager {
+  private goals = new Map<string, GoalState>();
+
+  constructor(private readonly deps: GoalManagerDeps) {}
+
+  private emit(goal: GoalState, previous?: GoalStatus): void {
+    this.deps.onChange?.(goal, previous);
+  }
+
+  set(sessionId: string, condition: string, opts?: {
+    maxIterations?: number;
+    blockCap?: number;
+    tokenBudget?: number;
+    tokensAtStart?: number;
+  }): GoalState {
+    // Replacing an existing goal: settle the old one before overwriting.
+    const existing = this.goals.get(sessionId);
+    if (existing && !TERMINAL_GOAL_STATUSES.has(existing.status)) {
+      existing.status = 'cleared';
+    }
+    const start = opts?.tokensAtStart ?? 0;
+    const goal: GoalState = {
+      id: this.deps.generateId(),
+      sessionId,
+      condition,
+      status: 'active',
+      setAt: this.deps.now(),
+      iterations: 0,
+      maxIterations: opts?.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+      consecutiveNoProgress: 0,
+      blockCap: opts?.blockCap ?? DEFAULT_BLOCK_CAP,
+      tokenBudget: opts?.tokenBudget,
+      tokensAtStart: start,
+      tokensNow: start,
+      tokensBaselinePending: true,
+    };
+    this.goals.set(sessionId, goal);
+    this.emit(goal);
+    return goal;
+  }
+
+  get(sessionId: string): GoalState | undefined {
+    return this.goals.get(sessionId);
+  }
+
+  getActive(sessionId: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    return goal?.status === 'active' ? goal : undefined;
+  }
+
+  tokensSpent(sessionId: string): number {
+    const goal = this.goals.get(sessionId);
+    if (!goal) return 0;
+    return Math.max(0, goal.tokensNow - goal.tokensAtStart);
+  }
+
+  incrementIteration(sessionId: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'active') return undefined;
+    const previous = goal.status;
+    goal.iterations++;
+    if (goal.iterations >= goal.maxIterations) {
+      goal.status = 'max_iterations';
+      goal.lastReason = `Reached maximum iterations (${goal.maxIterations})`;
+    }
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  recordProgress(sessionId: string, madeProgress: boolean): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'active') return undefined;
+    const previous = goal.status;
+    if (madeProgress) {
+      goal.consecutiveNoProgress = 0;
+    } else {
+      goal.consecutiveNoProgress++;
+      if (goal.consecutiveNoProgress >= goal.blockCap) {
+        goal.status = 'stalled';
+        goal.lastReason = `No progress for ${goal.blockCap} consecutive turns`;
+      }
+    }
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  recordTokens(sessionId: string, tokensNow: number): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal) return undefined;
+    const previous = goal.status;
+    // The first real observation establishes the baseline (see field doc).
+    if (goal.tokensBaselinePending) {
+      goal.tokensAtStart = tokensNow;
+      goal.tokensNow = tokensNow;
+      goal.tokensBaselinePending = false;
+      this.emit(goal, previous);
+      return goal;
+    }
+    // Token counts are monotonic; never let a stale/smaller read regress spend.
+    goal.tokensNow = Math.max(goal.tokensNow, tokensNow);
+    if (
+      goal.status === 'active' &&
+      goal.tokenBudget !== undefined &&
+      goal.tokensNow - goal.tokensAtStart >= goal.tokenBudget
+    ) {
+      goal.status = 'budget_limited';
+      goal.lastReason = `Token budget exhausted (${goal.tokenBudget} tokens)`;
+    }
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  markAchieved(sessionId: string, reason: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'active') return undefined;
+    const previous = goal.status;
+    goal.status = 'achieved';
+    goal.lastReason = reason;
+    goal.achievedAt = this.deps.now();
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  markImpossible(sessionId: string, reason: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'active') return undefined;
+    const previous = goal.status;
+    goal.status = 'impossible';
+    goal.lastReason = reason;
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  pause(sessionId: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'active') return undefined;
+    const previous = goal.status;
+    goal.status = 'paused';
+    goal.pausedAt = this.deps.now();
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  resume(sessionId: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal || goal.status !== 'paused') return undefined;
+    const previous = goal.status;
+    goal.status = 'active';
+    goal.pausedAt = undefined;
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  clear(sessionId: string): GoalState | undefined {
+    const goal = this.goals.get(sessionId);
+    if (!goal) return undefined;
+    const previous = goal.status;
+    if (!TERMINAL_GOAL_STATUSES.has(goal.status)) {
+      goal.status = 'cleared';
+    }
+    this.emit(goal, previous);
+    return goal;
+  }
+
+  remove(sessionId: string): boolean {
+    const goal = this.goals.get(sessionId);
+    const deleted = this.goals.delete(sessionId);
+    if (goal && deleted) this.emit(goal, goal.status);
+    return deleted;
+  }
+
+  dispose(): void {
+    this.goals.clear();
+  }
+}

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -1,0 +1,155 @@
+/**
+ * Goal tools — GoalSet / GoalClear / GoalStatus / GoalPause / GoalResume.
+ *
+ * Model-facing autonomous-execution controls. The agent can arm its own stop
+ * condition (GoalSet), and pause/resume/clear the loop. PascalCase names match
+ * the builtin tool family (Bash/Read/TaskCreate/Automation).
+ */
+
+import { z } from 'zod';
+import type { MakaTool } from './tool-runtime.js';
+import type { GoalManager, GoalState } from './goal-state.js';
+
+export const GOAL_SET_TOOL_NAME = 'GoalSet';
+export const GOAL_CLEAR_TOOL_NAME = 'GoalClear';
+export const GOAL_STATUS_TOOL_NAME = 'GoalStatus';
+export const GOAL_PAUSE_TOOL_NAME = 'GoalPause';
+export const GOAL_RESUME_TOOL_NAME = 'GoalResume';
+
+export interface GoalToolsDeps {
+  goalManager: GoalManager;
+  /** Current cumulative token count for a session (baseline for budget). */
+  getTokenCount?: (sessionId: string) => number;
+  now?: () => number;
+}
+
+export function buildGoalTools(deps: GoalToolsDeps): MakaTool[] {
+  return [
+    buildGoalSetTool(deps),
+    buildGoalClearTool(deps),
+    buildGoalStatusTool(deps),
+    buildGoalPauseTool(deps),
+    buildGoalResumeTool(deps),
+  ];
+}
+
+function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<{
+  condition: string;
+  max_iterations?: number;
+  block_cap?: number;
+  token_budget?: number;
+}, string> {
+  return {
+    name: GOAL_SET_TOOL_NAME,
+    displayName: 'Goal Set',
+    description:
+      'Set an autonomous execution goal. After each turn an evaluator judges progress; '
+      + 'if the condition is not met the system continues working turn after turn until it is '
+      + 'met, deemed impossible, stalls, or hits a limit. Only one goal is active per session; '
+      + 'setting a new one replaces the previous.',
+    parameters: z.object({
+      condition: z.string().trim().min(1).max(500)
+        .describe('The objective to achieve. Should be observable and verifiable (e.g. "all tests in packages/runtime pass", "PR #522 review comments addressed").'),
+      max_iterations: z.number().int().min(1).max(200).optional()
+        .describe('Absolute ceiling on total turns before giving up. Defaults to 50.'),
+      block_cap: z.number().int().min(1).max(50).optional()
+        .describe('Stop after this many consecutive turns with no progress (stall detection). Defaults to 8.'),
+      token_budget: z.number().int().min(1000).optional()
+        .describe('Optional token budget; the goal stops (budget_limited) once this many tokens are spent working toward it.'),
+    }),
+    permissionRequired: false,
+    impl: (input, ctx) => {
+      const tokensAtStart = deps.getTokenCount?.(ctx.sessionId) ?? 0;
+      const goal = deps.goalManager.set(ctx.sessionId, input.condition, {
+        maxIterations: input.max_iterations,
+        blockCap: input.block_cap,
+        tokenBudget: input.token_budget,
+        tokensAtStart,
+      });
+      const limits = [
+        `max ${goal.maxIterations} turns`,
+        `stall after ${goal.blockCap} no-progress turns`,
+        goal.tokenBudget ? `budget ${goal.tokenBudget} tokens` : undefined,
+      ].filter(Boolean).join(', ');
+      return `Goal set: "${goal.condition}" (${limits}). `
+        + 'The system will evaluate progress after each turn and continue autonomously until the condition is met.';
+    },
+  };
+}
+
+function buildGoalClearTool(deps: GoalToolsDeps): MakaTool<Record<string, never>, string> {
+  return {
+    name: GOAL_CLEAR_TOOL_NAME,
+    displayName: 'Goal Clear',
+    description: 'Clear the active goal, stopping autonomous execution after the current turn.',
+    parameters: z.object({}),
+    permissionRequired: false,
+    impl: (_input, ctx) => {
+      const goal = deps.goalManager.clear(ctx.sessionId);
+      if (!goal) return 'No active goal to clear.';
+      return `Goal cleared: "${goal.condition}" after ${goal.iterations} turn(s).`;
+    },
+  };
+}
+
+function buildGoalPauseTool(deps: GoalToolsDeps): MakaTool<Record<string, never>, string> {
+  return {
+    name: GOAL_PAUSE_TOOL_NAME,
+    displayName: 'Goal Pause',
+    description: 'Pause the active goal. Autonomous continuation stops until GoalResume is called; state is preserved.',
+    parameters: z.object({}),
+    permissionRequired: false,
+    impl: (_input, ctx) => {
+      const goal = deps.goalManager.pause(ctx.sessionId);
+      if (!goal) return 'No active goal to pause.';
+      return `Goal paused: "${goal.condition}" at turn ${goal.iterations}. Use GoalResume to continue.`;
+    },
+  };
+}
+
+function buildGoalResumeTool(deps: GoalToolsDeps): MakaTool<Record<string, never>, string> {
+  return {
+    name: GOAL_RESUME_TOOL_NAME,
+    displayName: 'Goal Resume',
+    description: 'Resume a paused goal, re-enabling autonomous continuation.',
+    parameters: z.object({}),
+    permissionRequired: false,
+    impl: (_input, ctx) => {
+      const goal = deps.goalManager.resume(ctx.sessionId);
+      if (!goal) return 'No paused goal to resume.';
+      return `Goal resumed: "${goal.condition}". Autonomous continuation re-enabled.`;
+    },
+  };
+}
+
+function buildGoalStatusTool(deps: GoalToolsDeps): MakaTool<Record<string, never>, string> {
+  return {
+    name: GOAL_STATUS_TOOL_NAME,
+    displayName: 'Goal Status',
+    description: 'Check the current goal status for this session.',
+    parameters: z.object({}),
+    permissionRequired: false,
+    impl: (_input, ctx) => {
+      const goal = deps.goalManager.get(ctx.sessionId);
+      if (!goal) return 'No goal set for this session.';
+      return formatGoal(goal, deps);
+    },
+  };
+}
+
+function formatGoal(goal: GoalState, deps: GoalToolsDeps): string {
+  const now = deps.now?.() ?? Date.now();
+  const elapsed = Math.round((now - goal.setAt) / 1000);
+  const spent = Math.max(0, goal.tokensNow - goal.tokensAtStart);
+  const lines = [
+    `Goal: "${goal.condition}"`,
+    `Status: ${goal.status}`,
+    `Turns: ${goal.iterations}/${goal.maxIterations}`,
+    `No-progress streak: ${goal.consecutiveNoProgress}/${goal.blockCap}`,
+    `Elapsed: ${elapsed}s`,
+  ];
+  if (goal.tokenBudget) lines.push(`Tokens: ${spent}/${goal.tokenBudget}`);
+  else if (spent > 0) lines.push(`Tokens spent: ${spent}`);
+  if (goal.lastReason) lines.push(`Last evaluation: ${goal.lastReason}`);
+  return lines.join('\n');
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -680,3 +680,27 @@ export { buildAutomationTool, AUTOMATION_TOOL_NAME } from './automation-tools.js
 export type { AutomationToolDeps } from './automation-tools.js';
 export { evaluateAutomationCanFire, HEARTBEAT_IDLE_STATUSES } from './automation-can-fire.js';
 export type { CanFireSessionHeader, EvaluateAutomationCanFireDeps } from './automation-can-fire.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// Goal execution (Issue #15 Primitive 6).
+// ───────────────────────────────────────────────────────────────────────────
+export { GoalManager, TERMINAL_GOAL_STATUSES, DEFAULT_MAX_ITERATIONS, DEFAULT_BLOCK_CAP } from './goal-state.js';
+export type { GoalState, GoalStatus, GoalManagerDeps } from './goal-state.js';
+export {
+  evaluateGoal,
+  buildGoalEvaluationPrompt,
+  parseGoalEvaluation,
+  DEFAULT_EVALUATOR_TIMEOUT_MS,
+} from './goal-evaluator.js';
+export type { GoalEvaluation, GoalEvaluatorDeps } from './goal-evaluator.js';
+export {
+  buildGoalTools,
+  GOAL_SET_TOOL_NAME,
+  GOAL_CLEAR_TOOL_NAME,
+  GOAL_STATUS_TOOL_NAME,
+  GOAL_PAUSE_TOOL_NAME,
+  GOAL_RESUME_TOOL_NAME,
+} from './goal-tools.js';
+export type { GoalToolsDeps } from './goal-tools.js';
+export { handleGoalContinuation } from './goal-continuation.js';
+export type { GoalContinuationDeps, GoalContinuationOutcome } from './goal-continuation.js';

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -14,6 +14,7 @@ import {
   Info,
   Loader2,
   RefreshCcw,
+  Target,
   Sparkles,
   Timer,
 } from './icons.js';
@@ -191,6 +192,19 @@ export function ChatView(props: {
    * from persisted messages/session state.
    */
   eventStreamAlert?: ChatHeaderAlert;
+  /**
+   * Active autonomous-goal indicator for the session, or undefined when no
+   * goal is running. Surfaces the loop (turn counter) with a one-click clear
+   * affordance so a token-burning goal is never invisible or unstoppable —
+   * this IS the desktop kill switch. `onClear` stops autonomous continuation.
+   */
+  goalIndicator?: {
+    condition: string;
+    status: string;
+    iterations: number;
+    maxIterations: number;
+    onClear: () => void;
+  };
   /** Error from loading the active session's persisted message log. */
   messageLoadError?: string;
   messageLoadRetryPending?: boolean;
@@ -604,6 +618,23 @@ export function ChatView(props: {
             <Sparkles size={12} aria-hidden="true" />
             <span>深度研究</span>
           </span>
+        )}
+        {props.goalIndicator && (
+          /* Goal kill-switch pill: an active autonomous loop must be visible and
+             stoppable. Reuses the mode-pill styling; clicking it clears the goal
+             (the shell confirms), so the user always has a one-click stop. */
+          <UiButton
+            type="button"
+            variant="quiet"
+            className="maka-chat-header-mode-pill"
+            data-mode="goal"
+            onClick={() => props.goalIndicator?.onClear()}
+            title={`自主执行目标进行中：「${props.goalIndicator.condition}」（第 ${props.goalIndicator.iterations}/${props.goalIndicator.maxIterations} 轮，${props.goalIndicator.status}）。系统每轮后自动续行；点击可清除目标、停止续行。`}
+            aria-label={`清除自主执行目标（已进行 ${props.goalIndicator.iterations}/${props.goalIndicator.maxIterations} 轮）`}
+          >
+            <Target size={12} aria-hidden="true" />
+            <span>目标 {props.goalIndicator.iterations}/{props.goalIndicator.maxIterations} · 清除</span>
+          </UiButton>
         )}
         {/* PR-MOVE-PERMISSION-MODE: switcher relocated into the
             composer left-controls. Header keeps the per-session status

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -99,6 +99,7 @@ export {
   SquarePen,
   Sun,
   SunMoon,
+  Target,
   Terminal,
   Timer,
   Trash2,


### PR DESCRIPTION
> **Standalone on `main`.** Rebased off the Automation stack — this PR now shows the Goal delta only (single commit, 16 files, +1679 / −6). Goal (P6) and Automation (P4) are independent primitives, so this reviews on its own.

## What

P6 Goal-based autonomous execution (Issue #15) — CC-style external evaluator + Codex lifecycle:

- `GoalManager` + `evaluateGoal` (30s timeout; evaluator failure treated as **neutral**, never blocks the turn) + `handleGoalContinuation` (evaluate-first ordering, in-flight re-entrancy guard, block cap → `stalled`, token budget → `budget_limited`, agent-settable goals)
- Turn-boundary wiring in **both** hosts: CLI (`runtime-bootstrap` + pi-tui `onTurnComplete`) and desktop (`goal-wiring` + `main.ts` continuation, gated on `!turnAborted` so Stop halts the loop)
- Active-goal turn-tail fragment in both system-prompt builders (informational, not promoted to system/developer instructions)
- **Independent of Automation** — no heartbeat bridge; Goal is self-contained and bounded by its own caps

## Why standalone

Goal (P6) and Automation (P4) are independent primitives; keeping this PR standalone on `main` (rather than stacked) makes the review surface focused and avoids repeated rebases as `main` advances.

## Tests

- runtime goal unit tests **25 / 0** (goal-state / goal-tools / goal-evaluator / goal-continuation)
- full runtime **977 / 0** · CLI **1017 / 0** — no regressions from the goal wiring
- full dependency-order build green (core → storage/runtime → headless → desktop/cli)