### PR TITLE
refactor(runtime): move the backend port and context-budget helpers to their home modules

### DIFF
--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -3,16 +3,18 @@
  *
  * Source: V0.1_TECH_SPEC.md §13 + §6.1
  *
- * The full `AgentBackend` interface lives in @maka/runtime since
- * the implementations (AiSdkBackend / FakeBackend) are runtime
- * concerns. Core only exports the request/response shapes that cross the
- * runtime boundary.
+ * The `AgentBackend` port interface and the request/response shapes that
+ * cross the runtime boundary live here in @maka/core so that every backend
+ * implementation (AiSdkBackend / PiAgentBackend / FakeBackend) and their
+ * consumers depend on a small pure-type module, not on a concrete backend
+ * implementation file.
  */
 
-import type { AttachmentRef } from './events.js';
+import type { AttachmentRef, SessionEvent } from './events.js';
 import type { RuntimeEvent } from './runtime-event.js';
-import type { StoredMessage } from './session.js';
+import type { StoredMessage, BackendKind } from './session.js';
 import type { PermissionResponse } from './permission.js';
+import type { ContextBudgetDiagnostic } from './usage-stats/types.js';
 
 export interface BackendSendInput {
   /** AgentRun id for this invocation, when the caller has a run ledger. */
@@ -38,3 +40,22 @@ export interface BackendSendInput {
 
 /** Alias for clarity at the backend boundary. */
 export type PermissionDecision = PermissionResponse;
+
+export interface BackendCompactHistoryInput {
+  turnId: string;
+  runtimeContext: readonly RuntimeEvent[];
+}
+
+export interface BackendCompactHistoryResult {
+  contextBudget?: ContextBudgetDiagnostic;
+}
+
+export interface AgentBackend {
+  readonly kind: BackendKind;
+  readonly sessionId: string;
+  send(input: BackendSendInput): AsyncIterable<SessionEvent>;
+  compactHistory?(input: BackendCompactHistoryInput): Promise<BackendCompactHistoryResult>;
+  stop(reason: 'user_stop' | 'redirect'): Promise<void>;
+  respondToPermission(decision: PermissionDecision): Promise<void>;
+  dispose(): Promise<void>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -673,7 +673,13 @@ export {
 } from './voice.js';
 
 // backend-types.ts
-export type { BackendSendInput, PermissionDecision } from './backend-types.js';
+export type {
+  BackendSendInput,
+  PermissionDecision,
+  AgentBackend,
+  BackendCompactHistoryInput,
+  BackendCompactHistoryResult,
+} from './backend-types.js';
 
 // llm-connections.ts
 export type {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -23,9 +23,9 @@ import {
   formatSyntheticToolErrorText,
   normalizeAiSdkUsage,
   repairMakaToolCall,
-  type MakaTool,
   type RunTraceEvent,
 } from '../ai-sdk-backend.js';
+import type { MakaTool } from '../tool-runtime.js';
 import { LOAD_TOOLS_NAME } from '../tool-availability.js';
 import { PermissionEngine } from '../permission-engine.js';
 import {

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -19,7 +19,7 @@ import {
 import {
   flowSupportsControl,
 } from '../agent-flow.js';
-import type { AgentBackend } from '../ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
 import { RuntimeRunner } from '../runtime-runner.js';
 import type { InvocationContext } from '../invocation-context.js';
 

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -7,7 +7,8 @@ import type { LlmConnection, SessionHeader } from '@maka/core';
 import type { LlmCallRecord } from '@maka/core/usage-stats/types';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 
-import { AiSdkBackend, type MakaTool } from '../ai-sdk-backend.js';
+import { AiSdkBackend } from '../ai-sdk-backend.js';
+import type { MakaTool } from '../tool-runtime.js';
 import { PermissionEngine } from '../permission-engine.js';
 import {
   ToolAvailabilityRuntime,

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -24,7 +24,7 @@ import {
   type BackendFactoryContext,
   type SessionStore,
 } from '../session-manager.js';
-import type { AgentBackend } from '../ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
 import {
   buildRecoveredTerminalRuntimeEvent,
   buildSyntheticTerminalRuntimeEvent,

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -27,7 +27,8 @@ import {
 } from '../session-manager.js';
 import type { RuntimeKernelLike } from '../runtime-kernel.js';
 import { RuntimeReadModel } from '../runtime-read-model.js';
-import type { AgentBackend, MakaTool } from '../ai-sdk-backend.js';
+import type { AgentBackend } from '../ai-sdk-backend.js';
+import type { MakaTool } from '../tool-runtime.js';
 import type { InvocationResult } from '../invocation-context.js';
 import type { ActiveFullCompactBlock } from '../active-full-compact.js';
 import {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -27,7 +27,7 @@ import {
 } from '../session-manager.js';
 import type { RuntimeKernelLike } from '../runtime-kernel.js';
 import { RuntimeReadModel } from '../runtime-read-model.js';
-import type { AgentBackend } from '../ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
 import type { MakaTool } from '../tool-runtime.js';
 import type { InvocationResult } from '../invocation-context.js';
 import type { ActiveFullCompactBlock } from '../active-full-compact.js';

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -12,8 +12,7 @@ import type {
 } from '@maka/core/session';
 import type { UserMessageInput } from '@maka/core/runtime-inputs';
 import type { SessionEvent } from '@maka/core/events';
-import type { BackendSendInput } from '@maka/core/backend-types';
-import type { AgentBackend } from './ai-sdk-backend.js';
+import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
 import type { RunTraceEvent } from './run-trace.js';
 import type { SessionStore, StopSessionInput } from './session-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -66,7 +66,6 @@ import type { AgentSpec } from '@maka/core/runtime-inputs';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type {
-  CompactionDecisionDiagnostic,
   LlmCallRecord,
   PricingConfig,
   ToolInvocationRecord,
@@ -143,21 +142,27 @@ import {
 import {
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,
   applyRuntimeEventContextBudget,
+  buildContextBudgetDiagnosticShell,
+  buildHistorySearchSource,
   buildPromptSegmentEstimates,
   collectStaleToolResultArchiveCandidates,
   estimateRuntimeEventsTokens,
-  historyCompactBlockToRuntimeEvent,
+  mergeContextBudgetDiagnostic,
+  mergeContextBudgetDiagnosticPatches,
+  mergeRuntimeEventsInOriginalOrder,
+  minimalContextBudgetDiagnostic,
   rawEvidenceRequestReason,
+  replaceHistoryCompactReplayBlocks,
   retrieveArchivedToolResultsForReplay,
+  retrieveReplayHistoryAroundSearchSource,
   retrieveRuntimeEventHistoryAround,
-  searchRuntimeEventHistory,
+  runtimeEventTurnKey,
   selectSynthesisCacheForReplay,
+  shouldAppendContextCompactedNote,
   type ContextBudgetPolicy,
   type HistoryCompactBlock,
   type ActiveArchivedToolResultPlaceholder,
   type ActiveToolResultArchiveCandidate,
-  type RuntimeEventHistoryAroundResult,
-  type RuntimeEventHistorySearchPolicy,
   type StaleToolResultArchiveCandidate,
   type SynthesisCacheBlock,
   type SynthesisSourceRef,
@@ -2581,197 +2586,6 @@ function hasBlockingReplayDiagnostics(plan: RuntimeEventModelReplayPlan): boolea
   );
 }
 
-function mergeRuntimeEventsInOriginalOrder(
-  original: readonly RuntimeEvent[],
-  current: readonly RuntimeEvent[],
-  extra: readonly RuntimeEvent[],
-): RuntimeEvent[] {
-  const wantedIds = new Set<string>();
-  const byId = new Map<string, RuntimeEvent>();
-  for (const event of current) {
-    wantedIds.add(event.id);
-    byId.set(event.id, event);
-  }
-  for (const event of extra) {
-    wantedIds.add(event.id);
-    if (!byId.has(event.id)) byId.set(event.id, event);
-  }
-  const out: RuntimeEvent[] = [];
-  for (const event of original) {
-    if (!wantedIds.has(event.id)) continue;
-    out.push(byId.get(event.id) ?? event);
-  }
-  return out;
-}
-
-function buildContextBudgetDiagnosticShell(
-  before: readonly RuntimeEvent[],
-  after: readonly RuntimeEvent[],
-  policy: ContextBudgetPolicy | undefined,
-): ContextBudgetDiagnostic {
-  const charsPerToken = policy?.charsPerToken ?? 4;
-  const turnCountBefore = new Set(before.map((event) => runtimeEventTurnKey(event))).size;
-  const turnCountAfter = new Set(after.map((event) => runtimeEventTurnKey(event))).size;
-  return {
-    enabled: true,
-    ...(policy?.name ? { policyName: policy.name } : {}),
-    ...(policy?.maxHistoryEstimatedTokens !== undefined
-      ? { maxHistoryEstimatedTokens: policy.maxHistoryEstimatedTokens }
-      : {}),
-    ...(policy?.maxHistoryTurns !== undefined ? { maxHistoryTurns: policy.maxHistoryTurns } : {}),
-    estimatedTokensBefore: estimateRuntimeEventsTokens(before, charsPerToken),
-    estimatedTokensAfter: estimateRuntimeEventsTokens(after, charsPerToken),
-    keptTurns: turnCountAfter,
-    droppedTurns: Math.max(0, turnCountBefore - turnCountAfter),
-    keptEvents: after.length,
-    droppedEvents: Math.max(0, before.length - after.length),
-    ...(policy?.historyRewrite?.enabled === true
-      ? {
-          historyRewriteVersion: policy.historyRewrite.historyRewriteVersion,
-          historyRewriteResetReason: policy.historyRewrite.resetReason,
-          historyRewriteGate: policy.historyRewrite.name ?? 'history-rewrite',
-        }
-      : {}),
-  };
-}
-
-function runtimeEventTurnKey(event: RuntimeEvent): string {
-  return event.turnId || '<unknown-turn>';
-}
-
-function retrieveReplayHistoryAroundSearchSource(
-  replayEvents: readonly RuntimeEvent[],
-  searchEvents: readonly RuntimeEvent[],
-  query: string,
-  policy: RuntimeEventHistorySearchPolicy | undefined,
-  options: { charsPerToken?: number } = {},
-): RuntimeEventHistoryAroundResult {
-  if (policy?.enabled !== true) {
-    return { events: [], hits: [], diagnosticPatch: {} };
-  }
-  const charsPerToken = options.charsPerToken ?? 4;
-  const around = Math.max(0, Math.floor(policy.around ?? 1));
-  const maxEstimatedTokens = typeof policy.maxEstimatedTokens === 'number'
-    && Number.isFinite(policy.maxEstimatedTokens)
-    && policy.maxEstimatedTokens > 0
-    ? Math.floor(policy.maxEstimatedTokens)
-    : 4_096;
-  const hits = searchRuntimeEventHistory(searchEvents, policy.query ?? query, policy);
-  const selectedIndexes = new Set<number>();
-  const indexesByEventId = new Map(replayEvents.map((event, index) => [event.id, index]));
-  let skipped = 0;
-  for (const hit of hits) {
-    const index = indexesByEventId.get(hit.eventId);
-    if (index === undefined) {
-      skipped += 1;
-      continue;
-    }
-    for (let cursor = Math.max(0, index - around); cursor <= Math.min(replayEvents.length - 1, index + around); cursor += 1) {
-      selectedIndexes.add(cursor);
-    }
-  }
-
-  const selectedEvents: RuntimeEvent[] = [];
-  let selectedTokens = 0;
-  for (const index of [...selectedIndexes].sort((a, b) => a - b)) {
-    const event = replayEvents[index]!;
-    const estimate = estimateRuntimeEventsTokens([event], charsPerToken);
-    if (selectedTokens + estimate > maxEstimatedTokens) {
-      skipped += 1;
-      continue;
-    }
-    selectedEvents.push(event);
-    selectedTokens += estimate;
-  }
-
-  return {
-    events: selectedEvents,
-    hits,
-    diagnosticPatch: {
-      historySearchMatches: hits.length,
-      historyAroundRetrievedEvents: selectedEvents.length,
-      historyAroundEstimatedTokens: selectedTokens,
-      ...(skipped > 0 ? { historyAroundSkippedEvents: skipped } : {}),
-    },
-  };
-}
-
-function buildHistorySearchSource(
-  events: readonly RuntimeEvent[],
-  policy: ContextBudgetPolicy | undefined,
-): readonly RuntimeEvent[] {
-  if (policy?.staleToolResultPrune?.enabled !== true) return events;
-  return applyRuntimeEventContextBudget(events, {
-    ...policy,
-    maxHistoryEstimatedTokens: undefined,
-    maxHistoryTurns: undefined,
-    archiveRetrieval: undefined,
-    historySearch: undefined,
-    historyRewrite: undefined,
-  })?.events ?? events;
-}
-
-function mergeContextBudgetDiagnostic(
-  base: ContextBudgetDiagnostic,
-  patch: Partial<ContextBudgetDiagnostic>,
-): ContextBudgetDiagnostic {
-  return {
-    ...base,
-    ...patch,
-    archiveRetrievalFailureReasonCounts: mergeCountRecords(
-      base.archiveRetrievalFailureReasonCounts,
-      patch.archiveRetrievalFailureReasonCounts,
-    ),
-    archiveRetrievalSkippedReasonCounts: mergeCountRecords(
-      base.archiveRetrievalSkippedReasonCounts,
-      patch.archiveRetrievalSkippedReasonCounts,
-    ),
-    synthesisCacheSkippedReasonCounts: mergeCountRecords(
-      base.synthesisCacheSkippedReasonCounts,
-      patch.synthesisCacheSkippedReasonCounts,
-    ),
-    synthesisCacheInvalidationReasonCounts: mergeCountRecords(
-      base.synthesisCacheInvalidationReasonCounts,
-      patch.synthesisCacheInvalidationReasonCounts,
-    ),
-    synthesisCacheLoadSkippedReasonCounts: mergeCountRecords(
-      base.synthesisCacheLoadSkippedReasonCounts,
-      patch.synthesisCacheLoadSkippedReasonCounts,
-    ),
-    synthesisCacheWriteSkippedReasonCounts: mergeCountRecords(
-      base.synthesisCacheWriteSkippedReasonCounts,
-      patch.synthesisCacheWriteSkippedReasonCounts,
-    ),
-    synthesisCacheEvictionReasonCounts: mergeCountRecords(
-      base.synthesisCacheEvictionReasonCounts,
-      patch.synthesisCacheEvictionReasonCounts,
-    ),
-    historyCompactSkippedReasonCounts: mergeCountRecords(
-      base.historyCompactSkippedReasonCounts,
-      patch.historyCompactSkippedReasonCounts,
-    ),
-    historyCompactLoadSkippedReasonCounts: mergeCountRecords(
-      base.historyCompactLoadSkippedReasonCounts,
-      patch.historyCompactLoadSkippedReasonCounts,
-    ),
-    historyCompactWriteSkippedReasonCounts: mergeCountRecords(
-      base.historyCompactWriteSkippedReasonCounts,
-      patch.historyCompactWriteSkippedReasonCounts,
-    ),
-    ...mergeCompactionDecisionDiagnostics(base.compactionDecisions, patch.compactionDecisions),
-  };
-}
-
-function mergeContextBudgetDiagnosticPatches(
-  left: Partial<ContextBudgetDiagnostic> | undefined,
-  right: Partial<ContextBudgetDiagnostic> | undefined,
-): Partial<ContextBudgetDiagnostic> | undefined {
-  if (!left && !right) return undefined;
-  if (!left) return right;
-  if (!right) return left;
-  return mergeContextBudgetDiagnostic(left as ContextBudgetDiagnostic, right);
-}
-
 function mergeActiveToolResultPruneDiagnosticPatches(
   left: ActiveToolResultPruneDiagnosticPatch,
   right: ActiveToolResultPruneDiagnosticPatch,
@@ -2809,71 +2623,6 @@ function contextBudgetWithActivePrepareStepDiagnostics(
   const mergedPatch = mergeContextBudgetDiagnosticPatches(prunePatch, activeFullCompactPatch);
   if (!mergedPatch) return base;
   return mergeContextBudgetDiagnostic(base ?? minimalContextBudgetDiagnostic(), mergedPatch);
-}
-
-function shouldAppendContextCompactedNote(contextBudget: ContextBudgetDiagnostic | undefined): boolean {
-  if ((contextBudget?.historyCompactBlocksWritten ?? 0) <= 0) return false;
-  return contextBudget?.compactionDecisions?.some((decision) =>
-    decision.stage === 'priorReplay'
-    && decision.boundaryKind === 'historyCompact'
-    && decision.decision === 'replaced'
-  ) === true;
-}
-
-function minimalContextBudgetDiagnostic(): ContextBudgetDiagnostic {
-  return {
-    enabled: true,
-    estimatedTokensBefore: 0,
-    estimatedTokensAfter: 0,
-    keptTurns: 0,
-    droppedTurns: 0,
-    keptEvents: 0,
-    droppedEvents: 0,
-  };
-}
-
-function mergeCountRecords(
-  left: Record<string, number> | undefined,
-  right: Record<string, number> | undefined,
-): Record<string, number> | undefined {
-  if (!left && !right) return undefined;
-  const out: Record<string, number> = { ...(left ?? {}) };
-  for (const [key, value] of Object.entries(right ?? {})) {
-    out[key] = (out[key] ?? 0) + value;
-  }
-  return out;
-}
-
-function mergeCompactionDecisionDiagnostics(
-  left: readonly CompactionDecisionDiagnostic[] | undefined,
-  right: readonly CompactionDecisionDiagnostic[] | undefined,
-): { compactionDecisions: CompactionDecisionDiagnostic[] } | Record<string, never> {
-  if (!left && !right) return {};
-  if (!right || right.length === 0) return { compactionDecisions: [...(left ?? [])] };
-  const replacesHistoryCompact = right.some((decision) =>
-    decision.stage === 'priorReplay'
-    && decision.boundaryKind === 'historyCompact'
-  );
-  const retainedLeft = replacesHistoryCompact
-    ? (left ?? []).filter((decision) =>
-        !(
-          decision.stage === 'priorReplay'
-          && decision.boundaryKind === 'historyCompact'
-        )
-      )
-    : (left ?? []);
-  return { compactionDecisions: [...retainedLeft, ...right] };
-}
-
-function replaceHistoryCompactReplayBlocks(
-  events: readonly RuntimeEvent[],
-  blocks: readonly HistoryCompactBlock[],
-): RuntimeEvent[] {
-  if (blocks.length === 0) return [...events];
-  return [
-    ...blocks.map((block) => historyCompactBlockToRuntimeEvent(block)),
-    ...events.filter((event) => !event.id.startsWith('history-compact:')),
-  ];
 }
 
 function incrementRecord(counts: Record<string, number>, key: string): void {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -177,7 +177,6 @@ export {
   TOOL_ERROR_RESULT_MAX_CHARS,
   formatSyntheticToolErrorText,
 } from './tool-runtime.js';
-export type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export { normalizeAiSdkUsage } from './model-adapter.js';
 export type { ModelFactory, ModelFactoryInput, RepairableAiSdkToolCall } from './model-adapter.js';
 export type { RunTraceEvent, RunTraceRecorder } from './run-trace.js';

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -56,6 +56,9 @@ import type {
   SessionHeader,
 } from '@maka/core/session';
 import type {
+  AgentBackend,
+  BackendCompactHistoryInput,
+  BackendCompactHistoryResult,
   BackendSendInput,
   PermissionDecision,
 } from '@maka/core/backend-types';
@@ -175,27 +178,15 @@ export type { ModelFactory, ModelFactoryInput, RepairableAiSdkToolCall } from '.
 export type { RunTraceEvent, RunTraceRecorder } from './run-trace.js';
 
 // ============================================================================
-// AgentBackend interface
+// AgentBackend interface — port contract now lives in @maka/core/backend-types;
+// re-exported here for backward compatibility with existing import sites.
 // ============================================================================
 
-export interface BackendCompactHistoryInput {
-  turnId: string;
-  runtimeContext: readonly RuntimeEvent[];
-}
-
-export interface BackendCompactHistoryResult {
-  contextBudget?: ContextBudgetDiagnostic;
-}
-
-export interface AgentBackend {
-  readonly kind: BackendKind;
-  readonly sessionId: string;
-  send(input: BackendSendInput): AsyncIterable<SessionEvent>;
-  compactHistory?(input: BackendCompactHistoryInput): Promise<BackendCompactHistoryResult>;
-  stop(reason: 'user_stop' | 'redirect'): Promise<void>;
-  respondToPermission(decision: PermissionDecision): Promise<void>;
-  dispose(): Promise<void>;
-}
+export type {
+  AgentBackend,
+  BackendCompactHistoryInput,
+  BackendCompactHistoryResult,
+} from '@maka/core/backend-types';
 
 export const INVALID_TOOL_NAME = 'invalid';
 

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -35,7 +35,7 @@ import type { CompleteEvent, SessionEvent } from '@maka/core/events';
 import type { PermissionDecision } from '@maka/core/backend-types';
 import { isTerminalRuntimeEvent, type RuntimeEvent, type RuntimeEventStatus } from '@maka/core/runtime-event';
 
-import type { AgentBackend } from './ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
 import {
   type AgentFlow,
   type AgentFlowControl,

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -23,8 +23,8 @@ import {
   type WorkspaceExecutor,
 } from './workspace-executor.js';
 
-// Single source of truth for tool shape. AiSdkBackend exports them; we just
-// re-export here for back-compat with external callers that imported from
+// tool-runtime.ts is the single source of truth for the tool shape; this
+// re-export only keeps back-compat for callers that imported from
 // builtin-tools directly.
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type { MakaTool, MakaToolContext };

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -26,7 +26,7 @@ import {
 // Single source of truth for tool shape. AiSdkBackend exports them; we just
 // re-export here for back-compat with external callers that imported from
 // builtin-tools directly.
-import type { MakaTool, MakaToolContext } from './ai-sdk-backend.js';
+import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type { MakaTool, MakaToolContext };
 import { withFileWriteLock } from './file-write-lock.js';
 

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { ModelMessage } from 'ai';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type {
+  CompactionDecisionDiagnostic,
   ContextBudgetDiagnostic,
   PromptSegmentEstimate,
 } from '@maka/core/usage-stats/types';
@@ -2536,4 +2537,266 @@ function normalizeWhitespace(value: string): string {
 function boundText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return `${value.slice(0, Math.max(0, maxChars - 14)).trimEnd()}\n[truncated]`;
+}
+
+// ============================================================================
+// Replay ordering + context-budget diagnostic merge helpers.
+// Relocated from ai-sdk-backend.ts: these are pure functions over
+// RuntimeEvent / ContextBudgetDiagnostic and belong to this budgeting domain.
+// ============================================================================
+
+export function mergeRuntimeEventsInOriginalOrder(
+  original: readonly RuntimeEvent[],
+  current: readonly RuntimeEvent[],
+  extra: readonly RuntimeEvent[],
+): RuntimeEvent[] {
+  const wantedIds = new Set<string>();
+  const byId = new Map<string, RuntimeEvent>();
+  for (const event of current) {
+    wantedIds.add(event.id);
+    byId.set(event.id, event);
+  }
+  for (const event of extra) {
+    wantedIds.add(event.id);
+    if (!byId.has(event.id)) byId.set(event.id, event);
+  }
+  const out: RuntimeEvent[] = [];
+  for (const event of original) {
+    if (!wantedIds.has(event.id)) continue;
+    out.push(byId.get(event.id) ?? event);
+  }
+  return out;
+}
+
+export function buildContextBudgetDiagnosticShell(
+  before: readonly RuntimeEvent[],
+  after: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): ContextBudgetDiagnostic {
+  const charsPerToken = policy?.charsPerToken ?? 4;
+  const turnCountBefore = new Set(before.map((event) => runtimeEventTurnKey(event))).size;
+  const turnCountAfter = new Set(after.map((event) => runtimeEventTurnKey(event))).size;
+  return {
+    enabled: true,
+    ...(policy?.name ? { policyName: policy.name } : {}),
+    ...(policy?.maxHistoryEstimatedTokens !== undefined
+      ? { maxHistoryEstimatedTokens: policy.maxHistoryEstimatedTokens }
+      : {}),
+    ...(policy?.maxHistoryTurns !== undefined ? { maxHistoryTurns: policy.maxHistoryTurns } : {}),
+    estimatedTokensBefore: estimateRuntimeEventsTokens(before, charsPerToken),
+    estimatedTokensAfter: estimateRuntimeEventsTokens(after, charsPerToken),
+    keptTurns: turnCountAfter,
+    droppedTurns: Math.max(0, turnCountBefore - turnCountAfter),
+    keptEvents: after.length,
+    droppedEvents: Math.max(0, before.length - after.length),
+    ...(policy?.historyRewrite?.enabled === true
+      ? {
+          historyRewriteVersion: policy.historyRewrite.historyRewriteVersion,
+          historyRewriteResetReason: policy.historyRewrite.resetReason,
+          historyRewriteGate: policy.historyRewrite.name ?? 'history-rewrite',
+        }
+      : {}),
+  };
+}
+
+export function runtimeEventTurnKey(event: RuntimeEvent): string {
+  return event.turnId || '<unknown-turn>';
+}
+
+export function retrieveReplayHistoryAroundSearchSource(
+  replayEvents: readonly RuntimeEvent[],
+  searchEvents: readonly RuntimeEvent[],
+  query: string,
+  policy: RuntimeEventHistorySearchPolicy | undefined,
+  options: { charsPerToken?: number } = {},
+): RuntimeEventHistoryAroundResult {
+  if (policy?.enabled !== true) {
+    return { events: [], hits: [], diagnosticPatch: {} };
+  }
+  const charsPerToken = options.charsPerToken ?? 4;
+  const around = Math.max(0, Math.floor(policy.around ?? 1));
+  const maxEstimatedTokens = typeof policy.maxEstimatedTokens === 'number'
+    && Number.isFinite(policy.maxEstimatedTokens)
+    && policy.maxEstimatedTokens > 0
+    ? Math.floor(policy.maxEstimatedTokens)
+    : 4_096;
+  const hits = searchRuntimeEventHistory(searchEvents, policy.query ?? query, policy);
+  const selectedIndexes = new Set<number>();
+  const indexesByEventId = new Map(replayEvents.map((event, index) => [event.id, index]));
+  let skipped = 0;
+  for (const hit of hits) {
+    const index = indexesByEventId.get(hit.eventId);
+    if (index === undefined) {
+      skipped += 1;
+      continue;
+    }
+    for (let cursor = Math.max(0, index - around); cursor <= Math.min(replayEvents.length - 1, index + around); cursor += 1) {
+      selectedIndexes.add(cursor);
+    }
+  }
+
+  const selectedEvents: RuntimeEvent[] = [];
+  let selectedTokens = 0;
+  for (const index of [...selectedIndexes].sort((a, b) => a - b)) {
+    const event = replayEvents[index]!;
+    const estimate = estimateRuntimeEventsTokens([event], charsPerToken);
+    if (selectedTokens + estimate > maxEstimatedTokens) {
+      skipped += 1;
+      continue;
+    }
+    selectedEvents.push(event);
+    selectedTokens += estimate;
+  }
+
+  return {
+    events: selectedEvents,
+    hits,
+    diagnosticPatch: {
+      historySearchMatches: hits.length,
+      historyAroundRetrievedEvents: selectedEvents.length,
+      historyAroundEstimatedTokens: selectedTokens,
+      ...(skipped > 0 ? { historyAroundSkippedEvents: skipped } : {}),
+    },
+  };
+}
+
+export function buildHistorySearchSource(
+  events: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): readonly RuntimeEvent[] {
+  if (policy?.staleToolResultPrune?.enabled !== true) return events;
+  return applyRuntimeEventContextBudget(events, {
+    ...policy,
+    maxHistoryEstimatedTokens: undefined,
+    maxHistoryTurns: undefined,
+    archiveRetrieval: undefined,
+    historySearch: undefined,
+    historyRewrite: undefined,
+  })?.events ?? events;
+}
+
+export function mergeContextBudgetDiagnostic(
+  base: ContextBudgetDiagnostic,
+  patch: Partial<ContextBudgetDiagnostic>,
+): ContextBudgetDiagnostic {
+  return {
+    ...base,
+    ...patch,
+    archiveRetrievalFailureReasonCounts: mergeCountRecords(
+      base.archiveRetrievalFailureReasonCounts,
+      patch.archiveRetrievalFailureReasonCounts,
+    ),
+    archiveRetrievalSkippedReasonCounts: mergeCountRecords(
+      base.archiveRetrievalSkippedReasonCounts,
+      patch.archiveRetrievalSkippedReasonCounts,
+    ),
+    synthesisCacheSkippedReasonCounts: mergeCountRecords(
+      base.synthesisCacheSkippedReasonCounts,
+      patch.synthesisCacheSkippedReasonCounts,
+    ),
+    synthesisCacheInvalidationReasonCounts: mergeCountRecords(
+      base.synthesisCacheInvalidationReasonCounts,
+      patch.synthesisCacheInvalidationReasonCounts,
+    ),
+    synthesisCacheLoadSkippedReasonCounts: mergeCountRecords(
+      base.synthesisCacheLoadSkippedReasonCounts,
+      patch.synthesisCacheLoadSkippedReasonCounts,
+    ),
+    synthesisCacheWriteSkippedReasonCounts: mergeCountRecords(
+      base.synthesisCacheWriteSkippedReasonCounts,
+      patch.synthesisCacheWriteSkippedReasonCounts,
+    ),
+    synthesisCacheEvictionReasonCounts: mergeCountRecords(
+      base.synthesisCacheEvictionReasonCounts,
+      patch.synthesisCacheEvictionReasonCounts,
+    ),
+    historyCompactSkippedReasonCounts: mergeCountRecords(
+      base.historyCompactSkippedReasonCounts,
+      patch.historyCompactSkippedReasonCounts,
+    ),
+    historyCompactLoadSkippedReasonCounts: mergeCountRecords(
+      base.historyCompactLoadSkippedReasonCounts,
+      patch.historyCompactLoadSkippedReasonCounts,
+    ),
+    historyCompactWriteSkippedReasonCounts: mergeCountRecords(
+      base.historyCompactWriteSkippedReasonCounts,
+      patch.historyCompactWriteSkippedReasonCounts,
+    ),
+    ...mergeCompactionDecisionDiagnostics(base.compactionDecisions, patch.compactionDecisions),
+  };
+}
+
+export function mergeContextBudgetDiagnosticPatches(
+  left: Partial<ContextBudgetDiagnostic> | undefined,
+  right: Partial<ContextBudgetDiagnostic> | undefined,
+): Partial<ContextBudgetDiagnostic> | undefined {
+  if (!left && !right) return undefined;
+  if (!left) return right;
+  if (!right) return left;
+  return mergeContextBudgetDiagnostic(left as ContextBudgetDiagnostic, right);
+}
+
+export function shouldAppendContextCompactedNote(contextBudget: ContextBudgetDiagnostic | undefined): boolean {
+  if ((contextBudget?.historyCompactBlocksWritten ?? 0) <= 0) return false;
+  return contextBudget?.compactionDecisions?.some((decision) =>
+    decision.stage === 'priorReplay'
+    && decision.boundaryKind === 'historyCompact'
+    && decision.decision === 'replaced'
+  ) === true;
+}
+
+export function minimalContextBudgetDiagnostic(): ContextBudgetDiagnostic {
+  return {
+    enabled: true,
+    estimatedTokensBefore: 0,
+    estimatedTokensAfter: 0,
+    keptTurns: 0,
+    droppedTurns: 0,
+    keptEvents: 0,
+    droppedEvents: 0,
+  };
+}
+
+function mergeCountRecords(
+  left: Record<string, number> | undefined,
+  right: Record<string, number> | undefined,
+): Record<string, number> | undefined {
+  if (!left && !right) return undefined;
+  const out: Record<string, number> = { ...(left ?? {}) };
+  for (const [key, value] of Object.entries(right ?? {})) {
+    out[key] = (out[key] ?? 0) + value;
+  }
+  return out;
+}
+
+function mergeCompactionDecisionDiagnostics(
+  left: readonly CompactionDecisionDiagnostic[] | undefined,
+  right: readonly CompactionDecisionDiagnostic[] | undefined,
+): { compactionDecisions: CompactionDecisionDiagnostic[] } | Record<string, never> {
+  if (!left && !right) return {};
+  if (!right || right.length === 0) return { compactionDecisions: [...(left ?? [])] };
+  const replacesHistoryCompact = right.some((decision) =>
+    decision.stage === 'priorReplay'
+    && decision.boundaryKind === 'historyCompact'
+  );
+  const retainedLeft = replacesHistoryCompact
+    ? (left ?? []).filter((decision) =>
+        !(
+          decision.stage === 'priorReplay'
+          && decision.boundaryKind === 'historyCompact'
+        )
+      )
+    : (left ?? []);
+  return { compactionDecisions: [...retainedLeft, ...right] };
+}
+
+export function replaceHistoryCompactReplayBlocks(
+  events: readonly RuntimeEvent[],
+  blocks: readonly HistoryCompactBlock[],
+): RuntimeEvent[] {
+  if (blocks.length === 0) return [...events];
+  return [
+    ...blocks.map((block) => historyCompactBlockToRuntimeEvent(block)),
+    ...events.filter((event) => !event.id.startsWith('history-compact:')),
+  ];
 }

--- a/packages/runtime/src/fake-backend.ts
+++ b/packages/runtime/src/fake-backend.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { BackendKind, SessionEvent, SessionHeader, StoredMessage } from '@maka/core';
-import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
-import type { AgentBackend } from './ai-sdk-backend.js';
+import type { AgentBackend, BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { SessionStore } from './session-manager.js';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -32,6 +32,7 @@ export { PermissionEngine, createDefaultPermissionEngineDeps } from './permissio
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';
 
 export { AiSdkBackend } from './ai-sdk-backend.js';
+export type { MakaTool, MakaToolContext } from './tool-runtime.js';
 export type {
   AgentBackend,
   BackendCompactHistoryInput,
@@ -39,8 +40,6 @@ export type {
   AiSdkBackendInput,
   AppendMessageFn,
   AttachmentByteReader,
-  MakaTool,
-  MakaToolContext,
   ModelFactory,
   ModelFactoryInput,
   RunTraceEvent,

--- a/packages/runtime/src/pi-agent-backend.ts
+++ b/packages/runtime/src/pi-agent-backend.ts
@@ -13,7 +13,8 @@ import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-ty
 import { redactSecrets } from '@maka/core/redaction';
 import type { ToolCategory } from '@maka/core/permission';
 
-import type { AgentBackend, AppendMessageFn } from './ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
+import type { AppendMessageFn } from './ai-sdk-backend.js';
 import { PermissionEngine } from './permission-engine.js';
 
 export interface PiAgentBackendInput {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -11,7 +11,8 @@ import type { ChildAgentTurnInput, UserMessageInput } from '@maka/core/runtime-i
 import type { PermissionResponse } from '@maka/core/permission';
 import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
 import { AiSdkFlow, mapSessionEventToRuntimeEvent } from './ai-sdk-flow.js';
-import type { AgentBackend, MakaTool } from './ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
+import type { MakaTool } from './ai-sdk-backend.js';
 import type { InvocationContext, InvocationResult, InvocationSource } from './invocation-context.js';
 import { RuntimeRunner } from './runtime-runner.js';
 import type { BackendRegistry, CompactSessionInput, SessionStore, StopSessionInput } from './session-manager.js';

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -12,7 +12,7 @@ import type { PermissionResponse } from '@maka/core/permission';
 import { AgentRun, type AgentRunActiveSession, type AgentRunBeginResult, type AgentRunLineage } from './agent-run.js';
 import { AiSdkFlow, mapSessionEventToRuntimeEvent } from './ai-sdk-flow.js';
 import type { AgentBackend } from '@maka/core/backend-types';
-import type { MakaTool } from './ai-sdk-backend.js';
+import type { MakaTool } from './tool-runtime.js';
 import type { InvocationContext, InvocationResult, InvocationSource } from './invocation-context.js';
 import { RuntimeRunner } from './runtime-runner.js';
 import type { BackendRegistry, CompactSessionInput, SessionStore, StopSessionInput } from './session-manager.js';

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -63,7 +63,7 @@ import {
 } from './terminal-run-commit.js';
 
 import type { AgentBackend } from '@maka/core/backend-types';
-import type { MakaTool } from './ai-sdk-backend.js';
+import type { MakaTool } from './tool-runtime.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -62,7 +62,8 @@ import {
   terminalRunStatusFromRuntimeEvent,
 } from './terminal-run-commit.js';
 
-import type { AgentBackend, MakaTool } from './ai-sdk-backend.js';
+import type { AgentBackend } from '@maka/core/backend-types';
+import type { MakaTool } from './ai-sdk-backend.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';


### PR DESCRIPTION
## Summary

Pure-move boundary cleanup of `ai-sdk-backend.ts`, zero behavior change: the `AgentBackend` port contract moves to `@maka/core/backend-types` (re-export kept), ~254 lines of context-budget diagnostic pure functions move back to `context-budget.ts`, and `MakaTool` imports unify on `tool-runtime.js`.

## Why

Six production consumers imported a ~2900-line implementation file just for its interface, and a dozen budget/diagnostic pure functions lived away from their module. Extracting the prior-message assembler was evaluated and deliberately deferred: two cross-boundary shared helpers (`appendImageParts`, `computeTokenUsageCostUsd`) plus prepareStep closures give it a different risk profile — tracked as a follow-up PR.

## Scope

Changed: 15 files, +336/−305, four commits, each independently buildable and revertible.

Not included: send() split (won't do — 15 closure variables and 8 fields are genuinely entangled); PriorMessageAssembler extraction (follow-up).

## Verification

`git diff --color-moved` confirms the moved blocks are line-identical; root typecheck across all workspaces; `@maka/runtime` 1006 pass; `@maka/headless` 740 pass. External review: Codex GATE PASS (its only P1 — deep-path `MakaTool` re-export compatibility — refuted: the package is private and repo-wide grep shows zero deep-path consumers); Pi concluded zero behavior change, mergeable, and its P3 (test imports lagging the canonical source) is fixed in the last commit.

## User-facing impact

None.

## Reviewer notes

Review commit-by-commit; each is a mechanical move verified by typecheck and tests. The four `ActiveToolResultPrune` merge helpers stay in `ai-sdk-backend.ts` on purpose — moving them would give `context-budget.ts` a new dependency edge on `active-tool-result-prune.ts`, which already imports context-budget in the other direction.
