### PR TITLE
fix(ui): detail round 7 — 定时任务 CTA joins the unified module-page primary

### DIFF
--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -82,39 +82,12 @@
   flex-wrap: wrap;
 }
 
-/* PR-UI-PIXEL-3: signature off-black CTA, matching the reference's restrained
-   primary command treatment without using the app accent. Pure #000 is banned
-   per design-taste rules — use oklch off-black (charcoal) for premium feel. */
+/* Detail round 7: the CTA rides UiButton variant="default" untouched — the
+   former charcoal re-skin (hardcoded oklch literals + radius-pill) diverged
+   from every other module-page primary (skills 添加, daily-review 生成每日回顾).
+   Only the icon/label gap remains. */
 .maka-plan-new-task-button {
   gap: var(--space-1);
-  border-color: oklch(0.20 0 0);
-  border-radius: var(--radius-pill);
-  background: oklch(0.18 0 0);
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.15),
-    0 1px 2px oklch(from var(--foreground) l c h / 0.10);
-  color: oklch(1 0 0);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  transition:
-    background-color var(--duration-base) var(--ease-out-strong),
-    border-color var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-emphasized) var(--ease-out-strong),
-    box-shadow var(--duration-emphasized) var(--ease-out-strong);
-}
-
-.maka-plan-new-task-button:hover {
-  border-color: oklch(0.28 0 0);
-  background: oklch(0.26 0 0);
-  color: oklch(1 0 0);
-  transform: translateY(var(--lift-hover));
-  box-shadow:
-    inset 0 1px 0 oklch(1 0 0 / 0.20),
-    0 4px 14px -8px oklch(from var(--foreground) l c h / 0.32);
-}
-
-.maka-plan-new-task-button:active:not(:disabled) {
-  background: oklch(0.14 0 0);
 }
 
 .maka-plan-refresh-button {


### PR DESCRIPTION
Follow-up to #649. The 定时任务 page's 新建定时任务 CTA carried the same component-re-skin antipattern round 6 removed from the skills page: `variant=default` UiButton overridden by CSS into a charcoal pill (`oklch(0.18 0 0)` literals that ignore theme palettes + `radius-pill` off the button radius family).

With this, all three module-page primaries — skills 添加, daily-review 生成每日回顾, 定时任务 新建定时任务 — wear the same real `variant=default` chrome. The re-skin block (rest/hover/active, 30 lines) reduces to the icon/label gap.

Also swept this round with no findings: permission-destructive dialog (clean), dark-theme regression over the round 5/6 surfaces (lineage pills + skills CTA render correctly in dark).

## Verification
- Desktop suite 2250/2250 green; check-dead-css clean
- CDP re-capture of `plan-reminders` fixture confirms the unified CTA