### PR TITLE
feat(desktop): 语气偏好 autosaves like every sibling — the 保存 button retires

### DIFF
--- a/apps/desktop/src/main/__tests__/personalization-sync-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/personalization-sync-contract.test.ts
@@ -1,10 +1,18 @@
 /**
  * Source-grounded contract for PR-PERSONALIZATION-SYNC-0
- * (WAWQAQ msg 23c079a9 round 7). The personalization form
- * initializes from `props.settings.personalization` once on mount.
- * Without a sync effect, the visible inputs diverge from the
- * persisted store after server-side sanitization rewrites the
- * saved value.
+ * (WAWQAQ msg 23c079a9 round 7) + PR-TONE-AUTOSAVE-0.
+ *
+ * The personalization form initializes from
+ * `props.settings.personalization` once on mount. Without a sync
+ * effect, the visible inputs diverge from the persisted store after
+ * server-side sanitization rewrites the saved value.
+ *
+ * PR-TONE-AUTOSAVE-0: the block used to carry the page's only explicit
+ * save control + helper line while every neighbor persisted silently on
+ * change/blur. It now autosaves like its siblings — 显示名称 flushes on
+ * blur, 界面语言 persists on change, 助手语气偏好 debounces mid-typing and
+ * flushes on blur — with no button and no success toast (silence is the
+ * page's success language; only failures surface via toast.error).
  */
 
 import { strict as assert } from 'node:assert';
