### PR TITLE
fix(desktop): skills header control alignment + models list radius language (round 10)

### DIFF
--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -1,11 +1,15 @@
+/* Round 10: the search field and the 添加 CTA share one header row —
+   they align on the SAME control height (36px, the default button) and
+   the SAME radius family (radius-control). Previously 32px/8px vs
+   36px/6px read as two misaligned controls. */
 .maka-skill-search {
   width: min(280px, 30vw);
-  height: 32px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
   gap: var(--space-1-5);
   border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-surface);
+  border-radius: var(--radius-control);
   background: var(--background);
   color: var(--muted-foreground);
   padding: 0 var(--space-2-5);

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -34,6 +34,10 @@
   transition: background-color var(--duration-quick) var(--ease-out-strong);
 }
 
+/* Round 10: interactive fills in the seamless list are ROUNDED like every
+   other row surface in the app (sidebar nav, session list) — square
+   full-bleed bands broke the radius language. */
+.enabledProviderTrigger { border-radius: var(--radius-control); }
 .enabledProviderTrigger:hover { background: var(--state-hover-bg); }
 
 .enabledProviderName {
@@ -106,6 +110,10 @@
 
 .enabledProviderPanel li + li .enabledConnRow {
   border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
+}
+
+.enabledConnRow {
+  border-radius: var(--radius-control);
 }
 
 .enabledConnRow[data-default="true"] {


### PR DESCRIPTION
Two maintainer reports, both root-caused with CDP measurement:

**1. 技能 header misalignment** — the 搜索技能 field rendered 32px tall with radius-surface (8px) while the adjacent 添加 primary is 36px with radius-control (6px): two heights and two radius families in one row. The search field now matches the control recipe: 36px + radius-control. Measured after: 36/36, 6px/6px.

**2. 模型连接 square corners** — the connection list's interactive fills (provider hover band, selected-connection band) were square edge-to-edge bands, breaking the app's radius language where every other row surface (sidebar nav rows, session list rows) rounds its fill. Row fills now carry radius-control (measured 0→6px); the deliberate seamless-list shell (no card — an earlier decision to de-weight the page) is preserved.

Desktop 2285/2285 gated on exit code; check-dead-css clean.