### PR TITLE
feat(cli): actionable first-run connection-error guidance (#549)

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
-import { parseMakaCliArgs } from '../cli.js';
+import { parseMakaCliArgs, formatStartupConnectionError } from '../cli.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -57,5 +57,36 @@ describe('Maka CLI args', () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('startup connection-error guidance', () => {
+  const workspaceRoot = '/tmp/maka-workspace';
+
+  test('translates a missing default connection into actionable first-run help', () => {
+    const guidance = formatStartupConnectionError(
+      new Error('NO_REAL_CONNECTION:missing_default_connection'),
+      workspaceRoot,
+    );
+    assert.ok(guidance);
+    // Reason-specific fix line (shared core copy) plus the CLI-only footer that
+    // points at the desktop app and the on-disk workspace.
+    assert.match(guidance, /还没有可用的模型连接/);
+    assert.match(guidance, /设置 · 模型/);
+    assert.match(guidance, /Maka 桌面应用/);
+    assert.match(guidance, new RegExp(workspaceRoot));
+  });
+
+  test('uses the credential-specific copy for a missing API key', () => {
+    const guidance = formatStartupConnectionError(
+      new Error('NO_REAL_CONNECTION:missing_api_key'),
+      workspaceRoot,
+    );
+    assert.ok(guidance);
+    assert.match(guidance, /API key/);
+  });
+
+  test('returns null for an unrelated startup error so it propagates unchanged', () => {
+    assert.equal(formatStartupConnectionError(new Error('ENOENT: workspace missing'), workspaceRoot), null);
   });
 });

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -69,8 +69,11 @@ describe('startup connection-error guidance', () => {
       workspaceRoot,
     );
     assert.ok(guidance);
-    // Reason-specific fix line (shared core copy) plus the CLI-only footer that
-    // points at the desktop app and the on-disk workspace.
+    // Reason-specific fix line (shared core copy) — distinct per reason, so this
+    // asserts the translation ran, not just the static header/footer.
+    assert.match(guidance, /等待配置默认模型/);
+    // Static header plus the CLI-only footer that points at the desktop app and
+    // the on-disk workspace.
     assert.match(guidance, /还没有可用的模型连接/);
     assert.match(guidance, /设置 · 模型/);
     assert.match(guidance, /Maka 桌面应用/);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { chatConfigurationReasonFromError, describeChatConfigurationReason } from '@maka/core';
 import { createMakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
@@ -57,10 +58,23 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       process.stderr.write(`${command.message}\n\n${helpText()}\n`);
       return command.exitCode;
     case 'run': {
-      const context = await createMakaCliRuntimeContext({
-        workspaceRoot: resolveMakaWorkspaceRoot(),
-        cwd: process.cwd(),
-      });
+      const workspaceRoot = resolveMakaWorkspaceRoot();
+      let context;
+      try {
+        context = await createMakaCliRuntimeContext({
+          workspaceRoot,
+          cwd: process.cwd(),
+        });
+      } catch (error) {
+        // A missing / misconfigured connection is the first thing a new user
+        // hits. Translate the raw `NO_REAL_CONNECTION:<reason>` throw into
+        // actionable guidance; let anything else propagate to the top-level
+        // handler unchanged.
+        const guidance = formatStartupConnectionError(error, workspaceRoot);
+        if (guidance === null) throw error;
+        process.stderr.write(`${guidance}\n`);
+        return 1;
+      }
       try {
         const driver = createMakaSessionDriver({
           runtime: context.runtime,
@@ -85,6 +99,28 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       }
     }
   }
+}
+
+/**
+ * Turn a startup failure into first-run connection guidance, or `null` when the
+ * error is not a `NO_REAL_CONNECTION` failure (so the caller re-throws it). The
+ * reason-specific line reuses the shared core copy; the footer explains the CLI
+ * has no in-app settings — connections are configured in the desktop app, which
+ * writes the same workspace this CLI reads.
+ */
+export function formatStartupConnectionError(error: unknown, workspaceRoot: string): string | null {
+  const raw = error instanceof Error ? error.message : String(error);
+  if (!raw.includes('NO_REAL_CONNECTION')) return null;
+  const reason = chatConfigurationReasonFromError(error);
+  return [
+    '无法启动 Maka：还没有可用的模型连接。',
+    '',
+    describeChatConfigurationReason(reason),
+    '',
+    'Maka CLI 复用 Maka 桌面应用的配置。请打开 Maka 桌面应用，在 设置 · 模型',
+    '添加并启用一个模型连接（含 API key），然后重新运行 maka。',
+    `连接与凭据存储于：${workspaceRoot}`,
+  ].join('\n');
 }
 
 async function readPackageVersion(): Promise<string> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { chatConfigurationReasonFromError, describeChatConfigurationReason } from '@maka/core';
+import { describeChatConfigurationReason, parseNoRealConnectionError } from '@maka/core';
 import { createMakaSessionDriver } from './session-driver.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { selectableModelIdsForTarget } from './connection-target.js';
@@ -109,13 +109,12 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
  * writes the same workspace this CLI reads.
  */
 export function formatStartupConnectionError(error: unknown, workspaceRoot: string): string | null {
-  const raw = error instanceof Error ? error.message : String(error);
-  // Intentional heuristic: `resolveDefaultSessionTarget` is the only producer on
-  // this startup path, so a substring match is enough to claim the error. An
-  // unrecognized token still resolves to the generic fix copy below, so a false
-  // match degrades to generic guidance rather than hiding a crash.
-  if (!raw.includes('NO_REAL_CONNECTION')) return null;
-  const reason = chatConfigurationReasonFromError(error);
+  // `resolveDefaultSessionTarget` is the only producer of `NO_REAL_CONNECTION`
+  // on this startup path. A matched error with an unknown reason still yields
+  // generic fix copy below; a non-match returns null so the real error keeps
+  // propagating to the top-level handler unchanged.
+  const { matched, reason } = parseNoRealConnectionError(error);
+  if (!matched) return null;
   return [
     '无法启动 Maka：还没有可用的模型连接。',
     '',

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -110,6 +110,10 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
  */
 export function formatStartupConnectionError(error: unknown, workspaceRoot: string): string | null {
   const raw = error instanceof Error ? error.message : String(error);
+  // Intentional heuristic: `resolveDefaultSessionTarget` is the only producer on
+  // this startup path, so a substring match is enough to claim the error. An
+  // unrecognized token still resolves to the generic fix copy below, so a false
+  // match degrades to generic guidance rather than hiding a crash.
   if (!raw.includes('NO_REAL_CONNECTION')) return null;
   const reason = chatConfigurationReasonFromError(error);
   return [

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -1,28 +1,21 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import type { ChatConfigurationReason } from '../connection-readiness.js';
 import {
+  CHAT_CONFIGURATION_REASONS,
   describeChatConfigurationReason,
   chatConfigurationReasonFromError,
 } from '../connection-error-copy.js';
 
-const ALL_REASONS: ChatConfigurationReason[] = [
-  'missing_default_connection',
-  'connection_missing',
-  'connection_disabled',
-  'missing_api_key',
-  'missing_model',
-  'empty_model_list',
-  'model_not_enabled',
-  'model_not_chat_capable',
-  'oauth_subscription_not_wired',
-  'fake_backend',
-];
-
 describe('describeChatConfigurationReason', () => {
+  it('covers every reason in the union', () => {
+    // Derived from the source list, so a new ChatConfigurationReason is exercised
+    // here automatically rather than needing a hand-updated array.
+    assert.equal(CHAT_CONFIGURATION_REASONS.length, 10);
+  });
+
   it('returns distinct, non-empty fix copy for every reason', () => {
     const seen = new Set<string>();
-    for (const reason of ALL_REASONS) {
+    for (const reason of CHAT_CONFIGURATION_REASONS) {
       const copy = describeChatConfigurationReason(reason);
       assert.ok(copy.length > 0, `${reason} has copy`);
       assert.equal(seen.has(copy), false, `${reason} copy is distinct`);

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -7,14 +7,12 @@ import {
 } from '../connection-error-copy.js';
 
 describe('describeChatConfigurationReason', () => {
-  it('covers every reason in the union', () => {
-    // CHAT_CONFIGURATION_REASONS is derived from the copy table's keys, which is
-    // typed Record<ChatConfigurationReason, string> — so a new reason is exercised
-    // here automatically and cannot ship without copy (the Record won't compile).
-    assert.equal(CHAT_CONFIGURATION_REASONS.length, 10);
-  });
-
   it('returns distinct, non-empty fix copy for every reason', () => {
+    // CHAT_CONFIGURATION_REASONS derives from the copy table's keys, which is
+    // typed Record<ChatConfigurationReason, string> — adding a reason (missing
+    // key) or removing one (excess key) already fails the build, so this needs no
+    // hardcoded count; it only checks each reason maps to its own real copy.
+    assert.ok(CHAT_CONFIGURATION_REASONS.length > 0);
     const seen = new Set<string>();
     for (const reason of CHAT_CONFIGURATION_REASONS) {
       const copy = describeChatConfigurationReason(reason);

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ChatConfigurationReason } from '../connection-readiness.js';
+import {
+  describeChatConfigurationReason,
+  chatConfigurationReasonFromError,
+} from '../connection-error-copy.js';
+
+const ALL_REASONS: ChatConfigurationReason[] = [
+  'missing_default_connection',
+  'connection_missing',
+  'connection_disabled',
+  'missing_api_key',
+  'missing_model',
+  'empty_model_list',
+  'model_not_enabled',
+  'model_not_chat_capable',
+  'oauth_subscription_not_wired',
+  'fake_backend',
+];
+
+describe('describeChatConfigurationReason', () => {
+  it('returns distinct, non-empty fix copy for every reason', () => {
+    const seen = new Set<string>();
+    for (const reason of ALL_REASONS) {
+      const copy = describeChatConfigurationReason(reason);
+      assert.ok(copy.length > 0, `${reason} has copy`);
+      assert.equal(seen.has(copy), false, `${reason} copy is distinct`);
+      seen.add(copy);
+    }
+  });
+
+  it('names the credential fix for a missing API key and the model fix for a bad model', () => {
+    assert.match(describeChatConfigurationReason('missing_api_key'), /API key/);
+    assert.match(describeChatConfigurationReason('missing_api_key'), /设置 · 模型/);
+    assert.match(describeChatConfigurationReason('model_not_chat_capable'), /模型/);
+  });
+
+  it('falls back to generic copy for undefined rather than throwing', () => {
+    const copy = describeChatConfigurationReason(undefined);
+    assert.match(copy, /设置 · 模型/);
+  });
+});
+
+describe('chatConfigurationReasonFromError', () => {
+  it('parses the bare CLI form NO_REAL_CONNECTION:<reason>', () => {
+    assert.equal(
+      chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:missing_default_connection')),
+      'missing_default_connection',
+    );
+  });
+
+  it('parses the wrapped form NO_REAL_CONNECTION:<reason>: <message>', () => {
+    assert.equal(
+      chatConfigurationReasonFromError(
+        new Error("Error invoking remote method 'send': Error: NO_REAL_CONNECTION:missing_api_key: no key"),
+      ),
+      'missing_api_key',
+    );
+  });
+
+  it('returns undefined for a non-NO_REAL_CONNECTION error', () => {
+    assert.equal(chatConfigurationReasonFromError(new Error('network timeout')), undefined);
+  });
+
+  it('returns undefined for an unrecognized reason token', () => {
+    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:not_a_real_reason')), undefined);
+  });
+
+  it('accepts a non-Error value', () => {
+    assert.equal(chatConfigurationReasonFromError('NO_REAL_CONNECTION:fake_backend'), 'fake_backend');
+  });
+});

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -60,6 +60,13 @@ describe('chatConfigurationReasonFromError', () => {
     assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:not_a_real_reason')), undefined);
   });
 
+  it('rejects a malformed token that merely starts with a known reason', () => {
+    // The token is captured whole, so a known-reason prefix followed by extra
+    // characters is not mistaken for the known reason.
+    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:missing_api_key2')), undefined);
+    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:fake_backend-extra')), undefined);
+  });
+
   it('accepts a non-Error value', () => {
     assert.equal(chatConfigurationReasonFromError('NO_REAL_CONNECTION:fake_backend'), 'fake_backend');
   });

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 import {
   CHAT_CONFIGURATION_REASONS,
   describeChatConfigurationReason,
-  chatConfigurationReasonFromError,
+  parseNoRealConnectionError,
 } from '../connection-error-copy.js';
 
 describe('describeChatConfigurationReason', () => {
   it('covers every reason in the union', () => {
-    // Derived from the source list, so a new ChatConfigurationReason is exercised
-    // here automatically rather than needing a hand-updated array.
+    // CHAT_CONFIGURATION_REASONS is derived from the copy table's keys, which is
+    // typed Record<ChatConfigurationReason, string> — so a new reason is exercised
+    // here automatically and cannot ship without copy (the Record won't compile).
     assert.equal(CHAT_CONFIGURATION_REASONS.length, 10);
   });
 
@@ -35,39 +36,58 @@ describe('describeChatConfigurationReason', () => {
   });
 });
 
-describe('chatConfigurationReasonFromError', () => {
+describe('parseNoRealConnectionError', () => {
   it('parses the bare CLI form NO_REAL_CONNECTION:<reason>', () => {
-    assert.equal(
-      chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:missing_default_connection')),
-      'missing_default_connection',
+    assert.deepEqual(
+      parseNoRealConnectionError(new Error('NO_REAL_CONNECTION:missing_default_connection')),
+      { matched: true, reason: 'missing_default_connection' },
     );
   });
 
   it('parses the wrapped form NO_REAL_CONNECTION:<reason>: <message>', () => {
-    assert.equal(
-      chatConfigurationReasonFromError(
+    assert.deepEqual(
+      parseNoRealConnectionError(
         new Error("Error invoking remote method 'send': Error: NO_REAL_CONNECTION:missing_api_key: no key"),
       ),
-      'missing_api_key',
+      { matched: true, reason: 'missing_api_key' },
     );
   });
 
-  it('returns undefined for a non-NO_REAL_CONNECTION error', () => {
-    assert.equal(chatConfigurationReasonFromError(new Error('network timeout')), undefined);
+  it('reports no match for a non-NO_REAL_CONNECTION error', () => {
+    assert.deepEqual(parseNoRealConnectionError(new Error('network timeout')), { matched: false });
   });
 
-  it('returns undefined for an unrecognized reason token', () => {
-    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:not_a_real_reason')), undefined);
+  it('matches but yields no reason for an unrecognized reason token', () => {
+    assert.deepEqual(
+      parseNoRealConnectionError(new Error('NO_REAL_CONNECTION:not_a_real_reason')),
+      { matched: true, reason: undefined },
+    );
+  });
+
+  it('matches but yields no reason for the bare code with no token', () => {
+    assert.deepEqual(parseNoRealConnectionError(new Error('NO_REAL_CONNECTION')), {
+      matched: true,
+      reason: undefined,
+    });
   });
 
   it('rejects a malformed token that merely starts with a known reason', () => {
     // The token is captured whole, so a known-reason prefix followed by extra
-    // characters is not mistaken for the known reason.
-    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:missing_api_key2')), undefined);
-    assert.equal(chatConfigurationReasonFromError(new Error('NO_REAL_CONNECTION:fake_backend-extra')), undefined);
+    // characters matches the failure but resolves to no known reason.
+    assert.deepEqual(parseNoRealConnectionError(new Error('NO_REAL_CONNECTION:missing_api_key2')), {
+      matched: true,
+      reason: undefined,
+    });
+    assert.deepEqual(parseNoRealConnectionError(new Error('NO_REAL_CONNECTION:fake_backend-extra')), {
+      matched: true,
+      reason: undefined,
+    });
   });
 
   it('accepts a non-Error value', () => {
-    assert.equal(chatConfigurationReasonFromError('NO_REAL_CONNECTION:fake_backend'), 'fake_backend');
+    assert.deepEqual(parseNoRealConnectionError('NO_REAL_CONNECTION:fake_backend'), {
+      matched: true,
+      reason: 'fake_backend',
+    });
   });
 });

--- a/packages/core/src/__tests__/connection-error-copy.test.ts
+++ b/packages/core/src/__tests__/connection-error-copy.test.ts
@@ -57,6 +57,15 @@ describe('parseNoRealConnectionError', () => {
     assert.deepEqual(parseNoRealConnectionError(new Error('network timeout')), { matched: false });
   });
 
+  it('does not match a longer word that merely starts with the code', () => {
+    // The optional reason group means the bare code can match on its own, so the
+    // trailing word boundary must stop `NO_REAL_CONNECTIONS...` from matching and
+    // swallowing an unrelated startup error as connection guidance.
+    assert.deepEqual(parseNoRealConnectionError(new Error('NO_REAL_CONNECTIONS cache failed')), {
+      matched: false,
+    });
+  });
+
   it('matches but yields no reason for an unrecognized reason token', () => {
     assert.deepEqual(
       parseNoRealConnectionError(new Error('NO_REAL_CONNECTION:not_a_real_reason')),

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -21,9 +21,10 @@
 import type { ChatConfigurationReason } from './connection-readiness.js';
 
 /**
- * Compile-time exhaustiveness anchor: every `ChatConfigurationReason` must have
- * an entry here, so adding a new reason to the union fails the build until its
- * copy and known-reason membership are added below.
+ * Runtime membership anchor: `Object.keys` of this record is the set of valid
+ * reason tokens the parser accepts. Typed as `Record<ChatConfigurationReason,
+ * true>`, so adding a reason to the union fails the build until it is listed
+ * here (which also keeps the parser's known-token set complete).
  */
 const CHAT_CONFIGURATION_REASON_PRESENCE: Record<ChatConfigurationReason, true> = {
   missing_default_connection: true,
@@ -43,12 +44,16 @@ const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(
 );
 
 /**
- * Fix instructions for a not-ready connection. `undefined` (or any unrecognized
- * reason routed through here) returns the generic fallback rather than throwing,
- * so a future reason still renders help.
+ * Fix instructions for a not-ready connection. `undefined` (the parser's result
+ * for an unrecognized error) returns the generic fallback; every known reason
+ * has its own line. The switch is exhaustive over `ChatConfigurationReason` —
+ * `assertUnhandledReason` gives it a `never` tail, so adding a reason to the
+ * union fails the build here until its copy is added.
  */
 export function describeChatConfigurationReason(reason: ChatConfigurationReason | undefined): string {
   switch (reason) {
+    case undefined:
+      return '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
     case 'missing_default_connection':
       return '等待配置默认模型。请到 设置 · 模型 添加一个可用模型连接后再发送。';
     case 'connection_missing':
@@ -70,8 +75,16 @@ export function describeChatConfigurationReason(reason: ChatConfigurationReason 
     case 'fake_backend':
       return '当前会话来自旧的本地模拟连接。请到 设置 · 模型 添加真实模型后新建会话。';
     default:
-      return '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
+      return assertUnhandledReason(reason);
   }
+}
+
+/**
+ * Compile-time exhaustiveness guard: reachable only if a `ChatConfigurationReason`
+ * has no `case` above, which makes `reason` non-`never` and fails the build.
+ */
+function assertUnhandledReason(reason: never): never {
+  throw new Error(`Unhandled ChatConfigurationReason: ${String(reason)}`);
 }
 
 const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([a-z_]+)/;

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -1,0 +1,91 @@
+/**
+ * Human-readable copy for a not-ready chat connection — the single source of
+ * truth shared by every surface (desktop renderer, CLI first-run) so the
+ * `NO_REAL_CONNECTION:<reason>` codes map to one set of fix instructions rather
+ * than a per-surface table.
+ *
+ * Pure & sync. `describeChatConfigurationReason` turns a `ChatConfigurationReason`
+ * into a Chinese sentence that names what is missing and where to fix it (设置 ·
+ * 模型); `chatConfigurationReasonFromError` recovers the reason code from a thrown
+ * `NO_REAL_CONNECTION:<reason>` error, tolerating both the bare CLI form and the
+ * `NO_REAL_CONNECTION:<reason>: <message>` form that IPC wrapping produces.
+ *
+ * This module is the canonical home for the copy. The desktop renderer still
+ * carries an identical inline switch in
+ * `apps/desktop/src/renderer/model-connection-errors.ts` (`noRealConnectionSetupDescription`),
+ * pinned verbatim by a source-snapshot boundary test; delegating that copy to
+ * this function is a follow-up left out of the CLI-scoped change that introduced
+ * this module.
+ */
+
+import type { ChatConfigurationReason } from './connection-readiness.js';
+
+/**
+ * Compile-time exhaustiveness anchor: every `ChatConfigurationReason` must have
+ * an entry here, so adding a new reason to the union fails the build until its
+ * copy and known-reason membership are added below.
+ */
+const CHAT_CONFIGURATION_REASON_PRESENCE: Record<ChatConfigurationReason, true> = {
+  missing_default_connection: true,
+  connection_missing: true,
+  connection_disabled: true,
+  missing_api_key: true,
+  missing_model: true,
+  empty_model_list: true,
+  model_not_enabled: true,
+  model_not_chat_capable: true,
+  oauth_subscription_not_wired: true,
+  fake_backend: true,
+};
+
+const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(
+  Object.keys(CHAT_CONFIGURATION_REASON_PRESENCE),
+);
+
+/**
+ * Fix instructions for a not-ready connection. `undefined` (or any unrecognized
+ * reason routed through here) returns the generic fallback rather than throwing,
+ * so a future reason still renders help.
+ */
+export function describeChatConfigurationReason(reason: ChatConfigurationReason | undefined): string {
+  switch (reason) {
+    case 'missing_default_connection':
+      return '等待配置默认模型。请到 设置 · 模型 添加一个可用模型连接后再发送。';
+    case 'connection_missing':
+      return '该会话依赖的模型连接已删除，请到 设置 · 模型 重新选择或重建连接。';
+    case 'connection_disabled':
+      return '当前模型连接已禁用。请到 设置 · 模型 启用或选择其他默认模型。';
+    case 'missing_api_key':
+      return '当前模型连接还没有可用凭据。请到 设置 · 模型 补齐 API key 或重新登录后再发送。';
+    case 'missing_model':
+      return '当前模型连接还没有可用模型。请到 设置 · 模型 选择默认模型后再发送。';
+    case 'empty_model_list':
+      return '当前模型连接没有启用模型。请到 设置 · 模型 添加或启用模型后再发送。';
+    case 'model_not_enabled':
+      return '当前会话选择的模型未启用。请到 设置 · 模型 重新选择可用模型后再发送。';
+    case 'model_not_chat_capable':
+      return '当前会话选择的模型不能用于聊天。请到 设置 · 模型 重新选择支持聊天的模型后再发送。';
+    case 'oauth_subscription_not_wired':
+      return '这个订阅账号暂时不能作为聊天模型。请先选择可用的 API key 或已接入 OAuth 模型连接。';
+    case 'fake_backend':
+      return '当前会话来自旧的本地模拟连接。请到 设置 · 模型 添加真实模型后新建会话。';
+    default:
+      return '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
+  }
+}
+
+const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([a-z_]+)/;
+
+/**
+ * Recover the `ChatConfigurationReason` from a `NO_REAL_CONNECTION:<reason>`
+ * error. Returns `undefined` when the error is not a NO_REAL_CONNECTION error or
+ * carries a token that is not a known reason (so callers fall back to the
+ * generic copy rather than trusting an unrecognized code).
+ */
+export function chatConfigurationReasonFromError(error: unknown): ChatConfigurationReason | undefined {
+  const raw = error instanceof Error ? error.message : String(error);
+  const token = raw.match(NO_REAL_CONNECTION_REASON_RE)?.[1];
+  return token && KNOWN_CHAT_CONFIGURATION_REASONS.has(token)
+    ? (token as ChatConfigurationReason)
+    : undefined;
+}

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -58,11 +58,14 @@ export function describeChatConfigurationReason(reason: ChatConfigurationReason 
   return reason === undefined ? GENERIC_FIX_COPY : REASON_FIX_COPY[reason];
 }
 
-// Capture the whole reason token up to the next delimiter (`:` in the wrapped
-// `NO_REAL_CONNECTION:<reason>: <msg>` form, whitespace, or end) so a malformed
-// token that only prefixes a known reason (e.g. `missing_api_key2`) is not
-// mistaken for it. The reason group is optional so the bare code still matches.
-const NO_REAL_CONNECTION_RE = /NO_REAL_CONNECTION(?::([^\s:]+))?/;
+// `\bNO_REAL_CONNECTION\b` pins the whole code: the trailing boundary stops it
+// matching a longer word like `NO_REAL_CONNECTIONS` (the reason group is
+// optional, so without the boundary that prefix alone would falsely match and
+// swallow an unrelated error). Then capture the reason token whole, up to the
+// next delimiter (`:` in the wrapped `...:<reason>: <msg>` form, whitespace, or
+// end), so a token that only prefixes a known reason (`missing_api_key2`) is
+// not mistaken for it.
+const NO_REAL_CONNECTION_RE = /\bNO_REAL_CONNECTION\b(?::([^\s:]+))?/;
 
 export interface ParsedNoRealConnectionError {
   /** True when the error is a `NO_REAL_CONNECTION` failure. */

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -1,8 +1,7 @@
 /**
- * Human-readable copy for a not-ready chat connection — the single source of
- * truth shared by every surface (desktop renderer, CLI first-run) so the
- * `NO_REAL_CONNECTION:<reason>` codes map to one set of fix instructions rather
- * than a per-surface table.
+ * Human-readable copy for a not-ready chat connection. This module is the
+ * canonical home: it maps the `NO_REAL_CONNECTION:<reason>` codes to one set of
+ * fix instructions so callers do not reimplement the table.
  *
  * Pure & sync. `describeChatConfigurationReason` turns a `ChatConfigurationReason`
  * into a Chinese sentence that names what is missing and where to fix it (设置 ·
@@ -10,21 +9,21 @@
  * `NO_REAL_CONNECTION:<reason>` error, tolerating both the bare CLI form and the
  * `NO_REAL_CONNECTION:<reason>: <message>` form that IPC wrapping produces.
  *
- * This module is the canonical home for the copy. The desktop renderer still
- * carries an identical inline switch in
- * `apps/desktop/src/renderer/model-connection-errors.ts` (`noRealConnectionSetupDescription`),
- * pinned verbatim by a source-snapshot boundary test; delegating that copy to
- * this function is a follow-up left out of the CLI-scoped change that introduced
- * this module.
+ * The desktop renderer (`apps/desktop/src/renderer/model-connection-errors.ts`,
+ * `noRealConnectionSetupDescription`) still carries its own identical copy; a
+ * boundary test substring-pins only three of its reasons, so the other seven can
+ * drift until that copy is delegated to this function — a follow-up left out of
+ * the CLI-scoped change that introduced this module.
  */
 
 import type { ChatConfigurationReason } from './connection-readiness.js';
 
 /**
- * Runtime membership anchor: `Object.keys` of this record is the set of valid
- * reason tokens the parser accepts. Typed as `Record<ChatConfigurationReason,
- * true>`, so adding a reason to the union fails the build until it is listed
- * here (which also keeps the parser's known-token set complete).
+ * Compile-time completeness anchor: the `Record<ChatConfigurationReason, true>`
+ * literal cannot omit a union member, so adding a reason fails the build until
+ * it is listed here. `CHAT_CONFIGURATION_REASONS` is the runtime list derived
+ * from it — the single source both the parser's known-token set and the tests
+ * read, so coverage tracks the union automatically.
  */
 const CHAT_CONFIGURATION_REASON_PRESENCE: Record<ChatConfigurationReason, true> = {
   missing_default_connection: true,
@@ -39,9 +38,11 @@ const CHAT_CONFIGURATION_REASON_PRESENCE: Record<ChatConfigurationReason, true> 
   fake_backend: true,
 };
 
-const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(
-  Object.keys(CHAT_CONFIGURATION_REASON_PRESENCE),
-);
+export const CHAT_CONFIGURATION_REASONS = Object.keys(
+  CHAT_CONFIGURATION_REASON_PRESENCE,
+) as ChatConfigurationReason[];
+
+const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(CHAT_CONFIGURATION_REASONS);
 
 /**
  * Fix instructions for a not-ready connection. `undefined` (the parser's result

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -1,110 +1,91 @@
 /**
- * Human-readable copy for a not-ready chat connection. This module is the
- * canonical home: it maps the `NO_REAL_CONNECTION:<reason>` codes to one set of
- * fix instructions so callers do not reimplement the table.
+ * Human-readable copy for a not-ready chat connection: maps each
+ * `NO_REAL_CONNECTION:<reason>` code to one fix sentence so a first-run / CLI
+ * surface does not hand-roll its own table.
  *
- * Pure & sync. `describeChatConfigurationReason` turns a `ChatConfigurationReason`
- * into a Chinese sentence that names what is missing and where to fix it (设置 ·
- * 模型); `chatConfigurationReasonFromError` recovers the reason code from a thrown
- * `NO_REAL_CONNECTION:<reason>` error, tolerating both the bare CLI form and the
+ * Pure & sync. `describeChatConfigurationReason` turns a reason into a Chinese
+ * sentence naming what is missing and where to fix it (设置 · 模型);
+ * `parseNoRealConnectionError` reports whether an error is a NO_REAL_CONNECTION
+ * failure and recovers its reason, tolerating both the bare CLI form and the
  * `NO_REAL_CONNECTION:<reason>: <message>` form that IPC wrapping produces.
  *
- * The desktop renderer (`apps/desktop/src/renderer/model-connection-errors.ts`,
- * `noRealConnectionSetupDescription`) still carries its own identical copy; a
- * boundary test substring-pins only three of its reasons, so the other seven can
- * drift until that copy is delegated to this function — a follow-up left out of
- * the CLI-scoped change that introduced this module.
+ * The desktop renderer (`apps/desktop/src/renderer/model-connection-errors.ts`)
+ * still carries its own copy of these strings and its own parser, so this is the
+ * canonical home for the CLI path only; delegating the desktop copy+parser here
+ * (and converting its source-snapshot boundary test to a behavior test) is a
+ * tracked follow-up in the PR description. Until then the desktop copy can drift.
  */
 
 import type { ChatConfigurationReason } from './connection-readiness.js';
 
+const GENERIC_FIX_COPY = '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
+
 /**
- * Compile-time completeness anchor: the `Record<ChatConfigurationReason, true>`
- * literal cannot omit a union member, so adding a reason fails the build until
- * it is listed here. `CHAT_CONFIGURATION_REASONS` is the runtime list derived
- * from it — the single source both the parser's known-token set and the tests
- * read, so coverage tracks the union automatically.
+ * The one hand-maintained table: reason → fix copy. Typed as
+ * `Record<ChatConfigurationReason, string>`, so adding a reason to the union
+ * fails the build until its copy is added here — completeness and copy live in
+ * one place. `CHAT_CONFIGURATION_REASONS` and the parser's known-token set are
+ * derived from its keys, so neither can drift from it.
  */
-const CHAT_CONFIGURATION_REASON_PRESENCE: Record<ChatConfigurationReason, true> = {
-  missing_default_connection: true,
-  connection_missing: true,
-  connection_disabled: true,
-  missing_api_key: true,
-  missing_model: true,
-  empty_model_list: true,
-  model_not_enabled: true,
-  model_not_chat_capable: true,
-  oauth_subscription_not_wired: true,
-  fake_backend: true,
+const REASON_FIX_COPY: Record<ChatConfigurationReason, string> = {
+  missing_default_connection: '等待配置默认模型。请到 设置 · 模型 添加一个可用模型连接后再发送。',
+  connection_missing: '该会话依赖的模型连接已删除，请到 设置 · 模型 重新选择或重建连接。',
+  connection_disabled: '当前模型连接已禁用。请到 设置 · 模型 启用或选择其他默认模型。',
+  missing_api_key: '当前模型连接还没有可用凭据。请到 设置 · 模型 补齐 API key 或重新登录后再发送。',
+  missing_model: '当前模型连接还没有可用模型。请到 设置 · 模型 选择默认模型后再发送。',
+  empty_model_list: '当前模型连接没有启用模型。请到 设置 · 模型 添加或启用模型后再发送。',
+  model_not_enabled: '当前会话选择的模型未启用。请到 设置 · 模型 重新选择可用模型后再发送。',
+  model_not_chat_capable: '当前会话选择的模型不能用于聊天。请到 设置 · 模型 重新选择支持聊天的模型后再发送。',
+  oauth_subscription_not_wired: '这个订阅账号暂时不能作为聊天模型。请先选择可用的 API key 或已接入 OAuth 模型连接。',
+  fake_backend: '当前会话来自旧的本地模拟连接。请到 设置 · 模型 添加真实模型后新建会话。',
 };
 
-export const CHAT_CONFIGURATION_REASONS = Object.keys(
-  CHAT_CONFIGURATION_REASON_PRESENCE,
-) as ChatConfigurationReason[];
+/**
+ * Every reason, derived from the copy table so test coverage and the parser's
+ * known-token set track the union automatically. Module-scoped (the package
+ * index does not re-export it) — only the parser and the tests read it.
+ */
+export const CHAT_CONFIGURATION_REASONS = Object.keys(REASON_FIX_COPY) as ChatConfigurationReason[];
 
 const KNOWN_CHAT_CONFIGURATION_REASONS: ReadonlySet<string> = new Set(CHAT_CONFIGURATION_REASONS);
 
 /**
- * Fix instructions for a not-ready connection. `undefined` (the parser's result
- * for an unrecognized error) returns the generic fallback; every known reason
- * has its own line. The switch is exhaustive over `ChatConfigurationReason` —
- * `assertUnhandledReason` gives it a `never` tail, so adding a reason to the
- * union fails the build here until its copy is added.
+ * Fix instructions for a not-ready connection. `undefined` (a missing or
+ * unrecognized reason) returns the generic fallback; every known reason has its
+ * own line, guaranteed present by the `Record` type above.
  */
 export function describeChatConfigurationReason(reason: ChatConfigurationReason | undefined): string {
-  switch (reason) {
-    case undefined:
-      return '模型连接暂时无法用于发送，请到 设置 · 模型 检查后重试。';
-    case 'missing_default_connection':
-      return '等待配置默认模型。请到 设置 · 模型 添加一个可用模型连接后再发送。';
-    case 'connection_missing':
-      return '该会话依赖的模型连接已删除，请到 设置 · 模型 重新选择或重建连接。';
-    case 'connection_disabled':
-      return '当前模型连接已禁用。请到 设置 · 模型 启用或选择其他默认模型。';
-    case 'missing_api_key':
-      return '当前模型连接还没有可用凭据。请到 设置 · 模型 补齐 API key 或重新登录后再发送。';
-    case 'missing_model':
-      return '当前模型连接还没有可用模型。请到 设置 · 模型 选择默认模型后再发送。';
-    case 'empty_model_list':
-      return '当前模型连接没有启用模型。请到 设置 · 模型 添加或启用模型后再发送。';
-    case 'model_not_enabled':
-      return '当前会话选择的模型未启用。请到 设置 · 模型 重新选择可用模型后再发送。';
-    case 'model_not_chat_capable':
-      return '当前会话选择的模型不能用于聊天。请到 设置 · 模型 重新选择支持聊天的模型后再发送。';
-    case 'oauth_subscription_not_wired':
-      return '这个订阅账号暂时不能作为聊天模型。请先选择可用的 API key 或已接入 OAuth 模型连接。';
-    case 'fake_backend':
-      return '当前会话来自旧的本地模拟连接。请到 设置 · 模型 添加真实模型后新建会话。';
-    default:
-      return assertUnhandledReason(reason);
-  }
+  return reason === undefined ? GENERIC_FIX_COPY : REASON_FIX_COPY[reason];
+}
+
+// Capture the whole reason token up to the next delimiter (`:` in the wrapped
+// `NO_REAL_CONNECTION:<reason>: <msg>` form, whitespace, or end) so a malformed
+// token that only prefixes a known reason (e.g. `missing_api_key2`) is not
+// mistaken for it. The reason group is optional so the bare code still matches.
+const NO_REAL_CONNECTION_RE = /NO_REAL_CONNECTION(?::([^\s:]+))?/;
+
+export interface ParsedNoRealConnectionError {
+  /** True when the error is a `NO_REAL_CONNECTION` failure. */
+  matched: boolean;
+  /** The known reason, or `undefined` for a missing/unrecognized token. */
+  reason?: ChatConfigurationReason;
 }
 
 /**
- * Compile-time exhaustiveness guard: reachable only if a `ChatConfigurationReason`
- * has no `case` above, which makes `reason` non-`never` and fails the build.
+ * Classify a thrown error: whether it is a NO_REAL_CONNECTION failure and, if
+ * so, its reason. A matched error with a missing or unrecognized token yields
+ * `{ matched: true, reason: undefined }`, so a caller still renders generic fix
+ * copy rather than mistaking it for an unrelated failure and re-throwing.
  */
-function assertUnhandledReason(reason: never): never {
-  throw new Error(`Unhandled ChatConfigurationReason: ${String(reason)}`);
-}
-
-// Capture the whole token up to the next delimiter (`:` in the IPC-wrapped
-// `NO_REAL_CONNECTION:<reason>: <msg>` form, whitespace, or end of message)
-// rather than a `[a-z_]+` prefix — otherwise a malformed token that starts with
-// a known reason (e.g. `missing_api_key2`) would capture `missing_api_key` and
-// pass the set check, returning the wrong reason-specific copy.
-const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([^\s:]+)/;
-
-/**
- * Recover the `ChatConfigurationReason` from a `NO_REAL_CONNECTION:<reason>`
- * error. Returns `undefined` when the error is not a NO_REAL_CONNECTION error or
- * carries a token that is not a known reason (so callers fall back to the
- * generic copy rather than trusting an unrecognized code).
- */
-export function chatConfigurationReasonFromError(error: unknown): ChatConfigurationReason | undefined {
+export function parseNoRealConnectionError(error: unknown): ParsedNoRealConnectionError {
   const raw = error instanceof Error ? error.message : String(error);
-  const token = raw.match(NO_REAL_CONNECTION_REASON_RE)?.[1];
-  return token && KNOWN_CHAT_CONFIGURATION_REASONS.has(token)
-    ? (token as ChatConfigurationReason)
-    : undefined;
+  const match = raw.match(NO_REAL_CONNECTION_RE);
+  if (!match) return { matched: false };
+  const token = match[1];
+  return {
+    matched: true,
+    reason: token && KNOWN_CHAT_CONFIGURATION_REASONS.has(token)
+      ? (token as ChatConfigurationReason)
+      : undefined,
+  };
 }

--- a/packages/core/src/connection-error-copy.ts
+++ b/packages/core/src/connection-error-copy.ts
@@ -88,7 +88,12 @@ function assertUnhandledReason(reason: never): never {
   throw new Error(`Unhandled ChatConfigurationReason: ${String(reason)}`);
 }
 
-const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([a-z_]+)/;
+// Capture the whole token up to the next delimiter (`:` in the IPC-wrapped
+// `NO_REAL_CONNECTION:<reason>: <msg>` form, whitespace, or end of message)
+// rather than a `[a-z_]+` prefix — otherwise a malformed token that starts with
+// a known reason (e.g. `missing_api_key2`) would capture `missing_api_key` and
+// pass the set check, returning the wrong reason-specific copy.
+const NO_REAL_CONNECTION_REASON_RE = /NO_REAL_CONNECTION:([^\s:]+)/;
 
 /**
  * Recover the `ChatConfigurationReason` from a `NO_REAL_CONNECTION:<reason>`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -675,6 +675,7 @@ export {
 
 // connection-error-copy.ts — shared not-ready-connection fix copy
 export {
+  CHAT_CONFIGURATION_REASONS,
   describeChatConfigurationReason,
   chatConfigurationReasonFromError,
 } from './connection-error-copy.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -673,6 +673,12 @@ export {
   isRealConnection,
 } from './connection-readiness.js';
 
+// connection-error-copy.ts — shared not-ready-connection fix copy
+export {
+  describeChatConfigurationReason,
+  chatConfigurationReasonFromError,
+} from './connection-error-copy.js';
+
 // session-name.ts (PR-UI-IPC-2)
 export type { NormalizeSessionNameResult } from './session-name.js';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -675,10 +675,10 @@ export {
 
 // connection-error-copy.ts — shared not-ready-connection fix copy
 export {
-  CHAT_CONFIGURATION_REASONS,
   describeChatConfigurationReason,
-  chatConfigurationReasonFromError,
+  parseNoRealConnectionError,
 } from './connection-error-copy.js';
+export type { ParsedNoRealConnectionError } from './connection-error-copy.js';
 
 // session-name.ts (PR-UI-IPC-2)
 export type { NormalizeSessionNameResult } from './session-name.js';


### PR DESCRIPTION
## Summary
Turn the CLI's first-run connection failure into actionable guidance. With no configured connection, `resolveDefaultSessionTarget` throws `NO_REAL_CONNECTION:<reason>` and the entrypoint printed the raw code to stderr with no help — the first thing a new user hits (Refs #549, T0 "First-run / connection error UX").

## Approach
The reason codes are the existing `ChatConfigurationReason` taxonomy; the desktop renderer already maps them to fix copy. Rather than invent a CLI-local table, this lifts the mapping into `packages/core` as the canonical home and consumes it from the CLI.

## Scope
- `packages/core/src/connection-error-copy.ts` (new) — canonical reason→fix copy, built around one hand-maintained table:
  - `REASON_FIX_COPY: Record<ChatConfigurationReason, string>` — the single source of truth. The `Record<Union, string>` type enforces compile-time completeness (adding a reason fails the build until its copy is added), the values are the copy, and `CHAT_CONFIGURATION_REASONS` + the parser's known-token set derive from its keys, so neither can drift.
  - `describeChatConfigurationReason(reason)` returns the shared Chinese fix sentence (什么缺失 + 到 设置 · 模型 怎么配), generic fallback for `undefined`.
  - `parseNoRealConnectionError(error) -> { matched, reason }` classifies a thrown error in one call: whether it is a `NO_REAL_CONNECTION` failure and, if so, its reason. Tolerates both the bare CLI form `NO_REAL_CONNECTION:<reason>` and the IPC-wrapped `NO_REAL_CONNECTION:<reason>: <msg>` form; a matched error with a missing/unknown token yields `{ matched: true, reason: undefined }` so the caller still shows generic copy.
  - `describeChatConfigurationReason` + `parseNoRealConnectionError` exported from `@maka/core`; the derived reason list stays module-private (only the parser and tests read it).
- `packages/cli/src/cli.ts` — `runMakaCli`'s `run` path catches the startup throw; `formatStartupConnectionError` calls `parseNoRealConnectionError` (no looser `includes` guard), prints the reason-specific line plus a CLI-only footer (open the Maka desktop app → 设置 · 模型, and where the workspace lives on disk). Non-match returns `null` so any other startup error propagates to the existing top-level handler unchanged. Exported for tests.

## Not included / follow-up
- [ ] **Delegate the desktop copy+parser to core.** The desktop renderer (`apps/desktop/src/renderer/model-connection-errors.ts`) keeps its identical inline `noRealConnectionSetupDescription` switch, pinned verbatim by a source-snapshot boundary test (`permission-response-ipc-boundary.test.ts`, 3/10 reasons substring-pinned). Delegating it to the new core function — and converting that boundary test from a source snapshot to a behavior test — is left out here to keep this change CLI-scoped (desktop UI is a #549 non-goal). Until then the desktop copy can drift from core; the module docstring says so.

## Verification
- `npm run typecheck` — clean across all workspaces (core/runtime/headless/cli/ui/desktop).
- `npm run -w @maka/core test` — 786 pass (copy + parser: all 10 reasons distinct/non-empty, both error forms, bare code, unknown/malformed token, non-error value).
- `npm run -w maka-agent test` — 154 pass (`formatStartupConnectionError`: reason-specific help, credential copy, null-for-unrelated).

## User-facing impact
A new user launching `maka` with no configured connection now sees what is missing and how to fix it (open the desktop app → 设置 · 模型, plus the on-disk workspace path), instead of a raw `NO_REAL_CONNECTION:missing_default_connection` line.
