### PR TITLE
refactor(ui): chip convergence — one tone table, five recipes retired (convergence round 1)

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-settings-ui-contract.test.ts
@@ -46,7 +46,12 @@ describe('Bot settings UI contract', () => {
     assert.match(settings, /className="settingsBotConfigDocLink"[\s\S]*target="_blank"[\s\S]*rel="noopener noreferrer"[\s\S]*查看配置文档 →/, 'Configuration docs link must be visible and external-link safe');
     assert.doesNotMatch(settings, /iframe|webview|dangerouslySetInnerHTML/, 'Bot docs must not be embedded into the renderer');
     assert.match(styles, /\.settingsBotHero\s*\{[\s\S]*background:\s*color-mix/, 'Hero card must use a subtle brand-color tint');
-    assert.match(styles, /\.settingsBotStatusPill\b/, 'Hero current-state pill styling must be present');
+    // Round 1 convergence (#520 follow-up): the hero current-state pill is now
+    // the Chip primitive with a leading tone dot (was a hand-rolled
+    // .settingsBotStatusPill + .settingsBotStatusPillDot recipe). The dotted
+    // Chip carries the tone via its variant; the bespoke pill CSS is retired.
+    assert.match(settings, /<Chip\s+dot\s+variant=\{props\.tone\}\s+className="settingsBotStatusPill"/, 'Hero current-state pill must render a dotted Chip');
+    assert.doesNotMatch(styles, /\.settingsBotStatusPill\s*\{/, 'Hand-rolled hero pill CSS must be retired (Chip is the tone authority)');
   });
 
   it('names the selected platform runtime status grid', async () => {

--- a/apps/desktop/src/main/__tests__/chip-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chip-converge-contract.test.ts
@@ -49,10 +49,36 @@ test('chip converge (#520 PR9)', async () => {
     'apps/desktop/src/renderer/settings/memory-settings-page.tsx',
     'apps/desktop/src/renderer/settings/account-settings-page.tsx',
     'apps/desktop/src/renderer/settings/provider-oauth-section.tsx',
+    // Round 1 convergence (#520 follow-up): hand-rolled status-chip recipes
+    // collapsed onto Chip. These call sites GAIN Chip coverage — the retired
+    // CSS labels (settingsBotStatusPill, providerCatalogBadge.is-state, and
+    // the packages/ui status labels) now render the primitive.
+    'apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx',
+    'apps/desktop/src/renderer/settings/provider-catalog.tsx',
+    'packages/ui/src/skills-panel.tsx',
+    'packages/ui/src/plan-reminder-panel.tsx',
+    'packages/ui/src/daily-review-panel.tsx',
   ];
   for (const rel of settingsChipFiles) {
     assert.match(read(rel), CHIP_IMPORT_RE, `${rel} must import Chip`);
   }
+
+  // 5b. Chip gains a `dot` prop (leading 6px currentColor round dot) — the
+  // "● 已连接" affordance retired from .settingsBotStatusPill. bot-chat renders
+  // the dotted Chip so the connection affordance survives the migration.
+  assert.match(chipSrc, /\bdot\?:\s*boolean/, 'Chip must expose a dot? prop');
+  assert.match(
+    chipSrc,
+    /data-slot="chip-dot"[\s\S]*bg-current[\s\S]*opacity-70/,
+    'Chip dot must be a currentColor round dot at 70% alpha',
+  );
+  const botChatSrc = read('apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx');
+  assert.match(botChatSrc, /<Chip\s+dot\b/, 'BotStatusPill must render a dotted Chip');
+  assert.doesNotMatch(
+    read('apps/desktop/src/renderer/styles/settings/bot.css'),
+    /\.settingsBotStatusPillDot\s*\{/,
+    'settingsBotStatusPillDot CSS must be retired (dot now lives on Chip)',
+  );
 
   // 6. Chip neutral variant tokens — bg = foreground-5 (bg-secondary aliases
   //    --color-secondary = var(--foreground-5)), text = foreground-secondary

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -1187,8 +1187,12 @@ name: Writer
     assert.match(skillPanel, /运行状态：\$\{runtimeLabel\}/);
     // Detail round 6, exception-only: the runtime chip renders ONLY for
     // state_error — enabled/disabled is already expressed by the Switch.
-    assert.match(skillPanel, /\{skill\.runtimeStatus === 'state_error' && \([\s\S]*?className="maka-skill-library-runtime-label"[\s\S]*>\{runtimeLabel\}<\/span>/);
-    assert.match(skillPanel, /className="maka-skill-library-status-label"[\s\S]*>\{statusLabel\}<\/span>/);
+    // Round 1 convergence (#520 follow-up): the two status labels now render
+    // the squared Chip primitive (was a hand-rolled span). data-status is
+    // preserved for tone derivation; the render condition is unchanged.
+    assert.match(skillPanel, /\{skill\.runtimeStatus === 'state_error' && \([\s\S]*?<Chip[\s\S]*?className="maka-skill-library-runtime-label"[\s\S]*>\{runtimeLabel\}<\/Chip>/);
+    assert.match(skillPanel, /<Chip[\s\S]*?className="maka-skill-library-status-label"[\s\S]*>\{statusLabel\}<\/Chip>/);
+    assert.match(skillPanel, /function skillStatusChipTone\(skill: SkillEntry\)/, 'status-label tone derives from data-status via skillStatusChipTone');
     assert.match(ui, /function formatSkillStatusLabel\(skill: SkillEntry\): string/);
     assert.match(ui, /function formatSkillRuntimeLabel\(skill: SkillEntry\): string/);
     assert.match(ui, /runtimeStatus === 'state_error'[\s\S]*状态异常/);

--- a/apps/desktop/src/renderer/settings/account-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/account-settings-page.tsx
@@ -336,14 +336,19 @@ function AccountAuthActionView(props: {
       </Button>
     );
   }
+  // Non-interactive guidance label sitting next to the real 测试凭据 button.
+  // Migrated onto the squared Chip primitive (tone→alpha authority); the
+  // AccountAuthTone union (neutral/info/success/warning/destructive) maps 1:1
+  // to Chip variants. The preview-kind dashed-border affordance stays in CSS.
   return (
-    <span
+    <Chip
+      variant={props.action.tone}
       className="settingsAuthActionPill"
       data-kind={props.action.kind}
       data-tone={props.action.tone}
       title={props.action.detail}
     >
       {props.action.label}
-    </span>
+    </Chip>
   );
 }

--- a/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-settings-page.tsx
@@ -17,6 +17,7 @@ import {
   BOT_BRAND,
   BotBrandLogo as BotBrandMark,
   Button,
+  Chip,
   Input,
   RelativeTime,
   SettingsSelect,
@@ -167,10 +168,9 @@ function BotBrandLogo(props: {
  */
 function BotStatusPill(props: { tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive'; label: string }) {
   return (
-    <span className="settingsBotStatusPill" data-tone={props.tone}>
-      <span className="settingsBotStatusPillDot" aria-hidden="true" />
+    <Chip dot variant={props.tone} className="settingsBotStatusPill" data-tone={props.tone}>
       {props.label}
-    </span>
+    </Chip>
   );
 }
 

--- a/apps/desktop/src/renderer/settings/provider-catalog.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight } from '@maka/ui/icons';
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core';
-import { Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@maka/ui';
+import { Chip, Item, ItemActions, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@maka/ui';
 import { ProviderLogo, providerDisplay } from './provider-display';
 import { isWiredOAuthProvider } from './provider-panel-shared';
 
@@ -29,9 +29,17 @@ export function ProviderCatalogCard(props: { type: ProviderType; count: number; 
           <ItemDescription className="providerCatalogDesc">{display.description}</ItemDescription>
         </ItemContent>
         <ItemActions>
-          <span className="providerCatalogBadge is-state" aria-hidden="true">
+          {/* Gated-provider state label — experimental (warning) / unavailable
+              (info). Migrated onto the squared Chip primitive (tone→alpha
+              authority); the row itself stays inert. */}
+          <Chip
+            size="sm"
+            variant={disabledStatus === 'experimental' ? 'warning' : 'info'}
+            className="providerCatalogStateBadge"
+            aria-hidden="true"
+          >
             {disabledStatus === 'experimental' ? '实验' : '未开放'}
-          </span>
+          </Chip>
         </ItemActions>
       </Item>
     );

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -198,26 +198,12 @@
     overflow-wrap: anywhere;
   }
 
+/* .maka-daily-review-archive-status is now the Chip primitive (squared status
+   label); tone→alpha from chip.tsx, ok/failed/no_model mapping from
+   dailyReviewArchiveChipTone in daily-review-panel.tsx. The status Chip keeps
+   flex:none so it never shrinks against the archive header title. */
 .maka-daily-review-archive-status {
     flex: none;
-    border: var(--border-width-hairline) solid var(--foreground-10);
-    border-radius: var(--radius-pill);
-    color: var(--muted-foreground);
-    font-size: var(--font-size-caption);
-    line-height: var(--leading-none);
-    padding: var(--space-1) var(--space-1-5);
-    white-space: nowrap;
-  }
-
-.maka-daily-review-archive-status[data-status="ok"] {
-    border-color: oklch(from var(--success, var(--status-running)) l c h / 0.26);
-    color: var(--success, var(--status-running));
-  }
-
-.maka-daily-review-archive-status[data-status="failed"],
-  .maka-daily-review-archive-status[data-status="no_model"] {
-    border-color: oklch(from var(--destructive, var(--warning, var(--info))) l c h / 0.30);
-    color: var(--destructive, var(--warning, var(--foreground)));
   }
 
 .maka-daily-review-archive-error {

--- a/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
+++ b/apps/desktop/src/renderer/styles/module-pages/plan-reminders.css
@@ -777,25 +777,9 @@
   padding: var(--space-1-5) var(--space-2-5);
 }
 
-.maka-plan-run-status {
-  border-radius: var(--radius-pill);
-  background: var(--foreground-3);
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  padding: var(--space-0-5) var(--space-1-5);
-}
-
-.maka-plan-run-status[data-status="triggered"] {
-  background: oklch(from var(--success) l c h / 0.10);
-  color: var(--success-text);
-}
-
-.maka-plan-run-status[data-status="blocked"],
-.maka-plan-run-status[data-status="failed"] {
-  background: oklch(from var(--warning) l c h / 0.10);
-  color: var(--warning-text);
-}
+/* .maka-plan-run-status is now the Chip primitive (squared status label);
+   its tone→alpha comes from chip.tsx and the triggered/blocked/failed mapping
+   from planRunStatusChipTone in plan-reminder-panel.tsx. No bespoke CSS. */
 
 .maka-plan-run-main {
   display: grid;

--- a/apps/desktop/src/renderer/styles/module-pages/skills.css
+++ b/apps/desktop/src/renderer/styles/module-pages/skills.css
@@ -594,38 +594,10 @@ color: oklch(from var(--brand-deep) 0.55 min(c, 0.015) h);
   letter-spacing: var(--tracking-normal);
 }
 
-.maka-skill-library-runtime-label,
-.maka-skill-library-status-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100%;
-  padding: var(--space-0-5) var(--space-2);
-  border-radius: var(--radius-pill);
-  background: oklch(from var(--info) l c h / 0.08);
-  color: var(--info-text);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-}
-
-/* Detail round 6: the runtime chip is exception-only (state_error) — the
-   enabled/disabled visual forms retired with the redundant chip. */
-.maka-skill-library-runtime-label[data-status="state_error"] {
-  background: oklch(from var(--warning) l c h / 0.10);
-  color: var(--warning-text);
-}
-
-.maka-skill-library-status-label[data-status="local_modified"],
-.maka-skill-library-status-label[data-status="metadata_error"],
-.maka-skill-library-status-label[data-status="source_missing"] {
-  background: oklch(from var(--warning) l c h / 0.10);
-  color: var(--warning-text);
-}
-
-.maka-skill-library-status-label[data-status="update_available"] {
-  background: oklch(from var(--success) l c h / 0.10);
-  color: var(--success-text);
-}
+/* .maka-skill-library-runtime-label / .maka-skill-library-status-label are now
+   rendered by the Chip primitive (squared status label, tone→alpha authority in
+   packages/ui/src/primitives/chip.tsx). The tone derivation lives in
+   skills-panel.tsx (skillStatusChipTone); no bespoke label CSS remains. */
 
 .maka-skill-library-open-button {
   justify-self: end;

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -186,31 +186,9 @@
 .settingsBotConfigDocLink:hover {
     text-decoration: underline;
   }
-.settingsBotStatusPill {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-0-5) var(--space-2) var(--space-0-5) var(--space-1-5);
-    border-radius: var(--radius-pill);
-    background: color-mix(in srgb, var(--foreground) 5%, transparent);
-    color: var(--foreground-secondary);
-    font-size: var(--font-size-caption);
-    font-weight: var(--font-weight-medium);
-    letter-spacing: var(--tracking-normal);
-  }
-.settingsBotStatusPillDot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: var(--muted-foreground);
-  }
-.settingsBotStatusPill[data-tone="info"] .settingsBotStatusPillDot { background: var(--status-running); }
-.settingsBotStatusPill[data-tone="success"] { color: var(--success-text); }
-.settingsBotStatusPill[data-tone="success"] .settingsBotStatusPillDot { background: var(--success); }
-.settingsBotStatusPill[data-tone="warning"] { color: var(--info-text); }
-.settingsBotStatusPill[data-tone="warning"] .settingsBotStatusPillDot { background: var(--info); }
-.settingsBotStatusPill[data-tone="destructive"] { color: var(--destructive-text); }
-.settingsBotStatusPill[data-tone="destructive"] .settingsBotStatusPillDot { background: var(--destructive); }
+/* .settingsBotStatusPill is now the Chip primitive with dot (squared status
+   label + leading tone dot). tone→alpha and the 6px currentColor dot come from
+   chip.tsx; the "● 已连接" affordance is preserved by the Chip `dot` prop. */
 .settingsHelpText {
     margin: 0;
   }

--- a/apps/desktop/src/renderer/styles/settings/connection.css
+++ b/apps/desktop/src/renderer/styles/settings/connection.css
@@ -157,42 +157,33 @@
     font-size: var(--font-size-caption);
     line-height: var(--leading-normal);
   }
-.settingsAuthContractBadge,
-  .settingsAuthActionPill {
+.settingsAuthContractBadge {
     display: inline-flex;
     align-items: center;
     min-height: 20px;
-    /* Detail audit round 4: these are non-clickable guidance labels sitting
-       in the same row as a REAL button (测试凭据) — bare text next to a
-       button read as broken controls. A quiet filled label form makes the
-       affordance difference legible. */
+    /* Detail audit round 4: a non-clickable guidance label sitting in the
+       same row as a REAL button (测试凭据) — bare text next to a button read
+       as broken controls. A quiet filled label form makes the affordance
+       difference legible. (.settingsAuthActionPill migrated onto Chip.) */
     padding: var(--space-0-5) var(--space-2);
     border-radius: var(--radius-control);
     background: var(--foreground-5);
-    color: var(--muted-foreground);
+    color: var(--foreground-secondary);
     white-space: nowrap;
     font-size: var(--font-size-caption);
     font-weight: var(--font-weight-medium);
   }
-.settingsAuthContractBadge {
-    padding: var(--space-0-5) var(--space-2);
-    background: var(--foreground-5);
-    color: var(--foreground-secondary);
-  }
-/* success-tone badges/pills fall through to the neutral base — the
-   label text (已验证 etc.) carries the meaning. */
-.settingsAuthContractBadge[data-tone="info"],
-  .settingsAuthActionPill[data-tone="info"] {
+/* success-tone badges fall through to the neutral base — the label text
+   (已验证 etc.) carries the meaning. */
+.settingsAuthContractBadge[data-tone="info"] {
     background: oklch(from var(--info) l c h / 0.14);
     color: var(--info-text);
   }
-.settingsAuthContractBadge[data-tone="warning"],
-  .settingsAuthActionPill[data-tone="warning"] {
+.settingsAuthContractBadge[data-tone="warning"] {
     background: oklch(from var(--info) l c h / 0.18);
     color: var(--info-text);
   }
-.settingsAuthContractBadge[data-tone="destructive"],
-  .settingsAuthActionPill[data-tone="destructive"] {
+.settingsAuthContractBadge[data-tone="destructive"] {
     background: oklch(from var(--destructive) l c h / 0.14);
     color: var(--destructive);
   }
@@ -217,11 +208,9 @@
     gap: var(--space-2);
     margin-top: var(--space-1);
   }
-.settingsAuthActionPill {
-    padding: var(--space-0-5) var(--space-2);
-    background: var(--foreground-5);
-    color: var(--foreground-secondary);
-  }
+/* .settingsAuthActionPill is now the Chip primitive (squared status label,
+   tone→alpha from chip.tsx). Only the preview-kind dashed-border affordance
+   remains as a bespoke rule layered on top of the Chip. */
 .settingsAuthActionPill[data-kind="preview"] {
     border: var(--border-width-hairline) dashed oklch(from var(--info) l c h / 0.30);
   }

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -189,16 +189,9 @@
 /* Gated providers carry a real trailing state badge in ItemActions (not an
  * absolute ::after), tinted by the gate reason. The row itself is a plain
  * div Item with no render prop, so it is inert — the provider-surface gate
- * never lets a gated provider read as clickable. */
-.providerCatalogRow[data-status="unavailable"] .providerCatalogBadge.is-state {
-  background: oklch(from var(--info) l c h / 0.14);
-  color: var(--info-text);
-}
-
-.providerCatalogRow[data-status="experimental"] .providerCatalogBadge.is-state {
-  background: oklch(from var(--warning) l c h / 0.14);
-  color: var(--warning-text);
-}
+ * never lets a gated provider read as clickable. The state badge is now the
+ * Chip primitive (info = unavailable, warning = experimental); tone→alpha
+ * lives in chip.tsx, so no bespoke .is-state tint rules remain here. */
 
 /* PR-UI-13 (@yuejing 2026-05-22): ProviderLogo size normalization.
  *

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -18,6 +18,7 @@ import {
   formatDailyReviewModelLabel,
 } from './daily-review-helpers.js';
 import { Button as UiButton } from './ui.js';
+import { Chip, type ChipProps } from './primitives/chip.js';
 import { SettingsSegmented } from './primitives/settings-segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
 import { EmptyState } from './empty-state.js';
@@ -48,6 +49,15 @@ const DAILY_REVIEW_ARCHIVE_TRIGGER_LABEL: Record<DailyReviewArchive['trigger'], 
 };
 
 const EMPTY_MODEL_OPTIONS: ReadonlyArray<readonly [string, string]> = [];
+
+// Archive-status Chip tone. ok = generated cleanly (success), failed /
+// no_model = the run could not produce a report (destructive). no_data /
+// skipped are expected non-events and stay neutral (exception-only color).
+function dailyReviewArchiveChipTone(status: DailyReviewArchive['status']): ChipProps['variant'] {
+  if (status === 'ok') return 'success';
+  if (status === 'failed' || status === 'no_model') return 'destructive';
+  return 'neutral';
+}
 
 export function DailyReviewPanel(props: {
   bridge: DailyReviewBridge;
@@ -638,9 +648,14 @@ function DailyReviewArchiveBody(props: { archive: DailyReviewArchive | null; loa
             {archive.modelKey ? ` · ${formatDailyReviewModelLabel(archive.modelKey)}` : ' · 默认对话模型'}
           </p>
         </div>
-        <span className="maka-daily-review-archive-status" data-status={archive.status}>
+        <Chip
+          size="sm"
+          variant={dailyReviewArchiveChipTone(archive.status)}
+          className="maka-daily-review-archive-status"
+          data-status={archive.status}
+        >
           {DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}
-        </span>
+        </Chip>
       </header>
       {archive.errorMessage && (
         <p className="maka-daily-review-archive-error">{archive.errorMessage}</p>

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -62,6 +62,7 @@ import {
   TabsTrigger,
 } from './ui.js';
 import { Badge } from './primitives/badge.js';
+import { Chip, type ChipProps } from './primitives/chip.js';
 import { Input } from './primitives/input.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { Alert, AlertTitle } from './primitives/alert.js';
@@ -88,6 +89,18 @@ function PlanReminderSelect<T extends string>(props: {
   disabled?: boolean;
 }) {
   return <SettingsSelect width="full" {...props} />;
+}
+
+// Run-history status Chip tone. triggered = it fired (info, informational,
+// not a health signal), blocked = intentionally skipped (warning), failed =
+// delivery error (destructive). Exception-only: no success green for a plain
+// "it ran" record.
+function planRunStatusChipTone(
+  status: NonNullable<PlanReminder['lastRun']>['status'],
+): ChipProps['variant'] {
+  if (status === 'blocked') return 'warning';
+  if (status === 'failed') return 'destructive';
+  return 'info';
 }
 
 export function PlanReminderPanel(props: {
@@ -630,9 +643,14 @@ export function PlanReminderPanel(props: {
               <div className="maka-plan-run-list" aria-label="计划提醒执行记录">
                 {visibleRunEntries.map(({ reminder, run }) => (
                   <article key={`${reminder.id}:${run.id}`} className="maka-plan-run-row">
-                    <div className="maka-plan-run-status" data-status={run.status}>
+                    <Chip
+                      size="sm"
+                      variant={planRunStatusChipTone(run.status)}
+                      className="maka-plan-run-status"
+                      data-status={run.status}
+                    >
                       {runStatusLabel(run.status)}
-                    </div>
+                    </Chip>
                     <div className="maka-plan-run-main">
                       <strong>{reminder.title}</strong>
                       <span>{run.message}</span>

--- a/packages/ui/src/primitives/chip.tsx
+++ b/packages/ui/src/primitives/chip.tsx
@@ -42,18 +42,37 @@ export const chipVariants = cva(
 export interface ChipProps extends useRender.ComponentProps<"span"> {
   variant?: VariantProps<typeof chipVariants>["variant"];
   size?: VariantProps<typeof chipVariants>["size"];
+  // Render a leading 6px round status dot (currentColor at 70% alpha) before
+  // the label — the "● 已连接" affordance from the retired .settingsBotStatusPill.
+  // The dot inherits the chip's tone via currentColor, so it stays in sync
+  // with the variant with no extra tone plumbing.
+  dot?: boolean;
 }
 
 export function Chip({
   className,
   variant,
   size,
+  dot,
+  children,
   render,
   ...props
 }: ChipProps): React.ReactElement {
   const defaultProps = {
-    className: cn(chipVariants({ className, size, variant })),
+    className: cn(chipVariants({ className, size, variant }), dot && "gap-[var(--space-1)]"),
     "data-slot": "chip",
+    children: (
+      <>
+        {dot ? (
+          <span
+            aria-hidden="true"
+            data-slot="chip-dot"
+            className="size-1.5 shrink-0 rounded-full bg-current opacity-70"
+          />
+        ) : null}
+        {children}
+      </>
+    ),
   };
 
   return useRender({

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -12,6 +12,7 @@ import {
 import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
 import { Button as UiButton, Switch, TabsRoot, TabsList, TabsTrigger, TabsPanel } from './ui.js';
+import { Chip, type ChipProps } from './primitives/chip.js';
 import { Input } from './primitives/input.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
@@ -273,9 +274,9 @@ function SkillLibraryPanel(props: {
                           appears for states the switch can't express
                           (state_error). 已启用/已停用 stay in the hover text. */}
                       {skill.runtimeStatus === 'state_error' && (
-                        <span className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus}>{runtimeLabel}</span>
+                        <Chip size="sm" variant="warning" className="maka-skill-library-runtime-label" data-status={skill.runtimeStatus}>{runtimeLabel}</Chip>
                       )}
-                      <span className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'}>{statusLabel}</span>
+                      <Chip size="sm" variant={skillStatusChipTone(skill)} className="maka-skill-library-status-label" data-status={skill.managedUpdateStatus ?? skill.validationStatus ?? skill.sourceType ?? 'workspace'}>{statusLabel}</Chip>
                       {opening && <span>打开中…</span>}
                       {updating && <span>更新中…</span>}
                       {toggling && <span>切换中…</span>}
@@ -559,6 +560,21 @@ function formatSkillStatusLabel(skill: SkillEntry): string {
 function formatSkillRuntimeLabel(skill: SkillEntry): string {
   if (skill.runtimeStatus === 'state_error') return '状态异常';
   return skill.enabled ? '已启用' : '已停用';
+}
+
+// Derive the source-status Chip tone from the same data-status the retired
+// .maka-skill-library-status-label CSS keyed off. Exception-only: 内置 / 本地
+// (expected states) stay neutral; only genuine attention states carry a tone.
+//   metadata_error / local_modified → warning (needs the user's attention)
+//   受管理 (managed base) → info (managed but nothing wrong)
+//   bundled / workspace default → neutral
+function skillStatusChipTone(skill: SkillEntry): ChipProps['variant'] {
+  if (skill.validationStatus === 'metadata_error') return 'warning';
+  if (skill.sourceType === 'managed') {
+    if (skill.managedUpdateStatus === 'local_modified' || skill.managedUpdateStatus === 'metadata_error') return 'warning';
+    return 'info';
+  }
+  return 'neutral';
 }
 
 function previewText(content: string): string {


### PR DESCRIPTION
Round 1 of the convergence map (notes/ui-convergence-map-2026-07-09.md): the status-chip family had the highest duplication — 5+ hand-rolled CSS recipes each re-declaring the tone→alpha table that primitives/chip.tsx already owns.

Migrated onto `Chip`:
- skills 状态/runtime labels (exception-only render condition preserved)
- plan-reminder 运行状态 (triggered→info / blocked→warning / failed→destructive)
- daily-review 归档状态 (ok→success / failed→destructive)
- connection guidance labels (settingsAuthActionPill; real buttons untouched)
- bot 状态灯 — Chip gains a `dot` prop (6px currentColor dot), settingsBotStatusPill retired
- provider catalog state badges (unavailable→info / experimental→warning); category/OAuth badges stay (different role)

Old CSS deleted; chip-converge contract EXTENDED to pin all new call sites + the dot prop; skills/bot contracts re-pinned to the Chip form. Minor intended normalization: legacy alphas snap to Chip's pinned values (warning /14→/18) — Chip is the authority.

Verified in worktree: desktop 2291/2291 + ui 46/46 (exit-code gated), dead-css clean, alignment auditor clean, CDP captures across all five touched surfaces. Implemented by an opus worktree agent to the convergence-map spec.