### PR TITLE
fix(desktop): topbar aligns to the traffic lights' MEASURED optical center

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -502,7 +502,7 @@
      (sidebar.css) and the in-flow chat status row (module-pages.css).
      The status row only shares the toolbar's right edge; it no longer
      anchors off the toolbar bottom. */
-  --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 17px);
+  --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 16px); /* pixel-measured lockstep with sidebar rail — lights' optical center is 20.75 */
   --maka-workspace-top-actions-right: 24px;
   /* Horizontal footprint the absolutely-positioned .maka-workspace-top-actions
      toolbar occupies in the top-right corner: its right offset + four 24px icon

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -36,12 +36,14 @@
 .maka-shell-2col {
   --maka-sidebar-topbar-button-size: 24px;
   --maka-sidebar-topbar-gap: 8px;
-  /* Alignment governance: the rail is 34px tall with centered 24px buttons,
-     so top = safe-top(20, the traffic-light center) - 17 centers the buttons
-     EXACTLY on the traffic lights — same math as
-     --maka-workspace-top-actions-top. The old -18 left this cluster 1px
-     higher than both the lights and the right-side action cluster. */
-  --maka-sidebar-topbar-offset-y: calc(var(--maka-titlebar-control-safe-top) - 17px);
+  /* Alignment governance, PIXEL-MEASURED (screencapture + centroid): the
+     macOS traffic lights draw ~13.5pt tall with their optical center at
+     y=20.75 — NOT the theoretical 20 (position 14 + 12/2). Icon glyphs
+     centered at 19.8 read visibly high. top = safe-top - 16 puts the
+     34px rail's 24px buttons at center 21 (0.25px inside the lights'
+     center — imperceptible, integer-safe). Keep in lockstep with
+     --maka-workspace-top-actions-top. */
+  --maka-sidebar-topbar-offset-y: calc(var(--maka-titlebar-control-safe-top) - 16px);
   --maka-sidebar-topbar-offset-x: calc(var(--maka-titlebar-control-safe-left) - 10px);
   --maka-sidebar-collapsed-topbar-inset: calc(
     var(--maka-sidebar-topbar-offset-x) + var(--maka-sidebar-topbar-button-size) +


### PR DESCRIPTION
Follow-up to #672 — the maintainer correctly reported the misalignment persisted. Root cause of the root cause: #672 aligned to the THEORETICAL traffic-light center (y = 14 + 12/2 = 20), but a pixel-level measurement of a real focused-window capture (`screencapture -l` + pure-python PNG centroid of the light circles) shows macOS draws them ~13.5pt tall centered at **y=20.75**. Icon glyph centroid measured 19.8 → visibly ~1px high.

Both topbar clusters (sidebar rail + workspace actions, kept in lockstep) shift +1px: glyph centers land at ~20.8 vs lights 20.75. The CSS comment now records the measured ground truth so nobody re-derives the wrong theoretical value.

Method note: DOM math can't see OS-drawn chrome — this class of check needs window-level screenshots. Desktop 2291/2291 exit-code gated.