### PR TITLE
refactor(ui): Item primitive adoption for state-fill list rows (convergence round 2)

### DIFF
--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -234,7 +234,7 @@ export function ProvidersPanel({ bridge }: { bridge: ConnectionsBridge }) {
                           <li key={connection.slug}>
                             <Item
                               className="enabledConnRow mx-2 py-2 pr-6 pl-10"
-                              data-default={connection.slug === defaultSlug ? 'true' : undefined}
+                              selected={connection.slug === defaultSlug}
                               data-test-status={connection.lastTestStatus ?? 'untested'}
                               data-disabled={connection.enabled ? undefined : 'true'}
                               aria-label={chipAriaLabel(connection)}

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -112,28 +112,18 @@
     padding: 0;
   }
 
+/* Migrated onto the Item primitive (round 2): hover 4% / selected 6.5%
+   fills + the stacked title-over-meta column now come from Item +
+   ItemContent, so this rule keeps only geometry (padding, radius) and the
+   selected-state border accent. `data-selected` is Item's selected hook. */
 .maka-daily-review-archive-row {
-  appearance: none;
   border: var(--border-width-hairline) solid transparent;
   border-radius: var(--radius-control);
-  background: transparent;
-  color: inherit;
-  display: grid;
-  gap: 1px;
   min-width: 0;
   padding: var(--space-1-5) var(--space-2);
-  text-align: left;
-  transition:
-    background var(--duration-quick) var(--ease-out-strong),
-    border-color var(--duration-quick) var(--ease-out-strong);
 }
 
