### PR TITLE
fix(cli): cap expanded tool output, Claude-Code style (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -590,23 +590,57 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /Read 4 lines, 59 bytes/);
   });
 
-  test('shows maka://runtime resource Read output instead of a read summary', () => {
+  test('shows maka://runtime resource Read output in full, never summarized or capped', () => {
     const state = createMakaPiTranscriptState();
-    // Reading a maka://runtime/... resource returns live state (e.g. background
-    // task output) that only lives in the transcript, so it must not be summarized.
+    // A runtime resource read returns live state (background-task metadata +
+    // output) that only lives in the transcript. Its body opens with several
+    // metadata lines, so it must be neither summarized nor head/tail-capped.
+    const body = [
+      'ref: maka://runtime/background-tasks/abc',
+      'status: running',
+      'cwd: /repo',
+      'command: npm test',
+      'started: 1',
+      'updated: 2',
+      '',
+      'stdout:',
+      'first-output-line',
+      'middle-output-line',
+      'last-output-line',
+    ].join('\n');
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start', toolUseId: 'read-rt', toolName: 'Read',
       args: { path: 'maka://runtime/background-tasks/abc' },
     }));
     applyMakaSessionEventToTranscript(state, event({
-      type: 'tool_result', toolUseId: 'read-rt', isError: false,
-      content: { kind: 'text', text: 'task-status: running\nlast-line-output' },
+      type: 'tool_result', toolUseId: 'read-rt', isError: false, content: { kind: 'text', text: body },
     }));
 
     assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(expanded, /task-status: running/);
-    assert.match(expanded, /last-line-output/);
+    assert.match(expanded, /command: npm test/); // a mid-body line a cap would hide
+    assert.match(expanded, /stdout:/);
+    assert.match(expanded, /middle-output-line/);
+    assert.doesNotMatch(expanded, /lines hidden/);
+    assert.doesNotMatch(expanded, /Read \d+ lines,/);
+  });
+
+  test('keeps an archived Read placeholder status visible instead of a line count', () => {
+    const state = createMakaPiTranscriptState();
+    // Compaction can replace a completed filesystem Read's result with an archive
+    // placeholder; its not_loaded/missing status must stay visible, not be read as
+    // a one-line file body.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-arch', toolName: 'Read', args: { path: 'README.md' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-arch', isError: false,
+      content: { kind: 'archived_tool_result', status: 'not_loaded' },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /Archived tool result: not_loaded/);
     assert.doesNotMatch(expanded, /Read \d+ lines,/);
   });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -659,6 +659,80 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(expanded, /Read \d+ lines,/);
   });
 
+  test('reports the same Read line count collapsed and expanded for a trailing-newline file', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-count', toolName: 'Read', args: { path: 'three.txt' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-count', isError: false,
+      content: { kind: 'json', value: { content: 'a\nb\nc\n' } },
+    }));
+
+    // Collapsed and expanded must agree: both drop the trailing newline, so the
+    // same card cannot flip from "4 lines" to "3 lines" when toggled with Ctrl+O.
+    const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(compact, /3 lines, 6 bytes/);
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /Read 3 lines, 6 bytes/);
+  });
+
+  test('keeps shell_run status and exit visible while capping its stream body', () => {
+    const state = createMakaPiTranscriptState();
+    // A background command's status/exit is the whole point of expanding the
+    // card; a bare head/tail cap would keep only `$ cmd` + the last stdout lines
+    // and hide whether the process failed or timed out.
+    const stdout = Array.from({ length: 10 }, (_, i) => `out-line-${i}`).join('\n');
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'shell-1', toolName: 'StopBackgroundTask',
+      args: { ref: 'bg-42' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'shell-1', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'bg-42', status: 'failed', cwd: '/repo',
+        cmd: 'npm run watch', startedAt: 1, updatedAt: 2, exitCode: 137,
+        failureMessage: 'killed by signal',
+        stdout, stderr: 'boom-stderr',
+        stdoutTruncated: false, stderrTruncated: false,
+      },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // Failure metadata a bare head/tail cap would bury stays visible.
+    assert.match(expanded, /failed/);
+    assert.match(expanded, /exit 137/);
+    assert.match(expanded, /killed by signal/);
+    assert.match(expanded, /bg-42/);
+    // The stream body is still capped, and stderr keeps its label.
+    assert.match(expanded, /lines hidden/);
+    assert.match(expanded, /\[stderr\]/);
+    assert.match(expanded, /boom-stderr/);
+  });
+
+  test('renders a report-style result in full instead of head/tail capping it', () => {
+    const state = createMakaPiTranscriptState();
+    // Report-style kinds (agent reports, summaries) are content the user expands
+    // to read in full; unlike a raw command dump they must not be capped.
+    const report = Array.from({ length: 12 }, (_, i) => `report-line-${i}`).join('\n');
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'sum-1', toolName: 'Task', args: {},
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'sum-1', isError: false,
+      content: { kind: 'summary', original: 'x', summarized: report, reason: 'too_large' },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /report-line-0/);
+    assert.match(expanded, /report-line-6/); // a mid-body line a head/tail cap would hide
+    assert.match(expanded, /report-line-11/);
+    assert.doesNotMatch(expanded, /lines hidden/);
+  });
+
   test('summarizes Grep results as a match count and shows matches expanded', () => {
     const state = createMakaPiTranscriptState();
     const matches = Array.from({ length: 12 }, (_, i) => `match-${i}`);

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1132,11 +1132,13 @@ describe('transcript entry render memoization', () => {
 
   test('re-renders a tool entry when Ctrl+O expansion is toggled', () => {
     const state = createMakaPiTranscriptState();
+    // A Grep (not a filesystem Read, which now renders only a summary) so
+    // expansion genuinely changes the rendered block and its body is shown.
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_start',
       toolUseId: 'tool-1',
-      toolName: 'Read',
-      args: { path: 'file.ts' },
+      toolName: 'Grep',
+      args: { pattern: 'beta' },
     }));
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_result',

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -590,6 +590,21 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /Read 4 lines, 59 bytes/);
   });
 
