### PR TITLE
fix(headless): validate verifier workspace paths

### DIFF
--- a/packages/headless/src/__tests__/verifier.test.ts
+++ b/packages/headless/src/__tests__/verifier.test.ts
@@ -1,10 +1,73 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { Task } from '../contracts.js';
 import { normalizeVerifier, runVerifier } from '../verifier.js';
+
+describe('command verifiers', () => {
+  test('rejects cwd values outside the workspace', () => {
+    for (const cwd of ['../outside', '/tmp/outside', 'C:\\outside']) {
+      assert.throws(() => normalizeVerifier({
+        id: 'command-task',
+        instruction: 'solve',
+        workspaceDir: '/tmp/example',
+        verifier: {
+          kind: 'command',
+          command: 'true',
+          cwd,
+          protectedPaths: [],
+        },
+      }), /command verifier cwd must be a workspace-relative path/);
+    }
+  });
+
+  test('rejects protectedPaths with Windows drive paths on POSIX hosts', () => {
+    assert.throws(() => normalizeVerifier({
+      id: 'command-task',
+      instruction: 'solve',
+      workspaceDir: '/tmp/example',
+      verifier: {
+        kind: 'command',
+        command: 'true',
+        protectedPaths: ['C:\\outside'],
+      },
+    }), /protectedPaths entry must be a workspace-relative path/);
+  });
+
+  test('runs command verifier from a legal workspace-relative cwd', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-command-verifier-'));
+    try {
+      await mkdir(join(dir, 'subdir'));
+      await writeFile(join(dir, 'subdir', 'marker.txt'), 'ok', 'utf8');
+      const verifier = normalizeVerifier({
+        id: 'command-task',
+        instruction: 'solve',
+        workspaceDir: dir,
+        verifier: {
+          kind: 'command',
+          command: 'test -f marker.txt',
+          cwd: 'subdir',
+          protectedPaths: [],
+        },
+      });
+
+      const result = await runVerifier({
+        verifier,
+        taskRunId: 'run-1',
+        ts: 100,
+        id: 'verifier-1',
+        workspaceDir: dir,
+      });
+
+      assert.equal(result.passed, true);
+      assert.equal(result.exitCode, 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('benchmark verifiers', () => {
   test('normalizes enriched Terminal-Bench verifier specs', () => {

--- a/packages/headless/src/verifier.ts
+++ b/packages/headless/src/verifier.ts
@@ -16,6 +16,7 @@ export function normalizeVerifier(task: Task): VerifierSpec {
       if (typeof verifier.command !== 'string' || verifier.command.trim().length === 0) {
         throw new Error(`task "${task.id}": command verifier requires a non-empty command`);
       }
+      validateOptionalWorkspaceRelativePath(task.id, verifier.cwd, 'cwd');
       validateProtectedPaths(task.id, verifier.protectedPaths);
       return {
         ...verifier,
@@ -251,9 +252,24 @@ function validateProtectedPaths(taskId: string, protectedPaths: unknown): assert
     );
   }
   for (const rel of protectedPaths) {
-    if (typeof rel !== 'string' || isAbsolute(rel) || rel.split(/[\\/]+/).includes('..')) {
+    if (typeof rel !== 'string') {
       throw new Error(`task "${taskId}": protectedPaths entry must be a workspace-relative path: ${String(rel)}`);
     }
+    assertWorkspaceRelativePath(taskId, rel, 'protectedPaths entry');
+  }
+}
+
+function validateOptionalWorkspaceRelativePath(taskId: string, value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    throw new Error(`task "${taskId}": command verifier ${field} must be a workspace-relative path: ${String(value)}`);
+  }
+  assertWorkspaceRelativePath(taskId, value, `command verifier ${field}`);
+}
+
+function assertWorkspaceRelativePath(taskId: string, value: string, label: string): void {
+  if (isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value) || value.split(/[\\/]+/).includes('..')) {
+    throw new Error(`task "${taskId}": ${label} must be a workspace-relative path: ${value}`);
   }
 }
 


### PR DESCRIPTION
## Problem

  Headless verifier paths should never escape the prepared workspace, or grading can depend on host state instead of the task snapshot.

  ## Approach

  Use one workspace-relative path guard for command verifier `cwd` and protected grading paths.

  ## Validation

  - `npm --workspace @maka/headless test`