### PR TITLE
refactor(ui): PageHeader primitive — one header shell for module pages and settings intros (convergence round 3)

### DIFF
--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { Sparkles } from '@maka/ui/icons';
-import { Button, useToast } from '@maka/ui';
+import { Button, PageHeader, useToast } from '@maka/ui';
 import { SettingsRows, SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -114,13 +114,16 @@ export function AboutSettingsPage() {
 
   return (
     <div className="settingsAboutPage">
-      <header className="settingsAboutHero">
-        <span className="settingsAboutLogo" aria-hidden="true">
-          <Sparkles size={26} />
-        </span>
-        <div>
-          <div className="settingsAboutHeading">
-            <h2>Maka</h2>
+      <PageHeader
+        as_wrapper="div"
+        className="settingsAboutHero"
+        as="h2"
+        icon={<Sparkles size={26} />}
+        iconClassName="settingsAboutLogo"
+        headingRowClassName="settingsAboutHeading"
+        title="Maka"
+        badge={
+          <>
             <span className="settingsAboutVersion">v{info.appVersion}</span>
             <span className="settingsAboutChannel">
               {info.buildMode === 'dev'
@@ -129,10 +132,11 @@ export function AboutSettingsPage() {
                   : '本地开发版'
                 : '正式版'}
             </span>
-          </div>
-          <p className="settingsAboutTagline">本地优先的 AI 助手 · 桌面端运行环境</p>
-        </div>
-      </header>
+          </>
+        }
+        subtitle="本地优先的 AI 助手 · 桌面端运行环境"
+        subtitleClassName="settingsAboutTagline"
+      />
 
       <section className="settingsAboutPrivacy" aria-label="隐私与安全">
         <h3>本地优先 · 隐私默认</h3>

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -7,7 +7,7 @@ import type {
   HealthSnapshot,
 } from '@maka/core';
 import { HEALTH_SIGNAL_LAYERS } from '@maka/core';
-import { Button, Badge, RelativeTime } from '@maka/ui';
+import { Button, Badge, RelativeTime, PageHeader } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -117,29 +117,33 @@ export function HealthCenterPage() {
 
   return (
     <div className="settingsHealthPage">
-      <header className="settingsHealthIntro">
-        <div>
-          <h3>健康中心</h3>
-          <p>
+      <PageHeader
+        className="settingsHealthIntro"
+        as="h3"
+        title="健康中心"
+        subtitle={
+          <>
             按层级（配置 · 验证 · 权限 · 功能 · 操作审批 · 记忆 · 运行态 · 存储）展示当前快照。
             <strong>验证通过 ≠ 运行可用</strong> — 凭据测试只属于验证层；发送通路以运行态探测结果为准。
-          </p>
-        </div>
-        <div className="settingsHealthMeta">
-          <Badge variant="info">只读快照</Badge>
-          <small>
-            最近一次读取：<RelativeTime ts={healthCheckedAtMs} className="settingsHelpInlineTime" />
-          </small>
-          <Button
-            type="button"
-            className="settingsHealthRefresh"
-            variant="secondary"
-            onClick={() => setRefreshTick((tick) => tick + 1)}
-          >
-            刷新
-          </Button>
-        </div>
-      </header>
+          </>
+        }
+        meta={
+          <div className="settingsHealthMeta">
+            <Badge variant="info">只读快照</Badge>
+            <small>
+              最近一次读取：<RelativeTime ts={healthCheckedAtMs} className="settingsHelpInlineTime" />
+            </small>
+            <Button
+              type="button"
+              className="settingsHealthRefresh"
+              variant="secondary"
+              onClick={() => setRefreshTick((tick) => tick + 1)}
+            >
+              刷新
+            </Button>
+          </div>
+        }
+      />
 
       {/* PR-HEALTH-SUMMARY-LIST-A11Y-0 (round 19/30): fifth
           application of the ARIA list semantics fix. Was

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionSnapshot,
 } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
-import { Button, Badge, RelativeTime, useToast } from '@maka/ui';
+import { Button, Badge, RelativeTime, PageHeader, useToast } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { statusBadgeVariant } from './settings-status-badge';
 import { SettingsSkeletonStack } from './settings-skeleton';
@@ -199,28 +199,27 @@ export function PermissionCenterPage() {
 
   return (
     <div className="settingsPermissionPage">
-      <header className="settingsPermissionIntro">
-        <div>
-          <h3>权限与能力</h3>
-          <p>
-            查看 Maka 需要的系统权限和当前授权状态，
-            直接从这里前往「系统设置 → 隐私与安全性」完成授权或撤销，不必自己翻菜单。
-          </p>
-        </div>
-        <div className="settingsPermissionMeta">
-          <small>
-            最近读取：<RelativeTime ts={checkedAtMs} className="settingsHelpInlineTime" />
-          </small>
-          <Button
-            type="button"
-            className="settingsPermissionRefresh"
-            variant="secondary"
-            onClick={() => setRefreshTick((tick) => tick + 1)}
-          >
-            重新检测
-          </Button>
-        </div>
-      </header>
+      <PageHeader
+        className="settingsPermissionIntro"
+        as="h3"
+        title="权限与能力"
+        subtitle="查看 Maka 需要的系统权限和当前授权状态，直接从这里前往「系统设置 → 隐私与安全性」完成授权或撤销，不必自己翻菜单。"
+        meta={
+          <div className="settingsPermissionMeta">
+            <small>
+              最近读取：<RelativeTime ts={checkedAtMs} className="settingsHelpInlineTime" />
+            </small>
+            <Button
+              type="button"
+              className="settingsPermissionRefresh"
+              variant="secondary"
+              onClick={() => setRefreshTick((tick) => tick + 1)}
+            >
+              重新检测
+            </Button>
+          </div>
+        }
+      />
 
       <section className="settingsPermissionSummary" aria-label="权限概览">
         <PermissionSummaryTile label="已授权" value={counts.granted} tone="success" />

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { Volume2 } from '@maka/ui/icons';
 import type { VoicePermissionStatus } from '@maka/core';
 import { defaultVoiceCaptureCaps, validateVoiceCaptureRequest } from '@maka/core';
-import { Button, useToast } from '@maka/ui';
+import { Button, PageHeader, useToast } from '@maka/ui';
 
 type VoiceSmokeState =
   | { status: 'idle'; message: string }
@@ -136,21 +136,17 @@ export function VoiceModelsSettingsPage() {
           gone — release notes don't live in settings, and its privacy copy
           duplicated the 隐私 tile + 当前边界 section below. (daily-review
           made the same banner exception-only earlier.) */}
-      <div className="settingsFeatureStatusHero">
-        <span className="settingsFeatureStatusIcon" aria-hidden="true">
-          <Volume2 size={24} />
-        </span>
-        <div>
-          <div className="settingsFeatureStatusHeroHeading">
-            <h3>语音模型</h3>
-            <span className="settingsFeatureStatusBadge">本地自检</span>
-          </div>
-          <p>
-            这页现在可以验证麦克风权限和本地录音链路。语音转写和语音朗读模型必须遵守这个边界：
-            转写结果必须先回到消息输入框，由用户编辑确认后才能发送；音频样本默认不落盘。
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        as_wrapper="div"
+        className="settingsFeatureStatusHero"
+        as="h3"
+        icon={<Volume2 size={24} />}
+        iconClassName="settingsFeatureStatusIcon"
+        headingRowClassName="settingsFeatureStatusHeroHeading"
+        title="语音模型"
+        badge={<span className="settingsFeatureStatusBadge">本地自检</span>}
+        subtitle="这页现在可以验证麦克风权限和本地录音链路。语音转写和语音朗读模型必须遵守这个边界：转写结果必须先回到消息输入框，由用户编辑确认后才能发送；音频样本默认不落盘。"
+      />
 
       <dl className="settingsBotStatusGrid" aria-label="语音能力状态">
         <div>

--- a/notes/ui-convergence-map-2026-07-09.md
+++ b/notes/ui-convergence-map-2026-07-09.md
@@ -41,7 +41,23 @@ already contract-governed — the work is moving STRUCTURE onto shared primitive
       daily-review session rows (composite: preview sibling outside the button),
       maka-skill-library-row (bespoke grid + parent-li hover, skills.test.ts
       pin — interactive={false} support landed for a future adoption).
-- [ ] 3 PageHeader — next
+- [x] 3 PageHeader — SHIPPED on feat/page-header-convergence: new
+      primitives/page-header.tsx (title/subtitle/eyebrow/icon/badge/
+      as('h2'|'h3')/actions/meta + contentClassName/iconClassName/
+      headingRowClassName/subtitleClassName/as_wrapper escape hatches).
+      Migrated all 6 call sites: skills-panel maka-module-main-header,
+      plan-reminder-panel maka-plan-hero (contentClassName=maka-plan-heading),
+      permission-center settingsPermissionIntro (meta), health-center
+      settingsHealthIntro (meta + <strong> subtitle), voice-settings
+      settingsFeatureStatusHero (icon + 本地自检 badge), about-settings
+      settingsAboutHero (icon + version/channel badge fragment + h2 scale).
+      NO CSS re-pin needed: every wrapper's typography CSS uses DESCENDANT
+      selectors (`.wrap h2/h3/p`) that keep matching through the primitive's
+      slot divs; radius/pruning contracts untouched (wrapper blocks
+      unchanged). check-a11y: added `Maka` to the brand allow-list (About
+      title prop tripped english-aria-label). Verified: ui+desktop builds,
+      2293 desktop / 46 ui tests, dead-css clean, alignment audit clean,
+      5 CDP captures in notes/round3-page-header-captures/.
 - [ ] 4 StatTile
 - [ ] 5 SectionHeader/ActionRow
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -110,6 +110,12 @@ export type { BadgeProps } from './primitives/badge.js';
 // / destructive.
 export { Chip, chipVariants } from './primitives/chip.js';
 export type { ChipProps } from './primitives/chip.js';
+// PageHeader — the shared page-header shell (convergence round 3). One shell
+// for the module hero (as='h2': 技能 / 定时任务) and the settings intros
+// (as='h3': permission / health / voice / about). Wrapper class + per-slot
+// CSS stay at the call site; the primitive converges STRUCTURE only.
+export { PageHeader } from './primitives/page-header.js';
+export type { PageHeaderProps } from './primitives/page-header.js';
 // Streaming UI rework: Codex-style tool "trow" grouping helpers. Pure bucketing
 // + summary used by the timeline tool renderer (ToolTrow) and unit-tested.
 export {

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -63,6 +63,7 @@ import {
 } from './ui.js';
 import { Badge } from './primitives/badge.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
+import { PageHeader } from './primitives/page-header.js';
 import { Input } from './primitives/input.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { Alert, AlertTitle } from './primitives/alert.js';
@@ -337,13 +338,14 @@ export function PlanReminderPanel(props: {
   return (
     <div className="maka-plan-panel">
       <div className="maka-plan-shell agents-inner-view-clamp">
-        <div className="maka-plan-hero">
-          <div className="maka-plan-heading">
-            <h2>定时任务</h2>
-            <p>
-              创建和管理周期性任务，让 Maka 按计划执行提醒、复盘和投递。
-            </p>
-          </div>
+        <PageHeader
+          as_wrapper="div"
+          className="maka-plan-hero"
+          as="h2"
+          title="定时任务"
+          subtitle="创建和管理周期性任务，让 Maka 按计划执行提醒、复盘和投递。"
+          contentClassName="maka-plan-heading"
+          actions={
           <div className="maka-plan-top-actions" aria-label="计划提醒操作">
             <UiButton
               type="button"
@@ -368,7 +370,8 @@ export function PlanReminderPanel(props: {
               新建定时任务
             </UiButton>
           </div>
-        </div>
+          }
+        />
 
         {/* PR-UI-ALIGN-1 (2026-06-21): the inline example-template strip
             (每日新闻摘要 / 周末待办整理) cluttered the top of the page and has no

--- a/packages/ui/src/primitives/page-header.tsx
+++ b/packages/ui/src/primitives/page-header.tsx
@@ -1,0 +1,174 @@
+// packages/ui/src/primitives/page-header.tsx
+//
+// PageHeader — the one shared header shell for the two coexisting
+// page-header dialects the app grew independently:
+//
+//   1. MODULE pages (as='h2'): the 技能 / 定时任务 hero — a big 2em
+//      semibold title, an optional lede line, and a right-aligned actions
+//      cluster (search box + primary CTA + refresh). Previously hand-rolled
+//      as `.maka-module-main-header` (h2+p+.maka-module-main-actions) and
+//      `.maka-plan-hero` (.maka-plan-heading > h2+p + .maka-plan-top-actions).
+//
+//   2. SETTINGS intros (as='h3'): the smaller Permission / Health / Voice /
+//      About page intro cards — an --font-size-ui semibold title, a lede,
+//      and a trailing quieter META cluster (RelativeTime + refresh Button)
+//      or a leading feature ICON + trailing BADGE chip. Previously
+//      `.settingsPermissionIntro`, `.settingsHealthIntro`,
+//      `.settingsFeatureStatusHero`, `.settingsAboutHero`.
+//
+// Layout & typography strategy: the shell is styled with portable Tailwind
+// utilities, but every call site KEEPS its existing wrapper class (passed via
+// `className`) so the wrapper CSS — which already owns the surface chrome
+// (card border/background/radius, flex vs grid layout, gap, mobile
+// breakpoints) and the per-slot typography (`.maka-module-main-header h2`,
+// `.settingsPermissionIntro p`, …) — keeps governing the visuals unchanged.
+// The primitive only converges the STRUCTURE (slot order, title/subtitle/
+// eyebrow/badge/icon/actions/meta arrangement). Slots expose `data-slot`
+// hooks so contracts that used to pin the old `h2`/`p` direct children can
+// re-pin the primitive's slots where DOM structure genuinely moved.
+
+import type { ReactNode } from 'react';
+import { cn } from '../utils.js';
+
+export interface PageHeaderProps {
+  /** Title text. Rendered as an <h2> (module scale) or <h3> (settings scale). */
+  title: ReactNode;
+  /** Optional lede line under the title (muted). */
+  subtitle?: ReactNode;
+  /**
+   * Optional small caps/eyebrow line ABOVE the title (e.g. a section kicker).
+   * Rendered muted+semibold before the title row.
+   */
+  eyebrow?: ReactNode;
+  /** Optional leading glyph, rendered in a framed icon box left of the content. */
+  icon?: ReactNode;
+  /**
+   * Optional marker rendered inline right AFTER the title (voice 本地自检
+   * chip, About version/channel pills). Accepts one node or a fragment.
+   */
+  badge?: ReactNode;
+  /**
+   * Title heading level + scale. 'h2' = module hero scale, 'h3' = settings
+   * intro scale. Defaults to 'h2'. The exact font-size/weight is left to the
+   * wrapper CSS (`.maka-module-main-header h2`, `.settingsPermissionIntro h3`,
+   * …); this only picks the semantic tag.
+   */
+  as?: 'h2' | 'h3';
+  /** Id applied to the title element (aria-labelledby targets). */
+  titleId?: string;
+  /**
+   * Right-aligned action cluster (buttons, search box). The cluster's own
+   * positioning class (e.g. `maka-module-main-actions`, `maka-plan-top-actions`)
+   * is passed as a child by the call site; the shell only slots it to the end.
+   */
+  actions?: ReactNode;
+  /**
+   * Trailing quieter cluster — the settings meta stack (RelativeTime +
+   * refresh Button + optional read-only badge). Like `actions`, the cluster's
+   * own class (`settingsPermissionMeta`, `settingsHealthMeta`) rides on the
+   * child; the shell only slots it.
+   */
+  meta?: ReactNode;
+  /** Wrapper class — the existing call-site hook (kept so CSS + contracts stay pinned). */
+  className?: string;
+  /**
+   * Class for the title+subtitle content column (e.g. `maka-plan-heading`).
+   * Lets a call site keep a wrapper that its CSS targets as the heading group.
+   */
+  contentClassName?: string;
+  /** Class for the leading icon box (e.g. `settingsFeatureStatusIcon`, `settingsAboutLogo`). */
+  iconClassName?: string;
+  /** Class for the inline title+badge row (e.g. `settingsFeatureStatusHeroHeading`, `settingsAboutHeading`). */
+  headingRowClassName?: string;
+  /** Class for the subtitle line (e.g. `settingsAboutTagline`), when a call site's CSS targets it. */
+  subtitleClassName?: string;
+  /** Render the wrapper as a <header> (default) or a <div>. */
+  as_wrapper?: 'header' | 'div';
+}
+
+export function PageHeader({
+  title,
+  subtitle,
+  eyebrow,
+  icon,
+  badge,
+  as = 'h2',
+  titleId,
+  actions,
+  meta,
+  className,
+  contentClassName,
+  iconClassName,
+  headingRowClassName,
+  subtitleClassName,
+  as_wrapper = 'header',
+}: PageHeaderProps): ReactNode {
+  const Title = as;
+  const Wrapper = as_wrapper;
+
+  // The title row: the heading, then any inline badge marker. When neither a
+  // badge nor a headingRow class is supplied we render the bare heading, so
+  // simple call sites (skills/plan/permission/health) keep a plain `h2`/`h3`
+  // as the direct descendant their CSS expects.
+  const heading = (
+    <Title
+      id={titleId}
+      data-slot="page-header-title"
+      // No typography utilities here — the wrapper CSS owns h2/h3 sizing.
+      className="m-0"
+    >
+      {title}
+    </Title>
+  );
+  const titleRow =
+    badge != null || headingRowClassName ? (
+      <div
+        data-slot="page-header-heading-row"
+        className={cn('flex flex-wrap items-center gap-2', headingRowClassName)}
+      >
+        {heading}
+        {badge != null ? badge : null}
+      </div>
+    ) : (
+      heading
+    );
+
+  const content = (
+    <div
+      data-slot="page-header-content"
+      className={cn('min-w-0', contentClassName)}
+    >
+      {eyebrow != null ? (
+        <p data-slot="page-header-eyebrow" className="m-0">
+          {eyebrow}
+        </p>
+      ) : null}
+      {titleRow}
+      {subtitle != null ? (
+        <p
+          data-slot="page-header-subtitle"
+          className={cn('m-0', subtitleClassName)}
+        >
+          {subtitle}
+        </p>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <Wrapper data-slot="page-header" className={className}>
+      {icon != null ? (
+        <span
+          data-slot="page-header-icon"
+          aria-hidden="true"
+          className={iconClassName}
+        >
+          {icon}
+        </span>
+      ) : null}
+      {content}
+      {actions != null ? actions : null}
+      {meta != null ? meta : null}
+    </Wrapper>
+  );
+}

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -13,6 +13,7 @@ import type { CapabilityAuditReport } from '@maka/core';
 import { deriveCapabilityAuditReport } from '@maka/core';
 import { Button as UiButton, Switch, TabsRoot, TabsList, TabsTrigger, TabsPanel } from './ui.js';
 import { Chip, type ChipProps } from './primitives/chip.js';
+import { PageHeader } from './primitives/page-header.js';
 import { Input } from './primitives/input.js';
 import { EmptyState } from './empty-state.js';
 import { CapabilityAuditStrip } from './capability-audit-strip.js';
@@ -635,11 +636,12 @@ export function SkillsModuleMain(props: {
   const auditReport = props.auditReport ?? deriveCapabilityAuditReport({ skills: props.skills ?? [] });
   return (
     <main className="maka-main detailPane maka-module-main agents-chat-panel" aria-label="技能">
-      <header className="maka-module-main-header">
-        <div>
-          <h2>技能</h2>
-          <p>安装与管理技能，在对话中扩展 Maka 的能力。</p>
-        </div>
+      <PageHeader
+        className="maka-module-main-header"
+        as="h2"
+        title="技能"
+        subtitle="安装与管理技能，在对话中扩展 Maka 的能力。"
+        actions={
         <div className="maka-module-main-actions" role="group" aria-label="技能操作">
           <label className="maka-skill-search" aria-label="搜索技能">
             <Search size={15} aria-hidden="true" />
@@ -685,7 +687,8 @@ export function SkillsModuleMain(props: {
             {pendingSkillAction === 'refresh' ? '刷新中…' : '刷新'}
           </UiButton>
         </div>
-      </header>
+        }
+      />
       <CapabilityAuditStrip report={auditReport} />
       <SkillLibraryPanel
         skills={props.skills}

--- a/scripts/check-a11y.mjs
+++ b/scripts/check-a11y.mjs
@@ -315,6 +315,9 @@ const RULES = [
  * impose Chinese on every brand name).
  */
 const ALLOWED_ENGLISH_PATTERNS = [
+  // The app's own product name — a proper noun, kept in Latin script
+  // everywhere (About hero title, brand marks). Not a missing translation.
+  /^Maka$/,
   // Model providers / brand names
   /^OpenAI$/i,
   /^Anthropic$/i,


### PR DESCRIPTION
Round 3 of notes/ui-convergence-map-2026-07-09.md: the two page-header dialects (module h2 shells, settings h3 intros) converge onto one `PageHeader` primitive with title/subtitle/eyebrow/icon/badge/as/actions/meta slots + data-slot hooks. All 6 call sites migrated, none skipped; daily-review stays header-less by design. No CSS re-pins needed (wrapper descendant selectors match through the slots — verified via live computed styles: module 26px/600, intro 13px/600 preserved). check-a11y brand allow-list gains Maka. Desktop 2293/2293 + ui 46/46 exit-code gated; dead-css + alignment auditor clean; 5 CDP captures verified. Implemented by an opus worktree agent to the map spec.