### PR TITLE
refactor(ui): unify streaming and settled answers onto a single render path (#642)

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-marker-cascade-contract.test.ts
@@ -45,7 +45,11 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
     for (const selector of [
       // The `.maka-turn` flex/measure container is NOT a marker — it stays.
       '.maka-turn {',
-      '.maka-turn-streaming',
+      // #642 single render path: the separate `.maka-turn-streaming` section is
+      // gone; the streaming answer rides the tail turn's own `.maka-turn` node,
+      // and the content-visibility override that keeps the growing turn painted
+      // re-keys onto its `data-live-streaming` hook.
+      '.maka-turn[data-live-streaming="true"]',
       '.maka-turn[data-search-highlight="true"]',
       // NOTE: `.maka-turn-thinking` and `.maka-turn-tools` were retired by the
       // streaming UI rework — reasoning now renders through the `DeepThinking`
@@ -83,8 +87,10 @@ describe('chat Marker shell migration contract (#332 PR2)', () => {
       // lineage badge directions (models.css)
       'data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]',
       'data-[direction=reverse]:text-[oklch(from_var(--brand-deep)_calc(l_-_0.04)_c_h)]',
-      // footer + footer action (models.css)
-      'opacity-[0.72] hover:opacity-100 focus-within:opacity-100',
+      // footer + footer action (models.css). #642: the footer is hidden by
+      // default and revealed on hover / focus-within of the answer block
+      // (`group/answer`), replacing the retired quiet-0.72 + settle fade-in.
+      'opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/answer:opacity-100 focus-within:opacity-100',
       'min-h-[28px]',
       // `h-8` (→30px) is folded into the footer-action / lineage-badge shells
       // now that the call sites use `UiButton size="nav"` (bare); it used to

--- a/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-status-cluster-layout-contract.test.ts
@@ -53,31 +53,33 @@ describe('chat status cluster layout contract', () => {
     assert.match(emptyBody, /opacity:\s*0/);
   });
 
-  it('reserves the footer placeholder for every live turn, not only text answers', async () => {
-    // Three-way review (ChatGPT P2): a settled turn ALWAYS mounts a footer
-    // (deriveTurnFooterActions yields regenerate/branch from TurnStatus alone;
-    // materialize emits a timeline item for a step's thinking even with empty
-    // text), so a thinking-only turn settles WITH a footer. The live footer
-    // placeholder must live inside the `streamingText || thinkingText` section
-    // and render unconditionally there — never re-narrowed to streamingText —
-    // so it reserves the footer box for every live turn.
-    //
-    // Groundwork only: this locks the reserved box. It makes the swap
-    // height-neutral where the live section is held to settle (text turns, via
-    // the draining handshake). The textless / thinking-only completion path is
-    // still non-atomic (clears live before the committed footer mounts); that
-    // is tracked in the single-render-path convergence (#642), not asserted
-    // here.
+  it('reserves the footer placeholder inside the tail turn while it streams (#642)', async () => {
+    // #642 single render path: there is no longer a separate
+    // `.maka-turn-streaming` section — the in-flight answer rides the tail
+    // turn's own TurnView. While that turn is live (`props.liveStreaming`),
+    // its footer slot is a reserved-height placeholder (same `mt-0.5 h-8` box
+    // the real footer occupies), NOT the actionable TurnFooterActions: the
+    // live tail's derived status is `completed`, so a real footer would offer
+    // a clickable regenerate/branch on a still-streaming answer. Reserving the
+    // box keeps the live→settled swap height-neutral on the one node.
     const src = await readRepo('packages/ui/src/chat-view.tsx');
-    assert.match(
-      src,
-      /Unconditional \(not gated on streamingText\)[\s\S]*?\*\/\}\s*<div aria-hidden="true" className="mt-0\.5 h-8" \/>/,
-      'the footer placeholder must render unconditionally inside the live section (covers thinking-only turns)',
-    );
     assert.doesNotMatch(
       src,
-      /\{props\.streamingText && <div aria-hidden="true" className="mt-0\.5 h-8" \/>\}/,
-      'the placeholder must not be re-gated on streamingText alone — that misses thinking-only settle',
+      /maka-turn-streaming/,
+      'the separate streaming section must be gone — the tail turn owns the live answer',
+    );
+    assert.match(
+      src,
+      /props\.liveStreaming \? \([\s\S]*?<div aria-hidden="true" className="mt-0\.5 h-8" \/>[\s\S]*?\) : \(/,
+      'while live, the tail turn footer slot must be the reserved-height placeholder, not the real footer',
+    );
+    // The assistant answer block mounts for a live tail turn even with an empty
+    // committed timeline (thinking-only / textless), so its answer never
+    // disappears at settle.
+    assert.match(
+      src,
+      /const showAssistantMessage = turn\.timeline\.length > 0 \|\| !!props\.liveStreaming;/,
+      'the assistant Message must mount when the turn has timeline content OR is the live tail',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/design-system-governance-406-contract.test.ts
@@ -120,11 +120,10 @@ describe('issue #406 design-system governance contract', () => {
       // per-word entrance that signals freshly streamed text.
       'maka-text-shimmer',
       'maka-stream-fade-in',
-      // Handoff polish: the turn footer toolbar fades in when a live turn
-      // settles (opacity only, into an equal-height placeholder slot) —
-      // functional "the answer is final, actions are now available" signal,
-      // never applied on history-hydration mounts.
-      'maka-footer-fade-in',
+      // #642: the `maka-footer-fade-in` settle-entrance keyframe was retired.
+      // The footer no longer appears on settle — it is hidden by default and
+      // revealed on hover / focus-within of the answer block, so there is no
+      // live mount transition to animate.
       'maka-shimmer',
       'maka-status-spin',
       'maka-tool-pulse',

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -52,6 +52,79 @@ describe('assistant streaming handoff', () => {
     );
   });
 
+  it('renders the streaming answer inside the tail turn, not a separate section (#642)', () => {
+    const markup = renderChat({
+      messages: [{ type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' }],
+      streamingText: 'hello',
+      streamingComplete: false,
+    });
+    assert.doesNotMatch(markup, /maka-turn-streaming/, 'the separate streaming section is gone');
+    assert.match(markup, /data-turn-id="turn-1"/);
+    assert.match(markup, /data-live-streaming="true"/, 'the tail turn is flagged live for content-visibility');
+    assert.match(markup, /maka-bubble-streaming/, 'the live answer rides the tail turn');
+    assert.equal(
+      countOccurrences(markup, 'data-turn-id='),
+      1,
+      'exactly one turn node owns the whole streaming exchange (user bubble + live answer)',
+    );
+  });
+
+  it('suppresses the actionable footer while the tail turn streams (#642 R1)', () => {
+    const markup = renderChat({
+      messages: [{ type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' }],
+      streamingText: 'hello',
+      streamingComplete: false,
+      // Even when footer actions exist for the turn, a live tail must not render
+      // a clickable regenerate/branch — its derived status is `completed`.
+      turnFooterActionsByTurn: { 'turn-1': [{ id: 'regenerate', label: '重新生成', enabled: true }] },
+    });
+    assert.doesNotMatch(markup, /aria-label="本轮回答操作"/, 'no footer toolbar while live');
+    assert.doesNotMatch(markup, /重新生成/, 'no clickable regenerate on a still-streaming turn');
+    assert.match(markup, /aria-hidden="true" class="mt-0\.5 h-8"/, 'reserved-height footer placeholder instead');
+  });
+
+  it('renders the hover-gated footer once the turn has settled (#642)', () => {
+    const markup = renderChat({
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'done', modelId: 'model' },
+      ],
+      turnFooterActionsByTurn: { 'turn-1': [{ id: 'regenerate', label: '重新生成', enabled: true }] },
+    });
+    assert.match(markup, /aria-label="本轮回答操作"/, 'settled turn renders the real footer toolbar');
+    assert.match(markup, /group-hover\/answer:opacity-100/, 'the footer is revealed on hover of the answer block');
+    assert.match(markup, /重新生成/, 'the settled footer carries its actions');
+  });
+
+  it('renders committed steps and the live step in one tail-turn section (#642 multi-step)', () => {
+    const markup = renderChat({
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'step one', modelId: 'model' },
+      ],
+      streamingText: 'step two',
+      streamingComplete: false,
+    });
+    assert.match(markup, /step one/, 'the committed earlier step renders from the timeline');
+    assert.match(markup, /maka-bubble-streaming/, 'the in-flight step rides the same tail turn');
+    assert.equal(countOccurrences(markup, 'data-turn-id='), 1, 'committed + live steps share one turn node');
+  });
+
+  it('attaches the live answer to the last turn only (#642 tail selection)', () => {
+    const markup = renderChat({
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'first ask' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'first answer', modelId: 'model' },
+        { type: 'user', id: 'user-2', turnId: 'turn-2', ts: 3, text: 'second ask' },
+      ],
+      streamingText: 'second answer',
+      streamingComplete: false,
+    });
+    assert.equal(countOccurrences(markup, 'maka-bubble-streaming'), 1, 'only the tail turn streams');
+    assert.equal(countOccurrences(markup, 'data-live-streaming="true"'), 1, 'exactly one live turn node');
+    assert.equal(countOccurrences(markup, 'data-turn-id='), 2, 'both turns still render');
+  });
+
   it('text_complete replaces the live slot with the final draining text', () => {
     const current: AssistantStreamSlots = {
       'session-1': { text: 'part', truncated: true, phase: 'streaming', messageId: 'assistant-1' },
@@ -103,8 +176,16 @@ describe('assistant streaming handoff', () => {
     assert.doesNotMatch(completeCase, /if \(!deferMessageRefresh\) \{[\s\S]*refreshMessages\(sessionId\)/);
     assert.match(
       completeCase,
-      /refreshMessagesOptions = \{ requiredAssistantMessageId: slot\.messageId \};[\s\S]*void refreshSessions\(\);\s*void refreshMessages\(sessionId, refreshMessagesOptions\);/,
+      /refreshMessagesOptions = \{ requiredAssistantMessageId: slot\.messageId \};[\s\S]*void refreshSessions\(\);\s*\{\s*const refreshed = refreshMessages\(sessionId, refreshMessagesOptions\);/,
       'complete must refresh committed history for the draining assistant message without making every refresh use settle delays',
+    );
+    // #642: a textless / thinking-only completion holds the live buffer until
+    // that same refresh resolves (refresh-before-clear), so the tail turn's
+    // answer block never unmounts before the committed message lands.
+    assert.match(
+      completeCase,
+      /holdTextlessClear = true;[\s\S]*if \(holdTextlessClear\) void refreshed\.finally\(\(\) => clearStreaming\(sessionId\)\);/,
+      'textless complete must defer clearStreaming until after the committed refresh',
     );
   });
 
@@ -232,6 +313,40 @@ describe('assistant streaming handoff', () => {
     }
   });
 
+  it('holds a textless completion until the committed message lands, then clears (#642)', async () => {
+    // Thinking-only / textless turn: the tail turn's live 深度思考 must stay
+    // mounted until the committed (empty-text) assistant message is refreshed
+    // in, so the answer block never unmounts before it lands.
+    const staleMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+    ];
+    const committedMessages: StoredMessage[] = [
+      ...staleMessages,
+      { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: '', modelId: 'model' },
+    ];
+    const windowFixture = installReadMessagesWindow([staleMessages, committedMessages, committedMessages]);
+    try {
+      const harness = buildEventHarness({ text: '', truncated: false, phase: 'streaming', messageId: 'assistant-1' });
+      harness.handlers.handleEvent('session-1', {
+        type: 'text_complete', id: 'tc-1', turnId: 'turn-1', ts: 3, messageId: 'assistant-1', text: '',
+      } as SessionEvent);
+      await flushAsyncWork();
+
+      assert.ok(
+        harness.getMessages().some((message) => message.type === 'assistant' && message.id === 'assistant-1'),
+        'the committed message is refreshed in before the live buffer clears',
+      );
+      assert.equal(windowFixture.readCount(), 2, 'the refresh waited for the committed message');
+      assert.equal(
+        harness.getStreaming()['session-1']?.text,
+        '',
+        'the live buffer is cleared only after the committed refresh (refresh-before-clear)',
+      );
+    } finally {
+      windowFixture.restore();
+    }
+  });
+
   it('settled slot reducer keeps refresh-before-clear callers race-safe for a newer stream slot', () => {
     const settledSlot = { text: 'old final', truncated: false, phase: 'draining' as const, messageId: 'assistant-old' };
     const slots: AssistantStreamSlots = {
@@ -291,6 +406,32 @@ function countOccurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
+function renderChat(overrides: Partial<Parameters<typeof ChatView>[0]>): string {
+  const props: Parameters<typeof ChatView>[0] = {
+    activeSession: {
+      id: 'session-1',
+      name: 'handoff',
+      lastMessageAt: 1,
+      status: 'active',
+      backend: 'ai-sdk',
+      labels: [],
+      isFlagged: false,
+      isArchived: false,
+      hasUnread: false,
+      llmConnectionSlug: 'conn',
+      model: 'model',
+      permissionMode: 'ask',
+    },
+    messages: [],
+    streamingText: '',
+    tools: [],
+    mode: 'sessions',
+    onNew() {},
+    ...overrides,
+  };
+  return renderToStaticMarkup(createElement(ChatView, props));
+}
+
 function completeEvent(): SessionEvent {
   return {
     type: 'complete',
@@ -347,4 +488,63 @@ async function flushAsyncWork(): Promise<void> {
   for (let index = 0; index < 8; index += 1) {
     await Promise.resolve();
   }
+}
+
+function buildEventHarness(initialSlot: AssistantStreamSlot): {
+  handlers: ReturnType<typeof createAppShellSessionEventHandlers>;
+  getMessages: () => StoredMessage[];
+  getStreaming: () => Record<string, AssistantStreamSlot>;
+} {
+  const activeIdRef = { current: 'session-1' as string | undefined };
+  let messages: StoredMessage[] = [];
+  let streamingBySession: Record<string, AssistantStreamSlot> = { 'session-1': initialSlot };
+  const streamingBySessionRef = { current: streamingBySession };
+
+  const chatActions = createAppShellChatActions({
+    activeIdRef,
+    addPendingSessionAction: () => true,
+    captureComposerImportOwner: () => ({ sessionId: 'session-1', navSection: 'sessions' }),
+    clearPendingSessionAction: () => {},
+    isNewChatSendSurfaceActive: () => false,
+    markSessionReadLocally: () => {},
+    messageRetryPendingRef: { current: new Set<string>() },
+    refreshSessions: async () => [],
+    setActiveId: (sessionId) => {
+      activeIdRef.current = sessionId;
+    },
+    setMessageLoadErrorBySession: () => {},
+    setMessageRetryPendingBySession: () => {},
+    setMessages: (next) => {
+      messages = typeof next === 'function' ? next(messages) : next;
+    },
+    setNavSelection: () => {},
+    showModelSetupToast: () => {},
+    toastApi: { error: () => {} },
+    upsertSessionSummary: () => {},
+    validPendingNewChatModel: null,
+    pendingNewChatThinkingLevel: null,
+  });
+
+  const handlers = createAppShellSessionEventHandlers({
+    activeIdRef,
+    refreshMessages: chatActions.refreshMessages,
+    refreshSessions: async () => [],
+    setLiveToolsBySession: createStateSetter<Record<string, ToolActivityItem[]>>({}),
+    setPermissionBySession: createStateSetter<PermissionQueues>({}),
+    setStreamingBySession: (updater) => {
+      streamingBySession = updater(streamingBySession);
+      streamingBySessionRef.current = streamingBySession;
+    },
+    setThinkingBySession: createStateSetter<Record<string, string>>({}),
+    setThinkingTruncatedBySession: createStateSetter<Record<string, boolean>>({}),
+    showModelSetupToast: () => {},
+    streamingBySessionRef,
+    toastApi: { error: () => {} },
+  });
+
+  return {
+    handlers,
+    getMessages: () => messages,
+    getStreaming: () => streamingBySession,
+  };
 }

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -125,6 +125,37 @@ describe('assistant streaming handoff', () => {
     assert.equal(countOccurrences(markup, 'data-turn-id='), 2, 'both turns still render');
   });
 
+  it('shimmers an in-flight tool trow so the user can tell a tool is running (#642 issue 3)', () => {
+    // A live tool rides the tail turn's timeline (materializeTurns appends
+    // live-only tools to the last turn). Its trow summary must render the
+    // TextShimmer sweep — the SAME "working" light-band the 深度思考 title uses
+    // — for the whole run window. `running` covers pending too, since many
+    // non-streaming tools (read/edit/grep) never leave `pending` before their
+    // tool_result lands. A settled (completed) tool must NOT shimmer.
+    const runningMarkup = renderChat({
+      messages: [{ type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' }],
+      streamingText: '',
+      tools: [{ toolUseId: 't1', toolName: 'bash', intent: '运行一个耗时命令', status: 'running', args: {} }],
+    });
+    assert.equal(countOccurrences(runningMarkup, 'data-slot="text-shimmer"'), 1, 'a running tool trow shimmers');
+
+    const pendingMarkup = renderChat({
+      messages: [{ type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' }],
+      streamingText: '',
+      tools: [{ toolUseId: 't1', toolName: 'read', intent: '读取文件', status: 'pending', args: {} }],
+    });
+    assert.equal(countOccurrences(pendingMarkup, 'data-slot="text-shimmer"'), 1, 'a pending tool trow shimmers too');
+
+    const settledMarkup = renderChat({
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'done', modelId: 'model' },
+      ],
+      tools: [{ toolUseId: 't1', toolName: 'bash', intent: '运行一个耗时命令', status: 'completed', args: {}, durationMs: 1200 }],
+    });
+    assert.equal(countOccurrences(settledMarkup, 'data-slot="text-shimmer"'), 0, 'a completed tool trow does not shimmer');
+  });
+
   it('text_complete replaces the live slot with the final draining text', () => {
     const current: AssistantStreamSlots = {
       'session-1': { text: 'part', truncated: true, phase: 'streaming', messageId: 'assistant-1' },

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -156,6 +156,36 @@ describe('assistant streaming handoff', () => {
     assert.equal(countOccurrences(settledMarkup, 'data-slot="text-shimmer"'), 0, 'a completed tool trow does not shimmer');
   });
 
+  it('suppresses the actionable footer while only a tool is running, with no answer text (#642 review P2-B)', () => {
+    // A tool step can start (tool_start / running) before any answer text or
+    // thinking streams. The tail turn must still count as live so its footer is
+    // the reserved placeholder, NOT an actionable regenerate/branch on a
+    // still-running answer (whose derived status defaults to `completed`).
+    const running = renderChat({
+      messages: [{ type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' }],
+      streamingText: '',
+      tools: [{ toolUseId: 't1', toolName: 'bash', intent: '运行命令', status: 'running', args: {} }],
+      turnFooterActionsByTurn: { 'turn-1': [{ id: 'regenerate', label: '重新生成', enabled: true }] },
+    });
+    assert.equal(countOccurrences(running, 'data-live-streaming="true"'), 1, 'the tool-only tail turn is still marked live');
+    assert.doesNotMatch(running, /aria-label="本轮回答操作"/, 'no actionable footer toolbar while a tool runs');
+    assert.doesNotMatch(running, /重新生成/, 'regenerate must not be clickable on a still-running answer');
+
+    // Once the tool settles and the answer commits, the real footer returns —
+    // the guard must not over-suppress the footer on a genuinely finished turn.
+    const settled = renderChat({
+      messages: [
+        { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+        { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: 'done', modelId: 'model' },
+      ],
+      streamingText: '',
+      tools: [{ toolUseId: 't1', toolName: 'bash', intent: '运行命令', status: 'completed', args: {}, durationMs: 100 }],
+      turnFooterActionsByTurn: { 'turn-1': [{ id: 'regenerate', label: '重新生成', enabled: true }] },
+    });
+    assert.match(settled, /aria-label="本轮回答操作"/, 'a settled turn with a completed tool shows the real footer');
+    assert.equal(countOccurrences(settled, 'data-live-streaming="true"'), 0, 'a settled turn is not marked live');
+  });
+
   it('text_complete replaces the live slot with the final draining text', () => {
     const current: AssistantStreamSlots = {
       'session-1': { text: 'part', truncated: true, phase: 'streaming', messageId: 'assistant-1' },
@@ -212,11 +242,13 @@ describe('assistant streaming handoff', () => {
     );
     // #642: a textless / thinking-only completion holds the live buffer until
     // that same refresh resolves (refresh-before-clear), so the tail turn's
-    // answer block never unmounts before the committed message lands.
+    // answer block never unmounts before the committed message lands. The
+    // deferred clear is identity-guarded (review P2-A) so a newer turn started
+    // during the refresh isn't wiped.
     assert.match(
       completeCase,
-      /holdTextlessClear = true;[\s\S]*if \(holdTextlessClear\) void refreshed\.finally\(\(\) => clearStreaming\(sessionId\)\);/,
-      'textless complete must defer clearStreaming until after the committed refresh',
+      /heldTextless = \{[\s\S]*if \(heldTextless\) \{[\s\S]*void refreshed\.finally\(\(\) => clearStreamingIfCurrent\(sessionId, held\)\);/,
+      'textless complete must defer an identity-guarded clear until after the committed refresh',
     );
   });
 
@@ -324,6 +356,7 @@ describe('assistant streaming handoff', () => {
         setThinkingTruncatedBySession: createStateSetter<Record<string, boolean>>({}),
         showModelSetupToast: () => {},
         streamingBySessionRef,
+        thinkingBySessionRef: { current: {} as Record<string, string> },
         toastApi: { error: () => {} },
       });
 
@@ -373,6 +406,89 @@ describe('assistant streaming handoff', () => {
         '',
         'the live buffer is cleared only after the committed refresh (refresh-before-clear)',
       );
+    } finally {
+      windowFixture.restore();
+    }
+  });
+
+  it('deferred textless clear does not wipe a newer turn that took over the slot (#642 review P2-A)', async () => {
+    // Turn-1 is thinking-only: its text_complete schedules a refresh-before-clear.
+    // Before that async refresh resolves, the user sends turn-2 whose first
+    // text_delta takes over the session's live slot with a new messageId. The
+    // deferred clear must recognise the slot is no longer turn-1's and leave
+    // turn-2's answer intact (the pre-P2-A unguarded clearStreaming blanked it).
+    const committedMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+      { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: '', modelId: 'model' },
+    ];
+    const windowFixture = installReadMessagesWindow([committedMessages, committedMessages, committedMessages]);
+    try {
+      const harness = buildEventHarness(
+        { text: '', truncated: false, phase: 'streaming', messageId: 'assistant-1' },
+        { 'session-1': 'turn-1 reasoning' },
+      );
+      harness.handlers.handleEvent('session-1', {
+        type: 'text_complete', id: 'tc-1', turnId: 'turn-1', ts: 3, messageId: 'assistant-1', text: '',
+      } as SessionEvent);
+      // turn-2 starts before the refresh resolves — a new step's messageId.
+      harness.handlers.handleEvent('session-1', {
+        type: 'text_delta', id: 'td-2', turnId: 'turn-2', ts: 4, messageId: 'assistant-2', text: 'turn-2 answer',
+      } as SessionEvent);
+      await flushAsyncWork();
+
+      assert.equal(harness.getStreaming()['session-1']?.text, 'turn-2 answer', 'the newer turn answer survives');
+      assert.equal(harness.getStreaming()['session-1']?.messageId, 'assistant-2', 'the newer slot identity is untouched');
+    } finally {
+      windowFixture.restore();
+    }
+  });
+
+  it('deferred textless clear does not wipe a newer turn thinking (#642 review P2-A)', async () => {
+    const committedMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+      { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: '', modelId: 'model' },
+    ];
+    const windowFixture = installReadMessagesWindow([committedMessages, committedMessages, committedMessages]);
+    try {
+      const harness = buildEventHarness(
+        { text: '', truncated: false, phase: 'streaming', messageId: 'assistant-1' },
+        { 'session-1': 'turn-1 reasoning' },
+      );
+      harness.handlers.handleEvent('session-1', {
+        type: 'text_complete', id: 'tc-1', turnId: 'turn-1', ts: 3, messageId: 'assistant-1', text: '',
+      } as SessionEvent);
+      // turn-2 is thinking-only: its reasoning must not be clobbered by clearThinking.
+      harness.handlers.handleEvent('session-1', {
+        type: 'thinking_delta', id: 'th-2', turnId: 'turn-2', ts: 4, text: 'turn-2 reasoning',
+      } as SessionEvent);
+      await flushAsyncWork();
+
+      assert.match(harness.getThinking()['session-1'] ?? '', /turn-2 reasoning/, 'the newer turn reasoning survives');
+    } finally {
+      windowFixture.restore();
+    }
+  });
+
+  it('deferred textless clear still clears the turn buffer when no newer turn raced in (#642 review P2-A control)', async () => {
+    // Positive control: the identity guard must NOT break the normal path — with
+    // no racing turn-2, the held snapshot still matches, so the live thinking is
+    // cleared after the committed message lands (no stale reasoning left behind).
+    const committedMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
+      { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: '', modelId: 'model' },
+    ];
+    const windowFixture = installReadMessagesWindow([committedMessages, committedMessages, committedMessages]);
+    try {
+      const harness = buildEventHarness(
+        { text: '', truncated: false, phase: 'streaming', messageId: 'assistant-1' },
+        { 'session-1': 'turn-1 reasoning' },
+      );
+      harness.handlers.handleEvent('session-1', {
+        type: 'text_complete', id: 'tc-1', turnId: 'turn-1', ts: 3, messageId: 'assistant-1', text: '',
+      } as SessionEvent);
+      await flushAsyncWork();
+
+      assert.equal(harness.getThinking()['session-1'], '', 'turn-1 reasoning is cleared once its committed message lands');
     } finally {
       windowFixture.restore();
     }
@@ -521,15 +637,21 @@ async function flushAsyncWork(): Promise<void> {
   }
 }
 
-function buildEventHarness(initialSlot: AssistantStreamSlot): {
+function buildEventHarness(
+  initialSlot: AssistantStreamSlot,
+  initialThinking: Record<string, string> = {},
+): {
   handlers: ReturnType<typeof createAppShellSessionEventHandlers>;
   getMessages: () => StoredMessage[];
   getStreaming: () => Record<string, AssistantStreamSlot>;
+  getThinking: () => Record<string, string>;
 } {
   const activeIdRef = { current: 'session-1' as string | undefined };
   let messages: StoredMessage[] = [];
   let streamingBySession: Record<string, AssistantStreamSlot> = { 'session-1': initialSlot };
   const streamingBySessionRef = { current: streamingBySession };
+  let thinkingBySession: Record<string, string> = { ...initialThinking };
+  const thinkingBySessionRef = { current: thinkingBySession };
 
   const chatActions = createAppShellChatActions({
     activeIdRef,
@@ -566,10 +688,14 @@ function buildEventHarness(initialSlot: AssistantStreamSlot): {
       streamingBySession = updater(streamingBySession);
       streamingBySessionRef.current = streamingBySession;
     },
-    setThinkingBySession: createStateSetter<Record<string, string>>({}),
+    setThinkingBySession: (updater) => {
+      thinkingBySession = updater(thinkingBySession);
+      thinkingBySessionRef.current = thinkingBySession;
+    },
     setThinkingTruncatedBySession: createStateSetter<Record<string, boolean>>({}),
     showModelSetupToast: () => {},
     streamingBySessionRef,
+    thinkingBySessionRef,
     toastApi: { error: () => {} },
   });
 
@@ -577,5 +703,6 @@ function buildEventHarness(initialSlot: AssistantStreamSlot): {
     handlers,
     getMessages: () => messages,
     getStreaming: () => streamingBySession,
+    getThinking: () => thinkingBySession,
   };
 }

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -48,6 +48,7 @@ export function createAppShellSessionEventHandlers(options: {
   setThinkingTruncatedBySession: StateUpdater<Record<string, boolean>>;
   showModelSetupToast: (description: string, reason?: string) => void;
   streamingBySessionRef: RefBox<Record<string, AssistantStreamSlot>>;
+  thinkingBySessionRef: RefBox<Record<string, string>>;
   toastApi: ToastApi;
   /** Report a terminal turn to the main process, which decides whether
    * to raise an OS notification (gated on a product toggle + window
@@ -67,6 +68,7 @@ export function createAppShellSessionEventHandlers(options: {
     setThinkingTruncatedBySession,
     showModelSetupToast,
     streamingBySessionRef,
+    thinkingBySessionRef,
     toastApi,
     notifyRunEnded,
   } = options;
@@ -101,6 +103,51 @@ export function createAppShellSessionEventHandlers(options: {
     clearThinking(sessionId);
   }
 
+  /**
+   * #642 review P2-A: the deferred textless clear (refresh-before-clear) must not
+   * clobber a NEWER turn's live buffer if the async refresh resolves after the
+   * user has already started the next turn. Unlike the text path's
+   * `clearSettledAssistantStreamSlot` (guarded by messageId + draining phase), the
+   * textless path has no draining slot, so we snapshot the turn's identity at
+   * schedule time and clear only the parts that are still this turn's:
+   *  - the streaming slot, only if its messageId still matches the snapshot (a
+   *    newer text step sets a different messageId), and
+   *  - the thinking buffer, only if it is still byte-identical to the snapshot (a
+   *    newer thinking step appends/replaces the string, so any change means the
+   *    reasoning on screen is no longer this turn's).
+   * The plain `clearStreaming` above is unguarded and stays the right choice for
+   * synchronous callers (abort / error), which run before any next turn exists.
+   */
+  function clearStreamingIfCurrent(
+    sessionId: string,
+    held: { messageId?: string; slot?: AssistantStreamSlot; thinking?: string },
+  ) {
+    setStreamingBySession((current) => {
+      const prev = current[sessionId];
+      if (!prev || (prev.text === '' && prev.truncated === false)) return current;
+      const stillOurs = held.messageId !== undefined
+        ? prev.messageId === held.messageId
+        : prev === held.slot;
+      if (!stillOurs) return current;
+      return { ...current, [sessionId]: { text: '', truncated: false, phase: 'streaming' } };
+    });
+    let clearedThinking = false;
+    setThinkingBySession((current) => {
+      const prev = current[sessionId];
+      if (!prev || prev !== held.thinking) return current;
+      clearedThinking = true;
+      return { ...current, [sessionId]: '' };
+    });
+    if (clearedThinking) {
+      setThinkingTruncatedBySession((current) => {
+        if (!current[sessionId]) return current;
+        const next = { ...current };
+        delete next[sessionId];
+        return next;
+      });
+    }
+  }
+
   function drainAssistantStreaming(sessionId: string, text: string, messageId?: string) {
     const applied = applyAssistantComplete(text);
     if (!applied.text) {
@@ -111,9 +158,16 @@ export function createAppShellSessionEventHandlers(options: {
       // Refresh the committed message in FIRST (gated on `messageId` when the
       // runtime gave one), THEN clear, so the block stays mounted across the
       // swap. (Text turns get this via the draining→settle handshake instead.)
+      // Snapshot this turn's live identity now so the async clear can't wipe a
+      // newer turn that started before the refresh resolved (review P2-A).
+      const held = {
+        messageId,
+        slot: streamingBySessionRef.current[sessionId],
+        thinking: thinkingBySessionRef.current[sessionId],
+      };
       void refreshMessages(sessionId, messageId ? { requiredAssistantMessageId: messageId } : undefined)
         .catch(() => false)
-        .finally(() => clearStreaming(sessionId));
+        .finally(() => clearStreamingIfCurrent(sessionId, held));
       return;
     }
     setStreamingBySession((current) => drainAssistantStreamSlot(current, sessionId, applied, messageId));
@@ -480,7 +534,7 @@ export function createAppShellSessionEventHandlers(options: {
         break;
       case 'complete':
         let refreshMessagesOptions: RefreshMessagesOptions | undefined;
-        let holdTextlessClear = false;
+        let heldTextless: { messageId?: string; slot?: AssistantStreamSlot; thinking?: string } | undefined;
         if (event.stopReason !== 'permission_handoff') {
           const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
@@ -494,8 +548,14 @@ export function createAppShellSessionEventHandlers(options: {
             // the tail turn's live 深度思考 mounted until the committed message
             // lands via the refresh below, so a textless / thinking-only turn
             // doesn't drop its assistant block for a frame (unmount gap on the
-            // shared single node). Cleared once the refresh resolves.
-            holdTextlessClear = true;
+            // shared single node). Snapshot this turn's identity so the deferred
+            // clear can't wipe a newer turn's buffer (review P2-A); cleared once
+            // the refresh resolves.
+            heldTextless = {
+              messageId: slot?.messageId,
+              slot,
+              thinking: thinkingBySessionRef.current[sessionId],
+            };
           }
           // PR-PERMISSION-UI-CLEANUP-0: parallel the `abort` branch
           // above — drop any stranded permission request for this
@@ -520,8 +580,12 @@ export function createAppShellSessionEventHandlers(options: {
           const refreshed = refreshMessages(sessionId, refreshMessagesOptions);
           void refreshed.catch(() => false);
           // #642: clear the held live buffer only AFTER the committed message
-          // has been refreshed in (textless / thinking-only completion).
-          if (holdTextlessClear) void refreshed.finally(() => clearStreaming(sessionId));
+          // has been refreshed in (textless / thinking-only completion), and only
+          // if this turn's buffer is still current (review P2-A).
+          if (heldTextless) {
+            const held = heldTextless;
+            void refreshed.finally(() => clearStreamingIfCurrent(sessionId, held));
+          }
         }
         break;
       default:

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -104,8 +104,16 @@ export function createAppShellSessionEventHandlers(options: {
   function drainAssistantStreaming(sessionId: string, text: string, messageId?: string) {
     const applied = applyAssistantComplete(text);
     if (!applied.text) {
-      clearStreaming(sessionId);
-      void refreshMessages(sessionId);
+      // #642 refresh-before-clear: a textless / thinking-only turn has no answer
+      // bubble to hold the tail turn's assistant block open, so clearing the
+      // live buffer first would drop the live 深度思考 for a frame before the
+      // committed message lands — an unmount gap on the now-shared single node.
+      // Refresh the committed message in FIRST (gated on `messageId` when the
+      // runtime gave one), THEN clear, so the block stays mounted across the
+      // swap. (Text turns get this via the draining→settle handshake instead.)
+      void refreshMessages(sessionId, messageId ? { requiredAssistantMessageId: messageId } : undefined)
+        .catch(() => false)
+        .finally(() => clearStreaming(sessionId));
       return;
     }
     setStreamingBySession((current) => drainAssistantStreamSlot(current, sessionId, applied, messageId));
@@ -472,6 +480,7 @@ export function createAppShellSessionEventHandlers(options: {
         break;
       case 'complete':
         let refreshMessagesOptions: RefreshMessagesOptions | undefined;
+        let holdTextlessClear = false;
         if (event.stopReason !== 'permission_handoff') {
           const slot = streamingBySessionRef.current[sessionId];
           if (slot?.text) {
@@ -481,7 +490,12 @@ export function createAppShellSessionEventHandlers(options: {
               refreshMessagesOptions = { requiredAssistantMessageId: slot.messageId };
             }
           } else {
-            clearStreaming(sessionId);
+            // #642 refresh-before-clear (mirrors drainAssistantStreaming): hold
+            // the tail turn's live 深度思考 mounted until the committed message
+            // lands via the refresh below, so a textless / thinking-only turn
+            // doesn't drop its assistant block for a frame (unmount gap on the
+            // shared single node). Cleared once the refresh resolves.
+            holdTextlessClear = true;
           }
           // PR-PERMISSION-UI-CLEANUP-0: parallel the `abort` branch
           // above — drop any stranded permission request for this
@@ -502,7 +516,13 @@ export function createAppShellSessionEventHandlers(options: {
           }
         }
         void refreshSessions();
-        void refreshMessages(sessionId, refreshMessagesOptions);
+        {
+          const refreshed = refreshMessages(sessionId, refreshMessagesOptions);
+          void refreshed.catch(() => false);
+          // #642: clear the held live buffer only AFTER the committed message
+          // has been refreshed in (textless / thinking-only completion).
+          if (holdTextlessClear) void refreshed.finally(() => clearStreaming(sessionId));
+        }
         break;
       default:
         break;

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -88,12 +88,17 @@ export function createAppShellSessionUiStateController(
 ) {
   let currentState = initialState;
   const streamingBySessionRef = { current: currentState.streamingBySession };
+  // Live thinking has no per-turn identity in state (it's a plain string buffer),
+  // so a deferred #642 textless refresh-before-clear needs a synchronous snapshot
+  // of it at schedule time to avoid wiping a newer turn's reasoning (review P2-A).
+  const thinkingBySessionRef = { current: currentState.thinkingBySession };
   const sessionEventHealthBySessionRef = { current: currentState.sessionEventHealthBySession };
 
   function replaceState(next: AppShellSessionUiState): void {
     if (next === currentState) return;
     currentState = next;
     streamingBySessionRef.current = next.streamingBySession;
+    thinkingBySessionRef.current = next.thinkingBySession;
     sessionEventHealthBySessionRef.current = next.sessionEventHealthBySession;
     onChange(next);
   }
@@ -115,6 +120,7 @@ export function createAppShellSessionUiStateController(
   return {
     getState: () => currentState,
     streamingBySessionRef,
+    thinkingBySessionRef,
     sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession: createMapSetter('messageLoadErrorBySession'),
     setMessageRetryPendingBySession: createMapSetter('messageRetryPendingBySession'),
@@ -149,6 +155,7 @@ export function useAppShellSessionUiState() {
   return {
     state: controller.getState(),
     streamingBySessionRef: controller.streamingBySessionRef,
+    thinkingBySessionRef: controller.thinkingBySessionRef,
     sessionEventHealthBySessionRef: controller.sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession: controller.setMessageLoadErrorBySession,
     setMessageRetryPendingBySession: controller.setMessageRetryPendingBySession,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -200,6 +200,7 @@ export function AppShell({
   const {
     state: sessionUiState,
     streamingBySessionRef,
+    thinkingBySessionRef,
     sessionEventHealthBySessionRef,
     setMessageLoadErrorBySession,
     setMessageRetryPendingBySession,
@@ -987,6 +988,7 @@ export function AppShell({
     setThinkingTruncatedBySession,
     showModelSetupToast,
     streamingBySessionRef,
+    thinkingBySessionRef,
     toastApi,
     notifyRunEnded: ({ kind, sessionId, body }) => {
       const title = sessionsRef.current.find((session) => session.id === sessionId)?.name;

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1211,9 +1211,15 @@
     contain-intrinsic-size: auto 250px;
   }
 
-  /* The streaming turn must never be skipped: it grows every frame and
-     anchors the auto-scroll-to-bottom behavior. */
-  .maka-turn-streaming {
+  /* #642 single render path: the streaming answer now rides the tail turn's
+     own `.maka-turn` node (not a separate `.maka-turn-streaming` section), so
+     the content-visibility override keys off the `data-live-streaming` hook
+     the tail turn carries. It must never be skipped: it grows every frame and
+     anchors the auto-scroll-to-bottom behavior. The old `.maka-turn-streaming`
+     box + `margin-top` position-parity rule is gone: the tail turn is already
+     spaced by its parent `.maka-turn` gap, so there is no out-of-band section
+     to re-align. */
+  .maka-turn[data-live-streaming="true"] {
     content-visibility: visible;
   }
 
@@ -1222,25 +1228,6 @@
      now render inline via the flat `ToolTrow` and reasoning via the
      `DeepThinking` disclosure, both Tailwind-literal + the `TextShimmer`
      primitive — see packages/ui/src/tool-activity.tsx and chat-view.tsx. */
-
-  /* The streaming bubble (out-of-band, before the in-progress turn is
-   * fully persisted) sits at the bottom of the chat surface; give it the
-   * same horizontal frame as a real turn message. */
-  .maka-turn-streaming {
-    /* maka-message-row already handles padding; this just keeps the
-       in-progress assistant streaming-row visually separated from any
-       previous turn while it lands. */
-    box-sizing: border-box;
-    /* Streaming-settle position parity: the committed answer sits one
-       within-turn gap (12px, `.maka-turn { gap: var(--space-3) }`) below the
-       user row, but this out-of-band section used to butt flush against the
-       committed turn above it (sections have no parent gap). The 12px
-       mismatch made the answer text jump DOWN by exactly that much the frame
-       the stream settled into the committed turn. Matching the gap here means
-       the streaming text renders at the same y it will occupy once committed,
-       so the swap is position-neutral. */
-    margin-top: var(--space-3);
-  }
 
   /* ---- Tool activity ---------------------------------------------- */
 
@@ -1493,18 +1480,11 @@
   animation: maka-stream-fade-in var(--duration-large) var(--ease-out-strong) both;
 }
 
-/* Turn footer toolbar settle entrance (streaming UI rework, handoff polish).
-   `from`-only on purpose: the footer's steady state is its own cascaded
-   opacity (0.72 quiet, 1 on hover), so the animation must fade from 0 up to
-   the element's natural value and then get out of the way — an explicit
-   `to { opacity: 1 }` with fill `both` would pin the toolbar at full opacity
-   forever and defeat the quiet/hover treatment. Applied by chat-view's
-   TurnFooterActions only when the footer appears on an already-mounted turn
-   (a live settle); history hydration mounts don't animate. Reduced-motion /
-   visual-smoke globals in base.css collapse it. */
-@keyframes maka-footer-fade-in {
-  from { opacity: 0; }
-}
+/* #642: the footer settle-entrance keyframe (`maka-footer-fade-in`) is gone.
+   The footer no longer "appears" on settle — it is hidden by default and
+   revealed on hover / focus-within of the answer block (see the `footer`
+   marker variant in packages/ui/src/primitives/chat.tsx), so there is no live
+   mount transition to animate. */
 .maka-shimmer {
   background-image: linear-gradient(
     90deg,

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -37,6 +37,21 @@ export function formatAbsoluteTimestamp(ts: number): string {
   return createAbsoluteTimeFormat().format(new Date(ts));
 }
 
+function createClockTimeFormat(): Intl.DateTimeFormat {
+  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+    return { format: (d: Date) => d.toISOString().slice(11, 16) } as unknown as Intl.DateTimeFormat;
+  }
+  return new Intl.DateTimeFormat(
+    detectUiLocale() === 'en' ? 'en' : 'zh-CN',
+    { hour: '2-digit', minute: '2-digit', hour12: false },
+  );
+}
+
+/** Wall-clock `HH:mm` (24-hour), for the always-absolute user-message time. */
+export function formatClockTime(ts: number): string {
+  return createClockTimeFormat().format(new Date(ts));
+}
+
 export function formatTurnDuration(ms: number): string {
   // Same shape as tool-activity's formatDuration — the turn meta chip
   // and tool cards sit stacked in one view;「1 m 0 s」vs「8.2s」read as

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -322,7 +322,19 @@ export function ChatView(props: {
   // timeline — as `turns[last]`. Only the tail TurnView gets a fresh
   // `liveStreaming` object per delta (→ it alone re-renders); every sibling
   // gets a stable `undefined` and its memo skips (the plain-text perf path).
-  const streamingActive = !!(props.streamingText || props.thinkingText);
+  // A turn is "still live" — and must keep its non-actionable footer placeholder
+  // instead of a clickable regenerate/branch — while ANY of text, thinking, OR a
+  // tool is in flight. Deriving liveness from streamingText/thinkingText alone
+  // let a tool-only step (tool_start with no answer text yet) fall through to the
+  // settled branch, whose derived status is `completed`, rendering an actionable
+  // footer on a still-running answer (review P2-B). LiveStreamingEntries already
+  // no-ops when text and thinking are both empty, so a tool-only tail renders the
+  // running tool from its timeline with no empty live bubble.
+  const hasInFlightTool = props.tools.some(
+    (tool) =>
+      tool.status === 'running' || tool.status === 'pending' || tool.status === 'waiting_permission',
+  );
+  const streamingActive = !!(props.streamingText || props.thinkingText || hasInFlightTool);
   const tailTurnId = streamingActive ? turns[turns.length - 1]?.turnId : undefined;
   // One rail tick per turn that carries a user prompt (Codex-style prompt
   // navigation). Memoized so the rail's IntersectionObserver isn't rebuilt

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -1599,9 +1599,10 @@ function DeepThinking(props: { text: string; live: boolean; truncated?: boolean 
             已截断
           </span>
         )}
-        {/* Quiet trailing chevron: rides in on hover / open, matching the tool
-            trow rows. No always-on affordance so the folded row stays calm. */}
-        <span className="ml-auto inline-flex shrink-0 items-center text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
+        {/* Quiet chevron sits right after the label (near the text, not pinned
+            to the far edge), rides in on hover / open, matching the tool trow
+            rows. No always-on affordance so the folded row stays calm. */}
+        <span className="inline-flex shrink-0 items-center text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
           <ChevronRight
             size={14}
             strokeWidth={2}
@@ -1627,7 +1628,11 @@ function DeepThinking(props: { text: string; live: boolean; truncated?: boolean 
             </pre>
           ) : (
             <>
-              <div className="whitespace-pre-wrap [word-break:break-word] text-[length:var(--font-size-caption)] leading-normal text-[color:var(--muted-foreground)]">
+              {/* Same `max-h-64 overflow-y-auto` bound as the live `<pre>` above
+                  so an expanded panel doesn't jump taller the frame thinking
+                  settles (live→settled swaps this body in place). Long reasoning
+                  stays a compact scroll box in both states. */}
+              <div className="max-h-64 overflow-y-auto whitespace-pre-wrap [word-break:break-word] text-[length:var(--font-size-caption)] leading-normal text-[color:var(--muted-foreground)]">
                 {props.text}
               </div>
               <div className="absolute right-0 top-0 opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/reasoning:opacity-100 focus-within:opacity-100">

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -19,7 +19,7 @@ import {
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
-import { formatAbsoluteTimestamp, turnAbortMarkerLabel } from './chat-display-helpers.js';
+import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from './chat-display-helpers.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { tokenizeFade, useStreamFade, type StreamFade } from './stream-fade.js';
@@ -72,7 +72,6 @@ function ModulePanelFallback(props: { message: string }) {
     </div>
   );
 }
-import { RelativeTime } from './relative-time.js';
 import { ToolTrow } from './tool-activity.js';
 
 /**
@@ -778,12 +777,13 @@ function AttachmentImage(props: { attachment: AttachmentRef }) {
 const MessageBody = memo(function MessageBody(props: { role: string; text: string; ts?: number; attachments?: readonly AttachmentRef[] }) {
   if (props.role === 'user') {
     // User turn: the message sits in a tinted, width-capped block aligned to
-    // the right (so the right-anchor reads even for long messages), with a
-    // quiet always-visible time + a copy affordance in a meta row beneath it.
-    // The time is no longer hover-gated (was `opacity: 0` until hover, which
-    // hid it from touch + assistive tech). Copy reuses MessageCopyButton in
-    // `footerStyle`, so it's the same quiet ghost action as the assistant
-    // turn footer's copy (same primitive + `markerVariants('footer-action')`).
+    // the right (so the right-anchor reads even for long messages), with an
+    // absolute HH:mm time + a copy affordance in a meta row beneath it. #642:
+    // the whole meta row is hover-gated on the user bubble (`group/usermsg`) —
+    // hidden at rest, revealed on hover / focus-within, matching the assistant
+    // footer's hover reveal. Copy reuses MessageCopyButton in `footerStyle`, so
+    // it's the same quiet ghost action as the assistant turn footer's copy
+    // (same primitive + `markerVariants('footer-action')`).
     return (
       <>
         <Bubble variant="user">
@@ -805,17 +805,22 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
             </div>
           ) : null}
         </Bubble>
-        <div className="maka-message-meta">
+        {/* #642: the whole meta row — absolute HH:mm time + copy — hides by
+            default and appears when the user bubble is hovered or keyboard
+            focus lands inside (keys off `group/usermsg` on the user Message).
+            Absolute wall-clock time (not relative "N 小时前"); the full date
+            stays on the time's `title` and the bubble's own `title`. */}
+        <div className="maka-message-meta opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/usermsg:opacity-100 focus-within:opacity-100">
           {props.ts !== undefined && (
-            <RelativeTime ts={props.ts} className="maka-message-time-inline" />
+            <small
+              className="maka-message-time-inline tabular-nums"
+              aria-hidden="true"
+              title={formatAbsoluteTimestamp(props.ts)}
+            >
+              {formatClockTime(props.ts)}
+            </small>
           )}
-          {/* #642: copy hides by default, appears when the user bubble is
-              hovered or focus lands inside (keys off `group/usermsg` on the
-              user Message). The time stays always-visible (a11y: it must reach
-              touch + assistive tech, see the role==='user' note above). */}
-          <span className="opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/usermsg:opacity-100 focus-within:opacity-100">
-            <MessageCopyButton text={props.text} footerStyle />
-          </span>
+          <MessageCopyButton text={props.text} footerStyle />
         </div>
       </>
     );

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -314,6 +314,17 @@ export function ChatView(props: {
   const storedTools = useMemo(() => materializeTools(visibleMessages), [visibleMessages]);
   const tools = useMemo(() => mergeTools(storedTools, props.tools), [storedTools, props.tools]);
   const turns = useMemo(() => materializeTurns(visibleMessages, props.tools), [visibleMessages, props.tools]);
+  // #642 single render path: the in-flight answer is injected into the tail
+  // turn's TurnView (the SAME node as the eventual committed turn) instead of a
+  // separate streaming <section>, so live→settled is a data-source swap, not an
+  // unmount/mount. The streaming turn is always the last turn: the user message
+  // is committed optimistically (showOptimisticUserMessage) before streaming
+  // starts, so `materializeTurns` already emits it — with an empty assistant
+  // timeline — as `turns[last]`. Only the tail TurnView gets a fresh
+  // `liveStreaming` object per delta (→ it alone re-renders); every sibling
+  // gets a stable `undefined` and its memo skips (the plain-text perf path).
+  const streamingActive = !!(props.streamingText || props.thinkingText);
+  const tailTurnId = streamingActive ? turns[turns.length - 1]?.turnId : undefined;
   // One rail tick per turn that carries a user prompt (Codex-style prompt
   // navigation). Memoized so the rail's IntersectionObserver isn't rebuilt
   // on every render.
@@ -622,7 +633,7 @@ export function ChatView(props: {
               )
             )
           )}
-          {turns.map((turn, idx) => {
+          {turns.map((turn) => {
             return (
               <TurnView
                 key={turn.turnId}
@@ -635,83 +646,40 @@ export function ChatView(props: {
                 lineageBadges={props.turnLineageBadgesByTurn?.[turn.turnId]}
                 onLineageBadgeClick={stableLineageBadgeClick}
                 searchHighlighted={highlightedTurnId === turn.turnId}
+                liveStreaming={
+                  turn.turnId === tailTurnId
+                    ? {
+                        streamingText: props.streamingText ?? '',
+                        thinkingText: props.thinkingText,
+                        streamingComplete: props.streamingComplete,
+                        streamingTruncated: props.streamingTruncated,
+                        thinkingTruncated: props.thinkingTruncated,
+                        onStreamingSettled: props.onStreamingSettled,
+                      }
+                    : undefined
+                }
               />
             );
           })}
-          {(props.streamingText || props.thinkingText) && (
-            // PR-STREAM-TURN-CENTER: the in-flight answer must use the SAME
-            // `.maka-turn` shell a committed turn uses. `.maka-turn` owns the
-            // centered 680px reading column (max-width + margin:0 auto). A bare
-            // `.message.assistant` instead left-aligns — its unlayered
-            // margin-right:auto outranks `.maka-message-row`'s margin:0 auto —
-            // so without this wrapper the streaming answer rendered ~110px left
-            // of where it lands once committed, a visible horizontal jump on
-            // text_complete. Wrapping here makes streaming structurally
-            // identical to TurnView's committed turn.
-            <section className="maka-turn maka-turn-streaming">
-              <Message variant="assistant">
-                {/* Same `flex flex-col gap-2` timeline wrapper a committed turn
-                    uses (TurnView), so the live 深度思考 + answer share the exact
-                    spacing rhythm and chrome as the settled timeline — the two
-                    DeepThinking sites are structurally identical. */}
+          {/* #642 fallback: streaming began before the optimistic user turn
+              materialized (rare — e.g. an event replay while messages are still
+              loading), so there is no tail turn to inject into. Render the live
+              answer in a bare `.maka-turn` so it isn't dropped. Mutually
+              exclusive with the tail injection above (only fires when
+              `tailTurnId` is undefined), so the answer never double-renders. */}
+          {streamingActive && !tailTurnId && (
+            <section className="maka-turn" data-live-streaming="true">
+              <Message variant="assistant" className="group/answer">
                 <div className="flex flex-col gap-2">
-                  {/* PR-UI-LAYOUT-42: Reasoning panel for Anthropic-style
-                   * extended thinking. Renders ABOVE the streaming
-                   * answer because thinking always precedes the
-                   * answer. Default-open during streaming so the user
-                   * sees the model reasoning; users can collapse it
-                   * if too verbose. The panel disappears entirely on
-                   * text_complete / abort / error (parent clears the
-                   * thinkingBySession entry). */}
-                  {props.thinkingText && (
-                    <DeepThinking
-                      text={props.thinkingText}
-                      live={!props.streamingText}
-                      truncated={props.thinkingTruncated === true}
-                    />
-                  )}
-                  {props.streamingText && (
-                    <StreamingAssistantBubble
-                      text={props.streamingText}
-                      live={props.streamingComplete !== true}
-                      truncated={props.streamingTruncated === true}
-                      onSettled={props.onStreamingSettled}
-                    />
-                  )}
+                  <LiveStreamingEntries
+                    streamingText={props.streamingText ?? ''}
+                    thinkingText={props.thinkingText}
+                    streamingComplete={props.streamingComplete}
+                    streamingTruncated={props.streamingTruncated}
+                    thinkingTruncated={props.thinkingTruncated}
+                    onStreamingSettled={props.onStreamingSettled}
+                  />
                 </div>
-                {/* Equal-height placeholder for the turn footer toolbar
-                    (TurnFooterActions: mt-0.5 + h-8 buttons). The committed
-                    turn mounts a footer the live section doesn't have; in a
-                    bottom-pinned chat that extra row used to re-anchor the
-                    scroll and shift the whole conversation up by the footer
-                    height at the settle swap. Reserving the same box here
-                    makes the swap height-neutral — the real footer then only
-                    fades in (opacity, no layout). Outside the gap-2 timeline
-                    div, mirroring the committed structure.
-
-                    Unconditional (not gated on streamingText): a settled turn
-                    ALWAYS mounts a footer — deriveTurnFooterActions yields
-                    regenerate/branch from TurnStatus alone, independent of
-                    answer text (turn-footer-actions.ts), and materialize emits
-                    a timeline item for a step's thinking even with empty text
-                    (materialize.ts). So a thinking-only / textless turn
-                    (think → tool → end, or aborted mid-think) settles WITH a
-                    footer too; gating the placeholder on streamingText left
-                    that shape unreserved. We are already inside the
-                    `streamingText || thinkingText` section, so rendering it
-                    always reserves the footer box for every live turn.
-
-                    Groundwork, not a full fix for the textless case: this only
-                    makes the swap height-neutral when the live section is held
-                    until the committed footer mounts. Text turns get that via
-                    the draining→settleAssistantStreaming handshake (refresh the
-                    committed message BEFORE clearing the live slot). Textless /
-                    thinking-only completion currently clears the live section
-                    first and refreshes messages async (drainAssistantStreaming
-                    `!applied.text`), so the swap is non-atomic and can still
-                    flash for that shape. Closing that is tracked in the
-                    single-render-path convergence (#642), which removes the
-                    two-subtree seam entirely. */}
                 <div aria-hidden="true" className="mt-0.5 h-8" />
               </Message>
             </section>
@@ -841,7 +809,13 @@ const MessageBody = memo(function MessageBody(props: { role: string; text: strin
           {props.ts !== undefined && (
             <RelativeTime ts={props.ts} className="maka-message-time-inline" />
           )}
-          <MessageCopyButton text={props.text} footerStyle />
+          {/* #642: copy hides by default, appears when the user bubble is
+              hovered or focus lands inside (keys off `group/usermsg` on the
+              user Message). The time stays always-visible (a11y: it must reach
+              touch + assistive tech, see the role==='user' note above). */}
+          <span className="opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/usermsg:opacity-100 focus-within:opacity-100">
+            <MessageCopyButton text={props.text} footerStyle />
+          </span>
         </div>
       </>
     );
@@ -1041,28 +1015,37 @@ const TurnView = memo(function TurnView(props: {
   onLineageBadgeClick?: (targetTurnId: string) => void;
   /** True when a search result just navigated to this turn. */
   searchHighlighted?: boolean;
+  /**
+   * #642 single render path: set only on the active streaming tail turn. When
+   * present, the assistant `Message` renders the live 深度思考 + answer bubble as
+   * the trailing entries of its timeline — the SAME node the committed turn
+   * will settle into, so live→settled is a data-source swap (no unmount/mount).
+   * While live the footer is a reserved-height placeholder, not the real
+   * `TurnFooterActions`: the tail turn's derived status is `completed` (a live
+   * turn has no `turn_state`), so rendering the real footer would offer a
+   * clickable regenerate/branch on a still-streaming answer.
+   */
+  liveStreaming?: {
+    streamingText: string;
+    thinkingText?: string;
+    streamingComplete?: boolean;
+    streamingTruncated?: boolean;
+    thinkingTruncated?: boolean;
+    onStreamingSettled?: () => void;
+  };
 }) {
   const { turn } = props;
   const forwardBadges = props.lineageBadges?.filter((b) => b.direction === 'forward') ?? [];
   const reverseBadges = props.lineageBadges?.filter((b) => b.direction === 'reverse') ?? [];
-  // Streaming-settle polish: fade the footer toolbar in ONLY when it appears
-  // on an already-mounted turn (a live turn just settled). Turns hydrated from
-  // history mount WITH their footer and must not animate (default mounts don't
-  // animate — motion doc), so a ref pins whether the footer was VISIBLE at
-  // mount. "Visible" must mirror the render condition — the footer renders
-  // inside the `turn.timeline.length > 0` assistant block, and during a live
-  // turn `footerActions` can already be non-empty while the timeline is still
-  // empty; keying the ref on footerActions alone would mark it present-at-
-  // mount and suppress the entrance. Once the footer has appeared the class
-  // is inert: CSS animations run on element insertion only, so later
-  // re-renders never re-flash it.
-  const footerVisible = turn.timeline.length > 0 && !!(props.footerActions && props.footerActions.length > 0);
-  const footerVisibleOnMountRef = useRef(footerVisible);
-  const footerEntrance = footerVisible && !footerVisibleOnMountRef.current;
+  // The assistant `Message` mounts once the turn has any timeline content OR
+  // this is the live streaming tail (a thinking-only / textless streaming turn
+  // has an empty committed timeline but must still show its live answer block).
+  const showAssistantMessage = turn.timeline.length > 0 || !!props.liveStreaming;
   return (
     <section
       className="maka-turn"
       data-turn-id={turn.turnId}
+      data-live-streaming={props.liveStreaming ? 'true' : undefined}
       data-search-highlight={props.searchHighlighted ? 'true' : undefined}
       tabIndex={props.searchHighlighted ? -1 : undefined}
     >
@@ -1090,6 +1073,7 @@ const TurnView = memo(function TurnView(props: {
           variant="user"
           aria-label="你发送的消息"
           title={turn.user.ts ? formatAbsoluteTimestamp(turn.user.ts) : undefined}
+          className="group/usermsg"
         >
           <MessageBody role="user" text={turn.user.text} ts={turn.user.ts} attachments={turn.user.attachments} />
         </Message>
@@ -1103,11 +1087,12 @@ const TurnView = memo(function TurnView(props: {
           <MessageBody role="system" text={note.text} ts={note.ts} />
         </Message>
       ))}
-      {turn.timeline.length > 0 && (
+      {showAssistantMessage && (
         <Message
           variant="assistant"
           data-turn-status={turn.status}
           aria-label="Maka 的回答"
+          className="group/answer"
         >
           <div className="flex flex-col gap-2">
             {/* PR109d-c: aborted turn gets a muted "(已中断)" marker + Ban icon
@@ -1143,6 +1128,22 @@ const TurnView = memo(function TurnView(props: {
             {turn.timeline.map((item, index) => (
               <TurnTimelineEntry key={timelineEntryKey(item, index)} item={item} />
             ))}
+            {/* #642: live 深度思考 + answer bubble as the trailing entries of the
+                tail turn. On settle these are replaced by the committed
+                timeline items above (same turnId → same node) — a data-source
+                swap, not an unmount/mount. In a multi-step turn, earlier
+                committed steps render above via `turn.timeline`; only the
+                in-flight step rides here. */}
+            {props.liveStreaming && (
+              <LiveStreamingEntries
+                streamingText={props.liveStreaming.streamingText}
+                thinkingText={props.liveStreaming.thinkingText}
+                streamingComplete={props.liveStreaming.streamingComplete}
+                streamingTruncated={props.liveStreaming.streamingTruncated}
+                thinkingTruncated={props.liveStreaming.thinkingTruncated}
+                onStreamingSettled={props.liveStreaming.onStreamingSettled}
+              />
+            )}
           </div>
           {reverseBadges.length > 0 && (
             <Marker variant="lineage-row-reverse" aria-label="本轮回答的衍生">
@@ -1163,13 +1164,22 @@ const TurnView = memo(function TurnView(props: {
               ))}
             </Marker>
           )}
-          {props.footerActions && props.footerActions.length > 0 && (
-            <TurnFooterActions
-              actions={props.footerActions}
-              onAction={props.onFooterAction ? (actionId) => props.onFooterAction?.(turn.turnId, actionId) : undefined}
-              assistantText={turn.assistant?.text ?? ''}
-              entrance={footerEntrance}
-            />
+          {props.liveStreaming ? (
+            /* #642: reserved-height footer placeholder while streaming — same
+               `mt-0.5 h-8` box the real footer occupies, so the live→settled
+               swap is height-neutral (the footer slot never grows/shrinks). No
+               actionable footer here: the live tail's derived status is
+               `completed`, so a real `TurnFooterActions` would render a
+               clickable regenerate/branch on a still-streaming answer. */
+            <div aria-hidden="true" className="mt-0.5 h-8" />
+          ) : (
+            props.footerActions && props.footerActions.length > 0 && (
+              <TurnFooterActions
+                actions={props.footerActions}
+                onAction={props.onFooterAction ? (actionId) => props.onFooterAction?.(turn.turnId, actionId) : undefined}
+                assistantText={turn.assistant?.text ?? ''}
+              />
+            )
           )}
         </Message>
       )}
@@ -1261,12 +1271,6 @@ function TurnFooterActions(props: {
   onAction?: (actionId: TurnFooterActionMeta['id']) => void;
   /** Assistant text used by the inline copy action. */
   assistantText?: string;
-  /**
-   * True when this footer appeared on an already-mounted turn (a live turn
-   * just settled): fade it in instead of popping. History-hydrated turns pass
-   * false — default mounts don't animate.
-   */
-  entrance?: boolean;
 }) {
   const [copyPhase, setCopyPhase] = useState<ClipboardCopyPhase | null>(null);
   const copyPendingRef = useRef(false);
@@ -1326,13 +1330,6 @@ function TurnFooterActions(props: {
       variant="footer"
       role="toolbar"
       aria-label="本轮回答操作"
-      // Settle entrance: opacity-only fade via the governed
-      // `@keyframes maka-footer-fade-in` (maka-tokens.css) — a `from`-only
-      // keyframe so the fade lands on the footer's own quiet 0.72 opacity
-      // instead of pinning 1. Reduced-motion collapses the duration via the
-      // base.css globals; visual-smoke never exercises a live settle, so the
-      // paused-at-0% hazard cannot occur.
-      className={props.entrance ? '[animation:maka-footer-fade-in_var(--duration-large)_var(--ease-out-strong)_both]' : undefined}
     >
       {props.actions.map((action) => {
         // Per @kenji review: pending state must keep the original button
@@ -1410,6 +1407,44 @@ const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
  * `live=false` after `text_complete`: keep the bubble mounted until
  * the smoother catches up, then notify the parent to hand off to history.
  */
+/**
+ * #642 single render path: the live 深度思考 + streaming answer, rendered as the
+ * trailing entries of the active tail turn. Shared by `TurnView` (the normal
+ * path — injected into the committed tail turn's timeline) and the ChatView
+ * fallback (rare: streaming began before the optimistic user turn materialized).
+ * Thinking renders above the answer (it always precedes it) and is `live` only
+ * until the answer text starts; the answer bubble fires `onStreamingSettled`
+ * once it finishes catching up.
+ */
+function LiveStreamingEntries(props: {
+  streamingText: string;
+  thinkingText?: string;
+  streamingComplete?: boolean;
+  streamingTruncated?: boolean;
+  thinkingTruncated?: boolean;
+  onStreamingSettled?: () => void;
+}) {
+  return (
+    <>
+      {props.thinkingText && (
+        <DeepThinking
+          text={props.thinkingText}
+          live={!props.streamingText}
+          truncated={props.thinkingTruncated === true}
+        />
+      )}
+      {props.streamingText && (
+        <StreamingAssistantBubble
+          text={props.streamingText}
+          live={props.streamingComplete !== true}
+          truncated={props.streamingTruncated === true}
+          onSettled={props.onStreamingSettled}
+        />
+      )}
+    </>
+  );
+}
+
 function StreamingAssistantBubble(props: { text: string; live: boolean; truncated?: boolean; onSettled?: () => void }) {
   // PR-UI-C1 review fixup (@kenji msg fbb8f119): the smoother
   // typewriters PREFIXES of its input string. If the raw text

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -171,10 +171,14 @@ const markerVariants = cva("", {
         + " focus-visible:[outline:2px_solid_var(--focus-ring)] focus-visible:[outline-offset:2px]"
         + " data-[direction=forward]:bg-[oklch(from_var(--info)_l_c_h_/_0.06)] data-[direction=forward]:text-[oklch(from_var(--info-text)_calc(l_-_0.06)_c_h)]"
         + " data-[direction=reverse]:bg-[oklch(from_var(--brand-deep)_l_c_h_/_0.06)] data-[direction=reverse]:text-[oklch(from_var(--brand-deep)_calc(l_-_0.04)_c_h)]",
-      // `.maka-turn-footer` (+ measure-column re-anchor) — quiet toolbar that
-      // lifts to full opacity on hover / focus-within.
+      // `.maka-turn-footer` (+ measure-column re-anchor) — hidden by default,
+      // revealed when the answer block is hovered or keyboard focus lands
+      // inside it (#642). `group-hover/answer` keys off the `group/answer` on
+      // the assistant `Message`; `focus-within` keeps it reachable without a
+      // pointer. Opacity-only (layout stays reserved) so live→settled is
+      // height-neutral. Sole consumer is the assistant turn footer.
       footer:
-        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-0.5 mt-0.5 ml-0 mr-auto p-0 opacity-[0.72] hover:opacity-100 focus-within:opacity-100",
+        "flex w-full max-w-[var(--maka-chat-measure,680px)] flex-wrap items-center justify-start gap-0.5 mt-0.5 ml-0 mr-auto p-0 opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover/answer:opacity-100 focus-within:opacity-100",
       // `.maka-turn-footer-action` (UiButton) — borderless ghost action. Also
       // reused by the user-message copy (`MessageCopyButton footerStyle`), so
       // it carries only the button look, never the footer's measure column.

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -386,7 +386,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
           size={14}
           strokeWidth={2}
           aria-hidden="true"
-          className="ml-auto shrink-0 text-[color:var(--muted-foreground)] opacity-0 [transition:transform_var(--duration-quick)_var(--ease-out-strong),opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:rotate-90 group-data-[panel-open]:opacity-100"
+          className="shrink-0 text-[color:var(--muted-foreground)] opacity-0 [transition:transform_var(--duration-quick)_var(--ease-out-strong),opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:rotate-90 group-data-[panel-open]:opacity-100"
         />
       </CollapsibleTrigger>
       <CollapsiblePanel>
@@ -439,10 +439,11 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
         ) : (
           <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{resolveToolDisplayName(item)}</span>
         )}
-        {/* Quiet meta: the duration + chevron ride in on hover / open, matching
+        {/* Quiet meta sits right after the label (near the text, not pinned to
+            the far edge): duration + chevron ride in on hover / open, matching
             the multi-tool summary row — status is carried by the shimmer /
             destructive tint, so no always-on status word. */}
-        <span className="ml-auto inline-flex shrink-0 items-center gap-2 text-[length:var(--font-size-caption)] text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
+        <span className="inline-flex shrink-0 items-center gap-2 text-[length:var(--font-size-caption)] text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
           {duration && <span className="[font-variant-numeric:tabular-nums]">{duration}</span>}
           <ChevronRight
             size={14}


### PR DESCRIPTION
Closes #642

## Why

A single assistant answer used to be rendered by **two unrelated React subtrees**: the settled `turns.map(TurnView)` and a separate live `<section className="maka-turn maka-turn-streaming">`. The stream-to-settled handoff worked by **unmounting one subtree and mounting the other**, and that seam forced a whole set of hand-tuned special cases (streaming-shell margin, footer placeholder, fade-in, always-mounted status cluster, a 1000ms grace window). Worse, the textless / thinking-only completion path cleared the live region *before* the settled turn mounted, leaving a non-atomic flicker.

The key opening: the user message commits synchronously the moment it is sent, so during streaming `materializeTurns(messages)` **already** emits the tail turn (user bubble + correct turnId + an empty assistant timeline), and the runtime assigns the assistant rows the **same turnId**. Injecting the live content into that already-present tail turn turns the handoff into a **data-source swap on one stable `key={turnId}` node** — no unmount.

## What changed

- **Tail-turn injection**: `TurnView` gains an optional `liveStreaming` prop; only the `turn.turnId === tailTurnId` TurnView receives a fresh object per delta (so only it re-renders), every sibling gets a stable `undefined` and skips via memo. The standalone `maka-turn-streaming` subtree and its alignment special-cases are deleted. The perf invariant holds: exactly one TurnView re-renders per frame, same as before.
- **Hover-revealed footer / user time**: both answer footers and the user-message time default to fully transparent and fade in on hover of their own content block (`group-hover/answer`, `group-hover/usermsg`, with `focus-within` preserving a11y). Height is reserved throughout, so the handoff is height-neutral. The user-message time is now an absolute `HH:mm`.
- **content-visibility remap**: the `content-visibility: visible` override moves from `.maka-turn-streaming` to `.maka-turn[data-live-streaming="true"]`; dead rules removed.
- **Atomic textless / thinking-only handoff**: the textless branch of `drainAssistantStreaming` now refreshes committed history before clearing the live buffer (refresh-before-clear), holding the live answer until the committed message lands — no unmount gap.
- **Folded-timeline polish** (from manual testing): the DeepThinking settled body gets the same `max-h-64` scroll bound as the live `<pre>`, so an expanded long reasoning no longer jumps taller the frame it settles; the chevron on all three folded trows (deep-thinking, tool group, tool row) drops `ml-auto` so it sits next to the label text instead of the far edge.

## Deferred (split into #646, does not block this PR)

Real-time status feedback across the communication stages: a "connecting" state while the LLM connects, an "outputting" state during streaming, and a clear running-to-done seam for tools. The tool shimmer is correctly wired and verified to animate, but it flashes by on sub-second tools and lacks an explicit running-to-done transition.

## Verification

- `npm run typecheck` clean; `@maka/ui` 46 + `@maka/desktop` 2257 tests pass (including the new #642 behavior tests and a tool-shimmer render regression test).
- CDP live check (clean build): turnId stays stable across the handoff, no `maka-turn-streaming` node, footer and user time reveal only on hover. Issue 1 (a long settled reasoning is capped at a 256px scroll box, no height jump) and issue 2 (chevron sits 8px after the label, not far-right) both confirmed live.