### PR TITLE
feat(desktop): ⌘N creates a new task — global shortcut, sidebar hint, help entry

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -186,6 +186,7 @@ function BootstrapSubscriptionProbe(props: {
     bootstrapSessions: async () => {},
     clearPendingTurnActionsForSession: () => {},
     clearSessionRendererState: () => {},
+    createSession: () => {},
     handleConnectionEvent: props.onConnectionEvent,
     openSettings: () => {},
     pendingPermissionModeChangesRef: props.refs.pendingPermissionModeChangesRef,

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -160,6 +160,7 @@ export function useAppShellBootstrapSubscriptions(options: {
   bootstrapSessions: () => Promise<void>;
   clearPendingTurnActionsForSession: (sessionId: string) => void;
   clearSessionRendererState: (sessionId: string) => void;
+  createSession: () => Promise<void> | void;
   handleConnectionEvent: (event: ConnectionEvent) => void;
   openSettings: () => void;
   pendingPermissionModeChangesRef: RefBox<Set<string>>;
@@ -251,6 +252,12 @@ export function useAppShellBootstrapSubscriptions(options: {
     if ((event.metaKey || event.ctrlKey) && event.key === ',') {
       event.preventDefault();
       options.openSettings();
+    }
+    // ⌘/Ctrl+N — new task, mirroring the sidebar 新任务 row (whose kbd hint
+    // advertises this). Plain N only: shift/alt combos stay free.
+    if ((event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey && (event.key === 'n' || event.key === 'N')) {
+      event.preventDefault();
+      void options.createSession();
     }
   });
   const markRendererMounted = useEffectEvent(() => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1041,6 +1041,7 @@ export function AppShell({
     bootstrapSessions,
     clearPendingTurnActionsForSession,
     clearSessionRendererState,
+    createSession,
     handleConnectionEvent,
     openSettings,
     pendingPermissionModeChangesRef,

--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -21,6 +21,7 @@ const SHORTCUTS: Section[] = [
     rows: [
       { keys: ['⌘', 'K'], description: '打开命令面板（跳会话 / 设置 / 主题等）' },
       { keys: ['?'], description: '打开 / 关闭此快捷键面板' },
+      { keys: ['⌘', 'N'], description: '新建任务' },
       { keys: ['⌘', ','], description: '打开设置' },
       { keys: ['Esc'], description: '关闭当前模态框' },
     ],

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -719,3 +719,19 @@
 .maka-list-row:hover .maka-list-row-name {
   color: var(--foreground);
 }
+
+/* ⌘N hint on the 新任务 row — quiet kbd chip pushed to the right rail,
+   visible at rest like the reference app (it advertises a real global
+   shortcut registered in app-shell-effects). */
+.maka-nav-kbd {
+  margin-left: auto;
+  padding: 0 var(--space-1);
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--foreground-3);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-normal);
+  white-space: nowrap;
+}

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -71,6 +71,7 @@ export function SessionSidebarNav(props: {
       >
         <Plus className="maka-nav-icon" aria-hidden="true" />
         <span>新任务</span>
+        <kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>
       </UiButton>
       <UiButton
         variant="quiet"


### PR DESCRIPTION
Reference-app parity item from the icon-governance round: the competitor's 新任务 row advertises ⌘+N. Ours now does too — honestly: a real global ⌘/Ctrl+N handler in app-shell-effects (same seam as ⌘,), a quiet kbd chip on the sidebar row's right rail, and a 新建任务 entry in the keyboard-help 通用 section. Plain N only — shift/alt combos remain free. Desktop 2286/2286 exit-code gated; CDP capture confirms the hint renders like the reference.