### PR TITLE
refactor(ui): unify sidebar nav/list-row rhythm — shared tokens, 13px muted group headers (#546 PR7)

### DIFF
--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -34,7 +34,8 @@
   min-height: 34px;
   margin-left: calc(
     var(--maka-sidebar-topbar-offset-x) + var(--maka-sidebar-topbar-button-size) +
-      var(--maka-sidebar-topbar-button-size) + var(--maka-sidebar-topbar-gap) + 8px
+      var(--maka-sidebar-topbar-button-size) + var(--maka-sidebar-topbar-gap) +
+      var(--maka-sidebar-topbar-gap)
   );
   box-sizing: border-box;
   -webkit-app-region: drag;
@@ -120,12 +121,13 @@
   align-content: start;
   display: grid;
   gap: 1px;
-  padding: var(--space-1) var(--space-1-5);
+  /* #546 PR7: left/right padding aligned with .maka-list-stackContent
+     (var(--space-2)) so nav rows and session rows share the same inset. */
+  padding: var(--space-1) var(--space-2);
 }
 
 .maka-nav-row {
-  width: calc(100% - 12px);
-  margin-inline: var(--space-1-5);
+  width: 100%;
   display: grid;
   grid-template-columns: var(--icon-size) minmax(0, 1fr) auto;
   align-items: center;
@@ -212,17 +214,18 @@
   border-top: 0;
 }
 
-/* Group label — section header for session groups. Weight-based
-   hierarchy (not uppercase/letter-spacing) so Chinese labels read
-   cleanly without artificial tracking. */
+/* Group label — section header for session groups. #546 PR7: unified with
+   project-heading on font-size-ui + muted-foreground + medium so all three
+   group-header variants (plain label / collapsible toggle / project heading)
+   share one visual rhythm, distinguished from session rows by color not size. */
 .maka-list-group-label {
   display: flex;
   align-items: baseline;
   gap: var(--space-0-5);
   padding: 0 var(--space-1-5) var(--space-0-5);
   color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
   font-variant-numeric: tabular-nums;
 }
 
@@ -232,12 +235,11 @@
   justify-content: flex-start;
   gap: var(--space-1-5);
   width: 100%;
-  min-height: var(--h-control-lg);
   padding: 0 var(--space-1-5);
   border: 0;
   border-radius: var(--radius-control);
   background: transparent;
-  color: var(--foreground-secondary);
+  color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
   text-align: left;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -235,6 +235,7 @@
   justify-content: flex-start;
   gap: var(--space-1-5);
   width: 100%;
