### PR TITLE
fix(desktop): global radius sweep, plain-text ⌘N hint, 已阻塞 → 需要处理 (round 14)

### DIFF
--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -502,7 +502,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
 
     assert.match(
       section,
-      /className="providerCatalogRow providerOAuthCard rounded-none"/,
+      /className="providerCatalogRow providerOAuthCard"/,
       'OAuth tab rows must reuse the same governed provider catalog row chrome as 国内 / 海外 / 本地 rows',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -129,7 +129,7 @@ describe('sessionStatusAriaLabel', () => {
 
   it('blocked status combines status label + blocked reason', () => {
     const text = sessionStatusAriaLabel('blocked', 'auth');
-    assert.match(text, /已阻塞/);
+    assert.match(text, /需要处理/);
     assert.match(text, /登录|登陆/);
     // Separator stays consistent
     assert.match(text, / · /);
@@ -137,7 +137,7 @@ describe('sessionStatusAriaLabel', () => {
 
   it('blocked without reason falls back to actionable recovery copy', () => {
     const text = sessionStatusAriaLabel('blocked');
-    assert.match(text, /已阻塞/);
+    assert.match(text, /需要处理/);
     assert.match(text, /运行中断，可重试/);
     assert.doesNotMatch(text, /未知阻塞/);
   });

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -285,7 +285,7 @@ function NeedsConnectionHero(props: {
             return (
               <li key={entry.type}>
                 <Item
-                  className="maka-firstrun-row px-3.5 py-2 rounded-none"
+                  className="maka-firstrun-row px-3.5 py-2"
                   render={
                     <button
                       type="button"

--- a/apps/desktop/src/renderer/session-status-grouping.ts
+++ b/apps/desktop/src/renderer/session-status-grouping.ts
@@ -79,7 +79,7 @@ const GROUP_LABEL: Record<SessionGroupId, string> = {
   pinned: '已置顶',
   running: '进行中',
   waiting_for_user: '等待你',
-  blocked: '已阻塞',
+  blocked: '需要处理',
   active: '会话',
   review: '待审核',
   done: '已完成',

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -91,7 +91,7 @@ const STATUS_PRESENTATION: Record<SessionStatus, SessionStatusPresentation> = {
   // honestly conveys "you need to do something" without screaming
   // failure. Real hard failures surface through ChatHeaderAlertBadge,
   // which still uses destructive.
-  blocked: { label: '已阻塞', tone: 'warning', interactive: true },
+  blocked: { label: '需要处理', tone: 'warning', interactive: true },
   review: { label: '待审核', tone: 'info', interactive: true },
   done: { label: '已完成', tone: 'success', interactive: true },
   archived: { label: '已归档', tone: 'muted', interactive: false },
@@ -129,7 +129,7 @@ export function describeBlockedReason(reason: SessionBlockedReason | undefined):
 /**
  * Compose a single-line aria-label / tooltip for a blocked session,
  * combining the status label and the cause. Example:
- *   "已阻塞 · 等待配置可用模型连接"
+ *   "需要处理 · 等待配置可用模型连接"
  *
  * Non-blocked sessions return just the status label.
  */

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -233,7 +233,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
                         {group.connections.map((connection) => (
                           <li key={connection.slug}>
                             <Item
-                              className="enabledConnRow py-2 pr-8 pl-12 rounded-none"
+                              className="enabledConnRow py-2 pr-8 pl-12"
                               data-default={connection.slug === defaultSlug ? 'true' : undefined}
                               data-test-status={connection.lastTestStatus ?? 'untested'}
                               data-disabled={connection.enabled ? undefined : 'true'}

--- a/apps/desktop/src/renderer/settings/provider-catalog.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog.tsx
@@ -14,7 +14,7 @@ export function ProviderCatalogCard(props: { type: ProviderType; count: number; 
   if (disabled) {
     return (
       <Item
-        className="providerCatalogRow rounded-none"
+        className="providerCatalogRow"
         data-provider={props.type}
         data-status={disabledStatus}
         data-disabled="true"
@@ -39,7 +39,7 @@ export function ProviderCatalogCard(props: { type: ProviderType; count: number; 
 
   return (
     <Item
-      className="providerCatalogRow rounded-none"
+      className="providerCatalogRow"
       data-provider={props.type}
       data-status="ready"
       aria-label={providerCatalogAriaLabel(display, props.count)}

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -170,7 +170,7 @@ export function ModelOAuthSection(props: { onConnectionsChanged(): Promise<void>
           return (
             <Item
               key={card.id}
-              className="providerCatalogRow providerOAuthCard rounded-none"
+              className="providerCatalogRow providerOAuthCard"
               data-card-id={card.id}
               data-provider={card.providerType}
               data-status="ready"

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -164,6 +164,10 @@
   overflow: auto;
 }
 
+.providerCatalogRow {
+  border-radius: var(--radius-control);
+}
+
 .providerMarketGrid .providerCatalogRow + .providerCatalogRow,
 .providerOAuthGrid .providerCatalogRow + .providerCatalogRow {
   border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -723,15 +723,21 @@
 /* ⌘N hint on the 新任务 row — quiet kbd chip pushed to the right rail,
    visible at rest like the reference app (it advertises a real global
    shortcut registered in app-shell-effects). */
+/* Plain muted text, no chip chrome — the reference treatment. A boxed
+   chip made the hint compete with the row label. Explicit resets beat
+   the global tactile `kbd` element rule in maka-tokens.css. */
 .maka-nav-kbd {
   margin-left: auto;
-  padding: 0 var(--space-1);
-  border: var(--border-width-hairline) solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--foreground-3);
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   color: var(--muted-foreground);
-  font-family: var(--font-mono);
+  font-family: inherit;
   font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: var(--tracking-wide);
   line-height: var(--leading-normal);
   white-space: nowrap;
 }


### PR DESCRIPTION
Three maintainer reports, each answered at the class level:

**1. Square corners — swept globally, not per-report.** A static CSS scan (hover/selected fills whose rule family lacks radius) + a tsx grep for `rounded-none` found every instance at once: provider catalog rows (the reported one), OAuth cards, connection rows, and the onboarding first-run rows — all full-bleed fills squaring against the app's rounded-fill language. All fixed in this PR; the only surviving `rounded-none` is the input primitive's bare-field reset (legitimately zero inside a chrome'd wrapper).

**2. The ⌘N chip was ugly** — agreed; the boxed 'physical key' look came from the global `kbd` element rule. The sidebar hint is now plain muted text, matching the reference app the maintainer compared against.

**3. 已阻塞 was meaningless** — correct: the status means 'the session needs YOUR action before it can proceed' (configure a model connection / re-login). Renamed to 需要处理 everywhere (group header, chip, presentation line '需要处理 · 等待配置可用模型连接'), which matches its warning tone and the 需要重新登录 phrasing family.

Desktop 2291/2291 exit-code gated; dead-css clean; CDP verified.