### PR TITLE
fix(desktop): 模型连接 rows speak the same row language as the catalog below

### DIFF
--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -233,7 +233,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
                         {group.connections.map((connection) => (
                           <li key={connection.slug}>
                             <Item
-                              className="enabledConnRow py-2 pr-8 pl-12"
+                              className="enabledConnRow mx-2 py-2 pr-6 pl-10"
                               data-default={connection.slug === defaultSlug ? 'true' : undefined}
                               data-test-status={connection.lastTestStatus ?? 'untested'}
                               data-disabled={connection.enabled ? undefined : 'true'}

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -97,9 +97,14 @@
 .enabledRollup.is-idle,
 .enabledConnStatus.is-untested { color: var(--muted-foreground); }
 
+/* Connection-row harmonization: the expanded panel used to paint a
+   full-bleed 2% wash + top border from x=0 — an edge-to-edge band under
+   the logo column that read as a different component from the catalog
+   rows below. The panel is transparent now; the rounded row fills
+   (hover / selected) carry the state, inset from the edges like every
+   other row surface. */
 .enabledProviderPanel {
-  background: oklch(from var(--foreground) l c h / 0.02);
-  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.07);
+  padding-bottom: var(--space-1);
 }
 
 .enabledProviderPanel ul {


### PR DESCRIPTION
Maintainer report: the connection sub-rows under 模型连接 clash with the well-formed 模型供应商 rows below — same page, two row implementations.

Root cause: the expanded provider panel painted its own full-bleed 2% wash + hairline from x=0, an edge-to-edge band running under the logo column. No other list surface in the app does this — sidebar rows, session rows, catalog rows all carry state on rounded, inset row fills.

Fix: panel chrome removed; hover/selected state now lives on the rounded row fills (radius from #666), inset mx-2 with pl-10 so the text column stays at the same 48px absolute position under the provider name. All spacing on the 4px ruler — the spacing-converge contract correctly rejected the first pl-[42px] attempt, which is the governance system working as designed.

On the maintainer's broader point (shared solutions, per-site implementations): the audit keeps converging these one recipe at a time with contracts pinning each convergence; the standing NEXT item to extract shared PageShell/row primitives is recorded in the audit plan. CDP capture verified; desktop 2291/2291 exit-code gated.