@@ -17,7 +25,10 @@ describe('Personalization form state sync (PR-PERSONALIZATION-SYNC-0)', () => {
     const src = await readSettingsCombinedSource();
     const pageStart = src.indexOf('function PersonalizationSettingsPage');
     assert.notEqual(pageStart, -1, 'PersonalizationSettingsPage must exist');
-    return src.slice(pageStart, pageStart + 7000);
+    // Window widened for PR-TONE-AUTOSAVE-0: the autosave rewrite added the
+    // shared persist path + per-field handlers, pushing the tone textarea's
+    // blur flush (the last JSX row) past the old 7000-char slice.
+    return src.slice(pageStart, pageStart + 8500);
   }
 
   it('PersonalizationSettingsPage syncs state when persisted personalization changes', async () => {
@@ -30,6 +41,13 @@ describe('Personalization form state sync (PR-PERSONALIZATION-SYNC-0)', () => {
       head,
       /useEffect\(\(\) => \{[\s\S]*?setDisplayName\(value\.displayName\)[\s\S]*?setAssistantTone\(value\.assistantTone\)[\s\S]*?setUiLocale\(value\.uiLocale\)[\s\S]*?\},\s*\[\s*value\.displayName,\s*value\.assistantTone,\s*value\.uiLocale,?\s*\]\)/,
       'PersonalizationSettingsPage must sync local state when persisted values change',
+    );
+    // The sync must not clobber a value the user is mid-editing while an
+    // autosave for it is still in flight — guarded on the pending count.
+    assert.match(
+      head,
+      /if \(persistPendingCountRef\.current > 0\) return;[\s\S]*?setDisplayName\(value\.displayName\)/,
+      'Personalization state sync must skip while an autosave is in flight',
     );
   });
 
@@ -48,63 +66,124 @@ describe('Personalization form state sync (PR-PERSONALIZATION-SYNC-0)', () => {
     );
   });
 
-  it('PersonalizationSettingsPage gates saves synchronously and freezes the draft while saving', async () => {
+  it('PersonalizationSettingsPage autosaves via a last-write-wins persist path', async () => {
     const page = await readPersonalizationPage();
 
+    // Shared persist helper takes a partial personalization patch and
+    // routes through onUpdate.
     assert.match(
       page,
-      /const savingRef = useRef\(false\)/,
-      'Personalization save must have a synchronous ref gate, not only React state',
+      /async function persistPersonalization\(patch: Partial<PersonalizationSettings>\) \{[\s\S]*?await props\.onUpdate\(\{ personalization: patch \}\)/,
+      'Personalization must persist a partial patch through a shared autosave path',
+    );
+    // Monotonic ticket disambiguates overlapping in-flight saves so a
+    // stale earlier response can't clobber a newer write (last write wins).
+    assert.match(
+      page,
+      /const persistTicketRef = useRef\(0\)/,
+      'Personalization autosave must carry a monotonic ticket for last-write-wins',
     );
     assert.match(
       page,
-      /async function save\(\) \{[\s\S]*if \(savingRef\.current\) return;[\s\S]*savingRef\.current = true;[\s\S]*setSaving\(true\)/,
-      'Personalization save must lock before the first async settings update',
+      /const ticket = \+\+persistTicketRef\.current;[\s\S]*?if \(!personalizationMountedRef\.current \|\| ticket !== persistTicketRef\.current\) return;/,
+      'Personalization autosave must ignore responses whose ticket is no longer current',
     );
     assert.match(
       page,
-      /finally \{[\s\S]*savingRef\.current = false;[\s\S]*setSaving\(false\)/,
-      'Personalization save must release the synchronous gate in finally',
-    );
-    assert.match(
-      page,
-      /disabled=\{saving\}[\s\S]*aria-label="显示名称"/,
-      'Display name input must freeze while the saved payload is in flight',
-    );
-    assert.match(
-      page,
-      /ariaLabel="界面语言"[\s\S]*disabled=\{saving\}/,
-      'Locale segmented control must freeze while the saved payload is in flight',
-    );
-    assert.match(
-      page,
-      /disabled=\{saving\}[\s\S]*aria-label="助手语气偏好"/,
-      'Assistant tone textarea must freeze while the saved payload is in flight',
-    );
-    assert.match(
-      page,
-      /disabled=\{saving\}[\s\S]*aria-busy=\{saving\}[\s\S]*data-pending=\{saving \? 'true' : undefined\}/,
-      'Save button must expose pending state to the UI and accessibility tree',
+      /const persistPendingCountRef = useRef\(0\)/,
+      'Personalization autosave must track pending saves so the sync effect can defer',
     );
   });
 
-  it('PersonalizationSettingsPage describes the save action with its persistence boundary copy', async () => {
+  it('PersonalizationSettingsPage debounces the tone textarea and flushes on blur', async () => {
+    const page = await readPersonalizationPage();
+
+    // A debounce timer + a fixed interval constant.
+    assert.match(
+      page,
+      /const TONE_AUTOSAVE_DEBOUNCE_MS = \d+/,
+      'Tone autosave must debounce on a fixed interval constant',
+    );
+    assert.match(
+      page,
+      /const toneDebounceRef = useRef<ReturnType<typeof setTimeout> \| null>\(null\)/,
+      'Tone autosave must hold a debounce timer ref',
+    );
+    assert.match(
+      page,
+      /function scheduleToneSave\([\s\S]*?toneDebounceRef\.current = setTimeout\([\s\S]*?assistantTone:[\s\S]*?\},\s*TONE_AUTOSAVE_DEBOUNCE_MS\)/,
+      'Tone autosave must schedule a debounced persist after the user stops typing',
+    );
+    // Blur wins immediately: clears the pending timer and persists now.
+    assert.match(
+      page,
+      /function flushTone\([\s\S]*?clearTimeout\(toneDebounceRef\.current\)[\s\S]*?persistPersonalization\(\{ assistantTone:/,
+      'Tone blur must clear the debounce timer and flush the save immediately',
+    );
+    assert.match(
+      page,
+      /onBlur=\{\(event\) => flushTone\(event\.currentTarget\.value\)\}/,
+      'Tone textarea must flush on blur',
+    );
+    // The tone textarea change handler must schedule the debounced save.
+    assert.match(
+      page,
+      /onChange=\{\(event\) => \{[\s\S]*?setAssistantTone\(event\.currentTarget\.value\);[\s\S]*?scheduleToneSave\(event\.currentTarget\.value\);/,
+      'Tone textarea onChange must schedule the debounced autosave',
+    );
+  });
+
+  it('PersonalizationSettingsPage autosaves display name on blur and locale on change', async () => {
     const page = await readPersonalizationPage();
 
     assert.match(
       page,
-      /const personalizationSaveHelpId = useId\(\)/,
-      'Personalization save help copy must have a stable React-generated id',
+      /onBlur=\{\(event\) => flushDisplayName\(event\.currentTarget\.value\)\}[\s\S]*?aria-label="显示名称"/,
+      'Display name must flush its autosave on blur',
     );
     assert.match(
+      page,
+      /onChange=\{\(next\) => persistLocale\(next as UiLocalePreference\)\}[\s\S]*?ariaLabel="界面语言"/,
+      'Locale segmented control must persist immediately on change',
+    );
+  });
+
+  it('PersonalizationSettingsPage has no explicit save control in the personalization block', async () => {
+    const page = await readPersonalizationPage();
+
+    // Autosave siblings never render an in-row commit control; the block
+    // must not reintroduce one, nor its describing helper id/copy.
+    assert.doesNotMatch(
+      page,
+      /<Button[\s\S]*?onClick=\{\(\) => void save\(\)\}/,
+      'Personalization block must not carry an in-row commit control',
+    );
+    assert.doesNotMatch(
+      page,
+      /const personalizationSaveHelpId = useId\(\)/,
+      'The dropped commit control must not leave its describing help id behind',
+    );
+    assert.doesNotMatch(
       page,
       /aria-describedby=\{personalizationSaveHelpId\}/,
-      'Personalization save button must reference the visible persistence boundary help text',
+      'No control should reference the removed persistence-boundary help copy',
     );
-    assert.match(
+  });
+
+  it('PersonalizationSettingsPage stays silent on success (no toast, autosave language)', async () => {
+    const page = await readPersonalizationPage();
+
+    // Silence is the page's success language — matching every autosave
+    // sibling. No confirmation toast on a successful persist.
+    assert.doesNotMatch(
       page,
-      /<p id=\{personalizationSaveHelpId\} className="settingsHelpText">保存后立即生效，下一次发送对话时模型会拿到新偏好。<\/p>/,
-      'Personalization save help text must remain visible and programmatically associated',
+      /toast\.success\(/,
+      'Personalization autosave must not fire a success toast',
+    );
+    assert.doesNotMatch(
+      page,
+      /toast\.warning\(/,
+      'Personalization autosave must not fire a warning toast',
     );
   });
 
@@ -118,33 +197,27 @@ describe('Personalization form state sync (PR-PERSONALIZATION-SYNC-0)', () => {
     );
     assert.match(
       page,
-      /useEffect\(\(\) => \{[\s\S]*personalizationMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*personalizationMountedRef\.current = false;[\s\S]*savingRef\.current = false;/,
-      'Personalization cleanup must release the synchronous save owner when Settings closes',
+      /useEffect\(\(\) => \{[\s\S]*personalizationMountedRef\.current = true;[\s\S]*return \(\) => \{[\s\S]*personalizationMountedRef\.current = false;/,
+      'Personalization cleanup must release page ownership when Settings closes',
     );
+    // Cleanup must invalidate any in-flight save's late apply (bump ticket)
+    // and drop a pending debounced flush so it can't fire post-unmount.
     assert.match(
       page,
-      /const result = await props\.onUpdate\([\s\S]*?\);[\s\S]*if \(!personalizationMountedRef\.current\) return;[\s\S]*applyUiLocale\(uiLocale\);/,
+      /return \(\) => \{[\s\S]*persistTicketRef\.current \+= 1;[\s\S]*clearTimeout\(toneDebounceRef\.current\)/,
+      'Personalization cleanup must invalidate in-flight saves and cancel the pending debounce',
+    );
+    // A stale locale must not be applied after Settings closes: the mount +
+    // ticket guard gates the applyUiLocale side effect.
+    assert.match(
+      page,
+      /if \(!personalizationMountedRef\.current \|\| ticket !== persistTicketRef\.current\) return;[\s\S]*applyUiLocale\(patch\.uiLocale\)/,
       'Personalization save must not apply a stale UI locale after Settings is closed',
     );
     assert.match(
       page,
-      /if \(warnings\) \{[\s\S]*if \(personalizationMountedRef\.current\) \{[\s\S]*toast\.warning\('已保存并做安全清理'/,
-      'Personalization warning toast must only fire while the page is still mounted',
-    );
-    assert.match(
-      page,
-      /else \{[\s\S]*if \(personalizationMountedRef\.current\) \{[\s\S]*toast\.success\('个性化已保存'\)/,
-      'Personalization success toast must only fire while the page is still mounted',
-    );
-    assert.match(
-      page,
-      /catch \(error\) \{[\s\S]*if \(personalizationMountedRef\.current\) \{[\s\S]*toast\.error\('保存失败', settingsActionErrorMessage\(error\)\)/,
-      'Personalization failure toast must only fire while the page is still mounted',
-    );
-    assert.match(
-      page,
-      /finally \{[\s\S]*savingRef\.current = false;[\s\S]*if \(personalizationMountedRef\.current\) \{[\s\S]*setSaving\(false\);/,
-      'Personalization save cleanup must not write React state after unmount',
+      /catch \(error\) \{[\s\S]*if \(personalizationMountedRef\.current && ticket === persistTicketRef\.current\) \{[\s\S]*toast\.error\('保存失败', settingsActionErrorMessage\(error\)\)/,
+      'Personalization failure toast must only fire while the page still owns the save',
     );
   });
 });

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SettingsRows } from './settings-rows';
 import type {
   AppSettings,
-  PersonalizationSettingsWarning,
+  PersonalizationSettings,
   ThemePalette,
   ThemePreference,
   UpdateAppSettingsResult,
 } from '@maka/core';
-import { Button, ChoiceCard, ChoiceCardGroup, Input, SettingsSegmented as Segmented, Textarea, useToast } from '@maka/ui';
+import { ChoiceCard, ChoiceCardGroup, Input, SettingsSegmented as Segmented, Textarea, useToast } from '@maka/ui';
 import { applyUiLocale, type UiLocalePreference } from '../theme';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
@@ -43,25 +43,48 @@ export function AppearanceSettingsPage(props: {
   );
 }
 
+// PR-TONE-AUTOSAVE-0: the personalization block used to be the page's ONLY
+// control with an explicit 保存 button + helper line — every neighboring row
+// (显示名称 / 界面语言 / 默认模型 / switches) persists silently on change or
+// blur. Two save models on one page. This block now autosaves like its
+// siblings: 显示名称 and 助手语气偏好 flush on blur (and the tone textarea
+// also debounces mid-typing), 界面语言 persists on change. No button, no
+// success toast — silence is the page's success language; only failures
+// surface (toast.error, like every sibling persist path).
+
 export function PersonalizationSettingsPage(props: {
   settings: AppSettings;
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
 }) {
+  // Persist the tone textarea this long after the user stops typing; blur
+  // flushes immediately regardless.
+  const TONE_AUTOSAVE_DEBOUNCE_MS = 800;
   const value = props.settings.personalization;
   const [displayName, setDisplayName] = useState(value.displayName);
   const [assistantTone, setAssistantTone] = useState(value.assistantTone);
   const [uiLocale, setUiLocale] = useState<UiLocalePreference>(value.uiLocale);
   const toast = useToast();
-  const [saving, setSaving] = useState(false);
-  const savingRef = useRef(false);
   const personalizationMountedRef = useRef(false);
-  const personalizationSaveHelpId = useId();
+  // Last-write-wins persist queue, mirrored on NetworkProxySection below:
+  // a monotonic ticket disambiguates overlapping in-flight saves so a stale
+  // response can't clobber a newer one, and a pending-count keeps the sync
+  // effect from resetting local state mid-edit.
+  const persistTicketRef = useRef(0);
+  const persistPendingCountRef = useRef(0);
+  // Debounce timer for the tone textarea; flushed immediately on blur.
+  const toneDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     personalizationMountedRef.current = true;
     return () => {
       personalizationMountedRef.current = false;
-      savingRef.current = false;
+      // Invalidate any in-flight save's late UI write, and drop the pending
+      // debounced flush so it can't fire after the panel closes.
+      persistTicketRef.current += 1;
+      if (toneDebounceRef.current) {
+        clearTimeout(toneDebounceRef.current);
+        toneDebounceRef.current = null;
+      }
     };
   }, []);
 
@@ -73,55 +96,68 @@ export function PersonalizationSettingsPage(props: {
   //      persisted store has the sanitized version.
   //   2. Another agent / background sync mutates settings while the
   //      panel is open.
-  // The user's in-progress edits aren't blown away — this only
-  // fires when the persisted reference identity actually changes.
+  // Guarded on the pending-save count so an autosave that's still in
+  // flight doesn't get its optimistic local value reset out from under
+  // the user mid-edit — the sync only lands when nothing is in flight.
   useEffect(() => {
+    if (persistPendingCountRef.current > 0) return;
     setDisplayName(value.displayName);
     setAssistantTone(value.assistantTone);
     setUiLocale(value.uiLocale);
   }, [value.displayName, value.assistantTone, value.uiLocale]);
 
-  async function save() {
-    if (savingRef.current) return;
-    savingRef.current = true;
-    setSaving(true);
+  // Shared persist path for every personalization field. Newest write wins:
+  // each call bumps the ticket, and only the response whose ticket is still
+  // current is allowed to apply side effects (locale) — a slow earlier save
+  // resolving after a newer one is discarded.
+  async function persistPersonalization(patch: Partial<PersonalizationSettings>) {
+    const ticket = ++persistTicketRef.current;
+    persistPendingCountRef.current += 1;
     try {
-      const result = await props.onUpdate({
-        personalization: {
-          displayName: displayName.trim().slice(0, 60),
-          assistantTone: assistantTone.trim().slice(0, 500),
-          uiLocale,
-        },
-      });
-      if (!personalizationMountedRef.current) return;
-      // PR-LANG-PREF-0: apply the chosen locale to <html> right
-      // after save so the change takes effect immediately in the
-      // current window. The persisted value also drives next-boot
-      // detection (main.tsx applies it on settings load).
-      applyUiLocale(uiLocale);
-      // Single toast either way. With warnings, surface generic policy
-      // statements (no raw user text echoed back, no specific keyword
-      // disclosed) per kenji's personalization-prompt-contract.
-      const warnings = collectPersonalizationWarningCopy(result.warnings?.personalization ?? []);
-      if (warnings) {
-        if (personalizationMountedRef.current) {
-          toast.warning('已保存并做安全清理', warnings);
-        }
-      } else {
-        if (personalizationMountedRef.current) {
-          toast.success('个性化已保存');
-        }
+      await props.onUpdate({ personalization: patch });
+      if (!personalizationMountedRef.current || ticket !== persistTicketRef.current) return;
+      if (patch.uiLocale !== undefined) {
+        // PR-LANG-PREF-0: apply the chosen locale to <html> right after save
+        // so the change takes effect immediately in the current window. The
+        // persisted value also drives next-boot detection (main.tsx applies
+        // it on settings load).
+        applyUiLocale(patch.uiLocale);
       }
     } catch (error) {
-      if (personalizationMountedRef.current) {
+      if (personalizationMountedRef.current && ticket === persistTicketRef.current) {
         toast.error('保存失败', settingsActionErrorMessage(error));
       }
     } finally {
-      savingRef.current = false;
-      if (personalizationMountedRef.current) {
-        setSaving(false);
-      }
+      persistPendingCountRef.current = Math.max(0, persistPendingCountRef.current - 1);
     }
+  }
+
+  function flushDisplayName(nextValue: string) {
+    void persistPersonalization({ displayName: nextValue.trim().slice(0, 60) });
+  }
+
+  function persistLocale(next: UiLocalePreference) {
+    setUiLocale(next);
+    void persistPersonalization({ uiLocale: next });
+  }
+
+  // Tone autosave: debounce mid-typing so we don't hammer settings.update on
+  // every keystroke, then flush the pending value immediately on blur (blur
+  // wins — clears the timer and saves right away).
+  function scheduleToneSave(nextValue: string) {
+    if (toneDebounceRef.current) clearTimeout(toneDebounceRef.current);
+    toneDebounceRef.current = setTimeout(() => {
+      toneDebounceRef.current = null;
+      void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
+    }, TONE_AUTOSAVE_DEBOUNCE_MS);
+  }
+
+  function flushTone(nextValue: string) {
+    if (toneDebounceRef.current) {
+      clearTimeout(toneDebounceRef.current);
+      toneDebounceRef.current = null;
+    }
+    void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
   }
 
   return (
@@ -141,11 +177,11 @@ export function PersonalizationSettingsPage(props: {
             type="text"
             value={displayName}
             onChange={(event) => setDisplayName(event.currentTarget.value)}
+            onBlur={(event) => flushDisplayName(event.currentTarget.value)}
             placeholder="例如：JK"
             maxLength={60}
             autoComplete="off"
             spellCheck={false}
-            disabled={saving}
             aria-label="显示名称"
           />
         </div>
@@ -159,7 +195,7 @@ export function PersonalizationSettingsPage(props: {
         <div className="settingsFormRow">
           <div>
             <strong>界面语言</strong>
-            <small>选择 Maka 界面的显示语言。保存后立即生效，重启后保持。</small>
+            <small>选择 Maka 界面的显示语言。切换后立即生效，重启后保持。</small>
           </div>
           <Segmented
             value={uiLocale}
@@ -168,9 +204,8 @@ export function PersonalizationSettingsPage(props: {
               ['zh', '中文'],
               ['en', 'English'],
             ]}
-            onChange={(next) => setUiLocale(next as UiLocalePreference)}
+            onChange={(next) => persistLocale(next as UiLocalePreference)}
             ariaLabel="界面语言"
-            disabled={saving}
           />
         </div>
 
@@ -179,52 +214,27 @@ export function PersonalizationSettingsPage(props: {
             <strong>助手语气偏好</strong>
             <small>
               最多 500 字，只影响回答的语气和风格。权限确认与安全规则不受它影响——
-              写"跳过确认"这类指令不会生效。
+              写"跳过确认"这类指令不会生效。改动会自动保存，下一次发送对话时模型会拿到新偏好。
             </small>
           </div>
           <Textarea
             value={assistantTone}
-            onChange={(event) => setAssistantTone(event.currentTarget.value)}
+            onChange={(event) => {
+              setAssistantTone(event.currentTarget.value);
+              scheduleToneSave(event.currentTarget.value);
+            }}
+            onBlur={(event) => flushTone(event.currentTarget.value)}
             placeholder="一句话告诉助手期望的语气，比如：技术严谨 / 偏简洁 / 不要 emoji / 多反问。"
             rows={4}
             maxLength={500}
             spellCheck={false}
-            disabled={saving}
             aria-label="助手语气偏好"
             className="min-h-21 w-full"
           />
-          <div className="settingsActionRow">
-            <Button
-              type="button"
-              variant="secondary"
-              disabled={saving}
-              aria-busy={saving}
-              aria-describedby={personalizationSaveHelpId}
-              data-pending={saving ? 'true' : undefined}
-              onClick={() => void save()}
-            >
-              {saving ? '保存中…' : '保存'}
-            </Button>
-            <p id={personalizationSaveHelpId} className="settingsHelpText">保存后立即生效，下一次发送对话时模型会拿到新偏好。</p>
-          </div>
         </div>
       </SettingsRows>
     </div>
   );
-}
-
-function collectPersonalizationWarningCopy(warnings: PersonalizationSettingsWarning[]): string | undefined {
-  if (warnings.length === 0) return undefined;
-  // Copy per kenji's personalization-prompt-contract: enum -> generic policy
-  // statement. Never quote, name, or echo the matched phrase / keyword;
-  // each line describes the action taken + the invariant that still holds.
-  const copy: Record<PersonalizationSettingsWarning, string> = {
-    'override-attempt':
-      '检测到可能尝试改变助手行为的内容，已按低优先级偏好处理；权限策略不受影响。',
-    'sensitive-pattern': '检测到疑似敏感凭据，已避免在提示或日志中回显原文。',
-    'control-chars': '已清理不可见控制字符，避免影响提示结构。',
-  };
-  return warnings.map((warning) => copy[warning]).join('\n');
 }
 
 /**


### PR DESCRIPTION
Closes the last recorded save-model inconsistency on the 通用 page: 语气偏好 was the only control with an explicit 保存 button while every neighbor persists on change/blur.

- Debounced autosave (800ms) + blur flush (blur wins, timer cleared); last-write-wins via a monotonic persist ticket; state sync defers while saves are in flight
- Success is silent like every autosave sibling; failure keeps the toast.error path
- 保存 button, helper line and save-time warning toasts removed; helper copy reworded to autosave language
- personalization-sync contract fully re-pinned to the autosave form (debounce constant, blur flush, ticket, bans on the button/success-toast returning)

Verified in worktree: builds + typecheck, desktop 2289/2289 exit-code gated, dead-css clean, CDP probe confirms 0 保存 buttons in the personalization block. Implemented by an opus worktree agent to the maintainer's spec.