### PR TITLE
feat(cli): animate the busy tab title with a spinner

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5,6 +5,7 @@ import { visibleWidth } from '@earendil-works/pi-tui';
 import type { PermissionMode, PermissionResponse, SessionEvent, SessionSummary, StoredMessage, ThinkingLevel } from '@maka/core';
 import type { MakaSessionDriver, MakaSessionSwitchResult, RewindTarget } from '../session-driver.js';
 import { runMakaPiTui } from '../pi-tui-runner.js';
+import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import { arrangeAutocompleteAboveEditor } from '../tui-autocomplete-layout.js';
 import {
   assertBottomPickerPlacement,
@@ -2359,7 +2360,10 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => driver.prompts.length === 1);
     await waitFor(() => bellCount(terminal) === 1);
-    assert.ok(terminal.titles.includes('● Maka'), 'title marks busy during the turn');
+    assert.ok(
+      terminal.titles.includes(`${BUSY_SPINNER_FRAMES[0]} Maka`),
+      'title marks busy during the turn',
+    );
     assert.ok(terminal.titles.includes('★ Maka'), 'title marks attention after the unfocused finish');
 
     terminal.input('\x03');
@@ -2516,7 +2520,7 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await waitFor(() => terminal.titles.includes('● Maka'));
+    await waitFor(() => terminal.titles.includes(`${BUSY_SPINNER_FRAMES[0]} Maka`));
 
     // Quit while the turn is still parked: close() must reset the title so the
     // shell tab is not left marked busy after Maka exits.

--- a/packages/cli/src/__tests__/tui-attention.test.ts
+++ b/packages/cli/src/__tests__/tui-attention.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { AttentionController } from '../tui-attention.js';
+import { AttentionController, BUSY_SPINNER_FRAMES } from '../tui-attention.js';
+
+const BUSY = `${BUSY_SPINNER_FRAMES[0]} Maka`;
 
 const BELL = '\x07';
 
@@ -21,16 +23,31 @@ class SpyTerminal {
   }
 }
 
