### PR TITLE
fix(desktop): status-color restraint — expected states stop shouting green

### DIFF
--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -47,6 +47,7 @@ const VISUAL_SMOKE_SCENARIOS = new Set<VisualSmokeScenario>([
   'settings-general',
   'settings-memory',
   'settings-daily-review',
+  'settings-permissions',
   'module-skills',
   'module-daily-review',
   // PR109b: workstation-statuses — seed one session per SessionStatus
@@ -357,6 +358,8 @@ export function getVisualSmokeState(fixture: VisualSmokeFixture | null): VisualS
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'memory' };
     case 'settings-daily-review':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'daily-review' };
+    case 'settings-permissions':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'permissions' };
     case 'module-skills':
       return { ...state, activeSessionId: TURN_SESSION_ID, sidebarSection: 'skills', sidebarCollapsed: false };
     case 'module-daily-review':

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -91,7 +91,9 @@ const OS_PERMISSION_STATE_COPY: Record<OsPermissionState, { label: string; tone:
   unknown: { label: '无法读取状态', tone: 'neutral' },
   not_determined: { label: '等待授权', tone: 'warning' },
   denied: { label: '已拒绝', tone: 'destructive' },
-  granted: { label: '已授权', tone: 'success' },
+  // Status-color restraint: granted is the expected state — neutral badge;
+  // color is reserved for the states that need the user's attention.
+  granted: { label: '已授权', tone: 'neutral' },
 };
 
 const OFFICECLI_INSTALL_COMMAND = 'curl -fsSL https://raw.githubusercontent.com/iOfficeAI/OfficeCLI/main/install.sh | bash';
@@ -287,8 +289,11 @@ function PermissionSummaryTile(props: {
   value: number;
   tone: 'success' | 'warning' | 'destructive' | 'neutral';
 }) {
+  // A zero count is not an exception — the tone only paints when there is
+  // actually something to look at (0 已拒绝 in red read as a false alarm).
+  const effectiveTone = props.value > 0 ? props.tone : 'neutral';
   return (
-    <div className="settingsPermissionSummaryTile" data-tone={props.tone}>
+    <div className="settingsPermissionSummaryTile" data-tone={effectiveTone} data-empty={props.value === 0}>
       <span className="settingsPermissionSummaryValue">{props.value}</span>
       <span className="settingsPermissionSummaryLabel">{props.label}</span>
     </div>

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -8,10 +8,8 @@
     background: var(--foreground-2);
     box-shadow: 0 1px 3px oklch(from var(--foreground) l c h / 0.03);
   }
-.settingsConnectionRow[data-status="verified"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
-    background: oklch(from var(--success) l c h / 0.04);
-  }
+/* Status-color restraint: verified is the expected state — default
+   card chrome; color is reserved for exception states below. */
 .settingsConnectionRow[data-status="needs_reauth"] {
     border-color: oklch(from var(--info) l c h / 0.30);
     background: oklch(from var(--info) l c h / 0.06);
@@ -34,10 +32,7 @@
     border-color: oklch(from var(--info) l c h / 0.30);
     background: oklch(from var(--info) l c h / 0.04);
   }
-.settingsConnectionRow[data-status="authenticated"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
-    background: oklch(from var(--success) l c h / 0.04);
-  }
+/* authenticated: expected state, default card chrome (see above). */
 .settingsConnectionRow[data-status="refresh_failed"],
   .settingsConnectionRow[data-status="quota_unavailable"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.30);
@@ -184,11 +179,8 @@
     background: var(--foreground-5);
     color: var(--foreground-secondary);
   }
-.settingsAuthContractBadge[data-tone="success"],
-  .settingsAuthActionPill[data-tone="success"] {
-    background: oklch(from var(--success) l c h / 0.12);
-    color: var(--success);
-  }
+/* success-tone badges/pills fall through to the neutral base — the
+   label text (已验证 etc.) carries the meaning. */
 .settingsAuthContractBadge[data-tone="info"],
   .settingsAuthActionPill[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -144,13 +144,8 @@
     opacity: var(--opacity-disabled);
   }
 
