### PR TITLE
fix(desktop): purge engineering-speak from user-facing copy (detail round 5)

### DIFF
--- a/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
+++ b/apps/desktop/src/renderer/derive-turn-lineage-badges.ts
@@ -15,11 +15,6 @@
 
 import type { TurnLineageBadge } from '@maka/ui';
 
-/** Strip the `turn-` id prefix before truncating, matching the view-model. */
-function shortId(turnId: string): string {
-  return turnId.replace(/^turn-/, '').slice(0, 6);
-}
-
 export interface TurnLineageBadgeInput {
   turnId: string;
   /** Legacy retry lineage (old data). Falls back behind regenerated. */
@@ -39,8 +34,8 @@ export function deriveTurnLineageBadges(input: TurnLineageBadgeInput): TurnLinea
   if (forwardFrom && input.existsTurn(forwardFrom)) {
     badges.push({
       id: `forward-regen-${input.turnId}`,
-      label: `重新生成自 turn ${shortId(forwardFrom)}`,
-      tooltip: `保留旧回答，重新生成的并行回答`,
+      label: `重新生成自旧回答`,
+      tooltip: `这是重新生成的并行回答，点击查看被保留的旧回答`,
       targetTurnId: forwardFrom,
       direction: 'forward',
     });
@@ -50,8 +45,8 @@ export function deriveTurnLineageBadges(input: TurnLineageBadgeInput): TurnLinea
   if (reverseTo && input.existsTurn(reverseTo)) {
     badges.push({
       id: `reverse-regen-${input.turnId}`,
-      label: `已重新生成 → turn ${shortId(reverseTo)}`,
-      tooltip: `跳转到对此回答的重新生成`,
+      label: `已重新生成 → 新回答`,
+      tooltip: `点击跳转到重新生成的新回答`,
       targetTurnId: reverseTo,
       direction: 'reverse',
     });

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -152,6 +152,7 @@ export function AboutSettingsPage() {
           title="工作区"
           detail="会话、设置和凭据全部留在本地这条路径下。"
           value={info.workspacePath}
+          mono
         />
         <SettingRow
           title="存储"

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -195,7 +195,7 @@ function GeneralDefaultsCard(props: {
       <div className="settingsRow" data-control-width="select">
         <div>
           <strong>默认模型</strong>
-          <small>新对话默认使用的具体模型；按连接分组，不显示 OAuth 账号邮箱。</small>
+          <small>新对话默认使用的模型。</small>
         </div>
         {/* Shared searchable picker with the composer's model switcher
             (ModelPicker in @maka/ui) so the grouped list, provider marks,


### PR DESCRIPTION
Detail-audit round 5, continuing the systematic copy/affordance sweep — this round targets **engineering-speak leaking into user-facing copy**, found while reviewing the post-#636 streaming UI.

## Findings & fixes

### 1. Lineage badges exposed raw internal turn IDs
`deriveTurnLineageBadges` rendered `重新生成自 turn ${shortId(id)}` — a 6-char slice of the internal turn ID. Users can't correlate these IDs with anything on screen (they appear nowhere else), and the hard `slice(0, 6)` truncates mid-word with no ellipsis (fixture showed "turn regen-"). The pill is a jump button; its label should state the action, not an internal pointer:

- forward: `重新生成自旧回答` (tooltip: 点击查看被保留的旧回答)
- reverse: `已重新生成 → 新回答` (tooltip: 点击跳转到重新生成的新回答)

Dead `shortId()` removed. Contract tests only pin the 重新生成自/已重新生成 vocabulary prefixes (#546 retry→regenerate merge) — unchanged.

### 2. 默认模型 helper text described implementation, not the setting
"新对话默认使用的具体模型；按连接分组，不显示 OAuth 账号邮箱。" — the second clause narrates picker internals (grouping + privacy of the dropdown). Now: "新对话默认使用的模型。"

### 3. 关于 page workspace path missed the mono treatment
The 数据 page renders paths left-aligned mono caption (`SettingRow mono`); the 关于 page's 工作区 row rendered the same path right-aligned proportional, wrapping into a ragged multi-line block. Added `mono`.

## Verification
- Desktop suite 2250/2250 green
- CDP re-capture of `turn-control-history` fixture confirms clean pill labels (screenshot-verified)
- `check-dead-css` clean