### PR TITLE
feat(cli): transcript viewport, scrollback, and render memoization (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -989,6 +989,25 @@ describe('transcript entry render memoization', () => {
     assert.notEqual(expanded, collapsed);
     assert.match(expanded, /beta/);
   });
+
+  test('re-renders thinking when a same-length final replaces the streamed text', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_delta', messageId: 'message-1', text: 'AAAA',
+    }));
+    assert.equal(toggleAllThinkingExpansion(state), true);
+    const streamed = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi).join('\n');
+    assert.match(streamed, /AAAA/);
+
+    // thinking_complete replaces the text in place; same length must still bust
+    // the render cache so the final reasoning is shown, not the streamed draft.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'thinking_complete', messageId: 'message-1', text: 'BBBB',
+    }));
+    const finalized = renderMakaPiTranscript(state, meta(), 80).map(stripAnsi).join('\n');
+    assert.match(finalized, /BBBB/);
+    assert.doesNotMatch(finalized, /AAAA/);
+  });
 });
 
 function meta() {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -13,6 +13,7 @@ import {
   submitPromptToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
+  windowTranscriptLines,
 } from '../pi-transcript.js';
 
 describe('Maka Pi TUI transcript', () => {
@@ -886,6 +887,98 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(rendered, /secret/);
     assert.match(rendered, /\[redacted\]/);
     assert.match(rendered, /\[stderr\]/);
+  });
+});
+
+describe('transcript viewport windowing', () => {
+  const lines = Array.from({ length: 50 }, (_, i) => `line-${i}`);
+
+  test('returns every line unchanged when the transcript fits', () => {
+    const short = lines.slice(0, 5);
+    const win = windowTranscriptLines(short, 24, 0, 80);
+    assert.deepEqual(win.lines, short);
+    assert.equal(win.scrollable, false);
+    assert.equal(win.scrollOffset, 0);
+    assert.equal(win.hiddenAbove, 0);
+    assert.equal(win.hiddenBelow, 0);
+  });
+
+  test('follows the tail at offset 0, reserving a row for the scroll indicator', () => {
+    const win = windowTranscriptLines(lines, 10, 0, 80);
+    assert.equal(win.scrollable, true);
+    assert.equal(win.lines.length, 10);
+    // Nine content rows (10 minus the indicator) ending at the last line.
+    assert.equal(stripAnsi(win.lines[0]!), 'line-41');
+    assert.equal(stripAnsi(win.lines[8]!), 'line-49');
+    assert.equal(win.hiddenAbove, 41);
+    assert.equal(win.hiddenBelow, 0);
+    assert.match(stripAnsi(win.lines[9]!), /↑ 41 more/);
+  });
+
+  test('reveals older lines and reports the split when scrolled up', () => {
+    const win = windowTranscriptLines(lines, 10, 9, 80);
+    assert.equal(win.scrollOffset, 9);
+    assert.equal(stripAnsi(win.lines[0]!), 'line-32');
+    assert.equal(stripAnsi(win.lines[8]!), 'line-40');
+    assert.equal(win.hiddenAbove, 32);
+    assert.equal(win.hiddenBelow, 9);
+    assert.match(stripAnsi(win.lines[9]!), /↑ 32 more.*↓ 9 more/);
+  });
+
+  test('clamps an over-scroll to the top of the transcript', () => {
+    const win = windowTranscriptLines(lines, 10, 9_999, 80);
+    // contentRows = 9, so the deepest offset lands the window on the first lines.
+    assert.equal(stripAnsi(win.lines[0]!), 'line-0');
+    assert.equal(win.hiddenAbove, 0);
+    assert.equal(win.scrollOffset, lines.length - 9);
+    assert.match(stripAnsi(win.lines[9]!), /↓ \d+ more/);
+  });
+
+  test('truncates the indicator to the viewport width', () => {
+    const win = windowTranscriptLines(lines, 10, 5, 12);
+    assert.ok(win.lines.every((line) => visibleWidth(line) <= 12));
+  });
+});
+
+describe('transcript entry render memoization', () => {
+  test('reuses the rendered lines of an unchanged entry across renders', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'text_delta',
+      messageId: 'message-1',
+      text: 'stable answer',
+    }));
+    applyMakaSessionEventToTranscript(state, event({ type: 'complete', stopReason: 'end_turn' }));
+
+    const first = renderMakaPiTranscript(state, meta(), 80);
+    const second = renderMakaPiTranscript(state, meta(), 80);
+    assert.deepEqual(second, first);
+
+    // A width change must bust the cache and re-wrap.
+    const narrow = renderMakaPiTranscript(state, meta(), 20);
+    assert.notDeepEqual(narrow, first);
+  });
+
+  test('re-renders a tool entry when Ctrl+O expansion is toggled', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start',
+      toolUseId: 'tool-1',
+      toolName: 'Read',
+      args: { path: 'file.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result',
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'text', text: 'alpha\nbeta\ngamma' },
+    }));
+
+    const collapsed = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.notEqual(expanded, collapsed);
+    assert.match(expanded, /beta/);
   });
 });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -938,6 +938,15 @@ describe('transcript viewport windowing', () => {
     const win = windowTranscriptLines(lines, 10, 5, 12);
     assert.ok(win.lines.every((line) => visibleWidth(line) <= 12));
   });
