### PR TITLE
fix(desktop): separate the three near-identical blue palettes

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -664,7 +664,7 @@
 [data-maka-theme="onedark"] {
   --background: oklch(0.95 0.005 250);
   --foreground: oklch(0.30 0.02 250);
-  --accent: oklch(0.60 0.14 250);              /* blue */
+  --accent: oklch(0.62 0.13 237);              /* One Dark blue (#61AFEF family) */
   --info: oklch(0.72 0.14 60);                 /* warm amber */
   --success: oklch(0.62 0.16 145);
   --destructive: oklch(0.62 0.20 22);
@@ -674,7 +674,7 @@
 [data-maka-theme="onedark"].dark {
   --background: oklch(0.21 0.010 250);
   --foreground: oklch(0.90 0.010 250);
-  --accent: oklch(0.68 0.15 250);
+  --accent: oklch(0.70 0.13 237);
   --info: oklch(0.74 0.15 70);
   --success: oklch(0.65 0.16 145);
   --destructive: oklch(0.70 0.18 22);
@@ -774,7 +774,7 @@
 [data-maka-theme="azure"] {
   --background: oklch(0.98 0.005 250);
   --foreground: oklch(0.20 0.015 250);
-  --accent: oklch(0.58 0.18 252);               /* product blue */
+  --accent: oklch(0.55 0.12 195);               /* lake cyan */
   --info: oklch(0.68 0.13 240);
   --success: oklch(0.66 0.15 150);
   --destructive: oklch(0.62 0.18 22);
@@ -784,7 +784,7 @@
 [data-maka-theme="azure"].dark {
   --background: oklch(0.20 0.015 250);
   --foreground: oklch(0.93 0.010 250);
-  --accent: oklch(0.70 0.18 252);
+  --accent: oklch(0.72 0.13 195);
   --info: oklch(0.74 0.13 240);
   --success: oklch(0.72 0.14 150);
   --destructive: oklch(0.72 0.18 22);

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -369,12 +369,12 @@
    palette's brand identity even when the current page is on a
    different palette. */
 .settingsPaletteSwatch-default          { background: oklch(0.70 0.135 250); }
-.settingsPaletteSwatch-onedark          { background: oklch(0.60 0.14 250); }
+.settingsPaletteSwatch-onedark          { background: oklch(0.62 0.13 237); }
 .settingsPaletteSwatch-catppuccin-mocha { background: oklch(0.65 0.18 330); }
 .settingsPaletteSwatch-tokyo-night      { background: oklch(0.55 0.16 215); }
 .settingsPaletteSwatch-nord             { background: oklch(0.62 0.12 215); }
 .settingsPaletteSwatch-coral            { background: oklch(0.68 0.18 25); }
-.settingsPaletteSwatch-azure            { background: oklch(0.58 0.18 252); }
+.settingsPaletteSwatch-azure            { background: oklch(0.55 0.12 195); }
 .settingsPaletteSwatch-forest           { background: oklch(0.50 0.12 152); }
 .settingsPaletteSwatch-dusk             { background: oklch(0.55 0.18 305); }
 .settingsPaletteSwatch-sand             { background: oklch(0.62 0.14 55); }


### PR DESCRIPTION
Recorded finding from the settings detail audit: the 外观 palette picker showed three nearly identical blue swatches — 默认 (oklch h250), One Dark (h250), 湖蓝 (h252) differed only in lightness/chroma, making the choices meaningless at swatch size.

Each accent now owns a hue, faithful to its name: One Dark moves to h237 (the real #61AFEF One Dark blue), 湖蓝 becomes an actual lake cyan at h195 (clear of Tokyo Night/Nord at h215), 默认 keeps brand h250. Dark-mode variants adjusted to match; picker swatch literals synced.

Desktop suite 2262/2262 green; CDP capture of settings-appearance confirms the three are now distinguishable at a glance.