+  test('counts a Read summary without the file trailing newline', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-nl', toolName: 'Read', args: { path: 'one.txt' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-nl', isError: false,
+      content: { kind: 'json', value: { content: 'only-line\n' } },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /Read 1 line, 10 bytes/);
+  });
+
   test('shows maka://runtime resource Read output in full, never summarized or capped', () => {
     const state = createMakaPiTranscriptState();
     // A runtime resource read returns live state (background-task metadata +

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -731,6 +731,29 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /boom-stderr/);
   });
 
+  test('does not repeat the command when a Bash yield already shows it', () => {
+    const state = createMakaPiTranscriptState();
+    // A Bash background yield carries the command on both the input and the
+    // shell_run result; the expanded card must print `$ cmd` once, not twice.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-bg', toolName: 'Bash', args: { command: 'npm run watch' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-bg', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'bg-9', status: 'running', cwd: '/repo',
+        cmd: 'npm run watch', startedAt: 1, updatedAt: 2,
+        stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+      },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    const occurrences = expanded.split('$ npm run watch').length - 1;
+    assert.equal(occurrences, 1);
+    assert.match(expanded, /cwd: \/repo/); // cwd is not in the input summary, so shown once here
+  });
+
   test('renders a report-style result in full instead of head/tail capping it', () => {
     const state = createMakaPiTranscriptState();
     // Report-style kinds (agent reports, summaries) are content the user expands
@@ -776,10 +799,13 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /12 matches \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /match-0/);
 
+    // Expanding a Grep card shows every match — a structured list the user
+    // opened the card to scan, not a raw dump to head/tail cap. All 12 rows,
+    // including the middle ones, must survive and there is no hidden-count marker.
     assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(expanded, /match-0/);
-    assert.match(expanded, /match-11/);
+    for (let i = 0; i < 12; i += 1) assert.match(expanded, new RegExp(`match-${i}\\b`));
+    assert.doesNotMatch(expanded, /lines hidden/);
   });
 
   test('summarizes Glob results as a file count and shows the list expanded', () => {
@@ -1142,6 +1168,28 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(rendered, /secret/);
     assert.match(rendered, /\[redacted\]/);
     assert.match(rendered, /\[stderr\]/);
+  });
+
+  test('caps a long live stream group in the expanded card', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-stream', toolName: 'Bash', args: { command: 'seq 20' },
+    }));
+    // Ten single-line stdout chunks form one stream group; the expanded card
+    // head/tail caps the group body just like a finished command dump.
+    for (let i = 0; i < 10; i += 1) {
+      applyMakaSessionEventToTranscript(state, event({
+        type: 'tool_output_delta', toolUseId: 'bash-stream', seq: i, stream: 'stdout',
+        chunk: `${i === 0 ? '' : '\n'}stream-line-${i}`, redacted: false,
+      }));
+    }
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /stream-line-0/);
+    assert.match(expanded, /stream-line-9/);
+    assert.match(expanded, /lines hidden/);
+    assert.doesNotMatch(expanded, /stream-line-5/); // a middle line the cap hides
   });
 });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -590,6 +590,26 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /Read 4 lines, 59 bytes/);
   });
 
+  test('shows maka://runtime resource Read output instead of a read summary', () => {
+    const state = createMakaPiTranscriptState();
+    // Reading a maka://runtime/... resource returns live state (e.g. background
+    // task output) that only lives in the transcript, so it must not be summarized.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-rt', toolName: 'Read',
+      args: { path: 'maka://runtime/background-tasks/abc' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-rt', isError: false,
+      content: { kind: 'text', text: 'task-status: running\nlast-line-output' },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /task-status: running/);
+    assert.match(expanded, /last-line-output/);
+    assert.doesNotMatch(expanded, /Read \d+ lines,/);
+  });
+
   test('summarizes Grep results as a match count and shows matches expanded', () => {
     const state = createMakaPiTranscriptState();
     const matches = Array.from({ length: 12 }, (_, i) => `match-${i}`);
@@ -777,6 +797,46 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /out-19/);
     assert.doesNotMatch(expanded, /out-10\b/);
     assert.match(expanded, /⋯ 14 lines hidden ⋯/);
+  });
+
+  test('ignores a trailing newline when counting terminal output for the cap', () => {
+    const state = createMakaPiTranscriptState();
+    // Real command output ends in a newline. The seven content lines are within
+    // the cap, so a trailing newline must not push the count to eight and cap it.
+    const stdout = `${Array.from({ length: 7 }, (_, i) => `row-${i}`).join('\n')}\n`;
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-nl', toolName: 'Bash', args: { command: 'seq 7' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-nl', isError: false, content: terminalResult(stdout),
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /row-0\b/);
+    assert.match(expanded, /row-3\b/);
+    assert.match(expanded, /row-6\b/);
+    assert.doesNotMatch(expanded, /lines hidden/);
+  });
+
+  test('counts real tail lines past a trailing newline when capping', () => {
+    const state = createMakaPiTranscriptState();
+    // Ten real lines plus a trailing newline: the tail must be the last three
+    // real lines (not two plus a blank), and the hidden count must be four.
+    const stdout = `${Array.from({ length: 10 }, (_, i) => `row-${i}`).join('\n')}\n`;
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-nl2', toolName: 'Bash', args: { command: 'seq 10' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-nl2', isError: false, content: terminalResult(stdout),
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /row-7\b/);
+    assert.match(expanded, /row-9\b/);
+    assert.doesNotMatch(expanded, /row-5\b/);
+    assert.match(expanded, /⋯ 4 lines hidden ⋯/);
   });
 
   test('shows a long diff in full when expanded — diffs are the head/tail exception', () => {

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -754,6 +754,29 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /cwd: \/repo/); // cwd is not in the input summary, so shown once here
   });
 
