### PR TITLE
fix(cli): disable in-turn semantic compaction in the TUI

### DIFF
--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -183,6 +183,48 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('honors an explicit MAKA_CONTEXT_SEMANTIC_COMPACT opt-in', async () => {
+    await withCleanContextBudgetEnv(async () => {
+      process.env.MAKA_CONTEXT_SEMANTIC_COMPACT = 'on';
+      try {
+        await withWorkspace(async (workspaceRoot) => {
+          const connectionStore = createConnectionStore(workspaceRoot);
+          await connectionStore.create({
+            slug: 'local',
+            name: 'Local Ollama',
+            providerType: 'ollama',
+            defaultModel: 'llama3.2',
+          });
+
+          const context = await createMakaCliRuntimeContext({ workspaceRoot, cwd: '/repo' });
+          const session = await context.runtime.createSession({
+            cwd: context.cwd,
+            backend: 'ai-sdk',
+            llmConnectionSlug: context.target.connection.slug,
+            model: context.target.model,
+            permissionMode: 'bypass',
+            name: 'semantic-opt-in',
+          });
+          const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+          const header = await runtimeDeps.store.readHeader(session.id);
+          const backend = await runtimeDeps.backends.build('ai-sdk', {
+            sessionId: session.id,
+            workspaceRoot,
+            header,
+            store: runtimeDeps.store,
+          });
+          const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
+
+          // The CLI default strips semantic compaction, but an explicit env
+          // opt-in must reach the backend so the path stays exercisable.
+          assert.equal(backendInput.contextBudget?.semanticCompact?.enabled, true);
+        });
+      } finally {
+        delete process.env.MAKA_CONTEXT_SEMANTIC_COMPACT;
+      }
+    });
+  });
+
   test('keeps ordinary send policy read-write for providers without a context-window budget', async () => {
     await withCleanContextBudgetEnv(async () => {
       process.env.MAKA_CONTEXT_HISTORY_COMPACT = 'on';

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -170,7 +170,10 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.equal(backendInput.contextBudget?.name, 'cli-default-history-budget');
         assert.equal(backendInput.contextBudget?.maxHistoryEstimatedTokens, 32_000);
         assert.equal(backendInput.contextBudget?.activeToolResultPrune?.enabled, true);
-        assert.equal(backendInput.contextBudget?.semanticCompact?.enabled, true);
+        // In-turn semantic compaction is stripped for the CLI: it interrupts the
+        // live reply with a compaction notice for small savings. History/turn
+        // compaction stays.
+        assert.equal(backendInput.contextBudget?.semanticCompact, undefined);
         assert.equal(backendInput.contextBudget?.historyCompact?.enabled, true);
         assert.equal(backendInput.contextBudget?.historyCompact?.mode, 'read_write');
         assert.equal(backendInput.contextBudget?.historyCompact?.highWaterRatio, 1);

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -158,22 +158,45 @@ export async function createMakaCliRuntimeContext(
 }
 
 // The CLI keeps turn-boundary history compaction but disables *in-turn* semantic
-// compaction. Firing mid-turn, it interrupts the live reply with a
+// compaction by default. Firing mid-turn, it interrupts the live reply with a
 // `Context compacted: semanticCompact` notice for small savings, which reads as
-// noise in an interactive session. Strip it from the default policy rather than
-// setting an env override, so the rest of the budget (history compact, tool-result
-// pruning) is untouched.
+// noise in an interactive session. So we drop it from the default policy rather
+// than setting an env override, leaving the rest of the budget (history compact,
+// tool-result pruning) untouched.
+//
+// But only the *default* is off: if the user explicitly opts in via
+// `MAKA_CONTEXT_SEMANTIC_COMPACT` or `MAKA_CONTEXT_SEMANTIC_COMPACT_MODE`, honor
+// it so the path can still be exercised and debugged from the CLI.
 function buildCliContextBudgetPolicy(
   connection: Parameters<typeof buildDefaultContextBudgetPolicy>[0],
   modelId: string,
+  env: Record<string, string | undefined> = process.env,
 ): ReturnType<typeof buildDefaultContextBudgetPolicy> {
   const policy = buildDefaultContextBudgetPolicy(connection, {
     name: 'cli-default-history-budget',
     modelId,
   });
   if (!policy?.semanticCompact) return policy;
+  // buildDefaultContextBudgetPolicy already reflects env-off (policy would have
+  // no semanticCompact), so reaching here means default-on or an explicit opt-in.
+  // Keep it only for the explicit opt-in; otherwise apply the CLI default (off).
+  if (userOptedIntoSemanticCompact(env)) return policy;
   const { semanticCompact: _omitted, ...rest } = policy;
   return rest;
+}
+
+// True when the environment explicitly turns semantic compaction on — either a
+// truthy `MAKA_CONTEXT_SEMANTIC_COMPACT`, or a `MAKA_CONTEXT_SEMANTIC_COMPACT_MODE`
+// set to a mode other than `off`. Mirrors the spellings the runtime policy
+// accepts. An invalid boolean would already have thrown inside the default
+// policy build above, so this only classifies well-formed values.
+function userOptedIntoSemanticCompact(env: Record<string, string | undefined>): boolean {
+  const enable = env.MAKA_CONTEXT_SEMANTIC_COMPACT?.trim().toLowerCase();
+  if (enable === '1' || enable === 'true' || enable === 'yes' || enable === 'on' || enable === 'enabled') {
+    return true;
+  }
+  const mode = env.MAKA_CONTEXT_SEMANTIC_COMPACT_MODE?.trim().toLowerCase();
+  return mode === 'validate_only' || mode === 'prepare_step_dry_run' || mode === 'replace';
 }
 
 export async function getOrCreateCliClaudeDeviceId(

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -109,10 +109,7 @@ export async function createMakaCliRuntimeContext(
       modelFactory: (modelInput) => getAIModel({ ...modelInput, fetch: modelFetch }),
       tools,
       providerOptions: buildProviderOptions(ready.connection, ready.model, ctx.header.thinkingLevel),
-      contextBudget: buildDefaultContextBudgetPolicy(ready.connection, {
-        name: 'cli-default-history-budget',
-        modelId: ready.model,
-      }),
+      contextBudget: buildCliContextBudgetPolicy(ready.connection, ready.model),
       loadHistoryCompact: (event) => loadHistoryCompactBlocksFromArtifacts(artifactStore, event),
       writeHistoryCompact: (event) => persistHistoryCompactBlocksToArtifacts(artifactStore, event, {
         summarize: buildLlmHistorySummarizer({
@@ -158,6 +155,25 @@ export async function createMakaCliRuntimeContext(
     tools,
     close: () => shellRuns.terminateAll(),
   };
+}
+
+// The CLI keeps turn-boundary history compaction but disables *in-turn* semantic
+// compaction. Firing mid-turn, it interrupts the live reply with a
+// `Context compacted: semanticCompact` notice for small savings, which reads as
+// noise in an interactive session. Strip it from the default policy rather than
+// setting an env override, so the rest of the budget (history compact, tool-result
+// pruning) is untouched.
+function buildCliContextBudgetPolicy(
+  connection: Parameters<typeof buildDefaultContextBudgetPolicy>[0],
+  modelId: string,
+): ReturnType<typeof buildDefaultContextBudgetPolicy> {
+  const policy = buildDefaultContextBudgetPolicy(connection, {
+    name: 'cli-default-history-budget',
+    modelId,
+  });
+  if (!policy?.semanticCompact) return policy;
+  const { semanticCompact: _omitted, ...rest } = policy;
+  return rest;
 }
 
 export async function getOrCreateCliClaudeDeviceId(


### PR DESCRIPTION
## Summary

The CLI showed `Note: Context compacted: semanticCompact; 1 turns / 0 events; saved ~2955 tokens.` mid-turn. That is in-turn semantic compaction firing during the live reply — it interrupts the turn with a compaction notice for small savings, which reads as noise in an interactive session.

This strips `semanticCompact` from the CLI's default context-budget policy while keeping turn-boundary history compaction and tool-result pruning.

## Why

In-turn compaction is a benchmark/autonomy feature; in the interactive TUI it just surfaces distracting notices. Refs the CLI polish backlog (in-turn semantic compact should be off).

## Scope

Changed:
- `packages/cli/src/runtime-bootstrap.ts` — new `buildCliContextBudgetPolicy` omits `semanticCompact` from the default policy.
- `packages/cli/src/__tests__/runtime-bootstrap.test.ts` — assert the ai-sdk backend receives no `semanticCompact` policy (history compaction stays enabled).

Not included: the rest of the CLI polish backlog.

## Verification

- `tsc -p tsconfig.json --noEmit` (cli) — clean.
- `node --test dist/__tests__/runtime-bootstrap.test.js` — 7/7 pass.

## User-facing impact

No more in-turn `Context compacted: semanticCompact` notices in the TUI. Manual `/compact` and turn-boundary history compaction are unchanged. Behavior is opt-out via the same env the policy already reads; this only changes the CLI default.

## Reviewer notes

Only the CLI default is affected — headless/benchmark wiring builds its own policy and is untouched.