### PR TITLE
fix(desktop): 快捷键面板 '打开 Settings' → '打开设置'

### DIFF
--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -21,7 +21,7 @@ const SHORTCUTS: Section[] = [
     rows: [
       { keys: ['⌘', 'K'], description: '打开命令面板（跳会话 / 设置 / 主题等）' },
       { keys: ['?'], description: '打开 / 关闭此快捷键面板' },
-      { keys: ['⌘', ','], description: '打开 Settings' },
+      { keys: ['⌘', ','], description: '打开设置' },
       { keys: ['Esc'], description: '关闭当前模态框' },
     ],
   },


### PR DESCRIPTION
Keyboard-help sweep finding: the shortcut list is fully Chinese except one row. Desktop 2281/2281.

Also recorded for a follow-up round (bigger surface): the app currently ships three modal-header languages — keyboard-help (eyebrow + title + boxed close), search modal (plain title + bare X), command palette (no header) — a unification candidate.