### PR TITLE
feat(cli): command discoverability and session flow (#549)

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1670,6 +1670,11 @@ describe('Maka Pi TUI runner', () => {
     // All 12 are in the list (not sliced to 10): the scroll indicator counts the
     // full total, so the window shows "(1/12)".
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/12)'));
+    // And the 12th is genuinely reachable: scrolling down brings it into view,
+    // even though it starts below the visible window.
+    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('chat 11'), false);
+    for (let i = 0; i < 11; i += 1) terminal.input('\x1b[B');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('chat 11'));
 
     terminal.input('\x1b');
     terminal.input('\x03');

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1509,7 +1509,8 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
-    await waitFor(() => terminal.output().includes('session-2'));
+    // The picker labels rows by human name, not the raw session id.
+    await waitFor(() => terminal.output().includes('Existing chat'));
     const titleLine = latestPlainLineContaining(terminal.output(), 'Resume Session (Current Folder)');
     assert.equal(titleLine.startsWith('Resume Session (Current Folder)'), true);
     assert.equal(visibleWidth(titleLine), terminal.columns);
@@ -1615,8 +1616,8 @@ describe('Maka Pi TUI runner', () => {
   test('shows only current-cwd sessions in the session picker', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([
-      fakeSessionSummary('session-current', '/repo'),
-      fakeSessionSummary('session-other', '/elsewhere'),
+      fakeSessionSummary('session-current', '/repo', 'Current chat'),
+      fakeSessionSummary('session-other', '/elsewhere', 'Other chat'),
     ]);
     const run = runMakaPiTui({
       title: 'Maka',
@@ -1631,11 +1632,112 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('session-current'));
+    await waitFor(() => terminal.output().includes('Current chat'));
     const output = plainTerminalOutput(terminal.output());
-    assert.equal(output.includes('session-other'), false);
+    assert.equal(output.includes('Other chat'), false);
 
     terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('notes older sessions hidden by the picker cap', async () => {
+    const terminal = new FakeTerminal();
+    const sessions = Array.from({ length: 12 }, (_, i) => fakeSessionSummary(`session-${i}`, '/repo', `chat ${i}`));
+    const driver = new SlashCommandDriver(sessions);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Showing the 10 most recent sessions. Use /session <id>'));
+
+    terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('/help lists commands and keybindings', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/help');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Commands'));
+    const out = plainTerminalOutput(terminal.output());
+    // Commands are derived from the registry, so a representative one shows up.
+    assert.ok(out.includes('/rewind'));
+    assert.ok(out.includes('Rewind to an earlier turn'));
+    assert.ok(out.includes('/new'));
+    // Keybindings — the whole reason /help exists (they are otherwise hidden).
+    assert.ok(out.includes('Keybindings'));
+    assert.ok(out.includes('Ctrl+O'));
+    assert.ok(out.includes('Esc Esc'));
+    assert.deepEqual(driver.prompts, []);
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('/new clears the transcript and starts a fresh session', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('remember this');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('remember this'));
+
+    terminal.input('/new');
+    terminal.input('\r');
+
+    await waitFor(() => driver.startNewSessionCalls === 1);
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Started a new session'));
+    // The previous turn is gone from the visible transcript.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('remember this'));
+
     terminal.input('\x03');
     await Promise.race([
       run,
@@ -2420,6 +2522,7 @@ class RejectingStopDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2495,6 +2598,7 @@ class PermissionPromptDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2545,6 +2649,7 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2599,6 +2704,7 @@ class SlowStopDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2663,6 +2769,7 @@ class HangingStopDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2717,6 +2824,7 @@ class ThinkingOutputDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2758,6 +2866,7 @@ class ScrollThenSwitchDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2795,6 +2904,7 @@ class MultiTurnLongDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2843,6 +2953,7 @@ class LongReplyDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2918,6 +3029,7 @@ class PermissionAfterLongDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -2990,6 +3102,7 @@ class PermissionThenTailDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3041,6 +3154,7 @@ class LateThinkingDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3091,6 +3205,7 @@ class StreamingTailDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3142,6 +3257,7 @@ class ShrinkingTailDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3196,6 +3312,7 @@ class MixedFrameDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3245,6 +3362,7 @@ class StreamRaceDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3312,6 +3430,7 @@ class ToolOutputDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3324,6 +3443,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly thinkingLevelUpdates: Array<ThinkingLevel | undefined> = [];
   readonly sessionIds: string[] = [];
   readonly renames: string[] = [];
+  startNewSessionCalls = 0;
   private sessionId = 'session-1';
 
   constructor(
@@ -3382,6 +3502,10 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   async rewindToTurn(_turnId: string): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
+  }
+  startNewSession(): void {
+    this.startNewSessionCalls += 1;
+    this.sessionId = 'session-new';
   }
   getSessionId(): string {
     return this.sessionId;
@@ -3508,6 +3632,7 @@ class DeferredControlDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3560,6 +3685,7 @@ class RejectingPermissionDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3644,6 +3770,7 @@ class PermissionThenErrorDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3688,6 +3815,7 @@ class QuickErrorDriver implements MakaSessionDriver {
   async rewindToTurn(): Promise<MakaSessionSwitchResult> {
     throw new Error('rewind not supported in this fake');
   }
+  startNewSession(): void {}
   getSessionId(): string {
     return 'session-1';
   }
@@ -3717,11 +3845,11 @@ function switchResult(summary: SessionSummary, messages: StoredMessage[] = []): 
   return { summary, messages };
 }
 
-function fakeSessionSummary(sessionId: string, cwd = '/repo'): SessionSummary {
+function fakeSessionSummary(sessionId: string, cwd = '/repo', name = 'Existing chat'): SessionSummary {
   return {
     id: sessionId,
     cwd,
-    name: 'Existing chat',
+    name,
     isFlagged: false,
     isArchived: false,
     labels: [],

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -876,6 +876,9 @@ describe('Maka Pi TUI runner', () => {
     assert.ok(exitIndex < modelIndex);
     assert.ok(modelIndex < permissionsIndex);
     assert.ok(permissionsIndex < sessionIndex);
+    // The whole menu is visible at once — including the last command
+    // alphabetically — so new commands don't push older ones below the fold.
+    assert.ok(output.indexOf('/thinking') > sessionIndex);
 
     terminal.input('\x03');
     await Promise.race([
@@ -1646,7 +1649,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('notes older sessions hidden by the picker cap', async () => {
+  test('the session picker scrolls through every session rather than capping', async () => {
     const terminal = new FakeTerminal();
     const sessions = Array.from({ length: 12 }, (_, i) => fakeSessionSummary(`session-${i}`, '/repo', `chat ${i}`));
     const driver = new SlashCommandDriver(sessions);
@@ -1663,7 +1666,44 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/session');
     terminal.input('\r');
 
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Showing the 10 most recent sessions. Use /session <id>'));
+    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
+    // All 12 are in the list (not sliced to 10): the scroll indicator counts the
+    // full total, so the window shows "(1/12)".
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('/12)'));
+
+    terminal.input('\x1b');
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
+  test('the session picker disambiguates same-named sessions by short id', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('aaaa1111-2222-3333', '/repo', 'Same name'),
+      fakeSessionSummary('bbbb4444-5555-6666', '/repo', 'Same name'),
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Resume Session (Current Folder)'));
+    // Same label on both rows, but the short id in the description tells them apart.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('aaaa1111'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('bbbb4444'));
 
     terminal.input('\x1b');
     terminal.input('\x03');

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -516,6 +516,29 @@ describe('Maka session driver', () => {
     await assert.rejects(driver.rewindToTurn('turn-1'), /before a session starts/);
     assert.deepEqual(runtime.branched, []);
   });
+
+  test('startNewSession makes the next prompt create a fresh session, keeping settings', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+    await driver.setModel('claude-opus-4-1');
+    await collect(driver.sendPrompt('first'));
+    assert.equal(driver.getSessionId(), 'session-1');
+
+    driver.startNewSession();
+    assert.equal(driver.getSessionId(), null);
+
+    await collect(driver.sendPrompt('second'));
+    // A second createSession call — the prompt started a new session rather than
+    // reusing the old one — and it kept the current model.
+    assert.equal(runtime.created.length, 2);
+    assert.equal(runtime.created[1]?.model, 'claude-opus-4-1');
+    assert.equal(runtime.created[1]?.name, 'second');
+  });
 });
 
 class RecordingRuntime {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -410,22 +410,15 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
 
-    // Sessions are recency-sorted; show the 10 most recent by their human name
-    // (the id is the selection value, not something the user should have to read).
-    const items: SelectItem[] = currentSessions.slice(0, SESSION_PICKER_LIMIT).map((session) => ({
+    // Recency-sorted. Label each row by its human name (the id is the selection
+    // value, not something the user should have to read) and disambiguate
+    // same-named sessions with a short id in the description. The list scrolls,
+    // so every session stays reachable — nothing is capped or hidden.
+    const items: SelectItem[] = currentSessions.map((session) => ({
       value: session.id,
       label: session.name || session.id,
-      description: session.model,
+      description: `${shortSessionId(session.id)} ${session.model}`,
     }));
-    if (currentSessions.length > SESSION_PICKER_LIMIT) {
-      // Don't let the cap hide sessions silently: point at the /session <id> path
-      // that still reaches any older session directly.
-      state.entries.push({
-        kind: 'notice',
-        level: 'info',
-        text: `Showing the ${SESSION_PICKER_LIMIT} most recent sessions. Use /session <id> to resume an older one.`,
-      });
-    }
     showSelectPicker(
       'Resume Session (Current Folder)',
       'Current Folder',
@@ -1234,9 +1227,11 @@ const BOTTOM_PICKER_MARGIN_ROWS = 4;
 // visible on a bare `/` rather than scrolling a subset.
 const SLASH_COMMAND_MENU_MAX_VISIBLE = 12;
 
-// The session picker shows only the most recent sessions; older ones stay
-// reachable via `/session <id>`.
-const SESSION_PICKER_LIMIT = 10;
+// A short, stable slice of a session id — enough to tell two same-named
+// sessions apart in the picker without showing the full unreadable uuid.
+function shortSessionId(id: string): string {
+  return id.slice(0, 8);
+}
 
 // Two Escapes this close together read as one deliberate "stop the turn".
 const DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS = 600;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -104,7 +104,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const transcript = new MakaTranscriptComponent(state, metadata);
   const statusLine = new MakaStatusLineComponent(metadata);
-  const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: 8 });
+  // Show the whole slash-command set at once — discoverability is the point of
+  // the menu. Keep a little headroom above the current command count.
+  const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: SLASH_COMMAND_MENU_MAX_VISIBLE });
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
   const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
   const attention = new AttentionController(terminal, {
@@ -408,11 +410,22 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
 
-    const items: SelectItem[] = currentSessions.slice(0, 10).map((session) => ({
+    // Sessions are recency-sorted; show the 10 most recent by their human name
+    // (the id is the selection value, not something the user should have to read).
+    const items: SelectItem[] = currentSessions.slice(0, SESSION_PICKER_LIMIT).map((session) => ({
       value: session.id,
-      label: session.id,
-      description: `${session.name} ${session.model}`,
+      label: session.name || session.id,
+      description: session.model,
     }));
+    if (currentSessions.length > SESSION_PICKER_LIMIT) {
+      // Don't let the cap hide sessions silently: point at the /session <id> path
+      // that still reaches any older session directly.
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: `Showing the ${SESSION_PICKER_LIMIT} most recent sessions. Use /session <id> to resume an older one.`,
+      });
+    }
     showSelectPicker(
       'Resume Session (Current Folder)',
       'Current Folder',
@@ -448,6 +461,41 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
       { minPrimaryColumnWidth: 24, maxPrimaryColumnWidth: 48 },
     );
+  };
+
+  const newSession = () => {
+    input.driver.startNewSession();
+    // Fresh transcript for the fresh session; the next prompt creates it on disk.
+    replaceTranscriptWithStoredMessages(state, []);
+    layout.followTailNow();
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: 'Started a new session. Send a prompt to begin.',
+    });
+    requestRender();
+  };
+
+  const showHelp = () => {
+    // Derive the command list from the registry so /help never drifts from the
+    // real commands. Keybindings are not commands, so they are listed by hand.
+    const commands = slashCommands
+      .map((command) => `  /${command.name} — ${command.description}`)
+      .join('\n');
+    const keybindings = [
+      '  Ctrl+O — expand or collapse all tool output',
+      '  Ctrl+T — expand or collapse the latest thinking block',
+      '  PageUp / PageDown — scroll the transcript',
+      '  Esc Esc (during a turn) — interrupt the turn',
+      '  Esc Esc (when idle) — rewind to an earlier turn',
+      '  Ctrl+C / Ctrl+D — exit Maka',
+    ].join('\n');
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Commands\n${commands}\n\nKeybindings\n${keybindings}`,
+    });
+    requestRender();
   };
 
   const showModelList = () => {
@@ -533,6 +581,20 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       description: 'Exit Maka',
       run: () => {
         void close();
+      },
+    },
+    {
+      name: 'help',
+      description: 'Show commands and keybindings',
+      run: () => {
+        void runControl(async () => showHelp());
+      },
+    },
+    {
+      name: 'new',
+      description: 'Start a new session',
+      run: () => {
+        void runControl(async () => newSession());
       },
     },
     {
@@ -1167,6 +1229,14 @@ function padLine(text: string, width: number): string {
 }
 
 const BOTTOM_PICKER_MARGIN_ROWS = 4;
+
+// Fits the current slash-command set (10) with headroom, so the full menu is
+// visible on a bare `/` rather than scrolling a subset.
+const SLASH_COMMAND_MENU_MAX_VISIBLE = 12;
+
+// The session picker shows only the most recent sessions; older ones stay
+// reachable via `/session <id>`.
+const SESSION_PICKER_LIMIT = 10;
 
 // Two Escapes this close together read as one deliberate "stop the turn".
 const DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS = 600;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -106,7 +106,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const statusLine = new MakaStatusLineComponent(metadata);
   // Show the whole slash-command set at once — discoverability is the point of
   // the menu. Keep a little headroom above the current command count.
-  const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: SLASH_COMMAND_MENU_MAX_VISIBLE });
+  const editor = new Editor(tui, editorTheme(), { paddingX: 1, autocompleteMaxVisible: EDITOR_AUTOCOMPLETE_MAX_VISIBLE });
   const editorSurface = new MakaAutocompleteAboveEditorComponent(editor);
   const layout = new MakaPiLayoutComponent(transcript, editorSurface, statusLine, terminal);
   const attention = new AttentionController(terminal, {
@@ -1223,9 +1223,10 @@ function padLine(text: string, width: number): string {
 
 const BOTTOM_PICKER_MARGIN_ROWS = 4;
 
-// Fits the current slash-command set (10) with headroom, so the full menu is
-// visible on a bare `/` rather than scrolling a subset.
-const SLASH_COMMAND_MENU_MAX_VISIBLE = 12;
+// The editor's autocomplete window height. Sized to fit the whole slash-command
+// menu (10 today) with headroom, so a bare `/` shows every command rather than
+// scrolling a subset.
+const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 12;
 
 // A short, stable slice of a session id — enough to tell two same-named
 // sessions apart in the picker without showing the full unreadable uuid.

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -56,6 +56,8 @@ export interface MakaSessionDriver {
   listRewindTargets(): Promise<RewindTarget[]>;
   /** Rewind to a turn: branch the session through it and switch onto the branch. */
   rewindToTurn(turnId: string): Promise<MakaSessionSwitchResult>;
+  /** Abandon the active session so the next prompt starts a fresh one. */
+  startNewSession(): void;
   stop(): Promise<void>;
   getSessionId(): string | null;
 }
@@ -198,6 +200,13 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     // resumed session and the original session is left untouched.
     const branch = await this.input.runtime.branchFromTurn(this.sessionId, { sourceTurnId: turnId });
     return this.switchSession(branch.id);
+  }
+
+  startNewSession(): void {
+    // Drop the active session id only. The current model / thinking / permission
+    // stay put, so the next prompt lazily creates a fresh session that inherits
+    // them (via ensureSession). The old session is left intact on disk.
+    this.sessionId = null;
   }
 
   getSessionId(): string | null {


### PR DESCRIPTION
## What

Closes the **Command discoverability and session flow** T1 item in #549 as one PR.

- **`/help`** — lists every slash command (derived from the command registry, so it can't drift) plus the keybindings that are otherwise undiscoverable inside the app: `Ctrl+O`, `Ctrl+T`, `PageUp`/`PageDown`, `Esc Esc` (interrupt / rewind), `Ctrl+C`/`Ctrl+D`.
- **`/new`** — start a fresh session without exiting. `driver.startNewSession()` drops the active session id so the next prompt lazily creates a new session (keeping the current model / thinking / permission); the runner clears the transcript. The old session is left intact on disk.
- **Session picker fix** — rows are labeled by the human session name instead of the raw UUID (the id remains the selection value), and a short id in the description keeps same-named sessions tellable apart. The list scrolls (`SelectList` already supports it, as the rewind picker relies on), so the previous hard 10-item slice is gone and every session is reachable — nothing capped or hidden.
- **Full command menu** — a bare `/` now shows the whole slash-command set (editor autocomplete window 8 → 12) so the two new commands don't push older ones below the fold.

## Why these choices

- `/new` resets only the session id and reuses the existing lazy `ensureSession` path — no new session-creation code, and current settings carry over by construction.
- `/help` derives its command list from the same registry the autocomplete uses, so there is one source of truth.
- The session picker's 10-item cap was artificial: the underlying `SelectList` scrolls, so removing the slice makes every session reachable directly instead of hiding older ones behind a `/session <id>` hint.

## Verification

- `npm run -w maka-agent typecheck` — clean
- `npm run -w maka-agent test` — 190/190 pass (new: driver `startNewSession`, `/help`, `/new`, picker scroll/no-cap, same-name disambiguation; plus updated picker/autocomplete expectations)

## Review

Dual-reviewed (codex + pi glm-5.2 xhigh). First round: codex raised two P2s on the picker (same-name ambiguity; the cap hint was non-actionable since ids were no longer shown) — both fixed by removing the cap (scroll instead) and adding a short id to the description. pi PASS with P3s (addressed). Re-reviewed on the final commit.