### PR TITLE
feat(desktop): automation-fired turns say so — provenance chip above the user bubble (F6)

### DIFF
--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -562,3 +562,20 @@ describe('deriveTurnLineageMap', () => {
     assert.equal(JSON.stringify(input), before);
   });
 });
+
+describe('automation turn attribution (F6)', () => {
+  it('projects an automation origin onto the turn user entry', () => {
+    const turns = materializeTurns([
+      { type: 'user', id: 'u1', turnId: 't1', ts: 1, text: '早报', origin: { kind: 'automation', automationId: 'auto-1' } },
+      { type: 'assistant', id: 'a1', turnId: 't1', ts: 2, text: '好的' },
+    ] as StoredMessage[]);
+    assert.equal(turns[0]?.user?.automationOrigin?.automationId, 'auto-1');
+  });
+
+  it('hand-typed turns carry no automation origin', () => {
+    const turns = materializeTurns([
+      { type: 'user', id: 'u1', turnId: 't1', ts: 1, text: '你好' },
+    ] as StoredMessage[]);
+    assert.equal(turns[0]?.user?.automationOrigin, undefined);
+  });
+});

--- a/apps/desktop/src/main/visual-smoke-fixture.ts
+++ b/apps/desktop/src/main/visual-smoke-fixture.ts
@@ -996,7 +996,7 @@ function multiStepTurnMessages(now: number): StoredMessage[] {
   const step1 = 'msg-assistant-2a';
   const step2 = 'msg-assistant-2b';
   return [
-    { type: 'user', id: 'msg-user-2', turnId, ts: now - 6 * 60_000, text: '确认 stream-fade 的环逻辑没有边界问题，然后跑一下单测。' },
+    { type: 'user', id: 'msg-user-2', turnId, ts: now - 6 * 60_000, text: '确认 stream-fade 的环逻辑没有边界问题，然后跑一下单测。', origin: { kind: 'automation', automationId: 'auto-fixture-demo' } },
     {
       type: 'tool_call',
       id: 'tool-read-fade',

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -178,6 +178,9 @@ export interface UserMessage {
   ts: number;
   text: string;
   attachments?: AttachmentRef[];
+  /** Non-user trigger source (automation fire). Lets the chat mark turns the
+   *  user did not hand-type. Mirrors TurnOrigin in runtime-inputs. */
+  origin?: { kind: 'automation'; automationId: string };
 }
 
 export interface AssistantMessage {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -294,6 +294,7 @@ export class AgentRun {
         ts: userMessageTs,
         text: this.input.userInput.text,
         ...(this.input.userInput.attachments ? { attachments: this.input.userInput.attachments } : {}),
+        ...(this.input.userInput.origin ? { origin: this.input.userInput.origin } : {}),
       };
       await this.input.store.appendMessage(this.sessionId, userMsg);
       await this.input.hooks.appendTurnState(this.sessionId, this.turnId, 'running', this.lineage);

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   RefreshCcw,
   Sparkles,
+  Timer,
 } from './icons.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
@@ -1083,6 +1084,19 @@ const TurnView = memo(function TurnView(props: {
               <span>{badge.label}</span>
             </UiButton>
           ))}
+        </Marker>
+      )}
+      {/* Automation provenance: a turn injected by a scheduled automation is
+          NOT something the user typed — say so above the bubble instead of
+          impersonating the user. Id stays in the tooltip (no raw ids inline). */}
+      {turn.user?.automationOrigin && (
+        <Marker
+          variant="automation-origin"
+          role="note"
+          title={`由定时任务触发 · ${turn.user.automationOrigin.automationId}`}
+        >
+          <Timer size={12} aria-hidden="true" />
+          <span>定时任务触发</span>
         </Marker>
       )}
       {turn.user && (

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -9,6 +9,8 @@ export interface ChatItem {
   ts?: number;
   /** User-message attachments projected from StoredMessage; absent on assistant/system rows. */
   attachments?: AttachmentRef[];
+  /** Present when the turn was fired by an automation, not hand-typed. */
+  automationOrigin?: { automationId: string };
 }
 
 /**
@@ -316,6 +318,7 @@ export function materializeTurns(
         text: message.text,
         ts: message.ts,
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
+        ...(message.origin?.kind === 'automation' ? { automationOrigin: { automationId: message.origin.automationId } } : {}),
       };
     } else if (message.type === 'assistant') {
       // A turn now holds one AssistantMessage per model step. Concatenate their

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -143,6 +143,11 @@ const markerVariants = cva("", {
       // `.maka-turn-aborted-marker` (+ its italic `em`) — dormant, muted.
       aborted:
         "inline-flex w-fit items-center gap-1 mx-0 mt-0.5 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--foreground-secondary)] text-xs italic [&_em]:italic",
+      // `.maka-turn-automation-origin` — quiet provenance chip above a user
+      // bubble whose turn was fired by an automation, not hand-typed. Sits on
+      // the user side (self-end) so it reads as the bubble's byline.
+      "automation-origin":
+        "inline-flex w-fit items-center gap-1 self-end mx-0 mb-1 px-1.5 py-0.5 rounded-[var(--radius-control)] bg-[var(--foreground-5)] text-[color:var(--muted-foreground)] text-xs",
       // `.maka-turn-failed-banner` — fault state, destructive tone.
       "failed-banner":
         "inline-flex w-fit flex-wrap items-center gap-1.5 mx-0 mt-0.5 mb-1.5 px-2 py-1 rounded-[var(--radius-control)] border border-[oklch(from_var(--destructive)_l_c_h_/_0.28)] bg-[oklch(from_var(--destructive)_l_c_h_/_0.10)] text-[color:var(--destructive)] text-xs",


### PR DESCRIPTION
Closes the F6 gap recorded at the #643 adoption: a heartbeat automation's injected prompt rendered as a plain user bubble — impersonating the user. Now the turn carries provenance end-to-end: `UserMessage.origin` (persisted from the existing TurnOrigin plumbing) → `materializeTurns` projects `automationOrigin` → chat renders a quiet 「⏱ 定时任务触发」 chip above the bubble (id in tooltip only). Cron fresh sessions already had session-level attribution (labels + name). Marker variant follows the aborted-chip recipe; fixture baseline + materialize present/absent tests included. Desktop 2293/2293, runtime green, dead-css clean, CDP verified.