### PR TITLE
fix(cli): stop stray `^[[I` echo on TUI launch

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2311,7 +2311,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('enables focus reporting and sets the initial terminal title', async () => {
+  test('enables focus reporting only after raw mode, so no stray ^[[I leaks on launch', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
     const run = runMakaPiTui({
@@ -2324,8 +2324,18 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await waitFor(() => terminal.output().includes('\x1b[?1004h'));
+    await waitFor(() => terminal.writes.includes('\x1b[?1004h'));
     assert.ok(terminal.titles.includes('Maka'));
+
+    // Enabling focus reporting before raw mode makes the terminal's focus-in
+    // reply (`\x1b[I`) echo onto the screen as `^[[I`. The enable must be written
+    // strictly after start() (raw mode on), never before.
+    assert.notEqual(terminal.startWriteIndex, null);
+    const focusEnableIndex = terminal.writes.indexOf('\x1b[?1004h');
+    assert.ok(
+      focusEnableIndex >= terminal.startWriteIndex!,
+      'focus reporting was enabled before raw mode; a stray ^[[I can leak on launch',
+    );
 
     terminal.input('\x03');
     await Promise.race([

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -10,9 +10,14 @@ export class FakeTerminal implements Terminal {
   readonly writes: string[] = [];
   readonly titles: string[] = [];
   stopCalls = 0;
+  // Index into `writes` at the moment `start()` (raw mode) ran. Anything written
+  // before this went out while the terminal was still in cooked mode. Null until
+  // start() is called.
+  startWriteIndex: number | null = null;
   private onInput: ((data: string) => void) | null = null;
 
   start(onInput: (data: string) => void, _onResize: () => void): void {
+    this.startWriteIndex = this.writes.length;
     this.onInput = onInput;
   }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -848,13 +848,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     return undefined;
   });
 
-  // The AttentionController set the initial title in its constructor. Enable
-  // focus reporting so it learns when the terminal is backgrounded; the input
-  // listener forwards the `\x1b[I` / `\x1b[O` reports.
-  terminal.write(ENABLE_FOCUS_REPORTING);
   tui.addChild(layout);
   tui.setFocus(editorSurface);
   tui.start();
+  // The AttentionController set the initial title in its constructor. Enable
+  // focus reporting so it learns when the terminal is backgrounded; the input
+  // listener forwards the `\x1b[I` / `\x1b[O` reports. This must run *after*
+  // tui.start() puts the terminal in raw mode — otherwise the terminal's reply
+  // to the enable sequence (a focus-in `\x1b[I`) is echoed by the cooked-mode
+  // line discipline and leaks onto the screen as a stray `^[[I` on launch.
+  terminal.write(ENABLE_FOCUS_REPORTING);
 
   return closedPromise;
 }


### PR DESCRIPTION
## Summary

On launch the Maka TUI printed a stray `^[[I` at the top of the screen. Root cause: `runMakaPiTui` enabled DEC 1004 focus reporting (`\x1b[?1004h`) *before* `tui.start()`, but `tui.start()` is what puts the terminal into raw mode. In cooked mode the terminal's focus-in reply (`\x1b[I`) was echoed by the line discipline and leaked onto the screen.

Fix: move the `ENABLE_FOCUS_REPORTING` write to after `tui.start()`.

## Why

First thing a user sees on every launch is a garbage escape sequence. Refs the CLI polish backlog (stray `^[[I` on open).

## Scope

Changed:
- `packages/cli/src/pi-tui-runner.ts` — enable focus reporting after `tui.start()`.
- `packages/cli/src/__tests__/tui-terminal-mock.ts` — `FakeTerminal` records `startWriteIndex` (the write position when raw mode began).
- `packages/cli/src/__tests__/pi-tui-runner.test.ts` — assert the focus-enable is written after `start()`.

Not included: the rest of the CLI polish backlog (onboarding, multi-provider `/model`, scroll/long-output, busy spinner, in-turn semantic compact) — each ships separately.

## Verification

- `tsc -p tsconfig.json --noEmit` (cli) — clean.
- `node --test dist/__tests__/pi-tui-runner.test.js` — 69/69 pass, including the new ordering contract.

## User-facing impact

No more `^[[I` on TUI launch. Focus reporting / BEL behavior is otherwise unchanged (still enabled, just one tick later).

## Reviewer notes

The regression is locked by a write-ordering contract rather than a raw-mode simulation, since `FakeTerminal` does not model `setRawMode`.