### PR TITLE
feat(cli): attention layer for long turns, prompts, and errors (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2172,6 +2172,35 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('clears the busy title marker when Ctrl-C exits mid-turn', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new InterruptibleTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => terminal.titles.includes('● Maka'));
+
+    // Quit while the turn is still parked: close() must reset the title so the
+    // shell tab is not left marked busy after Maka exits.
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+    assert.equal(terminal.titles.at(-1), 'Maka');
+  });
+
 });
 
 /** Count the standalone BEL bytes the attention layer wrote. */

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1982,7 +1982,170 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('enables focus reporting and sets the initial terminal title', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => terminal.output().includes('\x1b[?1004h'));
+    assert.ok(terminal.titles.includes('Maka'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('rings the bell and marks the title when a long turn ends unfocused', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      // Zero threshold: every completed turn counts as long, so the test drives
+      // the ring path without waiting real seconds.
+      attentionLongTurnThresholdMs: 0,
+      terminal,
+    });
+
+    // Report the terminal as backgrounded, then run a turn to completion.
+    terminal.input('\x1b[O');
+    terminal.input('go');
+    terminal.input('\r');
+
+    await waitFor(() => driver.prompts.length === 1);
+    await waitFor(() => bellCount(terminal) === 1);
+    assert.ok(terminal.titles.includes('● Maka'), 'title marks busy during the turn');
+    assert.ok(terminal.titles.includes('★ Maka'), 'title marks attention after the unfocused finish');
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('does not ring when a short turn ends unfocused', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      // Default (large) threshold: the immediate-complete turn is far too short.
+      terminal,
+    });
+
+    terminal.input('\x1b[O');
+    terminal.input('go');
+    terminal.input('\r');
+
+    await waitFor(() => driver.prompts.length === 1);
+    await delay(30);
+    assert.equal(bellCount(terminal), 0);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('does not ring when a long turn ends while still focused', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      attentionLongTurnThresholdMs: 0,
+      terminal,
+    });
+
+    // No blur report: the terminal is assumed focused, so a finished turn is
+    // silent — the user is watching it.
+    terminal.input('go');
+    terminal.input('\r');
+
+    await waitFor(() => driver.prompts.length === 1);
+    await delay(30);
+    assert.equal(bellCount(terminal), 0);
+    assert.equal(terminal.titles.includes('★ Maka'), false);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('rings when a permission prompt appears unfocused', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new PermissionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('\x1b[O');
+    terminal.input('run');
+    terminal.input('\r');
+
+    await waitFor(() => driver.permissionRequests === 1);
+    await waitFor(() => bellCount(terminal) >= 1);
+    assert.ok(terminal.titles.includes('★ Maka'));
+
+    // Answer so the parked turn can finish and the TUI closes cleanly.
+    terminal.input('y');
+    await waitFor(() => driver.permissionResponses.length === 1);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
 });
+
+/** Count the standalone BEL bytes the attention layer wrote. */
+function bellCount(terminal: FakeTerminal): number {
+  return terminal.writes.filter((write) => write === '\x07').length;
+}
 
 class RejectingStopDriver implements MakaSessionDriver {
   stopCalls = 0;

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2140,6 +2140,38 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('rings when a short turn fails unfocused', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new QuickErrorDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      // Default (large) threshold: the ring must come from the error path, not
+      // from turn duration — the turn fails immediately.
+      terminal,
+    });
+
+    terminal.input('\x1b[O');
+    terminal.input('go');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('turn failed'));
+    await waitFor(() => bellCount(terminal) === 1);
+    assert.ok(terminal.titles.includes('★ Maka'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
 });
 
 /** Count the standalone BEL bytes the attention layer wrote. */