+  min-height: var(--h-control-lg);
   padding: 0 var(--space-1-5);
   border: 0;
   border-radius: var(--radius-control);

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -6,14 +6,14 @@ import { cva } from 'class-variance-authority';
 
 const navRowVariants = cva(
   [
-    'min-h-8 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
+    'min-h-[var(--h-control-lg)] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
     'text-left text-sm text-[var(--foreground-secondary)]',
     'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
-    'hover:bg-foreground/6 hover:text-foreground',
-    'data-[active=true]:bg-foreground/9 data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
+    'hover:bg-[var(--state-hover-bg)] hover:text-foreground',
+    'data-[active=true]:bg-[var(--state-selected-bg)] data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
     'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
-    '[&_.maka-nav-count]:bg-foreground/6 [&_.maka-nav-count]:text-[var(--muted-foreground)]',
-    'data-[active=true]:[&_.maka-nav-count]:bg-foreground/8 data-[active=true]:[&_.maka-nav-count]:text-foreground',
+    '[&_.maka-nav-count]:bg-[var(--state-hover-bg)] [&_.maka-nav-count]:text-[var(--muted-foreground)]',
+    'data-[active=true]:[&_.maka-nav-count]:bg-[var(--state-selected-bg)] data-[active=true]:[&_.maka-nav-count]:text-foreground',
     'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
     'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
   ],
@@ -36,7 +36,7 @@ const settingsButtonClass =
   'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-2 py-1.5 ' +
   'text-left text-sm font-medium text-[var(--foreground-secondary)] ' +
   'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
-  'hover:bg-foreground/6 hover:text-foreground';
+  'hover:bg-[var(--state-hover-bg)] hover:text-foreground';
 
 const MODULE_NAV_LABEL: Record<ModuleNavId, string> = {
   automations: '定时任务',


### PR DESCRIPTION
## Summary

统一 sidebar 的 nav row 和 list-row 视觉节奏。nav row 视觉从 Tailwind alpha 值统一到 CSS variable token，和 list-row 共用 hover/active/height；三种 group header 统一成 13px + muted-foreground + medium，靠颜色区分层级而非字号；nav row 内缩从 calc(100%-12px)+margin 改成父容器 padding 对齐 list。

## Why

#546 Phase B PR7。nav row（cvA）和 list-row（CSS）是两套样式系统，hover/active 深度不同（nav 6%/9% vs list 4%/6.5%），三种 group header 字号/高度/颜色各异，项目标题和会话项同高同大分不清层级。统一后同一面里的行节奏一致，改 token 值两边同步。

Refs #546

## Scope

Changed:
- `packages/ui/src/session-sidebar-nav.tsx`: navRowVariants + settingsButtonClass 的 Tailwind alpha 值（bg-foreground/6, /9）改成 CSS variable token（--state-hover-bg, --state-selected-bg, --h-control-lg），和 list-row 共用
- `apps/desktop/src/renderer/styles/sidebar.css`:
  - .maka-sidebar-modules padding: var(--space-1-5) → var(--space-2)，对齐 .maka-list-stackContent
  - .maka-nav-row: 删 width:calc(100%-12px)+margin-inline，改 width:100%
  - .maka-list-group-label: font-size caption→ui, font-weight semibold→medium
  - .maka-list-project-heading: color foreground-secondary→muted-foreground, 删 min-height
  - .maka-sidebar-drag-strip: magic number 8px → var(--maka-sidebar-topbar-gap)

Not included:
- action overlay 定位策略（absolute overlay + gradient 保留，替代方案已验证在窄 sidebar 截断更严重）
- streaming-dot vs unread 视觉区分（status-icon 已区分）
- React 结构重构（拆 SessionRow / 统一状态 map / keyboard 改 ref）—— #546 out of scope
- keyframes 归属迁移（642 约定未稳定）

## Verification

- `npm run build` 全绿
- `npm --workspace @maka/ui test`: 46 pass, 0 fail
- desktop test (apps/desktop cwd): 2250 pass, 0 fail
- `npm --workspace @maka/desktop run test:checks`: console/a11y/copy 全 OK
- radius-converge-contract: nav row 保留 rounded-sm（control tier），符合契约
- sidebar-scroll-contract: grid/minmax/scroll 架构不动
- sidebar-topbar-rail-contract: drag-strip margin-left:calc() 保留

## User-facing impact

sidebar 视觉变化：
- nav row hover/active 深度从 6%/9% 降到 4%/6.5%（和 list-row 一致）
- nav row 高度从 min-h-8(32px Tailwind) 到 var(--h-control-lg)(32px token)，实际高度不变但来源统一
- 分组标题从混搭（11px caption / 13px ui + 32px 高）统一成 13px + muted + 自然高度，标题比会话项矮且淡
- nav row 和 list row 左右对齐（都 8px 缩进）

## Reviewer notes

- nav row 的 cva 保留（覆盖 UiButton quiet variant 的 hover:bg-muted），只把视觉值从 Tailwind alpha 改成 CSS variable token。不能删 cva 把视觉搬 CSS，因为 Tailwind utilities 层高于 components 层，CSS 会被覆盖。
- rounded-sm 保留不改 rounded-[var(--radius-control)]，因为 radius-converge-contract 要求 nav row 用 rounded-sm（control tier utility）。
- group header 的 folder icon / chevron 尺寸不改（14px / 12px），因为 13px 不是 icon token 档位（16/20/24）。

## Checklist

- [x] Scope matches the PR title and excludes unrelated changes
- [x] Verification lists commands/results
- [x] User-facing impact noted
- [x] Risk called out (cva 保留原因、rounded-sm 契约约束)
- [ ] UI changes include screenshots — 未截图，改动可由契约测试 + token 一致性验证