-.settingsHealthSummaryTile[data-tone="success"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
-  }
-
-.settingsHealthSummaryTile[data-tone="success"] strong {
-    color: var(--success-text);
-  }
+/* Status-color restraint: a healthy tile keeps the default hairline and
+   ink — color is reserved for the exception tones. */
 
 .settingsHealthSummaryTile[data-tone="info"] {
     border-color: oklch(from var(--info) l c h / 0.24);
@@ -223,9 +218,7 @@
     transition: border-color var(--duration-base) var(--ease-out-strong);
   }
 
-.settingsHealthSignalRow[data-status="ok"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
-  }
+/* data-status="ok" keeps the default hairline — ok is the expected state. */
 
 .settingsHealthSignalRow[data-status="warning"] {
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -115,9 +115,9 @@
     display: grid;
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-2-5);
-    border: var(--border-width-hairline) solid oklch(from var(--success) l c h / 0.28);
+    border: var(--border-width-hairline) solid var(--border);
     border-radius: var(--radius-surface);
-    background: oklch(from var(--success) l c h / 0.08);
+    background: var(--foreground-3);
   }
 .settingsMemorySaveSummary strong {
     color: var(--foreground);

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -147,9 +147,8 @@
     border-color: oklch(from var(--warning, var(--info)) l c h / 0.28);
   }
 
-.settingsCapabilityRow[data-readiness="enabled"] {
-    border-color: oklch(from var(--success) l c h / 0.24);
-  }
+/* Status-color restraint: "enabled" is the expected state — it keeps the
+   default hairline. Only exceptions (denied/degraded) wear a colored border. */
 
 .settingsCapabilityHeader {
     display: flex;
@@ -220,7 +219,8 @@
     color: var(--muted-foreground);
   }
 
-.settingsCapabilityLayers dd[data-tone="success"] { color: var(--success-text); }
+/* data-tone="success" intentionally has no rule — a healthy layer reads
+   in the default ink; color is reserved for warning/destructive/info. */
 
 .settingsCapabilityLayers dd[data-tone="warning"] { color: var(--warning-text, var(--info-text)); }
 
@@ -273,10 +273,8 @@
     color: var(--foreground-secondary);
   }
 