@@ -3267,6 +3299,44 @@ class PermissionThenErrorDriver implements MakaSessionDriver {
     this.respondCalls += 1;
   }
 
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
+class QuickErrorDriver implements MakaSessionDriver {
+  readonly prompts: string[] = [];
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *sendPrompt(prompt: string): AsyncIterable<SessionEvent> {
+    this.prompts.push(prompt);
+    // The turn fails immediately, so its duration never crosses the long-turn
+    // threshold — the attention ring must come from the error, not the timer.
+    yield {
+      type: 'error',
+      id: 'event-error',
+      turnId: 'turn-1',
+      ts: 1,
+      message: 'turn failed',
+      recoverable: false,
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_response: PermissionResponse): Promise<void> {}
   async renameSession(): Promise<void> {}
   async setModel(): Promise<void> {}
   async setPermissionMode(): Promise<void> {}

--- a/packages/cli/src/__tests__/tui-attention.test.ts
+++ b/packages/cli/src/__tests__/tui-attention.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { AttentionController } from '../tui-attention.js';
+
+const BELL = '\x07';
+
+class SpyTerminal {
+  readonly writes: string[] = [];
+  readonly titles: string[] = [];
+  write(data: string): void {
+    this.writes.push(data);
+  }
+  setTitle(title: string): void {
+    this.titles.push(title);
+  }
+  get bells(): number {
+    return this.writes.filter((w) => w === BELL).length;
+  }
+  get title(): string | undefined {
+    return this.titles.at(-1);
+  }
+}
+
+/** A controller wired to a spy terminal and a clock the test advances by hand. */
+function makeController(longTurnThresholdMs = 8000) {
+  const terminal = new SpyTerminal();
+  let clock = 0;
+  const controller = new AttentionController(terminal, {
+    baseTitle: 'Maka',
+    now: () => clock,
+    longTurnThresholdMs,
+  });
+  return { terminal, controller, advance: (ms: number) => (clock += ms) };
+}
+
+describe('AttentionController title', () => {
+  test('starts on the plain base title', () => {
+    const { terminal } = makeController();
+    assert.equal(terminal.title, 'Maka');
+  });
+
+  test('marks busy while a turn runs and returns to plain when it ends quickly', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, '● Maka');
+    advance(500);
+    controller.promptTurnEnded();
+    assert.equal(terminal.title, 'Maka');
+    assert.equal(terminal.bells, 0);
+  });
+
+  test('control actions mark busy without ever ringing', () => {
+    const { terminal, controller } = makeController();
+    controller.focusChanged(false);
+    controller.controlStarted();
+    assert.equal(terminal.title, '● Maka');
+    controller.controlEnded();
+    assert.equal(terminal.title, 'Maka');
+    assert.equal(terminal.bells, 0);
+  });
+
+  test('writes the title only on a real change', () => {
+    const { terminal, controller } = makeController();
+    const before = terminal.titles.length;
+    controller.focusChanged(true); // still focused, still idle → no new title
+    assert.equal(terminal.titles.length, before);
+  });
+});
+
+describe('AttentionController long-turn ring', () => {
+  test('rings and marks attention when a long turn ends while unfocused', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    advance(9000);
+    controller.promptTurnEnded();
+    assert.equal(terminal.bells, 1);
+    assert.equal(terminal.title, '★ Maka');
+  });
+
+  test('stays silent when a long turn ends while focused', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.promptTurnStarted();
+    advance(9000);
+    controller.promptTurnEnded();
+    assert.equal(terminal.bells, 0);
+    assert.equal(terminal.title, 'Maka');
+  });
+
+  test('does not ring for a short turn even while unfocused', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    advance(200);
+    controller.promptTurnEnded();
+    assert.equal(terminal.bells, 0);
+    assert.equal(terminal.title, 'Maka');
+  });
+
+  test('regaining focus clears the attention marker', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    advance(9000);
+    controller.promptTurnEnded();
+    assert.equal(terminal.title, '★ Maka');
+    controller.focusChanged(true);
+    assert.equal(terminal.title, 'Maka');
+  });
+
+  test('a new turn clears a stale attention marker', () => {
+    const { terminal, controller, advance } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    advance(9000);
+    controller.promptTurnEnded();
+    assert.equal(terminal.title, '★ Maka');
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, '● Maka');
+  });
+});
+
+describe('AttentionController attention events', () => {
+  test('rings for a permission prompt or error while unfocused', () => {
+    const { terminal, controller } = makeController();
+    controller.focusChanged(false);
+    controller.attentionNeeded();
+    assert.equal(terminal.bells, 1);
+    assert.equal(terminal.title, '★ Maka');
+  });
+
+  test('stays silent for a permission prompt or error while focused', () => {
+    const { terminal, controller } = makeController();
+    controller.attentionNeeded();
+    assert.equal(terminal.bells, 0);
+    assert.equal(terminal.title, 'Maka');
+  });
+
+  test('never rings on a terminal that never reports a blur (no 1004 support)', () => {
+    // Without focus reports the controller assumes focus and suppresses every
+    // ring — the conservative degradation. Title busy/idle still tracks.
+    const { terminal, controller, advance } = makeController(8000);
+    controller.promptTurnStarted();
+    advance(60_000);
+    controller.promptTurnEnded();
+    controller.attentionNeeded();
+    assert.equal(terminal.bells, 0);
+  });
+});