-.maka-daily-review-archive-row:hover {
-  background: var(--state-hover-bg);
-}
-
-.maka-daily-review-archive-row[data-active="true"] {
-  background: var(--state-selected-bg);
+.maka-daily-review-archive-row[data-selected] {
   border-color: var(--border-strong);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/models.css
+++ b/apps/desktop/src/renderer/styles/settings/models.css
@@ -121,9 +121,9 @@
   border-radius: var(--radius-control);
 }
 
-.enabledConnRow[data-default="true"] {
-  background: var(--state-selected-bg);
-}
+/* The default-connection selected wash now rides the Item `selected` prop
+   (data-selected → --state-selected-bg), so no bespoke [data-default] fill
+   rule remains here — one selected-row implementation across the app. */
 
 .enabledConnRow[data-disabled="true"] {
   opacity: var(--opacity-muted);

--- a/notes/ui-convergence-map-2026-07-09.md
+++ b/notes/ui-convergence-map-2026-07-09.md
@@ -32,7 +32,15 @@ already contract-governed — the work is moving STRUCTURE onto shared primitive
 
 ## Status
 - [x] 1 Chip — SHIPPED #681 (5 recipes retired, dot prop added, contract extended)
-- [ ] 2 Item rows — started 2026-07-09
+- [~] 2 Item rows — round 2 shipped on feat/item-row-convergence: Item gained
+      `selected` (→ --state-selected-bg) + `interactive` gate. Migrated
+      enabledConnRow (data-default → selected) and daily-review archive rows
+      (UiButton → Item). providerCatalogRow already on Item. DEFERRED with
+      reasons: enabledProviderTrigger (accordion header, not a row),
+      settingsOsPermissionRow (static grid + stripe, pinned grid/div-actions),
+      daily-review session rows (composite: preview sibling outside the button),
+      maka-skill-library-row (bespoke grid + parent-li hover, skills.test.ts
+      pin — interactive={false} support landed for a future adoption).
 - [ ] 3 PageHeader
 - [ ] 4 StatTile
 - [ ] 5 SectionHeader/ActionRow

--- a/packages/ui/src/daily-review-panel.tsx
+++ b/packages/ui/src/daily-review-panel.tsx
@@ -18,6 +18,7 @@ import {
   formatDailyReviewModelLabel,
 } from './daily-review-helpers.js';
 import { Button as UiButton } from './ui.js';
+import { Item, ItemContent } from './primitives/item.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
 import { SettingsSegmented } from './primitives/settings-segmented.js';
 import { Alert, AlertAction, AlertDescription } from './primitives/alert.js';
@@ -404,25 +405,38 @@ export function DailyReviewPanel(props: {
               <ul className="maka-daily-review-archive-list" aria-label="回顾报告历史">
                 {archives.map((archive) => (
                   <li key={archive.id}>
-                    <UiButton
-                      type="button"
-                      variant="quiet"
+                    {/* Archive row now speaks the shared Item row language:
+                        hover 4% / selected 6.5% come from the primitive
+                        (selected → --state-selected-bg), ItemContent stacks
+                        the title over the meta line. The row class keeps only
+                        geometry (padding, radius, selected border). */}
+                    <Item
                       className="maka-daily-review-archive-row"
-                      data-active={selectedArchiveId === archive.id ? 'true' : undefined}
-                      onClick={() => chooseDailyReviewArchive(archive.id)}
+                      selected={selectedArchiveId === archive.id}
+                      render={
+                        <button
+                          type="button"
+                          onClick={() => chooseDailyReviewArchive(archive.id)}
+                        />
+                      }
                     >
-                      <span className="maka-daily-review-archive-row-title">
-                        {formatDailyReviewArchiveTitle(archive)}
-                      </span>
-                      {/* Designer audit P2-11: the row used to repeat the
-                          detail card's entire header (status + timestamp).
-                          The list only needs to identify the report; status
-                          and generation time live in the detail. */}
-                      <span className="maka-daily-review-archive-row-meta">
-                        {archive.totals.sessionCount} 对话
-                        {archive.status !== 'ok' ? ` · ${DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}` : ''}
-                      </span>
-                    </UiButton>
+                      <ItemContent>
+                        {/* Plain span (not ItemTitle): the row title relies on
+                            block-level text-overflow ellipsis, which ItemTitle's
+                            flex layout would defeat. */}
+                        <span className="maka-daily-review-archive-row-title">
+                          {formatDailyReviewArchiveTitle(archive)}
+                        </span>
+                        {/* Designer audit P2-11: the row used to repeat the
+                            detail card's entire header (status + timestamp).
+                            The list only needs to identify the report; status
+                            and generation time live in the detail. */}
+                        <span className="maka-daily-review-archive-row-meta">
+                          {archive.totals.sessionCount} 对话
+                          {archive.status !== 'ok' ? ` · ${DAILY_REVIEW_ARCHIVE_STATUS_LABEL[archive.status]}` : ''}
+                        </span>
+                      </ItemContent>
+                    </Item>
                   </li>
                 ))}
               </ul>

--- a/packages/ui/src/primitives/item.tsx
+++ b/packages/ui/src/primitives/item.tsx
@@ -21,16 +21,21 @@ import type React from "react";
 
 export const itemVariants = cva(
   // Clickable affordances (`hover`, `cursor`, `:active`) only light up
-  // when the row is rendered as a button/anchor via `render`; a plain
-  // div Item stays inert.
+  // when the row is rendered as a button/anchor via `render` AND the row
+  // is interactive; a plain div Item, or an `interactive={false}` row,
+  // stays inert.
   // Row hover stays NEUTRAL (a faint foreground wash), not the brand
   // `accent` — in this theme `accent` maps to the brand color, and the
   // app reserves it for active/selected rows, keeping plain hover quiet.
-  "group/item relative flex w-full items-center rounded-md border border-transparent text-left text-sm outline-none transition-colors [a&,button&]:cursor-pointer [a&,button&]:hover:bg-foreground/4 [a&,button&]:data-pressed:bg-foreground/8 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64",
+  // hover 4% (--state-hover-bg) / pressed 8% / selected 6.5%
+  // (--state-selected-bg) — the same governed foreground-alpha state
+  // tiers the CSS list rows use, so a migrated row keeps its exact fills.
+  "group/item relative flex w-full items-center rounded-md border border-transparent text-left text-sm outline-none transition-colors data-selected:bg-[var(--state-selected-bg)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-64",
   {
     defaultVariants: {
       variant: "default",
       size: "default",
+      interactive: true,
     },
     variants: {
       variant: {
@@ -42,6 +47,15 @@ export const itemVariants = cva(
         default: "gap-3 px-2 py-1.5",
         sm: "gap-2 px-2 py-1",
       },
+      // `interactive` gates the hover/pressed washes. Default rows light up
+      // only when rendered as a button/anchor. `interactive={false}` is for
+      // inert geometry-only rows (e.g. a skills-library row whose click
+      // targets live outside the row): they borrow Item's media/content/
+      // actions layout without ever painting a hover fill.
+      interactive: {
+        true: "[a&,button&]:cursor-pointer [a&,button&]:hover:bg-foreground/4 [a&,button&]:data-pressed:bg-foreground/8",
+        false: "",
+      },
     },
   },
 );
@@ -49,18 +63,34 @@ export const itemVariants = cva(
 export interface ItemProps extends useRender.ComponentProps<"div"> {
   variant?: VariantProps<typeof itemVariants>["variant"];
   size?: VariantProps<typeof itemVariants>["size"];
+  /**
+   * Selected/active row — paints the 6.5% `--state-selected-bg` wash and
+   * exposes `data-selected` for CSS/contract hooks. Independent of hover:
+   * a selected row still lights hover when interactive.
+   */
+  selected?: boolean;
+  /**
+   * Inert geometry-only row — suppresses the hover/pressed washes even when
+   * rendered as a button/anchor. Use for rows whose surface must not react
+   * (skills library row, catalog gated row). Equivalent to
+   * `interactive={false}`.
+   */
+  interactive?: VariantProps<typeof itemVariants>["interactive"];
 }
 
 export function Item({
   className,
   variant,
   size,
+  selected,
+  interactive,
   render,
   ...props
 }: ItemProps): React.ReactElement {
   const defaultProps = {
-    className: cn(itemVariants({ className, size, variant })),
+    className: cn(itemVariants({ className, size, variant, interactive })),
     "data-slot": "item",
+    ...(selected ? { "data-selected": "" } : {}),
   };
   return useRender({
     defaultTagName: "div",


### PR DESCRIPTION
Round 2 of notes/ui-convergence-map-2026-07-09.md: `Item` becomes the one list-row implementation for state fills.

- Item gains `selected` (→ governed --state-selected-bg token, data-selected hook) and `interactive` (suppress hover/pressed for inert geometry rows)
- Migrated: models 连接行 (bespoke data-default fill retired; #675 geometry preserved), daily-review archive rows (quiet-button recipe → Item with selected)
- providerCatalogRow was already an Item — no bespoke fill left to fold
- Deferred with reasons (recorded in the map): enabledProviderTrigger (accordion header semantics), settingsOsPermissionRow (static grid + contract-pinned structure, no fill), daily-review session rows (composite hover target), skills row (inert grid; interactive=false now exists for a future adoption), sidebar rows (densest contracts, by design)

Verified in worktree: ui 46/46 + desktop 2291/2291 exit-code gated, dead-css clean, alignment auditor clean, CDP captures on all four touched fixtures. Implemented by an opus worktree agent to the map spec.