### PR TITLE
fix(ui): text action buttons wear an edge — ghost is icon-only (round 8b)

### DIFF
--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -61,7 +61,10 @@
   flex-wrap: wrap;
 }
 
-.maka-panel-detail[data-agents-view="skills"] .maka-module-main-actions > .maka-button-ghost:not(.maka-skill-add-button) {
+/* Round 8b: the hidden utilities are outline now (text buttons wear an
+   edge; ghost is icon-only), so key the rule on .maka-button instead of
+   the retired .maka-button-ghost class. */
+.maka-panel-detail[data-agents-view="skills"] .maka-module-main-actions > .maka-button:not(.maka-skill-add-button) {
   display: none;
 }
 

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -428,7 +428,7 @@ export function DailyReviewPanel(props: {
           {props.onCopyMarkdown && (
               <UiButton
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 className="maka-daily-review-copy min-w-[4rem]"
                 onClick={() => void runDailyReviewAction('copy', async () => {
@@ -446,7 +446,7 @@ export function DailyReviewPanel(props: {
             {props.onAppendMarkdown && (
               <UiButton
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 className="maka-daily-review-append min-w-[5rem]"
                 onClick={() => void runDailyReviewAction('append', async () => {
@@ -464,7 +464,7 @@ export function DailyReviewPanel(props: {
             {props.onSaveMarkdown && (
               <UiButton
                 type="button"
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 className="maka-daily-review-save min-w-[4rem]"
                 onClick={() => void runDailyReviewAction('save', async () => {

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -636,8 +636,8 @@ export function SkillsModuleMain(props: {
             />
           </label>
           <UiButton
-            className="maka-button maka-button-ghost"
-            variant="ghost"
+            className="maka-button"
+            variant="outline"
             type="button"
             onClick={() => void runSkillAction('folder', props.onOpenSkillsFolder)}
             disabled={!props.onOpenSkillsFolder || skillActionBusy}
@@ -660,8 +660,8 @@ export function SkillsModuleMain(props: {
             <span className="maka-visually-hidden">{skillCreateLegacyLabel}</span>
           </UiButton>
           <UiButton
-            className="maka-button maka-button-ghost"
-            variant="ghost"
+            className="maka-button"
+            variant="outline"
             type="button"
             onClick={() => void runSkillAction('refresh', props.onRefreshSkills)}
             disabled={!props.onRefreshSkills || skillActionBusy}


### PR DESCRIPTION
Uniformity follow-up to #659, applying the #613 rule everywhere: a text-labeled action button renders with a visible border (outline); ghost is reserved for icon-only controls.

- daily-review report actions 复制/追加/保存: three text ghosts → outline
- skills header 打开目录/刷新: text ghosts sitting directly beside the primary 添加 CTA (same defect class as 前往系统设置) → outline
- module-shell's skills-view hide rule re-keyed from the retired .maka-button-ghost marker to .maka-button

Icon ghosts (steppers, row utilities) unchanged and still contract-pinned. Desktop 2281/2281, check-dead-css clean, module-daily-review capture verified.