### PR TITLE
fix(desktop): settings row switches end-align — tag-qualified selector matched nothing

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -299,4 +299,23 @@ describe('Settings form accessibility labels', () => {
       'Settings active nav item must not draw the left green accent rail',
     );
   });
+
+  // Alignment-governance round (maintainer report: 每日回顾 switches sat
+  // mid-page while every other row control hugs the right rail). The
+  // original end-align rule was tag-qualified (`button[role="switch"]`)
+  // but Base UI renders the Switch root as a SPAN — the selector matched
+  // nothing and rotted silently for weeks. Two pins: the rule exists in
+  // tag-agnostic form, and no settings CSS ever tag-qualifies role
+  // selectors again (role is the contract; the rendered tag is not).
+  it('end-aligns settings row switches with a tag-agnostic role selector', async () => {
+    const styles = await readRendererContractCss();
+    const alignRule = styles.match(/\.settingsRow\s*>\s*\[role="switch"\]\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    assert.ok(alignRule, '.settingsRow > [role="switch"] rule must exist');
+    assert.match(alignRule, /justify-self:\s*end;/, 'settings row switches must end-align like every other row control');
+    assert.doesNotMatch(
+      styles,
+      /button\[role="switch"\]/,
+      'never tag-qualify role selectors — Base UI renders the Switch root as a span, so button[role="switch"] silently matches nothing',
+    );
+  });
 });

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -414,10 +414,13 @@
   transition: background var(--duration-base) var(--ease-out-strong);
 }
 
-/* Detail audit: bare Switch controls sat at the value column's START
-   (x≈mid-page) while inputs/selects hug the right rail — two alignments
-   in one list. Controls end-align like every other row control. */
-.settingsRow > button[role="switch"] {
+/* Detail audit + alignment-governance round: bare Switch controls sat at
+   the value column's START (x≈mid-page) while inputs/selects hug the right
+   rail. The original fix was tag-qualified (`button[role="switch"]`) but
+   Base UI renders the Switch root as a SPAN — the selector matched nothing
+   and rotted silently. Tag-AGNOSTIC by rule: role is the contract, the
+   rendered tag never is. */
+.settingsRow > [role="switch"] {
   justify-self: end;
 }
 


### PR DESCRIPTION
Maintainer report: 每日回顾 switches sat mid-page while every other settings control right-aligns, plus 'why is only this one different — our governance is failing'. The diagnosis proves the point sharper than the symptom:

**The end-align rule already existed** (`.settingsRow > button[role="switch"] { justify-self: end }`, shipped in an earlier detail round) — **but Base UI renders the Switch root as a `<span role="switch">`**, so the tag-qualified selector matched zero elements, silently, for weeks. No contract could catch it because we pinned the selector's existence, not its effect.

Fixes:
- Tag-agnostic rule `.settingsRow > [role="switch"]` — CDP-measured: switch right-gap 461px → 20px (the row's right rail) on settings-daily-review, geometry still symmetric 3/21↔21/3
- New contract: pins the rule in tag-agnostic form **and bans `button[role=…]` tag-qualified role selectors across settings CSS** — role is the contract, the rendered tag never is. This kills the whole rot class, not just this instance.

Note: the thumb-gap detail in the user's screenshot was the rem-arbitrary-value bug already fixed in #659 (their build predated it); re-measured symmetric here.

Desktop 2285/2285 (new contract +1), check-dead-css clean.