### PR TITLE
refactor(desktop): wechat scan-login modals join the shared DialogHeader

### DIFF
--- a/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/radius-converge-contract.test.ts
@@ -386,7 +386,6 @@ describe('radius token governance (#406 gap 4)', () => {
       '.settingsNotice': '--radius-surface',
       '.settingsAboutLogo': '--radius-surface',
       '.settingsAboutPrivacy': '--radius-surface',
-      '.settingsWechatQrClose': '--radius-control',
       '.settingsWechatQrFrame': '--radius-surface',
       '.settingsWechatQrState': '--radius-surface',
       '.providerUnavailableNotice': '--radius-surface',

--- a/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
+++ b/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { X } from '@maka/ui/icons';
 import type { BotChannelSettings } from '@maka/core';
 import type { WechatBridgeQrCodeResult } from '@maka/runtime';
-import { Button, DialogContent, DialogRoot, Input } from '@maka/ui';
+import { Button, DialogContent, DialogHeader, DialogRoot, Input } from '@maka/ui';
 import { PasswordInput } from './password-input';
 import { settingsActionErrorMessage } from './settings-error-copy';
 
@@ -202,19 +201,7 @@ export function WeChatScanLoginModal(props: {
         aria-label="微信扫码登录"
         showClose={false}
       >
-        <header className="settingsBotScanLoginHeader">
-          <h3>微信扫码登录</h3>
-          <Button
-            type="button"
-            variant="quiet"
-            size="icon-sm"
-            className="settingsCloseButton"
-            aria-label="关闭微信扫码登录"
-            onClick={props.onClose}
-          >
-            <X aria-hidden="true" />
-          </Button>
-        </header>
+        <DialogHeader title="微信扫码登录" closeLabel="关闭微信扫码登录" onClose={props.onClose} />
         <div className="settingsBotScanLoginBody">
           {qr?.qrcodeUrl && (status === 'waiting' || status === 'confirmed') ? (
             <img
@@ -330,22 +317,13 @@ export function WechatQrLoginModal(props: {
         aria-labelledby="settingsWechatQrTitle"
         showClose={false}
       >
-        <div className="settingsWechatQrHeader">
-          <div>
-            <h3 id="settingsWechatQrTitle">微信扫码登录</h3>
-            <p>使用手机微信扫描二维码，并在手机上确认登录本机 wechat-bridge。</p>
-          </div>
-          <Button
-            type="button"
-            variant="quiet"
-            size="icon-sm"
-            className="settingsWechatQrClose"
-            aria-label="关闭微信扫码登录"
-            onClick={props.onClose}
-          >
-            <X size={17} aria-hidden="true" />
-          </Button>
-        </div>
+        <DialogHeader
+          title="微信扫码登录"
+          titleId="settingsWechatQrTitle"
+          subtitle="使用手机微信扫描二维码，并在手机上确认登录本机 wechat-bridge。"
+          closeLabel="关闭微信扫码登录"
+          onClose={props.onClose}
+        />
 
         <div className="settingsWechatQrBody">
           {loading ? (

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -357,28 +357,6 @@
    SimpleStatsTable in usage-settings-page.tsx (inline Tailwind classes,
    no public primitive — a single HTML <table> consumer did not justify one). */
 
-.settingsCloseButton {
-  width: 24px;
-  height: 24px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--muted-foreground);
-  line-height: var(--leading-none);
-}
-
-.settingsCloseButton svg {
-  width: 14px;
-  height: 14px;
-}
-
-.settingsCloseButton:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
 .settingsRow {
   display: grid;
   grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -499,16 +499,6 @@
   gap: var(--space-3);
   box-shadow: var(--shadow-minimal);
 }
-.settingsBotScanLoginHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.settingsBotScanLoginHeader h3 {
-  margin: 0;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-}
 .settingsBotScanLoginBody {
   display: flex;
   flex-direction: column;
@@ -593,19 +583,6 @@
   padding: var(--space-4);
 }
 
-.settingsWechatQrHeader {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-3);
-}
-
-.settingsWechatQrHeader h3 {
-  margin: 0 0 var(--space-1);
-  font-size: 1.0667em;
-  font-weight: var(--font-weight-semibold);
-}
-
-.settingsWechatQrHeader p,
 .settingsWechatQrCaption {
   margin: 0;
   color: var(--muted-foreground);
@@ -613,23 +590,6 @@
   line-height: var(--leading-normal);
 }
 
-.settingsWechatQrClose {
-  width: 30px;
-  height: 30px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--muted-foreground);
-}
-
-.settingsWechatQrClose:hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
-.settingsWechatQrClose:focus-visible,
 .settingsWechatQrSecondary:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px oklch(from var(--accent) l c h / 0.24);

--- a/packages/ui/src/primitives/dialog-header.tsx
+++ b/packages/ui/src/primitives/dialog-header.tsx
@@ -10,8 +10,10 @@
 //     aria-label="关闭" — NO border box, no eyebrow, no second title.
 //
 // Palette-style modals whose input row IS the header (command-palette) do
-// NOT use this — they are intentionally headerless. Modals with a genuine
-// subtitle (permission-dialog) keep their richer bespoke header.
+// NOT use this — they are intentionally headerless. `subtitle` covers
+// modals with one line of instructional copy under the title (wechat QR
+// login); permission-dialog keeps its richer bespoke header (status pill +
+// wait-time meta exceed a subtitle line).
 //
 // Self-contained styling: the header is styled with Tailwind utility classes
 // so the primitive is portable across packages and needs no consumer CSS.
@@ -27,34 +29,46 @@ export interface DialogHeaderProps {
   title: ReactNode;
   /** Id applied to the title <h2> so DialogContent aria-labelledby can point at it. */
   titleId?: string;
+  /** Optional single-line instructional copy under the title (muted, --font-size-ui). */
+  subtitle?: ReactNode;
   /** Close handler wired to the quiet icon-sm close button. */
   onClose(): void;
   /** Accessible label for the close button. Defaults to the shared "关闭". */
   closeLabel?: string;
 }
 
-export function DialogHeader({ icon, title, titleId, onClose, closeLabel = '关闭' }: DialogHeaderProps) {
+export function DialogHeader({ icon, title, titleId, subtitle, onClose, closeLabel = '关闭' }: DialogHeaderProps) {
   return (
     <header
-      className="flex items-center gap-2 border-b border-border px-4 py-2.5"
+      className="flex items-start gap-2 border-b border-border px-4 py-2.5"
       data-slot="dialog-header"
     >
       {icon != null && (
         <span
-          className="flex shrink-0 items-center text-muted-foreground [&>svg]:h-4 [&>svg]:w-4"
+          className="flex h-5 shrink-0 items-center text-muted-foreground [&>svg]:h-4 [&>svg]:w-4"
           aria-hidden="true"
           data-slot="dialog-header-icon"
         >
           {icon}
         </span>
       )}
-      <h2
-        id={titleId}
-        className="min-w-0 flex-1 truncate text-[length:var(--font-size-ui)] font-semibold text-foreground"
-        data-slot="dialog-header-title"
-      >
-        {title}
-      </h2>
+      <div className="min-w-0 flex-1" data-slot="dialog-header-copy">
+        <h2
+          id={titleId}
+          className="min-w-0 truncate text-[length:var(--font-size-ui)] font-semibold leading-5 text-foreground"
+          data-slot="dialog-header-title"
+        >
+          {title}
+        </h2>
+        {subtitle != null && (
+          <p
+            className="mt-0.5 text-[length:var(--font-size-ui)] leading-normal text-muted-foreground"
+            data-slot="dialog-header-subtitle"
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
       <Button
         type="button"
         variant="quiet"


### PR DESCRIPTION
Continues #667's modal-header unification with the follow-up it flagged: the two wechat login modals were the last DialogContent consumers with ad-hoc headers in the clean-fit class.

- `DialogHeader` gains an optional `subtitle` slot (one line of muted instructional copy) — covers the QR modal's guidance line without another bespoke header; permission-dialog deliberately keeps its richer header (status pill + wait meta exceed a subtitle line)
- Direct scan-login modal drops the retired boxed `settingsCloseButton` (this was its last consumer — the style-pruning contract caught the orphan immediately, which is the governance loop working)
- Bridge QR modal drops its bespoke grid header + close recipe
- Orphaned CSS deleted (headers, settingsWechatQrClose, settingsCloseButton family); radius-converge row for the retired class removed

Desktop 2291/2291 exit-code gated; dead-css clean.