### PR TITLE
feat(cli): welcome block on an empty session

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -17,6 +17,23 @@ import {
 } from '../pi-transcript.js';
 
 describe('Maka Pi TUI transcript', () => {
+  test('greets on a fresh empty session and drops the welcome once a prompt lands', () => {
+    const state = createMakaPiTranscriptState();
+
+    const welcome = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(welcome, /maka/);
+    assert.match(welcome, /\/help/);
+    // The welcome orients with the active model/connection/folder.
+    assert.match(welcome, /deepseek-v4-flash/);
+    assert.ok(welcome.includes('输入消息开始对话'));
+
+    // Once a turn exists the transcript takes over — the welcome never returns.
+    appendUserPrompt(state, 'hello world');
+    const afterPrompt = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.equal(afterPrompt.includes('/help'), false);
+    assert.ok(afterPrompt.includes('hello world'));
+  });
+
   test('keeps assistant text after a tool call visible after the tool block', () => {
     const state = createMakaPiTranscriptState();
     appendUserPrompt(state, 'inspect the package');

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1779,7 +1779,10 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => driver.startNewSessionCalls === 1);
-    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Started a new session'));
+    // /new empties the transcript, so it opens on the same welcome block as a
+    // cold start rather than a one-off notice — that block is the "fresh session"
+    // cue and a notice would suppress it.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('输入消息开始对话，或用斜杠命令：'));
     // The previous turn is gone from the visible transcript.
     await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('remember this'));
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -484,12 +484,24 @@ export interface RenderedTranscript {
 
 export function renderMakaPiTranscriptSource(
   state: MakaPiTranscriptState,
-  _metadata: MakaPiTranscriptMetadata,
+  metadata: MakaPiTranscriptMetadata,
   width: number,
 ): RenderedTranscript {
   const safeWidth = Math.max(1, width);
   const lines: string[] = [];
   const owners: (TranscriptLineOwner | null)[] = [];
+
+  // A fresh session (no history, nothing pending) opens on a welcome block so the
+  // first screen greets and orients instead of showing an empty pane. It carries
+  // no entry identity (null owners); once the first prompt lands, entries take
+  // over and it never renders again.
+  if (state.entries.length === 0 && !state.pendingPermission) {
+    for (const line of renderWelcomeBlock(metadata, safeWidth)) {
+      lines.push(line);
+      owners.push(null);
+    }
+    return { lines, owners };
+  }
 
   for (const entry of state.entries) {
     // A blank spacer above every entry, then its (memoized) rendered block. The
@@ -764,6 +776,31 @@ function renderTextBlock(
 function renderNotice(entry: MakaPiNoticeEntry, width: number): string[] {
   const label = entry.level === 'error' ? ansi.red('Error') : ansi.dim('Note');
   return renderIndented(`${label}: ${entry.text}`, width, 0).map((line) => fitLine(line, width));
+}
+
+// Shown on a fresh, empty session. Greets, states where we are (model /
+// connection / folder), and lists the handful of commands and keys worth
+// knowing up front — enough to start without reading docs.
+function renderWelcomeBlock(metadata: MakaPiTranscriptMetadata, width: number): string[] {
+  // Point at /help for the full command list rather than duplicating it here —
+  // the autocomplete already teaches commands as you type. Just the greeting plus
+  // the keys you cannot discover by typing `/`.
+  const tips: [string, string][] = [
+    ['/help', '查看全部命令与快捷键'],
+    ['Ctrl+O', '展开或折叠工具输出'],
+    ['Esc Esc', '回退到较早的轮次'],
+  ];
+  const keyWidth = Math.max(...tips.map(([key]) => key.length));
+  const lines = [
+    fitLine(ansi.accent('maka'), width),
+    fitLine(ansi.dim(`${metadata.model} · ${metadata.connectionSlug} · ${metadata.cwd}`), width),
+    '',
+    fitLine('输入消息开始对话，或用斜杠命令：', width),
+  ];
+  for (const [key, description] of tips) {
+    lines.push(fitLine(ansi.dim(`  ${key.padEnd(keyWidth)}  ${description}`), width));
+  }
+  return lines;
 }
 
 function renderPermissionPrompt(request: PermissionRequestEvent, width: number): string[] {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -459,13 +459,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const newSession = () => {
     input.driver.startNewSession();
     // Fresh transcript for the fresh session; the next prompt creates it on disk.
+    // Leave the transcript empty (no confirmation notice) so /new opens on the
+    // same welcome block as a cold start — the welcome block is the "fresh
+    // session, send a prompt to begin" cue. A notice here would make entries
+    // non-empty and suppress it.
     replaceTranscriptWithStoredMessages(state, []);
     layout.followTailNow();
-    state.entries.push({
-      kind: 'notice',
-      level: 'info',
-      text: 'Started a new session. Send a prompt to begin.',
-    });
     requestRender();
   };
 


### PR DESCRIPTION
## Summary

A fresh Maka session opened on a blank pane with no greeting or orientation. This renders a welcome block whenever the transcript has no entries and nothing is pending: the `maka` mark, the active model / connection / folder, and a few starting hints.

## Why

Refs the CLI polish backlog: no onboarding — the first screen is empty. Requested scope was a lightweight welcome/orientation block on an empty session (not a full onboarding flow).

## Scope

Changed:
- `packages/cli/src/pi-transcript.ts` — `renderMakaPiTranscriptSource` renders `renderWelcomeBlock` when `entries` is empty and no permission is pending; the block has null owners and is replaced by the transcript once the first prompt lands.
- `packages/cli/src/__tests__/pi-transcript.test.ts` — assert the welcome greets + orients, and disappears after a prompt.

The block points at `/help` rather than duplicating the command list (the slash autocomplete already teaches commands), which also keeps it clear of the runner test that greps cumulative output for slash-command ordering.

## Verification

- `tsc -p tsconfig.json --noEmit` (cli) — clean.
- `node --test dist/__tests__/pi-transcript.test.js` — 55/55.
- `node --test dist/__tests__/pi-tui-runner.test.js` — 69/69 (layout unaffected: the layout still pads the transcript to the viewport, so editor/status positions are unchanged).
- Eyeballed the rendered block.

Rendered:
```
maka
glm-5.2 · zai · /Users/yuhan/workspace/oss/maka-agent

输入消息开始对话，或用斜杠命令：
  /help    查看全部命令与快捷键
  Ctrl+O   展开或折叠工具输出
  Esc Esc  回退到较早的轮次
```

## User-facing impact

New sessions (and `/new`) open on this welcome block instead of an empty pane. Copy is Chinese to match the app's existing in-TUI strings; happy to adjust wording.