### PR TITLE
fix(desktop): onboarding text actions wear edges — round-8 rule applied

### DIFF
--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -323,7 +323,7 @@ function NeedsConnectionHero(props: {
         {props.onRefreshConnections && (
           <Button
             type="button"
-            variant="ghost"
+            variant="outline"
             onClick={props.onRefreshConnections}
             disabled={props.refreshConnectionsPending === true}
             aria-busy={props.refreshConnectionsPending === true ? 'true' : undefined}
@@ -786,7 +786,7 @@ function ReadyEmptyHero(props: {
                 <div key={suggestion.id} className="maka-first-run-task-suggestion-chip">
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="outline"
                     size="sm"
                     className="maka-first-run-task-suggestion"
                     onClick={() => prefillSuggestion(suggestion.prompt, suggestion.mode)}
@@ -823,7 +823,7 @@ function SkipButton(props: { onSkip: () => Promise<void> | void; label?: string 
   return (
     <Button
       type="button"
-      variant="ghost"
+      variant="outline"
       onClick={onClick}
       disabled={pending}
       aria-busy={pending ? 'true' : undefined}
@@ -892,7 +892,7 @@ function SetupHero(props: SetupHeroProps) {
         {props.secondaryCta && (
           <Button
             type="button"
-            variant="ghost"
+            variant="outline"
             onClick={props.secondaryCta.onClick}
             disabled={props.secondaryCta.disabled === true}
             aria-busy={props.secondaryCta.busy === true ? 'true' : undefined}


### PR DESCRIPTION
Continues the affordance-honesty unification (#659/#660): the onboarding footer's 已经配好了？刷新检测 and 跳过，先逛逛 (plus first-run task suggestions and the early-onboarding secondaryCta) were text ghosts — visually indistinguishable from plain copy. All four now outline per the codified rule: text-labeled action buttons wear an edge, ghost is icon-only. CDP first-run capture verified; desktop 2285/2285, gated on the test exit code.