+
+  test('never exceeds a one-row viewport (drops the indicator)', () => {
+    const win = windowTranscriptLines(lines, 1, 0, 80);
+    // A one-row viewport holds a content line OR the indicator, not both; the
+    // content wins so the layout budget of exactly one row is kept.
+    assert.equal(win.lines.length, 1);
+    assert.equal(stripAnsi(win.lines[0]!), 'line-49');
+    assert.equal(win.scrollable, true);
+  });
 });
 
 describe('transcript entry render memoization', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -449,6 +449,56 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('holds the reader position when one frame mixes above-fold and below-fold growth', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new MixedFrameDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    const visibleParas = () =>
+      (plainTerminalOutput(terminal.screenOutput()).match(/para-\d\d/g) ?? []).sort().join(',');
+
+    terminal.input('run');
+    terminal.input('\r');
+    // Expand thinking, then page up so the short thinking draft sits above the fold
+    // and a stable middle slice of the reply shows, with the reply tail below it.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
+    terminal.input('\x14');
+    await delay(20);
+    await pageUpBelowFold(terminal, 'para-39');
+    const before = visibleParas();
+    assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput()).includes('para-00'),
+      false,
+      'expected a middle slice, not the top, so a drift would be observable',
+    );
+
+    // One coalesced frame carries a thinking_complete (grows the block above the
+    // fold) and a text_delta (grows the reply tail below the fold) back-to-back.
+    // An offset-delta heuristic can only compensate for one side; anchoring to the
+    // visible content must hold the middle slice steady through both at once.
+    driver.releaseTail();
+    await waitFor(() => driver.completed);
+    await delay(50);
+    assert.equal(visibleParas(), before, 'viewport drifted on a mixed above/below-fold frame');
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
@@ -2432,6 +2482,54 @@ class ShrinkingTailDriver implements MakaSessionDriver {
 
   releaseThinking(): void {
     this.continueThinking?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class MixedFrameDriver implements MakaSessionDriver {
+  completed = false;
+  private continueTail: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // A short thinking draft (first entry), then a reply long enough to scroll
+    // through with the thinking above the fold and the reply tail below it.
+    yield { type: 'thinking_delta', id: 'th', turnId: 't', ts: 1, messageId: 'm1', text: 'draft' };
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'tx1', turnId: 't', ts: 2, messageId: 'm1', text: body };
+    await new Promise<void>((resolve) => {
+      this.continueTail = resolve;
+    });
+    // Back-to-back with no await between: the runner applies both before the
+    // scheduled render fires, so they land in one coalesced frame — thinking grows
+    // above the fold while the reply tail grows below it.
+    const tall = Array.from({ length: 8 }, (_, i) => `reason-${i}`).join('\n');
+    yield { type: 'thinking_complete', id: 'thc', turnId: 't', ts: 3, messageId: 'm1', text: tall };
+    const more = `\n\n${Array.from({ length: 10 }, (_, i) => `para-${String(i + 40).padStart(2, '0')}`).join('\n\n')}`;
+    yield { type: 'text_delta', id: 'tx2', turnId: 't', ts: 4, messageId: 'm1', text: more };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 5, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseTail(): void {
+    this.continueTail?.();
   }
 
   async stop(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -159,10 +159,16 @@ describe('Maka Pi TUI runner', () => {
     // Expanding the 31-line result makes it overflow the viewport; its head line
     // `expanded-tail` scrolls off the top when following the tail, so page up to
     // bring it into view. This exercises the global expand and scrollback together.
-    await waitFor(() => {
+    // Press once per settled render rather than inside a waitFor predicate, which
+    // would re-check a stale async screen and over-scroll.
+    for (let i = 0; i < 8 && !plainTerminalOutput(terminal.screenOutput()).includes('expanded-tail'); i += 1) {
       terminal.input('\x1b[5~');
-      return plainTerminalOutput(terminal.screenOutput()).includes('expanded-tail');
-    });
+      await delay(20);
+    }
+    assert.ok(
+      plainTerminalOutput(terminal.screenOutput()).includes('expanded-tail'),
+      'expected the expanded head line in view after paging up',
+    );
 
     terminal.input('\x03');
     await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -499,6 +499,51 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('lands PageUp on the previous page when the render coalesces with new output', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new StreamRaceDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    const visibleParaNums = () =>
+      (plainTerminalOutput(terminal.screenOutput()).match(/r-para-(\d\d)/g) ?? []).map((s) => Number(s.slice(-2)));
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('r-para-29'));
+
+    // Press PageUp and let the next chunk stream in the same tick, so the paging
+    // render coalesces with the growth. The offset was computed against the shorter
+    // frame; applied verbatim to the taller one it would under-scroll toward the
+    // new tail. Anchoring to the target row instead lands the real previous page.
+    terminal.input('\x1b[5~');
+    driver.releaseTail();
+    await waitFor(() => driver.completed);
+    await delay(50);
+
+    const nums = visibleParaNums();
+    assert.ok(nums.length > 0, 'the scrolled-up view should still show reply paragraphs');
+    assert.ok(
+      Math.max(...nums) < 29,
+      `PageUp drifted toward the streamed tail: showed up to r-para-${Math.max(...nums)}`,
+    );
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
@@ -2525,6 +2570,49 @@ class MixedFrameDriver implements MakaSessionDriver {
     const more = `\n\n${Array.from({ length: 10 }, (_, i) => `para-${String(i + 40).padStart(2, '0')}`).join('\n\n')}`;
     yield { type: 'text_delta', id: 'tx2', turnId: 't', ts: 4, messageId: 'm1', text: more };
     yield { type: 'complete', id: 'c', turnId: 't', ts: 5, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseTail(): void {
+    this.continueTail?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class StreamRaceDriver implements MakaSessionDriver {
+  completed = false;
+  private continueTail: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // First chunk overflows the viewport; the reader pages up from its tail.
+    const head = Array.from({ length: 30 }, (_, i) => `r-para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e1', turnId: 't', ts: 1, messageId: 'm1', text: head };
+    await new Promise<void>((resolve) => {
+      this.continueTail = resolve;
+    });
+    // More output appended below the fold, released in the same tick as the PageUp
+    // so its render coalesces with the paging one.
+    const more = `\n\n${Array.from({ length: 15 }, (_, i) => `r-para-${String(i + 30).padStart(2, '0')}`).join('\n\n')}`;
+    yield { type: 'text_delta', id: 'e2', turnId: 't', ts: 2, messageId: 'm1', text: more };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 3, stopReason: 'end_turn' };
     this.completed = true;
   }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -327,6 +327,52 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('holds the reader position when streaming re-wraps the tail below the fold', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new StreamingTailDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    const visibleParas = () =>
+      (plainTerminalOutput(terminal.screenOutput()).match(/s-para-\d\d/g) ?? []).sort().join(',');
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('typing-tail'));
+
+    // Page up so the streaming tail (the partial last line about to grow) is off
+    // the bottom of the viewport and a stable middle slice of the reply shows.
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('s-para-00') && !screen.includes('typing-tail');
+    });
+    const before = visibleParas();
+    assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
+
+    // Streaming continues: the next delta re-wraps the partial tail line (an
+    // in-place edit, not a pure append) and adds paragraphs — all below the fold.
+    // The reader's slice must not move even though the tail block mutated.
+    driver.releaseStream();
+    await waitFor(() => driver.completed);
+    assert.equal(visibleParas(), before, 'viewport drifted when the tail grew below the fold');
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
@@ -2221,6 +2267,50 @@ class LateThinkingDriver implements MakaSessionDriver {
 
   releaseReply(): void {
     this.continuePastReply?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class StreamingTailDriver implements MakaSessionDriver {
+  completed = false;
+  private continueStream: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // First chunk overflows the viewport and ends mid-line ("typing-tail" with no
+    // trailing newline) so the next delta mutates that last rendered line in
+    // place rather than only appending fresh lines.
+    const head = Array.from({ length: 30 }, (_, i) => `s-para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e1', turnId: 't', ts: 1, messageId: 'm1', text: `${head}\n\ntyping-tail` };
+    await new Promise<void>((resolve) => {
+      this.continueStream = resolve;
+    });
+    // The continuation re-wraps the partial tail line and appends more paragraphs.
+    const more = Array.from({ length: 10 }, (_, i) => `s-para-${String(i + 30).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e2', turnId: 't', ts: 2, messageId: 'm1', text: ` continued\n\n${more}` };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 3, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseStream(): void {
+    this.continueStream?.();
   }
 
   async stop(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -15,6 +15,22 @@ import {
   waitFor,
 } from './tui-terminal-mock.js';
 
+// Page up until `marker` scrolls below the fold, letting each render settle
+// before the next press. Pressing inside a waitFor predicate re-checks a stale
+// async screen and over-scrolls (the offset advances a page past what the screen
+// shows), which would decouple a captured slice from the real scroll state.
+async function pageUpBelowFold(terminal: FakeTerminal, marker: string): Promise<void> {
+  for (let i = 0; i < 8 && plainTerminalOutput(terminal.screenOutput()).includes(marker); i += 1) {
+    terminal.input('\x1b[5~');
+    await delay(20);
+  }
+  assert.equal(
+    plainTerminalOutput(terminal.screenOutput()).includes(marker),
+    false,
+    `expected "${marker}" to scroll below the fold`,
+  );
+}
+
 describe('Maka Pi TUI runner', () => {
   test('restores the terminal when driver stop rejects during close', async () => {
     const terminal = new FakeTerminal();
@@ -301,13 +317,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
 
-    // Expand thinking, then page up once so the (still short) thinking block sits
-    // above the fold and the viewport shows a stable middle slice of the reply.
+    // Expand thinking, then page up so the (still short) thinking block sits above
+    // the fold and the viewport shows a stable middle slice of the reply.
     terminal.input('\x14');
-    await waitFor(() => {
-      terminal.input('\x1b[5~');
-      return !plainTerminalOutput(terminal.screenOutput()).includes('para-39');
-    });
+    await delay(20);
+    await pageUpBelowFold(terminal, 'para-39');
     const before = visibleParas();
     assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
 
@@ -316,6 +330,9 @@ describe('Maka Pi TUI runner', () => {
     // append, or the window drifts and the reader loses their place.
     driver.releaseReply();
     await waitFor(() => driver.completed);
+    // driver.completed flips inside the generator before the queued render paints;
+    // let the scheduled render flush before reading the screen.
+    await delay(50);
     assert.equal(visibleParas(), before, 'viewport drifted when a block above the fold grew');
 
     terminal.input('\x03');
@@ -348,21 +365,80 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('typing-tail'));
 
     // Page up so the streaming tail (the partial last line about to grow) is off
-    // the bottom of the viewport and a stable middle slice of the reply shows.
-    await waitFor(() => {
-      terminal.input('\x1b[5~');
-      const screen = plainTerminalOutput(terminal.screenOutput());
-      return screen.includes('s-para-00') && !screen.includes('typing-tail');
-    });
+    // the bottom and a stable middle slice of the reply shows.
+    await pageUpBelowFold(terminal, 'typing-tail');
     const before = visibleParas();
     assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput()).includes('s-para-00'),
+      false,
+      'expected a middle slice, not the top, so a drift would be observable',
+    );
 
     // Streaming continues: the next delta re-wraps the partial tail line (an
     // in-place edit, not a pure append) and adds paragraphs — all below the fold.
     // The reader's slice must not move even though the tail block mutated.
     driver.releaseStream();
     await waitFor(() => driver.completed);
+    // driver.completed flips inside the generator before the queued render paints;
+    // let the scheduled render flush before reading the screen.
+    await delay(50);
     assert.equal(visibleParas(), before, 'viewport drifted when the tail grew below the fold');
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('holds the reader position when a tail block below the fold shrinks', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ShrinkingTailDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    const visibleParas = () =>
+      (plainTerminalOutput(terminal.screenOutput()).match(/para-\d\d/g) ?? []).sort().join(',');
+
+    terminal.input('run');
+    terminal.input('\r');
+    // Expand thinking so the tall draft (at the tail, after the reply) is on screen.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
+    terminal.input('\x14');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('draftline-7'));
+
+    // Page up so the tall thinking draft drops below the fold and a stable middle
+    // slice of the reply shows. Stop mid-transcript, not at the very top: at the
+    // top `start` is pinned to 0 and an upward drift would be clamped away,
+    // masking the bug this test guards.
+    await pageUpBelowFold(terminal, 'draftline-7');
+    const before = visibleParas();
+    assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput()).includes('para-00'),
+      false,
+      'expected a middle slice, not the top, so a drift would be observable',
+    );
+
+    // thinking_complete replaces the tall draft with a one-line result below the
+    // fold. A shrink is the symmetric case of a tail append; the reader's slice
+    // must not move even though the tail block lost rows.
+    driver.releaseThinking();
+    await waitFor(() => driver.completed);
+    // driver.completed flips inside the generator before the queued render paints;
+    // let the scheduled render flush before reading the screen.
+    await delay(50);
+    assert.equal(visibleParas(), before, 'viewport drifted when the tail shrank below the fold');
 
     terminal.input('\x03');
     await Promise.race([
@@ -2311,6 +2387,51 @@ class StreamingTailDriver implements MakaSessionDriver {
 
   releaseStream(): void {
     this.continueStream?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class ShrinkingTailDriver implements MakaSessionDriver {
+  completed = false;
+  private continueThinking: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // A long reply, then a tall thinking draft appended after it (its own
+    // messageId, so it lands as a separate block at the tail).
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'tx', turnId: 't', ts: 1, messageId: 'm1', text: body };
+    const draft = Array.from({ length: 8 }, (_, i) => `draftline-${i}`).join('\n');
+    yield { type: 'thinking_delta', id: 'th', turnId: 't', ts: 2, messageId: 'm2', text: draft };
+    await new Promise<void>((resolve) => {
+      this.continueThinking = resolve;
+    });
+    // thinking_complete collapses the tall draft to a single line — a below-the-
+    // fold shrink once the reader has scrolled past it.
+    yield { type: 'thinking_complete', id: 'thc', turnId: 't', ts: 3, messageId: 'm2', text: 'brief' };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 4, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseThinking(): void {
+    this.continueThinking?.();
   }
 
   async stop(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -140,7 +140,59 @@ describe('Maka Pi TUI runner', () => {
     assert.equal(terminal.output().includes('expanded-tail'), false);
 
     terminal.input('\x0f');
-    await waitFor(() => terminal.output().includes('expanded-tail'));
+    // Expanding the 31-line result makes it overflow the viewport; its head line
+    // `expanded-tail` scrolls off the top when following the tail, so page up to
+    // bring it into view. This exercises the global expand and scrollback together.
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return plainTerminalOutput(terminal.screenOutput()).includes('expanded-tail');
+    });
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('pages transcript scrollback and re-follows the tail', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new LongReplyDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('go');
+    terminal.input('\r');
+
+    // A 40-paragraph reply overflows the 24-row viewport, so the tail is pinned
+    // to the bottom and a scroll indicator advertises the hidden lines above.
+    await waitFor(() => {
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('para-39') && /↑ \d+ more/.test(screen);
+    });
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('para-00'), false);
+
+    // Page up far enough to reach the head of the transcript.
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return plainTerminalOutput(terminal.screenOutput()).includes('para-00');
+    });
+
+    // Page back down until the live tail follows again (no lines hidden below).
+    await waitFor(() => {
+      terminal.input('\x1b[6~');
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('para-39') && !/↓ \d+ more/.test(screen);
+    });
 
     terminal.input('\x03');
     await Promise.race([
@@ -1794,6 +1846,48 @@ class ThinkingOutputDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class LongReplyDriver implements MakaSessionDriver {
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // Blank lines separate paragraphs so markdown keeps them on their own rows,
+    // giving a reply that reliably overflows the 24-row viewport.
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield {
+      type: 'text_delta',
+      id: 'event-text',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'message-1',
+      text: body,
+    };
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 2,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
   getSessionId(): string {
     return 'session-1';
   }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -203,6 +203,42 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('re-pins to the tail when the user submits after scrolling up', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new MultiTurnLongDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('go');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('t1-para-39'));
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return plainTerminalOutput(terminal.screenOutput()).includes('t1-para-00');
+    });
+
+    // Submitting a new prompt while scrolled up must snap back to the tail so the
+    // new turn is visible, not preserve the old scrolled-up position.
+    terminal.input('again');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('t2-para-39'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
@@ -1920,6 +1956,37 @@ class ScrollThenSwitchDriver implements MakaSessionDriver {
     }
     messages.push(storedAssistantMessage('a-last', 't', 'switched-tail-marker'));
     return switchResult(fakeSessionSummary(sessionId, '/repo'), messages);
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class MultiTurnLongDriver implements MakaSessionDriver {
+  private turn = 0;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    this.turn += 1;
+    const n = this.turn;
+    const body = Array.from({ length: 40 }, (_, i) => `t${n}-para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: `e${n}`, turnId: `t${n}`, ts: 1, messageId: `m${n}`, text: body };
+    yield { type: 'complete', id: `c${n}`, turnId: `t${n}`, ts: 2, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
   }
   getSessionId(): string {
     return 'session-1';

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -239,6 +239,94 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('snaps to the tail when a permission prompt appears while scrolled up', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionAfterLongDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+
+    // The long reply overflows the viewport; scroll up so the tail (where the
+    // permission prompt will land) is off-screen while the turn is still running.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return plainTerminalOutput(terminal.screenOutput()).includes('para-00');
+    });
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('Permission required'), false);
+
+    // The runtime now raises a permission request. It renders at the tail, below
+    // the scrolled-up viewport — the session must snap to the tail so the y/n
+    // prompt is visible instead of leaving the user staring at old output.
+    driver.releaseBody();
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Permission required'));
+
+    terminal.input('y');
+    driver.releasePermission();
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('holds the reader position when a late thinking completion grows a block above the fold', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new LateThinkingDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    const visibleParas = () =>
+      (plainTerminalOutput(terminal.screenOutput()).match(/para-\d\d/g) ?? []).sort().join(',');
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
+
+    // Expand thinking, then page up once so the (still short) thinking block sits
+    // above the fold and the viewport shows a stable middle slice of the reply.
+    terminal.input('\x14');
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return !plainTerminalOutput(terminal.screenOutput()).includes('para-39');
+    });
+    const before = visibleParas();
+    assert.ok(before.length > 0, 'expected reply paragraphs on screen while scrolled up');
+
+    // A late thinking_complete replaces the short draft in place with a much
+    // taller block above the fold. That growth must not be mistaken for a tail
+    // append, or the window drifts and the reader loses their place.
+    driver.releaseReply();
+    await waitFor(() => driver.completed);
+    assert.equal(visibleParas(), before, 'viewport drifted when a block above the fold grew');
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('keeps tool expansion when kitty protocol reports the Ctrl-O release', async () => {
     const terminal = new FakeTerminal();
     const driver = new ToolOutputDriver();
@@ -2019,6 +2107,120 @@ class LongReplyDriver implements MakaSessionDriver {
       ts: 2,
       stopReason: 'end_turn',
     };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class PermissionAfterLongDriver implements MakaSessionDriver {
+  permissionRequests = 0;
+  private continuePastBody: (() => void) | null = null;
+  private continuePastPermission: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e', turnId: 't', ts: 1, messageId: 'm1', text: body };
+    // Pause mid-turn so the test can scroll up before the permission request lands.
+    await new Promise<void>((resolve) => {
+      this.continuePastBody = resolve;
+    });
+    this.permissionRequests += 1;
+    yield {
+      type: 'permission_request',
+      id: 'event-permission',
+      turnId: 't',
+      ts: 2,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+    };
+    await new Promise<void>((resolve) => {
+      this.continuePastPermission = resolve;
+    });
+    yield {
+      type: 'permission_decision_ack',
+      id: 'event-decision',
+      turnId: 't',
+      ts: 3,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      decision: 'allow',
+      rememberForTurn: true,
+    };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 4, stopReason: 'end_turn' };
+  }
+
+  releaseBody(): void {
+    this.continuePastBody?.();
+  }
+
+  releasePermission(): void {
+    this.continuePastPermission?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class LateThinkingDriver implements MakaSessionDriver {
+  completed = false;
+  private continuePastReply: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    // A short thinking draft, then a reply long enough to push it above the fold.
+    yield { type: 'thinking_delta', id: 'th', turnId: 't', ts: 1, messageId: 'm1', text: 'draft' };
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'tx', turnId: 't', ts: 2, messageId: 'm1', text: body };
+    // Pause so the test can expand thinking and scroll up before the late completion.
+    await new Promise<void>((resolve) => {
+      this.continuePastReply = resolve;
+    });
+    // thinking_complete replaces the one-line draft in place with a much taller
+    // block — an in-place edit above the fold, not a tail append.
+    const thinking = Array.from({ length: 8 }, (_, i) => `reason-${i}`).join('\n');
+    yield { type: 'thinking_complete', id: 'thc', turnId: 't', ts: 3, messageId: 'm1', text: thinking };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 4, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseReply(): void {
+    this.continuePastReply?.();
   }
 
   async stop(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -297,6 +297,48 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('re-pins to the tail after answering a permission prompt scrolled off-screen', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionThenTailDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('para-39'));
+
+    // The prompt appears and snaps into view; then the user pages up past it to
+    // re-read context before deciding.
+    driver.releaseBody();
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Permission required'));
+    await pageUpBelowFold(terminal, 'Permission required');
+
+    // Answering resumes the turn at the tail. The continuation must be visible,
+    // not left below the scrolled-up viewport making the session look stuck.
+    terminal.input('y');
+    await waitFor(() => driver.completed);
+    await delay(50);
+    assert.ok(
+      plainTerminalOutput(terminal.screenOutput()).includes('after-permission-tail'),
+      'the post-decision continuation should be on screen',
+    );
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('holds the reader position when a late thinking completion grows a block above the fold', async () => {
     const terminal = new FakeTerminal();
     const driver = new LateThinkingDriver();
@@ -2397,6 +2439,72 @@ class PermissionAfterLongDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class PermissionThenTailDriver implements MakaSessionDriver {
+  completed = false;
+  private responded = false;
+  private continuePastBody: (() => void) | null = null;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e', turnId: 't', ts: 1, messageId: 'm1', text: body };
+    await new Promise<void>((resolve) => {
+      this.continuePastBody = resolve;
+    });
+    yield {
+      type: 'permission_request',
+      id: 'event-permission',
+      turnId: 't',
+      ts: 2,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'npm test' },
+    };
+    while (!this.responded) await delay(2);
+    yield {
+      type: 'permission_decision_ack',
+      id: 'event-decision',
+      turnId: 't',
+      ts: 3,
+      requestId: 'permission-1',
+      toolUseId: 'tool-1',
+      decision: 'allow',
+      rememberForTurn: true,
+    };
+    // The turn resumes at the tail with output the user must see.
+    yield { type: 'text_delta', id: 'tail', turnId: 't', ts: 4, messageId: 'm1', text: '\n\nafter-permission-tail' };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 5, stopReason: 'end_turn' };
+    this.completed = true;
+  }
+
+  releaseBody(): void {
+    this.continuePastBody?.();
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {
+    this.responded = true;
+  }
   async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1183,6 +1183,46 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('re-pins to the tail after switching sessions while scrolled up', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new ScrollThenSwitchDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('go');
+    terminal.input('\r');
+    await waitFor(() => {
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('para-39') && /↑ \d+ more/.test(screen);
+    });
+    // Scroll up into history so the layout is no longer following the tail.
+    await waitFor(() => {
+      terminal.input('\x1b[5~');
+      return plainTerminalOutput(terminal.screenOutput()).includes('para-00');
+    });
+
+    // Switching replaces the transcript wholesale; the resumed session must open
+    // at its tail, not carry the old scroll offset into a different document.
+    terminal.input('/session session-2');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('switched-tail-marker'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('shows only current-cwd sessions in the session picker', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([
@@ -1846,6 +1886,41 @@ class ThinkingOutputDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class ScrollThenSwitchDriver implements MakaSessionDriver {
+  async listSessions(): Promise<SessionSummary[]> {
+    return [fakeSessionSummary('session-2', '/repo')];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(_prompt: string): AsyncIterable<SessionEvent> {
+    const body = Array.from({ length: 40 }, (_, i) => `para-${String(i).padStart(2, '0')}`).join('\n\n');
+    yield { type: 'text_delta', id: 'e', turnId: 't', ts: 1, messageId: 'm1', text: body };
+    yield { type: 'complete', id: 'c', turnId: 't', ts: 2, stopReason: 'end_turn' };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    // A history long enough to overflow the viewport, ending in a marker line so
+    // the test can assert the tail is on screen after the switch.
+    const messages: StoredMessage[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      messages.push(storedUserMessage(`u${i}`, 't', `history-q-${i}`));
+      messages.push(storedAssistantMessage(`a${i}`, 't', `history-a-${i}`));
+    }
+    messages.push(storedAssistantMessage('a-last', 't', 'switched-tail-marker'));
+    return switchResult(fakeSessionSummary(sessionId, '/repo'), messages);
+  }
   getSessionId(): string {
     return 'session-1';
   }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -461,24 +461,9 @@ export function renderMakaPiTranscript(
   const lines: string[] = [];
 
   for (const entry of state.entries) {
+    // A blank spacer above every entry, then its (memoized) rendered block.
     lines.push('');
-    switch (entry.kind) {
-      case 'user':
-        lines.push(...renderTextBlock('User', entry.text, safeWidth, { markdown: false, heading: ansi.accent }));
-        break;
-      case 'assistant':
-        lines.push(...renderTextBlock('maka', entry.text, safeWidth, { markdown: true, heading: ansi.accent }));
-        break;
-      case 'thinking':
-        lines.push(...renderThinkingBlock(entry, safeWidth, state.expandAllThinking));
-        break;
-      case 'tool':
-        lines.push(...renderToolBlock(entry, safeWidth, state.expandAllTools));
-        break;
-      case 'notice':
-        lines.push(...renderNotice(entry, safeWidth));
-        break;
-    }
+    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking));
   }
 
   if (state.pendingPermission) {
@@ -487,6 +472,148 @@ export function renderMakaPiTranscript(
   }
 
   return lines;
+}
+
+/**
+ * Per-entry render cache. The transcript re-renders on every keystroke and
+ * stream delta, but only the tail entry actually changes; caching the rendered
+ * lines of unchanged entries avoids rebuilding a `Markdown` instance per block
+ * on each pass. Keyed by entry identity (a fresh entry object is a cache miss);
+ * the signature busts the cache when anything that affects the entry's rendered
+ * lines changes (its growing text, tool status, width, or an expansion toggle).
+ */
+interface TranscriptEntryRender {
+  signature: string;
+  lines: string[];
+}
+
+const transcriptEntryRenderCache = new WeakMap<MakaPiTranscriptEntry, TranscriptEntryRender>();
+
+function renderTranscriptEntryMemoized(
+  entry: MakaPiTranscriptEntry,
+  width: number,
+  expandAllTools: boolean,
+  expandAllThinking: boolean,
+): string[] {
+  const signature = transcriptEntrySignature(entry, width, expandAllTools, expandAllThinking);
+  const cached = transcriptEntryRenderCache.get(entry);
+  if (cached && cached.signature === signature) return cached.lines;
+  const lines = renderTranscriptEntryBlock(entry, width, expandAllTools, expandAllThinking);
+  transcriptEntryRenderCache.set(entry, { signature, lines });
+  return lines;
+}
+
+function renderTranscriptEntryBlock(
+  entry: MakaPiTranscriptEntry,
+  width: number,
+  expandAllTools: boolean,
+  expandAllThinking: boolean,
+): string[] {
+  switch (entry.kind) {
+    case 'user':
+      return renderTextBlock('User', entry.text, width, { markdown: false, heading: ansi.accent });
+    case 'assistant':
+      return renderTextBlock('maka', entry.text, width, { markdown: true, heading: ansi.accent });
+    case 'thinking':
+      return renderThinkingBlock(entry, width, expandAllThinking);
+    case 'tool':
+      return renderToolBlock(entry, width, expandAllTools);
+    case 'notice':
+      return renderNotice(entry, width);
+  }
+}
+
+function transcriptEntrySignature(
+  entry: MakaPiTranscriptEntry,
+  width: number,
+  expandAllTools: boolean,
+  expandAllThinking: boolean,
+): string {
+  switch (entry.kind) {
+    case 'user':
+      return `user|${width}|${entry.text.length}`;
+    case 'assistant':
+      return `assistant|${width}|${entry.text.length}`;
+    case 'thinking':
+      return `thinking|${width}|${expandAllThinking ? 1 : 0}|${entry.text.length}`;
+    case 'notice':
+      return `notice|${width}|${entry.level}|${entry.text.length}`;
+    case 'tool':
+      // A tool entry mutates in place as it runs: status/duration flip on the
+      // result, and progress/output deltas append while running. Its result
+      // object is set once and never rewritten, so counting these fields is
+      // enough to detect every change to the rendered block.
+      return [
+        'tool',
+        width,
+        expandAllTools ? 1 : 0,
+        entry.status,
+        entry.durationMs ?? '',
+        entry.title ?? entry.toolName,
+        entry.progress.length,
+        entry.outputDeltas.length,
+        entry.output?.length ?? '',
+        entry.result ? entry.result.kind : '',
+      ].join('|');
+  }
+}
+
+export interface TranscriptWindow {
+  /** The viewport-sized slice of transcript lines, including a scroll indicator row when scrolled. */
+  lines: string[];
+  /** Clamped scroll offset actually applied — lines hidden below the viewport bottom (0 = following the tail). */
+  scrollOffset: number;
+  /** Lines hidden above the top of the viewport. */
+  hiddenAbove: number;
+  /** Lines hidden below the bottom of the viewport. */
+  hiddenBelow: number;
+  /** True when the transcript is taller than the viewport (a scroll indicator is shown). */
+  scrollable: boolean;
+}
+
+/**
+ * Window a fully rendered transcript to the viewport. When the transcript fits,
+ * every line is returned unchanged. When it overflows, one row is reserved for a
+ * dim scroll indicator so the remaining rows show a `scrollOffset`-anchored slice
+ * — offset 0 follows the live tail, larger offsets reveal older lines.
+ */
+export function windowTranscriptLines(
+  allLines: readonly string[],
+  viewportRows: number,
+  scrollOffset: number,
+  width: number,
+): TranscriptWindow {
+  const rows = Math.max(0, Math.trunc(viewportRows));
+  if (rows === 0) {
+    return { lines: [], scrollOffset: 0, hiddenAbove: 0, hiddenBelow: 0, scrollable: false };
+  }
+  if (allLines.length <= rows) {
+    return { lines: [...allLines], scrollOffset: 0, hiddenAbove: 0, hiddenBelow: 0, scrollable: false };
+  }
+  const contentRows = Math.max(1, rows - 1); // reserve one row for the scroll indicator
+  const maxOffset = allLines.length - contentRows;
+  const offset = Math.min(Math.max(0, Math.trunc(scrollOffset)), maxOffset);
+  const end = allLines.length - offset;
+  const start = Math.max(0, end - contentRows);
+  const hiddenAbove = start;
+  const hiddenBelow = allLines.length - end;
+  const indicator = fitLine(transcriptScrollIndicator(hiddenAbove, hiddenBelow), Math.max(1, width));
+  return {
+    lines: [...allLines.slice(start, end), indicator],
+    scrollOffset: offset,
+    hiddenAbove,
+    hiddenBelow,
+    scrollable: true,
+  };
+}
+
+function transcriptScrollIndicator(hiddenAbove: number, hiddenBelow: number): string {
+  const counts: string[] = [];
+  if (hiddenAbove > 0) counts.push(`↑ ${hiddenAbove} more`);
+  if (hiddenBelow > 0) counts.push(`↓ ${hiddenBelow} more`);
+  const status = counts.join('  ') || 'top';
+  const keys = hiddenBelow > 0 ? 'PgUp/PgDn scroll · PgDn to follow' : 'PgUp/PgDn scroll';
+  return ansi.dim(`── ${status} · ${keys} ──`);
 }
 
 export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width: number): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -452,26 +452,64 @@ function systemNoteText(message: SystemNoteMessage): string | undefined {
   }
 }
 
-export function renderMakaPiTranscript(
+/**
+ * Identifies which transcript entry (and which line within its rendered block)
+ * a given transcript row came from. Spacer rows and the permission prompt have
+ * no stable entry identity and are reported as `null` owners. The scroll layout
+ * uses this to anchor the viewport to a piece of content rather than a line
+ * offset, so it stays pinned to what the reader is looking at across arbitrary
+ * re-renders (blocks growing, shrinking, above or below the fold, or all at
+ * once in one coalesced frame).
+ */
+export interface TranscriptLineOwner {
+  entry: MakaPiTranscriptEntry;
+  /** 0-based line index within the entry's rendered block. */
+  row: number;
+}
+
+export interface RenderedTranscript {
+  lines: string[];
+  owners: (TranscriptLineOwner | null)[];
+}
+
+export function renderMakaPiTranscriptSource(
   state: MakaPiTranscriptState,
   _metadata: MakaPiTranscriptMetadata,
   width: number,
-): string[] {
+): RenderedTranscript {
   const safeWidth = Math.max(1, width);
   const lines: string[] = [];
+  const owners: (TranscriptLineOwner | null)[] = [];
 
   for (const entry of state.entries) {
     // A blank spacer above every entry, then its (memoized) rendered block.
     lines.push('');
-    lines.push(...renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking));
+    owners.push(null);
+    const block = renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking);
+    block.forEach((line, row) => {
+      lines.push(line);
+      owners.push({ entry, row });
+    });
   }
 
   if (state.pendingPermission) {
     lines.push('');
-    lines.push(...renderPermissionPrompt(state.pendingPermission, safeWidth));
+    owners.push(null);
+    for (const line of renderPermissionPrompt(state.pendingPermission, safeWidth)) {
+      lines.push(line);
+      owners.push(null);
+    }
   }
 
-  return lines;
+  return { lines, owners };
+}
+
+export function renderMakaPiTranscript(
+  state: MakaPiTranscriptState,
+  metadata: MakaPiTranscriptMetadata,
+  width: number,
+): string[] {
+  return renderMakaPiTranscriptSource(state, metadata, width).lines;
 }
 
 /**
@@ -489,6 +527,10 @@ interface TranscriptEntryRender {
 
 const transcriptEntryRenderCache = new WeakMap<MakaPiTranscriptEntry, TranscriptEntryRender>();
 
+// Returns the cached line array by reference on a hit — callers must treat it as
+// read-only (copy the lines into their own buffer rather than mutating in place),
+// or a later render would serve corrupted content for that entry. The only
+// caller, renderMakaPiTranscriptSource, copies each line out.
 function renderTranscriptEntryMemoized(
   entry: MakaPiTranscriptEntry,
   width: number,

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -590,21 +590,23 @@ export function windowTranscriptLines(
   if (allLines.length <= rows) {
     return { lines: [...allLines], scrollOffset: 0, hiddenAbove: 0, hiddenBelow: 0, scrollable: false };
   }
-  const contentRows = Math.max(1, rows - 1); // reserve one row for the scroll indicator
+  // Reserve one row for the scroll indicator — but only when the viewport is at
+  // least two rows tall. A one-row viewport (very short terminal, or a tall
+  // editor/autocomplete area) can hold either a content line or the indicator,
+  // not both; showing the content keeps the total within the layout budget.
+  const showIndicator = rows >= 2;
+  const contentRows = showIndicator ? rows - 1 : rows;
   const maxOffset = allLines.length - contentRows;
   const offset = Math.min(Math.max(0, Math.trunc(scrollOffset)), maxOffset);
   const end = allLines.length - offset;
   const start = Math.max(0, end - contentRows);
   const hiddenAbove = start;
   const hiddenBelow = allLines.length - end;
-  const indicator = fitLine(transcriptScrollIndicator(hiddenAbove, hiddenBelow), Math.max(1, width));
-  return {
-    lines: [...allLines.slice(start, end), indicator],
-    scrollOffset: offset,
-    hiddenAbove,
-    hiddenBelow,
-    scrollable: true,
-  };
+  const windowLines = allLines.slice(start, end);
+  const lines = showIndicator
+    ? [...windowLines, fitLine(transcriptScrollIndicator(hiddenAbove, hiddenBelow), Math.max(1, width))]
+    : [...windowLines];
+  return { lines, scrollOffset: offset, hiddenAbove, hiddenBelow, scrollable: true };
 }
 
 function transcriptScrollIndicator(hiddenAbove: number, hiddenBelow: number): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -530,6 +530,10 @@ function transcriptEntrySignature(
   expandAllThinking: boolean,
 ): string {
   switch (entry.kind) {
+    // user and assistant text is append-only (user is immutable; assistant only
+    // grows via appendAssistantText, and text_complete is guarded from replacing
+    // it), so length is a safe change key. If a path ever replaces their text in
+    // place, switch these to full-text keys like thinking below.
     case 'user':
       return `user|${width}|${entry.text.length}`;
     case 'assistant':

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -535,7 +535,10 @@ function transcriptEntrySignature(
     case 'assistant':
       return `assistant|${width}|${entry.text.length}`;
     case 'thinking':
-      return `thinking|${width}|${expandAllThinking ? 1 : 0}|${entry.text.length}`;
+      // Not just the length: `thinking_complete` can replace the streamed text
+      // in place with a same-length final, which a length-only key would miss and
+      // then serve stale reasoning from the cache. Key on the full text.
+      return `thinking|${width}|${expandAllThinking ? 1 : 0}|${entry.text}`;
     case 'notice':
       return `notice|${width}|${entry.level}|${entry.text.length}`;
     case 'tool':
@@ -610,12 +613,13 @@ export function windowTranscriptLines(
 }
 
 function transcriptScrollIndicator(hiddenAbove: number, hiddenBelow: number): string {
+  // Only reached from the scrollable path, where the window is smaller than the
+  // transcript, so at least one side always has hidden lines.
   const counts: string[] = [];
   if (hiddenAbove > 0) counts.push(`↑ ${hiddenAbove} more`);
   if (hiddenBelow > 0) counts.push(`↓ ${hiddenBelow} more`);
-  const status = counts.join('  ') || 'top';
   const keys = hiddenBelow > 0 ? 'PgUp/PgDn scroll · PgDn to follow' : 'PgUp/PgDn scroll';
-  return ansi.dim(`── ${status} · ${keys} ──`);
+  return ansi.dim(`── ${counts.join('  ')} · ${keys} ──`);
 }
 
 export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width: number): string {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -482,13 +482,16 @@ export function renderMakaPiTranscriptSource(
   const owners: (TranscriptLineOwner | null)[] = [];
 
   for (const entry of state.entries) {
-    // A blank spacer above every entry, then its (memoized) rendered block.
+    // A blank spacer above every entry, then its (memoized) rendered block. The
+    // spacer belongs to the entry (row 0) so the scroll anchor stays stable when
+    // the viewport top lands on it — otherwise anchoring to the block's first line
+    // would drop the spacer and drift the view up a row on the next re-render.
     lines.push('');
-    owners.push(null);
+    owners.push({ entry, row: 0 });
     const block = renderTranscriptEntryMemoized(entry, safeWidth, state.expandAllTools, state.expandAllThinking);
     block.forEach((line, row) => {
       lines.push(line);
-      owners.push({ entry, row });
+      owners.push({ entry, row: row + 1 });
     });
   }
 
@@ -591,7 +594,9 @@ function transcriptEntrySignature(
       // A tool entry mutates in place as it runs: status/duration flip on the
       // result, and progress/output deltas append while running. Its result
       // object is set once and never rewritten, so counting these fields is
-      // enough to detect every change to the rendered block.
+      // enough to detect every change to the rendered block. `input` and
+      // `toolName` are omitted deliberately: both are set once at `tool_start`,
+      // before the first render, and never change, so they can't go stale.
       return [
         'tool',
         width,

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -32,6 +32,7 @@ import {
   submitPromptToTranscript,
   toggleAllThinkingExpansion,
   toggleAllToolExpansion,
+  windowTranscriptLines,
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
 } from './pi-transcript.js';
@@ -578,6 +579,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return { consume: true };
       }
     }
+    // Page through transcript scrollback. Swallow the key whether or not the
+    // view moved so PageUp/PageDown never leak into the editor at a scroll edge.
+    if (matchesKey(data, Key.pageUp)) {
+      if (layout.scrollUp()) tui.requestRender();
+      return { consume: true };
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      if (layout.scrollDown()) tui.requestRender();
+      return { consume: true };
+    }
     if (state.pendingPermission) {
       if (matchesKey(data, 'y') || matchesKey(data, Key.enter) || matchesKey(data, Key.return)) {
         respondToPendingPermission('allow');
@@ -648,6 +659,16 @@ class MakaStatusLineComponent implements Component {
 }
 
 class MakaPiLayoutComponent extends Container {
+  // Scroll position as lines hidden below the viewport bottom; 0 = following the
+  // live tail. `followTail` re-pins to the bottom as new output streams in, so a
+  // user reading history is only ever moved by an explicit scroll, never by the
+  // agent's next line.
+  private scrollOffset = 0;
+  private followTail = true;
+  private lastTotalLines = 0;
+  private lastViewportRows = 0;
+  private lastWidth = 0;
+
   constructor(
     private readonly transcript: Component,
     private readonly editor: Component,
@@ -664,14 +685,64 @@ class MakaPiLayoutComponent extends Container {
     const transcriptLines = this.transcript.render(width);
     const editorLines = this.editor.render(width);
     const statusLines = this.statusLine.render(width);
-    const transcriptRows = Math.max(0, this.terminal.rows - editorLines.length - statusLines.length);
-    const paddingRows = Math.max(0, transcriptRows - transcriptLines.length);
+    const viewportRows = Math.max(0, this.terminal.rows - editorLines.length - statusLines.length);
+
+    if (width !== this.lastWidth) {
+      // Rewrapping at a new width invalidates every line offset, so re-pin to the
+      // tail rather than land the viewport on an arbitrary mid-message row.
+      this.followTail = true;
+      this.scrollOffset = 0;
+    } else if (!this.followTail && transcriptLines.length > this.lastTotalLines) {
+      // New lines land at the bottom; hold the reader's view fixed by counting
+      // them into the below-the-fold offset instead of letting the window drift.
+      this.scrollOffset += transcriptLines.length - this.lastTotalLines;
+    }
+
+    const windowed = windowTranscriptLines(
+      transcriptLines,
+      viewportRows,
+      this.followTail ? 0 : this.scrollOffset,
+      width,
+    );
+    this.scrollOffset = windowed.scrollOffset;
+    this.followTail = windowed.scrollOffset === 0;
+    this.lastTotalLines = transcriptLines.length;
+    this.lastViewportRows = viewportRows;
+    this.lastWidth = width;
+
+    const paddingRows = Math.max(0, viewportRows - windowed.lines.length);
     return [
-      ...transcriptLines,
+      ...windowed.lines,
       ...Array.from({ length: paddingRows }, () => ''),
       ...editorLines,
       ...statusLines,
     ];
+  }
+
+  /** One indicator row is reserved when scrolling, so a page is that many content rows. */
+  private pageSize(): number {
+    return Math.max(1, this.lastViewportRows - 1);
+  }
+
+  private scrollBy(offsetDelta: number): boolean {
+    if (this.lastTotalLines <= this.lastViewportRows) return false; // nothing hidden
+    const maxOffset = Math.max(0, this.lastTotalLines - this.pageSize());
+    const current = this.followTail ? 0 : this.scrollOffset;
+    const next = Math.min(Math.max(0, current + offsetDelta), maxOffset);
+    if (next === current) return false;
+    this.scrollOffset = next;
+    this.followTail = next === 0;
+    return true;
+  }
+
+  /** Scroll toward older output by one page. Returns false when already at the top. */
+  scrollUp(): boolean {
+    return this.scrollBy(this.pageSize());
+  }
+
+  /** Scroll toward newer output by one page. Returns false when already following the tail. */
+  scrollDown(): boolean {
+    return this.scrollBy(-this.pageSize());
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -26,7 +26,7 @@ import type { MakaSessionDriver } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
   renderMakaPiStatusLine,
-  renderMakaPiTranscript,
+  renderMakaPiTranscriptSource,
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   submitPromptToTranscript,
@@ -35,6 +35,8 @@ import {
   windowTranscriptLines,
   type MakaPiTranscriptMetadata,
   type MakaPiTranscriptState,
+  type RenderedTranscript,
+  type TranscriptLineOwner,
 } from './pi-transcript.js';
 import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
 import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
@@ -675,7 +677,11 @@ class MakaTranscriptComponent implements Component {
   invalidate(): void {}
 
   render(width: number): string[] {
-    return renderMakaPiTranscript(this.state, this.metadata(), width);
+    return this.renderSource(width).lines;
+  }
+
+  renderSource(width: number): RenderedTranscript {
+    return renderMakaPiTranscriptSource(this.state, this.metadata(), width);
   }
 }
 
@@ -690,16 +696,32 @@ class MakaStatusLineComponent implements Component {
 }
 
 /**
- * Index of the first line that differs between `prev` and `next`, or the length
- * of the shorter array when one is a prefix of the other. Used to locate where a
- * transcript re-render changed relative to the viewport.
+ * Row of the line the scroll anchor points at in a freshly rendered transcript,
+ * or -1 when the anchored entry is gone entirely (e.g. compaction replaced the
+ * transcript). If the entry survives but its block shrank past the anchored row,
+ * fall back to the entry's last remaining row so the viewport stays on that
+ * entry instead of jumping.
  */
-function firstDivergentLine(prev: readonly string[], next: readonly string[]): number {
-  const shared = Math.min(prev.length, next.length);
-  for (let i = 0; i < shared; i++) {
-    if (prev[i] !== next[i]) return i;
+function findAnchorRow(owners: readonly (TranscriptLineOwner | null)[], anchor: TranscriptLineOwner): number {
+  let lastRowOfEntry = -1;
+  for (let i = 0; i < owners.length; i++) {
+    const owner = owners[i];
+    if (!owner || owner.entry !== anchor.entry) continue;
+    if (owner.row === anchor.row) return i;
+    lastRowOfEntry = i; // rows are emitted in order, so this tracks the max seen
   }
-  return shared;
+  return lastRowOfEntry;
+}
+
+/** The owner of the first content line at or after `start` (skipping spacers). */
+function anchorOwnerAt(owners: readonly (TranscriptLineOwner | null)[], start: number): TranscriptLineOwner | null {
+  for (let i = Math.max(0, start); i < owners.length; i++) {
+    if (owners[i]) return owners[i];
+  }
+  for (let i = Math.min(start, owners.length) - 1; i >= 0; i--) {
+    if (owners[i]) return owners[i];
+  }
+  return null;
 }
 
 class MakaPiLayoutComponent extends Container {
@@ -712,10 +734,18 @@ class MakaPiLayoutComponent extends Container {
   private lastTotalLines = 0;
   private lastViewportRows = 0;
   private lastWidth = 0;
-  private lastLines: string[] = [];
+  // The content the top of the viewport is pinned to while scrolled. Anchoring to
+  // a piece of content (an entry + row) rather than a line offset keeps the
+  // reader on the same text no matter how blocks re-render between frames —
+  // growing or shrinking, above or below the fold, or several at once in one
+  // coalesced paint. Null while following the tail.
+  private anchor: TranscriptLineOwner | null = null;
+  // Set by an explicit scroll so the next render honours the new offset verbatim
+  // instead of re-deriving it from the (now stale) anchor.
+  private pendingUserScroll = false;
 
   constructor(
-    private readonly transcript: Component,
+    private readonly transcript: MakaTranscriptComponent,
     private readonly editor: Component,
     private readonly statusLine: Component,
     private readonly terminal: Terminal,
@@ -727,7 +757,8 @@ class MakaPiLayoutComponent extends Container {
   }
 
   render(width: number): string[] {
-    const transcriptLines = this.transcript.render(width);
+    const source = this.transcript.renderSource(width);
+    const transcriptLines = source.lines;
     const editorLines = this.editor.render(width);
     const statusLines = this.statusLine.render(width);
     const viewportRows = Math.max(0, this.terminal.rows - editorLines.length - statusLines.length);
@@ -737,23 +768,26 @@ class MakaPiLayoutComponent extends Container {
       // tail rather than land the viewport on an arbitrary mid-message row.
       this.followTail = true;
       this.scrollOffset = 0;
-    } else if (!this.followTail && transcriptLines.length !== this.lastTotalLines) {
-      // The transcript's line count changed. Preserve the reader's position by
-      // holding the top of the visible slice fixed — but only when the change is
-      // entirely below the fold, so the visible slice itself is untouched. A
-      // streamed append or in-place edit to the tail block (a `text_delta`
-      // re-wrapping the last line, a `thinking_complete` growing or shrinking an
-      // expanded block below the fold, a resolved permission prompt collapsing to
-      // a notice) qualifies; an edit above the fold (a block the reader has
-      // scrolled past) does not — there the tail is unchanged, so the
-      // below-the-fold offset must stay put or the window drifts.
-      // `firstDivergentLine` locates the change; a first difference at or below
-      // the old viewport bottom means the visible slice is a stable prefix, so
-      // shift the offset by the (signed) delta to track the tail. Growth and
-      // shrink are symmetric; windowTranscriptLines clamps the result.
-      const viewportBottom = this.lastTotalLines - this.scrollOffset;
-      if (firstDivergentLine(this.lastLines, transcriptLines) >= viewportBottom) {
-        this.scrollOffset += transcriptLines.length - this.lastTotalLines;
+      this.anchor = null;
+    } else if (this.pendingUserScroll) {
+      // An explicit scroll already set scrollOffset; honour it as-is, then re-derive
+      // the anchor from the resulting window below.
+    } else if (!this.followTail && this.anchor) {
+      // A re-render (stream delta, expansion toggle, ...). Recompute the offset so
+      // the anchored content line is back at the top of the viewport. Deriving it
+      // from the anchor's live position — rather than nudging the old offset by a
+      // line delta — is correct for every kind of change at once: only the anchor's
+      // current row matters, not where or how the transcript grew or shrank.
+      const anchorRow = findAnchorRow(source.owners, this.anchor);
+      if (anchorRow < 0) {
+        // The anchored entry is gone (e.g. a session switch replaced the
+        // transcript); fall back to the tail rather than a stale position.
+        this.followTail = true;
+        this.scrollOffset = 0;
+        this.anchor = null;
+      } else {
+        const contentRows = viewportRows >= 2 ? viewportRows - 1 : viewportRows;
+        this.scrollOffset = Math.max(0, transcriptLines.length - anchorRow - contentRows);
       }
     }
 
@@ -765,7 +799,8 @@ class MakaPiLayoutComponent extends Container {
     );
     this.scrollOffset = windowed.scrollOffset;
     this.followTail = windowed.scrollOffset === 0;
-    this.lastLines = transcriptLines;
+    this.anchor = this.followTail ? null : anchorOwnerAt(source.owners, windowed.hiddenAbove);
+    this.pendingUserScroll = false;
     this.lastTotalLines = transcriptLines.length;
     this.lastViewportRows = viewportRows;
     this.lastWidth = width;
@@ -792,6 +827,9 @@ class MakaPiLayoutComponent extends Container {
     if (next === current) return false;
     this.scrollOffset = next;
     this.followTail = next === 0;
+    // The user moved the viewport; the next render must apply this offset, not the
+    // old anchor. The render then re-anchors to whatever is now on top.
+    this.pendingUserScroll = true;
     return true;
   }
 
@@ -818,13 +856,14 @@ class MakaPiLayoutComponent extends Container {
 
   /**
    * Re-pin to the live tail. Call when the transcript is replaced wholesale (a
-   * session switch), so the render's "new lines appended" heuristic does not
-   * mistake a different, larger transcript for appended output and open the
-   * resumed session scrolled into its history.
+   * session switch) or the user submits, so the viewport follows the newest
+   * output instead of holding a now-irrelevant scroll position.
    */
   followTailNow(): void {
     this.followTail = true;
     this.scrollOffset = 0;
+    this.anchor = null;
+    this.pendingUserScroll = false;
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -582,13 +582,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return { consume: true };
       }
     }
-    // Page through transcript scrollback. Swallow the key whether or not the
-    // view moved so PageUp/PageDown never leak into the editor at a scroll edge.
+    // Page through transcript scrollback — but only when there is scrollback to
+    // page. PageUp/PageDown are also the editor's prompt-paging keys, so when the
+    // transcript fits the viewport we let the key fall through to the editor
+    // instead of swallowing it.
     if (matchesKey(data, Key.pageUp)) {
+      if (!layout.isScrollable()) return undefined;
       if (layout.scrollUp()) tui.requestRender();
       return { consume: true };
     }
     if (matchesKey(data, Key.pageDown)) {
+      if (!layout.isScrollable()) return undefined;
       if (layout.scrollDown()) tui.requestRender();
       return { consume: true };
     }
@@ -746,6 +750,15 @@ class MakaPiLayoutComponent extends Container {
   /** Scroll toward newer output by one page. Returns false when already following the tail. */
   scrollDown(): boolean {
     return this.scrollBy(-this.pageSize());
+  }
+
+  /**
+   * True when the transcript overflows the viewport, i.e. paging keys should
+   * scroll it. When false the transcript fits and PageUp/PageDown belong to the
+   * editor's prompt paging instead.
+   */
+  isScrollable(): boolean {
+    return this.lastTotalLines > this.lastViewportRows;
   }
 
   /**

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -740,9 +740,10 @@ class MakaPiLayoutComponent extends Container {
   // growing or shrinking, above or below the fold, or several at once in one
   // coalesced paint. Null while following the tail.
   private anchor: TranscriptLineOwner | null = null;
-  // Set by an explicit scroll so the next render honours the new offset verbatim
-  // instead of re-deriving it from the (now stale) anchor.
-  private pendingUserScroll = false;
+  // Owners of the last painted frame, so an explicit scroll can translate its
+  // target row into a content anchor rather than a bottom-relative offset (which
+  // a render coalesced with fresh stream deltas would misapply to a taller frame).
+  private lastOwners: readonly (TranscriptLineOwner | null)[] = [];
 
   constructor(
     private readonly transcript: MakaTranscriptComponent,
@@ -769,9 +770,6 @@ class MakaPiLayoutComponent extends Container {
       this.followTail = true;
       this.scrollOffset = 0;
       this.anchor = null;
-    } else if (this.pendingUserScroll) {
-      // An explicit scroll already set scrollOffset; honour it as-is, then re-derive
-      // the anchor from the resulting window below.
     } else if (!this.followTail && this.anchor) {
       // A re-render (stream delta, expansion toggle, ...). Recompute the offset so
       // the anchored content line is back at the top of the viewport. Deriving it
@@ -800,7 +798,7 @@ class MakaPiLayoutComponent extends Container {
     this.scrollOffset = windowed.scrollOffset;
     this.followTail = windowed.scrollOffset === 0;
     this.anchor = this.followTail ? null : anchorOwnerAt(source.owners, windowed.hiddenAbove);
-    this.pendingUserScroll = false;
+    this.lastOwners = source.owners;
     this.lastTotalLines = transcriptLines.length;
     this.lastViewportRows = viewportRows;
     this.lastWidth = width;
@@ -825,11 +823,21 @@ class MakaPiLayoutComponent extends Container {
     const current = this.followTail ? 0 : this.scrollOffset;
     const next = Math.min(Math.max(0, current + offsetDelta), maxOffset);
     if (next === current) return false;
-    this.scrollOffset = next;
-    this.followTail = next === 0;
-    // The user moved the viewport; the next render must apply this offset, not the
-    // old anchor. The render then re-anchors to whatever is now on top.
-    this.pendingUserScroll = true;
+    if (next === 0) {
+      this.followTail = true;
+      this.scrollOffset = 0;
+      this.anchor = null;
+      return true;
+    }
+    // Translate the target offset into a content anchor from the last painted
+    // frame. If the pending render coalesces with fresh stream deltas, deriving
+    // the offset from that anchor against the taller transcript lands the user on
+    // the page they asked for, instead of applying a stale bottom-relative offset.
+    const contentRows = this.lastViewportRows >= 2 ? this.lastViewportRows - 1 : this.lastViewportRows;
+    const targetStart = Math.max(0, this.lastTotalLines - next - contentRows);
+    this.followTail = false;
+    this.scrollOffset = next; // provisional; render recomputes from the anchor when set
+    this.anchor = anchorOwnerAt(this.lastOwners, targetStart);
     return true;
   }
 
@@ -863,7 +871,6 @@ class MakaPiLayoutComponent extends Container {
     this.followTail = true;
     this.scrollOffset = 0;
     this.anchor = null;
-    this.pendingUserScroll = false;
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -203,11 +203,27 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     terminal.setProgress(true);
     requestRender();
 
+    let permissionSnapped = false;
     void submitPromptToTranscript({
       state,
       driver: input.driver,
       prompt,
-      onChange: requestRender,
+      onChange: () => {
+        // A newly raised permission prompt renders at the transcript tail. If the
+        // user has paged up, it would land below the fold and the session would
+        // look stuck waiting for a y/n they cannot see. Snap to the tail once when
+        // the prompt first appears — not on every render, so the user can still
+        // page up to read context before answering.
+        if (state.pendingPermission) {
+          if (!permissionSnapped) {
+            permissionSnapped = true;
+            layout.followTailNow();
+          }
+        } else {
+          permissionSnapped = false;
+        }
+        requestRender();
+      },
     }).finally(() => {
       busy = false;
       turnRunning = false;
@@ -673,6 +689,19 @@ class MakaStatusLineComponent implements Component {
   }
 }
 
+/**
+ * True when `next` is `prev` with zero or more lines appended at the end and
+ * nothing above changed — i.e. the growth is a pure tail append. Used to tell
+ * streamed output landing below the fold apart from an in-place edit above it.
+ */
+function isTailAppend(prev: readonly string[], next: readonly string[]): boolean {
+  if (next.length < prev.length) return false;
+  for (let i = 0; i < prev.length; i++) {
+    if (next[i] !== prev[i]) return false;
+  }
+  return true;
+}
+
 class MakaPiLayoutComponent extends Container {
   // Scroll position as lines hidden below the viewport bottom; 0 = following the
   // live tail. `followTail` re-pins to the bottom as new output streams in, so a
@@ -683,6 +712,7 @@ class MakaPiLayoutComponent extends Container {
   private lastTotalLines = 0;
   private lastViewportRows = 0;
   private lastWidth = 0;
+  private lastLines: string[] = [];
 
   constructor(
     private readonly transcript: Component,
@@ -707,9 +737,18 @@ class MakaPiLayoutComponent extends Container {
       // tail rather than land the viewport on an arbitrary mid-message row.
       this.followTail = true;
       this.scrollOffset = 0;
-    } else if (!this.followTail && transcriptLines.length > this.lastTotalLines) {
-      // New lines land at the bottom; hold the reader's view fixed by counting
-      // them into the below-the-fold offset instead of letting the window drift.
+    } else if (
+      !this.followTail &&
+      transcriptLines.length > this.lastTotalLines &&
+      isTailAppend(this.lastLines, transcriptLines)
+    ) {
+      // Streamed lines land at the bottom; hold the reader's view fixed by
+      // counting them into the below-the-fold offset instead of letting the
+      // window drift. Only do this for a pure tail append: an in-place edit
+      // above the fold (e.g. a late `thinking_complete` re-rendering an expanded
+      // thinking block to a different height) also grows the line count, but
+      // there the lines below the fold are unchanged, so the offset must stay
+      // put — adding the delta would drift the window up by that height.
       this.scrollOffset += transcriptLines.length - this.lastTotalLines;
     }
 
@@ -721,6 +760,7 @@ class MakaPiLayoutComponent extends Container {
     );
     this.scrollOffset = windowed.scrollOffset;
     this.followTail = windowed.scrollOffset === 0;
+    this.lastLines = transcriptLines;
     this.lastTotalLines = transcriptLines.length;
     this.lastViewportRows = viewportRows;
     this.lastWidth = width;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -113,6 +113,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Refuse nested control actions: an overlay onSelect bypasses editor.onSubmit,
     // so without this guard a switch could start while a prompt is still running.
     if (busy) return;
+    // Control actions are user-initiated and append their result (a notice, a
+    // compaction summary); follow the tail so it is visible even if the user had
+    // scrolled up.
+    layout.followTailNow();
     busy = true;
     editor.disableSubmit = true;
     terminal.setProgress(true);
@@ -185,6 +189,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
       return;
     }
+    // A submission is the user acting; snap back to the tail so their prompt and
+    // its response are visible, rather than treating the appended rows as
+    // background stream output and preserving a scrolled-up position.
+    layout.followTailNow();
     if (handleSlashCommand(prompt)) return;
 
     busy = true;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -607,9 +607,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       }
     }
     // Page through transcript scrollback — but only when there is scrollback to
-    // page. PageUp/PageDown are also the editor's prompt-paging keys, so when the
-    // transcript fits the viewport we let the key fall through to the editor
-    // instead of swallowing it.
+    // page. PageUp/PageDown also page the editor's own multi-line input buffer,
+    // so when the transcript fits the viewport we let the key fall through to the
+    // editor instead of swallowing it.
     if (matchesKey(data, Key.pageUp)) {
       if (!layout.isScrollable()) return undefined;
       if (layout.scrollUp()) tui.requestRender();
@@ -690,16 +690,16 @@ class MakaStatusLineComponent implements Component {
 }
 
 /**
- * True when `next` is `prev` with zero or more lines appended at the end and
- * nothing above changed — i.e. the growth is a pure tail append. Used to tell
- * streamed output landing below the fold apart from an in-place edit above it.
+ * Index of the first line that differs between `prev` and `next`, or the length
+ * of the shorter array when one is a prefix of the other. Used to locate where a
+ * transcript re-render changed relative to the viewport.
  */
-function isTailAppend(prev: readonly string[], next: readonly string[]): boolean {
-  if (next.length < prev.length) return false;
-  for (let i = 0; i < prev.length; i++) {
-    if (next[i] !== prev[i]) return false;
+function firstDivergentLine(prev: readonly string[], next: readonly string[]): number {
+  const shared = Math.min(prev.length, next.length);
+  for (let i = 0; i < shared; i++) {
+    if (prev[i] !== next[i]) return i;
   }
-  return true;
+  return shared;
 }
 
 class MakaPiLayoutComponent extends Container {
@@ -737,19 +737,20 @@ class MakaPiLayoutComponent extends Container {
       // tail rather than land the viewport on an arbitrary mid-message row.
       this.followTail = true;
       this.scrollOffset = 0;
-    } else if (
-      !this.followTail &&
-      transcriptLines.length > this.lastTotalLines &&
-      isTailAppend(this.lastLines, transcriptLines)
-    ) {
-      // Streamed lines land at the bottom; hold the reader's view fixed by
-      // counting them into the below-the-fold offset instead of letting the
-      // window drift. Only do this for a pure tail append: an in-place edit
-      // above the fold (e.g. a late `thinking_complete` re-rendering an expanded
-      // thinking block to a different height) also grows the line count, but
-      // there the lines below the fold are unchanged, so the offset must stay
-      // put — adding the delta would drift the window up by that height.
-      this.scrollOffset += transcriptLines.length - this.lastTotalLines;
+    } else if (!this.followTail && transcriptLines.length > this.lastTotalLines) {
+      // The transcript grew. Preserve the reader's position by holding the top of
+      // the visible slice fixed — but only when the growth is entirely below the
+      // fold, so the visible slice itself is untouched. Streaming appends and
+      // even in-place edits to the tail block (a `text_delta` re-wrapping the last
+      // line) qualify; an edit above the fold (a late `thinking_complete` growing
+      // an expanded block the reader has scrolled past) does not — there the tail
+      // is unchanged, so the below-the-fold offset must stay put or the window
+      // drifts. `firstDivergentLine` locates the change; a first difference at or
+      // below the old viewport bottom means the visible slice is a stable prefix.
+      const viewportBottom = this.lastTotalLines - this.scrollOffset;
+      if (firstDivergentLine(this.lastLines, transcriptLines) >= viewportBottom) {
+        this.scrollOffset += transcriptLines.length - this.lastTotalLines;
+      }
     }
 
     const windowed = windowTranscriptLines(
@@ -802,8 +803,8 @@ class MakaPiLayoutComponent extends Container {
 
   /**
    * True when the transcript overflows the viewport, i.e. paging keys should
-   * scroll it. When false the transcript fits and PageUp/PageDown belong to the
-   * editor's prompt paging instead.
+   * scroll it. When false the transcript fits and PageUp/PageDown page the
+   * editor's own multi-line input buffer instead.
    */
   isScrollable(): boolean {
     return this.lastTotalLines > this.lastViewportRows;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -245,6 +245,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = input.providerType ? thinkingVariantsForModel(input.providerType, summary.model) : [];
     replaceTranscriptWithStoredMessages(state, messages);
+    // The transcript is a different document now; drop any scroll position so the
+    // resumed session opens following its latest messages, not mid-history.
+    layout.followTailNow();
     if (messages.length === 0) {
       state.entries.push({
         kind: 'notice',
@@ -743,6 +746,17 @@ class MakaPiLayoutComponent extends Container {
   /** Scroll toward newer output by one page. Returns false when already following the tail. */
   scrollDown(): boolean {
     return this.scrollBy(-this.pageSize());
+  }
+
+  /**
+   * Re-pin to the live tail. Call when the transcript is replaced wholesale (a
+   * session switch), so the render's "new lines appended" heuristic does not
+   * mistake a different, larger transcript for appended output and open the
+   * resumed session scrolled into its history.
+   */
+  followTailNow(): void {
+    this.followTail = true;
+    this.scrollOffset = 0;
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -737,16 +737,20 @@ class MakaPiLayoutComponent extends Container {
       // tail rather than land the viewport on an arbitrary mid-message row.
       this.followTail = true;
       this.scrollOffset = 0;
-    } else if (!this.followTail && transcriptLines.length > this.lastTotalLines) {
-      // The transcript grew. Preserve the reader's position by holding the top of
-      // the visible slice fixed — but only when the growth is entirely below the
-      // fold, so the visible slice itself is untouched. Streaming appends and
-      // even in-place edits to the tail block (a `text_delta` re-wrapping the last
-      // line) qualify; an edit above the fold (a late `thinking_complete` growing
-      // an expanded block the reader has scrolled past) does not — there the tail
-      // is unchanged, so the below-the-fold offset must stay put or the window
-      // drifts. `firstDivergentLine` locates the change; a first difference at or
-      // below the old viewport bottom means the visible slice is a stable prefix.
+    } else if (!this.followTail && transcriptLines.length !== this.lastTotalLines) {
+      // The transcript's line count changed. Preserve the reader's position by
+      // holding the top of the visible slice fixed — but only when the change is
+      // entirely below the fold, so the visible slice itself is untouched. A
+      // streamed append or in-place edit to the tail block (a `text_delta`
+      // re-wrapping the last line, a `thinking_complete` growing or shrinking an
+      // expanded block below the fold, a resolved permission prompt collapsing to
+      // a notice) qualifies; an edit above the fold (a block the reader has
+      // scrolled past) does not — there the tail is unchanged, so the
+      // below-the-fold offset must stay put or the window drifts.
+      // `firstDivergentLine` locates the change; a first difference at or below
+      // the old viewport bottom means the visible slice is a stable prefix, so
+      // shift the offset by the (signed) delta to track the tail. Growth and
+      // shrink are symmetric; windowTranscriptLines clamps the result.
       const viewportBottom = this.lastTotalLines - this.scrollOffset;
       if (firstDivergentLine(this.lastLines, transcriptLines) >= viewportBottom) {
         this.scrollOffset += transcriptLines.length - this.lastTotalLines;
@@ -804,10 +808,12 @@ class MakaPiLayoutComponent extends Container {
   /**
    * True when the transcript overflows the viewport, i.e. paging keys should
    * scroll it. When false the transcript fits and PageUp/PageDown page the
-   * editor's own multi-line input buffer instead.
+   * editor's own multi-line input buffer instead. A zero-row viewport (the
+   * editor and status filled a very short terminal) renders no transcript at
+   * all, so paging must fall through to the editor even with content buffered.
    */
   isScrollable(): boolean {
-    return this.lastTotalLines > this.lastViewportRows;
+    return this.lastViewportRows > 0 && this.lastTotalLines > this.lastViewportRows;
   }
 
   /**

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -158,6 +158,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     const request = state.pendingPermission;
     if (!request || permissionInFlight) return false;
     permissionInFlight = true;
+    // Answering is the user acting; the decision resumes the turn at the tail
+    // (tool output, the next reply, or an error). Snap back to the tail so that
+    // continuation is visible even if the user had paged up past the prompt to
+    // read context before deciding — otherwise the session looks stuck.
+    layout.followTailNow();
     // Keep the prompt visible until the driver accepts the response. If it
     // rejects, the user can retry with y/n instead of being stuck.
     void input.driver.respondToPermission({


### PR DESCRIPTION
## Summary
Window the transcript to the viewport with PageUp/PageDown scrollback, and memoize per-entry rendering.

## Why
The transcript emitted every rendered line, so once history exceeded the screen earlier messages were unreadable in-app (an alt-screen TUI has no native scrollback). Every entry — including a fresh `Markdown` instance per block — was also rebuilt on each keystroke and stream delta.

Refs #549 (T1: Transcript viewport + render memoization)

## Scope
Changed:
- `packages/cli/src/pi-transcript.ts` — `windowTranscriptLines()` viewport slice + scroll indicator; per-entry render cache keyed by entry identity + a content signature.
- `packages/cli/src/pi-tui-runner.ts` — `MakaPiLayoutComponent` owns the scroll position; PageUp/PageDown paging; tail-follow and width-change re-pin.
- `packages/cli/src/__tests__/{pi-transcript,pi-tui-runner}.test.ts` — windowing, memoization, scroll integration.

Not included:
- Tool-output expansion cap — separate PR #628.

## Verification
- `npm run -w maka-agent typecheck` — clean.
- `npm run -w maka-agent test` — 126 pass (adds 5 windowing, 2 memoization, 1 scroll integration).

## User-facing impact
PageUp/PageDown now scroll transcript history; new output re-pins to the tail only when already following it. A dim indicator row shows hidden-line counts and the scroll keys.

## Reviewer notes
Scroll offset = lines hidden below the viewport bottom (0 = following the tail). A width change re-pins because rewrap invalidates line offsets. The memo signature busts on width, growing text, tool status, and expansion toggles.

## Checklist
- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact noted
- [x] Review focus called out
- [x] UI changes: terminal-only render; behavior locked by unit + integration tests instead of screenshots