### PR TITLE
fix(ui): detail-audit round 4 — guidance labels get label form, last stray dashed border unified

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -426,7 +426,10 @@
   gap: var(--space-3);
   padding: var(--space-4) var(--space-4);
   border-radius: var(--radius-surface);
-  border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.32);
+  /* Detail audit round 4: solid — dashed was the app's last stray border
+     language (the markdown dangerous-link underline is the one deliberate
+     dashed exception). */
+  border: var(--border-width-hairline) solid oklch(from var(--info) l c h / 0.32);
   background: oklch(from var(--info) l c h / 0.06);
   color: var(--foreground-secondary);
 }

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -167,10 +167,17 @@
     display: inline-flex;
     align-items: center;
     min-height: 20px;
+    /* Detail audit round 4: these are non-clickable guidance labels sitting
+       in the same row as a REAL button (测试凭据) — bare text next to a
+       button read as broken controls. A quiet filled label form makes the
+       affordance difference legible. */
+    padding: var(--space-0-5) var(--space-2);
     border-radius: var(--radius-control);
+    background: var(--foreground-5);
+    color: var(--muted-foreground);
     white-space: nowrap;
     font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-medium);
   }
 .settingsAuthContractBadge {
     padding: var(--space-0-5) var(--space-2);


### PR DESCRIPTION
细节审查第 4 轮（非 settings 界面扫查的首批产出）：

1. **连接错误卡的可点击性汤**：不可点击的指路项（"在模型设置中保存模型密钥"等）以裸文字形态与真按钮「测试凭据」同排——没有任何信号区分什么能按。现在指路项穿明确的「标签」形态（5% 填充底 + muted 字 + padding），按钮/标签的层差可读。文案缩短后置（字符串被 account-auth-ui 契约语义锁定）。
2. **最后一处散落的虚线边框**（artifact 不支持预览卡）统一为实线；markdown 危险链接下划线保留为唯一刻意虚线例外。

CDP computed style 验证（15 个标签全部应用）；2250/2250；dead-css 干净。