### PR TITLE
feat(cli): /model across all connected providers

### DIFF
--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core/llm-connections';
-import { resolveDefaultSessionTarget } from '../connection-target.js';
+import { listReadyModelChoices, resolveDefaultSessionTarget } from '../connection-target.js';
 
 describe('default session target resolver', () => {
   test('uses the default ready connection and requested model', async () => {
@@ -144,6 +144,58 @@ describe('default session target resolver', () => {
       }),
       /NO_REAL_CONNECTION:missing_default_connection/,
     );
+  });
+});
+
+describe('listReadyModelChoices', () => {
+  test('lists models across every ready connection and skips fake / not-ready', async () => {
+    const zai = makeConnection({
+      slug: 'zai',
+      name: 'Z.ai',
+      providerType: 'ollama', // authKind none → ready without a stored secret
+      defaultModel: 'glm-5.2',
+      models: [{ id: 'glm-5.2' }, { id: 'glm-5-air' }],
+    });
+    const openai = makeConnection({
+      slug: 'openai',
+      name: 'OpenAI',
+      providerType: 'openai', // needs an api key
+      defaultModel: 'gpt-5.5',
+      models: [{ id: 'gpt-5.5' }],
+    });
+    const openaiNoKey = makeConnection({
+      slug: 'openai-2',
+      name: 'OpenAI 2',
+      providerType: 'openai',
+      defaultModel: 'gpt-5.5',
+    });
+    const fake = makeConnection({ slug: 'fake', name: 'Fake', providerType: 'ollama', defaultModel: 'x' });
+
+    const choices = await listReadyModelChoices({
+      connectionStore: {
+        list: async () => [zai, openai, openaiNoKey, fake],
+        getDefault: async () => 'zai',
+      },
+      credentialStore: {
+        getSecret: async (slug) => (slug === 'openai' ? 'sk-real' : null),
+      },
+    });
+
+    // Two ready connections contribute; the keyless OpenAI and the fake are skipped.
+    assert.deepEqual(
+      choices.filter((choice) => choice.connectionSlug === 'zai').map((choice) => choice.model),
+      ['glm-5.2', 'glm-5-air'],
+    );
+    assert.deepEqual(
+      choices.filter((choice) => choice.connectionSlug === 'openai').map((choice) => choice.model),
+      ['gpt-5.5'],
+    );
+    assert.equal(choices.some((choice) => choice.connectionSlug === 'openai-2'), false);
+    assert.equal(choices.some((choice) => choice.connectionSlug === 'fake'), false);
+    // The default connection is flagged so the picker can mark it.
+    assert.equal(choices.find((choice) => choice.connectionSlug === 'zai')?.isDefaultConnection, true);
+    assert.equal(choices.find((choice) => choice.connectionSlug === 'openai')?.isDefaultConnection, false);
+    assert.equal(choices.find((choice) => choice.connectionSlug === 'zai')?.connectionName, 'Z.ai');
   });
 });
 

--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -197,6 +197,43 @@ describe('listReadyModelChoices', () => {
     assert.equal(choices.find((choice) => choice.connectionSlug === 'openai')?.isDefaultConnection, false);
     assert.equal(choices.find((choice) => choice.connectionSlug === 'zai')?.connectionName, 'Z.ai');
   });
