### PR TITLE
feat(cli): rewind to an earlier turn via branch (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1945,6 +1945,40 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('a non-Escape key between two Escapes does not open the rewind picker', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+
+    // The editor stays neutral (empty) throughout, but a left-arrow between the
+    // two Escapes breaks the gesture: the two Escapes must be consecutive.
+    terminal.input('\x1b');
+    await delay(20);
+    terminal.input('\x1b[D');
+    await delay(20);
+    terminal.input('\x1b');
+    await delay(40);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'), false);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('interrupts at most once while the stop is still settling', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlowStopDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1910,6 +1910,41 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('does not open the rewind picker while the editor has a draft', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+
+    // While a draft is present, Escape belongs to the editor (clear input), not
+    // the rewind gesture. Two Escapes must not open the picker.
+    terminal.input('draft in progress');
+    await delay(20);
+    terminal.input('\x1b');
+    await delay(20);
+    terminal.input('\x1b');
+    await delay(40);
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'), false);
+    assert.deepEqual(driver.rewound, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('interrupts at most once while the stop is still settling', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlowStopDriver();

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -3,7 +3,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage, ThinkingLevel } from '@maka/core';
-import type { MakaSessionDriver, MakaSessionSwitchResult } from '../session-driver.js';
+import type { MakaSessionDriver, MakaSessionSwitchResult, RewindTarget } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
 import {
@@ -1782,11 +1782,124 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('Stopped: user_stop'));
     await waitFor(() => terminal.progressStates.at(-1) === false);
 
-    // Idle double Escape must not stop anything: the session is between turns.
+    // Idle double Escape opens the rewind picker, never a stop: the session is
+    // between turns. This fake exposes no rewind targets, so it only shows a
+    // notice, but the contract under test is that stopSession is not fired again.
     terminal.input('\x1b');
     terminal.input('\x1b');
     await delay(20);
     assert.equal(driver.stopCalls, 1);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('opens a rewind picker from /rewind and branches on select', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RewindDriver(
+      [
+        { turnId: 'turn-2', label: 'second question' },
+        { turnId: 'turn-1', label: 'first question' },
+      ],
+      [
+        storedUserMessage('user-1', 'turn-1', 'first question'),
+        storedAssistantMessage('assistant-1', 'turn-1', 'first answer'),
+      ],
+    );
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('回到选定轮次'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('second question'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first question'));
+
+    // The picker lists targets newest-first, so the default selection is turn-2.
+    terminal.input('\r');
+    await waitFor(() => driver.rewound.length === 1);
+    assert.deepEqual(driver.rewound, ['turn-2']);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('已回退到选定轮次'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first answer'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('reports when /rewind has no earlier turns', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RewindDriver([]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('没有可回退的轮次'));
+    assert.equal(plainTerminalOutput(terminal.output()).includes('回到选定轮次'), false);
+    assert.deepEqual(driver.rewound, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('idle double Escape opens the rewind picker; a single Escape does not', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RewindDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka claude-sonnet-4-5 claude-subscription ask /repo'));
+
+    // A single Escape falls through to the editor: no picker yet.
+    terminal.input('\x1b');
+    await delay(40);
+    assert.equal(plainTerminalOutput(terminal.output()).includes('回到选定轮次'), false);
+
+    // A second Escape within the window completes the gesture and opens the picker.
+    terminal.input('\x1b');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('回到选定轮次'));
+
+    // Cancel the picker so Ctrl-C reaches the runner rather than the overlay.
+    terminal.input('\x1b');
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'));
 
     terminal.input('\x03');
     await Promise.race([
@@ -2232,6 +2345,12 @@ class RejectingStopDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2301,6 +2420,12 @@ class PermissionPromptDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2345,6 +2470,12 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2393,6 +2524,12 @@ class SlowStopDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2451,6 +2588,12 @@ class HangingStopDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2499,6 +2642,12 @@ class ThinkingOutputDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2534,6 +2683,12 @@ class ScrollThenSwitchDriver implements MakaSessionDriver {
     messages.push(storedAssistantMessage('a-last', 't', 'switched-tail-marker'));
     return switchResult(fakeSessionSummary(sessionId, '/repo'), messages);
   }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2564,6 +2719,12 @@ class MultiTurnLongDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -2606,6 +2767,12 @@ class LongReplyDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -2676,6 +2843,12 @@ class PermissionAfterLongDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
   }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2742,6 +2915,12 @@ class PermissionThenTailDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
   }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2787,6 +2966,12 @@ class LateThinkingDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
   }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2830,6 +3015,12 @@ class StreamingTailDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -2875,6 +3066,12 @@ class ShrinkingTailDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -2924,6 +3121,12 @@ class MixedFrameDriver implements MakaSessionDriver {
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
   }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -2966,6 +3169,12 @@ class StreamRaceDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -3027,6 +3236,12 @@ class ToolOutputDriver implements MakaSessionDriver {
   async setThinkingLevel(): Promise<void> {}
   async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
     return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return 'session-1';
@@ -3092,6 +3307,12 @@ class SlashCommandDriver implements MakaSessionDriver {
     const summary = this.sessions.find((session) => session.id === sessionId);
     const nextSummary = summary ?? fakeSessionSummary(sessionId);
     return switchResult(nextSummary, [...(this.sessionMessages.get(nextSummary.id) ?? [])]);
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(_turnId: string): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
   }
   getSessionId(): string {
     return this.sessionId;
@@ -3212,6 +3433,12 @@ class DeferredControlDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -3258,6 +3485,12 @@ class RejectingPermissionDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -3336,6 +3569,12 @@ class PermissionThenErrorDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
   }
@@ -3374,8 +3613,34 @@ class QuickErrorDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionSwitchResult> {
+    throw new Error('rewind not supported in this fake');
+  }
   getSessionId(): string {
     return 'session-1';
+  }
+}
+
+class RewindDriver extends SlashCommandDriver {
+  readonly rewound: string[] = [];
+
+  constructor(
+    private readonly targets: RewindTarget[],
+    private readonly branchMessages: readonly StoredMessage[] = [],
+  ) {
+    super();
+  }
+
+  override async listRewindTargets(): Promise<RewindTarget[]> {
+    return this.targets;
+  }
+
+  override async rewindToTurn(turnId: string): Promise<MakaSessionSwitchResult> {
+    this.rewound.push(turnId);
+    return switchResult(fakeSessionSummary('session-branch'), [...this.branchMessages]);
   }
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -411,6 +411,54 @@ describe('Maka session driver', () => {
     ]);
   });
 
+  test('keeps the last prompted turn as a target when the head is a non-prompt turn (e.g. compact)', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    await collect(driver.sendPrompt('first question'));
+    // After /compact the conversation head is the compact turn (no user
+    // message). turn-2 is still a real, rewindable turn: rewinding to it
+    // discards the compact, so it must not be dropped as "the latest turn".
+    runtime.sessionMessages.set('session-1', [
+      storedUserMessage('user-1', 'turn-1', 'first question'),
+      storedAssistantMessage('assistant-1', 'turn-1', 'first answer'),
+      storedUserMessage('user-2', 'turn-2', 'second question'),
+      storedAssistantMessage('assistant-2', 'turn-2', 'second answer'),
+      storedContextCompactedNote('note-1', 'turn-compact'),
+    ]);
+
+    const targets = await driver.listRewindTargets();
+
+    assert.deepEqual(targets, [
+      { turnId: 'turn-2', label: 'second question' },
+      { turnId: 'turn-1', label: 'first question' },
+    ]);
+  });
+
+  test('keeps the only prompted turn as a target after a compact', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    await collect(driver.sendPrompt('only question'));
+    runtime.sessionMessages.set('session-1', [
+      storedUserMessage('user-1', 'turn-1', 'only question'),
+      storedAssistantMessage('assistant-1', 'turn-1', 'only answer'),
+      storedContextCompactedNote('note-1', 'turn-compact'),
+    ]);
+
+    assert.deepEqual(await driver.listRewindTargets(), [
+      { turnId: 'turn-1', label: 'only question' },
+    ]);
+  });
+
   test('lists no rewind targets before a session starts or with a single turn', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -636,6 +684,16 @@ function storedAssistantMessage(id: string, turnId: string, text: string): Store
     ts: 2,
     text,
     modelId: 'claude-sonnet-4-5',
+  };
+}
+
+function storedContextCompactedNote(id: string, turnId: string): StoredMessage {
+  return {
+    type: 'system_note',
+    id,
+    turnId,
+    ts: 3,
+    kind: 'context_compacted',
   };
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -383,6 +383,91 @@ describe('Maka session driver', () => {
       },
     }]);
   });
