### PR TITLE
fix(ui): switch thumb geometry + settings switch unification + permission button affordance (round 8)

### DIFF
--- a/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/permissions-unified-card-contract.test.ts
@@ -89,13 +89,19 @@ describe('PR-PERMISSIONS-UNIFIED-CARD-0 contract (#309)', () => {
       'open-settings button must render before request button so primary anchors the right edge',
     );
 
-    // When both are shown, open-settings collapses to variant=ghost; when
-    // alone (no `请求授权`) it returns to variant=default so the row
-    // still has a primary CTA.
+    // Affordance honesty (round 8, maintainer report): ghost beside the
+    // primary read as a plain text label. When both are shown, open-settings
+    // is a BORDERED secondary; when alone it returns to variant=default so
+    // the row still has a primary CTA. Never ghost in this row.
     assert.match(
       actionsBlock,
-      /variant=\{showRequest \? 'ghost' : 'default'\}/,
-      'open-settings button must be ghost when paired with request, default when alone',
+      /variant=\{showRequest \? 'secondary' : 'default'\}/,
+      'open-settings button must be bordered secondary when paired with request, default when alone',
+    );
+    assert.doesNotMatch(
+      actionsBlock,
+      /'ghost'/,
+      'no ghost variant in the OS-permission actions row — a clickable beside a real button needs a visible edge',
     );
 
     // Request button does not pass a `variant` prop — it defaults to the

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -537,10 +537,14 @@ function OsPermissionRow(props: {
           request flow for the permission), it still falls under the
           primary slot — no awkward "lonely secondary" state. */}
       <div className="settingsOsPermissionActions">
+        {/* Affordance honesty (round 8): ghost next to the primary read as a
+            plain text label — a clickable action sitting beside a real button
+            needs its own visible edge. Secondary keeps it quieter than
+            请求授权 without hiding that it's a button. */}
         {showOpenSettings && (
           <Button
             type="button"
-            variant={showRequest ? 'ghost' : 'default'}
+            variant={showRequest ? 'secondary' : 'default'}
             size="sm"
             onClick={props.onOpenSettings}
             disabled={busy}

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -650,48 +650,39 @@
   .settingsField textarea {
     transition: none !important;
   }
-  .settingsFormRow [role="switch"] > span,
-  .settingsField [role="switch"] > span {
+  .settingsModal [role="switch"] > span {
     transition: none;
   }
 }
 
-/* PR-SETTINGS-SWITCH-SCALE-0 (round 3/15, WAWQAQ msg `f7e9d166`):
-   the BaseSwitch shared adapter renders at `h-5 w-9` (20×36px) with a
-   16×16 thumb — too small inside the now-roomy settings rows.
-   Reference toggles inside Settings are noticeably larger and the
-   on-state is a more saturated green. Scope the bigger size to
-   settings rows only so the Switch primitive stays compact in chat /
-   sidebar usage. The thumb translate offset (`1.125rem` for h-5)
-   no longer reaches the right side at h-6.5, so we override it with
-   a calc that scales with the new track width. */
-.settingsFormRow [role="switch"],
-.settingsField [role="switch"] {
+/* PR-SETTINGS-SWITCH-SCALE-0 (round 3/15) + switch-geometry round 8:
+   the BaseSwitch shared adapter renders at 36×20 with a 16×16 thumb —
+   too small inside the roomy settings rows. ONE scope for the bigger
+   size: every switch inside the settings modal (`.settingsModal`), so
+   pages that aren't built from settingsFormRow/settingsField (数据
+   导入导出's category list, ad-hoc rows) can't fall back to the compact
+   scale and split the app into two switch sizes.
+   Geometry: 46px track − 2×1px border − 22px thumb − 2px inset = 20px
+   checked travel — SYMMETRIC 2px insets on both sides (the old 22px
+   value parked the thumb flush against the right border while the
+   unchecked side kept a 2px gap).
+   The overrides write the `translate:` property (not `transform:`)
+   because Tailwind v4's translate-x utilities emit `translate:` — a
+   `transform` override would stack additively instead of replacing. */
+.settingsModal [role="switch"] {
   height: 26px;
   width: 46px;
   border-radius: var(--radius-pill);
 }
 
-.settingsFormRow [role="switch"] > span,
-.settingsField [role="switch"] > span {
+.settingsModal [role="switch"] > span {
   height: 22px;
   width: 22px;
-  /* WAWQAQ msg `b45dc33d` 2026-06-25: Settings Switch thumbs ("白点")
-     were escaping the track to the right. Root cause: Tailwind v4's
-     `translate-x-0.5` / `translate-x-[1.125rem]` utilities applied on
-     <BaseSwitch.Thumb> in `packages/ui/src/ui.tsx:464` emit the
-     `translate:` CSS property, not `transform:`. The previous overrides
-     here set `transform: translateX(...)`, which is an INDEPENDENT
-     property — both stacked additively, pushing the thumb 2-18px past
-     the right edge of the 46px track at h-6.5 settings scale.
-     Fix: override the same `translate:` property so the value wins by
-     specificity instead of compounding. */
   translate: 2px 0;
 }
 
-.settingsFormRow [role="switch"][data-checked] > span,
-.settingsField [role="switch"][data-checked] > span {
-  translate: 22px 0;
+.settingsModal [role="switch"][data-checked] > span {
+  translate: 20px 0;
 }
 
 .settingsFormRow strong,

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -370,7 +370,13 @@ export const Switch = forwardRef<
       data-slot="switch"
       {...props}
     >
-      <BaseSwitch.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-[1.125rem]" />
+      {/* Checked travel MUST stay on the px-based spacing scale (translate-x-4
+          = 16px): track w-9 (36px) − 2×1px border − 16px thumb − 2px inset = 16,
+          giving symmetric 2px insets. The previous rem arbitrary value
+          (translate-x-[1.125rem]) silently shrank to 14.625px under the app's
+          13px root font — spacing utilities are px-calc'd, rem values are not —
+          leaving the thumb 4.4px short of the right edge. */}
+      <BaseSwitch.Thumb className="block h-4 w-4 translate-x-0.5 rounded-full bg-background shadow transition-transform data-[checked]:translate-x-4" />
     </BaseSwitch.Root>
   );
 });


### PR DESCRIPTION
Maintainer-reported defects, root-caused with CDP computed-style measurement (not eyeballing):

## 1. The switch bug — thumb stops 4.4px short of the edge
`Switch` checked travel was `translate-x-[1.125rem]` — a **rem arbitrary value**. The app runs a 13px root font, so it computed to 14.625px instead of 18px. Tailwind v4's spacing utilities (`w-9`, `h-5`, `translate-x-0.5`) are px-calc'd via `--spacing` and don't scale with root font — the one rem value in the recipe was the one that broke. Measured before: checked inset left 15.6 / right 4.4 (vs unchecked 3/17). Fix: `translate-x-4` (16px on the spacing scale) → measured after: 17/3, perfectly mirroring 3/17.

## 2. Two switch sizes inside settings
The 46×26 settings scale was scoped to `.settingsFormRow`/`.settingsField` only — 数据 配置导入导出's category list (and any ad-hoc row) silently fell back to the compact 36×20. One scope now: `.settingsModal [role=switch]`. Also fixed the scoped checked travel 22px→20px — the old value parked the thumb flush against the right border (0 inset) while unchecked kept 2px. Measured after: 3/21 ↔ 21/3 symmetric.

## 3. 前往系统设置 was a ghost button with no edge
Sitting directly beside the primary 请求授权, it read as a text label. Now a bordered `secondary`; the PR-PERMISSIONS-UNIFIED-CARD contract is re-pinned to the new form and additionally bans ghost in that actions row.

## Verification
- CDP geometry probes before/after on settings-data (46×26 scale) and module-skills (base scale) fixtures — all symmetric
- Screenshots of 权限与能力 + 数据 confirm the bordered button and correctly-filling switches
- Desktop suite 2281/2281, check-dead-css clean