+
+  test('skips a connection whose credential read throws instead of failing the whole list', async () => {
+    // A local keyless connection plus an API connection whose stored credentials
+    // are corrupt/legacy, so reading its secret throws.
+    const local = makeConnection({
+      slug: 'local',
+      name: 'Local',
+      providerType: 'ollama', // authKind none → no secret read
+      defaultModel: 'qwen',
+      models: [{ id: 'qwen' }],
+    });
+    const broken = makeConnection({
+      slug: 'openai',
+      name: 'OpenAI',
+      providerType: 'openai', // needs a secret → getSecret is called and throws
+      defaultModel: 'gpt-5.5',
+      models: [{ id: 'gpt-5.5' }],
+    });
+
+    const choices = await listReadyModelChoices({
+      connectionStore: {
+        list: async () => [local, broken],
+        getDefault: async () => 'local',
+      },
+      credentialStore: {
+        getSecret: async (slug) => {
+          if (slug === 'openai') throw new Error('credentials.json is unreadable');
+          return null;
+        },
+      },
+    });
+
+    // The broken connection is skipped; the keyless local model still lists, so
+    // startup (which awaits this) survives an unrelated corrupt credential file.
+    assert.deepEqual(choices.map((choice) => choice.connectionSlug), ['local']);
+    assert.deepEqual(choices.map((choice) => choice.model), ['qwen']);
+  });
 });
 
 function makeConnection(input: Partial<LlmConnection>): LlmConnection {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -1404,6 +1404,49 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('switches connection and model together from a cross-connection /model', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'gpt-5.5',
+      connectionSlug: 'openai',
+      providerType: 'openai',
+      modelChoices: [
+        { connectionSlug: 'openai', connectionName: 'OpenAI', providerType: 'openai', model: 'gpt-5.5', isDefaultConnection: true },
+        { connectionSlug: 'zai', connectionName: 'Z.ai', providerType: 'openai', model: 'glm-5.2', isDefaultConnection: false },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/model');
+    terminal.input('\r');
+
+    await waitFor(() => terminal.output().includes('Select Model'));
+    await waitFor(() => terminal.output().includes('glm-5.2'));
+    // The picker opens on the current model (gpt-5.5); move down to the choice on
+    // the other connection and select it.
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+
+    assert.deepEqual(driver.models, ['glm-5.2']);
+    assert.deepEqual(driver.modelConnections, ['zai']);
+    // The status line now reflects both the new model and the new connection.
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Maka glm-5.2 zai ask /repo'));
+
+    terminal.input('\x03');
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close after Ctrl-C');
+      }),
+    ]);
+  });
+
   test('handles /rename without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -3484,6 +3527,7 @@ class ToolOutputDriver implements MakaSessionDriver {
 class SlashCommandDriver implements MakaSessionDriver {
   readonly prompts: string[] = [];
   readonly models: string[] = [];
+  readonly modelConnections: Array<string | undefined> = [];
   readonly permissionModes: PermissionMode[] = [];
   readonly thinkingLevelUpdates: Array<ThinkingLevel | undefined> = [];
   readonly sessionIds: string[] = [];
@@ -3523,8 +3567,9 @@ class SlashCommandDriver implements MakaSessionDriver {
 
   async stop(): Promise<void> {}
   async respondToPermission(_response: PermissionResponse): Promise<void> {}
-  async setModel(model: string): Promise<void> {
+  async setModel(model: string, connectionSlug?: string): Promise<void> {
     this.models.push(model);
+    this.modelConnections.push(connectionSlug);
   }
   async renameSession(name: string): Promise<void> {
     this.renames.push(name);

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -125,6 +125,60 @@ describe('Maka session driver', () => {
     }]);
   });
 
+  test('switches connection and model together on an active session', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.setModel('glm-5.2', 'zai');
+
+    // The connection rides in the same updateSession patch, so the next turn
+    // rebuilds the backend on the new provider.
+    assert.deepEqual(runtime.sessionUpdates, [{
+      sessionId: 'session-1',
+      patch: { model: 'glm-5.2', thinkingLevel: undefined, llmConnectionSlug: 'zai' },
+    }]);
+  });
+
+  test('a same-connection setModel does not churn the connection', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await collect(driver.sendPrompt('run tests'));
+    await driver.setModel('claude-opus-4-1', 'anthropic');
+
+    assert.deepEqual(runtime.sessionUpdates, [{
+      sessionId: 'session-1',
+      patch: { model: 'claude-opus-4-1', thinkingLevel: undefined },
+    }]);
+  });
+
+  test('creates the next session on a connection chosen before any session exists', async () => {
+    const runtime = new RecordingRuntime();
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd: '/repo',
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await driver.setModel('glm-5.2', 'zai');
+    await collect(driver.sendPrompt('run tests'));
+
+    assert.equal(runtime.created[0]?.llmConnectionSlug, 'zai');
+    assert.equal(runtime.created[0]?.model, 'glm-5.2');
+  });
+
   test('renames the active session through runtime updateSession', async () => {
     const runtime = new RecordingRuntime();
     const driver = createMakaSessionDriver({
@@ -547,7 +601,7 @@ class RecordingRuntime {
   readonly compacted: Array<{ sessionId: string; input: { turnId?: string } }> = [];
   readonly permissionResponses: Array<{ sessionId: string; response: PermissionResponse }> = [];
   readonly permissionModes: Array<{ sessionId: string; mode: PermissionMode }> = [];
-  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
+  readonly sessionUpdates: Array<{ sessionId: string; patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string } }> = [];
   readonly branched: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
   sessionSummaries: SessionSummary[] = [];
@@ -622,7 +676,7 @@ class RecordingRuntime {
     };
   }
 
-  async updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
+  async updateSession(sessionId: string, patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined; name?: string }): Promise<SessionSummary> {
     this.sessionUpdates.push({ sessionId, patch });
     return {
       id: sessionId,
@@ -633,7 +687,7 @@ class RecordingRuntime {
       hasUnread: false,
       status: 'active',
       backend: 'ai-sdk',
-      llmConnectionSlug: 'anthropic',
+      llmConnectionSlug: patch.llmConnectionSlug ?? 'anthropic',
       model: patch.model ?? 'claude-sonnet-4-5',
       permissionMode: 'ask',
     };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -89,6 +89,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
           cwd: context.cwd,
           model: context.target.model,
           models: selectableModelIdsForTarget(context.target),
+          modelChoices: context.modelChoices,
           connectionSlug: context.target.connection.slug,
           providerType: context.target.connection.providerType,
           permissionMode: 'ask',

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -121,21 +121,30 @@ export async function listReadyModelChoices(input: {
   const choices: ModelChoice[] = [];
   for (const connection of connections) {
     if (connection.slug === 'fake') continue;
-    const credentialKind = credentialKindForConnection(connection);
-    const secret = credentialKind
-      ? await input.credentialStore.getSecret(connection.slug, credentialKind)
-      : '';
-    const hasSecret = credentialKind === null || (typeof secret === 'string' && secret.length > 0);
-    const verdict = isConnectionReady({ connection, hasSecret });
-    if (!verdict.ready) continue;
-    for (const model of selectableModelIdsForTarget({ connection, model: verdict.model })) {
-      choices.push({
-        connectionSlug: connection.slug,
-        connectionName: connection.name,
-        providerType: connection.providerType,
-        model,
-        isDefaultConnection: connection.slug === defaultSlug,
-      });
+    // Isolate each connection: reading one connection's secret can throw (a
+    // legacy or corrupt credentials.json), and this list is an optional
+    // convenience for the /model picker — it must never take down startup. A
+    // failing or not-ready connection is simply skipped, so a usable default
+    // (e.g. a keyless local model) still launches.
+    try {
+      const credentialKind = credentialKindForConnection(connection);
+      const secret = credentialKind
+        ? await input.credentialStore.getSecret(connection.slug, credentialKind)
+        : '';
+      const hasSecret = credentialKind === null || (typeof secret === 'string' && secret.length > 0);
+      const verdict = isConnectionReady({ connection, hasSecret });
+      if (!verdict.ready) continue;
+      for (const model of selectableModelIdsForTarget({ connection, model: verdict.model })) {
+        choices.push({
+          connectionSlug: connection.slug,
+          connectionName: connection.name,
+          providerType: connection.providerType,
+          model,
+          isDefaultConnection: connection.slug === defaultSlug,
+        });
+      }
+    } catch {
+      // Unreadable credentials for this connection: skip it, keep the rest.
     }
   }
   return choices;

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -1,5 +1,5 @@
 import { isConnectionReady, type ChatConfigurationReason } from '@maka/core/connection-readiness';
-import type { LlmConnection } from '@maka/core/llm-connections';
+import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
 import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
 import { isOAuthSubscriptionProvider, resolveOAuthSubscriptionTokens, type OAuthSubscriptionTokens } from '@maka/runtime';
 import type { ConnectionStore, CredentialKind, CredentialStore } from '@maka/storage';
@@ -9,6 +9,15 @@ export interface ReadySessionTarget {
   apiKey: string;
   model: string;
   oauthTokens?: OAuthSubscriptionTokens;
+}
+
+/** One selectable model in the `/model` picker, tagged with its owning connection. */
+export interface ModelChoice {
+  connectionSlug: string;
+  connectionName: string;
+  providerType: ProviderType;
+  model: string;
+  isDefaultConnection: boolean;
 }
 
 export function selectableModelIdsForTarget(target: Pick<ReadySessionTarget, 'connection' | 'model'>): string[] {
@@ -40,12 +49,30 @@ export interface ResolveDefaultSessionTargetInput {
 export async function resolveDefaultSessionTarget(
   input: ResolveDefaultSessionTargetInput,
 ): Promise<ReadySessionTarget> {
-  const slug = await input.connectionStore.getDefault();
+  return resolveSessionTargetForSlug(await input.connectionStore.getDefault(), input);
+}
+
+/**
+ * Resolve a ready target for a specific connection slug — the per-session path
+ * the backend uses so the active session's connection (not the global default)
+ * decides which provider a turn runs on, mirroring the desktop app.
+ */
+export async function resolveSessionTargetForSlug(
+  slug: string | null | undefined,
+  input: ResolveDefaultSessionTargetInput,
+): Promise<ReadySessionTarget> {
   if (!slug || slug === 'fake') throw noRealConnection('missing_default_connection');
 
   const connection = await input.connectionStore.get(slug);
   if (!connection) throw noRealConnection('connection_missing');
 
+  return resolveReadyTargetForConnection(connection, input);
+}
+
+async function resolveReadyTargetForConnection(
+  connection: LlmConnection,
+  input: ResolveDefaultSessionTargetInput,
+): Promise<ReadySessionTarget> {
   const oauthProviderType = isOAuthSubscriptionProvider(connection.providerType)
     ? connection.providerType
     : null;
@@ -75,6 +102,43 @@ export async function resolveDefaultSessionTarget(
     model: verdict.model,
     ...(oauthTokens ? { oauthTokens } : {}),
   };
+}
+
+/**
+ * Every selectable model across all ready connections, for the `/model` picker.
+ * Readiness here is cheap and side-effect free — a stored secret, no OAuth token
+ * refresh or network — since the backend does the real resolution at turn time;
+ * this only decides which connections' models are worth offering.
+ */
+export async function listReadyModelChoices(input: {
+  connectionStore: Pick<ConnectionStore, 'list' | 'getDefault'>;
+  credentialStore: Pick<CredentialStore, 'getSecret'>;
+}): Promise<ModelChoice[]> {
+  const [connections, defaultSlug] = await Promise.all([
+    input.connectionStore.list(),
+    input.connectionStore.getDefault(),
+  ]);
+  const choices: ModelChoice[] = [];
+  for (const connection of connections) {
+    if (connection.slug === 'fake') continue;
+    const credentialKind = credentialKindForConnection(connection);
+    const secret = credentialKind
+      ? await input.credentialStore.getSecret(connection.slug, credentialKind)
+      : '';
+    const hasSecret = credentialKind === null || (typeof secret === 'string' && secret.length > 0);
+    const verdict = isConnectionReady({ connection, hasSecret });
+    if (!verdict.ready) continue;
+    for (const model of selectableModelIdsForTarget({ connection, model: verdict.model })) {
+      choices.push({
+        connectionSlug: connection.slug,
+        connectionName: connection.name,
+        providerType: connection.providerType,
+        model,
+        isDefaultConnection: connection.slug === defaultSlug,
+      });
+    }
+  }
+  return choices;
 }
 
 function credentialKindForConnection(connection: LlmConnection): CredentialKind | null {

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -11,6 +11,7 @@ import {
 } from '@earendil-works/pi-tui';
 import { PERMISSION_MODES, type PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
+import type { ModelChoice } from './connection-target.js';
 import { ansi, stripAnsi } from './tui-ansi.js';
 
 export class MakaAutocompleteProvider implements AutocompleteProvider {
@@ -124,6 +125,25 @@ export function modelPickerItems(currentModel: string, models: readonly string[]
     label: id,
     ...(id === currentModel ? { description: 'current' } : {}),
   }));
+}
+
+/**
+ * `/model` items across every ready connection. The value is the choice's index
+ * (models can repeat across connections, so no id is unique on its own); the
+ * caller maps it back to the {@link ModelChoice}. The description carries the
+ * owning connection so identical model ids on different providers are readable.
+ */
+export function modelChoicePickerItems(
+  choices: readonly ModelChoice[],
+  current: { model: string; connectionSlug: string },
+): SelectItem[] {
+  return choices.map((choice, index) => {
+    const isCurrent = choice.model === current.model && choice.connectionSlug === current.connectionSlug;
+    const tags = [choice.connectionName || choice.connectionSlug];
+    if (isCurrent) tags.push('current');
+    else if (choice.isDefaultConnection) tags.push('default');
+    return { value: String(index), label: choice.model, description: tags.join(' · ') };
+  });
 }
 
 export function permissionModePickerItems(currentMode: PermissionMode): SelectItem[] {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -15,6 +15,7 @@ import {
 import { PERMISSION_MODES, isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { isThinkingLevel, thinkingVariantsForModel, type ThinkingLevel } from '@maka/core/model-thinking';
 import type { ProviderType } from '@maka/core/llm-connections';
+import type { ModelChoice } from './connection-target.js';
 import type { MakaSessionDriver, MakaSessionSwitchResult } from './session-driver.js';
 import {
   createMakaPiTranscriptState,
@@ -42,6 +43,7 @@ import {
 import {
   MakaAutocompleteProvider,
   PickerOverlay,
+  modelChoicePickerItems,
   modelPickerItems,
   permissionModePickerItems,
   thinkingLevelPickerItems,
@@ -54,6 +56,13 @@ export interface MakaPiTuiInput {
   cwd: string;
   model: string;
   models?: readonly string[];
+  /**
+   * Every selectable model across all ready connections. When present, `/model`
+   * lists these (grouped by connection) and selecting one rebinds the session to
+   * that connection + model. Falls back to `models` (current connection only)
+   * when absent.
+   */
+  modelChoices?: readonly ModelChoice[];
   connectionSlug: string;
   providerType?: ProviderType;
   permissionMode: PermissionMode;
@@ -73,10 +82,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let cwd = input.cwd;
   let model = input.model;
   let connectionSlug = input.connectionSlug;
+  // Mutable: a cross-connection /model switch rebinds the provider, which changes
+  // both the connection and the thinking variants the new model supports.
+  let providerType = input.providerType;
   let permissionMode = input.permissionMode;
   let thinkingLevel: ThinkingLevel | undefined = undefined;
-  let thinkingLevels: readonly ThinkingLevel[] = input.providerType
-    ? thinkingVariantsForModel(input.providerType, input.model)
+  let thinkingLevels: readonly ThinkingLevel[] = providerType
+    ? thinkingVariantsForModel(providerType, input.model)
     : [];
   let busy = false;
   let closed = false;
@@ -285,11 +297,28 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     await input.driver.setModel(nextModel);
     model = nextModel;
     thinkingLevel = undefined;
-    thinkingLevels = input.providerType ? thinkingVariantsForModel(input.providerType, nextModel) : [];
+    thinkingLevels = providerType ? thinkingVariantsForModel(providerType, nextModel) : [];
     state.entries.push({
       kind: 'notice',
       level: 'info',
       text: `Model: ${nextModel}`,
+    });
+    requestRender();
+  };
+
+  // Cross-connection /model: rebind the session to the chosen connection + model.
+  // Updates the provider (and thus the thinking variants) and the status line.
+  const setModelChoice = async (choice: ModelChoice) => {
+    await input.driver.setModel(choice.model, choice.connectionSlug);
+    model = choice.model;
+    connectionSlug = choice.connectionSlug;
+    providerType = choice.providerType;
+    thinkingLevel = undefined;
+    thinkingLevels = thinkingVariantsForModel(choice.providerType, choice.model);
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: `Model: ${choice.model} (${choice.connectionName || choice.connectionSlug})`,
     });
     requestRender();
   };
@@ -313,7 +342,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     connectionSlug = summary.llmConnectionSlug;
     permissionMode = summary.permissionMode;
     thinkingLevel = summary.thinkingLevel;
-    thinkingLevels = input.providerType ? thinkingVariantsForModel(input.providerType, summary.model) : [];
+    thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
     replaceTranscriptWithStoredMessages(state, messages);
     // The transcript is a different document now; drop any scroll position so the
     // resumed session opens following its latest messages, not mid-history.
@@ -492,6 +521,30 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   };
 
   const showModelList = () => {
+    const choices = input.modelChoices;
+    // Cross-connection picker when the caller supplied choices across all ready
+    // connections; otherwise the single-connection list (typed /model, tests).
+    if (choices && choices.length > 0) {
+      const selectedIndex = choices.findIndex(
+        (choice) => choice.model === model && choice.connectionSlug === connectionSlug,
+      );
+      showSelectPicker(
+        'Select Model',
+        connectionSlug,
+        modelChoicePickerItems(choices, { model, connectionSlug }),
+        (item) => {
+          const choice = choices[Number(item.value)];
+          if (!choice) return;
+          void runControl(() => setModelChoice(choice));
+        },
+        {
+          minPrimaryColumnWidth: 24,
+          maxPrimaryColumnWidth: 48,
+          ...(selectedIndex >= 0 ? { selectedIndex } : {}),
+        },
+      );
+      return;
+    }
     showSelectPicker(
       'Select Model',
       connectionSlug,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -26,8 +26,8 @@ import {
   createSettingsStore,
   createShellRunStore,
 } from '@maka/storage';
-import type { ReadySessionTarget } from './connection-target.js';
-import { resolveDefaultSessionTarget } from './connection-target.js';
+import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
+import { listReadyModelChoices, resolveDefaultSessionTarget, resolveSessionTargetForSlug } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
 
 export interface MakaCliRuntimeContext {
@@ -35,6 +35,8 @@ export interface MakaCliRuntimeContext {
   cwd: string;
   runtime: SessionManager;
   target: ReadySessionTarget;
+  /** Selectable models across every ready connection, for the `/model` picker. */
+  modelChoices: ModelChoice[];
   tools: ReturnType<typeof buildBuiltinTools>;
   close(): Promise<void>;
 }
@@ -71,6 +73,7 @@ export async function createMakaCliRuntimeContext(
     credentialStore,
     requestedModel: input.requestedModel,
   });
+  const modelChoices = await listReadyModelChoices({ connectionStore, credentialStore });
   const permissionEngine = new PermissionEngine({ newId: randomUUID, now: Date.now });
   const backends = new BackendRegistry();
   const shellRuns = new ShellRunProcessManager({
@@ -81,7 +84,10 @@ export async function createMakaCliRuntimeContext(
   const tools = buildBuiltinTools({ shellRuns });
 
   backends.register('ai-sdk', async (ctx) => {
-    const ready = await resolveDefaultSessionTarget({
+    // Resolve the session's own connection — not the global default — so a
+    // /model switch that rebinds the session to another provider actually runs
+    // on that provider (the desktop app resolves the backend the same way).
+    const ready = await resolveSessionTargetForSlug(ctx.header.llmConnectionSlug, {
       connectionStore,
       credentialStore,
       requestedModel: ctx.header.model,
@@ -155,6 +161,7 @@ export async function createMakaCliRuntimeContext(
     cwd: input.cwd,
     runtime,
     target,
+    modelChoices,
     tools,
     close: () => shellRuns.terminateAll(),
   };

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -15,7 +15,7 @@ export interface MakaSessionRuntime {
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  updateSession(sessionId: string, patch: { model?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
+  updateSession(sessionId: string, patch: { model?: string; llmConnectionSlug?: string; thinkingLevel?: ThinkingLevel | undefined; name?: string }): Promise<SessionSummary>;
   // Rewind reuses the runtime's branch primitive: a non-destructive copy of the
   // transcript + RuntimeEvent ledger through a turn boundary, so resume
   // correctness is inherited and the original session's log is left intact.
@@ -47,7 +47,12 @@ export interface MakaSessionDriver {
   sendPrompt(prompt: string): AsyncIterable<SessionEvent>;
   compactSession(): AsyncIterable<SessionEvent>;
   respondToPermission(response: PermissionResponse): Promise<void>;
-  setModel(model: string): Promise<void>;
+  /**
+   * Switch the active session's model, optionally rebinding it to another
+   * connection at the same time (cross-provider `/model`). The next turn builds
+   * a fresh backend on the new connection.
+   */
+  setModel(model: string, connectionSlug?: string): Promise<void>;
   setThinkingLevel(level: ThinkingLevel | undefined): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
   renameSession(name: string): Promise<void>;
@@ -69,6 +74,9 @@ export function createMakaSessionDriver(input: MakaSessionDriverInput): MakaSess
 class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private sessionId: string | null = null;
   private model: string;
+  // The connection the active/next session runs on. Mutable so a cross-provider
+  // /model switch can rebind it; new sessions are created on this connection.
+  private llmConnectionSlug: string;
   private thinkingLevel: ThinkingLevel | undefined;
   private permissionMode: PermissionMode;
   private readonly newId: () => string;
@@ -76,6 +84,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   constructor(private readonly input: MakaSessionDriverInput) {
     this.newId = input.newId ?? randomUUID;
     this.model = input.model;
+    this.llmConnectionSlug = input.llmConnectionSlug;
     this.permissionMode = input.permissionMode ?? 'ask';
   }
 
@@ -112,15 +121,24 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     await this.input.runtime.respondToPermission(this.sessionId, response);
   }
 
-  async setModel(model: string): Promise<void> {
+  async setModel(model: string, connectionSlug?: string): Promise<void> {
+    // Only rebind the connection when a different one is asked for; a same-slug
+    // /model is a plain model change and must not churn the backend needlessly.
+    const nextConnection = connectionSlug && connectionSlug !== this.llmConnectionSlug ? connectionSlug : undefined;
     if (this.sessionId) {
-      // Switching model clears the per-model thinking variant.
-      const summary = await this.input.runtime.updateSession(this.sessionId, { model, thinkingLevel: undefined });
+      // Switching model (or connection) clears the per-model thinking variant.
+      const summary = await this.input.runtime.updateSession(this.sessionId, {
+        model,
+        thinkingLevel: undefined,
+        ...(nextConnection ? { llmConnectionSlug: nextConnection } : {}),
+      });
       this.model = summary.model;
+      this.llmConnectionSlug = summary.llmConnectionSlug;
       this.thinkingLevel = summary.thinkingLevel;
       return;
     }
     this.model = model;
+    if (nextConnection) this.llmConnectionSlug = nextConnection;
     this.thinkingLevel = undefined;
   }
 
@@ -156,12 +174,13 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     if (summary.cwd !== this.input.cwd) {
       throw new Error('Session belongs to a different folder; run Maka in that folder to resume it.');
     }
-    if (summary.llmConnectionSlug !== this.input.llmConnectionSlug) {
+    if (summary.llmConnectionSlug !== this.llmConnectionSlug) {
       throw new Error('Session uses a different connection; run Maka with that connection to resume it.');
     }
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
     this.model = summary.model;
+    this.llmConnectionSlug = summary.llmConnectionSlug;
     this.thinkingLevel = summary.thinkingLevel;
     this.permissionMode = summary.permissionMode;
     return { summary, messages };
@@ -219,7 +238,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
       cwd: this.input.cwd,
       name: prompt.slice(0, 42) || '新建对话',
       backend: 'ai-sdk',
-      llmConnectionSlug: this.input.llmConnectionSlug,
+      llmConnectionSlug: this.llmConnectionSlug,
       model: this.model,
       permissionMode: this.permissionMode,
       ...(this.thinkingLevel !== undefined ? { thinkingLevel: this.thinkingLevel } : {}),


### PR DESCRIPTION
## Summary

`/model` in the TUI only listed the current connection's models, and the backend resolved from the *default* connection (`getDefault`), ignoring the session's own `llmConnectionSlug`. This makes `/model` list every model across all ready connections and rebind the active session (connection + model) on select — matching the desktop app, which already resolves the backend from `ctx.header.llmConnectionSlug`.

## Why

Refs the CLI polish backlog: the model list should show all connected providers, not just the current one.

## Scope

Changed (all in `packages/cli`):
- `connection-target.ts` — `resolveSessionTargetForSlug` (per-slug resolution, used by the backend) and `listReadyModelChoices` (cheap, side-effect-free readiness across every connection; no OAuth refresh / network).
- `runtime-bootstrap.ts` — backend resolves by `ctx.header.llmConnectionSlug` (mirrors desktop `main.ts`); exposes `modelChoices` on the runtime context.
- `session-driver.ts` — `setModel(model, connectionSlug?)` rebinds the connection via `updateSession` (the runtime already disposes the stale backend on a connection change, so the next turn runs on the new provider); the driver tracks the connection mutably.
- `pi-tui-pickers.ts` / `pi-tui-runner.ts` — cross-connection `/model` picker (grouped by connection, marks current/default), updating provider + thinking variants + status line on switch. Falls back to the single-connection list when no choices are supplied.

Runtime is unchanged — it already supported per-session connections and `updateSession({ llmConnectionSlug })`; only the CLI wiring diverged.

## Verification

- `tsc --noEmit` (cli) — clean.
- `node --test` connection-target / session-driver / runtime-bootstrap / pi-tui-runner — 110/110 (5 new: cross-connection choices, connection-switch `setModel` behaviors, cross-connection picker end-to-end).
- Ran `listReadyModelChoices` against the real workspace: **11 models across 4 providers** now listed (deepseek, codex-subscription, ollama-cloud, zai [default]) vs the current connection's 4 before.

Not yet driven: an actual turn on a freshly-switched second provider in the running app — worth a smoke test, but the resolution path is the same one the desktop app uses.

## User-facing impact

`/model` now shows models from every connected provider, tagged with their connection, and selecting one on another provider switches the session to it. Typed `/model <id>` (same connection) is unchanged.