--- a/packages/cli/src/__tests__/tui-attention.test.ts
+++ b/packages/cli/src/__tests__/tui-attention.test.ts
@@ -65,6 +65,22 @@ describe('AttentionController title', () => {
     controller.focusChanged(true); // still focused, still idle → no new title
     assert.equal(terminal.titles.length, before);
   });
+
+  test('reset clears the busy marker and goes inert', () => {
+    const { terminal, controller } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, '● Maka');
+    controller.reset();
+    assert.equal(terminal.title, 'Maka');
+    // A finalizer that settles after close must not re-dirty the handed-back
+    // title or ring — every event method is now a no-op.
+    controller.promptTurnEnded();
+    controller.attentionNeeded();
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, 'Maka');
+    assert.equal(terminal.bells, 0);
+  });
 });
 
 describe('AttentionController long-turn ring', () => {

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -8,6 +8,7 @@ export class FakeTerminal implements Terminal {
   readonly kittyProtocolActive = false;
   readonly progressStates: boolean[] = [];
   readonly writes: string[] = [];
+  readonly titles: string[] = [];
   stopCalls = 0;
   private onInput: ((data: string) => void) | null = null;
 
@@ -32,7 +33,10 @@ export class FakeTerminal implements Terminal {
   clearLine(): void {}
   clearFromCursor(): void {}
   clearScreen(): void {}
-  setTitle(_title: string): void {}
+
+  setTitle(title: string): void {
+    this.titles.push(title);
+  }
 
   setProgress(active: boolean): void {
     this.progressStates.push(active);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -126,6 +126,12 @@ export async function submitPromptToTranscript(input: {
   driver: Pick<MakaSessionDriver, 'sendPrompt'>;
   prompt: string;
   onChange?: () => void;
+  /**
+   * An error surfaced during the turn — either a stream `error` event or a
+   * thrown `sendPrompt` failure. Distinct from `onChange` so a caller can raise
+   * attention on failures without diffing transcript entries every render.
+   */
+  onError?: () => void;
 }): Promise<void> {
   appendUserPrompt(input.state, input.prompt);
   input.onChange?.();
@@ -133,6 +139,7 @@ export async function submitPromptToTranscript(input: {
   try {
     for await (const event of input.driver.sendPrompt(input.prompt)) {
       applyMakaSessionEventToTranscript(input.state, event);
+      if (event.type === 'error') input.onError?.();
       input.onChange?.();
     }
   } catch (error) {
@@ -141,6 +148,7 @@ export async function submitPromptToTranscript(input: {
       level: 'error',
       text: error instanceof Error ? error.message : String(error),
     });
+    input.onError?.();
     input.onChange?.();
   }
 }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -40,6 +40,13 @@ import {
 } from './pi-transcript.js';
 import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
 import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
+import {
+  AttentionController,
+  DISABLE_FOCUS_REPORTING,
+  ENABLE_FOCUS_REPORTING,
+  FOCUS_IN_SEQUENCE,
+  FOCUS_OUT_SEQUENCE,
+} from './tui-attention.js';
 
 export interface MakaPiTuiInput {
   title: string;
@@ -51,6 +58,12 @@ export interface MakaPiTuiInput {
   providerType?: ProviderType;
   permissionMode: PermissionMode;
   terminal?: Terminal;
+  /**
+   * How long a prompt turn must run before its completion rings the terminal
+   * BEL when unfocused. Injectable so tests exercise the long / short split
+   * without waiting real seconds; defaults to the attention layer's own value.
+   */
+  attentionLongTurnThresholdMs?: number;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
@@ -93,6 +106,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
   const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
+  const attention = new AttentionController(terminal, {
+    baseTitle: input.title,
+    ...(input.attentionLongTurnThresholdMs !== undefined
+      ? { longTurnThresholdMs: input.attentionLongTurnThresholdMs }
+      : {}),
+  });
 
   const requestRender = () => {
     transcript.invalidate();
@@ -105,6 +124,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       level: 'error',
       text: error instanceof Error ? error.message : String(error),
     });
+    // An error is worth pulling the user back to a background tab.
+    attention.attentionNeeded();
     requestRender();
   };
 
@@ -122,6 +143,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     busy = true;
     editor.disableSubmit = true;
     terminal.setProgress(true);
+    attention.controlStarted();
     requestRender();
     try {
       await action();
@@ -131,6 +153,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       busy = false;
       editor.disableSubmit = false;
       terminal.setProgress(false);
+      attention.controlEnded();
       requestRender();
     }
   };
@@ -150,6 +173,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       // has already failed or the session never fully started.
     }
     terminal.setProgress(false);
+    // Stop asking the terminal for focus reports before handing it back.
+    terminal.write(DISABLE_FOCUS_REPORTING);
     tui.stop();
     resolveClosed();
   };
@@ -208,6 +233,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     lastTurnEscapeAt = 0;
     editor.disableSubmit = true;
     terminal.setProgress(true);
+    attention.promptTurnStarted();
     requestRender();
 
     let permissionSnapped = false;
@@ -225,6 +251,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           if (!permissionSnapped) {
             permissionSnapped = true;
             layout.followTailNow();
+            // A pending decision blocks the turn; ring an unfocused terminal so
+            // the user is not left waiting on a prompt they cannot see.
+            attention.attentionNeeded();
           }
         } else {
           permissionSnapped = false;
@@ -237,6 +266,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       interruptRequested = false;
       editor.disableSubmit = false;
       terminal.setProgress(false);
+      attention.promptTurnEnded();
       requestRender();
     });
   };
@@ -593,6 +623,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // live listener while close() awaits the runtime stop; letting Escape or any
     // other key through here would mutate state or fire a second stop.
     if (closed) return { consume: true };
+    // DEC 1004 focus reports drive the attention layer. Consume them so they
+    // never reach the editor as stray input; they are not user keystrokes.
+    if (data === FOCUS_IN_SEQUENCE) {
+      attention.focusChanged(true);
+      return { consume: true };
+    }
+    if (data === FOCUS_OUT_SEQUENCE) {
+      attention.focusChanged(false);
+      return { consume: true };
+    }
     // Kitty keyboard protocol terminals (Ghostty/Kitty) emit separate press and
     // release events. pi-tui only filters releases on the focused-component
     // path, but this raw listener runs before that, so a release would
@@ -665,7 +705,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     return undefined;
   });
 