+
+  test('lists rewind targets newest-first, one per prompted turn, excluding the latest', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    await collect(driver.sendPrompt('first question'));
+    runtime.sessionMessages.set('session-1', [
+      storedUserMessage('user-1', 'turn-1', '  first question\nmore detail'),
+      storedAssistantMessage('assistant-1', 'turn-1', 'first answer'),
+      storedUserMessage('user-2', 'turn-2', 'second question'),
+      storedAssistantMessage('assistant-2', 'turn-2', 'second answer'),
+      storedUserMessage('user-3', 'turn-3', 'third question'),
+    ]);
+
+    const targets = await driver.listRewindTargets();
+
+    // turn-3 is the latest → excluded. Remaining newest-first, label = first
+    // non-empty prompt line.
+    assert.deepEqual(targets, [
+      { turnId: 'turn-2', label: 'second question' },
+      { turnId: 'turn-1', label: 'first question' },
+    ]);
+  });
+
+  test('lists no rewind targets before a session starts or with a single turn', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    assert.deepEqual(await driver.listRewindTargets(), []);
+
+    await collect(driver.sendPrompt('only question'));
+    runtime.sessionMessages.set('session-1', [
+      storedUserMessage('user-1', 'turn-1', 'only question'),
+      storedAssistantMessage('assistant-1', 'turn-1', 'only answer'),
+    ]);
+    assert.deepEqual(await driver.listRewindTargets(), []);
+  });
+
+  test('rewinds by branching through the turn and switching onto the branch', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-rewind-cwd-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [sessionSummary({ id: 'session-1', cwd: repo })];
+      runtime.sessionMessages.set('session-1', [
+        storedUserMessage('user-1', 'turn-1', 'first question'),
+        storedAssistantMessage('assistant-1', 'turn-1', 'first answer'),
+        storedUserMessage('user-2', 'turn-2', 'second question'),
+      ]);
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+      await driver.switchSession('session-1');
+
+      const result = await driver.rewindToTurn('turn-1');
+
+      assert.deepEqual(runtime.branched, [{ sessionId: 'session-1', sourceTurnId: 'turn-1' }]);
+      assert.equal(result.summary.id, 'session-1-branch');
+      assert.equal(driver.getSessionId(), 'session-1-branch');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects rewind before a session starts', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    await assert.rejects(driver.rewindToTurn('turn-1'), /before a session starts/);
+    assert.deepEqual(runtime.branched, []);
+  });
 });
 
 class RecordingRuntime {
@@ -392,6 +477,7 @@ class RecordingRuntime {
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
   readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
+  readonly branched: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
   sessionSummaries: SessionSummary[] = [];
 
@@ -488,6 +574,19 @@ class RecordingRuntime {
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {
     return this.sessionMessages.get(sessionId) ?? [];
+  }
+
+  async branchFromTurn(sessionId: string, input: { sourceTurnId: string; name?: string }): Promise<SessionSummary> {
+    this.branched.push({ sessionId, sourceTurnId: input.sourceTurnId });
+    // Model a branch by adding a new summary to the list switchSession reads.
+    const source = this.sessionSummaries.find((session) => session.id === sessionId);
+    const branch: SessionSummary = {
+      ...(source ?? sessionSummary({ id: sessionId })),
+      id: `${sessionId}-branch`,
+    };
+    this.sessionSummaries = [...this.sessionSummaries, branch];
+    this.sessionMessages.set(branch.id, this.sessionMessages.get(sessionId) ?? []);
+    return branch;
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -703,6 +703,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // releases here; returning undefined lets the TUI apply its own filtering.
     if (isKeyRelease(data)) return undefined;
     if (tui.hasOverlay()) return undefined;
+    // The idle rewind gesture requires two *consecutive* Escapes. Any other key
+    // in between breaks it, so a stale first Escape never pairs with a much later
+    // one (e.g. `Esc`, type, `Esc`).
+    if (!matchesKey(data, Key.escape)) lastIdleEscapeAt = 0;
     if (matchesKey(data, Key.ctrl('o')) && !isKeyRepeat(data)) {
       if (toggleAllToolExpansion(state)) {
         requestRender();
@@ -762,10 +766,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     }
     // Idle double Escape opens the rewind picker (the same gesture that
     // interrupts a running turn). This sits below the turnRunning branch, so it
-    // only arms when nothing is running. The first Escape falls through to the
-    // editor (preserving its clear/autocomplete behavior); only the second,
-    // within the window, consumes and opens the picker.
+    // only arms when nothing is running. It engages only when the editor has no
+    // Escape work of its own — empty draft, no autocomplete popup — so the
+    // editor keeps owning Escape for clearing input and closing autocomplete.
+    // The first Escape falls through to the editor; only the second, within the
+    // window, consumes and opens the picker.
     if (!busy && !turnRunning && matchesKey(data, Key.escape)) {
+      const editorNeutral = editor.getText().length === 0 && !editor.isShowingAutocomplete();
+      if (!editorNeutral) {
+        lastIdleEscapeAt = 0;
+        return undefined;
+      }
       const now = Date.now();
       if (lastIdleEscapeAt && now - lastIdleEscapeAt <= DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS) {
         lastIdleEscapeAt = 0;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -22,7 +22,7 @@ import {
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, thinkingVariantsForModel, type ThinkingLevel } from '@maka/core/model-thinking';
 import type { ProviderType } from '@maka/core/llm-connections';
-import type { MakaSessionDriver } from './session-driver.js';
+import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
   renderMakaPiStatusLine,
@@ -84,6 +84,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let turnRunning = false;
   let interruptRequested = false;
   let lastTurnEscapeAt = 0;
+  let lastIdleEscapeAt = 0;
   let resolveClosed: () => void;
   const closedPromise = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -302,11 +303,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
-  // Folder/connection safety is enforced inside driver.switchSession(),
-  // before it commits any internal state, so a rejected switch leaves the
-  // active session untouched and the next prompt still lands on the old one.
-  const switchSession = async (sessionId: string) => {
-    const { summary, messages } = await input.driver.switchSession(sessionId);
+  // Adopt a switch/rewind result: the active session is now `summary` with
+  // `messages`. Shared by switchSession and rewindToTurn so both land the same
+  // runner state (model/connection/thinking/transcript/scroll).
+  const applySwitchResult = ({ summary, messages }: MakaSessionSwitchResult): void => {
     model = summary.model;
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;
@@ -316,13 +316,35 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // The transcript is a different document now; drop any scroll position so the
     // resumed session opens following its latest messages, not mid-history.
     layout.followTailNow();
-    if (messages.length === 0) {
+  };
+
+  // Folder/connection safety is enforced inside driver.switchSession(),
+  // before it commits any internal state, so a rejected switch leaves the
+  // active session untouched and the next prompt still lands on the old one.
+  const switchSession = async (sessionId: string) => {
+    const result = await input.driver.switchSession(sessionId);
+    applySwitchResult(result);
+    if (result.messages.length === 0) {
       state.entries.push({
         kind: 'notice',
         level: 'info',
-        text: `Resumed session "${summary.name}"`,
+        text: `Resumed session "${result.summary.name}"`,
       });
     }
+    requestRender();
+  };
+
+  // Rewind branches the active session through the chosen turn and switches onto
+  // the branch (driver.rewindToTurn). The original session is left intact, so
+  // this is non-destructive and inherits the branch's resume guarantees.
+  const rewindToTurn = async (turnId: string) => {
+    const result = await input.driver.rewindToTurn(turnId);
+    applySwitchResult(result);
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: '已回退到选定轮次（分支为新会话，原会话保留）。',
+    });
     requestRender();
   };
 
@@ -399,6 +421,32 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(() => switchSession(item.value));
       },
       { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 40 },
+    );
+  };
+
+  const showRewindPicker = async () => {
+    const targets = await input.driver.listRewindTargets();
+    if (targets.length === 0) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: '没有可回退的轮次。',
+      });
+      requestRender();
+      return;
+    }
+    const items: SelectItem[] = targets.map((target) => ({
+      value: target.turnId,
+      label: target.label,
+    }));
+    showSelectPicker(
+      'Rewind — 回到选定轮次（保留到此轮，丢弃之后）',
+      'Rewind',
+      items,
+      (item) => {
+        void runControl(() => rewindToTurn(item.value));
+      },
+      { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48 },
     );
   };
 
@@ -593,6 +641,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     {
+      name: 'rewind',
+      description: 'Rewind to an earlier turn',
+      run: () => {
+        void runControl(showRewindPicker);
+      },
+    },
+    {
       name: 'session',
       description: 'Resume session',
       run: (parts: string[]) => {
@@ -704,6 +759,21 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         lastTurnEscapeAt = now;
       }
       return { consume: true };
+    }
+    // Idle double Escape opens the rewind picker (the same gesture that
+    // interrupts a running turn). This sits below the turnRunning branch, so it
+    // only arms when nothing is running. The first Escape falls through to the
+    // editor (preserving its clear/autocomplete behavior); only the second,
+    // within the window, consumes and opens the picker.
+    if (!busy && !turnRunning && matchesKey(data, Key.escape)) {
+      const now = Date.now();
+      if (lastIdleEscapeAt && now - lastIdleEscapeAt <= DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS) {
+        lastIdleEscapeAt = 0;
+        void runControl(showRewindPicker);
+        return { consume: true };
+      }
+      lastIdleEscapeAt = now;
+      return undefined;
     }
     if (matchesKey(data, Key.ctrl('c')) || matchesKey(data, Key.ctrl('d'))) {
       void close();

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -177,10 +177,15 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       promptByTurn.set(message.turnId, message.text);
       order.push(message.turnId);
     }
-    // Drop the latest turn: rewinding to it keeps everything, which is not a
-    // rewind. Remaining turns, newest first, are the real "go back to" points.
+    // Drop the turn at the conversation head: branching to it keeps everything,
+    // which is not a rewind. The head is the last message's turn, which is not
+    // always the last prompted turn — e.g. after /compact the head is the compact
+    // turn (no user message), so every prompted turn stays a valid rewind target
+    // (rewinding then discards the compact). Remaining turns, newest first, are
+    // the real "go back to" points.
+    const headTurnId = messages.length > 0 ? messages[messages.length - 1].turnId : undefined;
     return order
-      .slice(0, -1)
+      .filter((turnId) => turnId !== headTurnId)
       .reverse()
       .map((turnId) => ({ turnId, label: firstLine(promptByTurn.get(turnId) ?? '') }));
   }

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { realpath } from 'node:fs/promises';
 import type { SessionEvent } from '@maka/core/events';
 import type { PermissionMode, PermissionResponse } from '@maka/core/permission';
