### PR TITLE
fix(ui): detail round 6 — one affordance one home (palette hints, skills CTA, runtime chip)

### DIFF
--- a/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/command-palette-a11y-copy-contract.test.ts
@@ -76,13 +76,21 @@ describe('Command palette accessibility and visible copy', () => {
 
     assert.match(
       src,
-      /import \{[^}]*\bDialogContent\b[^}]*\bDialogRoot\b[^}]*\bInputGroup\b[^}]*\bInputGroupAddon\b[^}]*\bInputGroupInput\b[^}]*\bKbd\b[^}]*\bKbdGroup\b[^}]*\} from '@maka\/ui';/,
+      /import \{[^}]*\bDialogContent\b[^}]*\bDialogRoot\b[^}]*\bInputGroup\b[^}]*\bInputGroupInput\b[^}]*\bKbd\b[^}]*\bKbdGroup\b[^}]*\} from '@maka\/ui';/,
       'CommandPalette must consume shared primitive InputGroup + Dialog primitives from @maka/ui',
     );
     assert.match(
       src,
-      /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{[\s\S]*inputRef\.current\?\.focus\(\);[\s\S]*<InputGroupInput[\s\S]*aria-label="搜索命令、设置项或会话"[\s\S]*<InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">/,
-      'CommandPalette input shell must be shared primitive InputGroup with an accessible input label, whole-shell click focus, and trailing hint addon',
+      /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{[\s\S]*inputRef\.current\?\.focus\(\);[\s\S]*<InputGroupInput[\s\S]*aria-label="搜索命令、设置项或会话"/,
+      'CommandPalette input shell must be shared primitive InputGroup with an accessible input label and whole-shell click focus',
+    );
+    // Detail round 6: the shortcut hints (↵ 执行 / Esc 关闭) live in the
+    // footer bar ONLY. An inline input addon duplicated them in the same
+    // viewport — one affordance, one home.
+    assert.doesNotMatch(
+      src,
+      /maka-palette-input-hint/,
+      'Shortcut hints must not be duplicated in an input addon — the palette footer is the single source',
     );
     assert.doesNotMatch(
       src,
@@ -99,10 +107,10 @@ describe('Command palette accessibility and visible copy', () => {
       /margin:\s*var\(--space-2\)\s*var\(--space-2-5\);/,
       'Palette InputGroup should preserve the compact command-modal inset spacing',
     );
-    assert.match(
+    assert.doesNotMatch(
       styles,
-      /@media \(max-width: 720px\) \{[\s\S]*\.maka-palette-input-hint-addon \{[\s\S]*display:\s*none;/,
-      'Palette trailing key hint must collapse on narrow widths instead of squeezing the input',
+      /maka-palette-input-hint/,
+      'Input-addon hint CSS must stay deleted along with the duplicated hint markup',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -118,14 +118,16 @@ describe('renderer utility surfaces use shared UI primitives', () => {
   it('keeps command palette search and rows on shared primitives', async () => {
     const source = await readFile(join(process.cwd(), 'src/renderer/command-palette.tsx'), 'utf8');
 
-    assert.match(source, /import \{[^}]*\bDialogContent\b[^}]*\bDialogRoot\b[^}]*\bInputGroup\b[^}]*\bInputGroupAddon\b[^}]*\bInputGroupInput\b[^}]*\bKbd\b[^}]*\bKbdGroup\b[^}]*\} from '@maka\/ui';/);
+    assert.match(source, /import \{[^}]*\bDialogContent\b[^}]*\bDialogRoot\b[^}]*\bInputGroup\b[^}]*\bInputGroupInput\b[^}]*\bKbd\b[^}]*\bKbdGroup\b[^}]*\} from '@maka\/ui';/);
     assert.match(source, /import \{ Autocomplete \} from '@base-ui\/react\/autocomplete'/, 'CommandPalette must consume Base UI Autocomplete for the result list (#520 PR8)');
     assert.doesNotMatch(source, /<input\b/, 'Command palette search must use shared Input');
     assert.doesNotMatch(source, /<button\b/, 'Command palette rows must use shared Button');
     assert.doesNotMatch(source, /<kbd\b/, 'Command palette shortcut glyphs must use shared primitive Kbd');
     assert.match(source, /<InputGroup[\s\S]*className="maka-palette-input-wrap"[\s\S]*aria-label="命令面板搜索"[\s\S]*onMouseDown=\{\(event\) => \{/);
     assert.match(source, /<InputGroupInput[\s\S]*className="maka-palette-input"/);
-    assert.match(source, /<InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">/);
+    // Detail round 6: shortcut hints live in the palette footer only; the
+    // former inline-end addon duplicated ↵/Esc next to the input.
+    assert.doesNotMatch(source, /<InputGroupAddon\b/, 'Palette input must not regrow the duplicated shortcut-hint addon');
     assert.match(source, /<Autocomplete.Item[\s\S]*className="maka-palette-item"/, 'Command palette rows must be Autocomplete.Item (#520 PR8)');
     assert.match(source, /<KbdGroup className="maka-shortcut-group">[\s\S]*<Kbd className="maka-shortcut-kbd">↑<\/Kbd>[\s\S]*<Kbd className="maka-shortcut-kbd">↓<\/Kbd>/);
   });

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1185,7 +1185,9 @@ name: Writer
     assert.match(skillPanel, /const runtimeLabel = formatSkillRuntimeLabel\(skill\)/);
     assert.match(skillPanel, /来源状态：\$\{statusLabel\}/);
     assert.match(skillPanel, /运行状态：\$\{runtimeLabel\}/);
-    assert.match(skillPanel, /className="maka-skill-library-runtime-label"[\s\S]*>\{runtimeLabel\}<\/span>/);
+    // Detail round 6, exception-only: the runtime chip renders ONLY for
+    // state_error — enabled/disabled is already expressed by the Switch.
+    assert.match(skillPanel, /\{skill\.runtimeStatus === 'state_error' && \([\s\S]*?className="maka-skill-library-runtime-label"[\s\S]*>\{runtimeLabel\}<\/span>/);
     assert.match(skillPanel, /className="maka-skill-library-status-label"[\s\S]*>\{statusLabel\}<\/span>/);
     assert.match(ui, /function formatSkillStatusLabel\(skill: SkillEntry\): string/);
     assert.match(ui, /function formatSkillRuntimeLabel\(skill: SkillEntry\): string/);

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -41,7 +41,6 @@ import {
   EmptyMedia,
   EmptyTitle,
   InputGroup,
-  InputGroupAddon,
   InputGroupInput,
   Kbd,
   KbdGroup,
@@ -713,14 +712,6 @@ export function CommandPalette(props: {
                 />
               }
             />
-            <InputGroupAddon align="inline-end" className="maka-palette-input-hint-addon">
-              <span className="maka-palette-input-hint" aria-hidden="true">
-                <Kbd className="maka-shortcut-kbd">↵</Kbd>
-                <span>执行</span>
-                <Kbd className="maka-shortcut-kbd">Esc</Kbd>
-                <span>关闭</span>
-              </span>
-            </InputGroupAddon>
           </InputGroup>
           <Autocomplete.List className="maka-palette-list" id="maka-palette-list" aria-label="命令面板结果">
             {grouped.length === 0 ? (

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -30,23 +30,11 @@
   box-shadow: 0 0 0 2px oklch(from var(--foreground) l c h / 0.055);
 }
 
+/* Detail round 6: the add CTA rides UiButton variant="default" untouched —
+   the former ghost re-skin here (hardcoded black-gradient pill) was a
+   theme-leak + radius-family violation. Only the icon/label gap remains. */
 .maka-skill-add-button {
   gap: var(--space-1);
-  border-color: oklch(0.19 0 0);
-  border-radius: var(--radius-pill);
-  background: linear-gradient(oklch(0.32 0 0), oklch(0.19 0 0));
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.15),
-    0 1px 2px oklch(0.1 0 0 / 0.10);
-  color: oklch(1 0 0);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-}
-
-.maka-skill-add-button:hover {
-  border-color: oklch(0.24 0 0);
-  background: linear-gradient(oklch(0.36 0 0), oklch(0.24 0 0));
-  color: oklch(1 0 0);
 }
 
 /* Phase 2 — atlas-driven rewrite (notes/reference-atlas.md §10). Skills page
@@ -616,11 +604,8 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   font-weight: var(--font-weight-semibold);
 }
 
-.maka-skill-library-runtime-label[data-status="disabled"] {
-  background: oklch(from var(--foreground) l c h / 0.05);
-  color: var(--muted-foreground);
-}
-
+/* Detail round 6: the runtime chip is exception-only (state_error) — the
+   enabled/disabled visual forms retired with the redundant chip. */
 .maka-skill-library-runtime-label[data-status="state_error"] {
   background: oklch(from var(--warning) l c h / 0.10);
   color: var(--warning-text);

--- a/apps/desktop/src/renderer/styles/palette.css
+++ b/apps/desktop/src/renderer/styles/palette.css
@@ -84,21 +84,6 @@
   color: var(--muted-foreground);
 }
 
-.maka-palette-input-hint {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  min-height: 24px;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  white-space: nowrap;
-}
-
-.maka-palette-input-hint-addon {
-  flex-shrink: 0;
-  padding-inline-end: var(--space-1-5);
-}
-
 .maka-shortcut-group {
   display: inline-flex;
   align-items: center;
@@ -118,17 +103,6 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
-}
-
-.maka-palette-input-hint .maka-shortcut-kbd {
-  background: var(--foreground-5);
-  box-shadow: none;
-}
-
-@media (max-width: 720px) {
-  .maka-palette-input-hint-addon {
-    display: none;
-  }
 }
 
 .maka-palette-list {

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -268,7 +268,13 @@ function SkillLibraryPanel(props: {
                     </span>
                     <span className="maka-skill-library-meta">
                       <span>{skill.id}</span>
-                      <span className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus}>{runtimeLabel}</span>
+                      {/* Detail round 6, exception-only: the adjacent Switch
+                          already says enabled/disabled — the visible chip only
+                          appears for states the switch can't express
+                          (state_error). 已启用/已停用 stay in the hover text. */}
+                      {skill.runtimeStatus === 'state_error' && (
+                        <span className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus}>{runtimeLabel}</span>
+                      )}
                       <span className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'}>{statusLabel}</span>
                       {opening && <span>打开中…</span>}
                       {updating && <span>更新中…</span>}
@@ -638,9 +644,13 @@ export function SkillsModuleMain(props: {
           >
             打开目录
           </UiButton>
+          {/* Detail round 6: the page CTA is a REAL primary (variant default,
+              same recipe as daily-review's 生成每日回顾) — previously a ghost
+              re-skinned by CSS into a hardcoded black-gradient pill (theme-leak
+              literals + off-family radius). */}
           <UiButton
-            className="maka-button maka-skill-add-button"
-            variant="ghost"
+            className="maka-skill-add-button"
+            variant="default"
             type="button"
             onClick={() => void runSkillAction('create', props.onCreateSkillTemplate)}
             disabled={!props.onCreateSkillTemplate || skillActionBusy}


### PR DESCRIPTION
Detail-audit round 6 — non-settings sweep (command palette, skills module page), lens: duplicated affordances + component re-skin overrides.

## Findings & fixes

### 1. Command palette showed the same shortcut hints twice
The input row carried an inline-end addon (↵ 执行 / Esc 关闭) while the footer bar showed ↑↓ 选择 · ↵ 执行 · Esc 关闭 — both visible in the same viewport. The footer (the standard palette pattern, cf. VS Code/Raycast/Linear) is the single home now. Addon markup + its 4 CSS blocks removed; both pinning contracts updated to assert the absence instead.

### 2. Skills 添加 CTA was a ghost wearing fake primary chrome
`.maka-skill-add-button` re-skinned `variant=ghost` into a black-gradient pill with raw `oklch(0.19/0.32/1 0 0)` literals — a theme leak (ignores palette tokens entirely, wrong in dark/brand themes) plus `radius-pill` off the button radius family. This is exactly the component-re-skin antipattern from round 2 (killed .settingsInlineTextButton/.settingsBotAction). Now a genuine `variant=default` primary — the same recipe as daily-review's 生成每日回顾, so adjacent module pages share one CTA form.

### 3. Skills runtime chip duplicated the Switch
Every row showed an 已启用 chip immediately next to an ON switch — two controls saying the same thing (exception-only lens). The chip now renders only for `state_error` (状态异常), the one state the switch can't express; enabled/disabled wording remains in the row hover text. Dead `data-status=disabled` CSS variant removed.

## Verification
- Desktop suite 2250/2250 green (contracts updated in their new pinned form, incl. the second import-shape copy in command-palette-a11y-copy-contract)
- check-dead-css clean
- CDP re-captures of `module-skills` + `command-palette-open` fixtures verify all three visually