### PR TITLE
feat(ui): one dialog-header language — shared DialogHeader primitive

### DIFF
--- a/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/control-height-converge-contract.test.ts
@@ -88,7 +88,9 @@ interface ControlHeightCheck {
 const CONTROL_HEIGHT: ControlHeightCheck[] = [
   // sidebar / 会话 rows
   { selector: '.maka-list-row', props: ['min-height'], token: '--h-control-lg' },
-  { selector: '.maka-search-modal-close', props: ['width', 'height'], token: '--h-control-sm' },
+  // .maka-search-modal-close retired: the close button is the shared
+  // DialogHeader's quiet icon-sm Button, sized by buttonVariants, not a
+  // search-modal-specific class.
   { selector: '.maka-search-modal-clear', props: ['width', 'height'], token: '--h-control-sm' },
   // 设置 nav / triggers
   { selector: '.settingsBackButton', props: ['height', 'min-height'], token: '--h-control-xl' },

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -132,14 +132,52 @@ describe('renderer utility surfaces use shared UI primitives', () => {
     assert.match(source, /<KbdGroup className="maka-shortcut-group">[\s\S]*<Kbd className="maka-shortcut-kbd">↑<\/Kbd>[\s\S]*<Kbd className="maka-shortcut-kbd">↓<\/Kbd>/);
   });
 
-  it('keeps keyboard help close action on shared Button', async () => {
+  it('keeps keyboard help on the shared DialogHeader with a single title', async () => {
     const source = await readFile(join(process.cwd(), 'src/renderer/keyboard-help.tsx'), 'utf8');
 
-    assert.match(source, /import \{ Button, DialogContent, DialogRoot, Kbd \} from '@maka\/ui';/);
+    // Modal-header unification: keyboard-help consumes the shared DialogHeader
+    // primitive (single title row + quiet icon-sm close), not an ad-hoc
+    // eyebrow + second-title + boxed close stack.
+    assert.match(source, /import \{ DialogContent, DialogHeader, DialogRoot, Kbd \} from '@maka\/ui';/);
     assert.doesNotMatch(source, /<button\b/, 'KeyboardHelpModal close action must use shared Button');
     assert.doesNotMatch(source, /<kbd\b/, 'KeyboardHelpModal shortcut glyphs must use shared primitive Kbd');
-    assert.match(source, /<Button[\s\S]*className="settingsCloseButton"[\s\S]*aria-label="关闭快捷键面板"/);
+    assert.match(
+      source,
+      /<DialogHeader[\s\S]*title="键盘快捷键"[\s\S]*titleId="maka-help-title"[\s\S]*onClose=\{props\.onClose\}/,
+      'KeyboardHelpModal must render the shared DialogHeader with 键盘快捷键 as THE title',
+    );
+    // The redundant second title and eyebrow are gone.
+    assert.doesNotMatch(source, /所有可用快捷键/, 'The redundant second title must be dropped');
+    assert.doesNotMatch(source, /maka-help-eyebrow/, 'The eyebrow row must be dropped');
+    assert.doesNotMatch(source, /settingsCloseButton/, 'The boxed close-button class must be gone');
     assert.match(source, /<Kbd className="maka-shortcut-kbd">\{key\}<\/Kbd>/);
+  });
+
+  it('unifies titled DialogContent modals onto the shared DialogHeader primitive', async () => {
+    // Modal-header unification contract: every titled DialogContent modal
+    // consumes the shared DialogHeader (single title row + one quiet icon-sm
+    // close button) instead of an ad-hoc header. The command palette is
+    // intentionally headerless (its input row IS the header) and is excluded.
+    const header = await readFile(join(repoRoot, 'packages/ui/src/primitives/dialog-header.tsx'), 'utf8');
+    // The shared close button is the SAME form everywhere: quiet icon-sm
+    // Button + X, aria-label defaults to 关闭, no border box.
+    assert.match(header, /variant="quiet"/, 'DialogHeader close must be the quiet Button variant');
+    assert.match(header, /size="icon-sm"/, 'DialogHeader close must be icon-sm');
+    assert.match(header, /closeLabel = '关闭'/, 'DialogHeader close aria-label defaults to 关闭');
+    assert.match(header, /<X aria-hidden="true" \/>/, 'DialogHeader close renders the X icon');
+    assert.match(header, /export function DialogHeader/, 'DialogHeader must be exported');
+
+    // Both titled modals import + render the shared DialogHeader.
+    const keyboardHelp = await readFile(join(process.cwd(), 'src/renderer/keyboard-help.tsx'), 'utf8');
+    assert.match(keyboardHelp, /import \{[^}]*\bDialogHeader\b[^}]*\} from '@maka\/ui';/);
+    assert.match(keyboardHelp, /<DialogHeader\b/);
+
+    const searchModal = await readFile(join(repoRoot, 'packages/ui/src/search-modal.tsx'), 'utf8');
+    assert.match(searchModal, /import \{ DialogHeader \} from '\.\/primitives\/dialog-header\.js';/);
+    assert.match(searchModal, /<DialogHeader[\s\S]*title="搜索"[\s\S]*titleId="maka-search-modal-title"/);
+    // The old ad-hoc header language is gone.
+    assert.doesNotMatch(searchModal, /maka-search-modal-header/, 'Search modal must drop the ad-hoc header class');
+    assert.doesNotMatch(searchModal, /maka-search-modal-close/, 'Search modal must drop the ad-hoc close class');
   });
 
   it('keeps toast actions and confirm dialog buttons on shared Button without legacy classes', async () => {

--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -7,8 +7,8 @@
 // are handled by the same shell as SearchModal / Permission (#520 PR7).
 
 import { useEffect, useState } from 'react';
-import { Keyboard, X } from '@maka/ui/icons';
-import { Button, DialogContent, DialogRoot, Kbd } from '@maka/ui';
+import { Keyboard } from '@maka/ui/icons';
+import { DialogContent, DialogHeader, DialogRoot, Kbd } from '@maka/ui';
 
 type Section = {
   heading: string;
@@ -124,25 +124,12 @@ export function KeyboardHelpModal(props: { onClose(): void }) {
         aria-labelledby="maka-help-title"
         showClose={false}
       >
-        <div className="maka-modal-header maka-help-header">
-          <div>
-            <span className="maka-help-eyebrow" aria-hidden="true">
-              <Keyboard size={14} />
-              <span>键盘快捷键</span>
-            </span>
-            <h2 className="maka-modal-title" id="maka-help-title">所有可用快捷键</h2>
-          </div>
-          <Button
-            type="button"
-            className="settingsCloseButton"
-            variant="quiet"
-            size="icon-sm"
-            aria-label="关闭快捷键面板"
-            onClick={props.onClose}
-          >
-            <X aria-hidden="true" />
-          </Button>
-        </div>
+        <DialogHeader
+          icon={<Keyboard aria-hidden="true" />}
+          title="键盘快捷键"
+          titleId="maka-help-title"
+          onClose={props.onClose}
+        />
         <div className="maka-modal-body maka-help-body">
           {SHORTCUTS.map((section) => (
             <section key={section.heading} className="maka-help-section">

--- a/apps/desktop/src/renderer/styles/help.css
+++ b/apps/desktop/src/renderer/styles/help.css
@@ -18,24 +18,8 @@
   box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.05);
 }
 
-.maka-help-header {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: var(--space-3);
-}
-
-.maka-help-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  margin-bottom: var(--space-1);
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--tracking-normal);
-  text-transform: none;
-}
+/* The header row (title + close) is the shared DialogHeader primitive
+ * (@maka/ui) now — no help-specific header/eyebrow CSS. */
 
 .maka-help-body {
   display: grid;

--- a/apps/desktop/src/renderer/styles/search-modal.css
+++ b/apps/desktop/src/renderer/styles/search-modal.css
@@ -16,37 +16,8 @@
      adds the inner sheen. */
   box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.05);
 }
-.maka-search-modal-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  padding: var(--space-2) var(--space-3) var(--space-1-5);
-  border-bottom: var(--border-width-hairline) solid var(--border);
-}
-.maka-search-modal-title {
-  margin: 0;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  color: var(--foreground);
-}
-.maka-search-modal-close {
-  width: var(--h-control-sm);
-  height: var(--h-control-sm);
-  border: 0;
-  background: transparent;
-  color: var(--foreground-secondary);
-  font-size: 1.0667em;
-  line-height: var(--leading-none);
-  border-radius: var(--radius-control);
-}
-.maka-search-modal-close:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-.maka-search-modal-close:focus-visible {
-  outline: var(--focus-ring-width) solid var(--ring);
-  outline-offset: var(--focus-ring-offset);
-}
+/* Header band: the shared DialogHeader primitive (@maka/ui) owns the title
+ * row + quiet icon-sm close button now — no search-modal-specific header CSS. */
 /* PR-UX-POLISH-1 commit 5: real search modal layout.
  * - input-row: text input + leading magnifier icon, sits below the
  *   header band.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,6 +58,7 @@ export * from './primitives/item.js';
 export * from './primitives/spinner.js';
 export * from './primitives/kbd.js';
 export * from './primitives/menu.js';
+export * from './primitives/dialog-header.js';
 export * from './primitives/choice-card.js';
 export * from './primitives/settings-segmented.js';
 export * from './primitives/settings-select.js';

--- a/packages/ui/src/primitives/dialog-header.tsx
+++ b/packages/ui/src/primitives/dialog-header.tsx
@@ -1,0 +1,70 @@
+// packages/ui/src/primitives/dialog-header.tsx
+//
+// Shared header recipe for TITLED DialogContent modals (keyboard-help,
+// search modal, and any other DialogContent that carried an ad-hoc header).
+// One language everywhere:
+//   - a single title row: optional leading icon (16px, muted ink),
+//     title text (--font-size-ui, semibold, --foreground), a spacer, and
+//     exactly one close button.
+//   - the close button is the SAME quiet icon-sm Button + X icon with
+//     aria-label="关闭" — NO border box, no eyebrow, no second title.
+//
+// Palette-style modals whose input row IS the header (command-palette) do
+// NOT use this — they are intentionally headerless. Modals with a genuine
+// subtitle (permission-dialog) keep their richer bespoke header.
+//
+// Self-contained styling: the header is styled with Tailwind utility classes
+// so the primitive is portable across packages and needs no consumer CSS.
+
+import type { ReactNode } from 'react';
+import { X } from '../icons.js';
+import { Button } from '../ui.js';
+
+export interface DialogHeaderProps {
+  /** Optional leading glyph, rendered at 16px in muted ink. */
+  icon?: ReactNode;
+  /** Title text. Rendered as an <h2> at --font-size-ui, semibold. */
+  title: ReactNode;
+  /** Id applied to the title <h2> so DialogContent aria-labelledby can point at it. */
+  titleId?: string;
+  /** Close handler wired to the quiet icon-sm close button. */
+  onClose(): void;
+  /** Accessible label for the close button. Defaults to the shared "关闭". */
+  closeLabel?: string;
+}
+
+export function DialogHeader({ icon, title, titleId, onClose, closeLabel = '关闭' }: DialogHeaderProps) {
+  return (
+    <header
+      className="flex items-center gap-2 border-b border-border px-4 py-2.5"
+      data-slot="dialog-header"
+    >
+      {icon != null && (
+        <span
+          className="flex shrink-0 items-center text-muted-foreground [&>svg]:h-4 [&>svg]:w-4"
+          aria-hidden="true"
+          data-slot="dialog-header-icon"
+        >
+          {icon}
+        </span>
+      )}
+      <h2
+        id={titleId}
+        className="min-w-0 flex-1 truncate text-[length:var(--font-size-ui)] font-semibold text-foreground"
+        data-slot="dialog-header-title"
+      >
+        {title}
+      </h2>
+      <Button
+        type="button"
+        variant="quiet"
+        size="icon-sm"
+        aria-label={closeLabel}
+        onClick={onClose}
+        data-slot="dialog-header-close"
+      >
+        <X aria-hidden="true" />
+      </Button>
+    </header>
+  );
+}

--- a/packages/ui/src/search-modal.tsx
+++ b/packages/ui/src/search-modal.tsx
@@ -3,8 +3,9 @@ import type { SearchErrorReason, SearchRequest, SearchResult } from '@maka/core'
 import { generalizedErrorMessageChinese } from '@maka/core';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { Search, X } from './icons.js';
+import { DialogHeader } from './primitives/dialog-header.js';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './primitives/input-group.js';
-import { DialogClose, DialogContent, DialogRoot, Button as UiButton } from './ui.js';
+import { DialogContent, DialogRoot, Button as UiButton } from './ui.js';
 
 /**
  * PR-SIDEBAR-IA-0 Phase 2 fixup (xuan `91401163` + kenji `6465cf22`,
@@ -225,18 +226,12 @@ export function SearchModal(props: {
         initialFocus={inputRef}
         finalFocus={() => (suppressFocusRestoreRef.current ? false : true)}
       >
-        <header className="maka-search-modal-header">
-          <h2 id="maka-search-modal-title" className="maka-search-modal-title">搜索</h2>
-          <DialogClose
-            render={<UiButton variant="quiet" size="icon-sm" />}
-            type="button"
-            className="maka-search-modal-close"
-            onClick={() => props.onClose()}
-            aria-label="关闭搜索"
-          >
-            <X size={16} aria-hidden="true" />
-          </DialogClose>
-        </header>
+        <DialogHeader
+          icon={<Search aria-hidden="true" />}
+          title="搜索"
+          titleId="maka-search-modal-title"
+          onClose={() => props.onClose()}
+        />
         {/*
           #520 PR8: Autocomplete owns the listbox/option ARIA + ArrowUp/Down/
           Enter/Escape keyboard nav (activedescendant mode). `inline` keeps the


### PR DESCRIPTION
Unifies the three coexisting modal-header styles the audit flagged (keyboard-help eyebrow+double-title+boxed close / search modal plain title+bare X / palette headerless-by-design).

- New `DialogHeader` primitive in @maka/ui: optional 16px muted leading icon + single semibold title (h2, aria-labelledby wired) + one quiet icon-sm close (X, aria-label 关闭, no border box)
- keyboard-help: eyebrow + redundant second title 所有可用快捷键 dropped — 键盘快捷键 IS the title; boxed settingsCloseButton retired
- search modal: ad-hoc header replaced with the primitive
- command palette: headerless by design, untouched
- permission-dialog / plan-reminder / wechat-login headers carry subtitles the plain recipe doesn't cover — deliberately not migrated (wechat scan-login is the next clean-fit candidate)
- Orphaned header CSS deleted; contracts re-pinned (+1 new contract pinning the shared consumption + close-button shape)

Verified in worktree: builds, desktop 2286/2286 (exit-code gated), packages/ui tests, dead-css clean, CDP smoke on both modals (probes confirm shared header + 关闭 label). Implemented by an opus worktree agent to the maintainer's decided spec.