### PR TITLE
fix(desktop): reword bot.css comment — #663 contract matched its own documentation

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -416,7 +416,7 @@
 
 /* Detail audit + alignment-governance round: bare Switch controls sat at
    the value column's START (x≈mid-page) while inputs/selects hug the right
-   rail. The original fix was tag-qualified (`button[role="switch"]`) but
+   rail. The original fix tag-qualified the selector with a button prefix, but
    Base UI renders the Switch root as a SPAN — the selector matched nothing
    and rotted silently. Tag-AGNOSTIC by rule: role is the contract, the
    rendered tag never is. */


### PR DESCRIPTION
#663 shipped with a red suite on main: the new ban-assertion greps all renderer CSS for the tag-qualified selector pattern, and the explanatory comment in bot.css contained the literal string. My verification chain used && after a grep that still matched on partial success — process bug on my side, flagged and fixed. Suite is 2285/2285 green with this.