-/** A controller wired to a spy terminal and a clock the test advances by hand. */
+/** A controller wired to a spy terminal, a clock, and a spinner ticked by hand. */
 function makeController(longTurnThresholdMs = 8000) {
   const terminal = new SpyTerminal();
   let clock = 0;
+  let spinnerTick: (() => void) | null = null;
   const controller = new AttentionController(terminal, {
     baseTitle: 'Maka',
     now: () => clock,
     longTurnThresholdMs,
+    // Capture the spinner callback instead of scheduling a real interval, so the
+    // test drives frame advances deterministically and no timer leaks.
+    scheduleSpinnerInterval: (callback) => {
+      spinnerTick = callback;
+      return () => {
+        spinnerTick = null;
+      };
+    },
   });
-  return { terminal, controller, advance: (ms: number) => (clock += ms) };
+  return {
+    terminal,
+    controller,
+    advance: (ms: number) => (clock += ms),
+    tickSpinner: () => spinnerTick?.(),
+    spinnerRunning: () => spinnerTick !== null,
+  };
 }
 
 describe('AttentionController title', () => {
@@ -42,7 +59,7 @@ describe('AttentionController title', () => {
   test('marks busy while a turn runs and returns to plain when it ends quickly', () => {
     const { terminal, controller, advance } = makeController(8000);
     controller.promptTurnStarted();
-    assert.equal(terminal.title, '● Maka');
+    assert.equal(terminal.title, BUSY);
     advance(500);
     controller.promptTurnEnded();
     assert.equal(terminal.title, 'Maka');
@@ -53,7 +70,7 @@ describe('AttentionController title', () => {
     const { terminal, controller } = makeController();
     controller.focusChanged(false);
     controller.controlStarted();
-    assert.equal(terminal.title, '● Maka');
+    assert.equal(terminal.title, BUSY);
     controller.controlEnded();
     assert.equal(terminal.title, 'Maka');
     assert.equal(terminal.bells, 0);
@@ -70,7 +87,7 @@ describe('AttentionController title', () => {
     const { terminal, controller } = makeController(8000);
     controller.focusChanged(false);
     controller.promptTurnStarted();
-    assert.equal(terminal.title, '● Maka');
+    assert.equal(terminal.title, BUSY);
     controller.reset();
     assert.equal(terminal.title, 'Maka');
     // A finalizer that settles after close must not re-dirty the handed-back
@@ -80,6 +97,38 @@ describe('AttentionController title', () => {
     controller.promptTurnStarted();
     assert.equal(terminal.title, 'Maka');
     assert.equal(terminal.bells, 0);
+  });
+
+  test('animates the busy marker through spinner frames while a turn runs', () => {
+    const { terminal, controller, tickSpinner, spinnerRunning } = makeController(8000);
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[0]} Maka`);
+    assert.equal(spinnerRunning(), true);
+
+    tickSpinner();
+    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[1]} Maka`);
+    tickSpinner();
+    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[2]} Maka`);
+
+    controller.promptTurnEnded();
+    assert.equal(terminal.title, 'Maka');
+    // The interval is released and the frame resets, so the next turn opens on
+    // the first frame rather than mid-cycle.
+    assert.equal(spinnerRunning(), false);
+    controller.promptTurnStarted();
+    assert.equal(terminal.title, `${BUSY_SPINNER_FRAMES[0]} Maka`);
+  });
+
+  test('stops the spinner while an attention marker overrides the busy marker', () => {
+    const { controller, spinnerRunning } = makeController(8000);
+    controller.focusChanged(false);
+    controller.promptTurnStarted();
+    assert.equal(spinnerRunning(), true);
+    // A permission prompt while unfocused mid-turn raises attention (★), which
+    // outranks the busy marker; the spinner must stop rather than animate a
+    // marker that is no longer shown.
+    controller.attentionNeeded();
+    assert.equal(spinnerRunning(), false);
   });
 });
 
@@ -132,7 +181,7 @@ describe('AttentionController long-turn ring', () => {
     controller.promptTurnEnded();
     assert.equal(terminal.title, '★ Maka');
     controller.promptTurnStarted();
-    assert.equal(terminal.title, '● Maka');
+    assert.equal(terminal.title, BUSY);
   });
 });
 

--- a/packages/cli/src/tui-attention.ts
+++ b/packages/cli/src/tui-attention.ts
@@ -33,6 +33,16 @@ export interface AttentionControllerOptions {
    * are already watching. Permission prompts and errors ring regardless.
    */
   longTurnThresholdMs?: number;
+  /** Busy-marker spinner frames; defaults to the braille cycle. */
+  busySpinnerFrames?: readonly string[];
+  /** Spinner frame interval in ms; defaults to {@link DEFAULT_BUSY_SPINNER_INTERVAL_MS}. */
+  busySpinnerIntervalMs?: number;
+  /**
+   * Injectable interval scheduler for the spinner so tests can advance frames by
+   * hand instead of waiting real timers. Returns a cancel function. Defaults to
+   * an unref'd global setInterval so a lingering tick never blocks process exit.
+   */
+  scheduleSpinnerInterval?: (callback: () => void, intervalMs: number) => () => void;
 }
 
 /** DEC 1004 focus reports the runner enables and forwards to `focusChanged`. */
@@ -43,9 +53,21 @@ export const ENABLE_FOCUS_REPORTING = '\x1b[?1004h';
 export const DISABLE_FOCUS_REPORTING = '\x1b[?1004l';
 
 const BELL = '\x07';
-const BUSY_TITLE_MARKER = '● ';
+// Braille spinner (matches pi-tui's Loader frames) shown while a turn or control
+// action runs, so a glance at the tab tells you Maka is working — a static dot
+// could not be told apart from an idle indicator.
+export const BUSY_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
+export const DEFAULT_BUSY_SPINNER_INTERVAL_MS = 80;
 const ATTENTION_TITLE_MARKER = '★ ';
 const DEFAULT_LONG_TURN_THRESHOLD_MS = 8000;
+
+function defaultScheduleSpinnerInterval(callback: () => void, intervalMs: number): () => void {
+  const handle = setInterval(callback, intervalMs);
+  // Never let the spinner tick alone keep the process alive; it is always
+  // cleared when the turn ends or the session closes anyway.
+  handle.unref?.();
+  return () => clearInterval(handle);
+}
 
 export class AttentionController {
   private readonly now: () => number;
@@ -63,6 +85,12 @@ export class AttentionController {
   // Set once the session is closing; every event method then no-ops so a turn
   // finalizer that settles after close() cannot re-dirty the handed-back title.
   private stopped = false;
+  // Spinner animation state for the busy marker.
+  private readonly busySpinnerFrames: readonly string[];
+  private readonly busySpinnerIntervalMs: number;
+  private readonly scheduleSpinnerInterval: (callback: () => void, intervalMs: number) => () => void;
+  private spinnerFrame = 0;
+  private cancelSpinner: (() => void) | null = null;
 
   constructor(
     private readonly terminal: AttentionTerminal,
@@ -70,6 +98,13 @@ export class AttentionController {
   ) {
     this.now = options.now ?? Date.now;
     this.longTurnThresholdMs = options.longTurnThresholdMs ?? DEFAULT_LONG_TURN_THRESHOLD_MS;
+    this.busySpinnerFrames = options.busySpinnerFrames && options.busySpinnerFrames.length > 0
+      ? options.busySpinnerFrames
+      : BUSY_SPINNER_FRAMES;
+    this.busySpinnerIntervalMs = options.busySpinnerIntervalMs && options.busySpinnerIntervalMs > 0
+      ? options.busySpinnerIntervalMs
+      : DEFAULT_BUSY_SPINNER_INTERVAL_MS;
+    this.scheduleSpinnerInterval = options.scheduleSpinnerInterval ?? defaultScheduleSpinnerInterval;
     this.refreshTitle();
   }
 
@@ -162,18 +197,39 @@ export class AttentionController {
   }
 
   private refreshTitle(): void {
+    // Keep the spinner ticking exactly while the busy marker is on screen, so it
+    // animates during work and stops (freeing the timer) the moment it isn't.
+    this.syncSpinner();
     // Attention outranks busy: a turn parked on a permission prompt is "busy"
     // but what it actually needs is the user, so surface that first. Attention
     // is only ever set while unfocused, so a normal running turn still shows busy.
     const title = this.attention
       ? `${ATTENTION_TITLE_MARKER}${this.options.baseTitle}`
       : this.busy
-        ? `${BUSY_TITLE_MARKER}${this.options.baseTitle}`
+        ? `${this.busySpinnerFrames[this.spinnerFrame] ?? ''} ${this.options.baseTitle}`
         : this.options.baseTitle;
     // Only write on a real change so the title stream stays quiet between turns
-    // and a test can read the transitions rather than a run of duplicates.
+    // and a test can read the transitions rather than a run of duplicates. Each
+    // spinner tick advances the frame first, so the title genuinely differs.
     if (title === this.lastTitle) return;
     this.lastTitle = title;
     this.terminal.setTitle(title);
+  }
+
+  // Start or stop the spinner interval to match whether the busy marker is
+  // currently shown (busy, not overridden by attention, session still live).
+  private syncSpinner(): void {
+    const shouldRun = this.busy && !this.attention && !this.stopped && this.busySpinnerFrames.length > 0;
+    if (shouldRun && !this.cancelSpinner) {
+      this.cancelSpinner = this.scheduleSpinnerInterval(() => {
+        this.spinnerFrame = (this.spinnerFrame + 1) % this.busySpinnerFrames.length;
+        this.refreshTitle();
+      }, this.busySpinnerIntervalMs);
+    } else if (!shouldRun && this.cancelSpinner) {
+      this.cancelSpinner();
+      this.cancelSpinner = null;
+      // Reset so the next busy episode opens on the first frame, not mid-cycle.
+      this.spinnerFrame = 0;
+    }
   }
 }


### PR DESCRIPTION
## Summary

The TUI marked "working" with a static `●` in the tab title, which reads like a status dot, not activity. This replaces it with pi-tui's braille spinner frames (`⠋⠙⠹…`) animated on an 80ms interval while a turn or control action runs, so a glance at the tab shows Maka is busy.

## Why

Refs the CLI polish backlog: the working icon (a `●` circle in the tab, see the reported screenshots) is confusing; it should spin like Pi's loader.

## Scope

Changed:
- `packages/cli/src/tui-attention.ts` — busy marker is now an animated spinner. Exposes `BUSY_SPINNER_FRAMES` / `DEFAULT_BUSY_SPINNER_INTERVAL_MS`; adds `busySpinnerFrames`, `busySpinnerIntervalMs`, and an injectable `scheduleSpinnerInterval` option. The interval runs only while the busy marker is actually shown and is cleared on turn end / attention override / `reset()`.
- `packages/cli/src/__tests__/tui-attention.test.ts` — inject a hand-ticked scheduler; assert frames cycle, reset between turns, and stop when `★` attention overrides busy.
- `packages/cli/src/__tests__/pi-tui-runner.test.ts` — busy-title assertions use the first spinner frame.

## Verification

- `tsc -p tsconfig.json --noEmit` (cli) — clean.
- `node --test dist/__tests__/tui-attention.test.js` — 15/15.
- `node --test dist/__tests__/pi-tui-runner.test.js` — 69/69.

Not verified in-app: the spinner only sets the terminal title (OSC), so the exact per-frame cadence in the desktop tab depends on the host terminal's title-render rate. Logic is unit-covered; visual cadence is worth a glance in the desktop app.

## User-facing impact

The busy tab title animates (`⠋ Maka` → `⠙ Maka` → …) instead of showing a static `● Maka`. The attention (`★`) and idle titles are unchanged.

## Reviewer notes

The default scheduler is `unref`'d so a spinner tick never keeps the process alive; it is also always cancelled when the marker leaves the screen.