### PR TITLE
fix(ui): decouple daily review effects from bridge reference (#582 follow-up)

### DIFF
--- a/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-copy-feedback-contract.test.ts
@@ -188,7 +188,7 @@ describe('Daily Review copy feedback contract', () => {
   it('guards Daily Review archive body loads against stale async responses', async () => {
     const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx'), 'utf8');
     const panelBlock = extractFunctionBlock(ui, 'DailyReviewPanel');
-    const archiveLoadBlock = panelBlock.match(/useEffect\(\(\) => \{\s*const getArchive = props\.bridge\.getArchive;[\s\S]*?\}, \[archiveReloadToken, selectedArchiveId, props\.bridge\]\);/)?.[0] ?? '';
+    const archiveLoadBlock = panelBlock.match(/useEffect\(\(\) => \{\s*const getArchive = bridgeRef\.current\.getArchive;[\s\S]*?\}, \[archiveReloadToken, selectedArchiveId\]\);/)?.[0] ?? '';
     assert.ok(archiveLoadBlock, 'archive load effect not found in DailyReviewPanel');
 
     assert.match(panelBlock, /const archiveLoadRequestRef = useRef\(0\)/);
@@ -223,6 +223,46 @@ describe('Daily Review copy feedback contract', () => {
       archiveLoadBlock,
       /\.catch\(\(err: unknown\) => \{\s*if \(cancelled\) return;\s*if \(archiveLoadRequestRef\.current !== archiveRequestId\) return;\s*setSelectedArchive\(null\);/,
       'Older failed archive body loads must not clear or error the current selection',
+    );
+  });
+
+  it('decouples Daily Review data-fetching effects from the bridge object reference (PR-582 follow-up)', async () => {
+    const ui = await readFile(resolve(REPO_ROOT, 'packages/ui/src/daily-review-panel.tsx'), 'utf8');
+    const panelBlock = extractFunctionBlock(ui, 'DailyReviewPanel');
+
+    assert.match(
+      panelBlock,
+      /const bridgeRef = useRef\(props\.bridge\)/,
+      'DailyReviewPanel must track bridge via ref so effects survive bridge reference changes',
+    );
+    assert.match(
+      panelBlock,
+      /bridgeRef\.current = props\.bridge/,
+      'bridgeRef must be updated on every render so effects always use the latest bridge',
+    );
+
+    const fetchDayEffect = panelBlock.match(/useEffect\(\(\) => \{[\s\S]*?bridgeRef\.current\s*\n\s*\.fetchDay\([\s\S]*?\}, \[([^\]]*)\]\);/)?.[1] ?? '';
+    assert.ok(fetchDayEffect, 'fetchDay effect not found');
+    assert.doesNotMatch(
+      fetchDayEffect,
+      /props\.bridge/,
+      'fetchDay effect must not depend on props.bridge — use bridgeRef instead',
+    );
+
+    const listArchivesEffect = panelBlock.match(/useEffect\(\(\) => \{[\s\S]*?bridgeRef\.current\.listArchives[\s\S]*?\}, \[([^\]]*)\]\);/)?.[1] ?? '';
+    assert.ok(listArchivesEffect, 'listArchives effect not found');
+    assert.doesNotMatch(
+      listArchivesEffect,
+      /props\.bridge/,
+      'listArchives effect must not depend on props.bridge — use bridgeRef instead',
+    );
+
+    const getArchiveEffect = panelBlock.match(/useEffect\(\(\) => \{[\s\S]*?bridgeRef\.current\.getArchive[\s\S]*?\}, \[([^\]]*)\]\);/)?.[1] ?? '';
+    assert.ok(getArchiveEffect, 'getArchive effect not found');
+    assert.doesNotMatch(
+      getArchiveEffect,
+      /props\.bridge/,
+      'getArchive effect must not depend on props.bridge — use bridgeRef instead',
     );
   });
 

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -79,6 +79,13 @@ export function DailyReviewPanel(props: {
   const summaryScopeKeyRef = useRef<string | null>(null);
   const pendingDailyReviewActionRef = useRef<string | null>(null);
   const archiveLoadRequestRef = useRef(0);
+  // PR-582-FOLLOWUP: bridge methods (fetchDay, listArchives, getArchive)
+  // are thin IPC wrappers that don't depend on the connections array.
+  // Track the latest bridge via ref so effects don't re-fire when the
+  // bridge object is recreated due to an unrelated connections change
+  // (e.g. updatedAt timestamp bump from a provider status refresh).
+  const bridgeRef = useRef(props.bridge);
+  bridgeRef.current = props.bridge;
   const currentSummaryScopeKey = dailyReviewScopeKey(offsetDays, range);
   const visibleSummary = summaryScopeKey === currentSummaryScopeKey ? summary : null;
   const canLoadArchives = Boolean(props.bridge.listArchives && props.bridge.getArchive);
@@ -105,7 +112,7 @@ export function DailyReviewPanel(props: {
     const scopeKey = dailyReviewScopeKey(offsetDays, range);
     setLoading(true);
     setError(null);
-    props.bridge
+    bridgeRef.current
       .fetchDay(offsetDays, range)
       .then((next) => {
         if (cancelled) return;
@@ -127,10 +134,10 @@ export function DailyReviewPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [offsetDays, range, reloadToken, props.bridge]);
+  }, [offsetDays, range, reloadToken]);
 
   useEffect(() => {
-    const listArchives = props.bridge.listArchives;
+    const listArchives = bridgeRef.current.listArchives;
     if (!listArchives) {
       setArchives([]);
       setSelectedArchiveId(null);
@@ -155,10 +162,10 @@ export function DailyReviewPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [archiveReloadToken, props.bridge]);
+  }, [archiveReloadToken]);
 
   useEffect(() => {
-    const getArchive = props.bridge.getArchive;
+    const getArchive = bridgeRef.current.getArchive;
     if (!getArchive || !selectedArchiveId) {
       archiveLoadRequestRef.current += 1;
       setSelectedArchive(null);
@@ -188,7 +195,7 @@ export function DailyReviewPanel(props: {
     return () => {
       cancelled = true;
     };
-  }, [archiveReloadToken, selectedArchiveId, props.bridge]);
+  }, [archiveReloadToken, selectedArchiveId]);
 
   useEffect(() => {
     if (modelOptions.length === 0) {


### PR DESCRIPTION
## Summary

- **Root cause**: PR #582's `connectionsEqual` guard compares `slug` + `updatedAt`, so connections whose `updatedAt` changed (provider status refresh, credential re-verification) still produce a new `connections` reference → bridge `useMemo` invalidates → all three `DailyReviewPanel` effects re-fire → loading flicker loop (~250 DOM mutations / 5s)
- **Fix**: The bridge's IPC methods (`fetchDay`, `listArchives`, `getArchive`) don't depend on connections — they're thin wrappers over `window.maka.dailyReview.*`. Track the latest bridge via `useRef` and remove `props.bridge` from the three effect dependency arrays so they only re-run on user-driven state changes
- **Contract test**: Added source-code contract test verifying the `bridgeRef` pattern and that no data-fetching effect depends on `props.bridge`; updated existing archive-load contract regex to match new pattern

## Test plan

- [x] `npm --workspace @maka/desktop run test` — 2211 tests pass (0 fail), including new contract test
- [x] `npm --workspace @maka/ui test` — 46 tests pass
- [x] TypeScript compilation clean (`npx tsc --noEmit -p apps/desktop/tsconfig.renderer.json`)
- [x] Manual verification: date tabs (今日/本周/本月), archive selection, report content rendering all functional
- [x] `data-loading` stability: 0 toggles in 30s (was 30×/5s before fix)
- [x] Stress test: 149 `connections.list` IPC calls in 30s with zero loading flicker

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01WBXCLYznuwVqZeLXPReCLj