-.settingsCapabilityOsPermissions li em[data-tone="success"] {
-    color: var(--success-text);
-    background: oklch(from var(--success) l c h / 0.10);
-  }
+/* success chips fall through to the neutral base above — granted is the
+   expected state and doesn't need a green pill. */
 
 .settingsCapabilityOsPermissions li em[data-tone="warning"] {
     color: var(--warning-text, var(--info-text));
@@ -514,9 +512,12 @@
      granted are visible at a glance without re-introducing per-row
      borders that fight the unified card. */
 
+/* Status-color restraint: granted is the expected state — no stripe, no
+   green icon fill; the row label already says 已授权. Only the exception
+   states (denied / not_determined) keep an edge stripe. */
+
 .settingsOsPermissionRow[data-state="denied"]::before,
-  .settingsOsPermissionRow[data-state="not_determined"]::before,
-  .settingsOsPermissionRow[data-state="granted"]::before {
+  .settingsOsPermissionRow[data-state="not_determined"]::before {
     content: "";
     position: absolute;
     left: 0;
@@ -531,15 +532,6 @@
 
 .settingsOsPermissionRow[data-state="not_determined"]::before {
     background: oklch(from var(--warning, var(--info)) l c h / 0.55);
-  }
-
-.settingsOsPermissionRow[data-state="granted"]::before {
-    background: oklch(from var(--success) l c h / 0.45);
-  }
-
-.settingsOsPermissionRow[data-state="granted"] .settingsOsPermissionIcon {
-    background: oklch(from var(--success) l c h / 0.08);
-    color: oklch(from var(--success) l c h);
   }
 
 /* PR-PERMISSION-PAGE-REDESIGN: 4-cell summary above system permissions.
@@ -579,9 +571,8 @@
     letter-spacing: var(--tracking-wide);
   }
 
-.settingsPermissionSummaryTile[data-tone="success"] .settingsPermissionSummaryValue {
-    color: oklch(from var(--success) l c h);
-  }
+/* success tile keeps the default ink — the granted count is the normal
+   posture; only warning/destructive counts get colored. */
 
 .settingsPermissionSummaryTile[data-tone="warning"] .settingsPermissionSummaryValue {
     color: var(--warning-text, var(--info-text));

--- a/apps/desktop/src/renderer/styles/settings/provider-editor.css
+++ b/apps/desktop/src/renderer/styles/settings/provider-editor.css
@@ -571,8 +571,8 @@
 }
 
 .providerOAuthCard[data-logged-in="true"] .providerOAuthCardBadge {
-  background: color-mix(in srgb, var(--success) 16%, var(--background));
-  color: var(--success-text);
+  background: var(--foreground-5);
+  color: var(--foreground-secondary);
 }
 
 .providerOAuthCardDescription {

--- a/apps/desktop/src/renderer/styles/toast.css
+++ b/apps/desktop/src/renderer/styles/toast.css
@@ -92,10 +92,10 @@
   pointer-events: none;
 }
 
-.maka-toast[data-variant="success"] { border-left: var(--border-width-accent) solid var(--success); }
-.maka-toast[data-variant="warning"] { border-left: var(--border-width-accent) solid var(--info); }
-.maka-toast[data-variant="error"]   { border-left: var(--border-width-accent) solid var(--destructive); }
-.maka-toast[data-variant="info"]    { border-left: var(--border-width-accent) solid var(--toast-accent); }
+/* Status-color restraint (2026-07-09): the per-variant colored left
+   stripe was a second, louder copy of the signal the tinted icon below
+   already carries — and the stripe-on-card pattern reads as generic
+   template design. One signal per message: neutral card, tinted icon. */
 
 .maka-toast-icon {
   margin-top: var(--space-0-5);

--- a/packages/core/src/visual-smoke.ts
+++ b/packages/core/src/visual-smoke.ts
@@ -32,6 +32,7 @@ export type VisualSmokeScenario =
   | 'settings-general'
   | 'settings-memory'
   | 'settings-daily-review'
+  | 'settings-permissions'
   | 'module-skills'
   | 'module-daily-review'
   | 'workstation-statuses'


### PR DESCRIPTION
Addresses the maintainer's report: 权限与能力 still shows residual greens, and permission-toggle toasts show a green left edge ('AI 味').

## Diagnosis first: not a token leak
All of these greens ride `var(--success)` through the governed token system — theme governance is intact. The problem is **success-color overuse**: the EXPECTED state (granted / enabled / verified / healthy) was painted green across large surfaces, which both reads as old-brand residue and is the classic template-design tell (colored stripe on every card).

## Rule applied — exception-only status color
Normal states render neutral. Color is reserved for: states needing attention (denied / not_determined / degraded / needs_reauth), tiny dot-tier indicators (bot status dots, model-list status lines), transient action feedback (copy-success flash), and comparative semantics (permission diff old/new tags, hljs-addition).

## Changes
- **Toasts**: the per-variant colored left stripe (success green included) is gone for ALL variants — the tinted icon on a neutral card is the single signal
- **权限与能力**: granted rows lose stripe + icon fill + green badge (label 已授权 carries the meaning); enabled capability cards, healthy layer text, granted chips, granted summary count all neutral; denied/waiting keep their color; the 已拒绝 tile only turns red when count > 0, and zero-count tiles dim (matching the health page)
- **健康**: healthy tiles/signal rows keep the default hairline
- **模型连接**: verified/authenticated cards use default card chrome; success badges/pills fall to neutral; OAuth logged-in badge neutral
- **记忆**: the save-summary box is a neutral card, not a green wash
- Adds a `settings-permissions` visual-smoke fixture (page had no screenshot baseline)

## Verification
- Desktop suite 2262/2262 green, check-dead-css clean
- CDP before/after of the permission page confirms: only the genuine exception (等待授权 microphone) still carries color