-  terminal.setTitle(input.title);
+  // The AttentionController set the initial title in its constructor. Enable
+  // focus reporting so it learns when the terminal is backgrounded; the input
+  // listener forwards the `\x1b[I` / `\x1b[O` reports.
+  terminal.write(ENABLE_FOCUS_REPORTING);
   tui.addChild(layout);
   tui.setFocus(editorSurface);
   tui.start();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -173,6 +173,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       // has already failed or the session never fully started.
     }
     terminal.setProgress(false);
+    // Drop the busy / attention title marker so the tab is not handed back to
+    // the shell still marked busy when Ctrl-C exits mid-turn (before the turn
+    // finalizer runs). reset() also makes the controller inert.
+    attention.reset();
     // Stop asking the terminal for focus reports before handing it back.
     terminal.write(DISABLE_FOCUS_REPORTING);
     tui.stop();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -241,6 +241,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       state,
       driver: input.driver,
       prompt,
+      // A turn failing is worth pulling the user back, regardless of how long it
+      // ran — a quick failure in a background tab would otherwise stay silent.
+      onError: () => attention.attentionNeeded(),
       onChange: () => {
         // A newly raised permission prompt renders at the transcript tail. If the
         // user has paged up, it would land below the fold and the session would

--- a/packages/cli/src/tui-attention.ts
+++ b/packages/cli/src/tui-attention.ts
@@ -119,18 +119,23 @@ export class AttentionController {
   }
 
   /**
-   * Ring and mark the title only when the terminal is not focused: the marker
-   * means "this happened while you were away", and returning focus clears it.
-   * While focused the on-screen UI (the finished turn, the y/n prompt) is the
-   * signal, so no ring and no title decoration — just drop back to the plain
-   * title if the turn had made it busy.
+   * Ring and mark the title only when the terminal is not focused. The `★`
+   * marker means "an attention-worthy event fired while you were away", not a
+   * live needs-you state: it is set on the event and cleared when you return
+   * (focus) or a new turn starts. While focused the on-screen UI (the finished
+   * turn, the y/n prompt, the error notice) is the signal, so no ring and no
+   * decoration — just drop back to the plain title if the turn had made it busy.
+   *
+   * The bell rings once per away-episode: a second event while the marker is
+   * already up (e.g. a turn that errors and then ends long) does not re-ring, so
+   * a background tab is alerted once, not repeatedly, until the user engages.
    */
   private raiseAttention(): void {
     if (this.focused) {
       this.refreshTitle();
       return;
     }
-    this.terminal.write(BELL);
+    if (!this.attention) this.terminal.write(BELL);
     this.attention = true;
     this.refreshTitle();
   }

--- a/packages/cli/src/tui-attention.ts
+++ b/packages/cli/src/tui-attention.ts
@@ -1,0 +1,153 @@
+/**
+ * Attention layer for long-running turns, permission prompts, and errors.
+ *
+ * Two signals, driven from the runner's turn lifecycle:
+ *  - the terminal title carries a state marker (busy / attention-needed / idle),
+ *    so a glance at the tab tells you what the session is doing; and
+ *  - a terminal BEL rings when something wants the user *while the terminal is
+ *    not focused*, so a turn finishing or a prompt appearing in a background tab
+ *    is not missed.
+ *
+ * Focus is tracked out of band: the runner enables DEC private mode 1004 and
+ * feeds `focusChanged` from the `\x1b[I` / `\x1b[O` reports. Terminals that do
+ * not support 1004 never report a blur, so `focused` stays true and no BEL ever
+ * fires — the title markers still work everywhere, but the ring is suppressed
+ * rather than sounding while the user is watching. That is the conservative
+ * degradation: never ring when we cannot confirm the user is away.
+ */
+
+/** The terminal surface the attention layer writes to: a raw BEL plus the title. */
+export interface AttentionTerminal {
+  write(data: string): void;
+  setTitle(title: string): void;
+}
+
+export interface AttentionControllerOptions {
+  /** The bare title with no state marker, e.g. `Maka`. */
+  baseTitle: string;
+  /** Injectable clock so tests can drive turn duration; defaults to `Date.now`. */
+  now?: () => number;
+  /**
+   * A prompt turn must run at least this long for its completion to be worth a
+   * ring — a turn that finishes in a blink does not pull you back to a tab you
+   * are already watching. Permission prompts and errors ring regardless.
+   */
+  longTurnThresholdMs?: number;
+}
+
+/** DEC 1004 focus reports the runner enables and forwards to `focusChanged`. */
+export const FOCUS_IN_SEQUENCE = '\x1b[I';
+export const FOCUS_OUT_SEQUENCE = '\x1b[O';
+/** Enable / disable DEC private mode 1004 (focus reporting). */
+export const ENABLE_FOCUS_REPORTING = '\x1b[?1004h';
+export const DISABLE_FOCUS_REPORTING = '\x1b[?1004l';
+
+const BELL = '\x07';
+const BUSY_TITLE_MARKER = '● ';
+const ATTENTION_TITLE_MARKER = '★ ';
+const DEFAULT_LONG_TURN_THRESHOLD_MS = 8000;
+
+export class AttentionController {
+  private readonly now: () => number;
+  private readonly longTurnThresholdMs: number;
+  // Assume focused until the terminal reports a blur, so a terminal that never
+  // reports focus (no 1004 support) is treated as always-watching and stays
+  // silent, rather than ringing on every turn.
+  private focused = true;
+  private busy = false;
+  // Latched when something the user has not yet acknowledged is waiting; drives
+  // the attention title marker until they engage (focus, answer, or a new turn).
+  private attention = false;
+  private turnStartedAt = 0;
+  private lastTitle: string | null = null;
+
+  constructor(
+    private readonly terminal: AttentionTerminal,
+    private readonly options: AttentionControllerOptions,
+  ) {
+    this.now = options.now ?? Date.now;
+    this.longTurnThresholdMs = options.longTurnThresholdMs ?? DEFAULT_LONG_TURN_THRESHOLD_MS;
+    this.refreshTitle();
+  }
+
+  /** A prompt turn began: activity starts and any prior attention is acknowledged. */
+  promptTurnStarted(): void {
+    this.turnStartedAt = this.now();
+    this.attention = false;
+    this.busy = true;
+    this.refreshTitle();
+  }
+
+  /**
+   * A prompt turn ended (completed, errored, or aborted): a turn that ran past
+   * the threshold rings if the user is away, so a long turn finishing in a
+   * background tab pulls them back. The outcome does not matter — a long turn
+   * that failed is exactly as worth surfacing as one that succeeded.
+   */
+  promptTurnEnded(): void {
+    this.busy = false;
+    if (this.now() - this.turnStartedAt >= this.longTurnThresholdMs) {
+      this.raiseAttention();
+    } else {
+      this.refreshTitle();
+    }
+  }
+
+  /** A control action (model/session switch, compaction) started: busy, never rings. */
+  controlStarted(): void {
+    this.attention = false;
+    this.busy = true;
+    this.refreshTitle();
+  }
+
+  /** A control action ended. */
+  controlEnded(): void {
+    this.busy = false;
+    this.refreshTitle();
+  }
+
+  /** The app needs the user now (a permission prompt appeared, or an error surfaced). */
+  attentionNeeded(): void {
+    this.raiseAttention();
+  }
+
+  /** Terminal focus changed; regaining focus acknowledges any pending attention. */
+  focusChanged(focused: boolean): void {
+    this.focused = focused;
+    if (focused) this.attention = false;
+    this.refreshTitle();
+  }
+
+  /**
+   * Ring and mark the title only when the terminal is not focused: the marker
+   * means "this happened while you were away", and returning focus clears it.
+   * While focused the on-screen UI (the finished turn, the y/n prompt) is the
+   * signal, so no ring and no title decoration — just drop back to the plain
+   * title if the turn had made it busy.
+   */
+  private raiseAttention(): void {
+    if (this.focused) {
+      this.refreshTitle();
+      return;
+    }
+    this.terminal.write(BELL);
+    this.attention = true;
+    this.refreshTitle();
+  }
+
+  private refreshTitle(): void {
+    // Attention outranks busy: a turn parked on a permission prompt is "busy"
+    // but what it actually needs is the user, so surface that first. Attention
+    // is only ever set while unfocused, so a normal running turn still shows busy.
+    const title = this.attention
+      ? `${ATTENTION_TITLE_MARKER}${this.options.baseTitle}`
+      : this.busy
+        ? `${BUSY_TITLE_MARKER}${this.options.baseTitle}`
+        : this.options.baseTitle;
+    // Only write on a real change so the title stream stays quiet between turns
+    // and a test can read the transitions rather than a run of duplicates.
+    if (title === this.lastTitle) return;
+    this.lastTitle = title;
+    this.terminal.setTitle(title);
+  }
+}

--- a/packages/cli/src/tui-attention.ts
+++ b/packages/cli/src/tui-attention.ts
@@ -60,6 +60,9 @@ export class AttentionController {
   private attention = false;
   private turnStartedAt = 0;
   private lastTitle: string | null = null;
+  // Set once the session is closing; every event method then no-ops so a turn
+  // finalizer that settles after close() cannot re-dirty the handed-back title.
+  private stopped = false;
 
   constructor(
     private readonly terminal: AttentionTerminal,
@@ -72,6 +75,7 @@ export class AttentionController {
 
   /** A prompt turn began: activity starts and any prior attention is acknowledged. */
   promptTurnStarted(): void {
+    if (this.stopped) return;
     this.turnStartedAt = this.now();
     this.attention = false;
     this.busy = true;
@@ -85,6 +89,7 @@ export class AttentionController {
    * that failed is exactly as worth surfacing as one that succeeded.
    */
   promptTurnEnded(): void {
+    if (this.stopped) return;
     this.busy = false;
     if (this.now() - this.turnStartedAt >= this.longTurnThresholdMs) {
       this.raiseAttention();
@@ -95,6 +100,7 @@ export class AttentionController {
 
   /** A control action (model/session switch, compaction) started: busy, never rings. */
   controlStarted(): void {
+    if (this.stopped) return;
     this.attention = false;
     this.busy = true;
     this.refreshTitle();
@@ -102,19 +108,34 @@ export class AttentionController {
 
   /** A control action ended. */
   controlEnded(): void {
+    if (this.stopped) return;
     this.busy = false;
     this.refreshTitle();
   }
 
   /** The app needs the user now (a permission prompt appeared, or an error surfaced). */
   attentionNeeded(): void {
+    if (this.stopped) return;
     this.raiseAttention();
   }
 
   /** Terminal focus changed; regaining focus acknowledges any pending attention. */
   focusChanged(focused: boolean): void {
+    if (this.stopped) return;
     this.focused = focused;
     if (focused) this.attention = false;
+    this.refreshTitle();
+  }
+
+  /**
+   * The session is closing: drop any busy / attention marker so the tab is not
+   * handed back to the shell still marked busy, and go inert so a turn finalizer
+   * that settles after this cannot re-dirty the title.
+   */
+  reset(): void {
+    this.stopped = true;
+    this.busy = false;
+    this.attention = false;
     this.refreshTitle();
   }
 


### PR DESCRIPTION
## Summary
Give a long-running CLI session a visible attention layer (Refs #549, T1 "Attention and terminal title status"). Today the only busy signal is OS-level taskbar progress via `terminal.setProgress`; a turn finishing, a permission prompt appearing, or an error surfacing in a backgrounded tab is silent.

## Approach
A small `AttentionController` (`packages/cli/src/tui-attention.ts`) owns the attention state and drives two signals from the runner's existing turn lifecycle:

- **Terminal title marker.** `●` while a turn or control action runs, `★` when an attention-worthy event fired while you were away, plain when idle. Attention outranks busy, so a turn parked on a permission prompt reads as *needs-you* rather than *working*.
- **Terminal BEL**, rung only when something wants the user **while the terminal is not focused**: a prompt turn that ran past a threshold finishing, a permission prompt appearing, or an error surfacing (a stream `error` event or a thrown turn failure).

Focus is tracked out of band via DEC private mode 1004: the runner enables it on start, disables it on close, and forwards the `\x1b[I` / `\x1b[O` reports to the controller (consuming them so they never reach the editor). Terminals that do not support 1004 never report a blur, so the controller assumes focus and **suppresses every ring** — the conservative degradation. The title markers still work everywhere; only the ring is gated on confirmed unfocus, which is what the spec's "while the terminal is not focused" asks for.

## Scope
- `packages/cli/src/tui-attention.ts` (new) — `AttentionController` + the 1004 sequence constants. Pure logic; clock and BEL threshold are injectable.
- `packages/cli/src/pi-tui-runner.ts` — construct the controller, enable/disable focus reporting, parse focus reports, and call the lifecycle hooks (`promptTurnStarted/Ended`, `controlStarted/Ended`, `attentionNeeded` on permission-prompt appearance, on `reportError`, and on turn errors).
- `packages/cli/src/pi-transcript.ts` — `submitPromptToTranscript` gains an optional `onError` so the runner learns about in-turn failures (a stream `error` event or a thrown `sendPrompt`) that it renders internally, without diffing transcript entries every render.
- `MakaPiTuiInput.attentionLongTurnThresholdMs?` — injectable threshold so tests drive the long/short split deterministically; defaults to the controller's own value.

## Design notes
- **Ring gated on unfocus, not always-on.** BEL every long turn while you are watching would be noise. The spec explicitly says "while not focused", so the ring is suppressed until a blur is confirmed. The cost is that terminals without 1004 get no ring — accepted, and the title still updates there.
- **`★` is an away-marker, not a live needs-you state.** It is set when an attention event fires while unfocused and cleared when you return (focus) or start a new turn. A permission prompt seen while focused, then backgrounded before answering, keeps the busy marker rather than flipping to `★` — an accepted edge, since you already saw it. The bell rings once per away-episode (a turn that errors then ends long rings once).
- **Long-turn threshold, outcome-independent.** A turn that ran long enough rings whether it completed, errored, or was aborted. Errors ring regardless of duration via the `onError` path, so a quick failure in a background tab is not missed.
- **Follow-up (not in scope):** a richer OSC 9 / OSC 777 desktop notification on top of the BEL. BEL is the universal primitive and enough for this layer.

## Verification
- `npm run typecheck` — clean across all workspaces.
- `npm run -w maka-agent test` — 169 pass. New: `AttentionController` unit suite (title states, focus-gated ring, no-1004 degradation) and FakeTerminal integration through `runMakaPiTui` (focus reporting enabled at startup; unfocused long-turn, permission-prompt, and short-error rings + `★` title; focused-long-turn and short-turn silence).