+  test('renders the full command for a multiline background Bash yield', () => {
+    const state = createMakaPiTranscriptState();
+    // The Bash input summary shows only the first line, so a multiline command
+    // must be rendered in full by the result or the rest is lost.
+    const command = 'npm run build \\\n  --watch \\\n  --verbose';
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-ml', toolName: 'Bash', args: { command },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-ml', isError: false,
+      content: {
+        kind: 'shell_run', ref: 'bg-ml', status: 'running', cwd: '/repo',
+        cmd: command, startedAt: 1, updatedAt: 2,
+        stdout: '', stderr: '', stdoutTruncated: false, stderrTruncated: false,
+      },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /--watch/);
+    assert.match(expanded, /--verbose/);
+  });
+
   test('renders a report-style result in full instead of head/tail capping it', () => {
     const state = createMakaPiTranscriptState();
     // Report-style kinds (agent reports, summaries) are content the user expands

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -558,7 +558,7 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(compact, /step one/);
   });
 
-  test('summarizes Read results as a line/byte count when compact and shows text expanded', () => {
+  test('summarizes Read results as a line/byte count and never replays file content', () => {
     const state = createMakaPiTranscriptState();
     const fileText = Array.from({ length: 4 }, (_, i) => `content-line-${i}`).join('\n');
 
@@ -582,9 +582,12 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(compact, /4 lines, 59 bytes \(Ctrl\+O\)/);
     assert.doesNotMatch(compact, /content-line-0/);
 
+    // A successful Read pulled the file into the model's context; expanding the
+    // card confirms the read but must not dump the file into the transcript.
     assert.equal(toggleAllToolExpansion(state), true);
     const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
-    assert.match(expanded, /content-line-0/);
+    assert.doesNotMatch(expanded, /content-line-0/);
+    assert.match(expanded, /Read 4 lines, 59 bytes/);
   });
 
   test('summarizes Grep results as a match count and shows matches expanded', () => {
@@ -754,6 +757,54 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(raw, /\x1b\[31m-removed line\x1b\[39m/);
   });
 
+  test('caps long terminal output to head and tail lines when expanded', () => {
+    const state = createMakaPiTranscriptState();
+    const stdout = Array.from({ length: 20 }, (_, i) => `out-${i}`).join('\n');
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'bash-1', toolName: 'Bash', args: { command: 'seq 20' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'bash-1', isError: false, content: terminalResult(stdout),
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // First three and last three lines survive; the middle collapses to a marker.
+    assert.match(expanded, /out-0\n/);
+    assert.match(expanded, /out-2\n/);
+    assert.match(expanded, /out-17\n/);
+    assert.match(expanded, /out-19/);
+    assert.doesNotMatch(expanded, /out-10\b/);
+    assert.match(expanded, /⋯ 14 lines hidden ⋯/);
+  });
+
+  test('shows a long diff in full when expanded — diffs are the head/tail exception', () => {
+    const state = createMakaPiTranscriptState();
+    const diff = [
+      '--- a/file.ts',
+      '+++ b/file.ts',
+      '@@ -1 +20 @@',
+      ...Array.from({ length: 20 }, (_, i) => `+line-${i}`),
+    ].join('\n');
+
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'edit-2', toolName: 'Edit', args: { path: 'file.ts' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'edit-2', isError: false,
+      content: { kind: 'file_diff', paths: ['file.ts'], diff },
+    }));
+
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    // Every added line is present and no lines are hidden.
+    assert.match(expanded, /\+line-0\b/);
+    assert.match(expanded, /\+line-10\b/);
+    assert.match(expanded, /\+line-19\b/);
+    assert.doesNotMatch(expanded, /lines hidden/);
+  });
+
   test('renders file_write results as a byte summary', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(state, event({
@@ -779,22 +830,24 @@ describe('Maka Pi TUI transcript', () => {
     const state = createMakaPiTranscriptState();
 
     applyMakaSessionEventToTranscript(state, event({
-      type: 'tool_start', toolUseId: 'tool-a', toolName: 'Read', args: { path: 'a.ts' },
+      type: 'tool_start', toolUseId: 'tool-a', toolName: 'Bash', args: { command: 'echo a' },
     }));
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_result',
       toolUseId: 'tool-a',
       isError: false,
-      content: { kind: 'json', value: { content: 'alpha-body-line' } },
+      // The body is the first stdout line, so the compact tail summary hides it
+      // while expansion reveals it.
+      content: terminalResult('alpha-body-line\ntail-a'),
     }));
     applyMakaSessionEventToTranscript(state, event({
-      type: 'tool_start', toolUseId: 'tool-b', toolName: 'Read', args: { path: 'b.ts' },
+      type: 'tool_start', toolUseId: 'tool-b', toolName: 'Bash', args: { command: 'echo b' },
     }));
     applyMakaSessionEventToTranscript(state, event({
       type: 'tool_result',
       toolUseId: 'tool-b',
       isError: false,
-      content: { kind: 'json', value: { content: 'beta-body-line' } },
+      content: terminalResult('beta-body-line\ntail-b'),
     }));
 
     const compact = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
@@ -1017,6 +1070,20 @@ function meta() {
     model: 'deepseek-v4-flash',
     connectionSlug: 'deepseek',
     permissionMode: 'ask',
+  } as const;
+}
+
+function terminalResult(stdout: string, stderr = '') {
+  return {
+    kind: 'terminal',
+    cwd: '/repo',
+    cmd: 'echo',
+    status: 'completed',
+    exitCode: 0,
+    stdout,
+    stderr,
+    stdoutTruncated: false,
+    stderrTruncated: false,
   } as const;
 }
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -678,6 +678,22 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /Read 3 lines, 6 bytes/);
   });
 
+  test('preserves a real trailing blank line in the Read line count', () => {
+    const state = createMakaPiTranscriptState();
+    // Only the single conventional EOF newline is dropped: `a\n\n` keeps its
+    // trailing blank line (two lines), and a lone `\n` is one blank line.
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_start', toolUseId: 'read-blank', toolName: 'Read', args: { path: 'blank.txt' },
+    }));
+    applyMakaSessionEventToTranscript(state, event({
+      type: 'tool_result', toolUseId: 'read-blank', isError: false,
+      content: { kind: 'json', value: { content: 'a\n\n' } },
+    }));
+    assert.equal(toggleAllToolExpansion(state), true);
+    const expanded = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(expanded, /Read 2 lines, 3 bytes/);
+  });
+
   test('keeps shell_run status and exit visible while capping its stream body', () => {
     const state = createMakaPiTranscriptState();
     // A background command's status/exit is the whole point of expanding the
@@ -706,6 +722,9 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(expanded, /exit 137/);
     assert.match(expanded, /killed by signal/);
     assert.match(expanded, /bg-42/);
+    // The command/cwd live on the result, not the ref-only input, so the
+    // expanded card must repeat them to say which process this was.
+    assert.match(expanded, /npm run watch/);
     // The stream body is still capped, and stderr keeps its label.
     assert.match(expanded, /lines hidden/);
     assert.match(expanded, /\[stderr\]/);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -980,17 +980,32 @@ function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
   return renderIndented(ansi.dim(summary), width, 2);
 }
 
-/**
- * A Read whose path is a real file, not a `maka://runtime/...` resource. The
- * runtime scheme surfaces things like background-task output that only lives in
- * the transcript, so it must render its content rather than a "read" summary.
- */
-function isFilesystemReadPath(entry: MakaPiToolEntry): boolean {
+function readInputPath(entry: MakaPiToolEntry): string | undefined {
   const input = entry.input;
   const path = input !== null && typeof input === 'object'
     ? (input as { path?: unknown }).path
     : undefined;
-  return typeof path === 'string' && path.length > 0 && !path.startsWith('maka://runtime/');
+  return typeof path === 'string' && path.length > 0 ? path : undefined;
+}
+
+/** A Read whose path is a real file, not a `maka://runtime/...` resource. */
+function isFilesystemReadPath(entry: MakaPiToolEntry): boolean {
+  const path = readInputPath(entry);
+  return path !== undefined && !path.startsWith('maka://runtime/');
+}
+
+/** A Read of a `maka://runtime/...` resource (background-task output, etc.). */
+function isRuntimeResourceReadPath(entry: MakaPiToolEntry): boolean {
+  return readInputPath(entry)?.startsWith('maka://runtime/') ?? false;
+}
+
+/**
+ * True only for the result shapes a filesystem Read uses to carry actual file
+ * content. An `archived_tool_result` placeholder (or any other kind) is not a
+ * read body, so it renders its own status instead of a fabricated line count.
+ */
+function isReadBodyResult(result: ToolResultContent | undefined): boolean {
+  return result?.kind === 'text' || result?.kind === 'json';
 }
 
 /**
@@ -1031,12 +1046,23 @@ function groupOutputDeltas(
 
 function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
   const result = entry.result;
-  // A successful filesystem Read pulled the file into the model's context; the
-  // transcript only needs to note that it happened, so skip the content and keep
-  // a summary. A failed Read falls through so its error is still visible, and a
-  // `maka://runtime/...` resource Read (e.g. background-task output) also falls
-  // through — that output only lives here, so it must not be summarized away.
-  if (entry.toolName === 'Read' && entry.status !== 'error' && isFilesystemReadPath(entry)) {
+  // A `maka://runtime/...` resource Read surfaces live state (background-task
+  // metadata + stdout/stderr) that only lives in the transcript. Its body opens
+  // with several metadata/separator lines, so a head/tail cap would hide the very
+  // output the user expanded to see — render it in full.
+  if (entry.toolName === 'Read' && isRuntimeResourceReadPath(entry)) {
+    return renderToolText(plainResultText(entry), width);
+  }
+  // A successful filesystem Read that returned real file content pulled it into
+  // the model's context; the transcript only needs to note that it happened, so
+  // skip the content and keep a summary. Everything else falls through to render
+  // its content: a failed Read (its error), and — critically — an
+  // `archived_tool_result` placeholder, so its not_loaded/missing status stays
+  // visible instead of being mistaken for a one-line file.
+  if (entry.toolName === 'Read'
+    && entry.status !== 'error'
+    && isFilesystemReadPath(entry)
+    && isReadBodyResult(result)) {
     return renderReadSummary(entry, width);
   }
   if (result?.kind === 'terminal') return renderTerminalResult(result, width);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -844,7 +844,7 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
   const text = plainResultText(entry);
   if (!text) return undefined;
   if (entry.toolName === 'Read') {
-    const lineCount = text.split('\n').length;
+    const lineCount = readBodyLineCount(text);
     return {
       text: `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`,
       expandable: true,
@@ -973,13 +973,21 @@ function renderCappedResultText(
   ];
 }
 
+/**
+ * Line count for a Read body, dropping the file's normal trailing newline so
+ * `foo\n` counts as one line. Shared by the compact and expanded summaries so
+ * the same card can never flip its line count when toggled with Ctrl+O.
+ */
+function readBodyLineCount(text: string): number {
+  const trimmed = text.replace(/\n+$/, '');
+  return trimmed ? trimmed.split('\n').length : 0;
+}
+
 function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
   const text = plainResultText(entry);
-  // Drop the file's normal trailing newline before counting, matching the cap
-  // convention, so `foo\n` reads as one line rather than two. Byte count keeps
-  // the full content, since that is the file's real size on disk.
-  const trimmed = text.replace(/\n+$/, '');
-  const lineCount = trimmed ? trimmed.split('\n').length : 0;
+  // Byte count keeps the full content, since that is the file's real size on
+  // disk; the line count drops the trailing newline (see readBodyLineCount).
+  const lineCount = readBodyLineCount(text);
   const summary = `Read ${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
   return renderIndented(ansi.dim(summary), width, 2);
 }
@@ -1009,7 +1017,18 @@ function isRuntimeResourceReadPath(entry: MakaPiToolEntry): boolean {
  * read body, so it renders its own status instead of a fabricated line count.
  */
 function isReadBodyResult(result: ToolResultContent | undefined): boolean {
-  return result?.kind === 'text' || result?.kind === 'json';
+  if (result?.kind === 'text') return true;
+  // A json Read body is the `{ content: string }` shape the file loader
+  // returns; any other json (e.g. an `{ error }` payload) is a status object,
+  // not file content, and should render its real shape rather than a
+  // fabricated line/byte count.
+  if (result?.kind === 'json') {
+    const value = result.value;
+    return value !== null
+      && typeof value === 'object'
+      && typeof (value as { content?: unknown }).content === 'string';
+  }
+  return false;
 }
 
 /**
@@ -1070,13 +1089,28 @@ function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
     return renderReadSummary(entry, width);
   }
   if (result?.kind === 'terminal') return renderTerminalResult(result, width);
+  // A background `shell_run` carries process metadata (ref, status, exit) the
+  // head/tail cap must never hide — otherwise a failed or timed-out background
+  // command looks the same as a successful one. Render the status in full and
+  // cap only the stdout/stderr stream bodies.
+  if (result?.kind === 'shell_run') return renderShellRunResult(result, width);
   // Diffs are the deliberate exception to the head/tail cap: the whole change
   // is what the user is expanding to see.
   if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width);
   if (result?.kind === 'file_write') {
     return renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2);
   }
-  return renderCappedResultText(plainResultText(entry), width);
+  // Generic text/json dumps — a Grep/Bash body or raw tool text — are the
+  // file/command output the head/tail cap targets: the model already holds the
+  // full body, so the transcript only needs enough to orient. An undefined
+  // result with a formatted `output` string is treated the same way.
+  if (result === undefined || result.kind === 'text' || result.kind === 'json') {
+    return renderCappedResultText(plainResultText(entry), width);
+  }
+  // Everything else is report-style content (agent reports, web-search results,
+  // subagent / workflow summaries, office-doc output) the user expands to read
+  // in full — render without the cap, like a diff.
+  return renderToolText(plainResultText(entry), width);
 }
 
 /** Best-effort extraction of the human-readable body from a tool result. */
@@ -1107,6 +1141,36 @@ function renderTerminalResult(
   if (content.exitCode !== 0) {
     lines.push(...renderIndented(ansi.red(`exit ${content.exitCode}`), width, 2));
   }
+  if (content.stdout) {
+    lines.push(...renderCappedResultText(content.stdout, width));
+  }
+  if (content.stderr) {
+    lines.push(...renderIndented(ansi.dim('[stderr]'), width, 2));
+    lines.push(...renderCappedResultText(content.stderr, width, ansi.dim));
+  }
+  return lines;
+}
+
+/**
+ * Render a `shell_run` (background-process) result. The status line — status,
+ * exit code, failure message, and the run `ref` — is always shown in full so a
+ * head/tail cap can never hide whether the command failed or timed out; only
+ * the stdout/stderr stream bodies are capped.
+ */
+function renderShellRunResult(
+  content: Extract<ToolResultContent, { kind: 'shell_run' }>,
+  width: number,
+): string[] {
+  const lines: string[] = [];
+  const settled = content.status !== 'running' && content.status !== 'completed';
+  const parts: string[] = [content.status];
+  if (content.exitCode !== undefined) parts.push(`exit ${content.exitCode}`);
+  if (content.failureMessage) parts.push(content.failureMessage);
+  const head = parts.join(' · ');
+  // Keep the colored status and the dim ref as separate ansi spans; nesting one
+  // inside the other would let the inner reset terminate the outer color early.
+  const statusLine = `${settled ? ansi.red(head) : ansi.dim(head)} ${ansi.dim(`(${content.ref})`)}`;
+  lines.push(...renderIndented(statusLine, width, 2));
   if (content.stdout) {
     lines.push(...renderCappedResultText(content.stdout, width));
   }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -975,7 +975,11 @@ function renderCappedResultText(
 
 function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
   const text = plainResultText(entry);
-  const lineCount = text ? text.split('\n').length : 0;
+  // Drop the file's normal trailing newline before counting, matching the cap
+  // convention, so `foo\n` reads as one line rather than two. Byte count keeps
+  // the full content, since that is the file's real size on disk.
+  const trimmed = text.replace(/\n+$/, '');
+  const lineCount = trimmed ? trimmed.split('\n').length : 0;
   const summary = `Read ${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
   return renderIndented(ansi.dim(summary), width, 2);
 }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1175,16 +1175,20 @@ function renderShellRunResult(
   width: number,
 ): string[] {
   const lines: string[] = [];
-  // The command/cwd live on the result. Repeat the command only when the tool
-  // input does not already show it — a StopBackgroundTask input carries just the
-  // run ref, but a Bash background yield already renders `$ command`, so
-  // repeating it there would print the command twice. The cwd is not in either
+  // The command/cwd live on the result. The Bash input summary shows only the
+  // command's first line (`command.split('\n')[0]`), so skip the result-side
+  // `$ cmd` only when the input already shows the whole command — a single-line
+  // command. A multiline command, or a ref-only StopBackgroundTask input,
+  // renders the full command here so none of it is lost. The cwd is in neither
   // input summary, so show it once here.
   const input = entry.input;
-  const inputHasCommand = input !== null
-    && typeof input === 'object'
-    && typeof (input as { command?: unknown }).command === 'string';
-  if (!inputHasCommand) {
+  const command = input !== null && typeof input === 'object'
+    ? (input as { command?: unknown }).command
+    : undefined;
+  const inputShowsFullCommand = typeof command === 'string'
+    && command.trim() !== ''
+    && !command.includes('\n');
+  if (!inputShowsFullCommand) {
     lines.push(...renderIndented(ansi.dim(`$ ${content.cmd}`), width, 2));
   }
   lines.push(...renderIndented(ansi.dim(`cwd: ${content.cwd}`), width, 2));

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -936,6 +936,45 @@ function renderToolText(text: string, width: number): string[] {
   return renderIndented(limitText(text, 12_000), width, 2);
 }
 
+// Expanding a tool card should reveal enough to orient, not replay a whole
+// file or command dump into the transcript. Long output collapses to its first
+// and last few lines with a hidden-count marker; diffs are the deliberate
+// exception (rendered in full) because the whole change is the point.
+const EXPANDED_TOOL_HEAD_LINES = 3;
+const EXPANDED_TOOL_TAIL_LINES = 3;
+
+/**
+ * Render tool output for the expanded card, keeping at most the first
+ * `EXPANDED_TOOL_HEAD_LINES` and last `EXPANDED_TOOL_TAIL_LINES` source lines
+ * with a dim marker in between. `style` colors the content lines (e.g. dim for
+ * stderr); the marker is always dim.
+ */
+function renderCappedResultText(
+  text: string,
+  width: number,
+  style: (line: string) => string = (line) => line,
+): string[] {
+  const sourceLines = text.split('\n');
+  if (sourceLines.length <= EXPANDED_TOOL_HEAD_LINES + EXPANDED_TOOL_TAIL_LINES + 1) {
+    return renderToolText(text, width).map(style);
+  }
+  const hidden = sourceLines.length - EXPANDED_TOOL_HEAD_LINES - EXPANDED_TOOL_TAIL_LINES;
+  const head = sourceLines.slice(0, EXPANDED_TOOL_HEAD_LINES).join('\n');
+  const tail = sourceLines.slice(sourceLines.length - EXPANDED_TOOL_TAIL_LINES).join('\n');
+  return [
+    ...renderToolText(head, width).map(style),
+    ...renderIndented(ansi.dim(`⋯ ${hidden} lines hidden ⋯`), width, 2),
+    ...renderToolText(tail, width).map(style),
+  ];
+}
+
+function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
+  const text = plainResultText(entry);
+  const lineCount = text ? text.split('\n').length : 0;
+  const summary = `Read ${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
+  return renderIndented(ansi.dim(summary), width, 2);
+}
+
 /**
  * Render live `tool_output_delta` chunks. Chunks are de-duped and ordered by
  * `seq` (so a late or repeated seq cannot corrupt the display), consecutive
@@ -946,7 +985,7 @@ function renderToolStreams(deltas: readonly MakaPiToolOutputDelta[], width: numb
   const lines: string[] = [];
   for (const group of groupOutputDeltas(deltas)) {
     lines.push(fitLine(ansi.dim(`[${group.stream}]`), width));
-    lines.push(...renderToolText(group.text, width).map(ansi.dim));
+    lines.push(...renderCappedResultText(group.text, width, ansi.dim));
   }
   return lines;
 }
@@ -974,12 +1013,18 @@ function groupOutputDeltas(
 
 function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
   const result = entry.result;
+  // A successful Read pulled the file into the model's context; the transcript
+  // only needs to note that it happened, so skip the content and keep a summary.
+  // A failed Read falls through so its error is still visible.
+  if (entry.toolName === 'Read' && entry.status !== 'error') return renderReadSummary(entry, width);
   if (result?.kind === 'terminal') return renderTerminalResult(result, width);
+  // Diffs are the deliberate exception to the head/tail cap: the whole change
+  // is what the user is expanding to see.
   if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width);
   if (result?.kind === 'file_write') {
     return renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2);
   }
-  return renderToolText(plainResultText(entry), width);
+  return renderCappedResultText(plainResultText(entry), width);
 }
 
 /** Best-effort extraction of the human-readable body from a tool result. */
@@ -1011,11 +1056,11 @@ function renderTerminalResult(
     lines.push(...renderIndented(ansi.red(`exit ${content.exitCode}`), width, 2));
   }
   if (content.stdout) {
-    lines.push(...renderToolText(content.stdout, width));
+    lines.push(...renderCappedResultText(content.stdout, width));
   }
   if (content.stderr) {
     lines.push(...renderIndented(ansi.dim('[stderr]'), width, 2));
-    lines.push(...renderToolText(content.stderr, width).map(ansi.dim));
+    lines.push(...renderCappedResultText(content.stderr, width, ansi.dim));
   }
   return lines;
 }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -974,13 +974,15 @@ function renderCappedResultText(
 }
 
 /**
- * Line count for a Read body, dropping the file's normal trailing newline so
- * `foo\n` counts as one line. Shared by the compact and expanded summaries so
- * the same card can never flip its line count when toggled with Ctrl+O.
+ * Line count for a Read body, dropping only the single conventional EOF newline
+ * so `foo\n` counts as one line while a real trailing blank line is preserved
+ * (`a\n\n` is two lines, `\n` is one). Shared by the compact and expanded
+ * summaries so the same card can never flip its line count when toggled.
  */
 function readBodyLineCount(text: string): number {
-  const trimmed = text.replace(/\n+$/, '');
-  return trimmed ? trimmed.split('\n').length : 0;
+  if (text === '') return 0;
+  const body = text.endsWith('\n') ? text.slice(0, -1) : text;
+  return body.split('\n').length;
 }
 
 function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
@@ -1162,6 +1164,11 @@ function renderShellRunResult(
   width: number,
 ): string[] {
   const lines: string[] = [];
+  // Repeat the command and cwd: for a StopBackgroundTask the tool input carries
+  // only the run ref, so without these the expanded card loses which background
+  // process this result is about.
+  lines.push(...renderIndented(ansi.dim(`$ ${content.cmd}`), width, 2));
+  lines.push(...renderIndented(ansi.dim(`cwd: ${content.cwd}`), width, 2));
   const settled = content.status !== 'running' && content.status !== 'completed';
   const parts: string[] = [content.status];
   if (content.exitCode !== undefined) parts.push(`exit ${content.exitCode}`);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -954,9 +954,14 @@ function renderCappedResultText(
   width: number,
   style: (line: string) => string = (line) => line,
 ): string[] {
-  const sourceLines = text.split('\n');
+  // Command output almost always ends in a newline; splitting raw would count
+  // that trailing empty string as a line, capping 7 real lines as if they were
+  // 8 and spending a tail slot on a blank. Drop trailing newlines before both
+  // the cap decision and the slice so the head/tail counts are real lines.
+  const trimmed = text.replace(/\n+$/, '');
+  const sourceLines = trimmed.split('\n');
   if (sourceLines.length <= EXPANDED_TOOL_HEAD_LINES + EXPANDED_TOOL_TAIL_LINES + 1) {
-    return renderToolText(text, width).map(style);
+    return renderToolText(trimmed, width).map(style);
   }
   const hidden = sourceLines.length - EXPANDED_TOOL_HEAD_LINES - EXPANDED_TOOL_TAIL_LINES;
   const head = sourceLines.slice(0, EXPANDED_TOOL_HEAD_LINES).join('\n');
@@ -973,6 +978,19 @@ function renderReadSummary(entry: MakaPiToolEntry, width: number): string[] {
   const lineCount = text ? text.split('\n').length : 0;
   const summary = `Read ${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`;
   return renderIndented(ansi.dim(summary), width, 2);
+}
+
+/**
+ * A Read whose path is a real file, not a `maka://runtime/...` resource. The
+ * runtime scheme surfaces things like background-task output that only lives in
+ * the transcript, so it must render its content rather than a "read" summary.
+ */
+function isFilesystemReadPath(entry: MakaPiToolEntry): boolean {
+  const input = entry.input;
+  const path = input !== null && typeof input === 'object'
+    ? (input as { path?: unknown }).path
+    : undefined;
+  return typeof path === 'string' && path.length > 0 && !path.startsWith('maka://runtime/');
 }
 
 /**
@@ -1013,10 +1031,14 @@ function groupOutputDeltas(
 
 function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
   const result = entry.result;
-  // A successful Read pulled the file into the model's context; the transcript
-  // only needs to note that it happened, so skip the content and keep a summary.
-  // A failed Read falls through so its error is still visible.
-  if (entry.toolName === 'Read' && entry.status !== 'error') return renderReadSummary(entry, width);
+  // A successful filesystem Read pulled the file into the model's context; the
+  // transcript only needs to note that it happened, so skip the content and keep
+  // a summary. A failed Read falls through so its error is still visible, and a
+  // `maka://runtime/...` resource Read (e.g. background-task output) also falls
+  // through — that output only lives here, so it must not be summarized away.
+  if (entry.toolName === 'Read' && entry.status !== 'error' && isFilesystemReadPath(entry)) {
+    return renderReadSummary(entry, width);
+  }
   if (result?.kind === 'terminal') return renderTerminalResult(result, width);
   // Diffs are the deliberate exception to the head/tail cap: the whole change
   // is what the user is expanding to see.

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -843,7 +843,14 @@ function compactToolSummary(entry: MakaPiToolEntry, width: number): CompactToolS
 
   const text = plainResultText(entry);
   if (!text) return undefined;
-  if (entry.toolName === 'Read') {
+  // Only a successful filesystem Read that carries real file content gets the
+  // line/byte summary — the same guard the expanded card uses. A runtime
+  // resource, errored, or archived Read falls through to the generic first-line
+  // summary so its status shows instead of a fabricated count.
+  if (entry.toolName === 'Read'
+    && entry.status !== 'error'
+    && isFilesystemReadPath(entry)
+    && isReadBodyResult(result)) {
     const lineCount = readBodyLineCount(text);
     return {
       text: `${lineCount} line${lineCount === 1 ? '' : 's'}, ${byteLength(text)} bytes`,
@@ -1095,23 +1102,26 @@ function renderToolResult(entry: MakaPiToolEntry, width: number): string[] {
   // head/tail cap must never hide — otherwise a failed or timed-out background
   // command looks the same as a successful one. Render the status in full and
   // cap only the stdout/stderr stream bodies.
-  if (result?.kind === 'shell_run') return renderShellRunResult(result, width);
+  if (result?.kind === 'shell_run') return renderShellRunResult(entry, result, width);
   // Diffs are the deliberate exception to the head/tail cap: the whole change
   // is what the user is expanding to see.
   if (result?.kind === 'file_diff') return renderDiffResult(result.diff, width);
   if (result?.kind === 'file_write') {
     return renderIndented(`Wrote ${result.bytes} bytes to ${result.path}`, width, 2);
   }
-  // Generic text/json dumps — a Grep/Bash body or raw tool text — are the
-  // file/command output the head/tail cap targets: the model already holds the
-  // full body, so the transcript only needs enough to orient. An undefined
-  // result with a formatted `output` string is treated the same way.
-  if (result === undefined || result.kind === 'text' || result.kind === 'json') {
+  // A generic `text` dump — a Bash body or raw tool text — is what the head/tail
+  // cap targets: the model already holds the full body, so the transcript only
+  // needs enough to orient. An undefined result with a formatted `output` string
+  // is treated the same way. `json` is deliberately excluded: a Read json is
+  // summarized above, a Grep/Glob json is a structured list the user expands to
+  // scan in full, and any other json collapses to a single inline line where the
+  // cap would be a no-op anyway.
+  if (result === undefined || result.kind === 'text') {
     return renderCappedResultText(plainResultText(entry), width);
   }
-  // Everything else is report-style content (agent reports, web-search results,
-  // subagent / workflow summaries, office-doc output) the user expands to read
-  // in full — render without the cap, like a diff.
+  // Everything else — json lists (Grep/Glob), agent reports, web-search results,
+  // subagent / workflow summaries, office-doc output — is content the user
+  // expands to read in full, so render it without the cap, like a diff.
   return renderToolText(plainResultText(entry), width);
 }
 
@@ -1160,14 +1170,23 @@ function renderTerminalResult(
  * the stdout/stderr stream bodies are capped.
  */
 function renderShellRunResult(
+  entry: MakaPiToolEntry,
   content: Extract<ToolResultContent, { kind: 'shell_run' }>,
   width: number,
 ): string[] {
   const lines: string[] = [];
-  // Repeat the command and cwd: for a StopBackgroundTask the tool input carries
-  // only the run ref, so without these the expanded card loses which background
-  // process this result is about.
-  lines.push(...renderIndented(ansi.dim(`$ ${content.cmd}`), width, 2));
+  // The command/cwd live on the result. Repeat the command only when the tool
+  // input does not already show it — a StopBackgroundTask input carries just the
+  // run ref, but a Bash background yield already renders `$ command`, so
+  // repeating it there would print the command twice. The cwd is not in either
+  // input summary, so show it once here.
+  const input = entry.input;
+  const inputHasCommand = input !== null
+    && typeof input === 'object'
+    && typeof (input as { command?: unknown }).command === 'string';
+  if (!inputHasCommand) {
+    lines.push(...renderIndented(ansi.dim(`$ ${content.cmd}`), width, 2));
+  }
   lines.push(...renderIndented(ansi.dim(`cwd: ${content.cwd}`), width, 2));
   const settled = content.status !== 'running' && content.status !== 'completed';
   const parts: string[] = [content.status];


### PR DESCRIPTION
## Summary
Bound the expanded tool card so it no longer replays an entire file or command dump into the transcript, while keeping the metadata and structured content the user actually expands to read.

## Why
The transcript card is a navigation aid — the model already holds the full tool result — so it only needs enough to orient. Before this change, expanding a card replayed the whole result: a 200-line Read dumped 200 lines, a long Bash run dumped all of stdout, flooding scrollback and burying the point of the card. The cap must stay narrow, though: it must not swallow a background command's failure status or a Grep list / agent report the user opened the card to read.

Refs #549 (follow-up to the tool-result redesign in #585)

## Scope
`packages/cli/src/pi-transcript.ts` — expanded tool rendering, capped only for genuine raw dumps:
- Successful filesystem Read → `Read N lines, M bytes` summary (a failed / archived / `maka://runtime` resource Read falls through and renders its real status/content in full).
- `terminal` and `shell_run` keep their process metadata (status / exit / cmd / cwd / ref) in full and cap only the stdout/stderr stream bodies, so a failed or timed-out background command never looks successful. A `shell_run` repeats the command only when the ref-only or multiline input does not already show all of it.
- Only generic `text` (and an undefined result) head/tail cap to the first and last three source lines with a dim `⋯ N lines hidden ⋯` marker; live output-delta streams cap the same way.
- `file_diff`, Grep/Glob json lists, and report-style results (agent reports, web-search, subagent / summary / workflow, office-doc) render in full.
- One shared `readBodyLineCount` drops only the single EOF newline, so the compact and expanded Read summaries always agree and a real trailing blank line is preserved.

`packages/cli/src/__tests__/pi-transcript.test.ts` — coverage for the cap, shell_run metadata, multiline / no-duplicate command handling, report-style and Grep full render, live-stream capping, and Read line-count consistency.

Not included: compact (collapsed) card rendering, unchanged except the shared Read line count; viewport / scrollback (separate PR #627).

## Verification
- `npm run -w maka-agent typecheck` — clean.
- `npm run -w maka-agent test` — 151 pass.
- `/codex` review and `/pi zai/glm-5.2 xhigh` review — both PASS (four convergence rounds; shell_run metadata, multiline command, and Grep/Glob full-render regressions found and fixed along the way).

## User-facing impact
Expanding a tool card (Ctrl+O) now shows a bounded preview of raw command/file dumps instead of the full result. Diffs, Grep/Glob results, agent reports, web-search results, and background-command status still render in full.

## Reviewer notes
Head/tail is 3/3 lines (`EXPANDED_TOOL_HEAD_LINES` / `EXPANDED_TOOL_TAIL_LINES`). Capping is scoped to `text` results and terminal/shell stream bodies; every other result kind renders in full or its own summary. The Read summary is skipped for an errored, runtime-resource, or archived Read (compact and expanded share the same guard) so its message/status stays visible.

## Checklist
- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact noted
- [x] Review focus called out
- [x] UI changes: terminal-only render; behavior locked by unit tests instead of screenshots