-import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
+import type { BranchFromTurnInput, CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 
@@ -16,6 +16,16 @@ export interface MakaSessionRuntime {
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
   updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
+  // Rewind reuses the runtime's branch primitive: a non-destructive copy of the
+  // transcript + RuntimeEvent ledger through a turn boundary, so resume
+  // correctness is inherited and the original session's log is left intact.
+  branchFromTurn(sessionId: string, input: BranchFromTurnInput): Promise<SessionSummary>;
+}
+
+/** A turn the user can rewind to: its id plus a one-line label (its prompt). */
+export interface RewindTarget {
+  turnId: string;
+  label: string;
 }
 
 export interface MakaSessionDriverInput {
@@ -42,6 +52,10 @@ export interface MakaSessionDriver {
   setPermissionMode(mode: PermissionMode): Promise<void>;
   renameSession(name: string): Promise<void>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
+  /** Earlier turns the user can rewind to (excludes the current, latest turn). */
+  listRewindTargets(): Promise<RewindTarget[]>;
+  /** Rewind to a turn: branch the session through it and switch onto the branch. */
+  rewindToTurn(turnId: string): Promise<MakaSessionSwitchResult>;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -151,6 +165,36 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     return { summary, messages };
   }
 
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    if (!this.sessionId) return [];
+    const messages = await this.input.runtime.getMessages(this.sessionId);
+    // One target per turn that has a user prompt, in send order. The prompt text
+    // is the label — it is what the user recognizes a turn by.
+    const promptByTurn = new Map<string, string>();
+    const order: string[] = [];
+    for (const message of messages) {
+      if (message.type !== 'user' || promptByTurn.has(message.turnId)) continue;
+      promptByTurn.set(message.turnId, message.text);
+      order.push(message.turnId);
+    }
+    // Drop the latest turn: rewinding to it keeps everything, which is not a
+    // rewind. Remaining turns, newest first, are the real "go back to" points.
+    return order
+      .slice(0, -1)
+      .reverse()
+      .map((turnId) => ({ turnId, label: firstLine(promptByTurn.get(turnId) ?? '') }));
+  }
+
+  async rewindToTurn(turnId: string): Promise<MakaSessionSwitchResult> {
+    if (!this.sessionId) throw new Error('Cannot rewind before a session starts.');
+    // Branch through the turn (copies transcript + ledger up to it), then switch
+    // onto the branch. switchSession re-validates folder/connection and loads the
+    // branched messages, so the branch inherits the same resume guarantees as any
+    // resumed session and the original session is left untouched.
+    const branch = await this.input.runtime.branchFromTurn(this.sessionId, { sourceTurnId: turnId });
+    return this.switchSession(branch.id);
+  }
+
   getSessionId(): string | null {
     return this.sessionId;
   }
@@ -173,6 +217,12 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
 
 function cwdRank(session: SessionSummary, cwd: string): number {
   return session.cwd === cwd ? 0 : 1;
+}
+
+/** First non-empty line of a prompt, for a compact rewind-target label. */
+function firstLine(text: string): string {
+  const line = text.split('\n').map((part) => part.trim()).find((part) => part.length > 0);
+  return line ?? '(empty prompt)';
 }
 
 async function assertSessionCwdExists(cwd: string): Promise<void> {


### PR DESCRIPTION
## What

Adds a non-destructive **rewind** to the CLI, closing the T1 rewind/undo gap in #549.

Two entry points, both idle-only:
- **Idle double-Escape** — mirrors the in-turn double-Escape interrupt gesture. The first Escape falls through to the editor (preserving its clear/autocomplete behavior); the second, within the same window, opens the picker.
- **`/rewind`** — same picker.

The picker lists earlier *prompted* turns (one per turn, newest-first, excluding the latest — rewinding to the latest keeps everything, which is not a rewind). Selecting turn N calls `runtime.branchFromTurn` through that turn boundary and switches the CLI onto the resulting child session.

## Why branch-based

`branchFromTurn` is the existing, well-tested runtime primitive used by desktop: it copies the transcript **and** clones the RuntimeEvent ledger through a turn boundary into a new child session. Reusing it means:
- **Non-destructive** — the original session log is untouched; the rewind is a new lineage, fully reversible.
- **Resume correctness inherited** — the branch is just another session; `switchSession` re-validates folder/connection and reloads its messages, so it carries the same persistence/resume guarantees as any resumed session. No new in-place ledger mutation, no new resume risk.

## Changes

- `session-driver`: expose `runtime.branchFromTurn`; add `listRewindTargets()` and `rewindToTurn()`.
- `pi-tui-runner`: extract `applySwitchResult` (shared by `switchSession` and `rewindToTurn`); add the `/rewind` command, the picker, and the idle double-Escape binding.
- Tests: driver unit coverage (target listing semantics, branch+switch, guards) and runner integration (`/rewind` opens picker and branches on select, empty-state notice, idle double-Escape opens the picker while a single Escape does not).

## Verification

- `npm run -w maka-agent typecheck` — clean
- `npm run -w maka-agent test` — 181/181 pass